### PR TITLE
fix(kanban): spawn goal_mode workers with -Q so the goal loop actually runs

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6812,6 +6812,13 @@ def _default_spawn(
         "chat",
         "-q", prompt,
     ])
+    if task.goal_mode:
+        # Goal-mode workers must take the fully-quiet single-query path:
+        # the kanban goal-loop hook (_run_kanban_goal_loop_q) only runs in
+        # cli.py's quiet branch. Without -Q the worker gets exactly one
+        # turn, prints text, exits rc=0, and the dispatcher records a
+        # protocol violation (incident 2026-06-09 t_d9cbe312).
+        cmd.append("-Q")
     # Redirect output to a per-task log under <board-root>/logs/.
     # Anchored at the board root (not the shared kanban root), so
     # `hermes kanban log` on a specific board reads its own file and


### PR DESCRIPTION
## Bug

`_default_spawn()` in `hermes_cli/kanban_db.py` sets `HERMES_KANBAN_GOAL_MODE=1` for goal-mode cards, but launches workers with `chat -q <prompt>` and never passes `-Q/--quiet`. The kanban goal-loop hook (`_run_kanban_goal_loop_q`) only executes in `cli.py`'s quiet single-query branch — so for dispatcher-spawned workers, **goal mode never actually runs**: the worker gets exactly one turn, prints its final text, exits rc=0, and the dispatcher records `worker exited cleanly (rc=0) without calling kanban_complete or kanban_block — protocol violation`. After `failure_limit` strikes the card auto-blocks.

Both the env-var comment in `_default_spawn` ("Ralph-style /goal judge loop (see cli.py quiet-mode path)") and the hook's docstring ("Called from the quiet single-query path") show the quiet path was the design intent — the spawn args just never matched it.

## Repro / evidence (from a production board, 2026-06-09)

- Two goal_mode cards on the same profile, same night: one worker happened to run `hermes kanban complete` via the terminal tool and "succeeded"; the other did real work, printed a summary, exited 0, and burned 3 runs into the circuit breaker.
- The failing workers' transcripts contain **no** `KANBAN_GOAL_CONTINUATION_TEMPLATE` / `KANBAN_GOAL_FINALIZE_TEMPLATE` turns — the judge loop never started (ruling out "judge ended the run early").

## Fix

Append `-Q` to the spawn argv when `task.goal_mode` is set (7 lines, comment included). Non-goal workers keep their current behavior.

Validated in production: after this fix, a previously circuit-broken goal-mode card re-ran and terminated with a proper `kanban_block` carrying full evidence — no protocol violation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)