### PR TITLE
fix(cron): rewrite prompt skill refs during consolidation (#23398)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1143,13 +1143,68 @@ def save_job_output(job_id: str, output: str):
 # Skill reference rewriting (curator integration)
 # =============================================================================
 
+def _skill_ref_pattern(skill_name: str) -> re.Pattern:
+    """Return a regex that matches a standalone skill-name reference."""
+    return re.compile(r'(?<![`\w/-])(' + re.escape(skill_name) + r')(?![`\w/-])')
+
+
+def _prompt_has_skill_ref(prompt: Optional[str], skill_name: str) -> bool:
+    """Return True when prompt contains an exact skill-name reference."""
+    if not prompt:
+        return False
+    return bool(
+        re.search(r'`' + re.escape(skill_name) + r'`', prompt)
+        or _skill_ref_pattern(skill_name).search(prompt)
+    )
+
+
+def _rewrite_prompt_refs(
+    prompt: Optional[str],
+    consolidated: Dict[str, str],
+) -> tuple:
+    """Rewrite skill name references in cron prompt text.
+
+    Handles two patterns:
+    1. Backtick-wrapped references: `` `old-skill` `` → `` `new-skill` ``
+    2. Bare word references: ``old-skill`` → ``new-skill``
+
+    Only rewrites names that appear in ``consolidated`` (have a target).
+    Pruned/dropped names are left in place and reported separately.
+
+    Returns (new_prompt, was_rewritten).
+    """
+    if not prompt or not consolidated:
+        return prompt, False
+
+    rewritten = False
+    new_prompt = prompt
+
+    # Sort by longest name first to avoid partial matches
+    # (e.g., "old-skill-v2" before "old-skill" if both were consolidated)
+    for old_name in sorted(consolidated.keys(), key=len, reverse=True):
+        new_name = consolidated[old_name]
+        # Pattern 1: backtick-wrapped — `old_name` → `new_name`
+        bk_pattern = re.compile(r'`' + re.escape(old_name) + r'`')
+        new_prompt, count = bk_pattern.subn('`' + new_name + '`', new_prompt)
+        if count:
+            rewritten = True
+
+        # Pattern 2: bare word — match old_name as a standalone word
+        # (not part of a longer identifier like old-name-v2).
+        new_prompt, count = _skill_ref_pattern(old_name).subn(new_name, new_prompt)
+        if count:
+            rewritten = True
+
+    return new_prompt, rewritten
+
+
 def rewrite_skill_refs(
     consolidated: Optional[Dict[str, str]] = None,
     pruned: Optional[List[str]] = None,
 ) -> Dict[str, Any]:
     """Rewrite cron job skill references after a curator consolidation pass.
 
-    When the curator consolidates a skill X into umbrella Y (or archives X
+    When the curator consolidates skill X into umbrella Y (or archives X
     as pruned), any cron job that lists ``X`` in its ``skills`` field will
     fail to load ``X`` at run time — the scheduler logs a warning and
     skips the skill, so the job runs without the instructions it was
@@ -1165,6 +1220,8 @@ def rewrite_skill_refs(
       forwarding target.
     - Ordering and other skills in the list are preserved.
     - The legacy ``skill`` field is realigned via ``_apply_skill_fields``.
+    - Prompt text references to consolidated skills are rewritten when
+      unambiguous (backtick-wrapped or standalone word match).
 
     Args:
         consolidated: mapping of ``old_skill_name -> umbrella_skill_name``.
@@ -1182,6 +1239,8 @@ def rewrite_skill_refs(
                     "after": [...],
                     "mapped": {"old": "new", ...},
                     "dropped": ["old", ...],
+                    "prompt_rewritten": True/False,
+                    "prompt_warnings": ["...", ...],
                 },
                 ...
             ],
@@ -1234,6 +1293,29 @@ def rewrite_skill_refs(
             job["skill"] = new_skills[0] if new_skills else None
             changed = True
 
+            # Rewrite prompt text references for consolidated skills
+            prompt_rewritten = False
+            if mapped:
+                new_prompt, prompt_rewritten = _rewrite_prompt_refs(job.get("prompt"), mapped)
+                if prompt_rewritten:
+                    job["prompt"] = new_prompt
+
+            # Warn about pruned skill names still referenced in prompt text
+            prompt_warnings: List[str] = []
+            if dropped and job.get("prompt"):
+                _job_label = job.get("name") or job.get("id") or "unknown"
+                for _dropped_name in dropped:
+                    if _prompt_has_skill_ref(job["prompt"], _dropped_name):
+                        warning = (
+                            f"prompt still references pruned skill '{_dropped_name}' "
+                            "(no umbrella target)"
+                        )
+                        prompt_warnings.append(warning)
+                        logger.warning(
+                            "Curator: cron job '%s' %s",
+                            _job_label, warning,
+                        )
+
             rewrites.append({
                 "job_id": job.get("id"),
                 "job_name": job.get("name") or job.get("id"),
@@ -1241,6 +1323,8 @@ def rewrite_skill_refs(
                 "after": list(new_skills),
                 "mapped": mapped,
                 "dropped": dropped,
+                "prompt_rewritten": prompt_rewritten,
+                "prompt_warnings": prompt_warnings,
             })
 
         if changed:

--- a/tests/cron/test_rewrite_prompt_refs.py
+++ b/tests/cron/test_rewrite_prompt_refs.py
@@ -1,0 +1,250 @@
+"""Tests for prompt-text skill reference rewriting in rewrite_skill_refs.
+
+Bug: #23398 — when the curator consolidates a skill, rewrite_skill_refs
+updates the structured ``skills`` / ``skill`` fields but leaves stale skill
+names inside the freeform ``prompt`` text.  This produces a silent consistency
+gap: the job loads one skill while the prompt still names the old one.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure project root is importable
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+@pytest.fixture
+def cron_env(tmp_path, monkeypatch):
+    """Isolated cron environment with temp HERMES_HOME."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "cron").mkdir()
+    (hermes_home / "cron" / "output").mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    import cron.jobs as jobs_mod
+    monkeypatch.setattr(jobs_mod, "HERMES_DIR", hermes_home)
+    monkeypatch.setattr(jobs_mod, "CRON_DIR", hermes_home / "cron")
+    monkeypatch.setattr(jobs_mod, "JOBS_FILE", hermes_home / "cron" / "jobs.json")
+    monkeypatch.setattr(jobs_mod, "OUTPUT_DIR", hermes_home / "cron" / "output")
+
+    return hermes_home
+
+
+class TestPromptTextRewriteConsolidation:
+    """Consolidated skill names in prompt text should be rewritten."""
+
+    def test_backtick_wrapped_reference_rewritten(self, cron_env):
+        """Backtick-wrapped skill names should be rewritten automatically."""
+        from cron.jobs import create_job, get_job, rewrite_skill_refs
+
+        job = create_job(
+            prompt="Follow `old-skill` as the canonical spec.",
+            schedule="every 1h",
+            skills=["old-skill"],
+        )
+        rewrite_skill_refs(
+            consolidated={"old-skill": "umbrella-skill"},
+            pruned=[],
+        )
+
+        loaded = get_job(job["id"])
+        assert loaded["skills"] == ["umbrella-skill"]
+        assert "`umbrella-skill`" in loaded["prompt"]
+        assert "`old-skill`" not in loaded["prompt"]
+
+    def test_multiple_backtick_refs_all_rewritten(self, cron_env):
+        """Multiple backtick-wrapped references to the same old skill."""
+        from cron.jobs import create_job, get_job, rewrite_skill_refs
+
+        job = create_job(
+            prompt="See `old-skill` for details. Always follow `old-skill`.",
+            schedule="every 1h",
+            skills=["old-skill"],
+        )
+        rewrite_skill_refs(
+            consolidated={"old-skill": "new-skill"},
+            pruned=[],
+        )
+
+        loaded = get_job(job["id"])
+        assert "`new-skill`" in loaded["prompt"]
+        assert "`old-skill`" not in loaded["prompt"]
+        # Both occurrences replaced
+        assert loaded["prompt"].count("`new-skill`") == 2
+
+    def test_bare_word_reference_rewritten(self, cron_env):
+        """A bare skill name that is not backtick-wrapped but matches exactly."""
+        from cron.jobs import create_job, get_job, rewrite_skill_refs
+
+        job = create_job(
+            prompt="Load old-skill and execute it.",
+            schedule="every 1h",
+            skills=["old-skill"],
+        )
+        rewrite_skill_refs(
+            consolidated={"old-skill": "new-skill"},
+            pruned=[],
+        )
+
+        loaded = get_job(job["id"])
+        assert "new-skill" in loaded["prompt"]
+        assert "old-skill" not in loaded["prompt"]
+
+    def test_partial_name_not_rewritten(self, cron_env):
+        """A skill name that is a substring of a longer word should NOT be rewritten."""
+        from cron.jobs import create_job, get_job, rewrite_skill_refs
+
+        job = create_job(
+            prompt="Follow `old-skill-v2` as the spec.",
+            schedule="every 1h",
+            skills=["old-skill"],
+        )
+        rewrite_skill_refs(
+            consolidated={"old-skill": "new-skill"},
+            pruned=[],
+        )
+
+        loaded = get_job(job["id"])
+        # The skills list IS rewritten
+        assert loaded["skills"] == ["new-skill"]
+        # But the prompt reference `old-skill-v2` is NOT rewritten because
+        # it's a different name (substring match should not rewrite)
+        assert "`old-skill-v2`" in loaded["prompt"]
+
+    def test_prompt_none_handled_gracefully(self, cron_env):
+        """Jobs with no prompt should not crash."""
+        from cron.jobs import create_job, get_job, rewrite_skill_refs
+
+        job = create_job(
+            prompt=None,
+            schedule="every 1h",
+            skills=["old-skill"],
+        )
+        rewrite_skill_refs(
+            consolidated={"old-skill": "new-skill"},
+            pruned=[],
+        )
+
+        loaded = get_job(job["id"])
+        assert loaded["skills"] == ["new-skill"]
+
+
+class TestPromptTextRewritePruning:
+    """Pruned skill names in prompt text should be warned about."""
+
+    def test_pruned_skill_in_prompt_generates_warning(self, cron_env, caplog):
+        """When a pruned skill appears in prompt, report should note it."""
+        import logging
+
+        from cron.jobs import create_job, get_job, rewrite_skill_refs
+
+        job = create_job(
+            prompt="Follow `stale-skill` as the spec.",
+            schedule="every 1h",
+            skills=["stale-skill"],
+        )
+        with caplog.at_level(logging.WARNING, logger="cron.jobs"):
+            report = rewrite_skill_refs(
+                consolidated={},
+                pruned=["stale-skill"],
+            )
+
+        loaded = get_job(job["id"])
+        assert loaded["skills"] == []
+        # Prompt text is NOT auto-rewritten for pruned skills
+        # (there's no target to rewrite to), but the report should note it
+        assert len(report["rewrites"]) == 1
+        entry = report["rewrites"][0]
+        assert "stale-skill" in entry.get("dropped", [])
+        assert entry["prompt_warnings"] == [
+            "prompt still references pruned skill 'stale-skill' (no umbrella target)"
+        ]
+        assert "prompt still references pruned skill 'stale-skill'" in caplog.text
+
+    def test_pruned_skill_partial_name_does_not_warn(self, cron_env, caplog):
+        """Pruned skill warnings should not fire for longer skill-name substrings."""
+        import logging
+
+        from cron.jobs import create_job, rewrite_skill_refs
+
+        create_job(
+            prompt="Follow `stale-skill-v2` as the spec.",
+            schedule="every 1h",
+            skills=["stale-skill"],
+        )
+
+        with caplog.at_level(logging.WARNING, logger="cron.jobs"):
+            report = rewrite_skill_refs(
+                consolidated={},
+                pruned=["stale-skill"],
+            )
+
+        entry = report["rewrites"][0]
+        assert entry["prompt_warnings"] == []
+        assert "prompt still references pruned skill" not in caplog.text
+
+
+class TestPromptTextRewriteReport:
+    """Prompt rewrites should be recorded in the report."""
+
+    def test_report_includes_prompt_rewrites(self, cron_env):
+        from cron.jobs import create_job, rewrite_skill_refs
+
+        job = create_job(
+            prompt="Follow `old-skill` as the spec.",
+            schedule="every 1h",
+            skills=["old-skill"],
+        )
+        report = rewrite_skill_refs(
+            consolidated={"old-skill": "umbrella-skill"},
+            pruned=[],
+        )
+
+        assert len(report["rewrites"]) == 1
+        entry = report["rewrites"][0]
+        assert entry.get("prompt_rewritten") is True
+
+    def test_report_no_prompt_rewrite_when_no_prompt_refs(self, cron_env):
+        """Job has consolidated skill but prompt doesn't reference it."""
+        from cron.jobs import create_job, rewrite_skill_refs
+
+        job = create_job(
+            prompt="Do something unrelated.",
+            schedule="every 1h",
+            skills=["old-skill"],
+        )
+        report = rewrite_skill_refs(
+            consolidated={"old-skill": "umbrella-skill"},
+            pruned=[],
+        )
+
+        entry = report["rewrites"][0]
+        assert entry.get("prompt_rewritten") is False
+
+
+class TestPromptTextRewritePersistence:
+    """Prompt rewrites persist to disk."""
+
+    def test_prompt_rewrite_persists_to_disk(self, cron_env):
+        import json
+        from cron.jobs import create_job, rewrite_skill_refs, JOBS_FILE
+
+        create_job(
+            prompt="Follow `old-skill` as the canonical spec.",
+            schedule="every 1h",
+            skills=["old-skill"],
+        )
+        rewrite_skill_refs(
+            consolidated={"old-skill": "umbrella-skill"},
+            pruned=[],
+        )
+
+        data = json.loads(JOBS_FILE.read_text())
+        assert data["jobs"][0]["skills"] == ["umbrella-skill"]
+        assert "`umbrella-skill`" in data["jobs"][0]["prompt"]
+        assert "`old-skill`" not in data["jobs"][0]["prompt"]


### PR DESCRIPTION
## What changed

Fixes #23398 by keeping cron skill-consolidation rewrites consistent with freeform cron prompt text:

- Rewrites exact prompt references for consolidated skills, including backtick-wrapped references like `` `old-skill` `` and standalone bare references like `old-skill`.
- Preserves longer/partial names such as `` `old-skill-v2` `` so prompt prose is not rewritten accidentally.
- Emits and records `prompt_warnings` when a pruned skill still appears in the prompt and has no umbrella target.
- Persists prompt rewrites through the existing `rewrite_skill_refs()` save path and includes `prompt_rewritten` / `prompt_warnings` in the rewrite report.

## Verification

RED on upstream/main with the new regression tests:

```text
/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/cron/test_rewrite_prompt_refs.py -v -o addopts= --tb=short
8 failed, 2 passed
```

GREEN after the fix, rebased onto current upstream/main:

```text
/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/cron/test_rewrite_prompt_refs.py tests/cron/test_rewrite_skill_refs.py -v -o addopts= --tb=short
26 passed in 0.11s
```

Branch shape after rebase:

```text
git rev-list --left-right --count upstream/main...HEAD
0 1
```

## Competitor / duplicate check

Pre-publication gates found no open Tranquil-Flow PR for #23398 or `fix/23398*`.

A topic search found older PR #23433, but it is closed, not an open competing PR. Its approach was reviewed for scope; this PR keeps the fix focused to `rewrite_skill_refs()` plus production-path cron tests.

Auto-published by Moonsong via Path B automated pipeline.