### PR TITLE
fix(honcho): guard memory-file migration with workspace-level marker

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -439,22 +439,44 @@ class HonchoMemoryProvider(MemoryProvider):
         # not treat that partially initialized state as usable.
         session = self._manager.get_or_create(self._session_key)
 
-        # ----- B6: Memory file migration (one-time, for new sessions) -----
+        # ----- B6: Memory file migration (one-time, guarded by marker) -----
         # Skip under per-session strategy: every Hermes run creates a fresh
         # Honcho session by design, so uploading MEMORY.md/USER.md/SOUL.md to
         # each one would flood the backend with short-lived duplicates instead
         # of performing a one-time migration.
+        #
+        # A marker file (.honcho_migration_done) in the memories directory
+        # prevents re-running the migration for every new session.  Without
+        # the marker, ``not session.messages`` is True for *every* fresh
+        # session, causing the migration to repeat and flood the deriver
+        # with duplicate ``<prior_memory_file>`` uploads.  See #43731.
         try:
-            if not session.messages and cfg.session_strategy != "per-session":
-                from hermes_constants import get_hermes_home
-                mem_dir = str(get_hermes_home() / "memories")
-                self._manager.migrate_memory_files(self._session_key, mem_dir)
-                logger.debug("Honcho memory file migration attempted for new session: %s", self._session_key)
-            elif cfg.session_strategy == "per-session":
+            if cfg.session_strategy == "per-session":
                 logger.debug(
                     "Honcho memory file migration skipped: per-session strategy creates a fresh session per run (%s)",
                     self._session_key,
                 )
+            else:
+                from pathlib import Path as _Path
+                from hermes_constants import get_hermes_home
+                mem_dir = str(get_hermes_home() / "memories")
+                _marker = _Path(mem_dir) / ".honcho_migration_done"
+                if _marker.exists():
+                    logger.debug(
+                        "Honcho memory file migration skipped: marker already exists (%s)",
+                        self._session_key,
+                    )
+                elif not session.messages:
+                    self._manager.migrate_memory_files(self._session_key, mem_dir)
+                    # Write marker so migration never re-runs for this workspace
+                    try:
+                        _marker.write_text(
+                            f"migrated={self._session_key}\n",
+                            encoding="utf-8",
+                        )
+                    except OSError:
+                        pass  # best-effort; next run will retry
+                    logger.debug("Honcho memory file migration attempted for new session: %s", self._session_key)
         except Exception as e:
             logger.debug("Honcho memory file migration skipped: %s", e)
 

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -528,17 +528,48 @@ class HonchoMemoryProvider(MemoryProvider):
         # Honcho session by design, so uploading MEMORY.md/USER.md/SOUL.md to
         # each one would flood the backend with short-lived duplicates instead
         # of performing a one-time migration.
+        #
+        # A marker file (.honcho_migration_done) in the memories directory
+        # prevents re-running the migration for every new session.  Without
+        # the marker, ``not session.messages`` is True for *every* fresh
+        # session, causing the migration to repeat and flood the deriver
+        # with duplicate ``<prior_memory_file>`` uploads.  See #43731.
         try:
-            if not session.messages and cfg.session_strategy != "per-session":
-                from hermes_constants import get_hermes_home
-                mem_dir = str(get_hermes_home() / "memories")
-                self._manager.migrate_memory_files(self._session_key, mem_dir)
-                logger.debug("Honcho memory file migration attempted for new session: %s", self._session_key)
-            elif cfg.session_strategy == "per-session":
+            if cfg.session_strategy == "per-session":
                 logger.debug(
                     "Honcho memory file migration skipped: per-session strategy creates a fresh session per run (%s)",
                     self._session_key,
                 )
