### PR TITLE
feat(hyperliquid): add delegations command to surface staked HYPE

### DIFF
--- a/optional-skills/blockchain/hyperliquid/SKILL.md
+++ b/optional-skills/blockchain/hyperliquid/SKILL.md
@@ -16,9 +16,9 @@ metadata:
 Query Hyperliquid market and account data through the public `/info` endpoint.
 Read-only — no API key, no signing, no order placement.
 
-12 commands: `dexs`, `markets`, `spots`, `candles`, `funding`, `l2`, `state`,
-`spot-balances`, `fills`, `orders`, `review`, `export`. Stdlib only
-(`urllib`, `json`, `argparse`).
+13 commands: `dexs`, `markets`, `spots`, `candles`, `funding`, `l2`, `state`,
+`spot-balances`, `delegations`, `fills`, `orders`, `review`, `export`. Stdlib
+only (`urllib`, `json`, `argparse`).
 
 ---
 
@@ -73,14 +73,16 @@ hyperliquid_client.py funding <coin> [--hours 72] [--limit N]
 hyperliquid_client.py l2 <coin> [--levels N]
 hyperliquid_client.py state [address] [--dex DEX]
 hyperliquid_client.py spot-balances [address] [--limit N]
+hyperliquid_client.py delegations [address]
 hyperliquid_client.py fills [address] [--hours N] [--limit N] [--aggregate-by-time]
 hyperliquid_client.py orders [address] [--limit N]
 hyperliquid_client.py review [address] [--coin COIN] [--hours N] [--fills N]
 hyperliquid_client.py export <coin> [--interval 1h] [--hours N] [--output PATH]
 ```
 
-For `state`, `spot-balances`, `fills`, `orders`, and `review`, the address is
-optional when `HYPERLIQUID_USER_ADDRESS` is set in `${HERMES_HOME:-~/.hermes}/.env`.
+For `state`, `spot-balances`, `delegations`, `fills`, `orders`, and `review`,
+the address is optional when `HYPERLIQUID_USER_ADDRESS` is set in
+`${HERMES_HOME:-~/.hermes}/.env`.
 
 ---
 
@@ -133,11 +135,24 @@ python3 ~/.hermes/skills/blockchain/hyperliquid/scripts/hyperliquid_client.py \
 
 python3 ~/.hermes/skills/blockchain/hyperliquid/scripts/hyperliquid_client.py \
   spot-balances
+
+python3 ~/.hermes/skills/blockchain/hyperliquid/scripts/hyperliquid_client.py \
+  delegations
 ```
 
 `state` returns perp positions; `spot-balances` returns spot inventory.
 Use these for "how are my positions?", "what am I holding?", "how much is
 withdrawable?".
+
+Staked HYPE lives in a **separate staking account** and does not appear in
+`spot-balances` at all — not as `total`, not as `hold`. `spotClearinghouseState`
+only returns the spot account; its `hold` is spot HYPE locked at the spot level
+(e.g. open orders), which is unrelated to staking and does not equal the staked
+amount. Use `delegations` (the `delegatorSummary` endpoint) for the staking
+picture: `delegated` is current staked HYPE *including auto-compounded rewards*,
+`undelegated` is staked-account HYPE not yet delegated, and pending withdrawal
+reflects the 7-day unstaking queue. Reach for it on "how much HYPE am I
+staking?" / "what are my staking rewards?".
 
 ### 5. Review Fills and Orders
 
@@ -198,6 +213,12 @@ normalized candle rows, normalized funding rows, summary stats. Use
 - Spot aliases like `@107` are valid identifiers even when the UI shows
   a friendlier name.
 - `l2` is a point-in-time snapshot, not a time series.
+- Staked HYPE does not appear in `spot-balances` at all — it lives in a
+  separate staking account. The spot `hold` is unrelated to staking (it's spot
+  HYPE locked in open orders). Use `delegations` for staked totals.
+- `delegations` reports two distinct timers, do not conflate them: per-validator
+  undelegation has a 1-day lockup; the staking-to-spot withdrawal
+  (`Pending withdrawal`) has a separate 7-day unstaking queue.
 
 ---
 

