### PR TITLE
fix(config): honor key_env for custom provider

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -779,6 +779,13 @@ def _resolve_openrouter_runtime(
         if isinstance(v, str) and v.strip():
             cfg_api_key = v.strip()
             break
+    cfg_key_env_api_key = ""
+    for k in ("key_env", "api_key_env"):
+        env_name = model_cfg.get(k)
+        if isinstance(env_name, str) and env_name.strip():
+            cfg_key_env_api_key = os.getenv(env_name.strip(), "").strip()
+            if cfg_key_env_api_key:
+                break
     requested_norm = (requested_provider or "").strip().lower()
     cfg_provider = cfg_provider.strip().lower()
     # GitHub #27132: provider aliases that resolve to "custom" (ollama,
@@ -857,6 +864,7 @@ def _resolve_openrouter_runtime(
         api_key_candidates = [
             explicit_api_key,
             (cfg_api_key if use_config_base_url else ""),
+            (cfg_key_env_api_key if use_config_base_url else ""),
             (os.getenv("OLLAMA_API_KEY")     if _is_ollama_url                       else ""),
             (os.getenv("OPENAI_API_KEY")     if (_is_openai_url or _is_openai_azure) else ""),
             (os.getenv("OPENROUTER_API_KEY") if _is_openrouter_url                   else ""),

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -588,6 +588,29 @@ def test_custom_endpoint_uses_config_api_field_when_no_api_key(monkeypatch):
     assert resolved["api_key"] == "config-api-field"
 
 
+def test_custom_endpoint_uses_model_key_env(monkeypatch):
+    """Bare provider: custom should honor model.key_env before no-auth fallback."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "custom",
+            "base_url": "https://custom.example.com/v1",
+            "key_env": "MY_CUSTOM_API_KEY",
+        },
+    )
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("MY_CUSTOM_API_KEY", "env-custom-key")
+
+    resolved = rp.resolve_runtime_provider(requested="custom")
+
+    assert resolved["base_url"] == "https://custom.example.com/v1"
+    assert resolved["api_key"] == "env-custom-key"
+
+
 def test_custom_endpoint_explicit_custom_prefers_config_key(monkeypatch):
     """Explicit 'custom' provider with config base_url+api_key should use them.
 


### PR DESCRIPTION
## Summary
- honor model.key_env/api_key_env when resolving bare provider: custom
- keep inline api_key/api precedence ahead of env hints
- add regression coverage for custom model key_env

Fixes #43586

## Tests
- scripts/run_tests.sh tests/hermes_cli/test_runtime_provider_resolution.py
- venv312/bin/ruff check hermes_cli/runtime_provider.py tests/hermes_cli/test_runtime_provider_resolution.py