### PR TITLE
fix(web_server): add --yes to spawned skills install commands

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7381,7 +7381,7 @@ async def install_skill_hub(body: SkillInstallRequest):
     if not identifier:
         raise HTTPException(status_code=400, detail="identifier is required")
     try:
-        proc = _spawn_hermes_action(["skills", "install", identifier], "skills-install")
+        proc = _spawn_hermes_action(["skills", "install", identifier, "--yes"], "skills-install")
     except Exception as exc:
         _log.exception("Failed to spawn skills install")
         raise HTTPException(status_code=500, detail=f"Failed to install skill: {exc}")
@@ -8082,7 +8082,7 @@ async def create_profile_endpoint(body: ProfileCreate):
             continue
         try:
             proc = _spawn_hermes_action(
-                ["-p", body.name, "skills", "install", ident],
+                ["-p", body.name, "skills", "install", ident, "--yes"],
                 "skills-install",
             )
             hub_installs.append({"identifier": ident, "pid": proc.pid})

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4909,3 +4909,98 @@ class TestDesktopCronTicker:
 
         with self._client():
             assert not called.wait(0.5), "ticker must not run outside the desktop app"
+
+
+class TestSkillHubInstallYesFlag:
+    """Tests for the --yes flag on spawned skills install commands.
+
+    The dashboard spawns 'hermes skills install' as a background process.
+    Without --yes, the CLI prompts 'Confirm [y/N]:' and the process has no
+    stdin, so it immediately defaults to N and cancels the install.
+
+    Regression test for #43829.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, monkeypatch, _isolate_hermes_home):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+
+        import hermes_state
+        from hermes_constants import get_hermes_home
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db")
+        self.client = TestClient(app)
+        self.client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+
+    def test_hub_install_includes_yes_flag(self, monkeypatch):
+        """POST /api/skills/hub/install must spawn with --yes."""
+        import hermes_cli.web_server as web_server
+
+        calls = []
+
+        class _Proc:
+            pid = 12345
+
+        def fake_spawn(subcommand, name):
+            calls.append((subcommand, name))
+            return _Proc()
+
+        monkeypatch.setattr(web_server, "_spawn_hermes_action", fake_spawn)
+
+        resp = self.client.post("/api/skills/hub/install", json={"identifier": "my-skill"})
+        assert resp.status_code == 200
+        assert len(calls) == 1
+        assert calls[0][0] == ["skills", "install", "my-skill", "--yes"]
+
+    def test_hub_uninstall_already_has_yes_flag(self, monkeypatch):
+        """POST /api/skills/hub/uninstall already uses --yes (no regression)."""
+        import hermes_cli.web_server as web_server
+
+        calls = []
+
+        class _Proc:
+            pid = 12346
+
+        def fake_spawn(subcommand, name):
+            calls.append((subcommand, name))
+            return _Proc()
+
+        monkeypatch.setattr(web_server, "_spawn_hermes_action", fake_spawn)
+
+        resp = self.client.post("/api/skills/hub/uninstall", json={"name": "my-skill"})
+        assert resp.status_code == 200
+        assert len(calls) == 1
+        assert calls[0][0] == ["skills", "uninstall", "my-skill", "--yes"]
+
+    def test_profile_create_hub_skills_includes_yes_flag(self, monkeypatch):
+        """POST /api/profiles/create with hub_skills must spawn install with --yes."""
+        import hermes_cli.web_server as web_server
+        import hermes_cli.profiles as profiles_mod
+
+        calls = []
+
+        class _Proc:
+            pid = 12347
+
+        def fake_spawn(subcommand, name):
+            calls.append((subcommand, name))
+            return _Proc()
+
+        monkeypatch.setattr(web_server, "_spawn_hermes_action", fake_spawn)
+        monkeypatch.setattr(profiles_mod, "create_wrapper_script", lambda name: None)
+
+        resp = self.client.post("/api/profiles", json={
+            "name": "test-prof-hub",
+            "hub_skills": ["skill-a", "skill-b"],
+        })
+        assert resp.status_code == 200
+        # Should have 2 install calls, each with --yes
+        install_calls = [c for c in calls if "install" in c[0]]
+        assert len(install_calls) == 2
+        for subcommand, _ in install_calls:
+            assert "--yes" in subcommand, f"Missing --yes in {subcommand}"
+            assert "-p" in subcommand, f"Missing -p (profile) in {subcommand}"


### PR DESCRIPTION
## What does this PR do?

Adds the `--yes` flag to both `hermes skills install` spawn sites in the dashboard web server, so that hub skill installations from the "Browse Hub" UI and profile-builder no longer immediately cancel at the confirmation prompt.

## Related Issue

Fixes #43829

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py`: Added `"--yes"` to the spawned command in `POST /api/skills/hub/install` (line 7384), matching the pattern already used by the uninstall endpoint.
- `hermes_cli/web_server.py`: Added `"--yes"` to the profile-builder's optional hub-skill install spawn (line 8085), so new profiles with `hub_skills` also auto-confirm.
- `tests/hermes_cli/test_web_server.py`: Added `TestSkillHubInstallYesFlag` with 3 tests verifying both endpoints include `--yes` in the spawned argv.

## How to Test

1. Run `hermes dashboard` and navigate to the "Browse Hub" tab.
2. Click install on any community skill — it should complete successfully instead of showing "Installation cancelled."
3. Alternatively, run `pytest tests/hermes_cli/test_web_server.py::TestSkillHubInstallYesFlag -v` to verify the `--yes` flag is passed correctly.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `_spawn_hermes_action` call sites for `skills install` (2 locations in `hermes_cli/web_server.py`)
- Blast radius: LOW — only affects dashboard-initiated skill installs; the security scan → quarantine → verdict flow is unchanged (`--yes` only skips the confirmation prompt, not the security gate)
- Related patterns: The uninstall endpoint already uses `--yes` (line 7401), confirming this is the correct pattern
