### PR TITLE
feat(mattermost): thread context seeding, allowlist-filtered

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -18,6 +18,7 @@ import json
 import logging
 import os
 import re
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -49,7 +50,10 @@ _RECONNECT_BASE_DELAY = 2.0
 _RECONNECT_MAX_DELAY = 60.0
 _RECONNECT_JITTER = 0.2
 
-# In-thread auto-response parameter (Slack parity).
+# Thread-context / in-thread auto-response parameters (Slack parity).
+_THREAD_CONTEXT_MAX_MESSAGES = 30
+_THREAD_CONTEXT_MAX_CHARS = 1000
+_THREAD_CONTEXT_TTL = 60.0
 _MENTIONED_THREADS_MAX = 5000
 
 
@@ -102,8 +106,10 @@ class MattermostAdapter(BasePlatformAdapter):
         # Dedup cache (prevent reprocessing)
         self._dedup = MessageDeduplicator()
 
-        # In-thread auto-response (Slack parity): threads where the bot was @mentioned.
+        # In-thread auto-response (Slack parity): threads where the bot was
+        # @mentioned, and a TTL cache of fetched thread context.
         self._mentioned_threads: set[str] = set()
+        self._thread_context_cache: Dict[str, Tuple[str, float]] = {}
 
     # ------------------------------------------------------------------
     # HTTP helpers
@@ -705,6 +711,40 @@ class MattermostAdapter(BasePlatformAdapter):
             "true", "1", "yes", "on",
         }
 
+    def _thread_context_mode(self) -> str:
+        """Return the thread-context policy: 'off', 'allowlisted' (default), or 'all'."""
+        configured = self.config.extra.get("thread_context") if self.config.extra else None
+        raw = configured if configured is not None else os.getenv(
+            "MATTERMOST_THREAD_CONTEXT", "allowlisted"
+        )
+        mode = str(raw).strip().lower()
+        return mode if mode in {"off", "allowlisted", "all"} else "allowlisted"
+
+    def _thread_context_author_allowed(self, user_id: str) -> bool:
+        """Return True when a thread author may contribute to injected context.
+
+        authz only checks the triggering author; injected thread context bypasses
+        it, so non-allowlisted authors' posts are filtered here to avoid leaking
+        unauthorized content into the model. MATTERMOST_THREAD_CONTEXT=all opts
+        out of this filter without widening who may invoke the bot.
+        """
+        if self._thread_context_mode() == "all":
+            return True
+
+        def _truthy(value: str) -> bool:
+            return str(value).lower() in {"true", "1", "yes", "on"}
+
+        if _truthy(os.getenv("MATTERMOST_ALLOW_ALL_USERS", "")) or _truthy(
+            os.getenv("GATEWAY_ALLOW_ALL_USERS", "")
+        ):
+            return True
+        allowed = {
+            u.strip()
+            for u in os.getenv("MATTERMOST_ALLOWED_USERS", "").split(",")
+            if u.strip()
+        }
+        return bool(user_id) and user_id in allowed
+
     def _has_active_session_for_thread(
         self, channel_id: str, thread_id: str, chat_type: str, user_id: str
     ) -> bool:
@@ -742,6 +782,66 @@ class MattermostAdapter(BasePlatformAdapter):
             return session_key in session_store._entries
         except Exception:
             return False
+
+    async def _fetch_thread_context(
+        self, thread_root_id: str, current_post_id: str
+    ) -> str:
+        """Fetch prior thread messages to seed context on the first turn.
+
+        Fails open: returns an empty string on error or when nothing qualifies,
+        leaving the agent with just the triggering message.
+        """
+        now = time.monotonic()
+        cached = self._thread_context_cache.get(thread_root_id)
+        if cached and (now - cached[1]) < _THREAD_CONTEXT_TTL:
+            return cached[0]
+
+        data = await self._api_get(f"posts/{thread_root_id}/thread")
+        if not data:
+            return ""
+        order = data.get("order") or []
+        posts = data.get("posts") or {}
+        if not order or not posts:
+            return ""
+
+        post_objs = [posts[pid] for pid in order if pid in posts]
+        post_objs.sort(key=lambda p: p.get("create_at", 0))
+
+        parts: List[str] = []
+        for post in post_objs:
+            if post.get("id", "") == current_post_id:
+                continue
+            author = post.get("user_id", "")
+            if author == self._bot_user_id:
+                continue
+            if post.get("type"):
+                continue
+            if not self._thread_context_author_allowed(author):
+                continue
+            text = (post.get("message") or "").strip()
+            for pattern in (f"@{self._bot_username}", f"@{self._bot_user_id}"):
+                text = re.sub(re.escape(pattern), "", text, flags=re.IGNORECASE).strip()
+            if not text:
+                continue
+            if len(text) > _THREAD_CONTEXT_MAX_CHARS:
+                text = text[:_THREAD_CONTEXT_MAX_CHARS] + "..."
+            parts.append(f"[{author or 'unknown'}]: {text}")
+
+        if len(parts) > _THREAD_CONTEXT_MAX_MESSAGES:
+            parts = parts[-_THREAD_CONTEXT_MAX_MESSAGES:]
+
+        content = ""
+        if parts:
+            content = (
+                "[Thread context - prior messages in this thread:]\n"
+                + "\n".join(parts)
+                + "\n[End of thread context]"
+            )
+
+        if len(self._thread_context_cache) > _MENTIONED_THREADS_MAX:
+            self._thread_context_cache.clear()
+        self._thread_context_cache[thread_root_id] = (content, now)
+        return content
 
     async def _handle_ws_event(self, event: Dict[str, Any]) -> None:
         """Process a single WebSocket event."""
