### PR TITLE
fix(config): inherit default root config when loading profile configs

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -589,7 +589,7 @@ def get_container_exec_info() -> Optional[dict]:
 # =============================================================================
 
 # Re-export from hermes_constants — canonical definition lives there.
-from hermes_constants import get_hermes_home  # noqa: F811,E402
+from hermes_constants import get_default_hermes_root, get_hermes_home  # noqa: F811,E402
 from utils import atomic_replace
 
 def get_config_path() -> Path:
@@ -5332,6 +5332,22 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
             return copy.deepcopy(cached[2]) if want_deepcopy else cached[2]
 
         config = copy.deepcopy(DEFAULT_CONFIG)
+
+        # Profile config inheritance: when loading a profile config, merge
+        # the default root user config (~/.hermes/config.yaml) as a base
+        # layer so providers, custom_providers, and other dict-typed keys
+        # are inherited without manual duplication.  Profile-specific values
+        # override the defaults.  See issue #43713.
+        _default_root_config = get_default_hermes_root() / "config.yaml"
+        if config_path != _default_root_config:
+            try:
+                if _default_root_config.exists():
+                    with open(_default_root_config, encoding="utf-8") as f:
+                        _base_user_config = yaml.safe_load(f) or {}
+                    if isinstance(_base_user_config, dict) and _base_user_config:
+                        config = _deep_merge(config, _base_user_config)
+            except Exception:
+                pass  # corrupted default config, proceed with DEFAULT_CONFIG
 
         if cache_key is not None:
             try:

