### PR TITLE
fix(desktop): keep chat mounted under settings overlay

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -226,6 +226,11 @@ export function DesktopController() {
   } = useOverlayRouting()
 
   const terminalSidebarOpen = chatOpen && terminalTakeover
+  // Skills/messaging/artifacts replace the main pane; overlay routes (settings,
+  // command-center, …) only stack a modal — chat must stay mounted so the
+  // composer draft survives a route change like / → /settings (#43825).
+  const fullPageMainView =
+    currentView === 'skills' || currentView === 'messaging' || currentView === 'artifacts'
 
   const titlebarToolGroups = useGroupRegistry<TitlebarTool>()
   const statusbarItemGroups = useGroupRegistry<StatusbarItem>()
@@ -1013,9 +1018,10 @@ export function DesktopController() {
         </Pane>
       )}
       <PaneMain>
+        {!fullPageMainView ? chatView : null}
         <Routes>
-          <Route element={chatView} index />
-          <Route element={chatView} path=":sessionId" />
+          <Route element={null} index />
+          <Route element={null} path=":sessionId" />
           <Route
             element={
               <Suspense fallback={null}>
@@ -1040,11 +1046,11 @@ export function DesktopController() {
             }
             path="artifacts"
           />
-          <Route element={chatView} path="cron" />
-          <Route element={chatView} path="profiles" />
-          <Route element={chatView} path="settings" />
-          <Route element={chatView} path="command-center" />
-          <Route element={chatView} path="agents" />
+          <Route element={null} path="cron" />
+          <Route element={null} path="profiles" />
+          <Route element={null} path="settings" />
+          <Route element={null} path="command-center" />
+          <Route element={null} path="agents" />
           <Route element={<Navigate replace to={NEW_CHAT_ROUTE} />} path="new" />
           <Route element={<LegacySessionRedirect />} path="sessions/:sessionId" />
           <Route element={<Navigate replace to={NEW_CHAT_ROUTE} />} path="*" />

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -1040,11 +1040,11 @@ export function DesktopController() {
             }
             path="artifacts"
           />
-          <Route element={null} path="cron" />
-          <Route element={null} path="profiles" />
-          <Route element={null} path="settings" />
-          <Route element={null} path="command-center" />
-          <Route element={null} path="agents" />
+          <Route element={chatView} path="cron" />
+          <Route element={chatView} path="profiles" />
+          <Route element={chatView} path="settings" />
+          <Route element={chatView} path="command-center" />
+          <Route element={chatView} path="agents" />
           <Route element={<Navigate replace to={NEW_CHAT_ROUTE} />} path="new" />
           <Route element={<LegacySessionRedirect />} path="sessions/:sessionId" />
           <Route element={<Navigate replace to={NEW_CHAT_ROUTE} />} path="*" />

--- a/apps/desktop/src/app/overlay-routes.test.ts
+++ b/apps/desktop/src/app/overlay-routes.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+import { OVERLAY_VIEWS, SETTINGS_ROUTE, appViewForPath } from './routes'
+
+/**
+ * Regression for #43825: overlay routes must keep ChatView mounted so the
+ * assistant-ui composer draft survives opening Settings (and other overlays).
+ */
+describe('overlay routes preserve chat mount', () => {
+  it('settings is an overlay view, not chat', () => {
+    expect(OVERLAY_VIEWS.has('settings')).toBe(true)
+    expect(appViewForPath(SETTINGS_ROUTE)).toBe('settings')
+  })
+
+  it('desktop controller mounts chatView on overlay paths', () => {
+    const controllerPath = join(dirname(fileURLToPath(import.meta.url)), 'desktop-controller.tsx')
+    const source = readFileSync(controllerPath, 'utf8')
+
+    for (const route of ['settings', 'command-center', 'agents', 'cron', 'profiles']) {
+      expect(source).toContain(`<Route element={chatView} path="${route}" />`)
+      expect(source).not.toContain(`<Route element={null} path="${route}" />`)
+    }
+  })
+})

--- a/apps/desktop/src/app/overlay-routes.test.ts
+++ b/apps/desktop/src/app/overlay-routes.test.ts
@@ -7,8 +7,9 @@ import { describe, expect, it } from 'vitest'
 import { OVERLAY_VIEWS, SETTINGS_ROUTE, appViewForPath } from './routes'
 
 /**
- * Regression for #43825: overlay routes must keep ChatView mounted so the
- * assistant-ui composer draft survives opening Settings (and other overlays).
+ * Regression for #43825: overlay navigation must not unmount ChatView.
+ * Mounting chat on the overlay Route still remounts when switching / → /settings;
+ * chat is rendered outside <Routes> for non-full-page views instead.
  */
 describe('overlay routes preserve chat mount', () => {
   it('settings is an overlay view, not chat', () => {
@@ -16,12 +17,21 @@ describe('overlay routes preserve chat mount', () => {
     expect(appViewForPath(SETTINGS_ROUTE)).toBe('settings')
   })
 
-  it('desktop controller mounts chatView on overlay paths', () => {
+  it('desktop controller keeps chat outside Routes for overlay navigation', () => {
     const controllerPath = join(dirname(fileURLToPath(import.meta.url)), 'desktop-controller.tsx')
     const source = readFileSync(controllerPath, 'utf8')
 
+    expect(source).toContain('fullPageMainView')
+    expect(source).toContain('{!fullPageMainView ? chatView : null}')
+    expect(source).toContain('<Route element={null} index />')
+    expect(source).toContain('<Route element={null} path=":sessionId" />')
+    expect(source).not.toMatch(/<Route element=\{chatView\}/)
+
     for (const route of ['settings', 'command-center', 'agents', 'cron', 'profiles']) {
-      expect(source).toContain(`<Route element={chatView} path="${route}" />`)
+      expect(source).toContain(`<Route element={null} path="${route}" />`)
+    }
+
+    for (const route of ['skills', 'messaging', 'artifacts']) {
       expect(source).not.toContain(`<Route element={null} path="${route}" />`)
     }
   })


### PR DESCRIPTION
## Summary

Opening Settings navigated to `/settings`, which changed the matched React Router `<Route>`. That unmounted `ChatView` and destroyed the in-progress composer draft held in assistant-ui state (`useAuiState(s => s.composer.text)`).

An earlier approach mounted `chatView` on the overlay routes themselves; that still remounts when switching `/` → `/settings` because the matched route element changes.

## Fix

Render `chatView` **outside** `<Routes>` whenever the current view is not a full-page replacement (`skills`, `messaging`, `artifacts`). Overlay routes (`settings`, `command-center`, `agents`, `cron`, `profiles`) keep `element={null}` — the modal overlays render separately, while chat stays mounted underneath.

**Tradeoff:** gateway/message hooks continue while an overlay is open (chat is mounted but `chatOpen` is false, so side panes stay disabled). Draft retention is the goal.

**Out of scope:** navigating to `skills` / `messaging` / `artifacts` still unmounts chat (full-page views) — unchanged.

Fixes #43825

## Verification

```bash
cd apps/desktop && npm run test:ui -- src/app/overlay-routes.test.ts
```

Result: PASS (2 tests)