### PR TITLE
fix(langfuse): close root context during shutdown

### DIFF
--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -28,6 +28,7 @@ import os
 import re
 import threading
 import time
+import atexit
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
@@ -701,6 +702,28 @@ def _end_observation(observation: Any, *, output: Any = None, metadata: Optional
         _debug(f"end observation failed: {exc}")
 
 
+def _close_root_context(state: TraceState) -> None:
+    """Exit a manually-entered Langfuse root context exactly once.
+
+    The plugin keeps the root observation open across multiple request/tool
+    hooks by calling ``root_ctx.__enter__()`` directly in ``_start_root_trace``.
+    Ending the Langfuse span is not the same as exiting the context manager:
+    ``__exit__`` also detaches OpenTelemetry's active span context.  If that
+    generator context is left for interpreter shutdown, OpenTelemetry module
+    globals may already be torn down and Python can print a noisy ignored
+    exception from ``opentelemetry.trace.use_span``.
+    """
+
+    root_ctx = getattr(state, "root_ctx", None)
+    if root_ctx is None:
+        return
+    state.root_ctx = None
+    try:
+        root_ctx.__exit__(None, None, None)
+    except Exception as exc:  # pragma: no cover - fail-open
+        _debug(f"close root context failed: {exc}")
+
+
 def _merge_trace_output(output: Any, state: TraceState) -> Any:
     if not state.turn_tool_calls:
         return output
@@ -760,8 +783,41 @@ def _finish_trace(task_key: str, *, output: Any = None) -> None:
     except Exception as exc:  # pragma: no cover - fail-open
         _debug(f"finish trace failed: {exc}")
     finally:
+        _close_root_context(state)
         try:
             client.flush()
+        except Exception:
+            pass
+
+
+def _shutdown_active_traces() -> None:
+    """Best-effort cleanup for traces still open when Hermes exits."""
+
+    client = _LANGFUSE_CLIENT if _LANGFUSE_CLIENT is not _INIT_FAILED else None
+    with _STATE_LOCK:
+        states = list(_TRACE_STATE.values())
+        _TRACE_STATE.clear()
+
+    for state in states:
+        try:
+            for observation in state.generations.values():
+                _end_observation(observation)
+            for observation in state.tools.values():
+                _end_observation(observation)
+            for queue in state.pending_tools_by_name.values():
+                for observation in queue:
+                    _end_observation(observation)
+            if getattr(state, "root_span", None) is not None:
+                state.root_span.end()
+        except Exception as exc:  # pragma: no cover - fail-open
+            _debug(f"shutdown trace cleanup failed: {exc}")
+        finally:
+            _close_root_context(state)
+
+    flush = getattr(client, "flush", None) if client is not None else None
+    if callable(flush):
+        try:
+            flush()
         except Exception:
             pass
 
@@ -1135,3 +1191,6 @@ def register(ctx) -> None:
     ctx.register_hook("post_llm_call", on_post_llm_call)
     ctx.register_hook("pre_tool_call", on_pre_tool_call)
     ctx.register_hook("post_tool_call", on_post_tool_call)
+
+
+atexit.register(_shutdown_active_traces)

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -5,6 +5,7 @@ import importlib
 import logging
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -1021,3 +1022,57 @@ class TestUsageFromSanitizedResponse:
 
         assert seen["resp"] is resp
         assert captured["usage_details"] == {"input": 7, "output": 3}
+
+
+class TestRootContextCleanup:
+    def _state(self, mod):
+        calls = []
+
+        class RootCtx:
+            def __exit__(self, exc_type, exc, tb):
+                calls.append((exc_type, exc, tb))
+
+        class RootSpan:
+            def __init__(self):
+                self.ended = False
+
+            def set_trace_io(self, **_):
+                pass
+
+            def update(self, **_):
+                pass
+
+            def end(self):
+                self.ended = True
+
+        state = mod.TraceState(trace_id="trace-1", root_ctx=RootCtx(), root_span=RootSpan())
+        return state, calls
+
+    def test_finish_trace_exits_manually_entered_root_context(self, monkeypatch):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        mod = importlib.import_module("plugins.observability.langfuse")
+        state, calls = self._state(mod)
+        task_key = mod._trace_key("task-1", "session-1")
+        monkeypatch.setitem(mod._TRACE_STATE, task_key, state)
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: SimpleNamespace(flush=lambda: None))
+
+        mod._finish_trace(task_key, output={"content": "done"})
+
+        assert state.root_span.ended is True
+        assert state.root_ctx is None
+        assert calls == [(None, None, None)]
+
+    def test_shutdown_active_traces_closes_orphaned_root_contexts(self, monkeypatch):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        mod = importlib.import_module("plugins.observability.langfuse")
+        state, calls = self._state(mod)
+        task_key = mod._trace_key("task-1", "session-1")
+        monkeypatch.setitem(mod._TRACE_STATE, task_key, state)
+        monkeypatch.setattr(mod, "_LANGFUSE_CLIENT", SimpleNamespace(flush=lambda: None))
+
+        mod._shutdown_active_traces()
+
+        assert state.root_span.ended is True
+        assert state.root_ctx is None
+        assert calls == [(None, None, None)]
+        assert task_key not in mod._TRACE_STATE


