### PR TITLE
fix(gateway): keep Telegram topic bindings on compression descendants

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7771,7 +7771,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.debug("Failed to read Telegram topic binding", exc_info=True)
                 binding = None
             if binding:
-                bound_session_id = str(binding.get("session_id") or "")
+                original_bound_session_id = str(binding.get("session_id") or "")
+                bound_session_id = original_bound_session_id
                 # Heal bindings that point at a pre-compression parent: walk
                 # the compression-continuation chain forward to its tip so the
                 # next message resumes the compressed child instead of
@@ -7794,6 +7795,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         and canonical_session_id != bound_session_id
                     ):
                         bound_session_id = canonical_session_id
+                    elif (
+                        bound_session_id
+                        and bound_session_id != session_entry.session_id
+                        and str(binding.get("session_key") or "") == session_key
+                        and str(binding.get("managed_mode") or "") != "restored"
+                    ):
+                        try:
+                            if self._session_db.is_session_descendant(
+                                session_entry.session_id,
+                                bound_session_id,
+                            ):
+                                bound_session_id = session_entry.session_id
+                        except Exception:
+                            logger.debug(
+                                "session-lineage lookup failed for topic binding %s -> %s",
+                                bound_session_id, session_entry.session_id,
+                                exc_info=True,
+                            )
                 if bound_session_id and bound_session_id != session_entry.session_id:
                     # Route the override through SessionStore so the session_key
                     # → session_id mapping is persisted to disk and the previous
@@ -7805,10 +7824,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         session_entry = switched
                 # If the stored binding pointed at a parent, rewrite it to the
                 # canonical descendant now that we've followed the chain.
-                if (
-                    bound_session_id
-                    and bound_session_id != str(binding.get("session_id") or "")
-                ):
+                if bound_session_id and bound_session_id != original_bound_session_id:
                     self._sync_telegram_topic_binding(
                         source, session_entry, reason="compression-tip-walk",
                     )

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1836,6 +1836,29 @@ class SessionDB:
             current = row["id"]
         return current
 
+    def is_session_descendant(self, session_id: str, ancestor_session_id: str) -> bool:
+        """Return True when ``session_id`` is in ``ancestor_session_id``'s lineage."""
+        current = str(session_id or "")
+        ancestor = str(ancestor_session_id or "")
+        if not current or not ancestor or current == ancestor:
+            return bool(current and ancestor and current == ancestor)
+        for _ in range(100):
+            with self._lock:
+                row = self._conn.execute(
+                    "SELECT parent_session_id FROM sessions WHERE id = ?",
+                    (current,),
+                ).fetchone()
+            if row is None:
+                return False
+            parent = row["parent_session_id"] if hasattr(row, "keys") else row[0]
+            if not parent:
+                return False
+            parent = str(parent)
+            if parent == ancestor:
+                return True
+            current = parent
+        return False
+
     def list_sessions_rich(
         self,
         source: str = None,

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -267,6 +267,83 @@ async def test_managed_topic_binding_reuses_restored_session_over_static_lane_se
 
 
 @pytest.mark.asyncio
+async def test_restored_topic_binding_is_not_rewritten_to_descendant_session_store_entry(
+    tmp_path, monkeypatch
+):
+    import gateway.run as gateway_run
+
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    session_db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    session_db.create_session(
+        session_id="restored-session",
+        source="telegram",
+        user_id="208214988",
+    )
+    session_db.create_session(
+        session_id="descendant-session",
+        source="telegram",
+        user_id="208214988",
+        parent_session_id="restored-session",
+    )
+    topic_source = _make_source(thread_id="17585")
+    topic_key = build_session_key(topic_source)
+    session_db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="17585",
+        user_id="208214988",
+        session_key=topic_key,
+        session_id="restored-session",
+        managed_mode="restored",
+    )
+    runner = _make_runner(session_db=session_db)
+    runner.session_store.get_or_create_session.side_effect = lambda source, force_new=False: SessionEntry(
+        session_key=topic_key,
+        session_id="descendant-session",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        origin=source,
+    )
+    switched_entry = SessionEntry(
+        session_key=topic_key,
+        session_id="restored-session",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        origin=topic_source,
+    )
+    runner.session_store.switch_session = MagicMock(return_value=switched_entry)
+    captured = {}
+
+    async def fake_run_agent(*args, **kwargs):
+        captured["session_id"] = kwargs.get("session_id")
+        return {
+            "success": True,
+            "final_response": "restored response",
+            "session_id": kwargs.get("session_id"),
+            "messages": [],
+        }
+
+    runner._run_agent = AsyncMock(side_effect=fake_run_agent)
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    result = await runner._handle_message(_make_event("continue restored", thread_id="17585"))
+
+    assert result == "restored response"
+    assert captured["session_id"] == "restored-session"
+    runner.session_store.switch_session.assert_called_once_with(topic_key, "restored-session")
+    refreshed = session_db.get_telegram_topic_binding(
+        chat_id="208214988", thread_id="17585",
+    )
+    assert refreshed is not None
+    assert refreshed["session_id"] == "restored-session"
+
+
+@pytest.mark.asyncio
 async def test_telegram_group_prompt_is_not_topic_lobby_even_when_dm_topic_mode_enabled(
     tmp_path, monkeypatch
 ):
