### PR TITLE
HERMES-9: add confirmed Vapi call command

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2407,6 +2407,7 @@ class BasePlatformAdapter(ABC):
         session_key: str,
         confirm_id: str,
         metadata: Optional[Dict[str, Any]] = None,
+        allow_always: bool = True,
     ) -> SendResult:
         """Send a three-option slash-command confirmation prompt.
 
@@ -2416,9 +2417,9 @@ class BasePlatformAdapter(ABC):
         acknowledge — the current caller is ``/reload-mcp``, which
         invalidates the provider prompt cache.
 
-        Platforms with inline-button support (Telegram, Discord, Slack,
-        Matrix, Feishu) should override this to render three buttons:
-        Approve Once / Always Approve / Cancel.  Button callbacks MUST be
+        Platforms with inline-button support should override this to render
+        Approve Once / Always Approve / Cancel when ``allow_always`` is true,
+        or Approve / Cancel for one-time-only confirmations. Button callbacks MUST be
         routed back through the gateway by calling
         ``GatewayRunner._resolve_slash_confirm(confirm_id, choice)`` where
         ``choice`` is ``"once"`` / ``"always"`` / ``"cancel"``.

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -2766,8 +2766,9 @@ class SlackAdapter(BasePlatformAdapter):
         session_key: str,
         confirm_id: str,
         metadata: Optional[Dict[str, Any]] = None,
+        allow_always: bool = True,
     ) -> SendResult:
-        """Send a Block Kit three-option slash-command confirmation prompt."""
+        """Send a Block Kit slash-command confirmation prompt."""
         if not self._app:
             return SendResult(success=False, error="Not connected")
 
@@ -2777,6 +2778,34 @@ class SlackAdapter(BasePlatformAdapter):
             # Encode session_key and confirm_id into the button value so the
             # callback handler can resolve without extra bookkeeping.
             value = f"{session_key}|{confirm_id}"
+
+            elements = [
+                {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": "Approve Once" if allow_always else "Approve"},
+                    "style": "primary",
+                    "action_id": "hermes_confirm_once",
+                    "value": value,
+                },
+            ]
+            if allow_always:
+                elements.append(
+                    {
+                        "type": "button",
+                        "text": {"type": "plain_text", "text": "Always Approve"},
+                        "action_id": "hermes_confirm_always",
+                        "value": value,
+                    }
+                )
+            elements.append(
+                {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": "Cancel"},
+                    "style": "danger",
+                    "action_id": "hermes_confirm_cancel",
+                    "value": value,
+                }
+            )
 
             blocks = [
                 {
@@ -2788,28 +2817,7 @@ class SlackAdapter(BasePlatformAdapter):
                 },
                 {
                     "type": "actions",
-                    "elements": [
-                        {
-                            "type": "button",
-                            "text": {"type": "plain_text", "text": "Approve Once"},
-                            "style": "primary",
-                            "action_id": "hermes_confirm_once",
-                            "value": value,
-                        },
-                        {
-                            "type": "button",
-                            "text": {"type": "plain_text", "text": "Always Approve"},
-                            "action_id": "hermes_confirm_always",
-                            "value": value,
-                        },
-                        {
-                            "type": "button",
-                            "text": {"type": "plain_text", "text": "Cancel"},
-                            "style": "danger",
-                            "action_id": "hermes_confirm_cancel",
-                            "value": value,
-                        },
-                    ],
+                    "elements": elements,
                 },
             ]
 

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2736,23 +2736,32 @@ class TelegramAdapter(BasePlatformAdapter):
     async def send_slash_confirm(
         self, chat_id: str, title: str, message: str, session_key: str,
         confirm_id: str, metadata: Optional[Dict[str, Any]] = None,
+        allow_always: bool = True,
     ) -> SendResult:
-        """Render a three-button slash-command confirmation prompt."""
+        """Render a slash-command confirmation prompt."""
         if not self._bot:
             return SendResult(success=False, error="Not connected")
 
         try:
             preview = self.format_message(message if len(message) <= 3800 else message[:3800] + "...")
 
-            keyboard = InlineKeyboardMarkup([
-                [
-                    InlineKeyboardButton("✅ Approve Once", callback_data=f"sc:once:{confirm_id}"),
-                    InlineKeyboardButton("🔒 Always Approve", callback_data=f"sc:always:{confirm_id}"),
-                ],
-                [
-                    InlineKeyboardButton("❌ Cancel", callback_data=f"sc:cancel:{confirm_id}"),
-                ],
-            ])
+            if allow_always:
+                keyboard = InlineKeyboardMarkup([
+                    [
+                        InlineKeyboardButton("✅ Approve Once", callback_data=f"sc:once:{confirm_id}"),
+                        InlineKeyboardButton("🔒 Always Approve", callback_data=f"sc:always:{confirm_id}"),
+                    ],
+                    [
+                        InlineKeyboardButton("❌ Cancel", callback_data=f"sc:cancel:{confirm_id}"),
+                    ],
+                ])
+            else:
+                keyboard = InlineKeyboardMarkup([
+                    [
+                        InlineKeyboardButton("✅ Approve", callback_data=f"sc:once:{confirm_id}"),
+                        InlineKeyboardButton("❌ Cancel", callback_data=f"sc:cancel:{confirm_id}"),
+                    ],
+                ])
 
             thread_id = self._metadata_thread_id(metadata)
             kwargs: Dict[str, Any] = {

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7142,6 +7142,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if canonical == "voice":
             return await self._handle_voice_command(event)
 
+        if canonical == "call":
+            return await self._handle_call_command(event)
+
         if self._draining:
             return f"⏳ Gateway is {self._status_action_gerund()} and is not accepting new work right now."
 
@@ -9303,6 +9306,198 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return None
 
 
+    async def _handle_call_command(self, event: MessageEvent) -> Optional[str]:
+        """Handle /call — confirmation-safe Vapi outbound calling."""
+        parsed = self._parse_call_command_args(event.get_command_args())
+        if "error" in parsed:
+            return parsed["error"]
+
+        phone_number = parsed["phone_number"]
+        task = parsed["task"]
+        first_sentence = parsed.get("first_sentence") or ""
+        max_duration = int(parsed.get("max_duration") or 3)
+        masked_phone = self._mask_phone_for_display(phone_number)
+
+        async def _on_confirm(choice: str) -> Optional[str]:
+            if choice == "cancel":
+                return "🟡 /call cancelled. No outbound call was placed."
+            if choice == "always":
+                return (
+                    "Outbound calls require one-time approval. "
+                    "Re-run /call and choose Approve."
+                )
+            return await self._execute_confirmed_vapi_call(
+                phone_number=phone_number,
+                task=task,
+                first_sentence=first_sentence,
+                max_duration=max_duration,
+            )
+
+        task_preview = task[:500] + ("..." if len(task) > 500 else "")
+        first_line = (
+            f"\nFirst sentence: {first_sentence[:200]}"
+            if first_sentence else ""
+        )
+        message = (
+            "📞 **Confirm outbound Vapi call**\n\n"
+            f"To: `{masked_phone}`\n"
+            f"Max duration: {max_duration} minute(s){first_line}\n\n"
+            f"Task:\n{task_preview}\n\n"
+            "Approve only if this call is expected and appropriate.\n\n"
+            "_Text fallback: reply `/approve` to place the call or `/cancel` to abort._"
+        )
+        return await self._request_slash_confirm(
+            event=event,
+            command="call",
+            title="/call",
+            message=message,
+            handler=_on_confirm,
+            allow_always=False,
+        )
+
+    @staticmethod
+    def _mask_phone_for_display(phone_number: str) -> str:
+        digits = re.sub(r"\D", "", phone_number or "")
+        if len(digits) < 4:
+            return "***"
+        return f"***-***-{digits[-4:]}"
+
+    @staticmethod
+    def _parse_call_command_args(raw_args: str) -> Dict[str, Any]:
+        raw_args = (raw_args or "").strip()
+        usage = (
+            "Usage: `/call +15551234567 --task \"Ask whether they carry X\"`\n"
+            "Optional: `--first-sentence \"Hi, this is Hermes calling for Jesse.\"` "
+            "`--max-duration 3`"
+        )
+        if not raw_args:
+            return {"error": usage}
+        try:
+            tokens = shlex.split(raw_args)
+        except ValueError as exc:
+            return {"error": f"Could not parse /call arguments: {exc}\n\n{usage}"}
+        if not tokens:
+            return {"error": usage}
+
+        phone_number = tokens[0].strip()
+        if not phone_number.startswith("+") or len(re.sub(r"\D", "", phone_number)) < 8:
+            return {
+                "error": (
+                    "Phone number must be E.164 format, for example `+15551234567`.\n\n"
+                    + usage
+                )
+            }
+
+        task_parts: list[str] = []
+        first_sentence = ""
+        max_duration = 3
+        i = 1
+        while i < len(tokens):
+            token = tokens[i]
+            if token == "--task":
+                if i + 1 >= len(tokens):
+                    return {"error": "`--task` requires instructions.\n\n" + usage}
+                task_parts.append(tokens[i + 1])
+                i += 2
+                continue
+            if token == "--first-sentence":
+                if i + 1 >= len(tokens):
+                    return {"error": "`--first-sentence` requires text.\n\n" + usage}
+                first_sentence = tokens[i + 1].strip()
+                i += 2
+                continue
+            if token == "--max-duration":
+                if i + 1 >= len(tokens):
+                    return {"error": "`--max-duration` requires a number of minutes.\n\n" + usage}
+                try:
+                    max_duration = max(1, min(10, int(tokens[i + 1])))
+                except ValueError:
+                    return {"error": "`--max-duration` must be a whole number of minutes.\n\n" + usage}
+                i += 2
+                continue
+            task_parts.append(token)
+            i += 1
+
+        task = " ".join(part.strip() for part in task_parts if part.strip()).strip()
+        if not task:
+            return {"error": "A call task is required.\n\n" + usage}
+        return {
+            "phone_number": phone_number,
+            "task": task,
+            "first_sentence": first_sentence,
+            "max_duration": max_duration,
+        }
+
+    async def _execute_confirmed_vapi_call(
+        self,
+        *,
+        phone_number: str,
+        task: str,
+        first_sentence: str = "",
+        max_duration: int = 3,
+    ) -> str:
+        """Run the repo-shipped telephony helper after explicit approval."""
+        script = (
+            Path(__file__).resolve().parents[1]
+            / "optional-skills"
+            / "productivity"
+            / "telephony"
+            / "scripts"
+            / "telephony.py"
+        )
+        argv = [
+            sys.executable,
+            str(script),
+            "ai-call",
+            phone_number,
+            task,
+            "--provider",
+            "vapi",
+            "--max-duration",
+            str(max_duration),
+        ]
+        if first_sentence:
+            argv.extend(["--first-sentence", first_sentence])
+
+        def _run_call() -> tuple[int, str, str]:
+            import subprocess
+
+            proc = subprocess.run(
+                argv,
+                cwd=str(Path(__file__).resolve().parents[1]),
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=45,
+            )
+            return proc.returncode, proc.stdout, proc.stderr
+
+        try:
+            returncode, stdout, stderr = await asyncio.to_thread(_run_call)
+        except TimeoutError:
+            return "⚠️ Vapi call request timed out before a call id was returned."
+        except Exception as exc:
+            logger.warning("Confirmed Vapi call failed before request completed: %s", exc)
+            return f"⚠️ Vapi call failed: {exc}"
+
+        if returncode != 0:
+            detail = (stderr or stdout or "").strip()
+            if detail:
+                detail = detail.splitlines()[-1][:300]
+            return f"⚠️ Vapi call failed before dialing: {detail or f'exit code {returncode}'}"
+
+        try:
+            payload = json.loads(stdout or "{}")
+        except json.JSONDecodeError:
+            payload = {}
+
+        call_id = str(payload.get("call_id") or "")
+        status = str(payload.get("status") or "queued")
+        masked = str(payload.get("to_phone_number_masked") or self._mask_phone_for_display(phone_number))
+        if call_id:
+            return f"✅ Vapi outbound call queued to `{masked}`.\nCall ID: `{call_id}`\nStatus: {status}"
+        return f"✅ Vapi outbound call request completed for `{masked}`."
+
     async def _handle_voice_channel_join(self, event: MessageEvent) -> str:
         """Join the user's current Discord voice channel."""
         adapter = self.adapters.get(event.source.platform)
