### PR TITLE
Fix desktop WebSocket auth with served dashboard token

### DIFF
--- a/apps/desktop/electron/dashboard-token.cjs
+++ b/apps/desktop/electron/dashboard-token.cjs
@@ -1,0 +1,87 @@
+/**
+ * Helpers for local dashboard session-token discovery.
+ *
+ * The desktop main process can pass HERMES_DASHBOARD_SESSION_TOKEN when it
+ * spawns the local dashboard, but the dashboard is the source of truth for the
+ * token it actually serves to the renderer. If those drift, HTTP readiness
+ * probes still pass while /api/ws rejects the renderer's token.
+ */
+
+const http = require('node:http')
+const https = require('node:https')
+
+const DEFAULT_TOKEN_FETCH_TIMEOUT_MS = 3_000
+
+function fetchPublicText(url, options = {}) {
+  return new Promise((resolve, reject) => {
+    let parsed
+    try {
+      parsed = new URL(url)
+    } catch (error) {
+      reject(new Error(`Invalid URL: ${error.message}`))
+      return
+    }
+
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      reject(new Error(`Unsupported Hermes backend URL protocol: ${parsed.protocol}`))
+      return
+    }
+
+    const client = parsed.protocol === 'https:' ? https : http
+    const timeoutMs = options.timeoutMs ?? DEFAULT_TOKEN_FETCH_TIMEOUT_MS
+    const req = client.request(parsed, { method: options.method || 'GET' }, res => {
+      const chunks = []
+      res.on('data', chunk => chunks.push(chunk))
+      res.on('end', () => {
+        const text = Buffer.concat(chunks).toString('utf8')
+        if ((res.statusCode || 500) >= 400) {
+          reject(new Error(`${res.statusCode}: ${text || res.statusMessage}`))
+          return
+        }
+        resolve(text)
+      })
+    })
+
+    req.on('error', reject)
+    req.setTimeout(timeoutMs, () => {
+      req.destroy(new Error(`Timed out connecting to Hermes backend after ${timeoutMs}ms`))
+    })
+    req.end()
+  })
+}
+
+function extractInjectedDashboardToken(html) {
+  const match = /window\.__HERMES_SESSION_TOKEN__\s*=\s*("(?:\\.|[^"\\])*")/.exec(String(html || ''))
+  if (!match) return null
+  try {
+    return JSON.parse(match[1])
+  } catch {
+    return null
+  }
+}
+
+function dashboardIndexUrl(baseUrl) {
+  return `${String(baseUrl || '').replace(/\/+$/, '')}/`
+}
+
+async function resolveServedDashboardToken(baseUrl, fallbackToken, options = {}) {
+  const fetchText = options.fetchText || fetchPublicText
+  const html = await fetchText(dashboardIndexUrl(baseUrl), {
+    timeoutMs: options.timeoutMs ?? DEFAULT_TOKEN_FETCH_TIMEOUT_MS
+  })
+  const servedToken = extractInjectedDashboardToken(html)
+
+  if (servedToken && servedToken !== fallbackToken && typeof options.rememberLog === 'function') {
+    options.rememberLog('[boot] dashboard served a different session token; using served token for WebSocket auth')
+  }
+
+  return servedToken || fallbackToken
+}
+
+module.exports = {
+  DEFAULT_TOKEN_FETCH_TIMEOUT_MS,
+  dashboardIndexUrl,
+  extractInjectedDashboardToken,
+  fetchPublicText,
+  resolveServedDashboardToken
+}

