### PR TITLE
fix(acp): gate Windows→/mnt path translation behind is_wsl() in _path_from_file_uri

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -147,16 +147,41 @@ def _image_data_url(data: bytes, mime_type: str) -> str:
     return f"data:{mime_type};base64,{base64.b64encode(data).decode('ascii')}"
 
 
+def _drive_letter_path(drive: str, rest: str) -> Path:
+    """Build a readable Path for a Windows drive-letter path.
+
+    Under WSL the Windows filesystem is only reachable through the
+    ``/mnt/<drive>/`` mount, so rewrite to that form. On native Windows — and
+    any other non-WSL host — keep the real drive path. Mirrors the ``is_wsl()``
+    guard in ``session._translate_acp_cwd``; without it a native-Windows client
+    gets a bogus ``/mnt/c/...`` path that does not exist.
+    """
+    from hermes_constants import is_wsl
+
+    tail = rest.lstrip("/\\").replace("\\", "/")
+    if is_wsl():
+        return Path("/mnt") / drive.lower() / tail
+    return Path(f"{drive.upper()}:/{tail}")
+
+
 def _path_from_file_uri(uri: str) -> Path | None:
     """Convert local file URIs/paths from ACP clients into a readable Path.
 
-    Zed may send POSIX file URIs from Linux/WSL workspaces or Windows-ish paths
-    when launched through wsl.exe. Translate the common Windows drive form to
-    /mnt/<drive>/... so Hermes running in WSL can read it.
+    Zed may send POSIX ``file://`` URIs from Linux/WSL workspaces, Windows
+    drive URIs/paths (``file:///C:/...`` or ``C:\\Users\\...``), or bare POSIX
+    paths. Windows drive paths are rewritten to ``/mnt/<drive>/...`` only when
+    Hermes itself runs inside WSL; on native Windows the real drive path is
+    returned (see ``_drive_letter_path``).
     """
     raw = (uri or "").strip()
     if not raw:
         return None
+
+    # Bare Windows drive paths (``C:\Users\...`` / ``C:/Users/...``) must be
+    # handled before urlparse, which parses the leading drive letter as a URL
+    # scheme ("c:") and would trip the non-file scheme guard below.
+    if len(raw) >= 2 and raw[1] == ":" and raw[0].isalpha():
+        return _drive_letter_path(raw[0], raw[2:])
 
     parsed = urlparse(raw)
     if parsed.scheme and parsed.scheme != "file":
@@ -169,15 +194,12 @@ def _path_from_file_uri(uri: str) -> Path | None:
     else:
         path_text = unquote(raw)
 
-    # file:///C:/Users/... or C:\Users\...
+    # file:///C:/Users/... — drive letter sits after the URI's leading slash.
     if len(path_text) >= 3 and path_text[0] == "/" and path_text[2] == ":" and path_text[1].isalpha():
-        drive = path_text[1].lower()
-        rest = path_text[3:].lstrip("/\\").replace("\\", "/")
-        return Path("/mnt") / drive / rest
+        return _drive_letter_path(path_text[1], path_text[3:])
+    # Bare drive form only visible after percent-decoding (e.g. ``C%3A\...``).
     if len(path_text) >= 2 and path_text[1] == ":" and path_text[0].isalpha():
-        drive = path_text[0].lower()
-        rest = path_text[2:].lstrip("/\\").replace("\\", "/")
-        return Path("/mnt") / drive / rest
+        return _drive_letter_path(path_text[0], path_text[2:])
 
     return Path(path_text)
 

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -36,7 +36,12 @@ from acp.schema import (
     UserMessageChunk,
 )
 from acp_adapter.auth import TERMINAL_SETUP_AUTH_METHOD_ID
-from acp_adapter.server import HermesACPAgent, HERMES_VERSION
+from acp_adapter.server import (
+    HermesACPAgent,
+    HERMES_VERSION,
+    _drive_letter_path,
+    _path_from_file_uri,
+)
 from acp_adapter.session import SessionManager
 from hermes_state import SessionDB
 
@@ -1841,3 +1846,71 @@ class TestRegisterSessionMcpServers:
         with patch("tools.mcp_tool.register_mcp_servers", side_effect=RuntimeError("boom")):
             # Should not raise
             await agent._register_session_mcp_servers(state, [server])