@@ -10605,6 +10800,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         title: str,
         message: str,
         handler,
+        allow_always: bool = True,
     ) -> Optional[str]:
         """Ask the user to confirm an expensive slash command.
 
@@ -10650,6 +10846,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     session_key=session_key,
                     confirm_id=confirm_id,
                     metadata=metadata,
+                    allow_always=allow_always,
                 )
                 if button_result and getattr(button_result, "success", False):
                     used_buttons = True

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -156,6 +156,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                subcommands=("kaomoji", "emoji", "unicode", "ascii")),
     CommandDef("voice", "Toggle voice mode", "Configuration",
                args_hint="[on|off|tts|status]", subcommands=("on", "off", "tts", "status")),
+    CommandDef("call", "Place a confirmed Vapi outbound call", "Tools & Skills",
+               gateway_only=True, args_hint="<phone> --task <instructions>"),
     CommandDef("busy", "Control what Enter does while Hermes is working", "Configuration",
                cli_only=True, args_hint="[queue|steer|interrupt|status]",
                subcommands=("queue", "steer", "interrupt", "status")),

--- a/tests/gateway/test_call_command.py
+++ b/tests/gateway/test_call_command.py
@@ -1,0 +1,169 @@
+"""Tests for confirmation-safe gateway /call command."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(), message_id="m1")
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    adapter.send_slash_confirm = AsyncMock(return_value=None)
+    runner.adapters = {Platform.TELEGRAM: adapter}
+
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.append_to_transcript = MagicMock()
+
+    import itertools as _it
+
+    runner._slash_confirm_counter = _it.count(1)
+    runner._session_key_for_source = lambda src: build_session_key(src)
+    runner._thread_metadata_for_source = lambda *a, **kw: None
+    runner._reply_anchor_for_event = lambda _e: None
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), emit_collect=AsyncMock(return_value=[]))
+    return runner
+
+
+def test_parse_call_args_accepts_task_flags():
+    from gateway.run import GatewayRunner
+
+    parsed = GatewayRunner._parse_call_command_args(
+        '+15551234567 --task "Ask whether they carry lemon ejuice" '
+        '--first-sentence "Hi, this is Hermes calling for Jesse." --max-duration 2'
+    )
+
+    assert parsed["phone_number"] == "+15551234567"
+    assert parsed["task"] == "Ask whether they carry lemon ejuice"
+    assert parsed["first_sentence"] == "Hi, this is Hermes calling for Jesse."
+    assert parsed["max_duration"] == 2
+
+
+def test_parse_call_args_rejects_non_e164_phone():
+    from gateway.run import GatewayRunner
+
+    parsed = GatewayRunner._parse_call_command_args("5551234567 --task hi")
+
+    assert "error" in parsed
+    assert "E.164" in parsed["error"]
+
+
+@pytest.mark.asyncio
+async def test_call_command_registers_one_time_confirm_without_calling():
+    from tools import slash_confirm as slash_confirm
+
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+    slash_confirm.clear(session_key)
+    runner._execute_confirmed_vapi_call = AsyncMock(return_value="should not run")
+
+    result = await runner._handle_call_command(
+        _make_event('/call +15551234567 --task "Ask if they carry item X"')
+    )
+
+    runner._execute_confirmed_vapi_call.assert_not_awaited()
+    assert "Confirm outbound Vapi call" in result
+    runner.adapters[Platform.TELEGRAM].send_slash_confirm.assert_awaited_once()
+    assert runner.adapters[Platform.TELEGRAM].send_slash_confirm.await_args.kwargs["allow_always"] is False
+    assert slash_confirm.get_pending(session_key)["command"] == "call"
+    slash_confirm.clear(session_key)
+
+
+@pytest.mark.asyncio
+async def test_call_confirm_cancel_does_not_call_vapi():
+    from tools import slash_confirm as slash_confirm
+
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+    slash_confirm.clear(session_key)
+    runner._execute_confirmed_vapi_call = AsyncMock(return_value="should not run")
+
+    await runner._handle_call_command(
+        _make_event('/call +15551234567 --task "Ask if they carry item X"')
+    )
+    pending = slash_confirm.get_pending(session_key)
+    assert pending is not None
+
+    resolved = await slash_confirm.resolve(session_key, pending["confirm_id"], "cancel")
+
+    runner._execute_confirmed_vapi_call.assert_not_awaited()
+    assert "cancelled" in resolved.lower()
+
+
+@pytest.mark.asyncio
+async def test_call_confirm_always_is_rejected():
+    from tools import slash_confirm as slash_confirm
+
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+    slash_confirm.clear(session_key)
+    runner._execute_confirmed_vapi_call = AsyncMock(return_value="should not run")
+
+    await runner._handle_call_command(
+        _make_event('/call +15551234567 --task "Ask if they carry item X"')
+    )
+    pending = slash_confirm.get_pending(session_key)
+    assert pending is not None
+
+    resolved = await slash_confirm.resolve(session_key, pending["confirm_id"], "always")
+
+    runner._execute_confirmed_vapi_call.assert_not_awaited()
+    assert "one-time approval" in resolved
+
+
+@pytest.mark.asyncio
+async def test_call_confirm_once_executes_vapi():
+    from tools import slash_confirm as slash_confirm
+
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+    slash_confirm.clear(session_key)
+    runner._execute_confirmed_vapi_call = AsyncMock(return_value="queued")
+
+    await runner._handle_call_command(
+        _make_event('/call +15551234567 --task "Ask if they carry item X"')
+    )
+    pending = slash_confirm.get_pending(session_key)
+    assert pending is not None
+
+    resolved = await slash_confirm.resolve(session_key, pending["confirm_id"], "once")
+
+    runner._execute_confirmed_vapi_call.assert_awaited_once()
+    assert resolved == "queued"

