### PR TITLE
fix: never signal the wrong process — recycled-PID and port-cleanup kill-safety

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -34,8 +34,46 @@ from hermes_constants import get_hermes_dir
 logger = logging.getLogger(__name__)
 
 
+def _listener_pids_on_port(port: int) -> list:
+    """PIDs of processes *listening* on ``port`` (POSIX) — never clients.
+
+    This must match only LISTEN sockets. A bare ``lsof -i :PORT`` (or
+    ``fuser PORT/tcp``) also returns *clients* whose connection merely involves
+    that port number — e.g. a browser with a tab open on a local dev server
+    sharing the port. SIGTERMing those closed the user's browser at irregular
+    intervals. Restricting to LISTEN state frees the port for a new bridge
+    without ever touching an unrelated client.
+    """
+    pids: list = []
+    try:
+        result = subprocess.run(
+            ["lsof", "-ti", f"tcp:{port}", "-sTCP:LISTEN"],
+            capture_output=True, text=True, timeout=5,
+        )
+        for line in result.stdout.strip().splitlines():
+            try:
+                pids.append(int(line))
+            except ValueError:
+                pass
+        if pids:
+            return pids
+    except FileNotFoundError:
+        pass  # lsof not installed — fall through to ss
+    # Fallback: ss (iproute2, present on virtually every modern Linux).
+    try:
+        result = subprocess.run(
+            ["ss", "-ltnHp", f"sport = :{port}"],
+            capture_output=True, text=True, timeout=5,
+        )
+        for m in re.finditer(r"pid=(\d+)", result.stdout):
+            pids.append(int(m.group(1)))
+    except FileNotFoundError:
+        pass
+    return pids
+
+
 def _kill_port_process(port: int) -> None:
-    """Kill any process listening on the given TCP port."""
+    """Kill any process *listening* on the given TCP port (a stale bridge)."""
     try:
         if _IS_WINDOWS:
             # Use netstat to find the PID bound to this port, then taskkill
@@ -56,35 +94,14 @@ def _kill_port_process(port: int) -> None:
                         except subprocess.SubprocessError:
                             pass
         else:
-            # Try fuser first (Linux), fall back to lsof (macOS / WSL2)
-            killed = False
-            try:
-                result = subprocess.run(
-                    ["fuser", f"{port}/tcp"],
-                    capture_output=True, timeout=5,
-                )
-                if result.returncode == 0:
-                    subprocess.run(
-                        ["fuser", "-k", f"{port}/tcp"],
-                        capture_output=True, timeout=5,
-                    )
-                    killed = True
-            except FileNotFoundError:
-                pass  # fuser not installed
-
-            if not killed:
+            # POSIX: only ever signal a process LISTENING on the port. A client
+            # whose connection happens to involve this port number (a browser
+            # tab on a local dev server, etc.) must never be killed.
+            for pid in _listener_pids_on_port(port):
                 try:
-                    result = subprocess.run(
-                        ["lsof", "-ti", f":{port}"],
-                        capture_output=True, text=True, timeout=5,
-                    )
-                    for pid_str in result.stdout.strip().splitlines():
-                        try:
-                            os.kill(int(pid_str), signal.SIGTERM)
-                        except (ValueError, ProcessLookupError, PermissionError):
-                            pass
-                except FileNotFoundError:
-                    pass  # lsof not installed either
+                    os.kill(pid, signal.SIGTERM)
+                except (ProcessLookupError, PermissionError, OSError):
+                    pass
     except Exception:
         pass
 

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -89,33 +89,80 @@ def _kill_port_process(port: int) -> None:
         pass
 
 
