### PR TITLE
feat: add cron doctor health check

### DIFF
--- a/docs/cron-doctor-spec.md
+++ b/docs/cron-doctor-spec.md
@@ -1,0 +1,32 @@
+# Cron Doctor Spec
+
+## Problem
+
+Scheduled jobs can silently degrade when a script is moved, a workdir disappears,
+a provider run fails, or delivery starts failing. `hermes cron list` shows some of
+this inline, but there is no compact read-only health check that can be run from a
+terminal, cron job, or CI-style smoke check.
+
+## Goal
+
+Add `hermes cron doctor` as a read-only diagnostic command that summarizes cron
+job health and exits non-zero when actionable issues are found.
+
+## Non-goals
+
+- Do not mutate jobs or auto-repair state.
+- Do not start/stop the gateway.
+- Do not inspect secrets or print credentials.
+
+## Acceptance criteria
+
+- `hermes cron doctor` returns `0` and prints a healthy message when active jobs
+  have no detected issues.
+- It returns `1` and prints grouped job-level issues when any active job has:
+  - last run failure (`last_status` not `ok`),
+  - last delivery failure,
+  - no `next_run_at` while still active,
+  - `no_agent` enabled without a script,
+  - script path missing/outside `HERMES_HOME/scripts`, or
+  - configured workdir path missing.
+- Parser, command dispatch, and focused tests cover the new subcommand.

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -9,7 +9,7 @@ import json
 import re
 import sys
 from pathlib import Path
-from typing import Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 sys.path.insert(0, str(PROJECT_ROOT))
@@ -187,6 +187,100 @@ def cron_status():
     print()
 
 
+def _scripts_dir_for_cron() -> Path:
+    """Return the scripts directory used by cron jobs.
+
+    Prefer ``cron.jobs.CRON_DIR.parent`` over a fresh ``get_hermes_home()`` call
+    so tests and profile-aware callers that monkeypatch cron storage inspect the
+    same Hermes home the jobs were loaded from.
+    """
+    from cron.jobs import CRON_DIR
+
+    return CRON_DIR.parent / "scripts"
+
+
+def _script_health_issue(script: str) -> Optional[str]:
+    """Return a human-readable script issue, or ``None`` when the path is OK."""
+    scripts_dir = _scripts_dir_for_cron().resolve()
+    raw = Path(script).expanduser()
+    path = raw.resolve() if raw.is_absolute() else (scripts_dir / raw).resolve()
+
+    try:
+        path.relative_to(scripts_dir)
+    except ValueError:
+        return f"script resolves outside HERMES_HOME/scripts: {script!r}"
+
+    if not path.exists():
+        return f"script not found: {path}"
+    if not path.is_file():
+        return f"script path is not a file: {path}"
+    return None
+
+
+def _cron_doctor_issues_for_job(job: Dict[str, Any]) -> List[str]:
+    issues: List[str] = []
+
+    last_status = str(job.get("last_status") or "").strip().lower()
+    if last_status and last_status != "ok":
+        err = str(job.get("last_error") or "unknown error").strip()
+        issues.append(f"last run failed: {err}")
+
+    delivery_err = str(job.get("last_delivery_error") or "").strip()
+    if delivery_err:
+        issues.append(f"last delivery failed: {delivery_err}")
+
+    if job.get("enabled", True) and job.get("state") not in {"paused", "completed"}:
+        if not job.get("next_run_at"):
+            issues.append("active job has no next_run_at")
+
+    script = str(job.get("script") or "").strip()
+    if job.get("no_agent") and not script:
+        issues.append("no-agent job has no script")
+    if script:
+        script_issue = _script_health_issue(script)
+        if script_issue:
+            issues.append(script_issue)
+
+    workdir = str(job.get("workdir") or "").strip()
+    if workdir and not Path(workdir).expanduser().exists():
+        issues.append(f"workdir not found: {workdir}")
+
+    return issues
+
+
+def cron_doctor() -> int:
+    """Run read-only cron health checks and return a shell-friendly status."""
+    from cron.jobs import list_jobs
+
+    jobs = list_jobs(include_disabled=False)
+    findings: List[tuple[Dict[str, Any], List[str]]] = []
+    for job in jobs:
+        issues = _cron_doctor_issues_for_job(job)
+        if issues:
+            findings.append((job, issues))
+
+    if not findings:
+        print(color("✓ Cron doctor found no issues", Colors.GREEN))
+        if jobs:
+            print(color(f"  Checked {len(jobs)} active job(s).", Colors.DIM))
+        else:
+            print(color("  No active jobs configured.", Colors.DIM))
+        return 0
+
+    issue_count = sum(len(issues) for _, issues in findings)
+    print(color(f"Cron doctor found {issue_count} issue(s) across {len(findings)} job(s):", Colors.YELLOW))
+    print()
+    for job, issues in findings:
+        job_id = job.get("id", "?")
+        name = job.get("name", "(unnamed)")
+        print(f"  {color(job_id, Colors.YELLOW)} {name}")
+        for issue in issues:
+            print(f"    - {issue}")
+    print()
+    print(color("Next: fix the listed job config, then run `hermes cron doctor` again.", Colors.DIM))
+    return 1
+
+
 def cron_create(args):
     # Defense: reject cron jobs that contain gateway lifecycle commands.
     # Prevents agents from scheduling their own restart/stop, which creates
