### PR TITLE
fix(desktop): bridge Windows folder picker paths for WSL backends

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -26,16 +26,6 @@ from typing import Any, Dict, List, Optional
 logger = logging.getLogger(__name__)
 
 
-def _win_path_to_wsl(path: str) -> str | None:
-    """Convert a Windows drive path to its WSL /mnt/<drive>/... equivalent."""
-    match = re.match(r"^([A-Za-z]):[\\/](.*)$", path)
-    if not match:
-        return None
-    drive = match.group(1).lower()
-    tail = match.group(2).replace("\\", "/")
-    return f"/mnt/{drive}/{tail}"
-
-
 def _translate_acp_cwd(cwd: str) -> str:
     """Translate Windows ACP cwd values when Hermes itself is running in WSL.
 
@@ -45,12 +35,9 @@ def _translate_acp_cwd(cwd: str) -> str:
     sessions all agree on the usable workspace. Native Linux/macOS keeps the
     original cwd unchanged.
     """
-    from hermes_constants import is_wsl
+    from hermes_constants import translate_cwd_for_wsl_backend
 
-    if not is_wsl():
-        return cwd
-    translated = _win_path_to_wsl(str(cwd))
-    return translated if translated is not None else cwd
+    return translate_cwd_for_wsl_backend(str(cwd))
 
 
 def _normalize_cwd_for_compare(cwd: str | None) -> str:
@@ -61,7 +48,9 @@ def _normalize_cwd_for_compare(cwd: str | None) -> str:
 
     # Normalize Windows drive paths into the equivalent WSL mount form so
     # ACP history filters match the same workspace across Windows and WSL.