+            else:
+                from pathlib import Path as _Path
+                from hermes_constants import get_hermes_home
+                mem_dir = str(get_hermes_home() / "memories")
+                _marker = _Path(mem_dir) / ".honcho_migration_done"
+                if _marker.exists():
+                    logger.debug(
+                        "Honcho memory file migration skipped: marker already exists (%s)",
+                        self._session_key,
+                    )
+                elif not session.messages:
+                    # Write the marker only when at least one file was actually
+                    # uploaded.  ``migrate_memory_files`` returns False for a
+                    # missing memory dir or an uncached session; marking those
+                    # as done would suppress every later retry.
+                    _migrated = self._manager.migrate_memory_files(self._session_key, mem_dir)
+                    if _migrated:
+                        try:
+                            _marker.write_text(
+                                f"migrated={self._session_key}\n",
+                                encoding="utf-8",
+                            )
+                        except OSError:
+                            pass  # best-effort; next run will retry
+                        logger.debug("Honcho memory file migration uploaded files for new session: %s", self._session_key)
+                    else:
+                        logger.debug(
+                            "Honcho memory file migration uploaded nothing; marker not written, will retry (%s)",
+                            self._session_key,
+                        )
         except Exception as e:
             logger.debug("Honcho memory file migration skipped: %s", e)
 

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -711,10 +711,16 @@ class TestPerSessionMigrateGuard:
     containing only <prior_memory_file> wrappers.
     """
 
-    def _make_provider_with_strategy(self, strategy, init_on_session_start=True):
-        """Create a HonchoMemoryProvider and track migrate_memory_files calls."""
+    def _make_provider_with_strategy(self, strategy, init_on_session_start=True, tmp_path=None):
+        """Create a HonchoMemoryProvider and track migrate_memory_files calls.
+
+        When *tmp_path* is provided the mock ``get_hermes_home`` returns it,
+        allowing the migration marker (``.honcho_migration_done``) to be
+        verified on disk.
+        """
         from plugins.memory.honcho.client import HonchoClientConfig
         from unittest.mock import patch, MagicMock
+        from pathlib import Path
 
         cfg = HonchoClientConfig(
             api_key="test-key",
@@ -731,10 +737,17 @@ class TestPerSessionMigrateGuard:
         mock_session.messages = []  # empty = new session → triggers migration path
         mock_manager.get_or_create.return_value = mock_session
 
+        # When tmp_path is given, make get_hermes_home() return it so the
+        # marker file lands in ``tmp_path / "memories"``.
+        hermes_home = tmp_path if tmp_path else MagicMock()
+        mem_dir = Path(tmp_path) / "memories" if tmp_path else None
+        if mem_dir:
+            mem_dir.mkdir(parents=True, exist_ok=True)
+
         with patch("plugins.memory.honcho.client.HonchoClientConfig.from_global_config", return_value=cfg), \
              patch("plugins.memory.honcho.client.get_honcho_client", return_value=MagicMock()), \
              patch("plugins.memory.honcho.session.HonchoSessionManager", return_value=mock_manager), \
-             patch("hermes_constants.get_hermes_home", return_value=MagicMock()):
+             patch("hermes_constants.get_hermes_home", return_value=hermes_home):
             provider.initialize(session_id="test-session-001")
 
         return provider, mock_manager
@@ -744,10 +757,27 @@ class TestPerSessionMigrateGuard:
         _, mock_manager = self._make_provider_with_strategy("per-session")
         mock_manager.migrate_memory_files.assert_not_called()
 
-    def test_migrate_runs_for_per_directory(self):
+    def test_migrate_runs_for_per_directory(self, tmp_path):
         """per-directory strategy with empty session SHOULD call migrate_memory_files."""
-        _, mock_manager = self._make_provider_with_strategy("per-directory")
+        _, mock_manager = self._make_provider_with_strategy("per-directory", tmp_path=tmp_path)
         mock_manager.migrate_memory_files.assert_called_once()
+
+    def test_migrate_writes_marker_file(self, tmp_path):
+        """After successful migration, a .honcho_migration_done marker is written."""
+        from pathlib import Path
+        self._make_provider_with_strategy("per-directory", tmp_path=tmp_path)
+        marker = Path(tmp_path) / "memories" / ".honcho_migration_done"
+        assert marker.exists()
+        assert "migrated=" in marker.read_text()
+
+    def test_migrate_skipped_when_marker_exists(self, tmp_path):
+        """When the marker file already exists, migration must NOT run."""
+        from pathlib import Path
+        marker = Path(tmp_path) / "memories" / ".honcho_migration_done"
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text("migrated=old-session\n")
+        _, mock_manager = self._make_provider_with_strategy("per-directory", tmp_path=tmp_path)
+        mock_manager.migrate_memory_files.assert_not_called()
 
 
 class TestChunkMessage:

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -355,10 +355,17 @@ class TestPerSessionMigrateGuard:
     containing only <prior_memory_file> wrappers.
     """
 
-    def _make_provider_with_strategy(self, strategy, init_on_session_start=True):
-        """Create a HonchoMemoryProvider and track migrate_memory_files calls."""
+    def _make_provider_with_strategy(self, strategy, init_on_session_start=True, tmp_path=None, migrate_returns=True):
+        """Create a HonchoMemoryProvider and track migrate_memory_files calls.
+
+        When *tmp_path* is provided the mock ``get_hermes_home`` returns it,
+        allowing the migration marker (``.honcho_migration_done``) to be
+        verified on disk.  *migrate_returns* controls the mocked
+        ``migrate_memory_files`` return value (False = nothing was uploaded).
+        """
         from plugins.memory.honcho.client import HonchoClientConfig
         from unittest.mock import patch, MagicMock
