### PR TITLE
docs(providers): remove stray LM Studio admonition marker

### DIFF
--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -909,7 +909,6 @@ Alternatively, use the CLI: `lms load model-name --context-length 64000`
 You can use the CLI to estimate if the model will fit: `lms load model-name --context-length 64000 --estimate-only`
 
 To set persistent per-model defaults: My Models tab → gear icon on the model → set context size.
-:::
 
 **Tool calling:** Supported since LM Studio 0.3.6. Models with native tool-calling training (Qwen 2.5, Llama 3.x, Mistral, Hermes) are auto-detected and shown with a tool badge. Other models use a generic fallback that may be less reliable.
 


### PR DESCRIPTION
## Summary

- Removes a stray Docusaurus admonition close marker near the LM Studio section.
- Addresses item 25 from #36048.
- Keeps the surrounding documentation unchanged.

## Validation

- `git diff --check -- website/docs/integrations/providers.md`

Docs/markup-only change; runtime behavior is unchanged.