### PR TITLE
fix(gateway): prevent orphaned Discord typing loops

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -617,8 +617,9 @@ class DiscordAdapter(BasePlatformAdapter):
         # in those threads don't require @mention.  Persisted to disk so the
         # set survives gateway restarts.
         self._threads = ThreadParticipationTracker("discord")
-        # Persistent typing indicator loops per channel (DMs don't reliably
-        # show the standard typing gateway event for bots)
+        # Typing is single-shot per send_typing() call; BasePlatformAdapter._keep_typing
+        # owns the refresh cadence.  Keep this deprecated dict only so legacy
+        # introspection/tests do not AttributeError.
         self._typing_tasks: Dict[str, asyncio.Task] = {}
         self._bot_task: Optional[asyncio.Task] = None
         self._post_connect_task: Optional[asyncio.Task] = None
@@ -2976,68 +2977,48 @@ class DiscordAdapter(BasePlatformAdapter):
             return await super().send_document(chat_id, file_path, caption, file_name, reply_to, metadata=metadata)
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
-        """Start a persistent typing indicator for a channel.
+        """Send a single typing indicator pulse for a channel.
 
-        Discord's TYPING_START gateway event is unreliable in DMs for bots.
-        Instead, start a background loop that hits the typing endpoint every
-        12 seconds (typing indicator lasts ~10s).  The loop is cancelled when
-        stop_typing() is called (after the response is sent).
-
-        Rate-limit handling: if a 429 is encountered, the loop logs a
-        warning, sleeps for the ``retry_after`` duration (or a sensible
-        default), and continues — it does NOT die on a single rate-limit
-        hit.  Only CancelledError (from stop_typing) stops the loop.
+        Discord keeps a successful POST /channels/{id}/typing visible for
+        roughly 10 seconds.  BasePlatformAdapter._keep_typing already calls this
+        method on a short cadence while a turn is active, so an adapter-owned
+        persistent loop is both redundant and racy: cleanup could cancel one
+        inner loop while _keep_typing recreated another, leaving an orphan that
+        refreshed the typing indicator indefinitely.
         """
         if not self._client:
             return
-        # Don't start a duplicate loop
-        if chat_id in self._typing_tasks:
-            return
-
-        async def _typing_loop() -> None:
-            try:
-                while True:
-                    try:
-                        route = discord.http.Route(
-                            "POST", "/channels/{channel_id}/typing",
-                            channel_id=chat_id,
-                        )
-                        await self._client.http.request(route)
-                    except asyncio.CancelledError:
-                        return
-                    except Exception as e:
-                        # Don't die on 429 — backoff and continue
-                        retry_after = self._extract_discord_retry_after(e)
-                        if retry_after is not None:
-                            logger.warning(
-                                "Typing indicator rate-limited for %s; retrying in %.1fs",
-                                chat_id, retry_after,
-                            )
-                        else:
-                            logger.debug(
-                                "Discord typing indicator failed for %s: %s",
-                                chat_id, e,
-                            )
-                            return
-                        await asyncio.sleep(retry_after)
-                        continue
-                    await asyncio.sleep(12)
-            except asyncio.CancelledError:
-                pass
-            finally:
-                self._typing_tasks.pop(chat_id, None)
-
-        self._typing_tasks[chat_id] = asyncio.create_task(_typing_loop())
+        try:
+            route = discord.http.Route(
+                "POST", "/channels/{channel_id}/typing",
+                channel_id=chat_id,
+            )
+            await self._client.http.request(route)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            if self._is_discord_rate_limit(e):
+                retry_after = self._extract_discord_retry_after(e)
+                if retry_after is not None:
+                    logger.warning(
+                        "Typing indicator rate-limited for %s; next keep-typing tick will retry after %.1fs",
+                        chat_id,
+                        retry_after,
+                    )
+                else:
+                    logger.warning(
+                        "Typing indicator rate-limited for %s; next keep-typing tick will retry",
+                        chat_id,
+                    )
+            else:
+                logger.debug("Discord typing indicator failed for %s: %s", chat_id, e)
 
     async def stop_typing(self, chat_id: str) -> None:
-        """Stop the persistent typing indicator for a channel."""
-        task = self._typing_tasks.pop(chat_id, None)
-        if task:
-            task.cancel()
-            try:
-                await task
-            except (asyncio.CancelledError, Exception):
-                pass
+        """No-op: Discord typing now expires naturally after send_typing stops.
+
+        Kept for BasePlatformAdapter cleanup hooks and adapter API symmetry.
+        """
+        return
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Get information about a Discord channel."""

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 import sys
@@ -390,58 +391,142 @@ async def test_forum_post_file_creation_failure():
 
 
 # ---------------------------------------------------------------------------
