### PR TITLE
fix(config): resolve key_env and api_key from model config in direct-alias branch

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -675,8 +675,15 @@ def _resolve_named_custom_runtime(
             return pool_result
         _da_is_openai_url   = base_url_host_matches(base_url, "openai.com") or base_url_host_matches(base_url, "openai.azure.com")
         _da_is_openrouter   = base_url_host_matches(base_url, "openrouter.ai")
+        _model_cfg = _get_model_config()
+        _da_key_env = str(_model_cfg.get("key_env", "") or "").strip()
         api_key_candidates = [
             (explicit_api_key or "").strip(),
+            # Resolve key_env from model config — mirrors the named-provider
+            # branch (line 735) so bare `provider: custom` + `key_env` in the
+            # model: block is honored, not silently ignored.  (#43586)
+            os.getenv(_da_key_env, "").strip() if _da_key_env else "",
+            str(_model_cfg.get("api_key", "") or "").strip(),
             # Gate env key fallbacks on authoritative hosts (#28660)
             (os.getenv("OPENAI_API_KEY", "").strip()     if _da_is_openai_url else ""),
             (os.getenv("OPENROUTER_API_KEY", "").strip() if _da_is_openrouter  else ""),

--- a/tests/hermes_cli/test_regression_16767.py
+++ b/tests/hermes_cli/test_regression_16767.py
@@ -53,3 +53,121 @@ def test_resolve_named_custom_runtime_honors_explicit_base_url(monkeypatch):
     assert result["provider"] == "custom"
     assert result["api_key"] == "test-api-key"
     assert result["source"] == "direct-alias"
+
+
+# --- Regression tests for #43586 ---
+# The direct-alias branch (provider=custom + explicit_base_url) silently ignored
+# key_env and api_key from the model: config block, falling through to
+# "no-key-required".  The named-provider branch honored them.  These tests
+# verify parity between the two paths.
+
+def test_direct_alias_honors_key_env_from_model_config(monkeypatch):
+    """model: block with provider: custom + key_env must resolve the env var.
+
+    Reproducer for #43586: bare `provider: custom` with `key_env: MY_TOKEN`
+    in the model: block sent "no-key-required" instead of the env var value.
+    """
+    import hermes_cli.runtime_provider as rp
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("MY_GATEWAY_TOKEN", "env-secret-123")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {
+        "provider": "custom",
+        "base_url": "https://my-gateway.example.com/v1",
+        "key_env": "MY_GATEWAY_TOKEN",
+    })
+    monkeypatch.setattr(rp, "has_usable_secret", lambda x: bool(x and x != "no-key-required"))
+
+    result = _resolve_named_custom_runtime(
+        requested_provider="custom",
+        explicit_base_url="https://my-gateway.example.com/v1",
+    )
+
+    assert result is not None
+    assert result["api_key"] == "env-secret-123"
+    assert result["source"] == "direct-alias"
+
+
+def test_direct_alias_honors_inline_api_key_from_model_config(monkeypatch):
+    """model: block with provider: custom + api_key must use the inline value.
+
+    Verifies that the direct-alias branch reads api_key from model config,
+    matching the named-provider branch behavior.
+    """
+    import hermes_cli.runtime_provider as rp
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {
+        "provider": "custom",
+        "base_url": "https://my-gateway.example.com/v1",
+        "api_key": "inline-key-456",
+    })
+    monkeypatch.setattr(rp, "has_usable_secret", lambda x: bool(x and x != "no-key-required"))
+
+    result = _resolve_named_custom_runtime(
+        requested_provider="custom",
+        explicit_base_url="https://my-gateway.example.com/v1",
+    )
+
+    assert result is not None
+    assert result["api_key"] == "inline-key-456"
+
+
+def test_direct_alias_key_env_falls_through_when_env_var_unset(monkeypatch):
+    """key_env in model config that doesn't match any env var falls through.
+
+    When key_env is set but the env var doesn't exist, the next candidate
+    (e.g. _host_derived_api_key or no-key-required) should be used.
+    """
+    import hermes_cli.runtime_provider as rp
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("NONEXISTENT_KEY", raising=False)
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {
+        "provider": "custom",
+        "base_url": "https://my-gateway.example.com/v1",
+        "key_env": "NONEXISTENT_KEY",
+    })
+    monkeypatch.setattr(rp, "has_usable_secret", lambda x: bool(x and x != "no-key-required"))
+    monkeypatch.setattr(rp, "_host_derived_api_key", lambda url: "host-derived-key")
+
+    result = _resolve_named_custom_runtime(
+        requested_provider="custom",
+        explicit_base_url="https://my-gateway.example.com/v1",
+    )
+
+    assert result is not None
+    # Should fall through to host-derived key, not get stuck on empty string
+    assert result["api_key"] == "host-derived-key"
+
+
+def test_direct_alias_explicit_api_key_takes_precedence_over_key_env(monkeypatch):
+    """explicit_api_key parameter takes precedence over model config key_env.
+
+    When the caller passes explicit_api_key (e.g. from credential pool),
+    it should win over model config's key_env.
+    """
+    import hermes_cli.runtime_provider as rp
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("MY_TOKEN", "env-value")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {
+        "provider": "custom",
+        "base_url": "https://my-gateway.example.com/v1",
+        "key_env": "MY_TOKEN",
+    })
+    monkeypatch.setattr(rp, "has_usable_secret", lambda x: bool(x and x != "no-key-required"))
+
+    result = _resolve_named_custom_runtime(
+        requested_provider="custom",
+        explicit_api_key="pool-key-789",
+        explicit_base_url="https://my-gateway.example.com/v1",
+    )
+
+    assert result is not None
+    # explicit_api_key (first candidate) wins over key_env (second candidate)
+    assert result["api_key"] == "pool-key-789"


### PR DESCRIPTION
## What does this PR do?

Resolves `key_env` and `api_key` from the `model:` config block in the direct-alias branch of `_resolve_named_custom_runtime()`, so bare `provider: custom` with `key_env: MY_TOKEN` actually sends the env var as the bearer token instead of silently falling through to `"no-key-required"`.

## Related Issue

Fixes #43586

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/runtime_provider.py`: Added `key_env` and `api_key` lookups from `_get_model_config()` to the direct-alias `api_key_candidates` list (lines 678–686), mirroring the named-provider branch at line 735.
- `tests/hermes_cli/test_regression_16767.py`: Added 4 regression tests covering `key_env` resolution, inline `api_key` resolution, unset env var fallthrough, and `explicit_api_key` precedence.

## How to Test

1. Set `model.key_env: MY_GATEWAY_TOKEN` in `~/.hermes/config.yaml` with `provider: custom` and a `base_url`
2. Export `MY_GATEWAY_TOKEN=<valid-key>` in the environment
3. Run `hermes -z "hi"` — should authenticate successfully (previously sent `"no-key-required"` → 401)
4. Run `pytest tests/hermes_cli/test_regression_16767.py -v` — all 7 tests pass
5. Run `pytest tests/hermes_cli/test_runtime_provider_resolution.py -v` — all 127 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `hermes_cli/runtime_provider.py::_resolve_named_custom_runtime` (callers: 3, flows: direct-alias → named-provider → explicit → env fallback)
- Blast radius: LOW — adds candidates to an existing fallback chain; no control flow changes
- Related patterns: mirrors the named-provider branch at line 735 which already resolves `key_env` via `os.getenv(custom_provider.get("key_env"))`
