### PR TITLE
feat(discord): support threaded free-response channels

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3935,6 +3935,24 @@ class DiscordAdapter(BasePlatformAdapter):
             return {part.strip() for part in s.split(",") if part.strip()}
         return set()
 
+    def _discord_threaded_free_response_channels(self) -> set:
+        """Return free-response Discord channel IDs that should still auto-thread.
+
+        This is the same mention-bypass behavior as ``free_response_channels``,
+        but top-level channel messages keep ``auto_thread`` semantics instead of
+        replying directly in-channel. Parent channel IDs also match messages sent
+        inside existing threads under that channel.
+        """
+        raw = self.config.extra.get("free_response_threaded_channels")
+        if raw is None:
+            raw = os.getenv("DISCORD_FREE_RESPONSE_THREADED_CHANNELS", "")
+        if isinstance(raw, list):
+            return {str(part).strip() for part in raw if str(part).strip()}
+        s = str(raw).strip() if raw is not None else ""
+        if s:
+            return {part.strip() for part in s.split(",") if part.strip()}
+        return set()
+
     def _discord_thread_require_mention(self) -> bool:
         """Return whether thread participation requires @mention to follow up.
 
@@ -4750,6 +4768,9 @@ class DiscordAdapter(BasePlatformAdapter):
             parent_channel_id = self._get_parent_channel_id(message.channel)
 
         is_voice_linked_channel = False
+        is_free_channel = False
+        is_threaded_free_channel = False
+        channel_ids: set[str] = set()
 
         # Save mention-stripped text before auto-threading since create_thread()
         # can clobber message.content, breaking /command detection in channels.
@@ -4793,6 +4814,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 return
 
             free_channels = self._discord_free_response_channels()
+            threaded_free_channels = self._discord_threaded_free_response_channels()
             if parent_channel_id:
                 channel_ids.add(parent_channel_id)
 
@@ -4802,9 +4824,14 @@ class DiscordAdapter(BasePlatformAdapter):
             voice_linked_ids = {str(ch_id) for ch_id in self._voice_text_channels.values()}
             current_channel_id = str(message.channel.id)
             is_voice_linked_channel = current_channel_id in voice_linked_ids
+            is_threaded_free_channel = (
+                "*" in threaded_free_channels
+                or bool(channel_ids & threaded_free_channels)
+            )
             is_free_channel = (
                 "*" in free_channels
                 or bool(channel_ids & free_channels)
+                or is_threaded_free_channel
                 or is_voice_linked_channel
             )
 
@@ -4830,7 +4857,9 @@ class DiscordAdapter(BasePlatformAdapter):
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels_raw = os.getenv("DISCORD_NO_THREAD_CHANNELS", "")
             no_thread_channels = {ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()}
-            skip_thread = bool(channel_ids & no_thread_channels) or is_free_channel
+            skip_thread = bool(channel_ids & no_thread_channels) or (
+                is_free_channel and not is_threaded_free_channel
+            )
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in {"true", "1", "yes"}
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
             if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:
@@ -6520,6 +6549,11 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
         if isinstance(frc, list):
             frc = ",".join(str(v) for v in frc)
         os.environ["DISCORD_FREE_RESPONSE_CHANNELS"] = str(frc)
+    tfrc = discord_cfg.get("free_response_threaded_channels")
+    if tfrc is not None and not os.getenv("DISCORD_FREE_RESPONSE_THREADED_CHANNELS"):
+        if isinstance(tfrc, list):
+            tfrc = ",".join(str(v) for v in tfrc)
+        os.environ["DISCORD_FREE_RESPONSE_THREADED_CHANNELS"] = str(tfrc)
     if "auto_thread" in discord_cfg and not os.getenv("DISCORD_AUTO_THREAD"):
         os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
     if "reactions" in discord_cfg and not os.getenv("DISCORD_REACTIONS"):

--- a/tests/gateway/test_discord_channel_controls.py
+++ b/tests/gateway/test_discord_channel_controls.py
@@ -245,6 +245,47 @@ async def test_normal_channel_still_auto_threads(adapter, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_threaded_free_response_channel_bypasses_mention_and_auto_threads(adapter, monkeypatch):
+    """Threaded free-response channels should process unmentioned messages and still auto-thread."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_THREADED_CHANNELS", "901")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+
+    fake_thread = FakeThread(channel_id=999, name="auto-thread")
+    adapter._auto_create_thread = AsyncMock(return_value=fake_thread)
+
+    message = make_message(channel=FakeTextChannel(channel_id=901), content="hello without mention")
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_awaited_once()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_type == "thread"
+
+
+@pytest.mark.asyncio
+async def test_threaded_free_response_parent_matches_thread_replies(adapter, monkeypatch):
+    """Threads under a threaded free-response parent should process replies without mention."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_THREAD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_HISTORY_BACKFILL", "false")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_THREADED_CHANNELS", "901")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+
+    parent = FakeTextChannel(channel_id=901, name="oscar")
+    thread = FakeThread(channel_id=902, name="thread-in-oscar", parent=parent)
+    message = make_message(channel=thread, content="reply without mention")
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_no_thread_channels_csv_parsing(adapter, monkeypatch):
     """Multiple no_thread channel IDs parsed from CSV."""
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
@@ -322,6 +363,25 @@ def test_config_bridges_no_thread_channels(monkeypatch, tmp_path):
 
     import os
     assert os.getenv("DISCORD_NO_THREAD_CHANNELS") == "333"
+
+
+def test_config_bridges_threaded_free_response_channels(monkeypatch, tmp_path):
+    """gateway/config.py bridges discord.free_response_threaded_channels to env var."""
+    import yaml
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump({
+        "discord": {
+            "free_response_threaded_channels": ["444", "555"],
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_THREADED_CHANNELS", "")
+
+    from gateway.config import load_gateway_config
+    load_gateway_config()
+
+    import os
+    assert os.getenv("DISCORD_FREE_RESPONSE_THREADED_CHANNELS") == "444,555"
 
 
 def test_config_env_var_takes_precedence(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- add `discord.free_response_threaded_channels` / `DISCORD_FREE_RESPONSE_THREADED_CHANNELS`
- let selected Discord channels bypass @mention gating while still using auto-created threads for top-level messages
- keep parent-channel matching for replies in threads under those channels

## Verification
- `/Users/snaps/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_discord_channel_controls.py -q`
- `/Users/snaps/.hermes/hermes-agent/venv/bin/python -m py_compile plugins/platforms/discord/adapter.py`
