### PR TITLE
fix(security): suppress user dashboard plugin APIs on public insecure dashboards (#43719)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1679,6 +1679,10 @@ DEFAULT_CONFIG = {
         # Set this to True to re-enable the surfaces with the understanding
         # that the numbers are a local lower-bound estimate, not billing.
         "show_token_analytics": False,
+        # Public non-loopback ``--insecure`` dashboards suppress user-installed
+        # plugin Python APIs by default. This opt-in is for trusted lab setups
+        # only; bundled plugin APIs remain enabled either way.
+        "allow_insecure_user_plugin_api": False,
         # OAuth gate configuration (engaged when ``--host`` is set and
         # ``--insecure`` is not). The bundled Nous Portal plugin reads
         # both keys at startup; they are the canonical surface for these

--- a/hermes_cli/dashboard_host.py
+++ b/hermes_cli/dashboard_host.py
@@ -1,0 +1,45 @@
+"""Shared dashboard bind-host classification helpers."""
+
+from __future__ import annotations
+
+import ipaddress
+from typing import Optional
+
+
+_LOOPBACK_HOST_NAMES = frozenset({"localhost", "ip6-localhost", "ip6-loopback"})
+
+
+def normalize_dashboard_bind_host(host: Optional[str]) -> str:
+    """Return a non-empty dashboard bind host string.
+
+    Handles values such as ``None``, ``" [::1] "``, and ``"host."`` by
+    defaulting empty input to ``127.0.0.1``, trimming whitespace, removing
+    trailing dots, and stripping surrounding IPv6 brackets.
+    """
+    normalized = str(host or "127.0.0.1").strip().rstrip(".")
+    if normalized.startswith("[") and normalized.endswith("]"):
+        normalized = normalized[1:-1]
+    normalized = normalized.strip().rstrip(".")
+    return normalized or "127.0.0.1"
+
+
+def is_loopback_bind_host(host: Optional[str]) -> bool:
+    """Return True when a normalized bind host targets loopback.
+
+    In Python < 3.13, ``IPv6Address.is_loopback`` does not report
+    IPv4-mapped IPv6 loopback literals from ``ipaddress.ip_address`` as
+    loopback directly. The ``ipv4_mapped`` fallback ensures older runtimes
+    classify those binds the same way Python 3.13+ does.
+    """
+    normalized = normalize_dashboard_bind_host(host).lower()
+    if normalized in _LOOPBACK_HOST_NAMES:
+        return True
+    try:
+        address = ipaddress.ip_address(normalized)
+    except ValueError:
+        return False
+    if address.is_loopback:
+        return True
+    if isinstance(address, ipaddress.IPv6Address) and address.ipv4_mapped:
+        return address.ipv4_mapped.is_loopback
+    return False

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -67,6 +67,7 @@ from hermes_cli.memory_providers import (
     ProviderField,
     get_memory_provider,
 )
+from hermes_cli.dashboard_host import is_loopback_bind_host as _is_loopback_bind_host
 from gateway.status import (
     get_running_pid,
     get_runtime_status_running_pid,
@@ -204,6 +205,8 @@ def _get_chat_argv_lock(app: "FastAPI") -> asyncio.Lock:
 
 
 app = FastAPI(title="Hermes Agent", version=__version__, lifespan=_lifespan)
+app.state.dashboard_public_insecure = False
+app.state.insecure_user_plugin_api_allowed = False
 
 # ---------------------------------------------------------------------------
 # Session token for protecting sensitive endpoints (reveal).
@@ -327,11 +330,6 @@ def _require_token(request: Request) -> None:
 # checks because the browser now considers evil.test and our dashboard
 # "same origin". Validating the Host header at the app layer rejects any
 # request whose Host isn't one we bound for. See GHSA-ppp5-vxwm-4cf7.
-_LOOPBACK_HOST_VALUES: frozenset = frozenset({
-    "localhost", "127.0.0.1", "::1",
-})
-
-
 def should_require_auth(host: str, allow_public: bool) -> bool:
     """Return True iff the dashboard OAuth auth gate must be active.
 
@@ -340,12 +338,11 @@ def should_require_auth(host: str, allow_public: bool) -> bool:
       host != loopback AND allow_public (--insecure)→ False (legacy escape hatch)
       host != loopback AND NOT allow_public         → True  (gate engages)
 
-    "Loopback" matches the same set used by ``--insecure`` enforcement in
-    ``start_server``: 127.0.0.1, localhost, ::1. RFC1918 / CGNAT / link-local
-    are deliberately treated as PUBLIC — a hostile device on the same LAN is
-    exactly the threat model the gate is designed for.
+    "Loopback" matches localhost plus IP loopback literals. RFC1918 / CGNAT /
+    link-local are deliberately treated as PUBLIC — a hostile device on the
+    same LAN is exactly the threat model the gate is designed for.
     """
-    return (host not in _LOOPBACK_HOST_VALUES) and (not allow_public)
+    return (not _is_loopback_bind_host(host)) and (not allow_public)
 
 
 def _is_accepted_host(host_header: str, bound_host: str) -> bool:
@@ -385,8 +382,8 @@ def _is_accepted_host(host_header: str, bound_host: str) -> bool:
 
     # Loopback bind: accept the loopback names
     bound_lc = bound_host.lower()
-    if bound_lc in _LOOPBACK_HOST_VALUES:
-        return host_only in _LOOPBACK_HOST_VALUES
+    if _is_loopback_bind_host(bound_lc):
+        return _is_loopback_bind_host(host_only)
 
     # Explicit non-loopback bind: require exact host match
     return host_only == bound_lc
@@ -1254,10 +1251,12 @@ def _path_text(raw_path: str | None) -> str:
 def _local_dashboard_request(request: Request) -> bool:
     if getattr(request.app.state, "auth_required", False):
         return False
+    bound_host = (getattr(request.app.state, "bound_host", "") or "").strip().lower()
+    if bound_host and not _is_loopback_bind_host(bound_host):
+        return False
     host = (request.url.hostname or "").lower()
-    client_host = (request.client.host if request.client else "").lower()
-    local_hosts = {"", "localhost", "127.0.0.1", "::1", "testserver", "testclient"}
-    return host in local_hosts or client_host in local_hosts
+    local_hosts = {"", "testserver", "testclient"}
+    return host in local_hosts or _is_loopback_bind_host(host)
 
 
 def _default_hermes_root_is_opt_data() -> bool:
@@ -10915,9 +10914,9 @@ else:
 _RESIZE_RE = re.compile(rb"\x1b\[RESIZE:(\d+);(\d+)\]")
 _PTY_READ_CHUNK_TIMEOUT = 0.2
 _VALID_CHANNEL_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
-# Starlette's TestClient reports the peer as "testclient"; treat it as
-# loopback so tests don't need to rewrite request scope.
-_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost", "testclient"})
+# Starlette's TestClient reports the peer as "testclient"; keep that special
+# case so tests don't need to rewrite request scope.
+_LOOPBACK_CLIENT_HOSTS = frozenset({"testclient"})
 
 
 def _ws_client_reason(ws: "WebSocket") -> Optional[str]:
@@ -10932,12 +10931,12 @@ def _ws_client_reason(ws: "WebSocket") -> Optional[str]:
     if getattr(app.state, "auth_required", False):
         return None
     bound_host = (getattr(app.state, "bound_host", "") or "").strip().lower()
-    if bound_host and bound_host not in _LOOPBACK_HOSTS:
+    if bound_host and not _is_loopback_bind_host(bound_host):
         return None
     client_host = ws.client.host if ws.client else ""
     if not client_host:
         return None
-    if client_host in _LOOPBACK_HOSTS:
+    if client_host in _LOOPBACK_CLIENT_HOSTS or _is_loopback_bind_host(client_host):
         return None
     return f"peer_not_loopback peer={client_host} bound={bound_host or '?'}"
 
@@ -10974,12 +10973,15 @@ def _ws_client_is_allowed(ws: "WebSocket") -> bool:
     # an actual loopback bind; otherwise the WS handshake is rejected even
     # though same-bind HTTP requests pass _is_accepted_host.
     bound_host = (getattr(app.state, "bound_host", "") or "").strip().lower()
-    if bound_host and bound_host not in _LOOPBACK_HOSTS:
+    if bound_host and not _is_loopback_bind_host(bound_host):
         return True
     client_host = ws.client.host if ws.client else ""
     if not client_host:
         return True
-    return client_host in _LOOPBACK_HOSTS
+    return (
+        client_host in _LOOPBACK_CLIENT_HOSTS
+        or _is_loopback_bind_host(client_host)
+    )
 
 
 def _ws_host_origin_reason(ws: "WebSocket") -> Optional[str]:
@@ -11043,7 +11045,7 @@ def _ws_auth_mode() -> str:
     if getattr(app.state, "auth_required", False):
         return "gated"
     bound_host = (getattr(app.state, "bound_host", "") or "").strip().lower()
-    if bound_host and bound_host not in _LOOPBACK_HOSTS:
+    if bound_host and not _is_loopback_bind_host(bound_host):
         return "insecure"
     return "loopback"
 
@@ -11617,6 +11619,56 @@ def _normalise_prefix(raw: Optional[str]) -> str:
     """
     from hermes_cli.dashboard_auth.prefix import normalise_prefix
     return normalise_prefix(raw)
+
+
+def _public_insecure_dashboard_mode() -> bool:
+    """True when `hermes dashboard --host <non-loopback> --insecure` launched us."""
+    return bool(getattr(app.state, "dashboard_public_insecure", False))
+
+
+def _allow_insecure_user_plugin_api() -> bool:
+    """Return the launch-time opt-in for public-insecure user plugin APIs."""
+    return bool(getattr(app.state, "insecure_user_plugin_api_allowed", False))
+
+
+def _read_insecure_user_plugin_api_opt_in() -> bool:
+    try:
+        config = load_config()
+    except Exception:
+        return False
+    value = cfg_get(
+        config,
+        "dashboard",
+        "allow_insecure_user_plugin_api",
+        default=False,
+    )
+    return value is True
+
+
+def _snapshot_insecure_user_plugin_api_opt_in(public_insecure: bool) -> None:
+    """Capture the user plugin API opt-in before the insecure dashboard is served."""
+    app.state.dashboard_public_insecure = bool(public_insecure)
+    # Intentionally snapshotted at launch: in public-insecure mode
+    # browser-visible session tokens can mutate config, so re-reading here would
+    # let a later rescan remount user plugin Python without a dashboard restart.
+    app.state.insecure_user_plugin_api_allowed = (
+        _read_insecure_user_plugin_api_opt_in() if public_insecure else False
+    )
+
+
+def _user_plugin_api_disabled_for_public_insecure() -> bool:
+    """Return whether public insecure mode should suppress user plugin APIs."""
+    return (
+        _public_insecure_dashboard_mode()
+        and not _allow_insecure_user_plugin_api()
+    )
+
+
+def _set_public_insecure_dashboard_mode(host: str, allow_public: bool) -> bool:
+    """Persist the final public-insecure launch mode for plugin loaders."""
+    public_insecure = bool(allow_public) and not _is_loopback_bind_host(host)
+    _snapshot_insecure_user_plugin_api_opt_in(public_insecure)
+    return public_insecure
 
 
 def mount_spa(application: FastAPI):
@@ -12204,12 +12256,26 @@ def _discover_dashboard_plugins() -> list:
                 raw_api = data.get("api")
                 dashboard_dir = child / "dashboard"
                 safe_api = _safe_plugin_api_relpath(raw_api, dashboard_dir=dashboard_dir)
+                if (
+                    source == "user"
+                    and safe_api
+                    and _user_plugin_api_disabled_for_public_insecure()
+                ):
+                    _log.warning(
+                        "Plugin %s: dashboard backend api=%s disabled because "
+                        "the dashboard is running on a non-loopback host with "
+                        "--insecure. Use OAuth-gated dashboard auth or set "
+                        "dashboard.allow_insecure_user_plugin_api: true only "
+                        "for trusted plugins on trusted networks.",
+                        name, safe_api,
+                    )
+                    safe_api = None
                 if raw_api and safe_api is None:
                     _log.warning(
                         "Plugin %s: refusing unsafe api path %r (must be a "
                         "relative file inside the plugin's dashboard/ "
-                        "directory); backend routes from this plugin will "
-                        "not be mounted",
+                        "directory, or disabled for this dashboard launch); "
+                        "backend routes from this plugin will not be mounted",
                         name, raw_api,
                     )
                 plugins.append({
@@ -12607,11 +12673,71 @@ async def serve_plugin_asset(plugin_name: str, file_path: str):
     )
 
 
-def _mount_plugin_api_routes():
-    """Import and mount backend API routes from plugins that declare them.
+def _spa_catch_all_route_index(routes: Optional[list] = None) -> Optional[int]:
+    route_list = app.router.routes if routes is None else routes
+    for index, route in enumerate(route_list):
+        if getattr(route, "path", None) == "/{full_path:path}":
+            return index
+    return None
+
+
+def _plugin_api_module_name(plugin_name: str) -> str:
+    return f"hermes_dashboard_plugin_{plugin_name}"
+
+
+_plugin_api_user_routes_mounted = False
+_plugin_api_user_module_names: set[str] = set()
+_plugin_api_user_prefixes: set[str] = set()
+
+
+def _remove_user_plugin_api_routes() -> None:
+    """Remove user plugin API routes from the module-global FastAPI app."""
+    global _plugin_api_user_routes_mounted
+    prefixes = tuple(_plugin_api_user_prefixes)
+    if not _plugin_api_user_routes_mounted and not prefixes:
+        return
+
+    def _keep_route(route: Any) -> bool:
+        if getattr(route, "_hermes_dashboard_plugin_api_source", None) == "user":
+            return False
+        path = str(getattr(route, "path", ""))
+        return not any(
+            path == prefix or path.startswith(f"{prefix.rstrip('/')}/")
+            for prefix in prefixes
+        )
+
+    app.router.routes = [route for route in app.router.routes if _keep_route(route)]
+    for module_name in tuple(_plugin_api_user_module_names):
+        sys.modules.pop(module_name, None)
+    _plugin_api_user_module_names.clear()
+    _plugin_api_user_prefixes.clear()
+    _plugin_api_user_routes_mounted = False
+    app.openapi_schema = None
+
+
+def _move_new_routes_before_spa(original_routes: list) -> None:
+    new_routes = app.router.routes[len(original_routes):]
+    if not new_routes:
+        return
+    catch_all_index = _spa_catch_all_route_index(original_routes)
+    if catch_all_index is None:
+        return
+    app.router.routes = [
+        *original_routes[:catch_all_index],
+        *new_routes,
+        *original_routes[catch_all_index:],
+    ]
+
+
+def _mount_plugin_api_routes(
+    *,
+    include_user: bool = True,
+    only_sources: Optional[set[str]] = None,
+) -> None:
+    """Import backend API routes from plugins that declare them.
 
     Each plugin's ``api`` field points to a Python file that must expose
-    a ``router`` (FastAPI APIRouter).  Routes are mounted under
+    a ``router`` (FastAPI APIRouter). Routes are mounted under
     ``/api/plugins/<name>/``.
 
     Backend import is restricted to ``bundled`` and ``user`` sources.
@@ -12621,15 +12747,40 @@ def _mount_plugin_api_routes():
     static JS/CSS but their Python ``api`` file is never auto-imported
     by the web server.  See GHSA-5qr3-c538-wm9j (#29156).
     """
+    global _plugin_api_user_routes_mounted
+    _remove_user_plugin_api_routes()
+    original_routes = list(app.router.routes)
+    mounted_user_routes = False
     for plugin in _get_dashboard_plugins():
+        source = plugin.get("source")
+        if only_sources is not None and source not in only_sources:
+            continue
         api_file_name = plugin.get("_api_file")
         if not api_file_name:
             continue
-        if plugin.get("source") == "project":
+        if source == "project":
             _log.warning(
                 "Plugin %s: ignoring backend api=%s (project plugins may "
                 "not auto-import Python code; move the plugin to "
                 "~/.hermes/plugins/ if you trust it)",
+                plugin["name"], api_file_name,
+            )
+            continue
+        if source == "user" and not include_user:
+            _log.debug(
+                "Plugin %s: deferring user dashboard backend api=%s until "
+                "dashboard startup finalizes host/auth mode",
+                plugin["name"], api_file_name,
+            )
+            continue
+        if (
+            source == "user"
+            and _user_plugin_api_disabled_for_public_insecure()
+        ):
+            _log.warning(
+                "Plugin %s: ignoring backend api=%s because non-loopback "
+                "--insecure dashboards do not auto-import user plugin Python "
+                "code by default",
                 plugin["name"], api_file_name,
             )
             continue
@@ -12652,8 +12803,9 @@ def _mount_plugin_api_routes():
         if not api_path.exists():
             _log.warning("Plugin %s declares api=%s but file not found", plugin["name"], api_file_name)
             continue
+        module_name = _plugin_api_module_name(str(plugin["name"]))
         try:
-            module_name = f"hermes_dashboard_plugin_{plugin['name']}"
+            sys.modules.pop(module_name, None)
             spec = importlib.util.spec_from_file_location(module_name, api_path)
             if spec is None or spec.loader is None:
                 continue
@@ -12673,15 +12825,44 @@ def _mount_plugin_api_routes():
             router = getattr(mod, "router", None)
             if router is None:
                 _log.warning("Plugin %s api file has no 'router' attribute", plugin["name"])
+                sys.modules.pop(module_name, None)
                 continue
-            app.include_router(router, prefix=f"/api/plugins/{plugin['name']}")
+            route_start = len(app.router.routes)
+            prefix = f"/api/plugins/{plugin['name']}"
+            app.include_router(router, prefix=prefix)
+            mounted_user_routes = mounted_user_routes or source == "user"
+            if source == "user":
+                for route in app.router.routes[route_start:]:
+                    setattr(route, "_hermes_dashboard_plugin_api_source", "user")
+                    setattr(route, "_hermes_dashboard_plugin_api_prefix", prefix)
+                _plugin_api_user_module_names.add(module_name)
+                _plugin_api_user_prefixes.add(prefix)
             _log.info("Mounted plugin API routes: /api/plugins/%s/", plugin["name"])
         except Exception as exc:
+            sys.modules.pop(module_name, None)
             _log.warning("Failed to load plugin %s API routes: %s", plugin["name"], exc)
+    if mounted_user_routes:
+        _plugin_api_user_routes_mounted = True
+    _move_new_routes_before_spa(original_routes)
 
 
-# Mount plugin API routes before the SPA catch-all.
-_mount_plugin_api_routes()
+def _configure_user_plugin_api_routes_for_launch(host: str, allow_public: bool) -> None:
+    """Mount user plugin APIs once the final dashboard exposure is known."""
+    _set_public_insecure_dashboard_mode(host, allow_public)
+    _get_dashboard_plugins(force_rescan=True)
+    if _user_plugin_api_disabled_for_public_insecure():
+        _remove_user_plugin_api_routes()
+    elif not _plugin_api_user_routes_mounted:
+        _mount_plugin_api_routes(include_user=True, only_sources={"user"})
+        app.openapi_schema = None
+
+
+# Import-time mounting is fail-closed for user plugins, including direct
+# module-level ``app`` imports in tests or ASGI embedding. Bundled plugin
+# backend APIs are trusted and can mount before the SPA catch-all; user plugin
+# backend APIs wait until start_server() knows whether the dashboard is
+# public-insecure.
+_mount_plugin_api_routes(include_user=False)
 
 # Mount the dashboard auth routes (/login, /auth/*, /api/auth/*) before the
 # SPA catch-all so /{full_path:path} doesn't swallow them.  These are
@@ -12765,6 +12946,8 @@ def start_server(
     """
     import uvicorn
 
+    _configure_user_plugin_api_routes_for_launch(host, allow_public)
+
     # Phase 0: stash the auth-gate flag on app.state so middleware / SPA-token
     # injection / WS-auth paths can branch on it consistently.  Phase 3.5
     # uses this to decide whether to refuse the bind, log the gate-on
@@ -12822,7 +13005,7 @@ def start_server(
             host,
             ", ".join(p.name for p in list_providers()),
         )
-    elif host not in _LOOPBACK_HOST_VALUES and allow_public:
+    elif not _is_loopback_bind_host(host) and allow_public:
         # --insecure path — no auth, loud warning.
         _log.warning(
             "Binding to %s with --insecure — the dashboard has no robust "

--- a/tests/hermes_cli/test_project_plugin_rce_bypass.py
+++ b/tests/hermes_cli/test_project_plugin_rce_bypass.py
@@ -30,12 +30,14 @@ These tests pin each layer of the new defence:
 """
 from __future__ import annotations
 
+import contextlib
 import json
 import sys
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+import uvicorn
 
 from hermes_cli import web_server
 
@@ -47,8 +49,16 @@ def _reset_plugin_cache(monkeypatch):
     mask a regression — and so the production cache the import-time
     ``_mount_plugin_api_routes()`` populated doesn't bleed in."""
     web_server._dashboard_plugins_cache = None
+    web_server._snapshot_insecure_user_plugin_api_opt_in(False)
+    web_server._plugin_api_user_routes_mounted = False
+    web_server._plugin_api_user_module_names.clear()
+    web_server._plugin_api_user_prefixes.clear()
     yield
     web_server._dashboard_plugins_cache = None
+    web_server._snapshot_insecure_user_plugin_api_opt_in(False)
+    web_server._plugin_api_user_routes_mounted = False
+    web_server._plugin_api_user_module_names.clear()
+    web_server._plugin_api_user_prefixes.clear()
 
 
 def _write_plugin_manifest(root: Path, name: str, manifest: dict) -> Path:
@@ -58,6 +68,90 @@ def _write_plugin_manifest(root: Path, name: str, manifest: dict) -> Path:
     dashboard_dir.mkdir(parents=True)
     (dashboard_dir / "manifest.json").write_text(json.dumps(manifest))
     return dashboard_dir
+
+
+def _set_insecure_user_plugin_api_opt_in(monkeypatch, enabled) -> None:
+    config = {
+        "dashboard": {
+            "allow_insecure_user_plugin_api": enabled,
+        },
+    }
+    monkeypatch.setattr(
+        web_server,
+        "load_config",
+        lambda: config,
+    )
+
+
+def _configure_and_snapshot_public_insecure_mode(
+    monkeypatch, enabled, public_insecure: bool = True
+) -> None:
+    _set_insecure_user_plugin_api_opt_in(monkeypatch, enabled)
+    web_server._snapshot_insecure_user_plugin_api_opt_in(
+        public_insecure=public_insecure
+    )
+
+
+def _plugin_module_names(plugin_name: str) -> list[str]:
+    name = f"hermes_dashboard_plugin_{plugin_name}"
+    return [name] if name in sys.modules else []
+
+
+def _pop_plugin_modules(plugin_name: str) -> None:
+    for name in _plugin_module_names(plugin_name):
+        sys.modules.pop(name, None)
+
+
+def _stub_uvicorn_run(monkeypatch) -> dict:
+    """Stub uvicorn.Server so start_server performs setup without binding."""
+    captured: dict = {}
+
+    class _FakeConfig:
+        loaded = True
+        host = "127.0.0.1"
+        port = 8000
+
+        def __init__(self, *args, **kwargs):
+            captured.update(kwargs)
+
+        def load(self):
+            pass
+
+        class lifespan_class:
+            should_exit = False
+            state: dict = {}
+
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def startup(self):
+                pass
+
+            async def shutdown(self):
+                pass
+
+    class _FakeServer:
+        should_exit = False
+        started = True
+        servers: list = []
+        lifespan = None
+
+        @staticmethod
+        def capture_signals():
+            return contextlib.nullcontext()
+
+        async def startup(self, sockets=None):
+            pass
+
+        async def main_loop(self):
+            pass
+
+        async def shutdown(self, sockets=None):
+            pass
+
+    monkeypatch.setattr(uvicorn, "Config", _FakeConfig)
+    monkeypatch.setattr(uvicorn, "Server", lambda config: _FakeServer())
+    return captured
 
 
 # ---------------------------------------------------------------------------
@@ -234,6 +328,89 @@ class TestDiscoveryScrubsApiField:
         assert entry["has_api"] is True
 
 
+class TestPublicInsecureDashboardMode:
+    """Public-insecure mode controls when user plugin APIs are suppressed."""
+
+    def test_configured_public_insecure_mode_starts_disabled(self):
+        web_server._snapshot_insecure_user_plugin_api_opt_in(False)
+
+        assert web_server._public_insecure_dashboard_mode() is False
+
+    def test_configured_public_insecure_mode_can_be_enabled(self, monkeypatch):
+        _configure_and_snapshot_public_insecure_mode(monkeypatch, False)
+
+        assert web_server._public_insecure_dashboard_mode() is True
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "localhost",
+            "localhost.",
+            "LOCALHOST",
+            "LOCALHOST.",
+            "ip6-localhost",
+            "127.0.0.1",
+            "[127.0.0.1.]",
+            "127.0.0.2",
+            "::1",
+            "[::1]",
+            "[ ::1 ]",
+            "[::1].",
+            "::ffff:127.0.0.1",
+            "[::ffff:127.0.0.1]",
+            "[::ffff:127.0.0.1].",
+            "[::ffff:127.0.0.1.]",
+        ],
+    )
+    def test_loopback_hosts_keep_plugin_policy_and_auth_gate_local(
+        self, monkeypatch, host
+    ):
+        assert web_server.should_require_auth(host, allow_public=False) is False
+        assert web_server._set_public_insecure_dashboard_mode(
+            host, allow_public=True
+        ) is False
+        assert web_server._public_insecure_dashboard_mode() is False
+
+    def test_non_loopback_insecure_sets_public_plugin_policy(self, monkeypatch):
+        assert web_server.should_require_auth("0.0.0.0", allow_public=False) is True
+        assert web_server._set_public_insecure_dashboard_mode(
+            "0.0.0.0", allow_public=True
+        ) is True
+        assert web_server._public_insecure_dashboard_mode() is True
+
+    def test_ipv4_mapped_non_loopback_stays_public(self, monkeypatch):
+        assert web_server.should_require_auth(
+            "::ffff:192.168.1.10", allow_public=False
+        ) is True
+        assert web_server._set_public_insecure_dashboard_mode(
+            "::ffff:192.168.1.10", allow_public=True
+        ) is True
+        assert web_server._public_insecure_dashboard_mode() is True
+
+    @pytest.mark.parametrize("host", ["[::1", "::1]"])
+    def test_unmatched_ipv6_brackets_are_not_normalized_as_loopback(
+        self, monkeypatch, host
+    ):
+        assert web_server.should_require_auth(host, allow_public=False) is True
+
+    def test_ws_loopback_bind_uses_same_ip_loopback_classifier(self, monkeypatch):
+        class _Client:
+            def __init__(self, host: str):
+                self.host = host
+
+        class _WebSocket:
+            def __init__(self, host: str):
+                self.client = _Client(host)
+
+        monkeypatch.setattr(web_server.app.state, "auth_required", False, raising=False)
+        monkeypatch.setattr(web_server.app.state, "bound_host", "127.0.0.2", raising=False)
+
+        assert web_server._ws_client_is_allowed(_WebSocket("127.0.0.3")) is True
+        assert web_server._ws_client_reason(_WebSocket("127.0.0.3")) is None
+        assert web_server._ws_client_is_allowed(_WebSocket("192.168.1.10")) is False
+        assert web_server._ws_auth_mode() == "loopback"
+
+
 # ---------------------------------------------------------------------------
 # Layer 4 — _mount_plugin_api_routes refuses project-source + traversal.
 # ---------------------------------------------------------------------------
@@ -299,6 +476,491 @@ class TestMountApiRoutesRefusesUntrusted:
             web_server._mount_plugin_api_routes()
         assert spec.call_count == 0
 
+    def test_user_source_api_not_imported_on_public_insecure_dashboard(
+        self, tmp_path, monkeypatch
+    ):
+        """Public ``--insecure`` dashboards expose the legacy session-token
+        surface to the bound network. In that mode, user-installed dashboard
+        plugin API modules must not auto-import server-side Python code.
+        """
+        plugin = self._payload_plugin(tmp_path, source="user")
+        web_server._dashboard_plugins_cache = [plugin]
+
+        _configure_and_snapshot_public_insecure_mode(monkeypatch, False)
+
+        with patch("importlib.util.spec_from_file_location") as spec:
+            web_server._mount_plugin_api_routes()
+
+        assert spec.call_count == 0
+
+    def test_user_source_api_imports_on_public_insecure_explicit_opt_in(
+        self, tmp_path, monkeypatch
+    ):
+        """Trusted user plugin APIs can be re-enabled with explicit opt-in."""
+        plugin = self._payload_plugin(tmp_path, source="user")
+        web_server._dashboard_plugins_cache = [plugin]
+
+        _configure_and_snapshot_public_insecure_mode(monkeypatch, True)
+
+        with patch("importlib.util.spec_from_file_location") as spec:
+            spec.return_value = None
+            web_server._mount_plugin_api_routes()
+
+        assert spec.call_count == 1
+
+    def test_disabled_config_opt_in_does_not_enable_user_api(
+        self, tmp_path, monkeypatch
+    ):
+        plugin = self._payload_plugin(tmp_path, source="user")
+        web_server._dashboard_plugins_cache = [plugin]
+
+        _configure_and_snapshot_public_insecure_mode(monkeypatch, False)
+
+        with patch("importlib.util.spec_from_file_location") as spec:
+            web_server._mount_plugin_api_routes()
+
+        assert spec.call_count == 0
+
+    def test_enabled_config_opt_in_enables_user_api(
+        self, tmp_path, monkeypatch
+    ):
+        plugin = self._payload_plugin(tmp_path, source="user")
+        web_server._dashboard_plugins_cache = [plugin]
+
+        _configure_and_snapshot_public_insecure_mode(monkeypatch, True)
+
+        with patch("importlib.util.spec_from_file_location") as spec:
+            spec.return_value = None
+            web_server._mount_plugin_api_routes()
+
+        assert spec.call_count == 1
+
+    @pytest.mark.parametrize("opt_in_value", ["1", "true", "yes", 1])
+    def test_non_boolean_config_opt_in_does_not_enable_user_api(
+        self, tmp_path, monkeypatch, opt_in_value
+    ):
+        plugin = self._payload_plugin(tmp_path, source="user")
+        web_server._dashboard_plugins_cache = [plugin]
+
+        _configure_and_snapshot_public_insecure_mode(monkeypatch, opt_in_value)
+
+        with patch("importlib.util.spec_from_file_location") as spec:
+            web_server._mount_plugin_api_routes()
+
+        assert spec.call_count == 0
+
+    def test_bundled_source_api_imports_on_public_insecure_without_opt_in(
+        self, tmp_path, monkeypatch
+    ):
+        """Bundled plugin APIs are unaffected by the user-plugin gate."""
+        plugin = self._payload_plugin(tmp_path, source="bundled")
+        web_server._dashboard_plugins_cache = [plugin]
+
+        _configure_and_snapshot_public_insecure_mode(monkeypatch, False)
+
+        with patch("importlib.util.spec_from_file_location") as spec:
+            spec.return_value = None
+            web_server._mount_plugin_api_routes()
+
+        assert spec.call_count == 1
+
+    def test_start_server_mounts_user_routes_in_safe_mode(
+        self, tmp_path, monkeypatch
+    ):
+        """Safe dashboard launches preserve trusted user plugin backend APIs."""
+        original_routes = list(web_server.app.router.routes)
+        plugin = self._payload_plugin(tmp_path, source="user")
+        plugin["name"] = "safeuser"
+        api_path = Path(plugin["_dir"]) / "api.py"
+        api_path.write_text(
+            "from fastapi import APIRouter\n"
+            "router = APIRouter()\n"
+            "@router.get('/ping')\n"
+            "def ping():\n"
+            "    return {'ok': True}\n"
+        )
+        monkeypatch.setattr(
+            web_server,
+            "_get_dashboard_plugins",
+            lambda force_rescan=False: [plugin],
+        )
+        web_server._snapshot_insecure_user_plugin_api_opt_in(False)
+        _set_insecure_user_plugin_api_opt_in(monkeypatch, False)
+
+        try:
+            captured = _stub_uvicorn_run(monkeypatch)
+            web_server.start_server(
+                host="127.0.0.1",
+                port=9119,
+                open_browser=False,
+                allow_public=False,
+            )
+
+            assert captured["host"] == "127.0.0.1"
+            paths = [
+                getattr(route, "path", None)
+                for route in web_server.app.router.routes
+            ]
+            assert "/api/plugins/safeuser/ping" in paths
+            assert paths.index("/api/plugins/safeuser/ping") < paths.index(
+                "/{full_path:path}"
+            )
+            assert _plugin_module_names("safeuser")
+        finally:
+            web_server.app.router.routes[:] = original_routes
+            _pop_plugin_modules("safeuser")
+
+    def test_start_server_does_not_mount_user_routes_public_insecure(
+        self, tmp_path, monkeypatch
+    ):
+        original_routes = list(web_server.app.router.routes)
+        plugin = self._payload_plugin(tmp_path, source="user")
+        plugin["name"] = "publicuser"
+        api_path = Path(plugin["_dir"]) / "api.py"
+        api_path.write_text(
+            "from fastapi import APIRouter\n"
+            "router = APIRouter()\n"
+            "@router.get('/ping')\n"
+            "def ping():\n"
+            "    return {'ok': True}\n"
+        )
+        monkeypatch.setattr(
+            web_server,
+            "_get_dashboard_plugins",
+            lambda force_rescan=False: [plugin],
+        )
+        web_server._snapshot_insecure_user_plugin_api_opt_in(False)
+        _set_insecure_user_plugin_api_opt_in(monkeypatch, False)
+
+        try:
+            captured = _stub_uvicorn_run(monkeypatch)
+            web_server.start_server(
+                host="0.0.0.0",
+                port=9119,
+                open_browser=False,
+                allow_public=True,
+            )
+
+            assert captured["host"] == "0.0.0.0"
+            assert not _plugin_module_names("publicuser")
+            assert not any(
+                getattr(route, "path", None) == "/api/plugins/publicuser/ping"
+                for route in web_server.app.router.routes
+            )
+        finally:
+            web_server.app.router.routes[:] = original_routes
+            web_server._dashboard_plugins_cache = None
+            _pop_plugin_modules("publicuser")
+
+    def test_public_insecure_launch_removes_existing_user_routes(
+        self, tmp_path, monkeypatch
+    ):
+        """A reused process must not retain safe-mode user API routes."""
+        original_routes = list(web_server.app.router.routes)
+        plugin = self._payload_plugin(tmp_path, source="user")
+        plugin["name"] = "modeflip"
+        api_path = Path(plugin["_dir"]) / "api.py"
+        api_path.write_text(
+            "from fastapi import APIRouter\n"
+            "router = APIRouter()\n"
+            "@router.get('/ping')\n"
+            "def ping():\n"
+            "    return {'ok': True}\n"
+        )
+        monkeypatch.setattr(
+            web_server,
+            "_get_dashboard_plugins",
+            lambda force_rescan=False: [plugin],
+        )
+        web_server._snapshot_insecure_user_plugin_api_opt_in(False)
+        _set_insecure_user_plugin_api_opt_in(monkeypatch, False)
+
+        try:
+            captured = _stub_uvicorn_run(monkeypatch)
+            web_server.start_server(
+                host="127.0.0.1",
+                port=9119,
+                open_browser=False,
+                allow_public=False,
+            )
+            assert captured["host"] == "127.0.0.1"
+            assert _plugin_module_names("modeflip")
+            assert any(
+                getattr(route, "path", None) == "/api/plugins/modeflip/ping"
+                for route in web_server.app.router.routes
+            )
+
+            captured = _stub_uvicorn_run(monkeypatch)
+            web_server.start_server(
+                host="0.0.0.0",
+                port=9119,
+                open_browser=False,
+                allow_public=True,
+            )
+
+            assert captured["host"] == "0.0.0.0"
+            assert web_server._plugin_api_user_routes_mounted is False
+            assert not _plugin_module_names("modeflip")
+            assert not any(
+                getattr(route, "path", None) == "/api/plugins/modeflip/ping"
+                for route in web_server.app.router.routes
+            )
+        finally:
+            web_server.app.router.routes[:] = original_routes
+            web_server._dashboard_plugins_cache = None
+            _pop_plugin_modules("modeflip")
+
+    def test_mount_cleans_module_when_api_has_no_router(self, tmp_path):
+        original_routes = list(web_server.app.router.routes)
+        plugin = self._payload_plugin(tmp_path, source="user")
+        plugin["name"] = "norouter"
+        (Path(plugin["_dir"]) / "api.py").write_text("VALUE = 1\n")
+
+        try:
+            web_server._dashboard_plugins_cache = [plugin]
+            web_server._mount_plugin_api_routes()
+
+            assert not _plugin_module_names("norouter")
+            assert not any(
+                str(getattr(route, "path", "")).startswith(
+                    "/api/plugins/norouter/"
+                )
+                for route in web_server.app.router.routes
+            )
+        finally:
+            web_server.app.router.routes[:] = original_routes
+            web_server._dashboard_plugins_cache = None
+            _pop_plugin_modules("norouter")
+
+
+class TestDiscoveryDisablesUserApiOnPublicInsecure:
+    """Discovery hides user plugin API metadata in public-insecure mode."""
+
+    def test_real_user_api_not_imported_when_dashboard_public_insecure(
+        self, tmp_path, monkeypatch
+    ):
+        original_routes = list(web_server.app.router.routes)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        monkeypatch.setenv("HERMES_BUNDLED_PLUGINS", str(tmp_path / "bundled"))
+
+        _configure_and_snapshot_public_insecure_mode(monkeypatch, False)
+        dashboard = _write_plugin_manifest(
+            tmp_path / "home" / "plugins",
+            "real-public-risk",
+            {
+                "name": "real-public-risk",
+                "label": "Real Public Risk",
+                "api": "api.py",
+                "entry": "dist/index.js",
+            },
+        )
+        marker = tmp_path / "imported.txt"
+        dashboard.joinpath("api.py").write_text(
+            "from fastapi import APIRouter\n"
+            "from pathlib import Path\n"
+            f"Path({str(marker)!r}).write_text('imported')\n"
+            "router = APIRouter()\n"
+            "@router.get('/ping')\n"
+            "def ping():\n"
+            "    return {'ok': True}\n"
+        )
+
+        try:
+            plugins = web_server._get_dashboard_plugins(force_rescan=True)
+            entry = next(p for p in plugins if p["name"] == "real-public-risk")
+            assert entry["_api_file"] is None
+            assert entry["has_api"] is False
+
+            web_server._mount_plugin_api_routes()
+
+            assert not marker.exists()
+            assert not any(
+                getattr(route, "path", None)
+                == "/api/plugins/real-public-risk/ping"
+                for route in web_server.app.router.routes
+            )
+        finally:
+            web_server.app.router.routes[:] = original_routes
+            web_server.app.openapi_schema = None
+            web_server._dashboard_plugins_cache = None
+            _pop_plugin_modules("real-public-risk")
+
+    def test_real_user_api_imports_when_public_insecure_opt_in_enabled(
+        self, tmp_path, monkeypatch
+    ):
+        original_routes = list(web_server.app.router.routes)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        monkeypatch.setenv("HERMES_BUNDLED_PLUGINS", str(tmp_path / "bundled"))
+
+        _configure_and_snapshot_public_insecure_mode(monkeypatch, True)
+        dashboard = _write_plugin_manifest(
+            tmp_path / "home" / "plugins",
+            "real-opt-in",
+            {
+                "name": "real-opt-in",
+                "label": "Real Opt In",
+                "api": "api.py",
+                "entry": "dist/index.js",
+            },
+        )
+        marker = tmp_path / "imported.txt"
+        dashboard.joinpath("api.py").write_text(
+            "from fastapi import APIRouter\n"
+            "from pathlib import Path\n"
+            f"Path({str(marker)!r}).write_text('imported')\n"
+            "router = APIRouter()\n"
+            "@router.get('/ping')\n"
+            "def ping():\n"
+            "    return {'ok': True}\n"
+        )
+
+        try:
+            plugins = web_server._get_dashboard_plugins(force_rescan=True)
+            entry = next(p for p in plugins if p["name"] == "real-opt-in")
+            assert entry["_api_file"] == "api.py"
+            assert entry["has_api"] is True
+
+            web_server._mount_plugin_api_routes()
+
+            assert marker.read_text() == "imported"
+            assert any(
+                getattr(route, "path", None) == "/api/plugins/real-opt-in/ping"
+                for route in web_server.app.router.routes
+            )
+        finally:
+            web_server.app.router.routes[:] = original_routes
+            web_server.app.openapi_schema = None
+            web_server._dashboard_plugins_cache = None
+            _pop_plugin_modules("real-opt-in")
+
+    def test_user_api_scrubbed_when_dashboard_public_insecure(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        _configure_and_snapshot_public_insecure_mode(monkeypatch, False)
+        dashboard = _write_plugin_manifest(
+            tmp_path / "plugins",
+            "public-risk",
+            {
+                "name": "public-risk",
+                "label": "Public Risk",
+                "api": "api.py",
+                "entry": "dist/index.js",
+            },
+        )
+        (dashboard / "api.py").write_text("router = None\n")
+
+        plugins = web_server._get_dashboard_plugins(force_rescan=True)
+        entry = next(p for p in plugins if p["name"] == "public-risk")
+
+        assert entry["_api_file"] is None
+        assert entry["has_api"] is False
+
+    def test_runtime_config_flip_does_not_reenable_user_api(
+        self, tmp_path, monkeypatch
+    ):
+        original_routes = list(web_server.app.router.routes)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "bundled").mkdir()
+        monkeypatch.setenv("HERMES_BUNDLED_PLUGINS", str(tmp_path / "bundled"))
+
+        _configure_and_snapshot_public_insecure_mode(monkeypatch, False)
+        dashboard = _write_plugin_manifest(
+            tmp_path / "plugins",
+            "late-opt-in",
+            {
+                "name": "late-opt-in",
+                "label": "Late Opt In",
+                "api": "api.py",
+                "entry": "dist/index.js",
+            },
+        )
+        (dashboard / "api.py").write_text(
+            "from fastapi import APIRouter\n"
+            "router = APIRouter()\n"
+            "@router.get('/ping')\n"
+            "def ping():\n"
+            "    return {'ok': True}\n"
+        )
+
+        try:
+            plugins = web_server._get_dashboard_plugins(force_rescan=True)
+            entry = next(p for p in plugins if p["name"] == "late-opt-in")
+            assert entry["_api_file"] is None
+            assert entry["has_api"] is False
+
+            _set_insecure_user_plugin_api_opt_in(monkeypatch, True)
+            with patch("importlib.util.spec_from_file_location") as spec:
+                rescanned = web_server._get_dashboard_plugins(force_rescan=True)
+
+            entry = next(p for p in rescanned if p["name"] == "late-opt-in")
+            assert entry["_api_file"] is None
+            assert entry["has_api"] is False
+            for call in spec.call_args_list:
+                assert not call.args[0].startswith(
+                    "hermes_dashboard_plugin_late-opt-in"
+                )
+                assert Path(call.args[1]) != dashboard / "api.py"
+            assert not any(
+                getattr(route, "path", None) == "/api/plugins/late-opt-in/ping"
+                for route in web_server.app.router.routes
+            )
+        finally:
+            web_server.app.router.routes[:] = original_routes
+            web_server.app.openapi_schema = None
+            web_server._dashboard_plugins_cache = None
+            _pop_plugin_modules("late-opt-in")
+
+    def test_user_api_preserved_when_public_insecure_opt_in_enabled(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        _configure_and_snapshot_public_insecure_mode(monkeypatch, True)
+        dashboard = _write_plugin_manifest(
+            tmp_path / "plugins",
+            "opt-in",
+            {
+                "name": "opt-in",
+                "label": "Opt In",
+                "api": "api.py",
+                "entry": "dist/index.js",
+            },
+        )
+        (dashboard / "api.py").write_text("router = None\n")
+
+        plugins = web_server._get_dashboard_plugins(force_rescan=True)
+        entry = next(p for p in plugins if p["name"] == "opt-in")
+
+        assert entry["_api_file"] == "api.py"
+        assert entry["has_api"] is True
+
+    def test_bundled_api_preserved_when_dashboard_public_insecure(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        monkeypatch.setenv("HERMES_BUNDLED_PLUGINS", str(tmp_path / "bundled"))
+
+        _configure_and_snapshot_public_insecure_mode(monkeypatch, False)
+        dashboard = _write_plugin_manifest(
+            tmp_path / "bundled",
+            "bundled-risk",
+            {
+                "name": "bundled-risk",
+                "label": "Bundled Risk",
+                "api": "api.py",
+                "entry": "dist/index.js",
+            },
+        )
+        (dashboard / "api.py").write_text("router = None\n")
+
+        plugins = web_server._get_dashboard_plugins(force_rescan=True)
+        entry = next(p for p in plugins if p["name"] == "bundled-risk")
+
+        assert entry["source"] == "bundled"
+        assert entry["_api_file"] == "api.py"
+        assert entry["has_api"] is True
 
 # ---------------------------------------------------------------------------
 # Layer 5 — End-to-end: the original PoC manifest no longer triggers RCE.
@@ -357,4 +1019,4 @@ class TestEndToEndPocBlocked:
             assert module_name != "hermes_dashboard_plugin_evil"
             assert target != payload_py
             assert "evil-repo" not in target.parts
-        assert "hermes_dashboard_plugin_evil" not in sys.modules
+        assert not _plugin_module_names("evil")

--- a/tests/hermes_cli/test_web_server_files.py
+++ b/tests/hermes_cli/test_web_server_files.py
@@ -8,13 +8,17 @@ from starlette.testclient import TestClient
 from hermes_cli import web_server
 
 
-def _client_with_app_state():
+def _client_with_app_state(
+    *,
+    base_url: str = "http://testserver",
+    peer: tuple[str, int] = ("testclient", 50000),
+):
     prev_auth_required = getattr(web_server.app.state, "auth_required", None)
     prev_bound_host = getattr(web_server.app.state, "bound_host", None)
     web_server.app.state.auth_required = False
     web_server.app.state.bound_host = None
 
-    client = TestClient(web_server.app)
+    client = TestClient(web_server.app, base_url=base_url, client=peer)
     client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
     return client, prev_auth_required, prev_bound_host
 
@@ -488,3 +492,52 @@ def test_stream_upload_cleans_temp_on_cancellation(forced_files_client):
     # ... and no .upload temp file was left behind.
     leftovers = [p.name for p in target.parent.iterdir() if ".upload" in p.name]
     assert leftovers == [], f"temp upload files leaked on cancellation: {leftovers}"
+
+
+def test_managed_files_policy_treats_ipv4_mapped_loopback_as_local(monkeypatch):
+    """IPv4-mapped IPv6 loopback must keep file browsing in local mode."""
+    monkeypatch.delenv("HERMES_DASHBOARD_FILES_ROOT", raising=False)
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    client, prev_auth_required, prev_bound_host = _client_with_app_state()
+    try:
+        request = SimpleNamespace(
+            app=web_server.app,
+            client=SimpleNamespace(host="::ffff:127.0.0.1"),
+            url=SimpleNamespace(hostname="::ffff:127.0.0.1"),
+        )
+        policy = web_server._managed_files_policy(request, create_root=False)
+    finally:
+        _restore_app_state(prev_auth_required, prev_bound_host)
+        client.close()
+
+    assert policy.locked_root is None
+    assert policy.can_change_path is True
+
+
+def test_files_endpoint_treats_ipv4_mapped_loopback_as_local(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "local.txt").write_text("local")
+    monkeypatch.delenv("HERMES_DASHBOARD_FILES_ROOT", raising=False)
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setenv("HOME", str(home))
+
+    client, prev_auth_required, prev_bound_host = _client_with_app_state(
+        base_url="http://dashboard.example",
+        peer=("::ffff:127.0.0.1", 50000),
+    )
+    try:
+        response = client.get(
+            "/api/files",
+            headers={"Host": "[::ffff:127.0.0.1]:9119"},
+        )
+    finally:
+        _restore_app_state(prev_auth_required, prev_bound_host)
+        client.close()
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["path"] == str(home)
+    assert body["locked_root"] is None
+    assert body["can_change_path"] is True
+    assert body["entries"][0]["path"] == str(home / "local.txt")

--- a/tests/hermes_cli/test_web_server_host_header.py
+++ b/tests/hermes_cli/test_web_server_host_header.py
@@ -26,11 +26,12 @@ class TestHostHeaderValidator:
     def test_loopback_bind_accepts_loopback_names(self):
         from hermes_cli.web_server import _is_accepted_host
 
-        for bound in ("127.0.0.1", "localhost", "::1"):
+        for bound in ("127.0.0.1", "localhost", "::1", "::ffff:127.0.0.1"):
             for host_header in (
                 "127.0.0.1", "127.0.0.1:9119",
-                "localhost", "localhost:9119",
+                "localhost", "localhost.", "localhost:9119",
                 "[::1]", "[::1]:9119",
+                "[::ffff:127.0.0.1]", "[::ffff:127.0.0.1]:9119",
             ):
                 assert _is_accepted_host(host_header, bound), (
                     f"bound={bound} must accept host={host_header}"
@@ -131,6 +132,28 @@ class TestHostHeaderMiddleware:
             if hasattr(app.state, "bound_host"):
                 del app.state.bound_host
 
+    def test_ipv4_mapped_loopback_request_accepted(self, monkeypatch, tmp_path):
+        from fastapi.testclient import TestClient
+        from hermes_cli.web_server import app
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        app.state.bound_host = "::ffff:127.0.0.1"
+        try:
+            client = TestClient(
+                app,
+                base_url="http://dashboard.example",
+                client=("::ffff:127.0.0.1", 50000),
+            )
+            resp = client.get(
+                "/api/status",
+                headers={"Host": "[::ffff:127.0.0.1]:9119"},
+            )
+            assert resp.status_code != 400
+            assert "Invalid Host header" not in resp.json().get("detail", "")
+        finally:
+            if hasattr(app.state, "bound_host"):
+                del app.state.bound_host
+
     def test_no_bound_host_skips_validation(self):
         """If app.state.bound_host isn't set (e.g. running under test
         infra without calling start_server), middleware must pass through
@@ -212,6 +235,34 @@ class TestWebSocketHostOriginGuard:
             headers={
                 "Host": "localhost:9119",
                 "Origin": "http://localhost:9119",
+            },
+        ):
+            pass
+
+    def test_ipv4_mapped_loopback_websocket_host_and_origin_are_accepted(
+        self, monkeypatch, tmp_path
+    ):
+        from fastapi.testclient import TestClient
+
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        monkeypatch.setattr(
+            ws.app.state, "bound_host", "::ffff:127.0.0.1", raising=False
+        )
+        monkeypatch.setattr(ws, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
+
+        client = TestClient(
+            ws.app,
+            base_url="http://dashboard.example",
+            client=("::ffff:127.0.0.1", 50000),
+        )
+        url = f"/api/events?token={ws._SESSION_TOKEN}&channel=security-test"
+        with client.websocket_connect(
+            url,
+            headers={
+                "Host": "[::ffff:127.0.0.1]:9119",
+                "Origin": "http://[::ffff:127.0.0.1]:9119",
             },
         ):
             pass


### PR DESCRIPTION
## Summary

- suppress user-installed dashboard plugin Python API imports when the dashboard is launched with `--insecure` on a non-loopback host
- preserve bundled dashboard plugin APIs and preserve user-installed plugin APIs on loopback or OAuth-gated dashboards
- snapshot the `dashboard.allow_insecure_user_plugin_api` opt-in before serving a public-insecure dashboard, so a later config edit plus rescan cannot re-enable user plugin Python imports in the same unauthenticated process
- share dashboard bind-host loopback classification across auth gating, Host validation, WebSocket peer checks, managed file locality checks, and plugin API policy

## Root Cause

User-installed dashboard plugins can declare Python backend APIs. Before this change, those APIs could be imported into the legacy `--insecure` dashboard surface even when the final dashboard bind was public/non-loopback. That made trusted-local plugin backend code remotely reachable on a dashboard mode that intentionally skips the OAuth gate.

The broken invariant is that public non-loopback `--insecure` mode should not auto-import user plugin Python unless the operator explicitly opts into that risk before the server is exposed.

## Fix Strategy

Bundled plugin APIs still mount at import time because they ship with the application. User plugin APIs now mount once from `start_server()` after the final host and `--insecure` mode are known. If the same module-global app previously mounted user plugin routes in safe mode and then enters public-insecure mode, those user routes and modules are removed before serving.

The opt-in is intentionally strict: `dashboard.allow_insecure_user_plugin_api` must be the real YAML boolean `true`. String-like values such as `"true"` or `"1"` do not enable it.

This reduced version deliberately does **not** add dynamic backend route hot-reload, route reconciliation, or plugin lifecycle emulation. Backend plugin API changes still require a dashboard restart. That keeps the production change focused on the security boundary instead of turning the PR into a dashboard plugin runtime redesign.

## Relation to #44472

This PR supersedes #44472 if maintainers accept the compatibility-preserving complete fix. #44472 is the narrower partial mitigation: it disables non-bundled dashboard backend APIs entirely, which is simpler but also removes user plugin backend APIs from safe loopback/OAuth-gated dashboards.

The two PRs should be treated as alternatives, not stacked changes. If this PR lands, #44472 can be closed. If this PR is still considered too large, #44472 remains the smaller partial fallback.

## Relation to #43794

#43794 is complementary ingress hardening for public-insecure dashboards; it blocks dashboard-driven plugin installs. This PR governs backend API imports for dashboard plugins already present on disk. They cover different parts of the same risk area and do not directly replace each other.

## Validation

- `env HERMES_HOME=/tmp/hermes-codex-empty /home/mac/hermes-agent/.venv/bin/python -m pytest tests/hermes_cli/test_project_plugin_rce_bypass.py tests/hermes_cli/test_web_server.py::TestPluginAPIAuth tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_unauthenticated_api_blocked tests/hermes_cli/test_web_server_files.py tests/hermes_cli/test_web_server_host_header.py` (108 passed)
- `env HERMES_HOME=/tmp/hermes-codex-empty /home/mac/hermes-agent/.venv/bin/python -m py_compile hermes_cli/web_server.py hermes_cli/dashboard_host.py hermes_cli/config.py tests/hermes_cli/test_project_plugin_rce_bypass.py tests/hermes_cli/test_web_server_files.py tests/hermes_cli/test_web_server_host_header.py`
- `git diff --check`
- CodeRabbit committed review on the final tree before signing: 0 issues

Fixes #43719

---
Created by GPT-5.5-xhigh in Codex. Human involvement: general issue selection and resolution guidelines; commit signing; checking notifications.
