### PR TITLE
fix(memory): read endpoint.baseUrl from Honcho config; accept HONCHO_URL

### DIFF
--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -471,7 +471,16 @@ class HonchoClientConfig:
         """Create config from environment variables (fallback)."""
         resolved_host = host or resolve_active_host()
         api_key = get_secret("HONCHO_API_KEY")
-        base_url = os.environ.get("HONCHO_BASE_URL", "").strip() or None
+        # HONCHO_URL is the SDK's own env var (honcho.client resolves it when
+        # no environment is passed); accept it here so the fallback path
+        # behaves the same as from_global_config() when no config file exists.
+        # Read straight from os.environ, matching HONCHO_BASE_URL: a base URL
+        # is a deployment setting, not a profile-scoped credential.
+        base_url = (
+            os.environ.get("HONCHO_BASE_URL", "").strip()
+            or os.environ.get("HONCHO_URL", "").strip()
+            or None
+        )
         timeout = _resolve_optional_float(os.environ.get("HONCHO_TIMEOUT"))
         return cls(
             host=resolved_host,
@@ -534,10 +543,22 @@ class HonchoClientConfig:
             or raw.get("environment", "production")
         )
 
+        # The Honcho SDK's native config format — and what Claude Desktop
+        # writes — nests the URL at endpoint.baseUrl. Read it first: a user
+        # who has that block set almost certainly means it, and the flat
+        # baseUrl / base_url keys below are the Hermes-specific spelling.
+        endpoint_block = raw.get("endpoint")
+        native_base_url = (
+            endpoint_block.get("baseUrl")
+            if isinstance(endpoint_block, dict)
+            else None
+        )
         base_url = (
-            raw.get("baseUrl")
+            native_base_url
+            or raw.get("baseUrl")
             or raw.get("base_url")
             or os.environ.get("HONCHO_BASE_URL", "").strip()
+            or os.environ.get("HONCHO_URL", "").strip()
             or None
         )
         # Host config wins over flat/global config and environment.
@@ -1056,7 +1077,16 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
         if resolved_base_url:
             logger.info("Initializing Honcho client (base_url: %s, workspace: %s)", resolved_base_url, config.workspace_id)
         else:
-            logger.info("Initializing Honcho client (host: %s, workspace: %s)", config.host, config.workspace_id)
+            # No base_url resolved, so the SDK falls back to its own
+            # ENVIRONMENTS map (honcho.client: local -> http://localhost:8000,
+            # production -> https://api.honcho.dev). Name the target at INFO:
+            # a self-hosted user whose config wasn't picked up otherwise sees
+            # a healthy-looking startup and silently talks to the public cloud.
+            logger.info(
+                "Initializing Honcho client (host: %s, workspace: %s, "
+                "base_url unset — SDK will resolve from environment=%s)",
+                config.host, config.workspace_id, config.environment,
+            )
 
         # Local Honcho instances don't require an API key, but the SDK
         # expects a non-empty string.  Use a placeholder for local URLs.

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -67,6 +67,29 @@ class TestFromEnv:
         assert config.enabled is True
 
 
+    def test_honcho_url_env_var_is_honored(self):
+        """HONCHO_URL is the SDK's own env var; from_env() accepts it too."""
+        with patch.dict(os.environ, {"HONCHO_URL": "http://localhost:8000"}, clear=False):
+            os.environ.pop("HONCHO_API_KEY", None)
+            os.environ.pop("HONCHO_BASE_URL", None)
+            config = HonchoClientConfig.from_env()
+        assert config.base_url == "http://localhost:8000"
+        assert config.enabled is True
+
+
+    def test_honcho_base_url_wins_over_honcho_url(self):
+        with patch.dict(
+            os.environ,
+            {
+                "HONCHO_BASE_URL": "http://localhost:8000",
+                "HONCHO_URL": "http://localhost:9999",
+            },
+            clear=False,
+        ):
+            config = HonchoClientConfig.from_env()
+        assert config.base_url == "http://localhost:8000"
+
+
 class TestFromGlobalConfig:
     def test_missing_config_falls_back_to_env(self, tmp_path):
         with patch.dict(os.environ, {}, clear=True):
@@ -76,6 +99,60 @@ class TestFromGlobalConfig:
         # Should fall back to from_env
         assert config.enabled is False
         assert config.api_key is None
