### PR TITLE
fix(gateway): auto-continue after turn limits

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1614,6 +1614,10 @@ def merge_pending_message_event(
     """
     existing = pending_messages.get(session_key)
     if existing:
+        if getattr(existing, "internal", False) and not getattr(event, "internal", False):
+            pending_messages[session_key] = event
+            return
+
         existing_is_photo = getattr(existing, "message_type", None) == MessageType.PHOTO
         incoming_is_photo = event.message_type == MessageType.PHOTO
         existing_has_media = bool(existing.media_urls)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1916,6 +1916,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     _stop_task: Optional[asyncio.Task] = None
     _session_model_overrides: Dict[str, Dict[str, str]] = {}
     _session_reasoning_overrides: Dict[str, Dict[str, Any]] = {}
+    _MAX_LIMIT_AUTO_CONTINUATIONS: int = 3
 
     def __init__(self, config: Optional[GatewayConfig] = None):
         global _gateway_runner_ref
@@ -1993,6 +1994,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # /new and /reset.  /model and other mid-session operations
         # preserve the queue.
         self._queued_events: Dict[str, List[MessageEvent]] = {}
+        self._limit_auto_continue_counts: Dict[str, int] = {}
         self._pending_native_image_paths_by_session: Dict[str, List[str]] = {}
         self._busy_ack_ts: Dict[str, float] = {}  # last busy-ack timestamp per session (debounce)
         self._session_run_generation: Dict[str, int] = {}
@@ -3010,6 +3012,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         text = getattr(event_or_text, "text", event_or_text) or ""
         return str(text).startswith("[Continuing toward your standing goal]\nGoal:")
+
+    @staticmethod
+    def _is_limit_exhaustion_result(agent_result: Any) -> bool:
+        """Return True when a turn stopped only because per-turn limits ran out."""
+        if not isinstance(agent_result, dict):
+            return False
+        reason = str(agent_result.get("turn_exit_reason") or "")
+        return reason.startswith("max_iterations_reached") or reason.startswith("budget_exhausted")
+
+    @staticmethod
+    def _is_limit_auto_continue_event(event_or_text: Any) -> bool:
+        """Return True for synthetic max-turn/budget continuation turns."""
+        text = getattr(event_or_text, "text", event_or_text) or ""
+        return str(text).startswith("[Continuing prior work after a per-turn execution limit]")
 
     def _clear_goal_pending_continuations(self, session_key: str, adapter: Any) -> int:
         """Remove queued synthetic /goal continuations for one session.
@@ -7395,6 +7411,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         try:
             _agent_result = await self._handle_message_with_agent(event, source, _quick_key, _run_generation)
+            _limit_continuation_enqueued = False
+            try:
+                _limit_continuation_enqueued = await self._post_turn_limit_continuation(
+                    session_key=_quick_key,
+                    source=source,
+                    agent_result=_agent_result,
+                )
+            except Exception as _limit_exc:
+                logger.debug("limit auto-continuation hook failed: %s", _limit_exc)
             # Goal continuation: after the agent returns a final response
             # for this turn, check any standing /goal — the judge will
             # either mark it done, pause it (budget), or enqueue a
@@ -7409,8 +7434,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _final_text = _agent_result
                 # Skip for empty responses (interrupted / errored) — the
                 # judge would almost always say "continue" and we'd loop
-                # on error. Let the user drive the next turn.
-                if _final_text.strip():
+                # on error. Let the user drive the next turn. Also skip
+                # when limit auto-continuation queued a deterministic
+                # continuation for the same exhaustion boundary.
+                if _final_text.strip() and not _limit_continuation_enqueued:
                     try:
                         session_entry = self.session_store.get_or_create_session(source)
                     except Exception:
@@ -9336,6 +9363,83 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._enqueue_fifo(_quick_key, cont_event, adapter)
         except Exception as exc:
             logger.debug("goal continuation: enqueue failed: %s", exc)
+
+    async def _post_turn_limit_continuation(
+        self,
+        *,
+        session_key: str,
+        source: Any,
+        agent_result: Any,
+    ) -> bool:
+        """Enqueue a bounded continuation when the agent only hit turn limits.
+
+        Returns True when a continuation was enqueued. The counter is scoped to
+        the gateway session key and resets on the first non-exhaustion result.
+        """
+        counters = getattr(self, "_limit_auto_continue_counts", None)
+        if counters is None:
+            counters = {}
+            self._limit_auto_continue_counts = counters
+
+        if not self._is_limit_exhaustion_result(agent_result):
+            if session_key:
+                counters.pop(session_key, None)
+            return False
+
+        if not isinstance(agent_result, dict) or not session_key or source is None:
+            return False
+        if (
+            agent_result.get("failed")
+            or agent_result.get("interrupted")
+            or agent_result.get("partial")
+            or agent_result.get("error")
+        ):
+            return False
+
+        max_continuations = int(getattr(self, "_MAX_LIMIT_AUTO_CONTINUATIONS", 3) or 0)
+        used = counters.get(session_key, 0)
+        if max_continuations <= 0 or used >= max_continuations:
+            logger.info(
+                "Limit auto-continuation cap reached for session %s (%d/%d)",
+                session_key,
+                used,
+                max_continuations,
+            )
+            return False
+
+        try:
+            adapter = self.adapters.get(source.platform)
+            if adapter is None:
+                return False
+            prompt = (
+                "[Continuing prior work after a per-turn execution limit]\n"
+                "Continue the prior task from the current conversation state. "
+                "Take concrete next actions using the available tools. Do not ask "
+                "the user to resend or manually continue. Only provide a final "
+                "answer when the work is verified, or when you are genuinely "
+                "blocked and can explain the blocker precisely."
+            )
+            cont_event = MessageEvent(
+                text=prompt,
+                message_type=MessageType.TEXT,
+                source=source,
+                message_id=None,
+                channel_prompt=None,
+                internal=True,
+            )
+            self._enqueue_fifo(session_key, cont_event, adapter)
+        except Exception as exc:
+            logger.debug("limit auto-continuation: enqueue failed: %s", exc)
+            return False
+
+        counters[session_key] = used + 1
+        logger.info(
+            "Queued limit auto-continuation for session %s (%d/%d)",
+            session_key,
+            counters[session_key],
+            max_continuations,
+        )
+        return True
 
 
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -96,6 +96,9 @@ class GatewaySlashCommandsMixin:
         _qe = getattr(self, "_queued_events", None)
         if _qe is not None:
             _qe.pop(session_key, None)
+        _limit_counts = getattr(self, "_limit_auto_continue_counts", None)
+        if _limit_counts is not None:
+            _limit_counts.pop(session_key, None)
 
         try:
             from tools.env_passthrough import clear_env_passthrough

--- a/tests/gateway/test_queue_consumption.py
+++ b/tests/gateway/test_queue_consumption.py
@@ -8,14 +8,17 @@ after the agent finishes its current task — not silently dropped.
 import asyncio
 from unittest.mock import MagicMock
 
+import pytest
 
 from gateway.run import _dequeue_pending_event
+from gateway.session import SessionSource
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
     MessageType,
     PlatformConfig,
     Platform,
+    merge_pending_message_event,
 )
 
 
