### PR TITLE
fix(install): support non-pid-1 container entrypoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -315,6 +315,8 @@ ENV HERMES_LAZY_INSTALL_TARGET=/opt/data/lazy-packages
 # Recursion is impossible because the shim exec's the venv binary by
 # absolute path (/opt/hermes/.venv/bin/hermes). See the shim source for
 # the opt-out env var (HERMES_DOCKER_EXEC_AS_ROOT=1).
+COPY --chmod=0755 docker/hermes-exec-shim.sh /opt/hermes/bin/hermes
+COPY --chmod=0755 docker/entrypoint-dispatch.sh /opt/hermes/docker/entrypoint-dispatch.sh
 
 # Pre-s6 entrypoint.sh did `source .venv/bin/activate` which exported
 # the venv bin onto PATH; Architecture B's main-wrapper.sh does the
@@ -331,27 +333,37 @@ ENV PATH="/opt/hermes/bin:/opt/hermes/.venv/bin:/opt/data/.local/bin:${PATH}"
 RUN mkdir -p /opt/data
 VOLUME [ "/opt/data" ]
 
-# s6-overlay's /init is PID 1. It sets up the supervision tree, runs
-# /etc/cont-init.d/* (our stage2 hook), starts s6-rc services
-# declared in /etc/s6-overlay/s6-rc.d/, then exec's its remaining
-# argv as the container's "main program" with stdin/stdout/stderr
-# inherited (this is what makes interactive --tui work). When the
-# main program exits, /init begins stage 3 shutdown and the container
-# exits with the program's exit code. Replaces tini — see Phase 2 of
-# docs/plans/2026-05-07-s6-overlay-dynamic-subagent-gateways.md.
+# The image ENTRYPOINT is a tiny dispatcher rather than `/init` directly.
+# When the image really owns PID 1 (normal Docker / Podman), the dispatcher
+# execs `/init` and preserves the full s6 supervision tree. When a platform
+# wraps the image entrypoint under its own PID-1 init (Fly Machines,
+# `docker run --init`, some schedulers), `/init` would abort with
+# `can only run as pid 1`; in that case the dispatcher falls back to
+# `stage2-hook.sh` + `main-wrapper.sh` directly so foreground commands still
+# work. See #38349.
+#
+# On the PID-1 path, s6-overlay's /init sets up the supervision tree, runs
+# /etc/cont-init.d/* (our stage2 hook), starts s6-rc services declared in
+# /etc/s6-overlay/s6-rc.d/, then exec's its remaining argv as the container's
+# "main program" with stdin/stdout/stderr inherited (this is what makes
+# interactive --tui work). When the main program exits, /init begins stage 3
+# shutdown and the container exits with the program's exit code. Replaces
+# tini — see Phase 2 of docs/plans/2026-05-07-s6-overlay-dynamic-subagent-gateways.md.
 #
 # We use the ENTRYPOINT+CMD split rather than CMD alone so the
 # wrapper is prepended to user-supplied args automatically:
 #
-#   docker run <image>                  → /init main-wrapper.sh   (CMD default)
-#   docker run <image> chat -q "hi"     → /init main-wrapper.sh chat -q hi
-#   docker run <image> sleep infinity   → /init main-wrapper.sh sleep infinity
-#   docker run <image> --tui            → /init main-wrapper.sh --tui
+#   docker run <image>                  → entrypoint-dispatch.sh   (CMD default)
+#   docker run <image> chat -q "hi"     → entrypoint-dispatch.sh chat -q hi
+#   docker run <image> sleep infinity   → entrypoint-dispatch.sh sleep infinity
+#   docker run <image> --tui            → entrypoint-dispatch.sh --tui
 #
 # main-wrapper.sh handles arg routing (bare-exec vs. hermes
 # subcommand vs. no-args), drops to the hermes user via s6-setuidgid,
 # and exec's the final program so its exit code becomes the container
-# exit code. Without the wrapper-as-ENTRYPOINT, leading-dash args
-# like `--version` would be intercepted by /init's POSIX shell.
-ENTRYPOINT [ "/init", "/opt/hermes/docker/main-wrapper.sh" ]
+# exit code. The dispatcher preserves that contract across both the
+# supervised PID-1 path and the non-PID-1 fallback path. Without the
+# wrapper-as-ENTRYPOINT, leading-dash args like `--version` would be
+# intercepted by /init's POSIX shell.
+ENTRYPOINT [ "/opt/hermes/docker/entrypoint-dispatch.sh" ]
 CMD [ ]

