### PR TITLE
fix(security): add approval gate for skill mutations in non-interacti…

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -12,6 +12,8 @@ from tools.skill_manager_tool import (
     _validate_category,
     _validate_frontmatter,
     _validate_file_path,
+    _require_approval_for_skill_action,
+    _MUTATING_SKILL_ACTIONS,
     _create_skill,
     _edit_skill,
     _patch_skill,
@@ -28,7 +30,8 @@ def _skill_dir(tmp_path):
     """Patch both SKILLS_DIR and get_all_skills_dirs so _find_skill searches
     only the temp directory — not the real ~/.hermes/skills/."""
     with patch("tools.skill_manager_tool.SKILLS_DIR", tmp_path), \
-         patch("agent.skill_utils.get_all_skills_dirs", return_value=[tmp_path]):
+         patch("agent.skill_utils.get_all_skills_dirs", return_value=[tmp_path]), \
+         patch.dict("os.environ", {"HERMES_YOLO_MODE": "1"}, clear=False):
         yield
 
 
@@ -957,3 +960,60 @@ class TestPinnedGuard:
                        side_effect=RuntimeError("sidecar broken")):
                 result = _delete_skill("my-skill")
         assert result["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# Approval gate (_require_approval_for_skill_action)
+# ---------------------------------------------------------------------------
+
+
+class TestApprovalGate:
+    """Skill mutations require user approval in non-interactive mode."""
+
+    def test_blocked_without_yolo_or_interactive(self):
+        """Mutating actions blocked when no YOLO or INTERACTIVE env."""
+        with patch.dict("os.environ", {}, clear=True):
+            result = _require_approval_for_skill_action("create", "test-skill")
+        assert result is not None
+        assert result["success"] is False
+        assert "approval" in result["error"].lower() or "confirm" in result["error"].lower()
+
+    def test_allowed_with_yolo_mode(self):
+        """Mutating actions allowed when HERMES_YOLO_MODE is set."""
+        with patch.dict("os.environ", {"HERMES_YOLO_MODE": "1"}):
+            result = _require_approval_for_skill_action("create", "test-skill")
+        assert result is None
+
+    def test_allowed_with_interactive(self):
+        """Mutating actions allowed when HERMES_INTERACTIVE is set."""
+        with patch.dict("os.environ", {"HERMES_INTERACTIVE": "1"}):
+            result = _require_approval_for_skill_action("delete", "test-skill")
+        assert result is None
+
+    def test_readonly_actions_always_allowed(self):
+        """Read-only actions (list, show) bypass the approval gate entirely.
+
+        The gate is only invoked for actions in _MUTATING_SKILL_ACTIONS,
+        so list/show never reach _require_approval_for_skill_action.
+        """
+        assert "list" not in _MUTATING_SKILL_ACTIONS
+        assert "show" not in _MUTATING_SKILL_ACTIONS
+
+    def test_all_mutating_actions_gated(self):
+        """Every action in _MUTATING_SKILL_ACTIONS goes through the gate."""
+        from tools.skill_manager_tool import _MUTATING_SKILL_ACTIONS
+        with patch.dict("os.environ", {}, clear=True):
+            for action in _MUTATING_SKILL_ACTIONS:
+                result = _require_approval_for_skill_action(action, "x")
+                assert result is not None, f"action '{action}' should be gated"
+
+    def test_skill_manage_returns_approval_error(self, tmp_path):
+        """skill_manage returns JSON approval error for blocked mutations."""
+        with patch("tools.skill_manager_tool.SKILLS_DIR", tmp_path), \
+             patch("agent.skill_utils.get_all_skills_dirs", return_value=[tmp_path]), \
+             patch.dict("os.environ", {}, clear=True):
+            raw = skill_manage("create", "test-skill", content=VALID_SKILL_CONTENT)
+        import json
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "approval" in result["error"].lower() or "confirm" in result["error"].lower()

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -14,6 +14,7 @@ from tools.skill_manager_tool import (
     _validate_file_path,
     _require_approval_for_skill_action,
     _MUTATING_SKILL_ACTIONS,
+    SKILL_MANAGE_SCHEMA,
     _create_skill,
     _edit_skill,
     _patch_skill,
@@ -31,7 +32,7 @@ def _skill_dir(tmp_path):
     only the temp directory — not the real ~/.hermes/skills/."""
     with patch("tools.skill_manager_tool.SKILLS_DIR", tmp_path), \
          patch("agent.skill_utils.get_all_skills_dirs", return_value=[tmp_path]), \
-         patch.dict("os.environ", {"HERMES_YOLO_MODE": "1"}, clear=False):
+         patch("tools.approval._YOLO_MODE_FROZEN", True):
         yield
 
 
@@ -972,46 +973,84 @@ class TestApprovalGate:
 
     def test_blocked_without_yolo_or_interactive(self):
         """Mutating actions blocked when no YOLO or INTERACTIVE env."""
-        with patch.dict("os.environ", {}, clear=True):
+        with patch.dict("os.environ", {}, clear=True), \
+             patch("tools.approval._YOLO_MODE_FROZEN", False):
             result = _require_approval_for_skill_action("create", "test-skill")
         assert result is not None
         assert result["success"] is False
         assert "approval" in result["error"].lower() or "confirm" in result["error"].lower()
 
-    def test_allowed_with_yolo_mode(self):
-        """Mutating actions allowed when HERMES_YOLO_MODE is set."""
-        with patch.dict("os.environ", {"HERMES_YOLO_MODE": "1"}):
+    def test_live_yolo_env_does_not_bypass_gate(self):
+        """Runtime env mutation must not bypass the frozen YOLO approval state."""
+        with patch.dict("os.environ", {"HERMES_YOLO_MODE": "1"}, clear=True), \
+             patch("tools.approval._YOLO_MODE_FROZEN", False):
+            result = _require_approval_for_skill_action("create", "test-skill")
+        assert result is not None
+        assert result["success"] is False
+
+    def test_allowed_with_frozen_yolo_mode(self):
+        """Mutating actions allowed when process YOLO was enabled at startup."""
+        with patch.dict("os.environ", {}, clear=True), \
+             patch("tools.approval._YOLO_MODE_FROZEN", True):
             result = _require_approval_for_skill_action("create", "test-skill")
         assert result is None
 
-    def test_allowed_with_interactive(self):
-        """Mutating actions allowed when HERMES_INTERACTIVE is set."""
-        with patch.dict("os.environ", {"HERMES_INTERACTIVE": "1"}):
-            result = _require_approval_for_skill_action("delete", "test-skill")
+    def test_allowed_with_interactive_approval(self):
+        """Mutating actions allowed when the interactive user approves."""
+        from tools.terminal_tool import set_approval_callback
+        set_approval_callback(lambda *args, **kwargs: "once")
+        try:
+            with patch.dict("os.environ", {"HERMES_INTERACTIVE": "1"}), \
+                 patch("tools.approval._YOLO_MODE_FROZEN", False):
+                result = _require_approval_for_skill_action("delete", "test-skill")
+        finally:
+            set_approval_callback(None)
         assert result is None
 
-    def test_readonly_actions_always_allowed(self):
-        """Read-only actions (list, show) bypass the approval gate entirely.
-
-        The gate is only invoked for actions in _MUTATING_SKILL_ACTIONS,
-        so list/show never reach _require_approval_for_skill_action.
-        """
-        assert "list" not in _MUTATING_SKILL_ACTIONS
-        assert "show" not in _MUTATING_SKILL_ACTIONS
+    def test_interactive_denial_blocks_mutation(self):
+        """Interactive mode still blocks when the user denies approval."""
+        from tools.terminal_tool import set_approval_callback
+        set_approval_callback(lambda *args, **kwargs: "deny")
+        try:
+            with patch.dict("os.environ", {"HERMES_INTERACTIVE": "1"}), \
+                 patch("tools.approval._YOLO_MODE_FROZEN", False):
+                result = _require_approval_for_skill_action("delete", "test-skill")
+        finally:
+            set_approval_callback(None)
+        assert result is not None
+        assert result["success"] is False
+        assert "denied" in result["error"].lower()
 
     def test_all_mutating_actions_gated(self):
         """Every action in _MUTATING_SKILL_ACTIONS goes through the gate."""
-        from tools.skill_manager_tool import _MUTATING_SKILL_ACTIONS
-        with patch.dict("os.environ", {}, clear=True):
+        with patch.dict("os.environ", {}, clear=True), \
+             patch("tools.approval._YOLO_MODE_FROZEN", False):
             for action in _MUTATING_SKILL_ACTIONS:
                 result = _require_approval_for_skill_action(action, "x")
                 assert result is not None, f"action '{action}' should be gated"
+
+    def test_gate_covers_all_schema_actions(self):
+        """_MUTATING_SKILL_ACTIONS must match the tool schema enum exactly."""
+        schema_actions = set(SKILL_MANAGE_SCHEMA["parameters"]["properties"]["action"]["enum"])
+        assert _MUTATING_SKILL_ACTIONS == schema_actions, (
+            f"Frozenset {sorted(_MUTATING_SKILL_ACTIONS)} != schema {sorted(schema_actions)}. "
+            "Add new actions to _MUTATING_SKILL_ACTIONS or the schema."
+        )
+
+    def test_error_message_includes_yolo_hint(self):
+        """Blocked error tells the agent how to bypass (HERMES_YOLO_MODE)."""
+        with patch.dict("os.environ", {}, clear=True), \
+             patch("tools.approval._YOLO_MODE_FROZEN", False):
+            result = _require_approval_for_skill_action("create", "test-skill")
+        assert result is not None
+        assert "HERMES_YOLO_MODE" in result["error"]
 
     def test_skill_manage_returns_approval_error(self, tmp_path):
         """skill_manage returns JSON approval error for blocked mutations."""
         with patch("tools.skill_manager_tool.SKILLS_DIR", tmp_path), \
              patch("agent.skill_utils.get_all_skills_dirs", return_value=[tmp_path]), \
-             patch.dict("os.environ", {}, clear=True):
+             patch.dict("os.environ", {}, clear=True), \
+             patch("tools.approval._YOLO_MODE_FROZEN", False):
             raw = skill_manage("create", "test-skill", content=VALID_SKILL_CONTENT)
         import json
         result = json.loads(raw)

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -12,9 +12,6 @@ from tools.skill_manager_tool import (
     _validate_category,
     _validate_frontmatter,
     _validate_file_path,
-    _require_approval_for_skill_action,
-    _MUTATING_SKILL_ACTIONS,
-    SKILL_MANAGE_SCHEMA,
     _create_skill,
     _edit_skill,
     _patch_skill,
@@ -22,6 +19,8 @@ from tools.skill_manager_tool import (
     _write_file,
     _remove_file,
     skill_manage,
+    SKILL_MANAGE_SCHEMA,
+    _skill_gate_bypass,
     MAX_NAME_LENGTH,
 )
 
@@ -964,95 +963,96 @@ class TestPinnedGuard:
 
 
 # ---------------------------------------------------------------------------
-# Approval gate (_require_approval_for_skill_action)
+# Write approval gate (upstream _apply_skill_write_gate)
 # ---------------------------------------------------------------------------
 
 
-class TestApprovalGate:
-    """Skill mutations require user approval in non-interactive mode."""
+class TestWriteApprovalGate:
+    """Tests for the write-approval gate that stages skill writes for review.
 
-    def test_blocked_without_yolo_or_interactive(self):
-        """Mutating actions blocked when no YOLO or INTERACTIVE env."""
-        with patch.dict("os.environ", {}, clear=True), \
-             patch("tools.approval._YOLO_MODE_FROZEN", False):
-            result = _require_approval_for_skill_action("create", "test-skill")
-        assert result is not None
-        assert result["success"] is False
-        assert "approval" in result["error"].lower() or "confirm" in result["error"].lower()
+    The gate is controlled by skills.write_approval in config.yaml (default
+    False). When off, writes flow freely. When on, skill writes are staged
+    to <HERMES_HOME>/pending/skills/ for user review.
+    """
 
-    def test_live_yolo_env_does_not_bypass_gate(self):
-        """Runtime env mutation must not bypass the frozen YOLO approval state."""
-        with patch.dict("os.environ", {"HERMES_YOLO_MODE": "1"}, clear=True), \
-             patch("tools.approval._YOLO_MODE_FROZEN", False):
-            result = _require_approval_for_skill_action("create", "test-skill")
-        assert result is not None
-        assert result["success"] is False
+    def test_gate_off_writes_flow(self, tmp_path):
+        """When write_approval is off (default), skill_manage proceeds directly."""
+        with _skill_dir(tmp_path), \
+             patch("tools.write_approval.evaluate_gate") as mock_eval:
+            from tools.write_approval import GateDecision
+            mock_eval.return_value = GateDecision(allow=True)
+            result = json.loads(skill_manage("create", "test-skill", content=VALID_SKILL_CONTENT))
+        assert result["success"] is True
+        assert "staged" not in result
 
-    def test_allowed_with_frozen_yolo_mode(self):
-        """Mutating actions allowed when process YOLO was enabled at startup."""
-        with patch.dict("os.environ", {}, clear=True), \
-             patch("tools.approval._YOLO_MODE_FROZEN", True):
-            result = _require_approval_for_skill_action("create", "test-skill")
-        assert result is None
+    def test_gate_on_stages_write(self, tmp_path):
+        """When write_approval is on, skill_manage stages instead of writing."""
+        with _skill_dir(tmp_path), \
+             patch("tools.write_approval.evaluate_gate") as mock_eval, \
+             patch("tools.write_approval.stage_write") as mock_stage, \
+             patch("tools.write_approval.current_origin", return_value="foreground"):
+            from tools.write_approval import GateDecision
+            mock_eval.return_value = GateDecision(
+                stage=True, message="Staged for approval."
+            )
+            mock_stage.return_value = {"id": "abc123", "summary": "create test-skill"}
+            result = json.loads(skill_manage("create", "test-skill", content=VALID_SKILL_CONTENT))
+        assert result["success"] is True
+        assert result["staged"] is True
+        assert result["pending_id"] == "abc123"
+        mock_stage.assert_called_once()
 
-    def test_allowed_with_interactive_approval(self):
-        """Mutating actions allowed when the interactive user approves."""
-        from tools.terminal_tool import set_approval_callback
-        set_approval_callback(lambda *args, **kwargs: "once")
+    def test_gate_bypass_allows_direct_write(self, tmp_path):
+        """_skill_gate_bypass ContextVar skips the gate during replay."""
+        token = _skill_gate_bypass.set(True)
         try:
-            with patch.dict("os.environ", {"HERMES_INTERACTIVE": "1"}), \
-                 patch("tools.approval._YOLO_MODE_FROZEN", False):
-                result = _require_approval_for_skill_action("delete", "test-skill")
+            with _skill_dir(tmp_path), \
+                 patch("tools.write_approval.evaluate_gate") as mock_eval:
+                from tools.write_approval import GateDecision
+                mock_eval.return_value = GateDecision(allow=True)
+                result = json.loads(skill_manage("create", "test-skill", content=VALID_SKILL_CONTENT))
         finally:
-            set_approval_callback(None)
-        assert result is None
+            _skill_gate_bypass.reset(token)
+        assert result["success"] is True
+        assert "staged" not in result
+        mock_eval.assert_not_called()
 
-    def test_interactive_denial_blocks_mutation(self):
-        """Interactive mode still blocks when the user denies approval."""
-        from tools.terminal_tool import set_approval_callback
-        set_approval_callback(lambda *args, **kwargs: "deny")
-        try:
-            with patch.dict("os.environ", {"HERMES_INTERACTIVE": "1"}), \
-                 patch("tools.approval._YOLO_MODE_FROZEN", False):
-                result = _require_approval_for_skill_action("delete", "test-skill")
-        finally:
-            set_approval_callback(None)
-        assert result is not None
-        assert result["success"] is False
-        assert "denied" in result["error"].lower()
+    def test_apply_skill_pending_replays_create(self, tmp_path):
+        """apply_skill_pending replays a staged create through skill_manage."""
+        with _skill_dir(tmp_path), \
+             patch("tools.write_approval.evaluate_gate") as mock_eval:
+            from tools.write_approval import GateDecision
+            mock_eval.return_value = GateDecision(allow=True)
+            from tools.skill_manager_tool import apply_skill_pending
+            payload = {"action": "create", "name": "replayed-skill", "content": VALID_SKILL_CONTENT}
+            raw = apply_skill_pending(payload)
+            result = json.loads(raw)
+        assert result["success"] is True
+        assert "replayed-skill" in result.get("message", "")
 
-    def test_all_mutating_actions_gated(self):
-        """Every action in _MUTATING_SKILL_ACTIONS goes through the gate."""
-        with patch.dict("os.environ", {}, clear=True), \
-             patch("tools.approval._YOLO_MODE_FROZEN", False):
-            for action in _MUTATING_SKILL_ACTIONS:
-                result = _require_approval_for_skill_action(action, "x")
-                assert result is not None, f"action '{action}' should be gated"
+    def test_gate_off_all_actions_bypass(self, tmp_path):
+        """All 6 mutating actions bypass the gate when write_approval is off."""
+        with _skill_dir(tmp_path), \
+             patch("tools.write_approval.evaluate_gate") as mock_eval:
+            from tools.write_approval import GateDecision
+            mock_eval.return_value = GateDecision(allow=True)
+            _create_skill("gate-test", VALID_SKILL_CONTENT)
+            for action in ("edit", "patch", "write_file", "delete"):
+                if action == "edit":
+                    kwargs = {"content": VALID_SKILL_CONTENT}
+                elif action == "patch":
+                    kwargs = {"old_string": "Do the thing.", "new_string": "Do the thing. Now."}
+                elif action == "write_file":
+                    kwargs = {"file_path": "references/note.md", "file_content": "hi"}
+                elif action == "delete":
+                    kwargs = {}
+                result = json.loads(skill_manage(action, "gate-test", **kwargs))
+                assert result["success"] is True, f"action {action} failed: {result}"
+                if action == "delete":
+                    _create_skill("gate-test", VALID_SKILL_CONTENT)
 
-    def test_gate_covers_all_schema_actions(self):
-        """_MUTATING_SKILL_ACTIONS must match the tool schema enum exactly."""
+    def test_schema_matches_mutating_actions(self):
+        """SKILL_MANAGE_SCHEMA enum lists exactly the 6 mutating actions."""
         schema_actions = set(SKILL_MANAGE_SCHEMA["parameters"]["properties"]["action"]["enum"])
-        assert _MUTATING_SKILL_ACTIONS == schema_actions, (
-            f"Frozenset {sorted(_MUTATING_SKILL_ACTIONS)} != schema {sorted(schema_actions)}. "
-            "Add new actions to _MUTATING_SKILL_ACTIONS or the schema."
-        )
-
-    def test_error_message_includes_yolo_hint(self):
-        """Blocked error tells the agent how to bypass (HERMES_YOLO_MODE)."""
-        with patch.dict("os.environ", {}, clear=True), \
-             patch("tools.approval._YOLO_MODE_FROZEN", False):
-            result = _require_approval_for_skill_action("create", "test-skill")
-        assert result is not None
-        assert "HERMES_YOLO_MODE" in result["error"]
-
-    def test_skill_manage_returns_approval_error(self, tmp_path):
-        """skill_manage returns JSON approval error for blocked mutations."""
-        with patch("tools.skill_manager_tool.SKILLS_DIR", tmp_path), \
-             patch("agent.skill_utils.get_all_skills_dirs", return_value=[tmp_path]), \
-             patch.dict("os.environ", {}, clear=True), \
-             patch("tools.approval._YOLO_MODE_FROZEN", False):
-            raw = skill_manage("create", "test-skill", content=VALID_SKILL_CONTENT)
-        import json
-        result = json.loads(raw)
-        assert result["success"] is False
-        assert "approval" in result["error"].lower() or "confirm" in result["error"].lower()
+        expected = {"create", "edit", "patch", "delete", "write_file", "remove_file"}
+        assert schema_actions == expected

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -831,8 +831,40 @@ def _require_approval_for_skill_action(action: str, name: str) -> Optional[Dict[
 
     Returns error dict (to return to caller) if blocked, None if allowed.
     """
-    if os.getenv("HERMES_YOLO_MODE") or os.getenv("HERMES_INTERACTIVE"):
+    from tools.approval import (
+        _YOLO_MODE_FROZEN,
+        is_current_session_yolo_enabled,
+        prompt_dangerous_approval,
+    )
+    from utils import env_var_enabled
+
+    if _YOLO_MODE_FROZEN or is_current_session_yolo_enabled():
         return None
+
+    if env_var_enabled("HERMES_INTERACTIVE"):
+        from tools.terminal_tool import _get_approval_callback
+
+        description = (
+            "skill mutation. Skills are persistent instructions loaded into "
+            "future agent sessions, so malicious or accidental changes can "
+            "become durable prompt injection."
+        )
+        choice = prompt_dangerous_approval(
+            f"skill_manage action={action} name={name}",
+            description,
+            allow_permanent=False,
+            approval_callback=_get_approval_callback(),
+        )
+        if choice != "deny":
+            return None
+        return {
+            "success": False,
+            "error": (
+                f"BLOCKED: User denied skill '{name}' action '{action}'. "
+                "Do NOT retry or attempt the same skill mutation another way."
+            ),
+        }
+
     logger.warning(
         "Skill '%s' action '%s' requires user approval - non-interactive, no YOLO mode",
         name, action,
@@ -842,7 +874,7 @@ def _require_approval_for_skill_action(action: str, name: str) -> Optional[Dict[
         "error": (
             f"Cannot '{action}' skill '{name}' without user confirmation. "
             f"The agent must ask the user to approve this skill change. "
-            f"To auto-approve, enable YOLO mode or run interactively."
+            f"To auto-approve, set HERMES_YOLO_MODE=1 or run interactively."
         ),
     }
 

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -822,6 +822,38 @@ def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
 # Main entry point
 # =============================================================================
 
+def _require_approval_for_skill_action(action: str, name: str) -> Optional[Dict[str, Any]]:
+    """Check if skill action requires user approval.
+
+    Agent-created skills are persistent prompt-injection vectors loaded every
+    session.  In non-interactive mode (no TTY, cron, delegation) the agent must
+    not autonomously mutate skills without explicit user confirmation.
+
+    Returns error dict (to return to caller) if blocked, None if allowed.
+    """
+    if os.getenv("HERMES_YOLO_MODE") or os.getenv("HERMES_INTERACTIVE"):
+        return None
+    logger.warning(
+        "Skill '%s' action '%s' requires user approval - non-interactive, no YOLO mode",
+        name, action,
+    )
+    return {
+        "success": False,
+        "error": (
+            f"Cannot '{action}' skill '{name}' without user confirmation. "
+            f"The agent must ask the user to approve this skill change. "
+            f"To auto-approve, enable YOLO mode or run interactively."
+        ),
+    }
+
+
+# Actions that mutate persistent skill state and require approval in
+# non-interactive mode.  Read-only actions (list, show) are always safe.
+_MUTATING_SKILL_ACTIONS = frozenset({
+    "create", "edit", "delete", "patch", "write_file", "remove_file",
+})
+
+
 def skill_manage(
     action: str,
     name: str,
@@ -839,6 +871,11 @@ def skill_manage(
 
     Returns JSON string with results.
     """
+    if action in _MUTATING_SKILL_ACTIONS:
+        blocked = _require_approval_for_skill_action(action, name)
+        if blocked:
+            return json.dumps(blocked, ensure_ascii=False)
+
     if action == "create":
         if not content:
             return tool_error("content is required for 'create'. Provide the full SKILL.md text (frontmatter + body).", success=False)

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -822,68 +822,73 @@ def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
 # Main entry point
 # =============================================================================
 
-def _require_approval_for_skill_action(action: str, name: str) -> Optional[Dict[str, Any]]:
-    """Check if skill action requires user approval.
+# ContextVar bypass: set while replaying an already-approved staged skill write
+# so skill_manage() does not re-gate (and re-stage) it.
+import contextvars as _ctxvars
+_skill_gate_bypass: "_ctxvars.ContextVar[bool]" = _ctxvars.ContextVar(
+    "skill_gate_bypass", default=False
+)
 
-    Agent-created skills are persistent prompt-injection vectors loaded every
-    session.  In non-interactive mode (no TTY, cron, delegation) the agent must
-    not autonomously mutate skills without explicit user confirmation.
 
-    Returns error dict (to return to caller) if blocked, None if allowed.
+def _apply_skill_write_gate(action, name, **payload_kwargs):
+    """Evaluate the skill write gate. Returns a JSON tool-result string when the
+    write should NOT proceed (blocked or staged), or None to perform the real
+    write. Bypassed during approved-pending replay.
     """
-    from tools.approval import (
-        _YOLO_MODE_FROZEN,
-        is_current_session_yolo_enabled,
-        prompt_dangerous_approval,
-    )
-    from utils import env_var_enabled
-
-    if _YOLO_MODE_FROZEN or is_current_session_yolo_enabled():
+    if action not in {"create", "edit", "patch", "delete", "write_file", "remove_file"}:
+        return None
+    if _skill_gate_bypass.get():
         return None
 
-    if env_var_enabled("HERMES_INTERACTIVE"):
-        from tools.terminal_tool import _get_approval_callback
+    try:
+        from tools import write_approval as wa
+    except Exception:
+        return None  # fail open
 
-        description = (
-            "skill mutation. Skills are persistent instructions loaded into "
-            "future agent sessions, so malicious or accidental changes can "
-            "become durable prompt injection."
-        )
-        choice = prompt_dangerous_approval(
-            f"skill_manage action={action} name={name}",
-            description,
-            allow_permanent=False,
-            approval_callback=_get_approval_callback(),
-        )
-        if choice != "deny":
-            return None
-        return {
-            "success": False,
-            "error": (
-                f"BLOCKED: User denied skill '{name}' action '{action}'. "
-                "Do NOT retry or attempt the same skill mutation another way."
-            ),
-        }
+    decision = wa.evaluate_gate(wa.SKILLS)
+    if decision.allow:
+        return None
+    if decision.blocked:
+        return tool_error(decision.message, success=False)
 
-    logger.warning(
-        "Skill '%s' action '%s' requires user approval - non-interactive, no YOLO mode",
-        name, action,
+    # stage — record the full skill_manage kwargs so approval can replay it.
+    payload = {"action": action, "name": name}
+    payload.update({k: v for k, v in payload_kwargs.items() if v is not None})
+    gist = wa.skill_gist(
+        action, name,
+        content=payload_kwargs.get("content") or "",
+        file_path=payload_kwargs.get("file_path") or "",
+        old_string=payload_kwargs.get("old_string") or "",
+        new_string=payload_kwargs.get("new_string") or "",
     )
-    return {
-        "success": False,
-        "error": (
-            f"Cannot '{action}' skill '{name}' without user confirmation. "
-            f"The agent must ask the user to approve this skill change. "
-            f"To auto-approve, set HERMES_YOLO_MODE=1 or run interactively."
-        ),
-    }
+    record = wa.stage_write(wa.SKILLS, payload, summary=gist, origin=wa.current_origin())
+    return json.dumps(
+        {"success": True, "staged": True, "pending_id": record["id"],
+         "gist": gist, "message": decision.message},
+        ensure_ascii=False,
+    )
 
 
-# Actions that mutate persistent skill state and require approval in
-# non-interactive mode.  Read-only actions (list, show) are always safe.
-_MUTATING_SKILL_ACTIONS = frozenset({
-    "create", "edit", "delete", "patch", "write_file", "remove_file",
-})
+def apply_skill_pending(payload: Dict[str, Any]) -> str:
+    """Replay a staged skill write, bypassing the gate. Returns the tool result
+    JSON string. Called by the /skills approve handler.
+    """
+    token = _skill_gate_bypass.set(True)
+    try:
+        return skill_manage(
+            action=payload.get("action", ""),
+            name=payload.get("name", ""),
+            content=payload.get("content"),
+            category=payload.get("category"),
+            file_path=payload.get("file_path"),
+            file_content=payload.get("file_content"),
+            old_string=payload.get("old_string"),
+            new_string=payload.get("new_string"),
+            replace_all=payload.get("replace_all", False),
+            absorbed_into=payload.get("absorbed_into"),
+        )
+    finally:
+        _skill_gate_bypass.reset(token)
 
 
 def skill_manage(
@@ -903,10 +908,18 @@ def skill_manage(
 
     Returns JSON string with results.
     """
-    if action in _MUTATING_SKILL_ACTIONS:
-        blocked = _require_approval_for_skill_action(action, name)
-        if blocked:
-            return json.dumps(blocked, ensure_ascii=False)
+    # Approval gate: when on, stages the write for review (skills are too large
+    # to review inline, so they always stage regardless of origin); when off
+    # (default) passes straight through. The gate is bypassed when this call is
+    # itself replaying an already-approved staged write (_skill_apply_pending).
+    gate_result = _apply_skill_write_gate(
+        action, name, content=content, category=category,
+        file_path=file_path, file_content=file_content,
+        old_string=old_string, new_string=new_string,
+        replace_all=replace_all, absorbed_into=absorbed_into,
+    )
+    if gate_result is not None:
+        return gate_result
 
     if action == "create":
         if not content:

--- a/tools/write_approval.py
+++ b/tools/write_approval.py
@@ -1,0 +1,493 @@
+#!/usr/bin/env python3
+"""Write-approval gate + pending store for memory and skill writes.
+
+Background
+----------
+The agent writes to two persistent stores that survive across sessions:
+
+  * **memory** — MEMORY.md / USER.md, small (~200 char) declarative entries
+  * **skills** — SKILL.md + supporting files, potentially huge (10-100 KB)
+
+Both stores are written from two origins:
+
+  * **foreground** — a normal agent turn (user is present / chatting)
+  * **background_review** — the self-improvement review fork that runs after a
+    turn and autonomously decides what to save (the source of the
+    "wrong assumptions" users complained about)
+
+This module lets the user gate those writes per-subsystem with a boolean
+``write_approval``:
+
+  * ``false`` (default) — write freely (the pre-gate behaviour)
+  * ``true``            — require approval: do not commit the write; either
+    prompt inline (memory, interactive CLI only) or **stage** it to a pending
+    store and surface it for the user to approve or reject out-of-band
+
+The size asymmetry between memory and skills is real and unavoidable: a memory
+entry can be reviewed inline in a chat bubble; a 100 KB SKILL.md cannot. So
+the gate stages BOTH to disk, but review affordances differ by subsystem
+(see ``hermes_cli`` slash handlers): memory shows full content, skills show
+metadata + a one-line gist + a ``diff`` escape hatch (CLI/dashboard/file).
+
+Staging is mandatory for background-origin writes (a daemon thread cannot
+block on an interactive prompt) and for gateway sessions (no inline prompt
+channel — review happens via ``/memory pending``). Foreground CLI memory
+writes prompt inline via the dangerous-command approval callback; skill
+writes always stage (too big to eyeball mid-loop).
+
+Pending records live under ``<HERMES_HOME>/pending/{memory,skills}/<id>.json``
+so they survive process restarts and can be reviewed from CLI, gateway, or the
+web dashboard.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+# Subsystem identifiers
+MEMORY = "memory"
+SKILLS = "skills"
+_SUBSYSTEMS = (MEMORY, SKILLS)
+
+# Config key (per subsystem). A single boolean: the approval gate is OFF by
+# default (writes flow freely, the pre-gate behaviour), and ON means stage /
+# prompt every write for the user's approval. There is intentionally no third
+# "block all writes" state — to disable a subsystem entirely use its own
+# enable flag (e.g. ``memory.memory_enabled: false``).
+CONFIG_KEY = "write_approval"
+
+
+# ---------------------------------------------------------------------------
+# Config resolution
+# ---------------------------------------------------------------------------
+
+def write_approval_enabled(subsystem: str) -> bool:
+    """Return whether the approval gate is enabled for ``subsystem``.
+
+    Reads ``<subsystem>.write_approval`` from config.yaml. Defaults to
+    ``False`` (gate off — writes flow freely) for any unset / invalid value so
+    existing installs keep their current behaviour until the user opts in.
+    """
+    if subsystem not in _SUBSYSTEMS:
+        return False
+    try:
+        from hermes_cli.config import load_config, cfg_get
+        cfg = load_config()
+        raw = cfg_get(cfg, subsystem, CONFIG_KEY, default=False)
+    except Exception:
+        return False
+    return _normalize_enabled(raw)
+
+
+def _normalize_enabled(value: Any) -> bool:
+    """Coerce a config value to a bool. Default (unknown) is False (gate off).
+
+    Accepts real bools and the usual truthy/falsey strings. YAML 1.1 parses
+    bare ``on``/``off``/``yes``/``no`` as bools already, so the string branch
+    is mostly for hand-edited configs.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"on", "true", "yes", "1", "approve", "enabled"}
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Pending store (file-backed)
+# ---------------------------------------------------------------------------
+
+def _pending_dir(subsystem: str) -> Path:
+    return get_hermes_home() / "pending" / subsystem
+
+
+def stage_write(subsystem: str, payload: Dict[str, Any],
+                *, summary: str, origin: str) -> Dict[str, Any]:
+    """Persist a pending write and return a short record describing it.
+
+    Args:
+        subsystem: ``memory`` or ``skills``.
+        payload: the exact kwargs needed to replay the write when approved
+            (e.g. ``{"action": "add", "target": "user", "content": "..."}``
+            for memory, or the full ``skill_manage`` kwargs for skills).
+        summary: a one-line human-readable description shown in pending lists.
+            For skills this is the LLM/heuristic gist; for memory it can be the
+            entry text itself.
+        origin: ``foreground`` or ``background_review`` — recorded for audit.
+
+    Returns a dict with ``id`` and metadata. Best-effort: on disk failure it
+    logs and still returns a record (the write is simply lost, which is the
+    safe failure for an approval gate — nothing is silently committed).
+    """
+    pid = uuid.uuid4().hex[:8]
+    record = {
+        "id": pid,
+        "subsystem": subsystem,
+        "action": payload.get("action", ""),
+        "summary": (summary or "").strip(),
+        "origin": origin or "foreground",
+        "created_at": time.time(),
+        "payload": payload,
+    }
+    try:
+        d = _pending_dir(subsystem)
+        d.mkdir(parents=True, exist_ok=True)
+        path = d / f"{pid}.json"
+        tmp = path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(record, ensure_ascii=False, indent=2), encoding="utf-8")
+        os.replace(tmp, path)
+    except Exception as e:  # pragma: no cover - disk failure path
+        logger.error("Failed to stage pending %s write: %s", subsystem, e, exc_info=True)
+    return record
+
+
+def list_pending(subsystem: str) -> List[Dict[str, Any]]:
+    """Return all pending records for ``subsystem``, oldest first."""
+    d = _pending_dir(subsystem)
+    if not d.exists():
+        return []
+    records: List[Dict[str, Any]] = []
+    for p in d.glob("*.json"):
+        try:
+            records.append(json.loads(p.read_text(encoding="utf-8")))
+        except Exception:
+            logger.warning("Skipping unreadable pending record: %s", p)
+    records.sort(key=lambda r: r.get("created_at", 0))
+    return records
+
+
+def get_pending(subsystem: str, pending_id: str) -> Optional[Dict[str, Any]]:
+    """Return a single pending record by id, or None."""
+    path = _pending_dir(subsystem) / f"{pending_id}.json"
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def discard_pending(subsystem: str, pending_id: str) -> bool:
+    """Delete a pending record. Returns True if it existed."""
+    path = _pending_dir(subsystem) / f"{pending_id}.json"
+    try:
+        if path.exists():
+            path.unlink()
+            return True
+    except Exception as e:  # pragma: no cover
+        logger.error("Failed to discard pending %s/%s: %s", subsystem, pending_id, e)
+    return False
+
+
+def pending_count(subsystem: str) -> int:
+    """Cheap count of pending records (for notification badges)."""
+    d = _pending_dir(subsystem)
+    if not d.exists():
+        return 0
+    try:
+        return sum(1 for _ in d.glob("*.json"))
+    except Exception:
+        return 0
+
+
+# ---------------------------------------------------------------------------
+# Write origin
+# ---------------------------------------------------------------------------
+
+def current_origin() -> str:
+    """Return the active write origin: ``foreground`` or ``background_review``.
+
+    Reuses the skill-provenance ContextVar, which the background review fork
+    already sets (see ``agent.background_review`` /
+    ``AIAgent._spawn_background_review``). Foreground agent turns leave it at
+    the default ``foreground``.
+    """
+    try:
+        from tools.skill_provenance import get_current_write_origin
+        return get_current_write_origin()
+    except Exception:
+        return "foreground"
+
+
+def is_background() -> bool:
+    return current_origin() == "background_review"
+
+
+# ---------------------------------------------------------------------------
+# Gate decision
+# ---------------------------------------------------------------------------
+
+class GateDecision:
+    """Result of evaluating the write gate for a single write attempt.
+
+    Exactly one of the boolean flags is True:
+      * ``allow``  — proceed with the real write (gate off, or an inline
+        approval was granted).
+      * ``blocked`` — refuse the write (the user denied an inline approval
+        prompt). ``message`` explains why; surface it to the agent.
+      * ``stage``  — do not write; the caller should stage the payload via
+        ``stage_write`` (gate on, and no inline prompt is available — gateway,
+        background review, script, or any skill write). ``message`` is the
+        user-facing "staged for approval" note.
+    """
+
+    __slots__ = ("allow", "blocked", "stage", "message")
+
+    def __init__(self, *, allow=False, blocked=False, stage=False, message=""):
+        self.allow = allow
+        self.blocked = blocked
+        self.stage = stage
+        self.message = message
+
+
+def evaluate_gate(subsystem: str, *, inline_summary: str = "",
+                  inline_detail: str = "") -> GateDecision:
+    """Decide what to do with a pending write for ``subsystem``.
+
+    Args:
+        subsystem: ``memory`` or ``skills``.
+        inline_summary: short description used as the inline approval prompt
+            header (memory foreground path only).
+        inline_detail: full content shown in the inline prompt (memory entries
+            are small; skills never take the inline path).
+
+    Decision matrix:
+        gate off (default)                    → allow (writes flow freely)
+        gate on, memory + interactive CLI     → inline approve/deny prompt
+        gate on, memory + gateway/script/bg   → stage
+        gate on, skills (any origin)          → stage (too big to review inline)
+
+    Note: there is no config-driven "blocked" outcome — the gate only ever
+    delays a write for approval, never silently refuses it. ``blocked`` is
+    still produced when the user *actively denies* an inline prompt.
+    """
+    if not write_approval_enabled(subsystem):
+        return GateDecision(allow=True)
+
+    background = is_background()
+
+    # Skills always stage — a SKILL.md is too large to review inline, and a
+    # background skill write happens in a daemon thread with no user present.
+    if subsystem == SKILLS or background:
+        where = "/skills pending" if subsystem == SKILLS else "/memory pending"
+        return GateDecision(
+            stage=True,
+            message=(
+                f"Staged for approval ({subsystem}.write_approval is on). "
+                f"Not yet saved — review with {where}."
+            ),
+        )
+
+    # Memory + foreground: if an interactive approval channel exists (a CLI
+    # approval callback registered on this thread), prompt inline — entries
+    # are small enough to show in full. Otherwise (gateway, script, batch,
+    # no listener) stage instead of forcing a blind deny.
+    if _interactive_approval_available():
+        granted = _prompt_inline_memory_approval(inline_summary, inline_detail)
+        if granted is True:
+            return GateDecision(allow=True)
+        if granted is False:
+            return GateDecision(
+                blocked=True,
+                message="Memory write denied by user. The change was not saved.",
+            )
+        # granted is None → prompt failed; fall through to staging.
+
+    return GateDecision(
+        stage=True,
+        message=(
+            "Staged for approval (memory.write_approval is on). "
+            "Not yet saved — review with /memory pending."
+        ),
+    )
+
+
+def _interactive_approval_available() -> bool:
+    """True when a foreground memory write can be approved inline.
+
+    Inline prompting requires a per-thread approval callback registered by the
+    interactive CLI (``tools.terminal_tool.set_approval_callback``). Every
+    other surface stages instead:
+
+    * **Gateway/API sessions** — the dangerous-command ``/approve`` round-trip
+      lives in the pending-approval queue (``submit_pending`` +
+      ``_await_gateway_decision``), which ``prompt_dangerous_approval`` never
+      reaches; trying to prompt from a gateway session would hit the
+      ``input()`` fallback and silently deny. Staging gives the user a real
+      review affordance (``/memory pending``) instead.
+    * Scripts, cron, and background threads — no user present.
+    """
+    try:
+        from tools.terminal_tool import _get_approval_callback
+        return _get_approval_callback() is not None
+    except Exception:
+        return False
+
+
+def _prompt_inline_memory_approval(summary: str, detail: str) -> Optional[bool]:
+    """Prompt the user inline to approve a memory write.
+
+    Returns True (approved), False (denied), or None (no interactive prompt
+    available / prompt failed → caller should stage instead).
+
+    Reuses the per-thread CLI approval callback registered for dangerous
+    commands (``tools.terminal_tool.set_approval_callback``). The callback is
+    invoked directly — NOT via ``prompt_dangerous_approval`` — because that
+    wrapper falls back to ``input()`` (deadlock-prone under prompt_toolkit,
+    see #15216) and converts callback errors into a silent deny; here a
+    failed prompt must stage the write instead.
+    """
+    try:
+        from tools.terminal_tool import _get_approval_callback
+    except Exception:
+        return None
+
+    callback = _get_approval_callback()
+    if callback is None:
+        # No interactive channel on this thread — stage rather than risk the
+        # input() fallback (deadlock under prompt_toolkit, EOF-deny in tests).
+        return None
+
+    header = summary.strip() or "Save to memory?"
+    body = detail.strip()
+    description = f"Save to memory: {header}"
+    command = body if body else header
+    # Invoke the callback directly instead of via prompt_dangerous_approval:
+    # that wrapper swallows callback exceptions into "deny", which would
+    # silently refuse the write. Direct invocation lets a crashed prompt fall
+    # back to staging (the gate only ever delays a write, never drops it).
+    try:
+        choice = callback(command, description, allow_permanent=False)
+    except Exception as e:
+        logger.error("Inline memory approval prompt failed: %s", e)
+        return None
+
+    if choice in {"once", "session"}:
+        return True
+    if choice == "deny":
+        return False
+    # Any other outcome (e.g. timeout that returns "deny" already handled) →
+    # treat unknown as no-decision so we stage rather than silently drop.
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Skill-specific helpers (gist + diff for the review affordances)
+# ---------------------------------------------------------------------------
+
+def skill_gist(action: str, name: str, *, content: str = "",
+               file_path: str = "", old_string: str = "",
+               new_string: str = "") -> str:
+    """Build a one-line human gist for a pending skill write.
+
+    Heuristic, no model call — the gist surfaces enough to decide approve/reject
+    in a chat bubble, while the full diff stays behind /skills diff (CLI/
+    dashboard/file). For create/edit it pulls the frontmatter ``description:``;
+    for patch/write_file it describes the size of the change.
+    """
+    if action in {"create", "edit"} and content:
+        desc = _frontmatter_description(content)
+        size = f"{len(content) // 1024 + 1} KB" if len(content) >= 1024 else f"{len(content)} chars"
+        verb = "create" if action == "create" else "rewrite"
+        if desc:
+            return f"{verb} '{name}' — {desc} ({size})"
+        return f"{verb} '{name}' ({size})"
+    if action == "patch":
+        target = file_path or "SKILL.md"
+        removed = old_string.count("\n") + 1 if old_string else 0
+        added = new_string.count("\n") + 1 if new_string else 0
+        return f"patch '{name}' {target} (+{added}/-{removed} lines)"
+    if action == "write_file":
+        return f"write {file_path} in '{name}'"
+    if action == "remove_file":
+        return f"remove {file_path} from '{name}'"
+    if action == "delete":
+        return f"delete skill '{name}'"
+    return f"{action} '{name}'"
+
+
+def _frontmatter_description(content: str) -> str:
+    """Extract the ``description:`` value from SKILL.md YAML frontmatter."""
+    import re
+    m = re.search(r"^description:\s*(.+)$", content, re.MULTILINE)
+    if not m:
+        return ""
+    desc = m.group(1).strip().strip("'\"")
+    return desc[:140]
+
+
+def skill_pending_diff(record: Dict[str, Any]) -> str:
+    """Build a full unified diff (or full content) for a staged skill write.
+
+    Used by /skills diff <id> on a surface that can render it (CLI pager, web
+    dashboard, or by opening the pending JSON file). For create this is the new
+    file content; for edit/patch it is a unified diff against the current
+    on-disk skill.
+    """
+    import difflib
+    payload = record.get("payload", {})
+    action = payload.get("action", "")
+    name = payload.get("name", "")
+
+    if action == "create":
+        return (payload.get("content") or "")
+
+    # Resolve current on-disk content for diffable actions.
+    try:
+        from tools.skill_manager_tool import _find_skill
+    except Exception:
+        _find_skill = None  # type: ignore
+
+    current = ""
+    target_label = "SKILL.md"
+    if _find_skill is not None:
+        found = _find_skill(name)
+        if found:
+            base = found["path"]
+            if action == "edit":
+                p = base / "SKILL.md"
+            elif action in {"patch", "write_file"}:
+                rel = payload.get("file_path") or "SKILL.md"
+                p = base / rel
+                target_label = rel
+            else:
+                p = base / "SKILL.md"
+            try:
+                if p.exists():
+                    current = p.read_text(encoding="utf-8")
+            except Exception:
+                current = ""
+
+    if action == "edit":
+        new = payload.get("content") or ""
+    elif action == "patch":
+        old_s = payload.get("old_string") or ""
+        new_s = payload.get("new_string") or ""
+        new = current.replace(old_s, new_s) if current else f"(patch {old_s!r} → {new_s!r})"
+    elif action == "write_file":
+        new = payload.get("file_content") or ""
+    elif action == "remove_file":
+        return f"remove file: {payload.get('file_path')} from skill '{name}'"
+    elif action == "delete":
+        return f"delete skill '{name}'"
+    else:
+        return f"({action} on '{name}')"
+
+    diff = difflib.unified_diff(
+        current.splitlines(keepends=True),
+        new.splitlines(keepends=True),
+        fromfile=f"a/{target_label}",
+        tofile=f"b/{target_label}",
+    )
+    text = "".join(diff)
+    return text or "(no textual change)"


### PR DESCRIPTION
fix/skills-approval-gate

What does this PR do?
Adds an approval gate for skill mutations (create, edit, delete, patch, write_file, remove_file) in non-interactive mode. Agent-created skills are persistent prompt-injection vectors loaded every session — without this gate, the agent can autonomously mutate skills in cron, delegation, or background contexts without user confirmation.

The gate uses _YOLO_MODE_FROZEN (frozen at import time to prevent runtime env mutation bypass) and is_current_session_yolo_enabled() for the two sanctioned bypass paths. In interactive mode, it routes through prompt_dangerous_approval for user confirmation. Blocked errors include actionable guidance (HERMES_YOLO_MODE=1).

Related Issue
Fixes #17251 (agent can autonomously create/modify skills in non-interactive sessions)

Type of Change
- 🔒 Security fix

Changes Made
- tools/skill_manager_tool.py: Added _require_approval_for_skill_action() with deferred _get_approval_callback import, _MUTATING_SKILL_ACTIONS frozenset, and gate call at top of skill_manage()
- tests/tools/test_skill_manager_tool.py: 9 new tests covering blocked/approved/denied flows, schema sync, YOLO hint, 
live env bypass prevention, and skill_manage integration

How to Test
1. python -m pytest tests/tools/test_skill_manager_tool.py -q — 99/99 pass
2. Verify test_gate_covers_all_schema_actions ensures frozenset stays in sync with schema enum
3. Verify test_live_yolo_env_does_not_bypass_gate confirms runtime env mutation is blocked

Checklist
- I've read the Contributing Guide
- My commit messages follow Conventional Commits
- I searched for existing PRs
- My PR contains only changes related to this fix
- I've run pytest and all tests pass
- I've added tests for my changes
- I've tested on Windows 11