--- a/tests/hermes_cli/test_profile_config_inheritance.py
+++ b/tests/hermes_cli/test_profile_config_inheritance.py
@@ -1,0 +1,162 @@
+"""Regression tests for profile config inheritance (issue #43713).
+
+When a profile config is loaded, the default root user config
+(~/.hermes/config.yaml) should be merged as a base layer so that
+providers, custom_providers, and other dict-typed keys are inherited.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def _make_config_files(tmp_path, *, default_config=None, profile_config=None):
+    """Create default root and profile config files in tmp_path."""
+    hermes_root = tmp_path / ".hermes"
+    hermes_root.mkdir(parents=True, exist_ok=True)
+
+    # Default root config
+    if default_config is not None:
+        (hermes_root / "config.yaml").write_text(default_config, encoding="utf-8")
+
+    # Profile config
+    profile_dir = hermes_root / "profiles" / "testprof"
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    if profile_config is not None:
+        (profile_dir / "config.yaml").write_text(profile_config, encoding="utf-8")
+
+    return hermes_root, profile_dir
+
+
+class TestProfileConfigInheritance:
+    """Profile configs should inherit from the default root user config."""
+
+    def test_profile_inherits_providers_from_default(self, tmp_path, monkeypatch):
+        """Profile with empty providers inherits default root providers."""
+        from hermes_cli.config import _load_config_impl, _LOAD_CONFIG_CACHE
+
+        _LOAD_CONFIG_CACHE.clear()
+        hermes_root, profile_dir = _make_config_files(
+            tmp_path,
+            default_config="providers:\n  openrouter:\n    api_key_env: OPENROUTER_API_KEY\n",
+            profile_config="model:\n  default: openrouter/claude-sonnet-4\n",
+        )
+
+        # Point HERMES_HOME to the profile directory
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+
+        # Patch get_default_hermes_root to return our test root
+        with patch("hermes_cli.config.get_default_hermes_root", return_value=hermes_root):
+            config = _load_config_impl(want_deepcopy=True)
+
+        providers = config.get("providers", {})
+        assert "openrouter" in providers, f"Expected openrouter in providers, got {list(providers.keys())}"
+        assert providers["openrouter"]["api_key_env"] == "OPENROUTER_API_KEY"
+
+    def test_profile_overrides_default_provider(self, tmp_path, monkeypatch):
+        """Profile-specific provider overrides the default's provider."""
+        from hermes_cli.config import _load_config_impl, _LOAD_CONFIG_CACHE
+
+        _LOAD_CONFIG_CACHE.clear()
+        hermes_root, profile_dir = _make_config_files(
+            tmp_path,
+            default_config="providers:\n  openrouter:\n    api_key_env: OPENROUTER_KEY\n",
+            profile_config="providers:\n  openrouter:\n    api_key_env: MY_CUSTOM_KEY\n",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+
+        with patch("hermes_cli.config.get_default_hermes_root", return_value=hermes_root):
+            config = _load_config_impl(want_deepcopy=True)
+
+        providers = config.get("providers", {})
+        assert providers["openrouter"]["api_key_env"] == "MY_CUSTOM_KEY"
+
+    def test_profile_adds_provider_to_default(self, tmp_path, monkeypatch):
+        """Profile can add a provider not present in the default config."""
+        from hermes_cli.config import _load_config_impl, _LOAD_CONFIG_CACHE
+
+        _LOAD_CONFIG_CACHE.clear()
+        hermes_root, profile_dir = _make_config_files(
+            tmp_path,
+            default_config="providers:\n  openrouter:\n    api_key_env: OR_KEY\n",
+            profile_config="providers:\n  anthropic:\n    api_key_env: ANTHROPIC_KEY\n",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+
+        with patch("hermes_cli.config.get_default_hermes_root", return_value=hermes_root):
+            config = _load_config_impl(want_deepcopy=True)
+
+        providers = config.get("providers", {})
+        assert "openrouter" in providers, "Default provider should be inherited"
+        assert "anthropic" in providers, "Profile provider should be added"
+
+    def test_profile_without_config_file_inherits_default(self, tmp_path, monkeypatch):
+        """Profile with no config.yaml still inherits default root config."""
+        from hermes_cli.config import _load_config_impl, _LOAD_CONFIG_CACHE
+
+        _LOAD_CONFIG_CACHE.clear()
+        hermes_root, profile_dir = _make_config_files(
+            tmp_path,
+            default_config="providers:\n  openrouter:\n    api_key_env: OR_KEY\n",
+            profile_config=None,  # No profile config file
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+
+        with patch("hermes_cli.config.get_default_hermes_root", return_value=hermes_root):
+            config = _load_config_impl(want_deepcopy=True)
+
+        providers = config.get("providers", {})
+        assert "openrouter" in providers, "Default provider should be inherited even without profile config"
+
+    def test_default_config_not_affected_by_inheritance(self, tmp_path, monkeypatch):
+        """Loading the default config should NOT trigger inheritance logic."""
+        from hermes_cli.config import _load_config_impl, _LOAD_CONFIG_CACHE
+
+        _LOAD_CONFIG_CACHE.clear()
+        hermes_root, _ = _make_config_files(
+            tmp_path,
+            default_config="providers:\n  openrouter:\n    api_key_env: OR_KEY\n",
+        )
+
+        # Point HERMES_HOME to the root (not a profile)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_root))
+
+        with patch("hermes_cli.config.get_default_hermes_root", return_value=hermes_root):
+            config = _load_config_impl(want_deepcopy=True)
+
+        providers = config.get("providers", {})
+        assert "openrouter" in providers
+        # Should only have the default config's providers, no extra merge
+        assert providers["openrouter"]["api_key_env"] == "OR_KEY"
+
+    def test_profile_inherits_custom_providers(self, tmp_path, monkeypatch):
+        """custom_providers list is inherited from the default config."""
+        from hermes_cli.config import _load_config_impl, _LOAD_CONFIG_CACHE
+
+        _LOAD_CONFIG_CACHE.clear()
+        hermes_root, profile_dir = _make_config_files(
+            tmp_path,
+            default_config=(
+                "custom_providers:\n"
+                "  - name: my-provider\n"
+                "    base_url: https://my.api.com/v1\n"
+            ),
+            profile_config="model:\n  default: my-provider/model-x\n",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_dir))
+
+        with patch("hermes_cli.config.get_default_hermes_root", return_value=hermes_root):
+            config = _load_config_impl(want_deepcopy=True)
+
+        custom = config.get("custom_providers", [])
+        assert len(custom) == 1
+        assert custom[0]["name"] == "my-provider"


### PR DESCRIPTION
## What does this PR do?

Profile configs now inherit the default root user config (`~/.hermes/config.yaml`) as a base layer, so `providers`, `custom_providers`, `credential_pool_strategies`, and other dict-typed settings are inherited without manual duplication in every profile.

## Related Issue

Fixes #43713

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py`: Added profile config inheritance in `_load_config_impl` — when the config path differs from the default root config path (profile mode), the default root user config is loaded and deep-merged as a base layer before applying profile-specific overrides (+17 lines).
- `tests/hermes_cli/test_profile_config_inheritance.py`: 6 regression tests covering inheritance, override, addition, missing profile config, non-profile mode, and `custom_providers` inheritance (+162 lines).

## How to Test

1. Create a default config with providers: `hermes config set providers.openrouter.api_key_env OPENROUTER_API_KEY`
2. Create a profile: `hermes profile create builder`
3. Set a model in the profile: `hermes -p builder config set model.openrouter/claude-sonnet-4`
4. Verify the profile sees the provider: `hermes -p builder auth list` should show the OpenRouter key
5. Run tests: `pytest tests/hermes_cli/test_profile_config_inheritance.py -v`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `_load_config_impl` (callers: 2, flows: load_config → _load_config_impl, load_config_readonly → _load_config_impl)
- Blast radius: MEDIUM — changes the config loading path for all profile-mode invocations; non-profile mode is unaffected (guard: `config_path != _default_root_config`)
- Related patterns: `_deep_merge` preserves dict nesting; `get_default_hermes_root()` handles Docker deployments where HERMES_HOME is outside ~/.hermes
