### PR TITLE
feat(telegram): add sessions picker

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -473,6 +473,8 @@ class TelegramAdapter(BasePlatformAdapter):
         )
         # Interactive model picker state per chat
         self._model_picker_state: Dict[str, dict] = {}
+        # Interactive session picker state per chat (/sessions)
+        self._sessions_picker_state: Dict[str, dict] = {}
         # Approval button state: message_id → session_key
         self._approval_state: Dict[int, str] = {}
         # Slash-confirm button state: confirm_id → session_key (for /reload-mcp
@@ -2863,6 +2865,165 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.warning("[%s] send_clarify failed: %s", self.name, e)
             return SendResult(success=False, error=str(e))
 
+    def _session_picker_label(self, session: Dict[str, Any]) -> str:
+        """Return a compact Telegram button label for a session row."""
+        title = (session.get("title") or "").strip()
+        preview = (session.get("preview") or "").strip()
+        label = title or preview or session.get("id", "Untitled session")
+        label = re.sub(r"\s+", " ", str(label)).strip() or "Untitled session"
+        if len(label) > 52:
+            label = label[:49].rstrip() + "..."
+        return label
+
+    def _build_sessions_keyboard(self, sessions: list):
+        """Build the /sessions inline keyboard."""
+        rows = []
+        for idx, session in enumerate(sessions[:10]):
+            rows.append([
+                InlineKeyboardButton(
+                    self._session_picker_label(session),
+                    callback_data=f"sr:{idx}",
+                )
+            ])
+        rows.append([InlineKeyboardButton("➕ New session", callback_data="sn")])
+        rows.append([InlineKeyboardButton("✗ Cancel", callback_data="sx")])
+        return InlineKeyboardMarkup(rows)
+
+    async def send_sessions_picker(
+        self,
+        chat_id: str,
+        sessions: list,
+        current_session_id: str,
+        on_session_selected,
+        on_new_session=None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send an inline-keyboard picker for recent sessions.
+
+        The callback data stores only indexes (``sr:<n>``), keeping Telegram's
+        64-byte callback limit safe while the full session IDs live in adapter
+        memory for the short-lived picker.
+        """
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+        if not sessions:
+            return SendResult(success=False, error="No sessions")
+
+        try:
+            keyboard = self._build_sessions_keyboard(sessions)
+            text = self.format_message(
+                "🗂 *Sessions*\n\nTap a session to resume it, or start a new one."
+            )
+            thread_id = metadata.get("thread_id") if metadata else None
+            reply_to_id = self._reply_to_message_id_for_send(
+                None, metadata, reply_to_mode=self._reply_to_mode
+            )
+            msg = await self._send_message_with_thread_fallback(
+                chat_id=int(chat_id),
+                text=text,
+                parse_mode=ParseMode.MARKDOWN_V2,
+                reply_markup=keyboard,
+                reply_to_message_id=reply_to_id,
+                **self._thread_kwargs_for_send(
+                    chat_id,
+                    thread_id,
+                    metadata,
+                    reply_to_message_id=reply_to_id,
+                    reply_to_mode=self._reply_to_mode,
+                ),
+                **self._link_preview_kwargs(),
+            )
+            self._sessions_picker_state[str(chat_id)] = {
+                "msg_id": msg.message_id,
+                "sessions": sessions[:10],
+                "current_session_id": current_session_id,
+                "on_session_selected": on_session_selected,
+                "on_new_session": on_new_session,
+            }
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as e:
+            logger.warning("[%s] send_sessions_picker failed: %s", self.name, e)
+            return SendResult(success=False, error=str(e))
+
+    async def _handle_sessions_picker_callback(self, query, data: str, chat_id: str) -> None:
+        """Handle /sessions inline keyboard callbacks (sr:/sn/sx)."""
+        state = self._sessions_picker_state.get(chat_id)
+        if not state:
+            await query.answer(text="Session picker expired — use /sessions again.")
+            return
+
+        if data == "sx":
+            self._sessions_picker_state.pop(chat_id, None)
+            try:
+                await query.edit_message_text(text="Session picker cancelled.", reply_markup=None)
+            except Exception:
+                pass
+            await query.answer()
+            return
+
+        if data == "sn":
+            callback = state.get("on_new_session")
+            if not callback:
+                await query.answer(text="New-session action unavailable.")
+                return
+            try:
+                result_text = await callback()
+            except Exception as exc:
+                logger.error("Session picker new-session callback failed: %s", exc)
+                result_text = f"Error starting new session: {exc}"
+            self._sessions_picker_state.pop(chat_id, None)
+            try:
+                await query.edit_message_text(
+                    text=self.format_message(str(result_text)),
+                    parse_mode=ParseMode.MARKDOWN_V2,
+                    reply_markup=None,
+                )
+            except Exception:
+                try:
+                    await query.edit_message_text(text=str(result_text), reply_markup=None)
+                except Exception:
+                    pass
+            await query.answer(text="New session started")
+            return
+
+        if not data.startswith("sr:"):
+            await query.answer()
+            return
+
+        try:
+            idx = int(data[3:])
+        except ValueError:
+            await query.answer(text="Invalid session selection.")
+            return
+        sessions = state.get("sessions", [])
+        if idx < 0 or idx >= len(sessions):
+            await query.answer(text="Invalid session selection.")
+            return
+        target = sessions[idx]
+        target_id = target.get("id")
+        callback = state.get("on_session_selected")
+        if not target_id or not callback:
+            await query.answer(text="Session selection unavailable.")
+            return
+        try:
+            result_text = await callback(target_id)
+        except Exception as exc:
+            logger.error("Session picker resume callback failed: %s", exc)
+            result_text = f"Error resuming session: {exc}"
+        self._sessions_picker_state.pop(chat_id, None)
+        try:
+            await query.edit_message_text(
+                text=self.format_message(str(result_text)),
+                parse_mode=ParseMode.MARKDOWN_V2,
+                reply_markup=None,
+            )
+        except Exception:
+            try:
+                await query.edit_message_text(text=str(result_text), reply_markup=None)
+            except Exception:
+                pass
+        await query.answer(text="Session resumed")
+
     async def send_model_picker(
         self,
         chat_id: str,
@@ -3341,6 +3502,23 @@ class TelegramAdapter(BasePlatformAdapter):
         query_chat_type = getattr(query_chat, "type", None)
         query_thread_id = getattr(query_message, "message_thread_id", None)
         query_user_name = getattr(query.from_user, "first_name", None)
+
+        # --- Session picker callbacks (/sessions) ---
+        if data.startswith("sr:") or data in {"sn", "sx"}:
+            caller_id = str(getattr(query.from_user, "id", ""))
+            if not self._is_callback_user_authorized(
+                caller_id,
+                chat_id=query_chat_id,
+                chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                user_name=query_user_name,
+            ):
+                await query.answer(text="⛔ You are not authorized to switch sessions.")
+                return
+            chat_id = str(query.message.chat_id) if query.message else None
+            if chat_id:
+                await self._handle_sessions_picker_callback(query, data, chat_id)
+            return
 
         # --- Model picker callbacks ---
         if data.startswith(("mp:", "mpg:", "mm:", "mc:", "mb", "mx", "mg:")):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7160,6 +7160,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if canonical == "resume":
             return await self._handle_resume_command(event)
 
+        if canonical == "sessions":
+            return await self._handle_sessions_command(event)
+
         if canonical == "branch":
             return await self._handle_branch_command(event)
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2644,6 +2644,83 @@ class GatewaySlashCommandsMixin:
             else:
                 return t("gateway.title.current_no_title", session_id=session_id)
 
+    async def _handle_sessions_command(self, event: MessageEvent) -> Optional[str]:
+        """Handle /sessions — browse recent sessions, with buttons when supported."""
+        if not self._session_db:
+            from hermes_state import format_session_db_unavailable
+            return format_session_db_unavailable(prefix=t("gateway.shared.session_db_unavailable_prefix"))
+
+        source = event.source
+        current_entry = self.session_store.get_or_create_session(source)
+        current_session_id = current_entry.session_id
+        user_source = source.platform.value if source.platform else None
+
+        try:
+            sessions = self._session_db.list_sessions_rich(
+                source=user_source,
+                limit=10,
+                order_by_last_active=True,
+            )
+        except Exception as e:
+            logger.debug("Failed to list sessions: %s", e)
+            return t("gateway.resume.list_failed", error=e)
+
+        sessions = [s for s in sessions if s.get("id") != current_session_id][:10]
+        if not sessions:
+            return "No previous sessions found yet. Use `/new <name>` or `/title <name>` once you have a session to come back to."
+
+        adapter = self.adapters.get(source.platform) if source and source.platform else None
+        has_picker = adapter is not None and callable(getattr(adapter, "send_sessions_picker", None))
+        if has_picker and source.chat_id:
+            async def _on_session_selected(target_id: str) -> str:
+                old_text = event.text
+                try:
+                    event.text = f"/resume {target_id}"
+                    return await self._handle_resume_command(event)
+                finally:
+                    event.text = old_text
+
+            async def _on_new_session() -> str:
+                old_text = event.text
+                try:
+                    event.text = "/new"
+                    result = await self._handle_reset_command(event)
+                    return str(result)
+                finally:
+                    event.text = old_text
+
+            metadata = None
+            try:
+                metadata = self._thread_metadata_for_source(
+                    source, self._reply_anchor_for_event(event)
+                )
+            except Exception:
+                metadata = None
+
+            try:
+                result = await adapter.send_sessions_picker(
+                    chat_id=source.chat_id,
+                    sessions=sessions,
+                    current_session_id=current_session_id,
+                    on_session_selected=_on_session_selected,
+                    on_new_session=_on_new_session,
+                    metadata=metadata,
+                )
+                if result.success:
+                    return None
+            except Exception as e:
+                logger.debug("Session picker send failed; falling back to text: %s", e)
+
+        lines = ["🗂 Sessions"]
+        for idx, s in enumerate(sessions, start=1):
+            title = s.get("title") or s.get("preview") or s.get("id")
+            preview = (s.get("preview") or "")[:40]
+            suffix = f" — {preview}" if preview and preview != title else ""
+            lines.append(f"{idx}. {title}{suffix}")
+        lines.append("")
+        lines.append("Use `/resume <number>`, `/resume <session id>`, or `/resume <title>`.")
+        return "\n".join(lines)
+
     async def _handle_resume_command(self, event: MessageEvent) -> str:
         """Handle /resume command — list or switch to a previous session."""
         if not self._session_db:
@@ -2666,7 +2743,11 @@ class GatewaySlashCommandsMixin:
 
         def _list_titled_sessions() -> list[dict]:
             user_source = source.platform.value if source.platform else None
-            sessions = self._session_db.list_sessions_rich(source=user_source, limit=10)
+            sessions = self._session_db.list_sessions_rich(
+                source=user_source,
+                limit=10,
+                order_by_last_active=True,
+            )
             return [s for s in sessions if s.get("title")][:10]
 
         if not name:

--- a/tests/gateway/test_telegram_sessions_picker.py
+++ b/tests/gateway/test_telegram_sessions_picker.py
@@ -1,0 +1,187 @@
+"""Tests for Telegram /sessions inline picker UX."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, SendResult
+from gateway.platforms.telegram import TelegramAdapter
+from gateway.session import SessionSource, build_session_key
+
+
+def _make_source(chat_id="67890", user_id="12345"):
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="testuser",
+    )
+
+
+def _make_event(text="/sessions"):
+    return MessageEvent(text=text, source=_make_source())
+
+
+def _make_runner(session_db, event=None, current_session_id="current_session_001"):
+    from gateway.run import GatewayRunner
+
+    event = event or _make_event()
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._session_db = session_db
+    runner._running_agents = {}
+    runner._agent_cache = {}
+    runner._session_model_overrides = {}
+    runner._pending_model_notes = {}
+    runner._session_reasoning_overrides = {}
+    runner._update_prompt_pending = {}
+    runner._slash_confirm_state = {}
+    runner._approval_state = {}
+
+    session_key = build_session_key(event.source)
+    current_entry = MagicMock()
+    current_entry.session_id = current_session_id
+    current_entry.session_key = session_key
+
+    store = MagicMock()
+    store.get_or_create_session.return_value = current_entry
+    store.switch_session.return_value = current_entry
+    store.load_transcript.return_value = []
+    runner.session_store = store
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_gateway_sessions_command_uses_telegram_picker_when_available(tmp_path):
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("sess_001", "telegram")
+    db.set_session_title("sess_001", "Research")
+    db.create_session("sess_002", "telegram")
+    db.set_session_title("sess_002", "Coding")
+    db.create_session("current_session_001", "telegram")
+
+    event = _make_event("/sessions")
+    runner = _make_runner(db, event=event)
+    adapter = MagicMock()
+    adapter.send_sessions_picker = AsyncMock(return_value=SendResult(success=True))
+    runner.adapters[Platform.TELEGRAM] = adapter
+
+    result = await runner._handle_sessions_command(event)
+
+    assert result is None
+    adapter.send_sessions_picker.assert_awaited_once()
+    kwargs = adapter.send_sessions_picker.await_args.kwargs
+    assert kwargs["chat_id"] == "67890"
+    assert kwargs["sessions"][0]["title"] in {"Research", "Coding"}
+    assert kwargs["current_session_id"] == "current_session_001"
+    db.close()
+
+
+@pytest.mark.asyncio
+async def test_telegram_sessions_picker_builds_inline_buttons(monkeypatch):
+    import gateway.platforms.telegram as tg
+
+    built = []
+
+    class _Button:
+        def __init__(self, text, callback_data=None, **kwargs):
+            self.text = text
+            self.callback_data = callback_data
+            built.append((text, callback_data))
+
+    class _Markup:
+        def __init__(self, rows):
+            self.inline_keyboard = rows
+
+    monkeypatch.setattr(tg, "InlineKeyboardButton", _Button)
+    monkeypatch.setattr(tg, "InlineKeyboardMarkup", _Markup)
+
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._bot = AsyncMock()
+
+    async def fake_send(**kwargs):
+        return SimpleNamespace(message_id=101)
+
+    adapter._send_message_with_thread_fallback = AsyncMock(side_effect=fake_send)
+
+    result = await adapter.send_sessions_picker(
+        chat_id="67890",
+        sessions=[
+            {"id": "sess_001", "title": "Research", "preview": "notes", "last_active": "2026-06-11T10:00:00"},
+            {"id": "sess_002", "title": "Coding", "preview": "fix bug", "last_active": "2026-06-11T09:00:00"},
+        ],
+        current_session_id="current_session_001",
+        on_session_selected=AsyncMock(),
+        metadata=None,
+    )
+
+    assert result.success is True
+    assert ("Research", "sr:0") in built
+    assert ("Coding", "sr:1") in built
+    assert ("➕ New session", "sn") in built
+    assert ("✗ Cancel", "sx") in built
+    assert adapter._sessions_picker_state["67890"]["sessions"][0]["id"] == "sess_001"
+
+
+@pytest.mark.asyncio
+async def test_telegram_sessions_callback_resumes_selected_session(monkeypatch):
+    import gateway.platforms.telegram as tg
+
+    class _Button:
+        def __init__(self, text, callback_data=None, **kwargs):
+            self.text = text
+            self.callback_data = callback_data
+
+    class _Markup:
+        def __init__(self, rows):
+            self.inline_keyboard = rows
+
+    monkeypatch.setattr(tg, "InlineKeyboardButton", _Button)
+    monkeypatch.setattr(tg, "InlineKeyboardMarkup", _Markup)
+
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    callback = AsyncMock(return_value="Resumed session **Research**.")
+    adapter._sessions_picker_state["67890"] = {
+        "sessions": [{"id": "sess_001", "title": "Research"}],
+        "current_session_id": "current_session_001",
+        "on_session_selected": callback,
+    }
+
+    query = AsyncMock()
+    query.message = MagicMock()
+    query.message.chat_id = 67890
+    query.answer = AsyncMock()
+    query.edit_message_text = AsyncMock()
+
+    await adapter._handle_sessions_picker_callback(query, "sr:0", "67890")
+
+    callback.assert_awaited_once_with("sess_001")
+    query.edit_message_text.assert_awaited()
+    assert "67890" not in adapter._sessions_picker_state
+
+
+@pytest.mark.asyncio
+async def test_telegram_sessions_callback_new_session_runs_new_callback():
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    callback = AsyncMock(return_value="Started a new session.")
+    adapter._sessions_picker_state["67890"] = {
+        "sessions": [],
+        "current_session_id": "current_session_001",
+        "on_new_session": callback,
+    }
+
+    query = AsyncMock()
+    query.message = MagicMock()
+    query.message.chat_id = 67890
+    query.answer = AsyncMock()
+    query.edit_message_text = AsyncMock()
+
+    await adapter._handle_sessions_picker_callback(query, "sn", "67890")
+
+    callback.assert_awaited_once()
+    query.edit_message_text.assert_awaited()
+    assert "67890" not in adapter._sessions_picker_state


### PR DESCRIPTION
## Summary
- Add a Telegram inline `/sessions` picker for browsing recent Hermes sessions.
- Let users resume an existing session or start a new session from Telegram buttons.
- Keep non-button gateway behavior as a text fallback.

## Why
Telegram users can already interact with Hermes remotely, but session navigation is too hard to discover when it requires typing IDs or remembering commands. This makes session switching low-friction from the chat UI.

This also avoids a bad local-patch story: carrying this feature only in a local branch makes normal desktop updates fragile because updates can drop/rebase local commits. If Hermes supports Telegram session navigation, it should live upstream or behind a stable extension surface, not as a user-maintained patch.

## Test Plan
- `uv run --with pytest --with pytest-xdist --with pytest-timeout --with pytest-asyncio --with pyyaml python -m pytest tests/gateway/test_telegram_sessions_picker.py -q --tb=short -n 0`
- Result: `4 passed in 0.99s`