+def _bridge_pid_is_ours(pid: int, session_path: Path, expected_start) -> bool:
+    """True only if ``pid`` is alive AND still our node bridge for this session.
+
+    The PID is read from a file written by a previous run.  Once that process
+    exits and is reaped the kernel can recycle the number onto an unrelated
+    process — observed in the wild landing on a desktop browser's main process,
+    which a bare-liveness ``os.kill`` then SIGTERMed, closing the whole browser
+    at irregular intervals (every time the flapping bridge restarted).
+
+    Identity is confirmed two ways: the kernel start time captured when we wrote
+    the pidfile (definitive), and — for legacy pidfiles with no baseline — the
+    command line, which must contain ``node`` and this session's unique path.
+    A recycled PID (different start time / different cmdline) is never ours.
+    """
+    from gateway.status import _pid_exists
+    if not _pid_exists(pid):
+        return False
+    if expected_start is not None:
+        from gateway.status import get_process_start_time
+        # A matching (pid, start time) pair uniquely identifies the process.
+        return get_process_start_time(pid) == expected_start
+    # Legacy pidfile (no recorded start time): fall back to a command-line
+    # signature so a recycled PID is still never signalled.  If we cannot read
+    # the cmdline we refuse to kill rather than risk a stranger.
+    from gateway.status import _read_process_cmdline
+    cmdline = _read_process_cmdline(pid)
+    if not cmdline:
+        return False
+    return ("node" in cmdline) and (str(session_path) in cmdline)
+
+
 def _kill_stale_bridge_by_pidfile(session_path: Path) -> None:
     """Kill a bridge process recorded in a PID file from a previous run.
 
     The bridge writes ``bridge.pid`` into the session directory when it
     starts.  If the gateway crashed without a clean shutdown the old bridge
     process becomes orphaned — this helper finds and kills it.
+
+    Critically, the recorded PID is re-validated against the live process
+    (:func:`_bridge_pid_is_ours`) before any signal, so a recycled PID that now
+    names an unrelated process (e.g. the user's browser) is never killed.
     """
     pid_file = session_path / "bridge.pid"
     if not pid_file.exists():
         return
+    pid = None
+    recorded_start = None
     try:
-        pid = int(pid_file.read_text().strip())
-    except (ValueError, OSError, TypeError):
+        # Format: line 1 = pid, optional line 2 = kernel start time. Legacy
+        # files written before the guard existed have only the pid.
+        lines = pid_file.read_text().split("\n")
+        pid = int(lines[0].strip())
+        if len(lines) > 1 and lines[1].strip():
+            recorded_start = int(lines[1].strip())
+    except (ValueError, OSError, TypeError, IndexError):
         try:
             pid_file.unlink()
         except OSError:
             pass
         return
-    # ``os.kill(pid, 0)`` is NOT a no-op on Windows (bpo-14484) — use the
-    # cross-platform existence check before sending a real signal.
-    from gateway.status import _pid_exists
-    if _pid_exists(pid):
+    if _bridge_pid_is_ours(pid, session_path, recorded_start):
         try:
             os.kill(pid, signal.SIGTERM)
             logger.info("[whatsapp] Killed stale bridge PID %d from pidfile", pid)
         except (ProcessLookupError, PermissionError, OSError):
             pass
+    else:
+        from gateway.status import _pid_exists
+        if _pid_exists(pid):
+            logger.warning(
+                "[whatsapp] Not killing pidfile PID %d: it is no longer the "
+                "bridge (recycled onto an unrelated process); skipping to avoid "
+                "killing a stranger.", pid,
+            )
     try:
         pid_file.unlink()
     except OSError:
@@ -123,9 +170,17 @@ def _kill_stale_bridge_by_pidfile(session_path: Path) -> None:
 
 
 def _write_bridge_pidfile(session_path: Path, pid: int) -> None:
-    """Write the bridge PID to a file for later cleanup."""
+    """Write the bridge PID (and its kernel start time) for later cleanup.
+
+    The start time on line 2 lets a future run prove the PID still names this
+    exact process before signalling it, so a recycled PID can never be killed
+    as a "stale bridge". Older single-line files remain readable.
+    """
     try:
-        (session_path / "bridge.pid").write_text(str(pid))
+        from gateway.status import get_process_start_time
+        start = get_process_start_time(pid)
+        text = str(pid) if start is None else "{}\n{}".format(pid, start)
+        (session_path / "bridge.pid").write_text(text)
     except OSError:
         pass
 

--- a/tests/gateway/test_whatsapp_bridge_pidfile.py
+++ b/tests/gateway/test_whatsapp_bridge_pidfile.py
@@ -19,12 +19,17 @@ import time
 
 import pytest
 
+import os
+import socket
+
 from gateway.platforms.whatsapp import (
     _bridge_pid_is_ours,
+    _kill_port_process,
     _kill_stale_bridge_by_pidfile,
+    _listener_pids_on_port,
     _write_bridge_pidfile,
 )
-from gateway.status import get_process_start_time
+from gateway.status import get_process_start_time, _pid_exists
 
 
 def _spawn_sleeper(*extra_argv) -> subprocess.Popen:
@@ -116,3 +121,66 @@ class TestIdentityGuard:
     def test_missing_pidfile_is_noop(self, tmp_path):
         # No file -> must not raise.
         _kill_stale_bridge_by_pidfile(tmp_path)
