### PR TITLE
fix(api-server): resolve latest Teams session aliases

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -927,6 +927,77 @@ class APIServerAdapter(BasePlatformAdapter):
     # that the sanitized form is safe to pass into Honcho / state.db.
     _MAX_SESSION_HEADER_LEN = 256
 
+    _LATEST_TEAMS_SESSION_ALIASES = frozenset({
+        "@latest:teams",
+        "latest:teams",
+        "@current:teams",
+        "current:teams",
+        "hermes:latest:teams",
+        "hermes:current:teams",
+    })
+
+    def _resolve_session_id_alias(self, raw_session_id: str):
+        """Resolve dynamic session-id aliases used by bridge clients.
+
+        Desktop/Apollo continuity should not require rewriting a laptop config
+        every time the operator's Teams DM rotates to a new Hermes session id.
+        A trusted client may send ``X-Hermes-Session-Id: latest:teams`` and the
+        Apollo API server resolves it at request time to the newest non-archived
+        Teams transcript in this profile's state.db.
+        """
+        normalized = (raw_session_id or "").strip().lower()
+        if normalized not in self._LATEST_TEAMS_SESSION_ALIASES:
+            return raw_session_id, None
+
+        db = self._ensure_session_db()
+        conn = getattr(db, "_conn", None)
+        lock = getattr(db, "_lock", None)
+        if conn is None:
+            return None, web.json_response(
+                _openai_error(
+                    "Cannot resolve latest Teams session: SessionDB unavailable.",
+                    code="session_alias_unavailable",
+                ),
+                status=503,
+            )
+
+        query = """
+            SELECT s.id
+            FROM sessions s
+            WHERE s.source = 'teams'
+              AND COALESCE(s.archived, 0) = 0
+            ORDER BY COALESCE(
+                (SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = s.id),
+                s.started_at
+            ) DESC, s.started_at DESC, s.id DESC
+            LIMIT 1
+        """
+        try:
+            if lock is not None:
+                with lock:
+                    row = conn.execute(query).fetchone()
+            else:
+                row = conn.execute(query).fetchone()
+        except Exception as exc:
+            logger.warning("Failed to resolve latest Teams session alias: %s", exc)
+            return None, web.json_response(
+                _openai_error(
+                    "Cannot resolve latest Teams session alias.",
+                    code="session_alias_resolution_failed",
+                ),
+                status=500,
+            )
+
+        if row is None:
+            return None, web.json_response(
+                _openai_error(
+                    "No active Teams session found for X-Hermes-Session-Id alias latest:teams.",
+                    code="session_alias_not_found",
+                ),
+                status=404,
+            )
+        return str(row["id"] if hasattr(row, "keys") else row[0]), None
+
     def _parse_session_key_header(
         self, request: "web.Request"
     ) -> tuple[Optional[str], Optional["web.Response"]]:
@@ -1813,7 +1884,10 @@ class APIServerAdapter(BasePlatformAdapter):
                     {"error": {"message": "Invalid session ID", "type": "invalid_request_error"}},
                     status=400,
                 )
-            session_id = provided_session_id
+            session_id, alias_err = self._resolve_session_id_alias(provided_session_id)
+            if alias_err is not None:
+                return alias_err
+            session_id = session_id or provided_session_id
             try:
                 db = self._ensure_session_db()
                 if db is not None:

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -15,6 +15,7 @@ Tests cover:
 import asyncio
 import json
 import os
+import sqlite3
 import stat
 import time
 import uuid
@@ -336,6 +337,103 @@ class TestAdapterInit:
 
         assert isinstance(agent, FakeAgent)
         assert captured["reasoning_config"] == {"enabled": True, "effort": "xhigh"}
+
+
+class TestSessionIdAliases:
+    def _fake_session_db(self):
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                source TEXT,
+                archived INTEGER DEFAULT 0,
+                started_at TEXT
+            );
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY,
+                session_id TEXT,
+                timestamp TEXT
+            );
+            """
+        )
+        conn.executemany(
+            "INSERT INTO sessions (id, source, archived, started_at) VALUES (?, ?, ?, ?)",
+            [
+                ("teams-old", "teams", 0, "2026-06-09T10:00:00"),
+                ("teams-current", "teams", 0, "2026-06-10T10:00:00"),
+                ("teams-archived-newer", "teams", 1, "2026-06-11T10:00:00"),
+                ("api-newer", "api_server", 0, "2026-06-12T10:00:00"),
+            ],
+        )
+        conn.executemany(
+            "INSERT INTO messages (session_id, timestamp) VALUES (?, ?)",
+            [
+                ("teams-old", "2026-06-09T10:30:00"),
+                ("teams-current", "2026-06-10T10:30:00"),
+                ("teams-archived-newer", "2026-06-11T10:30:00"),
+                ("api-newer", "2026-06-12T10:30:00"),
+            ],
+        )
+
+        class FakeDB:
+            _conn = conn
+            _lock = None
+
+        return FakeDB(), conn
+
+    def test_resolve_latest_teams_alias_selects_newest_active_teams_session(self, monkeypatch):
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        fake_db, conn = self._fake_session_db()
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: fake_db)
+        try:
+            resolved, err = adapter._resolve_session_id_alias("latest:teams")
+        finally:
+            conn.close()
+
+        assert err is None
+        assert resolved == "teams-current"
+
+    def test_non_alias_session_id_passes_through_without_db_lookup(self, monkeypatch):
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(
+            adapter,
+            "_ensure_session_db",
+            MagicMock(side_effect=AssertionError("DB lookup should not run for non-alias ids")),
+        )
+
+        resolved, err = adapter._resolve_session_id_alias("explicit-session-id")
+
+        assert err is None
+        assert resolved == "explicit-session-id"
+
+    def test_latest_teams_alias_returns_404_when_no_active_teams_session(self, monkeypatch):
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.executescript(
+            """
+            CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, archived INTEGER, started_at TEXT);
+            CREATE TABLE messages (id INTEGER PRIMARY KEY, session_id TEXT, timestamp TEXT);
+            INSERT INTO sessions (id, source, archived, started_at)
+            VALUES ('archived-only', 'teams', 1, '2026-06-10T10:00:00');
+            """
+        )
+
+        class FakeDB:
+            _conn = conn
+            _lock = None
+
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: FakeDB())
+        try:
+            resolved, err = adapter._resolve_session_id_alias("@current:teams")
+        finally:
+            conn.close()
+
+        assert resolved is None
+        assert err is not None
+        assert err.status == 404
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add API-server support for dynamic `X-Hermes-Session-Id` aliases like `latest:teams` / `current:teams`
- resolve aliases at request time to the newest non-archived Teams session in `state.db`
- add regression coverage for alias passthrough, newest active Teams resolution, and no-active-session 404

## Verification
- `python -m py_compile gateway/platforms/api_server.py tests/gateway/test_api_server.py`
- `python -m pytest -o addopts="-m 'not integration'" tests/gateway/test_api_server.py -q` → 160 passed