--- a/docker/entrypoint-dispatch.sh
+++ b/docker/entrypoint-dispatch.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# shellcheck shell=sh
+# Entry-point dispatcher for runtimes that may or may not give the image
+# ownership of PID 1.
+#
+# Normal Docker / Podman path: this script is PID 1, so we delegate to
+# s6-overlay's /init exactly as before and keep the full supervision tree.
+#
+# Wrapped-runtime path (Fly Machines, `docker run --init`, some Nomad/K8s
+# setups): the platform's own init is already PID 1 and execs the image
+# entrypoint as a child. s6-overlay aborts there with "can only run as pid 1",
+# so we run the stage2 bootstrap directly and then exec the main wrapper
+# without /init.
+
+set -e
+
+if [ "$$" -eq 1 ]; then
+    exec /init /opt/hermes/docker/main-wrapper.sh "$@"
+fi
+
+echo "[hermes] WARNING: container entrypoint is not PID 1; skipping s6-overlay /init and falling back to direct bootstrap. Supervised services are unavailable in this runtime, but the requested command will still run." >&2
+# /init normally seeds PATH with s6's helpers; the non-PID-1 fallback skips it.
+export PATH="/command:/package/admin/s6/command:${PATH}"
+/opt/hermes/docker/stage2-hook.sh
+exec /opt/hermes/docker/main-wrapper.sh "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -19,9 +19,10 @@
 # Surface a warning to stderr so anyone still invoking this path
 # sees the migration notice in their logs.
 echo "[hermes] WARNING: docker/entrypoint.sh is a deprecated shim under " \
-    "s6-overlay. The container's real ENTRYPOINT is /init + " \
-    "main-wrapper.sh; this script only runs the stage2 cont-init hook " \
+    "s6-overlay. The container's real ENTRYPOINT is " \
+    "entrypoint-dispatch.sh (which delegates to /init + main-wrapper.sh " \
+    "when PID 1); this script only runs the stage2 cont-init hook " \
     "and does NOT exec the CMD. If you hard-coded docker/entrypoint.sh " \
     "as your ENTRYPOINT, drop the override — docker will use the image's " \
-    "default ENTRYPOINT (/init), which handles bootstrap AND CMD." >&2
+    "default ENTRYPOINT dispatcher, which handles bootstrap AND CMD." >&2
 exec /opt/hermes/docker/stage2-hook.sh "$@"

--- a/docker/main-wrapper.sh
+++ b/docker/main-wrapper.sh
@@ -1,15 +1,16 @@
-#!/command/with-contenv sh
+#!/bin/sh
 # shellcheck shell=sh
 # /opt/hermes/docker/main-wrapper.sh — wraps the container's CMD with
 # the same argument-routing logic the pre-s6 entrypoint.sh used. Runs
 # as /init's "main program" (Docker CMD) so it inherits stdin/stdout/
-# stderr from the container.
+# stderr from the container. The non-PID-1 entrypoint fallback also
+# execs this script directly after running the stage2 bootstrap.
 #
-# Shebang note: /init scrubs env before invoking CMD, so a plain
-# `#!/bin/sh` wrapper sees an empty environ and `ENV HERMES_HOME=/opt/data`
-# from the Dockerfile never reaches `hermes`. with-contenv repopulates
-# the env from /run/s6/container_environment before exec'ing, which is
-# what s6-supervised services use too (see main-hermes/run).
+# Env note: /init scrubs env before invoking CMD, so when this wrapper
+# is launched through the supervised path it must rehydrate via
+# with-contenv before touching HERMES_HOME / PATH. On the non-PID-1
+# fallback path the Dockerfile env is still intact, so we skip the
+# re-exec and continue directly.
 #
 # Routing:
 #   no args                       → exec `hermes` (the default)
@@ -18,6 +19,14 @@
 #
 # Drop to hermes via s6-setuidgid, but skip it when already non-root.
 set -e
+
+if [ -z "${HERMES_MAIN_WRAPPER_ENV_READY:-}" ] && \
+   [ -z "${HERMES_HOME:-}" ] && \
+   [ -x /command/with-contenv ]; then
+    export HERMES_MAIN_WRAPPER_ENV_READY=1
+    exec /command/with-contenv sh "$0" "$@"
+fi
+unset HERMES_MAIN_WRAPPER_ENV_READY
 
 drop() { [ "$(id -u)" = 0 ] && set -- s6-setuidgid hermes "$@"; exec "$@"; }
 

--- a/hermes_cli/container_boot.py
+++ b/hermes_cli/container_boot.py
@@ -281,6 +281,10 @@ def _strip_container_argv_prefix(argv: Sequence[str]) -> list[str]:
         # Defensive: an `init` prefix with no wrapper token in argv.
         args = args[1:]
 