-    translated = _win_path_to_wsl(expanded)
+    from hermes_constants import windows_path_to_wsl
+
+    translated = windows_path_to_wsl(expanded)
     if translated is not None:
         expanded = translated
     elif re.match(r"^/mnt/[A-Za-z]/", expanded):

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -42,6 +42,11 @@ const {
 } = require('./desktop-uninstall.cjs')
 const { isPackagedInstallPath: isPackagedInstallPathUnderRoots } = require('./workspace-cwd.cjs')
 const {
+  resolveLocalReadPath,
+  resolvePickerDefaultPath,
+  resolvePickerResultForRemoteBackend
+} = require('./wsl-path-bridge.cjs')
+const {
   authModeFromStatus,
   buildGatewayWsUrl,
   buildGatewayWsUrlWithTicket,
@@ -5416,7 +5421,10 @@ ipcMain.handle('hermes:selectPaths', async (_event, options = {}) => {
   let resolvedDefaultPath
   if (options?.defaultPath) {
     try {
-      resolvedDefaultPath = path.resolve(String(options.defaultPath))
+      const bridgedDefault = IS_WINDOWS
+        ? resolvePickerDefaultPath(String(options.defaultPath))
+        : String(options.defaultPath)
+      resolvedDefaultPath = path.resolve(bridgedDefault)
     } catch {
       resolvedDefaultPath = undefined
     }
@@ -5430,7 +5438,12 @@ ipcMain.handle('hermes:selectPaths', async (_event, options = {}) => {
   })
 
   if (result.canceled) return []
-  return result.filePaths
+
+  if (!IS_WINDOWS || !globalRemoteActive()) {
+    return result.filePaths
+  }
+
+  return result.filePaths.map(selected => resolvePickerResultForRemoteBackend(selected))
 })
 
 ipcMain.handle('hermes:writeClipboard', (_event, text) => {
@@ -5767,7 +5780,8 @@ function disposeTerminalSession(id) {
 }
 
 ipcMain.handle('hermes:fs:readDir', async (_event, dirPath) => {
-  const resolved = path.resolve(String(dirPath || ''))
+  const bridged = IS_WINDOWS ? resolveLocalReadPath(String(dirPath || '')) : String(dirPath || '')
+  const resolved = path.resolve(bridged)
 
   if (!resolved) {
     return { entries: [], error: 'invalid-path' }

--- a/apps/desktop/electron/wsl-path-bridge.cjs
+++ b/apps/desktop/electron/wsl-path-bridge.cjs
@@ -1,0 +1,136 @@
+const { execFileSync } = require('node:child_process')
+
+const WIN_DRIVE_RE = /^([A-Za-z]):[\\/](.*)$/
+const WSL_MOUNT_RE = /^\/mnt\/([a-z])\/(.*)$/i
+const WSL_UNC_RE = /^\\\\wsl(?:\.localhost|\$)\\([^\\]+)\\(.*)$/i
+
+let cachedDefaultDistro = null
+
+function resolveDefaultWslDistro() {
+  if (cachedDefaultDistro) {
+    return cachedDefaultDistro
+  }
+
+  if (process.platform !== 'win32') {
+    cachedDefaultDistro = 'Ubuntu'
+    return cachedDefaultDistro
+  }
+
+  try {
+    const output = execFileSync('wsl.exe', ['-l', '-q'], {
+      encoding: 'utf8',
+      windowsHide: true,
+      timeout: 2000
+    })
+    const distro = String(output)
+      .split(/\r?\n/)
+      .map(line => line.replace(/^\*?\s*/, '').trim())
+      .find(Boolean)
+
+    cachedDefaultDistro = distro || 'Ubuntu'
+  } catch {
+    cachedDefaultDistro = 'Ubuntu'
+  }
+
+  return cachedDefaultDistro
+}
+
+function windowsPathToWslMount(winPath) {
+  const normalized = String(winPath || '').trim()
+  const match = normalized.match(WIN_DRIVE_RE)
+
+  if (!match) {
+    return null
+  }
+
+  const drive = match[1].toLowerCase()
+  const tail = match[2].replace(/\\/g, '/')
+
+  return `/mnt/${drive}/${tail}`
+}
+
+function wslUncToPosix(uncPath) {
+  const normalized = String(uncPath || '').trim().replace(/\//g, '\\')
+  const match = normalized.match(WSL_UNC_RE)
+
+  if (!match) {
+    return null
+  }
+
+  const tail = match[2].replace(/\\/g, '/')
+  return tail ? `/${tail}` : '/'
+}
+
+function wslPosixToWindowsAccessible(posixPath, distro = resolveDefaultWslDistro()) {
+  const normalized = String(posixPath || '').trim().replace(/\\/g, '/')
+
+  if (!normalized.startsWith('/')) {
+    return normalized
+  }
+
+  const mountMatch = normalized.match(WSL_MOUNT_RE)
+
+  if (mountMatch) {
+    const letter = mountMatch[1].toUpperCase()
+    const tail = mountMatch[2].replace(/\//g, '\\')
+    return `${letter}:\\${tail}`
+  }
+
+  const relative = normalized.replace(/^\/+/, '').replace(/\//g, '\\')
+  return `\\\\wsl.localhost\\${distro}\\${relative}`
+}
+
+function resolvePickerDefaultPath(defaultPath, distro = resolveDefaultWslDistro()) {
+  if (!defaultPath) {
+    return undefined
+  }
+
+  const value = String(defaultPath).trim()
+
+  if (value.startsWith('/') && !value.match(WIN_DRIVE_RE)) {
+    return wslPosixToWindowsAccessible(value, distro)
+  }
+
+  return defaultPath
+}
+
+function resolvePickerResultForRemoteBackend(selectedPath) {
+  if (!selectedPath) {
+    return selectedPath
+  }
+
+  const value = String(selectedPath).trim()
+  const unc = wslUncToPosix(value)
+
+  if (unc) {
+    return unc
+  }
+
+  const mount = windowsPathToWslMount(value)
+
+  if (mount) {
+    return mount
+  }
+
+  return value
+}
+
+function resolveLocalReadPath(dirPath, distro = resolveDefaultWslDistro()) {
+  const value = String(dirPath || '').trim()
+
+  if (process.platform === 'win32' && value.startsWith('/') && !value.match(WIN_DRIVE_RE)) {
+    return wslPosixToWindowsAccessible(value, distro)
+  }
+
+  return value
+}
+
+module.exports = {
+  resolveDefaultWslDistro,
+  resolveLocalReadPath,
+  resolvePickerDefaultPath,
+  resolvePickerResultForRemoteBackend,
+  windowsPathToWslMount,
+  wslPosixToWindowsAccessible,
+  wslUncToPosix
+}

--- a/apps/desktop/electron/wsl-path-bridge.test.cjs
+++ b/apps/desktop/electron/wsl-path-bridge.test.cjs
@@ -1,0 +1,69 @@
+const assert = require('node:assert/strict')
+const test = require('node:test')
+
+const {
+  resolveLocalReadPath,
+  resolvePickerDefaultPath,
+  resolvePickerResultForRemoteBackend,
+  windowsPathToWslMount,
+  wslPosixToWindowsAccessible,
+  wslUncToPosix
+} = require('./wsl-path-bridge.cjs')
+
+test('windowsPathToWslMount converts drive paths', () => {
+  assert.equal(windowsPathToWslMount('C:\\Users\\don\\projects'), '/mnt/c/Users/don/projects')
+  assert.equal(windowsPathToWslMount('D:/work/project'), '/mnt/d/work/project')
+  assert.equal(windowsPathToWslMount('/home/user'), null)
+})
+
+test('wslUncToPosix converts WSL UNC paths', () => {
+  assert.equal(
+    wslUncToPosix('\\\\wsl.localhost\\Ubuntu\\home\\don\\projects'),
+    '/home/don/projects'
+  )
+  assert.equal(wslUncToPosix('\\\\wsl$\\Ubuntu\\home\\don\\projects'), '/home/don/projects')
+})
+
+test('wslPosixToWindowsAccessible maps mount and home paths', () => {
+  assert.equal(
+    wslPosixToWindowsAccessible('/mnt/c/Users/don/projects', 'Ubuntu'),
+    'C:\\Users\\don\\projects'
+  )
+  assert.equal(
+    wslPosixToWindowsAccessible('/home/don/projects', 'Ubuntu'),
+    '\\\\wsl.localhost\\Ubuntu\\home\\don\\projects'
+  )
+})
+
+test('resolvePickerDefaultPath exposes WSL paths in the Windows picker', () => {
+  assert.equal(
+    resolvePickerDefaultPath('/home/don/projects', 'Ubuntu'),
+    '\\\\wsl.localhost\\Ubuntu\\home\\don\\projects'
+  )
+})
+
+test('resolvePickerResultForRemoteBackend normalizes picker output for WSL backends', () => {
+  assert.equal(
+    resolvePickerResultForRemoteBackend('C:\\Users\\don\\projects'),
+    '/mnt/c/Users/don/projects'
+  )
+  assert.equal(
+    resolvePickerResultForRemoteBackend('\\\\wsl.localhost\\Ubuntu\\home\\don\\projects'),
+    '/home/don/projects'
+  )
+})
+
+test('resolveLocalReadPath maps WSL cwd values for Windows readDir', () => {
+  const original = process.platform
+  Object.defineProperty(process, 'platform', { value: 'win32' })
+
+  try {
+    assert.equal(
+      resolveLocalReadPath('/home/don/projects', 'Ubuntu'),
+      '\\\\wsl.localhost\\Ubuntu\\home\\don\\projects'
+    )
+    assert.equal(resolveLocalReadPath('/mnt/c/Users/don', 'Ubuntu'), 'C:\\Users\\don')
+  } finally {
+    Object.defineProperty(process, 'platform', { value: original })
+  }
+})

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -360,6 +360,41 @@ def is_wsl() -> bool:
     return _wsl_detected
 
 
+def windows_path_to_wsl(path: str) -> str | None:
+    """Convert a Windows drive path to its WSL ``/mnt/<drive>/...`` equivalent."""
+    import re
+
+    match = re.match(r"^([A-Za-z]):[\\/](.*)$", str(path or "").strip())
+    if not match:
+        return None
+    drive = match.group(1).lower()
+    tail = match.group(2).replace("\\", "/")
+    return f"/mnt/{drive}/{tail}"
+
+
+def wsl_unc_path_to_posix(path: str) -> str | None:
+    """Convert a Windows WSL UNC path to a POSIX path inside the distro."""
+    import re
+
+    normalized = str(path or "").strip().replace("/", "\\")
+    match = re.match(r"^\\\\wsl(?:\.localhost|\$)\\[^\\]+\\(.*)$", normalized, re.IGNORECASE)
+    if not match:
+        return None
+    tail = match.group(1).replace("\\", "/")
+    return f"/{tail}" if tail else "/"
+
+
+def translate_cwd_for_wsl_backend(cwd: str) -> str:
+    """Normalize cross-boundary cwd values when Hermes runs inside WSL."""
+    if not is_wsl():
+        return cwd
+    for translator in (wsl_unc_path_to_posix, windows_path_to_wsl):
+        translated = translator(cwd)
+        if translated is not None:
+            return translated
+    return cwd
+
+
 _container_detected: bool | None = None
 
 

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -298,3 +298,38 @@ class TestSecureParentDir:
         assert len(called_with) == 1
         assert called_with[0] == (str(real_dir), 0o700)
 
+
+class TestWslPathTranslation:
+    def test_windows_path_to_wsl(self):
+        from hermes_constants import windows_path_to_wsl
+
+        assert windows_path_to_wsl(r"C:\Users\don\projects") == "/mnt/c/Users/don/projects"
+        assert windows_path_to_wsl("D:/work/project") == "/mnt/d/work/project"
+        assert windows_path_to_wsl("/home/user") is None
+
+    def test_wsl_unc_path_to_posix(self):
+        from hermes_constants import wsl_unc_path_to_posix
+
+        assert (
+            wsl_unc_path_to_posix(r"\\wsl.localhost\Ubuntu\home\don\projects")
+            == "/home/don/projects"
+        )
+        assert wsl_unc_path_to_posix(r"\\wsl$\Ubuntu\home\don\projects") == "/home/don/projects"
+        assert wsl_unc_path_to_posix("/home/don/projects") is None
+
+    def test_translate_cwd_for_wsl_backend(self, monkeypatch):
+        from hermes_constants import translate_cwd_for_wsl_backend
+
+        monkeypatch.setattr(hermes_constants, "_wsl_detected", True)
+        assert (
+            translate_cwd_for_wsl_backend(r"C:\Users\don\projects")
+            == "/mnt/c/Users/don/projects"
+        )
+        assert (
+            translate_cwd_for_wsl_backend(r"\\wsl.localhost\Ubuntu\home\don\projects")
+            == "/home/don/projects"
+        )
+
+        monkeypatch.setattr(hermes_constants, "_wsl_detected", False)
+        assert translate_cwd_for_wsl_backend(r"C:\Users\don\projects") == r"C:\Users\don\projects"
+

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1172,7 +1172,10 @@ def _ensure_session_db_row(session: dict) -> None:
 
 
 def _set_session_cwd(session: dict, cwd: str) -> str:
-    resolved = os.path.abspath(os.path.expanduser(str(cwd)))
+    from hermes_constants import translate_cwd_for_wsl_backend
+
+    cwd = translate_cwd_for_wsl_backend(str(cwd))
+    resolved = os.path.abspath(os.path.expanduser(cwd))
     if not os.path.isdir(resolved):
         raise ValueError(f"working directory does not exist: {cwd}")
     session["cwd"] = resolved


### PR DESCRIPTION
## Summary

Fixes the Hermes Desktop working-directory picker when the UI runs on **Windows** and the gateway runs in **WSL** (remote mode).

## Problem

- The native Windows folder picker only exposes drive-letter paths (`C:\...`).
- The WSL backend expects POSIX paths (`/home/...` or `/mnt/c/...`).
- Selecting a folder left the session in an **UNREADABLE** state because the sidebar tried to `readDir` a WSL cwd from the Windows host.

Fixes #43744

## Solution

### Backend (gateway)
- Add shared translators in `hermes_constants.py` for Windows drive paths and `\\wsl.localhost\...` UNC paths.
- Apply translation in `session.cwd.set` when Hermes runs inside WSL.
- Reuse the same helper from ACP session cwd handling (no duplicate logic).

### Desktop (Electron on Windows)
- New `wsl-path-bridge.cjs` bridges paths in both directions:
  - **Picker defaultPath**: `/home/...` → `\\wsl.localhost\<distro>\home\...` so Linux paths are navigable in the Windows dialog.
  - **Picker result (remote mode)**: `C:\...` → `/mnt/c/...` and UNC picks → POSIX before `session.cwd.set`.
  - **readDir**: WSL cwd values → Windows-accessible paths so the project tree can load.

## Duplicate / overlap check

- **No open PR** references #43744.
- Related but distinct from #40247 (terminal/gateway cwd translation for tools) — this PR targets the **desktop picker + sidebar filesystem bridge** on a Windows host.

## Testing

```bash
# Python
uv run pytest tests/test_hermes_constants.py::TestWslPathTranslation tests/acp/test_session.py -q -k "wsl or Wsl or cwd_translates or translate_acp"
# 12 passed

# Desktop bridge
cd apps/desktop && node --test electron/wsl-path-bridge.test.cjs
# 6 passed
```

## Verification matrix

| Scenario | Before | After |
|---|---|---|
| Pick `C:\Users\...` with WSL backend | ENOENT / unreadable cwd | `/mnt/c/Users/...` accepted |
| Pick `\\wsl.localhost\Ubuntu\home\...` | mixed/invalid backend path | `/home/...` accepted |
| Sidebar with WSL cwd on Windows host | UNREADABLE (ENOENT) | Reads via `\\wsl.localhost\...` |
| Picker opened with existing WSL cwd | Windows-only roots | Starts under Linux UNC path |