@@ -339,6 +433,9 @@ def cron_command(args):
         cron_status()
         return 0
 
+    if subcmd == "doctor":
+        return cron_doctor()
+
     if subcmd == "tick":
         cron_tick()
         return 0
@@ -362,5 +459,5 @@ def cron_command(args):
         return _job_action("remove", args.job_id, "Removed")
 
     print(f"Unknown cron command: {subcmd}")
-    print("Usage: hermes cron [list|create|edit|pause|resume|run|remove|status|tick]")
+    print("Usage: hermes cron [list|create|edit|pause|resume|run|remove|status|doctor|tick]")
     sys.exit(1)

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -164,6 +164,9 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
     # cron status
     cron_subparsers.add_parser("status", help="Check if cron scheduler is running")
 
+    # cron doctor
+    cron_subparsers.add_parser("doctor", help="Check scheduled jobs for common health issues")
+
     # cron tick (mostly for debugging)
     cron_tick = cron_subparsers.add_parser("tick", help="Run due jobs once and exit")
     add_accept_hooks_flag(cron_tick)

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -4,7 +4,7 @@ from argparse import Namespace
 
 import pytest
 
-from cron.jobs import create_job, get_job, list_jobs
+from cron.jobs import create_job, get_job, list_jobs, load_jobs, save_jobs
 from hermes_cli.cron import cron_command
 
 
@@ -115,8 +115,6 @@ class TestCronCommandLifecycle:
     def test_list_does_not_crash_when_repeat_is_null(self, tmp_cron_dir, capsys):
         """A one-shot job can be persisted with ``"repeat": null``. `cron
         list` must render it as ∞ rather than crashing on .get(...)\\.get."""
-        from cron.jobs import load_jobs, save_jobs
-
         create_job(prompt="One shot", schedule="every 1h")
         # Force the present-but-null shape that .get("repeat", {}) mishandles.
         jobs = load_jobs()
@@ -127,3 +125,33 @@ class TestCronCommandLifecycle:
 
         out = capsys.readouterr().out
         assert "Repeat:    ∞" in out
