### PR TITLE
fix(cron): explicit UTF-8 encoding for script stdout capture

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1049,6 +1049,7 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             argv,
             capture_output=True,
             text=True,
+            encoding="utf-8",
             timeout=script_timeout,
             cwd=str(path.parent),
             env=run_env,


### PR DESCRIPTION
## Problem

The gateway sets `PYTHONIOENCODING=utf-8` (in `gateway_windows.py`, `stdio.py`, `__init__.py`), causing child processes to output UTF-8 bytes. But `subprocess.run(text=True)` in `_run_job_script` uses `locale.getpreferredencoding()` to decode, which varies by system locale (GBK on zh-CN Windows, cp1252 on Western European Windows, etc.).

This encoding mismatch causes `UnicodeDecodeError` in the pipe reader thread, silently dropping stdout and returning `returncode=0` with empty output. The scheduler then logs "script produced no output, skipping AI call" and the job is treated as SILENT.

**Impact**: All cron jobs with scripts that output non-ASCII characters (Chinese, emoji, accented letters, etc.) are silently broken on non-UTF-8 systems. The scripts run successfully but their output is lost in transit.

## Fix

Add `encoding="utf-8"` to the `subprocess.run()` call in `_run_job_script`, matching the gateway's `PYTHONIOENCODING=utf-8`.

```python
# Before
result = subprocess.run(
    argv,
    capture_output=True,
    text=True,
    ...
)

# After
result = subprocess.run(
    argv,
    capture_output=True,
    text=True,
    encoding="utf-8",
    ...
)
```

## Reproduction

1. On a Windows system with non-UTF-8 default locale (e.g. zh-CN with GBK)
2. Create a cron job with a script that prints non-ASCII characters (e.g. `print("🎉 test")`)
3. Run it — "script produced no output" despite the script executing successfully

## Related Issues

Closes #38633, closes #42384, closes #42785