### PR TITLE
ci(nix): keep the nix job green when the sticky lockfile comment can't post

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -63,6 +63,9 @@ jobs:
 
       - name: Post sticky PR comment (stale hashes)
         if: steps.hash_check.outputs.stale == 'true' && github.event_name == 'pull_request'
+        # The lockfile comment is cosmetic housekeeping: a comment-API failure
+        # (e.g. a transient 401) must not fail an otherwise green nix job.
+        continue-on-error: true
         uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728  # v2.9.1
         with:
           header: nix-lockfile-check
@@ -89,6 +92,9 @@ jobs:
           github.event_name == 'pull_request' &&
           (steps.hash_check.outputs.stale == 'false' ||
            steps.flake.outcome == 'success')
+        # The lockfile comment is cosmetic housekeeping: a comment-API failure
+        # (e.g. a transient 401) must not fail an otherwise green nix job.
+        continue-on-error: true
         uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728  # v2.9.1
         with:
           header: nix-lockfile-check


### PR DESCRIPTION
## Why

On pull-request runs where the workflow token can't post comments (fork-contributor PRs with restricted tokens, or transient comment-API auth failures), the nix job's final `Comment/Clear sticky PR comment` housekeeping step fails — and takes the whole job red even though the nix build itself succeeded. A red check that doesn't reflect the build trains reviewers to ignore nix results.

## What changed

`continue-on-error: true` on both `marocchino/sticky-pull-request-comment` steps in `.github/workflows/nix.yml`, with a comment explaining why. The lockfile-hash check still fails the job on a stale hash; only the advisory comment delivery becomes best-effort.

## Repair note

Rebased the upstream PR branch onto current `upstream/main` (`955fa4006287`) as a clean one-file cherry-pick: `7ee1d3fa6106d1aed9ae3d687dc4c3a577c6b3b7`. This removes accidental fork-drift ancestry from the previous PR view; the current PR diff is only `.github/workflows/nix.yml`.

## Testing

- YAML parsed locally with PyYAML.
- Verified both sticky comment steps are still `marocchino/sticky-pull-request-comment` and now have `continue-on-error: true`.
- `git diff --check upstream/main..HEAD`
- `git diff --name-only upstream/main..HEAD` -> `.github/workflows/nix.yml`
- Reproduced original fork symptom before this fix: nix build green, comment step 401s, job red (run: https://github.com/OmarB97/hermes-agent/actions/runs/27288537304/job/80603128133). With this change, the job result tracks the build because comment delivery is best-effort.