### PR TITLE
fix(gateway): strip MEDIA directives from WhatsApp text before delivery

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -919,6 +919,11 @@ class WhatsAppAdapter(BasePlatformAdapter):
 
         Formats markdown for WhatsApp, splits long messages into chunks
         that preserve code block boundaries, and sends each chunk sequentially.
+
+        As a backstop, ``MEDIA:<path>`` directives are extracted and delivered
+        as native attachments *before* the text body — mirroring the WeChat
+        adapter pattern.  This prevents internal filesystem paths from leaking
+        as visible text when the upstream dispatch path fails to strip them.
         """
         if not self._running or not self._http_session:
             return SendResult(success=False, error="Not connected")
@@ -932,12 +937,44 @@ class WhatsAppAdapter(BasePlatformAdapter):
         try:
             import aiohttp
 
+            # --- MEDIA: backstop (mirrors WeChat adapter pattern) ---
+            media_files, cleaned = self.extract_media(content)
+            media_files = self.filter_media_delivery_paths(media_files)
+            _, cleaned = self.extract_images(cleaned)
+
+            _AUDIO_EXTS = {".ogg", ".opus", ".mp3", ".wav", ".m4a", ".flac"}
+            _VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".webm", ".3gp"}
+            _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif"}
+
+            async def _deliver_media(path: str, is_voice: bool = False) -> None:
+                ext = Path(path).suffix.lower()
+                try:
+                    if is_voice or ext in _AUDIO_EXTS:
+                        await self.send_voice(chat_id=chat_id, audio_path=path)
+                    elif ext in _VIDEO_EXTS:
+                        await self.send_video(chat_id=chat_id, video_path=path)
+                    elif ext in _IMAGE_EXTS:
+                        await self.send_image_file(chat_id=chat_id, image_path=path)
+                    else:
+                        await self.send_document(chat_id=chat_id, file_path=path)
+                except Exception as exc:
+                    logger.warning(
+                        "[%s] media delivery failed for %s: %s",
+                        self.name, path, exc,
+                    )
+
+            for media_path, is_voice in media_files:
+                await _deliver_media(media_path, is_voice)
+            # --- end MEDIA: backstop ---
+
             # Format and chunk the message
-            formatted = self.format_message(content)
+            formatted = self.format_message(cleaned)
             chunks = self.truncate_message(formatted, self._outgoing_chunk_limit())
 
             last_message_id = None
             for chunk in chunks:
+                if not chunk.strip():
+                    continue
                 payload: Dict[str, Any] = {
                     "chatId": chat_id,
                     "message": chunk,

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -188,6 +188,7 @@ from gateway.platforms.base import (
     SUPPORTED_DOCUMENT_TYPES,
     cache_image_from_url,
     cache_audio_from_url,
+    _strip_media_directives,
 )
 
 
@@ -941,6 +942,10 @@ class WhatsAppAdapter(BasePlatformAdapter):
             media_files, cleaned = self.extract_media(content)
             media_files = self.filter_media_delivery_paths(media_files)
             _, cleaned = self.extract_images(cleaned)
+            # Strip any remaining MEDIA: tags from visible text (protected-span
+            # directives inside code blocks / inline code are not extracted but
+            # must not leak as visible path text — #43656).
+            cleaned = _strip_media_directives(cleaned).strip()
 
             _AUDIO_EXTS = {".ogg", ".opus", ".mp3", ".wav", ".m4a", ".flac"}
             _VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".webm", ".3gp"}

--- a/tests/gateway/test_whatsapp_media_backstop.py
+++ b/tests/gateway/test_whatsapp_media_backstop.py
@@ -1,0 +1,164 @@
+"""WhatsApp MEDIA: directive backstop tests (issue #43656).
+
+Verify that MEDIA:<path> directives in outgoing content are extracted and
+delivered as native attachments, not leaked as visible text.
+"""
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.platforms.whatsapp import WhatsAppAdapter
+from gateway.config import PlatformConfig
+
+
+class _FakeResponse:
+    """Async-context-manager response for aiohttp."""
+    def __init__(self, status=200, data=None):
+        self.status = status
+        self._data = data or {"messageId": "msg"}
+
+    async def json(self):
+        return self._data
+
+    async def text(self):
+        return "error"
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        pass
+
+
+def _make_adapter():
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={"session_name": "test"}))
+    adapter._running = True
+    adapter._http_session = MagicMock()
+    adapter._bridge_port = 8080
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_media_directive_stripped_from_text(tmp_path):
+    """MEDIA:<path> tags must not appear in the text sent to the bridge."""
+    media_file = tmp_path / "report.png"
+    media_file.write_bytes(b"\x89PNG")
+
+    adapter = _make_adapter()
+    sent_payloads = []
+
+    def _fake_post(url, json=None, **kw):
+        sent_payloads.append(json)
+        return _FakeResponse(200)
+
+    adapter._http_session.post = _fake_post
+
+    with patch.object(adapter, "send_image_file", new_callable=AsyncMock) as mock_img:
+        mock_img.return_value = MagicMock(success=True)
+        await adapter.send("chat1", f"Here is the report:\nMEDIA:{media_file}")
+
+    # Text sent to bridge must NOT contain MEDIA: or the file path
+    assert sent_payloads, "Bridge should have received a text message"
+    text = sent_payloads[0]["message"]
+    assert "MEDIA:" not in text
+    assert str(media_file) not in text
+
+    # Image file should have been sent natively
+    mock_img.assert_awaited_once()
+    call_kwargs = mock_img.call_args
+    assert str(media_file) in str(call_kwargs)
+
+
+@pytest.mark.asyncio
+async def test_no_media_directive_passthrough():
+    """Content without MEDIA: tags should pass through unchanged."""
+    adapter = _make_adapter()
+    sent_payloads = []
+
+    def _fake_post(url, json=None, **kw):
+        sent_payloads.append(json)
+        return _FakeResponse(200)
+
+    adapter._http_session.post = _fake_post
+
+    result = await adapter.send("chat1", "Hello, world!")
+    assert result.success is True
+    assert len(sent_payloads) == 1
+    assert "Hello, world!" in sent_payloads[0]["message"]
+
+
+@pytest.mark.asyncio
+async def test_multiple_media_directives(tmp_path):
+    """Multiple MEDIA: tags should all be extracted and delivered."""
+    img = tmp_path / "photo.jpg"
+    img.write_bytes(b"\xff\xd8\xff")
+    doc = tmp_path / "notes.pdf"
+    doc.write_bytes(b"%PDF")
+
+    adapter = _make_adapter()
+
+    def _fake_post(url, json=None, **kw):
+        return _FakeResponse(200)
+
+    adapter._http_session.post = _fake_post
+
+    with patch.object(adapter, "send_image_file", new_callable=AsyncMock) as mock_img, \
+         patch.object(adapter, "send_document", new_callable=AsyncMock) as mock_doc:
+        mock_img.return_value = MagicMock(success=True)
+        mock_doc.return_value = MagicMock(success=True)
+        await adapter.send("chat1", f"Here:\nMEDIA:{img}\nMEDIA:{doc}")
+
+    mock_img.assert_awaited_once()
+    mock_doc.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_media_delivery_failure_does_not_block_text(tmp_path, caplog):
+    """If media delivery fails, text should still be sent."""
+    media_file = tmp_path / "broken.mp4"
+    media_file.write_bytes(b"\x00\x00\x00\x18ftyp")
+
+    adapter = _make_adapter()
+    sent_payloads = []
+
+    def _fake_post(url, json=None, **kw):
+        sent_payloads.append(json)
+        return _FakeResponse(200)
+
+    adapter._http_session.post = _fake_post
+
+    with patch.object(adapter, "send_video", new_callable=AsyncMock) as mock_video:
+        mock_video.side_effect = RuntimeError("bridge down")
+        result = await adapter.send("chat1", f"Video:\nMEDIA:{media_file}")
+
+    assert result.success is True
+    assert sent_payloads
+    assert "MEDIA:" not in sent_payloads[0]["message"]
+
+
+@pytest.mark.asyncio
+async def test_only_whitespace_content_after_strip_skipped(tmp_path):
+    """If content is only MEDIA: tags, no empty text message should be sent."""
+    media_file = tmp_path / "image.png"
+    media_file.write_bytes(b"\x89PNG")
+
+    adapter = _make_adapter()
+    sent_payloads = []
+
+    def _fake_post(url, json=None, **kw):
+        sent_payloads.append(json)
+        return _FakeResponse(200)
+
+    adapter._http_session.post = _fake_post
+
+    with patch.object(adapter, "send_image_file", new_callable=AsyncMock) as mock_img:
+        mock_img.return_value = MagicMock(success=True)
+        result = await adapter.send("chat1", f"MEDIA:{media_file}")
+
+    assert result.success is True
+    # Image delivered, no empty text chunk sent
+    mock_img.assert_awaited_once()
+    assert len(sent_payloads) == 0

--- a/tests/gateway/test_whatsapp_media_backstop.py
+++ b/tests/gateway/test_whatsapp_media_backstop.py
@@ -162,3 +162,41 @@ async def test_only_whitespace_content_after_strip_skipped(tmp_path):
     # Image delivered, no empty text chunk sent
     mock_img.assert_awaited_once()
     assert len(sent_payloads) == 0
+
+
+@pytest.mark.asyncio
+async def test_protected_span_media_directive_stripped_from_visible_text():
+    """MEDIA: inside fenced code blocks must not be uploaded but must not leak
+    as visible text either (reviewer feedback on #43679)."""
+    adapter = _make_adapter()
+    sent_payloads = []
+
+    def _fake_post(url, json=None, **kw):
+        sent_payloads.append(json)
+        return _FakeResponse(200)
+
+    adapter._http_session.post = _fake_post
+
+    # MEDIA: inside a fenced code block — extract_media skips it (protected span)
+    # but _strip_media_directives should still clean it from visible text.
+    content = (
+        "Here is an example:\n"
+        "```json\n"
+        '  "path": "MEDIA:/home/agent/private/report.docx"\n'
+        "```\n"
+        "Done."
+    )
+
+    with patch.object(adapter, "send_document", new_callable=AsyncMock) as mock_doc:
+        result = await adapter.send("chat1", content)
+
+    assert result.success is True
+    # No attachment should be sent (protected span)
+    mock_doc.assert_not_awaited()
+    # Visible text must not contain MEDIA: or the internal path
+    assert sent_payloads, "Bridge should have received a text message"
+    text = sent_payloads[0]["message"]
+    assert "MEDIA:" not in text
+    assert "/home/agent/private/report.docx" not in text
+    # Normal trailing text should survive
+    assert "Done." in text


### PR DESCRIPTION
## Problem

`MEDIA:<path>` directives are internal control tags used by the gateway to deliver files natively. When the upstream dispatch path in `gateway/platforms/base.py` processes a response, it calls `extract_media()` + `_strip_media_directives()` to extract files and clean the text body before calling the platform adapter's `send()`.

However, several code paths call `adapter.send()` directly — bypassing the base class dispatch:
- Cron deliveries
- Status/progress messages
- Gateway restart notices
- Other internal notifications

When these paths send content containing `MEDIA:` tags to WhatsApp, the raw filesystem paths leak as visible text, exposing server layout, usernames, and workspace paths.

## Fix

Add a **backstop** in `WhatsAppAdapter.send()` that mirrors the existing WeChat adapter pattern (`gateway/platforms/weixin.py:1830-1865`):

1. `extract_media(content)` — extract `MEDIA:<path>` tags from the content
2. `filter_media_delivery_paths()` — validate paths (prevents path traversal)
3. `extract_images()` — extract inline image URLs
4. Deliver extracted media as native WhatsApp attachments (image/video/audio/document)
5. Send only the cleaned text body

This is a **defensive backstop** — the normal flow still strips `MEDIA:` tags in the base class. The backstop catches edge cases where `send()` receives unstripped content.

## Changes

- `gateway/platforms/whatsapp.py`: +38 lines — MEDIA: extraction + delivery in `send()`
- `tests/gateway/test_whatsapp_media_backstop.py`: +164 lines — 5 tests covering:
  - MEDIA: tag stripped from text, file sent as native attachment
  - Content without MEDIA: passes through unchanged
  - Multiple MEDIA: tags all extracted and delivered
  - Media delivery failure doesn't block text delivery
  - Content that's only MEDIA: tags produces no empty text message

## Testing

All 71 WhatsApp tests pass (5 new + 66 existing).

Fixes #43656
