### PR TITLE
fix(model_metadata): drop MiniMax-M3 1M guard, restore models.dev 512K

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1838,17 +1838,6 @@ def get_model_context_length(
         from agent.models_dev import lookup_models_dev_context
         ctx = lookup_models_dev_context(effective_provider, model)
         if ctx:
-            # MiniMax M3: models.dev reports 512K but actual context is 1M.
-            # Prefer hardcoded catalog over stale probe value.
-            if _model_name_suggests_minimax_m3(model):
-                catalog = DEFAULT_CONTEXT_LENGTHS.get("minimax-m3")
-                if catalog and ctx < catalog:
-                    logger.info(
-                        "Rejecting models.dev context=%s for %r "
-                        "(MiniMax-M3 underreport); using hardcoded default %s",
-                        ctx, model, f"{catalog:,}",
-                    )
-                    ctx = catalog
             return ctx
 
     # 6. OpenRouter live API metadata — provider-unaware fallback.


### PR DESCRIPTION
## What
Drop the unconditional MiniMax-M3 1M guard at `agent/model_metadata.py:1838-1851`.
Restore models.dev's 512K probe value as the default return for M3.

## Why (proposal, not hard revert)
5a4297a11 added this guard on the assumption that the community-catalog
1M value was authoritative and the models.dev 512K probe was stale. In
practice:

- M3 spec per upstream docs: **"up to 1M, guaranteed minimum 512K."**
  Standard tier uses 512K; long-context tier uses 1M.
- The guard unconditionally returns 1M for any M3 slug.
- Compressor threshold = `ctx * 0.5` → 500K threshold.
- On a 512K-cap standard-tier plan: 500K threshold **exceeds** the API's
  512K ceiling, so Compressor is effectively bypassed. Prompts past 512K
  get silently truncated by the API.

Restoring the 512K probe value brings the Compressor threshold to 256K,
safely below the ceiling. The 1M long-context tier is opt-in via
`model.context_length: 1000000` in config.yaml — explicit, not implicit.

## Scope
**Only `agent/model_metadata.py` is modified.** ~11 lines deleted,
0 lines added.

This PR does NOT touch:
- `cli.py` `_paint_now()` — that's the fix for #41098; restoring it
  re-introduces a modal-prompt race condition.
- `cron/scheduler.py` weixin-only fallback — that's the documented
  behavior; widening it back brings silent-fallback behavior we don't want.
- `cli.py` mixin split, max_tokens env, prefill resolution, notification
  system — these are unrelated cleanup/refactor; reverting them rolls
  back progress.

## Test
```
$ python3 -c "from agent.model_metadata import get_model_context_length; print(get_model_context_length('MiniMax-M3', provider='minimax-cn'))"
512000
```

- M3  minimax-cn  : 512000 ✓
- M3  minimax     : 512000 ✓
- M2.7 minimax-cn : 204800 ✓ (unchanged)
- M2.7 minimax    : 204800 ✓ (unchanged)

## Alternatives considered
1. **Keep 1M guard, gate on `model.context_length` config flag** — would
   preserve 5a4297a11's intent for long-context-tier users without
   hardcoding. More complex, but a valid follow-up if reviewer prefers.
2. **Tier-aware probe** — query upstream endpoint metadata to detect
   1M-capable plans dynamically. Out of scope; would need API research.

## Related
- Split from #43022 (closed) — that PR bundled 5 unrelated file changes;
  only this model_metadata portion is being re-submitted.
- 5a4297a11 — the 1M guard this PR undoes.
- aacee2a2c — same intent as this PR, was on a local branch and not
  merged to main.
- #42323 — original M3 1M guard PR (closed via #43022).
- liuhao1024 comment on #43022 surfaced the bundled-changes problem;
  the path forward is to split.

## Status
**Proposal.** Open to maintainer feedback. If the consensus is that
5a4297a11's 1M guard is the correct call and Compressor threshold
issues should be solved elsewhere, this PR can be closed without merge.
