### PR TITLE
feat(gateway): configurable bridge port for WhatsApp

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -971,6 +971,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["group_user_allowed_commands"] = platform_cfg["group_user_allowed_commands"]
                 if plat in {Platform.DISCORD, Platform.SLACK} and "channel_skill_bindings" in platform_cfg:
                     bridged["channel_skill_bindings"] = platform_cfg["channel_skill_bindings"]
+                if plat == Platform.WHATSAPP and "bridge_port" in platform_cfg:
+                    bridged["bridge_port"] = int(platform_cfg["bridge_port"])
                 if "channel_prompts" in platform_cfg:
                     channel_prompts = platform_cfg["channel_prompts"]
                     if isinstance(channel_prompts, dict):

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -833,6 +833,57 @@ class TestLoadGatewayConfig:
             == "https://custom-proxy.example.com/bot"
         )
 
+    def test_bridges_whatsapp_bridge_port_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "whatsapp:\n"
+            "  bridge_port: 4000\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.WHATSAPP].extra["bridge_port"] == 4000
+
+    def test_whatsapp_bridge_port_coerced_to_int(self, tmp_path, monkeypatch):
+        """bridge_port should be coerced to int even if YAML provides a string."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "whatsapp:\n"
+            "  bridge_port: '5000'\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.WHATSAPP].extra["bridge_port"] == 5000
+        assert isinstance(config.platforms[Platform.WHATSAPP].extra["bridge_port"], int)
+
+    def test_whatsapp_default_bridge_port_when_not_configured(self, tmp_path, monkeypatch):
+        """When bridge_port is not in config, extra should not contain it."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "whatsapp:\n"
+            "  require_mention: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert "bridge_port" not in config.platforms[Platform.WHATSAPP].extra
+
     def test_bridges_notice_delivery_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()


### PR DESCRIPTION
## Problem

The WhatsApp gateway bridge port is hardcoded to `3000`. When port 3000 conflicts with other services, users have no way to change it through configuration.

The adapter already reads `config.extra.get("bridge_port", 3000)` in `whatsapp.py:254`, but the shared-key loop in `load_gateway_config()` never bridges `bridge_port` from the YAML config into the platform's `extra` dict.

## Solution

Add `bridge_port` to the shared-key bridging loop in `gateway/config.py`, following the same pattern as `channel_skill_bindings` (Discord/Slack) and `disable_link_previews` (Telegram):

```python
if plat == Platform.WHATSAPP and "bridge_port" in platform_cfg:
    bridged["bridge_port"] = int(platform_cfg["bridge_port"])
```

Users can now set a custom port via `config.yaml`:

```yaml
whatsapp:
  bridge_port: 4000
```

The value is coerced to `int` to handle string-typed YAML values gracefully. When not configured, the adapter falls back to the existing default of `3000`.

## Files changed

- `gateway/config.py` — Bridge `bridge_port` from WhatsApp YAML config to `PlatformConfig.extra`
- `tests/gateway/test_config.py` — 3 tests: config bridging, int coercion, default absence

## Testing

```
$ python -m pytest tests/gateway/test_config.py -k "whatsapp_bridge_port or whatsapp_default_bridge" -xvs
3 passed in 0.94s
```

Closes #43554
