### PR TITLE
feat(gateway): Desktop-managed platform lifecycle

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -4861,6 +4861,27 @@ async function startHermes() {
       childAlive: () => hermesProcess !== null && hermesProcess.exitCode === null && !hermesProcess.killed,
       rememberLog
     })
+
+    // Auto-boot the gateway if any messaging platform is enabled.
+    // This ensures users who have configured a messaging platform
+    // get the gateway running without a manual /cron intervention.
+    if (!remote) {
+      try {
+        const platformsResp = await fetchJson(`${baseUrl}/api/messaging/platforms`, token)
+        const platforms = Array.isArray(platformsResp) ? platformsResp : (platformsResp?.platforms || [])
+        const hasEnabled = platforms.some(p => p.enabled)
+        if (hasEnabled) {
+          rememberLog('Auto-starting gateway — enabled messaging platform(s) detected')
+          await fetchJson(`${baseUrl}/api/gateway/start`, token, { method: 'POST' })
+        }
+      } catch (e) {
+        // Best-effort — gateway may already be running, or the endpoint might
+        // not exist (older backend). Either way, the cron health-check will
+        // pick it up soon.
+        rememberLog(`Gateway auto-start skipped (non-critical): ${e.message}`)
+      }
+    }
+
     updateBootProgress({
       phase: 'backend.ready',
       message: 'Hermes backend is ready. Finalizing desktop startup',

--- a/apps/desktop/src/app/messaging/index.tsx
+++ b/apps/desktop/src/app/messaging/index.tsx
@@ -184,7 +184,8 @@ export function MessagingView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
     try {
       await updateMessagingPlatform(platform.id, { enabled })
 
-      // 联动 gateway 进程：开启平台 → 启动 gateway；关闭最后一个 → 停止 gateway
+      // 联动 gateway：开启任意消息平台 → 自动启动 gateway
+      // 关闭不自动停 gateway（有其他平台可能在用），由用户通过 /cron 或 gateway CLI 管理
       if (enabled) {
         startGateway().catch((err: unknown) =>
           console.warn('gateway start (post-enable) failed', err)

--- a/apps/desktop/src/app/messaging/index.tsx
+++ b/apps/desktop/src/app/messaging/index.tsx
@@ -11,7 +11,8 @@ import {
   getMessagingPlatforms,
   type MessagingEnvVarInfo,
   type MessagingPlatformInfo,
-  updateMessagingPlatform
+  updateMessagingPlatform,
+  startGateway
 } from '@/hermes'
 import { type Translations, useI18n } from '@/i18n'
 import { AlertTriangle, ExternalLink, Save, Trash2 } from '@/lib/icons'
@@ -182,6 +183,14 @@ export function MessagingView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
 
     try {
       await updateMessagingPlatform(platform.id, { enabled })
+
+      // 联动 gateway 进程：开启平台 → 启动 gateway；关闭最后一个 → 停止 gateway
+      if (enabled) {
+        startGateway().catch((err: unknown) =>
+          console.warn('gateway start (post-enable) failed', err)
+        )
+      }
+
       setPlatforms(
         current =>
           current?.map(row =>
@@ -197,7 +206,7 @@ export function MessagingView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
       notify({
         kind: 'success',
         title: enabled ? m.platformEnabled(platform.name) : m.platformDisabled(platform.name),
-        message: m.restartToApply
+        message: enabled ? m.restartToApply : undefined
       })
     } catch (err) {
       notifyError(err, m.failedUpdate(platform.name))

--- a/apps/desktop/src/app/messaging/index.tsx
+++ b/apps/desktop/src/app/messaging/index.tsx
@@ -184,11 +184,12 @@ export function MessagingView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
     try {
       await updateMessagingPlatform(platform.id, { enabled })
 
-      // 联动 gateway：开启任意消息平台 → 自动启动 gateway
-      // 关闭不自动停 gateway（有其他平台可能在用），由用户通过 /cron 或 gateway CLI 管理
+      // Start gateway whenever a messaging platform is enabled.
+      // Don't auto-stop on disable — other platforms may still be
+      // using the gateway.  Users control lifecycle via /cron or CLI.
       if (enabled) {
-        startGateway().catch((err: unknown) =>
-          console.warn('gateway start (post-enable) failed', err)
+        startGateway().catch(() =>
+          notify({ kind: 'warning', title: m.gatewayStopped, message: m.hintGatewayStopped })
         )
       }
 

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -683,6 +683,20 @@ export function restartGateway(): Promise<ActionResponse> {
   })
 }
 
+export function startGateway(): Promise<ActionResponse> {
+  return window.hermesDesktop.api<ActionResponse>({
+    path: '/api/gateway/start',
+    method: 'POST'
+  })
+}
+
+export function stopGateway(): Promise<ActionResponse> {
+  return window.hermesDesktop.api<ActionResponse>({
+    path: '/api/gateway/stop',
+    method: 'POST'
+  })
+}
+
 export function updateHermes(): Promise<ActionResponse> {
   return window.hermesDesktop.api<ActionResponse>({
     path: '/api/hermes/update',

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2097,6 +2097,37 @@ def _write_gateway_state(state: Dict[str, Any]) -> None:
     tmp.replace(target)
 
 
+_DESKTOP_MANAGED_FLAG = ".desktop_managed"
+
+
+def _write_desktop_managed_flag(managed: bool) -> None:
+    """Write the desktop-managed companion flag.
+
+    Uses a separate file (``.desktop_managed``) instead of
+    ``gateway_state.json`` to avoid a race with the gateway's own
+    ``_write_runtime_status()`` which also writes gateway_state.json
+    and would overwrite our ``desktop_managed`` field.
+    """
+    try:
+        (get_hermes_home() / _DESKTOP_MANAGED_FLAG).write_text(
+            json.dumps({"desktop_managed": managed}, indent=2),
+            encoding="utf-8",
+        )
+    except Exception:
+        pass  # best-effort; not on the critical path
+
+
+def _read_desktop_managed_flag() -> bool:
+    """Read the desktop-managed companion flag, returning False if absent."""
+    try:
+        flag = get_hermes_home() / _DESKTOP_MANAGED_FLAG
+        if flag.exists():
+            return json.loads(flag.read_text(encoding="utf-8")).get("desktop_managed", False)
+    except Exception:
+        pass
+    return False
+
+
 def _spawn_gateway_restart() -> Tuple[subprocess.Popen, bool]:
     """Spawn ``hermes gateway restart``, reusing an in-flight restart.
 
@@ -4738,9 +4769,7 @@ async def update_messaging_platform(platform_id: str, body: MessagingPlatformUpd
             if body.enabled:
                 try:
                     _spawn_hermes_action(["gateway", "start"], "gateway-start")
-                    gw_state = _read_gateway_state()
-                    gw_state["desktop_managed"] = True
-                    _write_gateway_state(gw_state)
+                    _write_desktop_managed_flag(True)
                 except Exception:
                     pass  # best-effort
 
@@ -7551,12 +7580,7 @@ async def start_gateway():
             existing_pid = None
 
         if existing_pid is not None:
-            try:
-                gw_state = _read_gateway_state()
-                gw_state["desktop_managed"] = True
-                _write_gateway_state(gw_state)
-            except Exception:
-                pass
+            _write_desktop_managed_flag(True)
             return {"ok": True, "pid": existing_pid, "already_running": True}
 
         # 2 — Spawn ``hermes gateway start`` as a background action.
@@ -7566,13 +7590,11 @@ async def start_gateway():
         #     (schtasks /Run or detached pythonw.exe spawn).
         proc = _spawn_hermes_action(["gateway", "start"], "gateway-start")
 
-        # 3 — Mark as desktop-managed (cron health-check will keep alive)
-        try:
-            gw_state = _read_gateway_state()
-            gw_state["desktop_managed"] = True
-            _write_gateway_state(gw_state)
-        except Exception:
-            pass  # best-effort; gateway start is the critical path
+        # 3 — Mark as desktop-managed.  Uses a companion file (not
+        #     gateway_state.json) to avoid a race with the gateway's own
+        #     _write_runtime_status() which also writes gateway_state.json
+        #     and would overwrite our flag.
+        _write_desktop_managed_flag(True)
     except Exception as exc:
         _log.exception("Failed to spawn gateway start")
         raise HTTPException(status_code=500, detail=f"Failed to start gateway: {exc}")
@@ -7587,12 +7609,7 @@ async def stop_gateway():
     does not attempt to restart a gateway the user explicitly stopped."""
     try:
         proc = _spawn_hermes_action(["gateway", "stop"], "gateway-stop")
-        try:
-            gw_state = _read_gateway_state()
-            gw_state.pop("desktop_managed", None)
-            _write_gateway_state(gw_state)
-        except Exception:
-            pass
+        _write_desktop_managed_flag(False)
     except Exception as exc:
         _log.exception("Failed to spawn gateway stop")
         raise HTTPException(status_code=500, detail=f"Failed to stop gateway: {exc}")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7568,7 +7568,7 @@ async def set_webhook_enabled(name: str, body: WebhookEnabledToggle):
 
 
 @app.post("/api/gateway/start")
-async def start_gateway():
+async def start_gateway(request: Request):
     """Start Hermes Gateway.
 
     Delegates to ``hermes gateway start`` which dispatches to the
@@ -7579,6 +7579,7 @@ async def start_gateway():
     If a gateway is already running, the handler returns immediately
     and we still write the ``desktop_managed`` flag so the cron
     health-check knows the Desktop is in charge."""
+    _require_token(request)
     try:
         # 1 — Check if already running (fast path — mark as managed)
         try:
@@ -7603,24 +7604,25 @@ async def start_gateway():
         #     _write_runtime_status() which also writes gateway_state.json
         #     and would overwrite our flag.
         _write_desktop_managed_flag(True)
-    except Exception as exc:
+    except Exception:
         _log.exception("Failed to spawn gateway start")
-        raise HTTPException(status_code=500, detail=f"Failed to start gateway: {exc}")
+        raise HTTPException(status_code=500, detail="Internal server error")
     return {"ok": True, "pid": proc.pid, "name": "gateway-start"}
 
 
 @app.post("/api/gateway/stop")
-async def stop_gateway():
+async def stop_gateway(request: Request):
     """Stop Hermes Gateway (called from Desktop toggle).
 
     Also clears the desktop_managed flag so the cron health-check
     does not attempt to restart a gateway the user explicitly stopped."""
+    _require_token(request)
     try:
         proc = _spawn_hermes_action(["gateway", "stop"], "gateway-stop")
         _write_desktop_managed_flag(False)
-    except Exception as exc:
+    except Exception:
         _log.exception("Failed to spawn gateway stop")
-        raise HTTPException(status_code=500, detail=f"Failed to stop gateway: {exc}")
+        raise HTTPException(status_code=500, detail="Internal server error")
     return {"ok": True, "pid": proc.pid, "name": "gateway-stop"}
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2080,6 +2080,23 @@ def _tail_lines(path: Path, n: int) -> List[str]:
     return lines[-n:] if n > 0 else lines
 
 
+def _read_gateway_state() -> Dict[str, Any]:
+    """Read gateway_state.json, returning {} on any error."""
+    try:
+        return json.loads((get_hermes_home() / "gateway_state.json").read_text(encoding="utf-8"))  # type: ignore[union-attr]
+    except Exception:
+        return {}
+
+
+def _write_gateway_state(state: Dict[str, Any]) -> None:
+    """Atomically write gateway_state.json."""
+    home = get_hermes_home()
+    tmp = home / "gateway_state.json.tmp"
+    target = home / "gateway_state.json"
+    tmp.write_text(json.dumps(state, indent=2), encoding="utf-8")
+    tmp.replace(target)
+
+
 def _spawn_gateway_restart() -> Tuple[subprocess.Popen, bool]:
     """Spawn ``hermes gateway restart``, reusing an in-flight restart.
 
@@ -7505,8 +7522,19 @@ async def set_webhook_enabled(name: str, body: WebhookEnabledToggle):
 
 @app.post("/api/gateway/start")
 async def start_gateway():
+    """Start Hermes Gateway (called from Desktop toggle and auto-boot).
+
+    Also writes gateway_state.json to signal that the gateway is
+    desktop-managed, so the cron health-check knows to keep it alive."""
     try:
         proc = _spawn_hermes_action(["gateway", "start"], "gateway-start")
+        # Signal to cron health-check that this gateway is under Desktop management
+        try:
+            gw_state = _read_gateway_state()
+            gw_state["desktop_managed"] = True
+            _write_gateway_state(gw_state)
+        except Exception:
+            pass  # best-effort; gateway start is the critical path
     except Exception as exc:
         _log.exception("Failed to spawn gateway start")
         raise HTTPException(status_code=500, detail=f"Failed to start gateway: {exc}")
@@ -7515,8 +7543,18 @@ async def start_gateway():
 
 @app.post("/api/gateway/stop")
 async def stop_gateway():
+    """Stop Hermes Gateway (called from Desktop toggle).
+
+    Also clears the desktop_managed flag so the cron health-check
+    does not attempt to restart a gateway the user explicitly stopped."""
     try:
         proc = _spawn_hermes_action(["gateway", "stop"], "gateway-stop")
+        try:
+            gw_state = _read_gateway_state()
+            gw_state.pop("desktop_managed", None)
+            _write_gateway_state(gw_state)
+        except Exception:
+            pass
     except Exception as exc:
         _log.exception("Failed to spawn gateway stop")
         raise HTTPException(status_code=500, detail=f"Failed to stop gateway: {exc}")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4734,6 +4734,16 @@ async def update_messaging_platform(platform_id: str, body: MessagingPlatformUpd
         if body.enabled is not None:
             _write_platform_enabled(platform_id, body.enabled)
 
+            # 联动 gateway：任意消息平台被启用 → 自动启动 gateway（fire-and-forget）
+            if body.enabled:
+                try:
+                    _spawn_hermes_action(["gateway", "start"], "gateway-start")
+                    gw_state = _read_gateway_state()
+                    gw_state["desktop_managed"] = True
+                    _write_gateway_state(gw_state)
+                except Exception:
+                    pass  # best-effort
+
         return {"ok": True, "platform": platform_id}
     except HTTPException:
         raise
@@ -7522,13 +7532,41 @@ async def set_webhook_enabled(name: str, body: WebhookEnabledToggle):
 
 @app.post("/api/gateway/start")
 async def start_gateway():
-    """Start Hermes Gateway (called from Desktop toggle and auto-boot).
+    """Start Hermes Gateway.
 
-    Also writes gateway_state.json to signal that the gateway is
-    desktop-managed, so the cron health-check knows to keep it alive."""
+    Delegates to ``hermes gateway start`` which dispatches to the
+    platform-appropriate handler (systemd / launchd / gateway_windows).
+    On Windows, ``gateway_windows.start()`` prefers ``schtasks /Run``
+    and falls back to a detached ``pythonw.exe`` spawn.
+
+    If a gateway is already running, the handler returns immediately
+    and we still write the ``desktop_managed`` flag so the cron
+    health-check knows the Desktop is in charge."""
     try:
+        # 1 — Check if already running (fast path — mark as managed)
+        try:
+            from gateway.status import get_running_pid
+            existing_pid = get_running_pid(cleanup_stale=False)
+        except ImportError:
+            existing_pid = None
+
+        if existing_pid is not None:
+            try:
+                gw_state = _read_gateway_state()
+                gw_state["desktop_managed"] = True
+                _write_gateway_state(gw_state)
+            except Exception:
+                pass
+            return {"ok": True, "pid": existing_pid, "already_running": True}
+
+        # 2 — Spawn ``hermes gateway start`` as a background action.
+        #     On Linux this becomes ``systemctl start``.
+        #     On macOS this becomes ``launchctl kickstart``.
+        #     On Windows this becomes ``gateway_windows.start()``
+        #     (schtasks /Run or detached pythonw.exe spawn).
         proc = _spawn_hermes_action(["gateway", "start"], "gateway-start")
-        # Signal to cron health-check that this gateway is under Desktop management
+
+        # 3 — Mark as desktop-managed (cron health-check will keep alive)
         try:
             gw_state = _read_gateway_state()
             gw_state["desktop_managed"] = True

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1655,6 +1655,7 @@ async def get_status():
         "active_sessions": active_sessions,
         "auth_required": auth_required,
         "auth_providers": auth_providers,
+        "desktop_managed": _read_desktop_managed_flag(),
     }
 
 
@@ -2107,12 +2108,19 @@ def _write_desktop_managed_flag(managed: bool) -> None:
     ``gateway_state.json`` to avoid a race with the gateway's own
     ``_write_runtime_status()`` which also writes gateway_state.json
     and would overwrite our ``desktop_managed`` field.
+
+    Uses tmp+replace for atomic write — concurrent start/stop cannot
+    produce a torn file.
     """
     try:
-        (get_hermes_home() / _DESKTOP_MANAGED_FLAG).write_text(
+        home = get_hermes_home()
+        tmp = home / f"{_DESKTOP_MANAGED_FLAG}.tmp"
+        target = home / _DESKTOP_MANAGED_FLAG
+        tmp.write_text(
             json.dumps({"desktop_managed": managed}, indent=2),
             encoding="utf-8",
         )
+        tmp.replace(target)
     except Exception:
         pass  # best-effort; not on the critical path
 
@@ -4765,10 +4773,10 @@ async def update_messaging_platform(platform_id: str, body: MessagingPlatformUpd
         if body.enabled is not None:
             _write_platform_enabled(platform_id, body.enabled)
 
-            # 联动 gateway：任意消息平台被启用 → 自动启动 gateway（fire-and-forget）
+            # Record desktop_managed intent — frontend's toggle
+            # handler will POST /api/gateway/start separately.
             if body.enabled:
                 try:
-                    _spawn_hermes_action(["gateway", "start"], "gateway-start")
                     _write_desktop_managed_flag(True)
                 except Exception:
                     pass  # best-effort

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -125,6 +125,13 @@ def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60
             cron_tick(verbose=False, sync=False)
         except Exception as e:
             _log.debug("Desktop cron tick error: %s", e)
+
+        # Desktop-managed gateway self-healing (same loop, same interval).
+        try:
+            _gateway_health_tick()
+        except Exception as e:
+            _log.debug("Gateway health tick error: %s", e)
+
         stop_event.wait(interval)
 
 
@@ -2099,6 +2106,11 @@ def _write_gateway_state(state: Dict[str, Any]) -> None:
 
 
 _DESKTOP_MANAGED_FLAG = ".desktop_managed"
+_GATEWAY_MAX_CRASHES_PER_HOUR = 3
+
+# Gateway crash-rate limiting — in-memory window, resets on process restart.
+_gateway_crash_count = 0
+_gateway_crash_window_start = 0.0  # time.monotonic()
 
 
 def _write_desktop_managed_flag(managed: bool) -> None:
@@ -2134,6 +2146,58 @@ def _read_desktop_managed_flag() -> bool:
     except Exception:
         pass
     return False
+
+
+def _gateway_health_tick() -> None:
+    """Check whether the Desktop-managed gateway needs a restart.
+
+    This runs inline in the Desktop cron ticker loop (every 60 s) so that
+    a crashed gateway recovers without a manual intervention or external
+    watchdog.  Only acts when ``.desktop_managed`` is ``True`` — a user
+    who stops the gateway through the Desktop toggle clears the flag and
+    the health-check becomes a no-op.
+    """
+    import time
+
+    if not _read_desktop_managed_flag():
+        return
+
+    # Is the gateway already running?  Short-circuit — nothing to do.
+    try:
+        from gateway.status import get_running_pid
+
+        existing_pid = get_running_pid(cleanup_stale=False)
+    except Exception:
+        return  # can't determine; skip this tick
+
+    if existing_pid is not None:
+        return  # healthy
+
+    # Gateway is dead — honour the crash-rate limit.
+    global _gateway_crash_count, _gateway_crash_window_start
+    now = time.monotonic()
+    if now - _gateway_crash_window_start > 3600:
+        _gateway_crash_count = 0
+        _gateway_crash_window_start = now
+
+    if _gateway_crash_count >= _GATEWAY_MAX_CRASHES_PER_HOUR:
+        _log.warning(
+            "Gateway health-check: rate-limited (%d crashes in the last hour), "
+            "not restarting",
+            _gateway_crash_count,
+        )
+        return
+
+    _gateway_crash_count += 1
+    _log.info(
+        "Gateway health-check: restarting (crash %d/%d this hour)",
+        _gateway_crash_count,
+        _GATEWAY_MAX_CRASHES_PER_HOUR,
+    )
+    try:
+        _spawn_hermes_action(["gateway", "start"], "gateway-start")
+    except Exception:
+        _log.exception("Gateway health-check: restart spawn failed")
 
 
 def _spawn_gateway_restart() -> Tuple[subprocess.Popen, bool]:


### PR DESCRIPTION
## What

When a user enables a messaging platform (Telegram, Discord, Slack…) in Desktop Settings, the gateway backend starts automatically. On Desktop boot, any enabled platform automatically fires up the gateway. If the gateway crashes later, a built-in health-check in the same ticker loop restarts it — no watchdog, no cron script, no external dependency.

## Architecture

```
Frontend (React)
  ├─ handleToggle ON → startGateway() → POST /api/gateway/start
  │   Failure → amber toast notify({ kind: "warning" })
  └─ handleToggle OFF → no gateway stop (other platforms may use it)

Desktop (Electron main.cjs)
  └─ backendReady → GET /api/messaging/platforms
      → hasEnabled? → POST /api/gateway/start (auto-boot)

Backend (web_server.py)
  ├─ POST /api/gateway/start → _require_token → get_running_pid
  │   ├─ already running → mark .desktop_managed + return
  │   └─ dead → _spawn_hermes_action(["gateway", "start"])
  ├─ POST /api/gateway/stop → _require_token → spawn + clear .managed
  ├─ PUT /api/messaging/platforms → write .desktop_managed flag
  │     (frontend toggle handler triggers the actual start)
  │
  └─ Desktop cron ticker (every 60 s)
      ├─ cron_tick() (existing)
      └─ 🆕 _gateway_health_tick()
            ├─ .desktop_managed? → gateway PID alive? → no-op
            ├─ dead + crash < 3/h → auto-spawn ["gateway", "start"]
            └─ dead + crash ≥ 3/h → rate-limited, warn
```

## Design decisions

| Decision | Why |
|----------|-----|
| **Fire-and-forget** gateway start | Gateway startup takes seconds — dont block the toggle UI |
| **No auto-stop on disable** | Multiple platforms share one gateway; disabling Telegram shouldnt kill Discord users |
| `.desktop_managed` is a separate file | `gateway/status.py`s `_write_runtime_status()` overwrites `gateway_state.json` on startup → race condition. Independent file = zero collision |
| **Atomic `tmp+replace`** for `.desktop_managed` | Concurrent start/stop cant produce a torn file |
| **`_require_token`** on start/stop endpoints | Defense-in-depth — matches `/api/env/reveal` and `/api/providers/*` pattern |
| **`Internal server error`** not raw exception | Traceback logged server-side; client never sees internal paths |
| **Gateway health in ticker, not cron** | Zero new processes, zero new files — rides existing Desktop loop |
| **3 crashes/hour rate-limit** | Prevents infinite restart storms; resets every hour in memory only |

## Cross-platform gateway dispatch

| Platform | `hermes gateway start` → |
|----------|--------------------------|
| **Windows** | `gateway_windows.start()` → schtasks /Run or detached `pythonw.exe` spawn |
| **Linux** | `systemd_start()` → `systemctl start` |
| **macOS** | `launchd_start()` → `launchctl kickstart` |
| WSL | Prompt to enable systemd or run manually |

Desktop auto-boot (`main.cjs` proxy-only guard) and self-healing health-check are platform-agnostic — they call the same `POST /api/gateway/start` endpoint which delegates via the CLI.

## Files

| File | Change |
|------|--------|
| `hermes_cli/web_server.py` | start/stop endpoints, helpers, health tick, `.desktop_managed` companion file |
| `apps/desktop/src/hermes.ts` | +`startGateway()` / +`stopGateway()` |
| `apps/desktop/src/app/messaging/index.tsx` | `handleToggle` → startGateway + notify, English comments |
| `apps/desktop/electron/main.cjs` | Desktop auto-boot on backendReady |

## Testing

1. **Toggle**: Open Settings → Messaging → toggle Telegram ON → gateway auto-starts (visible in `/api/status`); failure shows amber warning toast.
2. **Desktop boot**: Quit & relaunch Hermes Desktop → gateway auto-starts if Telegram is enabled.
3. **Self-healing**: `taskkill /F /PID <gateway-pid>` (Windows) or `kill <pid>` (macOS/Linux) → wait ≤ 60 s → gateway auto-restarts. `gui.log` shows `Gateway health-check: restarting (crash 1/3 this hour)`.

Closes #43748