### PR TITLE
feat(mattermost): in-thread auto-response (Slack parity)

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -49,6 +49,9 @@ _RECONNECT_BASE_DELAY = 2.0
 _RECONNECT_MAX_DELAY = 60.0
 _RECONNECT_JITTER = 0.2
 
+# In-thread auto-response parameter (Slack parity).
+_MENTIONED_THREADS_MAX = 5000
+
 
 def check_mattermost_requirements() -> bool:
     """Return True if the Mattermost adapter can be used."""
@@ -98,6 +101,9 @@ class MattermostAdapter(BasePlatformAdapter):
 
         # Dedup cache (prevent reprocessing)
         self._dedup = MessageDeduplicator()
+
+        # In-thread auto-response (Slack parity): threads where the bot was @mentioned.
+        self._mentioned_threads: set[str] = set()
 
     # ------------------------------------------------------------------
     # HTTP helpers
@@ -688,6 +694,55 @@ class MattermostAdapter(BasePlatformAdapter):
                 logger.info("Mattermost: WebSocket closed (%s)", raw_msg.type)
                 break
 
+    def _strict_mention(self) -> bool:
+        """Return True when every turn requires a fresh @mention (in-thread auto-response opt-out)."""
+        configured = self.config.extra.get("strict_mention") if self.config.extra else None
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.lower() in {"true", "1", "yes", "on"}
+            return bool(configured)
+        return os.getenv("MATTERMOST_STRICT_MENTION", "false").lower() in {
+            "true", "1", "yes", "on",
+        }
+
+    def _has_active_session_for_thread(
+        self, channel_id: str, thread_id: str, chat_type: str, user_id: str
+    ) -> bool:
+        """Return True when a gateway session already exists for this thread."""
+        session_store = getattr(self, "_session_store", None)
+        if not session_store:
+            return False
+        try:
+            from gateway.session import SessionSource, build_session_key
+
+            source = SessionSource(
+                platform=Platform.MATTERMOST,
+                chat_id=channel_id,
+                chat_type=chat_type,
+                user_id=user_id,
+                thread_id=thread_id,
+            )
+            store_cfg = getattr(session_store, "config", None)
+            gspu = (
+                getattr(store_cfg, "group_sessions_per_user", True)
+                if store_cfg
+                else True
+            )
+            tspu = (
+                getattr(store_cfg, "thread_sessions_per_user", False)
+                if store_cfg
+                else False
+            )
+            session_key = build_session_key(
+                source,
+                group_sessions_per_user=gspu,
+                thread_sessions_per_user=tspu,
+            )
+            session_store._ensure_loaded()
+            return session_key in session_store._entries
+        except Exception:
+            return False
+
     async def _handle_ws_event(self, event: Dict[str, Any]) -> None:
         """Process a single WebSocket event."""
         event_type = event.get("event")
@@ -725,12 +780,21 @@ class MattermostAdapter(BasePlatformAdapter):
 
         # For DMs, user_id is sufficient.  For channels, check for @mention.
         message_text = post.get("message", "")
+        sender_id = post.get("user_id", "")
+        sender_name = data.get("sender_name", "").lstrip("@") or sender_id
+        thread_id = post.get("root_id") or None
+        # Mattermost root posts have an empty root_id; in thread mode the bot
+        # nests replies under the root, so seed thread_id from the post's own id
+        # to keep the root and its replies on one session (and one mentioned thread).
+        if thread_id is None and self._reply_mode == "thread":
+            thread_id = post.get("id") or None
 
         # Mention-gating for non-DM channels.
         # Config (config.yaml `mattermost.*` with env-var fallback):
         #   require_mention / MATTERMOST_REQUIRE_MENTION: Require @mention in channels (default: true)
         #   free_response_channels / MATTERMOST_FREE_RESPONSE_CHANNELS: Channel IDs where bot responds without mention
         #   allowed_channels / MATTERMOST_ALLOWED_CHANNELS: If set, bot ONLY responds in these channels (whitelist)
