### PR TITLE
fix(dashboard): block public insecure plugin installs

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -8967,9 +8967,27 @@ async def get_plugins_hub(request: Request):
         raise HTTPException(status_code=500, detail="Failed to build plugins hub.") from exc
 
 
+def _is_public_insecure_dashboard(request: Request) -> bool:
+    """True when the dashboard is publicly bound with the auth gate disabled."""
+    bound_host = getattr(request.app.state, "bound_host", None)
+    return (
+        bool(bound_host)
+        and bound_host not in _LOOPBACK_HOST_VALUES
+        and not getattr(request.app.state, "auth_required", False)
+    )
+
+
 @app.post("/api/dashboard/agent-plugins/install")
 async def post_agent_plugin_install(request: Request, body: _AgentPluginInstallBody):
     _require_token(request)
+    if _is_public_insecure_dashboard(request):
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "Agent plugin install is disabled on public --insecure dashboards. "
+                "Install plugins from the local CLI after auditing the source."
+            ),
+        )
     from hermes_cli.plugins_cmd import dashboard_install_plugin
 
     result = dashboard_install_plugin(

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1176,6 +1176,47 @@ class TestWebServerEndpoints:
         resp = self.client.get("/api/dashboard/plugins/rescan")
         assert resp.status_code == 200
 
+    def test_public_insecure_dashboard_rejects_agent_plugin_install(self, monkeypatch):
+        """Public --insecure dashboards must not clone third-party plugin code.
+
+        In loopback mode the SPA token protects this endpoint. On a public
+        --insecure bind, the same token is visible to any browser that can
+        reach the dashboard, so accepting plugin installs there turns the
+        dashboard into a remote arbitrary-git-clone trigger.
+        """
+        from hermes_cli import web_server as ws
+
+        old_auth_required = getattr(ws.app.state, "auth_required", None)
+        old_bound_host = getattr(ws.app.state, "bound_host", None)
+        ws.app.state.auth_required = False
+        ws.app.state.bound_host = "0.0.0.0"
+
+        def fail_install(*args, **kwargs):  # pragma: no cover - must not be called
+            raise AssertionError("dashboard_install_plugin must not run")
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins_cmd.dashboard_install_plugin",
+            fail_install,
+        )
+
+        try:
+            resp = self.client.post(
+                "/api/dashboard/agent-plugins/install",
+                json={"identifier": "jellyfinuser/csnl", "force": False, "enable": True},
+            )
+        finally:
+            if old_auth_required is None:
+                delattr(ws.app.state, "auth_required")
+            else:
+                ws.app.state.auth_required = old_auth_required
+            if old_bound_host is None:
+                delattr(ws.app.state, "bound_host")
+            else:
+                ws.app.state.bound_host = old_bound_host
+
+        assert resp.status_code == 403
+        assert "disabled on public --insecure dashboards" in resp.json()["detail"]
+
     def test_path_traversal_blocked(self):
         """Verify URL-encoded path traversal is blocked."""
         # %2e%2e = ..


### PR DESCRIPTION
## Summary
- blocks dashboard-driven agent plugin installs when the dashboard is publicly bound with auth disabled
- preserves local/loopback dashboard plugin installs protected by the session token
- adds regression coverage so public --insecure dashboards do not clone third-party plugin code

Fixes #43719

## Test Plan
- `python -m pytest tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_public_insecure_dashboard_rejects_agent_plugin_install -q`
- `python -m pytest tests/hermes_cli/test_project_plugin_rce_bypass.py tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_unauthenticated_api_blocked tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_public_insecure_dashboard_rejects_agent_plugin_install tests/hermes_cli/test_dashboard_auth_middleware.py::test_gated_require_token_endpoint_accepts_cookie_session tests/hermes_cli/test_dashboard_auth_middleware.py::test_gated_require_token_routes_accept_cookie_session -q`
- `scripts/run_tests.sh tests/hermes_cli/test_project_plugin_rce_bypass.py tests/hermes_cli/test_web_server.py tests/hermes_cli/test_dashboard_auth_middleware.py`