### PR TITLE
feat(photon): add native poll sending

### DIFF
--- a/plugins/platforms/photon/README.md
+++ b/plugins/platforms/photon/README.md
@@ -131,7 +131,9 @@ All env vars are documented in `plugin.yaml`. The most important:
   documents are sent via `space.send(attachment(...))` /
   `space.send(voice(...))` through the sidecar's `/send-attachment`
   endpoint; a caption is delivered as a separate text bubble after the media.
-- **Reactions, message effects, polls** — supported by `spectrum-ts` but not
-  yet exposed; the sidecar is the natural place to add them.
+- **Native polls are supported.** Hermes posts poll content through
+  `spectrum-ts`' `poll(...)` builder via the sidecar's `/send-poll` endpoint.
+- **Reactions and message effects** — supported by `spectrum-ts` but not yet
+  exposed; the sidecar is the natural place to add them.
 
 [photon]: https://photon.codes/

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -758,6 +758,29 @@ class PhotonAdapter(BasePlatformAdapter):
             chat_id, animation_url, caption, reply_to, metadata,
         )
 
+    async def send_poll(
+        self,
+        chat_id: str,
+        title: str,
+        options: list[str],
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a native iMessage poll through Photon Spectrum."""
+        choices = [str(option).strip() for option in options if str(option).strip()]
+        if len(choices) < 2:
+            return SendResult(
+                success=False,
+                error="Photon polls require at least two non-empty options",
+            )
+        try:
+            data = await self._sidecar_call(
+                "/send-poll",
+                {"spaceId": chat_id, "title": title.strip(), "options": choices},
+            )
+        except Exception as e:
+            return SendResult(success=False, error=str(e))
+        return SendResult(success=True, message_id=data.get("messageId"))
+
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         try:
             await self._sidecar_call(

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -24,6 +24,8 @@
 //       body: {"spaceId": "...", "path": "...", "name": "..." | null,
 //              "mimeType": "..." | null, "caption": "..." | null,
 //              "kind": "attachment" | "voice"}
+//   - POST /send-poll   -> {"ok": true, "messageId": "..."}
+//       body: {"spaceId": "...", "title": "...", "options": ["...", "..."]}
 //   - POST /typing      -> {"ok": true}
 //       body: {"spaceId": "...", "state": "start" | "stop"}
 //   - POST /shutdown    -> {"ok": true}; then process exits
@@ -70,12 +72,13 @@ if (!projectId || !projectSecret || !sharedToken) {
 
 // Lazy-load spectrum-ts so a missing install fails with a clear message
 // instead of a cryptic module-resolution error during import.
-let Spectrum, imessage, attachment, voice, spectrumText, spectrumTyping;
+let Spectrum, imessage, attachment, voice, spectrumPoll, spectrumText, spectrumTyping;
 try {
   ({
     Spectrum,
     attachment,
     voice,
+    poll: spectrumPoll,
     text: spectrumText,
     typing: spectrumTyping,
   } = await import("spectrum-ts"));
@@ -484,6 +487,21 @@ const server = http.createServer(async (req, res) => {
           );
         }
       }
+      return ok(res, { messageId: result?.id || null });
+    }
+    if (req.url === "/send-poll") {
+      const { spaceId, title, options } = body || {};
+      const choices = Array.isArray(options)
+        ? options.map((option) => String(option || "").trim()).filter(Boolean)
+        : [];
+      if (!spaceId || typeof title !== "string" || !title.trim()) {
+        return badRequest(res, "spaceId and title are required");
+      }
+      if (choices.length < 2) {
+        return badRequest(res, "options must contain at least two choices");
+      }
+      const space = await resolveSpace(spaceId);
+      const result = await space.send(spectrumPoll(title.trim(), choices));
       return ok(res, { messageId: result?.id || null });
     }
     if (req.url === "/typing") {

--- a/tests/plugins/platforms/photon/test_outbound_media.py
+++ b/tests/plugins/platforms/photon/test_outbound_media.py
@@ -183,6 +183,39 @@ async def test_send_image_url_fetch_failure_falls_back_to_text(
 
 
 @pytest.mark.asyncio
+async def test_send_poll_hits_poll_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    adapter = _make_adapter(monkeypatch)
+    calls = _capture_sidecar(adapter)
+
+    result = await adapter.send_poll(
+        "any;-;+1",
+        "Pick one",
+        ["  Alpha ", "", "Beta"],
+    )
+
+    assert result.success is True
+    assert result.message_id == "msg-123"
+    assert calls == [
+        (
+            "/send-poll",
+            {"spaceId": "any;-;+1", "title": "Pick one", "options": ["Alpha", "Beta"]},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_send_poll_requires_two_options(monkeypatch: pytest.MonkeyPatch) -> None:
+    adapter = _make_adapter(monkeypatch)
+    calls = _capture_sidecar(adapter)
+
+    result = await adapter.send_poll("any;-;+1", "Pick one", ["Alpha", " "])
+
+    assert result.success is False
+    assert "at least two" in (result.error or "")
+    assert calls == []
+
+
+@pytest.mark.asyncio
 async def test_send_attachment_rejects_unsafe_path(
     monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/website/docs/user-guide/messaging/photon.md
+++ b/website/docs/user-guide/messaging/photon.md
@@ -202,6 +202,8 @@ Common issues:
   `voice()` content builders via the sidecar's `/send-attachment`
   endpoint. Captions arrive as a separate iMessage bubble after the
   media.
+- **Native polls are supported.** Hermes sends poll content through
+  spectrum-ts' `poll()` builder via the sidecar's `/send-poll` endpoint.
 - **Photon's free quotas:** 5,000 messages per server per day,
   50 new-conversation initiations per shared line per day. Increases
   available — email `help@photon.codes`.


### PR DESCRIPTION
## Summary
- Adds a Photon sidecar `/send-poll` endpoint backed by `spectrum-ts`' native `poll(...)` builder
- Adds `PhotonAdapter.send_poll(...)` with basic option validation
- Updates Photon README and website docs to mark native polls as supported
- Adds regression coverage for the poll endpoint body shape and validation

## Why
`spectrum-ts` already supports native iMessage polls, and Hermes' Photon docs identified polls as a natural sidecar-level feature. This exposes the smallest useful slice without adding a new model tool or changing the generic tool schema.

## Verification
- `node --check plugins/platforms/photon/sidecar/index.mjs`
- `venv/bin/python -m pytest tests/plugins/platforms/photon/test_outbound_media.py -q -o 'addopts='` → 10 passed
- `venv/bin/python -m pytest tests/plugins/platforms/photon -q -o 'addopts='` → 68 passed
