### PR TITLE
fix(profile-builder): key skills by frontmatter name in _disable_unselected_skills

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7965,6 +7965,7 @@ def _disable_unselected_skills(profile_dir: Path, keep: List[str]) -> int:
     """
     from hermes_constants import set_hermes_home_override, reset_hermes_home_override
     from hermes_cli.skills_config import get_disabled_skills, save_disabled_skills
+    from agent.skill_utils import parse_frontmatter
 
     keep_set = {s.strip() for s in keep if s and s.strip()}
     disabled_count = 0
@@ -7974,7 +7975,17 @@ def _disable_unselected_skills(profile_dir: Path, keep: List[str]) -> int:
         skills_root = profile_dir / "skills"
         if skills_root.is_dir():
             for md in skills_root.rglob("SKILL.md"):
-                installed.append(md.parent.name)
+                # Use the frontmatter `name:` field so that skills whose
+                # directory name differs from their frontmatter name (e.g.
+                # "vllm" dir vs "serving-llms-vllm" frontmatter) are keyed
+                # consistently with what skills_list() and the runtime
+                # disabled-list check use.
+                try:
+                    fm, _ = parse_frontmatter(md.read_text(encoding="utf-8"))
+                    skill_name = fm.get("name") or md.parent.name
+                except Exception:
+                    skill_name = md.parent.name
+                installed.append(skill_name)
         cfg = load_config()
         disabled = get_disabled_skills(cfg)
         for name in installed:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2502,6 +2502,68 @@ class TestNewEndpoints:
         finally:
             reset_hermes_home_override(token)
 
+    def test_profiles_create_keep_skills_uses_frontmatter_name(self, monkeypatch):
+        """keep_skills matching uses frontmatter `name:` not the on-disk directory
+        name.  When a skill's directory is "vllm" but its frontmatter name is
+        "serving-llms-vllm", passing keep_skills=["serving-llms-vllm"] must keep
+        the skill active, and the disabled entry written for a *dropped* skill must
+        also use its frontmatter name so the runtime disabled-list check matches."""
+        from hermes_constants import (
+            get_hermes_home,
+            set_hermes_home_override,
+            reset_hermes_home_override,
+        )
+        from hermes_cli.config import load_config
+        from hermes_cli.skills_config import get_disabled_skills
+        import hermes_cli.profiles as profiles_mod
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(profiles_mod, "create_wrapper_script", lambda name: None)
+
+        # Seed two skills whose directory names differ from frontmatter names.
+        def fake_seed(profile_dir, quiet=False):
+            for dir_name, fm_name in (
+                ("vllm", "serving-llms-vllm"),        # user keeps this
+                ("audiocraft", "audiocraft-audio"),    # user drops this
+            ):
+                d = profile_dir / "skills" / "mlops" / dir_name
+                d.mkdir(parents=True)
+                (d / "SKILL.md").write_text(
+                    f"---\nname: {fm_name}\n---\n", encoding="utf-8"
+                )
+            return {"copied": ["vllm", "audiocraft"]}
+
+        monkeypatch.setattr(profiles_mod, "seed_profile_skills", fake_seed)
+        monkeypatch.setattr(web_server, "_spawn_hermes_action", lambda *a, **kw: type("P", (), {"pid": 1})())
+
+        resp = self.client.post(
+            "/api/profiles",
+            json={
+                "name": "fm-name-test",
+                # keep only the vllm skill (by its frontmatter name)
+                "keep_skills": ["serving-llms-vllm"],
+            },
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["skills_disabled"] == 1  # only audiocraft dropped
+
+        prof_dir = get_hermes_home() / "profiles" / "fm-name-test"
+        token = set_hermes_home_override(str(prof_dir))
+        try:
+            cfg = load_config()
+            disabled = get_disabled_skills(cfg)
+            # Kept skill must NOT be in disabled list.
+            assert "serving-llms-vllm" not in disabled
+            assert "vllm" not in disabled
+            # Dropped skill must be disabled by its frontmatter name so the
+            # runtime disabled-list check (which also uses frontmatter name) works.
+            assert "audiocraft-audio" in disabled
+            assert "audiocraft" not in disabled
+        finally:
+            reset_hermes_home_override(token)
+
     def test_profile_open_terminal_uses_macos_terminal(self, monkeypatch):
         from hermes_constants import get_hermes_home
         import hermes_cli.web_server as web_server


### PR DESCRIPTION
## Problem

`_disable_unselected_skills()` builds its `installed` list from on-disk **directory names** (`md.parent.name`), but both the frontend (`keep_skills` payload) and the runtime disabled-list check use **frontmatter `name:`** values.

For the 19 skills in the repo where directory name ≠ frontmatter name (e.g. `vllm/` → `"serving-llms-vllm"`, `audiocraft/` → `"audiocraft-audio-generation"`, `creative-ideation/` → `"ideation"`, …) this caused two silent failures:

1. **keep_set miss** — a skill the user selected to keep (by its frontmatter name) was not found in `keep_set`, so it was incorrectly added to the disabled list.
2. **Ineffective disable** — the disabled entry was written with the directory name, but `_find_all_skills()` checks `frontmatter.get("name", dir_name)` against the disabled set, so the disable had no effect — a deselected skill stayed active.

Net result: the profile builder's skill-selection step silently mismatches for these 19 skills. Skills the user kept active could be marked disabled (wrong key, no runtime effect), and skills the user deselected stayed active (disabled key never matched).

The 4 skills seeded into **every new profile** via `skills/mlops/` are affected on fresh profile creation: `vllm`, `audiocraft`, `segment-anything`, `lm-evaluation-harness`. The remaining 15 are in `optional-skills/` and affect clone-based profiles.

## Fix

Read the frontmatter `name:` field for each `SKILL.md`, falling back to the directory name on read/parse error. This mirrors the identical fix applied to `skill_view()` in 9caa12f4ec.

## Test

Adds a regression test (`test_profiles_create_keep_skills_uses_frontmatter_name`) that seeds two skills with mismatched directory/frontmatter names, then:
- asserts the kept skill (by frontmatter name) is **not** in the disabled list
- asserts the dropped skill's disabled entry uses its **frontmatter name** (so the runtime check matches)

The test fails on `main` (`skills_disabled == 2` instead of `1`) and passes with this fix.

## Checklist
- [x] Root cause identified and fixed
- [x] Regression test added (fails on `main`, passes with fix)
- [x] All 263 `test_web_server.py` tests pass
- [x] Mirrors the frontmatter-name resolution pattern from `9caa12f4ec`