### PR TITLE
feat(photon): add native reactions

### DIFF
--- a/plugins/platforms/photon/README.md
+++ b/plugins/platforms/photon/README.md
@@ -131,7 +131,9 @@ All env vars are documented in `plugin.yaml`. The most important:
   documents are sent via `space.send(attachment(...))` /
   `space.send(voice(...))` through the sidecar's `/send-attachment`
   endpoint; a caption is delivered as a separate text bubble after the media.
-- **Reactions, message effects, polls** — supported by `spectrum-ts` but not
-  yet exposed; the sidecar is the natural place to add them.
+- **Reactions/tapbacks are supported.** Hermes sends native reactions through
+  `spectrum-ts`' `reaction(...)` builder via the sidecar's `/react` endpoint.
+- **Message effects and polls** — supported by `spectrum-ts` but not yet
+  exposed; the sidecar is the natural place to add them.
 
 [photon]: https://photon.codes/

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -758,6 +758,29 @@ class PhotonAdapter(BasePlatformAdapter):
             chat_id, animation_url, caption, reply_to, metadata,
         )
 
+    async def send_reaction(
+        self,
+        chat_id: str,
+        message_id: str,
+        emoji: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a native iMessage reaction/tapback to a Photon message."""
+        if not message_id.strip() or not emoji.strip():
+            return SendResult(success=False, error="message_id and emoji are required")
+        try:
+            await self._sidecar_call(
+                "/react",
+                {
+                    "spaceId": chat_id,
+                    "messageId": message_id.strip(),
+                    "emoji": emoji.strip(),
+                },
+            )
+        except Exception as e:
+            return SendResult(success=False, error=str(e))
+        return SendResult(success=True)
+
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         try:
             await self._sidecar_call(

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -24,6 +24,8 @@
 //       body: {"spaceId": "...", "path": "...", "name": "..." | null,
 //              "mimeType": "..." | null, "caption": "..." | null,
 //              "kind": "attachment" | "voice"}
+//   - POST /react       -> {"ok": true}
+//       body: {"spaceId": "...", "messageId": "...", "emoji": "👍"}
 //   - POST /typing      -> {"ok": true}
 //       body: {"spaceId": "...", "state": "start" | "stop"}
 //   - POST /shutdown    -> {"ok": true}; then process exits
@@ -70,11 +72,12 @@ if (!projectId || !projectSecret || !sharedToken) {
 
 // Lazy-load spectrum-ts so a missing install fails with a clear message
 // instead of a cryptic module-resolution error during import.
-let Spectrum, imessage, attachment, voice, spectrumText, spectrumTyping;
+let Spectrum, imessage, attachment, spectrumReaction, voice, spectrumText, spectrumTyping;
 try {
   ({
     Spectrum,
     attachment,
+    reaction: spectrumReaction,
     voice,
     text: spectrumText,
     typing: spectrumTyping,
@@ -485,6 +488,21 @@ const server = http.createServer(async (req, res) => {
         }
       }
       return ok(res, { messageId: result?.id || null });
+    }
+    if (req.url === "/react") {
+      const { spaceId, messageId, emoji } = body || {};
+      if (!spaceId || !messageId || typeof emoji !== "string" || !emoji.trim()) {
+        return badRequest(res, "spaceId, messageId and emoji are required");
+      }
+      const space = await resolveSpace(spaceId);
+      const target = {
+        id: String(messageId),
+        content: await spectrumText("reaction target").build(),
+        sender: { id: "unknown" },
+        space: { id: spaceId },
+      };
+      await space.send(spectrumReaction(emoji.trim(), target));
+      return ok(res, {});
     }
     if (req.url === "/typing") {
       const { spaceId, state = "start" } = body || {};

--- a/tests/plugins/platforms/photon/test_outbound_media.py
+++ b/tests/plugins/platforms/photon/test_outbound_media.py
@@ -183,6 +183,34 @@ async def test_send_image_url_fetch_failure_falls_back_to_text(
 
 
 @pytest.mark.asyncio
+async def test_send_reaction_hits_react_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    adapter = _make_adapter(monkeypatch)
+    calls = _capture_sidecar(adapter)
+
+    result = await adapter.send_reaction("any;-;+1", " msg-abc ", " 👍 ")
+
+    assert result.success is True
+    assert calls == [
+        (
+            "/react",
+            {"spaceId": "any;-;+1", "messageId": "msg-abc", "emoji": "👍"},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_send_reaction_requires_target_and_emoji(monkeypatch: pytest.MonkeyPatch) -> None:
+    adapter = _make_adapter(monkeypatch)
+    calls = _capture_sidecar(adapter)
+
+    result = await adapter.send_reaction("any;-;+1", "", "👍")
+
+    assert result.success is False
+    assert "required" in (result.error or "")
+    assert calls == []
+
+
+@pytest.mark.asyncio
 async def test_send_attachment_rejects_unsafe_path(
     monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/website/docs/user-guide/messaging/photon.md
+++ b/website/docs/user-guide/messaging/photon.md
@@ -202,6 +202,8 @@ Common issues:
   `voice()` content builders via the sidecar's `/send-attachment`
   endpoint. Captions arrive as a separate iMessage bubble after the
   media.
+- **Reactions/tapbacks are supported.** Hermes sends native reactions through
+  spectrum-ts' `reaction()` builder via the sidecar's `/react` endpoint.
 - **Photon's free quotas:** 5,000 messages per server per day,
   50 new-conversation initiations per shared line per day. Increases
   available — email `help@photon.codes`.


### PR DESCRIPTION
## Summary
- Adds a Photon sidecar `/react` endpoint backed by `spectrum-ts`' native `reaction(...)` builder
- Adds `PhotonAdapter.send_reaction(...)` for sending iMessage tapbacks/reactions to a target Photon message id
- Updates Photon README and website docs to mark reactions/tapbacks as supported
- Adds regression coverage for the reaction endpoint body shape and validation

## Why
`spectrum-ts` already exposes reactions through the universal `reaction(emoji, targetMessage)` content builder. This exposes the existing Photon sidecar/adapter layer without adding a new model tool or changing the global tool schema.

## Verification
- `node --check plugins/platforms/photon/sidecar/index.mjs`
- Local reaction-builder smoke test with `spectrum-ts` → `reaction builder ok: 👍 msg-abc`
- `venv/bin/python -m pytest tests/plugins/platforms/photon/test_outbound_media.py -q -o 'addopts='` → 10 passed
- `venv/bin/python -m pytest tests/plugins/platforms/photon -q -o 'addopts='` → 68 passed