--- a/tests/gateway/test_telegram_slash_confirm.py
+++ b/tests/gateway/test_telegram_slash_confirm.py
@@ -107,3 +107,42 @@ class TestSendSlashConfirm:
         )
 
         assert result.success is False
+
+    @pytest.mark.asyncio
+    async def test_one_time_confirm_omits_always_button(self, monkeypatch):
+        import gateway.platforms.telegram as telegram_mod
+
+        class _Button:
+            def __init__(self, text, callback_data):
+                self.text = text
+                self.callback_data = callback_data
+
+        class _Keyboard:
+            def __init__(self, rows):
+                self.inline_keyboard = rows
+
+        monkeypatch.setattr(telegram_mod, "InlineKeyboardButton", _Button)
+        monkeypatch.setattr(telegram_mod, "InlineKeyboardMarkup", _Keyboard)
+
+        adapter = _make_adapter()
+        sent = {}
+
+        async def mock_send(**kwargs):
+            sent.update(kwargs)
+            return SimpleNamespace(message_id=9)
+
+        adapter._bot.send_message = AsyncMock(side_effect=mock_send)
+
+        result = await adapter.send_slash_confirm(
+            chat_id="100",
+            title="Confirm",
+            message="place call",
+            session_key="sk",
+            confirm_id="cid4",
+            allow_always=False,
+        )
+
+        assert result.success is True
+        buttons = sent["reply_markup"].inline_keyboard
+        labels = [button.text for row in buttons for button in row]
+        assert labels == ["✅ Approve", "❌ Cancel"]


### PR DESCRIPTION
## Summary\n- add a gateway-only /call command for confirmation-safe Vapi outbound calls\n- extend existing slash-confirm rendering with one-time-only approvals so outbound calls cannot use Always Approve\n- keep Vapi execution behind explicit approval and reuse the existing telephony helper\n\n## Safety\n- phone numbers are masked in confirmation prompts and responses\n- /cancel does not call Vapi\n- text fallback /always is rejected for outbound calls\n\n## Tests\n- scripts/run_tests.sh tests/gateway/test_slack_approval_buttons.py tests/gateway/test_telegram_approval_buttons.py tests/gateway/test_call_command.py tests/gateway/test_telegram_slash_confirm.py tests/gateway/test_destructive_slash_confirm.py\n- git diff --check\n\nLinear: HERMES-9