### PR TITLE
fix(agent): classify and actually recover the 'thinking blocks cannot be modified' 400 (#17861)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2221,30 +2221,54 @@ def run_conversation(
                     print(f"{agent.log_prefix}     • Legacy cleanup: hermes config set ANTHROPIC_TOKEN \"\"")
                     print(f"{agent.log_prefix}     • Clear stale keys: hermes config set ANTHROPIC_API_KEY \"\"")
 
-                # ── Thinking block signature recovery ─────────────────
+                # Thinking block signature recovery.
+                #
                 # Anthropic signs thinking blocks against the full turn
-                # content.  Any upstream mutation (context compression,
+                # content. Any upstream mutation (context compression,
                 # session truncation, message merging) invalidates the
-                # signature → HTTP 400.  Recovery: strip reasoning_details
-                # from all messages so the next retry sends no thinking
-                # blocks at all.  One-shot — don't retry infinitely.
+                # signature and the API replies HTTP 400 ("invalid
+                # signature" or "cannot be modified"). Recovery strips
+                # ``reasoning_details`` so the retry sends no thinking
+                # blocks at all. One-shot per outer loop.
+                #
+                # The strip targets ``api_messages``, which is the
+                # API-call-time list that ``_build_api_kwargs`` consumes
+                # on every retry. ``api_messages`` was populated once at
+                # the start of the turn from shallow copies of
+                # ``messages``, so mutating it does not touch the
+                # canonical store. The previous implementation popped
+                # ``reasoning_details`` from ``messages`` instead, which
+                # had two problems: ``api_messages`` carried its own
+                # reference to the field through the shallow copy, so the
+                # retry's wire payload still included thinking blocks and
+                # the recovery never reached the API; and the mutation
+                # persisted into ``state.db`` through any subsequent
+                # ``_persist_session`` call, permanently corrupting the
+                # conversation. Future turns would replay the stripped
+                # state, hit the same 400, and the agent would terminate
+                # with ``max_retries_exhausted``, often spawning
+                # cascading compaction-ended sessions chained off the
+                # corrupted parent.
                 if (
                     classified.reason == FailoverReason.thinking_signature
                     and not _retry.thinking_sig_retry_attempted
                 ):
                     _retry.thinking_sig_retry_attempted = True
-                    for _m in messages:
-                        if isinstance(_m, dict):
+                    _api_stripped = 0
+                    for _m in api_messages:
+                        if isinstance(_m, dict) and "reasoning_details" in _m:
                             _m.pop("reasoning_details", None)
+                            _api_stripped += 1
                     agent._vprint(
-                        f"{agent.log_prefix}⚠️  Thinking block signature invalid — "
-                        f"stripped all thinking blocks, retrying...",
+                        f"{agent.log_prefix}⚠️  Thinking block signature invalid, "
+                        f"stripped reasoning_details from api_messages for retry...",
                         force=True,
                     )
                     logger.warning(
                         "%sThinking block signature recovery: stripped "
-                        "reasoning_details from %d messages",
-                        agent.log_prefix, len(messages),
+                        "reasoning_details from %d api_messages "
+                        "(canonical messages unchanged)",
+                        agent.log_prefix, _api_stripped,
                     )
                     continue
 

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -549,14 +549,32 @@ def classify_api_error(
             should_fallback=True,
         )
 
-    # Anthropic thinking block signature invalid (400).
+    # Anthropic thinking block recovery (400).  Two distinct failure modes,
+    # same recovery (strip all reasoning_details and retry without thinking
+    # blocks — see the thinking_signature handler in conversation_loop.py):
+    #   1. Signature mismatch: a thinking block is signed against the full
+    #      turn content; any upstream mutation (context compression, session
+    #      truncation, message merging) invalidates the signature.
+    #      Pattern: "signature" + "thinking".
+    #   2. Frozen-block mutation: Anthropic rejects any change to the
+    #      thinking/redacted_thinking blocks in the *latest* assistant
+    #      message — "`thinking` or `redacted_thinking` blocks in the latest
+    #      assistant message cannot be modified. These blocks must remain as
+    #      they were in the original response."  This carries no "signature"
+    #      token, so the original pattern missed it and the turn hard-aborted
+    #      as a non-retryable client error instead of self-healing.
+    #      Pattern: "thinking" + ("cannot be modified" | "must remain as they were").
     # Don't gate on provider — OpenRouter proxies Anthropic errors, so the
     # provider may be "openrouter" even though the error is Anthropic-specific.
-    # The message pattern ("signature" + "thinking") is unique enough.
+    # The combined patterns are unique enough.
     if (
         status_code == 400
-        and "signature" in error_msg
         and "thinking" in error_msg
+        and (
+            "signature" in error_msg
+            or "cannot be modified" in error_msg
+            or "must remain as they were" in error_msg
+        )
     ):
         return _result(
             FailoverReason.thinking_signature,

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -942,6 +942,7 @@ AUTHOR_MAP = {
     "michel.belleau@malaiwah.com": "malaiwah",
     "gnanasekaran.sekareee@gmail.com": "gnanam1990",
     "jz.pentest@gmail.com": "0xyg3n",
+    "ian@culling.ca": "ianculling",  # PR #36087
     "7093928+0xyg3n@users.noreply.github.com": "0xyg3n",
     "nftpoetrist@gmail.com": "nftpoetrist",  # PR #18982
     "millerc79@users.noreply.github.com": "millerc79",  # PR #19033

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -661,6 +661,42 @@ class TestClassifyApiError:
         # Without "thinking" in the message, it shouldn't be thinking_signature
         assert result.reason != FailoverReason.thinking_signature
 
+    def test_anthropic_thinking_blocks_cannot_be_modified(self):
+        """Frozen-block mutation 400 (no 'signature' token) must route to
+        thinking_signature recovery, not hard-abort. Regression for the
+        real-world error: latest-assistant thinking blocks 'cannot be
+        modified' after upstream message mutation."""
+        e = MockAPIError(
+            "messages.73.content.10: `thinking` or `redacted_thinking` blocks "
+            "in the latest assistant message cannot be modified. These blocks "
+            "must remain as they were in the original response.",
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="anthropic")
+        assert result.reason == FailoverReason.thinking_signature
+        assert result.retryable is True
+
+    def test_anthropic_thinking_cannot_be_modified_via_openrouter(self):
+        """Same frozen-block error proxied through OpenRouter must also be
+        caught (provider is not gated)."""
+        e = MockAPIError(
+            "`thinking` or `redacted_thinking` blocks in the latest assistant "
+            "message cannot be modified.",
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="openrouter")
+        assert result.reason == FailoverReason.thinking_signature
+        assert result.retryable is True
+
+    def test_400_cannot_be_modified_without_thinking_not_classified(self):
+        """A 400 'cannot be modified' that has nothing to do with thinking
+        blocks must NOT be swept into thinking_signature recovery."""
+        e = MockAPIError(
+            "this field cannot be modified after creation", status_code=400,
+        )
+        result = classify_api_error(e, provider="anthropic", approx_tokens=0)
+        assert result.reason != FailoverReason.thinking_signature
+
     def test_invalid_encrypted_content_classified_as_retryable_replay_failure(self):
         body = {
             "error": {

--- a/tests/run_agent/test_thinking_sig_recovery_persistence.py
+++ b/tests/run_agent/test_thinking_sig_recovery_persistence.py
@@ -1,0 +1,93 @@
+"""Regression tests for the thinking-block signature recovery.
+
+The recovery in ``agent/conversation_loop.py`` strips ``reasoning_details``
+from ``api_messages`` (the API-call-time list rebuilt on every retry) and
+leaves ``messages`` (the canonical store) untouched. The previous
+implementation popped from ``messages`` directly, which never reached
+``api_messages`` because each entry in ``api_messages`` was a shallow
+copy of the corresponding entry in ``messages``, and the mutation also
+landed in ``state.db`` on the next ``_persist_session`` call, corrupting
+the conversation.
+
+These tests cover the surface that the recovery touches in isolation:
+shallow copies share inner field references; popping a key from one dict
+does not remove it from the other; and a list of shallow copies behaves
+the same way.
+"""
+
+
+def _shallow_copies(messages):
+    return [m.copy() for m in messages]
+
+
+def test_pop_on_shallow_copy_does_not_affect_source():
+    rd = [{"type": "thinking", "thinking": "r", "signature": "s"}]
+    src = {"role": "assistant", "content": "x", "reasoning_details": rd}
+    cp = src.copy()
+
+    cp.pop("reasoning_details", None)
+
+    assert "reasoning_details" not in cp
+    assert "reasoning_details" in src
+    assert src["reasoning_details"] is rd
+
+
+def test_strip_api_messages_leaves_canonical_messages_intact():
+    """Mirrors the recovery: pop reasoning_details from api_messages only.
+
+    The canonical ``messages`` list keeps its reasoning_details so future
+    persists carry the original signed blocks.
+    """
+    rd_one = [{"type": "thinking", "thinking": "one", "signature": "sig_one"}]
+    rd_two = [{"type": "thinking", "thinking": "two", "signature": "sig_two"}]
+    messages = [
+        {"role": "user", "content": "q1"},
+        {"role": "assistant", "content": "a1", "reasoning_details": rd_one},
+        {"role": "user", "content": "q2"},
+        {"role": "assistant", "content": "a2", "reasoning_details": rd_two},
+    ]
+    api_messages = _shallow_copies(messages)
+
+    stripped = 0
+    for m in api_messages:
+        if isinstance(m, dict) and "reasoning_details" in m:
+            m.pop("reasoning_details", None)
+            stripped += 1
+
+    assert stripped == 2
+    assert all("reasoning_details" not in m for m in api_messages)
+    canonical_rd = [
+        m.get("reasoning_details") for m in messages if m["role"] == "assistant"
+    ]
+    assert canonical_rd == [rd_one, rd_two]
+
+
+def test_strip_is_idempotent_when_run_twice():
+    """A second strip is a no-op when reasoning_details has already been
+    removed from api_messages. Guards against a duplicate firing path.
+    """
+    api_messages = [
+        {"role": "assistant", "content": "a", "reasoning_details": [{"x": 1}]},
+        {"role": "user", "content": "q"},
+    ]
+    for _ in range(2):
+        for m in api_messages:
+            if isinstance(m, dict) and "reasoning_details" in m:
+                m.pop("reasoning_details", None)
+
+    assert all("reasoning_details" not in m for m in api_messages)
+
+
+def test_strip_skips_messages_without_reasoning_details():
+    api_messages = [
+        {"role": "user", "content": "q"},
+        {"role": "assistant", "content": "a"},
+        {"role": "tool", "tool_call_id": "1", "content": "ok"},
+    ]
+    snapshot = [dict(m) for m in api_messages]
+
+    for m in api_messages:
+        if isinstance(m, dict) and "reasoning_details" in m:
+            m.pop("reasoning_details", None)
+
+    assert api_messages == snapshot


### PR DESCRIPTION
## Summary
Extended-thinking sessions on direct Anthropic no longer wedge permanently on the `thinking blocks ... cannot be modified` HTTP 400 — the error now routes to the existing thinking-signature recovery, and the recovery's retry actually omits the thinking blocks (salvages #36087 + #35265, refs #17861).

Root cause was two stacked gaps: the classifier pattern required the literal token "signature" (the "cannot be modified" variant has none → hard abort as non-retryable), and the recovery stripped `reasoning_details` from `messages` while the wire payload is rebuilt from `api_messages` (shallow copies that retain their own reference) → the retry re-sent a byte-identical payload and re-failed.

## Changes
- `agent/error_classifier.py`: also match `"thinking"` + (`"cannot be modified"` | `"must remain as they were"`) on 400 → `FailoverReason.thinking_signature` (@ianculling, #36087)
- `agent/conversation_loop.py`: thinking-signature recovery strips `reasoning_details` from `api_messages` (the wire list) instead of `messages` (the canonical store) — retry payload is actually clean, and the signed blocks stay intact in persisted history (@0xyg3n, #35265)
- `scripts/release.py`: AUTHOR_MAP entry for ianculling
- tests: 3 new classifier cases (incl. negative "cannot be modified without thinking" guard), new `tests/run_agent/test_thinking_sig_recovery_persistence.py`

## Validation
Live E2E via mock-HTTP `AIAgent.run_conversation` harness, seeded history with a signed thinking block in `reasoning_details`, server returns the field-exact 400 from #17861 (`messages.9.content.4: thinking ... cannot be modified`):

| | origin/main | this branch |
|---|---|---|
| API attempts | 1 (hard abort, "Non-retryable client error") | 2 |
| Retry payload has reasoning_details | n/a (no retry) | 0 messages |
| Outcome | failed=True, session wedged | "recovered answer", completed=True |
| Canonical history signature | — | intact (`Ek0sig==` preserved) |

Targeted tests: `tests/agent/test_error_classifier.py` + `tests/run_agent/test_thinking_sig_recovery_persistence.py` → 165 passed.

These are the recovery-side safety nets for #17861; the structural Option-B fix (raw Anthropic content persistence — #35586/#20997/#26959) is a separate review.

## Infographic
![Thinking-block 400 recovery](https://v3b.fal.media/files/b/0a9dc2bf/hrqpvQ23acU0wBlzzarXn_v5wOqyHH.png)
