### PR TITLE
feat(desktop): profile pictures

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -96,7 +96,7 @@ import {
 } from './hardening'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
 import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
-import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
+import { decideProfileDeleteAction, resolveRouteProfile } from './profile-delete-routing'
 import {
   buildSessionWindowUrl,
   chatWindowWebPreferences,
@@ -6377,6 +6377,15 @@ function primaryProfileKey() {
   return readActiveDesktopProfile() || 'default'
 }
 
+// Profiles with a delete or rename in flight. prepareProfileMutationRequest()
+// marks the name before tearing down its backend; the hermes:api handler
+// clears it once the request settles. Scoped requests racing the mutation
+// would otherwise respawn a backend whose directory is being rmtree'd or
+// renamed under it — a doomed child per retry, fresh Windows handle locks
+// that make the rename itself fail with EACCES, and (worse) a boot that
+// could resurrect a half-deleted profile husk.
+const busyProfiles = new Set()
+
 // Resolve a backend connection for the given profile. Routes the primary
 // profile to startHermes() (the window backend: boot UI, bootstrap, remote
 // mode), and any OTHER profile to a lazily-spawned pool backend. An empty /
@@ -6386,6 +6395,16 @@ async function ensureBackend(profile) {
 
   if (key === primaryProfileKey()) {
     return startHermes()
+  }
+
+  // Pool keys feed a path join and a child --profile flag below; reject
+  // anything that isn't a well-formed profile name before either.
+  if (!PROFILE_NAME_RE.test(key)) {
+    throw new Error(`Invalid Hermes profile name "${key}".`)
+  }
+
+  if (busyProfiles.has(key)) {
+    throw new Error(`Hermes profile "${key}" has a delete or rename in progress.`)
   }
 
   const existing = backendPool.get(key)
@@ -6501,6 +6520,15 @@ async function spawnPoolBackend(profile, entry) {
       logs: hermesLog.slice(-80),
       ...getWindowState()
     }
+  }
+
+  // A local pool backend needs the profile's directory on disk. A stale
+  // renderer reference (e.g. a reconnect loop still pointed at a just-deleted
+  // profile) would otherwise spawn `--profile <name>` children that exit 1
+  // immediately, once per backoff retry. Fail fast with a clear error instead.
+  const profileDir = profile === 'default' ? HERMES_HOME : path.join(HERMES_HOME, 'profiles', profile)
+  if (!fs.existsSync(profileDir)) {
+    throw new Error(`Hermes profile "${profile}" does not exist (was it deleted?).`)
   }
 
   const token = crypto.randomBytes(32).toString('base64url')
@@ -6636,38 +6664,76 @@ function stopAllPoolBackends() {
   }
 }
 
