### PR TITLE
fix(docker): honor HERMES_ENV_MODE for .env file permissions in stage2-hook

### DIFF
--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -349,9 +349,11 @@ seed_one "SOUL.md" "docker/SOUL.md"
 # .env holds API keys and secrets — restrict to owner-only access. Applied
 # unconditionally (not only on first-seed) so a host-mounted .env that was
 # created with a permissive umask gets tightened on every container start.
+# #43473: HERMES_ENV_MODE overrides the default 0600 for host-mounted setups
+# where the host user needs group-read access (e.g. docker-compose ${VAR}).
 if [ -f "$HERMES_HOME/.env" ]; then
     chown hermes:hermes "$HERMES_HOME/.env" 2>/dev/null || true
-    chmod 600 "$HERMES_HOME/.env" 2>/dev/null || true
+    chmod "${HERMES_ENV_MODE:-600}" "$HERMES_HOME/.env" 2>/dev/null || true
 fi
 
 # --- Migrate persisted config schema ---


### PR DESCRIPTION
## Problem

`docker/stage2-hook.sh` unconditionally applies `chmod 600` to `$HERMES_HOME/.env` on every container start. For host-mounted `.env` files, this makes the file unreadable to the host user, breaking docker-compose `${VAR}` substitution and host helper scripts.

Existing env vars don't help:
- `HERMES_SKIP_CHMOD` only gates the Python `_secure_file()` (config.py), not this shell hook
- `HERMES_HOME_MODE` controls directory mode only
- `HERMES_GID/PGID` can match the host group, but mode 0600 gives the group no read

## Fix

Add `HERMES_ENV_MODE` env var (default `600`) so operators can override the permission mode. Setting `HERMES_ENV_MODE=0640` allows group-read access, matching the `config.yaml` behaviour when `HERMES_GID` is set.

This follows the same naming convention as `HERMES_HOME_MODE`.

Fixes #43473

## Changes

- `docker/stage2-hook.sh`: Replace hardcoded `chmod 600` with `chmod "${HERMES_ENV_MODE:-600}"` and add comment with issue reference

## Testing

All 7 existing contract tests in `tests/tools/test_stage2_hook_env_mode.py` pass:
- `test_stage2_hook_references_hermes_env_mode`
- `test_stage2_hook_default_mode_is_600`
- `test_stage2_hook_env_mode_applied_to_env_file`
- `test_stage2_hook_env_mode_documented_with_issue_ref`
- `test_default_mode_is_owner_only`
- `test_env_mode_0640_allows_group_read`
- `test_env_mode_0644_allows_group_and_other_read`
