### PR TITLE
fix(dashboard): pass --yes to spawned skills hub installs

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7381,7 +7381,7 @@ async def install_skill_hub(body: SkillInstallRequest):
     if not identifier:
         raise HTTPException(status_code=400, detail="identifier is required")
     try:
-        proc = _spawn_hermes_action(["skills", "install", identifier], "skills-install")
+        proc = _spawn_hermes_action(["skills", "install", identifier, "--yes"], "skills-install")
     except Exception as exc:
         _log.exception("Failed to spawn skills install")
         raise HTTPException(status_code=500, detail=f"Failed to install skill: {exc}")
@@ -8082,7 +8082,7 @@ async def create_profile_endpoint(body: ProfileCreate):
             continue
         try:
             proc = _spawn_hermes_action(
-                ["-p", body.name, "skills", "install", ident],
+                ["-p", body.name, "skills", "install", ident, "--yes"],
                 "skills-install",
             )
             hub_installs.append({"identifier": ident, "pid": proc.pid})

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2486,7 +2486,7 @@ class TestNewEndpoints:
         assert data["hub_installs"] == [{"identifier": "someuser/some-skill", "pid": 4321}]
 
         # Hub install was scoped to the new profile.
-        assert spawned == [(["-p", "builder", "skills", "install", "someuser/some-skill"], "skills-install")]
+        assert spawned == [(["-p", "builder", "skills", "install", "someuser/some-skill", "--yes"], "skills-install")]
 
         # Verify the writes landed in the NEW profile's config, not the root.
         prof_dir = get_hermes_home() / "profiles" / "builder"
@@ -2501,6 +2501,30 @@ class TestNewEndpoints:
             assert "keep-me" not in disabled
         finally:
             reset_hermes_home_override(token)
+
+    def test_skill_hub_install_spawns_with_yes(self, monkeypatch):
+        """Dashboard hub installs must skip the TTY confirmation prompt (#43829)."""
+        import hermes_cli.web_server as web_server
+
+        spawned = []
+
+        class _FakeProc:
+            pid = 9999
+
+        monkeypatch.setattr(
+            web_server,
+            "_spawn_hermes_action",
+            lambda args, name: spawned.append((args, name)) or _FakeProc(),
+        )
+
+        resp = self.client.post(
+            "/api/skills/hub/install",
+            json={"identifier": "someuser/some-skill"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "skills-install"
+        assert spawned == [(["skills", "install", "someuser/some-skill", "--yes"], "skills-install")]
 
     def test_profile_open_terminal_uses_macos_terminal(self, monkeypatch):
         from hermes_constants import get_hermes_home


### PR DESCRIPTION
## Summary

Dashboard Browse Hub and profile-builder hub installs spawn `hermes skills install` without a TTY. The confirmation prompt defaults to cancel.

## Fix

Add `--yes` to both hub install spawn sites in `hermes_cli/web_server.py`, matching the uninstall path.

Fixes #43829

## Verification

```bash
uv run pytest tests/hermes_cli/test_web_server.py::TestNewEndpoints::test_skill_hub_install_spawns_with_yes -q
```