### PR TITLE
fix(desktop): allow stable local macOS signing

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -83,6 +83,16 @@ npm run pack         # unpacked app under release/ (no installer)
 
 Installers are built and uploaded to GitHub Releases manually. macOS/Windows signing & notarization happen automatically when the relevant credentials are present in the environment (`CSC_LINK` / `CSC_KEY_PASSWORD` / `APPLE_*` for macOS, `WIN_CSC_*` for Windows).
 
+For local source-built macOS apps (`npm run pack`, `hermes desktop`, or the installer desktop stage), ad-hoc signing is still the fallback. Ad-hoc bundles can relaunch after rebuilds, but macOS privacy grants such as Microphone/TCC are tied to the app's code-signing requirement and may not survive rebuild churn. To keep a stable local identity, export an explicit local signing certificate name before building:
+
+```bash
+export HERMES_DESKTOP_SIGNING_IDENTITY="Apple Development: Your Name (TEAMID)"
+# or, for existing scripts:
+export APPLE_SIGNING_IDENTITY="$HERMES_DESKTOP_SIGNING_IDENTITY"
+```
+
+The local signer uses the desktop entitlements, including microphone/audio input, and skips official `CSC_LINK`/`CSC_NAME` release-signing builds so it does not clobber notarized artifacts.
+
 ### How it works
 
 The packaged app ships only the Electron shell. On first launch it installs the Hermes Agent runtime into `HERMES_HOME` (`~/.hermes`, or `%LOCALAPPDATA%\hermes` on Windows) — the **same layout a CLI install uses**, so the two are interchangeable. The renderer (React, in `src/`) talks to a `hermes dashboard` backend over the standard gateway APIs and reuses the embedded TUI rather than reimplementing chat. The install, backend-resolution, and self-update logic all live in `electron/main.cjs`.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5046,24 +5046,26 @@ def _stop_desktop_processes_locking_build(desktop_dir: Path) -> list[int]:
 
 
 def _desktop_macos_relaunchable_fixup(desktop_dir: Path) -> None:
-    """Make a locally-built (unsigned) macOS desktop app survive in-place self-update.
+    """Make a locally-built macOS desktop app survive in-place self-update.
 
     An ad-hoc-signed .app has no stable Designated Requirement (no Team ID), so
     when the self-updater rebuilds the bundle in place with a fresh build (a new,
     different cdhash) Gatekeeper/LaunchServices treats the changed code as
-    tampering and macOS reports "Hermes is damaged and can't be opened." The
-    bundle also inherits the com.apple.quarantine flag from the downloaded
-    installer process chain. Both make the relaunch fail.
+    tampering and macOS reports "Hermes is damaged and can't be opened." The same
+    unstable identity also makes macOS TCC grants fragile: microphone permission
+    is tied to the app's designated requirement, not just the visible app name.
 
