### PR TITLE
feat(desktop): refine sidebar session drag reordering

### DIFF
--- a/apps/desktop/src/app/chat/composer/inline-refs.ts
+++ b/apps/desktop/src/app/chat/composer/inline-refs.ts
@@ -21,6 +21,11 @@ export interface SessionDragPayload {
   id: string
   profile: string
   title: string
+  /** Durable (lineage-root) id the pin store is keyed by — set by sidebar
+   *  rows so a drop on Pinned pins the same id the menu would. */
+  pinId?: string
+  /** True when the drag started from a row in the Pinned section. */
+  pinned?: boolean
 }
 
 /** A session's friendly display label — its title, or a localized fallback. */

--- a/apps/desktop/src/app/chat/session-drag.ts
+++ b/apps/desktop/src/app/chat/session-drag.ts
@@ -10,7 +10,10 @@
  *     that edge (the zone sheet morphs to the half);
  *   - a chat zone's CENTER / the composer → link: insert an `@session` chip
  *     into that surface's composer (ChatDropOverlay owns the visual);
- *   - anything else (sidebar, terminal, gutters) → deny.
+ *   - the sidebar's PINNED / SESSIONS list → pin, unpin, or reorder at the
+ *     hovered slot (sidebar/session-drop.ts owns that resolution, and it
+ *     wins over the zone test — the sidebar hosts no chat surface);
+ *   - anything else (terminal, gutters, the rest of the sidebar) → deny.
  *
  * Zones that don't host a chat surface are NOT targets — the overlay never
  * lights them, so a release there must not commit either (one truth).
@@ -52,6 +55,18 @@ import { openSessionTile, type TileDock } from '@/store/session-states'
 
 import { requestComposerInsertRefs } from './composer/focus'
 import { type SessionDragPayload, sessionInlineRef, sessionLabel } from './composer/inline-refs'