@@ -942,6 +1042,27 @@ class MattermostAdapter(BasePlatformAdapter):
             self.config.extra, channel_id, None,
         )
 
+        # On the first turn of a thread (no session yet), seed prior thread
+        # history so the agent sees the whole conversation, not just the
+        # triggering message. Later turns already carry it in the transcript.
+        channel_context: Optional[str] = None
+        if thread_id and channel_type_raw != "D" and self._thread_context_mode() != "off":
+            already_active = self._has_active_session_for_thread(
+                channel_id=channel_id,
+                thread_id=thread_id,
+                chat_type=chat_type,
+                user_id=sender_id,
+            )
+            if not already_active:
+                try:
+                    channel_context = await self._fetch_thread_context(
+                        thread_root_id=thread_id,
+                        current_post_id=post_id,
+                    ) or None
+                except Exception as exc:
+                    logger.debug("Mattermost: thread context fetch failed: %s", exc)
+                    channel_context = None
+
         msg_event = MessageEvent(
             text=message_text,
             message_type=msg_type,
@@ -951,6 +1072,7 @@ class MattermostAdapter(BasePlatformAdapter):
             media_urls=media_urls if media_urls else None,
             media_types=media_types if media_types else None,
             channel_prompt=_channel_prompt,
+            channel_context=channel_context,
         )
 
         await self.handle_message(msg_event)

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -49,6 +49,9 @@ _RECONNECT_BASE_DELAY = 2.0
 _RECONNECT_MAX_DELAY = 60.0
 _RECONNECT_JITTER = 0.2
 
+# In-thread auto-response parameter (Slack parity).
+_MENTIONED_THREADS_MAX = 5000
+
 
 def check_mattermost_requirements() -> bool:
     """Return True if the Mattermost adapter can be used."""
@@ -98,6 +101,9 @@ class MattermostAdapter(BasePlatformAdapter):
 
         # Dedup cache (prevent reprocessing)
         self._dedup = MessageDeduplicator()
+
+        # In-thread auto-response (Slack parity): threads where the bot was @mentioned.
+        self._mentioned_threads: set[str] = set()
 
     # ------------------------------------------------------------------
     # HTTP helpers
@@ -688,6 +694,55 @@ class MattermostAdapter(BasePlatformAdapter):
                 logger.info("Mattermost: WebSocket closed (%s)", raw_msg.type)
                 break
 
+    def _strict_mention(self) -> bool:
+        """Return True when every turn requires a fresh @mention (in-thread auto-response opt-out)."""
+        configured = self.config.extra.get("strict_mention") if self.config.extra else None
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.lower() in {"true", "1", "yes", "on"}
+            return bool(configured)
+        return os.getenv("MATTERMOST_STRICT_MENTION", "false").lower() in {
+            "true", "1", "yes", "on",
+        }
+
+    def _has_active_session_for_thread(
+        self, channel_id: str, thread_id: str, chat_type: str, user_id: str
+    ) -> bool:
+        """Return True when a gateway session already exists for this thread."""
+        session_store = getattr(self, "_session_store", None)
+        if not session_store:
+            return False
+        try:
+            from gateway.session import SessionSource, build_session_key
+
+            source = SessionSource(
+                platform=Platform.MATTERMOST,
+                chat_id=channel_id,
+                chat_type=chat_type,
+                user_id=user_id,
+                thread_id=thread_id,
+            )
+            store_cfg = getattr(session_store, "config", None)
+            gspu = (
+                getattr(store_cfg, "group_sessions_per_user", True)
+                if store_cfg
+                else True
+            )
+            tspu = (
+                getattr(store_cfg, "thread_sessions_per_user", False)
+                if store_cfg
+                else False
+            )
+            session_key = build_session_key(
+                source,
+                group_sessions_per_user=gspu,
+                thread_sessions_per_user=tspu,
+            )
+            session_store._ensure_loaded()
+            return session_key in session_store._entries
+        except Exception:
+            return False
+
     async def _handle_ws_event(self, event: Dict[str, Any]) -> None:
         """Process a single WebSocket event."""
         event_type = event.get("event")
