### PR TITLE
fix(tests): make the browser launch-hint test hermetic on macOS

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5369,6 +5369,15 @@ def test_browser_manage_connect_default_local_reports_launch_hint(monkeypatch):
                 "hermes_cli.browser_connect.get_chrome_debug_candidates",
                 return_value=[],
             ),
+            # On macOS ``manual_chrome_debug_command`` falls back to a
+            # hardcoded ``open -a "Google Chrome"`` command even when the
+            # candidate list is empty, which would replace the "No
+            # supported..." hint asserted below. Stub it so the test is
+            # hermetic on every platform.
+            patch(
+                "hermes_cli.browser_connect.manual_chrome_debug_command",
+                return_value=None,
+            ),
         ):
             resp = server.handle_request(
                 {


### PR DESCRIPTION
## Problem
`test_browser_manage_connect_default_local_reports_launch_hint` fails on every macOS machine (regardless of whether a browser is installed): it stubs `get_chrome_debug_candidates` to `[]`, but the failure-hint path also calls `manual_chrome_debug_command`, whose Darwin branch unconditionally returns a hardcoded `open -a "Google Chrome" …` command without checking that Chrome exists. With a non-None command the handler emits the *start-your-browser* hint instead of the *no-executable-found* hint the test asserts.

## Fix
Stub `manual_chrome_debug_command` to `None` alongside the test's existing patches — same stubbing style (call-time import resolves the patched module attribute). Test-only, +9 lines; no production code touched.

## Verification
Target test 3× green on a Darwin machine with Chrome installed (failed before); `-k browser` subset 20 passed; full `tests/test_tui_gateway_server.py` 253 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)