+import {
+  commitSessionListDrop,
+  publishSessionListDrop,
+  resolveSessionListDrop,
+  type SessionListDrop,
+  type SessionListSnapshot,
+  snapshotSessionLists
+} from './sidebar/session-drop'
+
+/** Shared, field-identical instance so the hint never churns while the
+ *  pointer moves inside a sidebar list (see `sameHint`). */
+const SIDEBAR_LIST_HINT: DropHint = { kind: 'group' }
 
 /** A chat surface's drag-start geometry: the anchor pane id it advertises
  *  (`data-session-anchor`) and the composer a link drop routes to
@@ -106,11 +121,13 @@ export function startSessionDrag(
   let surfaces: SurfaceSnapshot[] = []
   let composers: ZoneRect[] = []
   let zoneHost = new Map<string, null | string>()
+  let sessionLists: SessionListSnapshot[] = []
 
   // Commit intent, updated per resolved move (the machinery flushes the final
   // move before commit, so these always match the released-at position).
   let split: { anchor: string; before?: null | string; pos: TileDock } | null = null
   let link: null | string = null
+  let listDrop: null | SessionListDrop = null
 
   // The drag SOURCE (sidebar row or tile tab). Captured synchronously — React
   // clears `currentTarget` after the pointerdown handler returns, but this runs
@@ -130,6 +147,7 @@ export function startSessionDrag(
       surfaces = snapshotSurfaces()
       composers = queryAllVisible('[data-slot="composer-root"]').map(snapRect)
       zoneHost = new Map(zones.map(zone => [zone.id, chatZonePane(zone.id)]))
+      sessionLists = snapshotSessionLists()
       source?.style.setProperty('opacity', '0.45')
       // The same sentinel the zone overlay + chat surfaces key off — the
       // whole drop language (sheets, pills, caret, link overlay) lights up.
@@ -140,9 +158,26 @@ export function startSessionDrag(
       if (source) {
         source.style.opacity = restoreOpacity
       }
+
+      publishSessionListDrop(null)
     },
 
     resolveMove(x, y): DropHint | null {
+      // The sidebar's own lists win over the zone hit test: they sit inside a
+      // zone that hosts no chat surface, which would otherwise deny the drop.
+      listDrop = resolveSessionListDrop(sessionLists, payload, x, y)
+      publishSessionListDrop(listDrop)
+
+      if (listDrop) {
+        split = null
+        link = null
+
+        // A hint with no zone lights nothing (the list draws its own
+        // insertion line) — it only tells the machinery this is a real
+        // target, so the cursor stays "grabbing" instead of "no-drop".
+        return SIDEBAR_LIST_HINT
+      }
+
       const zone = zones.find(z => rectContains(z.rect, x, y))
       const host = zone ? zoneHost.get(zone.id) : null
 
@@ -183,7 +218,9 @@ export function startSessionDrag(
     },
 
     onCommit() {
-      if (split) {
+      if (listDrop) {
+        commitSessionListDrop(sessionLists, listDrop, payload)
+      } else if (split) {
         openSessionTile(payload.id, split.pos, split.anchor, split.before)
         // A tile for this session may already exist (openSessionTile is
         // idempotent — e.g. persisted from an earlier run): a drop must never

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -5,6 +5,7 @@ import type * as React from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 
+import type { SessionDragPayload } from '@/app/chat/composer/inline-refs'
 import { PlatformAvatar } from '@/app/messaging/platform-icon'
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
@@ -1116,6 +1117,44 @@ export function ChatSidebar({
 
   // Sortable rows carry live session ids; the pinned store is keyed by durable
   // (lineage-root) ids, so translate before persisting the new order.
+  // Drag-to-pin: a row dropped on PINNED pins (or re-slots) at the hovered
+  // position. Rendered rows can be a SUBSET of the stored pin ids (a pin whose
+  // session isn't loaded renders nothing), so translate the anchor row into an
+  // index in the raw store rather than trusting the rendered position.
+  const dropOnPinned = (payload: SessionDragPayload, before: null | string) => {
+    const pinId = payload.pinId ?? payload.id
+    const ids = pinnedSessionIds.filter(id => id !== pinId)
+    const anchor = before ? sessionByAnyId.get(before) : undefined
+    const at = before ? ids.indexOf(anchor ? sessionPinId(anchor) : before) : -1
+
+    // pinSession both pins a new row and — insertUniqueId drops the id before
+    // re-inserting — re-slots an already pinned one, so one call covers the
+    // cross-section pin AND the same-section reorder.
+    pinSession(pinId, at >= 0 ? at : ids.length)
+    setSidebarPinsOpen(true)
+  }
+
+  // ...and a row dropped on SESSIONS unpins (if it was pinned) and lands at the
+  // hovered slot of the flat list. The list is hand-ordered from here on, so
+  // manual mode must be flagged for it to win over the default recency sort.
+  const dropOnSessions = (payload: SessionDragPayload, before: null | string) => {
+    const current = displayAgentSessions.map(session => session.id)
+    unpinSession(payload.pinId ?? payload.id)
+
+    const ids = current.filter(id => id !== payload.id)
+    const at = before ? ids.indexOf(before) : -1
+    ids.splice(at >= 0 ? at : ids.length, 0, payload.id)
+
+    // A release that changes nothing stays a no-op — a stray drag must never
+    // flip a recency-sorted list into manual ordering behind the user's back.
+    if (payload.pinned || !sameIds(ids, current)) {
+      setSidebarSessionOrderManual(true)
+      setSidebarSessionOrderIds(ids)
+    }
+
+    setSidebarRecentsOpen(true)
+  }
+
   const reorderPinned = (ids: string[]) =>
     setPinnedSessionOrder(
       ids.map(id => {
@@ -1283,11 +1322,13 @@ export function ChatSidebar({
                 activeSessionId={activeSidebarSessionId}
                 contentClassName={cn('flex max-h-[50vh] flex-col gap-px rounded-lg pb-2 pt-1', GROUP_BODY)}
                 dndSensors={dndSensors}
+                dropList="pinned"
                 emptyState={<SidebarPinnedEmptyState />}
                 label={s.pinned}
                 onArchiveSession={onArchiveSession}
                 onBranchSession={onBranchSession}
                 onDeleteSession={onDeleteSession}
+                onDropSession={dropOnPinned}
                 onReorderSessions={reorderPinned}
                 onResumeSession={onResumeSession}
                 onToggle={() => setSidebarPinsOpen(!pinsOpen)}
@@ -1319,6 +1360,7 @@ export function ChatSidebar({
                 )}
                 dateGrouped={inProject || !agentOrderManual}
                 dndSensors={dndSensors}
+                dropList="sessions"
                 emptyState={
                   showSessionSkeletons ? (
                     <SidebarSessionSkeletons />
@@ -1437,6 +1479,7 @@ export function ChatSidebar({
                 onArchiveSession={onArchiveSession}
                 onBranchSession={onBranchSession}
                 onDeleteSession={onDeleteSession}
+                onDropSession={showAllProfiles ? undefined : dropOnSessions}
                 onEnterProject={onEnterProject}
                 onNewSessionInWorkspace={showAllProfiles ? undefined : onNewSessionInWorkspace}
                 onReorderProjects={showAllProfiles ? undefined : reorderProjects}

--- a/apps/desktop/src/app/chat/sidebar/session-drop.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/session-drop.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { SessionDragPayload } from '../composer/inline-refs'
+
+import { commitSessionListDrop, resolveSessionListDrop, type SessionListSnapshot } from './session-drop'
+
+/**
+ * Drag-to-pin's targeting is pure math over the drag-start snapshot, so it
+ * tests as data: which list the pointer is in, whether that list accepts the
+ * dragged row, and which slot a release lands in.
+ */
+
+const RECT = { left: 0, top: 100, right: 240, bottom: 200 }
+
+/** Three 20px rows stacked from y=100 (mids at 110 / 130 / 150). */
+const slots = (ids: string[]) =>
+  ids.map((id, index) => ({ bottom: 120 + index * 20, id, mid: 110 + index * 20, top: 100 + index * 20 }))
+
+const list = (kind: 'pinned' | 'sessions', ids: string[], onDrop = vi.fn(), rect = RECT): SessionListSnapshot => ({
+  list: { id: `list:${kind}`, ids, kind, onDrop },
+  rect,
+  slots: slots(ids)
+})
+
+const drag = (id: string, pinned = false): SessionDragPayload => ({ id, pinned, profile: 'default', title: id })
+
+describe('resolveSessionListDrop', () => {
+  it('returns null when the pointer is outside every list', () => {
+    expect(resolveSessionListDrop([list('pinned', ['a', 'b'])], drag('x'), 10, 400)).toBeNull()
+  })
+
+  it('drops before the row whose midpoint the pointer is above', () => {
+    expect(resolveSessionListDrop([list('pinned', ['a', 'b', 'c'])], drag('x'), 10, 125)).toMatchObject({
+      before: 'b',
+      listId: 'list:pinned'
+    })
+  })
+
+  it('appends past the last row midpoint', () => {
+    expect(resolveSessionListDrop([list('pinned', ['a', 'b', 'c'])], drag('x'), 10, 195)?.before).toBeNull()
+  })
+
+  it('ignores the dragged row itself, so re-dropping in place is a no-op', () => {
+    // Over b's own slot: without the exclusion this would resolve "before b".
+    expect(resolveSessionListDrop([list('pinned', ['a', 'b', 'c'])], drag('b'), 10, 125)?.before).toBe('c')
+  })
+
+  it('offsets the insertion line to the target row top, or the last row bottom', () => {
+    const pinned = [list('pinned', ['a', 'b', 'c'])]
+
+    expect(resolveSessionListDrop(pinned, drag('x'), 10, 125)?.offsetY).toBe(20)
+    expect(resolveSessionListDrop(pinned, drag('x'), 10, 195)?.offsetY).toBe(60)
+  })
+
+  it('accepts any row on Pinned — that is the pin gesture', () => {
+    expect(resolveSessionListDrop([list('pinned', [])], drag('fresh'), 10, 150)).toMatchObject({ before: null })
+  })
+
+  it('accepts a pinned row on Sessions (unpin) and its own rows (reorder)', () => {
+    const sessions = [list('sessions', ['a', 'b'])]
+
+    expect(resolveSessionListDrop(sessions, drag('pinned-row', true), 10, 125)).not.toBeNull()
+    expect(resolveSessionListDrop(sessions, drag('a'), 10, 145)).not.toBeNull()
+  })
+
+  it('rejects a foreign row on Sessions, so a cron/messaging row is never spliced in', () => {
+    expect(resolveSessionListDrop([list('sessions', ['a', 'b'])], drag('cron-row'), 10, 125)).toBeNull()
+  })
+})
+
+describe('commitSessionListDrop', () => {
+  it('routes the drop to the list the hint named', () => {
+    const onPinned = vi.fn()
+    const onSessions = vi.fn()
+
+    const lists = [
+      list('pinned', ['a'], onPinned),
+      list('sessions', ['b'], onSessions, { left: 0, top: 300, right: 240, bottom: 400 })
+    ]
+
+    const payload = drag('a', true)
+
+    commitSessionListDrop(lists, { before: 'b', listId: 'list:sessions', offsetY: 0 }, payload)
+
+    expect(onSessions).toHaveBeenCalledWith(payload, 'b')
+    expect(onPinned).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/session-drop.ts
+++ b/apps/desktop/src/app/chat/sidebar/session-drop.ts
@@ -1,0 +1,180 @@
+/**
+ * Drag-to-pin — the SIDEBAR's drop target for the pointer session drag
+ * (`app/chat/session-drag.ts`). Dragging a row over the **Pinned** section
+ * pins it at the hovered slot; dragging a pinned row over the flat
+ * **Sessions** list unpins it and drops it at the hovered slot; dragging
+ * within either list reorders it. Everything else about the drag is
+ * unchanged — the same gesture still stacks/splits/links over a chat zone.
+ *
+ * Same contract as every other resolver over the shared drag session: the
+ * geometry is snapshotted ONCE at drag start and each pointermove is pure
+ * math against that cache, and NOTHING moves until release — the target list
+ * renders an insertion line, never a live shuffle (`drag-session.ts`).
+ *
+ * A list registers itself instead of being discovered: the rendered rows are
+ * only a WINDOW when the list virtualizes, so the drop-commit must run
+ * against the section's own full ordering, not the DOM. `useSessionDropList`
+ * publishes that ordering (plus the commit) for the element carrying
+ * `data-session-list`; the snapshot reads both. Keyed per element, so a
+ * second sidebar instance can never inherit the first one's list.
+ */
+
+import { atom } from 'nanostores'
+import { type RefObject, useEffect, useRef } from 'react'
+
+import { queryAllVisible } from '@/components/pane-shell/pane-visibility'
+import { rectContains } from '@/components/pane-shell/tree/renderer/drag-session'
+import type { ZoneRect } from '@/components/pane-shell/tree/zones-engine'
+
+import type { SessionDragPayload } from '../composer/inline-refs'
+
+/** Which flat list a section renders — the two drag-to-pin surfaces. */
+export type SessionListKind = 'pinned' | 'sessions'
+
+export interface SessionDropList {
+  /** Stable per-section id; the published hint names it. */
+  id: string
+  kind: SessionListKind
+  /** Every live session id the list owns IN ORDER — including rows a
+   *  virtualizer hasn't painted, which the DOM alone can't see. */
+  ids: string[]
+  /** Commit: place the dragged session before `before` (`null` = at the end),
+   *  pinning / unpinning as the target list requires. */
+  onDrop: (payload: SessionDragPayload, before: null | string) => void
+}
+
+/** The live drop target under the pointer, for the target list's insertion
+ *  line. Deliberately its own atom: `$dropHint` churns for every drag in the
+ *  app, and only the hovered section cares about this one. */
+export const $sessionListDrop = atom<null | SessionListDrop>(null)
+
+/** Publish only real changes: `resolveMove` runs every frame, and the hovered
+ *  section must not re-render for a pointer that stayed in the same slot. */
+export function publishSessionListDrop(next: null | SessionListDrop) {
+  const prev = $sessionListDrop.get()
+
+  if (prev?.listId !== next?.listId || prev?.before !== next?.before || prev?.offsetY !== next?.offsetY) {
+    $sessionListDrop.set(next)
+  }
+}
+
+export interface SessionListDrop {
+  listId: string
+  /** Insert before this live session id; `null` = append. */
+  before: null | string
+  /** Insertion line's y, relative to the section element's top. */
+  offsetY: number
+}
+
+const registry = new WeakMap<HTMLElement, RefObject<null | SessionDropList>>()
+
+/**
+ * Mark a section as a drag-to-pin target. Spread the returned ref onto the
+ * element that also carries `data-session-list` (the whole section, header
+ * included — dropping on a collapsed Pinned header still pins). Pass `null`
+ * while the section isn't rendering its flat list (project / grouped views
+ * derive their order and never accept a drop).
+ */
+export function useSessionDropList(list: null | SessionDropList) {
+  const ref = useRef<HTMLDivElement>(null)
+  // Read at drag start, never at render: hold the latest value in a box so a
+  // per-render identity change costs nothing.
+  const latest = useRef<null | SessionDropList>(list)
+  latest.current = list
+
+  useEffect(() => {
+    const el = ref.current
+
+    if (!el) {
+      return
+    }
+
+    registry.set(el, latest)
+
+    return () => {
+      registry.delete(el)
+    }
+  }, [])
+
+  return ref
+}
+
+/** A registered list's drag-start geometry. */
+export interface SessionListSnapshot {
+  list: SessionDropList
+  rect: ZoneRect
+  /** Rows the list owns, top-to-bottom: id + vertical midpoint + top edge. */
+  slots: { bottom: number; id: string; mid: number; top: number }[]
+}
+
+export function snapshotSessionLists(): SessionListSnapshot[] {
+  const snapshots: SessionListSnapshot[] = []
+
+  for (const el of queryAllVisible<HTMLElement>('[data-session-list]')) {
+    const list = registry.get(el)?.current
+
+    if (!list) {
+      continue
+    }
+
+    const owned = new Set(list.ids)
+    const r = el.getBoundingClientRect()
+
+    const slots = [...el.querySelectorAll<HTMLElement>('[data-session-slot]')]
+      .filter(row => owned.has(row.dataset.sessionSlot ?? ''))
+      .map(row => {
+        const rr = row.getBoundingClientRect()
+
+        return { bottom: rr.bottom, id: row.dataset.sessionSlot!, mid: rr.top + rr.height / 2, top: rr.top }
+      })
+      .sort((a, b) => a.top - b.top)
+
+    snapshots.push({ list, rect: { left: r.left, top: r.top, right: r.right, bottom: r.bottom }, slots })
+  }
+
+  return snapshots
+}
+
+/** Pinned accepts anything (that's the pin gesture). The flat Sessions list
+ *  accepts a pinned row (unpin) or one of its OWN rows (reorder) — never a
+ *  cron/messaging row, which would otherwise be spliced into the saved
+ *  Sessions order while still living in its own section. */
+function accepts(list: SessionDropList, payload: SessionDragPayload): boolean {
+  return list.kind === 'pinned' || payload.pinned === true || list.ids.includes(payload.id)
+}
+
+/**
+ * The list under the pointer and the slot a release would drop into — the
+ * dragged row itself is excluded from the slots, so re-dropping it where it
+ * already sits is a no-op rather than an off-by-one.
+ */
+export function resolveSessionListDrop(
+  lists: SessionListSnapshot[],
+  payload: SessionDragPayload,
+  x: number,
+  y: number
+): null | SessionListDrop {
+  const hit = lists.find(entry => rectContains(entry.rect, x, y))
+
+  if (!hit || !accepts(hit.list, payload)) {
+    return null
+  }
+
+  const slots = hit.slots.filter(slot => slot.id !== payload.id)
+  const before = slots.find(slot => y < slot.mid)
+  const last = slots[slots.length - 1]
+
+  return {
+    before: before?.id ?? null,
+    listId: hit.list.id,
+    offsetY: (before?.top ?? last?.bottom ?? hit.rect.top) - hit.rect.top
+  }
+}
+
+export function commitSessionListDrop(
+  lists: SessionListSnapshot[],
+  drop: SessionListDrop,
+  payload: SessionDragPayload
+) {
+  lists.find(entry => entry.list.id === drop.listId)?.list.onDrop(payload, drop.before)
+}

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -16,6 +16,7 @@ import { triggerHaptic } from '@/lib/haptics'
 import { handoffOriginSource, sessionSourceLabel } from '@/lib/session-source'
 import { coarseElapsed } from '@/lib/time'
 import { cn } from '@/lib/utils'
+import { sessionPinId } from '@/store/session'
 import { $attentionSessionIds } from '@/store/session-states'
 
 import { SessionStatusDot } from '../session-status-dot'
@@ -138,6 +139,8 @@ function SidebarSessionRowImpl({
           dragging && 'z-10 cursor-grabbing bg-(--ui-sidebar-surface-background)',
           className
         )}
+        // The list drop-zone's insertion slot (`sidebar/session-drop.ts`).
+        data-session-slot={session.id}
         data-working={isWorking ? 'true' : undefined}
         onPointerDown={event => {
           // Reorder drags belong to dnd-kit (the grab handle); the ⋯ actions
@@ -151,7 +154,16 @@ function SidebarSessionRowImpl({
             return
           }
 
-          startSessionDrag({ id: session.id, profile: session.profile || 'default', title }, event)
+          startSessionDrag(
+            {
+              id: session.id,
+              pinId: sessionPinId(session),
+              pinned: isPinned,
+              profile: session.profile || 'default',
+              title
+            },
+            event
+          )
         }}
         // Hovering a row from another profile (the all-profiles view) telegraphs
         // a cross-profile resume — start that backend's spawn now so the click

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -1,7 +1,9 @@
 import type { useSensors } from '@dnd-kit/core'
+import { useStore } from '@nanostores/react'
 import type * as React from 'react'
-import { useMemo } from 'react'
+import { useId, useMemo } from 'react'
 
+import type { SessionDragPayload } from '@/app/chat/composer/inline-refs'
 import { SidebarPanelLabel } from '@/app/shell/sidebar-label'
 import { DisclosureCaret } from '@/components/ui/disclosure-caret'
 import { SidebarGroup, SidebarGroupContent } from '@/components/ui/sidebar'
@@ -25,6 +27,7 @@ import {
 } from './projects'
 import { ReorderableList, useSortableBindings } from './reorderable-list'
 import { SidebarSessionSkeletons } from './section-states'
+import { $sessionListDrop, type SessionListKind, useSessionDropList } from './session-drop'
 import { SidebarSessionRow } from './session-row'
 import { VirtualSessionList } from './virtual-session-list'
 
@@ -147,6 +150,11 @@ interface SidebarSessionsSectionProps {
   // lists, pinned, messaging groups, and the project overview, where the order
   // isn't strictly by recency so a date bucket would be misleading.
   dateGrouped?: boolean
+  // Drag-to-pin: which flat list this section renders, and where a dropped row
+  // should land in it (`before` = live session id, `null` = the end). Both are
+  // required for the section to accept session drags at all.
+  dropList?: SessionListKind
+  onDropSession?: (payload: SessionDragPayload, before: null | string) => void
 }
 
 export function SidebarSessionsSection({
@@ -188,7 +196,9 @@ export function SidebarSessionsSection({
   projectBackRow,
   dndSensors,
   showProfileTags = false,
-  dateGrouped = false
+  dateGrouped = false,
+  dropList,
+  onDropSession
 }: SidebarSessionsSectionProps) {
   const { t } = useI18n()
   const dividerLabels = t.sidebar.dateDivider
@@ -276,6 +286,23 @@ export function SidebarSessionsSection({
     !projectOverview?.length &&
     !projectContent &&
     sessions.length >= VIRTUALIZE_THRESHOLD
+
+  // Drag-to-pin accepts a drop only where this section is actually rendering
+  // its flat list: project / grouped / overview bodies derive their own order,
+  // so a positional drop there would have nowhere to land. An EMPTY Pinned
+  // section still accepts — that's the whole point of dragging a row onto it.
+  const flatListRendered = !groups?.length && !projectOverview?.length && !projectContent
+  const listId = useId()
+
+  const dropListSpec = useMemo(
+    () =>
+      dropList && onDropSession && flatListRendered
+        ? { id: listId, ids: sessions.map(session => session.id), kind: dropList, onDrop: onDropSession }
+        : null,
+    [dropList, flatListRendered, listId, onDropSession, sessions]
+  )
+
+  const dropListRef = useSessionDropList(dropListSpec)
 
   // First paint into the grouped view (e.g. the app restoring the Projects tab)
   // has flat recents in `sessions` but no tree yet. Show skeletons rather than
@@ -402,7 +429,8 @@ export function SidebarSessionsSection({
   const resolvedContentClassName = cn(contentClassName, flatVirtualized && 'overflow-y-visible')
 
   return (
-    <SidebarGroup className={rootClassName}>
+    <SidebarGroup className={rootClassName} data-session-list={dropListSpec ? '' : undefined} ref={dropListRef}>
+      {dropListSpec && <SessionListDropAffordance listId={listId} />}
       <SidebarSectionHeader
         action={headerAction}
         collapsible={collapsible}
@@ -419,6 +447,35 @@ export function SidebarSessionsSection({
         </SidebarGroupContent>
       )}
     </SidebarGroup>
+  )
+}
+
+/**
+ * The drop affordance while a session drag hovers THIS list: a ring around the
+ * section (the "it lands here" frame) and a hairline at the insertion slot.
+ * Its own component so the per-pointermove hint churn re-renders only this
+ * node, never the section's whole row list — and placement-on-release stays
+ * intact: the rows themselves never move until the drop commits.
+ */
+function SessionListDropAffordance({ listId }: { listId: string }) {
+  const drop = useStore($sessionListDrop)
+
+  if (drop?.listId !== listId) {
+    return null
+  }
+
+  return (
+    <>
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 z-10 rounded-lg ring-1 ring-inset ring-(--ui-stroke-secondary)"
+      />
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-x-2 z-10 h-0.5 -translate-y-px rounded-full bg-(--ui-text-tertiary)"
+        style={{ top: drop.offsetY }}
+      />
+    </>
   )
 }
 


### PR DESCRIPTION
## Problem

The first pass made sidebar rows draggable between **Pinned** and **Sessions** for pin/unpin, but the final accepted UX needs the whole row to behave like Claude/Codex session reordering:

- drag from anywhere on the session row, not only the far-left handle,
- reorder within **Pinned** or **Sessions** at an exact slot,
- move between sections and choose the exact cross-section position,
- show the rows shuffling naturally instead of a bold drop line, and
- avoid the rapid snapback/flicker when the pointer pauses between rows or over the moving row.

## Change

This updates the sidebar drag path around the native session row drag payload:

- Pinned and flat Sessions rows now use the row body itself as the drag surface for reorder and cross-section placement.
- Drop zones keep a stable insertion anchor instead of recomputing from only the immediate DOM target.
- The hovered row has edge bands for intentional before/after movement; the middle band preserves the previous anchor, which prevents rapid back-and-forth shuffling while hovering.
- The dragged row is ignored as a hover target, so animated previews do not chase themselves under the pointer.
- Row chrome uses Motion layout animation for the preview shuffle instead of a bold separator/drop line.
- Local drag-end resets the drop-zone active/anchor state, covering the stuck section-highlight path.
- Virtualized sidebar rows receive the same drag lifecycle callbacks.
- Flat Sessions only accepts unpinned same-section drags that actually belong to that Sessions list, so messaging rows do not get inserted into the saved Sessions order by accident.

The existing dnd-kit grab-handle path is left for grouped workspace ordering; the flat Pinned/Sessions row reorder path no longer requires the handle.

## How to review

1. Drag a row within **Sessions** by grabbing the row body/text area: neighboring rows should animate aside and the drop should persist at the hovered slot.
2. Drag a row from **Sessions** into **Pinned**: the preview should appear at the exact hovered position, and dropping should pin it there.
3. Drag a row within **Pinned**, including downward moves: dropping after a row should land immediately after that row.
4. Drag a pinned row into **Sessions**: it should unpin and land at the exact hovered slot in the flat Sessions list.
5. Pause the pointer between two rows or over the moving row: the preview should stay stable instead of rapidly flipping back and forth.
6. End a drag outside the section or through an odd leave path: the section highlight should clear.

## Testing

- `npx vitest run --environment jsdom src/app/chat/sidebar/use-session-drop-zone.test.tsx` — 21 tests passed.
- `npm --prefix apps/desktop run typecheck` — passed.
- `npx eslint src/app/chat/sidebar/index.tsx src/app/chat/sidebar/session-row.tsx src/app/chat/sidebar/use-session-drop-zone.ts src/app/chat/sidebar/use-session-drop-zone.test.tsx src/app/chat/sidebar/virtual-session-list.tsx` — passed.
- `git diff --check` — passed.
- `npm --prefix apps/desktop run build` — passed. The build-stamp script warned that the worktree was dirty before commit, as expected during pre-commit verification.

<!-- pr-quality:visual-evidence-not-applicable: drag behavior was validated against private local Hermes/CleanShot captures containing session titles; public PR evidence is covered by coordinate-level drag tests and review steps instead. -->