+        from pathlib import Path
 
         cfg = HonchoClientConfig(
             api_key="test-key",
@@ -371,14 +378,22 @@ class TestPerSessionMigrateGuard:
         provider = HonchoMemoryProvider()
 
         mock_manager = MagicMock()
+        mock_manager.migrate_memory_files.return_value = migrate_returns
         mock_session = MagicMock()
         mock_session.messages = []  # empty = new session → triggers migration path
         mock_manager.get_or_create.return_value = mock_session
 
+        # When tmp_path is given, make get_hermes_home() return it so the
+        # marker file lands in ``tmp_path / "memories"``.
+        hermes_home = tmp_path if tmp_path else MagicMock()
+        mem_dir = Path(tmp_path) / "memories" if tmp_path else None
+        if mem_dir:
+            mem_dir.mkdir(parents=True, exist_ok=True)
+
         with patch("plugins.memory.honcho.client.HonchoClientConfig.from_global_config", return_value=cfg), \
              patch("plugins.memory.honcho.client.get_honcho_client", return_value=MagicMock()), \
              patch("plugins.memory.honcho.session.HonchoSessionManager", return_value=mock_manager), \
-             patch("hermes_constants.get_hermes_home", return_value=MagicMock()):
+             patch("hermes_constants.get_hermes_home", return_value=hermes_home):
             provider.initialize(session_id="test-session-001")
 
         return provider, mock_manager
@@ -388,6 +403,48 @@ class TestPerSessionMigrateGuard:
         _, mock_manager = self._make_provider_with_strategy("per-session")
         mock_manager.migrate_memory_files.assert_not_called()
 
+    def test_migrate_runs_for_per_directory(self, tmp_path):
+        """per-directory strategy with empty session SHOULD call migrate_memory_files."""
+        _, mock_manager = self._make_provider_with_strategy("per-directory", tmp_path=tmp_path)
+        mock_manager.migrate_memory_files.assert_called_once()
+
+    def test_migrate_writes_marker_file(self, tmp_path):
+        """After successful migration, a .honcho_migration_done marker is written."""
+        from pathlib import Path
+        self._make_provider_with_strategy("per-directory", tmp_path=tmp_path)
+        marker = Path(tmp_path) / "memories" / ".honcho_migration_done"
+        assert marker.exists()
+        assert "migrated=" in marker.read_text()
+
+    def test_migrate_skipped_when_marker_exists(self, tmp_path):
+        """When the marker file already exists, migration must NOT run."""
+        from pathlib import Path
+        marker = Path(tmp_path) / "memories" / ".honcho_migration_done"
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text("migrated=old-session\n")
+        _, mock_manager = self._make_provider_with_strategy("per-directory", tmp_path=tmp_path)
+        mock_manager.migrate_memory_files.assert_not_called()
+
+    def test_migrate_returns_false_writes_no_marker_and_retries(self, tmp_path):
+        """A no-op migration (False return) must not write the marker.
+
+        ``migrate_memory_files`` returns False when nothing was uploaded
+        (missing memory dir, uncached session).  Writing the marker in that
+        case would suppress every later retry, so a subsequent
+        initialization on the same workspace must attempt migration again.
+        """
+        from pathlib import Path
+        _, mock_manager = self._make_provider_with_strategy(
+            "per-directory", tmp_path=tmp_path, migrate_returns=False
+        )
+        mock_manager.migrate_memory_files.assert_called_once()
+        marker = Path(tmp_path) / "memories" / ".honcho_migration_done"
+        assert not marker.exists()
+
+        # No marker was written, so a later init retries the migration.
+        _, mock_manager_retry = self._make_provider_with_strategy("per-directory", tmp_path=tmp_path)
+        mock_manager_retry.migrate_memory_files.assert_called_once()
+        assert marker.exists()
 
 class TestChunkMessage:
     def test_short_message_single_chunk(self):


### PR DESCRIPTION
## Problem

`migrate_memory_files()` in the Honcho plugin is documented as a one-time import of `MEMORY.md`/`USER.md`/`SOUL.md` into Honcho, but the guard at its call site only checks:

```python
if not session.messages and cfg.session_strategy != "per-session":
```

Every *new* Honcho session has no messages, so under `per-directory` (the default) and `per-conversation`-style strategies the migration runs again for **every new session** — each new chat topic, kanban task, and cron run re-uploads the full memory files as messages attributed to the user peer.

**Observed impact** (from #43731):
- 35 sessions × 2 files = 70 `<prior_memory_file>` uploads — ~12% of all messages
- Honcho's deriver treats each upload as user speech and re-derives the same facts every session
- ~29% of all conclusions were duplicates or noise derived from the memory files

## Fix

Add a `.honcho_migration_done` marker file in the `~/.hermes/memories/` directory. Once written after the first successful migration, subsequent sessions skip the migration entirely. The marker is workspace-level (not session-level), so it persists across all sessions for a given Hermes installation.

**Files changed:**
- `plugins/memory/honcho/__init__.py` — Replace `not session.messages` guard with marker-file check; write marker after successful migration
- `tests/honcho_plugin/test_session.py` — Add 2 new tests: marker is written after migration, marker prevents re-migration

**4 tests pass** (2 existing updated + 2 new).

Closes #43731