+
+
+# ---------------------------------------------------------------------------
+# _path_from_file_uri — Windows drive handling gated on is_wsl()
+# ---------------------------------------------------------------------------
+
+
+class TestPathFromFileUri:
+    """ACP clients can reference files as ``file:///C:/...`` URIs or bare
+    ``C:\\...`` paths. The ``/mnt/<drive>/`` rewrite is only correct when Hermes
+    itself runs inside WSL; on native Windows the real drive path must be kept,
+    mirroring the ``is_wsl()`` guard in ``session._translate_acp_cwd``.
+
+    Results are compared via ``.as_posix()`` so the assertions hold on both a
+    Windows test runner (``WindowsPath``) and Linux CI (``PosixPath``).
+    """
+
+    def test_drive_uri_returns_native_path_off_wsl(self, monkeypatch):
+        monkeypatch.setattr("hermes_constants._wsl_detected", False)
+        result = _path_from_file_uri("file:///C:/Users/foo/bar.txt")
+        assert result is not None
+        assert result.as_posix() == "C:/Users/foo/bar.txt"
+
+    def test_bare_drive_path_returns_native_path_off_wsl(self, monkeypatch):
+        monkeypatch.setattr("hermes_constants._wsl_detected", False)
+        # Bare backslash paths used to be rejected outright because urlparse
+        # reads the drive letter as scheme "c:"; they must now resolve.
+        result = _path_from_file_uri(r"C:\Users\foo\bar.txt")
+        assert result is not None
+        assert result.as_posix() == "C:/Users/foo/bar.txt"
+
+    def test_forward_slash_drive_path_off_wsl(self, monkeypatch):
+        monkeypatch.setattr("hermes_constants._wsl_detected", False)
+        result = _path_from_file_uri("D:/work/project")
+        assert result is not None
+        assert result.as_posix() == "D:/work/project"
+
+    def test_drive_uri_maps_to_mnt_on_wsl(self, monkeypatch):
+        monkeypatch.setattr("hermes_constants._wsl_detected", True)
+        result = _path_from_file_uri("file:///C:/Users/foo/bar.txt")
+        assert result is not None
+        assert result.as_posix() == "/mnt/c/Users/foo/bar.txt"
+
+    def test_bare_drive_path_maps_to_mnt_on_wsl(self, monkeypatch):
+        monkeypatch.setattr("hermes_constants._wsl_detected", True)
+        result = _path_from_file_uri(r"E:\Projects\AI\paperclip")
+        assert result is not None
+        assert result.as_posix() == "/mnt/e/Projects/AI/paperclip"
+
+    def test_posix_file_uri_unchanged_on_wsl(self, monkeypatch):
+        monkeypatch.setattr("hermes_constants._wsl_detected", True)
+        result = _path_from_file_uri("file:///home/user/notes.md")
+        assert result is not None
+        assert result.as_posix() == "/home/user/notes.md"
+
+    def test_non_file_scheme_returns_none(self, monkeypatch):
+        monkeypatch.setattr("hermes_constants._wsl_detected", False)
+        assert _path_from_file_uri("https://example.com/x") is None
+
+    def test_blank_uri_returns_none(self):
+        assert _path_from_file_uri("") is None
+        assert _path_from_file_uri("   ") is None
+
+    def test_drive_letter_path_helper_gates_on_wsl(self, monkeypatch):
+        monkeypatch.setattr("hermes_constants._wsl_detected", False)
+        assert _drive_letter_path("c", "/Users/foo").as_posix() == "C:/Users/foo"
+        monkeypatch.setattr("hermes_constants._wsl_detected", True)
+        assert _drive_letter_path("c", "/Users/foo").as_posix() == "/mnt/c/Users/foo"


### PR DESCRIPTION
## What does this PR do?

`_path_from_file_uri` (ACP resource handling) rewrote Windows drive paths to
`/mnt/<drive>/…` **unconditionally**, even when Hermes is not running under WSL.
On native Windows `/mnt/c/…` does not exist, so any file an ACP client (e.g. Zed)
referenced became unreadable. Two symptoms, one root cause:

- `file:///C:/Users/foo.txt` → `\mnt\c\Users\foo.txt` (nonexistent path)
- bare `C:\Users\foo.txt` → `None` — `urlparse` reads the drive letter as a URL
  scheme (`c:`), so the non-file scheme guard rejects it before the drive branch

The fix mirrors the sibling `session._translate_acp_cwd`, which already gates the
same translation behind `is_wsl()`.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `acp_adapter/server.py`: add `_drive_letter_path()` — maps a drive path to
  `/mnt/<drive>/…` **only** when `is_wsl()`, otherwise returns the real drive
  path. `_path_from_file_uri` now detects bare `C:\…` / `C:/…` before `urlparse`
  (so the scheme guard no longer drops them) and routes both the `file:///C:/…`
  and bare forms through the helper. POSIX URI handling is unchanged.
- `tests/acp/test_server.py`: add `TestPathFromFileUri` (9 cases).

## How to Test

`_path_from_file_uri` output with `is_wsl()` monkeypatched:

| Input | `is_wsl()` False | `is_wsl()` True |
|---|---|---|
| `file:///C:/Users/foo/bar.txt` | `C:/Users/foo/bar.txt` | `/mnt/c/Users/foo/bar.txt` |
| `C:\Users\foo\bar.txt` | `C:/Users/foo/bar.txt` | `/mnt/c/Users/foo/bar.txt` |
| `file:///home/user/notes.md` | `/home/user/notes.md` | `/home/user/notes.md` |

```
pytest tests/acp/test_server.py::TestPathFromFileUri -q   # -> 9 passed
pytest tests/acp/test_server.py tests/acp/test_session.py -q   # -> 130 passed
```

## Checklist

- [x] Commit messages follow Conventional Commits (`fix(acp):`)
- [x] PR contains only changes related to this fix
- [x] Added tests for the change (required for bug fixes)
- [x] Considered cross-platform impact (WSL vs native)