--- a/apps/desktop/electron/dashboard-token.test.cjs
+++ b/apps/desktop/electron/dashboard-token.test.cjs
@@ -1,0 +1,89 @@
+/**
+ * Tests for electron/dashboard-token.cjs.
+ *
+ * Run with: node --test electron/dashboard-token.test.cjs
+ * (Wired into npm test:desktop:platforms in package.json.)
+ */
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const {
+  dashboardIndexUrl,
+  extractInjectedDashboardToken,
+  fetchPublicText,
+  resolveServedDashboardToken
+} = require('./dashboard-token.cjs')
+
+test('extractInjectedDashboardToken reads the JSON-encoded dashboard token', () => {
+  const html = '<script>window.__HERMES_SESSION_TOKEN__="served-token";window.__HERMES_BASE_PATH__=""</script>'
+  assert.equal(extractInjectedDashboardToken(html), 'served-token')
+})
+
+test('extractInjectedDashboardToken handles escaped token strings', () => {
+  const html = '<script>window.__HERMES_SESSION_TOKEN__="served\\\\token\\"quoted";</script>'
+  assert.equal(extractInjectedDashboardToken(html), 'served\\token"quoted')
+})
+
+test('extractInjectedDashboardToken returns null for missing or malformed values', () => {
+  assert.equal(extractInjectedDashboardToken('<html></html>'), null)
+  assert.equal(extractInjectedDashboardToken('<script>window.__HERMES_SESSION_TOKEN__={bad}</script>'), null)
+})
+
+test('dashboardIndexUrl preserves dashboard path prefixes', () => {
+  assert.equal(dashboardIndexUrl('http://127.0.0.1:9120'), 'http://127.0.0.1:9120/')
+  assert.equal(dashboardIndexUrl('https://host.example/hermes/'), 'https://host.example/hermes/')
+})
+
+test('resolveServedDashboardToken uses the served token and logs when it differs', async () => {
+  const logs = []
+  const token = await resolveServedDashboardToken('http://127.0.0.1:9120', 'spawn-token', {
+    fetchText: async url => {
+      assert.equal(url, 'http://127.0.0.1:9120/')
+      return '<script>window.__HERMES_SESSION_TOKEN__="served-token";</script>'
+    },
+    rememberLog: line => logs.push(line)
+  })
+
+  assert.equal(token, 'served-token')
+  assert.equal(logs.length, 1)
+  assert.match(logs[0], /served a different session token/)
+})
+
+test('resolveServedDashboardToken falls back when the served HTML has no token', async () => {
+  const token = await resolveServedDashboardToken('http://127.0.0.1:9120', 'spawn-token', {
+    fetchText: async () => '<html></html>',
+    rememberLog: () => {
+      throw new Error('should not log when no served token is present')
+    }
+  })
+
+  assert.equal(token, 'spawn-token')
+})
+
+test('resolveServedDashboardToken does not log when served token matches fallback', async () => {
+  const token = await resolveServedDashboardToken('http://127.0.0.1:9120', 'same-token', {
+    fetchText: async () => '<script>window.__HERMES_SESSION_TOKEN__="same-token";</script>',
+    rememberLog: () => {
+      throw new Error('should not log when token already matches')
+    }
+  })
+
+  assert.equal(token, 'same-token')
+})
+
+test('resolveServedDashboardToken propagates fetch errors so callers can fall back explicitly', async () => {
+  await assert.rejects(
+    () =>
+      resolveServedDashboardToken('http://127.0.0.1:9120', 'spawn-token', {
+        fetchText: async () => {
+          throw new Error('boom')
+        }
+      }),
+    /boom/
+  )
+})
+
+test('fetchPublicText rejects unsupported protocols', async () => {
+  await assert.rejects(() => fetchPublicText('file:///tmp/index.html'), /Unsupported Hermes backend URL protocol/)
+})

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -29,6 +29,7 @@ const { runBootstrap } = require('./bootstrap-runner.cjs')
 const { buildSessionWindowUrl, createSessionWindowRegistry } = require('./session-windows.cjs')
 const { canImportHermesCli, verifyHermesCli } = require('./backend-probes.cjs')
 const { probeGatewayWebSocket } = require('./gateway-ws-probe.cjs')
