### PR TITLE
fix(api_server): parse Responses API function_call_output and function_call items in input array

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2836,12 +2836,48 @@ class APIServerAdapter(BasePlatformAdapter):
                 if isinstance(item, str):
                     input_messages.append({"role": "user", "content": item})
                 elif isinstance(item, dict):
-                    role = item.get("role", "user")
-                    try:
-                        content = _normalize_multimodal_content(item.get("content", ""))
-                    except ValueError as exc:
-                        return _multimodal_validation_error(exc, param=f"input[{idx}].content")
-                    input_messages.append({"role": role, "content": content})
+                    # Responses API structured items: convert to OpenAI
+                    # chat-completions message format so the agent loop
+                    # can process them correctly.
+                    _item_type = item.get("type", "")
+                    if _item_type == "function_call_output":
+                        # Tool result → OpenAI "tool" role message
+                        _call_id = item.get("call_id", "")
+                        _output = item.get("output", "")
+                        # output may be a list of content parts or a plain string
+                        if isinstance(_output, list):
+                            _texts = [
+                                p.get("text", "") for p in _output
+                                if isinstance(p, dict) and p.get("type") == "input_text"
+                            ]
+                            _output = "\n".join(_texts) if _texts else str(_output)
+                        input_messages.append({
+                            "role": "tool",
+                            "tool_call_id": _call_id,
+                            "content": str(_output),
+                        })
+                    elif _item_type == "function_call":
+                        # Tool invocation → OpenAI assistant tool_calls message
+                        input_messages.append({
+                            "role": "assistant",
+                            "tool_calls": [{
+                                "id": item.get("call_id", item.get("id", "")),
+                                "type": "function",
+                                "function": {
+                                    "name": item.get("name", ""),
+                                    "arguments": item.get("arguments", "{}"),
+                                },
+                            }],
+                            "content": None,
+                        })
+                    else:
+                        # Standard message (type "message" or items without a type)
+                        role = item.get("role", "user")
+                        try:
+                            content = _normalize_multimodal_content(item.get("content", ""))
+                        except ValueError as exc:
+                            return _multimodal_validation_error(exc, param=f"input[{idx}].content")
+                        input_messages.append({"role": role, "content": content})
         else:
             return web.json_response(_openai_error("'input' must be a string or array"), status=400)
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1604,6 +1604,96 @@ class TestResponsesEndpoint:
             assert len(call_kwargs["conversation_history"]) == 1
 
     @pytest.mark.asyncio
+    async def test_function_call_output_in_input_converted_to_tool_message(self, adapter):
+        """Responses API function_call_output items are converted to OpenAI tool messages."""
+        mock_result = {"final_response": "Done", "messages": [], "api_calls": 1}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": [
+                            {"role": "user", "content": "What is the weather?"},
+                            {"type": "function_call", "call_id": "call_abc", "name": "get_weather", "arguments": "{\"city\": \"Paris\"}"},
+                            {"type": "function_call_output", "call_id": "call_abc", "output": "Sunny, 22°C"},
+                            {"role": "user", "content": "Thanks!"},
+                        ],
+                    },
+                )
+
+        assert resp.status == 200
+        history = mock_run.call_args.kwargs["conversation_history"]
+        # First message: user
+        assert history[0] == {"role": "user", "content": "What is the weather?"}
+        # Second message: function_call → assistant with tool_calls
+        assert history[1]["role"] == "assistant"
+        assert history[1]["content"] is None
+        assert len(history[1]["tool_calls"]) == 1
+        assert history[1]["tool_calls"][0]["id"] == "call_abc"
+        assert history[1]["tool_calls"][0]["function"]["name"] == "get_weather"
+        # Third message: function_call_output → tool message
+        assert history[2] == {"role": "tool", "tool_call_id": "call_abc", "content": "Sunny, 22°C"}
+
+    @pytest.mark.asyncio
+    async def test_function_call_output_with_structured_output_list(self, adapter):
+        """function_call_output with list output (content parts) is flattened to text."""
+        mock_result = {"final_response": "Done", "messages": [], "api_calls": 1}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": [
+                            {"type": "function_call_output", "call_id": "call_1", "output": [
+                                {"type": "input_text", "text": "Result line 1"},
+                                {"type": "input_text", "text": "Result line 2"},
+                            ]},
+                            {"role": "user", "content": "Next question"},
+                        ],
+                    },
+                )
+
+        assert resp.status == 200
+        history = mock_run.call_args.kwargs["conversation_history"]
+        assert history[0]["role"] == "tool"
+        assert history[0]["tool_call_id"] == "call_1"
+        assert "Result line 1" in history[0]["content"]
+        assert "Result line 2" in history[0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_function_call_item_without_call_id_uses_id_fallback(self, adapter):
+        """function_call with no call_id falls back to 'id' field."""
+        mock_result = {"final_response": "Done", "messages": [], "api_calls": 1}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": [
+                            {"type": "function_call", "id": "fc_123", "name": "search", "arguments": "{}"},
+                            {"role": "user", "content": "Go ahead"},
+                        ],
+                    },
+                )
+
+        assert resp.status == 200
+        history = mock_run.call_args.kwargs["conversation_history"]
+        assert history[0]["role"] == "assistant"
+        assert history[0]["tool_calls"][0]["id"] == "fc_123"
+
+    @pytest.mark.asyncio
     async def test_instructions_as_ephemeral_prompt(self, adapter):
         """The instructions field maps to ephemeral_system_prompt."""
         mock_result = {"final_response": "Ahoy!", "messages": [], "api_calls": 1}


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in the Responses API (`/v1/responses`) input array parsing where `function_call_output` (tool results) and `function_call` (tool invocations) items were silently stripped to empty `{role, content}` dicts, causing tool results to be lost between turns for stateless clients.

## Related Issue

Fixes #43757

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/api_server.py`: Added structured item type handling in the `input` array parsing loop (lines ~2837-2880). Three branches now handle:
  - `type: "function_call_output"` → converted to OpenAI `{role: "tool", tool_call_id, content}` message
  - `type: "function_call"` → converted to OpenAI `{role: "assistant", tool_calls: [...], content: None}` message
  - Standard `role`/`content` items pass through unchanged (backward compatible)
- `tests/gateway/test_api_server.py`: Added 3 regression tests covering mixed input with function_call/function_call_output, structured output lists, and call_id fallback

## How to Test

1. Start the API server: `hermes gateway --platform api_server`
2. Send a Responses API request with tool history in the input array:
```bash
curl -X POST http://localhost:8 BuenosAires/v1/responses \
  -H "Content-Type: application/json" \
  -d '{"model":"hermes-agent","input":[
    {"role":"user","content":"What is the weather?"},
    {"type":"function_call","call_id":"call_1","name":"get_weather","arguments":"{}"},
    {"type":"function_call_output","call_id":"call_1","output":"Sunny, 22°C"},
    {"role":"user","content":"Thanks!"}
  ]}'
```
3. Verify the LLM response acknowledges the tool result "Sunny, 22°C" instead of acting as if it never happened
4. Run tests: `pytest tests/gateway/test_api_server.py::TestResponsesEndpoint -v`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `api_server.py` input array parsing (`_handle_responses_post` ~L2829-2880)
- Blast radius: LOW — only affects Responses API input array parsing; Chat Completions and other endpoints untouched
- Related patterns: mirrors the existing output conversion at L3446-3462 (`_extract_output_items`) which converts OpenAI tool messages → Responses API items; this PR adds the reverse (input) direction