+    # Non-PID-1 entrypoints go through the dispatch shim instead of /init.
+    if args and args[0].endswith("entrypoint-dispatch.sh"):
+        args = args[1:]
+
     # The wrapper re-execs `hermes <subcommand>`; peel an explicit hermes.
     if args and Path(args[0]).name == "hermes":
         args = args[1:]

--- a/tests/hermes_cli/test_container_boot.py
+++ b/tests/hermes_cli/test_container_boot.py
@@ -573,6 +573,7 @@ def test_default_slot_autostarts_when_root_state_running(tmp_path: Path) -> None
     "container_argv",
     [
         ("gateway", "run"),
+        ("/opt/hermes/docker/entrypoint-dispatch.sh", "gateway", "run"),
         ("/init", "/opt/hermes/docker/main-wrapper.sh", "gateway", "run"),
     ],
 )
@@ -606,6 +607,7 @@ def test_legacy_gateway_run_cmd_seeds_default_running_state(
     "container_argv",
     [
         ("gateway", "run", "--no-supervise"),
+        ("/opt/hermes/docker/entrypoint-dispatch.sh", "gateway", "run", "--no-supervise"),
         ("/init", "/opt/hermes/docker/main-wrapper.sh", "gateway", "run", "--no-supervise"),
     ],
 )

--- a/tests/test_dockerfile_tini_compat_shim.py
+++ b/tests/test_dockerfile_tini_compat_shim.py
@@ -38,12 +38,12 @@ def test_tini_compat_comment_explains_why():
 
 
 def test_entrypoint_still_init_not_tini():
-    """Sanity check: the actual ENTRYPOINT is still /init (s6-overlay).
-    The shim is for legacy external wrappers, not for the image's own
-    runtime — that path must continue to use the canonical /init."""
+    """Sanity check: the image ENTRYPOINT stays on the dispatcher, which
+    preserves the `/init` path when PID 1 and falls back only when the
+    runtime wraps the entrypoint under another init."""
     df = _dockerfile_text()
