### PR TITLE
fix(cli): allow configured Discord read tool

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -147,7 +147,10 @@ def _xai_credentials_present() -> bool:
 # server admin, Slack workspace admin, etc.).  Keeps every other platform's
 # checklist from filling up with irrelevant toggles.
 _TOOLSET_PLATFORM_RESTRICTIONS: Dict[str, Set[str]] = {
-    "discord": {"discord"},
+    # Non-admin Discord read/participate is useful from the CLI as an
+    # operations surface, too. It remains opt-in and runtime-gated by
+    # DISCORD_BOT_TOKEN. Admin actions stay Discord-platform only.
+    "discord": {"cli", "discord"},
     "discord_admin": {"discord"},
 }
 

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -1245,18 +1245,21 @@ def test_discord_toolsets_in_default_off():
     assert "discord_admin" in _DEFAULT_OFF_TOOLSETS
 
 
-def test_discord_toolsets_not_available_on_other_platforms():
-    """Platform-scoping: discord / discord_admin should not appear on CLI,
-    Telegram, etc. — not even as an opt-in."""
+def test_discord_toolsets_platform_scoping():
+    """Platform-scoping: read/participate Discord is allowed on CLI + Discord
+    as an explicit opt-in; admin actions remain Discord-platform only."""
     from hermes_cli.tools_config import _toolset_allowed_for_platform
-    for plat in ["cli", "telegram", "slack", "whatsapp", "signal"]:
+
+    assert _toolset_allowed_for_platform("discord", "cli")
+    assert _toolset_allowed_for_platform("discord", "discord")
+    for plat in ["telegram", "slack", "whatsapp", "signal"]:
         assert not _toolset_allowed_for_platform("discord", plat), (
             f"`discord` toolset leaked onto {plat}"
         )
         assert not _toolset_allowed_for_platform("discord_admin", plat), (
             f"`discord_admin` toolset leaked onto {plat}"
         )
-    assert _toolset_allowed_for_platform("discord", "discord")
+    assert not _toolset_allowed_for_platform("discord_admin", "cli")
     assert _toolset_allowed_for_platform("discord_admin", "discord")
 
 
@@ -1264,6 +1267,14 @@ def test_discord_toolsets_user_enabled_are_honored():
     """When the user opts in via `hermes tools`, the toolset appears."""
     config = {"platform_toolsets": {"discord": ["web", "terminal", "discord"]}}
     enabled = _get_platform_tools(config, "discord")
+    assert "discord" in enabled
+    assert "discord_admin" not in enabled
+
+
+def test_discord_toolset_user_enabled_on_cli_is_honored():
+    """CLI can opt into non-admin Discord read/participate without admin tools."""
+    config = {"platform_toolsets": {"cli": ["web", "terminal", "discord", "discord_admin"]}}
+    enabled = _get_platform_tools(config, "cli")
     assert "discord" in enabled
     assert "discord_admin" not in enabled
 


### PR DESCRIPTION
## What does this PR do?

Allows the non-admin Discord read/participate toolset to be explicitly enabled for CLI sessions while keeping `discord_admin` restricted to the Discord platform.

This fixes the current mismatch where the read-only Discord tool is useful as an operator surface from the CLI, but platform scoping strips it even when the user explicitly enables it. Runtime schema exposure remains gated by `DISCORD_BOT_TOKEN`.

## Related Issue

No linked issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/tools_config.py`: allow the non-admin `discord` toolset on `cli` and `discord`, while keeping `discord_admin` Discord-platform-only.
- `tests/hermes_cli/test_tools_config.py`: update platform-scoping coverage and add a CLI opt-in regression that proves `discord` is honored while `discord_admin` is stripped.

## How to Test

1. Duplicate search performed before PR creation: no open PR hits for `configured Discord read tool`, `Discord read CLI`, `discord_admin CLI tools_config`, `allow configured Discord read tool`, or `DISCORD_BOT_TOKEN CLI discord toolset`.
2. Run focused test suite:
   `python -m pytest -q -o 'addopts=' tests/hermes_cli/test_tools_config.py`
3. Result: `100 passed in 6.59s`.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux, Python 3.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — this PR does not add a skill.

## Screenshots / Logs

```text
$ python -m pytest -q -o 'addopts=' tests/hermes_cli/test_tools_config.py
........................................................................ [ 72%]
............................                                             [100%]
100 passed in 6.59s
```