-    Clearing the quarantine xattrs and re-applying a clean deep ad-hoc signature
-    (omitting the hardened-runtime flag, which is meaningless without a real
-    Developer ID) lets the rebuilt app relaunch. No-op when a real signing
-    identity is configured (CSC_LINK / APPLE_SIGNING_IDENTITY) so a properly
-    signed/notarized build is never clobbered. Best-effort: never raises.
+    If the user explicitly provides a local signing identity, re-sign the unpacked
+    Electron app with the desktop entitlements and hardened runtime so the bundle
+    keeps a stable local requirement across rebuilds. Otherwise preserve the old
+    best-effort behavior: strip quarantine and apply a clean ad-hoc signature so
+    the rebuilt app can at least relaunch. No-op when electron-builder release
+    signing is configured (CSC_LINK / CSC_NAME) so a properly signed/notarized
+    build is never clobbered. Best-effort: never raises.
     """
     if sys.platform != "darwin":
         return
-    if os.environ.get("CSC_LINK") or os.environ.get("APPLE_SIGNING_IDENTITY"):
+    if os.environ.get("CSC_LINK") or os.environ.get("CSC_NAME"):
         return
     exe = _desktop_packaged_executable(desktop_dir)
     if exe is None:
@@ -5075,8 +5077,41 @@ def _desktop_macos_relaunchable_fixup(desktop_dir: Path) -> None:
     codesign = shutil.which("codesign")
     if not codesign:
         return
+
+    identity = (
+        os.environ.get("HERMES_DESKTOP_SIGNING_IDENTITY")
+        or os.environ.get("APPLE_SIGNING_IDENTITY")
+        or ""
+    ).strip()
+    entitlements = desktop_dir / "electron" / "entitlements.mac.plist"
+
     try:
         subprocess.run(["xattr", "-cr", str(app)], check=False)
+        if identity and entitlements.is_file():
+            subprocess.run(
+                ["find", str(app), "-name", "_CodeSignature", "-type", "d", "-prune", "-exec", "rm", "-rf", "{}", "+"],
+                check=False,
+            )
+            subprocess.run(["find", str(app), "-name", "*.cstemp", "-type", "f", "-delete"], check=False)
+            sign_result = subprocess.run(
+                [
+                    codesign,
+                    "--force",
+                    "--deep",
+                    "--sign",
+                    identity,
+                    "--options",
+                    "runtime",
+                    "--timestamp=none",
+                    "--entitlements",
+                    str(entitlements),
+                    str(app),
+                ],
+                check=False,
+            )
+            if sign_result.returncode == 0:
+                return
+            print("  (warning: explicit macOS desktop signing failed; falling back to ad-hoc signature)")
         subprocess.run([codesign, "--force", "--deep", "--sign", "-", str(app)], check=False)
     except Exception as exc:
         print(f"  (warning: macOS relaunch fixup skipped: {exc})")

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2521,16 +2521,37 @@ install_desktop() {
         fi
     fi
 
-    # macOS: make the locally-built (ad-hoc) app relaunchable after an in-place
+    # macOS: make the locally-built app relaunchable after an in-place
     # self-update. An ad-hoc bundle has no stable Designated Requirement, so a
     # later in-place rebuild (new cdhash) plus the inherited quarantine flag
     # trips Gatekeeper's tamper check ("Hermes is damaged and can't be opened").
-    # Strip quarantine + re-apply a clean deep ad-hoc signature (no
-    # hardened-runtime flag, which an ad-hoc build can't satisfy). Skipped when a
-    # real signing identity is configured so a signed build isn't clobbered.
-    if [ "$OS" = "macos" ] && [ -z "${CSC_LINK:-}" ] && [ -z "${APPLE_SIGNING_IDENTITY:-}" ] && command -v codesign >/dev/null 2>&1; then
+    # The same unstable requirement also makes TCC grants fragile: microphone
+    # permission is tied to the app's code-signing requirement, not the visible
+    # app name. If the user explicitly provides a local signing identity, prefer
+    # that stable signature; otherwise preserve the old ad-hoc relaunch fixup.
+    # Skipped when electron-builder release signing is configured so a real
+    # signed/notarized build isn't clobbered.
+    if [ "$OS" = "macos" ] && [ -z "${CSC_LINK:-}" ] && [ -z "${CSC_NAME:-}" ] && command -v codesign >/dev/null 2>&1; then
         xattr -cr "$app" 2>/dev/null || true
-        codesign --force --deep --sign - "$app" >/dev/null 2>&1 || true
+        local local_identity="${HERMES_DESKTOP_SIGNING_IDENTITY:-${APPLE_SIGNING_IDENTITY:-}}"
+        local entitlements="$desktop_dir/electron/entitlements.mac.plist"
+        if [ -n "$local_identity" ] && [ -f "$entitlements" ]; then
+            # Clean stale CodeResources first: interrupted deep-sign attempts can
+            # leave *.cstemp entries that make the next sign fail before it can
+            # repair nested Electron frameworks.
+            find "$app" -name _CodeSignature -type d -prune -exec rm -rf {} + 2>/dev/null || true
+            find "$app" -name '*.cstemp' -type f -delete 2>/dev/null || true
+            if codesign --force --deep --sign "$local_identity" --options runtime --timestamp=none --entitlements "$entitlements" "$app" >/dev/null 2>&1; then
+                log_success "Desktop app signed with local macOS identity: $local_identity"
+            else
+                log_warn "Local macOS desktop signing failed; falling back to ad-hoc signature"
+                codesign --force --deep --sign - "$app" >/dev/null 2>&1 || true
+            fi
+        else
+            # Strip quarantine + re-apply a clean deep ad-hoc signature (no
+            # hardened-runtime flag, which an ad-hoc build can't satisfy).
+            codesign --force --deep --sign - "$app" >/dev/null 2>&1 || true
+        fi
     fi
 
     # `npm install` + `npm run pack` rewrite lockfiles; restore them so the

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -553,6 +553,48 @@ def test_gui_does_not_override_user_electron_mirror(tmp_path, monkeypatch, capsy
     assert "Desktop GUI build failed" in capsys.readouterr().out
 
 
+def test_macos_relaunchable_fixup_uses_explicit_signing_identity(tmp_path, monkeypatch):
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    _make_packaged_executable(root, monkeypatch, platform="darwin")
+    entitlements = desktop_dir / "electron" / "entitlements.mac.plist"
+    entitlements.parent.mkdir(parents=True)
+    entitlements.write_text("<plist />", encoding="utf-8")
+
+    monkeypatch.delenv("CSC_LINK", raising=False)
+    monkeypatch.delenv("CSC_NAME", raising=False)
+    monkeypatch.setenv("HERMES_DESKTOP_SIGNING_IDENTITY", "Apple Development: Test (TEAMID)")
+
+    ok = subprocess.CompletedProcess([], 0)
+    with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/codesign"), \
+         patch("hermes_cli.main.subprocess.run", return_value=ok) as run:
+        cli_main._desktop_macos_relaunchable_fixup(desktop_dir)
+
+    commands = [call.args[0] for call in run.call_args_list]
+    assert commands[0] == ["xattr", "-cr", str(desktop_dir / "release" / "mac-arm64" / "Hermes.app")]
+    assert any(cmd[:7] == ["find", str(desktop_dir / "release" / "mac-arm64" / "Hermes.app"), "-name", "_CodeSignature", "-type", "d", "-prune"] for cmd in commands)
+    sign_cmd = commands[-1]
+    assert sign_cmd[:6] == ["/usr/bin/codesign", "--force", "--deep", "--sign", "Apple Development: Test (TEAMID)", "--options"]
+    assert "runtime" in sign_cmd
+    assert "--timestamp=none" in sign_cmd
+    assert "--entitlements" in sign_cmd
+    assert str(entitlements) in sign_cmd
+
+
+def test_macos_relaunchable_fixup_skips_release_signing_env(tmp_path, monkeypatch):
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    _make_packaged_executable(root, monkeypatch, platform="darwin")
+    monkeypatch.setenv("CSC_NAME", "Developer ID Application: Nous Research")
+
+    with patch("hermes_cli.main.shutil.which") as which, \
+         patch("hermes_cli.main.subprocess.run") as run:
+        cli_main._desktop_macos_relaunchable_fixup(desktop_dir)
+
+    which.assert_not_called()
+    run.assert_not_called()
+
+
 class _FakeProc:
     """Minimal psutil.Process stand-in for the lock-breaker tests."""
 


### PR DESCRIPTION
## Summary

- Adds an explicit stable local macOS signing path for source-built/unpacked Hermes Desktop apps via `HERMES_DESKTOP_SIGNING_IDENTITY` / `APPLE_SIGNING_IDENTITY`.
- Uses the existing desktop entitlements and hardened runtime when a local identity is provided, preserving a stable designated requirement across rebuilds.
- Keeps the old ad-hoc relaunch fallback when no identity is configured and skips `CSC_LINK`/`CSC_NAME` release-signing builds so notarized artifacts are not clobbered.
- Documents the local signing option for macOS developers/users.

## Why

Ad-hoc signed Electron bundles can relaunch after rebuild fixups, but they do not provide a stable Team ID/designated requirement for macOS privacy grants. Microphone/TCC permission is tied to the app's code-signing requirement, so local rebuild/update churn can make the in-app mic fail with `Microphone access denied` even when system dictation still works.

This does not replace the need for official Developer ID/notarized release packaging for end users; it gives source-built/local desktop installs a stable opt-in path and avoids silently skipping signing when `APPLE_SIGNING_IDENTITY` is present.

Related issue: #43788

## Verification

```bash
python -m pytest tests/hermes_cli/test_gui_command.py -q
python -m ruff check hermes_cli/main.py tests/hermes_cli/test_gui_command.py
bash -n scripts/install.sh
git diff --check
```

All passed locally.