+
+
+class TestKillPortProcess:
+    """Freeing the bridge port must target only LISTENers, never clients.
+
+    Root cause of the live Firefox kills: ``lsof -ti :PORT`` (and ``fuser
+    PORT/tcp``) also returned *client* sockets whose connection merely involved
+    the port number. The WhatsApp bridge uses port 3000 by default — a common
+    local dev-server port — so a browser tab on ``localhost:3000`` was matched
+    and SIGTERMed every time the (crash-looping) bridge restarted.
+    """
+
+    def test_listener_lookup_excludes_client_process(self):
+        srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        srv.bind(("127.0.0.1", 0))
+        port = srv.getsockname()[1]
+        srv.listen(5)
+        # A separate process holding a *client* connection to that port.
+        client = subprocess.Popen([
+            sys.executable, "-c",
+            "import socket,time; c=socket.create_connection(('127.0.0.1',%d)); time.sleep(30)" % port,
+        ])
+        try:
+            conn, _ = srv.accept()  # establish the client connection
+            pids = _listener_pids_on_port(port)
+            if os.getpid() not in pids:
+                pytest.skip("neither lsof nor ss detected the listener here")
+            # The listener (this process) is found; the client process is NOT —
+            # the LISTEN filter is what spares unrelated clients like a browser.
+            assert client.pid not in pids
+            conn.close()
+        finally:
+            client.kill()
+            client.wait()
+            srv.close()
+
+    def test_kill_port_spares_client_process(self):
+        # Listener in a SEPARATE process — the legitimate kill target. This
+        # pytest process is the CLIENT: if port cleanup matched clients it would
+        # SIGTERM the test runner, so simply reaching the asserts proves the
+        # client was spared.
+        listener = subprocess.Popen(
+            [
+                sys.executable, "-c",
+                "import socket,time;"
+                "s=socket.socket();s.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1);"
+                "s.bind(('127.0.0.1',0));print(s.getsockname()[1],flush=True);"
+                "s.listen(5);time.sleep(30)",
+            ],
+            stdout=subprocess.PIPE, text=True,
+        )
+        try:
+            port = int(listener.stdout.readline().strip())
+            cli = socket.create_connection(("127.0.0.1", port))  # we are the client
+            _kill_port_process(port)
+            assert _pid_exists(os.getpid()), "client (test process) must survive"
+            assert _wait_dead(listener, timeout=5.0), "stale listener should be killed"
+            cli.close()
+        finally:
+            if listener.poll() is None:
+                listener.kill()
+                listener.wait()