@@ -725,12 +780,21 @@ class MattermostAdapter(BasePlatformAdapter):
 
         # For DMs, user_id is sufficient.  For channels, check for @mention.
         message_text = post.get("message", "")
+        sender_id = post.get("user_id", "")
+        sender_name = data.get("sender_name", "").lstrip("@") or sender_id
+        thread_id = post.get("root_id") or None
+        # Mattermost root posts have an empty root_id; in thread mode the bot
+        # nests replies under the root, so seed thread_id from the post's own id
+        # to keep the root and its replies on one session (and one mentioned thread).
+        if thread_id is None and self._reply_mode == "thread":
+            thread_id = post.get("id") or None
 
         # Mention-gating for non-DM channels.
         # Config (config.yaml `mattermost.*` with env-var fallback):
         #   require_mention / MATTERMOST_REQUIRE_MENTION: Require @mention in channels (default: true)
         #   free_response_channels / MATTERMOST_FREE_RESPONSE_CHANNELS: Channel IDs where bot responds without mention
         #   allowed_channels / MATTERMOST_ALLOWED_CHANNELS: If set, bot ONLY responds in these channels (whitelist)
+        #   strict_mention / MATTERMOST_STRICT_MENTION: Require a fresh @mention every turn (disables in-thread auto-response)
         if channel_type_raw != "D":
             # allowed_channels check (whitelist — must pass before other gating).
             # When set, messages from channels NOT in this list are silently
@@ -759,6 +823,8 @@ class MattermostAdapter(BasePlatformAdapter):
             free_channels = {ch.strip() for ch in free_channels_raw.split(",") if ch.strip()}
             is_free_channel = channel_id in free_channels
 
+            strict_mention = self._strict_mention()
+
             mention_patterns = [
                 f"@{self._bot_username}",
                 f"@{self._bot_user_id}",
@@ -768,12 +834,38 @@ class MattermostAdapter(BasePlatformAdapter):
                 for pattern in mention_patterns
             )
 
-            if require_mention and not is_free_channel and not has_mention:
+            in_mentioned_thread = False
+            has_session = False
+            if thread_id and not strict_mention:
+                in_mentioned_thread = thread_id in self._mentioned_threads
+                if not in_mentioned_thread:
+                    has_session = self._has_active_session_for_thread(
+                        channel_id=channel_id,
+                        thread_id=thread_id,
+                        chat_type=chat_type,
+                        user_id=sender_id,
+                    )
+
+            if is_free_channel or not require_mention:
+                pass
+            elif has_mention:
+                pass
+            elif in_mentioned_thread or has_session:
+                pass
+            else:
                 logger.debug(
-                    "Mattermost: skipping non-DM message without @mention (channel=%s)",
+                    "Mattermost: skipping non-DM message (no mention / not in "
+                    "mentioned thread / no session) channel=%s thread=%s",
                     channel_id,
+                    thread_id,
                 )
                 return
+
+            if has_mention and thread_id and not strict_mention:
+                self._mentioned_threads.add(thread_id)
+                if len(self._mentioned_threads) > _MENTIONED_THREADS_MAX:
+                    for stale in list(self._mentioned_threads)[: _MENTIONED_THREADS_MAX // 2]:
+                        self._mentioned_threads.discard(stale)
 
             # Strip @mention from the message text so the agent sees clean input.
             if has_mention:
@@ -781,13 +873,6 @@ class MattermostAdapter(BasePlatformAdapter):
                     message_text = re.sub(
                         re.escape(pattern), "", message_text, flags=re.IGNORECASE
                     ).strip()
-
-        # Resolve sender info.
-        sender_id = post.get("user_id", "")
-        sender_name = data.get("sender_name", "").lstrip("@") or sender_id
-
-        # Thread support: if the post is in a thread, use root_id.
-        thread_id = post.get("root_id") or None
 
         # Determine message type.
         file_ids = post.get("file_ids") or []

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -899,3 +899,112 @@ class TestMattermostInThreadAutoResponse:
                                 root_id="root_1", post_id="p9")
         )
         assert self.adapter.handle_message.called
