### PR TITLE
fix(desktop): handle prefill command.dispatch type for /undo

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -28,6 +28,7 @@ import {
   clearComposerAttachments,
   type ComposerAttachment,
   setComposerAttachmentUploadState,
+  setComposerDraft,
   terminalContextBlocksFromDraft,
   updateComposerAttachment
 } from '@/store/composer'
@@ -964,6 +965,16 @@ export function usePromptActions({
 
           if (dispatch.type === 'alias') {
             await runSlash(`/${dispatch.target}${arg ? ` ${arg}` : ''}`, sessionId, false)
+
+            return
+          }
+
+          if (dispatch.type === 'prefill') {
+            if (dispatch.notice) {
+              renderSlashOutput(dispatch.notice)
+            }
+
+            setComposerDraft(dispatch.message)
 
             return
           }

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -82,11 +82,18 @@ export interface SendCommandDispatchResponse {
   message: string
 }
 
+export interface PrefillCommandDispatchResponse {
+  type: 'prefill'
+  message: string
+  notice?: string
+}
+
 export type CommandDispatchResponse =
   | ExecCommandDispatchResponse
   | AliasCommandDispatchResponse
   | SkillCommandDispatchResponse
   | SendCommandDispatchResponse
+  | PrefillCommandDispatchResponse
 
 export type SidebarNavId = 'artifacts' | 'command-center' | 'messaging' | 'new-session' | 'settings' | 'skills'
 

--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { ComposerAttachment } from '@/store/composer'
 
-import { coerceThinkingText, optimisticAttachmentRef } from './chat-runtime'
+import { coerceThinkingText, optimisticAttachmentRef, parseCommandDispatch } from './chat-runtime'
 
 const DATA_URL = 'data:image/png;base64,iVBORw0KGgoAAAANS'
 
@@ -50,5 +50,27 @@ describe('coerceThinkingText', () => {
         "◉_◉ processing... I don't see any current rewritten thinking or next thinking to process. Could you provide the thinking content you'd like me to rewrite?"
       )
     ).toBe('')
+  })
+})
+
+describe('parseCommandDispatch', () => {
+  it('parses prefill type with message', () => {
+    expect(parseCommandDispatch({ type: 'prefill', message: 'edit me' })).toEqual({
+      type: 'prefill',
+      message: 'edit me'
+    })
+  })
+
+  it('parses prefill type with notice', () => {
+    expect(parseCommandDispatch({ type: 'prefill', message: 'edit me', notice: '↶ rewound 1 turn' })).toEqual({
+      type: 'prefill',
+      message: 'edit me',
+      notice: '↶ rewound 1 turn'
+    })
+  })
+
+  it('rejects prefill without message', () => {
+    expect(parseCommandDispatch({ type: 'prefill' })).toBeNull()
+    expect(parseCommandDispatch({ type: 'prefill', message: 42 })).toBeNull()
   })
 })

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -239,6 +239,11 @@ export function parseCommandDispatch(raw: unknown): CommandDispatchResponse | nu
     case 'send':
       return typeof row.message === 'string' ? { type: 'send', message: row.message } : null
 
+    case 'prefill':
+      return typeof row.message === 'string'
+        ? { type: 'prefill', message: row.message, notice: str(row.notice) }
+        : null
+
     default:
       return null
   }


### PR DESCRIPTION
## What does this PR do?

Adds support for the `prefill` command.dispatch type in the Desktop frontend. Previously, `/undo` (and any command returning a `prefill` dispatch) showed "error: invalid response: command.dispatch" because `parseCommandDispatch()` did not recognize the type.

## Related Issue

Fixes #43560

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/types.ts`: Add `PrefillCommandDispatchResponse` interface (`type: 'prefill'`, `message: string`, `notice?: string`) and add to `CommandDispatchResponse` union type
- `apps/desktop/src/lib/chat-runtime.ts`: Add `prefill` case to `parseCommandDispatch()` switch statement, matching the TUI's `asCommandDispatch` parity
- `apps/desktop/src/app/session/hooks/use-prompt-actions.ts`: Handle `prefill` dispatch — show notice via `renderSlashOutput` and set composer draft text via `setComposerDraft` without auto-submitting. Import `setComposerDraft` from `@/store/composer`
- `apps/desktop/src/lib/chat-runtime.test.ts`: Add 3 tests for prefill parsing (valid message, with notice, missing message)

## How to Test

1. Open Hermes Desktop
2. Open any session with conversation history
3. Type `/undo` and press Enter
4. **Before fix**: shows "error: invalid response: command.dispatch"
5. **After fix**: shows "↶ Undid 1 turn..." notice and prefills the composer with the undone message text

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `vitest run src/lib/chat-runtime.test.ts` and all 9 tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `parseCommandDispatch()` (callers: 1, flows: 1)
- Blast radius: LOW — only affects Desktop command.dispatch parsing; TUI already handles this type
- Related patterns: TUI `asCommandDispatch` in `ui-tui/src/lib/rpc.ts:37-43` is the reference implementation; this PR brings Desktop to parity