+
+    def test_doctor_reports_cron_health_issues(self, tmp_cron_dir, capsys):
+        job = create_job(prompt="Daily digest", schedule="every 1h", script="missing.py")
+        jobs = load_jobs()
+        jobs[0]["last_status"] = "error"
+        jobs[0]["last_error"] = "Provider returned error"
+        jobs[0]["last_delivery_error"] = "telegram timeout"
+        save_jobs(jobs)
+
+        rc = cron_command(Namespace(cron_command="doctor"))
+
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "Cron doctor found 3 issue(s)" in out
+        assert job["id"] in out
+        assert "last run failed: Provider returned error" in out
+        assert "last delivery failed: telegram timeout" in out
+        assert "script not found" in out
+
+    def test_doctor_reports_healthy_jobs(self, tmp_cron_dir, capsys):
+        scripts_dir = tmp_cron_dir / "scripts"
+        scripts_dir.mkdir()
+        (scripts_dir / "ok.py").write_text("print('ok')\n", encoding="utf-8")
+        create_job(prompt="Daily digest", schedule="every 1h", script="ok.py")
+
+        rc = cron_command(Namespace(cron_command="doctor"))
+
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "✓ Cron doctor found no issues" in out

--- a/tests/hermes_cli/test_subcommands_cron.py
+++ b/tests/hermes_cli/test_subcommands_cron.py
@@ -25,8 +25,8 @@ def _build():
 
 def test_cron_subactions_present():
     parser = _build()
-    for action in ("list", "create", "edit", "pause", "resume", "run", "remove", "status", "tick"):
-        ns = parser.parse_args(["cron", action] if action in ("list", "status", "tick")
+    for action in ("list", "create", "edit", "pause", "resume", "run", "remove", "status", "doctor", "tick"):
+        ns = parser.parse_args(["cron", action] if action in ("list", "status", "doctor", "tick")
                                else ["cron", action, "jobid"] if action in ("pause", "resume", "run", "remove", "edit")
                                else ["cron", "create", "30m"])
         assert ns.command == "cron"


### PR DESCRIPTION
## Summary
- add a read-only Cron doctor found 2 issue(s) across 2 job(s):

  a61111adcdb0 Daily smart Hermes collaboration tip for Joe
    - last run failed: RuntimeError: HTTP 404: Model 'openai/gpt-5.5' requires available credits. Your account balance is too low to use paid models — add credits at https://portal.nousresearch.com or pick a free model.
  7ff4afbace0e Daily Movement BD lead pre-mortem
    - last run failed: RuntimeError: Unknown provider 'openai'. Check 'hermes model' for available providers, or run 'hermes doctor' to diagnose config issues.

Next: fix the listed job config, then run `hermes cron doctor` again. command for scheduled-job health checks
- flag last run failures, delivery failures, missing next run times, invalid no-agent jobs, missing/out-of-sandbox scripts, and missing workdirs
- add a small spec plus focused CLI/parser tests

## Tests
- ▶ running per-file parallel test suite via run_tests_parallel.py
  (TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0; clean env)
Discovered 2 test files (12 tests) under ['tests/hermes_cli/test_cron.py', 'tests/hermes_cli/test_subcommands_cron.py']; running with -j 20
[ 50.0% |     6/12 | ✓6 | ✗0] ✓ tests/hermes_cli/test_subcommands_cron.py (6✓, 0.2s)
[100.0% |    12/12 | ✓12 | ✗ 0] ✓ tests/hermes_cli/test_cron.py (6✓, 0.2s)

=== Summary: 2 files, 12 tests passed, 0 failed (100% complete) in 0.2s (20 workers) ===
  Durations cached to test_durations.json (2 files)

=== Per-file subprocess time distribution ===
  Files:   2
  Total subprocess CPU-wall: 0.4s  (runner wall: 0.2s, parallelism: 20x)
  P50: 0.23s  P90: 0.23s  P95: 0.23s  P99: 0.23s  Max: 0.23s
  <1s: 2 files (100%)  <2s: 2 files (100%)
  Top 10 slowest:
      0.23s  tests/hermes_cli/test_cron.py
      0.20s  tests/hermes_cli/test_subcommands_cron.py
- ✓ Cron doctor found no issues
  No active jobs configured.

## Notes
- Read-only diagnostic only; it does not mutate jobs or start/stop the gateway.