### PR TITLE
fix(tui_gateway): register shell hooks at desktop/TUI startup

### DIFF
--- a/tests/tui_gateway/test_shell_hooks_registration.py
+++ b/tests/tui_gateway/test_shell_hooks_registration.py
@@ -1,0 +1,59 @@
+"""Test that tui_gateway/entry.py registers shell hooks at startup.
+
+Regression test for GitHub issue #43823 — shell hooks configured in
+config.yaml were silently ignored in the desktop/TUI entry point because
+``register_from_config()`` was never called from ``tui_gateway/entry.py``.
+"""
+
+import importlib
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestTuiEntryShellHooks:
+    """Verify shell hooks are registered during TUI startup."""
+
+    def test_register_from_config_called_at_startup(self):
+        """``main()`` must call ``register_from_config`` so that
+        declarative shell hooks (e.g. ``pre_tool_call``) fire in desktop
+        sessions just like they do in CLI and gateway sessions."""
+        # We need to mock the entire startup sequence so main() doesn't
+        # actually start reading stdin or writing to stdout.
+        mock_register = MagicMock()
+
+        with patch("tui_gateway.entry._install_sidecar_publisher"), \
+             patch("tui_gateway.entry.write_json", side_effect=[True, lambda *a, **k: True]) as mock_write, \
+             patch("hermes_cli.config.load_config", return_value={}), \
+             patch("agent.shell_hooks.register_from_config", mock_register), \
+             patch("sys.stdin", []):
+            # Reload to pick up the mock targets
+            import tui_gateway.entry as entry_mod
+            # main() reads from sys.stdin — empty list means no lines, exits loop
+            try:
+                entry_mod.main()
+            except SystemExit:
+                pass
+
+        mock_register.assert_called_once()
+        call_kwargs = mock_register.call_args
+        assert call_kwargs[1].get("accept_hooks") is False
+
+    def test_register_failure_does_not_block_startup(self):
+        """If ``register_from_config`` raises, the TUI must still start."""
+        mock_register = MagicMock(side_effect=RuntimeError("boom"))
+
+        with patch("tui_gateway.entry._install_sidecar_publisher"), \
+             patch("tui_gateway.entry.write_json", side_effect=[True, lambda *a, **k: True]), \
+             patch("hermes_cli.config.load_config", return_value={}), \
+             patch("agent.shell_hooks.register_from_config", mock_register), \
+             patch("sys.stdin", []):
+            import tui_gateway.entry as entry_mod
+            try:
+                entry_mod.main()
+            except SystemExit:
+                pass
+            # main() should not have crashed — it completed normally
+
+        mock_register.assert_called_once()

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -263,6 +263,21 @@ def main():
         global _mcp_discovery_thread
         _mcp_discovery_thread = _mcp_thread
 
+    # Register declarative shell hooks from config.yaml.  The TUI / desktop
+    # entry point has no TTY for consent prompts, so accept_hooks=False and
+    # the effective value is resolved from HERMES_ACCEPT_HOOKS env var or
+    # hooks_auto_accept in config — matching the gateway pattern.
+    # Failures are logged but must never block TUI startup.
+    try:
+        from hermes_cli.config import load_config
+        from agent.shell_hooks import register_from_config
+        register_from_config(load_config(), accept_hooks=False)
+    except Exception:
+        logger.debug(
+            "shell-hook registration failed at TUI startup",
+            exc_info=True,
+        )
+
     if not write_json({
         "jsonrpc": "2.0",
         "method": "event",


### PR DESCRIPTION
## What does this PR do?

Registers declarative shell hooks (`config.yaml` `hooks:` entries) at TUI/desktop startup, fixing a security gap where `pre_tool_call` blocking hooks were silently ignored in the desktop app.

## Related Issue

Fixes #43823

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/entry.py`: Added `register_from_config(load_config(), accept_hooks=False)` call in `main()`, wrapped in try/except to never block TUI startup. Matches the existing pattern in `gateway/run.py:4500-4508`.
- `tests/tui_gateway/test_shell_hooks_registration.py`: Added 2 tests — (1) `register_from_config` is called with `accept_hooks=False`, (2) registration failure does not block startup.

## How to Test

1. Add a shell hook to `config.yaml`:
   ```yaml
   hooks:
     pre_tool_call:
       - matcher: "terminal"
         command: "echo blocked"
         timeout: 5
   hooks_auto_accept: true
   ```
2. Start `hermes --tui`, send a prompt that triggers a terminal tool call.
3. Verify the hook fires (check `agent.log` for "shell hook" entries).
4. Without this fix, the hook is silently skipped in the desktop/TUI.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `tui_gateway/entry.py::main()` — entry point for desktop/TUI JSON-RPC server
- Blast radius: LOW — adds a single registration call with exception guard; no existing behavior changed
- Related patterns: entry-point parity gap (cli.py:943, gateway/run.py:4502 both call register_from_config; tui_gateway was the missing surface)
