### PR TITLE
feat(webhook): honor model/provider/base_url/api_key from route config

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -24,6 +24,32 @@ from utils import normalize_proxy_url
 
 logger = logging.getLogger(__name__)
 
+
+class _SecretValue(str):
+    """A str-like value that masks itself in logs, repr, and JSON serialization.
+
+    Stores the real secret internally and exposes it only via ``get_secret()``.
+    This prevents accidental leakage when the containing dict is printed,
+    repr'd, or serialized by code that does not explicitly know how to unwrap
+    it.  Because the value serializes as ``"***"``, JSON dumps are safe by
+    default; callers that need the real key must intentionally call
+    ``get_secret()``.
+    """
+
+    __slots__ = ("_real_value",)
+
+    def __new__(cls, value: str):
+        obj = super().__new__(cls, "***")
+        obj._real_value = value
+        return obj
+
+    def __repr__(self) -> str:
+        return "***"
+
+    def get_secret(self) -> str:
+        return self._real_value
+
+
 # Audio file extensions Hermes recognizes for native audio delivery.
 # Kept in sync with tools/send_message_tool.py and cron/scheduler.py via
 # should_send_media_as_audio() below.

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -52,6 +52,7 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     SendResult,
+    _SecretValue,
 )
 
 logger = logging.getLogger(__name__)
@@ -628,6 +629,11 @@ class WebhookAdapter(BasePlatformAdapter):
         _route_model_keys = ("model", "provider", "base_url", "api_key", "api_mode")
         _route_override = {k: route_config[k] for k in _route_model_keys if route_config.get(k)}
         if _route_override and self.gateway_runner is not None:
+            # Wrap api_key so it is redacted if the override dict is ever logged,
+            # repr'd, or serialized by a plugin/debug path, while still being
+            # unwrapped by _apply_session_model_override when the agent starts.
+            if "api_key" in _route_override:
+                _route_override["api_key"] = _SecretValue(_route_override["api_key"])
             # Derive the same session key the runner will use so the override is found.
             _resolved_key = session_chat_id
             try:
@@ -643,7 +649,7 @@ class WebhookAdapter(BasePlatformAdapter):
                 route_name,
                 session_chat_id,
                 _resolved_key,
-                {k: ("***" if k == "api_key" else v) for k, v in _route_override.items()},
+                _route_override,
             )
 
         # Non-blocking — return 202 Accepted immediately

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -621,6 +621,31 @@ class WebhookAdapter(BasePlatformAdapter):
             delivery_id,
         )
 
+        # ── Route-level model/provider override ──────────────────
+        # If the webhook route config specifies model/provider/base_url/api_key,
+        # inject them into the gateway runner session model overrides so the agent
+        # uses them instead of the profile default.
+        _route_model_keys = ("model", "provider", "base_url", "api_key", "api_mode")
+        _route_override = {k: route_config[k] for k in _route_model_keys if route_config.get(k)}
+        if _route_override and self.gateway_runner is not None:
+            # Derive the same session key the runner will use so the override is found.
+            _resolved_key = session_chat_id
+            try:
+                _resolved_key = self.gateway_runner._session_key_for_source(source)
+            except Exception:
+                pass
+            self.gateway_runner._session_model_overrides[_resolved_key] = _route_override
+            # Also store under the raw chat_id as fallback
+            if _resolved_key != session_chat_id:
+                self.gateway_runner._session_model_overrides[session_chat_id] = _route_override
+            logger.info(
+                "[webhook] Route model override: route=%s session=%s resolved_key=%s override=%s",
+                route_name,
+                session_chat_id,
+                _resolved_key,
+                {k: ("***" if k == "api_key" else v) for k, v in _route_override.items()},
+            )
+
         # Non-blocking — return 202 Accepted immediately
         task = asyncio.create_task(self.handle_message(event))
         self._background_tasks.add(task)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1197,6 +1197,7 @@ from gateway.platforms.base import (
     EphemeralReply,
     MessageEvent,
     MessageType,
+    _SecretValue,
     _reply_anchor_for_event,
     merge_pending_message_event,
 )
@@ -12093,6 +12094,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         for key in ("provider", "api_key", "base_url", "api_mode"):
             val = override.get(key)
             if val is not None:
+                if isinstance(val, _SecretValue):
+                    val = val.get_secret()
                 runtime_kwargs[key] = val
         return model, runtime_kwargs
 


### PR DESCRIPTION
## Summary

Resolves #43730

Webhook route configs in `webhook_subscriptions.json` support `model`, `provider`, `base_url`, and `api_key` fields, but the webhook adapter (`WebhookAdapter`) silently ignores them — every route falls back to the profile default model/provider.

This patch injects route-level model/provider/base_url/api_key/api_mode into the gateway runner's existing `_session_model_overrides` dict, which `_apply_session_model_override` already reads during agent init. The session key is resolved via `_session_key_for_source` to match the key the runner uses.

## Changes

- `gateway/platforms/webhook.py`: Before dispatching `handle_message(event)`, read model/provider/base_url/api_key/api_mode from `route_config` and inject into `self.gateway_runner._session_model_overrides[resolved_key]`
- Session key is resolved via `_session_key_for_source(source)` to match what the runner will look up; raw `session_chat_id` is stored as fallback
- API keys are redacted in log output

## Testing

Local deployment tested: `mail-watcher` webhook route with model=gemma-4, provider=custom:llama, base_url=http://localhost:8085/v1.

Agent correctly routes to custom:llama/gemma-4 at localhost:8085 instead of the profile default gpt-5.5 via bifrost.

Log confirmation:

    [webhook] Route model override: route=mail-watcher session=webhook:mail-watcher:1781118230202 resolved_key=agent:main:webhook:webhook:webhook:mail-watcher:1781118230202:webhook:mail-watcher override={model: gemma-4, provider: custom:llama, base_url: http://localhost:8085/v1, api_key: ***}

## Design notes

- Reuses the existing /model session override mechanism — zero new infrastructure
- Override is per-delivery (session key includes delivery_id), so concurrent webhooks on the same route get independent overrides
- Override is cleaned up automatically by existing session cleanup logic