+
+
+    def test_missing_config_still_reads_honcho_url(self, tmp_path):
+        """The env fallback path must honor HONCHO_URL, not just HONCHO_BASE_URL.
+
+        from_global_config() returns from_env() when the config file is
+        absent, so a fallback that only from_global_config() understood
+        would silently do nothing for users with no ~/.honcho/config.json.
+        """
+        with patch.dict(os.environ, {"HONCHO_URL": "http://localhost:8000"}, clear=True):
+            config = HonchoClientConfig.from_global_config(
+                config_path=tmp_path / "nonexistent.json"
+            )
+        assert config.base_url == "http://localhost:8000"
+        assert config.enabled is True
+
+
+    def test_base_url_from_sdk_native_endpoint_block(self, tmp_path):
+        """endpoint.baseUrl is the SDK-native spelling Claude Desktop writes."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({
+            "apiKey": "key",
+            "endpoint": {"baseUrl": "http://localhost:8000"},
+        }))
+
+        with patch.dict(os.environ, {}, clear=True):
+            config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.base_url == "http://localhost:8000"
+
+
+    def test_endpoint_base_url_wins_over_top_level_and_env(self, tmp_path):
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({
+            "endpoint": {"baseUrl": "http://localhost:8000"},
+            "baseUrl": "http://localhost:9001",
+            "base_url": "http://localhost:9002",
+        }))
+
+        with patch.dict(os.environ, {"HONCHO_BASE_URL": "http://localhost:9003"}, clear=True):
+            config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.base_url == "http://localhost:8000"
+
+
+    def test_endpoint_block_non_dict_is_ignored(self, tmp_path):
+        """A malformed endpoint value falls through instead of crashing."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({
+            "endpoint": "http://localhost:8000",
+            "baseUrl": "http://localhost:9001",
+        }))
+
+        with patch.dict(os.environ, {}, clear=True):
+            config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.base_url == "http://localhost:9001"
 
 
     def test_host_block_overrides_root(self, tmp_path):


### PR DESCRIPTION
## Summary

Narrowed to the Honcho config fix only, per @teknium1's review. The gateway/Discord/Slack changes and the README artifact are gone; the branch is rebuilt on current `main` as a single commit touching two files.

`HonchoClientConfig.from_global_config()` only consulted top-level `baseUrl` / `base_url` / `HONCHO_BASE_URL` in `~/.honcho/config.json`. The Honcho SDK's native config format — and what Claude Desktop writes — nests the URL at `endpoint.baseUrl`. Users with that format had their self-hosted container silently ignored: every `honcho_*` call routed to `https://api.honcho.dev` with a `workspace_id` that doesn't exist there, returning empty data with no error at startup or in tool returns.

Resolution order, highest first:

1. `endpoint.baseUrl` — SDK-native, what Claude Desktop writes
2. `baseUrl` / `base_url` — root-level, existing behavior
3. `HONCHO_BASE_URL` — existing env var
4. `HONCHO_URL` — the SDK's own env var

## Changes since the review

**1. The env fallback now works on the missing-config path.** You were right that it didn't — `from_global_config()` returns `from_env()` when the config file is absent or unreadable, and `from_env()` read only `HONCHO_BASE_URL`. The env var is now wired into both, with `test_missing_config_still_reads_honcho_url` pinning exactly that path.

**2. The env var is `HONCHO_URL`, not `HONCHO_ENDPOINT`.** My mistake in the previous revision — I asserted `HONCHO_ENDPOINT` was "the SDK's native env var name" without checking. It isn't; it appears nowhere in the SDK. The real one is `HONCHO_URL` (`honcho/client.py:234`). Fixed, and the claim is corrected here.

**3. The new INFO log no longer fabricates a URL.** The previous revision computed `https://api.{environment}.honcho.dev` for `environment=local`, which would have printed `https://api.local.honcho.dev` — not a real endpoint. The SDK's actual map (`honcho/client.py:36-39`) is `local → http://localhost:8000`, `production → https://api.honcho.dev`, and `ENVIRONMENTS[environment]` raises `KeyError` on anything else. Rather than mirror a table that can drift, the log line now just states that `base_url` is unset and names the `environment` the SDK will resolve from.

**4. Gateway changes dropped.** You're right that hard-coding suppression conflicts with the resolver at `gateway/display_config.py:191-225`, which intentionally honors explicit global/platform settings on top of the both-platforms-off default. Not reworked here — out of scope for this PR. I have a version that goes through the resolver instead of around it; happy to open it separately if that behavior is wanted.

**5. README fork-sanity line is gone** — the branch was rebuilt from `origin/main` rather than edited, so it never existed here. `git diff origin/main...HEAD --stat` is two files.

## Scoping note

`endpoint` is read from the config root only, not from `host_block`, even though `apiKey` / `environment` / `timeout` do consult `host_block` first. `hosts` is a Hermes-only construct — the SDK has no concept of it — so `hosts.<name>.endpoint.baseUrl` is not a shape the SDK or Claude Desktop ever writes. In the SDK-native format `endpoint` is a root-level connection-routing block.

## Testing

```
$ ./venv/bin/python -m pytest tests/honcho_plugin/test_client.py -q
47 passed in 1.96s
```

Six new tests. Reverting `client.py` and re-running fails four of them (`test_honcho_url_env_var_is_honored`, `test_missing_config_still_reads_honcho_url`, `test_base_url_from_sdk_native_endpoint_block`, `test_endpoint_base_url_wins_over_top_level_and_env`); the remaining two (`test_honcho_base_url_wins_over_honcho_url`, `test_endpoint_block_non_dict_is_ignored`) are precedence/defensive guards that hold under both old and new behavior.

Scope verified: the `tests/honcho_plugin/test_client.py` module. I have not run the full repo suite.

Closes #43800.
