### PR TITLE
fix(mcp): bump default discovery wait from 0.75s to 3.0s for npx cold start

### DIFF
--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -51,8 +51,23 @@ def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
         thread.start()
 
 
-def wait_for_mcp_discovery(timeout: float = 0.75) -> None:
-    """Briefly wait for background MCP discovery before the first tool snapshot."""
+# Default bounded wait before the first tool snapshot.  npx-driven MCP
+# servers (e.g. ``npx -y @griches/apple-mail-mcp``) typically take 2-4s to
+# install and start on first launch.  The previous 0.75s default was a race
+# that silently dropped any slow-but-reachable server from the agent's
+# tool list for the entire session (the snapshot is taken once and never
+# re-read).  3.0s catches npx cold starts while still bounding the worst
+# case: a dead/never-resolving server still gets cut off quickly.
+_DEFAULT_DISCOVERY_WAIT_SECONDS = 3.0
+
+
+def wait_for_mcp_discovery(timeout: float = _DEFAULT_DISCOVERY_WAIT_SECONDS) -> None:
+    """Briefly wait for background MCP discovery before the first tool snapshot.
+
+    The wait is bounded by ``timeout``; a hung or never-resolving server
+    cannot re-introduce a startup hang.  No-op when no discovery thread
+    was started or the thread has already finished.
+    """
     thread = _mcp_discovery_thread
     if thread is None or not thread.is_alive():
         return

--- a/tests/hermes_cli/test_mcp_startup.py
+++ b/tests/hermes_cli/test_mcp_startup.py
@@ -164,3 +164,19 @@ def test_init_agent_waits_for_mcp_discovery_before_agent_build(monkeypatch):
     monkeypatch.setattr(cli_mod, "AIAgent", _fake_agent)
 
     assert cli._init_agent() is True
+
+
+def test_default_discovery_wait_catches_slow_npx_mcp_servers():
+    """Regression test: npx-driven MCP servers (e.g. ``npx -y @griches/...``)
+    typically take 2-4s to install and spawn on first launch.  The default
+    wait must be long enough to let a slow-but-reachable server land before
+    the agent snapshots its tool list, otherwise its tools are silently
+    dropped for the whole session.  A 0.75s default (the previous value)
+    races; we require >= 2.0s."""
+    import inspect
+    sig = inspect.signature(mcp_startup.wait_for_mcp_discovery)
+    default = sig.parameters["timeout"].default
+    assert default >= 2.0, (
+        f"default MCP discovery wait is {default}s; npx cold start races "
+        f"and slow-but-reachable servers are dropped from the tool list"
+    )

--- a/tests/tui_gateway/test_wait_for_mcp_discovery.py
+++ b/tests/tui_gateway/test_wait_for_mcp_discovery.py
@@ -76,3 +76,19 @@ def test_hung_thread_is_bounded_by_timeout():
     finally:
         stop.set()
         _restore_thread_slot(saved)
+
+
+def test_default_timeout_catches_slow_npx_mcp_servers():
+    """Regression test: npx-driven MCP servers typically take 2-4s to start on
+    first launch (npm install + spawn).  The default wait must be long enough
+    to let at least one slow-but-reachable server land before the agent
+    snapshots its tool list, otherwise its tools are silently dropped for the
+    whole session.  A 0.75s default (the previous value) races; we require
+    >= 2.0s."""
+    import inspect
+    sig = inspect.signature(entry.wait_for_mcp_discovery)
+    default = sig.parameters["timeout"].default
+    assert default >= 2.0, (
+        f"default MCP discovery wait is {default}s; npx cold start races "
+        f"and slow-but-reachable servers are dropped from the tool list"
+    )

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -192,7 +192,7 @@ def _log_exit(reason: str) -> None:
     print(f"[gateway-exit] {reason}", file=sys.stderr, flush=True)
 
 
-def wait_for_mcp_discovery(timeout: float = 0.75) -> None:
+def wait_for_mcp_discovery(timeout: float = 3.0) -> None:
     """Briefly block until background MCP discovery finishes, up to ``timeout``.
 
     MCP discovery runs in a daemon thread spawned at startup (see main()) so a


### PR DESCRIPTION
## What

Bump the default `wait_for_mcp_discovery` timeout from 0.75s to 3.0s in both implementations (`hermes_cli/mcp_startup.py` and `tui_gateway/entry.py`). Add regression tests in both test files.

## Why

The agent snapshots its tool list once at build time and never re-reads it. npx-driven MCP servers (`npx -y @griches/apple-mail-mcp` and similar) typically take 2-4s to install and spawn on first launch. The previous 0.75s default was a race: any slow-but-reachable server that finished connecting after 0.75s was silently dropped from the agent's tool list for the entire session, even though the process was alive and healthy.

## Reproduction

1. Register four npx-driven Apple MCPs (mail, contacts, reminders, calendar) in `config.yaml`:
   ```yaml
   mcp_servers:
     apple-mail:
       command: npx
       args: [-y, "@griches/apple-mail-mcp", --read-only]
       enabled: true
     apple-contacts:
       command: npx
       args: [-y, "@griches/apple-contacts-mcp"]
       enabled: true
     # ... two more
   ```
2. `hermes mcp test apple-contacts` → shows 11 tools. Healthy.
3. `hermes chat -q "call mcp_apple_contacts_list_groups"` → "that tool isn't available in my current toolset".
4. `~/.hermes/logs/mcp-stderr.log` shows all four servers reporting "running on stdio". The processes are alive, but only the mail server is in the agent's tool list. The other three are invisible.

The fix: switch to local node paths in the config (works around the bug), or land this PR (fixes it for everyone).

## Why 3.0s

- `hermes mcp test` shows 0.3-3.8s startup for npx-driven servers on a warm cache. Cold cache is 2-4s.
- A 3.0s default catches npx cold starts while still bounding the worst case: a dead/never-resolving server still gets cut off quickly, so the startup-hang protection that motivated the original 0.75s default is preserved.
- Dead-server test (`test_hung_thread_is_bounded_by_timeout`) still passes against the new default — the bound is the timeout, not the value of the default.

## Tests

- All 107 `tests/tui_gateway/` tests pass.
- All 10 `tests/hermes_cli/test_mcp_startup.py` + `tests/tui_gateway/test_wait_for_mcp_discovery.py` tests pass.
- Two new regression tests pin the default to >= 2.0s so future refactors can't silently regress this.

## Diff

```
 hermes_cli/mcp_startup.py                        | 19 +++++++++++++++++--
 tests/hermes_cli/test_mcp_startup.py             | 16 ++++++++++++++++
 tests/tui_gateway/test_wait_for_mcp_discovery.py | 16 ++++++++++++++++
 tui_gateway/entry.py                             |  2 +-
 4 files changed, 50 insertions(+), 3 deletions(-)
```