-    assert 'ENTRYPOINT [ "/init"' in df, (
-        "Dockerfile ENTRYPOINT must remain /init (s6-overlay). The "
-        "tini shim is only for external wrappers that haven't been "
-        "updated yet."
+    assert 'ENTRYPOINT [ "/opt/hermes/docker/entrypoint-dispatch.sh" ]' in df, (
+        "Dockerfile ENTRYPOINT must stay on the dispatcher so the image "
+        "can preserve /init under PID 1 while still booting on non-PID-1 "
+        "platforms like Fly Machines."
     )

--- a/tests/tools/test_dockerfile_pid1_reaping.py
+++ b/tests/tools/test_dockerfile_pid1_reaping.py
@@ -28,6 +28,7 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DOCKERFILE = REPO_ROOT / "Dockerfile"
 DOCKERIGNORE = REPO_ROOT / ".dockerignore"
+ENTRYPOINT_DISPATCH = REPO_ROOT / "docker" / "entrypoint-dispatch.sh"
 
 
 # Init-process families this repo accepts as PID 1. ``tini`` /
@@ -113,12 +114,12 @@ def test_dockerfile_installs_an_init_for_zombie_reaping(dockerfile_text):
 
 
 def test_dockerfile_entrypoint_routes_through_the_init(dockerfile_text):
-    """The ENTRYPOINT must invoke the init, not the entrypoint script directly.
+    """The ENTRYPOINT must preserve a PID-1 init path, even with a dispatcher.
 
     Installing the init is only half the fix — the container must actually
-    run with it as PID 1.  If the ENTRYPOINT executes the shell script
-    directly, the shell becomes PID 1 and will ``exec`` into hermes,
-    which then runs as PID 1 without any zombie reaping.
+    run with it as PID 1.  A shell dispatcher is fine only if it execs the
+    real init when the image owns PID 1; otherwise the shell would become
+    PID 1 and hermes would run without zombie reaping.
     """
     # Find the last uncommented ENTRYPOINT line — Docker honours the final one.
     entrypoint_line = None
@@ -131,12 +132,30 @@ def test_dockerfile_entrypoint_routes_through_the_init(dockerfile_text):
 
     assert entrypoint_line is not None, "Dockerfile is missing an ENTRYPOINT directive"
 
-    routes_through_init = any(name in entrypoint_line for name in _KNOWN_INIT_TOKENS)
-    assert routes_through_init, (
-        f"ENTRYPOINT does not route through a PID-1 init: {entrypoint_line!r}. "
-        f"Expected one of {_KNOWN_INIT_TOKENS}. If the init is installed but "
-        "not wired into ENTRYPOINT, hermes still runs as PID 1 and zombies "
-        "will accumulate (#15012)."
+    if any(name in entrypoint_line for name in _KNOWN_INIT_TOKENS):
+        return
+
+    assert "/opt/hermes/docker/entrypoint-dispatch.sh" in entrypoint_line, (
+        f"Unexpected Dockerfile ENTRYPOINT: {entrypoint_line!r}"
+    )
+    assert ENTRYPOINT_DISPATCH.exists(), (
+        "Dockerfile points at entrypoint-dispatch.sh but the script is missing."
+    )
+    dispatcher = ENTRYPOINT_DISPATCH.read_text(encoding="utf-8")
+    assert 'if [ "$$" -eq 1 ]; then' in dispatcher
+    assert "exec /init /opt/hermes/docker/main-wrapper.sh" in dispatcher, (
+        "The entrypoint dispatcher must hand PID-1 execution off to /init; "
+        "otherwise the shell becomes PID 1 and zombies will accumulate."
+    )
+
+
+def test_dispatcher_non_pid1_fallback_restores_s6_helpers_on_path() -> None:
+    """Skipping /init must still expose s6-setuidgid to stage2/main-wrapper."""
+    dispatcher = ENTRYPOINT_DISPATCH.read_text(encoding="utf-8")
+    assert 'export PATH="/command:/package/admin/s6/command:${PATH}"' in dispatcher, (
+        "The non-PID-1 entrypoint fallback skips /init, so it must restore the "
+        "s6 helper directories on PATH before invoking stage2-hook.sh and "
+        "main-wrapper.sh."
     )
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes the Docker image regression behind #38349 by moving the image entrypoint to a small dispatcher. When the container truly owns PID 1, the dispatcher still execs s6 `/init` and preserves the existing supervision tree. When a platform wraps the image entrypoint under its own init, the dispatcher skips `/init`, runs the stage2 bootstrap directly, and then execs the normal command wrapper so foreground commands still start instead of crashing with `s6-overlay-suexec: fatal: can only run as pid 1`.

## Related Issue

Fixes #38349

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `docker/entrypoint-dispatch.sh`: added a dual-mode entrypoint that delegates to `/init` only when the image owns PID 1 and otherwise falls back to direct bootstrap + wrapper exec.
- `docker/main-wrapper.sh`: switched from a `with-contenv` shebang to a plain shell script that rehydrates its env only on the s6 `/init` path, so the same wrapper works in both entrypoint modes.
- `Dockerfile`: copied the new dispatcher into the image, made it the ENTRYPOINT, and documented the PID-1 vs non-PID-1 behavior.
- `docker/entrypoint.sh`: updated the deprecation warning so it points at the dispatcher-based default entrypoint.
- `hermes_cli/container_boot.py`: taught legacy `gateway run` reconciliation to recognize the new dispatcher argv shape.
- `tests/hermes_cli/test_container_boot.py`: covered the dispatcher argv in the legacy gateway-state migration tests.
- `tests/test_dockerfile_tini_compat_shim.py` and `tests/tools/test_dockerfile_pid1_reaping.py`: updated the Docker contract tests to assert the dispatcher keeps a real `/init` PID-1 path.

## How to Test

1. Run `pytest tests/hermes_cli/test_container_boot.py tests/test_dockerfile_tini_compat_shim.py tests/tools/test_dockerfile_pid1_reaping.py -q`.
2. Build the image and verify normal Docker still uses the supervised path: `docker run --rm <image> gateway run`.
3. Verify the non-PID-1 fallback path by running the image under a wrapper init (for example a platform/runtime equivalent to `docker run --init <image> gateway run`) and confirm it starts instead of exiting with `s6-overlay-suexec: fatal: can only run as pid 1`.
4. Run `python scripts/check-windows-footguns.py --diff main` and `git diff --check`.

## What platforms tested on

- macOS 15 on darwin-arm64 (local)
- Cross-platform impact reviewed for Linux container runtimes; no Windows-specific process or path logic was added

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.0 darwin-arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Focused covering tests passed: `pytest tests/hermes_cli/test_container_boot.py tests/test_dockerfile_tini_compat_shim.py tests/tools/test_dockerfile_pid1_reaping.py -q`
- `git diff --check` passed
- `python scripts/check-windows-footguns.py --diff main` passed
- Full suite command (`/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh`) stopped during collection on a pre-existing shared-venv issue: `tests/hermes_cli/test_dashboard_auth_401_reauth.py` failed with `ModuleNotFoundError: No module named 'fastapi'`

<!-- autocontrib:worker-id=issue-new-5f974cbd kind=pr-open -->