--- a/optional-skills/blockchain/hyperliquid/scripts/hyperliquid_client.py
+++ b/optional-skills/blockchain/hyperliquid/scripts/hyperliquid_client.py
@@ -23,7 +23,7 @@ Usage:
 Environment:
   HYPERLIQUID_API_URL  Override API base URL
                        (default: https://api.hyperliquid.xyz)
-  HYPERLIQUID_USER_ADDRESS  Default address for state/fills/orders/review commands
+  HYPERLIQUID_USER_ADDRESS  Default address for state/spot-balances/delegations/fills/orders/review commands
 """
 
 from __future__ import annotations

--- a/optional-skills/blockchain/hyperliquid/scripts/hyperliquid_client.py
+++ b/optional-skills/blockchain/hyperliquid/scripts/hyperliquid_client.py
@@ -14,6 +14,7 @@ Usage:
   python3 hyperliquid_client.py l2 <coin> [--levels 10]
   python3 hyperliquid_client.py state [address] [--dex DEX]
   python3 hyperliquid_client.py spot-balances [address]
+  python3 hyperliquid_client.py delegations [address]
   python3 hyperliquid_client.py fills [address] [--hours N] [--limit N]
   python3 hyperliquid_client.py orders [address] [--limit N]
   python3 hyperliquid_client.py review [address] [--coin COIN] [--hours N]
@@ -525,6 +526,22 @@ def _normalize_spot_balances(payload: Any) -> List[Dict[str, Any]]:
     return rows
 
 
+def _normalize_delegator_summary(payload: Any) -> Dict[str, Any]:
+    if not isinstance(payload, dict):
+        return {
+            "delegated": "0",
+            "undelegated": "0",
+            "total_pending_withdrawal": "0",
+            "n_pending_withdrawals": 0,
+        }
+    return {
+        "delegated": payload.get("delegated", "0"),
+        "undelegated": payload.get("undelegated", "0"),
+        "total_pending_withdrawal": payload.get("totalPendingWithdrawal", "0"),
+        "n_pending_withdrawals": payload.get("nPendingWithdrawals", 0),
+    }
+
+
 def _normalize_fills(payload: Any) -> List[Dict[str, Any]]:
     rows: List[Dict[str, Any]] = []
     if not isinstance(payload, list):
@@ -952,6 +969,13 @@ def run_spot_balances(args: argparse.Namespace) -> Dict[str, Any]:
     return {"user": user, "count": len(rows), "balances": _limit_items(rows, args.limit)}
 
 
+def run_delegations(args: argparse.Namespace) -> Dict[str, Any]:
+    user = _resolve_user(args.user)
+    payload = {"type": "delegatorSummary", "user": user}
+    data = _normalize_delegator_summary(_post_info(payload))
+    return {"user": user, **data}
+
+
 def run_fills(args: argparse.Namespace) -> Dict[str, Any]:
     user = _resolve_user(args.user)
     payload: Dict[str, Any] = {"user": user}
@@ -1356,6 +1380,19 @@ def render_spot_balances(data: Dict[str, Any]) -> str:
     )
 
 
+def render_delegations(data: Dict[str, Any]) -> str:
+    return "\n".join(
+        [
+            f"User: {data['user']}",
+            "",
+            f"Delegated (staked):           {_compact_number(data['delegated'])} HYPE",
+            f"Undelegated (available):      {_compact_number(data['undelegated'])} HYPE",
+            f"Pending withdrawal:           {_compact_number(data['total_pending_withdrawal'])} HYPE",
+            f"Pending withdrawals count:    {data['n_pending_withdrawals']}",
+        ]
+    )
+
+
 def render_fills(data: Dict[str, Any]) -> str:
     rows = [
         {
@@ -1598,6 +1635,11 @@ def build_parser() -> argparse.ArgumentParser:
     spot_balances.add_argument("--limit", type=int, default=20, help="Rows to display; 0 means all")
     _add_json_flag(spot_balances)
     spot_balances.set_defaults(func=run_spot_balances, renderer=render_spot_balances)
+
+    delegations = subparsers.add_parser("delegations", help="Inspect staked/delegated HYPE positions")
+    delegations.add_argument("user", nargs="?", default="", help=f"Optional address; falls back to ${DEFAULT_USER_ENV}")
+    _add_json_flag(delegations)
+    delegations.set_defaults(func=run_delegations, renderer=render_delegations)
 
     fills = subparsers.add_parser("fills", help="Inspect a user's recent fills")
     fills.add_argument("user", nargs="?", default="", help=f"Optional address; falls back to ${DEFAULT_USER_ENV}")

--- a/tests/skills/test_hyperliquid_skill.py
+++ b/tests/skills/test_hyperliquid_skill.py
@@ -326,6 +326,81 @@ def test_main_export_json_writes_expected_contract(tmp_path, capsys):
     assert len(saved["funding_history"]) == 2
 
 
+def test_normalize_delegator_summary_maps_camelcase_fields():
+    mod = load_module()
+
+    result = mod._normalize_delegator_summary(
+        {
+            "delegated": "423.32",
+            "undelegated": "1.5",
+            "totalPendingWithdrawal": "10",
+            "nPendingWithdrawals": 2,
+        }
+    )
+
+    assert result == {
+        "delegated": "423.32",
+        "undelegated": "1.5",
+        "total_pending_withdrawal": "10",
+        "n_pending_withdrawals": 2,
+    }
+
+
+def test_normalize_delegator_summary_defaults_for_non_dict():
+    mod = load_module()
+
+    assert mod._normalize_delegator_summary(None) == {
+        "delegated": "0",
+        "undelegated": "0",
+        "total_pending_withdrawal": "0",
+        "n_pending_withdrawals": 0,
+    }
+
+
+def test_main_delegations_json_surfaces_staked_hype(monkeypatch, capsys):
+    mod = load_module()
+    monkeypatch.setenv("HYPERLIQUID_USER_ADDRESS", "0xstaker")
+
+    summary = {
+        "delegated": "423.32",
+        "undelegated": "0.0",
+        "totalPendingWithdrawal": "0.0",
+        "nPendingWithdrawals": 0,
+    }
+
+    with patch.object(mod, "_post_info", return_value=summary) as mock_post:
+        exit_code = mod.main(["delegations", "--json"])
+
+    stdout = capsys.readouterr().out
+    rendered = json.loads(stdout)
+
+    assert exit_code == 0
+    assert mock_post.call_args[0][0] == {"type": "delegatorSummary", "user": "0xstaker"}
+    assert rendered["user"] == "0xstaker"
+    assert rendered["delegated"] == "423.32"
+    assert rendered["n_pending_withdrawals"] == 0
+
+
+def test_main_delegations_default_render_includes_staked(capsys):
+    mod = load_module()
+
+    summary = {
+        "delegated": "423.32",
+        "undelegated": "0",
+        "totalPendingWithdrawal": "0",
+        "nPendingWithdrawals": 0,
+    }
+
+    with patch.object(mod, "_post_info", return_value=summary):
+        exit_code = mod.main(["delegations", "0xabc"])
+
+    stdout = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "Delegated (staked):" in stdout
+    assert "423.32" in stdout
+
+
 def test_main_export_json_skips_funding_for_spot(tmp_path, capsys):
     mod = load_module()
     output_path = tmp_path / "purr-usdc.json"


### PR DESCRIPTION
## What does this PR do?

Adds a `delegations` command to the Hyperliquid skill so staked HYPE is
visible. Staked HYPE lives in a **separate staking account** that the
`spotClearinghouseState` endpoint never returns, so the skill previously had no
way to surface it — `spot-balances` showed only spot inventory, and its `hold`
field is spot balance locked in open orders, *not* the staked amount. The new
command queries the `delegatorSummary` info endpoint, exposing delegated
(current staked HYPE, including auto-compounded rewards), undelegated, and the
7-day unstaking queue. Read-only, stdlib only, consistent with the existing
`spot-balances` command pattern.

## Related Issue

N/A — no existing issue.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `optional-skills/blockchain/hyperliquid/scripts/hyperliquid_client.py` — added
  `_normalize_delegator_summary()`, `run_delegations()`, `render_delegations()`,
  the `delegations` subparser, and the usage-docstring line.
- `optional-skills/blockchain/hyperliquid/SKILL.md` — command count 12→13, quick
  reference, address-optional list, a "Review an Account" note explaining staking
  is a separate account (not `hold`), and two pitfalls (spot-balances omits
  staking; 1-day undelegation lockup vs 7-day unstaking queue).
- `tests/skills/test_hyperliquid_skill.py` — 4 new tests (field mapping, non-dict
  defaults, end-to-end JSON payload + request shape, default render).

## How to Test

1. Run against a public validator (validators self-stake), e.g. Anchorage By Figment:
   `python3 optional-skills/blockchain/hyperliquid/scripts/hyperliquid_client.py delegations 0x420a4ed7b6bb361da586868adec2f2bb9ab75e66`
   → prints non-zero `Delegated (staked)`, plus undelegated and the pending
   withdrawal queue.
2. Add `--json` for machine-readable output (`delegated`, `undelegated`,
   `total_pending_withdrawal`, `n_pending_withdrawals`).
3. `uv run --extra dev python -m pytest tests/skills/test_hyperliquid_skill.py -q`
   → 17 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(hyperliquid): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run the skill's test file and all tests pass (17 passed); full
      `pytest tests/ -q` recommended in CI
- [x] I've added tests for my changes
- [x] I've tested on my platform: Pop!_OS 22.04 LTS (kernel 7.0.11), Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (SKILL.md docstring + procedure + pitfalls)
- [x] N/A — no config keys added/changed (`cli-config.yaml.example`)
- [x] N/A — no architecture/workflow changes (`CONTRIBUTING.md`/`AGENTS.md`)
- [x] Cross-platform: stdlib only (`urllib`/`json`/`argparse`), no OS-specific code
- [x] I've updated tool descriptions/schemas — SKILL.md quick reference reflects the new command

## Screenshots / Logs

```console
$ python3 optional-skills/blockchain/hyperliquid/scripts/hyperliquid_client.py delegations 0x420a4ed7b6bb361da586868adec2f2bb9ab75e66

User: 0x420a4ed7b6bb361da586868adec2f2bb9ab75e66

Delegated (staked):           10.01K HYPE
Undelegated (available):      159.01 HYPE
Pending withdrawal:           1.11K HYPE
Pending withdrawals count:    4
```