@@ -529,6 +606,76 @@ async def test_topic_binding_follows_compression_tip_on_read(tmp_path, monkeypat
     )
     assert refreshed is not None
     assert refreshed["session_id"] == "child-session"
+
+
+@pytest.mark.asyncio
+async def test_topic_binding_prefers_newer_session_store_entry_when_tip_lookup_cannot_heal(tmp_path, monkeypatch):
+    """Do not let a stale topic binding rewind a topic after compression.
+
+    In the wild, a gateway process that compressed a Telegram DM topic updated
+    ``sessions.json`` to the new continuation session but left
+    ``telegram_dm_topic_bindings`` pointing at the old parent. Because the old
+    parent was ended as ``session_switch`` rather than ``compression``, the
+    ``get_compression_tip()`` read-path healer returned the stale parent and
+    the next inbound message rewound the topic back to old context.
+    """
+    import gateway.run as gateway_run
+
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    session_db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    session_db.create_session(
+        session_id="old-parent", source="telegram", user_id="208214988",
+    )
+    session_db.create_session(
+        session_id="json-child",
+        source="telegram",
+        user_id="208214988",
+        parent_session_id="old-parent",
+    )
+    topic_source = _make_source(thread_id="17585")
+    topic_key = build_session_key(topic_source)
+    session_db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="17585",
+        user_id="208214988",
+        session_key=topic_key,
+        session_id="old-parent",
+    )
+
+    runner = _make_runner(session_db=session_db)
+    runner.session_store.get_or_create_session.side_effect = lambda source, force_new=False: SessionEntry(
+        session_key=topic_key,
+        session_id="json-child",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        origin=source,
+    )
+    runner.session_store.switch_session = MagicMock(
+        side_effect=AssertionError("stale binding must not rewind the topic")
+    )
+    runner._run_agent = AsyncMock(
+        return_value={
+            "success": True,
+            "final_response": "ok",
+            "session_id": "json-child",
+            "messages": [],
+        }
+    )
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    await runner._handle_message(_make_event("follow up after stale binding", thread_id="17585"))
+
+    refreshed = session_db.get_telegram_topic_binding(
+        chat_id="208214988", thread_id="17585",
+    )
+    assert refreshed is not None
+    assert refreshed["session_id"] == "json-child"
+    runner.session_store.switch_session.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2889,6 +2889,17 @@ class TestCompressionChainProjection:
         # root1's tip must be tip1 (via mid1), not delegate1.
         assert db.get_compression_tip("root1") == "tip1"
 
+    def test_is_session_descendant_walks_parent_lineage(self, db):
+        db.create_session("root", "telegram")
+        db.create_session("child", "telegram", parent_session_id="root")
+        db.create_session("grandchild", "telegram", parent_session_id="child")
+
+        assert db.is_session_descendant("grandchild", "root") is True
+        assert db.is_session_descendant("child", "root") is True
+        assert db.is_session_descendant("root", "root") is True
+        assert db.is_session_descendant("root", "child") is False
+        assert db.is_session_descendant("missing", "root") is False
+
     def test_list_surfaces_tip_for_compressed_root(self, db):
         """The list must show the tip's id/message_count/preview in place of
         the root row, so users can see and resume the live conversation.


### PR DESCRIPTION
## Summary

  - Prevent Telegram DM topic bindings from rewinding to stale parent sessions when the session index has already advanced to a descendant after compression/
  session split.
  - Preserve explicit `managed_mode="restored"` topic bindings.
  - Add regression coverage for stale topic binding healing and restored binding preservation.

  ## Why

  A Telegram DM topic can end up with split-brain routing state:

  - `sessions.json` points at the latest descendant session.
  - `telegram_dm_topic_bindings` still points at an older parent session.

  On the next message, the gateway trusted the stale SQLite binding and switched the topic back to old context.

  ## Test Plan

  - `venv/bin/python -m pytest tests/gateway/test_telegram_topic_mode.py tests/test_hermes_state.py -q --tb=short`
    - 309 passed
  - Also verified the same command in a clean detached worktree from the PR commit.