### PR TITLE
docs: correct Docker persistence setting name

### DIFF
--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -204,7 +204,7 @@ When a Hermes process exits — `/quit`, closing a TUI session, gateway shutdown
 | Trigger | When it fires |
 |---|---|
 | `docker_persist_across_processes: false` | Explicit per-process isolation. Every `cleanup()` does `stop` + `rm -f`. Matches pre-issue-#20561 behavior. |
-| Idle reaper (`lifetime_seconds`, default 300s) | Only when the env is `persist_across_processes=false`. Persist-mode envs are no-op'd; container survives the idle sweep. |
+| Idle reaper (`lifetime_seconds`, default 300s) | Only when `docker_persist_across_processes: false` / `TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES=false`. Persist-mode envs are no-op'd; container survives the idle sweep. |
 | Orphan reaper at next startup | Sweeps **Exited** hermes-labeled containers older than `2 × lifetime_seconds` (default 600s = 10 min), scoped to the current profile. **Running containers are never touched** — sibling-process safety. Set `docker_orphan_reaper: false` to disable. |
 | Direct user action | `docker rm -f`, `docker system prune`, Docker Desktop restart. We don't set `--restart=always`, so a host reboot leaves the container `Exited` (its CoW layer survives and gets reused on next startup, but bg processes are gone). |
 


### PR DESCRIPTION
## What does this PR do?

Corrects the Docker container lifecycle docs to use the real user-facing setting, `docker_persist_across_processes`, instead of the internal `persist_across_processes` constructor flag.

Also includes the matching environment variable, `TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES`, so users can identify both supported forms from the teardown table.

## Related Issue

Related: #20561

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `website/docs/user-guide/configuration.md` so the idle-reaper row references `docker_persist_across_processes` / `TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES` instead of `persist_across_processes=false`.

## How to Test

1. Review `website/docs/user-guide/configuration.md` and confirm the idle-reaper row uses the documented config key and environment variable.
2. Run `git diff --check`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, via `git diff --check`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A; documentation-only correction.
