### PR TITLE
fix(honcho): surface init error details in tool call responses

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -353,6 +353,7 @@ class HonchoMemoryProvider(MemoryProvider):
         except Exception as e:
             logger.warning("Honcho init failed: %s", e)
             self._manager = None
+            self._init_error = str(e)
 
     def _resolve_session_key(self, cfg, session_id: str, **kwargs) -> str:
         """Resolve the Honcho session key without touching the network."""
@@ -528,6 +529,7 @@ class HonchoMemoryProvider(MemoryProvider):
         except Exception as e:
             self._manager = None
             self._session_initialized = False
+            self._init_error = str(e)
             logger.warning("Honcho lazy session init failed: %s", e)
             return False
 
@@ -1304,7 +1306,8 @@ class HonchoMemoryProvider(MemoryProvider):
             if self._init_thread and self._init_thread.is_alive():
                 return tool_error("Honcho session is still initializing; try again shortly.")
             if not self._ensure_session():
-                return tool_error("Honcho session could not be initialized.")
+                detail = f" — {self._init_error}" if self._init_error else ""
+                return tool_error(f"Honcho session could not be initialized{detail}.")
 
         if not self._manager or not self._session_key:
             return tool_error("Honcho is not active for this session.")

--- a/tests/test_honcho_startup_fail_open.py
+++ b/tests/test_honcho_startup_fail_open.py
@@ -311,7 +311,39 @@ def test_honcho_tools_eager_init_failure_does_not_leave_ready_manager(monkeypatc
 
     result = json.loads(provider.handle_tool_call("honcho_profile", {"peer": "user"}))
     assert "could not be initialized" in result["error"]
+    # Error detail from _ensure_session exception is surfaced to the caller
+    assert "boom" in result["error"]
     assert provider._manager is None
+
+
+def test_honcho_background_init_error_surfaces_in_tool_call(monkeypatch):
+    """Background init failure detail is surfaced in tool error response."""
+    provider = HonchoMemoryProvider()
+    cfg = _configured_hybrid_config()
+
+    monkeypatch.setattr(
+        "plugins.memory.honcho.client.HonchoClientConfig.from_global_config",
+        lambda: cfg,
+    )
+
+    def failing_session_init(self, cfg, session_id, **kwargs):
+        raise RuntimeError("pydantic validation error: unexpected keyword argument 'workspace'")
+
+    monkeypatch.setattr(HonchoMemoryProvider, "_do_session_init", failing_session_init)
+
+    # Hybrid mode: init happens in background thread with short wait
+    provider.initialize("session-1", platform="cli")
+    # Wait for background thread to finish
+    if provider._init_thread:
+        provider._init_thread.join(timeout=5)
+
+    assert provider._session_initialized is False
+    assert provider._init_error != ""
+
+    # Trigger lazy init which will fail and set _init_error
+    result = json.loads(provider.handle_tool_call("honcho_profile", {"peer": "user"}))
+    assert "could not be initialized" in result["error"]
+    assert "pydantic validation error" in result["error"]
 
 
 def test_honcho_tools_lazy_hooks_do_not_prestart_background_init(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Surfaces Honcho initialization error details in tool call responses. Previously, when the Honcho SDK failed to initialize (e.g., due to server version mismatch), the `_init_error` field was populated but never read. Tool calls returned a generic "Honcho session could not be initialized." message with no diagnostic information, forcing users to check logs at DEBUG/WARNING level.

## Related Issue

Fixes #43775

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/honcho/__init__.py`: 
  - Set `_init_error` in `initialize()` and `_ensure_session()` exception handlers (previously only set in background init thread)
  - Include `_init_error` detail in `handle_tool_call()` error message when session initialization fails
- `tests/test_honcho_startup_fail_open.py`:
  - Updated existing test to verify error detail ("boom") is included in tool error response
  - Added `test_honcho_background_init_error_surfaces_in_tool_call` for the background init failure path

## How to Test

1. Configure Honcho with a self-hosted server running v3.x (incompatible with SDK v2.x)
2. Set `memory.provider: honcho` in config.yaml
3. Call any honcho tool (e.g., `honcho_profile`)
4. Observe the error message now includes the actual pydantic validation error detail, e.g.: "Honcho session could not be initialized — pydantic validation error: unexpected keyword argument 'workspace'."
5. Run tests: `pytest tests/test_honcho_startup_fail_open.py -v` (10 passed)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `HonchoMemoryProvider._init_error`, `_ensure_session()`, `handle_tool_call()` (3 error paths: initialize, ensure_session, background _run)
- Blast radius: LOW — only affects error message text for failed Honcho init, no behavioral change
- Related patterns: `_init_error` was set but never read (dead field); `_ensure_session()` and `initialize()` exception handlers now consistently populate it