+
+
+class TestMattermostThreadContext:
+    """Thread-context seeding, allowlist filter, and MATTERMOST_THREAD_CONTEXT."""
+
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.adapter._bot_user_id = "bot_user_id"
+        self.adapter._bot_username = "hermes-bot"
+        self.adapter.handle_message = AsyncMock()
+
+    def _thread_event(self, message, root_id="root_1", post_id="p_trigger",
+                      user_id="user_123", channel_type="O"):
+        return _posted_event(message, post_id=post_id, root_id=root_id,
+                             user_id=user_id, channel_type=channel_type)
+
+    def _thread_payload(self):
+        return {
+            "order": ["root_1", "r_other", "r_bot", "p_trigger"],
+            "posts": {
+                "root_1": {"id": "root_1", "user_id": "user_123",
+                           "message": "Original question about X", "create_at": 1},
+                "r_other": {"id": "r_other", "user_id": "user_999",
+                            "message": "unrelated chatter", "create_at": 2},
+                "r_bot": {"id": "r_bot", "user_id": "bot_user_id",
+                          "message": "earlier bot reply", "create_at": 3},
+                "p_trigger": {"id": "p_trigger", "user_id": "user_123",
+                              "message": "@hermes-bot follow up", "create_at": 4},
+            },
+        }
+
+    def test_thread_context_mode_default_allowlisted(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MATTERMOST_THREAD_CONTEXT", None)
+            assert self.adapter._thread_context_mode() == "allowlisted"
+
+    def test_thread_context_mode_off_and_all(self):
+        with patch.dict(os.environ, {"MATTERMOST_THREAD_CONTEXT": "off"}):
+            assert self.adapter._thread_context_mode() == "off"
+        with patch.dict(os.environ, {"MATTERMOST_THREAD_CONTEXT": "all"}):
+            assert self.adapter._thread_context_mode() == "all"
+        with patch.dict(os.environ, {"MATTERMOST_THREAD_CONTEXT": "bogus"}):
+            assert self.adapter._thread_context_mode() == "allowlisted"
+
+    @pytest.mark.asyncio
+    async def test_first_mention_in_thread_fetches_context(self):
+        self.adapter._api_get = AsyncMock(return_value=self._thread_payload())
+        with patch.dict(os.environ, {"MATTERMOST_ALLOWED_USERS": "user_123"}):
+            await self.adapter._handle_ws_event(self._thread_event("@hermes-bot follow up"))
+        ctx = self.adapter.handle_message.call_args[0][0].channel_context
+        assert ctx is not None and "Original question about X" in ctx
+
+    @pytest.mark.asyncio
+    async def test_thread_context_filters_non_allowlisted_authors(self):
+        self.adapter._api_get = AsyncMock(return_value=self._thread_payload())
+        with patch.dict(os.environ, {"MATTERMOST_ALLOWED_USERS": "user_123"}):
+            await self.adapter._handle_ws_event(self._thread_event("@hermes-bot follow up"))
+        ctx = self.adapter.handle_message.call_args[0][0].channel_context
+        assert "Original question about X" in ctx
+        assert "unrelated chatter" not in ctx
+        assert "earlier bot reply" not in ctx
+        assert "follow up" not in ctx
+
+    @pytest.mark.asyncio
+    async def test_allow_all_users_includes_non_listed(self):
+        self.adapter._api_get = AsyncMock(return_value=self._thread_payload())
+        with patch.dict(os.environ, {"MATTERMOST_ALLOW_ALL_USERS": "true"}):
+            os.environ.pop("MATTERMOST_ALLOWED_USERS", None)
+            await self.adapter._handle_ws_event(self._thread_event("@hermes-bot follow up"))
+        ctx = self.adapter.handle_message.call_args[0][0].channel_context
+        assert "unrelated chatter" in ctx and "earlier bot reply" not in ctx
+
+    @pytest.mark.asyncio
+    async def test_thread_context_off_skips_fetch(self):
+        self.adapter._api_get = AsyncMock(return_value=self._thread_payload())
+        with patch.dict(os.environ, {"MATTERMOST_THREAD_CONTEXT": "off",
+                                     "MATTERMOST_ALLOWED_USERS": "user_123"}):
+            await self.adapter._handle_ws_event(self._thread_event("@hermes-bot follow up"))
+        assert self.adapter.handle_message.call_args[0][0].channel_context is None
+        self.adapter._api_get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_thread_context_all_decouples_from_allowlist(self):
+        self.adapter._api_get = AsyncMock(return_value=self._thread_payload())
+        with patch.dict(os.environ, {"MATTERMOST_THREAD_CONTEXT": "all"}):
+            os.environ.pop("MATTERMOST_ALLOWED_USERS", None)
+            os.environ.pop("MATTERMOST_ALLOW_ALL_USERS", None)
+            await self.adapter._handle_ws_event(self._thread_event("@hermes-bot follow up"))
+        ctx = self.adapter.handle_message.call_args[0][0].channel_context
+        assert "Original question about X" in ctx and "unrelated chatter" in ctx
+        assert "earlier bot reply" not in ctx
+
+    @pytest.mark.asyncio
+    async def test_thread_context_fetch_failure_fails_open(self):
+        self.adapter._api_get = AsyncMock(return_value={})
+        with patch.dict(os.environ, {"MATTERMOST_ALLOWED_USERS": "user_123"}):
+            await self.adapter._handle_ws_event(self._thread_event("@hermes-bot hi"))
+        assert self.adapter.handle_message.called
+        assert self.adapter.handle_message.call_args[0][0].channel_context is None
+
+    @pytest.mark.asyncio
+    async def test_dm_thread_does_not_fetch_context(self):
+        self.adapter._api_get = AsyncMock(return_value=self._thread_payload())
+        await self.adapter._handle_ws_event(
+            self._thread_event("hi in a dm", channel_type="D", post_id="p_dm")
+        )
+        assert self.adapter.handle_message.called
+        assert self.adapter.handle_message.call_args[0][0].channel_context is None
+        self.adapter._api_get.assert_not_called()

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -81,6 +81,16 @@ def _make_adapter():
     return adapter
 
 
+def _posted_event(message="hi", *, post_id="p1", root_id="", user_id="user_123",
+                  channel_type="O", channel_id="chan_456", sender_name="@alice"):
+    """Build a Mattermost 'posted' WebSocket event with a double-encoded post."""
+    post = {"id": post_id, "user_id": user_id, "channel_id": channel_id, "message": message}
+    if root_id:
+        post["root_id"] = root_id
+    return {"event": "posted", "data": {
+        "post": json.dumps(post), "channel_type": channel_type, "sender_name": sender_name}}
+
+
 class TestMattermostFormatMessage:
     def setup_method(self):
         self.adapter = _make_adapter()
@@ -750,3 +760,142 @@ class TestMattermostMediaTypes:
         assert msg.media_types == ["application/pdf"]
         assert not msg.media_types[0].startswith("image/")
         assert not msg.media_types[0].startswith("audio/")
+
+
+class TestMattermostThreadSessionContinuity:
+    """A thread's root post and its replies must resolve to one session."""
+
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.adapter._bot_user_id = "bot_user_id"
+        self.adapter._bot_username = "hermes-bot"
+        self.adapter.handle_message = AsyncMock()
+
+    def _event(self, post_id, root_id="", channel_type="D"):
+        return _posted_event(post_id=post_id, root_id=root_id, channel_type=channel_type)
+
+    async def _thread_id_for(self, **kwargs):
+        self.adapter.handle_message.reset_mock()
+        await self.adapter._handle_ws_event(self._event(**kwargs))
+        assert self.adapter.handle_message.called
+        return self.adapter.handle_message.call_args[0][0].source.thread_id
+
+    @pytest.mark.asyncio
+    async def test_thread_mode_root_post_seeds_thread_id_from_own_id(self):
+        self.adapter._reply_mode = "thread"
+        assert await self._thread_id_for(post_id="root_1", root_id="") == "root_1"
+
+    @pytest.mark.asyncio
+    async def test_thread_mode_reply_keeps_root_id(self):
+        self.adapter._reply_mode = "thread"
+        assert await self._thread_id_for(post_id="reply_9", root_id="root_1") == "root_1"
+
+    @pytest.mark.asyncio
+    async def test_off_mode_root_post_has_no_thread_id(self):
+        self.adapter._reply_mode = "off"
+        assert await self._thread_id_for(post_id="root_1", root_id="") is None
+
+    @pytest.mark.asyncio
+    async def test_root_and_reply_share_thread_id_in_thread_mode(self):
+        self.adapter._reply_mode = "thread"
+        root_tid = await self._thread_id_for(post_id="root_1", root_id="")
+        reply_tid = await self._thread_id_for(post_id="reply_9", root_id="root_1")
+        assert root_tid == reply_tid == "root_1"
+
+
+class TestMattermostInThreadAutoResponse:
+    """In-thread auto-response + MATTERMOST_STRICT_MENTION (Slack parity)."""
+
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.adapter._bot_user_id = "bot_user_id"
+        self.adapter._bot_username = "hermes-bot"
+        self.adapter.handle_message = AsyncMock()
+        self.adapter._api_get = AsyncMock(return_value={})
+
+    def _thread_event(self, message, root_id="root_1", post_id="p2",
+                      user_id="user_123", channel_type="O"):
+        return _posted_event(message, post_id=post_id, root_id=root_id,
+                             user_id=user_id, channel_type=channel_type)
+
+    def test_strict_mention_default_false(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MATTERMOST_STRICT_MENTION", None)
+            assert self.adapter._strict_mention() is False
+
+    def test_strict_mention_env_true(self):
+        with patch.dict(os.environ, {"MATTERMOST_STRICT_MENTION": "true"}):
+            assert self.adapter._strict_mention() is True
+
+    def test_strict_mention_config_override_wins(self):
+        self.adapter.config.extra["strict_mention"] = True
+        try:
+            with patch.dict(os.environ, {"MATTERMOST_STRICT_MENTION": "false"}):
+                assert self.adapter._strict_mention() is True
+        finally:
+            del self.adapter.config.extra["strict_mention"]
+
+    @pytest.mark.asyncio
+    async def test_auto_response_in_mentioned_thread_without_mention(self):
+        await self.adapter._handle_ws_event(
+            self._thread_event("@hermes-bot start", root_id="root_1", post_id="p1")
+        )
+        assert "root_1" in self.adapter._mentioned_threads
+        await self.adapter._handle_ws_event(
+            self._thread_event("a follow-up with no mention", root_id="root_1", post_id="p2")
+        )
+        assert self.adapter.handle_message.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_root_post_mention_in_thread_mode_enables_autoresponse(self):
+        self.adapter._reply_mode = "thread"
+        await self.adapter._handle_ws_event(
+            self._thread_event("@hermes-bot kick off", root_id="", post_id="root_1")
+        )
+        assert "root_1" in self.adapter._mentioned_threads
+        await self.adapter._handle_ws_event(
+            self._thread_event("follow-up no mention", root_id="root_1", post_id="reply_2")
+        )
+        assert self.adapter.handle_message.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_strict_mention_requires_mention_every_turn(self):
+        with patch.dict(os.environ, {"MATTERMOST_STRICT_MENTION": "true"}):
+            await self.adapter._handle_ws_event(
+                self._thread_event("@hermes-bot start", root_id="root_1", post_id="p1")
+            )
+            assert self.adapter._mentioned_threads == set()
+            await self.adapter._handle_ws_event(
+                self._thread_event("no mention follow-up", root_id="root_1", post_id="p2")
+            )
+        assert self.adapter.handle_message.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_non_thread_message_without_mention_still_skipped(self):
+        post = {"id": "p_flat", "user_id": "user_123", "channel_id": "chan_456",
+                "message": "just chatting, no mention"}
+        event = {"event": "posted", "data": {
+            "post": json.dumps(post), "channel_type": "O", "sender_name": "@alice"}}
+        await self.adapter._handle_ws_event(event)
+        assert not self.adapter.handle_message.called
+
+    @pytest.mark.asyncio
+    async def test_has_active_session_uses_correct_chat_type(self):
+        from gateway.session import SessionSource, build_session_key
+        source = SessionSource(
+            platform=Platform.MATTERMOST, chat_id="chan_456",
+            chat_type="channel", user_id="user_123", thread_id="root_1",
+        )
+        key = build_session_key(source, group_sessions_per_user=True,
+                                thread_sessions_per_user=False)
+        store = MagicMock()
+        store.config = MagicMock(group_sessions_per_user=True,
+                                 thread_sessions_per_user=False)
+        store._entries = {key: object()}
+        store._ensure_loaded = MagicMock()
+        self.adapter._session_store = store
+        await self.adapter._handle_ws_event(
+            self._thread_event("no mention but session exists",
+                                root_id="root_1", post_id="p9")
+        )
+        assert self.adapter.handle_message.called

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -391,6 +391,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `MATTERMOST_HOME_CHANNEL` | Channel ID for proactive message delivery (cron, notifications) |
 | `MATTERMOST_REQUIRE_MENTION` | Require `@mention` in channels (default: `true`). Set to `false` to respond to all messages. |
 | `MATTERMOST_FREE_RESPONSE_CHANNELS` | Comma-separated channel IDs where bot responds without `@mention` |
+| `MATTERMOST_STRICT_MENTION` | Require a fresh `@mention` every turn, disabling in-thread auto-response (default: `false`) |
 | `MATTERMOST_REPLY_MODE` | Reply style: `thread` (threaded replies) or `off` (flat messages, default) |
 | `MATRIX_HOMESERVER` | Matrix homeserver URL (e.g. `https://matrix.org`) |
 | `MATRIX_ACCESS_TOKEN` | Matrix access token for bot authentication |

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -392,6 +392,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `MATTERMOST_REQUIRE_MENTION` | Require `@mention` in channels (default: `true`). Set to `false` to respond to all messages. |
 | `MATTERMOST_FREE_RESPONSE_CHANNELS` | Comma-separated channel IDs where bot responds without `@mention` |
 | `MATTERMOST_STRICT_MENTION` | Require a fresh `@mention` every turn, disabling in-thread auto-response (default: `false`) |
+| `MATTERMOST_THREAD_CONTEXT` | First-turn thread-history seeding: `allowlisted` (default), `off`, or `all` |
 | `MATTERMOST_REPLY_MODE` | Reply style: `thread` (threaded replies) or `off` (flat messages, default) |
 | `MATRIX_HOMESERVER` | Matrix homeserver URL (e.g. `https://matrix.org`) |
 | `MATRIX_ACCESS_TOKEN` | Matrix access token for bot authentication |

--- a/website/docs/user-guide/messaging/mattermost.md
+++ b/website/docs/user-guide/messaging/mattermost.md
@@ -18,7 +18,7 @@ Before setup, here's the part most people want to know: how Hermes behaves once 
 |---------|----------|
 | **DMs** | Hermes responds to every message. No `@mention` needed. Each DM has its own session. |
 | **Public/private channels** | Hermes responds when you `@mention` it. Without a mention, Hermes ignores the message. |
-| **Threads** | After you `@mention` Hermes in a thread, it keeps answering follow-ups in that thread without a new `@mention` — disable with `MATTERMOST_STRICT_MENTION=true`. With `MATTERMOST_REPLY_MODE=thread`, replies nest under your message. |
+| **Threads** | When you `@mention` Hermes inside an existing thread, it seeds the prior thread history as context (filtered to allowlisted authors). After that first mention, it keeps answering follow-ups without a new `@mention` — disable with `MATTERMOST_STRICT_MENTION=true`. With `MATTERMOST_REPLY_MODE=thread`, replies nest under your message. |
 | **Shared channels with multiple users** | By default, Hermes isolates session history per user inside the channel. Two people talking in the same channel do not share one transcript unless you explicitly disable that. |
 
 :::tip
@@ -230,7 +230,17 @@ When the bot is `@mentioned`, the mention is automatically stripped from the mes
 
 Once the bot is `@mentioned` in a thread, it stays engaged: every subsequent message in that thread is answered without a new mention, so a back-and-forth feels natural. This matches the Slack adapter's behavior. To opt out and require a mention each turn, set `MATTERMOST_STRICT_MENTION=true`.
 
-Auto-response does **not** bypass the user allowlist: every message is still authorized by author, so a non-allowlisted user posting in an engaged thread is ignored.
+On the **first** turn in a pre-existing thread, Hermes also seeds the prior messages of that thread as context, so it understands the conversation it was pulled into — not just the single message it was tagged in. `MATTERMOST_THREAD_CONTEXT` controls this:
+
+| Value | Behavior |
+|-------|----------|
+| `allowlisted` (default) | Seed only messages from authors in `MATTERMOST_ALLOWED_USERS` |
+| `off` | Never seed thread history |
+| `all` | Seed the full thread regardless of author, without widening who may invoke the bot |
+
+:::warning Allowlist applies to thread context
+Neither auto-response nor context seeding bypasses the user allowlist. Every message is still authorized by author, so a non-allowlisted user posting in an engaged thread is ignored. And because seeded thread history is injected as context (which the authz layer does not re-check), it only includes messages from authors in `MATTERMOST_ALLOWED_USERS` (or everyone when `MATTERMOST_ALLOW_ALL_USERS=true`, or `MATTERMOST_THREAD_CONTEXT=all`) — a non-allowlisted participant's posts never reach the model as context.
+:::
 
 ## Channel allowlist (`allowed_channels`)
 

--- a/website/docs/user-guide/messaging/mattermost.md
+++ b/website/docs/user-guide/messaging/mattermost.md
@@ -18,7 +18,7 @@ Before setup, here's the part most people want to know: how Hermes behaves once 
 |---------|----------|
 | **DMs** | Hermes responds to every message. No `@mention` needed. Each DM has its own session. |
 | **Public/private channels** | Hermes responds when you `@mention` it. Without a mention, Hermes ignores the message. |
-| **Threads** | If `MATTERMOST_REPLY_MODE=thread`, Hermes replies in a thread under your message. Thread context stays isolated from the parent channel. |
+| **Threads** | After you `@mention` Hermes in a thread, it keeps answering follow-ups in that thread without a new `@mention` — disable with `MATTERMOST_STRICT_MENTION=true`. With `MATTERMOST_REPLY_MODE=thread`, replies nest under your message. |
 | **Shared channels with multiple users** | By default, Hermes isolates session history per user inside the channel. Two people talking in the same channel do not share one transcript unless you explicitly disable that. |
 
 :::tip
@@ -220,10 +220,17 @@ By default, the bot only responds in channels when `@mentioned`. You can change 
 |----------|---------|-------------|
 | `MATTERMOST_REQUIRE_MENTION` | `true` | Set to `false` to respond to all messages in channels (DMs always work). |
 | `MATTERMOST_FREE_RESPONSE_CHANNELS` | _(none)_ | Comma-separated channel IDs where the bot responds without `@mention`, even when require_mention is true. |
+| `MATTERMOST_STRICT_MENTION` | `false` | Set to `true` to require a fresh `@mention` on every turn, disabling in-thread auto-response. |
 
 To find a channel ID in Mattermost: open the channel, click the channel name header, and look for the ID in the URL or channel details.
 
 When the bot is `@mentioned`, the mention is automatically stripped from the message before processing.
+
+### In-thread conversations
+
+Once the bot is `@mentioned` in a thread, it stays engaged: every subsequent message in that thread is answered without a new mention, so a back-and-forth feels natural. This matches the Slack adapter's behavior. To opt out and require a mention each turn, set `MATTERMOST_STRICT_MENTION=true`.
+
+Auto-response does **not** bypass the user allowlist: every message is still authorized by author, so a non-allowlisted user posting in an engaged thread is ignored.
 
 ## Channel allowlist (`allowed_channels`)
 


### PR DESCRIPTION
## What does this PR do?

Seeds **prior thread history as context** when the bot is `@mentioned` inside an existing thread for the first time, so the agent understands the conversation it was pulled into — not just the single message it was tagged in. History is injected via `MessageEvent.channel_context` (consumed in `gateway/run.py`).

> 🔗 **Stacked on #43804** (in-thread auto-response). This branch contains that PR's commit plus one more — **please review the `thread context seeding` commit here**, and merge after #43804. (Cross-fork PRs can't target a fork branch as base, hence the cumulative diff.)

### Security: the allowlist must apply to seeded context

The user allowlist is enforced in `gateway/authz_mixin.py::_is_user_authorized`, **per message, by the triggering author** — downstream of the adapter. Injected `channel_context` rides *inside* the authorized user's message and is **not** re-checked by authz. So seeding the whole thread verbatim would feed a non-allowlisted user's messages into the model (an unauthorized-content / prompt-injection vector).

This PR filters seeded history to authors in `MATTERMOST_ALLOWED_USERS` (or everyone when `*_ALLOW_ALL_USERS` is set), and adds **`MATTERMOST_THREAD_CONTEXT`** to control the policy explicitly:

| Value | Behavior |
|-------|----------|
| `allowlisted` (default) | Seed only messages from allowlisted authors |
| `off` | Never seed thread history (no fetch) |
| `all` | Seed the full thread regardless of author, **without** widening who may invoke the bot |

This filtering is the piece the existing thread-context PRs (#38362, #38152) do not have.

## Type of Change

- [x] ✨ New feature (thread-context seeding)
- [x] 🔒 Security fix (allowlist-filtered context)
- [x] ✅ Tests
- [x] 📝 Documentation update

## Changes Made

All in `plugins/platforms/mattermost/adapter.py` (the thread-context commit):

- `_fetch_thread_context()` — fetches `GET /posts/{root}/thread`, fails open via the existing `_api_get`, TTL-cached, excludes the trigger/bot/system posts, **filters to allowlisted authors**, injects via `channel_context`.
- `_thread_context_author_allowed()` — mirrors the authz allowlist; honors `MATTERMOST_THREAD_CONTEXT=all`.
- `_thread_context_mode()` — `off` / `allowlisted` / `all`.
- First-turn injection guarded by `_has_active_session_for_thread` (from #43804) so it runs once per thread.
- Tests: `TestMattermostThreadContext` (filter, allow-all, knob off/all, fail-open, DM).
- Docs: `MATTERMOST_THREAD_CONTEXT` + the allowlist-context warning.

## How to Test

1. `MATTERMOST_ALLOWED_USERS=<you>`. `@mention` the bot in a thread with prior messages → reply reflects them.
2. A **non-allowlisted** user posts in the thread → ignored, and their text does not appear in the bot's context.
3. `MATTERMOST_THREAD_CONTEXT=off` → no seeding; `=all` → full thread seeded without opening invocation.
4. `pytest tests/gateway/test_mattermost.py -q` → 63 passed.

## Checklist

- [x] Conventional Commits (`feat(mattermost): …`)
- [x] Searched existing PRs — supersedes #38362, #38152 (adds the allowlist filter they lack); stacked on #43804
- [x] Tests added; `pytest tests/gateway/test_mattermost.py -q` passes (63)
- [x] Docs updated
- [x] Tested on Debian 13 (Linux 6.8)
- [x] `cli-config.yaml.example` — N/A (env/`config.extra`-driven)
