### PR TITLE
fix(desktop): honor --profile CLI argument on app launch

### DIFF
--- a/apps/desktop/electron/cli-profile-override.cjs
+++ b/apps/desktop/electron/cli-profile-override.cjs
@@ -1,0 +1,28 @@
+/**
+ * Parse --profile <name> from command-line arguments.
+ *
+ * When the desktop app is launched with `--profile <name>`, this module
+ * extracts and validates the profile name so it can be persisted before
+ * the backend starts.
+ *
+ * @param {string[]} argv - Command-line arguments (defaults to process.argv)
+ * @returns {string|null} Validated profile name, or null if not present/invalid
+ */
+function parseCliProfile(argv = process.argv) {
+  const args = argv || []
+  const idx = args.indexOf('--profile')
+  if (idx === -1 || idx + 1 >= args.length) return null
+
+  const name = String(args[idx + 1] || '').trim()
+  if (!name) return null
+
+  // Mirror PROFILE_NAME_RE from main.cjs: lowercase alphanumeric, hyphens,
+  // underscores, 1-64 chars.  "default" is always valid.
+  if (name !== 'default' && !/^[a-z0-9][a-z0-9_-]{0,63}$/.test(name)) {
+    return null
+  }
+
+  return name
+}
+
+module.exports = { parseCliProfile }

--- a/apps/desktop/electron/cli-profile-override.test.cjs
+++ b/apps/desktop/electron/cli-profile-override.test.cjs
@@ -1,0 +1,74 @@
+/**
+ * Tests for electron/cli-profile-override.cjs.
+ *
+ * Run with: node --test electron/cli-profile-override.test.cjs
+ */
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const { parseCliProfile } = require('./cli-profile-override.cjs')
+
+test('returns null when --profile is missing', () => {
+  assert.equal(parseCliProfile([]), null)
+  assert.equal(parseCliProfile(['--other', 'value']), null)
+  assert.equal(parseCliProfile(['electron', 'main.cjs']), null)
+})
+
+test('returns null when --profile has no value', () => {
+  assert.equal(parseCliProfile(['--profile']), null)
+  assert.equal(parseCliProfile(['--profile']), null)
+})
+
+test('returns null for empty or whitespace-only value', () => {
+  assert.equal(parseCliProfile(['--profile', '']), null)
+  assert.equal(parseCliProfile(['--profile', '   ']), null)
+})
+
+test('accepts "default" as a valid profile', () => {
+  assert.equal(parseCliProfile(['--profile', 'default']), 'default')
+})
+
+test('accepts valid lowercase profile names', () => {
+  assert.equal(parseCliProfile(['--profile', 'desktop']), 'desktop')
+  assert.equal(parseCliProfile(['--profile', 'my-profile']), 'my-profile')
+  assert.equal(parseCliProfile(['--profile', 'test_1']), 'test_1')
+  assert.equal(parseCliProfile(['--profile', 'a']), 'a')
+})
+
+test('rejects uppercase profile names', () => {
+  assert.equal(parseCliProfile(['--profile', 'Desktop']), null)
+  assert.equal(parseCliProfile(['--profile', 'MY_PROFILE']), null)
+})
+
+test('rejects names starting with hyphen or underscore', () => {
+  assert.equal(parseCliProfile(['--profile', '-desktop']), null)
+  assert.equal(parseCliProfile(['--profile', '_desktop']), null)
+})
+
+test('rejects names longer than 64 characters', () => {
+  const longName = 'a'.repeat(65)
+  assert.equal(parseCliProfile(['--profile', longName]), null)
+})
+
+test('accepts names up to 64 characters', () => {
+  const maxName = 'a'.repeat(64)
+  assert.equal(parseCliProfile(['--profile', maxName]), maxName)
+})
+
+test('finds --profile among other arguments', () => {
+  assert.equal(
+    parseCliProfile(['electron', 'main.cjs', '--other', 'val', '--profile', 'work']),
+    'work'
+  )
+})
+
+test('trims whitespace from profile name', () => {
+  assert.equal(parseCliProfile(['--profile', '  desktop  ']), 'desktop')
+})
+
+test('returns null for names with special characters', () => {
+  assert.equal(parseCliProfile(['--profile', 'my profile']), null)
+  assert.equal(parseCliProfile(['--profile', 'profile@home']), null)
+  assert.equal(parseCliProfile(['--profile', 'a/b']), null)
+})

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -3962,6 +3962,15 @@ function writeActiveDesktopProfile(name) {
   return value || null
 }
 
+// Apply --profile from CLI at module load so startHermes() sees it.
+const { parseCliProfile } = require('./cli-profile-override.cjs')
+{
+  const cliProfile = parseCliProfile()
+  if (cliProfile) {
+    try { writeActiveDesktopProfile(cliProfile) } catch { /* ignore */ }
+  }
+}
+
 // Sanitize a connection config into the renderer-facing shape. With no
 // `profile` this describes the global/default connection (the existing
 // behavior); with a `profile` it describes that profile's per-profile remote


### PR DESCRIPTION
## What does this PR do?

Respects the `--profile <name>` CLI argument when launching the desktop app. Previously the flag was silently ignored — the backend always started under whatever profile was stored in `active-profile.json` (or "default" if unset).

## Related Issue

Fixes #43571

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/cli-profile-override.cjs`: Pure parsing function that extracts and validates `--profile` from `process.argv` — mirrors `PROFILE_NAME_RE` validation from `main.cjs`
- `apps/desktop/electron/cli-profile-override.test.cjs`: 12 unit tests covering valid names, rejection of invalid names, edge cases, and argument positioning
- `apps/desktop/electron/main.cjs`: Requires the parser at module load and persists the CLI profile to `active-profile.json` before `startHermes()` reads it

## How to Test

1. Create a test profile: `hermes profile create desktop`
2. Launch the desktop app with: `Hermes.exe --profile desktop` (Windows) or `open -a "Hermes" --args --profile desktop` (macOS)
3. Verify the backend starts under the "desktop" profile (check logs for `Starting Hermes backend for profile "desktop"`)
4. Run unit tests: `cd apps/desktop && node --test electron/cli-profile-override.test.cjs`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `apps/desktop/electron/main.cjs` (profile resolution: `readActiveDesktopProfile()` → `writeActiveDesktopProfile()`)
- Blast radius: LOW — new module + 9-line wiring in main.cjs; no existing behavior changed
- Related patterns: `connection-config.cjs` follows the same extracted-module pattern for testable Electron helpers
