### PR TITLE
fix(webhook): add Fireflies V2 signature and event support (#43575)

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -442,6 +442,7 @@ class WebhookAdapter(BasePlatformAdapter):
             request.headers.get("X-GitHub-Event", "")
             or request.headers.get("X-GitLab-Event", "")
             or payload.get("event_type", "")
+            or payload.get("event", "")
             or payload.get("type", "")
             or "unknown"
         )
@@ -676,6 +677,15 @@ class WebhookAdapter(BasePlatformAdapter):
                 secret.encode(), body, hashlib.sha256
             ).hexdigest()
             return hmac.compare_digest(gh_sig, expected)
+
+        # Fireflies V2 / legacy GitHub: X-Hub-Signature = sha256=<hex>
+        # Same format as X-Hub-Signature-256 but without the -256 suffix.
+        hub_sig = request.headers.get("X-Hub-Signature", "")
+        if hub_sig:
+            expected = "sha256=" + hmac.new(
+                secret.encode(), body, hashlib.sha256
+            ).hexdigest()
+            return hmac.compare_digest(hub_sig, expected)
 
         # GitLab: X-Gitlab-Token = <plain secret>
         gl_token = request.headers.get("X-Gitlab-Token", "")

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -138,6 +138,23 @@ class TestValidateSignature:
         req = _mock_request(headers={"X-Hub-Signature-256": "sha256=deadbeef"})
         assert adapter._validate_signature(req, body, secret) is False
 
+    def test_validate_fireflies_v2_hub_signature(self):
+        """Fireflies V2 X-Hub-Signature (without -256) is accepted."""
+        adapter = _make_adapter()
+        body = b'{"event": "meeting.transcribed"}'
+        secret = "fireflies-secret"
+        sig = "sha256=" + hmac.new(
+            secret.encode(), body, hashlib.sha256
+        ).hexdigest()
+        req = _mock_request(headers={"X-Hub-Signature": sig})
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_validate_fireflies_v2_hub_signature_invalid(self):
+        """Wrong Fireflies X-Hub-Signature is rejected."""
+        adapter = _make_adapter()
+        req = _mock_request(headers={"X-Hub-Signature": "sha256=deadbeef"})
+        assert adapter._validate_signature(req, b'{}', "correct") is False
+
     def test_validate_gitlab_token(self):
         """GitLab plain-token match via X-Gitlab-Token."""
         adapter = _make_adapter()
@@ -463,6 +480,27 @@ class TestEventFilter:
             resp = await cli.post(
                 "/webhooks/svix",
                 json={"type": "message.received"},
+            )
+            assert resp.status == 202
+
+    @pytest.mark.asyncio
+    async def test_event_filter_accepts_payload_event_field(self):
+        """Fireflies V2 payloads use a top-level `event` field."""
+        routes = {
+            "fireflies": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["meeting.transcribed"],
+                "prompt": "got it",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/fireflies",
+                json={"event": "meeting.transcribed"},
             )
             assert resp.status == 202
 


### PR DESCRIPTION
Fixes #43575. Fireflies V2 webhooks use X-Hub-Signature (without -256 suffix) and event as the payload event field. Added support for both in the webhook adapter's signature validation and event type extraction.