### PR TITLE
fix(telegram): advance reply anchor to latest message_id when batching stacked prompts

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5391,6 +5391,10 @@ class TelegramAdapter(BasePlatformAdapter):
             if event.text:
                 existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
             existing._last_chunk_len = chunk_len  # type: ignore[attr-defined]
+            # Advance reply anchor to the latest message so the bot replies to
+            # the most recent user message when stacked prompts are batched.
+            if event.message_id:
+                existing.message_id = event.message_id
             # Merge any media that might be attached
             if event.media_urls:
                 existing.media_urls.extend(event.media_urls)

--- a/tests/gateway/test_telegram_text_batching.py
+++ b/tests/gateway/test_telegram_text_batching.py
@@ -123,6 +123,39 @@ class TestTextBatching:
         assert len(adapter._pending_text_batch_tasks) == 0
 
     @pytest.mark.asyncio
+    async def test_stacked_prompts_reply_anchor_advances_to_last_message(self):
+        """Reply anchor must track the latest message_id when user stacks prompts.
+
+        When two distinct user messages arrive quickly (stacked prompts, not
+        Telegram split-chunks), the batched event should carry the *last*
+        message_id so the bot replies to the most recent message the user sent,
+        not the first one.
+        """
+        adapter = _make_adapter()
+
+        event1 = _make_event("first prompt")
+        event1.message_id = "100"
+        event2 = _make_event("second prompt")
+        event2.message_id = "101"
+
+        adapter._enqueue_text_event(event1)
+        await asyncio.sleep(0.02)  # within batch window
+        adapter._enqueue_text_event(event2)
+
+        await asyncio.sleep(0.2)
+
+        adapter.handle_message.assert_called_once()
+        dispatched = adapter.handle_message.call_args[0][0]
+        # Text must be merged
+        assert "first prompt" in dispatched.text
+        assert "second prompt" in dispatched.text
+        # Reply anchor must be the LAST message, not the first
+        assert dispatched.message_id == "101", (
+            f"Expected reply anchor '101' (last message) but got {dispatched.message_id!r}. "
+            "Bot would have replied to the wrong message."
+        )
+
+    @pytest.mark.asyncio
     async def test_dm_topic_batching_recovers_thread_before_keying(self):
         """DM-topic text batches should use the recovered topic lane."""
         adapter = _make_adapter()


### PR DESCRIPTION
## Problem

When a user sends multiple messages quickly ("stacked prompts"), the text batching code in `_enqueue_text_event` merges them into a single event but never updated `existing.message_id` — it stayed pinned to the **first** message's ID. The bot's reply then anchored to that first message rather than the most recent one, which appeared to the user as the bot replying to the wrong message.

The merge path at `telegram.py`:
```python
else:
    if event.text:
        existing.text = ...  # text merged
    existing._last_chunk_len = chunk_len
    # ← message_id never updated here
    if event.media_urls:
        ...
```

## Root Cause

`_enqueue_text_event` was designed for Telegram's 4096-char message splits (where consecutive chunks belong to the same logical message). For that case the original `message_id` is fine. But the same code path runs for any two rapidly-sent messages, and in that case the reply anchor should track the **last** message so the reply threads to what the user most recently sent.

## Fix

One line: update `existing.message_id` to the incoming event's `message_id` when merging, guarded by truthiness so a missing id is never clobbered with `None`.

```python
if event.message_id:
    existing.message_id = event.message_id
```

## Test

Added `test_stacked_prompts_reply_anchor_advances_to_last_message` to the existing `test_telegram_text_batching.py` suite. It reproduces the exact scenario — two events with distinct `message_id`s batched within the window — and asserts:
1. Both texts are merged.
2. The dispatched event carries the **last** `message_id` as the reply anchor.

All 7 tests in the file pass.