@@ -452,3 +455,179 @@ class TestBusyInputModeQueueFifo:
         head = adapter._pending_messages[session_key]
         assert head.message_type == MessageType.PHOTO
         assert len(head.media_urls) == 3
+
+
+class TestLimitAutoContinuation:
+    """Gateway max-turn/budget exhaustion continuation uses the FIFO queue."""
+
+    def _runner(self):
+        from gateway.run import GatewayRunner
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.adapters = {}
+        runner._queued_events = {}
+        runner._limit_auto_continue_counts = {}
+        return runner
+
+    def _source(self):
+        return SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="123",
+            user_id="u1",
+            chat_type="dm",
+        )
+
+    @pytest.mark.asyncio
+    async def test_limit_exhaustion_enqueues_synthetic_continuation(self):
+        from gateway.run import GatewayRunner
+
+        runner = self._runner()
+        adapter = _StubAdapter()
+        runner.adapters[Platform.TELEGRAM] = adapter
+        source = self._source()
+        session_key = "telegram:user:123"
+
+        enqueued = await runner._post_turn_limit_continuation(
+            session_key=session_key,
+            source=source,
+            agent_result={
+                "turn_exit_reason": "max_iterations_reached(90/90)",
+                "completed": False,
+                "final_response": "I made progress but need another turn.",
+            },
+        )
+
+        assert enqueued is True
+        event = adapter._pending_messages[session_key]
+        assert GatewayRunner._is_limit_auto_continue_event(event)
+        assert event.internal is True
+        assert "Continue the prior task" in event.text
+        assert "Do not ask the user to resend" in event.text
+        assert runner._limit_auto_continue_counts[session_key] == 1
+
+    @pytest.mark.asyncio
+    async def test_limit_exhaustion_preserves_real_pending_message_priority(self):
+        runner = self._runner()
+        adapter = _StubAdapter()
+        runner.adapters[Platform.TELEGRAM] = adapter
+        source = self._source()
+        session_key = "telegram:user:123"
+
+        adapter._pending_messages[session_key] = MessageEvent(
+            text="real user follow-up",
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id="m-real",
+        )
+
+        enqueued = await runner._post_turn_limit_continuation(
+            session_key=session_key,
+            source=source,
+            agent_result={"turn_exit_reason": "budget_exhausted", "completed": False},
+        )
+
+        assert enqueued is True
+        assert adapter._pending_messages[session_key].text == "real user follow-up"
+        assert len(runner._queued_events[session_key]) == 1
+        assert runner._is_limit_auto_continue_event(runner._queued_events[session_key][0])
+
+    def test_real_user_text_replaces_existing_synthetic_continuation(self):
+        """Active-session user text must not merge into an internal continuation."""
+        source = self._source()
+        session_key = "telegram:user:123"
+        pending = {
+            session_key: MessageEvent(
+                text="[Continuing prior work after a per-turn execution limit]\nContinue...",
+                message_type=MessageType.TEXT,
+                source=source,
+                message_id=None,
+                internal=True,
+            )
+        }
+        user_event = MessageEvent(
+            text="real user follow-up",
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id="m-real",
+            internal=False,
+        )
+
+        merge_pending_message_event(
+            pending,
+            session_key,
+            user_event,
+            merge_text=True,
+        )
+
+        assert pending[session_key] is user_event
+        assert pending[session_key].text == "real user follow-up"
+        assert pending[session_key].internal is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "agent_result",
+        [
+            {"turn_exit_reason": "completed", "completed": True},
+            {"turn_exit_reason": "max_iterations_reached(1/1)", "failed": True},
+            {"turn_exit_reason": "max_iterations_reached(1/1)", "interrupted": True},
+            {"turn_exit_reason": "budget_exhausted", "partial": True},
+            {"turn_exit_reason": "budget_exhausted", "error": "provider failed"},
+        ],
+    )
+    async def test_limit_continuation_skips_normal_failed_interrupted_and_partial(
+        self,
+        agent_result,
+    ):
+        runner = self._runner()
+        adapter = _StubAdapter()
+        runner.adapters[Platform.TELEGRAM] = adapter
+        source = self._source()
+        session_key = "telegram:user:123"
+
+        enqueued = await runner._post_turn_limit_continuation(
+            session_key=session_key,
+            source=source,
+            agent_result=agent_result,
+        )
+
+        assert enqueued is False
+        assert adapter._pending_messages == {}
+        assert runner._queued_events == {}
+
+    @pytest.mark.asyncio
+    async def test_limit_continuation_is_bounded_and_resets_on_non_exhaustion(self):
+        runner = self._runner()
+        adapter = _StubAdapter()
+        runner.adapters[Platform.TELEGRAM] = adapter
+        source = self._source()
+        session_key = "telegram:user:123"
+        exhaustion = {"turn_exit_reason": "budget_exhausted", "completed": False}
+
+        for _ in range(3):
+            assert await runner._post_turn_limit_continuation(
+                session_key=session_key,
+                source=source,
+                agent_result=exhaustion,
+            )
+
+        assert runner._limit_auto_continue_counts[session_key] == 3
+        assert await runner._post_turn_limit_continuation(
+            session_key=session_key,
+            source=source,
+            agent_result=exhaustion,
+        ) is False
+        assert runner._limit_auto_continue_counts[session_key] == 3
+
+        assert await runner._post_turn_limit_continuation(
+            session_key=session_key,
+            source=source,
+            agent_result={"turn_exit_reason": "completed", "completed": True},
+        ) is False
+        assert session_key not in runner._limit_auto_continue_counts
+
+        assert await runner._post_turn_limit_continuation(
+            session_key=session_key,
+            source=source,
+            agent_result=exhaustion,
+        )
+        assert runner._limit_auto_continue_counts[session_key] == 1

