### PR TITLE
initial support for adding Diffbot Web Search API plugin support

### DIFF
--- a/plugins/web/diffbot/__init__.py
+++ b/plugins/web/diffbot/__init__.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from .provider import DiffbotWebSearchProvider
+
+
+def register(ctx) -> None:
+    """Register the Diffbot provider with the plugin context."""
+    ctx.register_web_search_provider(DiffbotWebSearchProvider())

--- a/plugins/web/diffbot/plugin.yaml
+++ b/plugins/web/diffbot/plugin.yaml
@@ -1,0 +1,9 @@
+name: web-diffbot
+version: 1.0.0
+description: "Diffbot Web Search"
+author: Raymond Camden
+kind: backend
+provides_web_providers:
+  - diffbot
+requires_env:
+  - DIFFBOT_API_KEY

--- a/plugins/web/diffbot/provider.py
+++ b/plugins/web/diffbot/provider.py
@@ -1,0 +1,68 @@
+# plugins/web/my-backend/provider.py
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List
+
+from agent.web_search_provider import WebSearchProvider
+
+class DiffbotWebSearchProvider(WebSearchProvider):
+    """Minimal search-only provider against the Diffbot HTTP API."""
+
+    @property
+    def name(self) -> str:
+        # Stable id used in web.search_backend / web.extract_backend / web.backend
+        # config keys. Lowercase, no spaces; hyphens permitted.
+        return "diffbot"
+
+    @property
+    def display_name(self) -> str:
+        # Human label shown in `hermes tools`. Defaults to `name`.
+        # Corrected typo in Diffbot
+        return "Diffbot Web Search"
+
+    def is_available(self) -> bool:
+        # Cheap check — env var present, optional dep importable, etc.
+        # MUST NOT make network calls (runs on every `hermes tools` paint).
+        return bool(os.getenv("DIFFBOT_API_TOKEN", "").strip()) or bool(os.getenv("DIFFBOT_API_KEY", "").strip())
+
+    def supports_search(self) -> bool:
+        return True
+
+    def supports_extract(self) -> bool:
+        return False
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        import httpx
+
+        api_key = os.getenv("DIFFBOT_API_TOKEN") or os.getenv("DIFFBOT_API_KEY")
+        if not api_key:
+            raise KeyError("Neither DIFFBOT_API_TOKEN nor DIFFBOT_API_KEY is set in the environment.")
+        try:
+            resp = httpx.get(
+                "https://llm.diffbot.com/api/v1/web_search",
+                params={"text": query, "count": max(1, min(int(limit), 20))},
+                headers={"Authorization": f"Bearer {api_key}"},
+                timeout=15,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        except httpx.HTTPError as exc:
+            return {"success": False, "error": str(exc)}
+
+        # Response shape is fixed — see "Response shape" below.
+        results_list = data.get("search_results") or data.get("results") or []
+        return {
+            "success": True,
+            "data": {
+                "web": [
+                    {
+                        "title": item.get("title", ""),
+                        "url": item.get("pageUrl") or item.get("url") or "",
+                        "description": item.get("content") or item.get("snippet") or item.get("description") or "",
+                        "position": idx + 1,
+                    }
+                    for idx, item in enumerate(results_list)
+                ],
+            },
+        }


### PR DESCRIPTION
## What does this PR do?

This adds a web search plugin for Diffbot's new Web Search API. 


## Related Issue

N/A

Fixes #

N/A

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

Adds `plugins/web/diffbot`.
- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Get a key from diffbot, https://app.diffbot.com/get-started
2. Set DIFFBOT_API_KEY=X (where X is your key obvious) in your environment
3. Enable the plugin in Hermes
4. Use a prompt that kicks off the web search plugin.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

Tests failed for me in a virgin clone with me touching nothing. I spoke about this in the Discord so afaik, it is not related to my change. 

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

