### PR TITLE
[codex] Add Monica mobile bug agent through stage F

### DIFF
--- a/docs/monica-agent.md
+++ b/docs/monica-agent.md
@@ -1,0 +1,521 @@
+# Monica Agent
+
+Monica is a mention-gated Slack agent for mobile frontend bug cleanup.
+
+## Behavior
+
+- Monica only starts when tagged in Slack.
+- Clear mobile or frontend app bugs create or update Linear.
+- Linear issues include observed behavior, expected behavior when inferable,
+  reproduction context, platform/device/build clues, Slack context, and
+  evidence links.
+- Slack context preserves message authors, timestamps, per-message permalinks,
+  thread permalink, file links, and attachment diagnostics.
+- Ambiguous tagged messages ask for clarification.
+- Code changes require explicit tagged approval in the same Slack thread.
+- Draft PR creation happens only after configured verification commands pass
+  and Monica has committed a real diff against the configured base branch.
+- Draft PR bodies include the Linear link, Slack context, evidence links,
+  Monica's worker summary, and captured verification output. PR publishing
+  fails closed before git or GitHub side effects if Linear, Slack, or
+  verification context is missing.
+
+## Required Slack Scopes
+
+- `app_mentions:read`
+- `channels:history`
+- `groups:history`
+- `chat:write`
+- `files:read`
+
+Generate a Slack App Manifest that matches these requirements with:
+
+```bash
+hermes mobile-bug-agent slack-manifest
+```
+
+Optional names are supported:
+
+```bash
+hermes mobile-bug-agent slack-manifest \
+  --app-name "Monica" \
+  --bot-display-name "monica"
+```
+
+Import that JSON in Slack's app manifest flow, install the app, invite Monica
+to the allowed channels, then capture the bot user ID from a `<@U...>` mention
+token and the channel IDs from Slack. If attachment downloads are disabled with
+`mobile_bug_agent.slack.download_attachments: false`, the generated manifest
+omits `files:read`.
+
+After `MONICA_SLACK_BOT_TOKEN` is in the Monica profile `.env`, Monica can list
+the bot user ID and visible channel IDs for you:
+
+```bash
+hermes mobile-bug-agent slack-metadata
+```
+
+For scripts or setup dashboards:
+
+```bash
+hermes mobile-bug-agent slack-metadata --json
+```
+
+Use the returned `auth.bot_user_id` value for `slack.bot_user_ids`; do not use
+the `bot_id` value. Use selected channel IDs, such as `C...` or `G...`, for
+`slack.allowed_channels`.
+
+## Required Tokens
+
+For Chandler separation, run Monica from her own Hermes profile/home and keep
+her Slack tokens out of Chandler's `.env`. In a profile layout, store Monica
+secrets in:
+
+```text
+~/.hermes/profiles/monica/.env
+```
+
+Use Monica-specific Slack names there:
+
+```text
+MONICA_SLACK_BOT_TOKEN=xoxb-...
+MONICA_SLACK_APP_TOKEN=xapp-...
+LINEAR_API_KEY=lin_api_...
+GITHUB_TOKEN=github_pat_...
+```
+
+When `mobile_bug_agent.enabled: true`, the Monica profile gateway bridges
+`MONICA_SLACK_BOT_TOKEN` and `MONICA_SLACK_APP_TOKEN` into the Slack adapter for
+that process only. Chandler can keep using `SLACK_BOT_TOKEN` and
+`SLACK_APP_TOKEN` in its own profile.
+
+For the live dry run, the safe shape is:
+
+```bash
+mkdir -p ~/.hermes/profiles/monica
+$EDITOR ~/.hermes/profiles/monica/.env
+```
+
+Then add Monica's two Slack tokens to that file:
+
+```text
+MONICA_SLACK_BOT_TOKEN=xoxb-monica...
+MONICA_SLACK_APP_TOKEN=xapp-monica...
+```
+
+Run Monica setup and gateway commands with that profile home:
+
+```bash
+HERMES_HOME=~/.hermes/profiles/monica hermes mobile-bug-agent configure-dry-run \
+  --bot-user-id U012ABCDEF \
+  --channel-id C012ABCDEF
+HERMES_HOME=~/.hermes/profiles/monica hermes mobile-bug-agent doctor --rollout-mode dry_run
+HERMES_HOME=~/.hermes/profiles/monica hermes gateway
+```
+
+For Slack DMs, enable the App Home Messages tab, subscribe to the `message.im`
+bot event, and grant `im:history` plus `im:read`. Monica treats 1:1 DMs as
+explicit intent, but channel/private-channel messages still require `@monica`.
+
+`GITHUB_TOKEN` is optional if `gh` is already authenticated in the environment that runs Hermes.
+
+## Configuration
+
+Enable the plugin first:
+
+```bash
+hermes plugins enable mobile-bug-agent
+```
+
+Or edit the profile config directly:
+
+```yaml
+plugins:
+  enabled:
+    - mobile-bug-agent
+```
+
+Then add this under `mobile_bug_agent` in `~/.hermes/config.yaml`:
+
+```yaml
+mobile_bug_agent:
+  enabled: true
+  rollout_mode: dry_run
+  dry_run: true
+
+  slack:
+    allowed_channels: []
+    bot_user_ids: []
+    approver_user_ids: []
+    download_attachments: true
+
+  loop:
+    create_linear: true
+    require_fix_approval: true
+    max_thread_messages: 40
+    max_attachment_bytes: 15000000
+
+  linear:
+    team_id: ""
+    project_id: ""
+    label_ids: []
+
+  repo:
+    url: ""
+    local_name: "mobile-app"
+    default_branch: "main"
+    branch_prefix: "monica"
+
+  verification:
+    commands:
+      - "npm test"
+      - "npm run lint"
+
+  proof:
+    enabled: false
+    required_for_done: false
+    platform_order:
+      - ios
+      - android
+    artifact_dir: "proof"
+    commands: []
+    ios_simulator_udid: ""
+    android_serial: ""
+    timeout_minutes: 10
+
+  runtime:
+    home_subdir: "agents/monica"
+    worker_session_prefix: "monica"
+    skip_memory: true
+
+  worker:
+    backend: "codex_cli"
+    codex_command: "codex"
+    codex_model: ""
+    codex_profile: ""
+    codex_sandbox: "workspace-write"
+    codex_approval_policy: "never"
+    timeout_minutes: 45
+```
+
+`slack.bot_user_ids` should contain Monica's Slack mention user ID, for example
+`U012ABCDEF` from the `<@U012ABCDEF>` mention token. Do not use Slack's
+`bot_id` value, which usually starts with `B`, handles like `@monica`, or
+free-form names like `monica`. If `bot_user_ids` is empty, Monica only wakes
+on Slack's explicit
+`app_mention` event and ignores generic channel messages.
+In `linear_only`, `local_fix_only`, and `approved_pr` modes, `bot_user_ids` is
+required and enforced: an `app_mention` whose mention token does not match
+Monica's configured user ID is ignored, and Slack `bot_id` values such as
+`B012...` are rejected. Leave `bot_user_ids` empty only during dry-run setup
+when relying on a dedicated Monica Slack app's `app_mention` events as the
+temporary identity boundary.
+
+`slack.allowed_channels` can stay empty during dry-run setup. Before enabling
+`linear_only`, `local_fix_only`, or `approved_pr`, configure the exact Slack
+channel IDs Monica may act in; the doctor command and runtime Slack hook fail
+closed without that allowlist.
+
+Monica stores her state, attachments, cloned repo, and worktrees under
+`<active HERMES_HOME>/agents/monica` by default. In approved draft PR mode,
+her default code worker is `codex exec`, rooted at the isolated mobile app
+worktree with `--sandbox workspace-write` and `approval_policy="never"`.
+The optional `internal_agent` backend uses `platform=monica` sessions with the
+`monica-` prefix and skips Hermes memory by default, so it does not share
+Chandler's conversation memory or ordinary chat sessions.
+
+When `proof.required_for_done: true`, Monica treats simulator or device proof
+as a hard completion gate. After code verification passes, she runs the
+configured `proof.commands` inside the mobile worktree with
+`MONICA_PROOF_DIR` pointing at her profile-owned proof directory. At least one
+file must be written there, such as a screenshot or screen recording. If proof
+is unavailable, the run stops at `proof_blocked`: Monica does not mark the run
+done and does not open a PR.
+
+For Stage D/E simulator proof, use Monica's bundled helper as the proof
+command. It runs from the exact `$MONICA_WORKTREE`, uses the app's real
+`npm run ios` / `npm run android` scripts, optionally opens
+`MONICA_DEEP_LINK` for deterministic navigation, and captures platform
+screenshots into `$MONICA_PROOF_DIR`:
+
+```yaml
+proof:
+  enabled: true
+  required_for_done: true
+  platform_order: [ios, android]
+  commands:
+    - 'uv run --project "$MONICA_HERMES_AGENT_ROOT" python -m plugins.mobile_bug_agent.simulator_proof --timeout-seconds 600'
+```
+
+The proof runner writes `monica-proof-manifest.json` after screenshot/video
+artifacts exist. The manifest records the Monica run ID, Linear issue, branch,
+worktree path, selected platforms, and proof artifact paths so reviewers can
+confirm the proof came from Monica's fixed branch.
+
+## Rollout Modes
+
+1. Dry run: set `rollout_mode: dry_run` and keep `dry_run: true`. Monica captures context and shows what she would file.
+2. Linear only: set `rollout_mode: linear_only` and `dry_run: false`. Monica creates/updates Linear and stops there; she does not ask for code approval in this mode.
+3. Local fix only: set `rollout_mode: local_fix_only`, configure `repo.url`, verification commands, and Slack approvers. Monica writes and verifies a local worktree branch after approval, but never pushes or opens a PR.
+4. Approved draft PRs: set `rollout_mode: approved_pr`, configure `repo.url`, verification commands, `gh` auth, and Slack approvers.
+
+In code-writing modes, Monica prepares a separate worktree under the active
+Hermes profile, asks Codex CLI to make the smallest safe React Native fix, runs
+the configured verification commands, and refuses no-op branches. In
+`local_fix_only`, she stops with the verified local branch. In `approved_pr`,
+she also commits any dirty worktree changes with the PR title, pushes, and
+opens a draft PR. When proof is required, both modes must capture proof before
+they can complete.
+
+In `approved_pr`, the draft PR body is also proof-gated: it must include the
+Linear link, Slack context, Monica summary, verification output, and proof
+artifacts. The PR publisher refuses to push/create a draft PR if that evidence
+is absent.
+
+`slack.approver_user_ids` must also use Slack user IDs such as `U012ABCDEF`.
+Do not use handles or display names there; Monica treats that list as the
+explicit allowlist for starting code-writing work.
+
+## Live Rollout Worksheet
+
+Collect these values before moving Monica beyond local simulation:
+
+- Monica Slack app token for Socket Mode: `MONICA_SLACK_APP_TOKEN`
+- Monica Slack bot token: `MONICA_SLACK_BOT_TOKEN`
+- Monica Slack mention user ID from `slack-metadata --json`: `auth.bot_user_id`
+- Private dry-run Slack channel ID, and later allowed live-action channel IDs:
+  `C...` or `G...`
+- Linear API token: `LINEAR_API_KEY`
+- Linear team ID, and optionally project and label IDs
+- React Native repo Git URL and default branch
+- Verification commands that must pass before draft PR creation
+- Proof command that captures simulator/device evidence into `MONICA_PROOF_DIR`
+- Slack user IDs allowed to approve code work
+- Attachment policy: download Slack files locally, or only reference Slack URLs
+
+The rollout should move in phases:
+
+1. Dry-run Slack: Monica can read tagged Slack threads and reply, but no Linear,
+   code, git, or GitHub side effects occur.
+2. Linear-only: Monica files or updates Linear issues in explicitly allowed
+   channels and stops before code work.
+3. Local fix only: Monica writes code only after tagged approval from an
+   allowed approver, runs verification, requires proof when configured, and
+   stops before push or PR creation.
+4. Approved draft PR: Monica writes code only after tagged approval from an
+   allowed approver, runs verification, requires proof when configured, pushes,
+   and opens a draft PR.
+
+Run the readiness check before each rollout step:
+
+```bash
+hermes mobile-bug-agent doctor
+```
+
+For the first private Slack dry run, persist the non-secret bootstrap settings.
+The Slack scope flags are optional, but using them keeps even dry-run traffic
+limited to Monica's real mention user ID and the private test channel. When
+provided, Monica ignores other app mentions and refuses tagged messages outside
+that channel. `doctor` rejects handles, Slack `bot_id` values, malformed user
+IDs, and channel names before the gateway starts:
+
+```bash
+hermes mobile-bug-agent configure-dry-run \
+  --bot-user-id U012ABCDEF \
+  --channel-id C012ABCDEF
+```
+
+To turn readiness failures into ordered setup actions, use:
+
+```bash
+hermes mobile-bug-agent setup-plan --rollout-mode dry_run
+```
+
+Then check the next gate:
+
+```bash
+hermes mobile-bug-agent setup-plan --rollout-mode linear_only
+```
+
+For automation:
+
+```bash
+hermes mobile-bug-agent setup-plan --rollout-mode dry_run --json
+hermes mobile-bug-agent setup-plan --rollout-mode linear_only --json
+```
+
+To preview the next rollout gate before editing config, pass the target mode:
+
+```bash
+hermes mobile-bug-agent doctor --rollout-mode linear_only
+```
+
+For automation, add `--json`. The JSON form includes stable readiness codes
+and keeps the same nonzero exit code when Monica is not ready:
+
+```bash
+hermes mobile-bug-agent doctor --rollout-mode approved_pr --json
+```
+
+Once the Slack and Linear IDs are known, persist the non-secret Linear-only
+settings with:
+
+```bash
+hermes mobile-bug-agent configure-linear-only \
+  --bot-user-id U012ABCDEF \
+  --channel-id C012ABCDEF \
+  --linear-team-id <linear-team-id>
+```
+
+Repeat `--channel-id` for each allowed Slack channel. Optional
+`--linear-project-id` and repeated `--linear-label-id` flags are supported.
+Secrets such as `MONICA_SLACK_BOT_TOKEN` and `LINEAR_API_KEY` stay in the
+Monica profile `.env`.
+
+To discover Linear team, project, and label IDs from the configured
+`LINEAR_API_KEY`, run:
+
+```bash
+hermes mobile-bug-agent linear-metadata
+```
+
+For scripts or setup dashboards:
+
+```bash
+hermes mobile-bug-agent linear-metadata --json
+```
+
+When the React Native repo, approvers, and verification commands are known,
+persist the non-secret local-fix settings with:
+
+```bash
+hermes mobile-bug-agent configure-local-fix-only \
+  --approver-user-id U012ABCDEF \
+  --repo-url git@github.com:acme/mobile-app.git \
+  --verification-command "npm test" \
+  --verification-command "npm run lint"
+```
+
+To require proof in this mode, set `proof.enabled: true`,
+`proof.required_for_done: true`, and add at least one `proof.commands` entry in
+the Monica profile config. Until the simulator command is available and writes
+an artifact, Monica will verify the code and then stop at `proof_blocked`.
+
+When GitHub push/PR tooling is ready, persist the non-secret approved-PR
+settings with:
+
+```bash
+hermes mobile-bug-agent configure-approved-pr \
+  --approver-user-id U012ABCDEF \
+  --repo-url git@github.com:acme/mobile-app.git \
+  --verification-command "npm test" \
+  --verification-command "npm run lint"
+```
+
+Optional `--repo-local-name`, `--default-branch`, and `--branch-prefix` flags
+are supported. Monica refuses handles, unsafe repo names, unsafe branch names,
+and Chandler-like branch prefixes before saving. GitHub credentials still stay
+outside config, either through `gh` auth or `GITHUB_TOKEN`. This command also
+restores Monica-owned runtime defaults and the non-interactive Codex guardrails
+required for approved PR work: `worker_session_prefix: monica`,
+`skip_memory: true`, `codex_sandbox: workspace-write`, and
+`codex_approval_policy: never`.
+
+Before inviting Monica into Slack channels, run a local simulation against the
+same Monica state machine. Simulation is safe by default: in `linear_only` or
+`approved_pr` modes it refuses to run unless side effects are explicitly allowed.
+
+```bash
+hermes mobile-bug-agent simulate "checkout crashes on Android after applying a promo code"
+```
+
+When `--thread-ts` is omitted, each simulation gets a unique local Slack-shaped
+thread ID. Pass `--thread-ts` only when you intentionally want to reuse or test
+a specific simulated thread.
+
+To deliberately exercise real Linear or approved-PR side effects from a local
+simulation, pass the explicit operator gate:
+
+```bash
+hermes mobile-bug-agent simulate "checkout crashes on Android" --allow-side-effects
+```
+
+Side-effect simulations run the same readiness checks as `doctor` before
+creating a Monica run, so missing Linear/GitHub/Codex/Slack setup stops before
+state or external services are touched.
+
+Code-writing simulations additionally require configured
+`slack.approver_user_ids`; otherwise the simulation stops before creating a run.
+Slack approvals use the same shared fail-closed readiness policy: Monica replies without
+approving the run when code rollout configuration, runtime secrets, or worker
+tools are not ready, or when the worker session is not clearly Monica-owned.
+
+## Slack Examples
+
+```text
+@monica checkout crashes on Android after applying a promo code. Screenshot above.
+@monica can you turn this thread into a mobile bug?
+@monica approved, fix it
+@monica yes, take the fix
+@monica go ahead
+@monica cancel
+```
+
+Untagged messages are ignored.
+
+## Operator CLI
+
+```bash
+hermes mobile-bug-agent status
+hermes mobile-bug-agent status --json
+hermes mobile-bug-agent doctor
+hermes mobile-bug-agent configure-dry-run
+hermes mobile-bug-agent configure-dry-run --bot-user-id U012ABCDEF --channel-id C012ABCDEF
+hermes mobile-bug-agent configure-linear-only --bot-user-id U012ABCDEF --channel-id C012ABCDEF --linear-team-id <team-id>
+hermes mobile-bug-agent configure-local-fix-only --approver-user-id U_APPROVER --repo-url <repo-url> --verification-command "npm test"
+hermes mobile-bug-agent configure-approved-pr --approver-user-id U_APPROVER --repo-url <repo-url> --verification-command "npm test"
+hermes mobile-bug-agent show <run_id>
+hermes mobile-bug-agent show <run_id> --json
+hermes mobile-bug-agent retry <run_id>
+hermes mobile-bug-agent retry <run_id> --json
+hermes mobile-bug-agent approve <run_id> --user-id U_APPROVER
+hermes mobile-bug-agent approve <run_id> --user-id U_APPROVER --json
+hermes mobile-bug-agent simulate "checkout crashes on Android"
+hermes mobile-bug-agent simulate "checkout crashes on Android" --json
+hermes mobile-bug-agent simulate "checkout crashes on Android" --allow-side-effects
+```
+
+`approve` is an operator escape hatch for the same approval gate used in
+Slack. The `--user-id` value must be one of
+`mobile_bug_agent.slack.approver_user_ids`; otherwise Monica refuses to start
+the code-writing loop. In approved-PR mode, local approval also runs the
+readiness checks before changing the run to approved. Retrying a run that still
+has stored approval also runs readiness checks before relaunching code work.
+
+`retry` can resume blocked, failed, or clarification-needed runs from the last
+safe gate. Runs cancelled from Slack stay cancelled; tag Monica again in the
+Slack thread with new context to start a fresh pass.
+
+`status` prints compact rollout context for recent runs: run ID, status, Slack
+channel/thread, Linear identifier, branch name, PR or Linear URL, and request
+text. `status --json` and `show <run_id> --json` provide machine-readable run
+payloads for dashboards and rollout scripts. `retry --json` and
+`approve --json` return `{ok, action, run}` on success and `{ok, action, error}`
+with a stable error code on refusal; when a run exists, the refusal payload also
+includes the current run. `simulate --json` returns the created run payload so
+dry-run rehearsals can be chained into `show` or dashboard checks; if the
+simulated thread already exists, it returns
+`created: false`, a `duplicate_thread` error code, and the existing run payload
+while preserving the nonzero exit code. Early simulation failures, such as
+disabled config, missing simulation text, missing `--allow-side-effects`,
+missing allowed channels, missing Monica Slack user IDs, disallowed channels,
+missing approved-PR approvers, readiness failures, or readiness exceptions,
+also return structured JSON errors when `--json` is used.
+
+`proof_blocked` means the code worker and verification completed, but Monica
+could not capture the required screenshot or recording artifact. Fix the local
+simulator/tooling or `proof.commands`, then retry the run.
+
+Monica loop logs use the `plugins.mobile_bug_agent.loop` logger and include
+the run ID, Slack channel/thread, Linear issue, branch, PR URL, status, stage,
+and failure reason when available.

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -761,6 +761,7 @@ def load_gateway_config() -> GatewayConfig:
     """
     _home = get_hermes_home()
     gw_data: dict = {}
+    monica_slack_bridge_enabled = False
 
     # Legacy fallback: gateway.json provides the base layer.
     # config.yaml keys always win when both specify the same setting.
@@ -783,6 +784,13 @@ def load_gateway_config() -> GatewayConfig:
         if config_yaml_path.exists():
             with open(config_yaml_path, encoding="utf-8") as f:
                 yaml_cfg = yaml.safe_load(f) or {}
+
+            monica_cfg = yaml_cfg.get("mobile_bug_agent")
+            if isinstance(monica_cfg, dict):
+                monica_slack_bridge_enabled = _coerce_bool(
+                    monica_cfg.get("enabled"),
+                    False,
+                )
 
             # Map config.yaml keys → GatewayConfig.from_dict() schema.
             # Each key overwrites whatever gateway.json may have set.
@@ -1247,6 +1255,14 @@ def load_gateway_config() -> GatewayConfig:
             _home / "config.yaml",
             e,
         )
+
+    if monica_slack_bridge_enabled:
+        monica_bot_token = os.getenv("MONICA_SLACK_BOT_TOKEN", "").strip()
+        if monica_bot_token:
+            os.environ["SLACK_BOT_TOKEN"] = monica_bot_token
+        monica_app_token = os.getenv("MONICA_SLACK_APP_TOKEN", "").strip()
+        if monica_app_token:
+            os.environ["SLACK_APP_TOKEN"] = monica_app_token
 
     config = GatewayConfig.from_dict(gw_data)
 

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -54,6 +54,70 @@ from gateway.platforms.base import (
 
 logger = logging.getLogger(__name__)
 
+
+def _approval_command_kind(command: str) -> str:
+    """Return a plain-language command category for Slack approval prompts."""
+    cmd = (command or "").lower()
+    if (
+        "scripts/run-ad-hoc-query.ts" in cmd
+        or "scripts/run-posthog-query.ts" in cmd
+        or "scripts/run-analytics-question.ts" in cmd
+        or "claude-analytics" in cmd
+    ):
+        return "local analytics command"
+    return "local command"
+
+
+def _humanize_approval_reason(description: str) -> str:
+    """Translate internal approval-rule names into Slack-user copy."""
+    desc = (description or "command flagged for review").strip()
+    normalized = desc.lower()
+
+    if "script execution via -e/-c flag" in normalized:
+        return (
+            "This command runs a short inline script. That can be normal for "
+            "analytics glue code, but Hermes asks before running generated scripts."
+        )
+    if "shell command via -c" in normalized:
+        return (
+            "This command asks a shell to run another command string. Hermes "
+            "pauses these because they can hide extra work inside the string."
+        )
+    if "sql delete without where" in normalized:
+        return "This looks like a broad SQL delete, so Hermes needs explicit confirmation."
+    if "sql drop" in normalized:
+        return "This looks like it could drop database objects, so Hermes needs explicit confirmation."
+
+    return f"Hermes flagged this command for review: {desc}."
+
+
+def _build_slack_exec_approval_text(command: str, description: str) -> str:
+    """Build a Slack section block under Slack's 3000-character cap."""
+    command_kind = _approval_command_kind(command)
+    reason = _humanize_approval_reason(description)
+    prefix = (
+        ":warning: *Permission needed to continue*\n"
+        f"The assistant needs to run a {command_kind} before it can answer. "
+        "If this matches the lookup you just asked for, choose *Allow Once*. "
+        "Choose *Deny* if this looks unexpected.\n\n"
+        f"*Why Hermes paused:* {reason}\n\n"
+        "*Command preview:*\n```"
+    )
+    suffix = "```"
+    budget = 3000 - len(prefix) - len(suffix) - len("...")
+    if budget < 0:
+        prefix = (
+            ":warning: *Permission needed to continue*\n"
+            "The assistant needs confirmation before running a local command. "
+            "Choose *Allow Once* only if this matches your request; otherwise choose *Deny*.\n\n"
+            "*Command preview:*\n```"
+        )
+        budget = 3000 - len(prefix) - len(suffix) - len("...")
+
+    cmd_preview = command[:budget] + "..." if len(command) > budget else command
+    return f"{prefix}{cmd_preview}{suffix}"
+
+
 # ContextVar carrying the user_id of the slash-command invoker.
 # Set in _handle_slash_command, read in send() to match the correct
 # stashed response_url when multiple users issue commands on the same
@@ -2699,24 +2763,15 @@ class SlackAdapter(BasePlatformAdapter):
         try:
             thread_ts = self._resolve_thread_ts(None, metadata)
 
-            # Slack hard-caps a section block's text at 3000 chars; an
-            # oversized block fails the whole send with ``invalid_blocks``
-            # and the gateway falls back to the plain-text prompt (no
-            # buttons).  execute_code approvals embed the entire script in
-            # ``command``, so budget the preview against the fixed parts
-            # instead of a flat truncation that overflows once the header +
-            # reason are added.
-            header = ":warning: *Command Approval Required*\n"
-            reason = f"Reason: {description[:500]}"
-            budget = 3000 - len(header) - len(reason) - len("``````\n") - len("...")
-            cmd_preview = command[:budget] + "..." if len(command) > budget else command
+            section_text = _build_slack_exec_approval_text(command, description)
+            cmd_preview = command[:100] + "..." if len(command) > 100 else command
 
             blocks = [
                 {
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": f"{header}```{cmd_preview}```\n{reason}",
+                        "text": section_text,
                     },
                 },
                 {

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -86,6 +86,15 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     re.IGNORECASE | re.DOTALL,
 )
 
+_CHAT_NOISY_STATUS_RE = re.compile(
+    r"("
+    r"codex\s+gpt-5\.5\s+caps\s+context"
+    r"|auto-compaction\s+was\s+raised"
+    r"|compression\.codex_gpt55_autoraise"
+    r")",
+    re.IGNORECASE | re.DOTALL,
+)
+
 _GATEWAY_PROVIDER_ERROR_RE = re.compile(
     r"("  # infrastructure/provider error preambles, not ordinary assistant prose
     r"api\s+(?:call\s+)?failed"
@@ -308,7 +317,10 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
     text = str(message or "").strip()
     if not text:
         return None
-    if _gateway_platform_value(platform) != "telegram":
+    platform_value = _gateway_platform_value(platform)
+    if platform_value != "local" and _CHAT_NOISY_STATUS_RE.search(text):
+        return None
+    if platform_value != "telegram":
         return text
 
     text = _redact_gateway_user_facing_secrets(text)
@@ -6261,6 +6273,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Fire pre_gateway_dispatch plugin hook for user-originated messages.
         # Plugins receive the MessageEvent and may return a dict influencing flow:
         #   {"action": "skip",    "reason": ...}    -> drop (no reply, plugin handled)
+        #   {"action": "skip_reply", "text": ...}   -> reply, then drop
         #   {"action": "rewrite", "text":  ...}     -> replace event.text, continue
         #   {"action": "allow"}   /   None          -> normal dispatch
         # Hook runs BEFORE auth so plugins can handle unauthorized senders
@@ -6285,6 +6298,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if _action == "skip":
                     logger.info(
                         "pre_gateway_dispatch skip: reason=%s platform=%s chat=%s",
+                        _result.get("reason"),
+                        source.platform.value if source.platform else "unknown",
+                        source.chat_id or "unknown",
+                    )
+                    return None
+                if _action == "skip_reply":
+                    _reply_text = _result.get("text")
+                    if isinstance(_reply_text, str) and _reply_text.strip():
+                        _adapter = self.adapters.get(source.platform)
+                        if _adapter and source.chat_id:
+                            try:
+                                await _adapter.send(
+                                    source.chat_id,
+                                    _reply_text.strip(),
+                                    metadata=self._thread_metadata_for_source(
+                                        source,
+                                        self._reply_anchor_for_event(event),
+                                    ),
+                                )
+                            except Exception as _send_exc:
+                                logger.warning(
+                                    "pre_gateway_dispatch skip_reply send failed: %s",
+                                    _send_exc,
+                                )
+                    logger.info(
+                        "pre_gateway_dispatch skip_reply: reason=%s platform=%s chat=%s",
                         _result.get("reason"),
                         source.platform.value if source.platform else "unknown",
                         source.chat_id or "unknown",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2237,6 +2237,67 @@ DEFAULT_CONFIG = {
         "trust_recent_files_seconds": 600,
     },
 
+    # Monica mobile bug agent plugin. Disabled by default and loaded only
+    # when `plugins.enabled` includes `mobile-bug-agent`.
+    "mobile_bug_agent": {
+        "enabled": False,
+        "rollout_mode": "dry_run",
+        "dry_run": True,
+        "slack": {
+            "allowed_channels": [],
+            "approver_user_ids": [],
+            "bot_user_ids": [],
+            "download_attachments": True,
+        },
+        "loop": {
+            "max_iterations": 8,
+            "timeout_minutes": 30,
+            "no_progress_limit": 2,
+            "create_linear": True,
+            "require_fix_approval": True,
+            "max_thread_messages": 40,
+            "max_attachment_bytes": 15_000_000,
+        },
+        "linear": {
+            "team_id": "",
+            "project_id": "",
+            "label_ids": [],
+        },
+        "repo": {
+            "url": "",
+            "local_name": "mobile-app",
+            "default_branch": "main",
+            "branch_prefix": "monica",
+        },
+        "verification": {
+            "commands": [],
+        },
+        "proof": {
+            "enabled": False,
+            "required_for_done": False,
+            "platform_order": ["ios", "android"],
+            "artifact_dir": "proof",
+            "commands": [],
+            "ios_simulator_udid": "",
+            "android_serial": "",
+            "timeout_minutes": 10,
+        },
+        "runtime": {
+            "home_subdir": "agents/monica",
+            "worker_session_prefix": "monica",
+            "skip_memory": True,
+        },
+        "worker": {
+            "backend": "codex_cli",
+            "codex_command": "codex",
+            "codex_model": "",
+            "codex_profile": "",
+            "codex_sandbox": "workspace-write",
+            "codex_approval_policy": "never",
+            "timeout_minutes": 45,
+        },
+    },
+
     # Real-time token streaming to messaging platforms (Telegram, Discord,
     # Slack, etc.). Read at the top level by the gateway; absent this block the
     # gateway falls back to these same defaults, so adding it here only makes
@@ -3230,6 +3291,20 @@ OPTIONAL_ENV_VARS = {
         "password": True,
         "category": "messaging",
     },
+    "MONICA_SLACK_BOT_TOKEN": {
+        "description": "Monica Slack bot token (xoxb-). Keep separate from Chandler's SLACK_BOT_TOKEN.",
+        "prompt": "Monica Slack Bot Token (xoxb-...)",
+        "url": "https://api.slack.com/apps",
+        "password": True,
+        "category": "messaging",
+    },
+    "MONICA_SLACK_APP_TOKEN": {
+        "description": "Monica Slack app-level token (xapp-) for Socket Mode. Keep separate from Chandler.",
+        "prompt": "Monica Slack App Token (xapp-...)",
+        "url": "https://api.slack.com/apps",
+        "password": True,
+        "category": "messaging",
+    },
     "MATTERMOST_URL": {
         "description": "Mattermost server URL (e.g. https://mm.example.com)",
         "prompt": "Mattermost server URL",
@@ -4077,7 +4152,7 @@ _KNOWN_ROOT_KEYS = {
     "fallback_providers", "credential_pool_strategies", "toolsets",
     "agent", "terminal", "display", "compression", "delegation",
     "auxiliary", "custom_providers", "context", "memory", "gateway",
-    "sessions", "streaming", "updates",
+    "sessions", "streaming", "updates", "mobile_bug_agent",
 }
 
 # Valid fields inside a custom_providers list entry

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11878,7 +11878,9 @@ def main():
 
     # Execute the command
     if hasattr(args, "func"):
-        args.func(args)
+        result = args.func(args)
+        if isinstance(result, int) and result != 0:
+            sys.exit(result)
     else:
         parser.print_help()
 

--- a/plugins/mobile_bug_agent/__init__.py
+++ b/plugins/mobile_bug_agent/__init__.py
@@ -1,0 +1,120 @@
+"""Monica mobile bug agent plugin.
+
+Monica is intentionally mention-gated and loop-driven: the Slack mention wakes
+the agentic workflow, then the workflow decides the next useful step.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import threading
+from functools import lru_cache
+from typing import Any
+
+from gateway.config import Platform
+
+from .config import load_monica_config, runtime_root
+from .cli import mobile_bug_agent_command, register_cli
+from .loop import MonicaLoop
+from .skills import DefaultMonicaSkills
+from .slack_flow import MonicaSlackFlow
+from .state import MonicaState
+
+logger = logging.getLogger(__name__)
+_SLACK_MENTION_RE = re.compile(r"<@([A-Z0-9_]+)(?:\|[^>]+)?>")
+
+
+@lru_cache(maxsize=1)
+def _runtime() -> MonicaSlackFlow:
+    config = load_monica_config()
+    state_path = runtime_root(config) / "state.sqlite"
+    state = MonicaState.open(state_path)
+    skills = DefaultMonicaSkills(config=config, state=state)
+    loop = MonicaLoop(config=config, state=state, skills=skills)
+
+    def launch(run_id: str) -> None:
+        thread = threading.Thread(
+            target=_run_loop_safely,
+            args=(loop, run_id),
+            name=f"monica-loop-{run_id[:8]}",
+            daemon=True,
+        )
+        thread.start()
+
+    return MonicaSlackFlow(config=config, state=state, loop_launcher=launch)
+
+
+def _run_loop_safely(loop: MonicaLoop, run_id: str) -> None:
+    try:
+        loop.run(run_id)
+    except Exception as exc:  # pragma: no cover - defensive gateway isolation
+        logger.warning("Monica loop %s failed: %s", run_id, exc, exc_info=True)
+        try:
+            loop.state.update_run(run_id, status="failed", failure_reason=str(exc))
+        except Exception:
+            logger.debug("Failed to mark Monica run %s failed", run_id, exc_info=True)
+
+
+def _on_pre_gateway_dispatch(event: Any, gateway: Any = None, **_: Any) -> dict[str, Any] | None:
+    try:
+        return _runtime().handle_gateway_event(event)
+    except Exception as exc:  # pragma: no cover - defensive gateway isolation
+        _runtime.cache_clear()
+        logger.warning("Monica gateway hook unavailable: %s", exc, exc_info=True)
+        if _is_slack_monica_mention_fallback(event):
+            return {
+                "action": "skip_reply",
+                "reason": "monica_runtime_unavailable",
+                "text": (
+                    "Monica could not start because her runtime is not configured correctly. "
+                    "Run `hermes mobile-bug-agent doctor` on the host for details."
+                ),
+            }
+        return None
+
+
+def _is_slack_monica_mention_fallback(event: Any) -> bool:
+    source = getattr(event, "source", None)
+    if getattr(source, "platform", None) != Platform.SLACK:
+        return False
+    raw = getattr(event, "raw_message", None)
+    if _is_slack_direct_message_fallback(event):
+        return True
+    text = str(raw.get("text") if isinstance(raw, dict) else getattr(event, "text", "") or "")
+    mentioned_ids = set(_SLACK_MENTION_RE.findall(text))
+    is_app_mention = isinstance(raw, dict) and str(raw.get("type") or "") == "app_mention"
+    try:
+        config = load_monica_config()
+    except Exception:
+        return bool(is_app_mention)
+    configured_ids = set(config.slack.bot_user_ids)
+    if configured_ids:
+        return bool(configured_ids & mentioned_ids)
+    return bool(is_app_mention)
+
+
+def _is_slack_direct_message_fallback(event: Any) -> bool:
+    source = getattr(event, "source", None)
+    raw = getattr(event, "raw_message", None)
+    if isinstance(raw, dict):
+        channel_type = str(raw.get("channel_type") or "")
+        if channel_type == "im":
+            return True
+        if channel_type == "mpim":
+            return False
+
+    channel_id = str(getattr(source, "chat_id", "") or "")
+    chat_type = str(getattr(source, "chat_type", "") or "")
+    return chat_type == "dm" and channel_id.startswith("D")
+
+
+def register(ctx) -> None:
+    ctx.register_cli_command(
+        name="mobile-bug-agent",
+        help="Inspect and operate Monica mobile bug loops",
+        setup_fn=register_cli,
+        handler_fn=mobile_bug_agent_command,
+        description="Operator CLI for Monica Slack-to-Linear mobile bug loops.",
+    )
+    ctx.register_hook("pre_gateway_dispatch", _on_pre_gateway_dispatch)

--- a/plugins/mobile_bug_agent/cli.py
+++ b/plugins/mobile_bug_agent/cli.py
@@ -1,0 +1,1967 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from dataclasses import replace
+from typing import Any
+
+from .config import MonicaConfig, load_monica_config, runtime_root
+from .linear_client import LinearClient, LinearClientError
+from .loop import MonicaLoop
+from .readiness import check_monica_readiness, _is_slack_channel_id, _is_slack_user_id
+from .repo_manager import (
+    RepoManagerError,
+    safe_branch_prefix,
+    safe_default_branch,
+    safe_repo_local_name,
+)
+from .secrets import MONICA_SLACK_BOT_TOKEN, monica_slack_bot_token
+from .skills import DefaultMonicaSkills
+from .slack_client import SlackClientError, SlackThreadClient
+from .state import MonicaState
+
+RETRYABLE_STATUSES = {"blocked", "failed", "needs_clarification"}
+_SIMULATION_THREAD_SEQUENCE = 0
+
+
+def register_cli(subparser: argparse.ArgumentParser) -> None:
+    subs = subparser.add_subparsers(dest="mobile_bug_agent_action")
+
+    status_p = subs.add_parser("status", help="List recent Monica runs")
+    status_p.add_argument("--limit", type=int, default=20)
+    status_p.add_argument("--json", action="store_true", help="Print recent runs as JSON")
+
+    doctor_p = subs.add_parser("doctor", help="Check Monica rollout readiness")
+    doctor_p.add_argument(
+        "--rollout-mode",
+        choices=("dry_run", "linear_only", "local_fix_only", "approved_pr"),
+        default="",
+        help="Preflight a rollout mode without changing config",
+    )
+    doctor_p.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable readiness JSON",
+    )
+
+    setup_plan_p = subs.add_parser(
+        "setup-plan",
+        help="Print ordered Monica rollout setup steps",
+    )
+    setup_plan_p.set_defaults(mobile_bug_agent_action="setup_plan")
+    setup_plan_p.add_argument(
+        "--rollout-mode",
+        choices=("dry_run", "linear_only", "local_fix_only", "approved_pr"),
+        default="",
+        help="Plan setup for a rollout mode without changing config",
+    )
+    setup_plan_p.add_argument("--json", action="store_true", help="Print setup plan as JSON")
+
+    manifest_p = subs.add_parser(
+        "slack-manifest",
+        help="Print a Slack App Manifest for Monica setup",
+    )
+    manifest_p.set_defaults(mobile_bug_agent_action="slack_manifest")
+    manifest_p.add_argument("--app-name", default="Monica")
+    manifest_p.add_argument("--bot-display-name", default="monica")
+
+    slack_metadata_p = subs.add_parser(
+        "slack-metadata",
+        help="List Slack bot identity and channel IDs for Monica setup",
+    )
+    slack_metadata_p.set_defaults(mobile_bug_agent_action="slack_metadata")
+    slack_metadata_p.add_argument(
+        "--json",
+        action="store_true",
+        help="Print Slack metadata as JSON",
+    )
+
+    linear_metadata_p = subs.add_parser(
+        "linear-metadata",
+        help="List Linear team/project/label IDs for Monica setup",
+    )
+    linear_metadata_p.set_defaults(mobile_bug_agent_action="linear_metadata")
+    linear_metadata_p.add_argument(
+        "--json",
+        action="store_true",
+        help="Print Linear metadata as JSON",
+    )
+
+    configure_dry_run_p = subs.add_parser(
+        "configure-dry-run",
+        help="Persist non-secret Monica settings for dry-run Slack rollout",
+    )
+    configure_dry_run_p.set_defaults(mobile_bug_agent_action="configure_dry_run")
+    configure_dry_run_p.add_argument(
+        "--bot-user-id",
+        dest="bot_user_ids",
+        action="append",
+        default=[],
+        help="Optional Monica Slack mention user ID, e.g. U012ABCDEF",
+    )
+    configure_dry_run_p.add_argument(
+        "--channel-id",
+        dest="channel_ids",
+        action="append",
+        default=[],
+        help="Optional private dry-run Slack channel ID, e.g. C012ABCDEF or G012ABCDEF",
+    )
+
+    configure_linear_p = subs.add_parser(
+        "configure-linear-only",
+        help="Persist non-secret Monica settings for Linear-only rollout",
+    )
+    configure_linear_p.set_defaults(mobile_bug_agent_action="configure_linear_only")
+    configure_linear_p.add_argument(
+        "--bot-user-id",
+        dest="bot_user_ids",
+        action="append",
+        required=True,
+        help="Monica Slack mention user ID, e.g. U012ABCDEF",
+    )
+    configure_linear_p.add_argument(
+        "--channel-id",
+        dest="channel_ids",
+        action="append",
+        required=True,
+        help="Allowed Slack channel ID, e.g. C012ABCDEF or G012ABCDEF",
+    )
+    configure_linear_p.add_argument(
+        "--linear-team-id",
+        required=True,
+        help="Linear team ID for mobile app issues",
+    )
+    configure_linear_p.add_argument(
+        "--linear-project-id",
+        default="",
+        help="Optional Linear project ID",
+    )
+    configure_linear_p.add_argument(
+        "--linear-label-id",
+        dest="linear_label_ids",
+        action="append",
+        default=[],
+        help="Optional Linear label ID; repeat for multiple labels",
+    )
+
+    configure_pr_p = subs.add_parser(
+        "configure-approved-pr",
+        help="Persist non-secret Monica settings for approved draft PR rollout",
+    )
+    configure_pr_p.set_defaults(mobile_bug_agent_action="configure_approved_pr")
+    configure_pr_p.add_argument(
+        "--approver-user-id",
+        dest="approver_user_ids",
+        action="append",
+        required=True,
+        help="Slack user ID allowed to approve Monica code work, e.g. U012ABCDEF",
+    )
+    configure_pr_p.add_argument(
+        "--repo-url",
+        required=True,
+        help="React Native app repository URL",
+    )
+    configure_pr_p.add_argument(
+        "--verification-command",
+        dest="verification_commands",
+        action="append",
+        required=True,
+        help="Command Monica must run before opening a draft PR; repeat for multiple commands",
+    )
+    configure_pr_p.add_argument("--repo-local-name", default="mobile-app")
+    configure_pr_p.add_argument("--default-branch", default="main")
+    configure_pr_p.add_argument("--branch-prefix", default="monica")
+
+    configure_local_fix_p = subs.add_parser(
+        "configure-local-fix-only",
+        help="Persist non-secret Monica settings for local fix rollout without push or PR",
+    )
+    configure_local_fix_p.set_defaults(mobile_bug_agent_action="configure_local_fix_only")
+    configure_local_fix_p.add_argument(
+        "--approver-user-id",
+        dest="approver_user_ids",
+        action="append",
+        required=True,
+        help="Slack user ID allowed to approve Monica code work, e.g. U012ABCDEF",
+    )
+    configure_local_fix_p.add_argument(
+        "--repo-url",
+        required=True,
+        help="React Native app repository URL",
+    )
+    configure_local_fix_p.add_argument(
+        "--verification-command",
+        dest="verification_commands",
+        action="append",
+        required=True,
+        help="Command Monica must run before marking a local fix ready; repeat for multiple commands",
+    )
+    configure_local_fix_p.add_argument("--repo-local-name", default="mobile-app")
+    configure_local_fix_p.add_argument("--default-branch", default="main")
+    configure_local_fix_p.add_argument("--branch-prefix", default="monica")
+
+    show_p = subs.add_parser("show", help="Show one Monica run")
+    show_p.add_argument("run_id")
+    show_p.add_argument("--json", action="store_true", help="Print the run as JSON")
+
+    retry_p = subs.add_parser("retry", help="Retry a Monica run from its last safe gate")
+    retry_p.add_argument("run_id")
+    retry_p.add_argument("--json", action="store_true", help="Print retry result as JSON")
+
+    approve_p = subs.add_parser("approve", help="Approve a Monica run locally and continue the fix loop")
+    approve_p.add_argument("run_id")
+    approve_p.add_argument("--user-id", default="local-operator")
+    approve_p.add_argument("--json", action="store_true", help="Print approval result as JSON")
+
+    simulate_p = subs.add_parser("simulate", help="Run a local Monica message simulation")
+    simulate_p.add_argument("text", nargs="+")
+    simulate_p.add_argument("--channel-id", default="LOCAL_MONICA_SIM")
+    simulate_p.add_argument("--user-id", default="local-operator")
+    simulate_p.add_argument("--thread-ts", default="")
+    simulate_p.add_argument(
+        "--allow-side-effects",
+        action="store_true",
+        help="Allow simulate to run real Linear/PR side effects when rollout_mode is not dry_run",
+    )
+    simulate_p.add_argument("--json", action="store_true", help="Print simulation result as JSON")
+
+    subparser.set_defaults(func=mobile_bug_agent_command)
+
+
+def mobile_bug_agent_command(args: argparse.Namespace) -> int:
+    action = getattr(args, "mobile_bug_agent_action", None)
+    config = load_monica_config()
+    if action == "doctor":
+        return run_doctor_command(
+            config=config,
+            target_rollout_mode=str(getattr(args, "rollout_mode", "") or ""),
+            json_output=bool(getattr(args, "json", False)),
+        )
+    if action == "setup_plan":
+        return run_setup_plan_command(
+            config=config,
+            target_rollout_mode=str(getattr(args, "rollout_mode", "") or ""),
+            json_output=bool(getattr(args, "json", False)),
+        )
+    if action == "slack_manifest":
+        return run_slack_manifest_command(
+            config=config,
+            app_name=str(getattr(args, "app_name", "") or ""),
+            bot_display_name=str(getattr(args, "bot_display_name", "") or ""),
+        )
+    if action == "slack_metadata":
+        return run_slack_metadata_command(json_output=bool(getattr(args, "json", False)))
+    if action == "linear_metadata":
+        return run_linear_metadata_command(json_output=bool(getattr(args, "json", False)))
+    if action == "configure_dry_run":
+        return run_configure_dry_run_command(
+            bot_user_ids=tuple(getattr(args, "bot_user_ids", ()) or ()),
+            channel_ids=tuple(getattr(args, "channel_ids", ()) or ()),
+        )
+    if action == "configure_linear_only":
+        return run_configure_linear_only_command(
+            bot_user_ids=tuple(getattr(args, "bot_user_ids", ()) or ()),
+            channel_ids=tuple(getattr(args, "channel_ids", ()) or ()),
+            linear_team_id=str(getattr(args, "linear_team_id", "") or ""),
+            linear_project_id=str(getattr(args, "linear_project_id", "") or ""),
+            linear_label_ids=tuple(getattr(args, "linear_label_ids", ()) or ()),
+        )
+    if action == "configure_approved_pr":
+        return run_configure_approved_pr_command(
+            approver_user_ids=tuple(getattr(args, "approver_user_ids", ()) or ()),
+            repo_url=str(getattr(args, "repo_url", "") or ""),
+            verification_commands=tuple(getattr(args, "verification_commands", ()) or ()),
+            repo_local_name=str(getattr(args, "repo_local_name", "") or ""),
+            default_branch=str(getattr(args, "default_branch", "") or ""),
+            branch_prefix=str(getattr(args, "branch_prefix", "") or ""),
+        )
+    if action == "configure_local_fix_only":
+        return run_configure_local_fix_only_command(
+            approver_user_ids=tuple(getattr(args, "approver_user_ids", ()) or ()),
+            repo_url=str(getattr(args, "repo_url", "") or ""),
+            verification_commands=tuple(getattr(args, "verification_commands", ()) or ()),
+            repo_local_name=str(getattr(args, "repo_local_name", "") or ""),
+            default_branch=str(getattr(args, "default_branch", "") or ""),
+            branch_prefix=str(getattr(args, "branch_prefix", "") or ""),
+        )
+
+    try:
+        state = _open_state(config)
+    except ValueError as exc:
+        print(f"Monica runtime is not configured correctly: {exc}")
+        return 1
+    if action == "status":
+        return run_status_command(
+            state=state,
+            limit=int(getattr(args, "limit", 20)),
+            json_output=bool(getattr(args, "json", False)),
+        )
+    if action == "show":
+        return run_show_command(
+            state=state,
+            run_id=str(args.run_id),
+            json_output=bool(getattr(args, "json", False)),
+        )
+    if action == "retry":
+        return run_retry_command(
+            state=state,
+            run_id=str(args.run_id),
+            config=config,
+            json_output=bool(getattr(args, "json", False)),
+        )
+    if action == "approve":
+        return run_approve_command(
+            state=state,
+            run_id=str(args.run_id),
+            user_id=str(getattr(args, "user_id", "") or "local-operator"),
+            config=config,
+            json_output=bool(getattr(args, "json", False)),
+        )
+    if action == "simulate":
+        return run_simulate_command(
+            config=config,
+            state=state,
+            text=" ".join(getattr(args, "text", []) or []),
+            channel_id=str(getattr(args, "channel_id", "") or "LOCAL_MONICA_SIM"),
+            user_id=str(getattr(args, "user_id", "") or "local-operator"),
+            thread_ts=str(getattr(args, "thread_ts", "") or ""),
+            allow_side_effects=bool(getattr(args, "allow_side_effects", False)),
+            json_output=bool(getattr(args, "json", False)),
+        )
+    print(
+        "Usage: hermes mobile-bug-agent "
+        "{status|doctor|setup-plan|configure-dry-run|configure-linear-only|configure-local-fix-only|"
+        "configure-approved-pr|"
+        "show|retry|approve|simulate}"
+    )
+    return 2
+
+
+def run_configure_linear_only_command(
+    *,
+    bot_user_ids: tuple[str, ...],
+    channel_ids: tuple[str, ...],
+    linear_team_id: str,
+    linear_project_id: str = "",
+    linear_label_ids: tuple[str, ...] = (),
+    load_config_fn: Any | None = None,
+    save_config_fn: Any | None = None,
+) -> int:
+    bot_ids = _clean_sequence(bot_user_ids)
+    channels = _clean_sequence(channel_ids)
+    team_id = str(linear_team_id or "").strip()
+    project_id = str(linear_project_id or "").strip()
+    label_ids = _clean_sequence(linear_label_ids)
+
+    errors = _linear_only_config_errors(
+        bot_user_ids=bot_ids,
+        channel_ids=channels,
+        linear_team_id=team_id,
+    )
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        print("Monica linear_only configuration was not saved.")
+        return 1
+
+    if load_config_fn is None or save_config_fn is None:
+        from hermes_cli.config import load_config, save_config
+
+        load = load_config if load_config_fn is None else load_config_fn
+        save = save_config if save_config_fn is None else save_config_fn
+    else:
+        load = load_config_fn
+        save = save_config_fn
+
+    config = load()
+    if not isinstance(config, dict):
+        config = {}
+    _enable_plugin(config)
+
+    monica_cfg = _ensure_dict(config, "mobile_bug_agent")
+    monica_cfg["enabled"] = True
+    monica_cfg["rollout_mode"] = "linear_only"
+    monica_cfg["dry_run"] = False
+
+    slack_cfg = _ensure_dict(monica_cfg, "slack")
+    slack_cfg["bot_user_ids"] = list(bot_ids)
+    slack_cfg["allowed_channels"] = list(channels)
+
+    loop_cfg = _ensure_dict(monica_cfg, "loop")
+    loop_cfg["create_linear"] = True
+
+    linear_cfg = _ensure_dict(monica_cfg, "linear")
+    linear_cfg["team_id"] = team_id
+    linear_cfg["project_id"] = project_id
+    linear_cfg["label_ids"] = list(label_ids)
+
+    save(config)
+    print("Configured Monica for linear_only rollout.")
+    print(
+        "Secrets were not written; keep MONICA_SLACK_BOT_TOKEN and LINEAR_API_KEY in the Monica profile .env."
+    )
+    print("Run `hermes mobile-bug-agent doctor --rollout-mode linear_only` before inviting Monica.")
+    return 0
+
+
+def run_configure_dry_run_command(
+    *,
+    bot_user_ids: tuple[str, ...] = (),
+    channel_ids: tuple[str, ...] = (),
+    load_config_fn: Any | None = None,
+    save_config_fn: Any | None = None,
+) -> int:
+    bot_ids = _clean_sequence(bot_user_ids)
+    channels = _clean_sequence(channel_ids)
+
+    errors = _slack_scope_config_errors(
+        bot_user_ids=bot_ids,
+        channel_ids=channels,
+    )
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        print("Monica dry_run configuration was not saved.")
+        return 1
+
+    if load_config_fn is None or save_config_fn is None:
+        from hermes_cli.config import load_config, save_config
+
+        load = load_config if load_config_fn is None else load_config_fn
+        save = save_config if save_config_fn is None else save_config_fn
+    else:
+        load = load_config_fn
+        save = save_config_fn
+
+    config = load()
+    if not isinstance(config, dict):
+        config = {}
+    _enable_plugin(config)
+
+    monica_cfg = _ensure_dict(config, "mobile_bug_agent")
+    monica_cfg["enabled"] = True
+    monica_cfg["rollout_mode"] = "dry_run"
+    monica_cfg["dry_run"] = True
+
+    if bot_ids or channels:
+        slack_cfg = _ensure_dict(monica_cfg, "slack")
+        if bot_ids:
+            slack_cfg["bot_user_ids"] = list(bot_ids)
+        if channels:
+            slack_cfg["allowed_channels"] = list(channels)
+
+    loop_cfg = _ensure_dict(monica_cfg, "loop")
+    loop_cfg["create_linear"] = True
+    loop_cfg["require_fix_approval"] = True
+
+    runtime_cfg = _ensure_dict(monica_cfg, "runtime")
+    runtime_cfg["home_subdir"] = "agents/monica"
+    runtime_cfg["worker_session_prefix"] = "monica"
+    runtime_cfg["skip_memory"] = True
+
+    save(config)
+    print("Configured Monica for dry_run rollout.")
+    print("Secrets were not written; keep MONICA_SLACK_BOT_TOKEN in the Monica profile .env.")
+    print("Run `hermes mobile-bug-agent doctor --rollout-mode dry_run` before inviting Monica.")
+    return 0
+
+
+def run_slack_manifest_command(
+    *,
+    config: MonicaConfig,
+    app_name: str = "Monica",
+    bot_display_name: str = "monica",
+) -> int:
+    manifest = _slack_app_manifest(
+        config=config,
+        app_name=app_name,
+        bot_display_name=bot_display_name,
+    )
+    print(json.dumps(manifest, indent=2, sort_keys=True))
+    return 0
+
+
+def run_linear_metadata_command(
+    *,
+    api_key: str | None = None,
+    json_output: bool = False,
+    client_factory: Any = LinearClient,
+) -> int:
+    key = str(api_key if api_key is not None else os.environ.get("LINEAR_API_KEY", "")).strip()
+    if not key:
+        message = "LINEAR_API_KEY is missing; keep it in ~/.hermes/.env before listing Linear IDs."
+        if json_output:
+            _print_linear_metadata_error_json("linear_api_key_missing", message)
+            return 1
+        print(message)
+        return 1
+    try:
+        metadata = client_factory(api_key=key).list_workspace_metadata()
+    except LinearClientError as exc:
+        message = str(exc)
+        if json_output:
+            _print_linear_metadata_error_json("linear_request_failed", message)
+            return 1
+        print(f"Could not list Linear metadata: {message}")
+        return 1
+    if json_output:
+        print(json.dumps(_linear_metadata_payload(metadata), sort_keys=True))
+        return 0
+    _print_linear_metadata_text(metadata)
+    return 0
+
+
+def _linear_metadata_payload(metadata: Any) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "teams": [
+            {
+                "id": str(getattr(team, "id", "") or ""),
+                "key": str(getattr(team, "key", "") or ""),
+                "name": str(getattr(team, "name", "") or ""),
+            }
+            for team in getattr(metadata, "teams", ()) or ()
+        ],
+        "projects": [
+            {
+                "id": str(getattr(project, "id", "") or ""),
+                "name": str(getattr(project, "name", "") or ""),
+                "state": str(getattr(project, "state", "") or ""),
+            }
+            for project in getattr(metadata, "projects", ()) or ()
+        ],
+        "labels": [
+            {
+                "id": str(getattr(label, "id", "") or ""),
+                "name": str(getattr(label, "name", "") or ""),
+                "color": str(getattr(label, "color", "") or ""),
+            }
+            for label in getattr(metadata, "labels", ()) or ()
+        ],
+    }
+
+
+def _print_linear_metadata_text(metadata: Any) -> None:
+    print("Linear metadata for Monica setup")
+    print("")
+    print("Teams:")
+    teams = getattr(metadata, "teams", ()) or ()
+    if teams:
+        for team in teams:
+            key = str(getattr(team, "key", "") or "")
+            key_suffix = f" [{key}]" if key else ""
+            print(f"- {getattr(team, 'name', '')}{key_suffix}: {getattr(team, 'id', '')}")
+    else:
+        print("- none returned")
+    print("")
+    print("Projects:")
+    projects = getattr(metadata, "projects", ()) or ()
+    if projects:
+        for project in projects:
+            state = str(getattr(project, "state", "") or "")
+            state_suffix = f" ({state})" if state else ""
+            print(f"- {getattr(project, 'name', '')}{state_suffix}: {getattr(project, 'id', '')}")
+    else:
+        print("- none returned")
+    print("")
+    print("Labels:")
+    labels = getattr(metadata, "labels", ()) or ()
+    if labels:
+        for label in labels:
+            print(f"- {getattr(label, 'name', '')}: {getattr(label, 'id', '')}")
+    else:
+        print("- none returned")
+    print("")
+    print(
+        "Use the chosen team ID with `hermes mobile-bug-agent configure-linear-only "
+        "--linear-team-id <id>`."
+    )
+
+
+def _print_linear_metadata_error_json(code: str, message: str) -> None:
+    print(
+        json.dumps(
+            {
+                "ok": False,
+                "error": {
+                    "code": code,
+                    "message": message,
+                },
+            },
+            sort_keys=True,
+        )
+    )
+
+
+def run_slack_metadata_command(
+    *,
+    token: str | None = None,
+    json_output: bool = False,
+    client_factory: Any = SlackThreadClient.from_token,
+) -> int:
+    bot_token = str(token if token is not None else monica_slack_bot_token()).strip()
+    if not bot_token:
+        message = (
+            f"{MONICA_SLACK_BOT_TOKEN} is missing; keep it in the Monica profile .env "
+            "before listing Slack IDs."
+        )
+        if json_output:
+            _print_slack_metadata_error_json("slack_bot_token_missing", message)
+            return 1
+        print(message)
+        return 1
+    try:
+        metadata = client_factory(token=bot_token).list_workspace_metadata()
+    except SlackClientError as exc:
+        message = str(exc)
+        if json_output:
+            _print_slack_metadata_error_json("slack_request_failed", message)
+            return 1
+        print(f"Could not list Slack metadata: {message}")
+        return 1
+    if json_output:
+        print(json.dumps(_slack_metadata_payload(metadata), sort_keys=True))
+        return 0
+    _print_slack_metadata_text(metadata)
+    return 0
+
+
+def _slack_metadata_payload(metadata: Any) -> dict[str, Any]:
+    auth = getattr(metadata, "auth", None)
+    return {
+        "ok": True,
+        "auth": {
+            "bot_user_id": str(getattr(auth, "bot_user_id", "") or ""),
+            "bot_id": str(getattr(auth, "bot_id", "") or ""),
+            "team_id": str(getattr(auth, "team_id", "") or ""),
+            "team_name": str(getattr(auth, "team_name", "") or ""),
+            "team_url": str(getattr(auth, "team_url", "") or ""),
+        },
+        "channels": [
+            {
+                "id": str(getattr(channel, "id", "") or ""),
+                "name": str(getattr(channel, "name", "") or ""),
+                "is_private": bool(getattr(channel, "is_private", False)),
+                "is_member": bool(getattr(channel, "is_member", False)),
+                "is_archived": bool(getattr(channel, "is_archived", False)),
+            }
+            for channel in getattr(metadata, "channels", ()) or ()
+        ],
+    }
+
+
+def _print_slack_metadata_text(metadata: Any) -> None:
+    auth = getattr(metadata, "auth", None)
+    print("Slack metadata for Monica setup")
+    print("")
+    print(f"Workspace: {getattr(auth, 'team_name', '') or '(unknown)'}")
+    print(f"Team ID: {getattr(auth, 'team_id', '') or '(unknown)'}")
+    print(f"Bot user ID: {getattr(auth, 'bot_user_id', '') or '(unknown)'}")
+    bot_id = str(getattr(auth, "bot_id", "") or "")
+    if bot_id:
+        print(f"Bot ID: {bot_id} (do not use this for slack.bot_user_ids)")
+    print("")
+    print("Channels visible to Monica:")
+    channels = getattr(metadata, "channels", ()) or ()
+    if channels:
+        for channel in channels:
+            privacy = "private" if getattr(channel, "is_private", False) else "public"
+            membership = "joined" if getattr(channel, "is_member", False) else "not joined"
+            print(
+                f"- #{getattr(channel, 'name', '')} ({privacy}, {membership}): "
+                f"{getattr(channel, 'id', '')}"
+            )
+    else:
+        print("- none returned")
+    print("")
+    print(
+        "Use the bot user ID and selected channel IDs with "
+        "`hermes mobile-bug-agent configure-linear-only --bot-user-id <U...> --channel-id <C...>`."
+    )
+
+
+def _print_slack_metadata_error_json(code: str, message: str) -> None:
+    print(
+        json.dumps(
+            {
+                "ok": False,
+                "error": {
+                    "code": code,
+                    "message": message,
+                },
+            },
+            sort_keys=True,
+        )
+    )
+
+
+def _slack_app_manifest(
+    *,
+    config: MonicaConfig,
+    app_name: str,
+    bot_display_name: str,
+) -> dict[str, Any]:
+    scopes = [
+        "app_mentions:read",
+        "channels:history",
+        "groups:history",
+        "im:history",
+        "im:read",
+        "chat:write",
+    ]
+    if config.slack.download_attachments:
+        scopes.append("files:read")
+    return {
+        "display_information": {
+            "name": str(app_name or "").strip() or "Monica",
+        },
+        "features": {
+            "app_home": {
+                "home_tab_enabled": False,
+                "messages_tab_enabled": True,
+                "messages_tab_read_only_enabled": False,
+            },
+            "bot_user": {
+                "display_name": str(bot_display_name or "").strip() or "monica",
+                "always_online": True,
+            },
+        },
+        "oauth_config": {
+            "scopes": {
+                "bot": scopes,
+            },
+        },
+        "settings": {
+            "event_subscriptions": {
+                "bot_events": ["app_mention", "message.im"],
+            },
+            "interactivity": {
+                "is_enabled": False,
+            },
+            "org_deploy_enabled": False,
+            "socket_mode_enabled": True,
+            "token_rotation_enabled": False,
+        },
+    }
+
+
+def run_configure_approved_pr_command(
+    *,
+    approver_user_ids: tuple[str, ...],
+    repo_url: str,
+    verification_commands: tuple[str, ...],
+    repo_local_name: str = "mobile-app",
+    default_branch: str = "main",
+    branch_prefix: str = "monica",
+    load_config_fn: Any | None = None,
+    save_config_fn: Any | None = None,
+) -> int:
+    approvers = _clean_sequence(approver_user_ids)
+    commands = _clean_sequence(verification_commands)
+    repo_url_value = str(repo_url or "").strip()
+    local_name = str(repo_local_name or "mobile-app").strip() or "mobile-app"
+    branch = str(default_branch or "main").strip() or "main"
+    prefix = str(branch_prefix or "monica").strip() or "monica"
+
+    errors = _approved_pr_config_errors(
+        approver_user_ids=approvers,
+        repo_url=repo_url_value,
+        verification_commands=commands,
+        repo_local_name=local_name,
+        default_branch=branch,
+        branch_prefix=prefix,
+    )
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        print("Monica approved_pr configuration was not saved.")
+        return 1
+
+    if load_config_fn is None or save_config_fn is None:
+        from hermes_cli.config import load_config, save_config
+
+        load = load_config if load_config_fn is None else load_config_fn
+        save = save_config if save_config_fn is None else save_config_fn
+    else:
+        load = load_config_fn
+        save = save_config_fn
+
+    config = load()
+    if not isinstance(config, dict):
+        config = {}
+    _enable_plugin(config)
+    monica_cfg = _ensure_dict(config, "mobile_bug_agent")
+    monica_cfg["enabled"] = True
+    monica_cfg["rollout_mode"] = "approved_pr"
+    monica_cfg["dry_run"] = False
+
+    slack_cfg = _ensure_dict(monica_cfg, "slack")
+    slack_cfg["approver_user_ids"] = list(approvers)
+
+    loop_cfg = _ensure_dict(monica_cfg, "loop")
+    loop_cfg["create_linear"] = True
+    loop_cfg["require_fix_approval"] = True
+
+    repo_cfg = _ensure_dict(monica_cfg, "repo")
+    repo_cfg["url"] = repo_url_value
+    repo_cfg["local_name"] = local_name
+    repo_cfg["default_branch"] = branch
+    repo_cfg["branch_prefix"] = prefix
+
+    verification_cfg = _ensure_dict(monica_cfg, "verification")
+    verification_cfg["commands"] = list(commands)
+
+    runtime_cfg = _ensure_dict(monica_cfg, "runtime")
+    runtime_cfg["home_subdir"] = "agents/monica"
+    runtime_cfg["worker_session_prefix"] = "monica"
+    runtime_cfg["skip_memory"] = True
+
+    worker_cfg = _ensure_dict(monica_cfg, "worker")
+    worker_cfg["backend"] = "codex_cli"
+    worker_cfg["codex_command"] = str(worker_cfg.get("codex_command") or "codex").strip() or "codex"
+    worker_cfg["codex_sandbox"] = "workspace-write"
+    worker_cfg["codex_approval_policy"] = "never"
+    if not worker_cfg.get("timeout_minutes"):
+        worker_cfg["timeout_minutes"] = 45
+
+    save(config)
+    print("Configured Monica for approved_pr rollout.")
+    print(
+        "Secrets were not written; keep MONICA_SLACK_BOT_TOKEN, LINEAR_API_KEY, and GITHUB_TOKEN/gh auth outside config."
+    )
+    print("Run `hermes mobile-bug-agent doctor --rollout-mode approved_pr` before approving fixes.")
+    return 0
+
+
+def run_configure_local_fix_only_command(
+    *,
+    approver_user_ids: tuple[str, ...],
+    repo_url: str,
+    verification_commands: tuple[str, ...],
+    repo_local_name: str = "mobile-app",
+    default_branch: str = "main",
+    branch_prefix: str = "monica",
+    load_config_fn: Any | None = None,
+    save_config_fn: Any | None = None,
+) -> int:
+    return _run_configure_code_rollout_command(
+        rollout_mode="local_fix_only",
+        saved_label="local_fix_only",
+        doctor_mode="local_fix_only",
+        approver_user_ids=approver_user_ids,
+        repo_url=repo_url,
+        verification_commands=verification_commands,
+        repo_local_name=repo_local_name,
+        default_branch=default_branch,
+        branch_prefix=branch_prefix,
+        load_config_fn=load_config_fn,
+        save_config_fn=save_config_fn,
+    )
+
+
+def _run_configure_code_rollout_command(
+    *,
+    rollout_mode: str,
+    saved_label: str,
+    doctor_mode: str,
+    approver_user_ids: tuple[str, ...],
+    repo_url: str,
+    verification_commands: tuple[str, ...],
+    repo_local_name: str = "mobile-app",
+    default_branch: str = "main",
+    branch_prefix: str = "monica",
+    load_config_fn: Any | None = None,
+    save_config_fn: Any | None = None,
+) -> int:
+    approvers = _clean_sequence(approver_user_ids)
+    commands = _clean_sequence(verification_commands)
+    repo_url_value = str(repo_url or "").strip()
+    local_name = str(repo_local_name or "mobile-app").strip() or "mobile-app"
+    branch = str(default_branch or "main").strip() or "main"
+    prefix = str(branch_prefix or "monica").strip() or "monica"
+
+    errors = _approved_pr_config_errors(
+        approver_user_ids=approvers,
+        repo_url=repo_url_value,
+        verification_commands=commands,
+        repo_local_name=local_name,
+        default_branch=branch,
+        branch_prefix=prefix,
+    )
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        print(f"Monica {saved_label} configuration was not saved.")
+        return 1
+
+    if load_config_fn is None or save_config_fn is None:
+        from hermes_cli.config import load_config, save_config
+
+        load = load_config if load_config_fn is None else load_config_fn
+        save = save_config if save_config_fn is None else save_config_fn
+    else:
+        load = load_config_fn
+        save = save_config_fn
+
+    config = load()
+    if not isinstance(config, dict):
+        config = {}
+    _enable_plugin(config)
+    monica_cfg = _ensure_dict(config, "mobile_bug_agent")
+    monica_cfg["enabled"] = True
+    monica_cfg["rollout_mode"] = rollout_mode
+    monica_cfg["dry_run"] = False
+
+    slack_cfg = _ensure_dict(monica_cfg, "slack")
+    slack_cfg["approver_user_ids"] = list(approvers)
+
+    loop_cfg = _ensure_dict(monica_cfg, "loop")
+    loop_cfg["create_linear"] = True
+    loop_cfg["require_fix_approval"] = True
+
+    repo_cfg = _ensure_dict(monica_cfg, "repo")
+    repo_cfg["url"] = repo_url_value
+    repo_cfg["local_name"] = local_name
+    repo_cfg["default_branch"] = branch
+    repo_cfg["branch_prefix"] = prefix
+
+    verification_cfg = _ensure_dict(monica_cfg, "verification")
+    verification_cfg["commands"] = list(commands)
+
+    runtime_cfg = _ensure_dict(monica_cfg, "runtime")
+    runtime_cfg["home_subdir"] = "agents/monica"
+    runtime_cfg["worker_session_prefix"] = "monica"
+    runtime_cfg["skip_memory"] = True
+
+    worker_cfg = _ensure_dict(monica_cfg, "worker")
+    worker_cfg["backend"] = "codex_cli"
+    worker_cfg["codex_command"] = str(worker_cfg.get("codex_command") or "codex").strip() or "codex"
+    worker_cfg["codex_sandbox"] = "workspace-write"
+    worker_cfg["codex_approval_policy"] = "never"
+    if not worker_cfg.get("timeout_minutes"):
+        worker_cfg["timeout_minutes"] = 45
+
+    save(config)
+    print(f"Configured Monica for {saved_label} rollout.")
+    print(
+        "Secrets were not written; keep MONICA_SLACK_BOT_TOKEN and LINEAR_API_KEY outside config."
+    )
+    print(f"Run `hermes mobile-bug-agent doctor --rollout-mode {doctor_mode}` before approving fixes.")
+    return 0
+
+
+def _linear_only_config_errors(
+    *,
+    bot_user_ids: tuple[str, ...],
+    channel_ids: tuple[str, ...],
+    linear_team_id: str,
+) -> list[str]:
+    errors: list[str] = []
+    if not bot_user_ids:
+        errors.append("at least one --bot-user-id is required")
+    if not channel_ids:
+        errors.append("at least one --channel-id is required")
+    if not str(linear_team_id or "").strip():
+        errors.append("--linear-team-id is required")
+    errors.extend(_slack_scope_config_errors(bot_user_ids=bot_user_ids, channel_ids=channel_ids))
+    return errors
+
+
+def _slack_scope_config_errors(
+    *,
+    bot_user_ids: tuple[str, ...],
+    channel_ids: tuple[str, ...],
+) -> list[str]:
+    errors: list[str] = []
+    for user_id in bot_user_ids:
+        if str(user_id).startswith("@"):
+            errors.append(
+                f"slack.bot_user_ids must contain Slack mention user IDs like U012ABCDEF, not handles like {user_id}"
+            )
+        elif str(user_id).upper().startswith("B"):
+            errors.append(
+                f"slack.bot_user_ids must contain Slack mention user IDs like U012ABCDEF, not bot_id values like {user_id}"
+            )
+        elif not _is_slack_user_id(user_id):
+            errors.append(
+                f"slack.bot_user_ids must contain Slack mention user IDs like U012ABCDEF, not invalid values like {user_id}"
+            )
+    for channel_id in channel_ids:
+        if str(channel_id).startswith("#"):
+            errors.append(
+                f"slack.allowed_channels must contain Slack channel IDs like C123 or G123, not names like {channel_id}"
+            )
+        elif not _is_slack_channel_id(channel_id):
+            errors.append(
+                f"slack.allowed_channels must contain Slack channel IDs like C123 or G123, not invalid values like {channel_id}"
+            )
+    return errors
+
+
+def _approved_pr_config_errors(
+    *,
+    approver_user_ids: tuple[str, ...],
+    repo_url: str,
+    verification_commands: tuple[str, ...],
+    repo_local_name: str,
+    default_branch: str,
+    branch_prefix: str,
+) -> list[str]:
+    errors: list[str] = []
+    if not approver_user_ids:
+        errors.append("at least one --approver-user-id is required")
+    if not str(repo_url or "").strip():
+        errors.append("--repo-url is required")
+    if not verification_commands:
+        errors.append("at least one --verification-command is required")
+    for user_id in approver_user_ids:
+        if str(user_id).startswith("@"):
+            errors.append(
+                f"slack.approver_user_ids must contain Slack user IDs like U123, not handles like {user_id}"
+            )
+        elif not _is_slack_user_id(user_id):
+            errors.append(
+                f"slack.approver_user_ids must contain Slack user IDs like U123, not invalid values like {user_id}"
+            )
+    for validator, value in (
+        (safe_repo_local_name, repo_local_name),
+        (safe_default_branch, default_branch),
+        (safe_branch_prefix, branch_prefix),
+    ):
+        try:
+            validator(value)
+        except RepoManagerError as exc:
+            errors.append(str(exc))
+    return errors
+
+
+def _clean_sequence(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        raw_values = value.split(",")
+    else:
+        try:
+            raw_values = list(value)
+        except TypeError:
+            raw_values = [value]
+    return tuple(str(item).strip() for item in raw_values if str(item).strip())
+
+
+def _enable_plugin(config: dict[str, Any]) -> None:
+    plugins_cfg = _ensure_dict(config, "plugins")
+    enabled = set(_clean_sequence(plugins_cfg.get("enabled", ())))
+    disabled = set(_clean_sequence(plugins_cfg.get("disabled", ())))
+    enabled.add("mobile-bug-agent")
+    disabled.discard("mobile-bug-agent")
+    plugins_cfg["enabled"] = sorted(enabled)
+    if disabled:
+        plugins_cfg["disabled"] = sorted(disabled)
+    elif "disabled" in plugins_cfg:
+        plugins_cfg["disabled"] = []
+
+
+def _ensure_dict(parent: dict[str, Any], key: str) -> dict[str, Any]:
+    value = parent.get(key)
+    if not isinstance(value, dict):
+        value = {}
+        parent[key] = value
+    return value
+
+
+def run_status_command(*, state: MonicaState, limit: int = 20, json_output: bool = False) -> int:
+    runs = state.list_runs(limit=limit)
+    if json_output:
+        print(
+            json.dumps(
+                {
+                    "count": len(runs),
+                    "runs": [_run_payload(run, include_raw_event=False) for run in runs],
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+    if not runs:
+        print("No Monica runs found.")
+        return 0
+    for run in runs:
+        parts = [
+            run.id,
+            run.status,
+            f"slack:{run.channel_id}/{run.thread_ts}",
+            f"linear:{run.linear_identifier or '-'}",
+            f"branch:{run.branch_name or '-'}",
+            f"url:{run.pr_url or run.linear_url or '-'}",
+            _one_line(run.request_text),
+        ]
+        print(" | ".join(parts))
+    return 0
+
+
+def run_show_command(*, state: MonicaState, run_id: str, json_output: bool = False) -> int:
+    run = state.get_run(run_id)
+    if run is None:
+        print(f"Monica run not found: {run_id}")
+        return 1
+    if json_output:
+        print(json.dumps(_run_payload(run, include_raw_event=True), sort_keys=True))
+        return 0
+    for key, value in run.__dict__.items():
+        print(f"{key}: {value}")
+    return 0
+
+
+def _run_payload(run: Any, *, include_raw_event: bool) -> dict[str, Any]:
+    payload = {
+        "id": run.id,
+        "platform": run.platform,
+        "status": run.status,
+        "intent": run.intent,
+        "request_text": run.request_text,
+        "slack": {
+            "channel_id": run.channel_id,
+            "thread_ts": run.thread_ts,
+            "message_ts": run.message_ts,
+            "user_id": run.user_id,
+        },
+        "linear": {
+            "identifier": run.linear_identifier,
+            "issue_id": run.linear_issue_id,
+            "url": run.linear_url,
+        },
+        "branch_name": run.branch_name,
+        "pr_url": run.pr_url,
+        "failure_reason": run.failure_reason,
+        "approved_by_user_id": run.approved_by_user_id,
+        "created_at": run.created_at,
+        "updated_at": run.updated_at,
+    }
+    if include_raw_event:
+        payload["raw_event"] = run.raw_event or {}
+    return payload
+
+
+def run_doctor_command(
+    *,
+    config: MonicaConfig,
+    target_rollout_mode: str = "",
+    json_output: bool = False,
+    environ: dict[str, str] | None = None,
+    which: Any | None = None,
+    module_available: Any | None = None,
+) -> int:
+    effective_config = _config_for_doctor_target(
+        config=config,
+        target_rollout_mode=target_rollout_mode,
+    )
+    report = check_monica_readiness(
+        config=effective_config,
+        environ=environ,
+        which=which,
+        module_available=module_available,
+    )
+
+    if json_output:
+        print(json.dumps(_readiness_report_payload(report), sort_keys=True))
+        return 0 if report.ready else 1
+
+    print(f"Monica rollout mode: {report.rollout_mode}")
+    if report.runtime_root_value:
+        print(f"Monica runtime root: {report.runtime_root_value}")
+    for warning in report.warnings:
+        print(f"WARN: {warning.message}")
+    for failure in report.failures:
+        print(f"FAIL: {failure.message}")
+    if report.failures:
+        print("Monica doctor: not ready")
+        return 1
+    print("Monica doctor: ready")
+    return 0
+
+
+def run_setup_plan_command(
+    *,
+    config: MonicaConfig,
+    target_rollout_mode: str = "",
+    json_output: bool = False,
+    environ: dict[str, str] | None = None,
+    which: Any | None = None,
+    module_available: Any | None = None,
+) -> int:
+    effective_config = _config_for_doctor_target(
+        config=config,
+        target_rollout_mode=target_rollout_mode,
+    )
+    report = check_monica_readiness(
+        config=effective_config,
+        environ=environ,
+        which=which,
+        module_available=module_available,
+    )
+    steps = _setup_plan_steps(report)
+    if json_output:
+        payload = _readiness_report_payload(report)
+        payload["steps"] = steps
+        print(json.dumps(payload, sort_keys=True))
+        return 0 if report.ready else 1
+
+    print(f"Monica setup plan: {report.rollout_mode}")
+    if report.ready:
+        print("Monica is ready for this rollout mode.")
+        return 0
+    print("")
+    print("Blocking readiness failures:")
+    for failure in report.failures:
+        print(f"- {failure.message}")
+    print("")
+    print("Next steps:")
+    for index, step in enumerate(steps, start=1):
+        print(f"{index}. {step['title']}")
+        print(f"   {step['command']}")
+        print(f"   {step['why']}")
+    return 1
+
+
+def _setup_plan_steps(report: Any) -> list[dict[str, str]]:
+    if bool(getattr(report, "ready", False)):
+        return []
+    failure_codes = {str(issue.code) for issue in getattr(report, "failures", ())}
+    rollout_mode = str(getattr(report, "rollout_mode", "") or "")
+    steps: list[dict[str, str]] = []
+    if rollout_mode == "dry_run" and "config_enabled" in failure_codes:
+        _append_setup_step(
+            steps,
+            step_id="configure_dry_run",
+            title="Persist Monica's dry-run rollout settings",
+            command="hermes mobile-bug-agent configure-dry-run",
+            why="This enables the Monica plugin and keeps her in no-side-effect dry-run mode.",
+        )
+    if failure_codes & {
+        "slack_bot_token",
+        "slack_sdk",
+        "slack_scope_app_mentions",
+        "slack_scope_chat_write",
+        "slack_scope_history",
+        "slack_scope_files_read",
+    }:
+        _append_setup_step(
+            steps,
+            step_id="create_slack_app",
+            title="Create or update the Monica Slack app",
+            command="hermes mobile-bug-agent slack-manifest",
+            why="Import the manifest in Slack, install the app, and invite Monica to the target channels.",
+        )
+    if "slack_bot_token" in failure_codes:
+        _append_setup_step(
+            steps,
+            step_id="set_slack_bot_token",
+            title="Store Monica's Slack bot token",
+            command="Add MONICA_SLACK_BOT_TOKEN=xoxb-... to the Monica profile .env",
+            why="Monica needs the bot token to read tagged threads and reply in Slack.",
+        )
+    if failure_codes & {
+        "slack_bot_user_ids_empty",
+        "slack_bot_id_value",
+        "slack_bot_handle_value",
+        "slack_bot_user_id_invalid",
+        "slack_allowed_channels_empty",
+        "slack_allowed_channel_invalid",
+    }:
+        _append_setup_step(
+            steps,
+            step_id="discover_slack_ids",
+            title="Discover Monica's Slack user ID and channel IDs",
+            command="hermes mobile-bug-agent slack-metadata --json",
+            why="Use auth.bot_user_id for --bot-user-id and selected C.../G... channel IDs for --channel-id.",
+        )
+    if "linear_api_key" in failure_codes:
+        _append_setup_step(
+            steps,
+            step_id="set_linear_api_key",
+            title="Store the Linear API key",
+            command="Add LINEAR_API_KEY=lin_api_... to ~/.hermes/.env",
+            why="Monica needs Linear access to create or update mobile bug tickets.",
+        )
+    if failure_codes & {"linear_api_key", "linear_team_id"}:
+        _append_setup_step(
+            steps,
+            step_id="discover_linear_ids",
+            title="Discover Linear team, project, and label IDs",
+            command="hermes mobile-bug-agent linear-metadata --json",
+            why="Use the selected team ID, and optionally project/label IDs, in Monica's rollout config.",
+        )
+    if rollout_mode in {"linear_only", "local_fix_only", "approved_pr"} and failure_codes & {
+        "config_enabled",
+        "slack_bot_user_ids_empty",
+        "slack_bot_id_value",
+        "slack_bot_handle_value",
+        "slack_bot_user_id_invalid",
+        "slack_allowed_channels_empty",
+        "slack_allowed_channel_invalid",
+        "linear_team_id",
+        "loop_create_linear",
+    }:
+        _append_setup_step(
+            steps,
+            step_id="configure_linear_only",
+            title="Persist Monica's Linear-only rollout settings",
+            command=(
+                "hermes mobile-bug-agent configure-linear-only "
+                "--bot-user-id <U...> --channel-id <C...> --linear-team-id <team-id>"
+            ),
+            why="This enables Monica only in explicitly allowed Slack channels and lets her file Linear issues.",
+        )
+    if rollout_mode == "local_fix_only" and failure_codes & {
+        "repo_url",
+        "verification_commands",
+        "slack_approvers_empty",
+        "slack_approver_handle_value",
+        "slack_approver_invalid",
+        "repo_local_name",
+        "repo_branch_prefix",
+        "repo_default_branch",
+        "loop_require_fix_approval",
+        "worker_session_prefix",
+    }:
+        _append_setup_step(
+            steps,
+            step_id="configure_local_fix_only",
+            title="Persist local code-fix rollout settings",
+            command=(
+                "hermes mobile-bug-agent configure-local-fix-only "
+                "--approver-user-id <U...> --repo-url <repo-url> "
+                "--verification-command '<command>'"
+            ),
+            why="This configures the React Native repo, approver allowlist, and verification gate without enabling push or PR creation.",
+        )
+    if rollout_mode == "approved_pr" and failure_codes & {
+        "repo_url",
+        "verification_commands",
+        "slack_approvers_empty",
+        "slack_approver_handle_value",
+        "slack_approver_invalid",
+        "repo_local_name",
+        "repo_branch_prefix",
+        "repo_default_branch",
+        "loop_require_fix_approval",
+        "worker_session_prefix",
+    }:
+        _append_setup_step(
+            steps,
+            step_id="configure_approved_pr",
+            title="Persist approved draft-PR rollout settings",
+            command=(
+                "hermes mobile-bug-agent configure-approved-pr "
+                "--approver-user-id <U...> --repo-url <repo-url> "
+                "--verification-command '<command>'"
+            ),
+            why="This configures the React Native repo, approver allowlist, and verification gate.",
+        )
+    if rollout_mode in {"local_fix_only", "approved_pr"} and failure_codes & {
+        "git_executable",
+        "codex_executable",
+        "codex_approval_policy",
+        "codex_sandbox",
+    }:
+        _append_setup_step(
+            steps,
+            step_id="prepare_code_tools",
+            title="Prepare local code-fix tooling",
+            command="git --version && codex --version",
+            why="Code rollout modes need Git and a non-interactive Codex CLI worker.",
+        )
+    if rollout_mode == "approved_pr" and failure_codes & {
+        "gh_executable",
+        "github_token",
+    }:
+        _append_setup_step(
+            steps,
+            step_id="prepare_pr_tools",
+            title="Prepare draft-PR tooling",
+            command="gh auth status",
+            why="Approved-PR mode needs GitHub CLI auth for pushing branches and opening draft PRs.",
+        )
+    _append_setup_step(
+        steps,
+        step_id="rerun_doctor",
+        title="Re-run the rollout readiness check",
+        command=f"hermes mobile-bug-agent doctor --rollout-mode {rollout_mode or 'linear_only'} --json",
+        why="Only continue to a live Slack test once Monica reports ready.",
+    )
+    return steps
+
+
+def _append_setup_step(
+    steps: list[dict[str, str]],
+    *,
+    step_id: str,
+    title: str,
+    command: str,
+    why: str,
+) -> None:
+    if any(step["id"] == step_id for step in steps):
+        return
+    steps.append(
+        {
+            "id": step_id,
+            "title": title,
+            "command": command,
+            "why": why,
+        }
+    )
+
+
+def _readiness_report_payload(report: Any) -> dict[str, Any]:
+    return {
+        "ready": report.ready,
+        "rollout_mode": report.rollout_mode,
+        "runtime_root": report.runtime_root_value,
+        "warnings": [_readiness_issue_payload(issue) for issue in report.warnings],
+        "failures": [_readiness_issue_payload(issue) for issue in report.failures],
+    }
+
+
+def _readiness_issue_payload(issue: Any) -> dict[str, str]:
+    return {
+        "code": str(issue.code),
+        "message": str(issue.message),
+    }
+
+
+def _config_for_doctor_target(
+    *,
+    config: MonicaConfig,
+    target_rollout_mode: str = "",
+) -> MonicaConfig:
+    target = str(target_rollout_mode or "").strip()
+    if not target:
+        return config
+    if target not in {"dry_run", "linear_only", "local_fix_only", "approved_pr"}:
+        return replace(config, rollout_mode=target)
+    return replace(config, rollout_mode=target, dry_run=(target == "dry_run"))
+
+
+def run_retry_command(
+    *,
+    state: MonicaState,
+    run_id: str,
+    config: MonicaConfig | None = None,
+    readiness_checker: Any | None = None,
+    json_output: bool = False,
+) -> int:
+    run = state.get_run(run_id)
+    if run is None:
+        message = f"Monica run not found: {run_id}"
+        if json_output:
+            _print_operator_error_json(action="retry", code="not_found", message=message)
+            return 1
+        print(message)
+        return 1
+    if run.status not in RETRYABLE_STATUSES:
+        message = f"Monica run {run.id} is not retryable from status `{run.status}`."
+        if json_output:
+            _print_operator_error_json(
+                action="retry",
+                code="not_retryable",
+                message=message,
+                run=run,
+            )
+            return 1
+        print(message)
+        return 1
+    if _is_cancelled_run(run):
+        message = (
+            f"Monica run {run.id} was cancelled from Slack and is not retryable from the CLI. "
+            "Tag Monica again in the Slack thread with new context to start a fresh pass."
+        )
+        if json_output:
+            _print_operator_error_json(
+                action="retry",
+                code="cancelled",
+                message=message,
+                run=run,
+            )
+            return 1
+        print(message)
+        return 1
+    if str(run.pr_url or "").strip():
+        message = (
+            f"Monica run {run.id} already has a draft PR: {run.pr_url}. "
+            "Open a new tagged Slack request for additional work instead of retrying this run."
+        )
+        if json_output:
+            _print_operator_error_json(
+                action="retry",
+                code="pr_exists",
+                message=message,
+                run=run,
+            )
+            return 1
+        print(message)
+        return 1
+    next_status = "approved" if run.approved_by_user_id else "queued"
+    if (
+        next_status == "approved"
+        and config is not None
+        and not _is_allowed_local_approver(config=config, user_id=run.approved_by_user_id)
+    ):
+        message = (
+            f"Monica run {run.id} cannot retry from approval because stored approver "
+            f"{run.approved_by_user_id} is not configured as a Monica code approver."
+        )
+        if json_output:
+            _print_operator_error_json(
+                action="retry",
+                code="approver_not_allowed",
+                message=message,
+                run=run,
+            )
+            return 1
+        print(message)
+        return 1
+    if next_status == "approved" and config is not None and config.rollout_mode in {"local_fix_only", "approved_pr"}:
+        checker = readiness_checker or (lambda: run_doctor_command(config=config))
+        try:
+            readiness_exit_code = int(checker())
+        except Exception as exc:
+            message = f"Monica readiness check failed: {exc}"
+            if json_output:
+                _print_operator_error_json(
+                    action="retry",
+                    code="readiness_exception",
+                    message=message,
+                    run=run,
+                )
+                return 1
+            print(message)
+            return 1
+        if readiness_exit_code != 0:
+            message = "Monica readiness check failed; not retrying the approved Monica run."
+            if json_output:
+                _print_operator_error_json(
+                    action="retry",
+                    code="readiness_failed",
+                    message=message,
+                    run=run,
+                )
+                return 1
+            print(message)
+            return 1
+    state.update_run(
+        run.id,
+        status=next_status,
+        failure_reason="",
+        branch_name="",
+        pr_url="",
+    )
+    _run_loop(run.id, state=state)
+    if json_output:
+        _print_operator_success_json(action="retry", run=state.get_run(run.id) or run)
+        return 0
+    print(f"Retried Monica run {run.id}.")
+    return 0
+
+
+def run_approve_command(
+    *,
+    state: MonicaState,
+    run_id: str,
+    user_id: str,
+    config: MonicaConfig | None = None,
+    readiness_checker: Any | None = None,
+    json_output: bool = False,
+) -> int:
+    run = state.get_run(run_id)
+    if run is None:
+        message = f"Monica run not found: {run_id}"
+        if json_output:
+            _print_operator_error_json(action="approve", code="not_found", message=message)
+            return 1
+        print(message)
+        return 1
+    if run.status != "awaiting_fix_approval":
+        message = (
+            f"Monica run {run.id} is not awaiting fix approval; current status is `{run.status}`."
+        )
+        if json_output:
+            _print_operator_error_json(
+                action="approve",
+                code="not_awaiting_approval",
+                message=message,
+                run=run,
+            )
+            return 1
+        print(message)
+        return 1
+    if config is not None and not _is_allowed_local_approver(config=config, user_id=user_id):
+        message = f"{user_id} is not configured as a Monica code approver."
+        if json_output:
+            _print_operator_error_json(
+                action="approve",
+                code="approver_not_allowed",
+                message=message,
+                run=run,
+            )
+            return 1
+        print(message)
+        return 1
+    if config is not None and config.rollout_mode in {"local_fix_only", "approved_pr"}:
+        checker = readiness_checker or (lambda: run_doctor_command(config=config))
+        try:
+            readiness_exit_code = int(checker())
+        except Exception as exc:
+            message = f"Monica readiness check failed: {exc}"
+            if json_output:
+                _print_operator_error_json(
+                    action="approve",
+                    code="readiness_exception",
+                    message=message,
+                    run=run,
+                )
+                return 1
+            print(message)
+            return 1
+        if readiness_exit_code != 0:
+            message = "Monica readiness check failed; not approving the Monica run."
+            if json_output:
+                _print_operator_error_json(
+                    action="approve",
+                    code="readiness_failed",
+                    message=message,
+                    run=run,
+                )
+                return 1
+            print(message)
+            return 1
+    approve_once = getattr(state, "approve_fix_once", None)
+    if callable(approve_once):
+        approved, changed = approve_once(run.id, approved_by_user_id=user_id)
+    else:
+        approved = state.approve_fix(run.id, approved_by_user_id=user_id)
+        changed = True
+    if not changed:
+        message = f"Monica run {run.id} is already approved or no longer awaiting fix approval."
+        if json_output:
+            _print_operator_error_json(
+                action="approve",
+                code="already_approved_or_changed",
+                message=message,
+                run=state.get_run(run.id) or run,
+            )
+            return 1
+        print(message)
+        return 1
+    _run_loop(approved.id, state=state)
+    if json_output:
+        _print_operator_success_json(action="approve", run=state.get_run(approved.id) or approved)
+        return 0
+    print(f"Approved Monica run {run.id}.")
+    return 0
+
+
+def run_simulate_command(
+    *,
+    config: MonicaConfig,
+    state: MonicaState,
+    text: str,
+    channel_id: str,
+    user_id: str,
+    thread_ts: str = "",
+    allow_side_effects: bool = False,
+    json_output: bool = False,
+    loop_runner: Any | None = None,
+    readiness_checker: Any | None = None,
+) -> int:
+    if not config.enabled:
+        if json_output:
+            _print_simulation_error_json(
+                code="config_disabled",
+                message="Monica is disabled: set mobile_bug_agent.enabled: true before simulating.",
+                config=config,
+                allow_side_effects=allow_side_effects,
+            )
+            return 1
+        print("Monica is disabled: set mobile_bug_agent.enabled: true before simulating.")
+        return 1
+    clean_text = " ".join(str(text or "").split())
+    if not clean_text:
+        if json_output:
+            _print_simulation_error_json(
+                code="empty_text",
+                message="Simulation text is required.",
+                config=config,
+                allow_side_effects=allow_side_effects,
+            )
+            return 2
+        print("Simulation text is required.")
+        return 2
+    if config.rollout_mode != "dry_run" and not allow_side_effects:
+        message = (
+            "Simulation is in a side-effect rollout mode "
+            f"(`{config.rollout_mode}`). Re-run with --allow-side-effects only if you "
+            "intend to create/update Linear issues or start a code-fix loop."
+        )
+        if json_output:
+            _print_simulation_error_json(
+                code="side_effects_not_allowed",
+                message=message,
+                config=config,
+                allow_side_effects=allow_side_effects,
+            )
+            return 1
+        print(message)
+        return 1
+    if config.rollout_mode in {"linear_only", "local_fix_only", "approved_pr"} and allow_side_effects:
+        allowed_channels = set(config.slack.allowed_channels)
+        if not allowed_channels:
+            message = (
+                "Simulation side effects require mobile_bug_agent.slack.allowed_channels. "
+                "Configure the exact Slack channel IDs Monica may act in."
+            )
+            if json_output:
+                _print_simulation_error_json(
+                    code="allowed_channels_empty",
+                    message=message,
+                    config=config,
+                    allow_side_effects=allow_side_effects,
+                )
+                return 1
+            print(message)
+            return 1
+        if not config.slack.bot_user_ids:
+            message = (
+                "Simulation side effects require mobile_bug_agent.slack.bot_user_ids. "
+                "Configure Monica's Slack mention user ID before exercising real side effects."
+            )
+            if json_output:
+                _print_simulation_error_json(
+                    code="bot_user_ids_empty",
+                    message=message,
+                    config=config,
+                    allow_side_effects=allow_side_effects,
+                )
+                return 1
+            print(message)
+            return 1
+        if channel_id not in allowed_channels:
+            message = (
+                f"Simulation channel {channel_id} is not in "
+                "mobile_bug_agent.slack.allowed_channels."
+            )
+            if json_output:
+                _print_simulation_error_json(
+                    code="channel_not_allowed",
+                    message=message,
+                    config=config,
+                    allow_side_effects=allow_side_effects,
+                )
+                return 1
+            print(message)
+            return 1
+        if config.rollout_mode in {"local_fix_only", "approved_pr"} and not config.slack.approver_user_ids:
+            message = (
+                "Simulation code-fix side effects require "
+                "mobile_bug_agent.slack.approver_user_ids. Configure at least one "
+                "Monica code approver."
+            )
+            if json_output:
+                _print_simulation_error_json(
+                    code="approver_user_ids_empty",
+                    message=message,
+                    config=config,
+                    allow_side_effects=allow_side_effects,
+                )
+                return 1
+            print(message)
+            return 1
+        checker = readiness_checker or (lambda: run_doctor_command(config=config))
+        try:
+            readiness_exit_code = int(checker())
+        except Exception as exc:
+            message = f"Monica readiness check failed: {exc}"
+            if json_output:
+                _print_simulation_error_json(
+                    code="readiness_exception",
+                    message=message,
+                    config=config,
+                    allow_side_effects=allow_side_effects,
+                )
+                return 1
+            print(message)
+            return 1
+        if readiness_exit_code != 0:
+            if json_output:
+                _print_simulation_error_json(
+                    code="readiness_failed",
+                    message="Monica readiness check failed; not creating a simulated side-effect run.",
+                    config=config,
+                    allow_side_effects=allow_side_effects,
+                )
+                return 1
+            print("Monica readiness check failed; not creating a simulated side-effect run.")
+            return 1
+
+    now_value = time.time()
+    now = f"{now_value:.6f}"
+    thread = thread_ts.strip() or _next_simulated_thread_ts(now_value)
+    run, created = state.create_run_once(
+        platform="slack",
+        channel_id=channel_id,
+        thread_ts=thread,
+        message_ts=now,
+        user_id=user_id,
+        request_text=clean_text,
+        raw_event={
+            "monica_simulated": True,
+            "type": "app_mention",
+            "text": f"<@MONICA_SIM> {clean_text}",
+            "channel": channel_id,
+            "user": user_id,
+            "thread_ts": thread,
+            "ts": now,
+            "permalink": f"local://monica/simulated/{thread}",
+            "files": [],
+        },
+    )
+    if not created:
+        if json_output:
+            print(
+                json.dumps(
+                    {
+                        "created": False,
+                        "rollout_mode": config.rollout_mode,
+                        "allow_side_effects": allow_side_effects,
+                        "error": {
+                            "code": "duplicate_thread",
+                            "message": (
+                                f"Monica simulation already exists for channel `{channel_id}` "
+                                f"thread `{thread}`."
+                            ),
+                        },
+                        "run": _run_payload(run, include_raw_event=True),
+                    },
+                    sort_keys=True,
+                )
+            )
+            return 1
+        print(
+            f"Monica simulation already exists for channel `{channel_id}` thread `{thread}`: {run.id}. "
+            "Use a different --thread-ts to start a new local simulation."
+        )
+        return 1
+    runner = loop_runner or _run_loop
+    runner(run.id, state=state)
+    updated = state.get_run(run.id) or run
+    if json_output:
+        print(
+            json.dumps(
+                {
+                    "created": True,
+                    "rollout_mode": config.rollout_mode,
+                    "allow_side_effects": allow_side_effects,
+                    "run": _run_payload(updated, include_raw_event=True),
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+    print(f"Simulated Monica run {run.id}: {updated.status}")
+    if updated.linear_identifier:
+        print(f"Linear: {updated.linear_identifier}")
+    if updated.linear_url:
+        print(f"Linear URL: {updated.linear_url}")
+    if updated.pr_url:
+        print(f"PR: {updated.pr_url}")
+    if updated.failure_reason:
+        print(f"Reason: {updated.failure_reason}")
+    return 0
+
+
+def _print_simulation_error_json(
+    *,
+    code: str,
+    message: str,
+    config: MonicaConfig,
+    allow_side_effects: bool,
+) -> None:
+    print(
+        json.dumps(
+            {
+                "created": False,
+                "rollout_mode": config.rollout_mode,
+                "allow_side_effects": allow_side_effects,
+                "error": {
+                    "code": code,
+                    "message": message,
+                },
+            },
+            sort_keys=True,
+        )
+    )
+
+
+def _print_operator_success_json(*, action: str, run: Any) -> None:
+    print(
+        json.dumps(
+                {
+                    "ok": True,
+                    "action": action,
+                    "run": _run_payload(run, include_raw_event=False),
+                },
+                sort_keys=True,
+            )
+    )
+
+
+def _print_operator_error_json(
+    *,
+    action: str,
+    code: str,
+    message: str,
+    run: Any | None = None,
+) -> None:
+    payload: dict[str, Any] = {
+        "ok": False,
+        "action": action,
+        "error": {
+            "code": code,
+            "message": message,
+        },
+    }
+    if run is not None:
+        payload["run"] = _run_payload(run, include_raw_event=False)
+    print(json.dumps(payload, sort_keys=True))
+
+
+def _run_loop(run_id: str, *, state: MonicaState) -> None:
+    config = load_monica_config()
+    skills = DefaultMonicaSkills(config=config, state=state)
+    MonicaLoop(config=config, state=state, skills=skills).run(run_id)
+
+
+def _open_state(config: MonicaConfig | None = None) -> MonicaState:
+    return MonicaState.open(runtime_root(config or load_monica_config()) / "state.sqlite")
+
+
+def _one_line(value: Any, limit: int = 100) -> str:
+    return " ".join(str(value).split())[:limit]
+
+
+def _next_simulated_thread_ts(now: float) -> str:
+    global _SIMULATION_THREAD_SEQUENCE
+    seconds = int(now)
+    micros = int((now - seconds) * 1_000_000)
+    _SIMULATION_THREAD_SEQUENCE = (_SIMULATION_THREAD_SEQUENCE + 1) % 1_000_000
+    micros = (micros + _SIMULATION_THREAD_SEQUENCE) % 1_000_000
+    return f"{seconds}.{micros:06d}"
+
+
+def _is_allowed_local_approver(*, config: MonicaConfig, user_id: str) -> bool:
+    return str(user_id or "").strip() in set(config.slack.approver_user_ids)
+
+
+def _is_cancelled_run(run: Any) -> bool:
+    return str(getattr(run, "failure_reason", "") or "").startswith("cancelled by ")

--- a/plugins/mobile_bug_agent/codex_worker.py
+++ b/plugins/mobile_bug_agent/codex_worker.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+from .config import MonicaConfig, runtime_root
+
+
+class CodexWorkerError(RuntimeError):
+    pass
+
+
+RunCodexCommand = Callable[[list[str], Path, str, int], str]
+
+
+def build_code_worker(config: MonicaConfig) -> Any:
+    if config.worker.backend == "codex_cli":
+        return CodexCliWorker(config=config)
+    if config.worker.backend == "internal_agent":
+        return InternalCodexWorker(config=config)
+    raise CodexWorkerError(f"unknown worker backend: {config.worker.backend}")
+
+
+@dataclass
+class CodexCliWorker:
+    config: MonicaConfig
+    run_command: RunCodexCommand | None = None
+
+    def run(self, *, run: Any, worktree: Any, brief: str) -> dict[str, Any]:
+        worktree_path = Path(getattr(worktree, "path", worktree))
+        _require_worktree(worktree_path)
+        _require_expected_branch(run=run, worktree=worktree)
+        _require_safe_codex_cli_settings(self.config)
+        output_dir = runtime_root(self.config) / "worker-output"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        output_file = output_dir / f"{getattr(run, 'id', 'run')}.md"
+        command = self._command(worktree_path=worktree_path, output_file=output_file)
+        prompt = "\n\n".join([_system_prompt(), _user_prompt(brief=brief, worktree_path=worktree_path)])
+        output = (self.run_command or self._default_run)(
+            command,
+            worktree_path,
+            prompt,
+            self.config.worker.timeout_minutes * 60,
+        )
+        summary = _read_text(output_file) or output.strip()
+        return {
+            "changed": bool(summary),
+            "summary": summary or "Codex CLI completed without a final message.",
+            "worktree": str(worktree_path),
+            "worker": "codex_cli",
+            "output_file": str(output_file),
+        }
+
+    def _command(self, *, worktree_path: Path, output_file: Path) -> list[str]:
+        command = [
+            self.config.worker.codex_command,
+            "exec",
+            "-c",
+            f'approval_policy="{self.config.worker.codex_approval_policy}"',
+            "--cd",
+            str(worktree_path),
+            "--sandbox",
+            self.config.worker.codex_sandbox,
+            "--color",
+            "never",
+            "--output-last-message",
+            str(output_file),
+        ]
+        if self.config.worker.codex_model:
+            command.extend(["--model", self.config.worker.codex_model])
+        if self.config.worker.codex_profile:
+            command.extend(["--profile", self.config.worker.codex_profile])
+        command.append("-")
+        return command
+
+    @staticmethod
+    def _default_run(command: list[str], cwd: Path, prompt: str, timeout: int) -> str:
+        try:
+            proc = subprocess.run(
+                command,
+                cwd=str(cwd),
+                input=prompt,
+                text=True,
+                capture_output=True,
+                check=False,
+                timeout=timeout,
+            )
+        except FileNotFoundError as exc:
+            raise CodexWorkerError(f"Codex CLI executable not found: {command[0]}") from exc
+        except subprocess.TimeoutExpired as exc:
+            raise CodexWorkerError("Codex CLI worker timed out.") from exc
+        if proc.returncode != 0:
+            raise CodexWorkerError(_command_failure_message(command, cwd, proc))
+        return proc.stdout
+
+
+@dataclass
+class InternalCodexWorker:
+    config: MonicaConfig
+    agent_factory: Any | None = None
+
+    def run(self, *, run: Any, worktree: Any, brief: str) -> dict[str, Any]:
+        worktree_path = Path(getattr(worktree, "path", worktree))
+        _require_worktree(worktree_path)
+        _require_expected_branch(run=run, worktree=worktree)
+        _require_monica_worker_session_prefix(self.config)
+        system_message = _system_prompt()
+        user_message = _user_prompt(brief=brief, worktree_path=worktree_path)
+
+        previous_cwd = os.environ.get("TERMINAL_CWD")
+        os.environ["TERMINAL_CWD"] = str(worktree_path)
+        try:
+            agent = self._agent(run_id=str(getattr(run, "id", "") or "run"))
+            result = agent.run_conversation(
+                user_message=user_message,
+                system_message=system_message,
+                task_id=f"monica-{getattr(run, 'id', '')}",
+            )
+        finally:
+            if previous_cwd is None:
+                os.environ.pop("TERMINAL_CWD", None)
+            else:
+                os.environ["TERMINAL_CWD"] = previous_cwd
+
+        summary = str((result or {}).get("final_response") or "").strip()
+        return {
+            "changed": bool(summary),
+            "summary": summary or "Monica worker completed without a summary.",
+            "worktree": str(worktree_path),
+            "worker": "internal_agent",
+        }
+
+    def _agent(self, *, run_id: str) -> Any:
+        session_id = f"{self.config.runtime.worker_session_prefix}-{run_id}"
+        if self.agent_factory is not None:
+            try:
+                return self.agent_factory(
+                    max_iterations=self.config.loop.max_iterations,
+                    quiet_mode=True,
+                    platform="monica",
+                    session_id=session_id,
+                    skip_context_files=True,
+                    skip_memory=self.config.runtime.skip_memory,
+                )
+            except TypeError:
+                return self.agent_factory()
+        from run_agent import AIAgent
+
+        return AIAgent(
+            max_iterations=self.config.loop.max_iterations,
+            quiet_mode=True,
+            platform="monica",
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=self.config.runtime.skip_memory,
+        )
+
+
+def _system_prompt() -> str:
+    return (
+        "You are Monica's code worker for a React Native mobile app.\n"
+        "Work only inside the provided repository worktree.\n"
+        "Fix the bug described in the brief with the smallest maintainable change.\n"
+        "Add or update focused tests when the repo has a nearby pattern.\n"
+        "Do not commit. Do not push. Do not create a pull request. Do not modify Hermes.\n"
+        "Stop and report blockers if the brief lacks enough information."
+    )
+
+
+def _user_prompt(*, brief: str, worktree_path: Path) -> str:
+    return "\n".join(
+        [
+            brief,
+            "",
+            "Worker sandbox:",
+            f"Repository worktree: {worktree_path}",
+        ]
+    )
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
+
+
+def _require_worktree(path: Path) -> None:
+    if not path.is_dir():
+        raise CodexWorkerError(f"worktree does not exist: {path}")
+    if not (path / ".git").exists():
+        raise CodexWorkerError(f"worktree is not a git worktree: {path}")
+
+
+def _require_expected_branch(*, run: Any, worktree: Any) -> None:
+    branch_name = str(getattr(worktree, "branch_name", "") or "").strip()
+    linear_identifier = str(getattr(run, "linear_identifier", "") or "").strip()
+    if not branch_name or not linear_identifier:
+        return
+    if linear_identifier not in branch_name or "monica" not in branch_name.lower():
+        raise CodexWorkerError(
+            f"worktree branch mismatch: {branch_name} does not look like Monica branch for {linear_identifier}"
+        )
+
+
+def _require_safe_codex_cli_settings(config: MonicaConfig) -> None:
+    if config.worker.codex_sandbox != "workspace-write":
+        raise CodexWorkerError("codex_sandbox must be workspace-write for Monica codex_cli runs.")
+    if config.worker.codex_approval_policy != "never":
+        raise CodexWorkerError("codex_approval_policy must be never for Monica codex_cli runs.")
+
+
+def _require_monica_worker_session_prefix(config: MonicaConfig) -> None:
+    if "monica" not in config.runtime.worker_session_prefix.lower():
+        raise CodexWorkerError("worker_session_prefix must include monica for Monica internal_agent runs.")
+
+
+def _command_failure_message(
+    command: list[str],
+    cwd: Path,
+    proc: subprocess.CompletedProcess[str],
+) -> str:
+    return "\n".join(
+        part
+        for part in [
+            f"Codex CLI failed ({proc.returncode}): {' '.join(command)}",
+            f"cwd: {cwd}",
+            f"stdout: {_tail(proc.stdout)}" if _tail(proc.stdout) else "",
+            f"stderr: {_tail(proc.stderr)}" if _tail(proc.stderr) else "",
+        ]
+        if part
+    )
+
+
+def _tail(value: str | None, *, limit: int = 2000) -> str:
+    return str(value or "").strip()[-limit:]

--- a/plugins/mobile_bug_agent/config.py
+++ b/plugins/mobile_bug_agent/config.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping
+
+from hermes_constants import get_hermes_home
+
+
+@dataclass(frozen=True)
+class SlackConfig:
+    allowed_channels: tuple[str, ...] = ()
+    approver_user_ids: tuple[str, ...] = ()
+    bot_user_ids: tuple[str, ...] = ()
+    download_attachments: bool = True
+
+
+@dataclass(frozen=True)
+class LoopConfig:
+    max_iterations: int = 8
+    timeout_minutes: int = 30
+    no_progress_limit: int = 2
+    create_linear: bool = True
+    require_fix_approval: bool = True
+    max_thread_messages: int = 40
+    max_attachment_bytes: int = 15_000_000
+
+
+@dataclass(frozen=True)
+class LinearConfig:
+    team_id: str = ""
+    project_id: str = ""
+    label_ids: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class RepoConfig:
+    url: str = ""
+    local_name: str = "mobile-app"
+    default_branch: str = "main"
+    branch_prefix: str = "monica"
+
+
+@dataclass(frozen=True)
+class VerificationConfig:
+    commands: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ProofConfig:
+    enabled: bool = False
+    required_for_done: bool = False
+    platform_order: tuple[str, ...] = ("ios", "android")
+    artifact_dir: str = "proof"
+    commands: tuple[str, ...] = ()
+    ios_simulator_udid: str = ""
+    android_serial: str = ""
+    timeout_minutes: int = 10
+
+
+@dataclass(frozen=True)
+class RuntimeConfig:
+    home_subdir: str = "agents/monica"
+    worker_session_prefix: str = "monica"
+    skip_memory: bool = True
+
+
+@dataclass(frozen=True)
+class WorkerConfig:
+    backend: str = "codex_cli"
+    codex_command: str = "codex"
+    codex_model: str = ""
+    codex_profile: str = ""
+    codex_sandbox: str = "workspace-write"
+    codex_approval_policy: str = "never"
+    timeout_minutes: int = 45
+
+
+@dataclass(frozen=True)
+class MonicaConfig:
+    enabled: bool = False
+    rollout_mode: str = "dry_run"
+    dry_run: bool = True
+    slack: SlackConfig = field(default_factory=SlackConfig)
+    loop: LoopConfig = field(default_factory=LoopConfig)
+    linear: LinearConfig = field(default_factory=LinearConfig)
+    repo: RepoConfig = field(default_factory=RepoConfig)
+    verification: VerificationConfig = field(default_factory=VerificationConfig)
+    proof: ProofConfig = field(default_factory=ProofConfig)
+    runtime: RuntimeConfig = field(default_factory=RuntimeConfig)
+    worker: WorkerConfig = field(default_factory=WorkerConfig)
+
+
+def _as_tuple(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return tuple(part.strip() for part in value.split(",") if part.strip())
+    if isinstance(value, (list, tuple, set)):
+        return tuple(str(part).strip() for part in value if str(part).strip())
+    return ()
+
+
+def _as_int(value: Any, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _as_bool(value: Any, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    if isinstance(value, (int, float)):
+        return bool(value)
+    lowered = str(value).strip().lower()
+    if lowered in {"1", "true", "yes", "on"}:
+        return True
+    if lowered in {"0", "false", "no", "off"}:
+        return False
+    return default
+
+
+def config_from_mapping(data: Mapping[str, Any] | None) -> MonicaConfig:
+    raw = data or {}
+    slack = raw.get("slack") if isinstance(raw.get("slack"), Mapping) else {}
+    loop = raw.get("loop") if isinstance(raw.get("loop"), Mapping) else {}
+    linear = raw.get("linear") if isinstance(raw.get("linear"), Mapping) else {}
+    repo = raw.get("repo") if isinstance(raw.get("repo"), Mapping) else {}
+    verification = raw.get("verification") if isinstance(raw.get("verification"), Mapping) else {}
+    proof = raw.get("proof") if isinstance(raw.get("proof"), Mapping) else {}
+    runtime = raw.get("runtime") if isinstance(raw.get("runtime"), Mapping) else {}
+    worker = raw.get("worker") if isinstance(raw.get("worker"), Mapping) else {}
+
+    raw_rollout_mode = str(raw.get("rollout_mode") or "").strip()
+    raw_dry_run = _as_bool(raw.get("dry_run"), True)
+    rollout_mode = raw_rollout_mode or ("dry_run" if raw_dry_run else "linear_only")
+    dry_run = rollout_mode == "dry_run" if raw_rollout_mode else raw_dry_run
+
+    return MonicaConfig(
+        enabled=_as_bool(raw.get("enabled"), False),
+        rollout_mode=rollout_mode,
+        dry_run=dry_run,
+        slack=SlackConfig(
+            allowed_channels=_as_tuple(slack.get("allowed_channels")),
+            approver_user_ids=_as_tuple(slack.get("approver_user_ids")),
+            bot_user_ids=_as_tuple(slack.get("bot_user_ids")),
+            download_attachments=_as_bool(slack.get("download_attachments"), True),
+        ),
+        loop=LoopConfig(
+            max_iterations=_as_int(loop.get("max_iterations"), 8),
+            timeout_minutes=_as_int(loop.get("timeout_minutes"), 30),
+            no_progress_limit=_as_int(loop.get("no_progress_limit"), 2),
+            create_linear=_as_bool(loop.get("create_linear"), True),
+            require_fix_approval=_as_bool(loop.get("require_fix_approval"), True),
+            max_thread_messages=_as_int(loop.get("max_thread_messages"), 40),
+            max_attachment_bytes=_as_int(loop.get("max_attachment_bytes"), 15_000_000),
+        ),
+        linear=LinearConfig(
+            team_id=str(linear.get("team_id") or "").strip(),
+            project_id=str(linear.get("project_id") or "").strip(),
+            label_ids=_as_tuple(linear.get("label_ids")),
+        ),
+        repo=RepoConfig(
+            url=str(repo.get("url") or "").strip(),
+            local_name=str(repo.get("local_name") or "mobile-app").strip() or "mobile-app",
+            default_branch=str(repo.get("default_branch") or "main").strip() or "main",
+            branch_prefix=str(repo.get("branch_prefix") or "monica").strip() or "monica",
+        ),
+        verification=VerificationConfig(
+            commands=_as_tuple(verification.get("commands")),
+        ),
+        proof=ProofConfig(
+            enabled=_as_bool(proof.get("enabled"), False),
+            required_for_done=_as_bool(proof.get("required_for_done"), False),
+            platform_order=_as_tuple(proof.get("platform_order")) or ("ios", "android"),
+            artifact_dir=str(proof.get("artifact_dir") or "proof").strip() or "proof",
+            commands=_as_tuple(proof.get("commands")),
+            ios_simulator_udid=str(proof.get("ios_simulator_udid") or "").strip(),
+            android_serial=str(proof.get("android_serial") or "").strip(),
+            timeout_minutes=_as_int(proof.get("timeout_minutes"), 10),
+        ),
+        runtime=RuntimeConfig(
+            home_subdir=(
+                str(runtime.get("home_subdir") or "agents/monica").strip()
+                or "agents/monica"
+            ),
+            worker_session_prefix=(
+                str(runtime.get("worker_session_prefix") or "monica").strip() or "monica"
+            ),
+            skip_memory=_as_bool(runtime.get("skip_memory"), True),
+        ),
+        worker=WorkerConfig(
+            backend=str(worker.get("backend") or "codex_cli").strip() or "codex_cli",
+            codex_command=str(worker.get("codex_command") or "codex").strip() or "codex",
+            codex_model=str(worker.get("codex_model") or "").strip(),
+            codex_profile=str(worker.get("codex_profile") or "").strip(),
+            codex_sandbox=(
+                str(worker.get("codex_sandbox") or "workspace-write").strip()
+                or "workspace-write"
+            ),
+            codex_approval_policy=(
+                str(worker.get("codex_approval_policy") or "never").strip() or "never"
+            ),
+            timeout_minutes=_as_int(worker.get("timeout_minutes"), 45),
+        ),
+    )
+
+
+def load_monica_config() -> MonicaConfig:
+    try:
+        from hermes_cli.config import load_config
+
+        config = load_config()
+    except Exception:
+        return MonicaConfig()
+
+    raw = config.get("mobile_bug_agent") if isinstance(config, Mapping) else None
+    return config_from_mapping(raw if isinstance(raw, Mapping) else None)
+
+
+def runtime_root(config: MonicaConfig) -> Path:
+    raw = config.runtime.home_subdir.strip() or "agents/monica"
+    if _path_mentions_chandler(raw):
+        raise ValueError(
+            "mobile_bug_agent.runtime.home_subdir must not point at a Chandler runtime path."
+        )
+    path = Path(raw).expanduser()
+    if path.is_absolute():
+        return path
+    home = get_hermes_home()
+    root = (home / path).resolve()
+    home_resolved = home.resolve()
+    if root != home_resolved and home_resolved not in root.parents:
+        raise ValueError("mobile_bug_agent.runtime.home_subdir must stay inside HERMES_HOME.")
+    return root
+
+
+def _path_mentions_chandler(value: str) -> bool:
+    return any(
+        "chandler" in part.lower()
+        for part in str(value or "").replace("\\", "/").split("/")
+        if part
+    )

--- a/plugins/mobile_bug_agent/intent.py
+++ b/plugins/mobile_bug_agent/intent.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass
+from typing import Any, Callable
+
+from .config import MonicaConfig
+
+
+SYSTEM_PROMPT = """You are Monica, an agentic mobile frontend bug triage agent.
+Classify only the tagged Slack request and its thread context.
+Return strict JSON with keys: is_mobile_bug, wants_linear, wants_fix,
+confidence, summary, observed_behavior, expected_behavior, reproduction_steps,
+platforms, device_context, build_context, missing_questions, reason.
+Do not require command syntax. Infer intent from natural language.
+When uncertain, ask for clarification instead of taking action."""
+
+
+@dataclass(frozen=True)
+class IntentResult:
+    is_mobile_bug: bool
+    wants_linear: bool
+    wants_fix: bool
+    confidence: float
+    summary: str
+    observed_behavior: str = ""
+    expected_behavior: str = ""
+    reproduction_steps: tuple[str, ...] = ()
+    platforms: tuple[str, ...] = ()
+    device_context: str = ""
+    build_context: str = ""
+    missing_questions: tuple[str, ...] = ()
+    reason: str = ""
+
+    @property
+    def needs_clarification(self) -> bool:
+        return bool(self.missing_questions) or self.confidence < 0.5
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["missing_questions"] = list(self.missing_questions)
+        data["reproduction_steps"] = list(self.reproduction_steps)
+        data["platforms"] = list(self.platforms)
+        data["needs_clarification"] = self.needs_clarification
+        return data
+
+
+AgentFactory = Callable[[], Any]
+
+
+class IntentClassifier:
+    def __init__(
+        self,
+        *,
+        config: MonicaConfig | None = None,
+        agent_factory: AgentFactory | None = None,
+    ) -> None:
+        self.config = config or MonicaConfig()
+        self.agent_factory = agent_factory or self._default_agent
+
+    def classify(self, *, request_text: str, thread_text: str) -> IntentResult:
+        prompt = "\n".join(
+            [
+                "Tagged request:",
+                request_text.strip() or "(empty)",
+                "",
+                "Slack thread:",
+                thread_text.strip() or "(empty)",
+            ]
+        )
+        try:
+            agent = self.agent_factory()
+            result = agent.run_conversation(user_message=prompt, system_message=SYSTEM_PROMPT)
+            content = str((result or {}).get("final_response") or "")
+            parsed = json.loads(_extract_json(content))
+            return _result_from_mapping(parsed)
+        except Exception:
+            return _fallback_intent(request_text=request_text, thread_text=thread_text)
+
+    def _default_agent(self) -> Any:
+        from run_agent import AIAgent
+
+        return AIAgent(
+            max_iterations=max(1, min(self.config.loop.max_iterations, 4)),
+            quiet_mode=True,
+            platform="monica",
+            skip_memory=True,
+        )
+
+
+def _extract_json(content: str) -> str:
+    stripped = content.strip()
+    if stripped.startswith("{") and stripped.endswith("}"):
+        return stripped
+    start = stripped.find("{")
+    end = stripped.rfind("}")
+    if start >= 0 and end > start:
+        return stripped[start : end + 1]
+    raise ValueError("no JSON object found in classifier response")
+
+
+def _result_from_mapping(data: dict[str, Any]) -> IntentResult:
+    return IntentResult(
+        is_mobile_bug=_coerce_bool(data.get("is_mobile_bug")),
+        wants_linear=_coerce_bool(data.get("wants_linear"), default=True),
+        wants_fix=_coerce_bool(data.get("wants_fix")),
+        confidence=_clamp_float(data.get("confidence"), 0.0, 1.0),
+        summary=str(data.get("summary") or "").strip()[:180],
+        observed_behavior=str(data.get("observed_behavior") or "").strip()[:1000],
+        expected_behavior=str(data.get("expected_behavior") or "").strip()[:1000],
+        reproduction_steps=_as_string_tuple(data.get("reproduction_steps"), limit=12),
+        platforms=_as_string_tuple(data.get("platforms"), limit=8),
+        device_context=str(data.get("device_context") or "").strip()[:500],
+        build_context=str(data.get("build_context") or "").strip()[:500],
+        missing_questions=_as_string_tuple(data.get("missing_questions"), limit=8),
+        reason=str(data.get("reason") or "").strip()[:1000],
+    )
+
+
+def _fallback_intent(*, request_text: str, thread_text: str) -> IntentResult:
+    text = "\n".join([request_text, thread_text]).lower()
+    bug_words = ("bug", "crash", "broken", "issue", "error", "regression", "not working", "fails")
+    fix_words = ("fix", "patch", "pr", "clean it up", "clean up", "ship", "resolve")
+    ticket_words = ("linear", "ticket", "file", "triage")
+    platforms = _fallback_platforms(text)
+    is_bug = any(word in text for word in bug_words)
+    is_mobile = _has_explicit_mobile_context(text)
+    wants_fix = any(word in text for word in fix_words)
+    asked_ticket = any(word in text for word in ticket_words)
+    is_mobile_bug = is_bug and is_mobile
+    question_only = _is_actionless_question(request_text.lower())
+    wants_linear = asked_ticket or (is_mobile_bug and not question_only)
+    summary = _first_line(request_text or thread_text)
+    questions: tuple[str, ...] = ()
+    confidence = 0.78 if is_mobile_bug else 0.25
+    if not is_mobile_bug:
+        questions = ("What mobile app bug or platform should I file or investigate?",)
+    return IntentResult(
+        is_mobile_bug=is_mobile_bug,
+        wants_linear=wants_linear,
+        wants_fix=wants_fix,
+        confidence=confidence,
+        summary=summary,
+        observed_behavior=summary if is_mobile_bug else "",
+        platforms=platforms,
+        missing_questions=questions,
+        reason="Fallback keyword triage used because model classification was unavailable.",
+    )
+
+
+def _has_explicit_mobile_context(text: str) -> bool:
+    if _has_negated_mobile_context(text):
+        return False
+    if _fallback_platforms(text):
+        return True
+    return (
+        "mobile app" in text
+        or "native app" in text
+        or "app store" in text
+        or "play store" in text
+    )
+
+
+def _has_negated_mobile_context(text: str) -> bool:
+    return bool(
+        re.search(
+            r"\b(?:not|isn'?t|is not|not the|not a)\s+(?:mobile|mobile app|native|native app)\b",
+            text,
+        )
+    )
+
+
+def _is_actionless_question(text: str) -> bool:
+    return bool(
+        re.search(
+            r"\b("
+            r"any thoughts"
+            r"|what do you think"
+            r"|wdyt"
+            r"|thoughts\?"
+            r"|is this"
+            r"|could this be"
+            r"|does this look like"
+            r")\b",
+            text,
+        )
+    )
+
+
+def _as_string_tuple(value: Any, *, limit: int) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        values = [value]
+    elif isinstance(value, (list, tuple, set)):
+        values = list(value)
+    else:
+        return ()
+    clean: list[str] = []
+    for item in values:
+        text = str(item).strip()
+        if text:
+            clean.append(text[:500])
+        if len(clean) >= limit:
+            break
+    return tuple(clean)
+
+
+def _fallback_platforms(text: str) -> tuple[str, ...]:
+    platforms: list[str] = []
+    if "android" in text:
+        platforms.append("Android")
+    if "ios" in text or "iphone" in text or "ipad" in text:
+        platforms.append("iOS")
+    if "react native" in text or "\nrn" in text or " rn " in text:
+        platforms.append("React Native")
+    return tuple(platforms)
+
+
+def _contains_term(text: str, term: str) -> bool:
+    return bool(re.search(rf"\b{re.escape(term)}\b", text))
+
+
+def _clamp_float(value: Any, lower: float, upper: float) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        parsed = lower
+    return max(lower, min(upper, parsed))
+
+
+def _coerce_bool(value: Any, *, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "yes", "y", "1", "on"}:
+            return True
+        if normalized in {"false", "no", "n", "0", "off", ""}:
+            return False
+    return default
+
+
+def _first_line(text: str) -> str:
+    for line in text.splitlines():
+        clean = re.sub(r"\s+", " ", line).strip()
+        if clean:
+            return clean[:180]
+    return "Tagged mobile bug report"

--- a/plugins/mobile_bug_agent/linear_client.py
+++ b/plugins/mobile_bug_agent/linear_client.py
@@ -1,0 +1,359 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+
+class LinearClientError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class LinearIssuePayload:
+    team_id: str
+    title: str
+    description: str
+    project_id: str = ""
+    label_ids: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class LinearIssue:
+    id: str
+    identifier: str
+    url: str
+
+
+@dataclass(frozen=True)
+class LinearTeam:
+    id: str
+    key: str
+    name: str
+
+
+@dataclass(frozen=True)
+class LinearProject:
+    id: str
+    name: str
+    state: str
+
+
+@dataclass(frozen=True)
+class LinearLabel:
+    id: str
+    name: str
+    color: str
+
+
+@dataclass(frozen=True)
+class LinearWorkspaceMetadata:
+    teams: tuple[LinearTeam, ...]
+    projects: tuple[LinearProject, ...]
+    labels: tuple[LinearLabel, ...]
+
+
+@dataclass(frozen=True)
+class LinearAttachmentPayload:
+    issue_id: str
+    title: str
+    url: str
+    subtitle: str = ""
+
+
+@dataclass(frozen=True)
+class LinearAttachment:
+    id: str
+    title: str
+    url: str
+
+
+class LinearClient:
+    API_URL = "https://api.linear.app/graphql"
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        transport: httpx.BaseTransport | None = None,
+        timeout: float = 30.0,
+    ) -> None:
+        self.api_key = api_key.strip()
+        self._transport = transport
+        self._timeout = timeout
+
+    def create_or_update_issue(
+        self,
+        payload: LinearIssuePayload,
+        *,
+        existing_issue_id: str = "",
+    ) -> LinearIssue:
+        if not self.api_key:
+            raise LinearClientError("LINEAR_API_KEY is not configured.")
+        if not existing_issue_id and not payload.team_id:
+            raise LinearClientError("Linear team_id is required when creating an issue.")
+
+        body = self._update_body(payload, existing_issue_id) if existing_issue_id else self._create_body(payload)
+        data = self._post_graphql(body)
+
+        if error_summary := _graphql_error_summary(data):
+            raise LinearClientError(f"Linear GraphQL error: {error_summary}")
+        if _mutation_success(data, "issueCreate", "issueUpdate") is False:
+            raise LinearClientError("Linear issue mutation did not report success.")
+
+        issue = self._extract_issue(data)
+        if issue is None:
+            raise LinearClientError(f"Linear write failed: {data}")
+        return issue
+
+    def create_attachment(self, payload: LinearAttachmentPayload) -> LinearAttachment:
+        if not self.api_key:
+            raise LinearClientError("LINEAR_API_KEY is not configured.")
+        if not payload.issue_id:
+            raise LinearClientError("Linear issue_id is required when creating an attachment.")
+        if not payload.url:
+            raise LinearClientError("Attachment url is required.")
+
+        data = self._post_graphql(self._attachment_body(payload))
+
+        if error_summary := _graphql_error_summary(data):
+            raise LinearClientError(f"Linear GraphQL error: {error_summary}")
+        if _mutation_success(data, "attachmentCreate") is False:
+            raise LinearClientError("Linear attachment mutation did not report success.")
+
+        attachment = self._extract_attachment(data)
+        if attachment is None:
+            raise LinearClientError(f"Linear attachment write failed: {data}")
+        return attachment
+
+    def list_workspace_metadata(self) -> LinearWorkspaceMetadata:
+        if not self.api_key:
+            raise LinearClientError("LINEAR_API_KEY is not configured.")
+        data = self._post_graphql(self._metadata_body())
+
+        if error_summary := _graphql_error_summary(data):
+            raise LinearClientError(f"Linear GraphQL error: {error_summary}")
+        body = data.get("data")
+        if not isinstance(body, dict):
+            raise LinearClientError(f"Linear metadata query failed: {data}")
+        return LinearWorkspaceMetadata(
+            teams=tuple(_extract_teams(body.get("teams"))),
+            projects=tuple(_extract_projects(body.get("projects"))),
+            labels=tuple(_extract_labels(body.get("issueLabels"))),
+        )
+
+    @staticmethod
+    def _create_body(payload: LinearIssuePayload) -> dict[str, Any]:
+        issue_input = {
+            "teamId": payload.team_id,
+            "title": payload.title,
+            "description": payload.description,
+        }
+        if payload.project_id:
+            issue_input["projectId"] = payload.project_id
+        if payload.label_ids:
+            issue_input["labelIds"] = list(payload.label_ids)
+        return {
+            "query": (
+                "mutation($input: IssueCreateInput!) "
+                "{ issueCreate(input: $input) { success issue { id identifier url } } }"
+            ),
+            "variables": {"input": issue_input},
+        }
+
+    @staticmethod
+    def _update_body(payload: LinearIssuePayload, existing_issue_id: str) -> dict[str, Any]:
+        return {
+            "query": (
+                "mutation($id: String!, $input: IssueUpdateInput!) "
+                "{ issueUpdate(id: $id, input: $input) { success issue { id identifier url } } }"
+            ),
+            "variables": {
+                "id": existing_issue_id,
+                "input": LinearClient._update_input(payload),
+            },
+        }
+
+    @staticmethod
+    def _update_input(payload: LinearIssuePayload) -> dict[str, Any]:
+        issue_input: dict[str, Any] = {
+            "title": payload.title,
+            "description": payload.description,
+        }
+        if payload.project_id:
+            issue_input["projectId"] = payload.project_id
+        if payload.label_ids:
+            issue_input["labelIds"] = list(payload.label_ids)
+        return issue_input
+
+    @staticmethod
+    def _attachment_body(payload: LinearAttachmentPayload) -> dict[str, Any]:
+        attachment_input = {
+            "issueId": payload.issue_id,
+            "title": payload.title,
+            "url": payload.url,
+        }
+        if payload.subtitle:
+            attachment_input["subtitle"] = payload.subtitle
+        return {
+            "query": (
+                "mutation($input: AttachmentCreateInput!) "
+                "{ attachmentCreate(input: $input) { success attachment { id title url } } }"
+            ),
+            "variables": {"input": attachment_input},
+        }
+
+    @staticmethod
+    def _metadata_body() -> dict[str, Any]:
+        return {
+            "query": (
+                "query MonicaLinearMetadata { "
+                "teams(first: 100) { nodes { id key name } } "
+                "projects(first: 100) { nodes { id name state } } "
+                "issueLabels(first: 100) { nodes { id name color } } "
+                "}"
+            ),
+            "variables": {},
+        }
+
+    def _post_graphql(self, body: dict[str, Any]) -> dict[str, Any]:
+        try:
+            with httpx.Client(timeout=self._timeout, transport=self._transport) as client:
+                response = client.post(
+                    self.API_URL,
+                    headers={"Authorization": self.api_key, "Content-Type": "application/json"},
+                    json=body,
+                )
+                response.raise_for_status()
+                try:
+                    data = response.json()
+                except ValueError as exc:
+                    detail = _truncate_detail(response.text.strip())
+                    message = "Linear returned invalid JSON"
+                    if detail:
+                        message += f": {detail}"
+                    raise LinearClientError(message) from exc
+        except httpx.HTTPStatusError as exc:
+            response = exc.response
+            detail = response.text.strip()
+            message = f"Linear HTTP error: {response.status_code} {response.reason_phrase}"
+            if detail:
+                message += f" - {detail}"
+            raise LinearClientError(message) from exc
+        except httpx.HTTPError as exc:
+            raise LinearClientError(f"Linear request failed: {exc}") from exc
+        if not isinstance(data, dict):
+            raise LinearClientError(f"Linear returned non-object response: {data}")
+        return data
+
+    @staticmethod
+    def _extract_issue(data: dict[str, Any]) -> LinearIssue | None:
+        issue = (
+            (((data.get("data") or {}).get("issueCreate") or {}).get("issue"))
+            or (((data.get("data") or {}).get("issueUpdate") or {}).get("issue"))
+        )
+        if not isinstance(issue, dict) or not issue.get("id"):
+            return None
+        return LinearIssue(
+            id=str(issue.get("id") or ""),
+            identifier=str(issue.get("identifier") or ""),
+            url=str(issue.get("url") or ""),
+        )
+
+    @staticmethod
+    def _extract_attachment(data: dict[str, Any]) -> LinearAttachment | None:
+        attachment = (((data.get("data") or {}).get("attachmentCreate") or {}).get("attachment"))
+        if not isinstance(attachment, dict) or not attachment.get("id"):
+            return None
+        return LinearAttachment(
+            id=str(attachment.get("id") or ""),
+            title=str(attachment.get("title") or ""),
+            url=str(attachment.get("url") or ""),
+        )
+
+
+def _graphql_error_summary(data: dict[str, Any]) -> str:
+    errors = data.get("errors")
+    if not isinstance(errors, list):
+        return ""
+    messages: list[str] = []
+    for item in errors:
+        if isinstance(item, dict):
+            message = str(item.get("message") or "").strip()
+        else:
+            message = str(item).strip()
+        if message:
+            messages.append(message)
+    return "; ".join(messages)
+
+
+def _mutation_success(data: dict[str, Any], *mutation_names: str) -> bool | None:
+    body = data.get("data")
+    if not isinstance(body, dict):
+        return None
+    for name in mutation_names:
+        result = body.get(name)
+        if isinstance(result, dict) and "success" in result:
+            return bool(result.get("success"))
+    return None
+
+
+def _extract_teams(connection: Any) -> list[LinearTeam]:
+    teams: list[LinearTeam] = []
+    for node in _connection_nodes(connection):
+        if not isinstance(node, dict) or not node.get("id"):
+            continue
+        teams.append(
+            LinearTeam(
+                id=str(node.get("id") or ""),
+                key=str(node.get("key") or ""),
+                name=str(node.get("name") or ""),
+            )
+        )
+    return teams
+
+
+def _extract_projects(connection: Any) -> list[LinearProject]:
+    projects: list[LinearProject] = []
+    for node in _connection_nodes(connection):
+        if not isinstance(node, dict) or not node.get("id"):
+            continue
+        projects.append(
+            LinearProject(
+                id=str(node.get("id") or ""),
+                name=str(node.get("name") or ""),
+                state=str(node.get("state") or ""),
+            )
+        )
+    return projects
+
+
+def _extract_labels(connection: Any) -> list[LinearLabel]:
+    labels: list[LinearLabel] = []
+    for node in _connection_nodes(connection):
+        if not isinstance(node, dict) or not node.get("id"):
+            continue
+        labels.append(
+            LinearLabel(
+                id=str(node.get("id") or ""),
+                name=str(node.get("name") or ""),
+                color=str(node.get("color") or ""),
+            )
+        )
+    return labels
+
+
+def _connection_nodes(connection: Any) -> list[Any]:
+    if not isinstance(connection, dict):
+        return []
+    nodes = connection.get("nodes")
+    if not isinstance(nodes, list):
+        return []
+    return nodes
+
+
+def _truncate_detail(detail: str, *, limit: int = 2000) -> str:
+    if len(detail) <= limit:
+        return detail
+    return f"{detail[:limit]}..."

--- a/plugins/mobile_bug_agent/loop.py
+++ b/plugins/mobile_bug_agent/loop.py
@@ -1,0 +1,456 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Protocol
+
+from .config import MonicaConfig
+from .state import MonicaState
+
+SUPPORTED_ROLLOUT_MODES = {"dry_run", "linear_only", "local_fix_only", "approved_pr"}
+LINEAR_ROLLOUT_MODES = {"linear_only", "local_fix_only", "approved_pr"}
+CODE_ROLLOUT_MODES = {"local_fix_only", "approved_pr"}
+logger = logging.getLogger(__name__)
+
+
+class MonicaLoopSkills(Protocol):
+    def read_slack_thread(self, run: Any) -> dict[str, Any]:
+        ...
+
+    def infer_user_intent(self, run: Any, thread: dict[str, Any]) -> dict[str, Any]:
+        ...
+
+    def create_or_update_linear(
+        self,
+        run: Any,
+        thread: dict[str, Any],
+        intent: dict[str, Any],
+    ) -> dict[str, Any]:
+        ...
+
+    def ask_fix_approval(self, run: Any, issue: dict[str, Any]) -> None:
+        ...
+
+    def run_internal_codex_worker(self, run: Any) -> dict[str, Any]:
+        ...
+
+    def run_verification(self, run: Any, worker_result: dict[str, Any]) -> dict[str, Any]:
+        ...
+
+    def run_proof(
+        self,
+        run: Any,
+        worker_result: dict[str, Any],
+        verification: dict[str, Any],
+    ) -> dict[str, Any]:
+        ...
+
+    def open_draft_pr(
+        self,
+        run: Any,
+        worker_result: dict[str, Any],
+        verification: dict[str, Any],
+    ) -> dict[str, Any]:
+        ...
+
+
+class MonicaLoop:
+    def __init__(self, *, config: MonicaConfig, state: MonicaState, skills: MonicaLoopSkills) -> None:
+        self.config = config
+        self.state = state
+        self.skills = skills
+
+    def run(self, run_id: str) -> None:
+        run = self.state.get_run(run_id)
+        if run is None:
+            raise KeyError(run_id)
+        try:
+            self._run(run)
+        except Exception as exc:
+            self._mark_failed(run_id, exc)
+
+    def _run(self, run: Any) -> None:
+        if self.config.rollout_mode not in SUPPORTED_ROLLOUT_MODES:
+            blocked = self.state.update_run(
+                run.id,
+                status="blocked",
+                failure_reason=f"unknown_rollout_mode: {self.config.rollout_mode}",
+            )
+            self._log_run("blocked", blocked, stage="preflight")
+            self._post_status(
+                blocked,
+                "Monica is not configured with a known rollout mode, so I stopped before taking action. "
+                "Use one of: `dry_run`, `linear_only`, `local_fix_only`, `approved_pr`.",
+            )
+            return
+
+        if self.config.rollout_mode in LINEAR_ROLLOUT_MODES and not self.config.loop.create_linear:
+            blocked = self.state.update_run(
+                run.id,
+                status="blocked",
+                failure_reason="linear_creation_disabled_in_rollout",
+            )
+            self._log_run("blocked", blocked, stage="preflight")
+            self._post_status(
+                blocked,
+                "Linear creation is disabled for this Monica rollout mode, so I stopped before taking action.",
+            )
+            return
+
+        if run.status == "approved":
+            self._run_approved_fix(run)
+            return
+
+        if run.status not in {"queued", "needs_clarification"}:
+            return
+
+        run = self.state.update_run(run.id, status="triaging")
+        thread = self.skills.read_slack_thread(run)
+        if self._is_cancelled(run.id):
+            return
+        intent = self.skills.infer_user_intent(run, thread)
+        if self._is_cancelled(run.id):
+            return
+
+        if intent.get("needs_clarification"):
+            needs_clarification = self.state.update_run(run.id, status="needs_clarification")
+            self._log_run("needs_clarification", needs_clarification, stage="triaging")
+            self._post_status(needs_clarification, self._clarification_text(intent))
+            return
+
+        if not intent.get("is_mobile_bug"):
+            blocked = self.state.update_run(run.id, status="blocked", failure_reason="not_a_mobile_bug")
+            self._log_run("blocked", blocked, stage="triaging")
+            self._post_status(
+                blocked,
+                "I could not confidently classify this as a mobile app bug. "
+                "Tag me again with the app/platform details if you want me to file it.",
+            )
+            return
+
+        if intent.get("wants_linear") is False and not intent.get("wants_fix"):
+            needs_clarification = self.state.update_run(run.id, status="needs_clarification")
+            self._log_run("needs_clarification", needs_clarification, stage="triaging")
+            self._post_status(
+                needs_clarification,
+                "I see mobile app bug context here, but I do not have a clear next step yet. "
+                "Tag me again if you want me to file a Linear issue or prepare a fix.",
+            )
+            return
+
+        if self.config.loop.create_linear:
+            run = self.state.update_run(run.id, status="creating_linear")
+            issue = self.skills.create_or_update_linear(run, thread, intent)
+            if self._is_cancelled(run.id):
+                return
+        else:
+            issue = {"identifier": "", "url": "", "dry_run": True, "title": intent.get("summary", "")}
+        run = self.state.update_run(
+            run.id,
+            status="linear_created",
+            linear_identifier=issue.get("identifier", ""),
+            linear_issue_id=issue.get("id", ""),
+            linear_url=issue.get("url", ""),
+        )
+
+        if issue.get("dry_run"):
+            self._post_status(run, self._linear_done_text(issue))
+            completed = self.state.update_run(run.id, status="done")
+            self._log_run("done", completed, stage="dry_run")
+            return
+
+        if intent.get("wants_fix") and self.config.rollout_mode not in CODE_ROLLOUT_MODES:
+            self._post_status(
+                run,
+                self._linear_done_text(issue)
+                + "\n\nCode fixes are disabled in the current Monica rollout mode.",
+            )
+            completed = self.state.update_run(run.id, status="done")
+            self._log_run("done", completed, stage=self.config.rollout_mode)
+            return
+
+        if intent.get("wants_fix"):
+            run = self.state.update_run(run.id, status="awaiting_fix_approval")
+            self._log_run("awaiting_fix_approval", run, stage="linear_created")
+            self.skills.ask_fix_approval(run, issue)
+            return
+
+        self._post_status(run, self._linear_done_text(issue))
+        completed = self.state.update_run(run.id, status="done")
+        self._log_run("done", completed, stage=self.config.rollout_mode)
+
+    def _run_approved_fix(self, run: Any) -> None:
+        if self.config.rollout_mode not in CODE_ROLLOUT_MODES:
+            blocked = self.state.update_run(
+                run.id,
+                status="blocked",
+                failure_reason="approved_pr_rollout_not_enabled",
+            )
+            self._log_run("blocked", blocked, stage="preflight")
+            self._post_status(
+                blocked,
+                "I have approval, but code rollout is not enabled. "
+                "Set `mobile_bug_agent.rollout_mode` to `local_fix_only` or `approved_pr` before I write code.",
+            )
+            return
+
+        if not (run.linear_identifier or run.linear_issue_id or run.linear_url):
+            blocked = self.state.update_run(
+                run.id,
+                status="blocked",
+                failure_reason="linear_issue_missing_before_fix",
+            )
+            self._log_run("blocked", blocked, stage="preflight")
+            self._post_status(
+                blocked,
+                "I have approval, but no Linear issue is attached to this Monica run, "
+                "so I stopped before writing code.",
+            )
+            return
+
+        if not any(command.strip() for command in self.config.verification.commands):
+            blocked = self.state.update_run(
+                run.id,
+                status="blocked",
+                failure_reason="verification_commands_missing",
+            )
+            self._log_run("blocked", blocked, stage="preflight")
+            self._post_status(
+                blocked,
+                "I have approval, but `mobile_bug_agent.verification.commands` is empty, "
+                "so I stopped before writing code.",
+            )
+            return
+
+        run = self.state.update_run(run.id, status="fixing")
+        worker_result = self.skills.run_internal_codex_worker(run)
+        if self._is_cancelled(run.id):
+            return
+        branch_name = str(worker_result.get("branch_name") or run.branch_name or "")
+        if not branch_name:
+            blocked = self.state.update_run(
+                run.id,
+                status="blocked",
+                failure_reason="worker_branch_missing",
+            )
+            self._log_run("blocked", blocked, stage="fixing")
+            self._post_status(
+                blocked,
+                "I stopped after the code worker because I could not identify a branch to verify and push.",
+            )
+            return
+        if not self._is_expected_worker_branch(run=run, branch_name=branch_name):
+            blocked = self.state.update_run(
+                run.id,
+                status="blocked",
+                failure_reason="worker_branch_mismatch",
+            )
+            self._log_run("blocked", blocked, stage="fixing")
+            self._post_status(
+                blocked,
+                "I stopped after the code worker because it returned an unexpected branch "
+                f"`{branch_name}` for this Monica run.",
+            )
+            return
+        run = self.state.update_run(run.id, branch_name=branch_name)
+        if worker_result.get("changed") is False:
+            blocked = self.state.update_run(
+                run.id,
+                status="blocked",
+                failure_reason="worker_no_changes",
+            )
+            self._log_run("blocked", blocked, stage="fixing")
+            self._post_status(
+                blocked,
+                "I stopped after the code worker because it did not report any code changes.",
+            )
+            return
+
+        run = self.state.update_run(run.id, status="verifying")
+        verification = self.skills.run_verification(run, worker_result)
+        if self._is_cancelled(run.id):
+            return
+        if not verification.get("passed"):
+            blocked = self.state.update_run(
+                run.id,
+                status="blocked",
+                failure_reason=f"verification_failed: {verification.get('summary', '')}".strip(),
+            )
+            self._log_run("blocked", blocked, stage="verifying")
+            self._post_status(run, f"Verification failed, so I did not open a PR.\n{verification.get('summary', '')}")
+            return
+
+        if self._proof_required():
+            run = self.state.update_run(run.id, status="proofing")
+            proof = self.skills.run_proof(run, worker_result, verification)
+            if self._is_cancelled(run.id):
+                return
+            artifacts = self._proof_artifacts(proof)
+            if not proof.get("passed") or not artifacts:
+                summary = str(proof.get("summary") or "Proof unavailable.").strip()
+                blocked = self.state.update_run(
+                    run.id,
+                    status="proof_blocked",
+                    failure_reason=f"proof_unavailable: {summary}".strip(),
+                )
+                self._log_run("proof_blocked", blocked, stage="proofing")
+                self._post_status(
+                    blocked,
+                    "Verification passed, but simulator proof is unavailable, "
+                    "so I did not mark this run done or open a PR.\n"
+                    f"{summary}",
+                )
+                return
+            worker_result["proof"] = dict(proof)
+
+        if self.config.rollout_mode == "local_fix_only":
+            completed = self.state.update_run(run.id, status="done")
+            self._log_run("done", completed, stage="local_fix_only")
+            proof_text = self._proof_status_text(worker_result.get("proof"))
+            self._post_status(
+                completed,
+                "Local fix is ready on branch "
+                f"`{completed.branch_name}`. Verification passed. "
+                "The branch was not pushed and no PR was opened."
+                f"{proof_text}",
+            )
+            return
+
+        run = self.state.update_run(run.id, status="opening_pr")
+        pr = self.skills.open_draft_pr(run, worker_result, verification)
+        pr_url = str(pr.get("url") or "")
+        if not pr_url:
+            blocked = self.state.update_run(
+                run.id,
+                status="blocked",
+                failure_reason="draft_pr_url_missing",
+            )
+            self._log_run("blocked", blocked, stage="opening_pr")
+            self._post_status(
+                blocked,
+                "I opened the final PR stage, but the publisher did not return a draft PR URL, "
+                "so I stopped before marking this run complete.",
+            )
+            return
+        if self._is_cancelled(run.id):
+            if pr_url:
+                cancelled = self.state.update_run(run.id, pr_url=pr_url)
+                self._log_run("blocked", cancelled, stage="opening_pr")
+            return
+        completed = self.state.update_run(
+            run.id,
+            status="done",
+            pr_url=pr_url,
+        )
+        self._log_run("done", completed, stage="opening_pr")
+        self._post_status(completed, f"Draft PR is ready: {pr_url}")
+
+    def _is_cancelled(self, run_id: str) -> bool:
+        run = self.state.get_run(run_id)
+        return bool(
+            run
+            and run.status == "blocked"
+            and str(run.failure_reason or "").startswith("cancelled by ")
+        )
+
+    def _post_status(self, run: Any, text: str) -> None:
+        poster = getattr(self.skills, "post_status", None)
+        if callable(poster):
+            try:
+                poster(run, text)
+            except Exception:
+                return
+
+    def _proof_required(self) -> bool:
+        return bool(self.config.proof.required_for_done)
+
+    @staticmethod
+    def _proof_artifacts(proof: dict[str, Any]) -> list[str]:
+        return [str(path).strip() for path in proof.get("artifacts") or [] if str(path).strip()]
+
+    def _proof_status_text(self, proof: object) -> str:
+        if not isinstance(proof, dict):
+            return ""
+        artifacts = self._proof_artifacts(proof)
+        if not artifacts:
+            return ""
+        visible = ", ".join(artifacts[:5])
+        suffix = "" if len(artifacts) <= 5 else f", +{len(artifacts) - 5} more"
+        return f"\nProof captured: {visible}{suffix}"
+
+    def _is_expected_worker_branch(self, *, run: Any, branch_name: str) -> bool:
+        branch = str(branch_name or "").strip()
+        if not branch:
+            return False
+        prefix = str(self.config.repo.branch_prefix or "").strip().rstrip("/")
+        if prefix and not branch.startswith(f"{prefix}/"):
+            return False
+        linear_identifier = str(getattr(run, "linear_identifier", "") or "").strip()
+        return not linear_identifier or linear_identifier in branch
+
+    def _mark_failed(self, run_id: str, exc: Exception) -> None:
+        run = self.state.get_run(run_id)
+        if run is None:
+            raise KeyError(run_id) from exc
+        stage = run.status or "unknown"
+        detail = str(exc) or exc.__class__.__name__
+        failed = self.state.update_run(
+            run_id,
+            status="failed",
+            failure_reason=f"{stage}_failed: {detail}",
+        )
+        self._log_run("failed", failed, stage=stage)
+        self._post_status(
+            failed,
+            "I hit a problem while working this Monica run, so I stopped before taking the next action.\n"
+            f"Stage: {stage}\n"
+            f"Check Monica logs or `hermes mobile-bug-agent show {failed.id}` on the host for details.",
+        )
+
+    @staticmethod
+    def _log_run(event: str, run: Any, *, stage: str = "") -> None:
+        logger.info(
+            "monica_run event=%s run_id=%s status=%s stage=%s channel_id=%s thread_ts=%s "
+            "linear_identifier=%s linear_url=%s branch_name=%s pr_url=%s failure_reason=%s",
+            event,
+            getattr(run, "id", ""),
+            getattr(run, "status", ""),
+            stage,
+            getattr(run, "channel_id", ""),
+            getattr(run, "thread_ts", ""),
+            getattr(run, "linear_identifier", ""),
+            getattr(run, "linear_url", ""),
+            getattr(run, "branch_name", ""),
+            getattr(run, "pr_url", ""),
+            getattr(run, "failure_reason", ""),
+        )
+
+    @staticmethod
+    def _clarification_text(intent: dict[str, Any]) -> str:
+        questions = intent.get("missing_questions") or []
+        if isinstance(questions, str):
+            questions = [questions]
+        clean = [str(question).strip() for question in questions if str(question).strip()]
+        if not clean:
+            return "I need a little more context before I file this as a mobile bug."
+        return "I need a little more context before I file this:\n" + "\n".join(f"- {q}" for q in clean)
+
+    @staticmethod
+    def _linear_done_text(issue: dict[str, Any]) -> str:
+        if issue.get("dry_run"):
+            preview = _compact(str(issue.get("description") or ""), limit=500)
+            if preview:
+                return (
+                    f"Dry run: I would create a Linear issue titled `{issue.get('title', 'Mobile bug')}`.\n"
+                    f"Preview:\n{preview}"
+                )
+            return f"Dry run: I would create a Linear issue titled `{issue.get('title', 'Mobile bug')}`."
+        if issue.get("url"):
+            return f"Created Linear issue: {issue.get('url')}"
+        return "Created the Linear issue."
+
+
+def _compact(value: str, *, limit: int) -> str:
+    compacted = "\n".join(line.rstrip() for line in value.strip().splitlines() if line.strip())
+    if len(compacted) <= limit:
+        return compacted
+    return compacted[: max(0, limit - 3)].rstrip() + "..."

--- a/plugins/mobile_bug_agent/plugin.yaml
+++ b/plugins/mobile_bug_agent/plugin.yaml
@@ -1,0 +1,6 @@
+name: mobile-bug-agent
+version: 0.1.0
+description: "Agentic Slack-to-Linear mobile bug loop. Docs: docs/monica-agent.md."
+author: "NousResearch"
+hooks:
+  - pre_gateway_dispatch

--- a/plugins/mobile_bug_agent/pr_publisher.py
+++ b/plugins/mobile_bug_agent/pr_publisher.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+from typing import Callable
+
+from .repo_manager import is_safe_git_branch_name
+
+
+class DraftPrPublisherError(RuntimeError):
+    pass
+
+
+RunCommand = Callable[[list[str], Path | None], str]
+
+
+class DraftPrPublisher:
+    def __init__(
+        self,
+        *,
+        run_command: RunCommand | None = None,
+        timeout_seconds: int = 600,
+    ) -> None:
+        self._run_command = run_command or self._default_run
+        self.timeout_seconds = timeout_seconds
+
+    def publish(
+        self,
+        *,
+        worktree: str | Path,
+        branch_name: str,
+        base_branch: str,
+        title: str,
+        body: str,
+    ) -> str:
+        safe_branch_name = str(branch_name or "").strip()
+        if not safe_branch_name:
+            raise DraftPrPublisherError("branch_name is required.")
+        if not is_safe_git_branch_name(safe_branch_name):
+            raise DraftPrPublisherError("branch_name must be a safe git branch name.")
+        safe_base_branch = str(base_branch or "").strip()
+        if not is_safe_git_branch_name(safe_base_branch):
+            raise DraftPrPublisherError("base_branch must be a safe git branch name.")
+        title_text = str(title or "").strip()
+        if not title_text:
+            raise DraftPrPublisherError("title is required.")
+        body_text = str(body or "").strip()
+        if not body_text:
+            raise DraftPrPublisherError("body is required.")
+        _validate_pr_body(body_text)
+        worktree_path = Path(worktree)
+        if not worktree_path.is_dir():
+            raise DraftPrPublisherError(f"worktree does not exist: {worktree_path}")
+        if not (worktree_path / ".git").exists():
+            raise DraftPrPublisherError(f"worktree is not a git worktree: {worktree_path}")
+        current_branch = self._run_command(["git", "branch", "--show-current"], worktree_path).strip()
+        if current_branch != safe_branch_name:
+            raise DraftPrPublisherError(
+                f"worktree branch mismatch: expected {safe_branch_name}, got {current_branch or 'detached HEAD'}"
+            )
+        status = self._run_command(["git", "status", "--porcelain"], worktree_path)
+        if status.strip():
+            self._run_command(["git", "add", "-A"], worktree_path)
+            self._run_command(
+                [
+                    "git",
+                    "-c",
+                    "user.name=Monica",
+                    "-c",
+                    "user.email=monica@hermes.local",
+                    "commit",
+                    "-m",
+                    title_text,
+                ],
+                worktree_path,
+            )
+
+        diff = self._run_command(
+            ["git", "diff", "--name-only", f"origin/{safe_base_branch}...HEAD"],
+            worktree_path,
+        )
+        if not diff.strip():
+            raise DraftPrPublisherError("No committed changes to publish.")
+
+        self._run_command(
+            ["git", "push", "origin", f"HEAD:{safe_branch_name}"],
+            worktree_path,
+        )
+        create_command = [
+            "gh",
+            "pr",
+            "create",
+            "--draft",
+            "--base",
+            safe_base_branch,
+            "--head",
+            safe_branch_name,
+            "--title",
+            title_text,
+            "--body",
+            body_text,
+        ]
+        try:
+            output = self._run_command(create_command, worktree_path)
+        except DraftPrPublisherError as exc:
+            if url := _extract_pr_url(str(exc)):
+                return url
+            raise
+        if not (match := _extract_pr_url(output)):
+            raise DraftPrPublisherError("gh did not return a draft PR URL.")
+        return match
+
+    def _default_run(self, cmd: list[str], cwd: Path | None = None) -> str:
+        try:
+            proc = subprocess.run(
+                cmd,
+                cwd=str(cwd) if cwd else None,
+                text=True,
+                capture_output=True,
+                check=False,
+                timeout=self.timeout_seconds,
+            )
+        except FileNotFoundError as exc:
+            executable = cmd[0] if cmd else "command"
+            raise DraftPrPublisherError(f"executable not found: {executable}") from exc
+        except subprocess.TimeoutExpired as exc:
+            raise DraftPrPublisherError(f"command timed out: {' '.join(cmd)}") from exc
+        if proc.returncode != 0:
+            raise DraftPrPublisherError(_command_failure_message(cmd, cwd, proc))
+        return proc.stdout
+
+
+def _command_failure_message(
+    cmd: list[str],
+    cwd: Path | None,
+    proc: subprocess.CompletedProcess[str],
+) -> str:
+    return "\n".join(
+        part
+        for part in [
+            f"command failed ({proc.returncode}): {' '.join(cmd)}",
+            f"cwd: {cwd}" if cwd else "",
+            f"stdout: {_tail(proc.stdout)}" if _tail(proc.stdout) else "",
+            f"stderr: {_tail(proc.stderr)}" if _tail(proc.stderr) else "",
+        ]
+        if part
+    )
+
+
+def _tail(value: str | None, *, limit: int = 2000) -> str:
+    return str(value or "").strip()[-limit:]
+
+
+def _extract_pr_url(value: str) -> str:
+    match = re.search(r"https://\S+/pull/\d+", str(value or ""))
+    return match.group(0) if match else ""
+
+
+def _validate_pr_body(body: str) -> None:
+    if not _has_named_link(body, "Linear"):
+        raise DraftPrPublisherError("body must include Linear issue context.")
+    if not _has_named_link(body, "Slack"):
+        raise DraftPrPublisherError("body must include Slack thread context.")
+    if not _verification_section_text(body):
+        raise DraftPrPublisherError("body must include verification evidence.")
+    if not _proof_section_text(body):
+        raise DraftPrPublisherError("body must include proof evidence.")
+
+
+def _has_named_link(body: str, label: str) -> bool:
+    pattern = re.compile(rf"(?im)^\s*(?:-\s*)?{re.escape(label)}\s*:\s*(.+?)\s*$")
+    match = pattern.search(body)
+    if not match:
+        return False
+    value = match.group(1).strip()
+    return bool(value and value.lower() not in {"unavailable", "none", "n/a"})
+
+
+def _verification_section_text(body: str) -> str:
+    match = re.search(r"(?ims)^##\s+Verification\s*$([\s\S]*?)(?:^##\s+|\Z)", body)
+    if not match:
+        return ""
+    return re.sub(r"[`#\s-]+", "", match.group(1)).strip()
+
+
+def _proof_section_text(body: str) -> str:
+    match = re.search(r"(?ims)^##\s+Proof\s*$([\s\S]*?)(?:^##\s+|\Z)", body)
+    if not match:
+        return ""
+    return re.sub(r"[`#\s-]+", "", match.group(1)).strip()

--- a/plugins/mobile_bug_agent/proof.py
+++ b/plugins/mobile_bug_agent/proof.py
@@ -1,0 +1,212 @@
+import json
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+from .config import MonicaConfig, runtime_root
+
+_MANIFEST_NAME = "monica-proof-manifest.json"
+
+
+@dataclass(frozen=True)
+class ProofResult:
+    passed: bool
+    summary: str
+    output: str
+    artifacts: tuple[str, ...]
+    platforms: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "passed": self.passed,
+            "summary": self.summary,
+            "output": self.output,
+            "artifacts": list(self.artifacts),
+            "platforms": list(self.platforms),
+        }
+
+
+RunCommand = Callable[[str, Path, int, dict[str, str]], tuple[int, str, str]]
+
+
+class ProofRunner:
+    def __init__(
+        self,
+        *,
+        config: MonicaConfig,
+        run_command: RunCommand | None = None,
+    ) -> None:
+        self.config = config
+        self._run_command = run_command or self._default_run
+
+    def run(
+        self,
+        *,
+        run: Any,
+        worktree: str | Path,
+        verification: dict[str, Any] | None = None,
+    ) -> ProofResult:
+        worktree_path = Path(worktree)
+        command_list = tuple(command for command in self.config.proof.commands if command.strip())
+        platforms = tuple(platform for platform in self.config.proof.platform_order if platform.strip())
+        proof_dir = self._proof_dir(run)
+        proof_dir.mkdir(parents=True, exist_ok=True)
+
+        if not worktree_path.is_dir():
+            return ProofResult(
+                passed=False,
+                summary="Proof blocked: worktree does not exist.",
+                output=f"Worktree does not exist: {worktree_path}",
+                artifacts=(),
+                platforms=platforms,
+            )
+        if not (worktree_path / ".git").exists():
+            return ProofResult(
+                passed=False,
+                summary="Proof blocked: worktree is not a git worktree.",
+                output=f"Worktree is not a git worktree: {worktree_path}",
+                artifacts=(),
+                platforms=platforms,
+            )
+        if not command_list:
+            return ProofResult(
+                passed=False,
+                summary="Proof blocked: proof.commands is empty.",
+                output="mobile_bug_agent.proof.commands is empty.",
+                artifacts=(),
+                platforms=platforms,
+            )
+
+        output_parts: list[str] = []
+        timeout = self.config.proof.timeout_minutes * 60
+        env = self._proof_env(run=run, worktree=worktree_path, proof_dir=proof_dir)
+        for command in command_list:
+            code, stdout, stderr = self._run_command(command, worktree_path, timeout, env)
+            output_parts.append(
+                "\n".join(
+                    [
+                        f"$ {command}",
+                        stdout.strip(),
+                        stderr.strip(),
+                    ]
+                ).strip()
+            )
+            if code != 0:
+                return ProofResult(
+                    passed=False,
+                    summary=f"Proof blocked: {command}",
+                    output="\n\n".join(output_parts),
+                    artifacts=self._collect_artifacts(proof_dir),
+                    platforms=platforms,
+                )
+
+        artifacts = self._collect_artifacts(proof_dir)
+        if not artifacts:
+            return ProofResult(
+                passed=False,
+                summary="Proof blocked: proof commands produced no artifacts.",
+                output="\n\n".join(output_parts),
+                artifacts=(),
+                platforms=platforms,
+            )
+
+        manifest_path = self._write_manifest(
+            run=run,
+            worktree=worktree_path,
+            proof_dir=proof_dir,
+            artifacts=artifacts,
+            platforms=platforms,
+        )
+        artifacts = tuple(sorted((str(manifest_path), *artifacts)))
+        return ProofResult(
+            passed=True,
+            summary="Proof captured.",
+            output="\n\n".join(output_parts),
+            artifacts=artifacts,
+            platforms=platforms,
+        )
+
+    def _proof_dir(self, run: Any) -> Path:
+        raw_artifact_dir = self.config.proof.artifact_dir.strip() or "proof"
+        artifact_dir = Path(raw_artifact_dir).expanduser()
+        if artifact_dir.is_absolute():
+            root = artifact_dir
+        else:
+            root = runtime_root(self.config) / artifact_dir
+        return root / str(getattr(run, "id", "") or "unknown-run")
+
+    def _proof_env(self, *, run: Any, worktree: Path, proof_dir: Path) -> dict[str, str]:
+        env = dict(os.environ)
+        hermes_agent_root = Path(__file__).resolve().parents[2]
+        pythonpath_parts = [str(hermes_agent_root)]
+        if env.get("PYTHONPATH"):
+            pythonpath_parts.append(str(env["PYTHONPATH"]))
+        env.update(
+            {
+                "MONICA_HERMES_AGENT_ROOT": str(hermes_agent_root),
+                "MONICA_PROOF_DIR": str(proof_dir),
+                "MONICA_WORKTREE": str(worktree),
+                "MONICA_RUN_ID": str(getattr(run, "id", "") or ""),
+                "MONICA_LINEAR_IDENTIFIER": str(getattr(run, "linear_identifier", "") or ""),
+                "MONICA_PROOF_PLATFORM_ORDER": ",".join(self.config.proof.platform_order),
+                "MONICA_IOS_SIMULATOR_UDID": self.config.proof.ios_simulator_udid,
+                "MONICA_ANDROID_SERIAL": self.config.proof.android_serial,
+                "PYTHONPATH": os.pathsep.join(pythonpath_parts),
+            }
+        )
+        return env
+
+    @staticmethod
+    def _collect_artifacts(proof_dir: Path) -> tuple[str, ...]:
+        if not proof_dir.is_dir():
+            return ()
+        return tuple(
+            str(path)
+            for path in sorted(proof_dir.rglob("*"))
+            if path.is_file() and path.name != _MANIFEST_NAME
+        )
+
+    def _write_manifest(
+        self,
+        *,
+        run: Any,
+        worktree: Path,
+        proof_dir: Path,
+        artifacts: tuple[str, ...],
+        platforms: tuple[str, ...],
+    ) -> Path:
+        manifest_path = proof_dir / _MANIFEST_NAME
+        payload = {
+            "run_id": str(getattr(run, "id", "") or ""),
+            "linear_identifier": str(getattr(run, "linear_identifier", "") or ""),
+            "branch_name": str(getattr(run, "branch_name", "") or ""),
+            "worktree": str(worktree),
+            "platforms": list(platforms),
+            "proof_artifacts": list(artifacts),
+        }
+        manifest_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+        return manifest_path
+
+    @staticmethod
+    def _default_run(
+        command: str,
+        cwd: Path,
+        timeout: int,
+        env: dict[str, str],
+    ) -> tuple[int, str, str]:
+        try:
+            proc = subprocess.run(
+                command,
+                cwd=str(cwd),
+                shell=True,
+                text=True,
+                capture_output=True,
+                timeout=timeout,
+                check=False,
+                env=env,
+            )
+        except subprocess.TimeoutExpired:
+            return 124, "", f"command timed out after {timeout}s"
+        return proc.returncode, proc.stdout, proc.stderr

--- a/plugins/mobile_bug_agent/readiness.py
+++ b/plugins/mobile_bug_agent/readiness.py
@@ -1,0 +1,423 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import re
+import shutil
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from .config import MonicaConfig, runtime_root
+from .repo_manager import (
+    RepoManagerError,
+    safe_branch_prefix,
+    safe_default_branch,
+    safe_repo_local_name,
+)
+from .secrets import MONICA_SLACK_APP_TOKEN, MONICA_SLACK_BOT_TOKEN
+
+_SLACK_CHANNEL_ID_RE = re.compile(r"^[CDG][A-Z0-9]{2,}$")
+_SLACK_USER_ID_RE = re.compile(r"^[UW][A-Z0-9_]{2,}$")
+
+
+@dataclass(frozen=True)
+class ReadinessIssue:
+    code: str
+    message: str
+
+
+@dataclass(frozen=True)
+class ReadinessReport:
+    rollout_mode: str
+    runtime_root_value: str
+    warnings: tuple[ReadinessIssue, ...]
+    failures: tuple[ReadinessIssue, ...]
+
+    @property
+    def ready(self) -> bool:
+        return not self.failures
+
+    def first_approval_failure(self) -> str:
+        if not self.failures:
+            return ""
+        by_code = {issue.code: issue.message for issue in self.failures}
+        for code in _APPROVAL_FAILURE_PRIORITY:
+            message = by_code.get(code)
+            if message:
+                return message
+        return self.failures[0].message
+
+
+def check_monica_readiness(
+    *,
+    config: MonicaConfig,
+    environ: dict[str, str] | None = None,
+    which: Callable[[str], str | None] | None = None,
+    module_available: Callable[[str], bool] | None = None,
+    command_succeeds: Callable[[tuple[str, ...]], bool] | None = None,
+) -> ReadinessReport:
+    env = environ if environ is not None else os.environ
+    resolve = which or shutil.which
+    has_module = module_available or _module_available
+    command_ok = command_succeeds or _command_succeeds
+    verify_commands = command_succeeds is not None or which is None
+    failures: list[ReadinessIssue] = []
+    warnings: list[ReadinessIssue] = []
+    runtime_root_value = ""
+
+    def require(code: str, condition: bool, message: str) -> None:
+        if not condition:
+            failures.append(ReadinessIssue(code, message))
+
+    def warn(code: str, condition: bool, message: str) -> None:
+        if not condition:
+            warnings.append(ReadinessIssue(code, message))
+
+    require("config_enabled", config.enabled, "mobile_bug_agent.enabled is false")
+    try:
+        runtime_root_value = str(runtime_root(config))
+    except ValueError as exc:
+        failures.append(ReadinessIssue("runtime_root", str(exc)))
+    require(
+        "runtime_chandler",
+        not _runtime_path_mentions_chandler(config.runtime.home_subdir),
+        "mobile_bug_agent.runtime.home_subdir must not point at a Chandler runtime path",
+    )
+    require(
+        "slack_bot_token",
+        _has_secret(env, MONICA_SLACK_BOT_TOKEN),
+        f"{MONICA_SLACK_BOT_TOKEN} is missing",
+    )
+    require(
+        "slack_sdk",
+        bool(has_module("slack_sdk")),
+        "slack-sdk Python package is not installed; install `hermes-agent[slack]` or `hermes-agent[messaging]`",
+    )
+    warn(
+        "slack_app_token",
+        _has_secret(env, MONICA_SLACK_APP_TOKEN),
+        f"{MONICA_SLACK_APP_TOKEN} is missing; Monica Slack Socket Mode may not start",
+    )
+    warn(
+        "slack_bot_user_ids_empty_warning",
+        bool(config.slack.bot_user_ids),
+        "slack.bot_user_ids is empty; Monica will rely only on app_mention events",
+    )
+    bot_id_values = [
+        user_id for user_id in config.slack.bot_user_ids if user_id.upper().startswith("B")
+    ]
+    require(
+        "slack_bot_id_value",
+        not bot_id_values,
+        (
+            "slack.bot_user_ids must contain Slack mention user IDs like U012ABCDEF, "
+            f"not bot_id values like {bot_id_values[0]}"
+        ) if bot_id_values else "",
+    )
+    handle_style_bot_ids = [
+        user_id for user_id in config.slack.bot_user_ids if str(user_id).strip().startswith("@")
+    ]
+    require(
+        "slack_bot_handle_value",
+        not handle_style_bot_ids,
+        (
+            "slack.bot_user_ids must contain Slack mention user IDs like U012ABCDEF, "
+            f"not handles like {handle_style_bot_ids[0]}"
+        ) if handle_style_bot_ids else "",
+    )
+    invalid_bot_user_ids = [
+        user_id
+        for user_id in config.slack.bot_user_ids
+        if not str(user_id).strip().startswith("@")
+        and not str(user_id).upper().startswith("B")
+        and not _is_slack_user_id(user_id)
+    ]
+    require(
+        "slack_bot_user_id_invalid",
+        not invalid_bot_user_ids,
+        (
+            "slack.bot_user_ids must contain Slack mention user IDs like U012ABCDEF, "
+            f"not invalid values like {invalid_bot_user_ids[0]}"
+        ) if invalid_bot_user_ids else "",
+    )
+    invalid_channels = [
+        channel for channel in config.slack.allowed_channels if not _is_slack_channel_id(channel)
+    ]
+    require(
+        "slack_allowed_channel_invalid",
+        not invalid_channels,
+        (
+            "slack.allowed_channels must contain Slack channel IDs like C123 or G123, "
+            f"not names like {invalid_channels[0]}"
+        ) if invalid_channels else "",
+    )
+
+    side_effect_rollout = config.rollout_mode in {"linear_only", "local_fix_only", "approved_pr"}
+    if side_effect_rollout:
+        require(
+            "slack_bot_user_ids_empty",
+            bool(config.slack.bot_user_ids),
+            "slack.bot_user_ids is empty; configure Monica's Slack mention user ID",
+        )
+        require(
+            "slack_allowed_channels_empty",
+            bool(config.slack.allowed_channels),
+            "slack.allowed_channels is empty; configure the Slack channels Monica may act in",
+        )
+    else:
+        warn(
+            "slack_allowed_channels_empty_warning",
+            bool(config.slack.allowed_channels),
+            "slack.allowed_channels is empty; Monica can run in any channel where the Slack app is present",
+        )
+
+    scopes = _scope_set(env.get("SLACK_BOT_SCOPES") or env.get("SLACK_SCOPES"))
+    if scopes:
+        require(
+            "slack_scope_app_mentions",
+            "app_mentions:read" in scopes,
+            "SLACK_BOT_SCOPES is missing required scope: app_mentions:read",
+        )
+        require(
+            "slack_scope_chat_write",
+            "chat:write" in scopes,
+            "SLACK_BOT_SCOPES is missing required scope: chat:write",
+        )
+        require(
+            "slack_scope_history",
+            bool(scopes & {"channels:history", "groups:history", "im:history", "mpim:history"}),
+            "SLACK_BOT_SCOPES needs at least one thread history scope: channels:history, groups:history, im:history, or mpim:history",
+        )
+        if config.slack.download_attachments:
+            require(
+                "slack_scope_files_read",
+                "files:read" in scopes,
+                "SLACK_BOT_SCOPES is missing required scope: files:read",
+            )
+
+    if config.rollout_mode not in {"dry_run", "linear_only", "local_fix_only", "approved_pr"}:
+        failures.append(ReadinessIssue("rollout_mode", f"unknown rollout_mode: {config.rollout_mode}"))
+
+    if config.rollout_mode in {"linear_only", "local_fix_only", "approved_pr"}:
+        require(
+            "loop_create_linear",
+            config.loop.create_linear,
+            f"loop.create_linear must be true in {config.rollout_mode} mode",
+        )
+
+    if config.rollout_mode in {"linear_only", "local_fix_only", "approved_pr"} and config.loop.create_linear:
+        require("linear_api_key", _has_secret(env, "LINEAR_API_KEY"), "LINEAR_API_KEY is missing")
+        require("linear_team_id", bool(config.linear.team_id), "linear.team_id is missing")
+
+    if config.rollout_mode in {"local_fix_only", "approved_pr"}:
+        require(
+            "loop_require_fix_approval",
+            config.loop.require_fix_approval,
+            f"loop.require_fix_approval must be true in {config.rollout_mode} mode",
+        )
+        require(
+            "worker_session_prefix",
+            "monica" in config.runtime.worker_session_prefix.lower(),
+            "runtime.worker_session_prefix must include `monica` to keep worker sessions segregated",
+        )
+        require("repo_url", bool(config.repo.url), "repo.url is missing")
+        try:
+            safe_repo_local_name(config.repo.local_name)
+        except RepoManagerError as exc:
+            failures.append(ReadinessIssue("repo_local_name", str(exc)))
+        try:
+            safe_branch_prefix(config.repo.branch_prefix)
+        except RepoManagerError as exc:
+            failures.append(ReadinessIssue("repo_branch_prefix", str(exc)))
+        try:
+            safe_default_branch(config.repo.default_branch)
+        except RepoManagerError as exc:
+            failures.append(ReadinessIssue("repo_default_branch", str(exc)))
+        require("verification_commands", bool(config.verification.commands), "verification.commands is empty")
+        require("git_executable", resolve("git") is not None, "git executable was not found")
+        if config.rollout_mode == "approved_pr":
+            require("gh_executable", resolve("gh") is not None, "gh executable was not found")
+        if config.worker.backend == "codex_cli":
+            require(
+                "codex_executable",
+                resolve(config.worker.codex_command) is not None,
+                f"{config.worker.codex_command} executable was not found",
+            )
+            require(
+                "codex_approval_policy",
+                config.worker.codex_approval_policy == "never",
+                f"worker.codex_approval_policy must be `never` for {config.rollout_mode} codex_cli runs",
+            )
+            require(
+                "codex_sandbox",
+                config.worker.codex_sandbox == "workspace-write",
+                f"worker.codex_sandbox must be `workspace-write` for {config.rollout_mode} codex_cli runs",
+            )
+        elif config.worker.backend != "internal_agent":
+            failures.append(ReadinessIssue("worker_backend", f"unknown worker.backend: {config.worker.backend}"))
+        if config.rollout_mode == "approved_pr":
+            warn(
+                "github_token",
+                _has_secret(env, "GITHUB_TOKEN"),
+                "GITHUB_TOKEN is missing; this is okay only if gh is already authenticated",
+            )
+        if config.proof.enabled or config.proof.required_for_done:
+            warn(
+                "proof_commands_empty",
+                bool(config.proof.commands),
+                "proof.commands is empty; Monica will block at proof after verification",
+            )
+            proof_platforms = {platform.lower() for platform in config.proof.platform_order}
+            if "ios" in proof_platforms:
+                ios_tools_present = resolve("xcrun") is not None and resolve("xcodebuild") is not None
+                ios_ready = ios_tools_present and (
+                    not verify_commands
+                    or (
+                        command_ok(("xcrun", "--find", "simctl"))
+                        and command_ok(("xcodebuild", "-version"))
+                    )
+                )
+                warn(
+                    "ios_proof_tooling",
+                    ios_ready,
+                    (
+                        "iOS proof is configured but xcrun/simctl or xcodebuild was not found; "
+                        "Monica will block at proof until a simulator is available"
+                    ),
+                )
+            if "android" in proof_platforms:
+                warn(
+                    "android_proof_tooling",
+                    resolve("adb") is not None and resolve("emulator") is not None,
+                    (
+                        "Android proof is configured but adb or emulator was not found; "
+                        "Monica will block at proof until an emulator is available"
+                    ),
+                )
+        require(
+            "slack_approvers_empty",
+            bool(config.slack.approver_user_ids),
+            "slack.approver_user_ids is empty; configure at least one Monica code approver",
+        )
+        handle_style_approvers = [
+            user_id
+            for user_id in config.slack.approver_user_ids
+            if str(user_id).strip().startswith("@")
+        ]
+        require(
+            "slack_approver_handle_value",
+            not handle_style_approvers,
+            (
+                "slack.approver_user_ids must contain Slack user IDs like U123, "
+                f"not handles like {handle_style_approvers[0]}"
+            ) if handle_style_approvers else "",
+        )
+        invalid_approvers = [
+            user_id
+            for user_id in config.slack.approver_user_ids
+            if not str(user_id).strip().startswith("@")
+            and not _is_slack_user_id(user_id)
+        ]
+        require(
+            "slack_approver_invalid",
+            not invalid_approvers,
+            (
+                "slack.approver_user_ids must contain Slack user IDs like U123, "
+                f"not invalid values like {invalid_approvers[0]}"
+            ) if invalid_approvers else "",
+        )
+
+    return ReadinessReport(
+        rollout_mode=config.rollout_mode,
+        runtime_root_value=runtime_root_value,
+        warnings=tuple(warnings),
+        failures=tuple(failures),
+    )
+
+
+_APPROVAL_FAILURE_PRIORITY = (
+    "config_enabled",
+    "rollout_mode",
+    "loop_create_linear",
+    "loop_require_fix_approval",
+    "worker_session_prefix",
+    "runtime_root",
+    "runtime_chandler",
+    "linear_api_key",
+    "linear_team_id",
+    "repo_url",
+    "repo_local_name",
+    "repo_branch_prefix",
+    "repo_default_branch",
+    "verification_commands",
+    "slack_approvers_empty",
+    "slack_approver_handle_value",
+    "slack_approver_invalid",
+    "git_executable",
+    "gh_executable",
+    "worker_backend",
+    "codex_executable",
+    "codex_approval_policy",
+    "codex_sandbox",
+    "slack_bot_token",
+    "slack_sdk",
+    "slack_bot_user_ids_empty",
+    "slack_bot_id_value",
+    "slack_bot_handle_value",
+    "slack_bot_user_id_invalid",
+    "slack_allowed_channels_empty",
+    "slack_allowed_channel_invalid",
+    "slack_scope_app_mentions",
+    "slack_scope_chat_write",
+    "slack_scope_history",
+    "slack_scope_files_read",
+)
+
+
+def _has_secret(env: dict[str, str], key: str) -> bool:
+    return bool(str(env.get(key) or "").strip())
+
+
+def _module_available(name: str) -> bool:
+    return importlib.util.find_spec(name) is not None
+
+
+def _command_succeeds(command: tuple[str, ...]) -> bool:
+    try:
+        proc = subprocess.run(
+            command,
+            text=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return proc.returncode == 0
+
+
+def _scope_set(value: object) -> set[str]:
+    return {
+        part.strip()
+        for part in str(value or "").replace("\n", ",").replace(" ", ",").split(",")
+        if part.strip()
+    }
+
+
+def _is_slack_channel_id(value: str) -> bool:
+    return bool(_SLACK_CHANNEL_ID_RE.fullmatch(str(value or "").strip()))
+
+
+def _is_slack_user_id(value: str) -> bool:
+    return bool(_SLACK_USER_ID_RE.fullmatch(str(value or "").strip()))
+
+
+def _runtime_path_mentions_chandler(value: str) -> bool:
+    return any(
+        "chandler" in part.lower()
+        for part in re.split(r"[\\/]+", str(value or ""))
+        if part
+    )

--- a/plugins/mobile_bug_agent/repo_manager.py
+++ b/plugins/mobile_bug_agent/repo_manager.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+from .config import RepoConfig
+
+
+class RepoManagerError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class Worktree:
+    branch_name: str
+    path: Path
+
+
+RunCommand = Callable[[list[str], Path | None], str]
+_UNSAFE_GIT_REF_CHARS_RE = re.compile(r"[\s~^:?*\\[\]\x00-\x1f\x7f]")
+
+
+class RepoManager:
+    def __init__(
+        self,
+        *,
+        config: RepoConfig,
+        workspace_root: str | Path,
+        run_command: RunCommand | None = None,
+        timeout_seconds: int = 300,
+    ) -> None:
+        self.config = config
+        self.workspace_root = Path(workspace_root)
+        self._run_command = run_command or self._default_run
+        self.timeout_seconds = timeout_seconds
+
+    def prepare_worktree(self, *, linear_identifier: str, summary: str) -> Worktree:
+        if not self.config.url:
+            raise RepoManagerError("mobile_bug_agent.repo.url is not configured.")
+
+        local_name = safe_repo_local_name(self.config.local_name)
+        default_branch = safe_default_branch(self.config.default_branch)
+        branch_prefix = safe_branch_prefix(self.config.branch_prefix)
+        repo_path = self.workspace_root / "repos" / local_name
+        worktrees_root = self.workspace_root / "worktrees"
+        repo_path.parent.mkdir(parents=True, exist_ok=True)
+        worktrees_root.mkdir(parents=True, exist_ok=True)
+
+        if repo_path.exists():
+            if not repo_path.is_dir():
+                raise RepoManagerError(f"repo path exists but is not a directory: {repo_path}")
+            self._run_command(
+                [
+                    "git",
+                    "-C",
+                    str(repo_path),
+                    "fetch",
+                    "origin",
+                    default_branch,
+                ],
+                None,
+            )
+        else:
+            self._run_command(["git", "clone", self.config.url, str(repo_path)], None)
+
+        branch_name = self._branch_name(
+            branch_prefix=branch_prefix,
+            linear_identifier=linear_identifier,
+            summary=summary,
+        )
+        worktree_path = worktrees_root / branch_name.replace("/", "-")
+        if worktree_path.exists():
+            if not worktree_path.is_dir():
+                raise RepoManagerError(f"worktree path exists but is not a directory: {worktree_path}")
+            if not _looks_like_git_worktree(worktree_path):
+                raise RepoManagerError(f"worktree path exists but is not a git worktree: {worktree_path}")
+            current_branch = self._run_command(
+                ["git", "-C", str(worktree_path), "branch", "--show-current"],
+                None,
+            ).strip()
+            if current_branch != branch_name:
+                raise RepoManagerError(
+                    f"worktree branch mismatch: expected {branch_name}, got {current_branch or 'detached HEAD'}"
+                )
+            return Worktree(branch_name=branch_name, path=worktree_path)
+
+        self._run_command(
+            [
+                "git",
+                "-C",
+                str(repo_path),
+                "worktree",
+                "add",
+                "-B",
+                branch_name,
+                str(worktree_path),
+                f"origin/{default_branch}",
+            ],
+            None,
+        )
+        return Worktree(branch_name=branch_name, path=worktree_path)
+
+    def _branch_name(self, *, branch_prefix: str, linear_identifier: str, summary: str) -> str:
+        ident = _slug(linear_identifier, fallback="slack", lowercase=False)
+        summary_slug = _slug(summary, fallback="bug", lowercase=True)
+        return f"{branch_prefix}/{ident}-{summary_slug}"
+
+    def _default_run(self, cmd: list[str], cwd: Path | None = None) -> str:
+        try:
+            proc = subprocess.run(
+                cmd,
+                cwd=str(cwd) if cwd else None,
+                check=False,
+                text=True,
+                capture_output=True,
+                timeout=self.timeout_seconds,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RepoManagerError(
+                "\n".join(
+                    part
+                    for part in [
+                        f"command timed out after {self.timeout_seconds}s: {' '.join(cmd)}",
+                        f"cwd: {cwd}" if cwd else "",
+                    ]
+                    if part
+                )
+            ) from exc
+        except FileNotFoundError as exc:
+            executable = cmd[0] if cmd else "command"
+            raise RepoManagerError(f"executable not found: {executable}") from exc
+        if proc.returncode != 0:
+            stdout = _tail(proc.stdout)
+            stderr = _tail(proc.stderr)
+            raise RepoManagerError(
+                "\n".join(
+                    part
+                    for part in [
+                        f"command failed ({proc.returncode}): {' '.join(cmd)}",
+                        f"cwd: {cwd}" if cwd else "",
+                        f"stdout: {stdout}" if stdout else "",
+                        f"stderr: {stderr}" if stderr else "",
+                    ]
+                    if part
+                )
+            )
+        return proc.stdout
+
+
+def _slug(value: str, *, fallback: str, lowercase: bool) -> str:
+    source = value.strip().lower() if lowercase else value.strip()
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", source).strip("-")
+    slug = re.sub(r"-+", "-", slug)
+    return (slug or fallback)[:80]
+
+
+def _looks_like_git_worktree(path: Path) -> bool:
+    return (path / ".git").exists()
+
+
+def safe_repo_local_name(value: str) -> str:
+    name = value.strip()
+    path = Path(name)
+    if not name or path.is_absolute() or len(path.parts) != 1 or name in {".", ".."}:
+        raise RepoManagerError("repo.local_name must be a simple directory name.")
+    if "chandler" in name.lower():
+        raise RepoManagerError("repo.local_name must not point at a Chandler directory.")
+    return name
+
+
+def safe_branch_prefix(value: str) -> str:
+    prefix = str(value or "").strip()
+    if not is_safe_git_branch_name(prefix):
+        raise RepoManagerError("repo.branch_prefix must be a safe git branch prefix.")
+    if "chandler" in prefix.lower():
+        raise RepoManagerError("repo.branch_prefix must not point at Chandler.")
+    return prefix
+
+
+def safe_default_branch(value: str) -> str:
+    branch = str(value or "").strip()
+    if not is_safe_git_branch_name(branch):
+        raise RepoManagerError("repo.default_branch must be a safe git branch name.")
+    return branch
+
+
+def is_safe_git_branch_name(value: str) -> bool:
+    branch = str(value or "").strip()
+    if not branch or branch.startswith("/") or branch.endswith("/") or "//" in branch:
+        return False
+    parts = branch.split("/")
+    return not (
+        branch == "@"
+        or "@{" in branch
+        or ".." in branch
+        or any(
+            not part
+            or part in {".", ".."}
+            or part.startswith((".", "-"))
+            or part.endswith(".")
+            or part.endswith(".lock")
+            or _UNSAFE_GIT_REF_CHARS_RE.search(part)
+            for part in parts
+        )
+    )
+
+
+def _tail(value: str, *, limit: int = 2000) -> str:
+    return value.strip()[-limit:]

--- a/plugins/mobile_bug_agent/secrets.py
+++ b/plugins/mobile_bug_agent/secrets.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+MONICA_SLACK_BOT_TOKEN = "MONICA_SLACK_BOT_TOKEN"
+MONICA_SLACK_APP_TOKEN = "MONICA_SLACK_APP_TOKEN"
+MONICA_LINEAR_API_KEY = "MONICA_LINEAR_API_KEY"
+MONICA_GITHUB_TOKEN = "MONICA_GITHUB_TOKEN"
+
+
+def secret_value(env: Mapping[str, str] | None, key: str) -> str:
+    source = env if env is not None else os.environ
+    return str(source.get(key) or "").strip()
+
+
+def monica_slack_bot_token(env: Mapping[str, str] | None = None) -> str:
+    return secret_value(env, MONICA_SLACK_BOT_TOKEN)
+
+
+def monica_slack_app_token(env: Mapping[str, str] | None = None) -> str:
+    return secret_value(env, MONICA_SLACK_APP_TOKEN)

--- a/plugins/mobile_bug_agent/simulator_proof.py
+++ b/plugins/mobile_bug_agent/simulator_proof.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from typing import Callable, Sequence
+
+
+RunText = Callable[[tuple[str, ...], Path, int], str]
+RunBytes = Callable[[tuple[str, ...], Path, int], bytes]
+
+
+class SimulatorProofHarness:
+    def __init__(
+        self,
+        *,
+        run_text: RunText | None = None,
+        run_bytes: RunBytes | None = None,
+    ) -> None:
+        self._run_text = run_text or _run_text_command
+        self._run_bytes = run_bytes or _run_bytes_command
+
+    def run(
+        self,
+        *,
+        worktree: str | Path,
+        proof_dir: str | Path,
+        platforms: Sequence[str],
+        ios_simulator_udid: str = "",
+        android_serial: str = "",
+        deep_link: str = "",
+        timeout_seconds: int = 600,
+    ) -> list[str]:
+        worktree_path = Path(worktree)
+        proof_path = Path(proof_dir)
+        self._validate_worktree(worktree_path)
+        proof_path.mkdir(parents=True, exist_ok=True)
+
+        artifacts: list[str] = []
+        for platform in _clean_platforms(platforms):
+            if platform == "ios":
+                artifacts.append(
+                    self._capture_ios(
+                        worktree=worktree_path,
+                        proof_dir=proof_path,
+                        simulator_udid=ios_simulator_udid,
+                        deep_link=deep_link,
+                        timeout_seconds=timeout_seconds,
+                    )
+                )
+            elif platform == "android":
+                artifacts.append(
+                    self._capture_android(
+                        worktree=worktree_path,
+                        proof_dir=proof_path,
+                        android_serial=android_serial,
+                        deep_link=deep_link,
+                        timeout_seconds=timeout_seconds,
+                    )
+                )
+            else:
+                raise RuntimeError(f"unsupported proof platform: {platform}")
+        return artifacts
+
+    @staticmethod
+    def _validate_worktree(worktree: Path) -> None:
+        if not worktree.is_dir():
+            raise RuntimeError(f"worktree does not exist: {worktree}")
+        if not (worktree / ".git").exists():
+            raise RuntimeError(f"worktree is not a git worktree: {worktree}")
+        if not (worktree / "package.json").exists():
+            raise RuntimeError(f"package.json was not found in worktree: {worktree}")
+
+    def _capture_ios(
+        self,
+        *,
+        worktree: Path,
+        proof_dir: Path,
+        simulator_udid: str,
+        deep_link: str,
+        timeout_seconds: int,
+    ) -> str:
+        target = simulator_udid.strip() or "booted"
+        screenshot = proof_dir / "ios-screenshot.png"
+        self._run_text(("xcrun", "--find", "simctl"), worktree, timeout_seconds)
+        self._run_text(("xcodebuild", "-version"), worktree, timeout_seconds)
+        self._run_text(("npm", "run", "ios"), worktree, timeout_seconds)
+        if deep_link.strip():
+            self._run_text(("xcrun", "simctl", "openurl", target, deep_link.strip()), worktree, timeout_seconds)
+        self._run_text(("xcrun", "simctl", "io", target, "screenshot", str(screenshot)), worktree, timeout_seconds)
+        if not screenshot.is_file():
+            raise RuntimeError(f"iOS simulator screenshot was not created: {screenshot}")
+        return str(screenshot)
+
+    def _capture_android(
+        self,
+        *,
+        worktree: Path,
+        proof_dir: Path,
+        android_serial: str,
+        deep_link: str,
+        timeout_seconds: int,
+    ) -> str:
+        screenshot = proof_dir / "android-screenshot.png"
+        adb = ("adb", "-s", android_serial.strip()) if android_serial.strip() else ("adb",)
+        self._run_text((*adb, "version"), worktree, timeout_seconds)
+        self._run_text(("emulator", "-list-avds"), worktree, timeout_seconds)
+        self._run_text(("npm", "run", "android"), worktree, timeout_seconds)
+        if deep_link.strip():
+            self._run_text(
+                (
+                    *adb,
+                    "shell",
+                    "am",
+                    "start",
+                    "-a",
+                    "android.intent.action.VIEW",
+                    "-d",
+                    deep_link.strip(),
+                ),
+                worktree,
+                timeout_seconds,
+            )
+        screenshot.write_bytes(self._run_bytes((*adb, "exec-out", "screencap", "-p"), worktree, timeout_seconds))
+        if not screenshot.is_file() or screenshot.stat().st_size == 0:
+            raise RuntimeError(f"Android emulator screenshot was not created: {screenshot}")
+        return str(screenshot)
+
+
+def _clean_platforms(platforms: Sequence[str]) -> tuple[str, ...]:
+    values = tuple(str(platform).strip().lower() for platform in platforms if str(platform).strip())
+    return values or ("ios", "android")
+
+
+def _run_text_command(args: tuple[str, ...], cwd: Path, timeout: int) -> str:
+    proc = _run(args, cwd, timeout, capture_bytes=False)
+    return str(proc.stdout or "")
+
+
+def _run_bytes_command(args: tuple[str, ...], cwd: Path, timeout: int) -> bytes:
+    proc = _run(args, cwd, timeout, capture_bytes=True)
+    return bytes(proc.stdout or b"")
+
+
+def _run(
+    args: tuple[str, ...],
+    cwd: Path,
+    timeout: int,
+    *,
+    capture_bytes: bool,
+) -> subprocess.CompletedProcess[str] | subprocess.CompletedProcess[bytes]:
+    try:
+        proc = subprocess.run(
+            list(args),
+            cwd=str(cwd),
+            text=not capture_bytes,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError(f"executable not found: {args[0]}") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"command timed out: {' '.join(args)}") from exc
+    if proc.returncode != 0:
+        stderr = proc.stderr.decode("utf-8", errors="replace") if isinstance(proc.stderr, bytes) else proc.stderr
+        stdout = proc.stdout.decode("utf-8", errors="replace") if isinstance(proc.stdout, bytes) else proc.stdout
+        raise RuntimeError(
+            "\n".join(
+                part
+                for part in [
+                    f"command failed ({proc.returncode}): {' '.join(args)}",
+                    f"stdout: {str(stdout or '').strip()[-2000:]}",
+                    f"stderr: {str(stderr or '').strip()[-2000:]}",
+                ]
+                if part
+            )
+        )
+    return proc
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Capture Monica simulator proof artifacts.")
+    parser.add_argument("--worktree", default="")
+    parser.add_argument("--proof-dir", default="")
+    parser.add_argument("--platform", dest="platforms", action="append", default=[])
+    parser.add_argument("--ios-simulator-udid", default="")
+    parser.add_argument("--android-serial", default="")
+    parser.add_argument("--deep-link", default="")
+    parser.add_argument("--timeout-seconds", type=int, default=600)
+    args = parser.parse_args(argv)
+
+    import os
+
+    worktree = args.worktree or os.getenv("MONICA_WORKTREE", "")
+    proof_dir = args.proof_dir or os.getenv("MONICA_PROOF_DIR", "")
+    platforms = args.platforms or os.getenv("MONICA_PROOF_PLATFORM_ORDER", "").split(",")
+    deep_link = args.deep_link or os.getenv("MONICA_DEEP_LINK", "")
+    if not worktree:
+        raise SystemExit("MONICA_WORKTREE is required")
+    if not proof_dir:
+        raise SystemExit("MONICA_PROOF_DIR is required")
+
+    try:
+        artifacts = SimulatorProofHarness().run(
+            worktree=worktree,
+            proof_dir=proof_dir,
+            platforms=platforms,
+            ios_simulator_udid=args.ios_simulator_udid or os.getenv("MONICA_IOS_SIMULATOR_UDID", ""),
+            android_serial=args.android_serial or os.getenv("MONICA_ANDROID_SERIAL", ""),
+            deep_link=deep_link,
+            timeout_seconds=max(args.timeout_seconds, 1),
+        )
+    except RuntimeError as exc:
+        raise SystemExit(str(exc)) from exc
+    print(json.dumps({"artifacts": artifacts}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/plugins/mobile_bug_agent/skills.py
+++ b/plugins/mobile_bug_agent/skills.py
@@ -1,0 +1,730 @@
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from .config import MonicaConfig, runtime_root
+from .codex_worker import build_code_worker
+from .intent import IntentClassifier
+from .linear_client import LinearAttachmentPayload, LinearClient, LinearIssuePayload
+from .pr_publisher import DraftPrPublisher
+from .proof import ProofRunner
+from .repo_manager import RepoManager
+from .secrets import monica_slack_bot_token
+from .slack_client import SlackClientError, SlackThreadClient
+from .state import MonicaState
+from .verifier import VerificationRunner
+
+logger = logging.getLogger(__name__)
+
+
+class DefaultMonicaSkills:
+    """Small v1 skill set used by the background loop.
+
+    This is deliberately conservative. It gives Monica an agentic loop shape
+    while defaulting to dry-run-safe behavior until real Linear/repo settings
+    are configured.
+    """
+
+    def __init__(
+        self,
+        *,
+        config: MonicaConfig,
+        state: MonicaState,
+        linear_client: Any | None = None,
+        repo_manager: Any | None = None,
+        codex_worker: Any | None = None,
+        slack_client: Any | None = None,
+        intent_classifier: Any | None = None,
+        verifier: Any | None = None,
+        proof_runner: Any | None = None,
+        pr_publisher: Any | None = None,
+    ) -> None:
+        self.config = config
+        self.state = state
+        self._linear_client = linear_client
+        self._repo_manager = repo_manager
+        self._codex_worker = codex_worker
+        self._slack_client = slack_client
+        self._intent_classifier = intent_classifier
+        self._verifier = verifier
+        self._proof_runner = proof_runner
+        self._pr_publisher = pr_publisher
+
+    def read_slack_thread(self, run: Any) -> dict[str, Any]:
+        raw_event = getattr(run, "raw_event", None)
+        if isinstance(raw_event, dict) and raw_event.get("monica_simulated"):
+            return self._fallback_thread_from_run(run)
+
+        client = self._resolve_slack_client(run)
+        if client is not None:
+            try:
+                context = client.read_thread(
+                    channel_id=run.channel_id,
+                    thread_ts=run.thread_ts,
+                    limit=self.config.loop.max_thread_messages,
+                )
+                return context.to_dict() if hasattr(context, "to_dict") else dict(context)
+            except Exception as exc:
+                fallback = self._fallback_thread_from_run(run)
+                fallback["context_errors"] = [f"Slack thread fetch failed: {exc}"]
+                return fallback
+        return self._fallback_thread_from_run(run)
+
+    @staticmethod
+    def _fallback_thread_from_run(run: Any) -> dict[str, Any]:
+        raw = getattr(run, "raw_event", None)
+        raw_event = raw if isinstance(raw, dict) else {}
+        permalink = str(raw_event.get("permalink") or "")
+        message_ts = str(raw_event.get("ts") or getattr(run, "message_ts", "") or "")
+        user_id = str(raw_event.get("user") or raw_event.get("bot_id") or getattr(run, "user_id", "") or "")
+        request_text = str(getattr(run, "request_text", "") or "").strip()
+        files = []
+        for item in raw_event.get("files") or []:
+            if not isinstance(item, dict):
+                continue
+            files.append(
+                {
+                    "id": str(item.get("id") or ""),
+                    "name": str(item.get("name") or item.get("title") or "Slack file"),
+                    "mimetype": str(item.get("mimetype") or ""),
+                    "url_private": str(item.get("url_private_download") or item.get("url_private") or ""),
+                    "permalink": str(item.get("permalink_public") or item.get("permalink") or ""),
+                }
+            )
+        for index, item in enumerate(raw_event.get("attachments") or [], start=1):
+            if not isinstance(item, dict):
+                continue
+            image_url = str(
+                item.get("image_url")
+                or item.get("thumb_url")
+                or item.get("url")
+                or ""
+            ).strip()
+            if not image_url:
+                continue
+            files.append(
+                {
+                    "id": f"attachment-{getattr(run, 'message_ts', '') or 'message'}-{index}",
+                    "name": str(
+                        item.get("title")
+                        or item.get("fallback")
+                        or item.get("text")
+                        or "Slack attachment"
+                    ),
+                    "mimetype": "image" if item.get("image_url") or item.get("thumb_url") else "",
+                    "url_private": image_url,
+                    "permalink": image_url,
+                }
+            )
+        return {
+            "channel_id": str(getattr(run, "channel_id", "") or ""),
+            "thread_ts": str(getattr(run, "thread_ts", "") or ""),
+            "permalink": permalink,
+            "messages": [request_text],
+            "message_details": [
+                {
+                    "user_id": user_id,
+                    "text": request_text,
+                    "ts": message_ts,
+                    "permalink": permalink,
+                }
+            ],
+            "files": files,
+            "attachments": [item.get("name") or item.get("id") or "Slack file" for item in files],
+        }
+
+    def infer_user_intent(self, run: Any, thread: dict[str, Any]) -> dict[str, Any]:
+        messages = [str(part) for part in thread.get("messages", [])]
+        classifier = self._intent_classifier or IntentClassifier(config=self.config)
+        result = classifier.classify(
+            request_text=run.request_text,
+            thread_text="\n".join(messages),
+        )
+        if hasattr(result, "to_dict"):
+            return result.to_dict()
+        return dict(result)
+
+    def create_or_update_linear(
+        self,
+        run: Any,
+        thread: dict[str, Any],
+        intent: dict[str, Any],
+    ) -> dict[str, Any]:
+        title = _linear_title(intent.get("summary") or run.request_text)
+        description = self._linear_description(run, thread, intent)
+        if self.config.rollout_mode == "dry_run":
+            return {
+                "id": "",
+                "identifier": "DRY-RUN",
+                "url": "",
+                "dry_run": True,
+                "title": title,
+                "description": description,
+                "attachments": [
+                    {
+                        "title": attachment.title,
+                        "url": attachment.url,
+                        "subtitle": attachment.subtitle,
+                    }
+                    for attachment in self._linear_attachment_payloads("", thread)
+                ],
+            }
+
+        client = self._linear_client or LinearClient(api_key=os.getenv("LINEAR_API_KEY", ""))
+        issue = client.create_or_update_issue(
+            LinearIssuePayload(
+                team_id=self.config.linear.team_id,
+                project_id=self.config.linear.project_id,
+                label_ids=self.config.linear.label_ids,
+                title=title,
+                description=description,
+            ),
+            existing_issue_id=run.linear_issue_id,
+        )
+        attachments, attachment_errors = self._attach_linear_evidence(client, issue.id, thread)
+        return {
+            "id": issue.id,
+            "identifier": issue.identifier,
+            "url": issue.url,
+            "dry_run": False,
+            "title": title,
+            "description": description,
+            "attachments": attachments,
+            "attachment_errors": attachment_errors,
+        }
+
+    def _linear_description(self, run: Any, thread: dict[str, Any], intent: dict[str, Any]) -> str:
+        body = _thread_context_lines(thread)
+        permalink = str(thread.get("permalink") or "").strip()
+        files = thread.get("files") or []
+        evidence = self._evidence_lines(files)
+        context_errors = thread.get("context_errors") or []
+        confidence = intent.get("confidence", "")
+        sections = [
+            "## Summary",
+            str(intent.get("summary") or run.request_text),
+            "",
+            "## Observed Behavior",
+            str(intent.get("observed_behavior") or intent.get("summary") or run.request_text),
+            "",
+            "## Expected Behavior",
+            str(intent.get("expected_behavior") or "Not specified."),
+            "",
+            "## Reproduction Context",
+            _markdown_list(intent.get("reproduction_steps")) or "- Not specified.",
+            "",
+            "## Platform And Build",
+            "\n".join(
+                [
+                    f"- Platforms: {_join_values(intent.get('platforms')) or 'Not specified.'}",
+                    f"- Device context: {intent.get('device_context') or 'Not specified.'}",
+                    f"- Build context: {intent.get('build_context') or 'Not specified.'}",
+                ]
+            ),
+            "",
+            "## Slack Context",
+            f"Slack thread: {permalink or 'unavailable'}",
+            f"Reporter: {run.user_id or 'unknown'}",
+            f"Channel: {run.channel_id}",
+            "",
+            "## Thread Context",
+            body,
+            "",
+            "## Evidence",
+            evidence or "- No files captured.",
+        ]
+        if context_errors:
+            sections.extend(
+                [
+                    "",
+                    "## Slack Fetch Notes",
+                    "\n".join(f"- {error}" for error in context_errors if str(error).strip()),
+                ]
+            )
+        if confidence != "":
+            sections.extend(
+                [
+                    "",
+                    "## Monica Triage",
+                    f"- Confidence: {confidence}",
+                    f"- Reason: {intent.get('reason', '') or 'No reason provided.'}",
+                ]
+            )
+        sections.extend(
+            [
+                "",
+                "## Fix Status",
+                self._fix_status_text(intent),
+            ]
+        )
+        return "\n".join(sections)
+
+    def ask_fix_approval(self, run: Any, issue: dict[str, Any]) -> None:
+        issue_ref = issue.get("url") or issue.get("identifier") or "the Linear issue"
+        approver_line = self._approver_line()
+        suffix = f"\n{approver_line}" if approver_line else ""
+        self.post_status(
+            run,
+            "I filed the mobile bug context and I am waiting for approval before code changes.\n"
+            f"Issue: {issue_ref}\n"
+            "Tag me in this thread with `approved, fix it` when you want me to start."
+            f"{suffix}",
+        )
+
+    def run_internal_codex_worker(self, run: Any) -> dict[str, Any]:
+        repo_manager = self._repo_manager or RepoManager(
+            config=self.config.repo,
+            workspace_root=runtime_root(self.config) / "workspace",
+        )
+        worker = self._codex_worker or build_code_worker(self.config)
+        summary = run.request_text.splitlines()[0] if run.request_text else "mobile bug"
+        worktree = repo_manager.prepare_worktree(
+            linear_identifier=run.linear_identifier or run.id[:8],
+            summary=summary,
+        )
+        thread = self.read_slack_thread(run)
+        worker_result = worker.run(
+            run=run,
+            worktree=worktree,
+            brief=self._fix_brief(run=run, worktree=worktree, thread=thread),
+        )
+        result = dict(worker_result)
+        result["branch_name"] = worktree.branch_name
+        result["worktree_path"] = str(worktree.path)
+        git_changed = _worktree_has_git_changes(
+            Path(str(worktree.path)),
+            base_branch=self.config.repo.default_branch,
+        )
+        if git_changed is not None:
+            result["changed"] = git_changed
+        result["slack_permalink"] = str(thread.get("permalink") or "")
+        result["evidence"] = _evidence_payloads(thread.get("files") or [])
+        return result
+
+    def run_verification(self, run: Any, worker_result: dict[str, Any]) -> dict[str, Any]:
+        verifier = self._verifier or VerificationRunner(
+            timeout_seconds=self.config.loop.timeout_minutes * 60,
+        )
+        worktree_path = worker_result.get("worktree_path") or worker_result.get("worktree")
+        result = verifier.run(Path(str(worktree_path)), self.config.verification.commands)
+        return result.to_dict()
+
+    def run_proof(
+        self,
+        run: Any,
+        worker_result: dict[str, Any],
+        verification: dict[str, Any],
+    ) -> dict[str, Any]:
+        proof_runner = self._proof_runner or ProofRunner(config=self.config)
+        worktree_path = worker_result.get("worktree_path") or worker_result.get("worktree")
+        result = proof_runner.run(
+            run=run,
+            worktree=Path(str(worktree_path)),
+            verification=verification,
+        )
+        return result.to_dict()
+
+    def open_draft_pr(
+        self,
+        run: Any,
+        worker_result: dict[str, Any],
+        verification: dict[str, Any],
+    ) -> dict[str, Any]:
+        publisher = self._pr_publisher or DraftPrPublisher()
+        branch_name = str(worker_result.get("branch_name") or run.branch_name or "")
+        worktree_path = str(worker_result.get("worktree_path") or worker_result.get("worktree") or "")
+        title = f"[{run.linear_identifier or 'Monica'}] {run.request_text.splitlines()[0][:90]}"
+        body = self._pr_body(run=run, worker_result=worker_result, verification=verification)
+        url = publisher.publish(
+            worktree=worktree_path,
+            branch_name=branch_name,
+            base_branch=self.config.repo.default_branch,
+            title=title,
+            body=body,
+        )
+        return {"url": url}
+
+    def post_status(self, run: Any, text: str) -> None:
+        client = self._resolve_slack_client(run)
+        if client is None:
+            return
+        try:
+            client.post_thread_reply(channel_id=run.channel_id, thread_ts=run.thread_ts, text=text)
+        except Exception as exc:
+            logger.warning(
+                "Slack status post failed run_id=%s channel_id=%s thread_ts=%s error=%s",
+                getattr(run, "id", ""),
+                getattr(run, "channel_id", ""),
+                getattr(run, "thread_ts", ""),
+                exc,
+            )
+            return
+
+    def _fix_status_text(self, intent: dict[str, Any]) -> str:
+        if not intent.get("wants_fix"):
+            return "Ticket-only triage."
+        if self.config.rollout_mode == "approved_pr":
+            return "Awaiting explicit tagged approval before code changes."
+        if self.config.rollout_mode == "local_fix_only":
+            return "Awaiting explicit tagged approval before local code changes; no push or PR will run."
+        if self.config.rollout_mode == "dry_run":
+            return "Dry run only; no code changes will run."
+        return "Code fixes are disabled in the current Monica rollout mode."
+
+    def _approver_line(self) -> str:
+        approvers = [f"<@{user_id}>" for user_id in self.config.slack.approver_user_ids if user_id]
+        if not approvers:
+            return ""
+        return f"Allowed approvers: {', '.join(approvers)}."
+
+    def _fix_brief(self, *, run: Any, worktree: Any, thread: dict[str, Any]) -> str:
+        messages = [str(message).strip() for message in thread.get("messages", []) if str(message).strip()]
+        message_lines = "\n".join(f"- {message}" for message in messages)
+        evidence = self._evidence_lines(thread.get("files") or [])
+        context_errors = thread.get("context_errors") or []
+        verification = "\n".join(
+            f"- {command}" for command in self.config.verification.commands if command.strip()
+        )
+        permalink = str(thread.get("permalink") or "").strip()
+        return "\n".join(
+            [
+                "# Monica Fix Brief",
+                "",
+                f"Run ID: {run.id}",
+                f"Linear: {run.linear_identifier or 'unlinked'}",
+                f"Linear URL: {run.linear_url or 'unavailable'}",
+                f"Branch: {worktree.branch_name}",
+                f"Worktree: {worktree.path}",
+                f"Slack thread: channel={run.channel_id} thread_ts={run.thread_ts}",
+                f"Slack permalink: {permalink or 'unavailable'}",
+                "",
+                "## User Request",
+                run.request_text,
+                "",
+                "## Slack Thread Context",
+                message_lines or "- No thread context captured.",
+                "",
+                "## Evidence",
+                evidence or "- No files captured.",
+                "",
+                "## Slack Fetch Notes",
+                "\n".join(f"- {error}" for error in context_errors if str(error).strip())
+                or "- None.",
+                "",
+                "## Verification Commands",
+                verification or "- No verification commands configured.",
+                "",
+                "## Instructions",
+                (
+                    "Investigate the React Native mobile app bug, make the smallest safe fix, "
+                    "and leave the worktree ready for verification."
+                ),
+            ]
+        )
+
+    def _resolve_slack_client(self, run: Any) -> Any | None:
+        if self._slack_client is not None:
+            return self._slack_client
+        token = monica_slack_bot_token()
+        if not token:
+            return None
+        try:
+            return SlackThreadClient.from_token(
+                token=token,
+                monica_user_ids=self.config.slack.bot_user_ids,
+                download_dir=runtime_root(self.config) / "attachments" / run.id,
+                download_attachments=self.config.slack.download_attachments,
+                max_attachment_bytes=self.config.loop.max_attachment_bytes,
+            )
+        except SlackClientError:
+            return None
+
+    @staticmethod
+    def _evidence_lines(files: Any) -> str:
+        lines: list[str] = []
+        for item in files:
+            if not isinstance(item, dict):
+                lines.append(f"- {item}")
+                continue
+            label = item.get("local_path") or item.get("name") or item.get("id") or "Slack file"
+            mimetype = item.get("mimetype") or "unknown type"
+            error = item.get("error") or ""
+            url = _evidence_url(item)
+            suffix = f" ({mimetype})"
+            if url:
+                suffix += f": {url}"
+            if error:
+                suffix += f" - access note: {error}"
+            lines.append(f"- {label}{suffix}")
+        return "\n".join(lines)
+
+    def _attach_linear_evidence(
+        self,
+        client: Any,
+        issue_id: str,
+        thread: dict[str, Any],
+    ) -> tuple[list[dict[str, str]], list[str]]:
+        attachments: list[dict[str, str]] = []
+        errors: list[str] = []
+        for payload in self._linear_attachment_payloads(issue_id, thread):
+            try:
+                attachment = client.create_attachment(payload)
+            except Exception as exc:
+                errors.append(f"{payload.title}: {exc}")
+                continue
+            attachments.append(
+                {
+                    "id": getattr(attachment, "id", ""),
+                    "title": getattr(attachment, "title", payload.title),
+                    "url": getattr(attachment, "url", payload.url),
+                }
+            )
+        return attachments, errors
+
+    @staticmethod
+    def _linear_attachment_payloads(
+        issue_id: str,
+        thread: dict[str, Any],
+    ) -> list[LinearAttachmentPayload]:
+        payloads: list[LinearAttachmentPayload] = []
+        for item in thread.get("files") or []:
+            if not isinstance(item, dict):
+                continue
+            url = str(
+                item.get("permalink_public")
+                or item.get("permalink")
+                or item.get("url_private_download")
+                or item.get("url_private")
+                or item.get("url")
+                or ""
+            ).strip()
+            url = _safe_evidence_url(url)
+            if not url:
+                continue
+            title = str(
+                item.get("name") or item.get("title") or item.get("id") or "Slack file"
+            ).strip()
+            subtitle = str(item.get("mimetype") or item.get("filetype") or "Slack evidence").strip()
+            payloads.append(
+                LinearAttachmentPayload(
+                    issue_id=issue_id,
+                    title=title or "Slack file",
+                    url=url,
+                    subtitle=subtitle,
+                )
+            )
+        return payloads
+
+    @staticmethod
+    def _pr_body(*, run: Any, worker_result: dict[str, Any], verification: dict[str, Any]) -> str:
+        slack_link = str(worker_result.get("slack_permalink") or "").strip()
+        slack_value = slack_link or f"channel={run.channel_id} thread={run.thread_ts}"
+        evidence = _pr_evidence_lines(worker_result.get("evidence") or [])
+        proof = _pr_proof_lines(worker_result.get("proof"))
+        return "\n".join(
+            _without_empty_sections(
+                [
+                    "## Monica Summary",
+                    str(worker_result.get("summary") or "Monica completed the requested fix."),
+                    "",
+                    "## Links",
+                    f"- Linear: {run.linear_url or run.linear_identifier or 'unavailable'}",
+                    f"- Slack: {slack_value}",
+                    "",
+                    "## Evidence" if evidence else "",
+                    evidence,
+                    "",
+                    "## Verification",
+                    str(verification.get("summary") or ""),
+                    "",
+                    "```",
+                    str(verification.get("output") or "")[:12000],
+                    "```",
+                    "",
+                    "## Proof" if proof else "",
+                    proof,
+                ]
+            )
+        )
+
+
+def _markdown_list(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        values = [value]
+    elif isinstance(value, (list, tuple, set)):
+        values = list(value)
+    else:
+        return ""
+    return "\n".join(f"- {str(item).strip()}" for item in values if str(item).strip())
+
+
+def _join_values(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, (list, tuple, set)):
+        return ", ".join(str(item).strip() for item in value if str(item).strip())
+    return ""
+
+
+def _linear_title(summary: Any, *, limit: int = 120) -> str:
+    body = " ".join(str(summary or "").split()) or "Tagged bug report"
+    title = f"[Mobile] {body}"
+    if len(title) <= limit:
+        return title
+    return title[: max(0, limit - 3)].rstrip() + "..."
+
+
+def _evidence_payloads(files: Any) -> list[dict[str, str]]:
+    payloads: list[dict[str, str]] = []
+    for item in files:
+        if not isinstance(item, dict):
+            continue
+        url = str(
+            item.get("permalink_public")
+            or item.get("permalink")
+            or item.get("url_private_download")
+            or item.get("url_private")
+            or item.get("url")
+            or item.get("local_path")
+            or ""
+        ).strip()
+        url = _safe_evidence_url(url)
+        name = str(item.get("name") or item.get("title") or item.get("id") or "Slack file").strip()
+        mimetype = str(item.get("mimetype") or item.get("filetype") or "").strip()
+        if name or url:
+            payloads.append({"name": name or "Slack file", "mimetype": mimetype, "url": url})
+    return payloads
+
+
+def _evidence_url(item: dict[str, Any]) -> str:
+    return _safe_evidence_url(
+        item.get("permalink_public")
+        or item.get("permalink")
+        or item.get("url_private_download")
+        or item.get("url_private")
+        or item.get("url")
+        or ""
+    )
+
+
+def _safe_evidence_url(value: Any) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    scheme = urlparse(text).scheme.lower()
+    return text if scheme in {"http", "https"} else ""
+
+
+def _pr_evidence_lines(evidence: Any) -> str:
+    lines: list[str] = []
+    for item in evidence:
+        if not isinstance(item, dict):
+            text = str(item).strip()
+            if text:
+                lines.append(f"- {text}")
+            continue
+        name = str(item.get("name") or "Slack file").strip()
+        mimetype = str(item.get("mimetype") or "").strip()
+        url = _safe_evidence_url(item.get("url") or "")
+        label = f"{name} ({mimetype})" if mimetype else name
+        lines.append(f"- {label}: {url}" if url else f"- {label}")
+    return "\n".join(lines)
+
+
+def _pr_proof_lines(proof: Any) -> str:
+    if not isinstance(proof, dict):
+        return ""
+    lines: list[str] = []
+    summary = str(proof.get("summary") or "").strip()
+    if summary:
+        lines.append(summary)
+    platforms = [
+        str(platform).strip()
+        for platform in proof.get("platforms") or []
+        if str(platform).strip()
+    ]
+    if platforms:
+        lines.append(f"Platforms: {', '.join(platforms)}")
+    artifacts = [str(path).strip() for path in proof.get("artifacts") or [] if str(path).strip()]
+    if artifacts:
+        lines.extend(f"- {path}" for path in artifacts)
+    return "\n".join(lines)
+
+
+def _worktree_has_git_changes(worktree_path: Path, *, base_branch: str = "main") -> bool | None:
+    try:
+        proc = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=str(worktree_path),
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        return None
+    if proc.stdout.strip():
+        return True
+
+    base_ref = f"origin/{(base_branch or 'main').strip() or 'main'}"
+    try:
+        diff = subprocess.run(
+            ["git", "diff", "--name-only", f"{base_ref}...HEAD"],
+            cwd=str(worktree_path),
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if diff.returncode != 0:
+        return False
+    return bool(diff.stdout.strip())
+
+
+def _without_empty_sections(parts: list[str]) -> list[str]:
+    cleaned: list[str] = []
+    for index, part in enumerate(parts):
+        if part != "":
+            cleaned.append(part)
+            continue
+        previous = parts[index - 1] if index > 0 else ""
+        next_part = parts[index + 1] if index + 1 < len(parts) else ""
+        if previous == "## Evidence" or next_part == "## Verification":
+            continue
+        cleaned.append(part)
+    return cleaned
+
+
+def _thread_context_lines(thread: dict[str, Any]) -> str:
+    detail_lines = []
+    for item in thread.get("message_details") or []:
+        if not isinstance(item, dict):
+            continue
+        text = str(item.get("text") or "").strip()
+        if not text:
+            continue
+        user = str(item.get("user_id") or "unknown").strip() or "unknown"
+        ts = str(item.get("ts") or "").strip()
+        permalink = str(item.get("permalink") or "").strip()
+        prefix = f"{user} at {ts}" if ts else user
+        suffix = f" ({permalink})" if permalink else ""
+        detail_lines.append(f"- {prefix}: {text}{suffix}")
+    if detail_lines:
+        return "\n".join(detail_lines)
+
+    messages = thread.get("messages") or []
+    fallback = "\n".join(f"- {message}" for message in messages if str(message).strip())
+    return fallback or "- No thread context captured."

--- a/plugins/mobile_bug_agent/slack_client.py
+++ b/plugins/mobile_bug_agent/slack_client.py
@@ -1,0 +1,417 @@
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+
+
+_MENTION_RE = re.compile(r"<@([A-Z0-9_]+)(?:\|[^>]+)?>")
+
+
+class SlackClientError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class SlackMessage:
+    user_id: str
+    text: str
+    ts: str
+    permalink: str = ""
+
+
+@dataclass(frozen=True)
+class SlackFile:
+    id: str
+    name: str
+    mimetype: str
+    url_private: str
+    permalink: str = ""
+    local_path: str = ""
+    error: str = ""
+    requires_auth: bool = False
+
+
+@dataclass(frozen=True)
+class SlackThreadContext:
+    channel_id: str
+    thread_ts: str
+    permalink: str
+    messages: list[SlackMessage]
+    files: list[SlackFile]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "channel_id": self.channel_id,
+            "thread_ts": self.thread_ts,
+            "permalink": self.permalink,
+            "messages": [f"{msg.user_id}: {msg.text}" if msg.user_id else msg.text for msg in self.messages],
+            "message_details": [asdict(message) for message in self.messages],
+            "files": [asdict(file) for file in self.files],
+            "attachments": [file.local_path or file.name for file in self.files],
+        }
+
+
+@dataclass(frozen=True)
+class SlackAuthInfo:
+    bot_user_id: str
+    bot_id: str
+    team_id: str
+    team_name: str
+    team_url: str
+
+
+@dataclass(frozen=True)
+class SlackChannelInfo:
+    id: str
+    name: str
+    is_private: bool
+    is_member: bool
+    is_archived: bool
+
+
+@dataclass(frozen=True)
+class SlackWorkspaceMetadata:
+    auth: SlackAuthInfo
+    channels: tuple[SlackChannelInfo, ...]
+
+
+class SlackThreadClient:
+    def __init__(
+        self,
+        *,
+        client: Any,
+        token: str = "",
+        monica_user_ids: tuple[str, ...] = (),
+        download_dir: str | Path | None = None,
+        download_attachments: bool = True,
+        max_attachment_bytes: int = 15_000_000,
+    ) -> None:
+        self.client = client
+        self.token = token.strip()
+        self.monica_user_ids = set(monica_user_ids)
+        self.download_dir = Path(download_dir) if download_dir else None
+        self.download_attachments = download_attachments
+        self.max_attachment_bytes = max_attachment_bytes
+
+    @classmethod
+    def from_token(
+        cls,
+        *,
+        token: str,
+        monica_user_ids: tuple[str, ...] = (),
+        download_dir: str | Path | None = None,
+        download_attachments: bool = True,
+        max_attachment_bytes: int = 15_000_000,
+    ) -> "SlackThreadClient":
+        try:
+            from slack_sdk import WebClient
+        except Exception as exc:  # pragma: no cover - depends on optional install
+            raise SlackClientError("slack_sdk is not installed.") from exc
+        return cls(
+            client=WebClient(token=token),
+            token=token,
+            monica_user_ids=monica_user_ids,
+            download_dir=download_dir,
+            download_attachments=download_attachments,
+            max_attachment_bytes=max_attachment_bytes,
+        )
+
+    def read_thread(self, *, channel_id: str, thread_ts: str, limit: int = 40) -> SlackThreadContext:
+        messages: list[SlackMessage] = []
+        files: list[SlackFile] = []
+        cursor = ""
+        seen_cursors: set[str] = set()
+        max_messages = max(1, limit)
+
+        while len(messages) < max_messages:
+            response = self._conversations_replies(
+                channel_id=channel_id,
+                thread_ts=thread_ts,
+                limit=max_messages - len(messages),
+                cursor=cursor,
+            )
+            if _response_get(response, "ok") is False:
+                error = str(_response_get(response, "error") or "unknown_error")
+                raise SlackClientError(f"Slack conversations_replies failed: {error}")
+            messages_payload = _response_get(response, "messages") or []
+            for payload in messages_payload:
+                if len(messages) >= max_messages:
+                    break
+                if not isinstance(payload, dict):
+                    continue
+                text = self._normalize_text(str(payload.get("text") or ""))
+                message_ts = str(payload.get("ts") or "")
+                messages.append(
+                    SlackMessage(
+                        user_id=str(payload.get("user") or payload.get("bot_id") or ""),
+                        text=text,
+                        ts=message_ts,
+                        permalink=self._message_permalink(
+                            channel_id=channel_id,
+                            message_ts=message_ts,
+                        ),
+                    )
+                )
+                for raw_file in payload.get("files") or []:
+                    if isinstance(raw_file, dict):
+                        files.append(self._file_from_payload(raw_file))
+                for attachment_file in self._files_from_message_attachments(
+                    payload.get("attachments") or [],
+                    message_ts=message_ts,
+                ):
+                    files.append(attachment_file)
+
+            cursor = _response_next_cursor(response)
+            if not cursor or not _response_get(response, "has_more"):
+                break
+            if cursor in seen_cursors:
+                break
+            seen_cursors.add(cursor)
+
+        return SlackThreadContext(
+            channel_id=channel_id,
+            thread_ts=thread_ts,
+            permalink=messages[0].permalink if messages else "",
+            messages=messages,
+            files=files,
+        )
+
+    def post_thread_reply(self, *, channel_id: str, thread_ts: str, text: str) -> None:
+        clean_text = str(text or "").strip()
+        if not clean_text:
+            raise SlackClientError("Slack reply text is required.")
+        response = self.client.chat_postMessage(
+            channel=channel_id,
+            thread_ts=thread_ts,
+            text=clean_text,
+        )
+        if _response_get(response, "ok") is False:
+            error = str(_response_get(response, "error") or "unknown_error")
+            raise SlackClientError(f"Slack chat_postMessage failed: {error}")
+
+    def list_workspace_metadata(self, *, limit: int = 200) -> SlackWorkspaceMetadata:
+        auth_response = self.client.auth_test()
+        if _response_get(auth_response, "ok") is False:
+            error = str(_response_get(auth_response, "error") or "unknown_error")
+            raise SlackClientError(f"Slack auth_test failed: {error}")
+        auth = SlackAuthInfo(
+            bot_user_id=str(_response_get(auth_response, "user_id") or ""),
+            bot_id=str(_response_get(auth_response, "bot_id") or ""),
+            team_id=str(_response_get(auth_response, "team_id") or ""),
+            team_name=str(_response_get(auth_response, "team") or ""),
+            team_url=str(_response_get(auth_response, "url") or ""),
+        )
+        channels: list[SlackChannelInfo] = []
+        cursor = ""
+        seen_cursors: set[str] = set()
+        page_limit = max(1, min(int(limit), 1000))
+        while True:
+            kwargs: dict[str, Any] = {
+                "types": "public_channel,private_channel",
+                "exclude_archived": True,
+                "limit": page_limit,
+            }
+            if cursor:
+                kwargs["cursor"] = cursor
+            response = self.client.conversations_list(**kwargs)
+            if _response_get(response, "ok") is False:
+                error = str(_response_get(response, "error") or "unknown_error")
+                raise SlackClientError(f"Slack conversations_list failed: {error}")
+            for payload in _response_get(response, "channels") or []:
+                if not isinstance(payload, dict) or not payload.get("id"):
+                    continue
+                channels.append(
+                    SlackChannelInfo(
+                        id=str(payload.get("id") or ""),
+                        name=str(payload.get("name") or ""),
+                        is_private=bool(payload.get("is_private")),
+                        is_member=bool(payload.get("is_member")),
+                        is_archived=bool(payload.get("is_archived")),
+                    )
+                )
+            cursor = _response_next_cursor(response)
+            if not cursor or not _response_get(response, "has_more"):
+                break
+            if cursor in seen_cursors:
+                break
+            seen_cursors.add(cursor)
+        return SlackWorkspaceMetadata(auth=auth, channels=tuple(channels))
+
+    def _conversations_replies(
+        self,
+        *,
+        channel_id: str,
+        thread_ts: str,
+        limit: int,
+        cursor: str = "",
+    ) -> Any:
+        kwargs: dict[str, Any] = {"channel": channel_id, "ts": thread_ts, "limit": limit}
+        if cursor:
+            kwargs["cursor"] = cursor
+        return self.client.conversations_replies(**kwargs)
+
+    def _file_from_payload(self, payload: dict[str, Any]) -> SlackFile:
+        slack_file = SlackFile(
+            id=str(payload.get("id") or ""),
+            name=str(payload.get("name") or payload.get("title") or "slack-file"),
+            mimetype=str(payload.get("mimetype") or ""),
+            url_private=str(payload.get("url_private_download") or payload.get("url_private") or ""),
+            permalink=str(payload.get("permalink_public") or payload.get("permalink") or ""),
+            requires_auth=True,
+        )
+        if not self.download_attachments or not self.download_dir or not slack_file.url_private:
+            return slack_file
+        return self._download_file(slack_file)
+
+    def _files_from_message_attachments(
+        self,
+        attachments: Any,
+        *,
+        message_ts: str,
+    ) -> list[SlackFile]:
+        files: list[SlackFile] = []
+        if not isinstance(attachments, list):
+            return files
+        for index, payload in enumerate(attachments, start=1):
+            if not isinstance(payload, dict):
+                continue
+            image_url = str(
+                payload.get("image_url")
+                or payload.get("thumb_url")
+                or payload.get("url")
+                or ""
+            ).strip()
+            if not image_url:
+                continue
+            title = str(
+                payload.get("title")
+                or payload.get("fallback")
+                or payload.get("text")
+                or _safe_filename(image_url.rsplit("/", 1)[-1])
+                or "Slack attachment"
+            ).strip()
+            slack_file = SlackFile(
+                id=f"attachment-{message_ts or 'message'}-{index}",
+                name=title or "Slack attachment",
+                mimetype="image" if payload.get("image_url") or payload.get("thumb_url") else "",
+                url_private=image_url,
+                permalink=image_url,
+                requires_auth=False,
+            )
+            if self.download_attachments and self.download_dir:
+                slack_file = self._download_file(slack_file)
+            files.append(slack_file)
+        return files
+
+    def _download_file(self, slack_file: SlackFile) -> SlackFile:
+        scheme = urlparse(slack_file.url_private).scheme.lower()
+        if scheme not in {"http", "https"}:
+            return _download_error(
+                slack_file,
+                f"unsupported Slack attachment URL scheme: {scheme or 'missing'}",
+            )
+        self.download_dir.mkdir(parents=True, exist_ok=True)
+        target = _unique_path(self.download_dir, _safe_filename(slack_file.name))
+        try:
+            with httpx.stream(
+                "GET",
+                slack_file.url_private,
+                headers=(
+                    {"Authorization": f"Bearer {self.token}"}
+                    if self.token and slack_file.requires_auth
+                    else {}
+                ),
+                follow_redirects=True,
+                timeout=30.0,
+            ) as response:
+                response.raise_for_status()
+                total = 0
+                with target.open("wb") as fh:
+                    for chunk in response.iter_bytes():
+                        total += len(chunk)
+                        if total > self.max_attachment_bytes:
+                            raise SlackClientError(
+                                f"Slack attachment exceeds {self.max_attachment_bytes} bytes"
+                            )
+                        fh.write(chunk)
+        except Exception as exc:
+            try:
+                target.unlink(missing_ok=True)
+            except OSError:
+                pass
+            return _download_error(slack_file, str(exc))
+        return SlackFile(
+            id=slack_file.id,
+            name=slack_file.name,
+            mimetype=slack_file.mimetype,
+            url_private=slack_file.url_private,
+            permalink=slack_file.permalink,
+            local_path=str(target),
+            requires_auth=slack_file.requires_auth,
+        )
+
+    def _normalize_text(self, text: str) -> str:
+        def replace(match: re.Match[str]) -> str:
+            user_id = match.group(1)
+            return "@monica" if user_id in self.monica_user_ids else f"@{user_id}"
+
+        return _MENTION_RE.sub(replace, text).strip()
+
+    def _message_permalink(self, *, channel_id: str, message_ts: str) -> str:
+        if not message_ts:
+            return ""
+        try:
+            link = self.client.chat_getPermalink(channel=channel_id, message_ts=message_ts)
+            return str(link.get("permalink") or "")
+        except Exception:
+            return ""
+
+
+def _safe_filename(value: str) -> str:
+    safe = re.sub(r"[^a-zA-Z0-9._-]+", "-", value.strip()).strip("-")
+    return safe or "slack-file"
+
+
+def _response_get(response: Any, key: str, default: Any = None) -> Any:
+    getter = getattr(response, "get", None)
+    if callable(getter):
+        return getter(key, default)
+    return default
+
+
+def _response_next_cursor(response: Any) -> str:
+    metadata = _response_get(response, "response_metadata") or {}
+    cursor = _response_get(metadata, "next_cursor", "")
+    if cursor:
+        return str(cursor).strip()
+    return str(_response_get(response, "next_cursor", "") or "").strip()
+
+
+def _unique_path(directory: Path, filename: str) -> Path:
+    target = directory / filename
+    if not target.exists():
+        return target
+    stem = target.stem
+    suffix = target.suffix
+    for index in range(2, 1000):
+        candidate = directory / f"{stem}-{index}{suffix}"
+        if not candidate.exists():
+            return candidate
+    raise SlackClientError(f"Could not choose a unique Slack attachment path for {filename}")
+
+
+def _download_error(slack_file: SlackFile, error: str) -> SlackFile:
+    return SlackFile(
+        id=slack_file.id,
+        name=slack_file.name,
+        mimetype=slack_file.mimetype,
+        url_private=slack_file.url_private,
+        permalink=slack_file.permalink,
+        error=error,
+        requires_auth=slack_file.requires_auth,
+    )

--- a/plugins/mobile_bug_agent/slack_flow.py
+++ b/plugins/mobile_bug_agent/slack_flow.py
@@ -1,0 +1,666 @@
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+from collections.abc import Callable
+from typing import Any
+
+from gateway.config import Platform
+
+from .config import MonicaConfig
+from .readiness import check_monica_readiness
+from .state import MonicaState
+
+_SLACK_MENTION_RE = re.compile(r"<@([A-Z0-9_]+)(?:\|[^>]+)?>")
+_SLACK_USER_ID_RE = re.compile(r"^[UW][A-Z0-9_]{2,}$")
+_SLACK_CHANNEL_ID_RE = re.compile(r"^[CDG][A-Z0-9_]{2,}$")
+logger = logging.getLogger(__name__)
+_APPROVAL_RE = re.compile(
+    r"\b("
+    r"approved"
+    r"|approve"
+    r"|approval granted"
+    r"|(?:yes|yep|yeah|sure|ok|okay),?\s+(?:fix it|start(?: the fix)?|take(?: the fix| it)?|open a draft pr|create a draft pr)"
+    r"|go ahead"
+    r"|proceed"
+    r"|start the fix"
+    r"|take the fix"
+    r"|take it"
+    r"|open a draft pr"
+    r"|create a draft pr"
+    r"|ship it"
+    r")\b",
+    re.I,
+)
+_NEGATED_APPROVAL_RE = re.compile(
+    r"\b("
+    r"not approved"
+    r"|not approve"
+    r"|do not approve"
+    r"|don't approve"
+    r"|not go ahead"
+    r"|do not go ahead"
+    r"|don't go ahead"
+    r"|not proceed"
+    r"|do not proceed"
+    r"|don't proceed"
+    r"|do not start the fix"
+    r"|don't start the fix"
+    r"|do not take the fix"
+    r"|don't take the fix"
+    r"|do not ship it"
+    r"|don't ship it"
+    r"|not ship it"
+    r")\b",
+    re.I,
+)
+_QUESTION_APPROVAL_RE = re.compile(
+    r"\b("
+    r"should\s+i\s+approve"
+    r"|should\s+we\s+approve"
+    r"|should\s+you\s+approve"
+    r"|can\s+i\s+approve"
+    r"|can\s+we\s+approve"
+    r"|can\s+you\s+approve"
+    r"|do\s+i\s+approve"
+    r"|do\s+we\s+approve"
+    r"|would\s+you\s+approve"
+    r"|is\s+this\s+approved"
+    r")\b",
+    re.I,
+)
+_APPROVAL_PHRASE_QUESTION_RE = re.compile(
+    r"\b("
+    r"approve"
+    r"|approved"
+    r"|go ahead"
+    r"|proceed"
+    r"|start(?: the fix)?"
+    r"|take(?: the fix| it)?"
+    r"|open a draft pr"
+    r"|create a draft pr"
+    r"|ship it"
+    r")\s*\?\s*$",
+    re.I,
+)
+_CANCEL_RE = re.compile(
+    r"("
+    r"^\s*(?:cancel|stop)\s*[.!?]*$"
+    r"|^\s*(?:please\s+)?(?:cancel|stop)\s+"
+    r"(?:monica|it|for now|this\s+(?:run|loop|fix)|the\s+(?:run|loop|fix))\s*[.!?]*$"
+    r"|\b(?:do not fix|don't fix|hold off)\b"
+    r")",
+    re.I,
+)
+_CANCEL_QUESTION_RE = re.compile(r"^\s*(?:cancel|stop)\s*\?\s*$", re.I)
+_NEGATED_CANCEL_RE = re.compile(
+    r"\b("
+    r"not cancel"
+    r"|not stop"
+    r"|do not cancel"
+    r"|do not stop"
+    r"|don't cancel"
+    r"|don't stop"
+    r")\b",
+    re.I,
+)
+_NOOP_RE = re.compile(
+    r"\b("
+    r"thanks?"
+    r"|thank you"
+    r"|fixed now"
+    r"|resolved"
+    r"|all good"
+    r"|looks good"
+    r")\b",
+    re.I,
+)
+_TERMINAL_NOOP_RE = re.compile(
+    r"\b("
+    r"fixed now"
+    r"|resolved"
+    r"|all good"
+    r"|looks good"
+    r")\b",
+    re.I,
+)
+_ACTION_HINT_RE = re.compile(
+    r"\b("
+    r"crash"
+    r"|bug"
+    r"|issue"
+    r"|repro"
+    r"|reproduce"
+    r"|regression"
+    r"|broken"
+    r"|failing"
+    r"|still"
+    r"|again"
+    r"|update"
+    r"|linear"
+    r"|ticket"
+    r"|pr"
+    r")\b",
+    re.I,
+)
+_NEW_WORK_HINT_RE = re.compile(
+    r"\b("
+    r"still"
+    r"|again"
+    r"|update"
+    r"|repro"
+    r"|reproduce"
+    r"|reproduction"
+    r"|detail"
+    r"|context"
+    r"|screenshot"
+    r"|attachment"
+    r"|attached"
+    r"|regression"
+    r"|broken"
+    r"|failing"
+    r"|not\s+fixed"
+    r"|isn'?t\s+fixed"
+    r"|is\s+not\s+fixed"
+    r"|linear"
+    r"|ticket"
+    r"|pr"
+    r")\b",
+    re.I,
+)
+
+
+class MonicaSlackFlow:
+    def __init__(
+        self,
+        *,
+        config: MonicaConfig,
+        state: MonicaState,
+        loop_launcher: Callable[[str], None],
+        approval_readiness_checker: Callable[[], tuple[bool, str]] | None = None,
+    ) -> None:
+        self.config = config
+        self.state = state
+        self.loop_launcher = loop_launcher
+        self.approval_readiness_checker = (
+            approval_readiness_checker or self._default_approval_readiness
+        )
+
+    def handle_gateway_event(self, event: Any) -> dict[str, str] | None:
+        source = getattr(event, "source", None)
+        if source is None:
+            return None
+
+        platform = getattr(source, "platform", None)
+        if platform != Platform.SLACK:
+            return None
+
+        channel_id = str(getattr(source, "chat_id", "") or "")
+        allowed = set(self.config.slack.allowed_channels)
+
+        if getattr(source, "is_bot", False):
+            return None
+
+        raw = getattr(event, "raw_message", None)
+        if isinstance(raw, dict):
+            subtype = str(raw.get("subtype") or "")
+            if subtype in {"bot_message", "message_deleted", "message_changed"}:
+                return None
+
+        if not self._is_monica_mention(event):
+            return None
+
+        if not self.config.enabled:
+            return {"action": "skip", "reason": "monica_disabled"}
+
+        if allowed:
+            invalid_channels = self._invalid_allowed_channels()
+            if invalid_channels:
+                return {
+                    "action": "skip_reply",
+                    "reason": "monica_allowed_channels_invalid",
+                    "text": (
+                        "I cannot start Monica here yet. "
+                        "mobile_bug_agent.slack.allowed_channels must contain Slack channel IDs "
+                        f"like C123 or G123, not names like {invalid_channels[0]}."
+                    ),
+                }
+
+        if allowed and channel_id not in allowed:
+            return {
+                "action": "skip_reply",
+                "reason": "monica_channel_not_allowed",
+                "text": (
+                    "I cannot run Monica in this channel. "
+                    "Ask an admin to add this channel to mobile_bug_agent.slack.allowed_channels."
+                ),
+            }
+
+        if self.config.rollout_mode in {"linear_only", "local_fix_only", "approved_pr"} and not allowed:
+            return {
+                "action": "skip_reply",
+                "reason": "monica_allowed_channels_required",
+                "text": (
+                    "I cannot start Monica here yet. "
+                    "Configure mobile_bug_agent.slack.allowed_channels before enabling real side effects."
+                ),
+            }
+
+        if self.config.rollout_mode in {"linear_only", "local_fix_only", "approved_pr"} and not self.config.slack.bot_user_ids:
+            return {
+                "action": "skip_reply",
+                "reason": "monica_bot_user_ids_required",
+                "text": (
+                    "I cannot start Monica here yet. "
+                    "Configure mobile_bug_agent.slack.bot_user_ids with Monica's Slack user ID "
+                    "before enabling real side effects."
+                ),
+            }
+        if self.config.rollout_mode in {"linear_only", "local_fix_only", "approved_pr"}:
+            bot_id_values = self._bot_id_user_ids()
+            if bot_id_values:
+                return {
+                    "action": "skip_reply",
+                    "reason": "monica_bot_user_ids_invalid",
+                    "text": (
+                        "I cannot start Monica here yet. "
+                        "mobile_bug_agent.slack.bot_user_ids must contain Slack mention user IDs "
+                        f"like U123, not bot_id values like {bot_id_values[0]}."
+                    ),
+                }
+            handle_style_bot_ids = [
+                user_id
+                for user_id in self.config.slack.bot_user_ids
+                if str(user_id).strip().startswith("@")
+            ]
+            if handle_style_bot_ids:
+                return {
+                    "action": "skip_reply",
+                    "reason": "monica_bot_user_ids_invalid",
+                    "text": (
+                        "I cannot start Monica here yet. "
+                        "mobile_bug_agent.slack.bot_user_ids must contain Slack mention user IDs "
+                        f"like U123, not handles like {handle_style_bot_ids[0]}."
+                    ),
+                }
+            invalid_bot_user_ids = self._invalid_bot_user_ids()
+            if invalid_bot_user_ids:
+                return {
+                    "action": "skip_reply",
+                    "reason": "monica_bot_user_ids_invalid",
+                    "text": (
+                        "I cannot start Monica here yet. "
+                        "mobile_bug_agent.slack.bot_user_ids must contain Slack mention user IDs "
+                        f"like U123, not invalid values like {invalid_bot_user_ids[0]}."
+                    ),
+                }
+
+        request_text = self._request_text(event)
+        thread_ts = self._thread_ts(event)
+        message_ts = str(getattr(event, "message_id", "") or "")
+        if isinstance(raw, dict):
+            message_ts = str(raw.get("ts") or message_ts)
+
+        existing = self.state.find_run(
+            platform="slack",
+            channel_id=channel_id,
+            thread_ts=thread_ts,
+        )
+        if existing is not None:
+            user_id = str(getattr(source, "user_id", "") or "")
+            if self._is_cancel(request_text):
+                if existing.status not in {"done", "blocked", "failed"}:
+                    cancelled = self.state.update_run(
+                        existing.id,
+                        status="blocked",
+                        failure_reason=f"cancelled by {user_id or 'unknown Slack user'}",
+                    )
+                    _log_slack_flow("cancelled", cancelled, cancelled_by=user_id)
+                return {"action": "skip", "reason": "monica_loop_cancelled"}
+            if existing.status == "awaiting_fix_approval":
+                if self._is_approval(request_text) and self._is_allowed_approver(user_id):
+                    ready, reason = self.approval_readiness_checker()
+                    if not ready:
+                        return {
+                            "action": "skip_reply",
+                            "reason": "monica_loop_approval_not_ready",
+                            "text": self._approval_not_ready_text(reason),
+                        }
+                    approve_once = getattr(self.state, "approve_fix_once", None)
+                    if callable(approve_once):
+                        approved, changed = approve_once(existing.id, approved_by_user_id=user_id)
+                    else:
+                        approved = self.state.approve_fix(existing.id, approved_by_user_id=user_id)
+                        changed = True
+                    if not changed:
+                        return {"action": "skip", "reason": "monica_loop_already_active"}
+                    _log_slack_flow("approved", approved, approved_by=user_id)
+                    self.loop_launcher(approved.id)
+                    return {"action": "skip", "reason": "monica_loop_approved"}
+                if self._is_approval(request_text):
+                    return {
+                        "action": "skip_reply",
+                        "reason": "monica_loop_approval_denied",
+                        "text": self._approval_denied_text(),
+                    }
+                if self._is_context_update_retag(request_text):
+                    rerun = self._requeue_existing_run(
+                        existing=existing,
+                        raw=raw,
+                        message_ts=message_ts,
+                        user_id=user_id,
+                        request_text=request_text,
+                    )
+                    self.loop_launcher(rerun.id)
+                    return {"action": "skip", "reason": "monica_loop_requeued"}
+            if existing.status in {"done", "blocked", "failed", "needs_clarification"}:
+                if (
+                    existing.status in {"done", "blocked", "failed"}
+                    and existing.pr_url
+                    and self._is_approval(request_text)
+                ):
+                    return {"action": "skip", "reason": "monica_loop_already_done"}
+                if (
+                    existing.status in {"done", "blocked", "failed"}
+                    and not existing.pr_url
+                    and self.config.rollout_mode in {"local_fix_only", "approved_pr"}
+                    and self._has_linear_issue(existing)
+                    and self._is_approval(request_text)
+                ):
+                    if not self._is_allowed_approver(user_id):
+                        return {
+                            "action": "skip_reply",
+                            "reason": "monica_loop_approval_denied",
+                            "text": self._approval_denied_text(),
+                        }
+                    ready, reason = self.approval_readiness_checker()
+                    if not ready:
+                        return {
+                            "action": "skip_reply",
+                            "reason": "monica_loop_approval_not_ready",
+                            "text": self._approval_not_ready_text(reason),
+                        }
+                    approved = self.state.update_run(
+                        existing.id,
+                        status="approved",
+                        approved_by_user_id=user_id,
+                        failure_reason="",
+                        branch_name="",
+                        pr_url="",
+                    )
+                    _log_slack_flow("approved", approved, approved_by=user_id)
+                    self.loop_launcher(approved.id)
+                    return {"action": "skip", "reason": "monica_loop_approved"}
+                if self._is_noop_retag(request_text):
+                    return {"action": "skip", "reason": "monica_loop_noop"}
+                rerun = self._requeue_existing_run(
+                    existing=existing,
+                    raw=raw,
+                    message_ts=message_ts,
+                    user_id=user_id,
+                    request_text=request_text,
+                )
+                self.loop_launcher(rerun.id)
+                return {"action": "skip", "reason": "monica_loop_requeued"}
+            return {"action": "skip", "reason": "monica_loop_already_active"}
+
+        create_once = getattr(self.state, "create_run_once", None)
+        if callable(create_once):
+            run, created = create_once(
+                platform="slack",
+                channel_id=channel_id,
+                thread_ts=thread_ts,
+                message_ts=message_ts,
+                user_id=str(getattr(source, "user_id", "") or ""),
+                request_text=request_text,
+                raw_event=raw if isinstance(raw, dict) else {},
+            )
+        else:
+            run = self.state.create_run(
+                platform="slack",
+                channel_id=channel_id,
+                thread_ts=thread_ts,
+                message_ts=message_ts,
+                user_id=str(getattr(source, "user_id", "") or ""),
+                request_text=request_text,
+                raw_event=raw if isinstance(raw, dict) else {},
+            )
+            created = True
+
+        if not created:
+            return {"action": "skip", "reason": "monica_loop_already_active"}
+
+        self.loop_launcher(run.id)
+        return {"action": "skip", "reason": "monica_loop_queued"}
+
+    def _is_monica_mention(self, event: Any) -> bool:
+        if self._is_direct_message(event):
+            return True
+
+        raw_text = self._raw_text(event)
+        raw = getattr(event, "raw_message", None)
+        is_app_mention = isinstance(raw, dict) and str(raw.get("type") or "") == "app_mention"
+        configured_ids = set(self.config.slack.bot_user_ids)
+        if configured_ids:
+            mentioned_ids = set(_SLACK_MENTION_RE.findall(raw_text))
+            if configured_ids & mentioned_ids:
+                return True
+            if self.config.rollout_mode in {"linear_only", "local_fix_only", "approved_pr"}:
+                if (
+                    self._bot_id_user_ids()
+                    or self._invalid_bot_user_ids()
+                    or self._handle_style_bot_user_ids()
+                ):
+                    return is_app_mention
+                return False
+            return False
+
+        return is_app_mention
+
+    def _is_direct_message(self, event: Any) -> bool:
+        source = getattr(event, "source", None)
+        raw = getattr(event, "raw_message", None)
+        if isinstance(raw, dict):
+            channel_type = str(raw.get("channel_type") or "")
+            if channel_type == "im":
+                return True
+            if channel_type == "mpim":
+                return False
+
+        channel_id = str(getattr(source, "chat_id", "") or "")
+        chat_type = str(getattr(source, "chat_type", "") or "")
+        return chat_type == "dm" and channel_id.startswith("D")
+
+    def _invalid_bot_user_ids(self) -> list[str]:
+        return [
+            user_id
+            for user_id in self.config.slack.bot_user_ids
+            if not str(user_id).strip().startswith("@")
+            and not str(user_id).upper().startswith("B")
+            and not _is_slack_user_id(user_id)
+        ]
+
+    def _handle_style_bot_user_ids(self) -> list[str]:
+        return [
+            user_id
+            for user_id in self.config.slack.bot_user_ids
+            if str(user_id).strip().startswith("@")
+        ]
+
+    def _bot_id_user_ids(self) -> list[str]:
+        return [
+            user_id
+            for user_id in self.config.slack.bot_user_ids
+            if str(user_id).upper().startswith("B")
+        ]
+
+    def _invalid_allowed_channels(self) -> list[str]:
+        return [
+            channel
+            for channel in self.config.slack.allowed_channels
+            if not _is_slack_channel_id(channel)
+        ]
+
+    def _request_text(self, event: Any) -> str:
+        text = str(getattr(event, "text", "") or "").strip()
+        if text:
+            return _SLACK_MENTION_RE.sub("", text).strip()
+        raw_text = self._raw_text(event)
+        return _SLACK_MENTION_RE.sub("", raw_text).strip()
+
+    def _raw_text(self, event: Any) -> str:
+        raw = getattr(event, "raw_message", None)
+        if isinstance(raw, dict):
+            return str(raw.get("text") or "")
+        return str(getattr(event, "text", "") or "")
+
+    def _thread_ts(self, event: Any) -> str:
+        source = getattr(event, "source", None)
+        raw = getattr(event, "raw_message", None)
+        if isinstance(raw, dict):
+            thread_ts = str(raw.get("thread_ts") or raw.get("ts") or "")
+            if thread_ts:
+                return thread_ts
+        return str(getattr(source, "thread_id", "") or getattr(event, "message_id", "") or "")
+
+    def _is_allowed_approver(self, user_id: str) -> bool:
+        allowed = set(self.config.slack.approver_user_ids)
+        return bool(allowed) and user_id in allowed
+
+    @staticmethod
+    def _has_linear_issue(run: Any) -> bool:
+        return bool(
+            str(getattr(run, "linear_identifier", "") or "").strip()
+            or str(getattr(run, "linear_issue_id", "") or "").strip()
+            or str(getattr(run, "linear_url", "") or "").strip()
+        )
+
+    def _approval_denied_text(self) -> str:
+        approvers = [f"<@{user_id}>" for user_id in self.config.slack.approver_user_ids if user_id]
+        if not approvers:
+            return (
+                "I cannot start the fix from this approval. "
+                "No Monica approver is configured for code changes."
+            )
+        return (
+            "I cannot start the fix from this approval. "
+            "A configured Monica approver must tag me to approve code changes. "
+            f"Allowed approvers: {', '.join(approvers)}."
+        )
+
+    def _approval_not_ready_text(self, reason: str) -> str:
+        mode_label = "approved-PR mode" if self.config.rollout_mode == "approved_pr" else "code-fix mode"
+        clean_reason = str(reason or "").strip() or "code rollout is not ready"
+        return (
+            "I cannot start the fix from this approval because Monica is not ready "
+            f"for {mode_label}: {clean_reason}"
+        )
+
+    def _default_approval_readiness(self) -> tuple[bool, str]:
+        if self.config.rollout_mode not in {"local_fix_only", "approved_pr"}:
+            return True, ""
+        report = check_monica_readiness(config=self.config, which=shutil.which)
+        if report.ready:
+            return True, ""
+        return False, report.first_approval_failure()
+
+    def _requeue_existing_run(
+        self,
+        *,
+        existing: Any,
+        raw: Any,
+        message_ts: str,
+        user_id: str,
+        request_text: str,
+    ) -> Any:
+        rerun = self.state.update_run(
+            existing.id,
+            status="queued",
+            message_ts=message_ts,
+            user_id=user_id,
+            request_text=request_text,
+            raw_event=raw if isinstance(raw, dict) else {},
+            branch_name="",
+            pr_url="",
+            failure_reason="",
+            approved_by_user_id="",
+        )
+        _log_slack_flow("requeued", rerun, requeued_by=user_id)
+        return rerun
+
+    @staticmethod
+    def _is_approval(text: str) -> bool:
+        if _NEGATED_APPROVAL_RE.search(text):
+            return False
+        if (
+            _QUESTION_APPROVAL_RE.search(text)
+            or _APPROVAL_PHRASE_QUESTION_RE.search(text)
+            or (text.strip().endswith("?") and _APPROVAL_RE.search(text))
+        ):
+            return False
+        return bool(_APPROVAL_RE.search(text))
+
+    @staticmethod
+    def _is_cancel(text: str) -> bool:
+        if _NEGATED_CANCEL_RE.search(text):
+            return False
+        if _CANCEL_QUESTION_RE.search(text) or (text.strip().endswith("?") and _CANCEL_RE.search(text)):
+            return False
+        return bool(_CANCEL_RE.search(text))
+
+    @staticmethod
+    def _is_noop_retag(text: str) -> bool:
+        if not _NOOP_RE.search(text):
+            return False
+        if _TERMINAL_NOOP_RE.search(text):
+            return not _NEW_WORK_HINT_RE.search(text)
+        return not _ACTION_HINT_RE.search(text)
+
+    @staticmethod
+    def _is_context_update_retag(text: str) -> bool:
+        if (
+            _NEGATED_APPROVAL_RE.search(text)
+            or _NEGATED_CANCEL_RE.search(text)
+            or _QUESTION_APPROVAL_RE.search(text)
+            or _APPROVAL_PHRASE_QUESTION_RE.search(text)
+            or _APPROVAL_RE.search(text)
+        ):
+            return False
+        return bool(_NEW_WORK_HINT_RE.search(text))
+
+
+def _log_slack_flow(
+    event: str,
+    run: Any,
+    *,
+    cancelled_by: str = "",
+    approved_by: str = "",
+    requeued_by: str = "",
+) -> None:
+    logger.info(
+        "monica_slack_flow event=%s run_id=%s status=%s channel_id=%s thread_ts=%s "
+        "linear_identifier=%s linear_url=%s branch_name=%s pr_url=%s failure_reason=%s "
+        "cancelled_by=%s approved_by=%s requeued_by=%s",
+        event,
+        getattr(run, "id", ""),
+        getattr(run, "status", ""),
+        getattr(run, "channel_id", ""),
+        getattr(run, "thread_ts", ""),
+        getattr(run, "linear_identifier", ""),
+        getattr(run, "linear_url", ""),
+        getattr(run, "branch_name", ""),
+        getattr(run, "pr_url", ""),
+        getattr(run, "failure_reason", ""),
+        cancelled_by,
+        approved_by,
+        requeued_by,
+    )
+
+
+def _is_slack_user_id(value: str) -> bool:
+    return bool(_SLACK_USER_ID_RE.fullmatch(str(value or "").strip()))
+
+
+def _is_slack_channel_id(value: str) -> bool:
+    return bool(_SLACK_CHANNEL_ID_RE.fullmatch(str(value or "").strip()))

--- a/plugins/mobile_bug_agent/state.py
+++ b/plugins/mobile_bug_agent/state.py
@@ -1,0 +1,399 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class MonicaRun:
+    id: str
+    platform: str
+    channel_id: str
+    thread_ts: str
+    message_ts: str
+    user_id: str
+    request_text: str
+    intent: str
+    status: str
+    raw_event: dict[str, Any] | None = None
+    linear_identifier: str = ""
+    linear_issue_id: str = ""
+    linear_url: str = ""
+    branch_name: str = ""
+    pr_url: str = ""
+    failure_reason: str = ""
+    approved_by_user_id: str = ""
+    created_at: str = ""
+    updated_at: str = ""
+
+
+class MonicaState:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._db = sqlite3.connect(self.path, check_same_thread=False)
+        self._db.row_factory = sqlite3.Row
+        self._lock = threading.RLock()
+        self._migrate()
+
+    @classmethod
+    def open(cls, path: str | Path) -> "MonicaState":
+        return cls(Path(path))
+
+    def _migrate(self) -> None:
+        with self._lock:
+            self._db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS runs (
+                    id TEXT PRIMARY KEY,
+                    platform TEXT NOT NULL,
+                    channel_id TEXT NOT NULL,
+                    thread_ts TEXT NOT NULL,
+                    message_ts TEXT NOT NULL,
+                    user_id TEXT NOT NULL,
+                    request_text TEXT NOT NULL,
+                    raw_event_json TEXT NOT NULL DEFAULT '{}',
+                    intent TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    linear_identifier TEXT NOT NULL DEFAULT '',
+                    linear_issue_id TEXT NOT NULL DEFAULT '',
+                    linear_url TEXT NOT NULL DEFAULT '',
+                    branch_name TEXT NOT NULL DEFAULT '',
+                    pr_url TEXT NOT NULL DEFAULT '',
+                    failure_reason TEXT NOT NULL DEFAULT '',
+                    approved_by_user_id TEXT NOT NULL DEFAULT '',
+                    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    UNIQUE(platform, channel_id, thread_ts)
+                )
+                """
+            )
+            existing = {
+                str(row["name"])
+                for row in self._db.execute("PRAGMA table_info(runs)").fetchall()
+            }
+            required = {
+                "linear_identifier": "TEXT NOT NULL DEFAULT ''",
+                "raw_event_json": "TEXT NOT NULL DEFAULT '{}'",
+                "linear_issue_id": "TEXT NOT NULL DEFAULT ''",
+                "linear_url": "TEXT NOT NULL DEFAULT ''",
+                "branch_name": "TEXT NOT NULL DEFAULT ''",
+                "pr_url": "TEXT NOT NULL DEFAULT ''",
+                "failure_reason": "TEXT NOT NULL DEFAULT ''",
+                "approved_by_user_id": "TEXT NOT NULL DEFAULT ''",
+                "created_at": "TEXT NOT NULL DEFAULT ''",
+                "updated_at": "TEXT NOT NULL DEFAULT ''",
+            }
+            for column, definition in required.items():
+                if column not in existing:
+                    self._db.execute(f"ALTER TABLE runs ADD COLUMN {column} {definition}")
+            self._deduplicate_thread_runs()
+            self._db.execute(
+                """
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_monica_runs_thread_unique
+                ON runs(platform, channel_id, thread_ts)
+                """
+            )
+            self._db.commit()
+
+    def _deduplicate_thread_runs(self) -> None:
+        rows = self._db.execute("SELECT rowid AS monica_rowid, * FROM runs").fetchall()
+        groups: dict[tuple[str, str, str], list[sqlite3.Row]] = {}
+        for row in rows:
+            key = (str(row["platform"]), str(row["channel_id"]), str(row["thread_ts"]))
+            groups.setdefault(key, []).append(row)
+
+        for grouped in groups.values():
+            if len(grouped) <= 1:
+                continue
+            winner = max(grouped, key=_run_dedup_score)
+            loser_rowids = [
+                int(row["monica_rowid"])
+                for row in grouped
+                if int(row["monica_rowid"]) != int(winner["monica_rowid"])
+            ]
+            if not loser_rowids:
+                continue
+            placeholders = ", ".join("?" for _ in loser_rowids)
+            self._db.execute(
+                f"DELETE FROM runs WHERE rowid IN ({placeholders})",
+                loser_rowids,
+            )
+
+    def create_run(
+        self,
+        *,
+        platform: str,
+        channel_id: str,
+        thread_ts: str,
+        message_ts: str,
+        user_id: str,
+        request_text: str,
+        raw_event: dict[str, Any] | None = None,
+        intent: str = "agentic_triage",
+        status: str = "queued",
+    ) -> MonicaRun:
+        run, _created = self.create_run_once(
+            platform=platform,
+            channel_id=channel_id,
+            thread_ts=thread_ts,
+            message_ts=message_ts,
+            user_id=user_id,
+            request_text=request_text,
+            raw_event=raw_event,
+            intent=intent,
+            status=status,
+        )
+        return run
+
+    def create_run_once(
+        self,
+        *,
+        platform: str,
+        channel_id: str,
+        thread_ts: str,
+        message_ts: str,
+        user_id: str,
+        request_text: str,
+        raw_event: dict[str, Any] | None = None,
+        intent: str = "agentic_triage",
+        status: str = "queued",
+    ) -> tuple[MonicaRun, bool]:
+        with self._lock:
+            existing = self._find_run_locked(
+                platform=platform,
+                channel_id=channel_id,
+                thread_ts=thread_ts,
+            )
+            if existing is not None:
+                return existing, False
+
+            run_id = uuid.uuid4().hex
+            try:
+                self._db.execute(
+                    """
+                    INSERT INTO runs (
+                        id, platform, channel_id, thread_ts, message_ts, user_id,
+                        request_text, raw_event_json, intent, status
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        run_id,
+                        platform,
+                        channel_id,
+                        thread_ts,
+                        message_ts,
+                        user_id,
+                        request_text,
+                        _json_dumps(raw_event or {}),
+                        intent,
+                        status,
+                    ),
+                )
+            except sqlite3.IntegrityError:
+                existing = self._find_run_locked(
+                    platform=platform,
+                    channel_id=channel_id,
+                    thread_ts=thread_ts,
+                )
+                if existing is None:
+                    raise
+                return existing, False
+            self._db.commit()
+            run = self.get_run(run_id)
+            if run is None:  # pragma: no cover - sqlite insert/get invariant
+                raise RuntimeError(f"failed to create Monica run {run_id}")
+            return run, True
+
+    def find_run(self, *, platform: str, channel_id: str, thread_ts: str) -> MonicaRun | None:
+        with self._lock:
+            return self._find_run_locked(
+                platform=platform,
+                channel_id=channel_id,
+                thread_ts=thread_ts,
+            )
+
+    def _find_run_locked(self, *, platform: str, channel_id: str, thread_ts: str) -> MonicaRun | None:
+        row = self._db.execute(
+            """
+            SELECT * FROM runs
+            WHERE platform = ? AND channel_id = ? AND thread_ts = ?
+            """,
+            (platform, channel_id, thread_ts),
+        ).fetchone()
+        return self._row_to_run(row) if row else None
+
+    def get_run(self, run_id: str) -> MonicaRun | None:
+        with self._lock:
+            row = self._db.execute("SELECT * FROM runs WHERE id = ?", (run_id,)).fetchone()
+            return self._row_to_run(row) if row else None
+
+    def list_runs(self, *, limit: int | None = None) -> list[MonicaRun]:
+        with self._lock:
+            query = "SELECT * FROM runs ORDER BY created_at DESC, id DESC"
+            params: tuple[Any, ...] = ()
+            if limit is not None and limit > 0:
+                query += " LIMIT ?"
+                params = (limit,)
+            rows = self._db.execute(query, params).fetchall()
+            return [self._row_to_run(row) for row in rows]
+
+    def update_run(self, run_id: str, **fields: Any) -> MonicaRun:
+        allowed = {
+            "intent",
+            "status",
+            "message_ts",
+            "user_id",
+            "request_text",
+            "raw_event",
+            "raw_event_json",
+            "linear_identifier",
+            "linear_issue_id",
+            "linear_url",
+            "branch_name",
+            "pr_url",
+            "failure_reason",
+            "approved_by_user_id",
+        }
+        updates: dict[str, str] = {}
+        for key, value in fields.items():
+            if key not in allowed:
+                continue
+            if key == "raw_event":
+                updates["raw_event_json"] = _json_dumps(value if isinstance(value, dict) else {})
+            elif key == "raw_event_json":
+                updates[key] = str(value)
+            else:
+                updates[key] = str(value)
+        if not updates:
+            run = self.get_run(run_id)
+            if run is None:
+                raise KeyError(run_id)
+            return run
+
+        assignments = ", ".join(f"{key} = ?" for key in updates)
+        values = list(updates.values())
+        values.append(run_id)
+        with self._lock:
+            self._db.execute(
+                f"UPDATE runs SET {assignments}, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+                values,
+            )
+            self._db.commit()
+            run = self.get_run(run_id)
+            if run is None:
+                raise KeyError(run_id)
+            return run
+
+    @staticmethod
+    def _row_to_run(row: sqlite3.Row) -> MonicaRun:
+        return MonicaRun(
+            id=row["id"],
+            platform=row["platform"],
+            channel_id=row["channel_id"],
+            thread_ts=row["thread_ts"],
+            message_ts=row["message_ts"],
+            user_id=row["user_id"],
+            request_text=row["request_text"],
+            intent=row["intent"],
+            status=row["status"],
+            raw_event=_json_loads(row["raw_event_json"]),
+            linear_identifier=row["linear_identifier"],
+            linear_issue_id=row["linear_issue_id"],
+            linear_url=row["linear_url"],
+            branch_name=row["branch_name"],
+            pr_url=row["pr_url"],
+            failure_reason=row["failure_reason"],
+            approved_by_user_id=row["approved_by_user_id"],
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+        )
+
+    def approve_fix(self, run_id: str, *, approved_by_user_id: str) -> MonicaRun:
+        return self.update_run(
+            run_id,
+            status="approved",
+            approved_by_user_id=approved_by_user_id,
+            failure_reason="",
+        )
+
+    def approve_fix_once(self, run_id: str, *, approved_by_user_id: str) -> tuple[MonicaRun, bool]:
+        with self._lock:
+            cursor = self._db.execute(
+                """
+                UPDATE runs
+                SET status = ?, approved_by_user_id = ?, failure_reason = '', updated_at = CURRENT_TIMESTAMP
+                WHERE id = ? AND status = ?
+                """,
+                ("approved", approved_by_user_id, run_id, "awaiting_fix_approval"),
+            )
+            changed = cursor.rowcount > 0
+            self._db.commit()
+            run = self.get_run(run_id)
+            if run is None:
+                raise KeyError(run_id)
+            return run, changed
+
+
+def _json_dumps(value: dict[str, Any]) -> str:
+    try:
+        return json.dumps(value, sort_keys=True, separators=(",", ":"))
+    except (TypeError, ValueError):
+        return "{}"
+
+
+def _json_loads(value: str) -> dict[str, Any]:
+    try:
+        parsed = json.loads(value or "{}")
+    except (TypeError, ValueError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+_STATUS_PRIORITY = {
+    "done": 100,
+    "opening_pr": 90,
+    "proof_blocked": 85,
+    "proofing": 82,
+    "verifying": 80,
+    "fixing": 70,
+    "approved": 60,
+    "awaiting_fix_approval": 50,
+    "linear_created": 45,
+    "creating_linear": 40,
+    "triaging": 30,
+    "needs_clarification": 20,
+    "failed": 15,
+    "blocked": 10,
+    "queued": 0,
+}
+
+
+def _run_dedup_score(row: sqlite3.Row) -> tuple[int, int, int, int, int, str, str, int]:
+    status = str(row["status"] or "")
+    has_pr = int(bool(str(row["pr_url"] or "").strip()))
+    has_branch = int(bool(str(row["branch_name"] or "").strip()))
+    has_linear = int(
+        bool(
+            str(row["linear_identifier"] or "").strip()
+            or str(row["linear_issue_id"] or "").strip()
+            or str(row["linear_url"] or "").strip()
+        )
+    )
+    has_approval = int(bool(str(row["approved_by_user_id"] or "").strip()))
+    return (
+        _STATUS_PRIORITY.get(status, 0),
+        has_pr,
+        has_branch,
+        has_linear,
+        has_approval,
+        str(row["updated_at"] or ""),
+        str(row["created_at"] or ""),
+        int(row["monica_rowid"]),
+    )

--- a/plugins/mobile_bug_agent/verifier.py
+++ b/plugins/mobile_bug_agent/verifier.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    passed: bool
+    summary: str
+    output: str
+    commands: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "passed": self.passed,
+            "summary": self.summary,
+            "output": self.output,
+            "commands": list(self.commands),
+        }
+
+
+RunCommand = Callable[[str, Path, int], tuple[int, str, str]]
+
+
+class VerificationRunner:
+    def __init__(
+        self,
+        *,
+        run_command: RunCommand | None = None,
+        timeout_seconds: int = 900,
+    ) -> None:
+        self._run_command = run_command or self._default_run
+        self.timeout_seconds = timeout_seconds
+
+    def run(self, worktree: str | Path, commands: list[str] | tuple[str, ...]) -> VerificationResult:
+        worktree_path = Path(worktree)
+        command_list = tuple(command for command in commands if command.strip())
+        if not worktree_path.is_dir():
+            return VerificationResult(
+                passed=False,
+                summary="Verification failed: worktree does not exist",
+                output=f"Worktree does not exist: {worktree_path}",
+                commands=command_list,
+            )
+        if not (worktree_path / ".git").exists():
+            return VerificationResult(
+                passed=False,
+                summary="Verification failed: worktree is not a git worktree",
+                output=f"Worktree is not a git worktree: {worktree_path}",
+                commands=command_list,
+            )
+        if not command_list:
+            return VerificationResult(
+                passed=False,
+                summary="No verification commands configured.",
+                output="mobile_bug_agent.verification.commands is empty.",
+                commands=(),
+            )
+
+        output_parts: list[str] = []
+        for command in command_list:
+            code, stdout, stderr = self._run_command(command, worktree_path, self.timeout_seconds)
+            output_parts.append(
+                "\n".join(
+                    [
+                        f"$ {command}",
+                        stdout.strip(),
+                        stderr.strip(),
+                    ]
+                ).strip()
+            )
+            if code != 0:
+                return VerificationResult(
+                    passed=False,
+                    summary=f"Verification failed: {command}",
+                    output="\n\n".join(output_parts),
+                    commands=command_list,
+                )
+
+        return VerificationResult(
+            passed=True,
+            summary="Verification passed.",
+            output="\n\n".join(output_parts),
+            commands=command_list,
+        )
+
+    @staticmethod
+    def _default_run(command: str, cwd: Path, timeout: int) -> tuple[int, str, str]:
+        try:
+            proc = subprocess.run(
+                command,
+                cwd=str(cwd),
+                shell=True,
+                text=True,
+                capture_output=True,
+                timeout=timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return 124, "", f"command timed out after {timeout}s"
+        return proc.returncode, proc.stdout, proc.stderr

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -311,6 +311,43 @@ class TestLoadGatewayConfig:
 
         assert config.quick_commands == {"limits": {"type": "exec", "command": "echo ok"}}
 
+    def test_monica_enabled_profile_bridges_monica_slack_tokens(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "mobile_bug_agent:\n"
+            "  enabled: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("MONICA_SLACK_BOT_TOKEN", "xoxb-monica")
+        monkeypatch.setenv("MONICA_SLACK_APP_TOKEN", "xapp-monica")
+        monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+        monkeypatch.delenv("SLACK_APP_TOKEN", raising=False)
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.SLACK].enabled is True
+        assert config.platforms[Platform.SLACK].token == "xoxb-monica"
+        assert os.environ["SLACK_APP_TOKEN"] == "xapp-monica"
+
+    def test_non_monica_profile_ignores_monica_slack_tokens(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text("{}\n", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("MONICA_SLACK_BOT_TOKEN", "xoxb-monica")
+        monkeypatch.setenv("MONICA_SLACK_APP_TOKEN", "xapp-monica")
+        monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+        monkeypatch.delenv("SLACK_APP_TOKEN", raising=False)
+
+        config = load_gateway_config()
+
+        assert Platform.SLACK not in config.platforms
+        assert "SLACK_APP_TOKEN" not in os.environ
+
     def test_bridges_group_sessions_per_user_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tests/gateway/test_pre_gateway_dispatch.py
+++ b/tests/gateway/test_pre_gateway_dispatch.py
@@ -27,7 +27,11 @@ def _clear_auth_env(monkeypatch) -> None:
         monkeypatch.delenv(key, raising=False)
 
 
-def _make_event(text: str = "hello", platform: Platform = Platform.WHATSAPP) -> MessageEvent:
+def _make_event(
+    text: str = "hello",
+    platform: Platform = Platform.WHATSAPP,
+    thread_id: str | None = None,
+) -> MessageEvent:
     return MessageEvent(
         text=text,
         message_id="m1",
@@ -37,6 +41,7 @@ def _make_event(text: str = "hello", platform: Platform = Platform.WHATSAPP) -> 
             chat_id="15551234567@s.whatsapp.net",
             user_name="tester",
             chat_type="dm",
+            thread_id=thread_id,
         ),
     )
 
@@ -78,6 +83,64 @@ async def test_hook_skip_short_circuits_dispatch(monkeypatch):
 
     assert result is None
     adapter.send.assert_not_awaited()
+    runner.pairing_store.generate_code.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_hook_skip_reply_sends_reply_then_short_circuits(monkeypatch):
+    """A plugin can drop dispatch while sending a visible reply."""
+    _clear_auth_env(monkeypatch)
+
+    def _fake_hook(name, **kwargs):
+        if name == "pre_gateway_dispatch":
+            return [{"action": "skip_reply", "text": "Approval denied."}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    runner, adapter = _make_runner(Platform.SLACK)
+
+    result = await runner._handle_message(
+        _make_event("approved, fix it", platform=Platform.SLACK)
+    )
+
+    assert result is None
+    adapter.send.assert_awaited_once_with(
+        "15551234567@s.whatsapp.net",
+        "Approval denied.",
+        metadata=None,
+    )
+    runner.pairing_store.generate_code.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_hook_skip_reply_preserves_thread_metadata(monkeypatch):
+    """Visible hook replies stay in the originating Slack thread."""
+    _clear_auth_env(monkeypatch)
+
+    def _fake_hook(name, **kwargs):
+        if name == "pre_gateway_dispatch":
+            return [{"action": "skip_reply", "text": "Approval denied."}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    runner, adapter = _make_runner(Platform.SLACK)
+
+    result = await runner._handle_message(
+        _make_event(
+            "approved, fix it",
+            platform=Platform.SLACK,
+            thread_id="1710000000.000100",
+        )
+    )
+
+    assert result is None
+    adapter.send.assert_awaited_once_with(
+        "15551234567@s.whatsapp.net",
+        "Approval denied.",
+        metadata={"thread_id": "1710000000.000100"},
+    )
     runner.pairing_store.generate_code.assert_not_called()
 
 

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -122,6 +122,29 @@ class TestSlackExecApproval:
             assert e["value"] == "agent:main:slack:group:C1:1111"
 
     @pytest.mark.asyncio
+    async def test_approval_copy_is_human_readable_for_inline_script_flag(self):
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_postMessage = AsyncMock(return_value={"ts": "1234.5678"})
+
+        await adapter.send_exec_approval(
+            chat_id="C1",
+            command="node --import tsx scripts/run-ad-hoc-query.ts --request-json \"$(python -c 'print(1)')\"",
+            session_key="agent:main:slack:dm:D1:1111",
+            description="script execution via -e/-c flag",
+        )
+
+        kwargs = mock_client.chat_postMessage.call_args[1]
+        section_text = kwargs["blocks"][0]["text"]["text"]
+
+        assert "Permission needed to continue" in section_text
+        assert "run a local analytics command" in section_text
+        assert "runs a short inline script" in section_text
+        assert "Allow Once" in section_text
+        assert "Deny" in section_text
+        assert "script execution via -e/-c flag" not in section_text
+
+    @pytest.mark.asyncio
     async def test_sends_in_thread(self):
         adapter = _make_adapter()
         mock_client = adapter._team_clients["T1"]

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -31,6 +31,18 @@ def test_non_telegram_status_is_unchanged():
     assert _prepare_gateway_status_message("local", "lifecycle", message) == message
 
 
+def test_slack_status_suppresses_codex_auto_compaction_notice():
+    """Codex compression config notices should stay out of Slack chat."""
+    message = (
+        "ℹ Codex gpt-5.5 caps context at 272K, so auto-compaction was "
+        "raised to 85% (from 50%) to use more of the window before summarizing.\n"
+        "Opt back out: hermes config set compression.codex_gpt55_autoraise false"
+    )
+
+    assert _prepare_gateway_status_message(Platform.SLACK, "lifecycle", message) is None
+    assert _prepare_gateway_status_message("local", "lifecycle", message) == message
+
+
 def test_telegram_status_sanitizes_raw_provider_security_errors():
     """Provider policy/security bodies should be replaced before chat delivery."""
     raw = (

--- a/tests/hermes_cli/test_plugin_cli_registration.py
+++ b/tests/hermes_cli/test_plugin_cli_registration.py
@@ -11,6 +11,7 @@ Covers:
 import sys
 from unittest.mock import MagicMock
 
+import pytest
 
 from hermes_cli.plugins import (
     PluginContext,
@@ -183,3 +184,48 @@ class TestProviderCollectorCliNoop:
         )
         # Should not store anything — CLI is discovered via file convention
         assert not hasattr(collector, "_cli_commands")
+
+
+def test_main_exits_with_plugin_command_status(monkeypatch):
+    """Plugin CLI handlers can return a process exit status."""
+    import hermes_cli.main as main_mod
+    import hermes_cli.plugins as plugin_mod
+    import plugins.memory as memory_mod
+
+    def setup_plugin_parser(_parser):
+        return None
+
+    def plugin_handler(_args):
+        return 7
+
+    monkeypatch.setattr(sys, "argv", ["hermes", "fake-plugin"])
+    monkeypatch.setattr(main_mod, "_set_process_title", lambda: None)
+    monkeypatch.setattr(main_mod, "_cleanup_quarantined_exes", lambda: None)
+    monkeypatch.setattr(main_mod, "_recover_from_interrupted_install", lambda: None)
+    monkeypatch.setattr(main_mod, "_try_termux_fast_tui_launch", lambda: False)
+    monkeypatch.setattr(main_mod, "_try_termux_fast_cli_launch", lambda: False)
+    monkeypatch.setattr(main_mod, "_plugin_cli_discovery_needed", lambda: True)
+    monkeypatch.setattr(main_mod, "_prepare_agent_startup", lambda _args: None)
+    monkeypatch.setattr(
+        memory_mod,
+        "discover_plugin_cli_commands",
+        lambda: [
+            {
+                "name": "fake-plugin",
+                "help": "Fake plugin",
+                "description": "Fake plugin",
+                "setup_fn": setup_plugin_parser,
+                "handler_fn": plugin_handler,
+            }
+        ],
+    )
+    monkeypatch.setattr(plugin_mod, "discover_plugins", lambda: None)
+
+    manager = MagicMock()
+    manager._cli_commands = {}
+    monkeypatch.setattr(plugin_mod, "get_plugin_manager", lambda: manager)
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod.main()
+
+    assert exc.value.code == 7

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -343,6 +343,28 @@ class TestReadManifest:
         assert result == {}
 
 
+def test_plugin_exists_accepts_bundled_manifest_name_with_different_directory(
+    tmp_path,
+    monkeypatch,
+):
+    import hermes_cli.plugins_cmd as pc
+
+    bundled_root = tmp_path / "bundled"
+    plugin_dir = bundled_root / "mobile_bug_agent"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.yaml").write_text(
+        yaml.safe_dump({"name": "mobile-bug-agent", "version": "0.1.0"}),
+        encoding="utf-8",
+    )
+    user_root = tmp_path / "user"
+    user_root.mkdir()
+
+    monkeypatch.setattr(pc, "_plugins_dir", lambda: user_root)
+    monkeypatch.setattr("hermes_cli.plugins.get_bundled_plugins_dir", lambda: bundled_root)
+
+    assert pc._plugin_exists("mobile-bug-agent") is True
+
+
 # ── cmd_install tests ─────────────────────────────────────────────────────────
 
 

--- a/tests/plugins/mobile_bug_agent/test_cli.py
+++ b/tests/plugins/mobile_bug_agent/test_cli.py
@@ -1,0 +1,3302 @@
+from __future__ import annotations
+
+import copy
+import json
+import re
+from argparse import ArgumentParser
+from types import SimpleNamespace
+
+from plugins.mobile_bug_agent import cli
+from plugins.mobile_bug_agent.cli import (
+    _open_state,
+    run_approve_command,
+    run_configure_approved_pr_command,
+    run_configure_linear_only_command,
+    run_configure_local_fix_only_command,
+    run_doctor_command,
+    run_linear_metadata_command,
+    run_retry_command,
+    run_setup_plan_command,
+    run_simulate_command,
+    run_show_command,
+    run_slack_manifest_command,
+    run_slack_metadata_command,
+    run_status_command,
+)
+from plugins.mobile_bug_agent.config import (
+    LinearConfig,
+    LoopConfig,
+    MonicaConfig,
+    ProofConfig,
+    RepoConfig,
+    RuntimeConfig,
+    SlackConfig,
+    VerificationConfig,
+    WorkerConfig,
+    config_from_mapping,
+)
+from plugins.mobile_bug_agent.state import MonicaState
+
+
+def test_status_lists_recent_runs(tmp_path, capsys):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    state.create_run(
+        platform="slack",
+        channel_id="C123",
+        thread_ts="T1",
+        message_ts="T1",
+        user_id="U1",
+        request_text="@monica checkout crash",
+    )
+
+    exit_code = run_status_command(state=state, limit=5)
+
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert "checkout crash" in out
+
+
+def test_status_lists_rollout_context_for_recent_runs(tmp_path, capsys):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C123",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U1",
+        request_text="@monica checkout crash",
+    )
+    state.update_run(
+        run.id,
+        status="failed",
+        linear_identifier="MOB-123",
+        linear_url="https://linear.app/acme/issue/MOB-123",
+        branch_name="monica/MOB-123-checkout-crash",
+    )
+
+    exit_code = run_status_command(state=state, limit=5)
+
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert "slack:C123/1710000000.000100" in out
+    assert "linear:MOB-123" in out
+    assert "branch:monica/MOB-123-checkout-crash" in out
+    assert "url:https://linear.app/acme/issue/MOB-123" in out
+
+
+def test_status_json_lists_recent_runs(tmp_path, capsys):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C123",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U1",
+        request_text="@monica checkout crash",
+    )
+    state.update_run(
+        run.id,
+        status="awaiting_fix_approval",
+        linear_identifier="MOB-123",
+        linear_url="https://linear.app/acme/issue/MOB-123",
+        branch_name="monica/MOB-123-checkout-crash",
+    )
+
+    exit_code = run_status_command(state=state, limit=5, json_output=True)
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload["count"] == 1
+    assert payload["runs"][0]["id"] == run.id
+    assert payload["runs"][0]["status"] == "awaiting_fix_approval"
+    assert payload["runs"][0]["slack"]["channel_id"] == "C123"
+    assert payload["runs"][0]["linear"]["identifier"] == "MOB-123"
+    assert payload["runs"][0]["branch_name"] == "monica/MOB-123-checkout-crash"
+    assert payload["runs"][0]["request_text"] == "@monica checkout crash"
+
+
+def test_show_missing_run_returns_error(tmp_path, capsys):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+
+    exit_code = run_show_command(state=state, run_id="missing")
+
+    assert exit_code == 1
+    assert "missing" in capsys.readouterr().out
+
+
+def test_show_json_outputs_full_run(tmp_path, capsys):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C123",
+        thread_ts="T1",
+        message_ts="T1",
+        user_id="U1",
+        request_text="@monica checkout crash",
+        raw_event={"type": "app_mention", "event_id": "E123"},
+    )
+    state.update_run(
+        run.id,
+        status="failed",
+        failure_reason="verification failed",
+        approved_by_user_id="U_APPROVER",
+        pr_url="https://github.com/acme/mobile/pull/123",
+    )
+
+    exit_code = run_show_command(state=state, run_id=run.id, json_output=True)
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload["id"] == run.id
+    assert payload["status"] == "failed"
+    assert payload["failure_reason"] == "verification failed"
+    assert payload["approved_by_user_id"] == "U_APPROVER"
+    assert payload["pr_url"] == "https://github.com/acme/mobile/pull/123"
+    assert payload["raw_event"] == {"type": "app_mention", "event_id": "E123"}
+
+
+def test_retry_refuses_completed_runs(tmp_path, capsys, monkeypatch):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C123",
+        thread_ts="T1",
+        message_ts="T1",
+        user_id="U1",
+        request_text="@monica checkout crash",
+    )
+    state.update_run(
+        run.id,
+        status="done",
+        pr_url="https://github.com/acme/mobile/pull/123",
+        approved_by_user_id="U1",
+    )
+    launched: list[str] = []
+    monkeypatch.setattr(cli, "_run_loop", lambda run_id, *, state: launched.append(run_id))
+
+    exit_code = run_retry_command(state=state, run_id=run.id)
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert exit_code == 1
+    assert updated.status == "done"
+    assert updated.pr_url == "https://github.com/acme/mobile/pull/123"
+    assert launched == []
+    assert "not retryable" in capsys.readouterr().out
+
+
+def test_retry_refuses_cancelled_runs(tmp_path, capsys, monkeypatch):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C123",
+        thread_ts="T1",
+        message_ts="T1",
+        user_id="U1",
+        request_text="@monica checkout crash",
+    )
+    state.update_run(
+        run.id,
+        status="blocked",
+        failure_reason="cancelled by U_APPROVER",
+    )
+    launched: list[str] = []
+    monkeypatch.setattr(cli, "_run_loop", lambda run_id, *, state: launched.append(run_id))
+
+    exit_code = run_retry_command(state=state, run_id=run.id)
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert exit_code == 1
+    assert updated.status == "blocked"
+    assert updated.failure_reason == "cancelled by U_APPROVER"
+    assert launched == []
+    assert "was cancelled from Slack" in capsys.readouterr().out
+
+
+def test_retry_failed_approved_run_resumes_from_approval_gate(tmp_path, capsys, monkeypatch):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C123",
+        thread_ts="T1",
+        message_ts="T1",
+        user_id="U1",
+        request_text="@monica checkout crash",
+    )
+    state.update_run(
+        run.id,
+        status="failed",
+        failure_reason="opening_pr_failed: gh pr create failed",
+        approved_by_user_id="U_APPROVER",
+    )
+    launched: list[str] = []
+    monkeypatch.setattr(cli, "_run_loop", lambda run_id, *, state: launched.append(run_id))
+
+    exit_code = run_retry_command(state=state, run_id=run.id)
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert exit_code == 0
+    assert updated.status == "approved"
+    assert updated.failure_reason == ""
+    assert updated.approved_by_user_id == "U_APPROVER"
+    assert launched == [run.id]
+    assert f"Retried Monica run {run.id}" in capsys.readouterr().out
+
+
+def test_retry_json_success_outputs_updated_run(tmp_path, capsys, monkeypatch):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C123",
+        thread_ts="T1",
+        message_ts="T1",
+        user_id="U1",
+        request_text="@monica checkout crash",
+    )
+    state.update_run(
+        run.id,
+        status="failed",
+        failure_reason="opening_pr_failed: transient gh error",
+        approved_by_user_id="U_APPROVER",
+    )
+    launched: list[str] = []
+
+    def fake_loop(run_id: str, *, state: MonicaState) -> None:
+        launched.append(run_id)
+        state.update_run(run_id, status="done", pr_url="https://github.com/acme/mobile/pull/123")
+
+    monkeypatch.setattr(cli, "_run_loop", fake_loop)
+
+    exit_code = run_retry_command(state=state, run_id=run.id, json_output=True)
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert launched == [run.id]
+    assert payload["ok"] is True
+    assert payload["action"] == "retry"
+    assert payload["run"]["id"] == run.id
+    assert payload["run"]["status"] == "done"
+    assert payload["run"]["pr_url"] == "https://github.com/acme/mobile/pull/123"
+    assert payload["run"]["approved_by_user_id"] == "U_APPROVER"
+
+
+def test_retry_json_missing_run_outputs_error(tmp_path, capsys, monkeypatch):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    launched: list[str] = []
+    monkeypatch.setattr(cli, "_run_loop", lambda run_id, *, state: launched.append(run_id))
+
+    exit_code = run_retry_command(state=state, run_id="missing", json_output=True)
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 1
+    assert launched == []
+    assert payload["ok"] is False
+    assert payload["action"] == "retry"
+    assert payload["error"]["code"] == "not_found"
+    assert "missing" in payload["error"]["message"]
+
+
+def test_retry_approved_run_refuses_unconfigured_stored_approver(tmp_path, capsys, monkeypatch):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C123",
+        thread_ts="T1",
+        message_ts="T1",
+        user_id="U1",
+        request_text="@monica checkout crash",
+    )
+    state.update_run(
+        run.id,
+        status="failed",
+        failure_reason="opening_pr_failed: gh pr create failed",
+        approved_by_user_id="U_OLD_APPROVER",
+    )
+    launched: list[str] = []
+    monkeypatch.setattr(cli, "_run_loop", lambda run_id, *, state: launched.append(run_id))
+
+    exit_code = run_retry_command(
+        state=state,
+        run_id=run.id,
+        config=MonicaConfig(slack=SlackConfig(approver_user_ids=("U_CURRENT_APPROVER",))),
+    )
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert exit_code == 1
+    assert updated.status == "failed"
+    assert updated.failure_reason == "opening_pr_failed: gh pr create failed"
+    assert updated.approved_by_user_id == "U_OLD_APPROVER"
+    assert launched == []
+    assert "stored approver U_OLD_APPROVER is not configured" in capsys.readouterr().out
+
+
+def test_retry_approved_run_refuses_when_readiness_check_fails(tmp_path, capsys, monkeypatch):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C123",
+        thread_ts="T1",
+        message_ts="T1",
+        user_id="U1",
+        request_text="@monica checkout crash",
+    )
+    state.update_run(
+        run.id,
+        status="failed",
+        failure_reason="opening_pr_failed: gh pr create failed",
+        approved_by_user_id="U_APPROVER",
+    )
+    launched: list[str] = []
+    monkeypatch.setattr(cli, "_run_loop", lambda run_id, *, state: launched.append(run_id))
+
+    exit_code = run_retry_command(
+        state=state,
+        run_id=run.id,
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="approved_pr",
+            slack=SlackConfig(approver_user_ids=("U_APPROVER",)),
+        ),
+        readiness_checker=lambda: 1,
+    )
+
+    updated = state.get_run(run.id)
+    out = capsys.readouterr().out
+    assert updated is not None
+    assert exit_code == 1
+    assert updated.status == "failed"
+    assert updated.failure_reason == "opening_pr_failed: gh pr create failed"
+    assert updated.approved_by_user_id == "U_APPROVER"
+    assert launched == []
+    assert "Monica readiness check failed" in out
+
+
+def test_retry_refuses_run_that_already_has_pr_url(tmp_path, capsys, monkeypatch):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C123",
+        thread_ts="T1",
+        message_ts="T1",
+        user_id="U1",
+        request_text="@monica checkout crash",
+    )
+    state.update_run(
+        run.id,
+        status="failed",
+        failure_reason="opening_pr_failed: transient Slack post failed",
+        branch_name="monica/MOB-123-checkout-crash",
+        pr_url="https://github.com/acme/mobile/pull/123",
+        approved_by_user_id="U_APPROVER",
+    )
+    launched: list[str] = []
+    monkeypatch.setattr(cli, "_run_loop", lambda run_id, *, state: launched.append(run_id))
+
+    exit_code = run_retry_command(state=state, run_id=run.id)
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert exit_code == 1
+    assert updated.status == "failed"
+    assert updated.failure_reason == "opening_pr_failed: transient Slack post failed"
+    assert updated.branch_name == "monica/MOB-123-checkout-crash"
+    assert updated.pr_url == "https://github.com/acme/mobile/pull/123"
+    assert launched == []
+    assert "already has a draft PR" in capsys.readouterr().out
+
+
+def test_retry_clears_stale_branch_metadata_before_relaunch(tmp_path, capsys, monkeypatch):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C123",
+        thread_ts="T1",
+        message_ts="T1",
+        user_id="U1",
+        request_text="@monica checkout crash",
+    )
+    state.update_run(
+        run.id,
+        status="failed",
+        failure_reason="opening_pr_failed: stale gh failure",
+        branch_name="monica/old-branch",
+    )
+    relaunched_state: list[tuple[str, str, str, str]] = []
+
+    def fake_run_loop(run_id: str, *, state: MonicaState) -> None:
+        current = state.get_run(run_id)
+        assert current is not None
+        relaunched_state.append(
+            (current.status, current.failure_reason, current.branch_name, current.pr_url)
+        )
+
+    monkeypatch.setattr(cli, "_run_loop", fake_run_loop)
+
+    exit_code = run_retry_command(state=state, run_id=run.id)
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert exit_code == 0
+    assert updated.status == "queued"
+    assert updated.failure_reason == ""
+    assert updated.branch_name == ""
+    assert updated.pr_url == ""
+    assert relaunched_state == [("queued", "", "", "")]
+    assert f"Retried Monica run {run.id}" in capsys.readouterr().out
+
+
+def test_approve_refuses_completed_runs(tmp_path, capsys, monkeypatch):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C123",
+        thread_ts="T1",
+        message_ts="T1",
+        user_id="U1",
+        request_text="@monica checkout crash",
+    )
+    state.update_run(
+        run.id,
+        status="done",
+        pr_url="https://github.com/acme/mobile/pull/123",
+    )
+    launched: list[str] = []
+    monkeypatch.setattr(cli, "_run_loop", lambda run_id, *, state: launched.append(run_id))
+
+    exit_code = run_approve_command(state=state, run_id=run.id, user_id="local-operator")
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert exit_code == 1
+    assert updated.status == "done"
+    assert updated.approved_by_user_id == ""
+    assert launched == []
+    assert "not awaiting fix approval" in capsys.readouterr().out
+
+
+def test_approve_waiting_run_marks_approved_and_invokes_loop(tmp_path, capsys, monkeypatch):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C123",
+        thread_ts="T1",
+        message_ts="T1",
+        user_id="U1",
+        request_text="@monica checkout crash",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    launched: list[str] = []
+    monkeypatch.setattr(cli, "_run_loop", lambda run_id, *, state: launched.append(run_id))
+
+    exit_code = run_approve_command(state=state, run_id=run.id, user_id="local-operator")
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert exit_code == 0
+    assert updated.status == "approved"
+    assert updated.approved_by_user_id == "local-operator"
+    assert launched == [run.id]
+    assert f"Approved Monica run {run.id}" in capsys.readouterr().out
+
+
+def test_approve_json_success_outputs_updated_run(tmp_path, capsys, monkeypatch):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C123",
+        thread_ts="T1",
+        message_ts="T1",
+        user_id="U1",
+        request_text="@monica checkout crash",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    launched: list[str] = []
+
+    def fake_loop(run_id: str, *, state: MonicaState) -> None:
+        launched.append(run_id)
+        state.update_run(run_id, status="fixing")
+
+    monkeypatch.setattr(cli, "_run_loop", fake_loop)
+
+    exit_code = run_approve_command(
+        state=state,
+        run_id=run.id,
+        user_id="local-operator",
+        json_output=True,
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert launched == [run.id]
+    assert payload["ok"] is True
+    assert payload["action"] == "approve"
+    assert payload["run"]["id"] == run.id
+    assert payload["run"]["status"] == "fixing"
+    assert payload["run"]["approved_by_user_id"] == "local-operator"
+
+
+def test_approve_json_unconfigured_user_outputs_error(tmp_path, capsys, monkeypatch):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C123",
+        thread_ts="T1",
+        message_ts="T1",
+        user_id="U1",
+        request_text="@monica checkout crash",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    launched: list[str] = []
+    monkeypatch.setattr(cli, "_run_loop", lambda run_id, *, state: launched.append(run_id))
+
+    exit_code = run_approve_command(
+        state=state,
+        run_id=run.id,
+        user_id="local-operator",
+        config=MonicaConfig(slack=SlackConfig(approver_user_ids=("U_APPROVER",))),
+        json_output=True,
+    )
+
+    updated = state.get_run(run.id)
+    payload = json.loads(capsys.readouterr().out)
+    assert updated is not None
+    assert exit_code == 1
+    assert updated.status == "awaiting_fix_approval"
+    assert updated.approved_by_user_id == ""
+    assert launched == []
+    assert payload["ok"] is False
+    assert payload["action"] == "approve"
+    assert payload["error"]["code"] == "approver_not_allowed"
+    assert payload["run"]["id"] == run.id
+    assert payload["run"]["status"] == "awaiting_fix_approval"
+
+
+def test_approve_refuses_user_outside_configured_approver_allowlist(tmp_path, capsys, monkeypatch):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C123",
+        thread_ts="T1",
+        message_ts="T1",
+        user_id="U1",
+        request_text="@monica checkout crash",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    launched: list[str] = []
+    monkeypatch.setattr(cli, "_run_loop", lambda run_id, *, state: launched.append(run_id))
+
+    exit_code = run_approve_command(
+        state=state,
+        run_id=run.id,
+        user_id="local-operator",
+        config=MonicaConfig(slack=SlackConfig(approver_user_ids=("U_APPROVER",))),
+    )
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert exit_code == 1
+    assert updated.status == "awaiting_fix_approval"
+    assert updated.approved_by_user_id == ""
+    assert launched == []
+    assert "not configured as a Monica code approver" in capsys.readouterr().out
+
+
+def test_approve_refuses_approved_pr_when_readiness_check_fails(tmp_path, capsys, monkeypatch):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C123",
+        thread_ts="T1",
+        message_ts="T1",
+        user_id="U1",
+        request_text="@monica checkout crash",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    launched: list[str] = []
+    monkeypatch.setattr(cli, "_run_loop", lambda run_id, *, state: launched.append(run_id))
+
+    exit_code = run_approve_command(
+        state=state,
+        run_id=run.id,
+        user_id="U_APPROVER",
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="approved_pr",
+            slack=SlackConfig(approver_user_ids=("U_APPROVER",)),
+        ),
+        readiness_checker=lambda: 1,
+    )
+
+    updated = state.get_run(run.id)
+    out = capsys.readouterr().out
+    assert updated is not None
+    assert exit_code == 1
+    assert updated.status == "awaiting_fix_approval"
+    assert updated.approved_by_user_id == ""
+    assert launched == []
+    assert "Monica readiness check failed" in out
+
+
+def test_approve_does_not_launch_when_atomic_approval_already_changed(tmp_path, capsys, monkeypatch):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C123",
+        thread_ts="T1",
+        message_ts="T1",
+        user_id="U1",
+        request_text="@monica checkout crash",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    launched: list[str] = []
+    monkeypatch.setattr(cli, "_run_loop", lambda run_id, *, state: launched.append(run_id))
+
+    def approve_once(run_id: str, *, approved_by_user_id: str):
+        approved = state.update_run(run_id, status="approved", approved_by_user_id="U_OTHER")
+        return approved, False
+
+    monkeypatch.setattr(state, "approve_fix_once", approve_once)
+
+    exit_code = run_approve_command(state=state, run_id=run.id, user_id="local-operator")
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert exit_code == 1
+    assert updated.status == "approved"
+    assert updated.approved_by_user_id == "U_OTHER"
+    assert launched == []
+    assert "already approved or no longer awaiting fix approval" in capsys.readouterr().out
+
+
+def test_simulate_requires_enabled_config(tmp_path, capsys):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+
+    exit_code = run_simulate_command(
+        config=MonicaConfig(enabled=False),
+        state=state,
+        text="checkout crashes on Android",
+        channel_id="LOCAL",
+        user_id="local-operator",
+    )
+
+    assert exit_code == 1
+    assert "Monica is disabled" in capsys.readouterr().out
+    assert state.list_runs() == []
+
+
+def test_simulate_json_reports_disabled_config_without_creating_run(tmp_path, capsys):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+
+    exit_code = run_simulate_command(
+        config=MonicaConfig(enabled=False),
+        state=state,
+        text="checkout crashes on Android",
+        channel_id="LOCAL",
+        user_id="local-operator",
+        json_output=True,
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 1
+    assert state.list_runs() == []
+    assert payload["created"] is False
+    assert payload["rollout_mode"] == "dry_run"
+    assert payload["error"]["code"] == "config_disabled"
+    assert "mobile_bug_agent.enabled" in payload["error"]["message"]
+
+
+def test_simulate_creates_local_slack_shaped_run_and_invokes_loop(tmp_path, capsys):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    launched: list[str] = []
+
+    def fake_loop(run_id: str, *, state: MonicaState) -> None:
+        launched.append(run_id)
+        state.update_run(run_id, status="done", linear_identifier="DRY-RUN")
+
+    exit_code = run_simulate_command(
+        config=MonicaConfig(enabled=True, rollout_mode="dry_run"),
+        state=state,
+        text="checkout crashes on Android",
+        channel_id="LOCAL",
+        user_id="local-operator",
+        thread_ts="sim-thread",
+        loop_runner=fake_loop,
+    )
+
+    runs = state.list_runs()
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert len(runs) == 1
+    assert launched == [runs[0].id]
+    assert runs[0].platform == "slack"
+    assert runs[0].channel_id == "LOCAL"
+    assert runs[0].thread_ts == "sim-thread"
+    assert runs[0].raw_event is not None
+    assert runs[0].raw_event["monica_simulated"] is True
+    assert runs[0].raw_event["type"] == "app_mention"
+    assert runs[0].raw_event["permalink"] == "local://monica/simulated/sim-thread"
+    assert "Simulated Monica run" in out
+    assert "DRY-RUN" in out
+
+
+def test_simulate_json_outputs_created_run(tmp_path, capsys):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    launched: list[str] = []
+
+    def fake_loop(run_id: str, *, state: MonicaState) -> None:
+        launched.append(run_id)
+        state.update_run(
+            run_id,
+            status="done",
+            linear_identifier="DRY-RUN",
+            linear_url="https://linear.app/acme/issue/DRY-RUN",
+        )
+
+    exit_code = run_simulate_command(
+        config=MonicaConfig(enabled=True, rollout_mode="dry_run"),
+        state=state,
+        text="checkout crashes on Android",
+        channel_id="LOCAL",
+        user_id="local-operator",
+        thread_ts="sim-thread",
+        loop_runner=fake_loop,
+        json_output=True,
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    runs = state.list_runs()
+    assert exit_code == 0
+    assert len(runs) == 1
+    assert launched == [runs[0].id]
+    assert payload["run"]["id"] == runs[0].id
+    assert payload["run"]["status"] == "done"
+    assert payload["run"]["slack"]["channel_id"] == "LOCAL"
+    assert payload["run"]["linear"]["identifier"] == "DRY-RUN"
+    assert payload["created"] is True
+    assert payload["allow_side_effects"] is False
+    assert payload["rollout_mode"] == "dry_run"
+
+
+def test_simulate_default_thread_ids_do_not_collide_when_clock_repeats(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    launched: list[str] = []
+    monkeypatch.setattr(cli.time, "time", lambda: 1710000000.0)
+
+    first = run_simulate_command(
+        config=MonicaConfig(enabled=True, rollout_mode="dry_run"),
+        state=state,
+        text="checkout crashes on Android",
+        channel_id="LOCAL",
+        user_id="local-operator",
+        loop_runner=lambda run_id, *, state: launched.append(run_id),
+    )
+    second = run_simulate_command(
+        config=MonicaConfig(enabled=True, rollout_mode="dry_run"),
+        state=state,
+        text="checkout still crashes on Android",
+        channel_id="LOCAL",
+        user_id="local-operator",
+        loop_runner=lambda run_id, *, state: launched.append(run_id),
+    )
+
+    runs = state.list_runs()
+    assert first == 0
+    assert second == 0
+    assert len(runs) == 2
+    assert len({run.thread_ts for run in runs}) == 2
+    assert set(launched) == {run.id for run in runs}
+    assert all(re.fullmatch(r"\d+\.\d{6}", run.thread_ts) for run in runs)
+    assert "already exists" not in capsys.readouterr().out
+
+
+def test_simulate_refuses_side_effect_rollout_without_explicit_flag(tmp_path, capsys):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    launched: list[str] = []
+
+    exit_code = run_simulate_command(
+        config=MonicaConfig(enabled=True, rollout_mode="linear_only", dry_run=False),
+        state=state,
+        text="checkout crashes on Android",
+        channel_id="LOCAL",
+        user_id="local-operator",
+        thread_ts="sim-thread",
+        loop_runner=lambda run_id, *, state: launched.append(run_id),
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert state.list_runs() == []
+    assert launched == []
+    assert "--allow-side-effects" in out
+
+
+def test_simulate_json_reports_empty_text_without_creating_run(tmp_path, capsys):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    launched: list[str] = []
+
+    exit_code = run_simulate_command(
+        config=MonicaConfig(enabled=True, rollout_mode="dry_run"),
+        state=state,
+        text="   ",
+        channel_id="LOCAL",
+        user_id="local-operator",
+        loop_runner=lambda run_id, *, state: launched.append(run_id),
+        json_output=True,
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 2
+    assert state.list_runs() == []
+    assert launched == []
+    assert payload["created"] is False
+    assert payload["rollout_mode"] == "dry_run"
+    assert payload["allow_side_effects"] is False
+    assert payload["error"]["code"] == "empty_text"
+    assert "text is required" in payload["error"]["message"]
+
+
+def test_simulate_json_reports_side_effect_rollout_without_explicit_flag(
+    tmp_path,
+    capsys,
+):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    launched: list[str] = []
+
+    exit_code = run_simulate_command(
+        config=MonicaConfig(enabled=True, rollout_mode="linear_only", dry_run=False),
+        state=state,
+        text="checkout crashes on Android",
+        channel_id="LOCAL",
+        user_id="local-operator",
+        thread_ts="sim-thread",
+        loop_runner=lambda run_id, *, state: launched.append(run_id),
+        json_output=True,
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 1
+    assert state.list_runs() == []
+    assert launched == []
+    assert payload["created"] is False
+    assert payload["rollout_mode"] == "linear_only"
+    assert payload["allow_side_effects"] is False
+    assert payload["error"]["code"] == "side_effects_not_allowed"
+    assert "--allow-side-effects" in payload["error"]["message"]
+
+
+def test_simulate_allows_side_effect_rollout_with_explicit_flag(tmp_path, capsys):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    launched: list[str] = []
+
+    exit_code = run_simulate_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="linear_only",
+            dry_run=False,
+            slack=SlackConfig(
+                allowed_channels=("C_SIM",),
+                bot_user_ids=("U_MONICA",),
+            ),
+        ),
+        state=state,
+        text="checkout crashes on Android",
+        channel_id="C_SIM",
+        user_id="local-operator",
+        thread_ts="sim-thread",
+        allow_side_effects=True,
+        loop_runner=lambda run_id, *, state: launched.append(run_id),
+        readiness_checker=lambda: 0,
+    )
+
+    runs = state.list_runs()
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert len(runs) == 1
+    assert launched == [runs[0].id]
+    assert "Simulated Monica run" in out
+
+
+def test_simulate_refuses_side_effect_rollout_when_readiness_check_fails(tmp_path, capsys):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    launched: list[str] = []
+
+    exit_code = run_simulate_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="linear_only",
+            dry_run=False,
+            slack=SlackConfig(
+                allowed_channels=("C_SIM",),
+                bot_user_ids=("U_MONICA",),
+            ),
+        ),
+        state=state,
+        text="checkout crashes on Android",
+        channel_id="C_SIM",
+        user_id="local-operator",
+        thread_ts="sim-thread",
+        allow_side_effects=True,
+        loop_runner=lambda run_id, *, state: launched.append(run_id),
+        readiness_checker=lambda: 1,
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert state.list_runs() == []
+    assert launched == []
+    assert "Monica readiness check failed" in out
+
+
+def test_simulate_json_reports_readiness_failure_without_creating_run(tmp_path, capsys):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    launched: list[str] = []
+
+    exit_code = run_simulate_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="linear_only",
+            dry_run=False,
+            slack=SlackConfig(
+                allowed_channels=("C_SIM",),
+                bot_user_ids=("U_MONICA",),
+            ),
+        ),
+        state=state,
+        text="checkout crashes on Android",
+        channel_id="C_SIM",
+        user_id="local-operator",
+        thread_ts="sim-thread",
+        allow_side_effects=True,
+        json_output=True,
+        loop_runner=lambda run_id, *, state: launched.append(run_id),
+        readiness_checker=lambda: 1,
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 1
+    assert state.list_runs() == []
+    assert launched == []
+    assert payload["created"] is False
+    assert payload["rollout_mode"] == "linear_only"
+    assert payload["allow_side_effects"] is True
+    assert payload["error"]["code"] == "readiness_failed"
+
+
+def test_simulate_json_reports_readiness_exception_without_creating_run(tmp_path, capsys):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    launched: list[str] = []
+
+    def fail_readiness() -> int:
+        raise RuntimeError("doctor exploded")
+
+    exit_code = run_simulate_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="linear_only",
+            dry_run=False,
+            slack=SlackConfig(
+                allowed_channels=("C_SIM",),
+                bot_user_ids=("U_MONICA",),
+            ),
+        ),
+        state=state,
+        text="checkout crashes on Android",
+        channel_id="C_SIM",
+        user_id="local-operator",
+        thread_ts="sim-thread",
+        allow_side_effects=True,
+        json_output=True,
+        loop_runner=lambda run_id, *, state: launched.append(run_id),
+        readiness_checker=fail_readiness,
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 1
+    assert state.list_runs() == []
+    assert launched == []
+    assert payload["created"] is False
+    assert payload["rollout_mode"] == "linear_only"
+    assert payload["allow_side_effects"] is True
+    assert payload["error"]["code"] == "readiness_exception"
+    assert "doctor exploded" in payload["error"]["message"]
+
+
+def test_simulate_refuses_side_effect_rollout_without_bot_user_ids(tmp_path, capsys):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    launched: list[str] = []
+
+    exit_code = run_simulate_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="linear_only",
+            dry_run=False,
+            slack=SlackConfig(allowed_channels=("C_SIM",)),
+        ),
+        state=state,
+        text="checkout crashes on Android",
+        channel_id="C_SIM",
+        user_id="local-operator",
+        thread_ts="sim-thread",
+        allow_side_effects=True,
+        loop_runner=lambda run_id, *, state: launched.append(run_id),
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert state.list_runs() == []
+    assert launched == []
+    assert "mobile_bug_agent.slack.bot_user_ids" in out
+
+
+def test_simulate_json_reports_missing_bot_user_ids_without_creating_run(tmp_path, capsys):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    launched: list[str] = []
+
+    exit_code = run_simulate_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="linear_only",
+            dry_run=False,
+            slack=SlackConfig(allowed_channels=("C_SIM",)),
+        ),
+        state=state,
+        text="checkout crashes on Android",
+        channel_id="C_SIM",
+        user_id="local-operator",
+        thread_ts="sim-thread",
+        allow_side_effects=True,
+        loop_runner=lambda run_id, *, state: launched.append(run_id),
+        json_output=True,
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 1
+    assert state.list_runs() == []
+    assert launched == []
+    assert payload["created"] is False
+    assert payload["rollout_mode"] == "linear_only"
+    assert payload["allow_side_effects"] is True
+    assert payload["error"]["code"] == "bot_user_ids_empty"
+    assert "mobile_bug_agent.slack.bot_user_ids" in payload["error"]["message"]
+
+
+def test_simulate_refuses_approved_pr_side_effects_without_configured_approvers(
+    tmp_path,
+    capsys,
+):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    launched: list[str] = []
+
+    exit_code = run_simulate_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="approved_pr",
+            dry_run=False,
+            slack=SlackConfig(allowed_channels=("C_SIM",), bot_user_ids=("U_MONICA",)),
+        ),
+        state=state,
+        text="checkout crashes on Android",
+        channel_id="C_SIM",
+        user_id="local-operator",
+        thread_ts="sim-thread",
+        allow_side_effects=True,
+        loop_runner=lambda run_id, *, state: launched.append(run_id),
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert state.list_runs() == []
+    assert launched == []
+    assert "mobile_bug_agent.slack.approver_user_ids" in out
+
+
+def test_simulate_json_reports_missing_approvers_without_creating_run(tmp_path, capsys):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    launched: list[str] = []
+
+    exit_code = run_simulate_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="approved_pr",
+            dry_run=False,
+            slack=SlackConfig(allowed_channels=("C_SIM",), bot_user_ids=("U_MONICA",)),
+        ),
+        state=state,
+        text="checkout crashes on Android",
+        channel_id="C_SIM",
+        user_id="local-operator",
+        thread_ts="sim-thread",
+        allow_side_effects=True,
+        loop_runner=lambda run_id, *, state: launched.append(run_id),
+        json_output=True,
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 1
+    assert state.list_runs() == []
+    assert launched == []
+    assert payload["created"] is False
+    assert payload["rollout_mode"] == "approved_pr"
+    assert payload["allow_side_effects"] is True
+    assert payload["error"]["code"] == "approver_user_ids_empty"
+    assert "mobile_bug_agent.slack.approver_user_ids" in payload["error"]["message"]
+
+
+def test_simulate_refuses_side_effect_rollout_when_allowed_channels_are_empty(
+    tmp_path,
+    capsys,
+):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    launched: list[str] = []
+
+    exit_code = run_simulate_command(
+        config=MonicaConfig(enabled=True, rollout_mode="linear_only", dry_run=False),
+        state=state,
+        text="checkout crashes on Android",
+        channel_id="C_SIM",
+        user_id="local-operator",
+        thread_ts="sim-thread",
+        allow_side_effects=True,
+        loop_runner=lambda run_id, *, state: launched.append(run_id),
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert state.list_runs() == []
+    assert launched == []
+    assert "mobile_bug_agent.slack.allowed_channels" in out
+
+
+def test_simulate_json_reports_missing_allowed_channels_without_creating_run(
+    tmp_path,
+    capsys,
+):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    launched: list[str] = []
+
+    exit_code = run_simulate_command(
+        config=MonicaConfig(enabled=True, rollout_mode="linear_only", dry_run=False),
+        state=state,
+        text="checkout crashes on Android",
+        channel_id="C_SIM",
+        user_id="local-operator",
+        thread_ts="sim-thread",
+        allow_side_effects=True,
+        loop_runner=lambda run_id, *, state: launched.append(run_id),
+        json_output=True,
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 1
+    assert state.list_runs() == []
+    assert launched == []
+    assert payload["created"] is False
+    assert payload["rollout_mode"] == "linear_only"
+    assert payload["allow_side_effects"] is True
+    assert payload["error"]["code"] == "allowed_channels_empty"
+    assert "mobile_bug_agent.slack.allowed_channels" in payload["error"]["message"]
+
+
+def test_simulate_refuses_side_effect_rollout_outside_allowed_channel(tmp_path, capsys):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    launched: list[str] = []
+
+    exit_code = run_simulate_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="linear_only",
+            dry_run=False,
+            slack=SlackConfig(allowed_channels=("C_MOBILE",), bot_user_ids=("U_MONICA",)),
+        ),
+        state=state,
+        text="checkout crashes on Android",
+        channel_id="C_OTHER",
+        user_id="local-operator",
+        thread_ts="sim-thread",
+        allow_side_effects=True,
+        loop_runner=lambda run_id, *, state: launched.append(run_id),
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert state.list_runs() == []
+    assert launched == []
+    assert "C_OTHER is not in mobile_bug_agent.slack.allowed_channels" in out
+
+
+def test_simulate_json_reports_disallowed_channel_without_creating_run(tmp_path, capsys):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    launched: list[str] = []
+
+    exit_code = run_simulate_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="linear_only",
+            dry_run=False,
+            slack=SlackConfig(allowed_channels=("C_MOBILE",), bot_user_ids=("U_MONICA",)),
+        ),
+        state=state,
+        text="checkout crashes on Android",
+        channel_id="C_OTHER",
+        user_id="local-operator",
+        thread_ts="sim-thread",
+        allow_side_effects=True,
+        loop_runner=lambda run_id, *, state: launched.append(run_id),
+        json_output=True,
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 1
+    assert state.list_runs() == []
+    assert launched == []
+    assert payload["created"] is False
+    assert payload["rollout_mode"] == "linear_only"
+    assert payload["allow_side_effects"] is True
+    assert payload["error"]["code"] == "channel_not_allowed"
+    assert "C_OTHER" in payload["error"]["message"]
+
+
+def test_simulate_refuses_duplicate_thread_without_relaunching(tmp_path, capsys):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    existing = state.create_run(
+        platform="slack",
+        channel_id="LOCAL",
+        thread_ts="sim-thread",
+        message_ts="sim-message",
+        user_id="local-operator",
+        request_text="old checkout crash simulation",
+        raw_event={"monica_simulated": True},
+    )
+    state.update_run(existing.id, status="done", linear_identifier="DRY-RUN")
+    launched: list[str] = []
+
+    exit_code = run_simulate_command(
+        config=MonicaConfig(enabled=True, rollout_mode="dry_run"),
+        state=state,
+        text="new checkout crash simulation",
+        channel_id="LOCAL",
+        user_id="local-operator",
+        thread_ts="sim-thread",
+        loop_runner=lambda run_id, *, state: launched.append(run_id),
+    )
+
+    updated = state.get_run(existing.id)
+    assert updated is not None
+    assert exit_code == 1
+    assert updated.status == "done"
+    assert updated.request_text == "old checkout crash simulation"
+    assert launched == []
+    assert "already exists" in capsys.readouterr().out
+
+
+def test_simulate_json_duplicate_thread_returns_existing_run(tmp_path, capsys):
+    state = MonicaState.open(tmp_path / "state.sqlite")
+    existing = state.create_run(
+        platform="slack",
+        channel_id="LOCAL",
+        thread_ts="sim-thread",
+        message_ts="sim-message",
+        user_id="local-operator",
+        request_text="old checkout crash simulation",
+        raw_event={"monica_simulated": True},
+    )
+    state.update_run(existing.id, status="done", linear_identifier="DRY-RUN")
+    launched: list[str] = []
+
+    exit_code = run_simulate_command(
+        config=MonicaConfig(enabled=True, rollout_mode="dry_run"),
+        state=state,
+        text="new checkout crash simulation",
+        channel_id="LOCAL",
+        user_id="local-operator",
+        thread_ts="sim-thread",
+        loop_runner=lambda run_id, *, state: launched.append(run_id),
+        json_output=True,
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 1
+    assert launched == []
+    assert payload["created"] is False
+    assert payload["error"]["code"] == "duplicate_thread"
+    assert payload["run"]["id"] == existing.id
+    assert payload["run"]["status"] == "done"
+    assert payload["run"]["linear"]["identifier"] == "DRY-RUN"
+
+
+def test_open_state_uses_configured_runtime_root(tmp_path):
+    config = config_from_mapping({"runtime": {"home_subdir": str(tmp_path / "monica")}})
+
+    state = _open_state(config)
+
+    assert state.path == tmp_path / "monica" / "state.sqlite"
+
+
+def test_slack_manifest_outputs_required_monica_app_manifest(capsys):
+    exit_code = run_slack_manifest_command(
+        config=MonicaConfig(),
+        app_name="Monica Staging",
+        bot_display_name="monica",
+    )
+
+    manifest = json.loads(capsys.readouterr().out)
+    scopes = manifest["oauth_config"]["scopes"]["bot"]
+    assert exit_code == 0
+    assert manifest["display_information"]["name"] == "Monica Staging"
+    assert manifest["features"]["app_home"] == {
+        "home_tab_enabled": False,
+        "messages_tab_enabled": True,
+        "messages_tab_read_only_enabled": False,
+    }
+    assert manifest["features"]["bot_user"]["display_name"] == "monica"
+    assert manifest["features"]["bot_user"]["always_online"] is True
+    assert manifest["settings"]["socket_mode_enabled"] is True
+    assert manifest["settings"]["event_subscriptions"]["bot_events"] == [
+        "app_mention",
+        "message.im",
+    ]
+    assert scopes == [
+        "app_mentions:read",
+        "channels:history",
+        "groups:history",
+        "im:history",
+        "im:read",
+        "chat:write",
+        "files:read",
+    ]
+
+
+def test_slack_manifest_omits_files_scope_when_attachment_downloads_disabled(capsys):
+    exit_code = run_slack_manifest_command(
+        config=MonicaConfig(slack=SlackConfig(download_attachments=False)),
+        app_name="",
+        bot_display_name="",
+    )
+
+    manifest = json.loads(capsys.readouterr().out)
+    scopes = manifest["oauth_config"]["scopes"]["bot"]
+    assert exit_code == 0
+    assert manifest["display_information"]["name"] == "Monica"
+    assert manifest["features"]["bot_user"]["display_name"] == "monica"
+    assert "files:read" not in scopes
+
+
+def test_linear_metadata_json_outputs_teams_projects_and_labels(capsys):
+    class FakeClient:
+        def __init__(self, *, api_key: str) -> None:
+            self.api_key = api_key
+
+        def list_workspace_metadata(self):
+            return SimpleNamespace(
+                teams=(SimpleNamespace(id="team-mobile", key="MOB", name="Mobile"),),
+                projects=(SimpleNamespace(id="project-app", name="Mobile App", state="started"),),
+                labels=(
+                    SimpleNamespace(id="label-bug", name="Bug", color="#e5484d"),
+                    SimpleNamespace(id="label-mobile", name="Mobile", color="#3b82f6"),
+                ),
+            )
+
+    exit_code = run_linear_metadata_command(
+        api_key="lin_api_key",
+        json_output=True,
+        client_factory=FakeClient,
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload["ok"] is True
+    assert payload["teams"][0] == {"id": "team-mobile", "key": "MOB", "name": "Mobile"}
+    assert payload["projects"][0] == {
+        "id": "project-app",
+        "name": "Mobile App",
+        "state": "started",
+    }
+    assert payload["labels"][1] == {
+        "id": "label-mobile",
+        "name": "Mobile",
+        "color": "#3b82f6",
+    }
+
+
+def test_linear_metadata_text_outputs_configure_hint(capsys):
+    class FakeClient:
+        def __init__(self, *, api_key: str) -> None:
+            self.api_key = api_key
+
+        def list_workspace_metadata(self):
+            return SimpleNamespace(
+                teams=(SimpleNamespace(id="team-mobile", key="MOB", name="Mobile"),),
+                projects=(),
+                labels=(),
+            )
+
+    exit_code = run_linear_metadata_command(
+        api_key="lin_api_key",
+        json_output=False,
+        client_factory=FakeClient,
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Teams:" in out
+    assert "team-mobile" in out
+    assert "configure-linear-only" in out
+
+
+def test_linear_metadata_refuses_missing_api_key_without_contacting_linear(capsys):
+    contacted = False
+
+    class FakeClient:
+        def __init__(self, *, api_key: str) -> None:
+            nonlocal contacted
+            contacted = True
+
+    exit_code = run_linear_metadata_command(
+        api_key="",
+        json_output=True,
+        client_factory=FakeClient,
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 1
+    assert contacted is False
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "linear_api_key_missing"
+
+
+def test_slack_metadata_json_outputs_bot_user_and_channels(capsys):
+    class FakeClient:
+        def __init__(self, *, token: str) -> None:
+            self.token = token
+
+        def list_workspace_metadata(self):
+            return SimpleNamespace(
+                auth=SimpleNamespace(
+                    bot_user_id="U_MONICA",
+                    bot_id="B_MONICA",
+                    team_id="T123",
+                    team_name="Acme",
+                    team_url="https://acme.slack.com/",
+                ),
+                channels=(
+                    SimpleNamespace(
+                        id="C_MOBILE",
+                        name="mobile-bugs",
+                        is_private=False,
+                        is_member=True,
+                        is_archived=False,
+                    ),
+                    SimpleNamespace(
+                        id="G_TRIAGE",
+                        name="app-triage",
+                        is_private=True,
+                        is_member=False,
+                        is_archived=False,
+                    ),
+                ),
+            )
+
+    exit_code = run_slack_metadata_command(
+        token="xoxb-token",
+        json_output=True,
+        client_factory=FakeClient,
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload["ok"] is True
+    assert payload["auth"]["bot_user_id"] == "U_MONICA"
+    assert payload["auth"]["bot_id"] == "B_MONICA"
+    assert payload["auth"]["team_id"] == "T123"
+    assert payload["channels"][0] == {
+        "id": "C_MOBILE",
+        "name": "mobile-bugs",
+        "is_private": False,
+        "is_member": True,
+        "is_archived": False,
+    }
+
+
+def test_slack_metadata_text_outputs_configure_hint(capsys):
+    class FakeClient:
+        def __init__(self, *, token: str) -> None:
+            self.token = token
+
+        def list_workspace_metadata(self):
+            return SimpleNamespace(
+                auth=SimpleNamespace(
+                    bot_user_id="U_MONICA",
+                    bot_id="B_MONICA",
+                    team_id="T123",
+                    team_name="Acme",
+                    team_url="https://acme.slack.com/",
+                ),
+                channels=(
+                    SimpleNamespace(
+                        id="C_MOBILE",
+                        name="mobile-bugs",
+                        is_private=False,
+                        is_member=True,
+                        is_archived=False,
+                    ),
+                ),
+            )
+
+    exit_code = run_slack_metadata_command(
+        token="xoxb-token",
+        json_output=False,
+        client_factory=FakeClient,
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Bot user ID: U_MONICA" in out
+    assert "C_MOBILE" in out
+    assert "configure-linear-only" in out
+
+
+def test_slack_metadata_refuses_missing_token_without_contacting_slack(capsys):
+    contacted = False
+
+    class FakeClient:
+        def __init__(self, *, token: str) -> None:
+            nonlocal contacted
+            contacted = True
+
+    exit_code = run_slack_metadata_command(
+        token="",
+        json_output=True,
+        client_factory=FakeClient,
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 1
+    assert contacted is False
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "slack_bot_token_missing"
+
+
+def test_slack_metadata_uses_monica_token_instead_of_shared_slack_token(capsys, monkeypatch):
+    seen: list[str] = []
+
+    class FakeClient:
+        def __init__(self, *, token: str) -> None:
+            seen.append(token)
+
+        def list_workspace_metadata(self):
+            return SimpleNamespace(auth=SimpleNamespace(), channels=())
+
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-chandler")
+    monkeypatch.setenv("MONICA_SLACK_BOT_TOKEN", "xoxb-monica")
+
+    exit_code = run_slack_metadata_command(
+        json_output=True,
+        client_factory=FakeClient,
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload["ok"] is True
+    assert seen == ["xoxb-monica"]
+
+
+def test_setup_plan_json_lists_ordered_linear_only_rollout_steps(capsys):
+    exit_code = run_setup_plan_command(
+        config=MonicaConfig(enabled=False),
+        target_rollout_mode="linear_only",
+        json_output=True,
+        environ={},
+        which=lambda command: f"/usr/bin/{command}",
+        module_available=lambda name: True,
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    step_ids = [step["id"] for step in payload["steps"]]
+    assert exit_code == 1
+    assert payload["ready"] is False
+    assert payload["rollout_mode"] == "linear_only"
+    assert payload["failures"][0]["code"] == "config_enabled"
+    assert step_ids == [
+        "create_slack_app",
+        "set_slack_bot_token",
+        "discover_slack_ids",
+        "set_linear_api_key",
+        "discover_linear_ids",
+        "configure_linear_only",
+        "rerun_doctor",
+    ]
+    assert payload["steps"][0]["command"] == "hermes mobile-bug-agent slack-manifest"
+    assert payload["steps"][2]["command"] == "hermes mobile-bug-agent slack-metadata --json"
+    assert payload["steps"][4]["command"] == "hermes mobile-bug-agent linear-metadata --json"
+    assert "configure-linear-only" in payload["steps"][5]["command"]
+
+
+def test_setup_plan_json_lists_ordered_dry_run_bootstrap_steps(capsys):
+    exit_code = run_setup_plan_command(
+        config=MonicaConfig(enabled=False),
+        target_rollout_mode="dry_run",
+        json_output=True,
+        environ={},
+        which=lambda command: f"/usr/bin/{command}",
+        module_available=lambda name: True,
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    step_ids = [step["id"] for step in payload["steps"]]
+    assert exit_code == 1
+    assert payload["ready"] is False
+    assert payload["rollout_mode"] == "dry_run"
+    assert payload["failures"][0]["code"] == "config_enabled"
+    assert step_ids == [
+        "configure_dry_run",
+        "create_slack_app",
+        "set_slack_bot_token",
+        "rerun_doctor",
+    ]
+    assert payload["steps"][0]["command"] == "hermes mobile-bug-agent configure-dry-run"
+
+
+def test_setup_plan_text_lists_next_commands(capsys):
+    exit_code = run_setup_plan_command(
+        config=MonicaConfig(enabled=False),
+        target_rollout_mode="linear_only",
+        json_output=False,
+        environ={},
+        which=lambda command: f"/usr/bin/{command}",
+        module_available=lambda name: True,
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "Monica setup plan: linear_only" in out
+    assert "hermes mobile-bug-agent slack-manifest" in out
+    assert "hermes mobile-bug-agent configure-linear-only" in out
+
+
+def test_setup_plan_json_has_no_steps_when_rollout_is_ready(capsys):
+    exit_code = run_setup_plan_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="linear_only",
+            dry_run=False,
+            slack=SlackConfig(
+                allowed_channels=("C123MOBILE",),
+                bot_user_ids=("U123MONICA",),
+            ),
+            linear=LinearConfig(team_id="team-mobile"),
+        ),
+        target_rollout_mode="linear_only",
+        json_output=True,
+        environ={
+            "MONICA_SLACK_BOT_TOKEN": "xoxb-token",
+            "LINEAR_API_KEY": "lin_api_key",
+        },
+        which=lambda command: f"/usr/bin/{command}",
+        module_available=lambda name: True,
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload["ready"] is True
+    assert payload["steps"] == []
+
+
+def test_setup_plan_json_lists_approved_pr_rollout_steps(capsys):
+    exit_code = run_setup_plan_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="linear_only",
+            dry_run=False,
+            slack=SlackConfig(
+                allowed_channels=("C123MOBILE",),
+                bot_user_ids=("U123MONICA",),
+            ),
+            linear=LinearConfig(team_id="team-mobile"),
+        ),
+        target_rollout_mode="approved_pr",
+        json_output=True,
+        environ={
+            "SLACK_BOT_TOKEN": "xoxb-token",
+            "LINEAR_API_KEY": "lin_api_key",
+        },
+        which=lambda command: None,
+        module_available=lambda name: True,
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    step_ids = [step["id"] for step in payload["steps"]]
+    assert exit_code == 1
+    assert payload["ready"] is False
+    assert payload["rollout_mode"] == "approved_pr"
+    assert "configure_approved_pr" in step_ids
+    assert "prepare_pr_tools" in step_ids
+    assert payload["steps"][-1]["id"] == "rerun_doctor"
+    assert "configure-approved-pr" in next(
+        step["command"] for step in payload["steps"] if step["id"] == "configure_approved_pr"
+    )
+
+
+def test_mobile_bug_agent_command_reports_invalid_runtime_root_for_state_actions(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile-home"))
+    monkeypatch.setattr(
+        cli,
+        "load_monica_config",
+        lambda: config_from_mapping({"runtime": {"home_subdir": "../outside-runtime"}}),
+    )
+
+    exit_code = cli.mobile_bug_agent_command(
+        SimpleNamespace(mobile_bug_agent_action="status", limit=5),
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "Monica runtime is not configured correctly" in out
+    assert "mobile_bug_agent.runtime.home_subdir must stay inside HERMES_HOME." in out
+
+
+def test_doctor_parser_accepts_target_rollout_mode():
+    parser = ArgumentParser()
+
+    cli.register_cli(parser)
+    args = parser.parse_args(["doctor", "--rollout-mode", "linear_only", "--json"])
+
+    assert args.mobile_bug_agent_action == "doctor"
+    assert args.rollout_mode == "linear_only"
+    assert args.json is True
+
+
+def test_setup_plan_parser_accepts_target_rollout_mode_and_json():
+    parser = ArgumentParser()
+
+    cli.register_cli(parser)
+    args = parser.parse_args(["setup-plan", "--rollout-mode", "linear_only", "--json"])
+
+    assert args.mobile_bug_agent_action == "setup_plan"
+    assert args.rollout_mode == "linear_only"
+    assert args.json is True
+
+
+def test_slack_manifest_parser_accepts_app_and_bot_names():
+    parser = ArgumentParser()
+
+    cli.register_cli(parser)
+    args = parser.parse_args(
+        ["slack-manifest", "--app-name", "Monica Staging", "--bot-display-name", "monica"]
+    )
+
+    assert args.mobile_bug_agent_action == "slack_manifest"
+    assert args.app_name == "Monica Staging"
+    assert args.bot_display_name == "monica"
+
+
+def test_linear_metadata_parser_accepts_json_flag():
+    parser = ArgumentParser()
+
+    cli.register_cli(parser)
+    args = parser.parse_args(["linear-metadata", "--json"])
+
+    assert args.mobile_bug_agent_action == "linear_metadata"
+    assert args.json is True
+
+
+def test_slack_metadata_parser_accepts_json_flag():
+    parser = ArgumentParser()
+
+    cli.register_cli(parser)
+    args = parser.parse_args(["slack-metadata", "--json"])
+
+    assert args.mobile_bug_agent_action == "slack_metadata"
+    assert args.json is True
+
+
+def test_status_and_show_parsers_accept_json_flags():
+    parser = ArgumentParser()
+
+    cli.register_cli(parser)
+    status_args = parser.parse_args(["status", "--json", "--limit", "3"])
+    show_args = parser.parse_args(["show", "run-id", "--json"])
+
+    assert status_args.mobile_bug_agent_action == "status"
+    assert status_args.json is True
+    assert status_args.limit == 3
+    assert show_args.mobile_bug_agent_action == "show"
+    assert show_args.json is True
+    assert show_args.run_id == "run-id"
+
+
+def test_retry_and_approve_parsers_accept_json_flags():
+    parser = ArgumentParser()
+
+    cli.register_cli(parser)
+    retry_args = parser.parse_args(["retry", "run-id", "--json"])
+    approve_args = parser.parse_args(["approve", "run-id", "--user-id", "U_APPROVER", "--json"])
+
+    assert retry_args.mobile_bug_agent_action == "retry"
+    assert retry_args.run_id == "run-id"
+    assert retry_args.json is True
+    assert approve_args.mobile_bug_agent_action == "approve"
+    assert approve_args.run_id == "run-id"
+    assert approve_args.user_id == "U_APPROVER"
+    assert approve_args.json is True
+
+
+def test_simulate_parser_accepts_json_flag():
+    parser = ArgumentParser()
+
+    cli.register_cli(parser)
+    args = parser.parse_args(["simulate", "checkout", "crash", "--json"])
+
+    assert args.mobile_bug_agent_action == "simulate"
+    assert args.text == ["checkout", "crash"]
+    assert args.json is True
+
+
+def test_configure_linear_only_parser_accepts_non_secret_rollout_values():
+    parser = ArgumentParser()
+
+    cli.register_cli(parser)
+    args = parser.parse_args(
+        [
+            "configure-linear-only",
+            "--bot-user-id",
+            "U123MONICA",
+            "--channel-id",
+            "C123MOBILE",
+            "--linear-team-id",
+            "team-id",
+            "--linear-project-id",
+            "project-id",
+            "--linear-label-id",
+            "label-one",
+            "--linear-label-id",
+            "label-two",
+        ]
+    )
+
+    assert args.mobile_bug_agent_action == "configure_linear_only"
+    assert args.bot_user_ids == ["U123MONICA"]
+    assert args.channel_ids == ["C123MOBILE"]
+    assert args.linear_team_id == "team-id"
+    assert args.linear_project_id == "project-id"
+    assert args.linear_label_ids == ["label-one", "label-two"]
+
+
+def test_configure_dry_run_parser_accepts_optional_slack_scope_values():
+    parser = ArgumentParser()
+
+    cli.register_cli(parser)
+    args = parser.parse_args(
+        [
+            "configure-dry-run",
+            "--bot-user-id",
+            "U123MONICA",
+            "--channel-id",
+            "C123PRIVATE",
+            "--channel-id",
+            "G456PRIVATE",
+        ]
+    )
+
+    assert args.mobile_bug_agent_action == "configure_dry_run"
+    assert args.bot_user_ids == ["U123MONICA"]
+    assert args.channel_ids == ["C123PRIVATE", "G456PRIVATE"]
+
+
+def test_configure_approved_pr_parser_accepts_non_secret_rollout_values():
+    parser = ArgumentParser()
+
+    cli.register_cli(parser)
+    args = parser.parse_args(
+        [
+            "configure-approved-pr",
+            "--approver-user-id",
+            "U123APPROVER",
+            "--repo-url",
+            "git@github.com:acme/mobile-app.git",
+            "--verification-command",
+            "npm test",
+            "--verification-command",
+            "npm run lint",
+            "--repo-local-name",
+            "mobile-app",
+            "--default-branch",
+            "main",
+            "--branch-prefix",
+            "monica",
+        ]
+    )
+
+    assert args.mobile_bug_agent_action == "configure_approved_pr"
+    assert args.approver_user_ids == ["U123APPROVER"]
+    assert args.repo_url == "git@github.com:acme/mobile-app.git"
+    assert args.verification_commands == ["npm test", "npm run lint"]
+    assert args.repo_local_name == "mobile-app"
+    assert args.default_branch == "main"
+    assert args.branch_prefix == "monica"
+
+
+def test_configure_local_fix_only_parser_accepts_non_secret_rollout_values():
+    parser = ArgumentParser()
+
+    cli.register_cli(parser)
+    args = parser.parse_args(
+        [
+            "configure-local-fix-only",
+            "--approver-user-id",
+            "U123APPROVER",
+            "--repo-url",
+            "git@github.com:acme/mobile-app.git",
+            "--verification-command",
+            "npm test",
+            "--repo-local-name",
+            "mobile-app",
+            "--default-branch",
+            "main",
+            "--branch-prefix",
+            "monica",
+        ]
+    )
+
+    assert args.mobile_bug_agent_action == "configure_local_fix_only"
+    assert args.approver_user_ids == ["U123APPROVER"]
+    assert args.repo_url == "git@github.com:acme/mobile-app.git"
+    assert args.verification_commands == ["npm test"]
+    assert args.repo_local_name == "mobile-app"
+    assert args.default_branch == "main"
+    assert args.branch_prefix == "monica"
+
+
+def test_configure_dry_run_persists_non_secret_bootstrap_config(capsys):
+    existing_config = {
+        "plugins": {
+            "enabled": ["other-plugin"],
+            "disabled": ["mobile-bug-agent", "legacy-plugin"],
+        },
+        "mobile_bug_agent": {
+            "enabled": False,
+            "rollout_mode": "linear_only",
+            "dry_run": False,
+            "slack": {
+                "download_attachments": False,
+                "allowed_channels": ["C123EXISTING"],
+            },
+            "runtime": {
+                "worker_session_prefix": "not-monica",
+                "skip_memory": False,
+            },
+        },
+    }
+    saved: list[dict] = []
+
+    exit_code = cli.run_configure_dry_run_command(
+        bot_user_ids=("U123MONICA",),
+        channel_ids=("C123PRIVATE", "G456PRIVATE"),
+        load_config_fn=lambda: copy.deepcopy(existing_config),
+        save_config_fn=lambda config: saved.append(config),
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Configured Monica for dry_run rollout" in out
+    assert len(saved) == 1
+    saved_config = saved[0]
+    assert saved_config["plugins"]["enabled"] == ["mobile-bug-agent", "other-plugin"]
+    assert saved_config["plugins"]["disabled"] == ["legacy-plugin"]
+    monica = saved_config["mobile_bug_agent"]
+    assert monica["enabled"] is True
+    assert monica["rollout_mode"] == "dry_run"
+    assert monica["dry_run"] is True
+    assert monica["slack"]["download_attachments"] is False
+    assert monica["slack"]["bot_user_ids"] == ["U123MONICA"]
+    assert monica["slack"]["allowed_channels"] == ["C123PRIVATE", "G456PRIVATE"]
+    assert monica["loop"]["create_linear"] is True
+    assert monica["loop"]["require_fix_approval"] is True
+    assert monica["runtime"]["home_subdir"] == "agents/monica"
+    assert monica["runtime"]["worker_session_prefix"] == "monica"
+    assert monica["runtime"]["skip_memory"] is True
+    assert "SLACK_BOT_TOKEN" not in str(saved_config)
+    assert "LINEAR_API_KEY" not in str(saved_config)
+
+
+def test_configure_dry_run_keeps_existing_slack_scope_when_not_provided(capsys):
+    existing_config = {
+        "plugins": {
+            "enabled": ["mobile-bug-agent"],
+        },
+        "mobile_bug_agent": {
+            "slack": {
+                "bot_user_ids": ["U123EXISTING"],
+                "allowed_channels": ["C123EXISTING"],
+            },
+        },
+    }
+    saved: list[dict] = []
+
+    exit_code = cli.run_configure_dry_run_command(
+        load_config_fn=lambda: copy.deepcopy(existing_config),
+        save_config_fn=lambda config: saved.append(config),
+    )
+
+    assert exit_code == 0
+    monica = saved[0]["mobile_bug_agent"]
+    assert monica["slack"]["bot_user_ids"] == ["U123EXISTING"]
+    assert monica["slack"]["allowed_channels"] == ["C123EXISTING"]
+
+
+def test_configure_dry_run_rejects_handles_and_channel_names_without_saving(capsys):
+    saved: list[dict] = []
+
+    exit_code = cli.run_configure_dry_run_command(
+        bot_user_ids=("@monica",),
+        channel_ids=("#mobile-bugs",),
+        load_config_fn=lambda: {},
+        save_config_fn=lambda config: saved.append(config),
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert saved == []
+    assert "Slack mention user IDs like U012ABCDEF, not handles like @monica" in out
+    assert "Slack channel IDs like C123 or G123, not names like #mobile-bugs" in out
+    assert "Monica dry_run configuration was not saved." in out
+
+
+def test_configure_linear_only_persists_non_secret_rollout_config(capsys):
+    existing_config = {
+        "plugins": {
+            "enabled": ["other-plugin"],
+            "disabled": ["mobile-bug-agent", "legacy-plugin"],
+        },
+        "mobile_bug_agent": {
+            "slack": {
+                "download_attachments": False,
+            },
+            "loop": {
+                "max_thread_messages": 12,
+            },
+        },
+    }
+    saved: list[dict] = []
+
+    exit_code = run_configure_linear_only_command(
+        bot_user_ids=("U123MONICA",),
+        channel_ids=("C123MOBILE", "G456PRIVATE"),
+        linear_team_id="team-id",
+        linear_project_id="project-id",
+        linear_label_ids=("label-one", "label-two"),
+        load_config_fn=lambda: copy.deepcopy(existing_config),
+        save_config_fn=lambda config: saved.append(config),
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Configured Monica for linear_only rollout" in out
+    assert len(saved) == 1
+    saved_config = saved[0]
+    assert saved_config["plugins"]["enabled"] == ["mobile-bug-agent", "other-plugin"]
+    assert saved_config["plugins"]["disabled"] == ["legacy-plugin"]
+    monica = saved_config["mobile_bug_agent"]
+    assert monica["enabled"] is True
+    assert monica["rollout_mode"] == "linear_only"
+    assert monica["dry_run"] is False
+    assert monica["slack"]["bot_user_ids"] == ["U123MONICA"]
+    assert monica["slack"]["allowed_channels"] == ["C123MOBILE", "G456PRIVATE"]
+    assert monica["slack"]["download_attachments"] is False
+    assert monica["loop"]["create_linear"] is True
+    assert monica["loop"]["max_thread_messages"] == 12
+    assert monica["linear"]["team_id"] == "team-id"
+    assert monica["linear"]["project_id"] == "project-id"
+    assert monica["linear"]["label_ids"] == ["label-one", "label-two"]
+    assert "SLACK_BOT_TOKEN" not in str(saved_config)
+    assert "LINEAR_API_KEY" not in str(saved_config)
+
+
+def test_configure_approved_pr_persists_non_secret_full_loop_config(capsys):
+    existing_config = {
+        "plugins": {
+            "enabled": ["mobile-bug-agent"],
+        },
+        "mobile_bug_agent": {
+            "enabled": True,
+            "rollout_mode": "linear_only",
+            "slack": {
+                "bot_user_ids": ["U123MONICA"],
+                "allowed_channels": ["C123MOBILE"],
+            },
+            "linear": {
+                "team_id": "team-id",
+            },
+            "runtime": {
+                "home_subdir": "agents/monica",
+                "worker_session_prefix": "not-monica",
+                "skip_memory": False,
+            },
+            "worker": {
+                "backend": "codex_cli",
+                "codex_command": "codex",
+                "codex_model": "gpt-5-codex",
+                "codex_profile": "monica",
+                "codex_sandbox": "danger-full-access",
+                "codex_approval_policy": "on-request",
+                "timeout_minutes": 99,
+            },
+        },
+    }
+    saved: list[dict] = []
+
+    exit_code = run_configure_approved_pr_command(
+        approver_user_ids=("U123APPROVER",),
+        repo_url="git@github.com:acme/mobile-app.git",
+        verification_commands=("npm test", "npm run lint"),
+        repo_local_name="mobile-app",
+        default_branch="main",
+        branch_prefix="monica",
+        load_config_fn=lambda: copy.deepcopy(existing_config),
+        save_config_fn=lambda config: saved.append(config),
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Configured Monica for approved_pr rollout" in out
+    assert len(saved) == 1
+    monica = saved[0]["mobile_bug_agent"]
+    assert monica["enabled"] is True
+    assert monica["rollout_mode"] == "approved_pr"
+    assert monica["dry_run"] is False
+    assert monica["loop"]["create_linear"] is True
+    assert monica["loop"]["require_fix_approval"] is True
+    assert monica["slack"]["approver_user_ids"] == ["U123APPROVER"]
+    assert monica["slack"]["bot_user_ids"] == ["U123MONICA"]
+    assert monica["linear"]["team_id"] == "team-id"
+    assert monica["repo"]["url"] == "git@github.com:acme/mobile-app.git"
+    assert monica["repo"]["local_name"] == "mobile-app"
+    assert monica["repo"]["default_branch"] == "main"
+    assert monica["repo"]["branch_prefix"] == "monica"
+    assert monica["verification"]["commands"] == ["npm test", "npm run lint"]
+    assert monica["runtime"]["worker_session_prefix"] == "monica"
+    assert monica["runtime"]["skip_memory"] is True
+    assert monica["worker"]["backend"] == "codex_cli"
+    assert monica["worker"]["codex_command"] == "codex"
+    assert monica["worker"]["codex_model"] == "gpt-5-codex"
+    assert monica["worker"]["codex_profile"] == "monica"
+    assert monica["worker"]["codex_sandbox"] == "workspace-write"
+    assert monica["worker"]["codex_approval_policy"] == "never"
+    assert monica["worker"]["timeout_minutes"] == 99
+    assert saved[0]["plugins"]["enabled"] == ["mobile-bug-agent"]
+    assert "GITHUB_TOKEN" not in str(saved[0])
+    assert "SLACK_BOT_TOKEN" not in str(saved[0])
+
+
+def test_configure_local_fix_only_persists_non_secret_local_code_config(capsys):
+    existing_config = {
+        "plugins": {
+            "enabled": ["mobile-bug-agent"],
+        },
+        "mobile_bug_agent": {
+            "enabled": True,
+            "rollout_mode": "linear_only",
+            "slack": {
+                "bot_user_ids": ["U123MONICA"],
+                "allowed_channels": ["D123MONICA"],
+            },
+            "linear": {
+                "team_id": "team-id",
+                "label_ids": ["bug-label"],
+            },
+            "worker": {
+                "backend": "codex_cli",
+                "codex_command": "codex",
+                "codex_sandbox": "danger-full-access",
+                "codex_approval_policy": "on-request",
+            },
+        },
+    }
+    saved: list[dict] = []
+
+    exit_code = run_configure_local_fix_only_command(
+        approver_user_ids=("U123APPROVER",),
+        repo_url="git@github.com:acme/mobile-app.git",
+        verification_commands=("npm test", "npm run lint"),
+        repo_local_name="mobile-app",
+        default_branch="main",
+        branch_prefix="monica",
+        load_config_fn=lambda: copy.deepcopy(existing_config),
+        save_config_fn=lambda config: saved.append(config),
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Configured Monica for local_fix_only rollout" in out
+    assert len(saved) == 1
+    monica = saved[0]["mobile_bug_agent"]
+    assert monica["enabled"] is True
+    assert monica["rollout_mode"] == "local_fix_only"
+    assert monica["dry_run"] is False
+    assert monica["loop"]["create_linear"] is True
+    assert monica["loop"]["require_fix_approval"] is True
+    assert monica["slack"]["approver_user_ids"] == ["U123APPROVER"]
+    assert monica["slack"]["bot_user_ids"] == ["U123MONICA"]
+    assert monica["slack"]["allowed_channels"] == ["D123MONICA"]
+    assert monica["linear"]["team_id"] == "team-id"
+    assert monica["linear"]["label_ids"] == ["bug-label"]
+    assert monica["repo"]["url"] == "git@github.com:acme/mobile-app.git"
+    assert monica["repo"]["local_name"] == "mobile-app"
+    assert monica["repo"]["default_branch"] == "main"
+    assert monica["repo"]["branch_prefix"] == "monica"
+    assert monica["verification"]["commands"] == ["npm test", "npm run lint"]
+    assert monica["worker"]["codex_sandbox"] == "workspace-write"
+    assert monica["worker"]["codex_approval_policy"] == "never"
+    assert "GITHUB_TOKEN" not in str(saved[0])
+
+
+def test_configure_linear_only_rejects_handles_and_channel_names_without_saving(capsys):
+    saved: list[dict] = []
+
+    exit_code = run_configure_linear_only_command(
+        bot_user_ids=("@monica",),
+        channel_ids=("#mobile-bugs",),
+        linear_team_id="team-id",
+        load_config_fn=lambda: {},
+        save_config_fn=lambda config: saved.append(config),
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert saved == []
+    assert "Slack mention user IDs like U012ABCDEF, not handles like @monica" in out
+    assert "Slack channel IDs like C123 or G123, not names like #mobile-bugs" in out
+
+
+def test_configure_approved_pr_rejects_unsafe_values_without_saving(capsys):
+    saved: list[dict] = []
+
+    exit_code = run_configure_approved_pr_command(
+        approver_user_ids=("@ritik",),
+        repo_url="",
+        verification_commands=(),
+        repo_local_name="../mobile-app",
+        default_branch="main branch",
+        branch_prefix="chandler",
+        load_config_fn=lambda: {},
+        save_config_fn=lambda config: saved.append(config),
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert saved == []
+    assert "Slack user IDs like U123, not handles like @ritik" in out
+    assert "--repo-url is required" in out
+    assert "at least one --verification-command is required" in out
+    assert "repo.local_name must be a simple directory name" in out
+    assert "repo.branch_prefix must not point at Chandler" in out
+    assert "repo.default_branch must be a safe git branch name" in out
+
+
+def test_doctor_allows_dry_run_with_slack_token(capsys):
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="dry_run",
+            slack=SlackConfig(bot_user_ids=("UMONICA",), allowed_channels=("C123",)),
+        ),
+        environ={"MONICA_SLACK_BOT_TOKEN": "xoxb-token"},
+        which=lambda name: f"/usr/bin/{name}",
+        module_available=lambda name: True,
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Monica doctor: ready" in out
+    assert "Monica runtime root:" in out
+
+
+def test_doctor_requires_monica_token_even_when_chandler_slack_token_exists(capsys):
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="dry_run",
+            slack=SlackConfig(bot_user_ids=("UMONICA",), allowed_channels=("C123",)),
+        ),
+        environ={"SLACK_BOT_TOKEN": "xoxb-chandler"},
+        which=lambda name: f"/usr/bin/{name}",
+        module_available=lambda name: True,
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "FAIL: MONICA_SLACK_BOT_TOKEN is missing" in out
+    assert "xoxb-chandler" not in out
+    assert "Monica doctor: not ready" in out
+
+
+def test_doctor_preflights_target_rollout_without_mutating_config(capsys):
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="dry_run",
+        dry_run=True,
+        slack=SlackConfig(
+            bot_user_ids=("U123MONICA",),
+            allowed_channels=("C123MOBILE",),
+        ),
+    )
+
+    exit_code = run_doctor_command(
+        config=config,
+        target_rollout_mode="linear_only",
+        environ={
+            "SLACK_BOT_TOKEN": "xoxb-token",
+            "SLACK_APP_TOKEN": "xapp-token",
+            "LINEAR_API_KEY": "lin_api_token",
+        },
+        which=lambda name: f"/usr/bin/{name}",
+        module_available=lambda _name: True,
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert config.rollout_mode == "dry_run"
+    assert config.dry_run is True
+    assert "Monica rollout mode: linear_only" in out
+    assert "FAIL: linear.team_id is missing" in out
+    assert "Monica doctor: not ready" in out
+
+
+def test_doctor_json_outputs_machine_readable_readiness(capsys):
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="dry_run",
+            slack=SlackConfig(bot_user_ids=("U123MONICA",), allowed_channels=("C123MOBILE",)),
+        ),
+        json_output=True,
+        environ={"MONICA_SLACK_BOT_TOKEN": "xoxb-token"},
+        which=lambda name: f"/usr/bin/{name}",
+        module_available=lambda name: name != "slack_sdk",
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 1
+    assert payload["ready"] is False
+    assert payload["rollout_mode"] == "dry_run"
+    assert payload["runtime_root"]
+    assert payload["warnings"] == [
+        {
+            "code": "slack_app_token",
+            "message": "MONICA_SLACK_APP_TOKEN is missing; Monica Slack Socket Mode may not start",
+        }
+    ]
+    assert payload["failures"] == [
+        {
+            "code": "slack_sdk",
+            "message": "slack-sdk Python package is not installed; install `hermes-agent[slack]` or `hermes-agent[messaging]`",
+        }
+    ]
+    assert "xoxb-token" not in json.dumps(payload)
+
+
+def test_doctor_fails_when_slack_sdk_is_missing(capsys):
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="dry_run",
+            slack=SlackConfig(bot_user_ids=("U_MONICA",), allowed_channels=("C123",)),
+        ),
+        environ={"SLACK_BOT_TOKEN": "xoxb-token"},
+        which=lambda name: f"/usr/bin/{name}",
+        module_available=lambda name: name != "slack_sdk",
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert (
+        "FAIL: slack-sdk Python package is not installed; install "
+        "`hermes-agent[slack]` or `hermes-agent[messaging]`"
+    ) in out
+    assert "Monica doctor: not ready" in out
+
+
+def test_doctor_reports_invalid_runtime_root_without_traceback(capsys):
+    exit_code = run_doctor_command(
+        config=config_from_mapping(
+            {
+                "enabled": True,
+                "rollout_mode": "dry_run",
+                "runtime": {"home_subdir": "../outside-runtime"},
+                "slack": {"bot_user_ids": ["U_MONICA"], "allowed_channels": ["C123"]},
+            }
+        ),
+        environ={"SLACK_BOT_TOKEN": "xoxb-token"},
+        which=lambda name: f"/usr/bin/{name}",
+        module_available=lambda name: True,
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "FAIL: mobile_bug_agent.runtime.home_subdir must stay inside HERMES_HOME." in out
+    assert "Monica doctor: not ready" in out
+
+
+def test_doctor_blocks_dry_run_with_bot_id_mentions(capsys):
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="dry_run",
+            slack=SlackConfig(bot_user_ids=("B012ABCDEF",), allowed_channels=("C123",)),
+        ),
+        environ={"SLACK_BOT_TOKEN": "xoxb-token"},
+        which=lambda name: f"/usr/bin/{name}",
+        module_available=lambda name: True,
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert (
+        "FAIL: slack.bot_user_ids must contain Slack mention user IDs like U012ABCDEF, "
+        "not bot_id values like B012ABCDEF"
+    ) in out
+    assert "Monica doctor: not ready" in out
+
+
+def test_doctor_blocks_dry_run_with_handle_style_bot_user_id(capsys):
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="dry_run",
+            slack=SlackConfig(bot_user_ids=("@monica",), allowed_channels=("C123",)),
+        ),
+        environ={"SLACK_BOT_TOKEN": "xoxb-token"},
+        which=lambda name: f"/usr/bin/{name}",
+        module_available=lambda name: True,
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert (
+        "FAIL: slack.bot_user_ids must contain Slack mention user IDs like U012ABCDEF, "
+        "not handles like @monica"
+    ) in out
+    assert "Monica doctor: not ready" in out
+
+
+def test_doctor_blocks_dry_run_with_malformed_bot_user_id(capsys):
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="dry_run",
+            slack=SlackConfig(bot_user_ids=("monica",), allowed_channels=("C123",)),
+        ),
+        environ={"SLACK_BOT_TOKEN": "xoxb-token"},
+        which=lambda name: f"/usr/bin/{name}",
+        module_available=lambda name: True,
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert (
+        "FAIL: slack.bot_user_ids must contain Slack mention user IDs like U012ABCDEF, "
+        "not invalid values like monica"
+    ) in out
+    assert "Monica doctor: not ready" in out
+
+
+def test_doctor_blocks_side_effect_rollouts_with_bot_id_mentions(capsys):
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="linear_only",
+            slack=SlackConfig(bot_user_ids=("B012ABCDEF",), allowed_channels=("C123",)),
+            linear=LinearConfig(team_id="team-id"),
+        ),
+        environ={
+            "SLACK_BOT_TOKEN": "xoxb-token",
+            "SLACK_APP_TOKEN": "xapp-token",
+            "LINEAR_API_KEY": "lin-key",
+        },
+        which=lambda name: f"/usr/bin/{name}",
+        module_available=lambda name: True,
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert (
+        "FAIL: slack.bot_user_ids must contain Slack mention user IDs like U012ABCDEF, "
+        "not bot_id values like B012ABCDEF"
+    ) in out
+    assert "Monica doctor: not ready" in out
+
+
+def test_doctor_blocks_side_effect_rollouts_with_handle_style_bot_user_id(capsys):
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="linear_only",
+            slack=SlackConfig(bot_user_ids=("@monica",), allowed_channels=("C123",)),
+            linear=LinearConfig(team_id="team-id"),
+        ),
+        environ={
+            "SLACK_BOT_TOKEN": "xoxb-token",
+            "SLACK_APP_TOKEN": "xapp-token",
+            "LINEAR_API_KEY": "lin-key",
+        },
+        which=lambda name: f"/usr/bin/{name}",
+        module_available=lambda name: True,
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert (
+        "FAIL: slack.bot_user_ids must contain Slack mention user IDs like U012ABCDEF, "
+        "not handles like @monica"
+    ) in out
+    assert "Monica doctor: not ready" in out
+
+
+def test_doctor_blocks_side_effect_rollouts_with_malformed_bot_user_id(capsys):
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="linear_only",
+            slack=SlackConfig(bot_user_ids=("monica",), allowed_channels=("C123",)),
+            linear=LinearConfig(team_id="team-id"),
+        ),
+        environ={
+            "SLACK_BOT_TOKEN": "xoxb-token",
+            "SLACK_APP_TOKEN": "xapp-token",
+            "LINEAR_API_KEY": "lin-key",
+        },
+        which=lambda name: f"/usr/bin/{name}",
+        module_available=lambda name: True,
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert (
+        "FAIL: slack.bot_user_ids must contain Slack mention user IDs like U012ABCDEF, "
+        "not invalid values like monica"
+    ) in out
+    assert "Monica doctor: not ready" in out
+
+
+def test_doctor_blocks_side_effect_rollouts_without_bot_user_ids(capsys):
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="linear_only",
+            slack=SlackConfig(allowed_channels=("C123",)),
+            linear=LinearConfig(team_id="team-id"),
+        ),
+        environ={
+            "SLACK_BOT_TOKEN": "xoxb-token",
+            "SLACK_APP_TOKEN": "xapp-token",
+            "LINEAR_API_KEY": "lin-key",
+        },
+        which=lambda name: f"/usr/bin/{name}",
+        module_available=lambda name: True,
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "FAIL: slack.bot_user_ids is empty; configure Monica's Slack mention user ID" in out
+    assert "Monica doctor: not ready" in out
+
+
+def test_doctor_fails_when_provided_slack_scopes_are_missing_required_post_scope(capsys):
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="dry_run",
+            slack=SlackConfig(bot_user_ids=("U_MONICA",), allowed_channels=("C123",)),
+        ),
+        environ={
+            "SLACK_BOT_TOKEN": "xoxb-token",
+            "SLACK_BOT_SCOPES": "app_mentions:read,channels:history",
+        },
+        which=lambda name: f"/usr/bin/{name}",
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "FAIL: SLACK_BOT_SCOPES is missing required scope: chat:write" in out
+    assert "Monica doctor: not ready" in out
+
+
+def test_doctor_blocks_approved_pr_without_repo_verification_and_tools(capsys):
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="approved_pr",
+            slack=SlackConfig(bot_user_ids=("BMONICA",), allowed_channels=("C123",)),
+            linear=LinearConfig(team_id="team-id"),
+        ),
+        environ={"SLACK_BOT_TOKEN": "xoxb-token", "LINEAR_API_KEY": "lin-key"},
+        which=lambda name: None,
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "FAIL: repo.url is missing" in out
+    assert "FAIL: verification.commands is empty" in out
+    assert "FAIL: git executable was not found" in out
+    assert "FAIL: gh executable was not found" in out
+    assert "FAIL: codex executable was not found" in out
+
+
+def test_doctor_blocks_approved_pr_without_configured_approvers(capsys):
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="approved_pr",
+            slack=SlackConfig(bot_user_ids=("U_MONICA",), allowed_channels=("C123",)),
+            linear=LinearConfig(team_id="team-id"),
+            repo=RepoConfig(url="git@github.com:acme/mobile.git"),
+            verification=VerificationConfig(commands=("npm test",)),
+        ),
+        environ={
+            "MONICA_SLACK_BOT_TOKEN": "xoxb-token",
+            "MONICA_SLACK_APP_TOKEN": "xapp-token",
+            "LINEAR_API_KEY": "lin-key",
+            "GITHUB_TOKEN": "gh-token",
+        },
+        which=lambda name: f"/usr/bin/{name}",
+        module_available=lambda name: True,
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "FAIL: slack.approver_user_ids is empty; configure at least one Monica code approver" in out
+    assert "Monica doctor: not ready" in out
+
+
+def test_doctor_blocks_approved_pr_with_unsafe_repo_local_name(capsys):
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="approved_pr",
+            slack=SlackConfig(
+                bot_user_ids=("U_MONICA",),
+                allowed_channels=("C123",),
+                approver_user_ids=("U_APPROVER",),
+            ),
+            linear=LinearConfig(team_id="team-id"),
+            repo=RepoConfig(url="git@github.com:acme/mobile.git", local_name="../outside-runtime"),
+            verification=VerificationConfig(commands=("npm test",)),
+        ),
+        environ={
+            "MONICA_SLACK_BOT_TOKEN": "xoxb-token",
+            "MONICA_SLACK_APP_TOKEN": "xapp-token",
+            "LINEAR_API_KEY": "lin-key",
+            "GITHUB_TOKEN": "gh-token",
+        },
+        which=lambda name: f"/usr/bin/{name}",
+        module_available=lambda name: True,
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "FAIL: repo.local_name must be a simple directory name." in out
+    assert "Monica doctor: not ready" in out
+
+
+def test_doctor_blocks_approved_pr_with_chandler_repo_local_name(capsys):
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="approved_pr",
+            slack=SlackConfig(
+                bot_user_ids=("U_MONICA",),
+                allowed_channels=("C123",),
+                approver_user_ids=("U_APPROVER",),
+            ),
+            linear=LinearConfig(team_id="team-id"),
+            repo=RepoConfig(url="git@github.com:acme/mobile.git", local_name="chandler"),
+            verification=VerificationConfig(commands=("npm test",)),
+        ),
+        environ={
+            "SLACK_BOT_TOKEN": "xoxb-token",
+            "SLACK_APP_TOKEN": "xapp-token",
+            "LINEAR_API_KEY": "lin-key",
+            "GITHUB_TOKEN": "gh-token",
+        },
+        which=lambda name: f"/usr/bin/{name}",
+        module_available=lambda name: True,
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "FAIL: repo.local_name must not point at a Chandler directory." in out
+    assert "Monica doctor: not ready" in out
+
+
+def test_doctor_blocks_approved_pr_with_unsafe_repo_branch_prefix(capsys):
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="approved_pr",
+            slack=SlackConfig(
+                bot_user_ids=("U_MONICA",),
+                allowed_channels=("C123",),
+                approver_user_ids=("U_APPROVER",),
+            ),
+            linear=LinearConfig(team_id="team-id"),
+            repo=RepoConfig(
+                url="git@github.com:acme/mobile.git",
+                branch_prefix="../chandler",
+            ),
+            verification=VerificationConfig(commands=("npm test",)),
+        ),
+        environ={
+            "SLACK_BOT_TOKEN": "xoxb-token",
+            "SLACK_APP_TOKEN": "xapp-token",
+            "LINEAR_API_KEY": "lin-key",
+            "GITHUB_TOKEN": "gh-token",
+        },
+        which=lambda name: f"/usr/bin/{name}",
+        module_available=lambda name: True,
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "FAIL: repo.branch_prefix must be a safe git branch prefix." in out
+    assert "Monica doctor: not ready" in out
+
+
+def test_doctor_blocks_approved_pr_with_chandler_repo_branch_prefix(capsys):
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="approved_pr",
+            slack=SlackConfig(
+                bot_user_ids=("U_MONICA",),
+                allowed_channels=("C123",),
+                approver_user_ids=("U_APPROVER",),
+            ),
+            linear=LinearConfig(team_id="team-id"),
+            repo=RepoConfig(
+                url="git@github.com:acme/mobile.git",
+                branch_prefix="chandler",
+            ),
+            verification=VerificationConfig(commands=("npm test",)),
+        ),
+        environ={
+            "SLACK_BOT_TOKEN": "xoxb-token",
+            "SLACK_APP_TOKEN": "xapp-token",
+            "LINEAR_API_KEY": "lin-key",
+            "GITHUB_TOKEN": "gh-token",
+        },
+        which=lambda name: f"/usr/bin/{name}",
+        module_available=lambda name: True,
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "FAIL: repo.branch_prefix must not point at Chandler." in out
+    assert "Monica doctor: not ready" in out
+
+
+def test_doctor_blocks_approved_pr_with_unsafe_repo_default_branch(capsys):
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="approved_pr",
+            slack=SlackConfig(
+                bot_user_ids=("U_MONICA",),
+                allowed_channels=("C123",),
+                approver_user_ids=("U_APPROVER",),
+            ),
+            linear=LinearConfig(team_id="team-id"),
+            repo=RepoConfig(
+                url="git@github.com:acme/mobile.git",
+                default_branch="../main",
+            ),
+            verification=VerificationConfig(commands=("npm test",)),
+        ),
+        environ={
+            "SLACK_BOT_TOKEN": "xoxb-token",
+            "SLACK_APP_TOKEN": "xapp-token",
+            "LINEAR_API_KEY": "lin-key",
+            "GITHUB_TOKEN": "gh-token",
+        },
+        which=lambda name: f"/usr/bin/{name}",
+        module_available=lambda name: True,
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "FAIL: repo.default_branch must be a safe git branch name." in out
+    assert "Monica doctor: not ready" in out
+
+
+def test_doctor_blocks_approved_pr_with_handle_style_approver(capsys):
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="approved_pr",
+            slack=SlackConfig(
+                bot_user_ids=("U_MONICA",),
+                allowed_channels=("C123",),
+                approver_user_ids=("@ritik",),
+            ),
+            linear=LinearConfig(team_id="team-id"),
+            repo=RepoConfig(url="git@github.com:acme/mobile.git"),
+            verification=VerificationConfig(commands=("npm test",)),
+        ),
+        environ={
+            "SLACK_BOT_TOKEN": "xoxb-token",
+            "SLACK_APP_TOKEN": "xapp-token",
+            "LINEAR_API_KEY": "lin-key",
+            "GITHUB_TOKEN": "gh-token",
+        },
+        which=lambda name: f"/usr/bin/{name}",
+        module_available=lambda name: True,
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "FAIL: slack.approver_user_ids must contain Slack user IDs like U123, not handles like @ritik" in out
+    assert "Monica doctor: not ready" in out
+
+
+def test_doctor_blocks_approved_pr_with_malformed_approver_user_id(capsys):
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="approved_pr",
+            slack=SlackConfig(
+                bot_user_ids=("U_MONICA",),
+                allowed_channels=("C123",),
+                approver_user_ids=("ritik",),
+            ),
+            linear=LinearConfig(team_id="team-id"),
+            repo=RepoConfig(url="git@github.com:acme/mobile.git"),
+            verification=VerificationConfig(commands=("npm test",)),
+        ),
+        environ={
+            "SLACK_BOT_TOKEN": "xoxb-token",
+            "SLACK_APP_TOKEN": "xapp-token",
+            "LINEAR_API_KEY": "lin-key",
+            "GITHUB_TOKEN": "gh-token",
+        },
+        which=lambda name: f"/usr/bin/{name}",
+        module_available=lambda name: True,
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert (
+        "FAIL: slack.approver_user_ids must contain Slack user IDs like U123, "
+        "not invalid values like ritik"
+    ) in out
+    assert "Monica doctor: not ready" in out
+
+
+def test_doctor_blocks_approved_pr_with_interactive_codex_approval_policy(capsys):
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="approved_pr",
+            slack=SlackConfig(
+                bot_user_ids=("U_MONICA",),
+                allowed_channels=("C123",),
+                approver_user_ids=("U_APPROVER",),
+            ),
+            linear=LinearConfig(team_id="team-id"),
+            repo=RepoConfig(url="git@github.com:acme/mobile.git"),
+            verification=VerificationConfig(commands=("npm test",)),
+            worker=WorkerConfig(codex_approval_policy="on-request"),
+        ),
+        environ={
+            "SLACK_BOT_TOKEN": "xoxb-token",
+            "SLACK_APP_TOKEN": "xapp-token",
+            "LINEAR_API_KEY": "lin-key",
+            "GITHUB_TOKEN": "gh-token",
+        },
+        which=lambda name: f"/usr/bin/{name}",
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "FAIL: worker.codex_approval_policy must be `never` for approved_pr codex_cli runs" in out
+    assert "Monica doctor: not ready" in out
+
+
+def test_doctor_blocks_approved_pr_with_non_workspace_codex_sandbox(capsys):
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="approved_pr",
+            slack=SlackConfig(
+                bot_user_ids=("U_MONICA",),
+                allowed_channels=("C123",),
+                approver_user_ids=("U_APPROVER",),
+            ),
+            linear=LinearConfig(team_id="team-id"),
+            repo=RepoConfig(url="git@github.com:acme/mobile.git"),
+            verification=VerificationConfig(commands=("npm test",)),
+            worker=WorkerConfig(codex_sandbox="danger-full-access"),
+        ),
+        environ={
+            "SLACK_BOT_TOKEN": "xoxb-token",
+            "SLACK_APP_TOKEN": "xapp-token",
+            "LINEAR_API_KEY": "lin-key",
+            "GITHUB_TOKEN": "gh-token",
+        },
+        which=lambda name: f"/usr/bin/{name}",
+        module_available=lambda name: True,
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "FAIL: worker.codex_sandbox must be `workspace-write` for approved_pr codex_cli runs" in out
+    assert "Monica doctor: not ready" in out
+
+
+def test_doctor_blocks_internal_worker_with_chandler_session_prefix(capsys):
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="approved_pr",
+            slack=SlackConfig(
+                bot_user_ids=("U_MONICA",),
+                allowed_channels=("C123",),
+                approver_user_ids=("U_APPROVER",),
+            ),
+            linear=LinearConfig(team_id="team-id"),
+            repo=RepoConfig(url="git@github.com:acme/mobile.git"),
+            runtime=RuntimeConfig(worker_session_prefix="chandler"),
+            verification=VerificationConfig(commands=("npm test",)),
+            worker=WorkerConfig(backend="internal_agent"),
+        ),
+        environ={
+            "SLACK_BOT_TOKEN": "xoxb-token",
+            "SLACK_APP_TOKEN": "xapp-token",
+            "LINEAR_API_KEY": "lin-key",
+            "GITHUB_TOKEN": "gh-token",
+        },
+        which=lambda name: f"/usr/bin/{name}",
+        module_available=lambda name: True,
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "FAIL: runtime.worker_session_prefix must include `monica` to keep worker sessions segregated" in out
+    assert "Monica doctor: not ready" in out
+
+
+def test_doctor_blocks_chandler_runtime_home_subdir(capsys):
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="approved_pr",
+            slack=SlackConfig(
+                bot_user_ids=("U_MONICA",),
+                allowed_channels=("C123",),
+                approver_user_ids=("U_APPROVER",),
+            ),
+            linear=LinearConfig(team_id="team-id"),
+            repo=RepoConfig(url="git@github.com:acme/mobile.git"),
+            runtime=RuntimeConfig(home_subdir="agents/chandler"),
+            verification=VerificationConfig(commands=("npm test",)),
+        ),
+        environ={
+            "SLACK_BOT_TOKEN": "xoxb-token",
+            "SLACK_APP_TOKEN": "xapp-token",
+            "LINEAR_API_KEY": "lin-key",
+            "GITHUB_TOKEN": "gh-token",
+        },
+        which=lambda name: f"/usr/bin/{name}",
+        module_available=lambda name: True,
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "FAIL: mobile_bug_agent.runtime.home_subdir must not point at a Chandler runtime path" in out
+    assert "Monica doctor: not ready" in out
+
+
+def test_doctor_blocks_approved_pr_when_linear_creation_is_disabled(capsys):
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="approved_pr",
+            slack=SlackConfig(
+                bot_user_ids=("U_MONICA",),
+                allowed_channels=("C123",),
+                approver_user_ids=("U_APPROVER",),
+            ),
+            loop=LoopConfig(create_linear=False),
+            linear=LinearConfig(team_id="team-id"),
+            repo=RepoConfig(url="git@github.com:acme/mobile.git"),
+            verification=VerificationConfig(commands=("npm test",)),
+        ),
+        environ={
+            "SLACK_BOT_TOKEN": "xoxb-token",
+            "SLACK_APP_TOKEN": "xapp-token",
+            "LINEAR_API_KEY": "lin-key",
+            "GITHUB_TOKEN": "gh-token",
+        },
+        which=lambda name: f"/usr/bin/{name}",
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "FAIL: loop.create_linear must be true in approved_pr mode" in out
+    assert "Monica doctor: not ready" in out
+
+
+def test_doctor_blocks_approved_pr_when_fix_approval_gate_is_disabled(capsys):
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="approved_pr",
+            slack=SlackConfig(
+                bot_user_ids=("U_MONICA",),
+                allowed_channels=("C123",),
+                approver_user_ids=("U_APPROVER",),
+            ),
+            loop=LoopConfig(require_fix_approval=False),
+            linear=LinearConfig(team_id="team-id"),
+            repo=RepoConfig(url="git@github.com:acme/mobile.git"),
+            verification=VerificationConfig(commands=("npm test",)),
+        ),
+        environ={
+            "SLACK_BOT_TOKEN": "xoxb-token",
+            "SLACK_APP_TOKEN": "xapp-token",
+            "LINEAR_API_KEY": "lin-key",
+            "GITHUB_TOKEN": "gh-token",
+        },
+        which=lambda name: f"/usr/bin/{name}",
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "FAIL: loop.require_fix_approval must be true in approved_pr mode" in out
+    assert "Monica doctor: not ready" in out
+
+
+def test_doctor_blocks_side_effect_rollouts_without_allowed_channels(capsys):
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="linear_only",
+            slack=SlackConfig(bot_user_ids=("U_MONICA",)),
+            linear=LinearConfig(team_id="team-id"),
+        ),
+        environ={
+            "SLACK_BOT_TOKEN": "xoxb-token",
+            "SLACK_APP_TOKEN": "xapp-token",
+            "LINEAR_API_KEY": "lin-key",
+        },
+        which=lambda name: f"/usr/bin/{name}",
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "FAIL: slack.allowed_channels is empty; configure the Slack channels Monica may act in" in out
+    assert "Monica doctor: not ready" in out
+
+
+def test_doctor_blocks_dry_run_with_slack_channel_names(capsys):
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="dry_run",
+            slack=SlackConfig(bot_user_ids=("U_MONICA",), allowed_channels=("#mobile-bugs",)),
+        ),
+        environ={"SLACK_BOT_TOKEN": "xoxb-token"},
+        which=lambda name: f"/usr/bin/{name}",
+        module_available=lambda name: True,
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "FAIL: slack.allowed_channels must contain Slack channel IDs like C123 or G123, not names like #mobile-bugs" in out
+    assert "Monica doctor: not ready" in out
+
+
+def test_doctor_blocks_side_effect_rollouts_with_slack_channel_names(capsys):
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="linear_only",
+            slack=SlackConfig(bot_user_ids=("U_MONICA",), allowed_channels=("#mobile-bugs",)),
+            linear=LinearConfig(team_id="team-id"),
+        ),
+        environ={
+            "SLACK_BOT_TOKEN": "xoxb-token",
+            "SLACK_APP_TOKEN": "xapp-token",
+            "LINEAR_API_KEY": "lin-key",
+        },
+        which=lambda name: f"/usr/bin/{name}",
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "FAIL: slack.allowed_channels must contain Slack channel IDs like C123 or G123, not names like #mobile-bugs" in out
+    assert "Monica doctor: not ready" in out
+
+
+def test_doctor_blocks_linear_only_when_linear_creation_is_disabled(capsys):
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="linear_only",
+            slack=SlackConfig(bot_user_ids=("U_MONICA",), allowed_channels=("C123",)),
+            loop=LoopConfig(create_linear=False),
+            linear=LinearConfig(team_id="team-id"),
+        ),
+        environ={
+            "SLACK_BOT_TOKEN": "xoxb-token",
+            "SLACK_APP_TOKEN": "xapp-token",
+            "LINEAR_API_KEY": "lin-key",
+        },
+        which=lambda name: f"/usr/bin/{name}",
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "FAIL: loop.create_linear must be true in linear_only mode" in out
+    assert "Monica doctor: not ready" in out
+
+
+def test_doctor_accepts_approved_pr_when_required_setup_exists(capsys):
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="approved_pr",
+            slack=SlackConfig(
+                bot_user_ids=("U_MONICA",),
+                allowed_channels=("C123",),
+                approver_user_ids=("U_APPROVER",),
+            ),
+            linear=LinearConfig(team_id="team-id"),
+            repo=RepoConfig(url="git@github.com:acme/mobile.git"),
+            verification=VerificationConfig(commands=("npm test",)),
+        ),
+        environ={
+            "MONICA_SLACK_BOT_TOKEN": "xoxb-token",
+            "MONICA_SLACK_APP_TOKEN": "xapp-token",
+            "LINEAR_API_KEY": "lin-key",
+            "GITHUB_TOKEN": "gh-token",
+        },
+        which=lambda name: f"/usr/bin/{name}",
+        module_available=lambda name: True,
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Monica doctor: ready" in out
+
+
+def test_doctor_accepts_local_fix_only_without_github_push_or_pr_tools(capsys):
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="local_fix_only",
+            slack=SlackConfig(
+                bot_user_ids=("U_MONICA",),
+                allowed_channels=("D123MONICA",),
+                approver_user_ids=("U_APPROVER",),
+            ),
+            linear=LinearConfig(team_id="team-id"),
+            repo=RepoConfig(url="git@github.com:acme/mobile.git"),
+            verification=VerificationConfig(commands=("npm test",)),
+        ),
+        environ={
+            "MONICA_SLACK_BOT_TOKEN": "xoxb-token",
+            "MONICA_SLACK_APP_TOKEN": "xapp-token",
+            "LINEAR_API_KEY": "lin-key",
+        },
+        which=lambda name: None if name == "gh" else f"/usr/bin/{name}",
+        module_available=lambda name: True,
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert "gh executable was not found" not in out
+    assert "GITHUB_TOKEN is missing" not in out
+    assert "Monica doctor: ready" in out
+
+
+def test_doctor_warns_when_required_proof_has_no_commands(capsys):
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="local_fix_only",
+            slack=SlackConfig(
+                bot_user_ids=("U_MONICA",),
+                allowed_channels=("D123MONICA",),
+                approver_user_ids=("U_APPROVER",),
+            ),
+            linear=LinearConfig(team_id="team-id"),
+            repo=RepoConfig(url="git@github.com:acme/mobile.git"),
+            verification=VerificationConfig(commands=("npm test",)),
+            proof=ProofConfig(enabled=True, required_for_done=True),
+        ),
+        environ={
+            "MONICA_SLACK_BOT_TOKEN": "xoxb-token",
+            "MONICA_SLACK_APP_TOKEN": "xapp-token",
+            "LINEAR_API_KEY": "lin-key",
+        },
+        which=lambda name: f"/usr/bin/{name}",
+        module_available=lambda name: True,
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert "WARN: proof.commands is empty; Monica will block at proof after verification" in out
+    assert "Monica doctor: ready" in out
+
+
+def test_doctor_warns_when_required_proof_tooling_is_missing(capsys):
+    missing = {"xcrun", "xcodebuild", "adb", "emulator"}
+
+    exit_code = run_doctor_command(
+        config=MonicaConfig(
+            enabled=True,
+            rollout_mode="local_fix_only",
+            slack=SlackConfig(
+                bot_user_ids=("U_MONICA",),
+                allowed_channels=("D123MONICA",),
+                approver_user_ids=("U_APPROVER",),
+            ),
+            linear=LinearConfig(team_id="team-id"),
+            repo=RepoConfig(url="git@github.com:acme/mobile.git"),
+            verification=VerificationConfig(commands=("npm test",)),
+            proof=ProofConfig(
+                enabled=True,
+                required_for_done=True,
+                commands=("npm run monica:proof",),
+                platform_order=("ios", "android"),
+            ),
+        ),
+        environ={
+            "MONICA_SLACK_BOT_TOKEN": "xoxb-token",
+            "MONICA_SLACK_APP_TOKEN": "xapp-token",
+            "LINEAR_API_KEY": "lin-key",
+        },
+        which=lambda name: None if name in missing else f"/usr/bin/{name}",
+        module_available=lambda name: True,
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert (
+        "WARN: iOS proof is configured but xcrun/simctl or xcodebuild was not found; "
+        "Monica will block at proof until a simulator is available"
+    ) in out
+    assert (
+        "WARN: Android proof is configured but adb or emulator was not found; "
+        "Monica will block at proof until an emulator is available"
+    ) in out
+    assert "Monica doctor: ready" in out

--- a/tests/plugins/mobile_bug_agent/test_codex_worker.py
+++ b/tests/plugins/mobile_bug_agent/test_codex_worker.py
@@ -1,0 +1,332 @@
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from plugins.mobile_bug_agent.codex_worker import (
+    CodexCliWorker,
+    CodexWorkerError,
+    InternalCodexWorker,
+    build_code_worker,
+)
+from plugins.mobile_bug_agent.config import MonicaConfig, RuntimeConfig, WorkerConfig
+
+
+@dataclass
+class FakeRun:
+    id: str = "run-id"
+    linear_identifier: str = "MOB-42"
+
+
+class FakeAgent:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def run_conversation(self, user_message, system_message=None, conversation_history=None, task_id=None):
+        assert "You are Monica's code worker" in system_message
+        assert "Do not commit" in system_message
+        assert "Do not push" in system_message
+        assert "Do not create a pull request" in system_message
+        assert "Slack thread" in user_message
+        assert task_id == "monica-run-id"
+        return {"final_response": "Changed src/Checkout.tsx and added a regression test."}
+
+
+def _mark_git_worktree(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / ".git").write_text("gitdir: /tmp/fake-worktree-git-dir", encoding="utf-8")
+    return path
+
+
+@dataclass
+class FakeWorktree:
+    path: Path
+    branch_name: str = "monica/MOB-42-checkout-crash"
+
+
+def test_codex_worker_runs_in_worktree(tmp_path):
+    worker = InternalCodexWorker(config=MonicaConfig(), agent_factory=FakeAgent)
+    worktree = _mark_git_worktree(tmp_path)
+
+    result = worker.run(
+        run=FakeRun(),
+        worktree=worktree,
+        brief="Slack thread: https://slack/thread\nBug: Android checkout crash",
+    )
+
+    assert result["summary"].startswith("Changed")
+    assert result["worktree"] == str(worktree)
+    assert result["changed"] is True
+    assert result["worker"] == "internal_agent"
+
+
+def test_codex_worker_uses_isolated_monica_session(tmp_path):
+    captured = {}
+
+    class CapturingAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        def run_conversation(self, user_message, system_message=None, conversation_history=None, task_id=None):
+            return {"final_response": "Changed src/Checkout.tsx."}
+
+    worker = InternalCodexWorker(config=MonicaConfig(), agent_factory=CapturingAgent)
+    worktree = _mark_git_worktree(tmp_path)
+
+    worker.run(
+        run=FakeRun(id="abc123"),
+        worktree=worktree,
+        brief="Slack thread: https://slack/thread\nBug: Android checkout crash",
+    )
+
+    assert captured["platform"] == "monica"
+    assert captured["session_id"] == "monica-abc123"
+    assert captured["skip_context_files"] is True
+    assert captured["skip_memory"] is True
+
+
+def test_codex_cli_worker_rejects_branch_mismatch_before_invoking_codex(tmp_path):
+    calls = []
+    worker = CodexCliWorker(config=MonicaConfig(), run_command=lambda *args: calls.append(args) or "")
+    worktree_path = _mark_git_worktree(tmp_path)
+    worktree = FakeWorktree(path=worktree_path, branch_name="chandler/MOB-42-checkout-crash")
+    run = FakeRun(linear_identifier="MOB-42")
+
+    with pytest.raises(CodexWorkerError, match="worktree branch mismatch"):
+        worker.run(
+            run=run,
+            worktree=worktree,
+            brief="Slack thread: https://slack/thread\nBug: Android checkout crash",
+        )
+
+    assert calls == []
+
+
+def test_internal_codex_worker_rejects_non_monica_session_prefix_before_invoking_agent(tmp_path):
+    created_agents = []
+
+    class CapturingAgent:
+        def __init__(self, **kwargs):
+            created_agents.append(kwargs)
+
+        def run_conversation(self, user_message, system_message=None, conversation_history=None, task_id=None):
+            return {"final_response": "Changed src/Checkout.tsx."}
+
+    worker = InternalCodexWorker(
+        config=MonicaConfig(
+            runtime=RuntimeConfig(worker_session_prefix="chandler"),
+            worker=WorkerConfig(backend="internal_agent"),
+        ),
+        agent_factory=CapturingAgent,
+    )
+    worktree = _mark_git_worktree(tmp_path)
+
+    with pytest.raises(CodexWorkerError, match="worker_session_prefix must include monica"):
+        worker.run(
+            run=FakeRun(id="abc123"),
+            worktree=worktree,
+            brief="Slack thread: https://slack/thread\nBug: Android checkout crash",
+        )
+
+    assert created_agents == []
+
+
+def test_codex_cli_worker_invokes_codex_exec_in_worktree(tmp_path):
+    calls = []
+
+    def fake_run(command, cwd, prompt, timeout):
+        calls.append((command, cwd, prompt, timeout))
+        output_file = Path(command[command.index("--output-last-message") + 1])
+        output_file.write_text("Changed via Codex CLI.", encoding="utf-8")
+        return "stdout fallback"
+
+    worker = CodexCliWorker(
+        config=MonicaConfig(
+            runtime=RuntimeConfig(home_subdir=str(tmp_path / "runtime")),
+            worker=WorkerConfig(
+                codex_model="gpt-5-codex",
+                codex_profile="monica",
+                timeout_minutes=7,
+            ),
+        ),
+        run_command=fake_run,
+    )
+    worktree = _mark_git_worktree(tmp_path)
+
+    result = worker.run(
+        run=FakeRun(id="abc123"),
+        worktree=worktree,
+        brief="Slack thread: https://slack/thread\nBug: Android checkout crash",
+    )
+
+    command, cwd, prompt, timeout = calls[0]
+    assert command[:2] == ["codex", "exec"]
+    assert command[command.index("-c") + 1] == 'approval_policy="never"'
+    assert command[command.index("--cd") + 1] == str(worktree)
+    assert command[command.index("--sandbox") + 1] == "workspace-write"
+    assert "--ask-for-approval" not in command
+    assert command[command.index("--model") + 1] == "gpt-5-codex"
+    assert command[command.index("--profile") + 1] == "monica"
+    assert command[-1] == "-"
+    assert cwd == worktree
+    assert "You are Monica's code worker" in prompt
+    assert "Do not push" in prompt
+    assert "Android checkout crash" in prompt
+    assert timeout == 420
+    assert result["worker"] == "codex_cli"
+    assert result["summary"] == "Changed via Codex CLI."
+    assert result["output_file"].endswith("abc123.md")
+
+
+def test_codex_cli_worker_requires_existing_worktree_before_invoking_codex(tmp_path):
+    calls = []
+    worker = CodexCliWorker(config=MonicaConfig(), run_command=lambda *args: calls.append(args) or "")
+
+    with pytest.raises(CodexWorkerError, match="worktree does not exist"):
+        worker.run(
+            run=FakeRun(id="abc123"),
+            worktree=tmp_path / "missing-worktree",
+            brief="Slack thread: https://slack/thread\nBug: Android checkout crash",
+        )
+
+    assert calls == []
+
+
+def test_codex_cli_worker_rejects_unsafe_sandbox_before_invoking_codex(tmp_path):
+    calls = []
+    worker = CodexCliWorker(
+        config=MonicaConfig(worker=WorkerConfig(codex_sandbox="danger-full-access")),
+        run_command=lambda *args: calls.append(args) or "",
+    )
+    worktree = _mark_git_worktree(tmp_path)
+
+    with pytest.raises(CodexWorkerError, match="codex_sandbox must be workspace-write"):
+        worker.run(
+            run=FakeRun(id="abc123"),
+            worktree=worktree,
+            brief="Slack thread: https://slack/thread\nBug: Android checkout crash",
+        )
+
+    assert calls == []
+
+
+def test_codex_cli_worker_rejects_interactive_approval_before_invoking_codex(tmp_path):
+    calls = []
+    worker = CodexCliWorker(
+        config=MonicaConfig(worker=WorkerConfig(codex_approval_policy="on-request")),
+        run_command=lambda *args: calls.append(args) or "",
+    )
+    worktree = _mark_git_worktree(tmp_path)
+
+    with pytest.raises(CodexWorkerError, match="codex_approval_policy must be never"):
+        worker.run(
+            run=FakeRun(id="abc123"),
+            worktree=worktree,
+            brief="Slack thread: https://slack/thread\nBug: Android checkout crash",
+        )
+
+    assert calls == []
+
+
+def test_codex_workers_require_git_worktree_before_invoking_tools(tmp_path):
+    plain_dir = tmp_path / "plain-directory"
+    plain_dir.mkdir()
+    codex_calls = []
+    worker = CodexCliWorker(config=MonicaConfig(), run_command=lambda *args: codex_calls.append(args) or "")
+
+    with pytest.raises(CodexWorkerError, match="worktree is not a git worktree"):
+        worker.run(
+            run=FakeRun(id="abc123"),
+            worktree=plain_dir,
+            brief="Slack thread: https://slack/thread\nBug: Android checkout crash",
+        )
+
+    created_agents = []
+
+    class CapturingAgent:
+        def __init__(self, **kwargs):
+            created_agents.append(kwargs)
+
+        def run_conversation(self, user_message, system_message=None, conversation_history=None, task_id=None):
+            return {"final_response": "Changed src/Checkout.tsx."}
+
+    internal_worker = InternalCodexWorker(config=MonicaConfig(), agent_factory=CapturingAgent)
+
+    with pytest.raises(CodexWorkerError, match="worktree is not a git worktree"):
+        internal_worker.run(
+            run=FakeRun(id="abc123"),
+            worktree=plain_dir,
+            brief="Slack thread: https://slack/thread\nBug: Android checkout crash",
+        )
+
+    assert codex_calls == []
+    assert created_agents == []
+
+
+def test_internal_codex_worker_requires_existing_worktree_before_invoking_agent(tmp_path):
+    created_agents = []
+
+    class CapturingAgent:
+        def __init__(self, **kwargs):
+            created_agents.append(kwargs)
+
+        def run_conversation(self, user_message, system_message=None, conversation_history=None, task_id=None):
+            return {"final_response": "Changed src/Checkout.tsx."}
+
+    worker = InternalCodexWorker(config=MonicaConfig(), agent_factory=CapturingAgent)
+
+    with pytest.raises(CodexWorkerError, match="worktree does not exist"):
+        worker.run(
+            run=FakeRun(id="abc123"),
+            worktree=tmp_path / "missing-worktree",
+            brief="Slack thread: https://slack/thread\nBug: Android checkout crash",
+        )
+
+    assert created_agents == []
+
+
+def test_codex_cli_worker_nonzero_exit_includes_command_context(tmp_path, monkeypatch):
+    def failed_run(*_: object, **__: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=["codex", "exec"],
+            returncode=2,
+            stdout="stdout detail",
+            stderr="stderr detail",
+        )
+
+    monkeypatch.setattr(subprocess, "run", failed_run)
+    worker = CodexCliWorker(config=MonicaConfig())
+    worktree = _mark_git_worktree(tmp_path)
+
+    with pytest.raises(CodexWorkerError) as exc_info:
+        worker.run(
+            run=FakeRun(id="abc123"),
+            worktree=worktree,
+            brief="Slack thread: https://slack/thread\nBug: Android checkout crash",
+        )
+
+    message = str(exc_info.value)
+    assert "Codex CLI failed (2): codex exec" in message
+    assert f"cwd: {worktree}" in message
+    assert "stdout: stdout detail" in message
+    assert "stderr: stderr detail" in message
+
+
+def test_build_code_worker_defaults_to_codex_cli():
+    worker = build_code_worker(MonicaConfig())
+
+    assert isinstance(worker, CodexCliWorker)
+
+
+def test_build_code_worker_can_use_internal_agent():
+    worker = build_code_worker(MonicaConfig(worker=WorkerConfig(backend="internal_agent")))
+
+    assert isinstance(worker, InternalCodexWorker)
+
+
+def test_build_code_worker_rejects_unknown_backend():
+    with pytest.raises(CodexWorkerError, match="unknown worker backend"):
+        build_code_worker(MonicaConfig(worker=WorkerConfig(backend="mystery")))

--- a/tests/plugins/mobile_bug_agent/test_config.py
+++ b/tests/plugins/mobile_bug_agent/test_config.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli.config import DEFAULT_CONFIG
+from plugins.mobile_bug_agent.config import config_from_mapping, runtime_root
+
+
+def test_config_defaults_are_safe():
+    cfg = config_from_mapping({})
+
+    assert cfg.enabled is False
+    assert cfg.rollout_mode == "dry_run"
+    assert cfg.dry_run is True
+    assert cfg.loop.require_fix_approval is True
+    assert cfg.repo.branch_prefix == "monica"
+    assert cfg.runtime.home_subdir == "agents/monica"
+    assert cfg.runtime.worker_session_prefix == "monica"
+    assert cfg.runtime.skip_memory is True
+    assert cfg.worker.backend == "codex_cli"
+    assert cfg.worker.codex_command == "codex"
+    assert cfg.worker.codex_sandbox == "workspace-write"
+    assert cfg.worker.codex_approval_policy == "never"
+    assert cfg.proof.enabled is False
+    assert cfg.proof.required_for_done is False
+    assert cfg.proof.platform_order == ("ios", "android")
+    assert cfg.proof.artifact_dir == "proof"
+    assert cfg.proof.commands == ()
+
+
+def test_default_config_shape_matches_monica_parser():
+    cfg = config_from_mapping(DEFAULT_CONFIG["mobile_bug_agent"])
+
+    assert cfg.enabled is False
+    assert cfg.rollout_mode == "dry_run"
+    assert cfg.slack.download_attachments is True
+    assert cfg.loop.create_linear is True
+    assert cfg.verification.commands == ()
+    assert cfg.runtime.home_subdir == "agents/monica"
+    assert cfg.worker.backend == "codex_cli"
+    assert cfg.proof.required_for_done is False
+
+
+def test_config_loads_nested_values():
+    cfg = config_from_mapping(
+        {
+            "enabled": True,
+            "dry_run": False,
+            "slack": {
+                "allowed_channels": ["C123"],
+                "bot_user_ids": ["U999"],
+                "approver_user_ids": ["U_APPROVER"],
+                "download_attachments": False,
+            },
+            "loop": {
+                "max_thread_messages": 25,
+                "max_attachment_bytes": 1234,
+                "require_fix_approval": True,
+            },
+            "linear": {
+                "team_id": "team",
+                "project_id": "project",
+                "label_ids": ["label"],
+            },
+            "repo": {
+                "url": "git@github.com:org/mobile.git",
+                "default_branch": "main",
+            },
+            "verification": {"commands": ["npm test", "npm run lint"]},
+            "runtime": {
+                "home_subdir": "agents/mobile-monica",
+                "worker_session_prefix": "mobile-monica",
+                "skip_memory": False,
+            },
+            "worker": {
+                "backend": "internal_agent",
+                "codex_command": "/opt/codex/bin/codex",
+                "codex_model": "gpt-5-codex",
+                "codex_profile": "monica",
+                "codex_sandbox": "danger-full-access",
+                "codex_approval_policy": "on-request",
+                "timeout_minutes": 12,
+            },
+            "proof": {
+                "enabled": True,
+                "required_for_done": True,
+                "platform_order": ["ios"],
+                "artifact_dir": "monica-proof",
+                "commands": ["npm run proof:ios"],
+                "ios_simulator_udid": "SIM-UDID",
+                "android_serial": "emulator-5554",
+                "timeout_minutes": 8,
+            },
+        }
+    )
+
+    assert cfg.enabled is True
+    assert cfg.rollout_mode == "linear_only"
+    assert cfg.dry_run is False
+    assert cfg.slack.allowed_channels == ("C123",)
+    assert cfg.slack.approver_user_ids == ("U_APPROVER",)
+    assert cfg.slack.download_attachments is False
+    assert cfg.loop.max_thread_messages == 25
+    assert cfg.loop.max_attachment_bytes == 1234
+    assert cfg.linear.label_ids == ("label",)
+    assert cfg.repo.url == "git@github.com:org/mobile.git"
+    assert cfg.verification.commands == ("npm test", "npm run lint")
+    assert cfg.runtime.home_subdir == "agents/mobile-monica"
+    assert cfg.runtime.worker_session_prefix == "mobile-monica"
+    assert cfg.runtime.skip_memory is False
+    assert cfg.worker.backend == "internal_agent"
+    assert cfg.worker.codex_command == "/opt/codex/bin/codex"
+    assert cfg.worker.codex_model == "gpt-5-codex"
+    assert cfg.worker.codex_profile == "monica"
+    assert cfg.worker.codex_sandbox == "danger-full-access"
+    assert cfg.worker.codex_approval_policy == "on-request"
+    assert cfg.worker.timeout_minutes == 12
+    assert cfg.proof.enabled is True
+    assert cfg.proof.required_for_done is True
+    assert cfg.proof.platform_order == ("ios",)
+    assert cfg.proof.artifact_dir == "monica-proof"
+    assert cfg.proof.commands == ("npm run proof:ios",)
+    assert cfg.proof.ios_simulator_udid == "SIM-UDID"
+    assert cfg.proof.android_serial == "emulator-5554"
+    assert cfg.proof.timeout_minutes == 8
+
+
+def test_runtime_root_is_profile_relative(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile-home"))
+    cfg = config_from_mapping({"runtime": {"home_subdir": "agents/monica"}})
+
+    assert runtime_root(cfg) == tmp_path / "profile-home" / "agents" / "monica"
+
+
+def test_runtime_root_rejects_relative_parent_traversal(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile-home"))
+    cfg = config_from_mapping({"runtime": {"home_subdir": "../outside-runtime"}})
+
+    with pytest.raises(ValueError, match="must stay inside HERMES_HOME"):
+        runtime_root(cfg)
+
+
+def test_runtime_root_rejects_chandler_named_subdir(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile-home"))
+    cfg = config_from_mapping({"runtime": {"home_subdir": "agents/chandler"}})
+
+    with pytest.raises(ValueError, match="must not point at a Chandler runtime path"):
+        runtime_root(cfg)
+
+
+def test_runtime_root_allows_absolute_override(tmp_path):
+    cfg = config_from_mapping({"runtime": {"home_subdir": str(tmp_path / "monica")}})
+
+    assert runtime_root(cfg) == tmp_path / "monica"

--- a/tests/plugins/mobile_bug_agent/test_default_skills.py
+++ b/tests/plugins/mobile_bug_agent/test_default_skills.py
@@ -1,0 +1,1138 @@
+from __future__ import annotations
+
+import logging
+import subprocess
+from dataclasses import dataclass, field
+from typing import Any
+
+from plugins.mobile_bug_agent.config import LinearConfig, MonicaConfig, SlackConfig, VerificationConfig
+from plugins.mobile_bug_agent.repo_manager import Worktree
+from plugins.mobile_bug_agent.skills import DefaultMonicaSkills
+from plugins.mobile_bug_agent.state import MonicaState
+
+
+@dataclass
+class FakeLinearClient:
+    calls: list[Any]
+    attachment_calls: list[Any] = field(default_factory=list)
+    fail_attachment: bool = False
+
+    def create_or_update_issue(self, payload: Any, *, existing_issue_id: str = "") -> Any:
+        self.calls.append((payload, existing_issue_id))
+
+        @dataclass(frozen=True)
+        class Issue:
+            id: str = "issue-id"
+            identifier: str = "MOB-123"
+            url: str = "https://linear.app/acme/issue/MOB-123"
+
+        return Issue()
+
+    def create_attachment(self, payload: Any) -> Any:
+        self.attachment_calls.append(payload)
+        if self.fail_attachment:
+            raise RuntimeError("Linear attachment failed")
+
+        @dataclass(frozen=True)
+        class Attachment:
+            id: str = "attachment-id"
+            title: str = payload.title
+            url: str = payload.url
+
+        return Attachment()
+
+
+class FailingSlackClient:
+    def post_thread_reply(self, *, channel_id: str, thread_ts: str, text: str) -> None:
+        raise RuntimeError("not_in_channel")
+
+
+@dataclass
+class CapturingSlackClient:
+    posts: list[dict[str, str]] = field(default_factory=list)
+
+    def post_thread_reply(self, *, channel_id: str, thread_ts: str, text: str) -> None:
+        self.posts.append({"channel_id": channel_id, "thread_ts": thread_ts, "text": text})
+
+
+def test_default_skills_create_real_linear_issue_when_not_dry_run(tmp_path):
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="Android checkout crashes after promo code",
+    )
+    calls: list[Any] = []
+    skills = DefaultMonicaSkills(
+        config=MonicaConfig(
+            rollout_mode="linear_only",
+            linear=LinearConfig(team_id="team-id", project_id="project-id"),
+        ),
+        state=state,
+        linear_client=FakeLinearClient(calls),
+    )
+
+    issue = skills.create_or_update_linear(
+        run,
+        {"permalink": "https://example.slack.com/thread", "messages": [run.request_text]},
+        {
+            "summary": "Android checkout crashes after promo code",
+            "confidence": 0.91,
+        },
+    )
+
+    payload, existing_issue_id = calls[0]
+    assert existing_issue_id == ""
+    assert payload.team_id == "team-id"
+    assert payload.project_id == "project-id"
+    assert payload.title == "[Mobile] Android checkout crashes after promo code"
+    assert "https://example.slack.com/thread" in payload.description
+    assert issue == {
+        "id": "issue-id",
+        "identifier": "MOB-123",
+        "url": "https://linear.app/acme/issue/MOB-123",
+        "dry_run": False,
+        "title": "[Mobile] Android checkout crashes after promo code",
+        "description": payload.description,
+        "attachments": [],
+        "attachment_errors": [],
+    }
+    assert issue["description"] == payload.description
+
+
+def test_default_skills_bounds_linear_issue_title_from_agentic_summary(tmp_path):
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="Android checkout crashes after promo code",
+    )
+    calls: list[Any] = []
+    skills = DefaultMonicaSkills(
+        config=MonicaConfig(
+            rollout_mode="linear_only",
+            linear=LinearConfig(team_id="team-id", project_id="project-id"),
+        ),
+        state=state,
+        linear_client=FakeLinearClient(calls),
+    )
+    long_summary = " ".join(["Android checkout crashes after promo code"] * 12)
+
+    issue = skills.create_or_update_linear(
+        run,
+        {"permalink": "https://example.slack.com/thread", "messages": [run.request_text]},
+        {
+            "summary": long_summary,
+            "confidence": 0.91,
+        },
+    )
+
+    payload, _existing_issue_id = calls[0]
+    assert len(payload.title) <= 120
+    assert payload.title.startswith("[Mobile] Android checkout crashes after promo code")
+    assert payload.title.endswith("...")
+    assert issue["title"] == payload.title
+
+
+def test_default_skills_fallback_thread_uses_raw_slack_files(tmp_path):
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="Android checkout crashes after promo code",
+        raw_event={
+            "permalink": "https://example.slack.com/thread",
+            "files": [
+                {
+                    "id": "F1",
+                    "name": "crash.png",
+                    "mimetype": "image/png",
+                    "url_private": "https://files/crash.png",
+                    "permalink": "https://example.slack.com/file/F1",
+                }
+            ],
+        },
+    )
+    skills = DefaultMonicaSkills(config=MonicaConfig(), state=state)
+
+    thread = skills.read_slack_thread(run)
+    description = skills._linear_description(
+        run,
+        thread,
+        {
+            "summary": "Android checkout crashes after promo code",
+            "confidence": 0.91,
+        },
+    )
+
+    assert thread["permalink"] == "https://example.slack.com/thread"
+    assert thread["files"][0]["name"] == "crash.png"
+    assert thread["files"][0]["permalink"] == "https://example.slack.com/file/F1"
+    assert "crash.png (image/png)" in description
+    assert "https://example.slack.com/thread" in description
+
+
+def test_default_skills_fallback_thread_preserves_triggering_message_metadata(tmp_path):
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="Android checkout crashes after promo code",
+        raw_event={
+            "permalink": "https://example.slack.com/thread",
+            "ts": "1710000000.000200",
+            "user": "U_TAGGER",
+            "text": "<@BMONICA> Android checkout crashes after promo code",
+        },
+    )
+    skills = DefaultMonicaSkills(config=MonicaConfig(), state=state)
+
+    thread = skills.read_slack_thread(run)
+    description = skills._linear_description(
+        run,
+        thread,
+        {
+            "summary": "Android checkout crashes after promo code",
+            "confidence": 0.91,
+        },
+    )
+
+    assert thread["channel_id"] == "C_MOBILE"
+    assert thread["thread_ts"] == "1710000000.000100"
+    assert thread["message_details"] == [
+        {
+            "user_id": "U_TAGGER",
+            "text": "Android checkout crashes after promo code",
+            "ts": "1710000000.000200",
+            "permalink": "https://example.slack.com/thread",
+        }
+    ]
+    assert (
+        "- U_TAGGER at 1710000000.000200: Android checkout crashes after promo code "
+        "(https://example.slack.com/thread)"
+    ) in description
+
+
+def test_default_skills_fallback_thread_uses_raw_slack_attachment_images(tmp_path):
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="Android checkout crashes after promo code",
+        raw_event={
+            "permalink": "https://example.slack.com/thread",
+            "attachments": [
+                {
+                    "title": "Checkout crash screenshot",
+                    "image_url": "https://files.example.com/checkout-crash.png",
+                    "fallback": "checkout screenshot",
+                }
+            ],
+        },
+    )
+    skills = DefaultMonicaSkills(config=MonicaConfig(), state=state)
+
+    thread = skills.read_slack_thread(run)
+    description = skills._linear_description(
+        run,
+        thread,
+        {
+            "summary": "Android checkout crashes after promo code",
+            "confidence": 0.91,
+        },
+    )
+
+    assert thread["files"] == [
+        {
+            "id": "attachment-1710000000.000200-1",
+            "name": "Checkout crash screenshot",
+            "mimetype": "image",
+            "url_private": "https://files.example.com/checkout-crash.png",
+            "permalink": "https://files.example.com/checkout-crash.png",
+        }
+    ]
+    assert thread["attachments"] == ["Checkout crash screenshot"]
+    assert "Checkout crash screenshot (image)" in description
+
+
+def test_default_skills_simulated_runs_do_not_call_slack_client(tmp_path):
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="LOCAL",
+        thread_ts="sim-thread",
+        message_ts="sim-message",
+        user_id="local-operator",
+        request_text="Android checkout crashes after promo code",
+        raw_event={
+            "monica_simulated": True,
+            "permalink": "local://monica/simulated/sim-thread",
+            "files": [
+                {
+                    "id": "F1",
+                    "name": "simulated-crash.png",
+                    "mimetype": "image/png",
+                    "permalink": "local://monica/simulated/file/F1",
+                }
+            ],
+        },
+    )
+
+    class RaisingSlackClient:
+        def read_thread(self, **_: Any) -> Any:
+            raise AssertionError("simulated runs must not fetch Slack")
+
+    skills = DefaultMonicaSkills(
+        config=MonicaConfig(),
+        state=state,
+        slack_client=RaisingSlackClient(),
+    )
+
+    thread = skills.read_slack_thread(run)
+
+    assert thread["permalink"] == "local://monica/simulated/sim-thread"
+    assert thread["messages"] == ["Android checkout crashes after promo code"]
+    assert thread["files"][0]["name"] == "simulated-crash.png"
+
+
+def test_default_skills_dry_run_returns_full_linear_payload(tmp_path):
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="Android checkout crashes after promo code",
+        raw_event={
+            "permalink": "https://example.slack.com/thread",
+            "files": [
+                {
+                    "id": "F1",
+                    "name": "crash.png",
+                    "mimetype": "image/png",
+                    "url_private": "https://files/crash.png",
+                    "permalink": "https://example.slack.com/file/F1",
+                }
+            ],
+        },
+    )
+    skills = DefaultMonicaSkills(config=MonicaConfig(rollout_mode="dry_run"), state=state)
+    thread = skills.read_slack_thread(run)
+
+    issue = skills.create_or_update_linear(
+        run,
+        thread,
+        {
+            "summary": "Android checkout crashes after promo code",
+            "confidence": 0.91,
+            "wants_fix": True,
+            "reason": "Crash report with Android context.",
+        },
+    )
+
+    assert issue["dry_run"] is True
+    assert issue["title"] == "[Mobile] Android checkout crashes after promo code"
+    assert "https://example.slack.com/thread" in issue["description"]
+    assert "crash.png (image/png)" in issue["description"]
+    assert "Dry run only; no code changes will run." in issue["description"]
+    assert issue["attachments"] == [
+        {
+            "title": "crash.png",
+            "url": "https://example.slack.com/file/F1",
+            "subtitle": "image/png",
+        }
+    ]
+
+
+def test_default_skills_linear_description_includes_structured_bug_context(tmp_path):
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="Android checkout crashes after promo code",
+    )
+    skills = DefaultMonicaSkills(config=MonicaConfig(rollout_mode="dry_run"), state=state)
+
+    description = skills._linear_description(
+        run,
+        {
+            "permalink": "https://example.slack.com/thread",
+            "messages": [
+                "Android checkout crashes after promo code",
+                "Pixel 7, latest beta, happens after tapping Pay",
+            ],
+        },
+        {
+            "summary": "Android checkout crashes after applying promo code",
+            "observed_behavior": "Checkout crashes after applying a promo code.",
+            "expected_behavior": "Checkout should keep the cart open and apply the discount.",
+            "reproduction_steps": ["Open checkout", "Apply a promo code", "Tap Pay"],
+            "platforms": ["Android"],
+            "device_context": "Pixel 7",
+            "build_context": "2.14.0 beta",
+            "confidence": 0.91,
+            "reason": "Crash report with platform and reproduction context.",
+        },
+    )
+
+    assert "## Observed Behavior\nCheckout crashes after applying a promo code." in description
+    assert "## Expected Behavior\nCheckout should keep the cart open and apply the discount." in description
+    assert "## Reproduction Context\n- Open checkout\n- Apply a promo code\n- Tap Pay" in description
+    assert "## Platform And Build\n- Platforms: Android\n- Device context: Pixel 7\n- Build context: 2.14.0 beta" in description
+
+
+def test_default_skills_linear_description_prefers_detailed_thread_messages(tmp_path):
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="Android checkout crashes after promo code",
+    )
+    skills = DefaultMonicaSkills(config=MonicaConfig(rollout_mode="dry_run"), state=state)
+
+    description = skills._linear_description(
+        run,
+        {
+            "permalink": "https://example.slack.com/thread",
+            "messages": ["legacy fallback message"],
+            "message_details": [
+                {
+                    "user_id": "U1",
+                    "text": "Android checkout crashes after promo code",
+                    "ts": "1710000000.000100",
+                    "permalink": "https://example.slack.com/msg/1",
+                },
+                {
+                    "user_id": "U2",
+                    "text": "Pixel 7, latest beta",
+                    "ts": "1710000001.000200",
+                    "permalink": "https://example.slack.com/msg/2",
+                },
+            ],
+        },
+        {
+            "summary": "Android checkout crashes after applying promo code",
+            "confidence": 0.91,
+        },
+    )
+
+    assert "- U1 at 1710000000.000100: Android checkout crashes after promo code (https://example.slack.com/msg/1)" in description
+    assert "- U2 at 1710000001.000200: Pixel 7, latest beta (https://example.slack.com/msg/2)" in description
+    assert "legacy fallback message" not in description
+
+
+def test_default_skills_linear_description_includes_evidence_links(tmp_path):
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="Android checkout crashes after promo code",
+    )
+    skills = DefaultMonicaSkills(config=MonicaConfig(rollout_mode="dry_run"), state=state)
+
+    description = skills._linear_description(
+        run,
+        {
+            "permalink": "https://example.slack.com/thread",
+            "messages": [run.request_text],
+            "files": [
+                {
+                    "id": "F1",
+                    "name": "crash.png",
+                    "mimetype": "image/png",
+                    "permalink": "https://example.slack.com/file/F1",
+                }
+            ],
+        },
+        {"summary": "Android checkout crashes after promo code", "confidence": 0.91},
+    )
+
+    assert "- crash.png (image/png): https://example.slack.com/file/F1" in description
+
+
+def test_default_skills_linear_description_marks_fix_disabled_in_linear_only_mode(tmp_path):
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="Android checkout crashes after promo code, please fix it",
+    )
+    skills = DefaultMonicaSkills(config=MonicaConfig(rollout_mode="linear_only"), state=state)
+
+    description = skills._linear_description(
+        run,
+        {"permalink": "https://example.slack.com/thread", "messages": [run.request_text]},
+        {
+            "summary": "Android checkout crashes after applying promo code",
+            "wants_fix": True,
+        },
+    )
+
+    assert "Code fixes are disabled in the current Monica rollout mode." in description
+    assert "Awaiting explicit tagged approval before code changes." not in description
+
+
+def test_default_skills_attaches_slack_file_links_to_linear_issue(tmp_path):
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="Android checkout crashes after promo code",
+    )
+    calls: list[Any] = []
+    client = FakeLinearClient(calls)
+    skills = DefaultMonicaSkills(
+        config=MonicaConfig(
+            rollout_mode="linear_only",
+            linear=LinearConfig(team_id="team-id", project_id="project-id"),
+        ),
+        state=state,
+        linear_client=client,
+    )
+
+    issue = skills.create_or_update_linear(
+        run,
+        {
+            "permalink": "https://example.slack.com/thread",
+            "messages": [run.request_text],
+            "files": [
+                {
+                    "id": "F1",
+                    "name": "crash.png",
+                    "mimetype": "image/png",
+                    "url_private": "https://files/crash.png",
+                    "permalink": "https://example.slack.com/file/F1",
+                }
+            ],
+        },
+        {
+            "summary": "Android checkout crashes after promo code",
+            "confidence": 0.91,
+        },
+    )
+
+    assert client.attachment_calls[0].issue_id == "issue-id"
+    assert client.attachment_calls[0].title == "crash.png"
+    assert client.attachment_calls[0].url == "https://example.slack.com/file/F1"
+    assert issue["attachments"] == [
+        {
+            "id": "attachment-id",
+            "title": "crash.png",
+            "url": "https://example.slack.com/file/F1",
+        }
+    ]
+    assert issue["attachment_errors"] == []
+
+
+def test_default_skills_skips_unsupported_evidence_urls_for_linear_issue(tmp_path):
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="Android checkout crashes after promo code",
+    )
+    calls: list[Any] = []
+    client = FakeLinearClient(calls)
+    skills = DefaultMonicaSkills(
+        config=MonicaConfig(
+            rollout_mode="linear_only",
+            linear=LinearConfig(team_id="team-id", project_id="project-id"),
+        ),
+        state=state,
+        linear_client=client,
+    )
+
+    issue = skills.create_or_update_linear(
+        run,
+        {
+            "permalink": "https://example.slack.com/thread",
+            "messages": [run.request_text],
+            "files": [
+                {
+                    "id": "F1",
+                    "name": "crash.png",
+                    "mimetype": "image/png",
+                    "url_private": "file:///Users/ritik/.hermes/secrets",
+                    "permalink": "file:///Users/ritik/.hermes/secrets",
+                }
+            ],
+        },
+        {
+            "summary": "Android checkout crashes after promo code",
+            "confidence": 0.91,
+        },
+    )
+
+    payload, _existing_issue_id = calls[0]
+    assert client.attachment_calls == []
+    assert issue["attachments"] == []
+    assert "file:///Users/ritik/.hermes/secrets" not in payload.description
+    assert "- crash.png (image/png)" in payload.description
+
+
+def test_default_skills_returns_created_linear_description(tmp_path):
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="Android checkout crashes after promo code",
+    )
+    calls: list[Any] = []
+    client = FakeLinearClient(calls)
+    skills = DefaultMonicaSkills(
+        config=MonicaConfig(
+            rollout_mode="linear_only",
+            linear=LinearConfig(team_id="team-id"),
+        ),
+        state=state,
+        linear_client=client,
+    )
+
+    issue = skills.create_or_update_linear(
+        run,
+        {"permalink": "https://example.slack.com/thread", "messages": [run.request_text]},
+        {"summary": "Android checkout crashes after promo code", "confidence": 0.91},
+    )
+
+    payload, _existing_issue_id = calls[0]
+    assert issue["description"] == payload.description
+    assert "## Slack Context" in issue["description"]
+    assert "https://example.slack.com/thread" in issue["description"]
+
+
+def test_default_skills_keeps_linear_issue_when_attachment_fails(tmp_path):
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="Android checkout crashes after promo code",
+    )
+    calls: list[Any] = []
+    client = FakeLinearClient(calls, fail_attachment=True)
+    skills = DefaultMonicaSkills(
+        config=MonicaConfig(
+            rollout_mode="linear_only",
+            linear=LinearConfig(team_id="team-id", project_id="project-id"),
+        ),
+        state=state,
+        linear_client=client,
+    )
+
+    issue = skills.create_or_update_linear(
+        run,
+        {
+            "permalink": "https://example.slack.com/thread",
+            "messages": [run.request_text],
+            "files": [
+                {
+                    "id": "F1",
+                    "name": "crash.png",
+                    "mimetype": "image/png",
+                    "url_private": "https://files/crash.png",
+                }
+            ],
+        },
+        {
+            "summary": "Android checkout crashes after promo code",
+            "confidence": 0.91,
+        },
+    )
+
+    assert issue["id"] == "issue-id"
+    assert issue["attachments"] == []
+    assert issue["attachment_errors"] == ["crash.png: Linear attachment failed"]
+
+
+def test_default_skills_logs_slack_status_post_failures(tmp_path, caplog):
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="Android checkout crashes after promo code",
+    )
+    skills = DefaultMonicaSkills(
+        config=MonicaConfig(),
+        state=state,
+        slack_client=FailingSlackClient(),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="plugins.mobile_bug_agent.skills"):
+        skills.post_status(run, "Created Linear issue")
+
+    logs = "\n".join(record.getMessage() for record in caplog.records)
+    assert "Slack status post failed" in logs
+    assert run.id in logs
+    assert "C_MOBILE" in logs
+    assert "1710000000.000100" in logs
+    assert "not_in_channel" in logs
+
+
+def test_default_skills_approval_prompt_names_configured_approvers(tmp_path):
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="Android checkout crashes after promo code",
+    )
+    slack_client = CapturingSlackClient()
+    skills = DefaultMonicaSkills(
+        config=MonicaConfig(
+            slack=SlackConfig(approver_user_ids=("U_APPROVER",)),
+        ),
+        state=state,
+        slack_client=slack_client,
+    )
+
+    skills.ask_fix_approval(
+        run,
+        {
+            "identifier": "MOB-123",
+            "url": "https://linear.app/acme/issue/MOB-123",
+        },
+    )
+
+    assert slack_client.posts == [
+        {
+            "channel_id": "C_MOBILE",
+            "thread_ts": "1710000000.000100",
+            "text": (
+                "I filed the mobile bug context and I am waiting for approval before code changes.\n"
+                "Issue: https://linear.app/acme/issue/MOB-123\n"
+                "Tag me in this thread with `approved, fix it` when you want me to start.\n"
+                "Allowed approvers: <@U_APPROVER>."
+            ),
+        }
+    ]
+
+
+def test_default_skills_updates_existing_linear_issue_when_run_has_issue_id(tmp_path):
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="Android checkout crashes after promo code",
+    )
+    run = state.update_run(run.id, linear_issue_id="issue-id")
+    calls: list[Any] = []
+    skills = DefaultMonicaSkills(
+        config=MonicaConfig(
+            rollout_mode="linear_only",
+            linear=LinearConfig(team_id="team-id", project_id="project-id"),
+        ),
+        state=state,
+        linear_client=FakeLinearClient(calls),
+    )
+
+    skills.create_or_update_linear(
+        run,
+        {"permalink": "https://example.slack.com/thread", "messages": [run.request_text]},
+        {
+            "summary": "Android checkout crashes after promo code",
+            "confidence": 0.91,
+        },
+    )
+
+    assert calls[0][1] == "issue-id"
+
+
+@dataclass
+class FakeRepoManager:
+    calls: list[Any]
+
+    def prepare_worktree(self, *, linear_identifier: str, summary: str) -> Worktree:
+        self.calls.append((linear_identifier, summary))
+        return Worktree(
+            branch_name="monica/MOB-123-checkout-crash",
+            path=PathLike("/tmp/monica-worktree"),
+        )
+
+
+@dataclass(frozen=True)
+class PathLike:
+    value: str
+
+    def __str__(self) -> str:
+        return self.value
+
+
+@dataclass
+class FakeCodexWorker:
+    calls: list[Any]
+
+    def run(self, *, run: Any, worktree: Worktree, brief: str) -> dict[str, Any]:
+        self.calls.append((run.id, worktree.branch_name, str(worktree.path), brief))
+        return {"changed": True, "summary": "Patched checkout crash"}
+
+
+@dataclass
+class FixedRepoManager:
+    worktree_path: Any
+    calls: list[Any] = field(default_factory=list)
+
+    def prepare_worktree(self, *, linear_identifier: str, summary: str) -> Worktree:
+        self.calls.append((linear_identifier, summary))
+        return Worktree(
+            branch_name="monica/MOB-123-checkout-crash",
+            path=self.worktree_path,
+        )
+
+
+def test_default_skills_prepare_worktree_then_call_codex_worker(tmp_path):
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="Android checkout crashes after promo code",
+    )
+    run = state.update_run(run.id, linear_identifier="MOB-123")
+    repo_calls: list[Any] = []
+    worker_calls: list[Any] = []
+    skills = DefaultMonicaSkills(
+        config=MonicaConfig(
+            rollout_mode="approved_pr",
+            verification=VerificationConfig(commands=("npm test",)),
+        ),
+        state=state,
+        repo_manager=FakeRepoManager(repo_calls),
+        codex_worker=FakeCodexWorker(worker_calls),
+    )
+
+    result = skills.run_internal_codex_worker(run)
+
+    assert repo_calls == [("MOB-123", "Android checkout crashes after promo code")]
+    assert worker_calls[0][1] == "monica/MOB-123-checkout-crash"
+    assert "Android checkout crashes after promo code" in worker_calls[0][3]
+    assert "## Slack Thread Context" in worker_calls[0][3]
+    assert "## Verification Commands" in worker_calls[0][3]
+    assert "npm test" in worker_calls[0][3]
+    assert result == {
+        "changed": True,
+        "summary": "Patched checkout crash",
+        "branch_name": "monica/MOB-123-checkout-crash",
+        "worktree_path": "/tmp/monica-worktree",
+        "slack_permalink": "",
+        "evidence": [],
+    }
+
+
+def test_default_skills_marks_worker_summary_noop_when_worktree_has_no_git_changes(tmp_path):
+    worktree_path = tmp_path / "mobile-worktree"
+    worktree_path.mkdir()
+    subprocess.run(["git", "init"], cwd=worktree_path, check=True, capture_output=True, text=True)
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="Android checkout crashes after promo code",
+    )
+    run = state.update_run(run.id, linear_identifier="MOB-123")
+    skills = DefaultMonicaSkills(
+        config=MonicaConfig(rollout_mode="approved_pr"),
+        state=state,
+        repo_manager=FixedRepoManager(worktree_path),
+        codex_worker=FakeCodexWorker([]),
+    )
+
+    result = skills.run_internal_codex_worker(run)
+
+    assert result["summary"] == "Patched checkout crash"
+    assert result["changed"] is False
+
+
+def test_default_skills_marks_worker_changed_when_worktree_has_git_changes(tmp_path):
+    worktree_path = tmp_path / "mobile-worktree"
+    worktree_path.mkdir()
+    subprocess.run(["git", "init"], cwd=worktree_path, check=True, capture_output=True, text=True)
+    (worktree_path / "Checkout.tsx").write_text("export const fixed = true;\n", encoding="utf-8")
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="Android checkout crashes after promo code",
+    )
+    run = state.update_run(run.id, linear_identifier="MOB-123")
+
+    class ConservativeWorker:
+        def run(self, *, run: Any, worktree: Worktree, brief: str) -> dict[str, Any]:
+            return {"changed": False, "summary": "I made the checkout fix."}
+
+    skills = DefaultMonicaSkills(
+        config=MonicaConfig(rollout_mode="approved_pr"),
+        state=state,
+        repo_manager=FixedRepoManager(worktree_path),
+        codex_worker=ConservativeWorker(),
+    )
+
+    result = skills.run_internal_codex_worker(run)
+
+    assert result["summary"] == "I made the checkout fix."
+    assert result["changed"] is True
+
+
+def test_default_skills_marks_worker_changed_when_worker_committed_diff(tmp_path):
+    worktree_path = tmp_path / "mobile-worktree"
+    worktree_path.mkdir()
+    subprocess.run(["git", "init"], cwd=worktree_path, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "config", "user.name", "Monica Test"],
+        cwd=worktree_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "monica-test@example.com"],
+        cwd=worktree_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    (worktree_path / "Checkout.tsx").write_text("export const fixed = false;\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=worktree_path, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "commit", "-m", "base"],
+        cwd=worktree_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        ["git", "update-ref", "refs/remotes/origin/main", "HEAD"],
+        cwd=worktree_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    (worktree_path / "Checkout.tsx").write_text("export const fixed = true;\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=worktree_path, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "commit", "-m", "fix checkout"],
+        cwd=worktree_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="Android checkout crashes after promo code",
+    )
+    run = state.update_run(run.id, linear_identifier="MOB-123")
+
+    class QuietWorker:
+        def run(self, *, run: Any, worktree: Worktree, brief: str) -> dict[str, Any]:
+            return {"changed": False, "summary": "Committed the checkout fix."}
+
+    skills = DefaultMonicaSkills(
+        config=MonicaConfig(
+            rollout_mode="approved_pr",
+            verification=VerificationConfig(commands=("npm test",)),
+        ),
+        state=state,
+        repo_manager=FixedRepoManager(worktree_path),
+        codex_worker=QuietWorker(),
+    )
+
+    result = skills.run_internal_codex_worker(run)
+
+    assert subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=worktree_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout == ""
+    assert result["summary"] == "Committed the checkout fix."
+    assert result["changed"] is True
+
+
+def test_default_skills_worker_result_carries_slack_permalink_and_evidence(tmp_path):
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="Android checkout crashes after promo code",
+        raw_event={
+            "permalink": "https://example.slack.com/thread",
+            "files": [
+                {
+                    "id": "F1",
+                    "name": "crash.png",
+                    "mimetype": "image/png",
+                    "permalink": "https://example.slack.com/file/F1",
+                }
+            ],
+        },
+    )
+    run = state.update_run(run.id, linear_identifier="MOB-123")
+    skills = DefaultMonicaSkills(
+        config=MonicaConfig(rollout_mode="approved_pr"),
+        state=state,
+        repo_manager=FakeRepoManager([]),
+        codex_worker=FakeCodexWorker([]),
+    )
+
+    result = skills.run_internal_codex_worker(run)
+
+    assert result["slack_permalink"] == "https://example.slack.com/thread"
+    assert result["evidence"] == [
+        {
+            "name": "crash.png",
+            "mimetype": "image/png",
+            "url": "https://example.slack.com/file/F1",
+        }
+    ]
+
+
+def test_default_skills_pr_body_includes_slack_permalink_and_evidence(tmp_path):
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="Android checkout crashes after promo code",
+    )
+    run = state.update_run(
+        run.id,
+        linear_identifier="MOB-123",
+        linear_url="https://linear.app/acme/issue/MOB-123",
+    )
+
+    body = DefaultMonicaSkills._pr_body(
+        run=run,
+        worker_result={
+            "summary": "Patched checkout crash.",
+            "slack_permalink": "https://example.slack.com/thread",
+            "evidence": [
+                {
+                    "name": "crash.png",
+                    "mimetype": "image/png",
+                    "url": "https://example.slack.com/file/F1",
+                }
+            ],
+            "proof": {
+                "summary": "Proof captured.",
+                "platforms": ["ios", "android"],
+                "artifacts": [
+                    "/tmp/monica-proof/monica-proof-manifest.json",
+                    "/tmp/monica-proof/ios-pdp-fixed.png",
+                    "/tmp/monica-proof/android-pdp-fixed.mp4",
+                ],
+            },
+        },
+        verification={"summary": "Verification passed.", "output": "npm test\nok"},
+    )
+
+    assert "- Slack: https://example.slack.com/thread" in body
+    assert "## Evidence" in body
+    assert "- crash.png (image/png): https://example.slack.com/file/F1" in body
+    assert "## Proof" in body
+    assert "Proof captured." in body
+    assert "Platforms: ios, android" in body
+    assert "- /tmp/monica-proof/monica-proof-manifest.json" in body
+    assert "- /tmp/monica-proof/ios-pdp-fixed.png" in body
+    assert "- /tmp/monica-proof/android-pdp-fixed.mp4" in body
+
+
+def test_default_skills_pr_body_omits_unsupported_evidence_urls(tmp_path):
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="Android checkout crashes after promo code",
+    )
+    run = state.update_run(
+        run.id,
+        linear_identifier="MOB-123",
+        linear_url="https://linear.app/acme/issue/MOB-123",
+    )
+
+    body = DefaultMonicaSkills._pr_body(
+        run=run,
+        worker_result={
+            "summary": "Patched checkout crash",
+            "slack_permalink": "https://example.slack.com/thread",
+            "evidence": [
+                {
+                    "name": "crash.png",
+                    "mimetype": "image/png",
+                    "url": "file:///Users/ritik/.hermes/secrets",
+                }
+            ],
+        },
+        verification={"summary": "Verification passed.", "output": "$ npm test\nok"},
+    )
+
+    assert "file:///Users/ritik/.hermes/secrets" not in body
+    assert "- crash.png (image/png)" in body
+    assert "npm test\nok" in body

--- a/tests/plugins/mobile_bug_agent/test_intent.py
+++ b/tests/plugins/mobile_bug_agent/test_intent.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from plugins.mobile_bug_agent.intent import IntentClassifier, IntentResult
+
+
+class FakeAgent:
+    def run_conversation(self, user_message, system_message=None, conversation_history=None, task_id=None):
+        assert "You are Monica" in system_message
+        assert "Tagged request:" in user_message
+        return {
+            "final_response": """{
+              "is_mobile_bug": true,
+              "wants_linear": true,
+              "wants_fix": true,
+              "confidence": 0.92,
+              "summary": "Android checkout crashes after applying promo code",
+              "missing_questions": [],
+              "reason": "The tagged thread describes a reproducible Android app crash."
+            }"""
+        }
+
+
+class BadAgent:
+    def run_conversation(self, user_message, system_message=None, conversation_history=None, task_id=None):
+        return {"final_response": "not json"}
+
+
+class StringBooleanAgent:
+    def run_conversation(self, user_message, system_message=None, conversation_history=None, task_id=None):
+        return {
+            "final_response": """{
+              "is_mobile_bug": "false",
+              "wants_linear": "false",
+              "wants_fix": "false",
+              "confidence": "0.81",
+              "summary": "Backend invoice sync is slow",
+              "missing_questions": [],
+              "reason": "The tagged thread is not about the mobile app."
+            }"""
+        }
+
+
+def test_classifier_parses_agent_json():
+    result = IntentClassifier(agent_factory=lambda: FakeAgent()).classify(
+        request_text="@monica checkout crashes on Android after promo",
+        thread_text="U1: checkout crashes on Android after promo\nU2: Pixel 7, latest build",
+    )
+
+    assert result.is_mobile_bug is True
+    assert result.wants_linear is True
+    assert result.wants_fix is True
+    assert result.summary.startswith("Android checkout")
+
+
+def test_classifier_treats_string_false_booleans_as_false():
+    result = IntentClassifier(agent_factory=lambda: StringBooleanAgent()).classify(
+        request_text="@monica invoice sync is slow",
+        thread_text="U1: backend invoice sync queue is behind",
+    )
+
+    assert result.is_mobile_bug is False
+    assert result.wants_linear is False
+    assert result.wants_fix is False
+    assert result.confidence == 0.81
+
+
+class RichAgent:
+    def run_conversation(self, user_message, system_message=None, conversation_history=None, task_id=None):
+        assert "observed_behavior" in system_message
+        return {
+            "final_response": """{
+              "is_mobile_bug": true,
+              "wants_linear": true,
+              "wants_fix": false,
+              "confidence": 0.87,
+              "summary": "Android checkout crashes after applying promo code",
+              "observed_behavior": "Checkout crashes after applying a promo code.",
+              "expected_behavior": "Checkout should keep the cart open and apply the discount.",
+              "reproduction_steps": ["Open checkout", "Apply a promo code", "Tap pay"],
+              "platforms": ["Android"],
+              "device_context": "Pixel 7 on latest build",
+              "build_context": "2.14.0 beta",
+              "missing_questions": [],
+              "reason": "Thread includes crash, platform, device, and reproduction context."
+            }"""
+        }
+
+
+def test_classifier_parses_rich_bug_context():
+    result = IntentClassifier(agent_factory=lambda: RichAgent()).classify(
+        request_text="@monica checkout crashes on Android after promo",
+        thread_text="U1: checkout crashes after promo\nU2: Pixel 7, latest build 2.14.0 beta",
+    )
+
+    assert result.observed_behavior == "Checkout crashes after applying a promo code."
+    assert result.expected_behavior == "Checkout should keep the cart open and apply the discount."
+    assert result.reproduction_steps == ("Open checkout", "Apply a promo code", "Tap pay")
+    assert result.platforms == ("Android",)
+    assert result.device_context == "Pixel 7 on latest build"
+    assert result.build_context == "2.14.0 beta"
+
+
+def test_classifier_falls_back_safely_on_bad_json():
+    result = IntentClassifier(agent_factory=lambda: BadAgent()).classify(
+        request_text="@monica hello",
+        thread_text="U1: hello",
+    )
+
+    assert isinstance(result, IntentResult)
+    assert result.is_mobile_bug is False
+    assert result.needs_clarification is True
+    assert result.confidence <= 0.5
+
+
+def test_fallback_does_not_classify_non_mobile_fix_request_as_mobile_bug():
+    result = IntentClassifier(agent_factory=lambda: BadAgent()).classify(
+        request_text="@monica backend API error is returning 500s, please fix it",
+        thread_text="U1: started after the billing deploy",
+    )
+
+    assert result.is_mobile_bug is False
+    assert result.wants_fix is True
+    assert result.needs_clarification is True
+    assert "mobile" in result.missing_questions[0].lower()
+
+
+def test_fallback_does_not_classify_web_frontend_bug_as_mobile_bug():
+    result = IntentClassifier(agent_factory=lambda: BadAgent()).classify(
+        request_text="@monica web frontend checkout regression after the header deploy, please fix it",
+        thread_text="U1: reproduces in Chrome desktop, not the native app",
+    )
+
+    assert result.is_mobile_bug is False
+    assert result.wants_fix is True
+    assert result.needs_clarification is True
+    assert "mobile" in result.missing_questions[0].lower()
+
+
+def test_fallback_does_not_classify_android_web_bug_as_native_mobile_bug():
+    result = IntentClassifier(agent_factory=lambda: BadAgent()).classify(
+        request_text="@monica checkout is broken on Android Chrome, please fix it",
+        thread_text="U1: this is the mobile web flow, not the native app",
+    )
+
+    assert result.is_mobile_bug is False
+    assert result.wants_fix is True
+    assert result.needs_clarification is True
+    assert "mobile" in result.missing_questions[0].lower()
+
+
+def test_fallback_keeps_question_only_mobile_bug_tag_actionless():
+    result = IntentClassifier(agent_factory=lambda: BadAgent()).classify(
+        request_text="@monica any thoughts on this Android checkout crash?",
+        thread_text="U1: Pixel 7 on 2.14.0 beta",
+    )
+
+    assert result.is_mobile_bug is True
+    assert result.wants_linear is False
+    assert result.wants_fix is False
+
+
+def test_fallback_classifies_clear_android_fix_request_as_mobile_bug():
+    result = IntentClassifier(agent_factory=lambda: BadAgent()).classify(
+        request_text="@monica Android checkout error after promo, please fix it",
+        thread_text="U1: Pixel 7 on 2.14.0 beta",
+    )
+
+    assert result.is_mobile_bug is True
+    assert result.wants_linear is True
+    assert result.wants_fix is True
+    assert result.platforms == ("Android",)
+    assert result.needs_clarification is False

--- a/tests/plugins/mobile_bug_agent/test_linear_client.py
+++ b/tests/plugins/mobile_bug_agent/test_linear_client.py
@@ -1,0 +1,399 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from plugins.mobile_bug_agent.linear_client import (
+    LinearAttachmentPayload,
+    LinearClient,
+    LinearClientError,
+    LinearIssuePayload,
+)
+
+
+def test_linear_client_creates_issue_with_project():
+    requests: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(json.loads(request.content.decode("utf-8")))
+        assert request.headers["Authorization"] == "lin_api_key"
+        return httpx.Response(
+            200,
+            json={
+                "data": {
+                    "issueCreate": {
+                        "success": True,
+                        "issue": {
+                            "id": "issue-id",
+                            "identifier": "MOB-123",
+                            "url": "https://linear.app/acme/issue/MOB-123",
+                        },
+                    }
+                }
+            },
+        )
+
+    client = LinearClient(api_key="lin_api_key", transport=httpx.MockTransport(handler))
+
+    issue = client.create_or_update_issue(
+        LinearIssuePayload(
+            team_id="team-id",
+            project_id="project-id",
+            title="[Mobile] Checkout crash",
+            description="## Summary\nAndroid checkout crashes.",
+        )
+    )
+
+    assert issue.identifier == "MOB-123"
+    assert issue.url == "https://linear.app/acme/issue/MOB-123"
+    assert requests[0]["variables"]["input"] == {
+        "teamId": "team-id",
+        "projectId": "project-id",
+        "title": "[Mobile] Checkout crash",
+        "description": "## Summary\nAndroid checkout crashes.",
+    }
+
+
+def test_linear_client_lists_workspace_metadata():
+    requests: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(json.loads(request.content.decode("utf-8")))
+        assert request.headers["Authorization"] == "lin_api_key"
+        return httpx.Response(
+            200,
+            json={
+                "data": {
+                    "teams": {
+                        "nodes": [
+                            {"id": "team-mobile", "key": "MOB", "name": "Mobile"},
+                            {"id": "team-web", "key": "WEB", "name": "Web"},
+                        ]
+                    },
+                    "projects": {
+                        "nodes": [
+                            {"id": "project-app", "name": "Mobile App", "state": "started"},
+                        ]
+                    },
+                    "issueLabels": {
+                        "nodes": [
+                            {"id": "label-bug", "name": "Bug", "color": "#e5484d"},
+                            {"id": "label-mobile", "name": "Mobile", "color": "#3b82f6"},
+                        ]
+                    },
+                }
+            },
+        )
+
+    client = LinearClient(api_key="lin_api_key", transport=httpx.MockTransport(handler))
+
+    metadata = client.list_workspace_metadata()
+
+    assert metadata.teams[0].id == "team-mobile"
+    assert metadata.teams[0].key == "MOB"
+    assert metadata.teams[0].name == "Mobile"
+    assert metadata.projects[0].id == "project-app"
+    assert metadata.projects[0].name == "Mobile App"
+    assert metadata.projects[0].state == "started"
+    assert metadata.labels[1].id == "label-mobile"
+    assert metadata.labels[1].name == "Mobile"
+    assert metadata.labels[1].color == "#3b82f6"
+    assert "teams" in requests[0]["query"]
+    assert "projects" in requests[0]["query"]
+    assert "issueLabels" in requests[0]["query"]
+
+
+def test_linear_client_lists_workspace_metadata_requires_api_key():
+    client = LinearClient(api_key="")
+
+    with pytest.raises(LinearClientError) as exc_info:
+        client.list_workspace_metadata()
+
+    assert str(exc_info.value) == "LINEAR_API_KEY is not configured."
+
+
+def test_linear_client_surfaces_graphql_metadata_errors():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"errors": [{"message": "Invalid token"}]})
+
+    client = LinearClient(api_key="lin_api_key", transport=httpx.MockTransport(handler))
+
+    with pytest.raises(LinearClientError) as exc_info:
+        client.list_workspace_metadata()
+
+    assert str(exc_info.value) == "Linear GraphQL error: Invalid token"
+
+
+def test_linear_client_updates_existing_issue():
+    requests: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(json.loads(request.content.decode("utf-8")))
+        return httpx.Response(
+            200,
+            json={
+                "data": {
+                    "issueUpdate": {
+                        "success": True,
+                        "issue": {
+                            "id": "issue-id",
+                            "identifier": "MOB-123",
+                            "url": "https://linear.app/acme/issue/MOB-123",
+                        },
+                    }
+                }
+            },
+        )
+
+    client = LinearClient(api_key="lin_api_key", transport=httpx.MockTransport(handler))
+
+    issue = client.create_or_update_issue(
+        LinearIssuePayload(
+            team_id="team-id",
+            title="[Mobile] Checkout crash",
+            description="Updated description",
+        ),
+        existing_issue_id="issue-id",
+    )
+
+    assert issue.id == "issue-id"
+    assert requests[0]["variables"] == {
+        "id": "issue-id",
+        "input": {
+            "title": "[Mobile] Checkout crash",
+            "description": "Updated description",
+        },
+    }
+
+
+def test_linear_client_sends_label_ids_on_create():
+    requests: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(json.loads(request.content.decode("utf-8")))
+        return httpx.Response(
+            200,
+            json={
+                "data": {
+                    "issueCreate": {
+                        "success": True,
+                        "issue": {
+                            "id": "issue-id",
+                            "identifier": "MOB-123",
+                            "url": "https://linear.app/acme/issue/MOB-123",
+                        },
+                    }
+                }
+            },
+        )
+
+    client = LinearClient(api_key="lin_api_key", transport=httpx.MockTransport(handler))
+
+    client.create_or_update_issue(
+        LinearIssuePayload(
+            team_id="team-id",
+            project_id="project-id",
+            label_ids=("bug-label", "mobile-label"),
+            title="[Mobile] Checkout crash",
+            description="## Summary\nAndroid checkout crashes.",
+        )
+    )
+
+    assert requests[0]["variables"]["input"]["labelIds"] == ["bug-label", "mobile-label"]
+
+
+def test_linear_client_surfaces_graphql_issue_errors():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"errors": [{"message": "Invalid Linear API key"}]})
+
+    client = LinearClient(api_key="lin_api_key", transport=httpx.MockTransport(handler))
+
+    with pytest.raises(LinearClientError) as exc_info:
+        client.create_or_update_issue(
+            LinearIssuePayload(
+                team_id="team-id",
+                title="[Mobile] Checkout crash",
+                description="## Summary\nAndroid checkout crashes.",
+            )
+        )
+
+    assert str(exc_info.value) == "Linear GraphQL error: Invalid Linear API key"
+
+
+def test_linear_client_refuses_unsuccessful_issue_mutation_with_partial_issue():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "data": {
+                    "issueCreate": {
+                        "success": False,
+                        "issue": {
+                            "id": "partial-issue-id",
+                            "identifier": "MOB-123",
+                            "url": "https://linear.app/acme/issue/MOB-123",
+                        },
+                    }
+                }
+            },
+        )
+
+    client = LinearClient(api_key="lin_api_key", transport=httpx.MockTransport(handler))
+
+    with pytest.raises(LinearClientError) as exc_info:
+        client.create_or_update_issue(
+            LinearIssuePayload(
+                team_id="team-id",
+                title="[Mobile] Checkout crash",
+                description="## Summary\nAndroid checkout crashes.",
+            )
+        )
+
+    assert str(exc_info.value) == "Linear issue mutation did not report success."
+
+
+def test_linear_client_surfaces_http_issue_errors():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, text="bad token", request=request)
+
+    client = LinearClient(api_key="lin_api_key", transport=httpx.MockTransport(handler))
+
+    with pytest.raises(LinearClientError) as exc_info:
+        client.create_or_update_issue(
+            LinearIssuePayload(
+                team_id="team-id",
+                title="[Mobile] Checkout crash",
+                description="## Summary\nAndroid checkout crashes.",
+            )
+        )
+
+    assert str(exc_info.value) == "Linear HTTP error: 401 Unauthorized - bad token"
+
+
+def test_linear_client_surfaces_non_json_issue_response():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text="<html>maintenance</html>", request=request)
+
+    client = LinearClient(api_key="lin_api_key", transport=httpx.MockTransport(handler))
+
+    with pytest.raises(LinearClientError) as exc_info:
+        client.create_or_update_issue(
+            LinearIssuePayload(
+                team_id="team-id",
+                title="[Mobile] Checkout crash",
+                description="## Summary\nAndroid checkout crashes.",
+            )
+        )
+
+    assert str(exc_info.value) == "Linear returned invalid JSON: <html>maintenance</html>"
+
+
+def test_linear_client_creates_attachment():
+    requests: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(json.loads(request.content.decode("utf-8")))
+        return httpx.Response(
+            200,
+            json={
+                "data": {
+                    "attachmentCreate": {
+                        "success": True,
+                        "attachment": {
+                            "id": "attachment-id",
+                            "title": "crash.png",
+                            "url": "https://files/crash.png",
+                        },
+                    }
+                }
+            },
+        )
+
+    client = LinearClient(api_key="lin_api_key", transport=httpx.MockTransport(handler))
+
+    attachment = client.create_attachment(
+        LinearAttachmentPayload(
+            issue_id="issue-id",
+            title="crash.png",
+            url="https://files/crash.png",
+            subtitle="image/png",
+        )
+    )
+
+    assert attachment.id == "attachment-id"
+    assert requests[0]["variables"]["input"] == {
+        "issueId": "issue-id",
+        "title": "crash.png",
+        "url": "https://files/crash.png",
+        "subtitle": "image/png",
+    }
+
+
+def test_linear_client_surfaces_graphql_attachment_errors():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"errors": [{"message": "Attachment URL is invalid"}]})
+
+    client = LinearClient(api_key="lin_api_key", transport=httpx.MockTransport(handler))
+
+    with pytest.raises(LinearClientError) as exc_info:
+        client.create_attachment(
+            LinearAttachmentPayload(
+                issue_id="issue-id",
+                title="crash.png",
+                url="https://files/crash.png",
+            )
+        )
+
+    assert str(exc_info.value) == "Linear GraphQL error: Attachment URL is invalid"
+
+
+def test_linear_client_refuses_unsuccessful_attachment_mutation_with_partial_attachment():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "data": {
+                    "attachmentCreate": {
+                        "success": False,
+                        "attachment": {
+                            "id": "partial-attachment-id",
+                            "title": "crash.png",
+                            "url": "https://files/crash.png",
+                        },
+                    }
+                }
+            },
+        )
+
+    client = LinearClient(api_key="lin_api_key", transport=httpx.MockTransport(handler))
+
+    with pytest.raises(LinearClientError) as exc_info:
+        client.create_attachment(
+            LinearAttachmentPayload(
+                issue_id="issue-id",
+                title="crash.png",
+                url="https://files/crash.png",
+            )
+        )
+
+    assert str(exc_info.value) == "Linear attachment mutation did not report success."
+
+
+def test_linear_client_surfaces_network_attachment_errors():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("network down", request=request)
+
+    client = LinearClient(api_key="lin_api_key", transport=httpx.MockTransport(handler))
+
+    with pytest.raises(LinearClientError) as exc_info:
+        client.create_attachment(
+            LinearAttachmentPayload(
+                issue_id="issue-id",
+                title="crash.png",
+                url="https://files/crash.png",
+            )
+        )
+
+    assert str(exc_info.value) == "Linear request failed: network down"

--- a/tests/plugins/mobile_bug_agent/test_monica_loop.py
+++ b/tests/plugins/mobile_bug_agent/test_monica_loop.py
@@ -1,0 +1,3784 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+from plugins.mobile_bug_agent.config import (
+    LinearConfig,
+    LoopConfig,
+    MonicaConfig,
+    ProofConfig,
+    RepoConfig,
+    RuntimeConfig,
+    SlackConfig,
+    VerificationConfig,
+)
+from plugins.mobile_bug_agent.loop import MonicaLoop, MonicaLoopSkills
+from plugins.mobile_bug_agent.slack_flow import MonicaSlackFlow
+from plugins.mobile_bug_agent.state import MonicaState
+
+
+def _slack_event(
+    text: str,
+    *,
+    raw_text: str | None = None,
+    raw_type: str = "message",
+    raw_channel_type: str | None = None,
+    raw_files: list[dict[str, Any]] | None = None,
+    channel_id: str = "C_MOBILE",
+    chat_type: str = "channel",
+    user_id: str = "U_TAGGER",
+    thread_ts: str = "1710000000.000100",
+    message_ts: str = "1710000000.000200",
+) -> MessageEvent:
+    raw_message = {
+        "type": raw_type,
+        "text": raw_text if raw_text is not None else text,
+        "channel": channel_id,
+        "user": user_id,
+        "thread_ts": thread_ts,
+        "ts": message_ts,
+        "permalink": "https://example.slack.com/archives/C_MOBILE/p1710000000000200",
+        "files": raw_files or [],
+    }
+    if raw_channel_type is not None:
+        raw_message["channel_type"] = raw_channel_type
+
+    return MessageEvent(
+        text=text,
+        source=SessionSource(
+            platform=Platform.SLACK,
+            chat_id=channel_id,
+            chat_type=chat_type,
+            user_id=user_id,
+            thread_id=thread_ts,
+            message_id=message_ts,
+        ),
+        raw_message=raw_message,
+        message_id=message_ts,
+    )
+
+
+def test_slack_flow_ignores_unmentioned_messages(tmp_path):
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=lambda run_id: None)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "checkout crashes on Android",
+            raw_text="checkout crashes on Android",
+        )
+    )
+
+    assert result is None
+    assert state.list_runs() == []
+
+
+def test_slack_flow_swallow_tagged_monica_message_when_config_disabled(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=False,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    flow = MonicaSlackFlow(
+        config=config,
+        state=state,
+        loop_launcher=launched.append,
+        approval_readiness_checker=lambda: (True, ""),
+    )
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "checkout crashes on Android",
+            raw_text="<@BMONICA> checkout crashes on Android",
+        )
+    )
+
+    assert result == {"action": "skip", "reason": "monica_disabled"}
+    assert state.list_runs() == []
+    assert launched == []
+
+
+def test_slack_flow_treats_tagged_natural_language_as_agentic_work(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    flow = MonicaSlackFlow(
+        config=config,
+        state=state,
+        loop_launcher=launched.append,
+        approval_readiness_checker=lambda: (True, ""),
+    )
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "this checkout crash looks like the same Android issue from last week, can you clean it up?",
+            raw_text="<@BMONICA> this checkout crash looks like the same Android issue from last week, can you clean it up?",
+        )
+    )
+
+    assert result == {"action": "skip", "reason": "monica_loop_queued"}
+    runs = state.list_runs()
+    assert len(runs) == 1
+    assert launched == [runs[0].id]
+    assert runs[0].status == "queued"
+    assert runs[0].intent == "agentic_triage"
+    assert "checkout crash" in runs[0].request_text
+    assert runs[0].raw_event is not None
+    assert runs[0].raw_event["permalink"].startswith("https://example.slack.com/")
+
+
+def test_slack_flow_strips_monica_mention_from_normalized_text(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    flow = MonicaSlackFlow(
+        config=config,
+        state=state,
+        loop_launcher=launched.append,
+        approval_readiness_checker=lambda: (True, ""),
+    )
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "<@BMONICA> checkout crashes after promo on Android",
+            raw_text="<@BMONICA> checkout crashes after promo on Android",
+        )
+    )
+
+    runs = state.list_runs()
+    assert result == {"action": "skip", "reason": "monica_loop_queued"}
+    assert len(runs) == 1
+    assert launched == [runs[0].id]
+    assert runs[0].request_text == "checkout crashes after promo on Android"
+
+
+def test_slack_flow_accepts_and_strips_display_label_mention(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("UMONICA",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    flow = MonicaSlackFlow(
+        config=config,
+        state=state,
+        loop_launcher=launched.append,
+        approval_readiness_checker=lambda: (True, ""),
+    )
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "<@UMONICA|monica> checkout crashes after promo on Android",
+            raw_text="<@UMONICA|monica> checkout crashes after promo on Android",
+        )
+    )
+
+    runs = state.list_runs()
+    assert result == {"action": "skip", "reason": "monica_loop_queued"}
+    assert len(runs) == 1
+    assert launched == [runs[0].id]
+    assert runs[0].request_text == "checkout crashes after promo on Android"
+
+
+def test_slack_flow_without_bot_user_ids_does_not_read_generic_channel_messages(tmp_path):
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(allowed_channels=("C_MOBILE",)),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=lambda run_id: None)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "checkout crashes on Android",
+            raw_text="checkout crashes on Android",
+            raw_type="message",
+        )
+    )
+
+    assert result is None
+    assert state.list_runs() == []
+
+
+def test_slack_flow_treats_direct_message_as_explicit_monica_intent(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(bot_user_ids=("U_MONICA",)),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    flow = MonicaSlackFlow(
+        config=config,
+        state=state,
+        loop_launcher=launched.append,
+        approval_readiness_checker=lambda: (True, ""),
+    )
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "checkout crashes on Android after applying a promo code",
+            raw_text="checkout crashes on Android after applying a promo code",
+            raw_channel_type="im",
+            channel_id="D_MONICA",
+            chat_type="dm",
+        )
+    )
+
+    runs = state.list_runs()
+    assert result == {"action": "skip", "reason": "monica_loop_queued"}
+    assert len(runs) == 1
+    assert launched == [runs[0].id]
+    assert runs[0].channel_id == "D_MONICA"
+    assert runs[0].request_text == "checkout crashes on Android after applying a promo code"
+
+
+def test_slack_flow_ignores_unmentioned_group_dm_messages(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(bot_user_ids=("U_MONICA",)),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    flow = MonicaSlackFlow(
+        config=config,
+        state=state,
+        loop_launcher=launched.append,
+        approval_readiness_checker=lambda: (True, ""),
+    )
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "checkout crashes on Android after applying a promo code",
+            raw_text="checkout crashes on Android after applying a promo code",
+            raw_channel_type="mpim",
+            channel_id="G_MONICA",
+            chat_type="dm",
+        )
+    )
+
+    assert result is None
+    assert state.list_runs() == []
+    assert launched == []
+
+
+def test_slack_flow_allows_app_mention_event_before_bot_user_id_is_configured(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(allowed_channels=("C_MOBILE",)),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    flow = MonicaSlackFlow(
+        config=config,
+        state=state,
+        loop_launcher=launched.append,
+        approval_readiness_checker=lambda: (True, ""),
+    )
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "checkout crash on Android",
+            raw_text="<@BMONICA> checkout crash on Android",
+            raw_type="app_mention",
+        )
+    )
+
+    runs = state.list_runs()
+    assert result == {"action": "skip", "reason": "monica_loop_queued"}
+    assert len(runs) == 1
+    assert launched == [runs[0].id]
+
+
+def test_slack_flow_dry_run_ignores_app_mention_for_different_configured_bot_user_id(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("U_STALE",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    flow = MonicaSlackFlow(
+        config=config,
+        state=state,
+        loop_launcher=launched.append,
+        approval_readiness_checker=lambda: (True, ""),
+    )
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "checkout crash on Android",
+            raw_text="<@U_ACTUAL> checkout crash on Android",
+            raw_type="app_mention",
+        )
+    )
+
+    assert result is None
+    assert state.list_runs() == []
+    assert launched == []
+
+
+def test_slack_flow_side_effect_mode_ignores_app_mention_for_different_bot_user_id(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="linear_only",
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("U_MONICA",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "checkout crash on Android",
+            raw_text="<@U_CHANDLER> checkout crash on Android",
+            raw_type="app_mention",
+        )
+    )
+
+    assert result is None
+    assert state.list_runs() == []
+    assert launched == []
+
+
+def test_slack_flow_side_effect_mode_requires_configured_bot_user_id(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="linear_only",
+        slack=SlackConfig(allowed_channels=("C_MOBILE",)),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "checkout crash on Android",
+            raw_text="<@U_MONICA> checkout crash on Android",
+            raw_type="app_mention",
+        )
+    )
+
+    assert result == {
+        "action": "skip_reply",
+        "reason": "monica_bot_user_ids_required",
+        "text": (
+            "I cannot start Monica here yet. "
+            "Configure mobile_bug_agent.slack.bot_user_ids with Monica's Slack user ID "
+            "before enabling real side effects."
+        ),
+    }
+    assert state.list_runs() == []
+    assert launched == []
+
+
+def test_slack_flow_side_effect_mode_rejects_bot_id_values_as_mentions(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="linear_only",
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "checkout crash on Android",
+            raw_text="<@BMONICA> checkout crash on Android",
+            raw_type="app_mention",
+        )
+    )
+
+    assert result == {
+        "action": "skip_reply",
+        "reason": "monica_bot_user_ids_invalid",
+        "text": (
+            "I cannot start Monica here yet. "
+            "mobile_bug_agent.slack.bot_user_ids must contain Slack mention user IDs "
+            "like U123, not bot_id values like BMONICA."
+        ),
+    }
+    assert state.list_runs() == []
+    assert launched == []
+
+
+def test_slack_flow_side_effect_mode_rejects_bot_id_config_on_real_app_mention(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="linear_only",
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "checkout crash on Android",
+            raw_text="<@U_MONICA> checkout crash on Android",
+            raw_type="app_mention",
+        )
+    )
+
+    assert result == {
+        "action": "skip_reply",
+        "reason": "monica_bot_user_ids_invalid",
+        "text": (
+            "I cannot start Monica here yet. "
+            "mobile_bug_agent.slack.bot_user_ids must contain Slack mention user IDs "
+            "like U123, not bot_id values like BMONICA."
+        ),
+    }
+    assert state.list_runs() == []
+    assert launched == []
+
+
+def test_slack_flow_side_effect_mode_rejects_malformed_bot_user_ids_on_app_mention(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="linear_only",
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("monica",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "checkout crash on Android",
+            raw_text="<@U_MONICA> checkout crash on Android",
+            raw_type="app_mention",
+        )
+    )
+
+    assert result == {
+        "action": "skip_reply",
+        "reason": "monica_bot_user_ids_invalid",
+        "text": (
+            "I cannot start Monica here yet. "
+            "mobile_bug_agent.slack.bot_user_ids must contain Slack mention user IDs "
+            "like U123, not invalid values like monica."
+        ),
+    }
+    assert state.list_runs() == []
+    assert launched == []
+
+
+def test_slack_flow_side_effect_mode_rejects_handle_style_bot_user_ids_on_app_mention(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="linear_only",
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("@monica",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "checkout crash on Android",
+            raw_text="<@U_MONICA> checkout crash on Android",
+            raw_type="app_mention",
+        )
+    )
+
+    assert result == {
+        "action": "skip_reply",
+        "reason": "monica_bot_user_ids_invalid",
+        "text": (
+            "I cannot start Monica here yet. "
+            "mobile_bug_agent.slack.bot_user_ids must contain Slack mention user IDs "
+            "like U123, not handles like @monica."
+        ),
+    }
+    assert state.list_runs() == []
+    assert launched == []
+
+
+def test_slack_flow_refuses_side_effect_rollout_when_allowed_channels_are_empty(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="linear_only",
+        slack=SlackConfig(bot_user_ids=("BMONICA",)),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "checkout crash on Android",
+            raw_text="<@BMONICA> checkout crash on Android",
+            raw_type="app_mention",
+        )
+    )
+
+    assert result == {
+        "action": "skip_reply",
+        "reason": "monica_allowed_channels_required",
+        "text": (
+            "I cannot start Monica here yet. "
+            "Configure mobile_bug_agent.slack.allowed_channels before enabling real side effects."
+        ),
+    }
+    assert state.list_runs() == []
+    assert launched == []
+
+
+def test_slack_flow_empty_allowlist_guard_still_ignores_unmentioned_messages(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="linear_only",
+        slack=SlackConfig(bot_user_ids=("BMONICA",)),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "checkout crash on Android",
+            raw_text="checkout crash on Android",
+            raw_type="message",
+        )
+    )
+
+    assert result is None
+    assert state.list_runs() == []
+    assert launched == []
+
+
+def test_slack_flow_refuses_side_effect_rollout_with_channel_names_in_allowlist(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="linear_only",
+        slack=SlackConfig(
+            allowed_channels=("#mobile-bugs",),
+            bot_user_ids=("U_MONICA",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "checkout crash on Android",
+            raw_text="<@U_MONICA> checkout crash on Android",
+            raw_type="app_mention",
+        )
+    )
+
+    assert result == {
+        "action": "skip_reply",
+        "reason": "monica_allowed_channels_invalid",
+        "text": (
+            "I cannot start Monica here yet. "
+            "mobile_bug_agent.slack.allowed_channels must contain Slack channel IDs "
+            "like C123 or G123, not names like #mobile-bugs."
+        ),
+    }
+    assert state.list_runs() == []
+    assert launched == []
+
+
+def test_slack_flow_refuses_dry_run_with_channel_names_in_allowlist(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="dry_run",
+        slack=SlackConfig(
+            allowed_channels=("#mobile-bugs",),
+            bot_user_ids=("U_MONICA",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "checkout crash on Android",
+            raw_text="<@U_MONICA> checkout crash on Android",
+            raw_type="app_mention",
+        )
+    )
+
+    assert result == {
+        "action": "skip_reply",
+        "reason": "monica_allowed_channels_invalid",
+        "text": (
+            "I cannot start Monica here yet. "
+            "mobile_bug_agent.slack.allowed_channels must contain Slack channel IDs "
+            "like C123 or G123, not names like #mobile-bugs."
+        ),
+    }
+    assert state.list_runs() == []
+    assert launched == []
+
+
+def test_slack_flow_tagged_message_in_disallowed_channel_does_not_fall_through(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="linear_only",
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "checkout crash on Android",
+            raw_text="<@BMONICA> checkout crash on Android",
+            raw_type="app_mention",
+            channel_id="C_OTHER",
+        )
+    )
+
+    assert result == {
+        "action": "skip_reply",
+        "reason": "monica_channel_not_allowed",
+        "text": "I cannot run Monica in this channel. Ask an admin to add this channel to mobile_bug_agent.slack.allowed_channels.",
+    }
+    assert state.list_runs() == []
+    assert launched == []
+
+
+def test_slack_flow_does_not_relaunch_existing_active_thread(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+    event = _slack_event(
+        "this checkout crash looks mobile, please clean it up",
+        raw_text="<@BMONICA> this checkout crash looks mobile, please clean it up",
+    )
+
+    first = flow.handle_gateway_event(event)
+    second = flow.handle_gateway_event(event)
+
+    runs = state.list_runs()
+    assert first == {"action": "skip", "reason": "monica_loop_queued"}
+    assert second == {"action": "skip", "reason": "monica_loop_already_active"}
+    assert len(runs) == 1
+    assert launched == [runs[0].id]
+
+
+def test_slack_flow_does_not_launch_when_create_discovers_existing_run(tmp_path, monkeypatch):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    existing = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="checkout crash on Android",
+    )
+    monkeypatch.setattr(state, "find_run", lambda **_: None)
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "checkout crash on Android",
+            raw_text="<@BMONICA> checkout crash on Android",
+            thread_ts="1710000000.000100",
+        )
+    )
+
+    assert result == {"action": "skip", "reason": "monica_loop_already_active"}
+    assert state.get_run(existing.id) == existing
+    assert launched == []
+
+
+def test_slack_flow_tagged_approval_resumes_waiting_run(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+            approver_user_ids=("U_APPROVER",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "approved, fix it",
+            raw_text="<@BMONICA> approved, fix it",
+            user_id="U_APPROVER",
+            thread_ts="1710000000.000100",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result == {"action": "skip", "reason": "monica_loop_approved"}
+    assert updated is not None
+    assert updated.status == "approved"
+    assert updated.approved_by_user_id == "U_APPROVER"
+    assert launched == [run.id]
+
+
+def test_slack_flow_tagged_approval_logs_breadcrumbs(tmp_path, caplog):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+            approver_user_ids=("U_APPROVER",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(
+        run.id,
+        status="awaiting_fix_approval",
+        linear_identifier="MOB-123",
+        linear_url="https://linear.app/acme/issue/MOB-123",
+    )
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    with caplog.at_level(logging.INFO, logger="plugins.mobile_bug_agent.slack_flow"):
+        result = flow.handle_gateway_event(
+            _slack_event(
+                "approved, fix it",
+                raw_text="<@BMONICA> approved, fix it",
+                user_id="U_APPROVER",
+                thread_ts="1710000000.000100",
+            )
+        )
+
+    logs = "\n".join(record.getMessage() for record in caplog.records)
+    assert result == {"action": "skip", "reason": "monica_loop_approved"}
+    assert "event=approved" in logs
+    assert run.id in logs
+    assert "C_MOBILE" in logs
+    assert "1710000000.000100" in logs
+    assert "MOB-123" in logs
+    assert "https://linear.app/acme/issue/MOB-123" in logs
+    assert "approved_by=U_APPROVER" in logs
+    assert launched == [run.id]
+
+
+def test_slack_flow_does_not_launch_when_approval_discovers_already_approved(tmp_path, monkeypatch):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+            approver_user_ids=("U_APPROVER",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    stale = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+        status="awaiting_fix_approval",
+    )
+    state.approve_fix(stale.id, approved_by_user_id="U_FIRST")
+    monkeypatch.setattr(state, "find_run", lambda **_: stale)
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "approved, fix it",
+            raw_text="<@BMONICA> approved, fix it",
+            user_id="U_APPROVER",
+            thread_ts="1710000000.000100",
+        )
+    )
+
+    updated = state.get_run(stale.id)
+    assert result == {"action": "skip", "reason": "monica_loop_already_active"}
+    assert updated is not None
+    assert updated.status == "approved"
+    assert updated.approved_by_user_id == "U_FIRST"
+    assert launched == []
+
+
+def test_slack_flow_accepts_take_the_fix_as_tagged_approval(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+            approver_user_ids=("U_APPROVER",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "yes, take the fix",
+            raw_text="<@BMONICA> yes, take the fix",
+            user_id="U_APPROVER",
+            thread_ts="1710000000.000100",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result == {"action": "skip", "reason": "monica_loop_approved"}
+    assert updated is not None
+    assert updated.status == "approved"
+    assert updated.approved_by_user_id == "U_APPROVER"
+    assert launched == [run.id]
+
+
+def test_slack_flow_accepts_yes_fix_it_as_tagged_approval(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+            approver_user_ids=("U_APPROVER",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "yes, fix it",
+            raw_text="<@BMONICA> yes, fix it",
+            user_id="U_APPROVER",
+            thread_ts="1710000000.000100",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result == {"action": "skip", "reason": "monica_loop_approved"}
+    assert updated is not None
+    assert updated.status == "approved"
+    assert updated.approved_by_user_id == "U_APPROVER"
+    assert launched == [run.id]
+
+
+def test_slack_flow_fix_request_is_not_approval(tmp_path):
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+            approver_user_ids=("U_APPROVER",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=lambda run_id: None)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "can you fix it?",
+            raw_text="<@BMONICA> can you fix it?",
+            user_id="U_APPROVER",
+            thread_ts="1710000000.000100",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result == {"action": "skip", "reason": "monica_loop_already_active"}
+    assert updated is not None
+    assert updated.status == "awaiting_fix_approval"
+    assert updated.approved_by_user_id == ""
+
+
+def test_slack_flow_new_context_requeues_waiting_run_for_linear_update(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+            approver_user_ids=("U_APPROVER",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(
+        run.id,
+        status="awaiting_fix_approval",
+        linear_identifier="MOB-123",
+        linear_issue_id="issue-id",
+        linear_url="https://linear.app/acme/issue/MOB-123",
+        approved_by_user_id="",
+    )
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "new reproduction detail: this also happens on iOS after Apple Pay",
+            raw_text="<@BMONICA> new reproduction detail: this also happens on iOS after Apple Pay",
+            user_id="U_REPRODUCER",
+            thread_ts="1710000000.000100",
+            message_ts="1710000002.000300",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result == {"action": "skip", "reason": "monica_loop_requeued"}
+    assert updated is not None
+    assert updated.status == "queued"
+    assert updated.linear_identifier == "MOB-123"
+    assert updated.linear_issue_id == "issue-id"
+    assert updated.linear_url == "https://linear.app/acme/issue/MOB-123"
+    assert updated.message_ts == "1710000002.000300"
+    assert updated.user_id == "U_REPRODUCER"
+    assert "new reproduction detail" in updated.request_text
+    assert updated.approved_by_user_id == ""
+    assert launched == [run.id]
+
+
+def test_slack_flow_question_shaped_approval_is_not_approval(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+            approver_user_ids=("U_APPROVER",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "should I approve this after QA is done?",
+            raw_text="<@BMONICA> should I approve this after QA is done?",
+            user_id="U_APPROVER",
+            thread_ts="1710000000.000100",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result == {"action": "skip", "reason": "monica_loop_already_active"}
+    assert updated is not None
+    assert updated.status == "awaiting_fix_approval"
+    assert updated.approved_by_user_id == ""
+    assert launched == []
+
+
+def test_slack_flow_bare_approved_question_is_not_approval(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+            approver_user_ids=("U_APPROVER",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "approved?",
+            raw_text="<@BMONICA> approved?",
+            user_id="U_APPROVER",
+            thread_ts="1710000000.000100",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result == {"action": "skip", "reason": "monica_loop_already_active"}
+    assert updated is not None
+    assert updated.status == "awaiting_fix_approval"
+    assert updated.approved_by_user_id == ""
+    assert launched == []
+
+
+def test_slack_flow_approve_this_question_is_not_approval(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+            approver_user_ids=("U_APPROVER",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "approve this?",
+            raw_text="<@BMONICA> approve this?",
+            user_id="U_APPROVER",
+            thread_ts="1710000000.000100",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result == {"action": "skip", "reason": "monica_loop_already_active"}
+    assert updated is not None
+    assert updated.status == "awaiting_fix_approval"
+    assert updated.approved_by_user_id == ""
+    assert launched == []
+
+
+def test_slack_flow_ship_it_question_is_not_approval(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+            approver_user_ids=("U_APPROVER",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "ship it?",
+            raw_text="<@BMONICA> ship it?",
+            user_id="U_APPROVER",
+            thread_ts="1710000000.000100",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result == {"action": "skip", "reason": "monica_loop_already_active"}
+    assert updated is not None
+    assert updated.status == "awaiting_fix_approval"
+    assert updated.approved_by_user_id == ""
+    assert launched == []
+
+
+def test_slack_flow_can_you_approve_question_is_not_approval(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+            approver_user_ids=("U_APPROVER",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "can you approve this once QA is done?",
+            raw_text="<@BMONICA> can you approve this once QA is done?",
+            user_id="U_APPROVER",
+            thread_ts="1710000000.000100",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result == {"action": "skip", "reason": "monica_loop_already_active"}
+    assert updated is not None
+    assert updated.status == "awaiting_fix_approval"
+    assert updated.approved_by_user_id == ""
+    assert launched == []
+
+
+def test_slack_flow_negated_approval_is_not_approval(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+            approver_user_ids=("U_APPROVER",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "not approved yet, still checking QA",
+            raw_text="<@BMONICA> not approved yet, still checking QA",
+            user_id="U_APPROVER",
+            thread_ts="1710000000.000100",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result == {"action": "skip", "reason": "monica_loop_already_active"}
+    assert updated is not None
+    assert updated.status == "awaiting_fix_approval"
+    assert updated.approved_by_user_id == ""
+    assert launched == []
+
+
+def test_slack_flow_negated_go_ahead_is_not_approval(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+            approver_user_ids=("U_APPROVER",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "don't go ahead yet, waiting for QA",
+            raw_text="<@BMONICA> don't go ahead yet, waiting for QA",
+            user_id="U_APPROVER",
+            thread_ts="1710000000.000100",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result == {"action": "skip", "reason": "monica_loop_already_active"}
+    assert updated is not None
+    assert updated.status == "awaiting_fix_approval"
+    assert updated.approved_by_user_id == ""
+    assert launched == []
+
+
+def test_slack_flow_negated_ship_it_is_not_approval(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+            approver_user_ids=("U_APPROVER",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "don't ship it yet, QA is still checking",
+            raw_text="<@BMONICA> don't ship it yet, QA is still checking",
+            user_id="U_APPROVER",
+            thread_ts="1710000000.000100",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result == {"action": "skip", "reason": "monica_loop_already_active"}
+    assert updated is not None
+    assert updated.status == "awaiting_fix_approval"
+    assert updated.approved_by_user_id == ""
+    assert launched == []
+
+
+def test_slack_flow_tagged_cancel_blocks_waiting_run(tmp_path):
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=lambda run_id: None)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "do not fix this",
+            raw_text="<@BMONICA> do not fix this",
+            user_id="U_APPROVER",
+            thread_ts="1710000000.000100",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result == {"action": "skip", "reason": "monica_loop_cancelled"}
+    assert updated is not None
+    assert updated.status == "blocked"
+    assert updated.failure_reason == "cancelled by U_APPROVER"
+
+
+def test_slack_flow_stop_question_does_not_cancel_waiting_run(tmp_path):
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=lambda run_id: None)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "stop?",
+            raw_text="<@BMONICA> stop?",
+            user_id="U_APPROVER",
+            thread_ts="1710000000.000100",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result == {"action": "skip", "reason": "monica_loop_already_active"}
+    assert updated is not None
+    assert updated.status == "awaiting_fix_approval"
+    assert updated.failure_reason == ""
+
+
+def test_slack_flow_do_not_fix_question_does_not_cancel_waiting_run(tmp_path):
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=lambda run_id: None)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "do not fix?",
+            raw_text="<@BMONICA> do not fix?",
+            user_id="U_APPROVER",
+            thread_ts="1710000000.000100",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result == {"action": "skip", "reason": "monica_loop_already_active"}
+    assert updated is not None
+    assert updated.status == "awaiting_fix_approval"
+    assert updated.failure_reason == ""
+
+
+def test_slack_flow_tagged_cancel_logs_breadcrumbs(tmp_path, caplog):
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(
+        run.id,
+        status="awaiting_fix_approval",
+        linear_identifier="MOB-123",
+        linear_url="https://linear.app/acme/issue/MOB-123",
+    )
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=lambda run_id: None)
+
+    with caplog.at_level(logging.INFO, logger="plugins.mobile_bug_agent.slack_flow"):
+        result = flow.handle_gateway_event(
+            _slack_event(
+                "do not fix this",
+                raw_text="<@BMONICA> do not fix this",
+                user_id="U_APPROVER",
+                thread_ts="1710000000.000100",
+            )
+        )
+
+    logs = "\n".join(record.getMessage() for record in caplog.records)
+    assert result == {"action": "skip", "reason": "monica_loop_cancelled"}
+    assert "event=cancelled" in logs
+    assert run.id in logs
+    assert "C_MOBILE" in logs
+    assert "1710000000.000100" in logs
+    assert "MOB-123" in logs
+    assert "https://linear.app/acme/issue/MOB-123" in logs
+    assert "cancelled_by=U_APPROVER" in logs
+
+
+def test_slack_flow_tagged_cancel_blocks_active_run_before_approval(tmp_path):
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="triaging")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=lambda run_id: None)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "cancel",
+            raw_text="<@BMONICA> cancel",
+            user_id="U_APPROVER",
+            thread_ts="1710000000.000100",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result == {"action": "skip", "reason": "monica_loop_cancelled"}
+    assert updated is not None
+    assert updated.status == "blocked"
+    assert updated.failure_reason == "cancelled by U_APPROVER"
+
+
+def test_slack_flow_tagged_cancel_does_not_requeue_blocked_run(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="blocked", failure_reason="cancelled by U_APPROVER")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "cancel",
+            raw_text="<@BMONICA> cancel",
+            user_id="U_APPROVER",
+            thread_ts="1710000000.000100",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result == {"action": "skip", "reason": "monica_loop_cancelled"}
+    assert updated is not None
+    assert updated.status == "blocked"
+    assert updated.failure_reason == "cancelled by U_APPROVER"
+    assert launched == []
+
+
+def test_slack_flow_tagged_cancel_does_not_requeue_completed_run(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(
+        run.id,
+        status="done",
+        linear_identifier="MOB-123",
+        pr_url="https://github.com/acme/mobile/pull/123",
+    )
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "stop",
+            raw_text="<@BMONICA> stop",
+            user_id="U_APPROVER",
+            thread_ts="1710000000.000100",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result == {"action": "skip", "reason": "monica_loop_cancelled"}
+    assert updated is not None
+    assert updated.status == "done"
+    assert updated.pr_url == "https://github.com/acme/mobile/pull/123"
+    assert launched == []
+
+
+def test_slack_flow_negated_cancel_does_not_block_waiting_run(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "don't stop yet, still checking QA",
+            raw_text="<@BMONICA> don't stop yet, still checking QA",
+            user_id="U_APPROVER",
+            thread_ts="1710000000.000100",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result == {"action": "skip", "reason": "monica_loop_already_active"}
+    assert updated is not None
+    assert updated.status == "awaiting_fix_approval"
+    assert updated.failure_reason == ""
+    assert launched == []
+
+
+def test_slack_flow_bug_context_with_stop_is_not_cancel(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+            approver_user_ids=("U_APPROVER",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "can you stop this Android checkout crash from happening?",
+            raw_text="<@BMONICA> can you stop this Android checkout crash from happening?",
+            user_id="U_TAGGER",
+            thread_ts="1710000000.000100",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result == {"action": "skip", "reason": "monica_loop_already_active"}
+    assert updated is not None
+    assert updated.status == "awaiting_fix_approval"
+    assert updated.failure_reason == ""
+    assert launched == []
+
+
+def test_slack_flow_untagged_approval_is_ignored(tmp_path):
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=lambda run_id: None)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "approved, fix it",
+            raw_text="approved, fix it",
+            user_id="U_APPROVER",
+            thread_ts="1710000000.000100",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result is None
+    assert updated is not None
+    assert updated.status == "awaiting_fix_approval"
+
+
+def test_slack_flow_tagged_approval_from_unauthorized_user_is_explicitly_denied(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+            approver_user_ids=("U_APPROVER",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "approved, fix it",
+            raw_text="<@BMONICA> approved, fix it",
+            user_id="U_RANDOM",
+            thread_ts="1710000000.000100",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result == {
+        "action": "skip_reply",
+        "reason": "monica_loop_approval_denied",
+        "text": (
+            "I cannot start the fix from this approval. "
+            "A configured Monica approver must tag me to approve code changes. "
+            "Allowed approvers: <@U_APPROVER>."
+        ),
+    }
+    assert updated is not None
+    assert updated.status == "awaiting_fix_approval"
+    assert updated.approved_by_user_id == ""
+    assert launched == []
+
+
+def test_slack_flow_tagged_approval_refuses_when_readiness_check_fails(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="approved_pr",
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("U_MONICA",),
+            approver_user_ids=("U_APPROVER",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    flow = MonicaSlackFlow(
+        config=config,
+        state=state,
+        loop_launcher=launched.append,
+        approval_readiness_checker=lambda: (False, "repo.url is missing"),
+    )
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "approved, fix it",
+            raw_text="<@U_MONICA> approved, fix it",
+            user_id="U_APPROVER",
+            thread_ts="1710000000.000100",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result == {
+        "action": "skip_reply",
+        "reason": "monica_loop_approval_not_ready",
+        "text": (
+            "I cannot start the fix from this approval because Monica is not ready for approved-PR mode: "
+            "repo.url is missing"
+        ),
+    }
+    assert updated is not None
+    assert updated.status == "awaiting_fix_approval"
+    assert updated.approved_by_user_id == ""
+    assert launched == []
+
+
+def test_slack_flow_tagged_approval_refuses_when_linear_api_key_is_missing(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.delenv("LINEAR_API_KEY", raising=False)
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="approved_pr",
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("U_MONICA",),
+            approver_user_ids=("U_APPROVER",),
+        ),
+        linear=LinearConfig(team_id="team-id"),
+        repo=RepoConfig(url="git@github.com:acme/mobile.git"),
+        verification=VerificationConfig(commands=("npm test",)),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "approved, fix it",
+            raw_text="<@U_MONICA> approved, fix it",
+            user_id="U_APPROVER",
+            thread_ts="1710000000.000100",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result == {
+        "action": "skip_reply",
+        "reason": "monica_loop_approval_not_ready",
+        "text": (
+            "I cannot start the fix from this approval because Monica is not ready for approved-PR mode: "
+            "LINEAR_API_KEY is missing"
+        ),
+    }
+    assert updated is not None
+    assert updated.status == "awaiting_fix_approval"
+    assert updated.approved_by_user_id == ""
+    assert launched == []
+
+
+def test_slack_flow_tagged_approval_refuses_when_slack_bot_token_is_missing(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("MONICA_SLACK_BOT_TOKEN", raising=False)
+    monkeypatch.setenv("LINEAR_API_KEY", "lin-key")
+    monkeypatch.setattr(
+        "plugins.mobile_bug_agent.slack_flow.shutil.which",
+        lambda name: f"/usr/bin/{name}",
+    )
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="approved_pr",
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("U_MONICA",),
+            approver_user_ids=("U_APPROVER",),
+        ),
+        linear=LinearConfig(team_id="team-id"),
+        repo=RepoConfig(url="git@github.com:acme/mobile.git"),
+        verification=VerificationConfig(commands=("npm test",)),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "approved, fix it",
+            raw_text="<@U_MONICA> approved, fix it",
+            user_id="U_APPROVER",
+            thread_ts="1710000000.000100",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result == {
+        "action": "skip_reply",
+        "reason": "monica_loop_approval_not_ready",
+            "text": (
+                "I cannot start the fix from this approval because Monica is not ready for approved-PR mode: "
+                "MONICA_SLACK_BOT_TOKEN is missing"
+            ),
+        }
+    assert updated is not None
+    assert updated.status == "awaiting_fix_approval"
+    assert updated.approved_by_user_id == ""
+    assert launched == []
+
+
+def test_slack_flow_tagged_approval_refuses_chandler_worker_session_prefix(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("LINEAR_API_KEY", "lin-key")
+    monkeypatch.setattr(
+        "plugins.mobile_bug_agent.slack_flow.shutil.which",
+        lambda name: f"/usr/bin/{name}",
+    )
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="approved_pr",
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("U_MONICA",),
+            approver_user_ids=("U_APPROVER",),
+        ),
+        linear=LinearConfig(team_id="team-id"),
+        repo=RepoConfig(url="git@github.com:acme/mobile.git"),
+        runtime=RuntimeConfig(worker_session_prefix="chandler"),
+        verification=VerificationConfig(commands=("npm test",)),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "approved, fix it",
+            raw_text="<@U_MONICA> approved, fix it",
+            user_id="U_APPROVER",
+            thread_ts="1710000000.000100",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result == {
+        "action": "skip_reply",
+        "reason": "monica_loop_approval_not_ready",
+        "text": (
+            "I cannot start the fix from this approval because Monica is not ready for approved-PR mode: "
+            "runtime.worker_session_prefix must include `monica` to keep worker sessions segregated"
+        ),
+    }
+    assert updated is not None
+    assert updated.status == "awaiting_fix_approval"
+    assert updated.approved_by_user_id == ""
+    assert launched == []
+
+
+def test_slack_flow_tagged_approval_is_denied_when_no_approvers_are_configured(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="approved_pr",
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("U_MONICA",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "approved, fix it",
+            raw_text="<@U_MONICA> approved, fix it",
+            user_id="U_RANDOM",
+            thread_ts="1710000000.000100",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result == {
+        "action": "skip_reply",
+        "reason": "monica_loop_approval_denied",
+        "text": (
+            "I cannot start the fix from this approval. "
+            "No Monica approver is configured for code changes."
+        ),
+    }
+    assert updated is not None
+    assert updated.status == "awaiting_fix_approval"
+    assert updated.approved_by_user_id == ""
+    assert launched == []
+
+
+def test_slack_flow_requeues_completed_thread_for_linear_update(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="original Android checkout crash",
+    )
+    state.update_run(
+        run.id,
+        status="done",
+        linear_identifier="MOB-123",
+        linear_issue_id="issue-id",
+        linear_url="https://linear.app/acme/issue/MOB-123",
+        branch_name="monica/MOB-123-checkout-crash",
+        pr_url="https://github.com/acme/mobile/pull/123",
+        failure_reason="old failure",
+        approved_by_user_id="U_OLD_APPROVER",
+    )
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "new reproduction detail: happens only after promo code",
+            raw_text="<@BMONICA> new reproduction detail: happens only after promo code",
+            user_id="U_REPRODUCER",
+            thread_ts="1710000000.000100",
+            message_ts="1710000002.000300",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result == {"action": "skip", "reason": "monica_loop_requeued"}
+    assert updated is not None
+    assert updated.status == "queued"
+    assert updated.linear_issue_id == "issue-id"
+    assert updated.linear_identifier == "MOB-123"
+    assert updated.linear_url == "https://linear.app/acme/issue/MOB-123"
+    assert updated.branch_name == ""
+    assert updated.pr_url == ""
+    assert updated.failure_reason == ""
+    assert updated.approved_by_user_id == ""
+    assert updated.user_id == "U_REPRODUCER"
+    assert updated.message_ts == "1710000002.000300"
+    assert "new reproduction detail" in updated.request_text
+    assert launched == [run.id]
+
+
+def test_slack_flow_requeue_logs_breadcrumbs(tmp_path, caplog):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="original Android checkout crash",
+    )
+    state.update_run(
+        run.id,
+        status="done",
+        linear_identifier="MOB-123",
+        linear_issue_id="issue-id",
+        linear_url="https://linear.app/acme/issue/MOB-123",
+        branch_name="monica/MOB-123-checkout-crash",
+        pr_url="https://github.com/acme/mobile/pull/123",
+    )
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    with caplog.at_level(logging.INFO, logger="plugins.mobile_bug_agent.slack_flow"):
+        result = flow.handle_gateway_event(
+            _slack_event(
+                "new reproduction detail: happens only after promo code",
+                raw_text="<@BMONICA> new reproduction detail: happens only after promo code",
+                user_id="U_REPRODUCER",
+                thread_ts="1710000000.000100",
+                message_ts="1710000002.000300",
+            )
+        )
+
+    logs = "\n".join(record.getMessage() for record in caplog.records)
+    assert result == {"action": "skip", "reason": "monica_loop_requeued"}
+    assert "event=requeued" in logs
+    assert run.id in logs
+    assert "C_MOBILE" in logs
+    assert "1710000000.000100" in logs
+    assert "MOB-123" in logs
+    assert "https://linear.app/acme/issue/MOB-123" in logs
+    assert "requeued_by=U_REPRODUCER" in logs
+    assert launched == [run.id]
+
+
+def test_slack_flow_does_not_requeue_completed_thread_for_tagged_thanks(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="original Android checkout crash",
+    )
+    state.update_run(
+        run.id,
+        status="done",
+        linear_identifier="MOB-123",
+        linear_issue_id="issue-id",
+        linear_url="https://linear.app/acme/issue/MOB-123",
+        pr_url="https://github.com/acme/mobile/pull/123",
+    )
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "thanks, this is fixed now",
+            raw_text="<@BMONICA> thanks, this is fixed now",
+            user_id="U_TAGGER",
+            thread_ts="1710000000.000100",
+            message_ts="1710000003.000400",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result == {"action": "skip", "reason": "monica_loop_noop"}
+    assert updated is not None
+    assert updated.status == "done"
+    assert updated.pr_url == "https://github.com/acme/mobile/pull/123"
+    assert updated.message_ts == "1710000000.000100"
+    assert updated.request_text == "original Android checkout crash"
+    assert launched == []
+
+
+def test_slack_flow_does_not_requeue_completed_thread_when_thanks_mentions_bug(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="original Android checkout crash",
+    )
+    state.update_run(
+        run.id,
+        status="done",
+        linear_identifier="MOB-123",
+        linear_issue_id="issue-id",
+        linear_url="https://linear.app/acme/issue/MOB-123",
+        pr_url="https://github.com/acme/mobile/pull/123",
+    )
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "thanks, the Android checkout crash is fixed now",
+            raw_text="<@BMONICA> thanks, the Android checkout crash is fixed now",
+            user_id="U_TAGGER",
+            thread_ts="1710000000.000100",
+            message_ts="1710000003.000400",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result == {"action": "skip", "reason": "monica_loop_noop"}
+    assert updated is not None
+    assert updated.status == "done"
+    assert updated.pr_url == "https://github.com/acme/mobile/pull/123"
+    assert updated.message_ts == "1710000000.000100"
+    assert updated.request_text == "original Android checkout crash"
+    assert launched == []
+
+
+def test_slack_flow_late_approval_resumes_completed_ticket_only_run(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="approved_pr",
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("U_MONICA",),
+            approver_user_ids=("U_APPROVER",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="original Android checkout crash",
+    )
+    state.update_run(
+        run.id,
+        status="done",
+        linear_identifier="MOB-123",
+        linear_issue_id="issue-id",
+        linear_url="https://linear.app/acme/issue/MOB-123",
+    )
+    flow = MonicaSlackFlow(
+        config=config,
+        state=state,
+        loop_launcher=launched.append,
+        approval_readiness_checker=lambda: (True, ""),
+    )
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "approved, fix it",
+            raw_text="<@U_MONICA> approved, fix it",
+            user_id="U_APPROVER",
+            thread_ts="1710000000.000100",
+            message_ts="1710000004.000500",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result == {"action": "skip", "reason": "monica_loop_approved"}
+    assert updated is not None
+    assert updated.status == "approved"
+    assert updated.approved_by_user_id == "U_APPROVER"
+    assert updated.linear_identifier == "MOB-123"
+    assert updated.linear_issue_id == "issue-id"
+    assert updated.linear_url == "https://linear.app/acme/issue/MOB-123"
+    assert updated.request_text == "original Android checkout crash"
+    assert launched == [run.id]
+
+
+def test_slack_flow_late_approval_logs_breadcrumbs(tmp_path, caplog):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="approved_pr",
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("U_MONICA",),
+            approver_user_ids=("U_APPROVER",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="original Android checkout crash",
+    )
+    state.update_run(
+        run.id,
+        status="done",
+        linear_identifier="MOB-123",
+        linear_issue_id="issue-id",
+        linear_url="https://linear.app/acme/issue/MOB-123",
+    )
+    flow = MonicaSlackFlow(
+        config=config,
+        state=state,
+        loop_launcher=launched.append,
+        approval_readiness_checker=lambda: (True, ""),
+    )
+
+    with caplog.at_level(logging.INFO, logger="plugins.mobile_bug_agent.slack_flow"):
+        result = flow.handle_gateway_event(
+            _slack_event(
+                "approved, fix it",
+                raw_text="<@U_MONICA> approved, fix it",
+                user_id="U_APPROVER",
+                thread_ts="1710000000.000100",
+                message_ts="1710000004.000500",
+            )
+        )
+
+    logs = "\n".join(record.getMessage() for record in caplog.records)
+    assert result == {"action": "skip", "reason": "monica_loop_approved"}
+    assert "event=approved" in logs
+    assert run.id in logs
+    assert "C_MOBILE" in logs
+    assert "1710000000.000100" in logs
+    assert "MOB-123" in logs
+    assert "https://linear.app/acme/issue/MOB-123" in logs
+    assert "approved_by=U_APPROVER" in logs
+    assert launched == [run.id]
+
+
+def test_slack_flow_tagged_approval_resumes_blocked_linear_run(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="approved_pr",
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("U_MONICA",),
+            approver_user_ids=("U_APPROVER",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="original Android checkout crash",
+    )
+    state.update_run(
+        run.id,
+        status="blocked",
+        linear_identifier="MOB-123",
+        linear_issue_id="issue-id",
+        linear_url="https://linear.app/acme/issue/MOB-123",
+        branch_name="monica/MOB-123-checkout-crash",
+        failure_reason="draft_pr_url_missing",
+        approved_by_user_id="U_APPROVER",
+    )
+    flow = MonicaSlackFlow(
+        config=config,
+        state=state,
+        loop_launcher=launched.append,
+        approval_readiness_checker=lambda: (True, ""),
+    )
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "approved, try again",
+            raw_text="<@U_MONICA> approved, try again",
+            user_id="U_APPROVER",
+            thread_ts="1710000000.000100",
+            message_ts="1710000005.000600",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result == {"action": "skip", "reason": "monica_loop_approved"}
+    assert updated is not None
+    assert updated.status == "approved"
+    assert updated.linear_identifier == "MOB-123"
+    assert updated.linear_issue_id == "issue-id"
+    assert updated.linear_url == "https://linear.app/acme/issue/MOB-123"
+    assert updated.failure_reason == ""
+    assert updated.approved_by_user_id == "U_APPROVER"
+    assert updated.pr_url == ""
+    assert updated.request_text == "original Android checkout crash"
+    assert launched == [run.id]
+
+
+def test_slack_flow_does_not_requeue_completed_pr_for_late_approval(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("BMONICA",),
+            approver_user_ids=("U_APPROVER",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="original Android checkout crash",
+    )
+    state.update_run(
+        run.id,
+        status="done",
+        linear_identifier="MOB-123",
+        linear_issue_id="issue-id",
+        linear_url="https://linear.app/acme/issue/MOB-123",
+        branch_name="monica/MOB-123-checkout-crash",
+        pr_url="https://github.com/acme/mobile/pull/123",
+        approved_by_user_id="U_APPROVER",
+    )
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "approved, fix it",
+            raw_text="<@BMONICA> approved, fix it",
+            user_id="U_APPROVER",
+            thread_ts="1710000000.000100",
+            message_ts="1710000004.000500",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result == {"action": "skip", "reason": "monica_loop_already_done"}
+    assert updated is not None
+    assert updated.status == "done"
+    assert updated.branch_name == "monica/MOB-123-checkout-crash"
+    assert updated.pr_url == "https://github.com/acme/mobile/pull/123"
+    assert updated.approved_by_user_id == "U_APPROVER"
+    assert updated.message_ts == "1710000000.000100"
+    assert updated.request_text == "original Android checkout crash"
+    assert launched == []
+
+
+def test_slack_flow_does_not_requeue_blocked_run_that_already_has_pr(tmp_path):
+    launched: list[str] = []
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="approved_pr",
+        slack=SlackConfig(
+            allowed_channels=("C_MOBILE",),
+            bot_user_ids=("U_MONICA",),
+            approver_user_ids=("U_APPROVER",),
+        ),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U_TAGGER",
+        request_text="original Android checkout crash",
+    )
+    state.update_run(
+        run.id,
+        status="blocked",
+        linear_identifier="MOB-123",
+        linear_issue_id="issue-id",
+        linear_url="https://linear.app/acme/issue/MOB-123",
+        branch_name="monica/MOB-123-checkout-crash",
+        pr_url="https://github.com/acme/mobile/pull/123",
+        failure_reason="cancelled by U_APPROVER",
+        approved_by_user_id="U_APPROVER",
+    )
+    flow = MonicaSlackFlow(config=config, state=state, loop_launcher=launched.append)
+
+    result = flow.handle_gateway_event(
+        _slack_event(
+            "approved, fix it",
+            raw_text="<@U_MONICA> approved, fix it",
+            user_id="U_APPROVER",
+            thread_ts="1710000000.000100",
+            message_ts="1710000006.000700",
+        )
+    )
+
+    updated = state.get_run(run.id)
+    assert result == {"action": "skip", "reason": "monica_loop_already_done"}
+    assert updated is not None
+    assert updated.status == "blocked"
+    assert updated.branch_name == "monica/MOB-123-checkout-crash"
+    assert updated.pr_url == "https://github.com/acme/mobile/pull/123"
+    assert updated.failure_reason == "cancelled by U_APPROVER"
+    assert updated.approved_by_user_id == "U_APPROVER"
+    assert updated.message_ts == "1710000000.000100"
+    assert updated.request_text == "original Android checkout crash"
+    assert launched == []
+
+
+@dataclass
+class FakeSkills(MonicaLoopSkills):
+    calls: list[str] = field(default_factory=list)
+    status_posts: list[str] = field(default_factory=list)
+
+    def read_slack_thread(self, run: Any) -> dict[str, Any]:
+        self.calls.append("read_slack_thread")
+        return {
+            "permalink": "https://example.slack.com/archives/C_MOBILE/p1710000000000200",
+            "messages": [
+                "Alice: Android checkout crashes after applying a promo code.",
+                "Bob: I reproduced on 2.14.1.",
+            ],
+            "attachments": ["screenshot.png"],
+        }
+
+    def infer_user_intent(self, run: Any, thread: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append("infer_user_intent")
+        return {
+            "is_mobile_bug": True,
+            "confidence": 0.91,
+            "wants_fix": True,
+            "needs_clarification": False,
+            "summary": "Android checkout crashes after applying a promo code.",
+        }
+
+    def create_or_update_linear(self, run: Any, thread: dict[str, Any], intent: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append("create_or_update_linear")
+        return {
+            "identifier": "DRY-RUN",
+            "url": "",
+            "dry_run": True,
+            "title": "[Mobile] Android checkout crashes after promo code",
+            "description": "## Summary\nAndroid checkout crashes after applying a promo code.",
+        }
+
+    def ask_fix_approval(self, run: Any, issue: dict[str, Any]) -> None:
+        self.calls.append("ask_fix_approval")
+
+    def post_status(self, run: Any, text: str) -> None:
+        self.status_posts.append(text)
+
+    def run_internal_codex_worker(self, run: Any) -> dict[str, Any]:
+        self.calls.append("run_internal_codex_worker")
+        raise AssertionError("Monica must not write code before approval")
+
+    def run_verification(self, run: Any, worker_result: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append("run_verification")
+        return {"passed": True}
+
+    def open_draft_pr(
+        self,
+        run: Any,
+        worker_result: dict[str, Any],
+        verification: dict[str, Any],
+    ) -> dict[str, Any]:
+        self.calls.append("open_draft_pr")
+        return {"url": "https://github.com/example/mobile/pull/123"}
+
+
+def test_dry_run_finishes_without_waiting_for_approval_or_code(tmp_path):
+    config = MonicaConfig(enabled=True, rollout_mode="dry_run")
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="can you clean this Android checkout crash up?",
+    )
+    skills = FakeSkills()
+
+    MonicaLoop(config=config, state=state, skills=skills).run(run.id)
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert updated.status == "done"
+    assert updated.linear_identifier == "DRY-RUN"
+    assert skills.calls == [
+        "read_slack_thread",
+        "infer_user_intent",
+        "create_or_update_linear",
+    ]
+    assert "Dry run" in skills.status_posts[0]
+    assert "Preview:" in skills.status_posts[0]
+    assert "## Summary" in skills.status_posts[0]
+
+
+def test_dry_run_logs_ticket_breadcrumbs(tmp_path, caplog):
+    config = MonicaConfig(enabled=True, rollout_mode="dry_run")
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="can you clean this Android checkout crash up?",
+    )
+    skills = FakeSkills()
+
+    with caplog.at_level(logging.INFO, logger="plugins.mobile_bug_agent.loop"):
+        MonicaLoop(config=config, state=state, skills=skills).run(run.id)
+
+    logs = "\n".join(record.getMessage() for record in caplog.records)
+    assert "event=done" in logs
+    assert "stage=dry_run" in logs
+    assert run.id in logs
+    assert "C_MOBILE" in logs
+    assert "1710000000.000100" in logs
+    assert "DRY-RUN" in logs
+
+
+@dataclass
+class CancellingReadSkills(FakeSkills):
+    state: MonicaState | None = None
+
+    def read_slack_thread(self, run: Any) -> dict[str, Any]:
+        self.calls.append("read_slack_thread")
+        assert self.state is not None
+        self.state.update_run(
+            run.id,
+            status="blocked",
+            failure_reason="cancelled by U_APPROVER",
+        )
+        return {"permalink": "https://example.slack.com/thread", "messages": [run.request_text]}
+
+
+def test_loop_stops_when_run_is_cancelled_during_triage(tmp_path):
+    config = MonicaConfig(enabled=True, rollout_mode="linear_only")
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="can you clean this Android checkout crash up?",
+    )
+    skills = CancellingReadSkills(state=state)
+
+    MonicaLoop(config=config, state=state, skills=skills).run(run.id)
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert updated.status == "blocked"
+    assert updated.failure_reason == "cancelled by U_APPROVER"
+    assert skills.calls == ["read_slack_thread"]
+
+
+def test_unknown_rollout_mode_blocks_before_side_effects(tmp_path):
+    config = MonicaConfig(enabled=True, rollout_mode="typo")
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="can you clean this Android checkout crash up?",
+    )
+    skills = FakeSkills()
+
+    MonicaLoop(config=config, state=state, skills=skills).run(run.id)
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert updated.status == "blocked"
+    assert updated.failure_reason == "unknown_rollout_mode: typo"
+    assert skills.calls == []
+    assert "known rollout mode" in skills.status_posts[0]
+
+
+def test_unknown_rollout_mode_logs_blocked_breadcrumbs(tmp_path, caplog):
+    config = MonicaConfig(enabled=True, rollout_mode="typo")
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="can you clean this Android checkout crash up?",
+    )
+    skills = FakeSkills()
+
+    with caplog.at_level(logging.INFO, logger="plugins.mobile_bug_agent.loop"):
+        MonicaLoop(config=config, state=state, skills=skills).run(run.id)
+
+    logs = "\n".join(record.getMessage() for record in caplog.records)
+    assert "event=blocked" in logs
+    assert "stage=preflight" in logs
+    assert "failure_reason=unknown_rollout_mode: typo" in logs
+    assert run.id in logs
+    assert "C_MOBILE" in logs
+    assert "1710000000.000100" in logs
+
+
+def test_linear_only_blocks_when_linear_creation_is_disabled(tmp_path):
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="linear_only",
+        loop=LoopConfig(create_linear=False),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="can you clean this Android checkout crash up?",
+    )
+    skills = FakeSkills()
+
+    MonicaLoop(config=config, state=state, skills=skills).run(run.id)
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert updated.status == "blocked"
+    assert updated.failure_reason == "linear_creation_disabled_in_rollout"
+    assert skills.calls == []
+    assert "Linear creation is disabled" in skills.status_posts[0]
+
+
+@dataclass
+class ClarificationNeededSkills(FakeSkills):
+    def infer_user_intent(self, run: Any, thread: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append("infer_user_intent")
+        return {
+            "is_mobile_bug": True,
+            "wants_linear": False,
+            "wants_fix": False,
+            "needs_clarification": True,
+            "confidence": 0.52,
+            "summary": "Android checkout report is missing reproduction details",
+            "missing_questions": ["Which app build and device reproduced this?"],
+        }
+
+    def create_or_update_linear(self, run: Any, thread: dict[str, Any], intent: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append("create_or_update_linear")
+        raise AssertionError("Monica must not file Linear before clarification")
+
+
+def test_clarification_needed_logs_triage_breadcrumbs(tmp_path, caplog):
+    config = MonicaConfig(enabled=True, rollout_mode="linear_only")
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="can you look into this checkout thing?",
+    )
+    skills = ClarificationNeededSkills()
+
+    with caplog.at_level(logging.INFO, logger="plugins.mobile_bug_agent.loop"):
+        MonicaLoop(config=config, state=state, skills=skills).run(run.id)
+
+    logs = "\n".join(record.getMessage() for record in caplog.records)
+    assert "event=needs_clarification" in logs
+    assert "stage=triaging" in logs
+    assert run.id in logs
+    assert "C_MOBILE" in logs
+    assert "1710000000.000100" in logs
+
+
+@dataclass
+class NonMobileBugSkills(FakeSkills):
+    def infer_user_intent(self, run: Any, thread: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append("infer_user_intent")
+        return {
+            "is_mobile_bug": False,
+            "wants_linear": False,
+            "wants_fix": False,
+            "needs_clarification": False,
+            "confidence": 0.24,
+            "summary": "Backend webhook discussion",
+            "reason": "The thread is about backend webhook delivery rather than the mobile app.",
+        }
+
+    def create_or_update_linear(self, run: Any, thread: dict[str, Any], intent: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append("create_or_update_linear")
+        raise AssertionError("Monica must not file Linear for non-mobile bugs")
+
+
+def test_not_mobile_bug_logs_blocked_breadcrumbs(tmp_path, caplog):
+    config = MonicaConfig(enabled=True, rollout_mode="linear_only")
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="can you clean up this webhook delivery bug?",
+    )
+    skills = NonMobileBugSkills()
+
+    with caplog.at_level(logging.INFO, logger="plugins.mobile_bug_agent.loop"):
+        MonicaLoop(config=config, state=state, skills=skills).run(run.id)
+
+    logs = "\n".join(record.getMessage() for record in caplog.records)
+    assert "event=blocked" in logs
+    assert "stage=triaging" in logs
+    assert "failure_reason=not_a_mobile_bug" in logs
+    assert run.id in logs
+    assert "C_MOBILE" in logs
+    assert "1710000000.000100" in logs
+
+
+@dataclass
+class QuestionOnlyBugSkills(FakeSkills):
+    def infer_user_intent(self, run: Any, thread: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append("infer_user_intent")
+        return {
+            "is_mobile_bug": True,
+            "wants_linear": False,
+            "wants_fix": False,
+            "needs_clarification": False,
+            "confidence": 0.86,
+            "summary": "Android checkout crash discussion",
+            "reason": "The thread is about a mobile bug, but the tag asks for thoughts only.",
+        }
+
+    def create_or_update_linear(self, run: Any, thread: dict[str, Any], intent: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append("create_or_update_linear")
+        raise AssertionError("Monica must not file Linear when the classifier says no action was requested")
+
+
+def test_question_only_mobile_bug_tag_asks_for_clarification_without_filing(tmp_path):
+    config = MonicaConfig(enabled=True, rollout_mode="linear_only")
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="any thoughts on this Android checkout crash?",
+    )
+    skills = QuestionOnlyBugSkills()
+
+    MonicaLoop(config=config, state=state, skills=skills).run(run.id)
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert updated.status == "needs_clarification"
+    assert updated.linear_identifier == ""
+    assert skills.calls == ["read_slack_thread", "infer_user_intent"]
+    assert "file a Linear issue or prepare a fix" in skills.status_posts[0]
+
+
+@dataclass
+class LinearOnlySkills(FakeSkills):
+    def create_or_update_linear(self, run: Any, thread: dict[str, Any], intent: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append("create_or_update_linear")
+        return {
+            "id": "issue-id",
+            "identifier": "MOB-123",
+            "url": "https://linear.app/acme/issue/MOB-123",
+            "dry_run": False,
+            "title": "[Mobile] Android checkout crashes after promo code",
+        }
+
+
+def test_linear_only_creates_ticket_without_waiting_for_code_approval(tmp_path):
+    config = MonicaConfig(enabled=True, rollout_mode="linear_only")
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="can you clean this Android checkout crash up?",
+    )
+    skills = LinearOnlySkills()
+
+    MonicaLoop(config=config, state=state, skills=skills).run(run.id)
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert updated.status == "done"
+    assert updated.linear_identifier == "MOB-123"
+    assert skills.calls == [
+        "read_slack_thread",
+        "infer_user_intent",
+        "create_or_update_linear",
+    ]
+    assert "Created Linear issue" in skills.status_posts[0]
+    assert "Code fixes are disabled" in skills.status_posts[0]
+
+
+def test_linear_only_logs_ticket_breadcrumbs(tmp_path, caplog):
+    config = MonicaConfig(enabled=True, rollout_mode="linear_only")
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="can you clean this Android checkout crash up?",
+    )
+    skills = LinearOnlySkills()
+
+    with caplog.at_level(logging.INFO, logger="plugins.mobile_bug_agent.loop"):
+        MonicaLoop(config=config, state=state, skills=skills).run(run.id)
+
+    logs = "\n".join(record.getMessage() for record in caplog.records)
+    assert "event=done" in logs
+    assert "stage=linear_only" in logs
+    assert run.id in logs
+    assert "C_MOBILE" in logs
+    assert "1710000000.000100" in logs
+    assert "MOB-123" in logs
+    assert "https://linear.app/acme/issue/MOB-123" in logs
+
+
+def test_approved_pr_creates_ticket_then_waits_for_approval_before_code(tmp_path):
+    config = MonicaConfig(enabled=True, rollout_mode="approved_pr")
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="can you clean this Android checkout crash up?",
+    )
+    skills = LinearOnlySkills()
+
+    MonicaLoop(config=config, state=state, skills=skills).run(run.id)
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert updated.status == "awaiting_fix_approval"
+    assert updated.linear_identifier == "MOB-123"
+    assert skills.calls == [
+        "read_slack_thread",
+        "infer_user_intent",
+        "create_or_update_linear",
+        "ask_fix_approval",
+    ]
+
+
+def test_approved_pr_logs_awaiting_approval_breadcrumbs(tmp_path, caplog):
+    config = MonicaConfig(enabled=True, rollout_mode="approved_pr")
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="can you clean this Android checkout crash up?",
+    )
+    skills = LinearOnlySkills()
+
+    with caplog.at_level(logging.INFO, logger="plugins.mobile_bug_agent.loop"):
+        MonicaLoop(config=config, state=state, skills=skills).run(run.id)
+
+    logs = "\n".join(record.getMessage() for record in caplog.records)
+    assert "event=awaiting_fix_approval" in logs
+    assert "stage=linear_created" in logs
+    assert run.id in logs
+    assert "C_MOBILE" in logs
+    assert "1710000000.000100" in logs
+    assert "MOB-123" in logs
+    assert "https://linear.app/acme/issue/MOB-123" in logs
+
+
+def test_approved_pr_still_requires_tagged_approval_when_config_disables_gate(tmp_path):
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="approved_pr",
+        loop=LoopConfig(require_fix_approval=False),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="can you clean this Android checkout crash up?",
+    )
+    skills = LinearOnlySkills()
+
+    MonicaLoop(config=config, state=state, skills=skills).run(run.id)
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert updated.status == "awaiting_fix_approval"
+    assert updated.approved_by_user_id == ""
+    assert skills.calls == [
+        "read_slack_thread",
+        "infer_user_intent",
+        "create_or_update_linear",
+        "ask_fix_approval",
+    ]
+
+
+@dataclass
+class FailingLinearSkills(FakeSkills):
+    def create_or_update_linear(self, run: Any, thread: dict[str, Any], intent: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append("create_or_update_linear")
+        raise RuntimeError("Linear write failed")
+
+
+@dataclass
+class SensitiveFailingLinearSkills(FakeSkills):
+    def create_or_update_linear(self, run: Any, thread: dict[str, Any], intent: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append("create_or_update_linear")
+        raise RuntimeError("Linear write failed at /Users/ritik/.hermes/secrets with xoxb-secret-token")
+
+
+def test_loop_marks_unexpected_linear_failure_with_stage(tmp_path):
+    config = MonicaConfig(enabled=True, rollout_mode="linear_only")
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="can you clean this Android checkout crash up?",
+    )
+    skills = FailingLinearSkills()
+
+    MonicaLoop(config=config, state=state, skills=skills).run(run.id)
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert updated.status == "failed"
+    assert updated.failure_reason == "creating_linear_failed: Linear write failed"
+    assert "Stage: creating_linear" in skills.status_posts[0]
+
+
+def test_loop_failure_status_does_not_post_sensitive_exception_details(tmp_path):
+    config = MonicaConfig(enabled=True, rollout_mode="linear_only")
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="can you clean this Android checkout crash up?",
+    )
+    skills = SensitiveFailingLinearSkills()
+
+    MonicaLoop(config=config, state=state, skills=skills).run(run.id)
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert updated.status == "failed"
+    assert updated.failure_reason == (
+        "creating_linear_failed: Linear write failed at /Users/ritik/.hermes/secrets "
+        "with xoxb-secret-token"
+    )
+    assert "Stage: creating_linear" in skills.status_posts[0]
+    assert "/Users/ritik/.hermes/secrets" not in skills.status_posts[0]
+    assert "xoxb-secret-token" not in skills.status_posts[0]
+    assert "Check Monica logs or `hermes mobile-bug-agent show" in skills.status_posts[0]
+
+
+@dataclass
+class ApprovedFixSkills(FakeSkills):
+    verification_passed: bool = True
+    proof_passed: bool = True
+    proof_artifacts: tuple[str, ...] = ("/tmp/monica-proof/screenshot.png",)
+
+    def run_internal_codex_worker(self, run: Any) -> dict[str, Any]:
+        self.calls.append("run_internal_codex_worker")
+        return {"branch_name": "monica/MOB-123-checkout-crash", "changed": True}
+
+    def run_verification(self, run: Any, worker_result: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append("run_verification")
+        return {"passed": self.verification_passed, "summary": "npm test"}
+
+    def run_proof(
+        self,
+        run: Any,
+        worker_result: dict[str, Any],
+        verification: dict[str, Any],
+    ) -> dict[str, Any]:
+        self.calls.append("run_proof")
+        return {
+            "passed": self.proof_passed,
+            "summary": "Simulator proof captured." if self.proof_passed else "simctl is unavailable",
+            "artifacts": list(self.proof_artifacts),
+            "output": "",
+        }
+
+    def open_draft_pr(
+        self,
+        run: Any,
+        worker_result: dict[str, Any],
+        verification: dict[str, Any],
+    ) -> dict[str, Any]:
+        self.calls.append("open_draft_pr")
+        return {"url": "https://github.com/example/mobile/pull/123"}
+
+
+def test_approved_run_writes_code_then_opens_draft_pr(tmp_path):
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="approved_pr",
+        verification=VerificationConfig(commands=("npm test",)),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    state.approve_fix(run.id, approved_by_user_id="U_TAGGER")
+    skills = ApprovedFixSkills()
+
+    MonicaLoop(config=config, state=state, skills=skills).run(run.id)
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert updated.status == "done"
+    assert updated.branch_name == "monica/MOB-123-checkout-crash"
+    assert updated.pr_url == "https://github.com/example/mobile/pull/123"
+    assert skills.calls == ["run_internal_codex_worker", "run_verification", "open_draft_pr"]
+
+
+def test_local_fix_only_run_writes_code_and_stops_before_pr(tmp_path):
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="local_fix_only",
+        verification=VerificationConfig(commands=("npm test",)),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    state.approve_fix(run.id, approved_by_user_id="U_TAGGER")
+    skills = ApprovedFixSkills()
+
+    MonicaLoop(config=config, state=state, skills=skills).run(run.id)
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert updated.status == "done"
+    assert updated.branch_name == "monica/MOB-123-checkout-crash"
+    assert updated.pr_url == ""
+    assert skills.calls == ["run_internal_codex_worker", "run_verification"]
+    assert "Local fix is ready" in skills.status_posts[0]
+    assert "not pushed" in skills.status_posts[0]
+
+
+def test_local_fix_only_requires_proof_before_done_when_configured(tmp_path):
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="local_fix_only",
+        verification=VerificationConfig(commands=("npm test",)),
+        proof=ProofConfig(enabled=True, required_for_done=True),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    state.approve_fix(run.id, approved_by_user_id="U_TAGGER")
+    skills = ApprovedFixSkills(proof_passed=False, proof_artifacts=())
+
+    MonicaLoop(config=config, state=state, skills=skills).run(run.id)
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert updated.status == "proof_blocked"
+    assert updated.branch_name == "monica/MOB-123-checkout-crash"
+    assert updated.pr_url == ""
+    assert updated.failure_reason == "proof_unavailable: simctl is unavailable"
+    assert skills.calls == ["run_internal_codex_worker", "run_verification", "run_proof"]
+    assert "Verification passed" in skills.status_posts[0]
+    assert "proof is unavailable" in skills.status_posts[0]
+    assert "not mark this run done" in skills.status_posts[0]
+
+
+def test_local_fix_only_marks_done_after_required_proof_artifact(tmp_path):
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="local_fix_only",
+        verification=VerificationConfig(commands=("npm test",)),
+        proof=ProofConfig(enabled=True, required_for_done=True),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    state.approve_fix(run.id, approved_by_user_id="U_TAGGER")
+    skills = ApprovedFixSkills()
+
+    MonicaLoop(config=config, state=state, skills=skills).run(run.id)
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert updated.status == "done"
+    assert updated.branch_name == "monica/MOB-123-checkout-crash"
+    assert updated.pr_url == ""
+    assert skills.calls == ["run_internal_codex_worker", "run_verification", "run_proof"]
+    assert "Proof captured" in skills.status_posts[0]
+    assert "/tmp/monica-proof/screenshot.png" in skills.status_posts[0]
+
+
+def test_approved_pr_requires_proof_before_opening_pr_when_configured(tmp_path):
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="approved_pr",
+        verification=VerificationConfig(commands=("npm test",)),
+        proof=ProofConfig(enabled=True, required_for_done=True),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    state.approve_fix(run.id, approved_by_user_id="U_TAGGER")
+    skills = ApprovedFixSkills(proof_passed=True, proof_artifacts=())
+
+    MonicaLoop(config=config, state=state, skills=skills).run(run.id)
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert updated.status == "proof_blocked"
+    assert updated.pr_url == ""
+    assert updated.failure_reason == "proof_unavailable: Simulator proof captured."
+    assert skills.calls == ["run_internal_codex_worker", "run_verification", "run_proof"]
+
+
+def test_local_fix_only_creates_ticket_then_waits_for_approval_before_code(tmp_path):
+    config = MonicaConfig(enabled=True, rollout_mode="local_fix_only")
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    skills = LinearOnlySkills()
+
+    MonicaLoop(config=config, state=state, skills=skills).run(run.id)
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert updated.status == "awaiting_fix_approval"
+    assert updated.linear_identifier == "MOB-123"
+    assert skills.calls == ["read_slack_thread", "infer_user_intent", "create_or_update_linear", "ask_fix_approval"]
+
+
+def test_approved_run_logs_operator_breadcrumbs(tmp_path, caplog):
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="approved_pr",
+        verification=VerificationConfig(commands=("npm test",)),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(
+        run.id,
+        status="awaiting_fix_approval",
+        linear_identifier="MOB-123",
+        linear_url="https://linear.app/acme/issue/MOB-123",
+    )
+    state.approve_fix(run.id, approved_by_user_id="U_TAGGER")
+    skills = ApprovedFixSkills()
+
+    with caplog.at_level(logging.INFO, logger="plugins.mobile_bug_agent.loop"):
+        MonicaLoop(config=config, state=state, skills=skills).run(run.id)
+
+    logs = "\n".join(record.getMessage() for record in caplog.records)
+    assert run.id in logs
+    assert "C_MOBILE" in logs
+    assert "1710000000.000100" in logs
+    assert "MOB-123" in logs
+    assert "monica/MOB-123-checkout-crash" in logs
+    assert "https://github.com/example/mobile/pull/123" in logs
+
+
+def test_approved_run_does_not_write_code_outside_approved_pr_rollout(tmp_path):
+    config = MonicaConfig(enabled=True, rollout_mode="linear_only")
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    state.approve_fix(run.id, approved_by_user_id="U_TAGGER")
+    skills = ApprovedFixSkills()
+
+    MonicaLoop(config=config, state=state, skills=skills).run(run.id)
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert updated.status == "blocked"
+    assert updated.failure_reason == "approved_pr_rollout_not_enabled"
+    assert skills.calls == []
+
+
+def test_approved_run_outside_approved_pr_rollout_logs_blocked_breadcrumbs(tmp_path, caplog):
+    config = MonicaConfig(enabled=True, rollout_mode="linear_only")
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    state.approve_fix(run.id, approved_by_user_id="U_TAGGER")
+    skills = ApprovedFixSkills()
+
+    with caplog.at_level(logging.INFO, logger="plugins.mobile_bug_agent.loop"):
+        MonicaLoop(config=config, state=state, skills=skills).run(run.id)
+
+    logs = "\n".join(record.getMessage() for record in caplog.records)
+    assert "event=blocked" in logs
+    assert "stage=preflight" in logs
+    assert "failure_reason=approved_pr_rollout_not_enabled" in logs
+    assert run.id in logs
+    assert "C_MOBILE" in logs
+    assert "1710000000.000100" in logs
+    assert "MOB-123" in logs
+
+
+def test_approved_run_does_not_write_code_without_linear_issue(tmp_path):
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="approved_pr",
+        verification=VerificationConfig(commands=("npm test",)),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval")
+    state.approve_fix(run.id, approved_by_user_id="U_TAGGER")
+    skills = ApprovedFixSkills()
+
+    MonicaLoop(config=config, state=state, skills=skills).run(run.id)
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert updated.status == "blocked"
+    assert updated.failure_reason == "linear_issue_missing_before_fix"
+    assert skills.calls == []
+    assert "Linear issue" in skills.status_posts[0]
+
+
+def test_approved_run_does_not_write_code_without_verification_commands(tmp_path):
+    config = MonicaConfig(enabled=True, rollout_mode="approved_pr")
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    state.approve_fix(run.id, approved_by_user_id="U_TAGGER")
+    skills = ApprovedFixSkills()
+
+    MonicaLoop(config=config, state=state, skills=skills).run(run.id)
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert updated.status == "blocked"
+    assert updated.failure_reason == "verification_commands_missing"
+    assert skills.calls == []
+    assert "verification.commands" in skills.status_posts[0]
+
+
+@dataclass
+class MissingBranchFixSkills(ApprovedFixSkills):
+    def run_internal_codex_worker(self, run: Any) -> dict[str, Any]:
+        self.calls.append("run_internal_codex_worker")
+        return {"changed": True, "summary": "Patched checkout crash"}
+
+
+def test_approved_run_blocks_when_worker_returns_no_branch(tmp_path):
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="approved_pr",
+        verification=VerificationConfig(commands=("npm test",)),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    state.approve_fix(run.id, approved_by_user_id="U_TAGGER")
+    skills = MissingBranchFixSkills()
+
+    MonicaLoop(config=config, state=state, skills=skills).run(run.id)
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert updated.status == "blocked"
+    assert updated.failure_reason == "worker_branch_missing"
+    assert updated.branch_name == ""
+    assert updated.pr_url == ""
+    assert skills.calls == ["run_internal_codex_worker"]
+    assert "could not identify a branch" in skills.status_posts[0]
+
+
+@dataclass
+class MismatchedBranchFixSkills(ApprovedFixSkills):
+    def run_internal_codex_worker(self, run: Any) -> dict[str, Any]:
+        self.calls.append("run_internal_codex_worker")
+        return {
+            "branch_name": "chandler/MOB-123-checkout-crash",
+            "changed": True,
+            "summary": "Patched checkout crash",
+        }
+
+
+def test_approved_run_blocks_when_worker_returns_mismatched_branch(tmp_path):
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="approved_pr",
+        verification=VerificationConfig(commands=("npm test",)),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    state.approve_fix(run.id, approved_by_user_id="U_TAGGER")
+    skills = MismatchedBranchFixSkills()
+
+    MonicaLoop(config=config, state=state, skills=skills).run(run.id)
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert updated.status == "blocked"
+    assert updated.failure_reason == "worker_branch_mismatch"
+    assert updated.branch_name == ""
+    assert updated.pr_url == ""
+    assert skills.calls == ["run_internal_codex_worker"]
+    assert "unexpected branch" in skills.status_posts[0]
+
+
+@dataclass
+class NoChangeFixSkills(ApprovedFixSkills):
+    def run_internal_codex_worker(self, run: Any) -> dict[str, Any]:
+        self.calls.append("run_internal_codex_worker")
+        return {
+            "branch_name": "monica/MOB-123-checkout-crash",
+            "changed": False,
+            "summary": "The worker did not make code changes.",
+        }
+
+
+def test_approved_run_blocks_when_worker_reports_no_changes(tmp_path):
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="approved_pr",
+        verification=VerificationConfig(commands=("npm test",)),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    state.approve_fix(run.id, approved_by_user_id="U_TAGGER")
+    skills = NoChangeFixSkills()
+
+    MonicaLoop(config=config, state=state, skills=skills).run(run.id)
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert updated.status == "blocked"
+    assert updated.failure_reason == "worker_no_changes"
+    assert updated.branch_name == "monica/MOB-123-checkout-crash"
+    assert updated.pr_url == ""
+    assert skills.calls == ["run_internal_codex_worker"]
+    assert "did not report any code changes" in skills.status_posts[0]
+
+
+def test_failed_verification_blocks_draft_pr(tmp_path, caplog):
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="approved_pr",
+        verification=VerificationConfig(commands=("npm test",)),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(
+        run.id,
+        status="awaiting_fix_approval",
+        linear_identifier="MOB-123",
+        linear_url="https://linear.app/acme/issue/MOB-123",
+    )
+    state.approve_fix(run.id, approved_by_user_id="U_TAGGER")
+    skills = ApprovedFixSkills(verification_passed=False)
+
+    with caplog.at_level(logging.INFO, logger="plugins.mobile_bug_agent.loop"):
+        MonicaLoop(config=config, state=state, skills=skills).run(run.id)
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert updated.status == "blocked"
+    assert updated.pr_url == ""
+    assert "verification_failed" in updated.failure_reason
+    assert skills.calls == ["run_internal_codex_worker", "run_verification"]
+    assert "Verification failed, so I did not open a PR." in skills.status_posts[0]
+    logs = "\n".join(record.getMessage() for record in caplog.records)
+    assert "event=blocked" in logs
+    assert "stage=verifying" in logs
+    assert run.id in logs
+    assert "C_MOBILE" in logs
+    assert "1710000000.000100" in logs
+    assert "MOB-123" in logs
+    assert "https://linear.app/acme/issue/MOB-123" in logs
+    assert "monica/MOB-123-checkout-crash" in logs
+    assert "verification_failed: npm test" in logs
+
+
+@dataclass
+class FailingPrSkills(ApprovedFixSkills):
+    def open_draft_pr(
+        self,
+        run: Any,
+        worker_result: dict[str, Any],
+        verification: dict[str, Any],
+    ) -> dict[str, Any]:
+        self.calls.append("open_draft_pr")
+        raise RuntimeError("gh pr create failed")
+
+
+@dataclass
+class MissingPrUrlSkills(ApprovedFixSkills):
+    def open_draft_pr(
+        self,
+        run: Any,
+        worker_result: dict[str, Any],
+        verification: dict[str, Any],
+    ) -> dict[str, Any]:
+        self.calls.append("open_draft_pr")
+        return {"url": ""}
+
+
+@dataclass
+class CancellingPrSkills(ApprovedFixSkills):
+    state: MonicaState | None = None
+
+    def open_draft_pr(
+        self,
+        run: Any,
+        worker_result: dict[str, Any],
+        verification: dict[str, Any],
+    ) -> dict[str, Any]:
+        self.calls.append("open_draft_pr")
+        assert self.state is not None
+        self.state.update_run(
+            run.id,
+            status="blocked",
+            failure_reason="cancelled by U_APPROVER",
+        )
+        return {"url": "https://github.com/example/mobile/pull/123"}
+
+
+def test_loop_does_not_overwrite_cancellation_during_pr_opening(tmp_path):
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="approved_pr",
+        verification=VerificationConfig(commands=("npm test",)),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    state.approve_fix(run.id, approved_by_user_id="U_TAGGER")
+    skills = CancellingPrSkills(state=state)
+
+    MonicaLoop(config=config, state=state, skills=skills).run(run.id)
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert updated.status == "blocked"
+    assert updated.failure_reason == "cancelled by U_APPROVER"
+    assert updated.pr_url == "https://github.com/example/mobile/pull/123"
+    assert skills.calls == ["run_internal_codex_worker", "run_verification", "open_draft_pr"]
+    assert not any("Draft PR is ready" in post for post in skills.status_posts)
+
+
+def test_loop_blocks_when_pr_publisher_returns_no_url(tmp_path):
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="approved_pr",
+        verification=VerificationConfig(commands=("npm test",)),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    state.approve_fix(run.id, approved_by_user_id="U_TAGGER")
+    skills = MissingPrUrlSkills()
+
+    MonicaLoop(config=config, state=state, skills=skills).run(run.id)
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert updated.status == "blocked"
+    assert updated.failure_reason == "draft_pr_url_missing"
+    assert updated.pr_url == ""
+    assert skills.calls == ["run_internal_codex_worker", "run_verification", "open_draft_pr"]
+    assert "did not return a draft PR URL" in skills.status_posts[0]
+
+
+def test_loop_marks_unexpected_pr_failure_with_stage(tmp_path):
+    config = MonicaConfig(
+        enabled=True,
+        rollout_mode="approved_pr",
+        verification=VerificationConfig(commands=("npm test",)),
+    )
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C_MOBILE",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000200",
+        user_id="U_TAGGER",
+        request_text="can you fix this Android checkout crash?",
+    )
+    state.update_run(run.id, status="awaiting_fix_approval", linear_identifier="MOB-123")
+    state.approve_fix(run.id, approved_by_user_id="U_TAGGER")
+    skills = FailingPrSkills()
+
+    MonicaLoop(config=config, state=state, skills=skills).run(run.id)
+
+    updated = state.get_run(run.id)
+    assert updated is not None
+    assert updated.status == "failed"
+    assert updated.failure_reason == "opening_pr_failed: gh pr create failed"
+    assert skills.calls == ["run_internal_codex_worker", "run_verification", "open_draft_pr"]
+    assert "Stage: opening_pr" in skills.status_posts[0]

--- a/tests/plugins/mobile_bug_agent/test_plugin_registration.py
+++ b/tests/plugins/mobile_bug_agent/test_plugin_registration.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from pathlib import Path
+
+import yaml
+
+import plugins.mobile_bug_agent as monica_plugin
+from gateway.config import Platform
+from plugins.mobile_bug_agent import register
+from plugins.mobile_bug_agent.config import MonicaConfig, SlackConfig
+
+SAFE_RUNTIME_UNAVAILABLE_TEXT = (
+    "Monica could not start because her runtime is not configured correctly. "
+    "Run `hermes mobile-bug-agent doctor` on the host for details."
+)
+
+
+class FakeContext:
+    def __init__(self) -> None:
+        self.cli_commands: list[dict] = []
+        self.hooks: list[str] = []
+
+    def register_cli_command(self, **kwargs):
+        self.cli_commands.append(kwargs)
+
+    def register_hook(self, name, fn):
+        self.hooks.append(name)
+
+
+def test_plugin_registers_cli_and_gateway_hook():
+    ctx = FakeContext()
+
+    register(ctx)
+
+    assert [cmd["name"] for cmd in ctx.cli_commands] == ["mobile-bug-agent"]
+    assert ctx.cli_commands[0]["help"] == "Inspect and operate Monica mobile bug loops"
+    assert ctx.hooks == ["pre_gateway_dispatch"]
+
+
+def test_plugin_manifest_points_to_operator_docs():
+    manifest_path = Path(__file__).resolve().parents[3] / "plugins" / "mobile_bug_agent" / "plugin.yaml"
+    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+
+    assert "docs/monica-agent.md" in manifest["description"]
+
+
+def test_bundled_plugin_loads_when_enabled(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes_home"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"plugins": {"enabled": ["mobile-bug-agent"]}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from hermes_cli.plugins import PluginManager
+
+    manager = PluginManager()
+    manager.discover_and_load()
+
+    loaded = manager._plugins["mobile-bug-agent"]
+    assert loaded.enabled
+    assert loaded.manifest.source == "bundled"
+    assert "pre_gateway_dispatch" in loaded.hooks_registered
+    assert "mobile-bug-agent" in manager._cli_commands
+
+
+def test_bundled_plugin_is_opt_in(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes_home"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"plugins": {"enabled": []}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from hermes_cli.plugins import PluginManager
+
+    manager = PluginManager()
+    manager.discover_and_load()
+
+    loaded = manager._plugins["mobile-bug-agent"]
+    assert not loaded.enabled
+    assert "not enabled" in str(loaded.error)
+
+
+def test_pre_gateway_dispatch_reports_runtime_bootstrap_failure(monkeypatch):
+    monica_plugin._runtime.cache_clear()
+    monkeypatch.setattr(monica_plugin, "load_monica_config", lambda: MonicaConfig(enabled=True))
+    monkeypatch.setattr(
+        monica_plugin,
+        "runtime_root",
+        lambda config: (_ for _ in ()).throw(ValueError("bad Monica runtime root")),
+    )
+    event = SimpleNamespace(
+        source=SimpleNamespace(platform=Platform.SLACK),
+        raw_message={"type": "app_mention", "text": "<@U_MONICA> checkout crash"},
+    )
+
+    try:
+        result = monica_plugin._on_pre_gateway_dispatch(event)
+    finally:
+        monica_plugin._runtime.cache_clear()
+
+    assert result == {
+        "action": "skip_reply",
+        "reason": "monica_runtime_unavailable",
+        "text": SAFE_RUNTIME_UNAVAILABLE_TEXT,
+    }
+
+
+def test_pre_gateway_dispatch_runtime_failure_does_not_leak_raw_exception_details(monkeypatch):
+    monica_plugin._runtime.cache_clear()
+    monkeypatch.setattr(monica_plugin, "load_monica_config", lambda: MonicaConfig(enabled=True))
+    monkeypatch.setattr(
+        monica_plugin,
+        "runtime_root",
+        lambda config: (_ for _ in ()).throw(ValueError("/Users/ritik/.hermes/secrets")),
+    )
+    event = SimpleNamespace(
+        source=SimpleNamespace(platform=Platform.SLACK),
+        raw_message={"type": "app_mention", "text": "<@U_MONICA> checkout crash"},
+    )
+
+    try:
+        result = monica_plugin._on_pre_gateway_dispatch(event)
+    finally:
+        monica_plugin._runtime.cache_clear()
+
+    assert result is not None
+    assert result["action"] == "skip_reply"
+    assert result["reason"] == "monica_runtime_unavailable"
+    assert result["text"] == SAFE_RUNTIME_UNAVAILABLE_TEXT
+    assert "/Users/ritik/.hermes/secrets" not in result["text"]
+
+
+def test_pre_gateway_dispatch_runtime_failure_catches_configured_message_mention(monkeypatch):
+    monica_plugin._runtime.cache_clear()
+    monkeypatch.setattr(
+        monica_plugin,
+        "load_monica_config",
+        lambda: MonicaConfig(enabled=True, slack=SlackConfig(bot_user_ids=("U_MONICA",))),
+    )
+    monkeypatch.setattr(
+        monica_plugin,
+        "runtime_root",
+        lambda config: (_ for _ in ()).throw(ValueError("bad Monica runtime root")),
+    )
+    event = SimpleNamespace(
+        source=SimpleNamespace(platform=Platform.SLACK),
+        raw_message={"type": "message", "text": "<@U_MONICA> checkout crash"},
+    )
+
+    try:
+        result = monica_plugin._on_pre_gateway_dispatch(event)
+    finally:
+        monica_plugin._runtime.cache_clear()
+
+    assert result == {
+        "action": "skip_reply",
+        "reason": "monica_runtime_unavailable",
+        "text": SAFE_RUNTIME_UNAVAILABLE_TEXT,
+    }
+
+
+def test_pre_gateway_dispatch_runtime_failure_ignores_other_app_mentions_when_configured(
+    monkeypatch,
+):
+    monica_plugin._runtime.cache_clear()
+    monkeypatch.setattr(
+        monica_plugin,
+        "load_monica_config",
+        lambda: MonicaConfig(enabled=True, slack=SlackConfig(bot_user_ids=("U_MONICA",))),
+    )
+    monkeypatch.setattr(
+        monica_plugin,
+        "runtime_root",
+        lambda config: (_ for _ in ()).throw(ValueError("bad Monica runtime root")),
+    )
+    event = SimpleNamespace(
+        source=SimpleNamespace(platform=Platform.SLACK),
+        raw_message={"type": "app_mention", "text": "<@U_CHANDLER> checkout crash"},
+    )
+
+    try:
+        result = monica_plugin._on_pre_gateway_dispatch(event)
+    finally:
+        monica_plugin._runtime.cache_clear()
+
+    assert result is None
+
+
+def test_pre_gateway_dispatch_runtime_failure_catches_punctuated_message_mention(monkeypatch):
+    monica_plugin._runtime.cache_clear()
+    monkeypatch.setattr(
+        monica_plugin,
+        "load_monica_config",
+        lambda: MonicaConfig(enabled=True, slack=SlackConfig(bot_user_ids=("U_MONICA",))),
+    )
+    monkeypatch.setattr(
+        monica_plugin,
+        "runtime_root",
+        lambda config: (_ for _ in ()).throw(ValueError("bad Monica runtime root")),
+    )
+    event = SimpleNamespace(
+        source=SimpleNamespace(platform=Platform.SLACK),
+        raw_message={"type": "message", "text": "<@U_MONICA>, checkout crash"},
+    )
+
+    try:
+        result = monica_plugin._on_pre_gateway_dispatch(event)
+    finally:
+        monica_plugin._runtime.cache_clear()
+
+    assert result == {
+        "action": "skip_reply",
+        "reason": "monica_runtime_unavailable",
+        "text": SAFE_RUNTIME_UNAVAILABLE_TEXT,
+    }
+
+
+def test_pre_gateway_dispatch_runtime_failure_catches_direct_message(monkeypatch):
+    monica_plugin._runtime.cache_clear()
+    monkeypatch.setattr(monica_plugin, "load_monica_config", lambda: MonicaConfig(enabled=True))
+    monkeypatch.setattr(
+        monica_plugin,
+        "runtime_root",
+        lambda config: (_ for _ in ()).throw(ValueError("bad Monica runtime root")),
+    )
+    event = SimpleNamespace(
+        source=SimpleNamespace(platform=Platform.SLACK, chat_id="D_MONICA", chat_type="dm"),
+        raw_message={
+            "type": "message",
+            "channel_type": "im",
+            "text": "checkout crash",
+        },
+    )
+
+    try:
+        result = monica_plugin._on_pre_gateway_dispatch(event)
+    finally:
+        monica_plugin._runtime.cache_clear()
+
+    assert result == {
+        "action": "skip_reply",
+        "reason": "monica_runtime_unavailable",
+        "text": SAFE_RUNTIME_UNAVAILABLE_TEXT,
+    }
+
+
+def test_pre_gateway_dispatch_runtime_failure_ignores_group_dm_without_mention(monkeypatch):
+    monica_plugin._runtime.cache_clear()
+    monkeypatch.setattr(monica_plugin, "load_monica_config", lambda: MonicaConfig(enabled=True))
+    monkeypatch.setattr(
+        monica_plugin,
+        "runtime_root",
+        lambda config: (_ for _ in ()).throw(ValueError("bad Monica runtime root")),
+    )
+    event = SimpleNamespace(
+        source=SimpleNamespace(platform=Platform.SLACK, chat_id="G_MONICA", chat_type="dm"),
+        raw_message={
+            "type": "message",
+            "channel_type": "mpim",
+            "text": "checkout crash",
+        },
+    )
+
+    try:
+        result = monica_plugin._on_pre_gateway_dispatch(event)
+    finally:
+        monica_plugin._runtime.cache_clear()
+
+    assert result is None

--- a/tests/plugins/mobile_bug_agent/test_pr_publisher.py
+++ b/tests/plugins/mobile_bug_agent/test_pr_publisher.py
@@ -1,0 +1,550 @@
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from plugins.mobile_bug_agent.pr_publisher import DraftPrPublisher, DraftPrPublisherError
+
+
+VALID_PR_BODY = """## Links
+- Linear: https://linear.app/acme/issue/MOB-42
+- Slack: https://example.slack.com/archives/C_MOBILE/p1710000000000200
+
+## Verification
+Verification passed.
+
+## Proof
+- /tmp/monica-proof/screenshot.png
+"""
+
+
+def _mark_git_worktree(path):
+    (path / ".git").write_text("gitdir: /tmp/fake-mobile-worktree-git-dir", encoding="utf-8")
+    return path
+
+
+def test_publisher_commits_pushes_and_creates_draft_pr(tmp_path):
+    calls = []
+
+    def run_command(args, cwd=None):
+        calls.append((args, cwd))
+        if args == ["git", "branch", "--show-current"]:
+            return "monica/MOB-42-checkout-crash\n"
+        if args == ["git", "status", "--porcelain"]:
+            return " M src/Checkout.tsx\n"
+        if args[:3] == ["git", "diff", "--name-only"]:
+            return "src/Checkout.tsx\n"
+        if args[:4] == ["gh", "pr", "create", "--draft"]:
+            return "https://github.com/acme/mobile/pull/123\n"
+        return ""
+
+    publisher = DraftPrPublisher(run_command=run_command)
+
+    url = publisher.publish(
+        worktree=_mark_git_worktree(tmp_path),
+        branch_name="monica/MOB-42-checkout-crash",
+        base_branch="main",
+        title="[MOB-42] Fix Android checkout crash",
+        body=VALID_PR_BODY,
+    )
+
+    assert url == "https://github.com/acme/mobile/pull/123"
+    assert calls[0][0] == ["git", "branch", "--show-current"]
+    assert calls[1][0] == ["git", "status", "--porcelain"]
+    assert calls[2][0] == ["git", "add", "-A"]
+    assert calls[3][0] == [
+        "git",
+        "-c",
+        "user.name=Monica",
+        "-c",
+        "user.email=monica@hermes.local",
+        "commit",
+        "-m",
+        "[MOB-42] Fix Android checkout crash",
+    ]
+    assert calls[4][0] == ["git", "diff", "--name-only", "origin/main...HEAD"]
+    assert calls[5][0] == ["git", "push", "origin", "HEAD:monica/MOB-42-checkout-crash"]
+    assert calls[6][0][:4] == ["gh", "pr", "create", "--draft"]
+    assert calls[6][1] == tmp_path
+
+
+def test_publisher_refuses_noop_draft_pr(tmp_path):
+    calls = []
+
+    def run_command(args, cwd=None):
+        calls.append((args, cwd))
+        if args == ["git", "branch", "--show-current"]:
+            return "monica/MOB-42-checkout-crash\n"
+        if args == ["git", "status", "--porcelain"]:
+            return ""
+        if args[:3] == ["git", "diff", "--name-only"]:
+            return ""
+        return ""
+
+    publisher = DraftPrPublisher(run_command=run_command)
+
+    with pytest.raises(DraftPrPublisherError, match="No committed changes"):
+        publisher.publish(
+            worktree=_mark_git_worktree(tmp_path),
+            branch_name="monica/MOB-42-checkout-crash",
+            base_branch="main",
+            title="[MOB-42] Fix Android checkout crash",
+            body=VALID_PR_BODY,
+        )
+
+    assert [call[0][0:2] for call in calls] == [
+        ["git", "branch"],
+        ["git", "status"],
+        ["git", "diff"],
+    ]
+
+
+def test_publisher_requires_branch_before_running_commands(tmp_path):
+    calls = []
+
+    def run_command(args, cwd=None):
+        calls.append((args, cwd))
+        return ""
+
+    publisher = DraftPrPublisher(run_command=run_command)
+
+    with pytest.raises(DraftPrPublisherError, match="branch_name is required"):
+        publisher.publish(
+            worktree=tmp_path,
+            branch_name="",
+            base_branch="main",
+            title="[MOB-42] Fix Android checkout crash",
+            body=VALID_PR_BODY,
+        )
+
+    assert calls == []
+
+
+def test_publisher_requires_title_before_running_commands(tmp_path):
+    calls = []
+
+    def run_command(args, cwd=None):
+        calls.append((args, cwd))
+        return ""
+
+    publisher = DraftPrPublisher(run_command=run_command)
+
+    with pytest.raises(DraftPrPublisherError, match="title is required"):
+        publisher.publish(
+            worktree=tmp_path,
+            branch_name="monica/MOB-42-checkout-crash",
+            base_branch="main",
+            title="   ",
+            body=VALID_PR_BODY,
+        )
+
+    assert calls == []
+
+
+def test_publisher_requires_body_before_running_commands(tmp_path):
+    calls = []
+
+    def run_command(args, cwd=None):
+        calls.append((args, cwd))
+        return ""
+
+    publisher = DraftPrPublisher(run_command=run_command)
+
+    with pytest.raises(DraftPrPublisherError, match="body is required"):
+        publisher.publish(
+            worktree=tmp_path,
+            branch_name="monica/MOB-42-checkout-crash",
+            base_branch="main",
+            title="[MOB-42] Fix Android checkout crash",
+            body="",
+        )
+
+    assert calls == []
+
+
+def test_publisher_requires_linear_reference_before_running_commands(tmp_path):
+    calls = []
+
+    def run_command(args, cwd=None):
+        calls.append((args, cwd))
+        return ""
+
+    publisher = DraftPrPublisher(run_command=run_command)
+
+    with pytest.raises(DraftPrPublisherError, match="body must include Linear"):
+        publisher.publish(
+            worktree=tmp_path,
+            branch_name="monica/MOB-42-checkout-crash",
+            base_branch="main",
+            title="[MOB-42] Fix Android checkout crash",
+            body="""## Links
+- Slack: https://example.slack.com/archives/C_MOBILE/p1710000000000200
+
+## Verification
+Verification passed.
+""",
+        )
+
+    assert calls == []
+
+
+def test_publisher_requires_slack_reference_before_running_commands(tmp_path):
+    calls = []
+
+    def run_command(args, cwd=None):
+        calls.append((args, cwd))
+        return ""
+
+    publisher = DraftPrPublisher(run_command=run_command)
+
+    with pytest.raises(DraftPrPublisherError, match="body must include Slack"):
+        publisher.publish(
+            worktree=tmp_path,
+            branch_name="monica/MOB-42-checkout-crash",
+            base_branch="main",
+            title="[MOB-42] Fix Android checkout crash",
+            body="""## Links
+- Linear: https://linear.app/acme/issue/MOB-42
+
+## Verification
+Verification passed.
+""",
+        )
+
+    assert calls == []
+
+
+def test_publisher_requires_verification_evidence_before_running_commands(tmp_path):
+    calls = []
+
+    def run_command(args, cwd=None):
+        calls.append((args, cwd))
+        return ""
+
+    publisher = DraftPrPublisher(run_command=run_command)
+
+    with pytest.raises(DraftPrPublisherError, match="body must include verification"):
+        publisher.publish(
+            worktree=tmp_path,
+            branch_name="monica/MOB-42-checkout-crash",
+            base_branch="main",
+            title="[MOB-42] Fix Android checkout crash",
+            body="""## Links
+- Linear: https://linear.app/acme/issue/MOB-42
+- Slack: https://example.slack.com/archives/C_MOBILE/p1710000000000200
+""",
+        )
+
+    assert calls == []
+
+
+def test_publisher_requires_proof_evidence_before_running_commands(tmp_path):
+    calls = []
+
+    def run_command(args, cwd=None):
+        calls.append((args, cwd))
+        return ""
+
+    publisher = DraftPrPublisher(run_command=run_command)
+
+    with pytest.raises(DraftPrPublisherError, match="body must include proof"):
+        publisher.publish(
+            worktree=tmp_path,
+            branch_name="monica/MOB-42-checkout-crash",
+            base_branch="main",
+            title="[MOB-42] Fix Android checkout crash",
+            body="""## Links
+- Linear: https://linear.app/acme/issue/MOB-42
+- Slack: https://example.slack.com/archives/C_MOBILE/p1710000000000200
+
+## Verification
+Verification passed.
+""",
+        )
+
+    assert calls == []
+
+
+def test_publisher_accepts_fenced_verification_output(tmp_path):
+    calls = []
+
+    def run_command(args, cwd=None):
+        calls.append((args, cwd))
+        if args == ["git", "branch", "--show-current"]:
+            return "monica/MOB-42-checkout-crash\n"
+        if args == ["git", "status", "--porcelain"]:
+            return ""
+        if args[:3] == ["git", "diff", "--name-only"]:
+            return "src/Checkout.tsx\n"
+        if args[:4] == ["gh", "pr", "create", "--draft"]:
+            return "https://github.com/acme/mobile/pull/123\n"
+        return ""
+
+    publisher = DraftPrPublisher(run_command=run_command)
+
+    url = publisher.publish(
+        worktree=_mark_git_worktree(tmp_path),
+        branch_name="monica/MOB-42-checkout-crash",
+        base_branch="main",
+        title="[MOB-42] Fix Android checkout crash",
+        body="""## Links
+- Linear: https://linear.app/acme/issue/MOB-42
+- Slack: https://example.slack.com/archives/C_MOBILE/p1710000000000200
+
+## Verification
+
+```
+$ npm test
+ok
+```
+
+## Proof
+- /tmp/monica-proof/screenshot.png
+""",
+    )
+
+    assert url == "https://github.com/acme/mobile/pull/123"
+    assert calls[0][0] == ["git", "branch", "--show-current"]
+
+
+def test_publisher_rejects_unsafe_base_branch_before_running_commands(tmp_path):
+    calls = []
+
+    def run_command(args, cwd=None):
+        calls.append((args, cwd))
+        return ""
+
+    publisher = DraftPrPublisher(run_command=run_command)
+
+    with pytest.raises(DraftPrPublisherError, match="base_branch must be a safe git branch name"):
+        publisher.publish(
+            worktree=tmp_path,
+            branch_name="monica/MOB-42-checkout-crash",
+            base_branch="../main",
+            title="[MOB-42] Fix Android checkout crash",
+            body=VALID_PR_BODY,
+        )
+
+    assert calls == []
+
+
+def test_publisher_rejects_unsafe_head_branch_before_running_commands(tmp_path):
+    calls = []
+
+    def run_command(args, cwd=None):
+        calls.append((args, cwd))
+        return ""
+
+    publisher = DraftPrPublisher(run_command=run_command)
+
+    with pytest.raises(DraftPrPublisherError, match="branch_name must be a safe git branch name"):
+        publisher.publish(
+            worktree=tmp_path,
+            branch_name="../monica/MOB-42",
+            base_branch="main",
+            title="[MOB-42] Fix Android checkout crash",
+            body=VALID_PR_BODY,
+        )
+
+    assert calls == []
+
+
+def test_publisher_requires_existing_worktree_before_running_commands(tmp_path):
+    calls = []
+
+    def run_command(args, cwd=None):
+        calls.append((args, cwd))
+        return ""
+
+    publisher = DraftPrPublisher(run_command=run_command)
+
+    with pytest.raises(DraftPrPublisherError, match="worktree does not exist"):
+        publisher.publish(
+            worktree=tmp_path / "missing-worktree",
+            branch_name="monica/MOB-42-checkout-crash",
+            base_branch="main",
+            title="[MOB-42] Fix Android checkout crash",
+            body=VALID_PR_BODY,
+        )
+
+    assert calls == []
+
+
+def test_publisher_requires_git_worktree_before_running_commands(tmp_path):
+    calls = []
+
+    def run_command(args, cwd=None):
+        calls.append((args, cwd))
+        if args == ["git", "branch", "--show-current"]:
+            return "monica/MOB-42-checkout-crash\n"
+        if args == ["git", "status", "--porcelain"]:
+            return ""
+        if args[:3] == ["git", "diff", "--name-only"]:
+            return "src/Checkout.tsx\n"
+        if args[:4] == ["gh", "pr", "create", "--draft"]:
+            return "https://github.com/acme/mobile/pull/123\n"
+        return ""
+
+    publisher = DraftPrPublisher(run_command=run_command)
+
+    with pytest.raises(DraftPrPublisherError, match="worktree is not a git worktree"):
+        publisher.publish(
+            worktree=tmp_path,
+            branch_name="monica/MOB-42-checkout-crash",
+            base_branch="main",
+            title="[MOB-42] Fix Android checkout crash",
+            body=VALID_PR_BODY,
+        )
+
+    assert calls == []
+
+
+def test_publisher_refuses_worktree_on_unexpected_branch(tmp_path):
+    calls = []
+
+    def run_command(args, cwd=None):
+        calls.append((args, cwd))
+        if args == ["git", "branch", "--show-current"]:
+            return "main\n"
+        return ""
+
+    publisher = DraftPrPublisher(run_command=run_command)
+
+    with pytest.raises(DraftPrPublisherError, match="worktree branch mismatch"):
+        publisher.publish(
+            worktree=_mark_git_worktree(tmp_path),
+            branch_name="monica/MOB-42-checkout-crash",
+            base_branch="main",
+            title="[MOB-42] Fix Android checkout crash",
+            body=VALID_PR_BODY,
+        )
+
+    assert calls == [(["git", "branch", "--show-current"], tmp_path)]
+
+
+def test_publisher_uses_existing_committed_diff_without_empty_commit(tmp_path):
+    calls = []
+
+    def run_command(args, cwd=None):
+        calls.append((args, cwd))
+        if args == ["git", "branch", "--show-current"]:
+            return "monica/MOB-42-checkout-crash\n"
+        if args == ["git", "status", "--porcelain"]:
+            return ""
+        if args[:3] == ["git", "diff", "--name-only"]:
+            return "src/Checkout.tsx\n"
+        if args[:4] == ["gh", "pr", "create", "--draft"]:
+            return "https://github.com/acme/mobile/pull/123\n"
+        return ""
+
+    publisher = DraftPrPublisher(run_command=run_command)
+
+    url = publisher.publish(
+        worktree=_mark_git_worktree(tmp_path),
+        branch_name="monica/MOB-42-checkout-crash",
+        base_branch="main",
+        title="[MOB-42] Fix Android checkout crash",
+        body=VALID_PR_BODY,
+    )
+
+    assert url == "https://github.com/acme/mobile/pull/123"
+    assert not any("commit" in call[0] for call in calls)
+    assert calls[3][0] == ["git", "push", "origin", "HEAD:monica/MOB-42-checkout-crash"]
+
+
+def test_publisher_recovers_existing_pr_url_from_gh_create_error(tmp_path):
+    calls = []
+
+    def run_command(args, cwd=None):
+        calls.append((args, cwd))
+        if args == ["git", "branch", "--show-current"]:
+            return "monica/MOB-42-checkout-crash\n"
+        if args == ["git", "status", "--porcelain"]:
+            return ""
+        if args[:3] == ["git", "diff", "--name-only"]:
+            return "src/Checkout.tsx\n"
+        if args[:4] == ["gh", "pr", "create", "--draft"]:
+            raise DraftPrPublisherError(
+                "command failed (1): gh pr create --draft\n"
+                "stderr: a pull request already exists for this branch: "
+                "https://github.com/acme/mobile/pull/456"
+            )
+        return ""
+
+    publisher = DraftPrPublisher(run_command=run_command)
+
+    url = publisher.publish(
+        worktree=_mark_git_worktree(tmp_path),
+        branch_name="monica/MOB-42-checkout-crash",
+        base_branch="main",
+        title="[MOB-42] Fix Android checkout crash",
+        body=VALID_PR_BODY,
+    )
+
+    assert url == "https://github.com/acme/mobile/pull/456"
+    assert calls[-1][0][:4] == ["gh", "pr", "create", "--draft"]
+
+
+def test_publisher_strips_punctuation_from_recovered_pr_url(tmp_path):
+    calls = []
+
+    def run_command(args, cwd=None):
+        calls.append((args, cwd))
+        if args == ["git", "branch", "--show-current"]:
+            return "monica/MOB-42-checkout-crash\n"
+        if args == ["git", "status", "--porcelain"]:
+            return ""
+        if args[:3] == ["git", "diff", "--name-only"]:
+            return "src/Checkout.tsx\n"
+        if args[:4] == ["gh", "pr", "create", "--draft"]:
+            raise DraftPrPublisherError(
+                "stderr: a pull request already exists for this branch "
+                "(https://github.com/acme/mobile/pull/456)."
+            )
+        return ""
+
+    publisher = DraftPrPublisher(run_command=run_command)
+
+    url = publisher.publish(
+        worktree=_mark_git_worktree(tmp_path),
+        branch_name="monica/MOB-42-checkout-crash",
+        base_branch="main",
+        title="[MOB-42] Fix Android checkout crash",
+        body=VALID_PR_BODY,
+    )
+
+    assert url == "https://github.com/acme/mobile/pull/456"
+
+
+def test_publisher_missing_executable_raises_typed_error(tmp_path, monkeypatch):
+    def missing_run(*_: object, **__: object) -> subprocess.CompletedProcess[str]:
+        raise FileNotFoundError("gh")
+
+    monkeypatch.setattr(subprocess, "run", missing_run)
+    publisher = DraftPrPublisher()
+
+    with pytest.raises(DraftPrPublisherError, match="executable not found: gh"):
+        publisher._default_run(["gh", "pr", "create"], tmp_path)
+
+
+def test_publisher_nonzero_exit_includes_command_context(tmp_path, monkeypatch):
+    def failed_run(*_: object, **__: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=["gh", "pr", "create"],
+            returncode=1,
+            stdout="stdout detail",
+            stderr="stderr detail",
+        )
+
+    monkeypatch.setattr(subprocess, "run", failed_run)
+    publisher = DraftPrPublisher()
+
+    with pytest.raises(DraftPrPublisherError) as exc_info:
+        publisher._default_run(["gh", "pr", "create"], tmp_path)
+
+    message = str(exc_info.value)
+    assert "command failed (1): gh pr create" in message
+    assert f"cwd: {tmp_path}" in message
+    assert "stdout: stdout detail" in message
+    assert "stderr: stderr detail" in message

--- a/tests/plugins/mobile_bug_agent/test_proof_runner.py
+++ b/tests/plugins/mobile_bug_agent/test_proof_runner.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+from plugins.mobile_bug_agent.config import MonicaConfig, ProofConfig, RuntimeConfig
+from plugins.mobile_bug_agent.proof import ProofRunner
+
+
+@dataclass(frozen=True)
+class FakeRun:
+    id: str = "run-123"
+    linear_identifier: str = "ENG-123"
+    branch_name: str = "monica/ENG-123-proof"
+
+
+def _mark_git_worktree(path):
+    path.mkdir(parents=True, exist_ok=True)
+    (path / ".git").write_text("gitdir: /tmp/fake-worktree-git-dir", encoding="utf-8")
+    return path
+
+
+def _config(tmp_path, **proof_overrides):
+    proof_values = {
+        "enabled": True,
+        "required_for_done": True,
+        "commands": ("capture-proof",),
+        "platform_order": ("ios",),
+        "artifact_dir": "proof",
+    }
+    proof_values.update(proof_overrides)
+    return MonicaConfig(
+        proof=ProofConfig(**proof_values),
+        runtime=RuntimeConfig(home_subdir=str(tmp_path / "monica-runtime")),
+    )
+
+
+def test_proof_runner_blocks_when_commands_are_empty(tmp_path):
+    runner = ProofRunner(config=_config(tmp_path, commands=()))
+
+    result = runner.run(run=FakeRun(), worktree=_mark_git_worktree(tmp_path / "worktree"))
+
+    assert result.passed is False
+    assert result.summary == "Proof blocked: proof.commands is empty."
+    assert result.artifacts == ()
+
+
+def test_proof_runner_passes_when_command_creates_artifact(tmp_path):
+    calls = []
+
+    def run(command, cwd, timeout, env):
+        calls.append((command, cwd, timeout, env["MONICA_PROOF_DIR"]))
+        proof_path = tmp_path / "monica-runtime" / "proof" / "run-123" / "screenshot.png"
+        proof_path.write_text("image bytes", encoding="utf-8")
+        return 0, "captured", ""
+
+    runner = ProofRunner(config=_config(tmp_path, timeout_minutes=3), run_command=run)
+
+    result = runner.run(run=FakeRun(), worktree=_mark_git_worktree(tmp_path / "worktree"))
+
+    assert result.passed is True
+    assert result.summary == "Proof captured."
+    proof_dir = tmp_path / "monica-runtime" / "proof" / "run-123"
+    manifest_path = proof_dir / "monica-proof-manifest.json"
+    assert result.artifacts == (
+        str(manifest_path),
+        str(proof_dir / "screenshot.png"),
+    )
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["run_id"] == "run-123"
+    assert manifest["linear_identifier"] == "ENG-123"
+    assert manifest["branch_name"] == "monica/ENG-123-proof"
+    assert manifest["worktree"] == str(tmp_path / "worktree")
+    assert manifest["platforms"] == ["ios"]
+    assert manifest["proof_artifacts"] == [str(proof_dir / "screenshot.png")]
+    assert calls == [
+        (
+            "capture-proof",
+            tmp_path / "worktree",
+            180,
+            str(tmp_path / "monica-runtime" / "proof" / "run-123"),
+        )
+    ]
+
+
+def test_proof_runner_blocks_when_command_produces_no_artifacts(tmp_path):
+    runner = ProofRunner(
+        config=_config(tmp_path),
+        run_command=lambda _cmd, _cwd, _timeout, _env: (0, "ok", ""),
+    )
+
+    result = runner.run(run=FakeRun(), worktree=_mark_git_worktree(tmp_path / "worktree"))
+
+    assert result.passed is False
+    assert result.summary == "Proof blocked: proof commands produced no artifacts."
+    assert result.artifacts == ()
+
+
+def test_proof_runner_preserves_partial_artifacts_on_command_failure(tmp_path):
+    def run(_command, _cwd, _timeout, env):
+        proof_path = tmp_path / "monica-runtime" / "proof" / "run-123" / "before-failure.txt"
+        proof_path.write_text(env["MONICA_LINEAR_IDENTIFIER"], encoding="utf-8")
+        return 1, "", "simulator failed"
+
+    runner = ProofRunner(config=_config(tmp_path), run_command=run)
+
+    result = runner.run(run=FakeRun(), worktree=_mark_git_worktree(tmp_path / "worktree"))
+
+    assert result.passed is False
+    assert result.summary == "Proof blocked: capture-proof"
+    assert result.artifacts == (str(tmp_path / "monica-runtime" / "proof" / "run-123" / "before-failure.txt"),)
+    assert "simulator failed" in result.output

--- a/tests/plugins/mobile_bug_agent/test_readiness.py
+++ b/tests/plugins/mobile_bug_agent/test_readiness.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from plugins.mobile_bug_agent.config import (
+    LinearConfig,
+    MonicaConfig,
+    ProofConfig,
+    RepoConfig,
+    SlackConfig,
+    VerificationConfig,
+)
+from plugins.mobile_bug_agent.readiness import check_monica_readiness
+
+
+def _code_rollout_config() -> MonicaConfig:
+    return MonicaConfig(
+        enabled=True,
+        rollout_mode="local_fix_only",
+        slack=SlackConfig(
+            bot_user_ids=("U_MONICA",),
+            allowed_channels=("D123MONICA",),
+            approver_user_ids=("U_APPROVER",),
+        ),
+        linear=LinearConfig(team_id="team-id"),
+        repo=RepoConfig(url="git@github.com:acme/mobile.git"),
+        verification=VerificationConfig(commands=("npm test",)),
+        proof=ProofConfig(
+            enabled=True,
+            required_for_done=True,
+            commands=("npm run monica:proof",),
+            platform_order=("ios",),
+        ),
+    )
+
+
+def test_readiness_warns_when_simctl_probe_fails_even_if_xcode_tools_exist():
+    report = check_monica_readiness(
+        config=_code_rollout_config(),
+        environ={
+            "MONICA_SLACK_BOT_TOKEN": "xoxb-token",
+            "MONICA_SLACK_APP_TOKEN": "xapp-token",
+            "LINEAR_API_KEY": "lin-key",
+        },
+        which=lambda name: f"/usr/bin/{name}",
+        module_available=lambda name: True,
+        command_succeeds=lambda command: command != ("xcrun", "--find", "simctl"),
+    )
+
+    assert report.ready is True
+    assert any(issue.code == "ios_proof_tooling" for issue in report.warnings)
+
+
+def test_readiness_accepts_ios_proof_when_simctl_probe_passes():
+    report = check_monica_readiness(
+        config=_code_rollout_config(),
+        environ={
+            "MONICA_SLACK_BOT_TOKEN": "xoxb-token",
+            "MONICA_SLACK_APP_TOKEN": "xapp-token",
+            "LINEAR_API_KEY": "lin-key",
+        },
+        which=lambda name: f"/usr/bin/{name}",
+        module_available=lambda name: True,
+        command_succeeds=lambda _command: True,
+    )
+
+    warning_codes = {issue.code for issue in report.warnings}
+    assert report.ready is True
+    assert "ios_proof_tooling" not in warning_codes

--- a/tests/plugins/mobile_bug_agent/test_repo_manager.py
+++ b/tests/plugins/mobile_bug_agent/test_repo_manager.py
@@ -1,0 +1,373 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from plugins.mobile_bug_agent.config import RepoConfig
+from plugins.mobile_bug_agent.repo_manager import RepoManager, RepoManagerError
+
+
+def test_repo_manager_clones_missing_repo_and_creates_named_worktree(tmp_path):
+    commands: list[list[str]] = []
+
+    def run(cmd: list[str], cwd: Path | None = None) -> str:
+        commands.append(cmd if cwd is None else ["cwd=" + str(cwd), *cmd])
+        if cmd[:2] == ["git", "clone"]:
+            Path(cmd[-1]).mkdir(parents=True)
+        return ""
+
+    manager = RepoManager(
+        config=RepoConfig(
+            url="git@github.com:acme/mobile-app.git",
+            local_name="mobile-app",
+            default_branch="main",
+            branch_prefix="monica",
+        ),
+        workspace_root=tmp_path,
+        run_command=run,
+    )
+
+    worktree = manager.prepare_worktree(
+        linear_identifier="MOB-123",
+        summary="Android checkout crash after promo code",
+    )
+
+    assert worktree.branch_name == "monica/MOB-123-android-checkout-crash-after-promo-code"
+    assert worktree.path == tmp_path / "worktrees" / "monica-MOB-123-android-checkout-crash-after-promo-code"
+    assert commands == [
+        [
+            "git",
+            "clone",
+            "git@github.com:acme/mobile-app.git",
+            str(tmp_path / "repos" / "mobile-app"),
+        ],
+        [
+            "git",
+            "-C",
+            str(tmp_path / "repos" / "mobile-app"),
+            "worktree",
+            "add",
+            "-B",
+            "monica/MOB-123-android-checkout-crash-after-promo-code",
+            str(tmp_path / "worktrees" / "monica-MOB-123-android-checkout-crash-after-promo-code"),
+            "origin/main",
+        ],
+    ]
+
+
+def test_repo_manager_fetches_existing_repo_before_worktree(tmp_path):
+    commands: list[list[str]] = []
+    (tmp_path / "repos" / "mobile-app").mkdir(parents=True)
+
+    def run(cmd: list[str], cwd: Path | None = None) -> str:
+        commands.append(cmd)
+        return ""
+
+    manager = RepoManager(
+        config=RepoConfig(url="git@github.com:acme/mobile-app.git", local_name="mobile-app"),
+        workspace_root=tmp_path,
+        run_command=run,
+    )
+
+    manager.prepare_worktree(linear_identifier="MOB-123", summary="Checkout crash")
+
+    assert commands[0] == [
+        "git",
+        "-C",
+        str(tmp_path / "repos" / "mobile-app"),
+        "fetch",
+        "origin",
+        "main",
+    ]
+
+
+def test_repo_manager_rejects_existing_repo_file(tmp_path):
+    commands: list[list[str]] = []
+    repo_path = tmp_path / "repos" / "mobile-app"
+    repo_path.parent.mkdir(parents=True)
+    repo_path.write_text("not a git repo")
+
+    manager = RepoManager(
+        config=RepoConfig(url="git@github.com:acme/mobile-app.git", local_name="mobile-app"),
+        workspace_root=tmp_path,
+        run_command=lambda cmd, cwd=None: commands.append(cmd) or "",
+    )
+
+    with pytest.raises(RepoManagerError, match="repo path exists but is not a directory"):
+        manager.prepare_worktree(linear_identifier="MOB-123", summary="Checkout crash")
+
+    assert commands == []
+
+
+def test_repo_manager_rejects_unsafe_local_name_before_commands(tmp_path):
+    for local_name in ("../outside-runtime", "/tmp/outside-runtime", "nested/mobile-app", ".", "..", ""):
+        commands: list[list[str]] = []
+        manager = RepoManager(
+            config=RepoConfig(url="git@github.com:acme/mobile-app.git", local_name=local_name),
+            workspace_root=tmp_path,
+            run_command=lambda cmd, cwd=None: commands.append(cmd) or "",
+        )
+
+        with pytest.raises(RepoManagerError, match="repo.local_name must be a simple directory name"):
+            manager.prepare_worktree(linear_identifier="MOB-123", summary="Checkout crash")
+
+        assert commands == []
+
+
+def test_repo_manager_rejects_chandler_local_name_before_commands(tmp_path):
+    commands: list[list[str]] = []
+    manager = RepoManager(
+        config=RepoConfig(url="git@github.com:acme/mobile-app.git", local_name="chandler"),
+        workspace_root=tmp_path,
+        run_command=lambda cmd, cwd=None: commands.append(cmd) or "",
+    )
+
+    with pytest.raises(RepoManagerError, match="repo.local_name must not point at a Chandler directory"):
+        manager.prepare_worktree(linear_identifier="MOB-123", summary="Checkout crash")
+
+    assert commands == []
+
+
+def test_repo_manager_rejects_unsafe_branch_prefix_before_commands(tmp_path):
+    unsafe_prefixes = (
+        "",
+        "../monica",
+        "/monica",
+        "monica branch",
+        "monica..bad",
+        "monica.lock",
+        "monica~bad",
+        "monica:bad",
+        "monica^bad",
+        "monica?bad",
+        "monica*bad",
+        "monica[bad",
+        "monica\\bad",
+    )
+    for branch_prefix in unsafe_prefixes:
+        commands: list[list[str]] = []
+        manager = RepoManager(
+            config=RepoConfig(
+                url="git@github.com:acme/mobile-app.git",
+                local_name="mobile-app",
+                branch_prefix=branch_prefix,
+            ),
+            workspace_root=tmp_path,
+            run_command=lambda cmd, cwd=None: commands.append(cmd) or "",
+        )
+
+        with pytest.raises(RepoManagerError, match="repo.branch_prefix must be a safe git branch prefix"):
+            manager.prepare_worktree(linear_identifier="MOB-123", summary="Checkout crash")
+
+        assert commands == []
+
+
+def test_repo_manager_rejects_chandler_branch_prefix_before_commands(tmp_path):
+    commands: list[list[str]] = []
+    manager = RepoManager(
+        config=RepoConfig(
+            url="git@github.com:acme/mobile-app.git",
+            local_name="mobile-app",
+            branch_prefix="chandler",
+        ),
+        workspace_root=tmp_path,
+        run_command=lambda cmd, cwd=None: commands.append(cmd) or "",
+    )
+
+    with pytest.raises(RepoManagerError, match="repo.branch_prefix must not point at Chandler"):
+        manager.prepare_worktree(linear_identifier="MOB-123", summary="Checkout crash")
+
+    assert commands == []
+
+
+def test_repo_manager_rejects_unsafe_default_branch_before_commands(tmp_path):
+    unsafe_branches = (
+        "",
+        "../main",
+        "/main",
+        "main branch",
+        "main..bad",
+        "main.lock",
+        "main~bad",
+        "main:bad",
+        "main^bad",
+        "main?bad",
+        "main*bad",
+        "main[bad",
+        "main\\bad",
+    )
+    for default_branch in unsafe_branches:
+        commands: list[list[str]] = []
+        manager = RepoManager(
+            config=RepoConfig(
+                url="git@github.com:acme/mobile-app.git",
+                local_name="mobile-app",
+                default_branch=default_branch,
+            ),
+            workspace_root=tmp_path,
+            run_command=lambda cmd, cwd=None: commands.append(cmd) or "",
+        )
+
+        with pytest.raises(RepoManagerError, match="repo.default_branch must be a safe git branch name"):
+            manager.prepare_worktree(linear_identifier="MOB-123", summary="Checkout crash")
+
+        assert commands == []
+
+
+def test_repo_manager_reuses_existing_worktree_for_retry(tmp_path):
+    commands: list[list[str]] = []
+    (tmp_path / "repos" / "mobile-app").mkdir(parents=True)
+    existing = tmp_path / "worktrees" / "monica-MOB-123-checkout-crash"
+    existing.mkdir(parents=True)
+    (existing / ".git").write_text("gitdir: /tmp/fake-worktree-git-dir")
+
+    def run(cmd: list[str], cwd: Path | None = None) -> str:
+        commands.append(cmd)
+        if cmd == ["git", "-C", str(existing), "branch", "--show-current"]:
+            return "monica/MOB-123-checkout-crash\n"
+        return ""
+
+    manager = RepoManager(
+        config=RepoConfig(url="git@github.com:acme/mobile-app.git", local_name="mobile-app"),
+        workspace_root=tmp_path,
+        run_command=run,
+    )
+
+    worktree = manager.prepare_worktree(linear_identifier="MOB-123", summary="Checkout crash")
+
+    assert worktree.branch_name == "monica/MOB-123-checkout-crash"
+    assert worktree.path == existing
+    assert not any(cmd[:4] == ["git", "-C", str(tmp_path / "repos" / "mobile-app"), "worktree"] for cmd in commands)
+    assert commands[-1] == ["git", "-C", str(existing), "branch", "--show-current"]
+
+
+def test_repo_manager_rejects_existing_worktree_on_unexpected_branch(tmp_path):
+    commands: list[list[str]] = []
+    (tmp_path / "repos" / "mobile-app").mkdir(parents=True)
+    existing = tmp_path / "worktrees" / "monica-MOB-123-checkout-crash"
+    existing.mkdir(parents=True)
+    (existing / ".git").write_text("gitdir: /tmp/fake-worktree-git-dir")
+
+    def run(cmd: list[str], cwd: Path | None = None) -> str:
+        commands.append(cmd)
+        if cmd == ["git", "-C", str(existing), "branch", "--show-current"]:
+            return "main\n"
+        return ""
+
+    manager = RepoManager(
+        config=RepoConfig(url="git@github.com:acme/mobile-app.git", local_name="mobile-app"),
+        workspace_root=tmp_path,
+        run_command=run,
+    )
+
+    with pytest.raises(RepoManagerError, match="worktree branch mismatch"):
+        manager.prepare_worktree(linear_identifier="MOB-123", summary="Checkout crash")
+
+    assert commands == [
+        [
+            "git",
+            "-C",
+            str(tmp_path / "repos" / "mobile-app"),
+            "fetch",
+            "origin",
+            "main",
+        ],
+        ["git", "-C", str(existing), "branch", "--show-current"],
+    ]
+
+
+def test_repo_manager_rejects_existing_worktree_directory_that_is_not_git_worktree(tmp_path):
+    commands: list[list[str]] = []
+    repo_path = tmp_path / "repos" / "mobile-app"
+    repo_path.mkdir(parents=True)
+    stale_path = tmp_path / "worktrees" / "monica-MOB-123-checkout-crash"
+    stale_path.mkdir(parents=True)
+
+    manager = RepoManager(
+        config=RepoConfig(url="git@github.com:acme/mobile-app.git", local_name="mobile-app"),
+        workspace_root=tmp_path,
+        run_command=lambda cmd, cwd=None: commands.append(cmd) or "",
+    )
+
+    with pytest.raises(RepoManagerError, match="worktree path exists but is not a git worktree"):
+        manager.prepare_worktree(linear_identifier="MOB-123", summary="Checkout crash")
+
+    assert commands == [
+        [
+            "git",
+            "-C",
+            str(repo_path),
+            "fetch",
+            "origin",
+            "main",
+        ]
+    ]
+
+
+def test_repo_manager_rejects_existing_worktree_file(tmp_path):
+    (tmp_path / "repos" / "mobile-app").mkdir(parents=True)
+    stale_path = tmp_path / "worktrees" / "monica-MOB-123-checkout-crash"
+    stale_path.parent.mkdir(parents=True)
+    stale_path.write_text("not a worktree")
+
+    manager = RepoManager(
+        config=RepoConfig(url="git@github.com:acme/mobile-app.git", local_name="mobile-app"),
+        workspace_root=tmp_path,
+        run_command=lambda cmd, cwd=None: "",
+    )
+
+    with pytest.raises(RepoManagerError, match="worktree path exists but is not a directory"):
+        manager.prepare_worktree(linear_identifier="MOB-123", summary="Checkout crash")
+
+
+def test_repo_manager_error_includes_command_and_stderr(tmp_path):
+    manager = RepoManager(
+        config=RepoConfig(url="git@github.com:acme/mobile-app.git", local_name="mobile-app"),
+        workspace_root=tmp_path,
+    )
+
+    try:
+        manager._default_run(["git", "definitely-not-a-command"], None)
+    except RepoManagerError as exc:
+        message = str(exc)
+    else:  # pragma: no cover - git invariant
+        raise AssertionError("expected RepoManagerError")
+
+    assert "git definitely-not-a-command" in message
+    assert "stderr:" in message or "stdout:" in message
+
+
+def test_repo_manager_timeout_raises_readable_error(tmp_path, monkeypatch):
+    manager = RepoManager(
+        config=RepoConfig(url="git@github.com:acme/mobile-app.git", local_name="mobile-app"),
+        workspace_root=tmp_path,
+        timeout_seconds=1,
+    )
+
+    def timeout_run(*_: object, **__: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(cmd=["git", "fetch"], timeout=1)
+
+    monkeypatch.setattr(subprocess, "run", timeout_run)
+
+    with pytest.raises(RepoManagerError, match="command timed out") as exc_info:
+        manager._default_run(["git", "fetch"], None)
+
+    assert "git fetch" in str(exc_info.value)
+    assert "1s" in str(exc_info.value)
+
+
+def test_repo_manager_missing_executable_raises_readable_error(tmp_path, monkeypatch):
+    manager = RepoManager(
+        config=RepoConfig(url="git@github.com:acme/mobile-app.git", local_name="mobile-app"),
+        workspace_root=tmp_path,
+    )
+
+    def missing_run(*_: object, **__: object) -> subprocess.CompletedProcess[str]:
+        raise FileNotFoundError("git")
+
+    monkeypatch.setattr(subprocess, "run", missing_run)
+
+    with pytest.raises(RepoManagerError, match="executable not found: git"):
+        manager._default_run(["git", "fetch"], None)

--- a/tests/plugins/mobile_bug_agent/test_simulator_proof.py
+++ b/tests/plugins/mobile_bug_agent/test_simulator_proof.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from plugins.mobile_bug_agent.simulator_proof import SimulatorProofHarness
+
+
+def _worktree(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / ".git").write_text("gitdir: /tmp/fake-mobile-worktree-git-dir", encoding="utf-8")
+    (path / "package.json").write_text('{"scripts":{"ios":"expo run:ios","android":"expo run:android"}}', encoding="utf-8")
+    return path
+
+
+def test_simulator_proof_ios_builds_launches_deep_link_and_screenshots(tmp_path):
+    calls = []
+    proof_dir = tmp_path / "proof"
+    worktree = _worktree(tmp_path / "app")
+
+    def run_text(args, cwd, timeout):
+        calls.append((args, cwd, timeout))
+        if args[:4] == ("xcrun", "simctl", "io", "SIM-123"):
+            Path(args[-1]).write_text("png", encoding="utf-8")
+        return "ok"
+
+    harness = SimulatorProofHarness(run_text=run_text)
+
+    result = harness.run(
+        worktree=worktree,
+        proof_dir=proof_dir,
+        platforms=("ios",),
+        ios_simulator_udid="SIM-123",
+        deep_link="elixir://marketplace/offer/fitness-first",
+        timeout_seconds=90,
+    )
+
+    assert result == [str(proof_dir / "ios-screenshot.png")]
+    assert calls == [
+        (("xcrun", "--find", "simctl"), worktree, 90),
+        (("xcodebuild", "-version"), worktree, 90),
+        (("npm", "run", "ios"), worktree, 90),
+        (
+            ("xcrun", "simctl", "openurl", "SIM-123", "elixir://marketplace/offer/fitness-first"),
+            worktree,
+            90,
+        ),
+        (("xcrun", "simctl", "io", "SIM-123", "screenshot", str(proof_dir / "ios-screenshot.png")), worktree, 90),
+    ]
+
+
+def test_simulator_proof_android_builds_launches_deep_link_and_screenshots(tmp_path):
+    text_calls = []
+    bytes_calls = []
+    proof_dir = tmp_path / "proof"
+    worktree = _worktree(tmp_path / "app")
+
+    def run_text(args, cwd, timeout):
+        text_calls.append((args, cwd, timeout))
+        return "ok"
+
+    def run_bytes(args, cwd, timeout):
+        bytes_calls.append((args, cwd, timeout))
+        return b"png"
+
+    harness = SimulatorProofHarness(run_text=run_text, run_bytes=run_bytes)
+
+    result = harness.run(
+        worktree=worktree,
+        proof_dir=proof_dir,
+        platforms=("android",),
+        android_serial="emulator-5554",
+        deep_link="elixir://marketplace/offer/fitness-first",
+        timeout_seconds=120,
+    )
+
+    assert result == [str(proof_dir / "android-screenshot.png")]
+    assert text_calls == [
+        (("adb", "-s", "emulator-5554", "version"), worktree, 120),
+        (("emulator", "-list-avds"), worktree, 120),
+        (("npm", "run", "android"), worktree, 120),
+        (
+            (
+                "adb",
+                "-s",
+                "emulator-5554",
+                "shell",
+                "am",
+                "start",
+                "-a",
+                "android.intent.action.VIEW",
+                "-d",
+                "elixir://marketplace/offer/fitness-first",
+            ),
+            worktree,
+            120,
+        ),
+    ]
+    assert bytes_calls == [
+        (("adb", "-s", "emulator-5554", "exec-out", "screencap", "-p"), worktree, 120)
+    ]
+    assert (proof_dir / "android-screenshot.png").read_bytes() == b"png"
+
+
+def test_simulator_proof_refuses_non_mobile_worktree(tmp_path):
+    proof_dir = tmp_path / "proof"
+    worktree = tmp_path / "app"
+    worktree.mkdir()
+    (worktree / ".git").write_text("gitdir: /tmp/fake-mobile-worktree-git-dir", encoding="utf-8")
+
+    harness = SimulatorProofHarness()
+
+    try:
+        harness.run(worktree=worktree, proof_dir=proof_dir, platforms=("ios",))
+    except RuntimeError as exc:
+        assert "package.json" in str(exc)
+    else:
+        raise AssertionError("expected proof harness to fail closed")

--- a/tests/plugins/mobile_bug_agent/test_slack_client.py
+++ b/tests/plugins/mobile_bug_agent/test_slack_client.py
@@ -1,0 +1,651 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import pytest
+
+from plugins.mobile_bug_agent import slack_client
+from plugins.mobile_bug_agent.slack_client import SlackClientError, SlackThreadClient
+
+
+class FakeWebClient:
+    def __init__(self) -> None:
+        self.posts: list[dict[str, str]] = []
+        self.permalink_calls: list[tuple[str, str]] = []
+
+    def conversations_replies(self, channel, ts, limit):
+        assert channel == "C123"
+        assert ts == "1710000000.000100"
+        assert limit == 40
+        return {
+            "ok": True,
+            "messages": [
+                {
+                    "user": "U1",
+                    "text": "<@U999> checkout crashes after promo",
+                    "ts": "1710000000.000100",
+                    "files": [
+                        {
+                            "id": "F1",
+                            "name": "crash.png",
+                            "mimetype": "image/png",
+                            "url_private": "https://files/crash.png",
+                            "permalink": "https://slack.example/file/F1",
+                        }
+                    ],
+                },
+                {"user": "U2", "text": "Android only, Pixel 7", "ts": "1710000001.000200"},
+            ],
+        }
+
+    def chat_getPermalink(self, channel, message_ts):
+        assert channel == "C123"
+        self.permalink_calls.append((channel, message_ts))
+        return {"ok": True, "permalink": f"https://slack.example/thread/{message_ts}"}
+
+    def chat_postMessage(self, channel, thread_ts, text):
+        self.posts.append({"channel": channel, "thread_ts": thread_ts, "text": text})
+        return {"ok": True}
+
+
+class DuplicateFileWebClient(FakeWebClient):
+    def conversations_replies(self, channel, ts, limit):
+        assert channel == "C123"
+        assert ts == "1710000000.000100"
+        assert limit == 40
+        return {
+            "ok": True,
+            "messages": [
+                {
+                    "user": "U1",
+                    "text": "<@U999> checkout crashes after promo",
+                    "ts": "1710000000.000100",
+                    "files": [
+                        {
+                            "id": "F1",
+                            "name": "crash.png",
+                            "mimetype": "image/png",
+                            "url_private": "https://files/crash-one.png",
+                            "permalink": "https://slack.example/file/F1",
+                        },
+                        {
+                            "id": "F2",
+                            "name": "crash.png",
+                            "mimetype": "image/png",
+                            "url_private": "https://files/crash-two.png",
+                            "permalink": "https://slack.example/file/F2",
+                        },
+                    ],
+                },
+            ],
+        }
+
+
+class LabeledMentionWebClient(FakeWebClient):
+    def conversations_replies(self, channel, ts, limit):
+        assert channel == "C123"
+        assert ts == "1710000000.000100"
+        assert limit == 40
+        return {
+            "ok": True,
+            "messages": [
+                {
+                    "user": "U1",
+                    "text": "<@U999|monica> checkout crashes after promo",
+                    "ts": "1710000000.000100",
+                },
+                {
+                    "user": "U2",
+                    "text": "<@U123|ritik> can repro on Android",
+                    "ts": "1710000001.000200",
+                },
+            ],
+        }
+
+
+class AttachmentImageWebClient(FakeWebClient):
+    def conversations_replies(self, channel, ts, limit):
+        assert channel == "C123"
+        assert ts == "1710000000.000100"
+        return {
+            "ok": True,
+            "messages": [
+                {
+                    "user": "U1",
+                    "text": "<@U999> screenshot from checkout",
+                    "ts": "1710000000.000100",
+                    "attachments": [
+                        {
+                            "title": "Checkout crash screenshot",
+                            "image_url": "https://files.example.com/screenshot.png",
+                            "fallback": "checkout screenshot",
+                        }
+                    ],
+                },
+            ],
+        }
+
+
+class UnsafeAttachmentImageWebClient(FakeWebClient):
+    def conversations_replies(self, channel, ts, limit):
+        assert channel == "C123"
+        assert ts == "1710000000.000100"
+        return {
+            "ok": True,
+            "messages": [
+                {
+                    "user": "U1",
+                    "text": "<@U999> screenshot from checkout",
+                    "ts": "1710000000.000100",
+                    "attachments": [
+                        {
+                            "title": "Local file attachment",
+                            "image_url": "file:///etc/passwd",
+                        }
+                    ],
+                },
+            ],
+        }
+
+
+class PaginatedWebClient(FakeWebClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.reply_calls: list[dict[str, str | int | None]] = []
+
+    def conversations_replies(self, channel, ts, limit, cursor=None):
+        self.reply_calls.append({"channel": channel, "ts": ts, "limit": limit, "cursor": cursor})
+        if cursor is None:
+            return {
+                "ok": True,
+                "has_more": True,
+                "response_metadata": {"next_cursor": "cursor-2"},
+                "messages": [
+                    {
+                        "user": "U1",
+                        "text": "<@U999> checkout crashes after promo",
+                        "ts": "1710000000.000100",
+                    },
+                ],
+            }
+        assert cursor == "cursor-2"
+        return {
+            "ok": True,
+            "has_more": False,
+            "response_metadata": {"next_cursor": ""},
+            "messages": [
+                {
+                    "user": "U2",
+                    "text": "Pixel 7, latest beta. It started after 2.14.0.",
+                    "ts": "1710000001.000200",
+                },
+            ],
+        }
+
+
+class RepeatedCursorWebClient(FakeWebClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.reply_calls = 0
+
+    def conversations_replies(self, channel, ts, limit, cursor=None):
+        self.reply_calls += 1
+        if self.reply_calls == 1:
+            return {
+                "ok": True,
+                "has_more": True,
+                "response_metadata": {"next_cursor": "cursor-repeat"},
+                "messages": [
+                    {
+                        "user": "U1",
+                        "text": "<@U999> checkout crashes after promo",
+                        "ts": "1710000000.000100",
+                    },
+                ],
+            }
+        if self.reply_calls == 2:
+            return {
+                "ok": True,
+                "has_more": True,
+                "response_metadata": {"next_cursor": "cursor-repeat"},
+                "messages": [],
+            }
+        raise AssertionError("repeated Slack cursors must not loop forever")
+
+
+class ErrorWebClient(FakeWebClient):
+    def conversations_replies(self, channel, ts, limit):
+        return {"ok": False, "error": "missing_scope"}
+
+
+class PostErrorWebClient(FakeWebClient):
+    def chat_postMessage(self, channel, thread_ts, text):
+        return {"ok": False, "error": "not_in_channel"}
+
+
+class MetadataWebClient(FakeWebClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.channel_calls: list[dict[str, object]] = []
+
+    def auth_test(self):
+        return {
+            "ok": True,
+            "user_id": "U_MONICA",
+            "bot_id": "B_MONICA",
+            "team_id": "T123",
+            "team": "Acme",
+            "url": "https://acme.slack.com/",
+        }
+
+    def conversations_list(self, **kwargs):
+        self.channel_calls.append(kwargs)
+        if not kwargs.get("cursor"):
+            return {
+                "ok": True,
+                "has_more": True,
+                "response_metadata": {"next_cursor": "next-page"},
+                "channels": [
+                    {
+                        "id": "C_MOBILE",
+                        "name": "mobile-bugs",
+                        "is_private": False,
+                        "is_member": True,
+                        "is_archived": False,
+                    }
+                ],
+            }
+        assert kwargs["cursor"] == "next-page"
+        return {
+            "ok": True,
+            "has_more": False,
+            "response_metadata": {"next_cursor": ""},
+            "channels": [
+                {
+                    "id": "G_PRIVATE",
+                    "name": "app-triage",
+                    "is_private": True,
+                    "is_member": False,
+                    "is_archived": False,
+                }
+            ],
+        }
+
+
+class AuthErrorMetadataWebClient(MetadataWebClient):
+    def auth_test(self):
+        return {"ok": False, "error": "invalid_auth"}
+
+
+class ChannelErrorMetadataWebClient(MetadataWebClient):
+    def conversations_list(self, **kwargs):
+        return {"ok": False, "error": "missing_scope"}
+
+
+class ResponseLike:
+    def __init__(self, data):
+        self.data = data
+
+    def get(self, key, default=None):
+        return self.data.get(key, default)
+
+
+class ResponseLikeErrorWebClient(FakeWebClient):
+    def conversations_replies(self, channel, ts, limit):
+        return ResponseLike({"ok": False, "error": "missing_scope"})
+
+    def chat_postMessage(self, channel, thread_ts, text):
+        return ResponseLike({"ok": False, "error": "not_in_channel"})
+
+
+def test_reads_thread_messages_files_and_permalink():
+    fake = FakeWebClient()
+    reader = SlackThreadClient(
+        client=fake,
+        token="xoxb-token",
+        monica_user_ids=("U999",),
+        download_attachments=False,
+    )
+
+    ctx = reader.read_thread(channel_id="C123", thread_ts="1710000000.000100", limit=40)
+
+    assert ctx.permalink == "https://slack.example/thread/1710000000.000100"
+    assert [m.text for m in ctx.messages] == [
+        "@monica checkout crashes after promo",
+        "Android only, Pixel 7",
+    ]
+    assert [m.ts for m in ctx.messages] == ["1710000000.000100", "1710000001.000200"]
+    assert [m.permalink for m in ctx.messages] == [
+        "https://slack.example/thread/1710000000.000100",
+        "https://slack.example/thread/1710000001.000200",
+    ]
+    assert ctx.files[0].name == "crash.png"
+    assert ctx.files[0].permalink == "https://slack.example/file/F1"
+    data = ctx.to_dict()
+    assert data["attachments"] == ["crash.png"]
+    assert data["message_details"] == [
+        {
+            "user_id": "U1",
+            "text": "@monica checkout crashes after promo",
+            "ts": "1710000000.000100",
+            "permalink": "https://slack.example/thread/1710000000.000100",
+        },
+        {
+            "user_id": "U2",
+            "text": "Android only, Pixel 7",
+            "ts": "1710000001.000200",
+            "permalink": "https://slack.example/thread/1710000001.000200",
+        },
+    ]
+    assert fake.permalink_calls == [
+        ("C123", "1710000000.000100"),
+        ("C123", "1710000001.000200"),
+    ]
+
+
+def test_lists_slack_workspace_metadata_with_channels():
+    fake = MetadataWebClient()
+    reader = SlackThreadClient(client=fake, token="xoxb-token")
+
+    metadata = reader.list_workspace_metadata()
+
+    assert metadata.auth.bot_user_id == "U_MONICA"
+    assert metadata.auth.bot_id == "B_MONICA"
+    assert metadata.auth.team_id == "T123"
+    assert metadata.auth.team_name == "Acme"
+    assert metadata.auth.team_url == "https://acme.slack.com/"
+    assert [(channel.id, channel.name, channel.is_private, channel.is_member) for channel in metadata.channels] == [
+        ("C_MOBILE", "mobile-bugs", False, True),
+        ("G_PRIVATE", "app-triage", True, False),
+    ]
+    assert fake.channel_calls[0]["types"] == "public_channel,private_channel"
+    assert fake.channel_calls[0]["exclude_archived"] is True
+    assert fake.channel_calls[1]["cursor"] == "next-page"
+
+
+def test_slack_workspace_metadata_surfaces_auth_errors():
+    reader = SlackThreadClient(client=AuthErrorMetadataWebClient(), token="xoxb-token")
+
+    with pytest.raises(SlackClientError) as exc_info:
+        reader.list_workspace_metadata()
+
+    assert str(exc_info.value) == "Slack auth_test failed: invalid_auth"
+
+
+def test_slack_workspace_metadata_surfaces_channel_errors():
+    reader = SlackThreadClient(client=ChannelErrorMetadataWebClient(), token="xoxb-token")
+
+    with pytest.raises(SlackClientError) as exc_info:
+        reader.list_workspace_metadata()
+
+    assert str(exc_info.value) == "Slack conversations_list failed: missing_scope"
+
+
+def test_normalizes_labeled_slack_mentions_in_thread_context():
+    fake = LabeledMentionWebClient()
+    reader = SlackThreadClient(
+        client=fake,
+        token="xoxb-token",
+        monica_user_ids=("U999",),
+        download_attachments=False,
+    )
+
+    ctx = reader.read_thread(channel_id="C123", thread_ts="1710000000.000100", limit=40)
+
+    assert [message.text for message in ctx.messages] == [
+        "@monica checkout crashes after promo",
+        "@U123 can repro on Android",
+    ]
+    assert ctx.to_dict()["messages"] == [
+        "U1: @monica checkout crashes after promo",
+        "U2: @U123 can repro on Android",
+    ]
+
+
+def test_reads_slack_attachment_images_as_evidence():
+    fake = AttachmentImageWebClient()
+    reader = SlackThreadClient(
+        client=fake,
+        token="xoxb-token",
+        monica_user_ids=("U999",),
+        download_attachments=False,
+    )
+
+    ctx = reader.read_thread(channel_id="C123", thread_ts="1710000000.000100", limit=40)
+
+    assert len(ctx.files) == 1
+    assert ctx.files[0].id == "attachment-1710000000.000100-1"
+    assert ctx.files[0].name == "Checkout crash screenshot"
+    assert ctx.files[0].mimetype == "image"
+    assert ctx.files[0].url_private == "https://files.example.com/screenshot.png"
+    assert ctx.files[0].permalink == "https://files.example.com/screenshot.png"
+    assert ctx.to_dict()["attachments"] == ["Checkout crash screenshot"]
+
+
+def test_reads_paginated_thread_messages_until_limit():
+    fake = PaginatedWebClient()
+    reader = SlackThreadClient(
+        client=fake,
+        token="xoxb-token",
+        monica_user_ids=("U999",),
+        download_attachments=False,
+    )
+
+    ctx = reader.read_thread(channel_id="C123", thread_ts="1710000000.000100", limit=2)
+
+    assert [message.text for message in ctx.messages] == [
+        "@monica checkout crashes after promo",
+        "Pixel 7, latest beta. It started after 2.14.0.",
+    ]
+    assert fake.reply_calls == [
+        {"channel": "C123", "ts": "1710000000.000100", "limit": 2, "cursor": None},
+        {"channel": "C123", "ts": "1710000000.000100", "limit": 1, "cursor": "cursor-2"},
+    ]
+
+
+def test_repeated_slack_cursor_stops_without_looping_forever():
+    fake = RepeatedCursorWebClient()
+    reader = SlackThreadClient(
+        client=fake,
+        token="xoxb-token",
+        monica_user_ids=("U999",),
+        download_attachments=False,
+    )
+
+    ctx = reader.read_thread(channel_id="C123", thread_ts="1710000000.000100", limit=5)
+
+    assert [message.text for message in ctx.messages] == ["@monica checkout crashes after promo"]
+    assert fake.reply_calls == 2
+
+
+def test_thread_read_raises_typed_error_on_slack_api_error():
+    reader = SlackThreadClient(client=ErrorWebClient(), token="xoxb-token")
+
+    with pytest.raises(SlackClientError, match="missing_scope"):
+        reader.read_thread(channel_id="C123", thread_ts="1710000000.000100", limit=40)
+
+
+def test_thread_read_raises_typed_error_on_slack_response_like_error():
+    reader = SlackThreadClient(client=ResponseLikeErrorWebClient(), token="xoxb-token")
+
+    with pytest.raises(SlackClientError, match="missing_scope"):
+        reader.read_thread(channel_id="C123", thread_ts="1710000000.000100", limit=40)
+
+
+def test_posts_thread_reply():
+    fake = FakeWebClient()
+    reader = SlackThreadClient(client=fake, token="xoxb-token")
+
+    reader.post_thread_reply(channel_id="C123", thread_ts="T1", text="Created Linear issue")
+
+    assert fake.posts == [{"channel": "C123", "thread_ts": "T1", "text": "Created Linear issue"}]
+
+
+def test_post_thread_reply_rejects_blank_text_before_calling_slack():
+    fake = FakeWebClient()
+    reader = SlackThreadClient(client=fake, token="xoxb-token")
+
+    with pytest.raises(SlackClientError, match="reply text is required"):
+        reader.post_thread_reply(channel_id="C123", thread_ts="T1", text="   ")
+
+    assert fake.posts == []
+
+
+def test_post_thread_reply_raises_typed_error_on_slack_api_error():
+    reader = SlackThreadClient(client=PostErrorWebClient(), token="xoxb-token")
+
+    with pytest.raises(SlackClientError, match="not_in_channel"):
+        reader.post_thread_reply(channel_id="C123", thread_ts="T1", text="Created Linear issue")
+
+
+def test_post_thread_reply_raises_typed_error_on_slack_response_like_error():
+    reader = SlackThreadClient(client=ResponseLikeErrorWebClient(), token="xoxb-token")
+
+    with pytest.raises(SlackClientError, match="not_in_channel"):
+        reader.post_thread_reply(channel_id="C123", thread_ts="T1", text="Created Linear issue")
+
+
+class FakeStreamResponse:
+    def __init__(self, chunks: Iterable[bytes]) -> None:
+        self.chunks = list(chunks)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def iter_bytes(self):
+        return iter(self.chunks)
+
+
+def test_downloads_thread_files_to_attachment_directory(monkeypatch, tmp_path):
+    fake = FakeWebClient()
+    download_dir = tmp_path / "attachments"
+    seen_headers: list[dict[str, str]] = []
+
+    def fake_stream(*args, **kwargs):
+        seen_headers.append(kwargs.get("headers") or {})
+        return FakeStreamResponse([b"image-bytes"])
+
+    monkeypatch.setattr(slack_client.httpx, "stream", fake_stream)
+    reader = SlackThreadClient(
+        client=fake,
+        token="xoxb-token",
+        monica_user_ids=("U999",),
+        download_dir=download_dir,
+    )
+
+    ctx = reader.read_thread(channel_id="C123", thread_ts="1710000000.000100", limit=40)
+
+    downloaded = download_dir / "crash.png"
+    assert ctx.files[0].local_path == str(downloaded)
+    assert ctx.files[0].error == ""
+    assert downloaded.read_bytes() == b"image-bytes"
+    assert ctx.to_dict()["attachments"] == [str(downloaded)]
+    assert seen_headers == [{"Authorization": "Bearer xoxb-token"}]
+
+
+def test_does_not_send_slack_token_when_downloading_public_attachment_image(
+    monkeypatch,
+    tmp_path,
+):
+    fake = AttachmentImageWebClient()
+    download_dir = tmp_path / "attachments"
+    seen_headers: list[dict[str, str]] = []
+
+    def fake_stream(*args, **kwargs):
+        seen_headers.append(kwargs.get("headers") or {})
+        return FakeStreamResponse([b"image-bytes"])
+
+    monkeypatch.setattr(slack_client.httpx, "stream", fake_stream)
+    reader = SlackThreadClient(
+        client=fake,
+        token="xoxb-token",
+        monica_user_ids=("U999",),
+        download_dir=download_dir,
+    )
+
+    ctx = reader.read_thread(channel_id="C123", thread_ts="1710000000.000100", limit=40)
+
+    assert ctx.files[0].local_path == str(download_dir / "Checkout-crash-screenshot")
+    assert seen_headers == [{}]
+
+
+def test_does_not_download_unsupported_attachment_url_schemes(monkeypatch, tmp_path):
+    fake = UnsafeAttachmentImageWebClient()
+    download_dir = tmp_path / "attachments"
+    stream_calls = []
+
+    def fake_stream(*args, **kwargs):
+        stream_calls.append((args, kwargs))
+        raise AssertionError("unsupported attachment URL must not be fetched")
+
+    monkeypatch.setattr(slack_client.httpx, "stream", fake_stream)
+    reader = SlackThreadClient(
+        client=fake,
+        token="xoxb-token",
+        monica_user_ids=("U999",),
+        download_dir=download_dir,
+    )
+
+    ctx = reader.read_thread(channel_id="C123", thread_ts="1710000000.000100", limit=40)
+
+    assert stream_calls == []
+    assert ctx.files[0].url_private == "file:///etc/passwd"
+    assert ctx.files[0].local_path == ""
+    assert "unsupported Slack attachment URL scheme: file" in ctx.files[0].error
+
+
+def test_downloads_duplicate_file_names_without_overwriting(monkeypatch, tmp_path):
+    fake = DuplicateFileWebClient()
+    download_dir = tmp_path / "attachments"
+    chunks_by_url = {
+        "https://files/crash-one.png": b"first-image",
+        "https://files/crash-two.png": b"second-image",
+    }
+
+    def fake_stream(method, url, **kwargs):
+        return FakeStreamResponse([chunks_by_url[url]])
+
+    monkeypatch.setattr(slack_client.httpx, "stream", fake_stream)
+    reader = SlackThreadClient(
+        client=fake,
+        token="xoxb-token",
+        monica_user_ids=("U999",),
+        download_dir=download_dir,
+    )
+
+    ctx = reader.read_thread(channel_id="C123", thread_ts="1710000000.000100", limit=40)
+
+    paths = [file.local_path for file in ctx.files]
+    assert len(paths) == 2
+    assert len(set(paths)) == 2
+    assert (download_dir / "crash.png").read_bytes() == b"first-image"
+    assert (download_dir / "crash-2.png").read_bytes() == b"second-image"
+    assert paths == [str(download_dir / "crash.png"), str(download_dir / "crash-2.png")]
+
+
+def test_download_failure_records_error_and_removes_partial_file(monkeypatch, tmp_path):
+    fake = FakeWebClient()
+    download_dir = tmp_path / "attachments"
+
+    def fake_stream(*args, **kwargs):
+        return FakeStreamResponse([b"abc", b"de"])
+
+    monkeypatch.setattr(slack_client.httpx, "stream", fake_stream)
+    reader = SlackThreadClient(
+        client=fake,
+        token="xoxb-token",
+        download_dir=download_dir,
+        max_attachment_bytes=4,
+    )
+
+    ctx = reader.read_thread(channel_id="C123", thread_ts="1710000000.000100", limit=40)
+
+    assert "exceeds 4 bytes" in ctx.files[0].error
+    assert ctx.files[0].local_path == ""
+    assert not (download_dir / "crash.png").exists()

--- a/tests/plugins/mobile_bug_agent/test_state.py
+++ b/tests/plugins/mobile_bug_agent/test_state.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import sqlite3
+
+from plugins.mobile_bug_agent.state import MonicaState
+
+
+def test_state_can_store_full_run_metadata(tmp_path):
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C123",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U123",
+        request_text="@monica fix checkout crash",
+    )
+
+    state.update_run(
+        run.id,
+        status="done",
+        linear_identifier="MOB-42",
+        linear_url="https://linear.app/acme/issue/MOB-42",
+        branch_name="monica/MOB-42-checkout-crash",
+        pr_url="https://github.com/acme/mobile/pull/123",
+    )
+
+    saved = state.get_run(run.id)
+    assert saved is not None
+    assert saved.status == "done"
+    assert saved.linear_identifier == "MOB-42"
+    assert saved.pr_url.endswith("/123")
+
+
+def test_state_persists_raw_slack_payload(tmp_path):
+    state = MonicaState.open(tmp_path / "monica.sqlite")
+    run = state.create_run(
+        platform="slack",
+        channel_id="C123",
+        thread_ts="1710000000.000100",
+        message_ts="1710000000.000100",
+        user_id="U123",
+        request_text="@monica fix checkout crash",
+        raw_event={
+            "permalink": "https://slack/thread",
+            "files": [{"id": "F1", "name": "crash.png", "mimetype": "image/png"}],
+        },
+    )
+
+    saved = state.get_run(run.id)
+
+    assert saved is not None
+    assert saved.raw_event == {
+        "files": [{"id": "F1", "mimetype": "image/png", "name": "crash.png"}],
+        "permalink": "https://slack/thread",
+    }
+
+
+def test_state_migrates_existing_run_table(tmp_path):
+    db_path = tmp_path / "old.sqlite"
+    db = sqlite3.connect(db_path)
+    db.execute(
+        """
+        CREATE TABLE runs (
+            id TEXT PRIMARY KEY,
+            platform TEXT NOT NULL,
+            channel_id TEXT NOT NULL,
+            thread_ts TEXT NOT NULL,
+            message_ts TEXT NOT NULL,
+            user_id TEXT NOT NULL,
+            request_text TEXT NOT NULL,
+            intent TEXT NOT NULL,
+            status TEXT NOT NULL,
+            UNIQUE(platform, channel_id, thread_ts)
+        )
+        """
+    )
+    db.execute(
+        """
+        INSERT INTO runs (
+            id, platform, channel_id, thread_ts, message_ts, user_id,
+            request_text, intent, status
+        ) VALUES ('run-id', 'slack', 'C123', 'T1', 'T1', 'U1', '@monica bug', 'agentic_triage', 'queued')
+        """
+    )
+    db.commit()
+    db.close()
+
+    state = MonicaState.open(db_path)
+    run = state.get_run("run-id")
+
+    assert run is not None
+    assert run.linear_identifier == ""
+    assert run.approved_by_user_id == ""
+    assert run.raw_event == {}
+
+
+def test_state_migration_adds_unique_thread_index_to_legacy_table(tmp_path):
+    db_path = tmp_path / "old-without-index.sqlite"
+    db = sqlite3.connect(db_path)
+    db.execute(
+        """
+        CREATE TABLE runs (
+            id TEXT PRIMARY KEY,
+            platform TEXT NOT NULL,
+            channel_id TEXT NOT NULL,
+            thread_ts TEXT NOT NULL,
+            message_ts TEXT NOT NULL,
+            user_id TEXT NOT NULL,
+            request_text TEXT NOT NULL,
+            raw_event_json TEXT NOT NULL DEFAULT '{}',
+            intent TEXT NOT NULL,
+            status TEXT NOT NULL,
+            linear_identifier TEXT NOT NULL DEFAULT '',
+            linear_issue_id TEXT NOT NULL DEFAULT '',
+            linear_url TEXT NOT NULL DEFAULT '',
+            branch_name TEXT NOT NULL DEFAULT '',
+            pr_url TEXT NOT NULL DEFAULT '',
+            failure_reason TEXT NOT NULL DEFAULT '',
+            approved_by_user_id TEXT NOT NULL DEFAULT '',
+            created_at TEXT NOT NULL DEFAULT '',
+            updated_at TEXT NOT NULL DEFAULT ''
+        )
+        """
+    )
+    db.execute(
+        """
+        INSERT INTO runs (
+            id, platform, channel_id, thread_ts, message_ts, user_id,
+            request_text, raw_event_json, intent, status
+        ) VALUES ('run-id', 'slack', 'C123', 'T1', 'T1', 'U1', '@monica bug', '{}', 'agentic_triage', 'queued')
+        """
+    )
+    db.commit()
+    db.close()
+
+    state = MonicaState.open(db_path)
+
+    with sqlite3.connect(db_path) as migrated:
+        indexes = migrated.execute("PRAGMA index_list(runs)").fetchall()
+        unique_indexes = {row[1] for row in indexes if row[2]}
+
+    assert "idx_monica_runs_thread_unique" in unique_indexes
+    run, created = state.create_run_once(
+        platform="slack",
+        channel_id="C123",
+        thread_ts="T1",
+        message_ts="T2",
+        user_id="U2",
+        request_text="@monica same thread",
+    )
+    assert created is False
+    assert run.id == "run-id"
+
+
+def test_state_migration_collapses_duplicate_legacy_thread_rows_before_indexing(tmp_path):
+    db_path = tmp_path / "old-with-duplicates.sqlite"
+    db = sqlite3.connect(db_path)
+    db.execute(
+        """
+        CREATE TABLE runs (
+            id TEXT PRIMARY KEY,
+            platform TEXT NOT NULL,
+            channel_id TEXT NOT NULL,
+            thread_ts TEXT NOT NULL,
+            message_ts TEXT NOT NULL,
+            user_id TEXT NOT NULL,
+            request_text TEXT NOT NULL,
+            raw_event_json TEXT NOT NULL DEFAULT '{}',
+            intent TEXT NOT NULL,
+            status TEXT NOT NULL,
+            linear_identifier TEXT NOT NULL DEFAULT '',
+            linear_issue_id TEXT NOT NULL DEFAULT '',
+            linear_url TEXT NOT NULL DEFAULT '',
+            branch_name TEXT NOT NULL DEFAULT '',
+            pr_url TEXT NOT NULL DEFAULT '',
+            failure_reason TEXT NOT NULL DEFAULT '',
+            approved_by_user_id TEXT NOT NULL DEFAULT '',
+            created_at TEXT NOT NULL DEFAULT '',
+            updated_at TEXT NOT NULL DEFAULT ''
+        )
+        """
+    )
+    db.execute(
+        """
+        INSERT INTO runs (
+            id, platform, channel_id, thread_ts, message_ts, user_id,
+            request_text, raw_event_json, intent, status
+        ) VALUES ('run-empty', 'slack', 'C123', 'T1', 'T1', 'U1', '@monica bug', '{}', 'agentic_triage', 'queued')
+        """
+    )
+    db.execute(
+        """
+        INSERT INTO runs (
+            id, platform, channel_id, thread_ts, message_ts, user_id,
+            request_text, raw_event_json, intent, status,
+            linear_identifier, linear_issue_id, linear_url, branch_name, pr_url
+        ) VALUES (
+            'run-done', 'slack', 'C123', 'T1', 'T2', 'U2', '@monica same bug',
+            '{}', 'agentic_triage', 'done',
+            'MOB-42', 'issue-id', 'https://linear.app/acme/issue/MOB-42',
+            'monica/MOB-42-checkout-crash', 'https://github.com/acme/mobile/pull/42'
+        )
+        """
+    )
+    db.commit()
+    db.close()
+
+    state = MonicaState.open(db_path)
+
+    runs = state.list_runs()
+    assert [run.id for run in runs] == ["run-done"]
+    assert runs[0].linear_identifier == "MOB-42"
+    assert runs[0].pr_url.endswith("/42")
+    run, created = state.create_run_once(
+        platform="slack",
+        channel_id="C123",
+        thread_ts="T1",
+        message_ts="T3",
+        user_id="U3",
+        request_text="@monica duplicate attempt",
+    )
+    assert created is False
+    assert run.id == "run-done"

--- a/tests/plugins/mobile_bug_agent/test_verifier.py
+++ b/tests/plugins/mobile_bug_agent/test_verifier.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import subprocess
+
+from plugins.mobile_bug_agent.verifier import VerificationRunner
+
+
+def _mark_git_worktree(path):
+    (path / ".git").write_text("gitdir: /tmp/fake-worktree-git-dir", encoding="utf-8")
+    return path
+
+
+def test_verifier_passes_all_commands(tmp_path):
+    commands = []
+    runner = VerificationRunner(
+        run_command=lambda cmd, cwd, timeout: commands.append((cmd, cwd, timeout)) or (0, "ok", "")
+    )
+
+    result = runner.run(_mark_git_worktree(tmp_path), ["npm test", "npm run lint"])
+
+    assert result.passed is True
+    assert [cmd for cmd, _cwd, _timeout in commands] == ["npm test", "npm run lint"]
+    assert result.summary == "Verification passed."
+
+
+def test_verifier_stops_on_first_failure(tmp_path):
+    calls = []
+
+    def run(cmd, cwd, timeout):
+        calls.append(cmd)
+        return 1, "", "lint failed"
+
+    runner = VerificationRunner(run_command=run)
+
+    result = runner.run(_mark_git_worktree(tmp_path), ["npm run lint", "npm test"])
+
+    assert result.passed is False
+    assert calls == ["npm run lint"]
+    assert "lint failed" in result.output
+
+
+def test_verifier_treats_command_timeout_as_failed_verification(tmp_path, monkeypatch):
+    def timeout_run(*_: object, **__: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(cmd="npm test", timeout=3)
+
+    monkeypatch.setattr(subprocess, "run", timeout_run)
+    runner = VerificationRunner(timeout_seconds=3)
+
+    result = runner.run(_mark_git_worktree(tmp_path), ["npm test", "npm run lint"])
+
+    assert result.passed is False
+    assert result.summary == "Verification failed: npm test"
+    assert result.commands == ("npm test", "npm run lint")
+    assert "$ npm test" in result.output
+    assert "timed out after 3s" in result.output
+
+
+def test_verifier_fails_closed_when_worktree_is_missing(tmp_path):
+    calls = []
+    runner = VerificationRunner(
+        run_command=lambda cmd, cwd, timeout: calls.append((cmd, cwd, timeout)) or (0, "ok", "")
+    )
+
+    result = runner.run(tmp_path / "missing-worktree", ["npm test"])
+
+    assert result.passed is False
+    assert result.summary == "Verification failed: worktree does not exist"
+    assert str(tmp_path / "missing-worktree") in result.output
+    assert result.commands == ("npm test",)
+    assert calls == []
+
+
+def test_verifier_fails_closed_when_directory_is_not_git_worktree(tmp_path):
+    calls = []
+    runner = VerificationRunner(
+        run_command=lambda cmd, cwd, timeout: calls.append((cmd, cwd, timeout)) or (0, "ok", "")
+    )
+
+    result = runner.run(tmp_path, ["npm test"])
+
+    assert result.passed is False
+    assert result.summary == "Verification failed: worktree is not a git worktree"
+    assert str(tmp_path) in result.output
+    assert result.commands == ("npm test",)
+    assert calls == []


### PR DESCRIPTION
## Summary
- add the Monica mobile bug agent plugin with Slack mention/DM gating, Linear creation, approval gates, Codex worker isolation, verification, proof gating, and draft PR publishing
- add simulator proof harness support for Stage D/E using the real Monica worktree, real npm iOS/Android scripts, optional deep links, screenshots, and a proof manifest
- require proof evidence in Monica draft PR bodies and keep PR publishing fail-closed when Linear/Slack/verification/proof context is missing

## Verification
- scripts/run_tests.sh tests/plugins/mobile_bug_agent tests/gateway/test_config.py tests/gateway/test_pre_gateway_dispatch.py tests/gateway/test_slack_approval_buttons.py tests/gateway/test_telegram_noise_filter.py tests/hermes_cli/test_plugin_cli_registration.py tests/hermes_cli/test_plugins_cmd.py
- uv run ruff check gateway/config.py gateway/platforms/slack.py gateway/run.py hermes_cli/config.py hermes_cli/main.py plugins/mobile_bug_agent tests/plugins/mobile_bug_agent tests/gateway/test_config.py tests/gateway/test_pre_gateway_dispatch.py tests/gateway/test_slack_approval_buttons.py tests/gateway/test_telegram_noise_filter.py tests/hermes_cli/test_plugin_cli_registration.py tests/hermes_cli/test_plugins_cmd.py docs/monica-agent.md
- uv run python -m compileall plugins/mobile_bug_agent gateway hermes_cli
- git diff --check

## Known Host Blockers
- iOS simulator proof currently blocks on missing simctl/full Xcode on this host
- Android simulator proof currently blocks on missing adb/emulator on this host
