### PR TITLE
docs(providers): add LLMBase custom provider

### DIFF
--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -21,6 +21,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **Anthropic** | `hermes model` (Claude Max + extra usage credits via OAuth; also supports Anthropic API key or manual setup-token — see note below) |
 | **OpenRouter** | `OPENROUTER_API_KEY` in `~/.hermes/.env` |
 | **NovitaAI** | `NOVITA_API_KEY` in `~/.hermes/.env` (provider: `novita`, 200+ models, Model API, Agent Sandbox, GPU Cloud) |
+| **LLMBase** | named custom provider in `config.yaml` with `LLMBASE_API_KEY` (OpenAI-compatible, provider: `llmbase`) |
 | **z.ai / GLM** | `GLM_API_KEY` in `~/.hermes/.env` (provider: `zai`) |
 | **Kimi / Moonshot** | `KIMI_API_KEY` in `~/.hermes/.env` (provider: `kimi-coding`) |
 | **Kimi / Moonshot (China)** | `KIMI_CN_API_KEY` in `~/.hermes/.env` (provider: `kimi-coding-cn`; aliases: `kimi-cn`, `moonshot-cn`) |
@@ -681,6 +682,61 @@ When switching providers, Hermes persists the base URL and provider to config so
 :::
 
 Everything below follows this same pattern — just change the URL, key, and model name.
+
+---
+
+### LLMBase — Sovereign Open-Source Model Platform
+
+[LLMBase](https://llmbase.ai) is a privacy-focused, sovereign AI platform for
+hosted open-source models. Its inference API speaks the OpenAI-compatible Chat
+Completions protocol, so Hermes can use it as a named custom provider.
+
+Create an API key in the LLMBase dashboard, add it to `~/.hermes/.env`, then add
+a `llmbase` custom provider in `~/.hermes/config.yaml`:
+
+```bash
+echo "LLMBASE_API_KEY=llmbase_..." >> ~/.hermes/.env
+```
+
+```yaml
+model:
+  provider: llmbase
+  model: deepseek/deepseek-v4-flash
+  base_url: https://api.llmbase.ai/v1
+  api_key: ${LLMBASE_API_KEY}
+  api_mode: chat_completions
+  max_tokens: 128
+
+custom_providers:
+  - name: llmbase
+    base_url: https://api.llmbase.ai/v1
+    api_key: ${LLMBASE_API_KEY}
+    api_mode: chat_completions
+    model: deepseek/deepseek-v4-flash
+```
+
+Run Hermes with the named provider:
+
+```bash
+hermes chat --provider llmbase --model deepseek/deepseek-v4-flash
+```
+
+List available models from LLMBase's OpenAI-compatible model endpoint:
+
+```bash
+curl https://api.llmbase.ai/v1/models \
+  -H "Authorization: Bearer $LLMBASE_API_KEY"
+```
+
+For agent-focused model discovery, LLMBase also exposes
+`https://api.llmbase.ai/v1/agents/models`.
+
+:::tip API key types
+Use a normal inference API key with the `llmbase_...` prefix for Hermes custom
+provider requests. LLMBase chat-agent keys with the `llmbase_chat_...` prefix
+are for subscription-backed agent tools and are not needed for this direct
+OpenAI-compatible setup.
+:::
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

Adds LLMBase to the AI Providers integration docs as a named custom OpenAI-compatible provider. The section documents the LLMBase API base URL, `LLMBASE_API_KEY`, `api_mode: chat_completions`, example model selection, model discovery endpoints, and the distinction between normal `llmbase_...` inference keys and `llmbase_chat_...` chat-agent keys.

This uses Hermes' existing `custom_providers` path rather than adding a first-class provider plugin, because LLMBase works through the standard OpenAI-compatible Chat Completions API.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `website/docs/integrations/providers.md` with an LLMBase row in the provider overview table.
- Added a dedicated LLMBase setup section under custom/self-hosted OpenAI-compatible providers.
- Included example `~/.hermes/.env` and `~/.hermes/config.yaml` snippets for running `hermes chat --provider llmbase --model deepseek/deepseek-v4-flash`.

## How to Test

1. `git diff --check`
2. `PATH=\"$HOME/Library/Python/3.13/bin:$PATH\" npm run lint:diagrams` from `website/`
3. `npm run build` from `website/`

`npm run build` exits 0. It still reports existing broken-link/broken-anchor warnings elsewhere in the docs site; this PR does not add those warnings.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS / local Docusaurus docs build

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Docs build verification:

```text
npm run lint:diagrams
Summary: Files checked: 348, Boxes found: 0, Errors: 0

npm run build
[SUCCESS] Generated static files in \"build\".
[SUCCESS] Generated static files in \"build/zh-Hans\".
```