+        #   strict_mention / MATTERMOST_STRICT_MENTION: Require a fresh @mention every turn (disables in-thread auto-response)
         if channel_type_raw != "D":
             # allowed_channels check (whitelist — must pass before other gating).
             # When set, messages from channels NOT in this list are silently
@@ -759,6 +823,8 @@ class MattermostAdapter(BasePlatformAdapter):
             free_channels = {ch.strip() for ch in free_channels_raw.split(",") if ch.strip()}
             is_free_channel = channel_id in free_channels
 
+            strict_mention = self._strict_mention()
+
             mention_patterns = [
                 f"@{self._bot_username}",
                 f"@{self._bot_user_id}",
@@ -768,12 +834,38 @@ class MattermostAdapter(BasePlatformAdapter):
                 for pattern in mention_patterns
             )
 
-            if require_mention and not is_free_channel and not has_mention:
+            in_mentioned_thread = False
+            has_session = False
+            if thread_id and not strict_mention:
+                in_mentioned_thread = thread_id in self._mentioned_threads
+                if not in_mentioned_thread:
+                    has_session = self._has_active_session_for_thread(
+                        channel_id=channel_id,
+                        thread_id=thread_id,
+                        chat_type=chat_type,
+                        user_id=sender_id,
+                    )
+
+            if is_free_channel or not require_mention:
+                pass
+            elif has_mention:
+                pass
+            elif in_mentioned_thread or has_session:
+                pass
+            else:
                 logger.debug(
-                    "Mattermost: skipping non-DM message without @mention (channel=%s)",
+                    "Mattermost: skipping non-DM message (no mention / not in "
+                    "mentioned thread / no session) channel=%s thread=%s",
                     channel_id,
+                    thread_id,
                 )
                 return
