### PR TITLE
fix(desktop): resolve hermes CLI via login shell on Linux

### DIFF
--- a/apps/desktop/electron/backend-probes.cjs
+++ b/apps/desktop/electron/backend-probes.cjs
@@ -64,6 +64,38 @@ function canImportHermesCli(pythonPath) {
   }
 }
 
+/** Commands permitted for login-shell PATH probes (prevents shell injection). */
+const LOGIN_SHELL_COMMAND_ALLOWLIST = new Set(['hermes'])
+
+/**
+ * Resolve a command via the user's login shell PATH.
+ *
+ * Electron apps on Linux (especially NixOS) often inherit a stripped PATH
+ * that omits profile/nix-shell entries where `hermes` is installed. A login
+ * shell probe matches what `hermes setup` users get in their terminal.
+ *
+ * @param {string} command
+ * @returns {string|null}
+ */
+function findCommandOnLoginShell(command) {
+  if (!command || IS_WINDOWS || !LOGIN_SHELL_COMMAND_ALLOWLIST.has(command)) return null
+  try {
+    const stdout = execFileSync('sh', ['-lc', `command -v ${command}`], {
+      encoding: 'utf8',
+      timeout: PROBE_TIMEOUT_MS,
+      stdio: ['ignore', 'pipe', 'ignore']
+    })
+    const resolved = String(stdout || '')
+      .trim()
+      .split('\n')
+      .pop()
+      ?.trim()
+    return resolved || null
+  } catch {
+    return null
+  }
+}
+
 /**
  * Return true iff `<hermesCommand> --version` exits 0.
  *
@@ -85,35 +117,6 @@ function canImportHermesCli(pythonPath) {
  *   in resolveHermesBackend.
  * @returns {boolean}
  */
