### PR TITLE
fix(agent): omit over-long item ids when replaying Codex Responses input

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -237,6 +237,24 @@ def _derive_responses_function_call_id(
     return f"fc_{digest}"
 
 
+# chatgpt.com/backend-api/codex caps input item ids at 64 chars and rejects
+# longer ones with HTTP 400 ``string_above_max_length``. With store=False the
+# backend returns ~400-char encrypted message ids; echoing them back on replay
+# fails the whole request. ``id`` is optional on replayed assistant messages,
+# so drop any id the backend would refuse rather than send it.
+_MAX_REPLAY_ITEM_ID_LEN = 64
+
+
+def _replayable_item_id(raw_id: Any) -> Optional[str]:
+    """Return a backend-legal input item id, or None to omit the id."""
+    if not isinstance(raw_id, str):
+        return None
+    candidate = raw_id.strip()
+    if not candidate or len(candidate) > _MAX_REPLAY_ITEM_ID_LEN:
+        return None
+    return candidate
+
+
 # ---------------------------------------------------------------------------
 # Schema conversion
 # ---------------------------------------------------------------------------
@@ -462,9 +480,9 @@ def _chat_messages_to_responses_input(
                             "status": _normalize_responses_message_status(raw_item.get("status")),
                             "content": normalized_content_parts,
                         }
-                        item_id = raw_item.get("id")
-                        if isinstance(item_id, str) and item_id.strip():
-                            replay_item["id"] = item_id.strip()
+                        item_id = _replayable_item_id(raw_item.get("id"))
+                        if item_id:
+                            replay_item["id"] = item_id
                         phase = raw_item.get("phase")
                         if isinstance(phase, str) and phase.strip():
                             replay_item["phase"] = phase.strip()
@@ -716,9 +734,9 @@ def _preflight_codex_input_items(raw_items: Any) -> List[Dict[str, Any]]:
                 "status": _normalize_responses_message_status(item.get("status")),
                 "content": normalized_content,
             }
-            item_id = item.get("id")
-            if isinstance(item_id, str) and item_id.strip():
-                normalized_item["id"] = item_id.strip()
+            item_id = _replayable_item_id(item.get("id"))
+            if item_id:
+                normalized_item["id"] = item_id
             phase = item.get("phase")
             if isinstance(phase, str) and phase.strip():
                 normalized_item["phase"] = phase.strip()

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -3,9 +3,13 @@ from types import SimpleNamespace
 import pytest
 
 from agent.codex_responses_adapter import (
+    _MAX_REPLAY_ITEM_ID_LEN,
+    _chat_messages_to_responses_input,
     _format_responses_error,
     _normalize_codex_response,
     _preflight_codex_api_kwargs,
+    _preflight_codex_input_items,
+    _replayable_item_id,
 )
 
 
@@ -284,3 +288,98 @@ def test_normalize_codex_response_failed_with_message_only():
     )
     with pytest.raises(RuntimeError, match=r"^model error$"):
         _normalize_codex_response(response)