### PR DESCRIPTION
## What does this PR do?

Closes the Langfuse root trace context during plugin shutdown and adds an `atexit` handler to clean up traces still open when the Python interpreter exits. Previously the plugin manually entered the root context via `root_ctx.__enter__()` in `_start_root_trace` but never called `root_ctx.__exit__()`, leaving OpenTelemetry's active span context attached until interpreter teardown — at which point module globals may already be torn down. This caused noisy `Exception ignored in: <generator object Langfuse._create_span_with_parent_context ...>` and `TypeError: isinstance() arg 2 must be a type...` errors on exit.

## Related Issue

No related issue; this is a bug fix identified from noisy shutdown logs.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/observability/langfuse/__init__.py`
  - Added `import atexit` at module level.
  - Added `_close_root_context(state)` helper — reads `state.root_ctx`, sets it to `None` **before** calling `__exit__` to guarantee single-close semantics, then calls `root_ctx.__exit__(None, None, None)` to detach the OpenTelemetry active span context.
  - Added `_shutdown_active_traces()` — iterates all open `TraceState` entries under the lock, ends any active observations and root spans, closes root contexts, and flushes the Langfuse client.
  - `_finish_trace` now calls `_close_root_context(state)` in its `finally` block so the context is always cleaned up on normal trace completion.
  - `atexit.register(_shutdown_active_traces)` is at **module level** (not inside `register()`) so the handler is registered as soon as the module is imported.
- `tests/plugins/test_langfuse_plugin.py`
  - Added `from types import SimpleNamespace`.
  - Added `TestRootContextCleanup` test class with two test methods.

## How to Test

1. Run the focused test suite: `pytest tests/plugins/test_langfuse_plugin.py::TestRootContextCleanup -v`
2. Run the plugin tests: `pytest tests/plugins/test_langfuse_plugin.py -q` — all 43 tests should pass.
3. Run linters: `ruff check plugins/observability/langfuse/__init__.py tests/plugins/test_langfuse_plugin.py` and `python -m py_compile plugins/observability/langfuse/__init__.py` — both should pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've ran the full `pytest tests/ -q` suite (not run for this PR; see verification above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Ubuntu 24.04, Python 3.x)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before fix (noisy exceptions on interpreter shutdown):
```
Exception ignored in: <generator object Langfuse._create_span_with_parent_context at 0x...>
Traceback (most recent call last):
  File ".../opentelemetry/trace/__init__.py", line ...
TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union
```

After fix: clean shutdown, no exceptions.