### PR TITLE
fix: vision fast-path incorrectly enabled for providers without tool-result multimodal support

### DIFF
--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -623,7 +623,7 @@ def _should_use_native_vision_fast_path() -> bool:
             return False
         return (
             _supports_media_in_tool_results(provider, model)
-            or _lookup_supports_vision(provider, model, cfg) is True
+            and _lookup_supports_vision(provider, model, cfg) is True
         )
     except Exception as exc:
         logger.debug("Native vision fast-path check failed: %s", exc)


### PR DESCRIPTION
## Summary

The native vision fast-path was incorrectly enabled for providers where the model supports vision but the provider doesn't accept images in tool results.

## Problem

In , the condition was:



This enabled the fast path if EITHER condition was true. For Xiaomi MiMo:
- : True (MiMo supports vision)
- : False (Xiaomi API doesn't accept images in tool results)

Result: Fast path was enabled, causing API errors when trying to attach images to tool results.

## Fix

Changed  to  so the fast path is only enabled when BOTH conditions are true:



## Testing

Verified that with this fix, Xiaomi MiMo correctly falls back to the aux-LLM path instead of crashing.

## Related

Fixes vision tool crashes reported by Xiaomi MiMo users.