### PR TITLE
fix(tui): register shell hooks at TUI gateway startup

### DIFF
--- a/tests/tui_gateway/test_shell_hook_registration.py
+++ b/tests/tui_gateway/test_shell_hook_registration.py
@@ -1,0 +1,61 @@
+"""Tests for tui_gateway/entry.py shell-hook registration (issue #43823).
+
+The TUI gateway must register declarative shell hooks from config.yaml at
+startup so that ``pre_tool_call`` and other hooks fire in Desktop/TUI
+sessions, matching CLI and gateway behaviour.
+"""
+
+from unittest.mock import patch
+
+
+def test_main_registers_shell_hooks():
+    """``main()`` must call ``register_from_config`` at startup."""
+    mock_config = {"hooks": {}}
+
+    with (
+        patch("tui_gateway.entry._install_sidecar_publisher"),
+        patch("tui_gateway.entry.write_json", return_value=True),
+        patch("tui_gateway.entry.resolve_skin", return_value="default"),
+        patch("hermes_cli.config.read_raw_config", return_value=mock_config),
+        patch("hermes_cli.config.load_config", return_value=mock_config),
+        patch(
+            "agent.shell_hooks.register_from_config"
+        ) as mock_register,
+        patch("sys.stdin", iter([])),  # EOF immediately → clean exit
+        patch("tui_gateway.entry._log_exit"),
+    ):
+        from tui_gateway.entry import main
+
+        try:
+            main()
+        except (SystemExit, StopIteration):
+            pass
+
+        mock_register.assert_called_once_with(mock_config, accept_hooks=False)
+
+
+def test_main_continues_on_shell_hook_failure():
+    """``main()`` must not abort if shell-hook registration fails."""
+    with (
+        patch("tui_gateway.entry._install_sidecar_publisher"),
+        patch("tui_gateway.entry.write_json", return_value=True),
+        patch("tui_gateway.entry.resolve_skin", return_value="default"),
+        patch("hermes_cli.config.read_raw_config", return_value=None),
+        patch(
+            "agent.shell_hooks.register_from_config",
+            side_effect=RuntimeError("config parse error"),
+        ),
+        patch("sys.stdin", iter([])),
+        patch("tui_gateway.entry._log_exit") as mock_log_exit,
+    ):
+        from tui_gateway.entry import main
+
+        try:
+            main()
+        except (SystemExit, StopIteration):
+            pass
+
+        # Should reach normal exit, not crash on hook registration failure
+        mock_log_exit.assert_called_once_with(
+            "stdin EOF (TUI closed the command pipe)"
+        )

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -271,6 +271,21 @@ def main():
         _log_exit("startup write failed (broken stdout pipe before first event)")
         sys.exit(0)
 
+    # Register declarative shell hooks from config.yaml so that pre_tool_call
+    # and other hooks fire in TUI/Desktop sessions, matching CLI and gateway
+    # behaviour.  ``accept_hooks=False`` lets ``register_from_config`` resolve
+    # the effective value from HERMES_ACCEPT_HOOKS / hooks_auto_accept — the
+    # same delegation the gateway uses (gateway/run.py ~L4667).
+    try:
+        from hermes_cli.config import load_config
+        from agent.shell_hooks import register_from_config
+        register_from_config(load_config(), accept_hooks=False)
+    except Exception:
+        logger.debug(
+            "shell-hook registration failed at TUI startup",
+            exc_info=True,
+        )
+
     for raw in sys.stdin:
         line = raw.strip()
         if not line:


### PR DESCRIPTION
## What does this PR do?

Registers declarative shell hooks (`pre_tool_call`, `post_tool_call`, etc.) at TUI gateway startup so they fire in Desktop/TUI sessions, matching CLI and gateway behaviour.

## Related Issue

Fixes #43823

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/entry.py`: Add `register_from_config(load_config(), accept_hooks=False)` after the `gateway.ready` event, wrapped in `try/except` so failures never block TUI startup. This matches the same delegation pattern used by `gateway/run.py` (~L4667).
- `tests/tui_gateway/test_shell_hook_registration.py`: Two tests verifying (1) `register_from_config` is called with `accept_hooks=False` at startup, and (2) TUI startup continues normally if hook registration fails.

## Why this matters

Users configure shell hooks (e.g. `pre_tool_call` to block dangerous commands) as a security surface. The CLI and gateway both register these hooks at startup, but the TUI/Desktop entry point never did — so hooks were silently ignored in Desktop sessions. A user could configure a blocking hook, see no error, and believe they were protected when they weren't.

## Testing

- [x] New tests pass (`tests/tui_gateway/test_shell_hook_registration.py`)
- [x] Existing TUI gateway tests pass
- [x] Syntax check passes
