### PR TITLE
fix(ci): only save test durations when tests pass

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -129,7 +129,7 @@ jobs:
   # (including PRs) get balanced slicing.
   save-durations:
     needs: test
-    if: always() && github.ref == 'refs/heads/main'
+    if: needs.test.result == 'success' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Download all slice durations


### PR DESCRIPTION
## What does this PR do?

The `save-durations` job in `.github/workflows/tests.yml` used `if: always()` which meant it would run even when the test matrix failed. This could cache duration data from a failed/incomplete run, poisoning the test-durations cache with partial or incorrect timings that would then skew slice balancing on future runs.

Changed the condition to `needs.test.result == 'success'` so durations are only cached when all test slices pass cleanly.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `.github/workflows/tests.yml`: Changed `save-durations` job `if` condition from `always() && github.ref == 'refs/heads/main'` to `needs.test.result == 'success' && github.ref == 'refs/heads/main'`

## How to Test

1. Push a commit to a branch on main that intentionally breaks a test
2. Observe that the `save-durations` job is now skipped (previously it would run)
3. Push a fix and verify `save-durations` runs and caches normally on success

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRUCTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes — N/A (CI workflow condition change, no testable code path)
- [ ] I've tested on my platform: N/A (CI-only change)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — or N/A
- [x] I've considered cross-platform impact — or N/A
- [x] I've updated tool descriptions/schemas — or N/A