-# Typing indicator task lifecycle
+# Typing indicator — single-shot semantics (regression for stuck typing)
+#
+# Before this behavior: DiscordAdapter.send_typing spawned an adapter-side
+# persistent _typing_loop task while BasePlatformAdapter._keep_typing also
+# refreshed typing every 2s.  If cleanup stopped one inner loop and _keep_typing
+# recreated another during the shutdown window, the new loop could become
+# orphaned and keep Discord's "typing" indicator alive indefinitely.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_typing_task_removed_after_api_error():
-    """When typing API call fails, stale task must be removed so typing can restart."""
+async def test_send_typing_issues_single_request_per_call():
+    """send_typing must POST exactly once and never spawn a background loop."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._client = MagicMock()
+    adapter._client.http = MagicMock()
+    adapter._client.http.request = AsyncMock()
+
+    await adapter.send_typing("12345")
+
+    assert adapter._client.http.request.await_count == 1, \
+        "send_typing must issue exactly one POST per call"
+    assert adapter._typing_tasks == {}, \
+        "send_typing must not spawn or track persistent typing tasks"
+
+
+@pytest.mark.asyncio
+async def test_send_typing_swallows_api_errors_without_raising():
+    """A network/rate-limit error during typing must not crash the caller."""
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
     adapter._client = MagicMock()
     adapter._client.http = MagicMock()
     adapter._client.http.request = AsyncMock(side_effect=Exception("rate limited"))
-    adapter._typing_tasks = {}
 
     await adapter.send_typing("12345")
-    await asyncio.sleep(0.1)
 
-    assert "12345" not in adapter._typing_tasks, \
-        "Stale task should be removed after API error"
+    assert adapter._typing_tasks == {}, \
+        "Failed typing call must not leave task state behind"
+
 
 
 @pytest.mark.asyncio
-async def test_typing_restartable_after_error():
-    """After a typing error, send_typing should start a new task (not blocked by stale entry)."""
+async def test_send_typing_propagates_cancellation():
+    """Cancellation must unwind _keep_typing instead of being swallowed."""
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
-    adapter._client = MagicMock()
-    adapter._client.http = MagicMock()
-    adapter._typing_tasks = {}
+    client = MagicMock()
+    client.http = MagicMock()
+    client.http.request = AsyncMock(side_effect=asyncio.CancelledError)
+    adapter._client = client
 
-    # First call fails
-    adapter._client.http.request = AsyncMock(side_effect=Exception("503"))
-    await adapter.send_typing("12345")
-    await asyncio.sleep(0.1)
+    with pytest.raises(asyncio.CancelledError):
+        await adapter.send_typing("12345")
 
-    # Second call should work
-    adapter._client.http.request = AsyncMock()
-    await adapter.send_typing("12345")
-
-    assert "12345" in adapter._typing_tasks, \
-        "Should restart typing after previous failure"
+    assert adapter._typing_tasks == {}
 
 
 @pytest.mark.asyncio
-async def test_typing_stop_cleans_up():
-    """stop_typing should remove the task from _typing_tasks."""
+async def test_send_typing_logs_rate_limit_retry_after(caplog):
+    """Single-shot typing still preserves 429 visibility from #29671."""
+
+    class DiscordRateLimit(Exception):
+        retry_after = 3.5
+
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    client = MagicMock()
+    client.http = MagicMock()
+    client.http.request = AsyncMock(side_effect=DiscordRateLimit("429"))
+    adapter._client = client
+
+    with caplog.at_level(logging.WARNING, logger="plugins.platforms.discord.adapter"):
+        await adapter.send_typing("12345")
+
+    assert adapter._typing_tasks == {}
+    assert "Typing indicator rate-limited for 12345" in caplog.text
+    assert "3.5s" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_send_typing_repeated_calls_each_issue_one_request():
+    """Each _keep_typing tick should produce exactly one POST."""
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
     adapter._client = MagicMock()
     adapter._client.http = MagicMock()
     adapter._client.http.request = AsyncMock()