+const { resolveServedDashboardToken } = require('./dashboard-token.cjs')
 const { serializeJsonBody, setJsonRequestHeaders } = require('./oauth-net-request.cjs')
 const { fetchMarketplaceThemes, searchMarketplaceThemes } = require('./vscode-marketplace.cjs')
 const {
@@ -4547,15 +4548,20 @@ async function spawnPoolBackend(profile, entry) {
   const baseUrl = `http://127.0.0.1:${port}`
   await Promise.race([waitForHermes(baseUrl, token), startFailed])
   ready = true
+  const authToken = await resolveServedDashboardToken(baseUrl, token, { rememberLog }).catch(error => {
+    rememberLog(`[boot] could not read served dashboard token for profile "${profile}": ${error.message}`)
+    return token
+  })
+  entry.token = authToken
 
   return {
     baseUrl,
     mode: 'local',
     source: 'local',
     authMode: 'token',
-    token,
+    token: authToken,
     profile,
-    wsUrl: `ws://127.0.0.1:${port}/api/ws?token=${encodeURIComponent(token)}`,
+    wsUrl: `ws://127.0.0.1:${port}/api/ws?token=${encodeURIComponent(authToken)}`,
     logs: hermesLog.slice(-80),
     ...getWindowState()
   }
@@ -4774,6 +4780,10 @@ async function startHermes() {
     await advanceBootProgress('backend.wait', 'Waiting for Hermes backend to become ready', 90)
     await Promise.race([waitForHermes(baseUrl, token), backendStartFailed])
     backendReady = true
+    const authToken = await resolveServedDashboardToken(baseUrl, token, { rememberLog }).catch(error => {
+      rememberLog(`[boot] could not read served dashboard token: ${error.message}`)
+      return token
+    })
     updateBootProgress({
       phase: 'backend.ready',
       message: 'Hermes backend is ready. Finalizing desktop startup',
@@ -4787,8 +4797,8 @@ async function startHermes() {
       mode: 'local',
       source: 'local',
       authMode: 'token',
-      token,
-      wsUrl: `ws://127.0.0.1:${port}/api/ws?token=${encodeURIComponent(token)}`,
+      token: authToken,
+      wsUrl: `ws://127.0.0.1:${port}/api/ws?token=${encodeURIComponent(authToken)}`,
       logs: hermesLog.slice(-80),
       ...getWindowState()
     }

--- a/apps/desktop/electron/windows-child-process.test.cjs
+++ b/apps/desktop/electron/windows-child-process.test.cjs
@@ -8,7 +8,7 @@ const path = require('node:path')
 const ELECTRON_DIR = __dirname
 
 function readElectronFile(name) {
-  return fs.readFileSync(path.join(ELECTRON_DIR, name), 'utf8')
+  return fs.readFileSync(path.join(ELECTRON_DIR, name), 'utf8').replace(/\r\n/g, '\n')
 }
 
 function requireHiddenChildOptions(source, needle) {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -35,7 +35,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/windows-child-process.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/dashboard-token.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/windows-child-process.test.cjs",
     "typecheck": "tsc -p . --noEmit",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",


### PR DESCRIPTION
What does this PR do?

Fixes a desktop startup/WebSocket auth failure where the local dashboard serves a different session token than the one the Electron main process generated when spawning the backend.

The old desktop path used the spawn-time token for renderer state and `/api/ws?token=...`. In the failure mode seen on Windows, `GET /api/status` still returned 200, but the rendered dashboard HTML injected a different `window.__HERMES_SESSION_TOKEN__`. The UI then attempted the WebSocket handshake with the stale token and the gateway rejected it, surfacing as `Could not connect to Hermes gateway` or follow-on renderer IPC errors after boot.

Production impact: Hermes Desktop could appear repaired or updated, launch the local dashboard, and pass HTTP readiness, but still fail to start the usable UI because the renderer could not authenticate the WebSocket session. Live local smoke on `127.0.0.1:9120` confirmed the served dashboard token differed from the fallback token; `/api/ws?token=<served>` connected, while `/api/ws?token=<fallback>` was rejected.

Why this approach: the served dashboard HTML is the source of truth for the token the renderer will use. The fix reads that injected token after the backend is ready and uses it for local desktop state and WebSocket URLs. If discovery fails or the served HTML has no token, the previous spawn-time token remains the fallback, so the new path does not do less than the old one.

Tags

- `type/bug`
- `area/auth`
- `javascript`
- `comp/gateway`
- `codex`
Related Issue

No existing issue found. This came from Windows desktop update/startup forensics after a local Hermes Desktop repair left the app unable to connect to its gateway.

Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

Changes Made

- `apps/desktop/electron/dashboard-token.cjs` - new helper for fetching the served dashboard index, extracting the JSON-encoded `window.__HERMES_SESSION_TOKEN__`, preserving path prefixes, and falling back safely when no token is present.
- `apps/desktop/electron/main.cjs` - after local backend readiness, resolves the served dashboard token and uses it for returned desktop session state and `/api/ws` URLs in both primary and pooled local backend paths.
- `apps/desktop/electron/dashboard-token.test.cjs` - focused unit coverage for token extraction, escaped strings, malformed HTML fallback, differing-token logging, fetch error propagation, and unsupported protocol rejection.
- `apps/desktop/package.json` - wires the new token tests into `test:desktop:platforms`.
- `apps/desktop/electron/windows-child-process.test.cjs` - normalizes CRLF to LF while reading source so the Windows child-process audit remains meaningful on Windows checkouts.

How to Test

Run the desktop platform suite:

```text
npm.cmd run test:desktop:platforms

tests 128
pass 128
fail 0
```

Run the desktop typecheck:

```text
npm.cmd run typecheck

tsc -p . --noEmit
```

Run scoped lint for the changed files:

```text
npm.cmd exec -- eslint electron/main.cjs electron/dashboard-token.cjs electron/dashboard-token.test.cjs electron/windows-child-process.test.cjs
```

Run the desktop build:

```text
npm.cmd run build

assert-dist-built: dist/index.html + assets present
```

Live smoke on the Windows desktop dashboard:

```text
resolveServedDashboardToken('http://127.0.0.1:9120', 'desktop-fallback-token')
=> token_source=served; length=44

probeGatewayWebSocket('ws://127.0.0.1:9120/api/ws?token=<served>')
=> {"tokenSource":"served","wsOk":true,"reason":null}

probeGatewayWebSocket('ws://127.0.0.1:9120/api/ws?token=desktop-fallback-token')
=> {"fallbackWsOk":false,"reason":"WebSocket connection failed."}
```

Package-wide lint note:

```text
npm.cmd run lint
=> still red on pre-existing unrelated app files.

Scoped ESLint on this PR's changed files passes.
```

Checklist

Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant tests for this change
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows desktop

Documentation & Housekeeping

- [x] I've updated relevant documentation - N/A, no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A, no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact - token helper supports HTTP/HTTPS and preserves dashboard path prefixes; fallback keeps prior behavior if discovery fails
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A, no schema changes

Screenshots / Logs

Before, stale fallback token rejected by the live gateway:

```text
{"fallbackWsOk":false,"reason":"WebSocket connection failed."}
```

After, served dashboard token accepted by the live gateway:

```text
{"tokenSource":"served","wsOk":true,"reason":null}
```

Hermes boot log when the served token differs:

```text
[boot] dashboard served a different session token; using served token for WebSocket auth
```