-// Returns the profile name whose backend was torn down, or null when the
-// request is not a profile-delete.  The caller uses this to skip ensureBackend
-// for the just-torn-down profile — otherwise ensureBackend respawns a pool
-// backend whose ensure_hermes_home() recreates the deleted profile directory.
-//
-// The routing *decision* (which branch fires, what profile name gets
-// returned) lives in the pure decideProfileDeleteAction() in
-// profile-delete-routing.ts; this function only performs the side effects
-// that decision calls for.
-async function prepareProfileDeleteRequest(request) {
-  const profile = profileNameFromDeleteRequest(request)
+// Detect a profile mutation request: DELETE /api/profiles/{name} (delete) or
+// PATCH /api/profiles/{name} (rename). Returns { kind, profile } or null.
+// Mirrors profileNameFromDeleteRequest's parsing (profile-delete-routing.ts)
+// but also recognizes the PATCH rename so both share one quiesce path.
+function profileMutationFromRequest(request) {
+  const method = String(request?.method || 'GET').toUpperCase()
+  const kind = method === 'DELETE' ? 'delete' : method === 'PATCH' ? 'rename' : null
+  if (!kind) {
+    return null
+  }
 
-  const decision = decideProfileDeleteAction(profile, {
+  const match = String(request?.path || '').match(/^\/api\/profiles\/([^/?#]+)(?:[?#].*)?$/)
+  if (!match) {
+    return null
+  }
+
+  let raw = ''
+  try {
+    raw = decodeURIComponent(match[1])
+  } catch {
+    return null
+  }
+
+  const name = raw.trim().toLowerCase()
+  if (!name) {
+    return null
+  }
+  return { kind, profile: name }
+}
+
+// Quiesce a profile ahead of a delete/rename: tombstone it in `busyProfiles`
+// and tear down its backend, waiting for the child to exit. The teardown
+// matters doubly on Windows — a live child holds open handles inside the
+// profile directory, which makes the backend's rmtree/rename fail with
+// access-denied.
+//
+// The teardown *decision* (default/invalid → no-op, primary vs pool) is
+// delegated to the pure decideProfileDeleteAction() in profile-delete-routing.ts
+// — shared with the original delete path — so rename inherits the exact same
+// routing. Returns the mutation ({ kind, profile }) — the caller MUST clear the
+// profile from `busyProfiles` once the request settles — or null when the
+// request isn't a profile mutation worth quiescing.
+async function prepareProfileMutationRequest(request) {
+  const mutation = profileMutationFromRequest(request)
+
+  const decision = decideProfileDeleteAction(mutation?.profile ?? null, {
     isDefaultProfile: p => p === 'default',
     isValidProfileName: p => PROFILE_NAME_RE.test(p),
     primaryProfileKey
   })
 
-  if (decision.action === 'noop') {
+  if (!mutation || decision.action === 'noop') {
     return null
   }
 
-  if (decision.action === 'teardown-primary') {
-    writeActiveDesktopProfile('default')
-    await teardownPrimaryBackendAndWait()
+  busyProfiles.add(mutation.profile)
 
-    return decision.profile
+  if (decision.action === 'teardown-primary') {
+    // A deleted primary falls back to default now; a renamed one follows to
+    // its new name only AFTER the backend confirms (see the hermes:api
+    // handler), so a failed rename leaves the preference valid.
+    if (mutation.kind === 'delete') {
+      writeActiveDesktopProfile('default')
+    }
+    await teardownPrimaryBackendAndWait()
+    return mutation
   }
 
-  await teardownPoolBackendAndWait(decision.profile)
-
-  return decision.profile
+  await teardownPoolBackendAndWait(mutation.profile)
+  return mutation
 }
 
 async function startHermes() {
@@ -7847,41 +7913,62 @@ ipcMain.handle('hermes:api', async (_event, request) => {
     return rerouted
   }
 
-  const tornDownProfile = await prepareProfileDeleteRequest(request)
+  const mutation = await prepareProfileMutationRequest(request)
 
-  const profile = request?.profile
-  // After tearing down a backend for profile deletion, route to the primary
-  // backend instead of spawning a fresh pool backend.  A freshly spawned
-  // backend calls ensure_hermes_home() which recreates the profile directory,
-  // defeating the deletion and leaving a zombie process.
-  const routeProfile = resolveRouteProfile(tornDownProfile, profile)
-  const connection = await ensureBackend(routeProfile)
-  const timeoutMs = resolveTimeoutMs(request?.timeoutMs, DEFAULT_FETCH_TIMEOUT_MS)
+  try {
+    const profile = request?.profile
+    // After tearing down a backend for a delete/rename, route THIS request away
+    // from the just-torn-down profile: resolveRouteProfile falls back to the
+    // primary backend. Respawning the target's own backend here would call
+    // ensure_hermes_home(), recreating the directory the delete removed (and, on
+    // Windows, re-locking the one a rename is trying to move).
+    const routeProfile = resolveRouteProfile(mutation?.profile ?? null, profile)
+    const connection = await ensureBackend(routeProfile)
+    const timeoutMs = resolveTimeoutMs(request?.timeoutMs, DEFAULT_FETCH_TIMEOUT_MS)
 
-  const requestPath = pathWithGlobalRemoteProfile(request.path, profile, {
-    globalRemote: globalRemoteActive(),
-    profileRemoteOverride: profileHasRemoteOverride(profile)
-  })
-
-  const url = `${connection.baseUrl}${requestPath}`
-
-  // OAuth gateways authenticate REST via the HttpOnly session cookie held in
-  // the OAuth partition — route through Electron's net stack bound to that
-  // session so the cookie attaches automatically. Token/local modes keep using
-  // the static session-token header.
-  if (connection.authMode === 'oauth') {
-    return fetchJsonViaOauthSession(url, {
-      method: request?.method,
-      body: request?.body,
-      timeoutMs
+    const requestPath = pathWithGlobalRemoteProfile(request.path, profile, {
+      globalRemote: globalRemoteActive(),
+      profileRemoteOverride: profileHasRemoteOverride(profile)
     })
-  }
 
-  return fetchJson(url, connection.token, {
-    method: request?.method,
-    body: request?.body,
-    timeoutMs
-  })
+    const url = `${connection.baseUrl}${requestPath}`
+
+    // OAuth gateways authenticate REST via the HttpOnly session cookie held in
+    // the OAuth partition — route through Electron's net stack bound to that
+    // session so the cookie attaches automatically. Token/local modes keep using
+    // the static session-token header.
+    const result =
+      connection.authMode === 'oauth'
+        ? await fetchJsonViaOauthSession(url, {
+            method: request?.method,
+            body: request?.body,
+            timeoutMs
+          })
+        : await fetchJson(url, connection.token, {
+            method: request?.method,
+            body: request?.body,
+            timeoutMs
+          })
+
+    // A confirmed rename of the desktop's pinned profile: follow the stored
+    // preference to the new name so the next primary boot doesn't point at a
+    // directory that no longer exists.
+    if (mutation?.kind === 'rename' && mutation.profile === primaryProfileKey()) {
+      const newName = String(request?.body?.new_name || '').trim().toLowerCase()
+      if (PROFILE_NAME_RE.test(newName)) {
+        writeActiveDesktopProfile(newName)
+      }
+    }
+
+    return result
+  } finally {
+    // The tombstone only needs to cover the teardown→rmtree/rename window;
+    // once the request settles (either way) the directory state is the source
+    // of truth again (spawnPoolBackend fails fast when the dir is gone).
+    if (mutation) {
+      busyProfiles.delete(mutation.profile)
+    }
+  }
 })
 
 ipcMain.handle('hermes:notify', (_event, payload) => {

--- a/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
@@ -39,6 +39,7 @@ import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
 import {
   $activeGatewayProfile,
+  $profileAvatars,
   $profileColors,
   $profileCreateRequest,
   $profileOrder,
@@ -540,6 +541,12 @@ function ProfileSquare({
   const { t } = useI18n()
   const p = t.profiles
   const hue = color ?? 'var(--ui-text-quaternary)'
+  const avatars = useStore($profileAvatars)
+  const avatarUrl = avatars[normalizeProfileKey(label)]
+  // With a picture the color no longer paints the square's face (only the thin
+  // active ring), so the color affordances — long-press picker and the
+  // context-menu item — are hidden as long as the picture is set.
+  const recolorable = !avatarUrl
   const [pickerOpen, setPickerOpen] = useState(false)
   const pressTimer = useRef<null | number>(null)
   const suppressClick = useRef(false)
@@ -591,7 +598,7 @@ function ProfileSquare({
                     )}
                     ref={setNodeRef}
                     style={{
-                      backgroundColor: profileColorSoft(hue, active ? 30 : 22),
+                      backgroundColor: avatarUrl ? undefined : profileColorSoft(hue, active ? 30 : 22),
                       boxShadow: [ring, lift].filter(Boolean).join(', ') || undefined,
                       color: color ?? undefined,
                       // Glide the dragged square between snapped cells with a little
@@ -626,6 +633,11 @@ function ProfileSquare({
 
                       suppressClick.current = false
                       clearPress()
+
+                      if (!recolorable) {
+                        return
+                      }
+
                       pressTimer.current = window.setTimeout(() => {
                         suppressClick.current = true
                         triggerHaptic('success')
@@ -635,7 +647,16 @@ function ProfileSquare({
                     onPointerLeave={clearPress}
                     onPointerUp={clearPress}
                   >
-                    {label.replace(/[^a-z0-9]/gi, '').charAt(0) || '?'}
+                    {avatarUrl ? (
+                      <img
+                        alt=""
+                        className="size-full rounded-[3px] object-cover"
+                        draggable={false}
+                        src={avatarUrl}
+                      />
+                    ) : (
+                      label.replace(/[^a-z0-9]/gi, '').charAt(0) || '?'
+                    )}
                   </button>
                 </TooltipTrigger>
               </ContextMenuTrigger>
@@ -655,10 +676,12 @@ function ProfileSquare({
           // Suppress the refocus and the picker survives.
           onCloseAutoFocus={event => event.preventDefault()}
         >
-          <ContextMenuItem onSelect={() => setPickerOpen(true)}>
-            <Codicon name="symbol-color" size="0.875rem" />
-            <span>{p.color}</span>
-          </ContextMenuItem>
+          {recolorable && (
+            <ContextMenuItem onSelect={() => setPickerOpen(true)}>
+              <Codicon name="symbol-color" size="0.875rem" />
+              <span>{p.color}</span>
+            </ContextMenuItem>
+          )}
           <ContextMenuItem onSelect={onRename}>
             <Codicon name="text-size" size="0.875rem" />
             <span>{p.renameMenu}</span>

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-group.tsx
@@ -1,6 +1,7 @@
 import type * as React from 'react'
 import { useState } from 'react'
 
+import { ProfileAvatar } from '@/components/profile-avatar'
 import { Codicon } from '@/components/ui/codicon'
 import type { SessionInfo } from '@/hermes'
 import { useI18n } from '@/i18n'
@@ -43,9 +44,12 @@ export function SidebarWorkspaceGroup({ group, renderRows, onNewSession, onRemov
   const hiddenCount = Math.max(0, totalCount - visibleSessions.length)
   const nextCount = Math.min(SIDEBAR_GROUP_PAGE, hiddenCount)
 
-  // Leading glyph: profile color dot, a home mark for the repo's primary
-  // checkout (labeled by its live branch), or a branch/kanban mark otherwise.
-  const leadingIcon = group.color ? (
+  // Leading glyph: a profile's picture/colored-initial face for profile lanes,
+  // else a profile color dot, a home mark for the repo's primary checkout
+  // (labeled by its live branch), or a branch/kanban mark otherwise.
+  const leadingIcon = isProfileGroup ? (
+    <ProfileAvatar className="size-4 rounded-[4px] text-[0.5625rem]" name={group.id} />
+  ) : group.color ? (
     <span aria-hidden="true" className="size-2 shrink-0 rounded-full" style={{ backgroundColor: group.color }} />
   ) : (
     <Codicon

--- a/apps/desktop/src/app/profiles/avatar-field.tsx
+++ b/apps/desktop/src/app/profiles/avatar-field.tsx
@@ -1,0 +1,95 @@
+import { useCallback } from 'react'
+
+import { ProfileAvatar } from '@/components/profile-avatar'
+import { Button } from '@/components/ui/button'
+import { useI18n } from '@/i18n'
+import { downscaleAvatar } from '@/lib/avatar-image'
+
+// Open the OS file picker, read the chosen image, and downscale it to a small
+// square data URL ready to PUT as a profile avatar. Returns null when the user
+// cancels; throws (with a user-facing message) when reading/decoding fails so
+// callers can surface it via their existing error path.
+export function useAvatarPicker() {
+  const { t } = useI18n()
+
+  return useCallback(async (): Promise<null | string> => {
+    const paths = await window.hermesDesktop?.selectPaths({
+      title: t.profiles.pickPictureTitle,
+      multiple: false,
+      filters: [{ name: t.composer.images, extensions: ['png', 'jpg', 'jpeg', 'webp', 'gif', 'bmp'] }]
+    })
+
+    const path = paths?.[0]
+
+    if (!path) {
+      return null
+    }
+
+    const dataUrl = await window.hermesDesktop.readFileDataUrl(path)
+
+    return downscaleAvatar(dataUrl)
+  }, [t])
+}
+
+// Form row for picking a profile picture in the create flow. Shows a square
+// preview (the picked image, or the colored-initial fallback for the typed
+// name) beside choose/remove buttons. Follows the dialog's label/hint pattern.
+export function AvatarField({
+  busy,
+  name,
+  onChange,
+  onError,
+  value
+}: {
+  busy?: boolean
+  name: string
+  onChange: (value: null | string) => void
+  onError: (message: string) => void
+  value: null | string
+}) {
+  const { t } = useI18n()
+  const p = t.profiles
+  const pickAvatar = useAvatarPicker()
+
+  const handlePick = useCallback(async () => {
+    try {
+      const next = await pickAvatar()
+
+      if (next) {
+        onChange(next)
+      }
+    } catch (err) {
+      onError(err instanceof Error ? err.message : p.failedSavePicture)
+    }
+  }, [onChange, onError, p, pickAvatar])
+
+  return (
+    <div className="grid gap-1.5">
+      {/* Not a <label>: there's no form control to bind — the buttons carry
+          their own accessible names. */}
+      <span className="text-xs font-medium">
+        {p.pictureLabel} <span className="font-normal text-muted-foreground">- {p.pictureOptional}</span>
+      </span>
+      <div className="flex items-center gap-3">
+        {value ? (
+          <span className="inline-grid size-14 shrink-0 place-items-center overflow-hidden rounded-lg">
+            <img alt="" className="size-full object-cover" draggable={false} src={value} />
+          </span>
+        ) : (
+          <ProfileAvatar className="size-14 rounded-lg text-xl" name={name || '?'} />
+        )}
+        <div className="flex items-center gap-1.5">
+          <Button disabled={busy} onClick={() => void handlePick()} size="sm" type="button" variant="outline">
+            {value ? p.changePicture : p.choosePicture}
+          </Button>
+          {value && (
+            <Button disabled={busy} onClick={() => onChange(null)} size="sm" type="button" variant="ghost">
+              {p.removePicture}
+            </Button>
+          )}
+        </div>
+      </div>
+      <p className="text-[0.66rem] leading-4 text-muted-foreground">{p.pictureHint}</p>
+    </div>
+  )
+}

--- a/apps/desktop/src/app/profiles/create-profile-dialog.tsx
+++ b/apps/desktop/src/app/profiles/create-profile-dialog.tsx
@@ -13,11 +13,14 @@ import {
 import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Textarea } from '@/components/ui/textarea'
-import { createProfile, updateProfileSoul } from '@/hermes'
+import { createProfile, updateProfileAvatar, updateProfileSoul } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { AlertTriangle } from '@/lib/icons'
 import { cn } from '@/lib/utils'
+import { setProfileAvatarLocal } from '@/store/profile'
 import type { ProfileInfo } from '@/types/hermes'
+
+import { AvatarField } from './avatar-field'
 
 const PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
 
@@ -44,6 +47,7 @@ export function CreateProfileDialog({
   const [name, setName] = useState('')
   const [cloneFrom, setCloneFrom] = useState<null | string>('default')
   const [soul, setSoul] = useState('')
+  const [avatar, setAvatar] = useState<null | string>(null)
   const [status, setStatus] = useState<'done' | 'idle' | 'saving'>('idle')
   const [error, setError] = useState<null | string>(null)
 
@@ -55,6 +59,7 @@ export function CreateProfileDialog({
     setName('')
     setCloneFrom('default')
     setSoul('')
+    setAvatar(null)
     setError(null)
     setStatus('idle')
   }, [open])
@@ -80,6 +85,11 @@ export function CreateProfileDialog({
 
       if (soul.trim()) {
         await updateProfileSoul(trimmed, soul)
+      }
+
+      if (avatar) {
+        await updateProfileAvatar(trimmed, avatar)
+        setProfileAvatarLocal(trimmed, avatar)
       }
 
       await onCreated?.(trimmed)
@@ -117,6 +127,8 @@ export function CreateProfileDialog({
             </p>
           </div>
 
+          <AvatarField busy={busy} name={trimmed} onChange={setAvatar} onError={setError} value={avatar} />
+
           <div className="grid gap-1.5">
             <label className="text-xs font-medium" htmlFor="new-profile-clone-from">
               {p.cloneFrom}
@@ -139,6 +151,7 @@ export function CreateProfileDialog({
             </Select>
             <p className="text-xs text-muted-foreground">{p.cloneFromDesc}</p>
           </div>
+
 
           <div className="grid gap-1.5">
             <label className="text-xs font-medium" htmlFor="new-profile-soul">

--- a/apps/desktop/src/app/profiles/delete-profile-dialog.tsx
+++ b/apps/desktop/src/app/profiles/delete-profile-dialog.tsx
@@ -1,7 +1,7 @@
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { deleteProfile } from '@/hermes'
 import { useI18n } from '@/i18n'
-import { $activeGatewayProfile, normalizeProfileKey, selectProfile, setActiveProfile } from '@/store/profile'
+import { removeProfileLocal } from '@/store/profile'
 
 // Thin wrapper over ConfirmDialog: owns the deleteProfile call, inherits
 // Enter-to-confirm + busy/done/error from the shared dialog. The single choke
@@ -43,20 +43,15 @@ export function DeleteProfileDialog({
           return
         }
 
-        // Deleting the profile the live gateway is on strands it on a dead
-        // backend. Capture that before the delete; reset *after* the host's
-        // onDeleted refresh so our reset is the last write — a refreshActiveProfile
-        // racing the (still-dying) backend can't clobber the pill back to it.
-        const wasActive = normalizeProfileKey(profile.name) === normalizeProfileKey($activeGatewayProfile.get())
         await deleteProfile(profile.name)
+        // Drop it from the rail immediately and unwind any routing still
+        // pointed at it (gateway socket, active profile, new-chat target) —
+        // the onDeleted refresh is best-effort and can fail when the deleted
+        // profile's own backend was the routed one, which would otherwise
+        // strand the gateway reconnect loop on a backend that can never
+        // come back.
+        removeProfileLocal(profile.name)
         await onDeleted?.()
-
-        if (wasActive) {
-          // Swap gateway/sidebar to default and set the pill now — the primary
-          // backend is always default, so this is correct, not just optimistic.
-          selectProfile('default')
-          setActiveProfile('default')
-        }
       }}
       open={open}
       title={p.deleteTitle}

--- a/apps/desktop/src/app/profiles/index.tsx
+++ b/apps/desktop/src/app/profiles/index.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { CodeEditor } from '@/components/chat/code-editor'
 import { PageLoader } from '@/components/page-loader'
+import { ProfileAvatar } from '@/components/profile-avatar'
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
 import {
@@ -19,19 +20,27 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import {
   createProfile,
   deleteProfile,
+  deleteProfileAvatar,
   getProfileSoul,
   type ProfileInfo,
   renameProfile,
+  updateProfileAvatar,
   updateProfileSoul
 } from '@/hermes'
 import { useI18n } from '@/i18n'
-import { AlertTriangle, Save } from '@/lib/icons'
-import { profileColorSoft, resolveProfileColor } from '@/lib/profile-color'
+import { AlertTriangle, Pencil, Save, X } from '@/lib/icons'
 import { slug } from '@/lib/sanitize'
 import { normalize } from '@/lib/text'
 import { cn } from '@/lib/utils'
 import { notify, notifyError } from '@/store/notifications'
-import { $profileColors, refreshProfiles } from '@/store/profile'
+import {
+  $profileAvatars,
+  normalizeProfileKey,
+  refreshProfiles,
+  removeProfileLocal,
+  renameProfileLocal,
+  setProfileAvatarLocal
+} from '@/store/profile'
 
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
 import {
@@ -48,6 +57,8 @@ import {
   PanelRowMenu,
   PanelSectionLabel
 } from '../overlays/panel'
+
+import { useAvatarPicker } from './avatar-field'
 
 const PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
 
@@ -141,6 +152,10 @@ export function ProfilesView({ onClose }: ProfilesViewProps) {
       }
 
       await renameProfile(from, target)
+      // Optimistically re-key the cached list, cosmetics (color/order/avatar)
+      // and gateway routing to the new name so the rail repaints instantly and
+      // no reconnect loop is left dialing the old, now-torn-down backend.
+      renameProfileLocal(from, target)
       notify({ kind: 'success', title: p.renamed, message: `${from} → ${target}` })
       setSelectedName(target)
       await refresh()
@@ -157,6 +172,10 @@ export function ProfilesView({ onClose }: ProfilesViewProps) {
 
     try {
       await deleteProfile(pendingDelete.name)
+      // Optimistically drop the row/avatar and retarget any routing at the
+      // deleted profile to default, so the rail square disappears at once and
+      // its reconnect backoff stops respawning a backend for a gone directory.
+      removeProfileLocal(pendingDelete.name)
       notify({ kind: 'success', title: p.deleted, message: pendingDelete.name })
       setPendingDelete(null)
       setSelectedName(null)
@@ -290,18 +309,10 @@ function ProfileRow({
   onSelect: () => void
   profile: ProfileInfo
 }) {
-  const colors = useStore($profileColors)
-
   return (
     <PanelListRow
       active={active}
-      lead={
-        <ProfileGlyph
-          color={resolveProfileColor(profile.name, colors)}
-          isDefault={profile.is_default}
-          name={profile.name}
-        />
-      }
+      lead={<ProfileGlyph isDefault={profile.is_default} name={profile.name} />}
       menu={menu}
       onSelect={onSelect}
       rowKey={profile.name}
@@ -311,29 +322,85 @@ function ProfileRow({
 }
 
 // Leading glyph for a profile row, mirroring the sidebar rail: the default
-// profile gets the `home` icon; named profiles get a soft color-tinted square
-// with their initial in the profile's color.
-function ProfileGlyph({ color, isDefault, name }: { color: null | string; isDefault: boolean; name: string }) {
+// profile keeps the `home` icon; named profiles show their picture (or the
+// colored-initial fallback ProfileAvatar draws when no picture is set).
+function ProfileGlyph({ isDefault, name }: { isDefault: boolean; name: string }) {
   if (isDefault) {
     return <Codicon className="shrink-0 text-muted-foreground/70" name="home" size="0.9rem" />
   }
 
-  const hue = color ?? 'var(--ui-text-quaternary)'
+  return <ProfileAvatar className="size-4 rounded-[3px] text-[0.5rem]" name={name} />
+}
 
-  const initial =
-    name
-      .replace(/[^a-z0-9]/gi, '')
-      .charAt(0)
-      .toUpperCase() || '?'
+// The profile picture in the detail header, doubling as its editor: click to
+// pick a new image (hover reveals a pencil overlay), and a corner button removes
+// the current one. Mirrors the SOUL.md save pattern — optimistic local update
+// plus a success toast — so the rail and lists refresh instantly.
+function ProfileDetailAvatar({ name }: { name: string }) {
+  const { t } = useI18n()
+  const p = t.profiles
+  const pickAvatar = useAvatarPicker()
+  const avatars = useStore($profileAvatars)
+  const hasPicture = Boolean(avatars[normalizeProfileKey(name)])
+  const [busy, setBusy] = useState(false)
+
+  const handlePick = useCallback(async () => {
+    setBusy(true)
+
+    try {
+      const next = await pickAvatar()
+
+      if (next) {
+        await updateProfileAvatar(name, next)
+        setProfileAvatarLocal(name, next)
+        notify({ kind: 'success', title: p.pictureSaved, message: name })
+      }
+    } catch (err) {
+      notifyError(err, p.failedSavePicture)
+    } finally {
+      setBusy(false)
+    }
+  }, [name, p, pickAvatar])
+
+  const handleRemove = useCallback(async () => {
+    setBusy(true)
+
+    try {
+      await deleteProfileAvatar(name)
+      setProfileAvatarLocal(name, null)
+    } catch (err) {
+      notifyError(err, p.failedRemovePicture)
+    } finally {
+      setBusy(false)
+    }
+  }, [name, p])
 
   return (
-    <span
-      aria-hidden="true"
-      className="grid size-4 shrink-0 place-items-center rounded-[3px] text-[0.5rem] font-semibold uppercase leading-none"
-      style={{ backgroundColor: profileColorSoft(hue, 22), color: color ?? undefined }}
-    >
-      {initial}
-    </span>
+    <div className="group/avatar relative shrink-0">
+      <button
+        aria-label={hasPicture ? p.changePicture : p.choosePicture}
+        className="block rounded-lg outline-none ring-offset-2 ring-offset-background focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60"
+        disabled={busy}
+        onClick={() => void handlePick()}
+        type="button"
+      >
+        <ProfileAvatar className="size-12 rounded-lg text-lg" name={name} />
+        <span className="absolute inset-0 grid place-items-center rounded-lg bg-black/45 text-white opacity-0 transition-opacity group-hover/avatar:opacity-100">
+          <Pencil className="size-4" />
+        </span>
+      </button>
+      {hasPicture && (
+        <button
+          aria-label={p.removePicture}
+          className="absolute -right-1.5 -top-1.5 grid size-5 place-items-center rounded-full border border-border bg-background text-muted-foreground opacity-0 transition hover:text-destructive group-hover/avatar:opacity-100 disabled:opacity-60"
+          disabled={busy}
+          onClick={() => void handleRemove()}
+          type="button"
+        >
+          <X className="size-3" />
+        </button>
+      )}
+    </div>
   )
 }
 
@@ -344,15 +411,18 @@ function ProfileDetail({ profile }: { profile: ProfileInfo }) {
   return (
     <PanelDetail>
       <header className="space-y-3">
-        <div className="min-w-0">
-          <div className="flex flex-wrap items-center gap-2">
-            <h3 className="text-[0.95rem] font-semibold tracking-tight text-foreground">{profile.name}</h3>
-            {profile.is_default && <PanelPill tone="good">{p.defaultBadge}</PanelPill>}
-            {profile.has_env && <PanelPill tone="muted">.env</PanelPill>}
+        <div className="flex items-start gap-3">
+          <ProfileDetailAvatar name={profile.name} />
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <h3 className="text-[0.95rem] font-semibold tracking-tight text-foreground">{profile.name}</h3>
+              {profile.is_default && <PanelPill tone="good">{p.defaultBadge}</PanelPill>}
+              {profile.has_env && <PanelPill tone="muted">.env</PanelPill>}
+            </div>
+            <p className="mt-1 truncate font-mono text-[0.66rem] text-muted-foreground/55" title={profile.path}>
+              {profile.path}
+            </p>
           </div>
-          <p className="mt-1 truncate font-mono text-[0.66rem] text-muted-foreground/55" title={profile.path}>
-            {profile.path}
-          </p>
         </div>
 
         <PanelMeta

--- a/apps/desktop/src/app/profiles/rename-profile-dialog.tsx
+++ b/apps/desktop/src/app/profiles/rename-profile-dialog.tsx
@@ -15,6 +15,7 @@ import { renameProfile } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { AlertTriangle } from '@/lib/icons'
 import { cn } from '@/lib/utils'
+import { renameProfileLocal } from '@/store/profile'
 
 import { isValidProfileName } from './create-profile-dialog'
 
@@ -72,6 +73,10 @@ export function RenameProfileDialog({
 
     try {
       await renameProfile(currentName, trimmed)
+      // Re-point local state (list, cosmetics, gateway routing) at the new
+      // name immediately — the old name's backend was torn down for the
+      // directory rename, so anything still aimed at it would strand.
+      renameProfileLocal(currentName, trimmed)
       await onRenamed?.(trimmed)
       setStatus('done')
       window.setTimeout(onClose, 800)

--- a/apps/desktop/src/components/profile-avatar.test.tsx
+++ b/apps/desktop/src/components/profile-avatar.test.tsx
@@ -1,0 +1,39 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// profile.ts imports from @/hermes; stub it so the store module loads cleanly.
+vi.mock('@/hermes', () => ({
+  getProfileAvatar: vi.fn(),
+  getProfiles: vi.fn(),
+  setApiRequestProfile: vi.fn()
+}))
+
+import { $profileAvatars } from '@/store/profile'
+
+import { ProfileAvatar } from './profile-avatar'
+
+describe('ProfileAvatar', () => {
+  beforeEach(() => {
+    $profileAvatars.set({})
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders the cached picture when one exists', () => {
+    $profileAvatars.set({ writer: 'data:image/png;base64,AAA' })
+    const { container } = render(<ProfileAvatar name="writer" />)
+
+    // alt="" makes the avatar decorative (no "img" role), so query by tag.
+    const img = container.querySelector('img')
+    expect(img?.getAttribute('src')).toBe('data:image/png;base64,AAA')
+  })
+
+  it('falls back to the uppercased initial when there is no picture', () => {
+    const { container } = render(<ProfileAvatar name="writer" />)
+
+    expect(container.querySelector('img')).toBeNull()
+    expect(screen.getByText('W')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/components/profile-avatar.tsx
+++ b/apps/desktop/src/components/profile-avatar.tsx
@@ -1,0 +1,48 @@
+import { useStore } from '@nanostores/react'
+
+import { profileColorSoft, resolveProfileColor } from '@/lib/profile-color'
+import { cn } from '@/lib/utils'
+import { $profileAvatars, $profileColors, normalizeProfileKey } from '@/store/profile'
+
+// A profile's face wherever it appears (rail squares, manage list/detail,
+// all-profiles group headers). Renders the uploaded picture when one is cached
+// in $profileAvatars, else the same colored-initial fallback the rail has always
+// drawn — so profiles with no picture look exactly as before.
+//
+// Pass sizing/shape via className (e.g. "size-5 rounded-[3px]"). The color
+// system is untouched: the initial fallback uses the profile's resolved hue.
+export function ProfileAvatar({ className, name }: { className?: string; name: string }) {
+  const avatars = useStore($profileAvatars)
+  const colors = useStore($profileColors)
+  const key = normalizeProfileKey(name)
+  const dataUrl = avatars[key]
+
+  const base = cn('inline-grid shrink-0 place-items-center overflow-hidden rounded-md', className)
+
+  if (dataUrl) {
+    return (
+      <span aria-hidden="true" className={base}>
+        <img alt="" className="size-full object-cover" draggable={false} src={dataUrl} />
+      </span>
+    )
+  }
+
+  const color = resolveProfileColor(name, colors)
+  const hue = color ?? 'var(--ui-text-quaternary)'
+
+  const initial =
+    name
+      .replace(/[^a-z0-9]/gi, '')
+      .charAt(0)
+      .toUpperCase() || '?'
+
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(base, 'font-semibold uppercase leading-none')}
+      style={{ backgroundColor: profileColorSoft(hue, 22), color: color ?? undefined }}
+    >
+      {initial}
+    </span>
+  )
+}

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -38,6 +38,7 @@ import type {
   OAuthStartResponse,
   OAuthSubmitResponse,
   PaginatedSessions,
+  ProfileAvatar,
   ProfileCreatePayload,
   ProfileSetupCommand,
   ProfileSoul,
@@ -133,6 +134,7 @@ export type {
   ModelOptionProvider,
   ModelOptionsResponse,
   PaginatedSessions,
+  ProfileAvatar,
   ProfileCreatePayload,
   ProfileInfo,
   ProfileSetupCommand,
@@ -860,6 +862,30 @@ export function updateProfileSoul(name: string, content: string): Promise<{ ok: 
 export function getProfileSetupCommand(name: string): Promise<ProfileSetupCommand> {
   return window.hermesDesktop.api<ProfileSetupCommand>({
     path: `/api/profiles/${encodeURIComponent(name)}/setup-command`
+  })
+}
+
+export function getProfileAvatar(name: string): Promise<ProfileAvatar> {
+  return window.hermesDesktop.api<ProfileAvatar>({
+    path: `/api/profiles/${encodeURIComponent(name)}/avatar`
+  })
+}
+
+export function updateProfileAvatar(
+  name: string,
+  dataUrl: string
+): Promise<{ avatar_updated_at: null | number; ok: boolean }> {
+  return window.hermesDesktop.api<{ avatar_updated_at: null | number; ok: boolean }>({
+    path: `/api/profiles/${encodeURIComponent(name)}/avatar`,
+    method: 'PUT',
+    body: { data_url: dataUrl }
+  })
+}
+
+export function deleteProfileAvatar(name: string): Promise<{ ok: boolean }> {
+  return window.hermesDesktop.api<{ ok: boolean }>({
+    path: `/api/profiles/${encodeURIComponent(name)}/avatar`,
+    method: 'DELETE'
   })
 }
 

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1362,13 +1362,23 @@ export const en: Translations = {
     deleted: 'Profile deleted',
     setupCopied: 'Setup command copied',
     soulSaved: 'SOUL.md saved',
+    pictureLabel: 'Picture',
+    pictureOptional: 'optional',
+    choosePicture: 'Choose image...',
+    changePicture: 'Change',
+    removePicture: 'Remove',
+    pictureHint: 'Shown in the profile rail and lists. Square images work best.',
+    pickPictureTitle: 'Choose profile picture',
+    pictureSaved: 'Profile picture updated',
     failedLoad: 'Failed to load profiles',
     failedDelete: 'Failed to delete profile',
     failedCopy: 'Failed to copy setup command',
     failedLoadSoul: 'Failed to load SOUL.md',
     failedSaveSoul: 'Failed to save SOUL.md',
     failedCreate: 'Failed to create profile',
-    failedRename: 'Failed to rename profile'
+    failedRename: 'Failed to rename profile',
+    failedSavePicture: 'Failed to save profile picture',
+    failedRemovePicture: 'Failed to remove profile picture'
   },
 
   cron: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1135,6 +1135,14 @@ export interface Translations {
     deleted: string
     setupCopied: string
     soulSaved: string
+    pictureLabel: string
+    pictureOptional: string
+    choosePicture: string
+    changePicture: string
+    removePicture: string
+    pictureHint: string
+    pickPictureTitle: string
+    pictureSaved: string
     failedLoad: string
     failedDelete: string
     failedCopy: string
@@ -1142,6 +1150,8 @@ export interface Translations {
     failedSaveSoul: string
     failedCreate: string
     failedRename: string
+    failedSavePicture: string
+    failedRemovePicture: string
   }
 
   cron: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1540,13 +1540,23 @@ export const zh: Translations = {
     deleted: '配置档案已删除',
     setupCopied: '安装命令已复制',
     soulSaved: 'SOUL.md 已保存',
+    pictureLabel: '头像',
+    pictureOptional: '可选',
+    choosePicture: '选择图片…',
+    changePicture: '更换',
+    removePicture: '移除',
+    pictureHint: '显示在配置档案侧栏和列表中。建议使用方形图片。',
+    pickPictureTitle: '选择配置档案头像',
+    pictureSaved: '配置档案头像已更新',
     failedLoad: '加载配置档案失败',
     failedDelete: '删除配置档案失败',
     failedCopy: '复制安装命令失败',
     failedLoadSoul: '加载 SOUL.md 失败',
     failedSaveSoul: '保存 SOUL.md 失败',
     failedCreate: '创建配置档案失败',
-    failedRename: '重命名配置档案失败'
+    failedRename: '重命名配置档案失败',
+    failedSavePicture: '保存配置档案头像失败',
+    failedRemovePicture: '移除配置档案头像失败'
   },
 
   cron: {

--- a/apps/desktop/src/lib/avatar-image.ts
+++ b/apps/desktop/src/lib/avatar-image.ts
@@ -1,0 +1,50 @@
+// Downscale a picked image to a small square data URL for use as a profile
+// avatar. Cover-crops to a centered square then re-encodes at `size`×`size`, so
+// the file we upload is tiny (~10-50 KB) regardless of the source resolution.
+// WebP keeps it small; we fall back to PNG if the platform can't encode WebP.
+
+const AVATAR_SIZE = 256
+const AVATAR_QUALITY = 0.85
+
+export async function downscaleAvatar(dataUrl: string, size = AVATAR_SIZE): Promise<string> {
+  if (!dataUrl.startsWith('data:image/')) {
+    throw new Error('Selected file is not an image.')
+  }
+
+  const image = await loadImage(dataUrl)
+
+  const canvas = document.createElement('canvas')
+  canvas.width = size
+  canvas.height = size
+
+  const ctx = canvas.getContext('2d')
+
+  if (!ctx) {
+    throw new Error('Could not process image.')
+  }
+
+  // Center cover-crop: scale the shorter side to fill the square.
+  const side = Math.min(image.naturalWidth, image.naturalHeight)
+  const sx = (image.naturalWidth - side) / 2
+  const sy = (image.naturalHeight - side) / 2
+  ctx.drawImage(image, sx, sy, side, side, 0, 0, size, size)
+
+  const webp = canvas.toDataURL('image/webp', AVATAR_QUALITY)
+
+  // toDataURL returns a PNG when the requested type is unsupported; only trust
+  // the WebP result when the platform actually produced one.
+  if (webp.startsWith('data:image/webp')) {
+    return webp
+  }
+
+  return canvas.toDataURL('image/png')
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image()
+    image.onload = () => resolve(image)
+    image.onerror = () => reject(new Error('Could not load the selected image.'))
+    image.src = src
+  })
+}

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -259,6 +259,25 @@ export function touchSecondaryGateways(): void {
   }
 }
 
+// Close + evict one profile's secondary socket (e.g. its profile was just
+// deleted). Stops the reconnect backoff loop dead — without this, a socket
+// whose backend can never come back keeps respawning it forever.
+export function dropSecondaryGateway(profile: string): void {
+  const key = normKey(profile)
+  const entry = secondaries.get(key)
+
+  if (!entry) {
+    return
+  }
+
+  entry.wantOpen = false
+  clearTimer(entry)
+  entry.offEvent()
+  entry.offState()
+  entry.gateway.close()
+  secondaries.delete(key)
+}
+
 // Close + evict secondaries whose profile is neither active nor in `keep`
 // (profiles with a running / needs-input session). Bounds cost to live work.
 export function pruneSecondaryGateways(keep: Set<string>): void {

--- a/apps/desktop/src/store/profile-avatars.test.ts
+++ b/apps/desktop/src/store/profile-avatars.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ProfileInfo } from '@/types/hermes'
+
+const getProfileAvatar = vi.fn()
+
+// profile.ts pulls these from @/hermes; only getProfileAvatar matters here.
+// HermesGateway is a minimal stand-in for the routing-follow tests, where
+// selectProfile() opens a secondary socket for the target profile (the real
+// connect is skipped — window.hermesDesktop doesn't exist under jsdom).
+vi.mock('@/hermes', () => ({
+  getProfileAvatar: (name: string) => getProfileAvatar(name),
+  getProfiles: vi.fn(),
+  setApiRequestProfile: vi.fn(),
+  HermesGateway: class {
+    connectionState = 'closed'
+    onEvent() {
+      return () => {}
+    }
+    onState() {
+      return () => {}
+    }
+    async connect() {}
+    close() {}
+  }
+}))
+
+import {
+  $activeGatewayProfile,
+  $activeProfile,
+  $newChatProfile,
+  $profileAvatars,
+  $profileColors,
+  $profileOrder,
+  $profiles,
+  ensureProfileAvatars,
+  removeProfileLocal,
+  renameProfileLocal,
+  setProfileAvatarLocal
+} from './profile'
+
+function profile(name: string, overrides: Partial<ProfileInfo> = {}): ProfileInfo {
+  return {
+    avatar_updated_at: null,
+    has_avatar: false,
+    has_env: false,
+    is_default: name === 'default',
+    model: null,
+    name,
+    path: `/profiles/${name}`,
+    provider: null,
+    skill_count: 0,
+    ...overrides
+  }
+}
+
+describe('ensureProfileAvatars', () => {
+  beforeEach(() => {
+    $profileAvatars.set({})
+    getProfileAvatar.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('fetches and caches avatars only for profiles that have one', async () => {
+    getProfileAvatar.mockResolvedValue({ data_url: 'data:image/png;base64,AAA', exists: true })
+
+    ensureProfileAvatars([
+      profile('alpha', { has_avatar: true, avatar_updated_at: 1 }),
+      profile('beta') // no avatar → no fetch
+    ])
+    await vi.waitFor(() => expect($profileAvatars.get().alpha).toBe('data:image/png;base64,AAA'))
+
+    expect(getProfileAvatar).toHaveBeenCalledTimes(1)
+    expect(getProfileAvatar).toHaveBeenCalledWith('alpha')
+    expect($profileAvatars.get().beta).toBeUndefined()
+  })
+
+  it('does not refetch when the version is unchanged but refetches when it changes', async () => {
+    // Distinct name from other tests — the version counter is module-level and
+    // persists across tests in this file.
+    getProfileAvatar.mockResolvedValue({ data_url: 'data:image/png;base64,V1', exists: true })
+
+    const p1 = profile('verprof', { has_avatar: true, avatar_updated_at: 1 })
+    ensureProfileAvatars([p1])
+    await vi.waitFor(() => expect($profileAvatars.get().verprof).toBe('data:image/png;base64,V1'))
+
+    // Same version → cache hit, no new request.
+    ensureProfileAvatars([p1])
+    expect(getProfileAvatar).toHaveBeenCalledTimes(1)
+
+    // Bumped version → refetch.
+    getProfileAvatar.mockResolvedValue({ data_url: 'data:image/png;base64,V2', exists: true })
+    ensureProfileAvatars([profile('verprof', { has_avatar: true, avatar_updated_at: 2 })])
+    await vi.waitFor(() => expect($profileAvatars.get().verprof).toBe('data:image/png;base64,V2'))
+    expect(getProfileAvatar).toHaveBeenCalledTimes(2)
+  })
+
+  it('drops cached avatars for profiles that vanish or lose their picture', async () => {
+    setProfileAvatarLocal('alpha', 'data:image/png;base64,AAA')
+    setProfileAvatarLocal('beta', 'data:image/png;base64,BBB')
+    expect(Object.keys($profileAvatars.get()).sort()).toEqual(['alpha', 'beta'])
+
+    // alpha is gone from the list, beta still exists but lost its picture.
+    ensureProfileAvatars([profile('beta', { has_avatar: false })])
+
+    expect($profileAvatars.get().alpha).toBeUndefined()
+    expect($profileAvatars.get().beta).toBeUndefined()
+  })
+})
+
+describe('removeProfileLocal', () => {
+  afterEach(() => {
+    $activeGatewayProfile.set('default')
+    $activeProfile.set('default')
+    $newChatProfile.set(null)
+  })
+
+  it('drops the profile from the cached list and clears its avatar', () => {
+    $profiles.set([profile('default'), profile('guy', { has_avatar: true })])
+    setProfileAvatarLocal('guy', 'data:image/png;base64,AAA')
+
+    removeProfileLocal('guy')
+
+    expect($profiles.get().map(p => p.name)).toEqual(['default'])
+    expect($profileAvatars.get().guy).toBeUndefined()
+  })
+
+  it('falls back to default when the deleted profile was the routed one', async () => {
+    // The gateway, statusbar pill, and new-chat target all point at the
+    // doomed profile — deletion must unwind every one of them, or the
+    // primary reconnect loop keeps dialing a backend that can't come back.
+    $profiles.set([profile('default'), profile('guy')])
+    $activeGatewayProfile.set('guy')
+    $activeProfile.set('guy')
+    $newChatProfile.set('guy')
+
+    removeProfileLocal('guy')
+
+    expect($activeProfile.get()).toBe('default')
+    // selectProfile points new chats at default rather than clearing outright.
+    expect($newChatProfile.get()).toBe('default')
+    // The gateway swap settles async (socket ensure → active pointer flip).
+    await vi.waitFor(() => expect($activeGatewayProfile.get()).toBe('default'))
+  })
+
+  it('leaves routing alone when the deleted profile was not active', () => {
+    $profiles.set([profile('default'), profile('alpha'), profile('beta')])
+    $activeGatewayProfile.set('alpha')
+    $activeProfile.set('alpha')
+    $newChatProfile.set('alpha')
+
+    removeProfileLocal('beta')
+
+    expect($activeGatewayProfile.get()).toBe('alpha')
+    expect($activeProfile.get()).toBe('alpha')
+    expect($newChatProfile.get()).toBe('alpha')
+    expect($profiles.get().map(p => p.name)).toEqual(['default', 'alpha'])
+  })
+})
+
+describe('renameProfileLocal', () => {
+  afterEach(() => {
+    $activeGatewayProfile.set('default')
+    $activeProfile.set('default')
+    $newChatProfile.set(null)
+    $profileColors.set({})
+    $profileOrder.set([])
+  })
+
+  it('renames the cached entry and carries color, order slot, and avatar across', () => {
+    $profiles.set([profile('default'), profile('old-name', { has_avatar: true })])
+    $profileColors.set({ 'old-name': 'hsl(120 68% 58%)' })
+    $profileOrder.set(['old-name', 'other'])
+    setProfileAvatarLocal('old-name', 'data:image/png;base64,AAA')
+
+    renameProfileLocal('old-name', 'new-name')
+
+    expect($profiles.get().map(p => p.name)).toEqual(['default', 'new-name'])
+    expect($profileColors.get()).toEqual({ 'new-name': 'hsl(120 68% 58%)' })
+    expect($profileOrder.get()).toEqual(['new-name', 'other'])
+    expect($profileAvatars.get()['old-name']).toBeUndefined()
+    expect($profileAvatars.get()['new-name']).toBe('data:image/png;base64,AAA')
+  })
+
+  it('follows routing to the new name when the renamed profile was active', async () => {
+    $profiles.set([profile('default'), profile('old-name')])
+    $activeGatewayProfile.set('old-name')
+    $activeProfile.set('old-name')
+    $newChatProfile.set('old-name')
+
+    renameProfileLocal('old-name', 'new-name')
+
+    expect($activeProfile.get()).toBe('new-name')
+    expect($newChatProfile.get()).toBe('new-name')
+    await vi.waitFor(() => expect($activeGatewayProfile.get()).toBe('new-name'))
+  })
+})

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -24,6 +24,8 @@ const { queryClient } = await import('@/lib/query-client')
 const { getProfiles } = await import('@/hermes')
 
 const profile = (name: string, isDefault = false): ProfileInfo => ({
+  avatar_updated_at: null,
+  has_avatar: false,
   has_env: false,
   is_default: isDefault,
   model: null,

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -1,6 +1,6 @@
 import { atom, computed } from 'nanostores'
 
-import { getProfiles, setApiRequestProfile, STARTUP_REQUEST_TIMEOUT_MS } from '@/hermes'
+import { getProfileAvatar, getProfiles, setApiRequestProfile, STARTUP_REQUEST_TIMEOUT_MS } from '@/hermes'
 import { queryClient } from '@/lib/query-client'
 import {
   arraysEqual,
@@ -11,7 +11,7 @@ import {
   storedStringArray,
   storedStringRecord
 } from '@/lib/storage'
-import { $gateway, ensureGatewayForProfile } from '@/store/gateway'
+import { $gateway, dropSecondaryGateway, ensureGatewayForProfile } from '@/store/gateway'
 import { setConnection } from '@/store/session'
 import { resetStarmapGraph } from '@/store/starmap'
 import type { ProfileInfo } from '@/types/hermes'
@@ -41,6 +41,9 @@ export function setActiveProfile(name: string): void {
 export async function refreshProfiles(): Promise<ProfileInfo[]> {
   const { profiles } = await getProfiles()
   $profiles.set(profiles)
+  // Reconcile the avatar cache on every list refresh so pictures set/removed
+  // elsewhere (or on another window) fetch/drop without an explicit call site.
+  ensureProfileAvatars(profiles)
 
   return profiles
 }
@@ -99,6 +102,170 @@ export function setProfileColor(name: string, color: null | string): void {
   }
 
   $profileColors.set(next)
+}
+
+// ── Rail avatars ───────────────────────────────────────────────────────────
+// Profile pictures, keyed by normalized profile name → data URL. In-memory only
+// (data URLs are far too big for localStorage, and the backend is the source of
+// truth). Fetched lazily by ensureProfileAvatars() whenever the profile list
+// refreshes; ProfileAvatar/ProfileSquare read from here and fall back to the
+// colored initial when a name has no entry.
+export const $profileAvatars = atom<Record<string, string>>({})
+
+// Version (avatar_updated_at) of each cached avatar, so we re-fetch only when
+// the file actually changes. Module-level — never rendered, just bookkeeping.
+const avatarVersions = new Map<string, number>()
+// In-flight fetches, deduped by key so a burst of refreshes issues one request.
+const avatarInFlight = new Map<string, Promise<void>>()
+
+// Reconcile the avatar cache against the latest profile list: fetch pictures for
+// profiles whose avatar is new or changed, and drop entries for profiles that no
+// longer exist or lost their picture (self-heals after rename/delete). Best
+// effort — a failed fetch just leaves the colored-initial fallback in place.
+export function ensureProfileAvatars(profiles: ProfileInfo[]): void {
+  const live = new Set(profiles.map(profile => normalizeProfileKey(profile.name)))
+
+  // Drop stale cache + version entries for profiles that vanished.
+  const current = $profileAvatars.get()
+  let pruned: null | Record<string, string> = null
+
+  for (const key of Object.keys(current)) {
+    if (!live.has(key)) {
+      pruned ??= { ...current }
+      delete pruned[key]
+      avatarVersions.delete(key)
+    }
+  }
+
+  if (pruned) {
+    $profileAvatars.set(pruned)
+  }
+
+  for (const profile of profiles) {
+    const key = normalizeProfileKey(profile.name)
+    const version = profile.avatar_updated_at ?? 0
+
+    if (!profile.has_avatar) {
+      // Picture was removed elsewhere — clear any cached copy.
+      if (key in $profileAvatars.get()) {
+        setProfileAvatarLocal(profile.name, null)
+      }
+
+      avatarVersions.delete(key)
+
+      continue
+    }
+
+    if (avatarVersions.get(key) === version || avatarInFlight.has(key)) {
+      continue
+    }
+
+    const request = getProfileAvatar(profile.name)
+      .then(res => {
+        if (res.data_url) {
+          avatarVersions.set(key, version)
+          $profileAvatars.set({ ...$profileAvatars.get(), [key]: res.data_url })
+        }
+      })
+      .catch(() => {
+        // Leave the fallback in place; a later refresh retries.
+      })
+      .finally(() => {
+        avatarInFlight.delete(key)
+      })
+
+    avatarInFlight.set(key, request)
+  }
+}
+
+// Optimistically set (or, with null, clear) a profile's cached picture after a
+// PUT/DELETE so the UI updates instantly without waiting for the next refresh.
+export function setProfileAvatarLocal(name: string, dataUrl: null | string): void {
+  const key = normalizeProfileKey(name)
+  const next = { ...$profileAvatars.get() }
+
+  if (dataUrl) {
+    next[key] = dataUrl
+    // Bump the version so the next ensureProfileAvatars() doesn't refetch over
+    // our fresh copy; the real mtime arrives on the following list refresh.
+    avatarVersions.set(key, Date.now() / 1000)
+  } else {
+    delete next[key]
+    avatarVersions.delete(key)
+  }
+
+  $profileAvatars.set(next)
+}
+
+// Re-point every live reference at `key` to the `to` profile: its secondary
+// socket, the new-chat target, the statusbar pill, and the active-gateway
+// routing. Shared unwind for delete (→ default) and rename (→ the new name).
+// Skipping this strands the gateway: the primary reconnect loop dials
+// $activeGatewayProfile, and a name whose backend can never come back keeps
+// failing to spawn `--profile <name>` forever.
+function retargetProfileRoutingLocal(key: string, to: string): void {
+  dropSecondaryGateway(key)
+
+  if ($newChatProfile.get() !== null && normalizeProfileKey($newChatProfile.get()) === key) {
+    $newChatProfile.set(to)
+  }
+
+  if (normalizeProfileKey($activeProfile.get()) === key) {
+    setActiveProfile(to)
+  }
+
+  if (normalizeProfileKey($activeGatewayProfile.get()) === key) {
+    selectProfile(to)
+  }
+}
+
+// Optimistically drop a deleted profile from the cached list (and its avatar)
+// so the rail square disappears the moment the DELETE succeeds, and retarget
+// any routing at it to default. The follow-up refreshActiveProfile() is
+// best-effort — if the backend is unreachable (e.g. the deleted profile's own
+// backend was the routed one), the stale list would otherwise keep the dead
+// square on screen indefinitely.
+export function removeProfileLocal(name: string): void {
+  const key = normalizeProfileKey(name)
+
+  $profiles.set($profiles.get().filter(profile => normalizeProfileKey(profile.name) !== key))
+  setProfileAvatarLocal(name, null)
+  retargetProfileRoutingLocal(key, 'default')
+}
+
+// Optimistically apply a confirmed rename: update the cached list, carry the
+// local cosmetics (color override, rail order slot, avatar cache) to the new
+// name, and retarget any routing at the old name — its backend was torn down
+// for the directory rename, so it strands exactly like a delete.
+export function renameProfileLocal(from: string, to: string): void {
+  const fromKey = normalizeProfileKey(from)
+  const toKey = normalizeProfileKey(to)
+
+  if (fromKey === toKey) {
+    return
+  }
+
+  $profiles.set(
+    $profiles.get().map(profile => (normalizeProfileKey(profile.name) === fromKey ? { ...profile, name: to } : profile))
+  )
+
+  const color = $profileColors.get()[fromKey]
+
+  if (color) {
+    setProfileColor(to, color)
+    setProfileColor(from, null)
+  }
+
+  setProfileOrder($profileOrder.get().map(name => (normalizeProfileKey(name) === fromKey ? to : name)))
+
+  const avatar = $profileAvatars.get()[fromKey]
+
+  if (avatar) {
+    setProfileAvatarLocal(to, avatar)
+    setProfileAvatarLocal(from, null)
+  }
+
+  retargetProfileRoutingLocal(fromKey, toKey)
 }
 
 interface ActiveProfileResponse {

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -596,6 +596,8 @@ export interface ProfileCreatePayload {
 }
 
 export interface ProfileInfo {
+  avatar_updated_at: null | number
+  has_avatar: boolean
   has_env: boolean
   is_default: boolean
   model: null | string
@@ -603,6 +605,11 @@ export interface ProfileInfo {
   path: string
   provider: null | string
   skill_count: number
+}
+
+export interface ProfileAvatar {
+  data_url: null | string
+  exists: boolean
 }
 
 export interface ProfileSetupCommand {

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -650,6 +650,36 @@ class ProfileInfo:
     # surfaces a "review" badge in this case so the user can edit or
     # accept.
     description_auto: bool = False
+    # True when the profile has a picture (``avatar.<ext>``) on disk.
+    has_avatar: bool = False
+    # mtime (epoch seconds) of the avatar file, used as a cache-busting
+    # version so clients only re-fetch the image when it actually changes.
+    # None when there is no avatar.
+    avatar_updated_at: Optional[float] = None
+
+
+# ---------------------------------------------------------------------------
+# Profile picture (avatar)
+# ---------------------------------------------------------------------------
+#
+# Stored as a single ``avatar.<ext>`` file in the profile directory, mirroring
+# the per-profile-file pattern used by SOUL.md. Living inside the profile dir
+# means the picture follows the profile through rename/delete for free.
+
+_AVATAR_EXTS = (".png", ".jpg", ".webp")
+
+
+def find_profile_avatar(profile_dir: Path) -> Optional[Path]:
+    """Return the profile's ``avatar.<ext>`` file if one exists, else None.
+
+    Checks the known extensions in order; there should only ever be one
+    (``PUT`` removes any prior variant before writing).
+    """
+    for ext in _AVATAR_EXTS:
+        candidate = profile_dir / f"avatar{ext}"
+        if candidate.is_file():
+            return candidate
+    return None
 
 
 def _read_distribution_meta(profile_dir: Path) -> tuple:
@@ -874,6 +904,21 @@ def write_profile_meta(
 # CRUD operations
 # ---------------------------------------------------------------------------
 
+def _avatar_meta(profile_dir: Path) -> tuple:
+    """Return ``(has_avatar, avatar_updated_at)`` for a profile directory.
+
+    Best-effort like ``_count_skills`` — a stat failure must never break
+    ``hermes profile list``.
+    """
+    try:
+        avatar_path = find_profile_avatar(profile_dir)
+        if avatar_path is None:
+            return False, None
+        return True, avatar_path.stat().st_mtime
+    except Exception:
+        return False, None
+
+
 def list_profiles() -> List[ProfileInfo]:
     """Return info for all profiles, including the default."""
     profiles = []
@@ -885,6 +930,7 @@ def list_profiles() -> List[ProfileInfo]:
         model, provider = _read_config_model(default_home)
         dist_name, dist_version, dist_source = _read_distribution_meta(default_home)
         meta = read_profile_meta(default_home)
+        has_avatar, avatar_updated_at = _avatar_meta(default_home)
         profiles.append(ProfileInfo(
             name="default",
             path=default_home,
@@ -899,6 +945,8 @@ def list_profiles() -> List[ProfileInfo]:
             distribution_source=dist_source,
             description=meta.get("description", ""),
             description_auto=meta.get("description_auto", False),
+            has_avatar=has_avatar,
+            avatar_updated_at=avatar_updated_at,
         ))
 
     # Named profiles
@@ -925,6 +973,7 @@ def list_profiles() -> List[ProfileInfo]:
                 alias_path = None
             dist_name, dist_version, dist_source = _read_distribution_meta(entry)
             meta = read_profile_meta(entry)
+            has_avatar, avatar_updated_at = _avatar_meta(entry)
             profiles.append(ProfileInfo(
                 name=name,
                 path=entry,
@@ -941,6 +990,8 @@ def list_profiles() -> List[ProfileInfo]:
                 distribution_source=dist_source,
                 description=meta.get("description", ""),
                 description_auto=meta.get("description_auto", False),
+                has_avatar=has_avatar,
+                avatar_updated_at=avatar_updated_at,
             ))
 
     return profiles

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12775,6 +12775,10 @@ class ProfileSoulUpdate(BaseModel):
     content: str
 
 
+class ProfileAvatarUpdate(BaseModel):
+    data_url: str
+
+
 class ProfileActiveUpdate(BaseModel):
     name: str
 
@@ -12815,6 +12819,8 @@ def _profile_to_dict(info) -> Dict[str, Any]:
         "distribution_version": _profile_attr(info, "distribution_version"),
         "distribution_source": _profile_attr(info, "distribution_source"),
         "has_alias": _profile_attr(info, "alias_path") is not None,
+        "has_avatar": bool(_profile_attr(info, "has_avatar", False)),
+        "avatar_updated_at": _profile_attr(info, "avatar_updated_at"),
     }
 
 
@@ -12829,6 +12835,7 @@ def _fallback_profile_dicts(profiles_mod) -> List[Dict[str, Any]]:
     default_home = profiles_mod._get_default_hermes_home()
     if default_home.is_dir():
         model, provider = _safe(lambda: profiles_mod._read_config_model(default_home), (None, None))
+        has_avatar, avatar_updated_at = profiles_mod._avatar_meta(default_home)
         profiles.append({
             "name": "default",
             "path": str(default_home),
@@ -12844,6 +12851,8 @@ def _fallback_profile_dicts(profiles_mod) -> List[Dict[str, Any]]:
             "distribution_version": None,
             "distribution_source": None,
             "has_alias": False,
+            "has_avatar": has_avatar,
+            "avatar_updated_at": avatar_updated_at,
         })
 
     profiles_root = profiles_mod._get_profiles_root()
@@ -12852,6 +12861,7 @@ def _fallback_profile_dicts(profiles_mod) -> List[Dict[str, Any]]:
             if not entry.is_dir() or not profiles_mod._PROFILE_ID_RE.match(entry.name):
                 continue
             model, provider = _safe(lambda entry=entry: profiles_mod._read_config_model(entry), (None, None))
+            has_avatar, avatar_updated_at = profiles_mod._avatar_meta(entry)
             profiles.append({
                 "name": entry.name,
                 "path": str(entry),
@@ -12867,6 +12877,8 @@ def _fallback_profile_dicts(profiles_mod) -> List[Dict[str, Any]]:
                 "distribution_version": None,
                 "distribution_source": None,
                 "has_alias": False,
+                "has_avatar": has_avatar,
+                "avatar_updated_at": avatar_updated_at,
             })
 
     return profiles
@@ -13281,6 +13293,93 @@ async def update_profile_soul(name: str, body: ProfileSoulUpdate):
     except OSError as e:
         _log.exception("PUT /api/profiles/%s/soul failed", name)
         raise HTTPException(status_code=500, detail=f"Could not write SOUL.md: {e}")
+    return {"ok": True}
+
+
+# Profile picture (avatar) endpoints. The image lives as ``avatar.<ext>`` in the
+# profile directory (mirrors SOUL.md), so it follows the profile through rename
+# and delete with no extra bookkeeping. Transport is a JSON data URL both ways.
+_AVATAR_MIME_EXT = {
+    "image/png": ".png",
+    "image/jpeg": ".jpg",
+    "image/webp": ".webp",
+}
+_AVATAR_EXT_MIME = {ext: mime for mime, ext in _AVATAR_MIME_EXT.items()}
+_AVATAR_MAX_BYTES = 2 * 1024 * 1024
+_AVATAR_DATA_URL_RE = re.compile(r"^data:(image/(?:png|jpeg|webp));base64,(.+)$", re.DOTALL)
+
+
+@app.get("/api/profiles/{name}/avatar")
+async def get_profile_avatar(name: str):
+    """Return the profile's picture as a base64 data URL, or null if unset.
+
+    Mirrors the soul endpoint's no-404-on-missing behavior so the client can
+    treat "no picture" as a normal state rather than an error.
+    """
+    from hermes_cli import profiles as profiles_mod
+
+    avatar_path = profiles_mod.find_profile_avatar(_resolve_profile_dir(name))
+    if avatar_path is None:
+        return {"data_url": None, "exists": False}
+    content_type = _AVATAR_EXT_MIME.get(avatar_path.suffix.lower(), "image/png")
+    try:
+        encoded = base64.b64encode(avatar_path.read_bytes()).decode("ascii")
+    except OSError as e:
+        raise HTTPException(status_code=500, detail=f"Could not read avatar: {e}")
+    return {"data_url": f"data:{content_type};base64,{encoded}", "exists": True}
+
+
+@app.put("/api/profiles/{name}/avatar")
+async def update_profile_avatar(name: str, body: ProfileAvatarUpdate):
+    """Store a profile picture from a ``data:image/...;base64,...`` payload.
+
+    Validates the mime against an allowlist and caps the decoded size; replaces
+    any existing ``avatar.*`` so exactly one variant remains on disk.
+    """
+    from hermes_cli import profiles as profiles_mod
+
+    profile_dir = _resolve_profile_dir(name)
+    match = _AVATAR_DATA_URL_RE.match(body.data_url or "")
+    if not match:
+        raise HTTPException(status_code=400, detail="Expected a PNG, JPEG, or WebP data URL")
+    mime, payload = match.group(1), match.group(2)
+    ext = _AVATAR_MIME_EXT[mime]
+    # Reject oversized payloads on encoded length first (base64 is ~4/3 the
+    # decoded size) so a huge body never gets decoded into memory at all.
+    if len(payload) > _AVATAR_MAX_BYTES * 4 // 3 + 4:
+        raise HTTPException(status_code=413, detail="Image too large")
+    try:
+        data = base64.b64decode(payload, validate=True)
+    except (binascii.Error, ValueError):
+        raise HTTPException(status_code=400, detail="Invalid base64 image data")
+    if len(data) > _AVATAR_MAX_BYTES:
+        raise HTTPException(status_code=413, detail="Image too large")
+
+    try:
+        # Drop any prior variant first so only one avatar.* file ever exists.
+        existing = profiles_mod.find_profile_avatar(profile_dir)
+        if existing is not None and existing.suffix != ext:
+            existing.unlink(missing_ok=True)
+        avatar_path = profile_dir / f"avatar{ext}"
+        avatar_path.write_bytes(data)
+    except OSError as e:
+        _log.exception("PUT /api/profiles/%s/avatar failed", name)
+        raise HTTPException(status_code=500, detail=f"Could not write avatar: {e}")
+    return {"ok": True, "avatar_updated_at": avatar_path.stat().st_mtime}
+
+
+@app.delete("/api/profiles/{name}/avatar")
+async def delete_profile_avatar(name: str):
+    """Remove the profile's picture. Idempotent — succeeds even if unset."""
+    from hermes_cli import profiles as profiles_mod
+
+    profile_dir = _resolve_profile_dir(name)
+    try:
+        for ext in profiles_mod._AVATAR_EXTS:
+            (profile_dir / f"avatar{ext}").unlink(missing_ok=True)
+    except OSError as e:
+        _log.exception("DELETE /api/profiles/%s/avatar failed", name)
+        raise HTTPException(status_code=500, detail=f"Could not delete avatar: {e}")
     return {"ok": True}
 
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1975,6 +1975,7 @@ AUTHOR_MAP = {
     "i@dex.moe": "dexhunter",  # PR #60339 salvage (skills snapshot manifest speedup)
     "1torhan@protonmail.com": "uzaylisak",  # PR #29988 salvage (detect_local_server_type process-lifetime cache)
     "zhchl@hermes-agent.local": "8294",  # PR #50572 salvage (honor config context_length on banner)
+    "shayankhanx1x@gmail.com": "devv-shayan",  # desktop profile pictures
 }
 
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4416,6 +4416,129 @@ class TestNewEndpoints:
         resp = self.client.get("/api/profiles/nonexistent/soul")
         assert resp.status_code == 404
 
+    # --- Profile avatar (picture) endpoints ---
+
+    # 1x1 transparent PNG, the smallest valid image we can round-trip.
+    _PNG_DATA_URL = (
+        "data:image/png;base64,"
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/wH5AAAAAElFTkSuQmCC"
+    )
+
+    def test_profile_avatar_round_trip(self, monkeypatch):
+        import hermes_cli.profiles as profiles_mod
+        monkeypatch.setattr(profiles_mod, "_cleanup_gateway_service", lambda *a, **kw: None)
+
+        self.client.post("/api/profiles", json={"name": "pic-prof"})
+
+        # No picture yet.
+        empty = self.client.get("/api/profiles/pic-prof/avatar")
+        assert empty.status_code == 200
+        assert empty.json() == {"data_url": None, "exists": False}
+
+        put = self.client.put(
+            "/api/profiles/pic-prof/avatar",
+            json={"data_url": self._PNG_DATA_URL},
+        )
+        assert put.status_code == 200
+        assert put.json()["ok"] is True
+        assert put.json()["avatar_updated_at"] is not None
+
+        got = self.client.get("/api/profiles/pic-prof/avatar").json()
+        assert got["exists"] is True
+        assert got["data_url"] == self._PNG_DATA_URL
+
+        # The list reflects the picture for cache-busting.
+        profiles = {p["name"]: p for p in self.client.get("/api/profiles").json()["profiles"]}
+        assert profiles["pic-prof"]["has_avatar"] is True
+        assert profiles["pic-prof"]["avatar_updated_at"] is not None
+
+        # Delete clears it.
+        assert self.client.delete("/api/profiles/pic-prof/avatar").status_code == 200
+        assert self.client.get("/api/profiles/pic-prof/avatar").json()["exists"] is False
+        profiles = {p["name"]: p for p in self.client.get("/api/profiles").json()["profiles"]}
+        assert profiles["pic-prof"]["has_avatar"] is False
+
+        self.client.delete("/api/profiles/pic-prof")
+
+    def test_profile_avatar_replaces_prior_variant(self, monkeypatch):
+        from hermes_constants import get_hermes_home
+        import hermes_cli.profiles as profiles_mod
+        monkeypatch.setattr(profiles_mod, "create_wrapper_script", lambda name: None)
+
+        self.client.post("/api/profiles", json={"name": "swap-prof"})
+
+        # Store a PNG, then a WebP — only one avatar.* file may remain.
+        assert self.client.put(
+            "/api/profiles/swap-prof/avatar", json={"data_url": self._PNG_DATA_URL}
+        ).status_code == 200
+        webp_data_url = "data:image/webp;base64,UklGRhIAAABXRUJQVlA4TAYAAAAvAAAAAAfQ//73v/+BiOh/AAA="
+        assert self.client.put(
+            "/api/profiles/swap-prof/avatar", json={"data_url": webp_data_url}
+        ).status_code == 200
+
+        profile_dir = get_hermes_home() / "profiles" / "swap-prof"
+        avatar_files = sorted(p.name for p in profile_dir.glob("avatar.*"))
+        assert avatar_files == ["avatar.webp"]
+
+    def test_profile_avatar_rejects_non_image(self, monkeypatch):
+        import hermes_cli.profiles as profiles_mod
+        monkeypatch.setattr(profiles_mod, "create_wrapper_script", lambda name: None)
+
+        self.client.post("/api/profiles", json={"name": "bad-prof"})
+
+        text = self.client.put(
+            "/api/profiles/bad-prof/avatar",
+            json={"data_url": "data:text/plain;base64,aGVsbG8="},
+        )
+        assert text.status_code == 400
+
+        garbage = self.client.put(
+            "/api/profiles/bad-prof/avatar",
+            json={"data_url": "data:image/png;base64,not-valid-base64!!!"},
+        )
+        assert garbage.status_code == 400
+
+    def test_profile_avatar_rejects_oversized(self, monkeypatch):
+        import base64
+
+        import hermes_cli.profiles as profiles_mod
+        monkeypatch.setattr(profiles_mod, "create_wrapper_script", lambda name: None)
+
+        self.client.post("/api/profiles", json={"name": "big-prof"})
+
+        oversized = base64.b64encode(b"\x00" * (2 * 1024 * 1024 + 1)).decode("ascii")
+        resp = self.client.put(
+            "/api/profiles/big-prof/avatar",
+            json={"data_url": f"data:image/png;base64,{oversized}"},
+        )
+        assert resp.status_code == 413
+
+    def test_profile_avatar_survives_rename(self, monkeypatch):
+        import hermes_cli.profiles as profiles_mod
+        monkeypatch.setattr(profiles_mod, "_cleanup_gateway_service", lambda *a, **kw: None)
+        monkeypatch.setattr(profiles_mod, "create_wrapper_script", lambda name: None)
+
+        self.client.post("/api/profiles", json={"name": "rename-pic"})
+        assert self.client.put(
+            "/api/profiles/rename-pic/avatar", json={"data_url": self._PNG_DATA_URL}
+        ).status_code == 200
+
+        assert self.client.patch(
+            "/api/profiles/rename-pic", json={"new_name": "rename-pic-2"}
+        ).status_code == 200
+
+        got = self.client.get("/api/profiles/rename-pic-2/avatar").json()
+        assert got["exists"] is True
+        assert got["data_url"] == self._PNG_DATA_URL
+
+    def test_profile_avatar_unknown_profile_404(self):
+        assert self.client.get("/api/profiles/nope/avatar").status_code == 404
+        assert self.client.delete("/api/profiles/nope/avatar").status_code == 404
+        put = self.client.put(
+            "/api/profiles/nope/avatar", json={"data_url": self._PNG_DATA_URL}
+        )
+        assert put.status_code == 404
+
     # --- New profiles endpoints: active / description / model / describe-auto ---
 
     def test_profiles_active_defaults(self):


### PR DESCRIPTION
Closes #38317

Adds profile pictures to the desktop app. You can set one when creating a profile, or change/remove it later from the manage view. The picture shows up everywhere a profile renders: the rail squares in the sidebar, the all-profiles group headers, the manage list rows, and the detail header. Profiles without a picture look exactly like they do today.

I tried to build this entirely out of patterns the repo already has. The avatar is stored as a single `avatar.<png|jpg|webp>` file inside the profile directory, same idea as the per-profile `SOUL.md`, which means rename and delete handle it for free since the file moves with the directory. The endpoints (`GET/PUT/DELETE /api/profiles/{name}/avatar`) copy the soul endpoints' shapes and error handling. PUT validates the data URL, returns 400 on a bad mime or base64 and 413 over 2 MB, with a cheap encoded-length precheck so huge payloads get rejected before decoding, and it replaces any existing `avatar.*` so there's only ever one file. On the client, images are downscaled to 256x256 WebP before upload, so stored files are tiny. The renderer keeps an in-memory cache keyed off `has_avatar`/`avatar_updated_at` from the profile list and only refetches when the file actually changed.

The color system is untouched. Picture-less profiles keep the colored initial, the active ring and the long-press picker. Once a picture is set, the color entry hides from the context menu, since the color no longer shows on the square anyway.

While testing this on Windows I hit two existing bugs in the profile lifecycle, fixed here in a separate commit:

- Renaming a profile whose backend was running failed with WinError 5, because the backend held open handles on the directory.
- After deleting a profile, the renderer's reconnect backoff kept respawning a backend for a directory that no longer existed, leaving the gateway permanently offline.

The main process now tombstones the profile and stops its backend before forwarding a delete or rename, and refuses to spawn backends for tombstoned or missing directories. The renderer updates its stores optimistically so deletes and renames paint instantly, with rename carrying color, sort order and avatar over to the new name.

Testing:

- 6 new backend tests in `tests/hermes_cli/test_web_server.py`: round trip, list fields, delete, 404/400/413, single-file replacement
- new vitest suites for the avatar cache reconciliation and the `ProfileAvatar` component, passing under `npm run test:ui`
- `ruff check .`, `tsc -b` and `eslint` clean on everything touched
- manual on Windows: create with and without a picture, change/remove from the detail view, rename and delete with live backends, drag reorder, color picker on picture-less squares, app restart

Also adds my AUTHOR_MAP entry per the contributor attribution check.
