### PR TITLE
fix(dashboard): pass --yes to spawned hub skill installs

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7381,7 +7381,7 @@ async def install_skill_hub(body: SkillInstallRequest):
     if not identifier:
         raise HTTPException(status_code=400, detail="identifier is required")
     try:
-        proc = _spawn_hermes_action(["skills", "install", identifier], "skills-install")
+        proc = _spawn_hermes_action(["skills", "install", identifier, "--yes"], "skills-install")
     except Exception as exc:
         _log.exception("Failed to spawn skills install")
         raise HTTPException(status_code=500, detail=f"Failed to install skill: {exc}")
@@ -8082,7 +8082,7 @@ async def create_profile_endpoint(body: ProfileCreate):
             continue
         try:
             proc = _spawn_hermes_action(
-                ["-p", body.name, "skills", "install", ident],
+                ["-p", body.name, "skills", "install", ident, "--yes"],
                 "skills-install",
             )
             hub_installs.append({"identifier": ident, "pid": proc.pid})

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2486,7 +2486,7 @@ class TestNewEndpoints:
         assert data["hub_installs"] == [{"identifier": "someuser/some-skill", "pid": 4321}]
 
         # Hub install was scoped to the new profile.
-        assert spawned == [(["-p", "builder", "skills", "install", "someuser/some-skill"], "skills-install")]
+        assert spawned == [(["-p", "builder", "skills", "install", "someuser/some-skill", "--yes"], "skills-install")]
 
         # Verify the writes landed in the NEW profile's config, not the root.
         prof_dir = get_hermes_home() / "profiles" / "builder"


### PR DESCRIPTION
## Problem

Installing any skill from the dashboard's **Browse Hub** page always fails at the confirmation prompt:

```
Install 'linkedin-profile-optimizer'?
Confirm [y/N]: Installation cancelled.
```

`POST /api/skills/hub/install` spawns `hermes skills install <identifier>` as a background process with no usable stdin, so the interactive `Confirm [y/N]:` prompt immediately resolves to the default **N** and every install is cancelled. There is no way to answer the prompt from the web UI.

The profile-builder's optional hub installs (`["-p", name, "skills", "install", ident]`) have the same problem.

## Fix

Pass `--yes` at both call sites, matching what the uninstall endpoint already does (`["skills", "uninstall", name, "--yes"]`).

This does not weaken skill safety: `--yes` only skips the confirmation prompt. The security scan still runs before install, and a blocked verdict still refuses to install — overriding that requires `--force`, which neither endpoint passes. The quarantine → scan → verdict flow shown in the action log is unchanged.

Also updates the existing profile-builder test assertion to expect the new arg.

## Testing

- `pytest tests/hermes_cli/test_web_server.py -k "hub or install or profile"` — 29 passed
- Verified manually on a live v0.16.0 dashboard: with `--yes`, Browse Hub installs complete and the skill lands in `~/.hermes/skills/<name>/`; without it, every install cancels as described.

Fixes #43829

🤖 Generated with [Claude Code](https://claude.com/claude-code)