-/**
- * Resolve a command via the user's login shell PATH.
- *
- * Electron apps on Linux (especially NixOS) often inherit a stripped PATH
- * that omits profile/nix-shell entries where `hermes` is installed. A login
- * shell probe matches what `hermes setup` users get in their terminal.
- *
- * @param {string} command
- * @returns {string|null}
- */
-function findCommandOnLoginShell(command) {
-  if (!command || IS_WINDOWS) return null
-  try {
-    const stdout = execFileSync('sh', ['-lc', `command -v ${command}`], {
-      encoding: 'utf8',
-      timeout: PROBE_TIMEOUT_MS,
-      stdio: ['ignore', 'pipe', 'ignore']
-    })
-    const resolved = String(stdout || '')
-      .trim()
-      .split('\n')
-      .pop()
-      ?.trim()
-    return resolved || null
-  } catch {
-    return null
-  }
-}
-
 function verifyHermesCli(hermesCommand, opts = {}) {
   if (!hermesCommand) return false
   try {

--- a/apps/desktop/electron/backend-probes.cjs
+++ b/apps/desktop/electron/backend-probes.cjs
@@ -35,6 +35,7 @@
 const { execFileSync } = require('node:child_process')
 
 const PROBE_TIMEOUT_MS = 5000
+const IS_WINDOWS = process.platform === 'win32'
 
 /**
  * Return true iff `python -c "import hermes_cli"` exits 0.
@@ -84,6 +85,35 @@ function canImportHermesCli(pythonPath) {
  *   in resolveHermesBackend.
  * @returns {boolean}
  */
+/**
+ * Resolve a command via the user's login shell PATH.
+ *
+ * Electron apps on Linux (especially NixOS) often inherit a stripped PATH
+ * that omits profile/nix-shell entries where `hermes` is installed. A login
+ * shell probe matches what `hermes setup` users get in their terminal.
+ *
+ * @param {string} command
+ * @returns {string|null}
+ */
+function findCommandOnLoginShell(command) {
+  if (!command || IS_WINDOWS) return null
+  try {
+    const stdout = execFileSync('sh', ['-lc', `command -v ${command}`], {
+      encoding: 'utf8',
+      timeout: PROBE_TIMEOUT_MS,
+      stdio: ['ignore', 'pipe', 'ignore']
+    })
+    const resolved = String(stdout || '')
+      .trim()
+      .split('\n')
+      .pop()
+      ?.trim()
+    return resolved || null
+  } catch {
+    return null
+  }
+}
+
 function verifyHermesCli(hermesCommand, opts = {}) {
   if (!hermesCommand) return false
   try {
@@ -101,6 +131,7 @@ function verifyHermesCli(hermesCommand, opts = {}) {
 
 module.exports = {
   canImportHermesCli,
+  findCommandOnLoginShell,
   verifyHermesCli,
   PROBE_TIMEOUT_MS
 }

--- a/apps/desktop/electron/backend-probes.test.cjs
+++ b/apps/desktop/electron/backend-probes.test.cjs
@@ -11,7 +11,7 @@ const fs = require('node:fs')
 const os = require('node:os')
 const path = require('node:path')
 
-const { canImportHermesCli, verifyHermesCli } = require('./backend-probes.cjs')
+const { canImportHermesCli, findCommandOnLoginShell, verifyHermesCli } = require('./backend-probes.cjs')
 
 // Resolve the host's own Node binary -- guaranteed to be on disk and
 // runnable. We use it as both a stand-in for "a python that doesn't
@@ -79,4 +79,20 @@ test('verifyHermesCli swallows timeouts (does not throw)', () => {
   // (because the binary is missing) returns false rather than
   // propagating. Same code path the timeout case takes.
   assert.equal(verifyHermesCli('/definitely/not/a/real/binary/anywhere'), false)
+})
+
+test('findCommandOnLoginShell returns null for falsy command', () => {
+  assert.equal(findCommandOnLoginShell(''), null)
+  assert.equal(findCommandOnLoginShell(null), null)
+})
+
+test('findCommandOnLoginShell resolves sh on POSIX hosts', () => {
+  if (process.platform === 'win32') {
+    assert.equal(findCommandOnLoginShell('sh'), null)
+    return
+  }
+
+  const resolved = findCommandOnLoginShell('sh')
+  assert.ok(resolved)
+  assert.match(resolved, /sh$/)
 })

--- a/apps/desktop/electron/backend-probes.test.cjs
+++ b/apps/desktop/electron/backend-probes.test.cjs
@@ -86,13 +86,16 @@ test('findCommandOnLoginShell returns null for falsy command', () => {
   assert.equal(findCommandOnLoginShell(null), null)
 })
 
-test('findCommandOnLoginShell resolves sh on POSIX hosts', () => {
-  if (process.platform === 'win32') {
-    assert.equal(findCommandOnLoginShell('sh'), null)
+test('findCommandOnLoginShell rejects commands outside allowlist', () => {
+  assert.equal(findCommandOnLoginShell('sh'), null)
+  assert.equal(findCommandOnLoginShell('python'), null)
+  assert.equal(findCommandOnLoginShell('hermes; rm -rf /'), null)
+})
+
+test('findCommandOnLoginShell is a no-op on Windows', () => {
+  if (process.platform !== 'win32') {
     return
   }
 
-  const resolved = findCommandOnLoginShell('sh')
-  assert.ok(resolved)
-  assert.match(resolved, /sh$/)
+  assert.equal(findCommandOnLoginShell('hermes'), null)
 })

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -27,7 +27,7 @@ const { execFileSync, spawn } = require('node:child_process')
 const { detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment } = require('./bootstrap-platform.cjs')
 const { runBootstrap } = require('./bootstrap-runner.cjs')
 const { buildSessionWindowUrl, createSessionWindowRegistry } = require('./session-windows.cjs')
-const { canImportHermesCli, verifyHermesCli } = require('./backend-probes.cjs')
+const { canImportHermesCli, findCommandOnLoginShell, verifyHermesCli } = require('./backend-probes.cjs')
 const { probeGatewayWebSocket } = require('./gateway-ws-probe.cjs')
 const { serializeJsonBody, setJsonRequestHeaders } = require('./oauth-net-request.cjs')
 const { fetchMarketplaceThemes, searchMarketplaceThemes } = require('./vscode-marketplace.cjs')
@@ -2157,6 +2157,9 @@ function resolveHermesBackend(dashboardArgs) {
       }
     } else {
       hermesCommand = findOnPath('hermes')
+      if (!hermesCommand && process.platform !== 'win32') {
+        hermesCommand = findCommandOnLoginShell('hermes')
+      }
     }
 
     if (hermesCommand) {


### PR DESCRIPTION
## Summary

On Linux/NixOS, Hermes Desktop can inherit a stripped `PATH` that omits nix profile shims where `hermes` is installed after `hermes setup`. The resolver then falls through to first-launch bootstrap even though the CLI works in the user's shell.

## Fix

When `findOnPath('hermes')` misses on non-Windows hosts, fall back to `sh -lc 'command -v hermes'` before bootstrap.

Fixes #42923

## Notes

This addresses PATH visibility for packaged Desktop launches. The separate "pick existing folder" validation for `~/.hermes` without a checkout tree may still need follow-up if that UI path remains broken on Nix.

## Verification

```bash
cd apps/desktop && node --test electron/backend-probes.test.cjs
```