+
+            if has_mention and thread_id and not strict_mention:
+                self._mentioned_threads.add(thread_id)
+                if len(self._mentioned_threads) > _MENTIONED_THREADS_MAX:
+                    for stale in list(self._mentioned_threads)[: _MENTIONED_THREADS_MAX // 2]:
+                        self._mentioned_threads.discard(stale)
 
             # Strip @mention from the message text so the agent sees clean input.
             if has_mention:
@@ -781,13 +873,6 @@ class MattermostAdapter(BasePlatformAdapter):
                     message_text = re.sub(
                         re.escape(pattern), "", message_text, flags=re.IGNORECASE
                     ).strip()
-
-        # Resolve sender info.
-        sender_id = post.get("user_id", "")
-        sender_name = data.get("sender_name", "").lstrip("@") or sender_id
-
-        # Thread support: if the post is in a thread, use root_id.
-        thread_id = post.get("root_id") or None
 
         # Determine message type.
         file_ids = post.get("file_ids") or []

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -81,6 +81,16 @@ def _make_adapter():
     return adapter
 
 
+def _posted_event(message="hi", *, post_id="p1", root_id="", user_id="user_123",
+                  channel_type="O", channel_id="chan_456", sender_name="@alice"):
+    """Build a Mattermost 'posted' WebSocket event with a double-encoded post."""
+    post = {"id": post_id, "user_id": user_id, "channel_id": channel_id, "message": message}
+    if root_id:
+        post["root_id"] = root_id
+    return {"event": "posted", "data": {
+        "post": json.dumps(post), "channel_type": channel_type, "sender_name": sender_name}}
+
+
 class TestMattermostFormatMessage:
     def setup_method(self):
         self.adapter = _make_adapter()
@@ -750,3 +760,142 @@ class TestMattermostMediaTypes:
         assert msg.media_types == ["application/pdf"]
         assert not msg.media_types[0].startswith("image/")
         assert not msg.media_types[0].startswith("audio/")
+
+
+class TestMattermostThreadSessionContinuity:
+    """A thread's root post and its replies must resolve to one session."""
+
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.adapter._bot_user_id = "bot_user_id"
+        self.adapter._bot_username = "hermes-bot"
+        self.adapter.handle_message = AsyncMock()
+
+    def _event(self, post_id, root_id="", channel_type="D"):
+        return _posted_event(post_id=post_id, root_id=root_id, channel_type=channel_type)
+
+    async def _thread_id_for(self, **kwargs):
+        self.adapter.handle_message.reset_mock()
+        await self.adapter._handle_ws_event(self._event(**kwargs))
+        assert self.adapter.handle_message.called
+        return self.adapter.handle_message.call_args[0][0].source.thread_id
+
+    @pytest.mark.asyncio
+    async def test_thread_mode_root_post_seeds_thread_id_from_own_id(self):
+        self.adapter._reply_mode = "thread"
+        assert await self._thread_id_for(post_id="root_1", root_id="") == "root_1"
+
+    @pytest.mark.asyncio
+    async def test_thread_mode_reply_keeps_root_id(self):
+        self.adapter._reply_mode = "thread"
+        assert await self._thread_id_for(post_id="reply_9", root_id="root_1") == "root_1"
+
+    @pytest.mark.asyncio
+    async def test_off_mode_root_post_has_no_thread_id(self):
+        self.adapter._reply_mode = "off"
+        assert await self._thread_id_for(post_id="root_1", root_id="") is None
+
+    @pytest.mark.asyncio
+    async def test_root_and_reply_share_thread_id_in_thread_mode(self):
+        self.adapter._reply_mode = "thread"
+        root_tid = await self._thread_id_for(post_id="root_1", root_id="")
+        reply_tid = await self._thread_id_for(post_id="reply_9", root_id="root_1")
+        assert root_tid == reply_tid == "root_1"
+
+
+class TestMattermostInThreadAutoResponse:
+    """In-thread auto-response + MATTERMOST_STRICT_MENTION (Slack parity)."""
+
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.adapter._bot_user_id = "bot_user_id"
+        self.adapter._bot_username = "hermes-bot"
+        self.adapter.handle_message = AsyncMock()
+        self.adapter._api_get = AsyncMock(return_value={})
+
+    def _thread_event(self, message, root_id="root_1", post_id="p2",
+                      user_id="user_123", channel_type="O"):
+        return _posted_event(message, post_id=post_id, root_id=root_id,
+                             user_id=user_id, channel_type=channel_type)
+
+    def test_strict_mention_default_false(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MATTERMOST_STRICT_MENTION", None)
+            assert self.adapter._strict_mention() is False
+
+    def test_strict_mention_env_true(self):
+        with patch.dict(os.environ, {"MATTERMOST_STRICT_MENTION": "true"}):
+            assert self.adapter._strict_mention() is True
+
+    def test_strict_mention_config_override_wins(self):
+        self.adapter.config.extra["strict_mention"] = True
+        try:
+            with patch.dict(os.environ, {"MATTERMOST_STRICT_MENTION": "false"}):
+                assert self.adapter._strict_mention() is True
+        finally:
+            del self.adapter.config.extra["strict_mention"]
+
+    @pytest.mark.asyncio
+    async def test_auto_response_in_mentioned_thread_without_mention(self):
+        await self.adapter._handle_ws_event(
+            self._thread_event("@hermes-bot start", root_id="root_1", post_id="p1")
+        )
+        assert "root_1" in self.adapter._mentioned_threads
+        await self.adapter._handle_ws_event(
+            self._thread_event("a follow-up with no mention", root_id="root_1", post_id="p2")
+        )
+        assert self.adapter.handle_message.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_root_post_mention_in_thread_mode_enables_autoresponse(self):
+        self.adapter._reply_mode = "thread"
+        await self.adapter._handle_ws_event(
+            self._thread_event("@hermes-bot kick off", root_id="", post_id="root_1")
+        )
+        assert "root_1" in self.adapter._mentioned_threads
+        await self.adapter._handle_ws_event(
+            self._thread_event("follow-up no mention", root_id="root_1", post_id="reply_2")
+        )
+        assert self.adapter.handle_message.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_strict_mention_requires_mention_every_turn(self):
+        with patch.dict(os.environ, {"MATTERMOST_STRICT_MENTION": "true"}):
+            await self.adapter._handle_ws_event(
+                self._thread_event("@hermes-bot start", root_id="root_1", post_id="p1")
+            )
+            assert self.adapter._mentioned_threads == set()
+            await self.adapter._handle_ws_event(
+                self._thread_event("no mention follow-up", root_id="root_1", post_id="p2")
+            )
+        assert self.adapter.handle_message.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_non_thread_message_without_mention_still_skipped(self):
+        post = {"id": "p_flat", "user_id": "user_123", "channel_id": "chan_456",
+                "message": "just chatting, no mention"}
+        event = {"event": "posted", "data": {
+            "post": json.dumps(post), "channel_type": "O", "sender_name": "@alice"}}
+        await self.adapter._handle_ws_event(event)
+        assert not self.adapter.handle_message.called
+
+    @pytest.mark.asyncio
+    async def test_has_active_session_uses_correct_chat_type(self):
+        from gateway.session import SessionSource, build_session_key
+        source = SessionSource(
+            platform=Platform.MATTERMOST, chat_id="chan_456",
+            chat_type="channel", user_id="user_123", thread_id="root_1",
+        )
+        key = build_session_key(source, group_sessions_per_user=True,
+                                thread_sessions_per_user=False)
+        store = MagicMock()
+        store.config = MagicMock(group_sessions_per_user=True,
+                                 thread_sessions_per_user=False)
+        store._entries = {key: object()}
+        store._ensure_loaded = MagicMock()
+        self.adapter._session_store = store
+        await self.adapter._handle_ws_event(
+            self._thread_event("no mention but session exists",
+                                root_id="root_1", post_id="p9")
+        )
+        assert self.adapter.handle_message.called

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -391,6 +391,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `MATTERMOST_HOME_CHANNEL` | Channel ID for proactive message delivery (cron, notifications) |
 | `MATTERMOST_REQUIRE_MENTION` | Require `@mention` in channels (default: `true`). Set to `false` to respond to all messages. |
 | `MATTERMOST_FREE_RESPONSE_CHANNELS` | Comma-separated channel IDs where bot responds without `@mention` |
+| `MATTERMOST_STRICT_MENTION` | Require a fresh `@mention` every turn, disabling in-thread auto-response (default: `false`) |
 | `MATTERMOST_REPLY_MODE` | Reply style: `thread` (threaded replies) or `off` (flat messages, default) |
 | `MATRIX_HOMESERVER` | Matrix homeserver URL (e.g. `https://matrix.org`) |
 | `MATRIX_ACCESS_TOKEN` | Matrix access token for bot authentication |

--- a/website/docs/user-guide/messaging/mattermost.md
+++ b/website/docs/user-guide/messaging/mattermost.md
@@ -18,7 +18,7 @@ Before setup, here's the part most people want to know: how Hermes behaves once 
 |---------|----------|
 | **DMs** | Hermes responds to every message. No `@mention` needed. Each DM has its own session. |
 | **Public/private channels** | Hermes responds when you `@mention` it. Without a mention, Hermes ignores the message. |
-| **Threads** | If `MATTERMOST_REPLY_MODE=thread`, Hermes replies in a thread under your message. Thread context stays isolated from the parent channel. |
+| **Threads** | After you `@mention` Hermes in a thread, it keeps answering follow-ups in that thread without a new `@mention` — disable with `MATTERMOST_STRICT_MENTION=true`. With `MATTERMOST_REPLY_MODE=thread`, replies nest under your message. |
 | **Shared channels with multiple users** | By default, Hermes isolates session history per user inside the channel. Two people talking in the same channel do not share one transcript unless you explicitly disable that. |
 
 :::tip
@@ -220,10 +220,17 @@ By default, the bot only responds in channels when `@mentioned`. You can change 
 |----------|---------|-------------|
 | `MATTERMOST_REQUIRE_MENTION` | `true` | Set to `false` to respond to all messages in channels (DMs always work). |
 | `MATTERMOST_FREE_RESPONSE_CHANNELS` | _(none)_ | Comma-separated channel IDs where the bot responds without `@mention`, even when require_mention is true. |
+| `MATTERMOST_STRICT_MENTION` | `false` | Set to `true` to require a fresh `@mention` on every turn, disabling in-thread auto-response. |
 
 To find a channel ID in Mattermost: open the channel, click the channel name header, and look for the ID in the URL or channel details.
 
 When the bot is `@mentioned`, the mention is automatically stripped from the message before processing.
+
+### In-thread conversations
+
+Once the bot is `@mentioned` in a thread, it stays engaged: every subsequent message in that thread is answered without a new mention, so a back-and-forth feels natural. This matches the Slack adapter's behavior. To opt out and require a mention each turn, set `MATTERMOST_STRICT_MENTION=true`.
+
+Auto-response does **not** bypass the user allowlist: every message is still authorized by author, so a non-allowlisted user posting in an engaged thread is ignored.
 
 ## Channel allowlist (`allowed_channels`)
 


### PR DESCRIPTION
## What does this PR do?

Brings the Mattermost adapter to parity with Slack for **in-thread engagement**: after the bot is `@mentioned` in a thread, it keeps answering follow-ups in that thread **without requiring a new `@mention`** each turn. Opt out with `MATTERMOST_STRICT_MENTION=true` (mirrors `SLACK_STRICT_MENTION`).

This is the first of two stacked PRs that port Slack's thread handling to Mattermost. The second (thread-context seeding, allowlist-filtered) builds on this one.

### Includes the root-post session-continuity fix (credit to #37144)

In-thread auto-response depends on a pre-existing bug being fixed: a Mattermost **root post** has an empty `root_id`, while its replies carry `root_id=<root post id>`. Under `reply_mode=thread` the bot nests replies under the root, so without a fix the root message lands in session `…:<chat>` while every follow-up lands in `…:<chat>:<root_id>` — the agent loses context (and the thread is never registered for auto-response).

The 2-line fix here (`seed thread_id from the post's own id for root posts in thread mode`) is **the same fix already proposed in #37144 by @brendanstennett**. I've included it so this PR works standalone and credited it explicitly — **happy to rebase and drop it if #37144 lands first.**

## Type of Change

- [x] ✨ New feature (in-thread auto-response)
- [x] 🐛 Bug fix (root-post session continuity — same as #37144)
- [x] ✅ Tests
- [x] 📝 Documentation update

## Changes Made

All in `plugins/platforms/mattermost/adapter.py`:

- `_strict_mention()` — reads `MATTERMOST_STRICT_MENTION` (default `false`) + `config.extra` override.
- `_has_active_session_for_thread()` — mirrors Slack, but passes the adapter's **real** `chat_type` (`_CHANNEL_TYPE_MAP[...]`) into `build_session_key`, so the key matches what `handle_message` persists (a hardcoded `"group"` would never match for `"O"` channels).
- `_mentioned_threads` set + mention-gate rewrite: after an `@mention` in a thread, follow-ups in that thread auto-trigger; registration is skipped in strict mode.
- Root-post `thread_id` seeding (credit #37144).
- Tests: `TestMattermostThreadSessionContinuity`, `TestMattermostInThreadAutoResponse`.
- Docs: `MATTERMOST_STRICT_MENTION` + the in-thread behavior.

**Security note:** auto-response does **not** bypass the user allowlist — every message is still authorized by author in `gateway/authz_mixin.py`, downstream of the adapter. A non-allowlisted user posting in an engaged thread is still ignored.

## How to Test

1. `MATTERMOST_ALLOWED_USERS=<you>`, bot in a channel.
2. `@mention` the bot in a thread → it replies. Post a follow-up **without** mentioning → it still replies.
3. Set `MATTERMOST_STRICT_MENTION=true` → it only replies when `@mentioned` each turn.
4. `pytest tests/gateway/test_mattermost.py -q` → 54 passed.

## Checklist

- [x] Conventional Commits (`feat(mattermost): …`)
- [x] Searched existing PRs (this builds on #37144, credited)
- [x] Tests added; `pytest tests/gateway/test_mattermost.py -q` passes (54)
- [x] Docs updated
- [x] Tested on Debian 13 (Linux 6.8)
- [x] `cli-config.yaml.example` — N/A (env/`config.extra`-driven, like the existing `MATTERMOST_*` toggles)
