### PR TITLE
fix(agent): teach models secret indirection instead of inlining credentials (#43083)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1005,11 +1005,17 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
             }
             # Defence-in-depth: redact credentials from tool call arguments
             # before they enter conversation history. Tool execution uses the
-            # raw API response object, not this dict, so redacting the
-            # persisted shape is safe and only affects storage. Catches the
-            # case where a model accidentally inlines a secret into a tool
-            # call (e.g. `terminal(command="curl -H 'Authorization: Bearer
-            # sk-...'")`). (#19798)
+            # raw API response object, not this dict, so the CURRENT tool call
+            # still runs with real values — but this dict IS replayed to the
+            # model on subsequent turns, so the model sees *** in its own
+            # history afterwards. That is intentional: the contract is that
+            # models reference secrets indirectly (env expansion, source .env)
+            # rather than inlining literal values — see SECRET_HANDLING_GUIDANCE
+            # in agent/prompt_builder.py. A model that inlines a secret anyway
+            # gets one working call; copying *** on the next turn fails loudly
+            # instead of silently persisting the credential. Users who need
+            # raw inline credentials can opt out via
+            # `security.redact_secrets: false`. (#19798, #43083)
             if isinstance(tc_dict["function"]["arguments"], str):
                 from agent.redact import redact_sensitive_text
                 tc_dict["function"]["arguments"] = redact_sensitive_text(

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -304,6 +304,30 @@ TASK_COMPLETION_GUIDANCE = (
     "is always better than inventing a result."
 )
 
+# Secret-handling guidance.  Injected only when global secret redaction is
+# enabled (security.redact_secrets, default True).  With redaction on, any
+# literal credential the model writes into a tool call or message is stored
+# as ``***`` in conversation history — so a model that inlines a password
+# once will copy the ``***`` placeholder on the next turn and the command
+# fails (#43083).  The contract: reference secrets indirectly (shell env
+# expansion, `source .env`, reading at execution time) so the raw value
+# never needs to round-trip through context.  Resolved once at session
+# start from a process-lifetime flag, so the system prompt stays
+# byte-stable for the whole conversation (cache-safe).
+SECRET_HANDLING_GUIDANCE = (
+    "# Handling secrets\n"
+    "Secret redaction is enabled: credentials (API keys, passwords, tokens) are "
+    "replaced with *** in your stored conversation history. A literal secret you "
+    "write into a command will appear as *** when you see it again — so never "
+    "copy credential values from earlier turns, and never inline a secret you "
+    "read from a file directly into a command. Reference secrets indirectly "
+    "instead: use shell variable expansion (`PGPASSWORD=\"$PGPASSWORD\" psql ...`), "
+    "`source .env` or `export $(grep -v '^#' .env | xargs)` before the command, "
+    "or have the command read the credential file itself at execution time. If "
+    "you see *** where a real value is needed, re-read the original source "
+    "(.env, config file) and use indirection — do not paste *** into commands."
+)
+
 # OpenAI GPT/Codex-specific execution guidance.  Addresses known failure modes
 # where GPT models abandon work on partial results, skip prerequisite lookups,
 # hallucinate instead of using tools, and declare "done" without verification.

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -323,6 +323,17 @@ def _redact_form_body(text: str) -> str:
     return _redact_query_string(text.strip())
 
 
+def is_redaction_enabled() -> bool:
+    """Return True when global secret redaction is enabled.
+
+    Reflects ``security.redact_secrets`` in config.yaml (bridged to the
+    ``HERMES_REDACT_SECRETS`` env var at startup). Fixed for the lifetime
+    of the process, so callers may bake the result into per-session state
+    (e.g. the cached system prompt) without cache-invalidation risk.
+    """
+    return _REDACT_ENABLED
+
+
 def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = False) -> str:
     """Apply all redaction patterns to a block of text.
 

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -34,6 +34,7 @@ from agent.prompt_builder import (
     MEMORY_GUIDANCE,
     OPENAI_MODEL_EXECUTION_GUIDANCE,
     PLATFORM_HINTS,
+    SECRET_HANDLING_GUIDANCE,
     SESSION_SEARCH_GUIDANCE,
     SKILLS_GUIDANCE,
     STEER_CHANNEL_NOTE,
@@ -110,6 +111,16 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # users who want a leaner prompt can turn it off.
     if getattr(agent, "_task_completion_guidance", True) and agent.valid_tool_names:
         stable_parts.append(TASK_COMPLETION_GUIDANCE)
+
+    # Secret-handling guidance: only meaningful when the agent has tools
+    # (the failure mode is credentials round-tripping through tool-call
+    # history) and global redaction is on. is_redaction_enabled() is
+    # process-lifetime-stable, so this block never changes mid-session
+    # (cache-safe). (#43083)
+    if agent.valid_tool_names:
+        from agent.redact import is_redaction_enabled
+        if is_redaction_enabled():
+            stable_parts.append(SECRET_HANDLING_GUIDANCE)
 
     # Tool-aware behavioral guidance: only inject when the tools are loaded
     tool_guidance = []

--- a/tests/agent/test_secret_handling_guidance.py
+++ b/tests/agent/test_secret_handling_guidance.py
@@ -1,0 +1,88 @@
+"""Tests for SECRET_HANDLING_GUIDANCE injection (#43083).
+
+When global secret redaction is enabled (the default), tool-call arguments
+are redacted to ``***`` in conversation history. The model must therefore
+reference secrets indirectly (env expansion, source .env) instead of
+inlining literal values. SECRET_HANDLING_GUIDANCE teaches that contract;
+it goes into the STABLE tier of the system prompt so it never changes
+mid-session (cache-safe), and is gated on:
+
+  * the agent having tools (the failure mode is credentials round-tripping
+    through tool-call history), and
+  * redaction being enabled (process-lifetime flag).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agent.prompt_builder import SECRET_HANDLING_GUIDANCE
+from agent.system_prompt import build_system_prompt_parts
+
+
+def _make_agent(**overrides):
+    base = dict(
+        load_soul_identity=False,
+        skip_context_files=True,
+        valid_tool_names=["terminal"],
+        _task_completion_guidance=False,
+        _tool_use_enforcement=False,
+        _environment_probe=False,
+        _kanban_worker_guidance="",
+        _memory_store=None,
+        _memory_manager=None,
+        model="",
+        provider="",
+        platform="",
+        pass_session_id=False,
+        session_id="",
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _build_stable(agent):
+    with (
+        patch("run_agent.load_soul_md", return_value=""),
+        patch("run_agent.build_nous_subscription_prompt", return_value=""),
+        patch("run_agent.build_environment_hints", return_value=""),
+        patch("run_agent.build_context_files_prompt", return_value=""),
+        patch("run_agent.get_toolset_for_tool", return_value=None),
+    ):
+        return build_system_prompt_parts(agent)["stable"]
+
+
+class TestSecretHandlingGuidance:
+    def test_injected_when_redaction_on_and_tools_present(self):
+        with patch("agent.redact._REDACT_ENABLED", True):
+            stable = _build_stable(_make_agent())
+        assert SECRET_HANDLING_GUIDANCE in stable
+
+    def test_skipped_when_redaction_disabled(self):
+        with patch("agent.redact._REDACT_ENABLED", False):
+            stable = _build_stable(_make_agent())
+        assert SECRET_HANDLING_GUIDANCE not in stable
+
+    def test_skipped_when_no_tools(self):
+        # Without tools there is no tool-call history for secrets to
+        # round-trip through — keep the prompt lean.
+        with patch("agent.redact._REDACT_ENABLED", True):
+            stable = _build_stable(_make_agent(valid_tool_names=[]))
+        assert SECRET_HANDLING_GUIDANCE not in stable
+
+    def test_guidance_teaches_indirection_not_placeholder_copying(self):
+        # Behavior contract: the guidance must tell the model (a) not to
+        # copy *** placeholders and (b) to use indirection. Asserts the
+        # relationship, not exact wording.
+        text = SECRET_HANDLING_GUIDANCE
+        assert "***" in text
+        assert "$PGPASSWORD" in text or "source .env" in text
+
+
+class TestRedactionEnabledFlag:
+    def test_is_redaction_enabled_reflects_flag(self):
+        from agent import redact
+
+        with patch("agent.redact._REDACT_ENABLED", True):
+            assert redact.is_redaction_enabled() is True
+        with patch("agent.redact._REDACT_ENABLED", False):
+            assert redact.is_redaction_enabled() is False


### PR DESCRIPTION
## Summary
Models stop breaking on redacted credentials: a new system-prompt block teaches secret indirection (`PGPASSWORD="$PGPASSWORD"`, `source .env`) when redaction is on, so secrets never need to round-trip through tool-call history. Root cause of #43083: tool-call arguments are redacted to `***` in replayed history by design, but nothing told the model not to inline literal credentials — it inlined once, then copied `***` on the next turn and failed.

## Changes
- `agent/prompt_builder.py`: add `SECRET_HANDLING_GUIDANCE` — never copy `***`, never inline secrets read from files; use env expansion / `source .env` / read-at-execution-time
- `agent/system_prompt.py`: inject into the **stable** tier, gated on the agent having tools AND redaction enabled. `is_redaction_enabled()` is process-lifetime-stable, so the prompt is byte-stable for the conversation (cache-safe)
- `agent/redact.py`: add `is_redaction_enabled()` accessor
- `agent/chat_completion_helpers.py`: correct the misleading "only affects storage" comment — the dict IS replayed to the model; the redaction is intentional and the contract is indirection
- `tests/agent/test_secret_handling_guidance.py`: gating tests (on/off, tools/no-tools) + indirection-contract invariant

## What this deliberately does NOT do
The in-context redaction stays. Removing it (the approach in #43092) would regress #19798's storage defence — on default installs the canonical state.db store would hold raw credentials. Users who want raw inline credentials already have the opt-out: `security.redact_secrets: false`.

## Validation
| | Result |
|---|---|
| `tests/agent/test_secret_handling_guidance.py` + `test_system_prompt.py` | 7/7 pass |
| E2E `build_system_prompt()` real import, redaction ON | guidance present |
| E2E redaction OFF | guidance absent |

Fixes #43083.

## Infographic
![Secret indirection infographic](https://v3b.fal.media/files/b/0a9dc2a2/hUiPn3T4FqTu1tsXNmNXh_gcbv7NFw.png)
