### PR TITLE
feat(desktop): add completed-unread indicator for background sessions

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -12,7 +12,7 @@ import { sessionTitle } from '@/lib/chat-runtime'
 import { triggerHaptic } from '@/lib/haptics'
 import { handoffOriginSource, sessionSourceLabel } from '@/lib/session-source'
 import { cn } from '@/lib/utils'
-import { $attentionSessionIds } from '@/store/session'
+import { $attentionSessionIds, $completedUnreadSessionIds } from '@/store/session'
 import { canOpenSessionWindow, openSessionInNewWindow } from '@/store/windows'
 
 import { SessionActionsMenu, SessionContextMenu } from './session-actions-menu'
@@ -80,6 +80,7 @@ export function SidebarSessionRow({
   // the atom is tiny and rarely non-empty. True when a clarify prompt in this
   // session is waiting on the user.
   const needsInput = useStore($attentionSessionIds).includes(session.id)
+  const completedUnread = useStore($completedUnreadSessionIds).includes(session.id)
 
   return (
     <SessionContextMenu
@@ -170,6 +171,7 @@ export function SidebarSessionRow({
             >
               <SidebarRowDot
                 className="transition-opacity group-hover/handle:opacity-0 group-focus-within/handle:opacity-0"
+                completedUnread={completedUnread}
                 isWorking={isWorking}
                 needsInput={needsInput}
               />
@@ -189,7 +191,7 @@ export function SidebarSessionRow({
                 needsInput ? 'overflow-visible' : 'overflow-hidden'
               )}
             >
-              <SidebarRowDot isWorking={isWorking} needsInput={needsInput} />
+              <SidebarRowDot completedUnread={completedUnread} isWorking={isWorking} needsInput={needsInput} />
             </span>
           )}
           {handoffSource && handoffLabel ? (
@@ -239,10 +241,12 @@ export function SidebarSessionRow({
 function SidebarRowDot({
   isWorking,
   needsInput = false,
+  completedUnread = false,
   className
 }: {
   isWorking: boolean
   needsInput?: boolean
+  completedUnread?: boolean
   className?: string
 }) {
   const { t } = useI18n()
@@ -259,6 +263,20 @@ function SidebarRowDot({
         className={cn('quest-glow relative size-1.5 rounded-full bg-amber-500', className)}
         role="status"
         title={r.waitingForAnswer}
+      />
+    )
+  }
+
+  // "Completed unread" shows when a background session finished its turn
+  // while the user was in a different session. Steady muted green dot,
+  // cleared when the user navigates to it.
+  if (completedUnread && !isWorking) {
+    return (
+      <span
+        aria-label={r.completedUnread}
+        className={cn('size-1.5 rounded-full bg-green-400/60', className)}
+        role="status"
+        title={r.responseReady}
       />
     )
   }

--- a/apps/desktop/src/app/session-switcher.tsx
+++ b/apps/desktop/src/app/session-switcher.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router-dom'
 
 import { sessionTitle } from '@/lib/chat-runtime'
 import { cn } from '@/lib/utils'
-import { $attentionSessionIds, $workingSessionIds } from '@/store/session'
+import { $attentionSessionIds, $completedUnreadSessionIds, $workingSessionIds } from '@/store/session'
 import { $switcherIndex, $switcherOpen, $switcherSessions, closeSwitcher } from '@/store/session-switcher'
 
 import { HUD_ITEM, HUD_POSITION, HUD_SURFACE, HUD_TEXT } from './floating-hud'
@@ -19,6 +19,7 @@ export function SessionSwitcher() {
   const index = useStore($switcherIndex)
   const working = useStore($workingSessionIds)
   const attention = useStore($attentionSessionIds)
+  const completedUnread = useStore($completedUnreadSessionIds)
   const navigate = useNavigate()
 
   const activeRef = useRef<HTMLDivElement>(null)
@@ -33,6 +34,7 @@ export function SessionSwitcher() {
 
   const workingIds = new Set(working)
   const attentionIds = new Set(attention)
+  const completedUnreadIds = new Set(completedUnread)
 
   const pick = (sessionId: string) => {
     closeSwitcher()
@@ -74,7 +76,7 @@ export function SessionSwitcher() {
               }}
               ref={selected ? activeRef : undefined}
             >
-              <SwitcherDot attention={attentionIds.has(session.id)} working={workingIds.has(session.id)} />
+              <SwitcherDot attention={attentionIds.has(session.id)} completedUnread={completedUnreadIds.has(session.id)} working={workingIds.has(session.id)} />
               <span className="min-w-0 flex-1 truncate">{sessionTitle(session)}</span>
               {i < 9 && (
                 <span
@@ -95,12 +97,12 @@ export function SessionSwitcher() {
   )
 }
 
-function SwitcherDot({ attention, working }: { attention: boolean; working: boolean }) {
+function SwitcherDot({ attention, completedUnread, working }: { attention: boolean; completedUnread: boolean; working: boolean }) {
   return (
     <span
       className={cn(
         'size-1 shrink-0 rounded-full',
-        attention ? 'bg-amber-400' : working ? 'animate-pulse bg-(--ui-accent)' : 'bg-(--ui-text-quaternary)/50'
+        attention ? 'bg-amber-400' : completedUnread && !working ? 'bg-green-400/60' : working ? 'animate-pulse bg-(--ui-accent)' : 'bg-(--ui-text-quaternary)/50'
       )}
     />
   )

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -15,6 +15,7 @@ import {
   setCurrentReasoningEffort,
   setCurrentServiceTier,
   setSessionAttention,
+  setSessionCompletedUnread,
   setSessionWorking,
   setTurnStartedAt,
   setYoloActive
@@ -79,6 +80,10 @@ export function useSessionStateCache({
 
   useEffect(() => {
     selectedStoredSessionIdRef.current = selectedStoredSessionId
+    // Clear completed-unread indicator when the user navigates to a session.
+    if (selectedStoredSessionId) {
+      setSessionCompletedUnread(selectedStoredSessionId, false)
+    }
   }, [selectedStoredSessionId])
 
   const ensureSessionState = useCallback((sessionId: string, storedSessionId?: string | null) => {
@@ -240,6 +245,13 @@ export function useSessionStateCache({
 
       setSessionWorking(next.storedSessionId, next.busy)
       setSessionAttention(next.storedSessionId, next.needsInput)
+
+      // When a background session finishes its turn, mark it as completed-unread
+      // so the sidebar shows a green dot until the user navigates to it.
+      if (previous.busy && !next.busy && next.storedSessionId &&
+          next.storedSessionId !== selectedStoredSessionIdRef.current) {
+        setSessionCompletedUnread(next.storedSessionId, true)
+      }
 
       // Every state update is effectively a "still alive" heartbeat for
       // streaming events. The session-store watchdog uses this to keep the

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1112,6 +1112,8 @@ export const en: Translations = {
       sessionRunning: 'Session running',
       needsInput: 'Needs your input',
       waitingForAnswer: 'Waiting for your answer',
+      completedUnread: 'Response ready',
+      responseReady: 'Background session finished — click to view',
       handoffOrigin: platform => `Handed off from ${platform}`,
       renamed: 'Renamed',
       renameFailed: 'Rename failed',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1245,6 +1245,8 @@ export const ja = defineLocale({
       sessionRunning: 'セッション実行中',
       needsInput: '入力が必要です',
       waitingForAnswer: '回答を待っています',
+      completedUnread: '回答準備完了',
+      responseReady: 'バックグラウンドセッションが完了しました — クリックして表示',
       handoffOrigin: platform => `${platform} から引き継ぎ`,
       renamed: '名前を変更しました',
       renameFailed: '名前の変更に失敗しました',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -859,6 +859,8 @@ export interface Translations {
       sessionRunning: string
       needsInput: string
       waitingForAnswer: string
+      completedUnread: string
+      responseReady: string
       handoffOrigin: (platform: string) => string
       renamed: string
       renameFailed: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1211,6 +1211,8 @@ export const zhHant = defineLocale({
       sessionRunning: '工作階段執行中',
       needsInput: '需要您的輸入',
       waitingForAnswer: '等待您的回答',
+      completedUnread: '回覆就緒',
+      responseReady: '背景工作階段已完成，點擊查看',
       handoffOrigin: platform => `從 ${platform} 轉接`,
       renamed: '已重新命名',
       renameFailed: '重新命名失敗',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1298,6 +1298,8 @@ export const zh: Translations = {
       sessionRunning: '会话运行中',
       needsInput: '需要你输入',
       waitingForAnswer: '正在等待你的回答',
+      completedUnread: '回复就绪',
+      responseReady: '后台会话已完成，点击查看',
       handoffOrigin: platform => `从 ${platform} 转接`,
       renamed: '已重命名',
       renameFailed: '重命名失败',

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -5,6 +5,7 @@ import type { SessionInfo } from '@/types/hermes'
 import {
   $activeSessionId,
   $attentionSessionIds,
+  $completedUnreadSessionIds,
   $currentCwd,
   $workingSessionIds,
   applyConfiguredDefaultProjectDir,
@@ -12,6 +13,7 @@ import {
   mergeSessionPage,
   sessionPinId,
   setSessionAttention,
+  setSessionCompletedUnread,
   setSessionWorking,
   workspaceCwdForNewSession
 } from './session'
@@ -60,6 +62,32 @@ describe('setSessionAttention', () => {
     setSessionAttention('', true)
     setSessionAttention('missing', false)
     expect($attentionSessionIds.get()).toEqual([])
+  })
+})
+
+describe('setSessionCompletedUnread', () => {
+  afterEach(() => {
+    $completedUnreadSessionIds.set([])
+  })
+
+  it('adds and removes a session id without duplicating it', () => {
+    setSessionCompletedUnread('s1', true)
+    setSessionCompletedUnread('s1', true)
+    expect($completedUnreadSessionIds.get()).toEqual(['s1'])
+
+    setSessionCompletedUnread('s2', true)
+    expect($completedUnreadSessionIds.get()).toEqual(['s1', 's2'])
+
+    setSessionCompletedUnread('s1', false)
+    expect($completedUnreadSessionIds.get()).toEqual(['s2'])
+  })
+
+  it('ignores empty ids and no-op clears', () => {
+    setSessionCompletedUnread(null, true)
+    setSessionCompletedUnread(undefined, true)
+    setSessionCompletedUnread('', true)
+    setSessionCompletedUnread('missing', false)
+    expect($completedUnreadSessionIds.get()).toEqual([])
   })
 })
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -365,6 +365,18 @@ export function setSessionAttention(sessionId: string | null | undefined, needsI
   }
 }
 
+// Sessions that completed a turn while not the active session. A steady muted
+// green dot appears in the sidebar and session-switcher until the user
+// navigates to them. Cleared automatically on session focus.
+export const $completedUnreadSessionIds = atom<string[]>([])
+export const setCompletedUnreadSessionIds = (next: Updater<string[]>) => updateAtom($completedUnreadSessionIds, next)
+
+export function setSessionCompletedUnread(sessionId: string | null | undefined, completed: boolean) {
+  if (sessionId) {
+    toggleMembership(setCompletedUnreadSessionIds, sessionId, completed)
+  }
+}
+
 export function setSessionWorking(sessionId: string | null | undefined, working: boolean) {
   if (!sessionId) {
     return


### PR DESCRIPTION
## Problem

When working with multiple sessions in Hermes Desktop, there is no visual indicator that a **background session has finished its turn** while you were in a different session. You have to manually switch to each session to know if Hermes is done.

The existing amber attention dot tracks `needsInput` / clarify-blocked sessions (Hermes is waiting for *you*). The missing indicator is the reverse: *you* are waiting for Hermes, Hermes finished, but you were elsewhere.

## Solution

Add a `$completedUnreadSessionIds` nanostore that tracks sessions which completed a turn while not the active session. A steady muted green dot (`bg-green-400/60`) appears in the sidebar and session-switcher, cleared automatically when the user navigates to that session.

### Indicator states

| State | Visual |
|---|---|
| Working (active turn) | Pulsing accent dot (unchanged) |
| Needs input / clarify | Steady amber dot (unchanged) |
| **Completed, unread** | **Steady muted green dot** |
| Idle / up to date | Gray dot (unchanged) |

### Changes

- **`store/session.ts`** — Add `$completedUnreadSessionIds` atom + `setSessionCompletedUnread()` helper (mirrors existing `$attentionSessionIds` pattern)
- **`use-session-state-cache.ts`** — Detect `working→idle` transition on non-active sessions; clear indicator on session focus
- **`session-row.tsx`** — Subscribe to new atom, show green dot in `SidebarRowDot`
- **`session-switcher.tsx`** — Show green dot in `SwitcherDot`
- **i18n** — Add `completedUnread` / `responseReady` strings in 4 locales
- **Tests** — Unit tests for the new atom (add/remove/null-guard)

### Implementation notes

- Reuses the existing `toggleMembership()` + `updateAtom()` pattern from `$attentionSessionIds`
- Turn-completion detection piggybacks on the existing `previous.busy → next.busy` transition in `updateSessionState()`
- Clear-on-focus uses the existing `selectedStoredSessionId` effect, no new lifecycle hooks
- Green dot only shows when session is NOT working and NOT needing input (priority: amber > green > accent pulse > gray)

Closes #43611