+
+
+# ---------------------------------------------------------------------------
+# Replay item id length cap
+# ---------------------------------------------------------------------------
+# chatgpt.com/backend-api/codex rejects input item ids longer than 64 chars
+# with HTTP 400 string_above_max_length. With store=False the backend returns
+# ~400-char encrypted message ids; echoing them back on replay fails the whole
+# request, so over-long ids must be omitted (id is optional on replayed
+# assistant messages).
+
+_LEGAL_ID = "msg_" + "a" * 60  # exactly 64 chars
+_ENCRYPTED_ID = "msg_" + "x" * 400  # store=False style encrypted id
+
+
+def test_replayable_item_id_accepts_backend_legal_ids():
+    assert _replayable_item_id(_LEGAL_ID) == _LEGAL_ID
+    assert _replayable_item_id("  msg_123  ") == "msg_123"
+
+
+def test_replayable_item_id_rejects_overlong_empty_and_non_string():
+    assert len(_LEGAL_ID) == _MAX_REPLAY_ITEM_ID_LEN
+    assert _replayable_item_id(_LEGAL_ID + "a") is None
+    assert _replayable_item_id(_ENCRYPTED_ID) is None
+    assert _replayable_item_id("   ") is None
+    assert _replayable_item_id(None) is None
+    assert _replayable_item_id(123) is None
+
+
+def _assistant_message_with_replay_id(item_id):
+    return {
+        "role": "assistant",
+        "content": "hello",
+        "codex_message_items": [
+            {
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "id": item_id,
+                "phase": "final",
+                "content": [{"type": "output_text", "text": "hello"}],
+            }
+        ],
+    }
+
+
+def test_replay_drops_overlong_encrypted_message_ids():
+    items = _chat_messages_to_responses_input(
+        [_assistant_message_with_replay_id(_ENCRYPTED_ID)]
+    )
+    replayed = [i for i in items if i.get("type") == "message" and i.get("role") == "assistant"]
+    assert len(replayed) == 1
+    # The over-long id is omitted; the rest of the item replays intact.
+    assert "id" not in replayed[0]
+    assert replayed[0]["phase"] == "final"
+    assert replayed[0]["content"] == [{"type": "output_text", "text": "hello"}]
+
+
+def test_replay_preserves_backend_legal_message_ids():
+    items = _chat_messages_to_responses_input(
+        [_assistant_message_with_replay_id(_LEGAL_ID)]
+    )
+    replayed = [i for i in items if i.get("type") == "message" and i.get("role") == "assistant"]
+    assert len(replayed) == 1
+    assert replayed[0]["id"] == _LEGAL_ID
+
+
+def test_preflight_drops_overlong_message_ids():
+    normalized = _preflight_codex_input_items(
+        [
+            {
+                "type": "message",
+                "role": "assistant",
+                "id": _ENCRYPTED_ID,
+                "content": [{"type": "output_text", "text": "hi"}],
+            }
+        ]
+    )
+    assert len(normalized) == 1
+    assert "id" not in normalized[0]
+
+
+def test_preflight_preserves_backend_legal_message_ids():
+    normalized = _preflight_codex_input_items(
+        [
+            {
+                "type": "message",
+                "role": "assistant",
+                "id": "  msg_short  ",
+                "content": [{"type": "output_text", "text": "hi"}],
+            }
+        ]
+    )
+    assert len(normalized) == 1
+    assert normalized[0]["id"] == "msg_short"


### PR DESCRIPTION
## What

Both Codex Responses replay paths (`_chat_messages_to_responses_input` and `_preflight_codex_input_items`) now route assistant-message item ids through a shared `_replayable_item_id` helper that omits any id longer than 64 characters instead of sending it.

## Why

The `chatgpt.com/backend-api/codex` endpoint caps input item ids at 64 characters and rejects longer ones with HTTP 400 `string_above_max_length`. With `store=False` (our default) the backend returns ~400-char encrypted message ids on `response.completed`; echoing those ids back inside `codex_message_items` on the next turn fails the entire request, breaking every subsequent turn of the session.

`id` is optional on replayed assistant messages, so dropping a backend-illegal id is safe — the message content, `status`, and `phase` still replay intact (phase is what the prefix-cache guidance actually cares about).

## How to test

```
scripts/run_tests.sh tests/agent/test_codex_responses_adapter.py
```

New tests cover the helper's accept/reject boundary (exactly 64 chars accepted, 65+ rejected, whitespace/non-string rejected) and both replay paths: a ~400-char encrypted id is omitted while content/phase survive, and backend-legal ids are preserved verbatim.

Full `tests/agent` + `tests/run_agent` suites: 5684 passed, 0 failed.

To reproduce the original failure manually: run `hermes` against ChatGPT-plan Codex OAuth (gpt-5.5), complete one assistant turn, then send a second message — pre-fix the second request 400s with `string_above_max_length` on the replayed message item id.

## Platforms

Tested on Linux (x86_64, Python 3.11). Pure data-normalization change, no platform-specific behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)