### PR TITLE
fix(mcp): apply backoff to reconnect-event path A, not just transport-exception path B

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1825,6 +1825,16 @@ class MCPServerTask:
         backoff = 1.0
 
         while True:
+            # If we've previously had a successful connect, reset the
+            # backoff and retry counter so the next reconnect starts from
+            # 1.0s instead of accumulated max.  H-019.2 — the reconnect
+            # main loop now uses the same backoff variable on both path A
+            # (reconnect event) and path B (transport exception); without
+            # this reset, a one-time blip would penalize all future
+            # reconnects with the max backoff.
+            if self._ready.is_set():
+                backoff = 1.0
+                retries = 0
             try:
                 if self._is_http():
                     await self._run_http(config)
@@ -1837,9 +1847,28 @@ class MCPServerTask:
                 #    touch the retry counters — this is not a failure.
                 if self._shutdown_event.is_set():
                     break
+                # Apply exponential backoff before re-entering the transport
+                # so that persistent reconnect failures get breathing room
+                # instead of busy-looping.
+                #
+                # Background (H-019.2 in hermes-agent docs): the reconnect
+                # main loop historically had two diverging code paths.  The
+                # ``except Exception`` branch (path B) already used the
+                # ``backoff`` variable.  The reconnect-event branch below
+                # (path A) re-entered the transport immediately, which causes
+                # a keepalive-failure -> reconnect -> keepalive-failure tight
+                # loop for stdio MCP servers whose subprocess takes seconds
+                # to spin up (npx-fetched packages: 7-15s; gRPC / OAuth hand­
+                # shake: variable).  Honoring the same backoff here collapses
+                # that loop into a benign retry.
+                #
+                # Backoff is reset to 1.0s after a successful spawn further
+                # down in the loop (search for ``backoff = 1.0`` reset).
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, _MAX_BACKOFF_SECONDS)
                 logger.info(
                     "MCP server '%s': reconnecting (OAuth recovery or "
-                    "manual refresh)",
+                    "manual refresh) after backoff",
                     self.name,
                 )
                 # Reset the session reference; _run_http/_run_stdio will


### PR DESCRIPTION
## Summary

The reconnect main loop in `MCPServerTask.run()` had two diverging code paths that honored exponential backoff inconsistently, causing keepalive-failure → reconnect → keepalive-failure tight loops for stdio MCP servers whose subprocess takes seconds to spin up.

## Problem

- **Path A** (reconnect event from keepalive failure): re-entered the transport immediately, with **no backoff at all**
- **Path B** (transport exception): used the `backoff` variable with exponential growth capped at `_MAX_BACKOFF_SECONDS`

The asymmetry caused busy-loops for any stdio MCP server whose subprocess can't satisfy the 30s keepalive window before fully initializing. Real-world culprits:

- npx-fetched packages (e.g. `@brightdata/mcp`): 7–15s for first-time install + MCP protocol handshake
- OAuth handshakes: variable latency before `list_tools` becomes responsive
- gRPC / HTTP MCP servers behind flaky proxies

**Symptom in the field**: `mcp_brightdata_*` and `mcp_gbrain_*` tool calls intermittently return `ClosedResourceError` while `gateway.error.log` fills with:

```
WARNING tools.mcp_tool: MCP server 'brightdata' keepalive failed, triggering reconnect: 
WARNING tools.mcp_tool: MCP server 'brightdata' keepalive failed, triggering reconnect: 
WARNING tools.mcp_tool: MCP server 'brightdata' keepalive failed, triggering reconnect: 
ERROR   tools.mcp_tool: MCP tool brightdata/search_engine call failed: 
```

…at 1–2 messages per second, until the next tool call finally gets a fresh subprocess initialized in time.

## Fix

Two minimal changes in `tools/mcp_tool.py`:

1. **Honor backoff on path A**: the reconnect-event branch now `await asyncio.sleep(backoff)` and increments `backoff` like path B does, before re-entering the transport.
2. **Reset backoff after successful reconnect**: at the top of `while True`, if `self._ready.is_set()` (i.e. we've previously had a successful connect, reset  and . This preserves the property that a one-time blip doesn't permanently penalize all future reconnects with the maximum backoff.

## Test plan

- [ ] Spin up a stdio MCP server whose spawn takes >5s (e.g. an  package that downloads on first use).
- [ ] Trigger keepalive failure (e.g. by killing the subprocess and waiting for the next keepalive cycle).
- [ ] Verify  shows the new  message and that subsequent reconnect attempts honor the exponential delay.
- [ ] Verify a successful reconnect resets backoff to 1.0s for the next failure cycle.
- [ ] Verify OAuth-recovery flow (e.g. token refresh) still works correctly — the 1.0s initial backoff is negligible compared to the actual OAuth round-trip.

## Notes

- The  reset at the top of the loop is gated on , so it doesn't affect the very first attempt (when  is still cleared).
- The fix does **not** change any public API or config schema. It is a pure behavioral change in the reconnect loop.
- 30 insertions, 1 deletion — minimal blast radius.
EOF
)