### PR TITLE
fix(desktop): read session token from .env to avoid BWS mismatch

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -256,7 +256,12 @@ function readSessionTokenFromEnvFile() {
       if (eqIdx === -1) continue
       const key = trimmed.slice(0, eqIdx).trim()
       if (key === 'HERMES_DASHBOARD_SESSION_TOKEN') {
-        return trimmed.slice(eqIdx + 1).trim()
+        let value = trimmed.slice(eqIdx + 1).trim()
+        if ((value.startsWith('"') && value.endsWith('"')) ||
+            (value.startsWith("'") && value.endsWith("'"))) {
+          value = value.slice(1, -1)
+        }
+        return value
       }
     }
   } catch { /* best effort */ }

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -242,6 +242,27 @@ function resolveHermesHome() {
 }
 
 const HERMES_HOME = resolveHermesHome()
+const ENV_PATH = path.join(HERMES_HOME, '.env')
+
+/** Read HERMES_DASHBOARD_SESSION_TOKEN from the .env file. */
+function readSessionTokenFromEnvFile() {
+  try {
+    if (!fs.existsSync(ENV_PATH)) return null
+    const content = fs.readFileSync(ENV_PATH, 'utf8')
+    for (const line of content.split('\n')) {
+      const trimmed = line.trim()
+      if (trimmed.startsWith('#')) continue
+      const eqIdx = trimmed.indexOf('=')
+      if (eqIdx === -1) continue
+      const key = trimmed.slice(0, eqIdx).trim()
+      if (key === 'HERMES_DASHBOARD_SESSION_TOKEN') {
+        return trimmed.slice(eqIdx + 1).trim()
+      }
+    }
+  } catch { /* best effort */ }
+  return null
+}
+
 // ACTIVE_HERMES_ROOT — the canonical mutable Hermes install. Same path
 // install.ps1 / install.sh use, so a desktop-only user and a CLI-only user end
 // up with identical layouts and can share one install.
@@ -4679,7 +4700,13 @@ async function startHermes() {
 
     await advanceBootProgress('backend.port', 'Finding an open local port', 16)
     const port = await pickPort()
-    const token = crypto.randomBytes(32).toString('base64url')
+    // Use the HERMES_DASHBOARD_SESSION_TOKEN from the .env file.  When
+    // Bitwarden Secrets Manager is active it applies secrets to the spawned
+    // child process (overriding any random token we set in the env), so the
+    // renderer must present the same token the backend will end up using.
+    // Reading from .env is safe — it is the same file the backend reads at
+    // import time.
+    const token = readSessionTokenFromEnvFile() || crypto.randomBytes(32).toString('base64url')
     const dashboardArgs = ['dashboard', '--no-open', '--host', '127.0.0.1', '--port', String(port)]
     // Pin the desktop's chosen profile via the global --profile flag. This is
     // deterministic (it wins over the sticky ~/.hermes/active_profile file) and


### PR DESCRIPTION
## Problem

When Bitwarden Secrets Manager (BWS) is active, the Hermes Desktop shows **"Could not connect to Hermes gateway"** or a white screen. The Desktop is unusable.

**Root cause chain:**
1. Electron main process generates a random `HERMES_DASHBOARD_SESSION_TOKEN` and passes it to the renderer
2. The same random token is set in the spawned backend env
3. BWS applies 31 secrets to the child process at startup, **overriding** the random token with the one from `~/.hermes/.env`
4. The renderer connects to WebSocket with the random token → 403 → "Could not connect"

The `ps -E` output shows the spawn-time env (random token), not what Python `os.environ` sees after BWS runs — which made this particularly hard to diagnose.

## Fix

Read `HERMES_DASHBOARD_SESSION_TOKEN` from `~/.hermes/.env` (the same file the Python backend reads at import time) so the renderer and backend always agree on the token. Falls back to `crypto.randomBytes()` when `.env` has no token (non-BWS setups).

## Testing

- Verified WebSocket connects with the .env token
- Verified zero restart loops in desktop.log
- Desktop UI loads and functions normally