--- a/tests/gateway/test_whatsapp_bridge_pidfile.py
+++ b/tests/gateway/test_whatsapp_bridge_pidfile.py
@@ -1,0 +1,118 @@
+"""Regression tests: the WhatsApp stale-bridge cleanup must never kill a stranger.
+
+The bridge records its PID in ``bridge.pid``. On the next start the gateway
+SIGTERMs that PID to reap an orphaned bridge. The original code checked only
+that the PID was *alive* — but once the bridge exits and is reaped the kernel
+can recycle its number onto an unrelated process. Because the WhatsApp bridge
+crash-loops, this cleanup ran constantly, and a recycled PID that had landed on
+the user's browser main process got SIGTERMed, closing the browser at irregular
+intervals (no crash, no coredump — a clean kill of a stranger).
+
+These tests prove the identity guard: a PID is only signalled when it is still
+our bridge (kernel start time matches, or — for legacy pidfiles — its command
+line names node + this session). A recycled PID is left alone.
+"""
+
+import subprocess
+import sys
+import time
+
+import pytest
+
+from gateway.platforms.whatsapp import (
+    _bridge_pid_is_ours,
+    _kill_stale_bridge_by_pidfile,
+    _write_bridge_pidfile,
+)
+from gateway.status import get_process_start_time
+
+
+def _spawn_sleeper(*extra_argv) -> subprocess.Popen:
+    """Spawn a real, short-lived process; optional extra argv shapes its cmdline."""
+    return subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(30)", *extra_argv]
+    )
+
+
+def _wait_dead(proc: subprocess.Popen, timeout: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            return True
+        time.sleep(0.05)
+    return False
+
+
+class TestWriteAndRoundTrip:
+    def test_pidfile_records_pid_and_start_time(self, tmp_path):
+        proc = _spawn_sleeper()
+        try:
+            _write_bridge_pidfile(tmp_path, proc.pid)
+            lines = (tmp_path / "bridge.pid").read_text().split("\n")
+            assert int(lines[0]) == proc.pid
+            # Line 2 is the kernel start time (present on Linux).
+            assert int(lines[1]) == get_process_start_time(proc.pid)
+        finally:
+            proc.kill()
+            proc.wait()
+
+
+class TestIdentityGuard:
+    def test_kills_when_start_time_matches(self, tmp_path):
+        """A genuine bridge (recorded start time matches) IS reaped."""
+        proc = _spawn_sleeper()
+        try:
+            _write_bridge_pidfile(tmp_path, proc.pid)
+            _kill_stale_bridge_by_pidfile(tmp_path)
+            assert _wait_dead(proc), "the real bridge process should be killed"
+            assert not (tmp_path / "bridge.pid").exists()
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait()
+
+    def test_spares_recycled_pid_start_time_mismatch(self, tmp_path):
+        """Alive PID whose start time changed (recycled) is NOT signalled."""
+        proc = _spawn_sleeper()
+        try:
+            real_start = get_process_start_time(proc.pid)
+            # Pidfile claims a different start time -> simulates a recycled PID.
+            (tmp_path / "bridge.pid").write_text("{}\n{}".format(proc.pid, real_start + 1))
+            _kill_stale_bridge_by_pidfile(tmp_path)
+            assert not _wait_dead(proc, timeout=1.0), "recycled PID must survive"
+            assert proc.poll() is None
+        finally:
+            proc.kill()
+            proc.wait()
+
+    def test_legacy_pidfile_spares_non_bridge_cmdline(self, tmp_path):
+        """Legacy pidfile (pid only): a PID that isn't node+session is spared."""
+        proc = _spawn_sleeper()  # cmdline is just python -c ... — not a bridge
+        try:
+            (tmp_path / "bridge.pid").write_text(str(proc.pid))  # legacy: pid only
+            _kill_stale_bridge_by_pidfile(tmp_path)
+            assert not _wait_dead(proc, timeout=1.0), "stranger must survive"
+            assert proc.poll() is None
+        finally:
+            proc.kill()
+            proc.wait()
+
+    def test_legacy_pidfile_kills_matching_bridge_cmdline(self, tmp_path):
+        """Legacy pidfile: a PID whose cmdline names node + session IS reaped."""
+        # Shape the cmdline to look like the node bridge for this session.
+        proc = _spawn_sleeper("node", str(tmp_path))
+        try:
+            (tmp_path / "bridge.pid").write_text(str(proc.pid))  # legacy: pid only
+            _kill_stale_bridge_by_pidfile(tmp_path)
+            assert _wait_dead(proc), "a cmdline-confirmed bridge should be killed"
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait()
+
+    def test_is_ours_false_for_dead_pid(self, tmp_path):
+        assert _bridge_pid_is_ours(999999999, tmp_path, None) is False
+
+    def test_missing_pidfile_is_noop(self, tmp_path):
+        # No file -> must not raise.
+        _kill_stale_bridge_by_pidfile(tmp_path)

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1263,3 +1263,121 @@ class TestTerminateHostPidPosix:
         pr.ProcessRegistry._terminate_host_pid(12345)
 
         assert kill_calls == [(12345, signal.SIGTERM)]
+
+
+# =========================================================================
+# PID-reuse guard — a recycled PID/PGID must never be signalled.
+#
+# Regression: once a background-session process exits and is reaped, the kernel
+# can recycle its PID onto an unrelated process (observed in the wild landing on
+# a desktop browser's session leader, whose whole tree we then SIGTERMed —
+# Firefox dying at irregular intervals).  Identity is re-validated via the
+# kernel start time captured at spawn before any signal is sent.
+# =========================================================================
+
+class TestPidReuseGuard:
+    def test_terminate_refuses_when_start_time_mismatches(self, registry):
+        """A live PID whose start time changed (recycled) is NOT killed."""
+        proc = _spawn_python_sleep(30)
+        try:
+            real_start = ProcessRegistry._safe_host_start_time(proc.pid)
+            assert real_start is not None, "no /proc start time on this platform?"
+            # Simulate recycling: the recorded baseline no longer matches.
+            registry._terminate_host_pid(proc.pid, expected_start=real_start + 1)
+            # The process must still be alive — the guard refused to signal it.
+            assert not _wait_until(lambda: proc.poll() is not None, timeout=1.0)
+            assert proc.poll() is None
+        finally:
+            proc.kill()
+            proc.wait()
+
+    def test_terminate_kills_when_start_time_matches(self, registry):
+        """The genuine process (start time matches) IS terminated."""
+        proc = _spawn_python_sleep(30)
+        try:
+            real_start = ProcessRegistry._safe_host_start_time(proc.pid)
+            registry._terminate_host_pid(proc.pid, expected_start=real_start)
+            assert _wait_until(lambda: proc.poll() is not None, timeout=5.0)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait()
+
+    def test_terminate_without_baseline_is_best_effort(self, registry):
+        """No baseline (legacy) → degrade to prior unconditional behaviour."""
+        proc = _spawn_python_sleep(30)
+        try:
+            registry._terminate_host_pid(proc.pid)  # expected_start=None
+            assert _wait_until(lambda: proc.poll() is not None, timeout=5.0)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait()
+
+    def test_recover_skips_recycled_pid(self, registry, tmp_path):
+        """Checkpoint PID is alive but its start time changed → not adopted."""
+        wrong_start = (ProcessRegistry._safe_host_start_time(os.getpid()) or 0) + 999
+        checkpoint = tmp_path / "procs.json"
+        checkpoint.write_text(json.dumps([{
+            "session_id": "proc_recycled",
+            "command": "sleep 999",
+            "pid": os.getpid(),            # alive...
+            "pid_scope": "host",
+            "host_start_time": wrong_start,  # ...but a different process now
+            "task_id": "t1",
+        }]))
+        with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
+            assert registry.recover_from_checkpoint() == 0
+            assert len(registry._running) == 0
+
+    def test_recover_adopts_when_start_time_matches(self, registry, tmp_path):
+        """Checkpoint PID alive AND start time matches → adopted as before."""
+        real_start = ProcessRegistry._safe_host_start_time(os.getpid())
+        checkpoint = tmp_path / "procs.json"
+        checkpoint.write_text(json.dumps([{
+            "session_id": "proc_match",
+            "command": "sleep 999",
+            "pid": os.getpid(),
+            "pid_scope": "host",
+            "host_start_time": real_start,
+            "task_id": "t1",
+        }]))
+        with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
+            assert registry.recover_from_checkpoint() == 1
+
+    def test_legacy_checkpoint_without_start_time_still_recovers(self, registry, tmp_path):
+        """Entries written before host_start_time existed degrade to liveness."""
+        checkpoint = tmp_path / "procs.json"
+        checkpoint.write_text(json.dumps([{
+            "session_id": "proc_legacy",
+            "command": "sleep 999",
+            "pid": os.getpid(),
+            "pid_scope": "host",
+            "task_id": "t1",
+        }]))
+        with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
+            assert registry.recover_from_checkpoint() == 1
+
+    def test_write_checkpoint_backfills_host_start_time(self, registry, tmp_path):
+        """A host session is checkpointed with a kernel start time recorded."""
+        with patch("tools.process_registry.CHECKPOINT_PATH", tmp_path / "procs.json"):
+            s = _make_session()
+            s.pid = os.getpid()
+            s.pid_scope = "host"
+            registry._running[s.id] = s
+            registry._write_checkpoint()
+            data = json.loads((tmp_path / "procs.json").read_text())
+            assert data[0]["host_start_time"] is not None
+
+    def test_refresh_detached_marks_recycled_pid_exited(self, registry):
+        """A detached session whose PID got recycled is moved to finished."""
+        wrong_start = (ProcessRegistry._safe_host_start_time(os.getpid()) or 0) + 999
+        s = _make_session(sid="proc_detached")
+        s.pid = os.getpid()          # alive, but...
+        s.pid_scope = "host"
+        s.detached = True
+        s.host_start_time = wrong_start  # ...identity no longer matches
+        registry._running[s.id] = s
+        refreshed = registry._refresh_detached_session(s)
+        assert refreshed.exited is True
+        assert s.id in registry._finished

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -97,7 +97,8 @@ class ProcessSession:
     process: Optional[subprocess.Popen] = None  # Popen handle (local only)
     env_ref: Any = None                         # Reference to the environment object
     cwd: Optional[str] = None                   # Working directory
-    started_at: float = 0.0                     # time.time() of spawn
+    started_at: float = 0.0                     # time.time() of spawn (wall clock)
+    host_start_time: Optional[int] = None       # kernel start ticks (/proc/<pid>/stat f22) — PID-reuse guard
     exited: bool = False                        # Whether the process has finished
     exit_code: Optional[int] = None             # Exit code (None if still running)
     output_buffer: str = ""                     # Rolling output (last MAX_OUTPUT_CHARS)
@@ -413,12 +414,47 @@ class ProcessRegistry:
         from gateway.status import _pid_exists
         return _pid_exists(pid)
 
+    @staticmethod
+    def _safe_host_start_time(pid: Optional[int]) -> Optional[int]:
+        """Kernel start ticks for a host PID, or None when unavailable."""
+        if not pid:
+            return None
+        try:
+            from gateway.status import get_process_start_time
+            return get_process_start_time(pid)
+        except Exception:
+            return None
+
+    @classmethod
+    def _host_pid_is_ours(cls, pid: Optional[int], expected_start: Optional[int]) -> bool:
+        """True only if ``pid`` is alive AND still the process we spawned.
+
+        The kernel recycles PID/PGID numbers once a process exits and is reaped,
+        so a stored PID can later name an *unrelated* process — observed in the
+        wild as a recycled number landing on a desktop browser's session leader,
+        which our tree-kill then SIGTERMs (Firefox dying at irregular intervals).
+        We compare the kernel start time captured at spawn against the live one;
+        a mismatch means the number was recycled and must never be signalled.
+
+        When no baseline was captured (legacy checkpoints, or platforms without
+        ``/proc``) we degrade to a bare liveness check rather than refusing to
+        act, preserving prior best-effort behaviour.
+        """
+        if not cls._is_host_pid_alive(pid):
+            return False
+        if expected_start is None:
+            return True
+        return cls._safe_host_start_time(pid) == expected_start
+
     def _refresh_detached_session(self, session: Optional[ProcessSession]) -> Optional[ProcessSession]:
         """Update recovered host-PID sessions when the underlying process has exited."""
         if session is None or session.exited or not session.detached or session.pid_scope != "host":
             return session
 
-        if self._is_host_pid_alive(session.pid):
+        # Identity-aware liveness: a recycled PID (alive but a different process
+        # than we spawned) must be treated as "our process exited", so it is
+        # moved to finished and can never be tree-killed by a later kill().
+        if self._host_pid_is_ours(session.pid, session.host_start_time):
             return session
 
         with session._lock:
@@ -432,9 +468,15 @@ class ProcessRegistry:
         self._move_to_finished(session)
         return session
 
-    @staticmethod
-    def _terminate_host_pid(pid: int) -> None:
+    @classmethod
+    def _terminate_host_pid(cls, pid: int, expected_start: Optional[int] = None) -> None:
         """Terminate a host-visible PID and its descendants.
+
+        ``expected_start`` is the kernel start time captured when we spawned the
+        process. When provided, it is re-validated against the live PID before
+        any signal is sent; a mismatch (or a dead PID) means the number was
+        recycled onto an unrelated process and we refuse to touch it, so a stale
+        background-session PID can never tree-kill a browser or other stranger.
 
         POSIX: walks the process tree with ``psutil`` and SIGTERMs
         children before the parent so subprocess trees (e.g. Chromium
@@ -464,6 +506,15 @@ class ProcessRegistry:
         POSIX and a missing ``taskkill.exe`` on Windows (effectively
         unreachable on real Windows installs, but cheap insurance).
         """
+        if expected_start is not None and not cls._host_pid_is_ours(pid, expected_start):
+            # PID was recycled (start time changed) or is gone — never signal a
+            # stranger. A leaked orphan is strictly preferable to killing e.g.
+            # a browser whose session leader reused this dead session's PID.
+            logger.warning(
+                "Refusing to terminate host pid %d: start-time mismatch — "
+                "PID was recycled onto an unrelated process.", pid,
+            )
+            return
         if _IS_WINDOWS:
             try:
                 subprocess.run(
@@ -558,6 +609,7 @@ class ProcessRegistry:
                     dimensions=(30, 120),
                 )
                 session.pid = pty_proc.pid
+                session.host_start_time = self._safe_host_start_time(session.pid)
                 # Store the pty handle on the session for read/write
                 session._pty = pty_proc
 
@@ -610,6 +662,7 @@ class ProcessRegistry:
 
         session.process = proc
         session.pid = proc.pid
+        session.host_start_time = self._safe_host_start_time(session.pid)
 
         try:
             # Start output reader thread
@@ -1174,7 +1227,10 @@ class ProcessRegistry:
                 # Non-local -- kill inside sandbox
                 session.env_ref.execute(f"kill {session.pid} 2>/dev/null", timeout=5)
             elif session.detached and session.pid_scope == "host" and session.pid:
-                if not self._is_host_pid_alive(session.pid):
+                # Identity check, not bare liveness: if the PID is gone OR was
+                # recycled onto an unrelated process, treat our process as
+                # exited and never tree-kill the stranger.
+                if not self._host_pid_is_ours(session.pid, session.host_start_time):
                     with session._lock:
                         session.exited = True
                         session.exit_code = None
@@ -1183,7 +1239,7 @@ class ProcessRegistry:
                         "status": "already_exited",
                         "exit_code": session.exit_code,
                     }