-    adapter._typing_tasks = {}
 
-    await adapter.send_typing("12345")
-    assert "12345" in adapter._typing_tasks
+    for _ in range(3):
+        await adapter.send_typing("12345")
+
+    assert adapter._client.http.request.await_count == 3, \
+        "Three send_typing calls must produce three POSTs"
+    assert adapter._typing_tasks == {}
+
+
+@pytest.mark.asyncio
+async def test_stop_typing_is_idempotent_noop():
+    """stop_typing is a no-op now because there is no adapter-side loop."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._client = MagicMock()
+    adapter._client.http = MagicMock()
+    adapter._client.http.request = AsyncMock()
 
     await adapter.stop_typing("12345")
-    assert "12345" not in adapter._typing_tasks
+    await adapter.send_typing("12345")
+    await adapter.stop_typing("12345")
+    await adapter.stop_typing("12345")
+
+    assert adapter._typing_tasks == {}, \
+        "stop_typing must never leave or require task state"
+    assert adapter._client.http.request.await_count == 1, \
+        "stop_typing must not issue HTTP requests"
+
+
+@pytest.mark.asyncio
+async def test_send_typing_no_client_is_silent():
+    """Pre-connect / post-disconnect: send_typing returns silently."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._client = None
+
+    await adapter.send_typing("12345")
+
+
+@pytest.mark.asyncio
+async def test_no_orphan_loop_after_stop_typing_send_typing_race():
+    """send_typing after stop_typing must not leave an orphan task."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._client = MagicMock()
+    adapter._client.http = MagicMock()
+    adapter._client.http.request = AsyncMock()
+
+    await adapter.send_typing("12345")
+    await adapter.stop_typing("12345")
+    await adapter.send_typing("12345")
+    await adapter.stop_typing("12345")
+    await asyncio.sleep(0.1)
+
+    assert adapter._typing_tasks == {}, \
+        "send_typing must never leave background tasks behind"
+    assert adapter._client.http.request.await_count == 2, \
+        "Each send_typing call must produce exactly one POST"


### PR DESCRIPTION
## What does this PR do?

Fixes a Discord stuck-typing race by making the Discord adapter's `send_typing()` issue one `/typing` pulse per call instead of starting its own persistent background loop.

`BasePlatformAdapter._keep_typing()` already owns the keep-typing cadence and cleanup lifetime. Keeping a second adapter-owned `_typing_loop` made it possible for a stop/cleanup race to leave an orphan loop that kept refreshing Discord's typing indicator after the response finished.

This keeps Discord typing best-effort and preserves cancellation semantics plus 429/rate-limit visibility.

## Related Issue

Fixes #26854

Supersedes #26857, which had the same root-fix direction but is now stale/conflicting with current `main`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/discord/adapter.py`
  - Makes `DiscordAdapter.send_typing()` a single-shot `/channels/{channel_id}/typing` request.
  - Removes adapter-side creation/tracking of persistent typing tasks.
  - Makes `stop_typing()` an idempotent no-op because Discord has no explicit typing-stop API and there is no longer an adapter-owned loop to cancel.
  - Re-raises `asyncio.CancelledError` so keep-typing cleanup can unwind correctly.
  - Logs Discord rate-limit failures at warning level with `retry_after` when available.
- `tests/gateway/test_discord_send.py`
  - Adds regression coverage for single-shot typing behavior.
  - Adds coverage for repeated pulses, no-client silence, stop/no-op behavior, no orphan task state after stop/send races, cancellation propagation, and rate-limit logging.

## How to Test

1. Run targeted gateway tests:

   ```bash
   scripts/run_tests.sh tests/gateway/test_discord_send.py tests/gateway/test_keep_typing_timeout.py
   ```

2. Run Windows/static guardrails:

   ```bash
   python scripts/check-windows-footguns.py --all
   ruff check .
   git diff --check origin/main..HEAD
   ```

Verified locally on macOS:

- `scripts/run_tests.sh tests/gateway/test_discord_send.py tests/gateway/test_keep_typing_timeout.py` → 27 passed
- `python scripts/check-windows-footguns.py --all` → no Windows footguns found
- `ruff check .` → all checks passed
- `git diff --check origin/main..HEAD` → clean

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted test output:

```text
=== Summary: 2 files, 27 tests passed, 0 failed (100% complete) in 6.9s (20 workers) ===
```
