### PR TITLE
feat(acp): configurable initial session mode via acp.default_mode

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -565,6 +565,53 @@ class HermesACPAgent(acp.Agent):
         policy = self._MODE_TO_EDIT_APPROVAL_POLICY.get(mode, self._EDIT_APPROVAL_POLICY_DEFAULT)
         return policy, state.cwd
 
+    def _configured_default_mode(self) -> str | None:
+        """Return the configured initial session mode (``acp.default_mode``), if any.
+
+        Interactive editors (Zed, ...) surface the ACP mode picker and send
+        ``session/set_mode``, but headless ACP clients (daemons, CI runners,
+        editor-less automation) typically never do — so every session starts in
+        the ``default`` mode, whose ``ask`` edit-approval policy denies file
+        edits when there is no interactive approver on the other end. Operators
+        of such deployments can pick the initial mode in
+        ``~/.hermes/config.yaml``::
+
+            acp:
+              default_mode: accept_edits   # default | accept_edits | dont_ask
+
+        Unset, empty, or invalid values fall back to the current behavior
+        (sessions start in ``default``).
+        """
+        try:
+            from hermes_cli.config import load_config_readonly
+
+            acp_cfg = load_config_readonly().get("acp")
+        except Exception:
+            logger.debug("Could not read acp.default_mode from config", exc_info=True)
+            return None
+        if not isinstance(acp_cfg, dict):
+            return None
+        mode = str(acp_cfg.get("default_mode") or "").strip()
+        if not mode:
+            return None
+        if mode not in self._MODE_TO_EDIT_APPROVAL_POLICY:
+            logger.warning(
+                "Ignoring acp.default_mode=%r — valid modes: %s",
+                mode,
+                ", ".join(sorted(self._MODE_TO_EDIT_APPROVAL_POLICY)),
+            )
+            return None
+        return mode
+
+    def _apply_configured_default_mode(self, state: SessionState) -> None:
+        """Start a freshly created session in the configured default mode."""
+        mode = self._configured_default_mode()
+        if mode and mode != self._MODE_DEFAULT:
+            setattr(state, "mode", mode)
+            logger.info(
+                "Session %s: initial mode %s (acp.default_mode)", state.session_id, mode
+            )
+
     @staticmethod
     def _encode_model_choice(provider: str | None, model: str | None) -> str:
         """Encode a model selection so ACP clients can keep provider context."""
@@ -1111,6 +1158,7 @@ class HermesACPAgent(acp.Agent):
         **kwargs: Any,
     ) -> NewSessionResponse:
         state = self.session_manager.create_session(cwd=cwd)
+        self._apply_configured_default_mode(state)
         await self._register_session_mcp_servers(state, mcp_servers)
         logger.info("New session %s (cwd=%s)", state.session_id, cwd)
         self._schedule_available_commands_update(state.session_id)
@@ -1182,6 +1230,7 @@ class HermesACPAgent(acp.Agent):
         if state is None:
             logger.warning("resume_session: session %s not found, creating new", session_id)
             state = self.session_manager.create_session(cwd=cwd)
+            self._apply_configured_default_mode(state)
         await self._register_session_mcp_servers(state, mcp_servers)
         logger.info("Resumed session %s", state.session_id)
         # See `load_session` above for the spec rationale — replay must

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -535,6 +535,19 @@ session_reset:
   idle_minutes: 1440   # Inactivity timeout in minutes (default: 1440 = 24 hours)
   at_hour: 4           # Daily reset hour, 0-23 local time (default: 4 AM)
 
+# ─────────────────────────────────────────────────────────────────────────────
+# ACP (Agent Client Protocol) adapter — editors like Zed, headless ACP clients
+# ─────────────────────────────────────────────────────────────────────────────
+# acp:
+#   # Initial mode for NEW ACP sessions: "default", "accept_edits", or "dont_ask".
+#   # Interactive editors expose a mode picker and send session/set_mode, but
+#   # headless ACP clients (daemons, CI automation) usually never do — with the
+#   # "default" mode their file edits are denied by the "ask" approval policy
+#   # because nobody is there to approve. Set "accept_edits" to auto-allow edits
+#   # inside the session cwd and /tmp (sensitive paths still gated).
+#   # Unset or invalid values keep the current behavior ("default").
+#   default_mode: "default"
+
 # Maximum number of simultaneously active chat sessions across CLI, TUI,
 # dashboard chat, and messaging gateway. Set to null, 0, or omit to allow
 # unlimited concurrent sessions. When the limit is reached, new sessions get a

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -82,6 +82,49 @@ async def test_set_config_option_persists_edit_approval_policy_without_advertisi
     assert getattr(state, "mode", None) == "accept_edits"
 
 