-                self._terminate_host_pid(session.pid)
+                self._terminate_host_pid(session.pid, session.host_start_time)
             else:
                 return {
                     "status": "error",
@@ -1383,11 +1439,17 @@ class ProcessRegistry:
                 entries = []
                 for s in self._running.values():
                     if not s.exited:
+                        # Lazily backfill the kernel start time for host PIDs so
+                        # recovery after restart can detect PID recycling even
+                        # for sessions spawned before this field existed.
+                        if s.host_start_time is None and s.pid_scope == "host" and s.pid:
+                            s.host_start_time = self._safe_host_start_time(s.pid)
                         entries.append({
                             "session_id": s.id,
                             "command": s.command,
                             "pid": s.pid,
                             "pid_scope": s.pid_scope,
+                            "host_start_time": s.host_start_time,
                             "cwd": s.cwd,
                             "started_at": s.started_at,
                             "task_id": s.task_id,
@@ -1442,49 +1504,63 @@ class ProcessRegistry:
                 )
                 continue
 
-            # Check if PID is still alive
-            alive = self._is_host_pid_alive(pid)
+            # The PID must be alive AND still the same process we spawned. A
+            # bare liveness check is unsafe: across a restart (especially a
+            # reboot or long uptime) the kernel may have recycled this number
+            # onto an unrelated process — adopting it would let a later kill or
+            # watcher tree-kill a stranger (e.g. a browser). Re-validate the
+            # kernel start time recorded in the checkpoint.
+            recorded_start = entry.get("host_start_time")
+            if not self._host_pid_is_ours(pid, recorded_start):
+                if self._is_host_pid_alive(pid):
+                    logger.info(
+                        "Not recovering session %s: pid %d is alive but its "
+                        "start time no longer matches — PID was recycled onto "
+                        "an unrelated process; refusing to adopt it.",
+                        entry.get("session_id", "?"), pid,
+                    )
+                continue
 
-            if alive:
-                session = ProcessSession(
-                    id=entry["session_id"],
-                    command=entry.get("command", "unknown"),
-                    task_id=entry.get("task_id", ""),
-                    session_key=entry.get("session_key", ""),
-                    pid=pid,
-                    pid_scope=pid_scope,
-                    cwd=entry.get("cwd"),
-                    started_at=entry.get("started_at", time.time()),
-                    detached=True,  # Can't read output, but can report status + kill
-                    watcher_platform=entry.get("watcher_platform", ""),
-                    watcher_chat_id=entry.get("watcher_chat_id", ""),
-                    watcher_user_id=entry.get("watcher_user_id", ""),
-                    watcher_user_name=entry.get("watcher_user_name", ""),
-                    watcher_thread_id=entry.get("watcher_thread_id", ""),
-                    watcher_message_id=entry.get("watcher_message_id", ""),
-                    watcher_interval=entry.get("watcher_interval", 0),
-                    notify_on_complete=entry.get("notify_on_complete", False),
-                    watch_patterns=entry.get("watch_patterns", []),
-                )
-                with self._lock:
-                    self._running[session.id] = session
-                recovered += 1
-                logger.info("Recovered detached process: %s (pid=%d)", session.command[:60], pid)
+            session = ProcessSession(
+                id=entry["session_id"],
+                command=entry.get("command", "unknown"),
+                task_id=entry.get("task_id", ""),
+                session_key=entry.get("session_key", ""),
+                pid=pid,
+                host_start_time=recorded_start,
+                pid_scope=pid_scope,
+                cwd=entry.get("cwd"),
+                started_at=entry.get("started_at", time.time()),
+                detached=True,  # Can't read output, but can report status + kill
+                watcher_platform=entry.get("watcher_platform", ""),
+                watcher_chat_id=entry.get("watcher_chat_id", ""),
+                watcher_user_id=entry.get("watcher_user_id", ""),
+                watcher_user_name=entry.get("watcher_user_name", ""),
+                watcher_thread_id=entry.get("watcher_thread_id", ""),
+                watcher_message_id=entry.get("watcher_message_id", ""),
+                watcher_interval=entry.get("watcher_interval", 0),
+                notify_on_complete=entry.get("notify_on_complete", False),
+                watch_patterns=entry.get("watch_patterns", []),
+            )
+            with self._lock:
+                self._running[session.id] = session
+            recovered += 1
+            logger.info("Recovered detached process: %s (pid=%d)", session.command[:60], pid)
 
-                # Re-enqueue watcher so gateway can resume notifications
-                if session.watcher_interval > 0:
-                    self.pending_watchers.append({
-                        "session_id": session.id,
-                        "check_interval": session.watcher_interval,
-                        "session_key": session.session_key,
-                        "platform": session.watcher_platform,
-                        "chat_id": session.watcher_chat_id,
-                        "user_id": session.watcher_user_id,
-                        "user_name": session.watcher_user_name,
-                        "thread_id": session.watcher_thread_id,
-                        "message_id": session.watcher_message_id,
-                        "notify_on_complete": session.notify_on_complete,
-                    })
+            # Re-enqueue watcher so gateway can resume notifications
+            if session.watcher_interval > 0:
+                self.pending_watchers.append({
+                    "session_id": session.id,
+                    "check_interval": session.watcher_interval,
+                    "session_key": session.session_key,
+                    "platform": session.watcher_platform,
+                    "chat_id": session.watcher_chat_id,
+                    "user_id": session.watcher_user_id,
+                    "user_name": session.watcher_user_name,
+                    "thread_id": session.watcher_thread_id,
+                    "message_id": session.watcher_message_id,
+                    "notify_on_complete": session.notify_on_complete,
+                })
 
         self._write_checkpoint()
 


### PR DESCRIPTION
## Summary

Three independent code paths could send a fatal signal to a process the gateway
never owned, closing unrelated desktop apps (the user's browser) at irregular
intervals with no crash and no coredump. This hardens all three. Same hazard
class as #43046 (MCP orphan reaper), but in separate subsystems — kept as its
own PR for reviewability.

Proven live with the kernel `signal:signal_generate` tracepoint:
```
hermes-gateway → sig=15 (code=0 / SI_USER) → comm=firefox
```
captured right after a gateway start while Firefox held a socket on the bridge
port.

## The three fixes

1. **process_registry — re-validate host-PID identity before killing.**
   Recovery adoption, detached-session refresh, and `kill`/`_terminate_host_pid`
   signalled a stored PID guarded only by a liveness check. Once a session's
   process exits and is reaped the kernel recycles its PID onto an unrelated
   process, which then got tree-killed. Now each host PID records its kernel
   start time (`/proc/<pid>/stat` field 22) at spawn, persisted in the
   checkpoint, and re-validated before every signal.

2. **whatsapp — validate bridge PID identity before killing a stale pidfile entry.**
   `_kill_stale_bridge_by_pidfile` SIGTERMed the PID in `bridge.pid` after only a
   liveness check. Because the bridge crash-loops, this ran constantly; a
   recycled PID landing on the browser got killed. The pidfile now also records
   the kernel start time and the kill is gated on an identity match (start time,
   or a `node`+session cmdline signature for legacy pidfiles).

3. **whatsapp — free the bridge port by killing only LISTENers, never clients.**
   `_kill_port_process` used `lsof -ti :PORT` / `fuser PORT/tcp`, which match any
   socket whose local OR remote endpoint involves that port number — including
   ESTABLISHED client connections. With the bridge on the common port 3000, a
   browser tab connected to a `:3000` host was matched and SIGTERMed on every
   bridge restart. Now only LISTEN-state sockets are targeted
   (`lsof -sTCP:LISTEN`, with an `ss -ltnp` fallback); a client is never touched,
   which is also more correct since a client never blocks the new bind.

## Tests

Real-process / real-socket regression tests for each path: a recycled PID
(start-time mismatch, or non-bridge cmdline) and an unrelated client process are
proven to survive, while the genuine target is still reaped. Legacy
checkpoints/pidfiles (no recorded baseline) degrade to the prior best-effort
behavior. Local run: 85 passed against current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)