### PR TITLE
feat(curator): add post_curator_run hook event through the plugin hook surface

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -1265,6 +1265,21 @@ def _write_run_report(
     except Exception as e:
         logger.debug("Curator cron_rewrites.json write failed: %s", e)
 
+    # Notify plugins/shell hooks that a curator pass completed. Lazy import
+    # keeps bare curator usage working in contexts where the plugin system
+    # isn't available; dispatch failures must never break the curator.
+    try:
+        from hermes_cli.plugins import invoke_hook
+
+        invoke_hook(
+            "post_curator_run",
+            run_dir=str(run_dir),
+            run_json_path=str(run_dir / "run.json"),
+            report_md_path=str(run_dir / "REPORT.md"),
+        )
+    except Exception as e:
+        logger.debug("post_curator_run hook dispatch failed: %s", e)
+
     return run_dir
 
 

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -222,6 +222,20 @@ and `child_goal`.
 Observers can use these hooks to model nested trajectories while keeping child
 agent execution linked to the parent turn that spawned it.
 
+### Curator Lifecycle
+
+| Hook | When it fires |
+| --- | --- |
+| `post_curator_run` | After a curator pass writes its per-run report directory. |
+
+Fields are `run_dir`, `run_json_path`, and `report_md_path`: filesystem paths
+to the completed report (`run.json` is the machine-readable record). Governance
+layers can react to curator output (profile routing, archival overrides, audit
+logging) without polling `logs/curator/`.
+
+`post_curator_run` is observer-only. Return values are ignored, and hook
+failures never affect the curator pass itself.
+
 ## Payload Safety
 
 Observer payloads are designed for telemetry consumers, not raw object access.

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -210,6 +210,14 @@ VALID_HOOKS: Set[str] = {
     "kanban_task_claimed",
     "kanban_task_completed",
     "kanban_task_blocked",
+    # Fired by agent/curator.py once per curator pass, after the per-run
+    # report directory (run.json + REPORT.md) is fully written. Lets
+    # governance layers (profile routing, archival overrides, audit
+    # logging) react to curator output without polling logs/curator/.
+    # Observers only: return values are ignored.
+    #
+    # Kwargs: run_dir: str, run_json_path: str, report_md_path: str
+    "post_curator_run",
 }
 
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"

--- a/tests/agent/test_post_curator_run_hook.py
+++ b/tests/agent/test_post_curator_run_hook.py
@@ -1,0 +1,141 @@
+"""Tests for the ``post_curator_run`` plugin hook.
+
+Fires once per curator pass, after the per-run report directory is fully
+written, with the ``run.json`` path in the payload. Goes through the
+standard plugin hook surface (``hermes_cli.plugins.invoke_hook``) so both
+Python plugins and shell-script hooks (``agent/shell_hooks.py``) receive
+it with no extra wiring. Observer-only: return values are ignored, and a
+failing callback must never break the curator.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+
+def _plugins():
+    """Resolve hermes_cli.plugins at call time, not import time.
+
+    Some test files (e.g. tests/plugins/test_security_guidance_plugin.py)
+    delete ``hermes_cli.plugins`` from ``sys.modules`` and re-import it,
+    which would leave a module-level binding here pointing at a stale
+    module object whose PluginManager the curator never sees.
+    """
+    return importlib.import_module("hermes_cli.plugins")
+
+
+@pytest.fixture
+def curator_env(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with a skills/ dir + reset curator module state."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "skills").mkdir()
+    (home / "logs").mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    import hermes_constants
+    importlib.reload(hermes_constants)
+    from agent import curator
+    importlib.reload(curator)
+    yield {"home": home, "curator": curator}
+
+
+@pytest.fixture(autouse=True)
+def _fresh_plugin_manager():
+    """Each test gets a fresh PluginManager so hook callbacks don't
+    leak between tests."""
+    plugins = _plugins()
+    original = plugins._plugin_manager
+    plugins._plugin_manager = plugins.PluginManager()
+    yield
+    plugins._plugin_manager = original
+
+
+def _llm_meta():
+    return {
+        "final": "short summary of the pass",
+        "summary": "short summary",
+        "model": "test-model",
+        "provider": "test-provider",
+        "tool_calls": [],
+        "error": None,
+    }
+
+
+def _write_report(curator):
+    return curator._write_run_report(
+        started_at=datetime.now(timezone.utc),
+        elapsed_seconds=1.5,
+        auto_counts={"checked": 2, "marked_stale": 0, "archived": 0, "reactivated": 0},
+        auto_summary="no changes",
+        before_report=[],
+        before_names=set(),
+        after_report=[],
+        llm_meta=_llm_meta(),
+    )
+
+
+def test_post_curator_run_is_a_valid_hook():
+    """Shell-hook config validation and register_hook() warnings both key
+    off VALID_HOOKS, so the event must be declared there."""
+    assert "post_curator_run" in _plugins().VALID_HOOKS
+
+
+def test_hook_fires_with_run_json_path(curator_env):
+    curator = curator_env["curator"]
+    received = []
+
+    mgr = _plugins().get_plugin_manager()
+    mgr._hooks.setdefault("post_curator_run", []).append(
+        lambda **kw: received.append(kw)
+    )
+
+    run_dir = _write_report(curator)
+
+    assert run_dir is not None
+    assert len(received) == 1
+    kw = received[0]
+    assert kw["run_dir"] == str(run_dir)
+    assert kw["run_json_path"] == str(run_dir / "run.json")
+    assert kw["report_md_path"] == str(run_dir / "REPORT.md")
+    # The report must be fully written by the time the hook fires
+    payload = json.loads(Path(kw["run_json_path"]).read_text(encoding="utf-8"))
+    assert "added" in payload
+    assert Path(kw["report_md_path"]).is_file()
+
+
+def test_raising_callback_does_not_break_report(curator_env):
+    """invoke_hook() isolates per-callback errors; the report writer must
+    still return the run dir when a plugin misbehaves."""
+    curator = curator_env["curator"]
+
+    def _boom(**kw):
+        raise RuntimeError("plugin bug")
+
+    mgr = _plugins().get_plugin_manager()
+    mgr._hooks.setdefault("post_curator_run", []).append(_boom)
+
+    run_dir = _write_report(curator)
+    assert run_dir is not None
+    assert (run_dir / "run.json").exists()
+
+
+def test_dispatch_layer_failure_does_not_break_report(curator_env, monkeypatch):
+    """Even if hook dispatch itself blows up (not just one callback), the
+    curator's report path must be unaffected."""
+    curator = curator_env["curator"]
+
+    def _explode(*a, **kw):
+        raise RuntimeError("dispatch layer down")
+
+    monkeypatch.setattr(_plugins(), "invoke_hook", _explode)
+
+    run_dir = _write_report(curator)
+    assert run_dir is not None
+    assert (run_dir / "run.json").exists()


### PR DESCRIPTION
## Problem

Multi-profile setups need to react when the curator finishes a pass (route agent-created skills to the right profile, apply archival overrides, audit-log changes). Today the only option is polling `logs/curator/` for new run directories.

This is the scoped-down follow-up to #43113, taking the approach suggested there: a single hook event through the existing plugin-hook surface, instead of a bespoke `post_hook_script` subprocess path.

## Change

One new event, `post_curator_run`, fired by `_write_run_report()` after the per-run report directory (`run.json` + `REPORT.md`) is fully written:

```python
invoke_hook(
    "post_curator_run",
    run_dir=str(run_dir),
    run_json_path=str(run_dir / "run.json"),
    report_md_path=str(run_dir / "REPORT.md"),
)
```

Because it goes through `hermes_cli.plugins.invoke_hook`, Python plugins and shell-script hooks (`agent/shell_hooks.py` `hooks:` config) both receive it with no extra wiring, and per-callback error isolation comes for free. The dispatch itself is additionally wrapped so a plugin-system failure can never break the curator (same pattern as `tools/approval.py`).

Observer-only: return values are ignored.

## Files

| File | What |
|------|------|
| `hermes_cli/plugins.py` | Add `post_curator_run` to `VALID_HOOKS` with kwargs doc |
| `agent/curator.py` | Fire the hook at the end of `_write_run_report()` |
| `docs/observability/README.md` | Curator Lifecycle section |
| `tests/agent/test_post_curator_run_hook.py` | 4 tests (see below) |

## Testing

Written test-first. Coverage:
- `post_curator_run` is declared in `VALID_HOOKS` (shell-hook config validation and `register_hook()` warnings key off it)
- callback fires exactly once with `run_dir` / `run_json_path` / `report_md_path`, and `run.json` + `REPORT.md` are fully written and parseable at fire time
- a raising callback does not break the report writer
- a dispatch-layer failure (`invoke_hook` itself raising) does not break the report writer

Ran the curator, plugin, shell-hook, and approval-hook suites together: 1429 passed. The new test resolves `hermes_cli.plugins` at call time rather than import time so it stays correct when run after suites that recycle that module in `sys.modules` (e.g. `test_security_guidance_plugin.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)