### PR TITLE
fix(gateway): backfill missing assistant transcript rows

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3200,6 +3200,64 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         cfg = _load_gateway_runtime_config()
         return str(cfg_get(cfg, "agent", "system_prompt", default="") or "").strip()
 
+    def _db_tail_id(self, session_id: str) -> int | None:
+        """Return the current last SQLite message id for a gateway session."""
+        try:
+            if self._session_db is None:
+                return None
+            messages = self._session_db.get_messages(session_id)
+            if not messages:
+                return None
+            return int(messages[-1].get("id") or 0)
+        except Exception:
+            return None
+
+    def _ensure_visible_response_persisted(
+        self,
+        *,
+        session_id: str,
+        response: str | None,
+        tail_id_before_turn: int | None,
+    ) -> None:
+        """Backfill the visible assistant response if agent DB flush missed it.
+
+        Gateway transcript fallback skips SQLite writes when a SessionDB exists,
+        because the agent usually persists its own messages.  Early user-message
+        persistence can make that assumption false: the inbound user row may be
+        in SQLite while the final visible assistant response is not.  If that
+        happens, next-turn replay looks like a user-only backlog and the agent
+        treats already answered messages as unresolved.
+        """
+        if not response or self._session_db is None:
+            return
+        try:
+            messages = self._session_db.get_messages(session_id)
+            new_messages = []
+            for message in messages:
+                try:
+                    message_id = int(message.get("id") or 0)
+                except Exception:
+                    message_id = 0
+                if tail_id_before_turn is None or message_id > tail_id_before_turn:
+                    new_messages.append(message)
+            if any(message.get("role") == "assistant" for message in new_messages):
+                return
+            self._session_db.append_message(
+                session_id=session_id,
+                role="assistant",
+                content=response,
+            )
+            logger.warning(
+                "Backfilled missing assistant transcript row for gateway session %s",
+                session_id,
+            )
+        except Exception as exc:
+            logger.debug(
+                "assistant transcript persistence guard failed for %s: %s",
+                session_id,
+                exc,
+            )
+
     @staticmethod
     def _load_reasoning_config() -> dict | None:
         """Load reasoning effort from config.yaml.
@@ -8387,6 +8445,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
 
         try:
+            db_tail_id_before_turn = self._db_tail_id(session_entry.session_id)
+
             # Emit agent:start hook
             hook_ctx = {
                 "platform": source.platform.value if source.platform else "",
@@ -8744,6 +8804,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             session_entry.session_id, entry,
                             skip_db=agent_persisted,
                         )
+
+            self._ensure_visible_response_persisted(
+                session_id=session_entry.session_id,
+                response=response,
+                tail_id_before_turn=db_tail_id_before_turn,
+            )
             
             # Token counts and model are now persisted by the agent directly.
             # Keep only last_prompt_tokens here for context-window tracking and

--- a/tests/gateway/test_gateway_assistant_persistence.py
+++ b/tests/gateway/test_gateway_assistant_persistence.py
@@ -1,0 +1,94 @@
+"""Regression tests for gateway assistant transcript persistence."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from gateway.run import GatewayRunner
+
+
+class _FakeSessionDB:
+    def __init__(self, messages):
+        self.messages = list(messages)
+        self.appended = []
+
+    def get_messages(self, session_id):
+        assert session_id == "session-1"
+        return list(self.messages)
+
+    def append_message(self, *, session_id, role, content):
+        assert session_id == "session-1"
+        row = {"id": len(self.messages) + 1, "role": role, "content": content}
+        self.messages.append(row)
+        self.appended.append(row)
+
+
+def _runner_with_db(messages):
+    runner = object.__new__(GatewayRunner)
+    db = _FakeSessionDB(messages)
+    runner_any = runner  # type: Any
+    runner_any._session_db = db
+    return runner, db
+
+
+def test_backfills_visible_assistant_response_when_agent_db_flush_missed_it():
+    """A visible gateway response must be present in SQLite replay history.
+
+    This covers the regression where the agent persisted the inbound user row
+    early, gateway skipped DB fallback writes because a SessionDB existed, and
+    the final assistant response was sent to the platform but missing from
+    state.db.  Next-turn replay then looked like a user-only backlog.
+    """
+    runner, db = _runner_with_db(
+        [
+            {"id": 1, "role": "user", "content": "previous"},
+            {"id": 2, "role": "assistant", "content": "previous reply"},
+            {"id": 3, "role": "user", "content": "latest user"},
+        ]
+    )
+
+    runner._ensure_visible_response_persisted(
+        session_id="session-1",
+        response="latest assistant reply",
+        tail_id_before_turn=2,
+    )
+
+    assert db.appended == [
+        {"id": 4, "role": "assistant", "content": "latest assistant reply"}
+    ]
+
+
+def test_does_not_duplicate_when_agent_already_persisted_assistant_response():
+    runner, db = _runner_with_db(
+        [
+            {"id": 1, "role": "user", "content": "previous"},
+            {"id": 2, "role": "assistant", "content": "previous reply"},
+            {"id": 3, "role": "user", "content": "latest user"},
+            {"id": 4, "role": "assistant", "content": "latest assistant reply"},
+        ]
+    )
+
+    runner._ensure_visible_response_persisted(
+        session_id="session-1",
+        response="latest assistant reply",
+        tail_id_before_turn=2,
+    )
+
+    assert db.appended == []
+
+
+def test_no_response_means_no_backfill():
+    runner, db = _runner_with_db(
+        [
+            {"id": 1, "role": "user", "content": "previous"},
+            {"id": 2, "role": "user", "content": "latest user"},
+        ]
+    )
+
+    runner._ensure_visible_response_persisted(
+        session_id="session-1",
+        response=None,
+        tail_id_before_turn=1,
+    )
+
+    assert db.appended == []


### PR DESCRIPTION
## Summary
- add a gateway persistence guard that backfills the visible assistant response into `state.db` when agent-side DB flush misses it
- preserve the existing duplicate-user/duplicate-transcript protection by only writing when no assistant row exists after the pre-turn DB tail
- add regression tests for the user-only backlog replay failure mode

## Why
A gateway turn can persist the inbound user message early, return/send a visible assistant response, but skip DB fallback writes because `SessionDB` exists. If the assistant row is missing from SQLite, the next gateway replay can look like a long user-only backlog, causing the agent to treat already answered messages as unresolved.

This restores the invariant: if the gateway visibly sends an assistant response, replay history must contain an assistant row for that response.

Closes #43849

## Test Plan
- `python -m pytest -q -o addopts='' tests/gateway/test_gateway_assistant_persistence.py`
- `python -m pytest -q -o addopts='' tests/gateway/test_gateway_assistant_persistence.py tests/run_agent/test_860_dedup.py tests/gateway/test_telegram_group_gating.py`