+@pytest.mark.asyncio
+async def test_new_session_starts_in_configured_default_mode(agent, monkeypatch):
+    """``acp.default_mode`` sets the initial mode for headless ACP clients
+    that never send ``session/set_mode``."""
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {"acp": {"default_mode": "accept_edits"}},
+    )
+    resp = await agent.new_session(cwd="/tmp")
+    state = agent.session_manager.get_session(resp.session_id)
+
+    assert resp.modes.current_mode_id == "accept_edits"
+    assert getattr(state, "mode", None) == "accept_edits"
+
+
+@pytest.mark.asyncio
+async def test_new_session_ignores_invalid_configured_default_mode(agent, monkeypatch):
+    """An unknown ``acp.default_mode`` value is ignored — behavior unchanged."""
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {"acp": {"default_mode": "yolo-mode"}},
+    )
+    resp = await agent.new_session(cwd="/tmp")
+    state = agent.session_manager.get_session(resp.session_id)
+
+    assert resp.modes.current_mode_id == "default"
+    assert getattr(state, "mode", None) is None
+
+
+@pytest.mark.asyncio
+async def test_resume_session_fallback_create_uses_configured_default_mode(agent, monkeypatch):
+    """The create-on-miss path of ``session/resume`` honors ``acp.default_mode`` too."""
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {"acp": {"default_mode": "dont_ask"}},
+    )
+    resp = await agent.resume_session(cwd="/tmp", session_id="no-such-session")
+
+    # ResumeSessionResponse carries no session_id; the advertised mode state
+    # reflects the freshly created session's mode.
+    assert resp.modes.current_mode_id == "dont_ask"
+
+
 # ---------------------------------------------------------------------------
 # initialize
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Adds an optional `acp.default_mode` config key that sets the **initial mode for new ACP sessions**.

The use case: headless ACP clients (daemons, CI automation, editor-less integrations driving Hermes over ACP stdio). Interactive editors like Zed render the mode picker and send `session/set_mode`, but a headless client typically never does — so every session starts in `default` mode, whose `ask` edit-approval policy denies `write_file`/`patch` because there is no interactive approver on the other end. The agent is then forced into shell-redirection fallbacks for file edits, losing the ACP edit pipeline.

With this change an operator of such a deployment can opt in via `~/.hermes/config.yaml`:

```yaml
acp:
  default_mode: accept_edits   # default | accept_edits | dont_ask
```

**Default behavior is unchanged**: when the key is unset, empty, or invalid, sessions start in `default` exactly as today (an invalid value logs a warning naming the valid modes). Interactive clients can still switch modes per session via `session/set_mode` afterwards — this only sets the *starting* mode.

## Related Issue

Fixes # — no existing issue; this came out of integrating a headless ACP client against the adapter. Happy to file one if you prefer the issue-first flow.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `acp_adapter/server.py`: new `_configured_default_mode()` / `_apply_configured_default_mode()` helpers (validated against `_MODE_TO_EDIT_APPROVAL_POLICY`, read via `load_config_readonly()`); applied in `new_session` and in the create-on-miss path of `resume_session`. The `NewSessionResponse.modes.current_mode_id` reflects the configured mode, so mode-aware clients see the truth.
- `tests/acp/test_server.py`: 3 tests — configured mode applied on `session/new` (response + state), invalid value ignored (behavior preserved), `session/resume` create-on-miss path honors the key.
- `cli-config.yaml.example`: documented the new `acp:` section.

## How to Test

1. `scripts/run_tests.sh tests/acp/` — 298 passed, 0 failed (the 3 new tests fail without the `server.py` change and pass with it).
2. Manual: add the YAML above to `~/.hermes/config.yaml`, connect any ACP client, call `session/new` — the response advertises `current_mode_id: accept_edits` and workspace-scoped edits no longer round-trip through `ask`.
3. Remove the key — sessions start in `default` as before.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run the test suite for the affected area via the canonical runner (`scripts/run_tests.sh tests/acp/` — 298 passed; full-suite run delegated to CI)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 22.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation — `cli-config.yaml.example` + docstring
- [x] I've updated `cli-config.yaml.example` (added/changed config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact considered — config read only, no platform-specific code
- [x] Tool descriptions/schemas — N/A