--- a/tests/gateway/test_session_model_reset.py
+++ b/tests/gateway/test_session_model_reset.py
@@ -57,6 +57,8 @@ def _make_runner():
     runner.session_store._generate_session_key.return_value = session_key
     runner._running_agents = {}
     runner._pending_messages = {}
+    runner._queued_events = {}
+    runner._limit_auto_continue_counts = {}
     runner._pending_approvals = {}
     runner._session_db = None
     runner._agent_cache_lock = None  # disables _evict_cached_agent lock path
@@ -139,3 +141,23 @@ async def test_new_command_only_clears_own_session():
     assert other_key in runner._session_reasoning_overrides
     assert session_key not in runner._pending_model_notes
     assert other_key in runner._pending_model_notes
+
+
+@pytest.mark.asyncio
+async def test_new_command_clears_limit_auto_continuation_state():
+    """/new must clear synthetic continuation counters for that session."""
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+    other_key = "other_session_key"
+
+    runner._queued_events[session_key] = [MessageEvent(text="synthetic", source=_make_source())]
+    runner._queued_events[other_key] = [MessageEvent(text="other", source=_make_source())]
+    runner._limit_auto_continue_counts[session_key] = 3
+    runner._limit_auto_continue_counts[other_key] = 2
+
+    await runner._handle_reset_command(_make_event("/new"))
+
+    assert session_key not in runner._queued_events
+    assert other_key in runner._queued_events
+    assert session_key not in runner._limit_auto_continue_counts
+    assert runner._limit_auto_continue_counts[other_key] == 2


### PR DESCRIPTION
Summary:
- enqueue a bounded synthetic gateway continuation when an agent turn stops only because max-iteration/tool-budget limits were exhausted
- skip duplicate /goal continuation when the limit continuation was queued
- reset continuation counters on non-exhaustion and /new session boundaries
- preserve real user priority over synthetic internal continuations, including the pending-slot race

Verification:
- venv/bin/python -m pytest tests/gateway/test_queue_consumption.py tests/gateway/test_session_model_reset.py -q -o 'addopts='  # 27 passed
- venv/bin/python -m pytest tests/gateway/test_platform_base.py tests/gateway/test_base_topic_sessions.py -q -o 'addopts='  # 158 passed, 2 skipped
- independent reviewer pass: no blocking security concerns or logic errors
