### PR TITLE
feat(feishu): add interactive card buttons for clarify prompts

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1470,6 +1470,9 @@ class FeishuAdapter(BasePlatformAdapter):
         # Update prompt button state (prompt_id → {session_key, message_id, chat_id})
         self._update_prompt_state: Dict[int, Dict[str, str]] = {}
         self._update_prompt_counter = itertools.count(1)
+        # Clarify button state (clarify_id_int → {session_key, clarify_id, message_id, chat_id})
+        self._clarify_state: Dict[int, Dict[str, str]] = {}
+        self._clarify_counter = itertools.count(1)
         # Feishu reaction deletion requires the opaque reaction_id returned
         # by create, so we cache it per message_id.
         self._pending_processing_reactions: "OrderedDict[str, str]" = OrderedDict()
@@ -2000,6 +2003,243 @@ class FeishuAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.warning("[Feishu] send_update_prompt failed: %s", exc)
             return SendResult(success=False, error=str(exc))
+
+    # ------------------------------------------------------------------
+    # Clarify interactive card
+    # ------------------------------------------------------------------
+
+    async def send_clarify(
+        self,
+        chat_id: str,
+        question: str,
+        choices: Optional[list],
+        clarify_id: str,
+        session_key: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a clarify prompt as an interactive card with clickable buttons.
+
+        Multi-choice: blue-header card with one button per choice plus an
+        "Other" button for free-text.  Open-ended: falls back to the base
+        class text rendering.
+        """
+        if not choices:
+            return await super().send_clarify(
+                chat_id=chat_id, question=question, choices=choices,
+                clarify_id=clarify_id, session_key=session_key, metadata=metadata,
+            )
+
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            clarify_id_int = next(self._clarify_counter)
+            card = self._build_clarify_card(
+                question=question,
+                choices=choices,
+                clarify_id=clarify_id,
+                clarify_id_int=clarify_id_int,
+            )
+            payload = json.dumps(card, ensure_ascii=False)
+            response = await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="interactive",
+                payload=payload,
+                reply_to=None,
+                metadata=metadata,
+            )
+
+            result = self._finalize_send_result(response, "send_clarify failed")
+            if result.success:
+                self._clarify_state[clarify_id_int] = {
+                    "session_key": session_key,
+                    "clarify_id": clarify_id,
+                    "message_id": result.message_id or "",
+                    "chat_id": chat_id,
+                }
+            return result
+        except Exception as exc:
+            logger.warning("[Feishu] send_clarify failed: %s", exc)
+            return SendResult(success=False, error=str(exc))
+
+    @staticmethod
+    def _build_clarify_card(
+        *, question: str, choices: list, clarify_id: str, clarify_id_int: int,
+    ) -> Dict[str, Any]:
+        """Build raw card JSON for a clarify prompt with choice buttons."""
+
+        def _btn(label: str, choice_index: int, btn_type: str = "default") -> dict:
+            return {
+                "tag": "button",
+                "text": {"tag": "plain_text", "content": label},
+                "type": btn_type,
+                "value": {
+                    "hermes_clarify_action": str(choice_index),
+                    "clarify_id": clarify_id,
+                    "clarify_id_int": clarify_id_int,
+                },
+            }
+
+        actions = []
+        for i, choice in enumerate(choices):
+            actions.append(_btn(f"{i + 1}. {choice}", i, "primary" if i == 0 else "default"))
+        actions.append(_btn("✏️ Other (type answer)", -1))
+
+        lines = [f"❓ {question}", ""]
+        for i, choice in enumerate(choices, start=1):
+            lines.append(f"  {i}. {choice}")
+
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": "❓ Clarification Needed", "tag": "plain_text"},
+                "template": "blue",
+            },
+            "elements": [
+                {"tag": "markdown", "content": "\n".join(lines)},
+                {"tag": "action", "actions": actions},
+            ],
+        }
+
+    def _handle_clarify_card_action(
+        self, *, event: Any, action_value: Dict[str, Any], loop: Any,
+    ) -> Any:
+        """Schedule clarify resolution and build the synchronous callback response."""
+        raw_id = action_value.get("clarify_id_int")
+        if raw_id is None:
+            logger.debug("[Feishu] Card action missing clarify_id_int, ignoring")
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+        try:
+            clarify_id_int = int(raw_id)
+        except (TypeError, ValueError):
+            logger.debug("[Feishu] Card action has invalid clarify_id_int=%r", raw_id)
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        state = self._clarify_state.get(clarify_id_int)
+        if not state:
+            logger.debug("[Feishu] Clarify %s already resolved or unknown", clarify_id_int)
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        choice_index_str = str(action_value.get("hermes_clarify_action", ""))
+        clarify_id = str(action_value.get("clarify_id", ""))
+
+        operator = getattr(event, "operator", None)
+        open_id = str(getattr(operator, "open_id", "") or "")
+        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
+        if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
+            logger.warning("[Feishu] Unauthorized clarify click by %s", open_id or "<unknown>")
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        callback_chat_id = str(getattr(getattr(event, "context", None), "open_chat_id", "") or "")
+        expected_chat_id = str(state.get("chat_id", "") or "")
+        if callback_chat_id and expected_chat_id and callback_chat_id != expected_chat_id:
+            logger.warning(
+                "[Feishu] Clarify callback chat mismatch for %s (expected=%s, got=%s)",
+                clarify_id_int, expected_chat_id, callback_chat_id,
+            )
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        user_name = self._get_cached_sender_name(open_id) or open_id
+
+        # "Other" button → enter text-capture mode
+        if choice_index_str == "-1":
+            if not self._submit_on_loop(loop, self._resolve_clarify_other(clarify_id_int, clarify_id, user_name)):
+                return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+            if P2CardActionTriggerResponse is None:
+                return None
+            response = P2CardActionTriggerResponse()
+            if CallBackCard is not None:
+                card = CallBackCard()
+                card.type = "raw"
+                card.data = self._build_resolved_clarify_card(
+                    choice_text="✏️ Waiting for your answer...",
+                    user_name=user_name,
+                )
+                response.card = card
+            return response
+
+        # Regular choice → resolve immediately
+        try:
+            choice_index = int(choice_index_str)
+        except (TypeError, ValueError):
+            logger.debug("[Feishu] Clarify action has invalid choice index=%r", choice_index_str)
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        if not self._submit_on_loop(
+            loop,
+            self._resolve_clarify(clarify_id_int, clarify_id, choice_index, user_name),
+        ):
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        if P2CardActionTriggerResponse is None:
+            return None
+        response = P2CardActionTriggerResponse()
+        if CallBackCard is not None:
+            card = CallBackCard()
+            card.type = "raw"
+            card.data = self._build_resolved_clarify_card(
+                choice_text=f"✅ Choice {choice_index + 1}",
+                user_name=user_name,
+            )
+            response.card = card
+        return response
+
+    async def _resolve_clarify(
+        self,
+        clarify_id_int: int,
+        clarify_id: str,
+        choice_index: int,
+        user_name: str,
+    ) -> None:
+        """Pop clarify state and unblock the agent thread with the chosen option."""
+        state = self._clarify_state.pop(clarify_id_int, None)
+        if not state:
+            return
+        try:
+            from tools.clarify_gateway import resolve_gateway_clarify
+            # The resolve function expects the response string; use the index as text
+            resolved = resolve_gateway_clarify(clarify_id, str(choice_index))
+            logger.info(
+                "Feishu clarify button resolved for %s (choice=%d, user=%s, result=%s)",
+                clarify_id, choice_index, user_name, resolved,
+            )
+        except Exception as exc:
+            logger.error("Failed to resolve gateway clarify from Feishu button: %s", exc)
+
+    async def _resolve_clarify_other(
+        self,
+        clarify_id_int: int,
+        clarify_id: str,
+        user_name: str,
+    ) -> None:
+        """Flip clarify entry into text-capture mode (user picked 'Other')."""
+        state = self._clarify_state.get(clarify_id_int)
+        if not state:
+            return
+        try:
+            from tools.clarify_gateway import mark_awaiting_text
+            mark_awaiting_text(clarify_id)
+            logger.info(
+                "Feishu clarify 'Other' for %s — awaiting text input (user=%s)",
+                clarify_id, user_name,
+            )
+        except Exception as exc:
+            logger.error("Failed to mark clarify awaiting text: %s", exc)
+
+    @staticmethod
+    def _build_resolved_clarify_card(*, choice_text: str, user_name: str) -> Dict[str, Any]:
+        """Build raw card JSON for a resolved clarify action."""
+        is_waiting = "Waiting" in choice_text
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": choice_text, "tag": "plain_text"},
+                "template": "green" if not is_waiting else "blue",
+            },
+            "elements": [
+                {"tag": "markdown", "content": f"Answered by **{user_name}**"},
+            ],
+        }
 
     @staticmethod
     def _build_resolved_approval_card(*, choice: str, user_name: str) -> Dict[str, Any]:
@@ -2541,10 +2781,20 @@ class FeishuAdapter(BasePlatformAdapter):
             if isinstance(action_value, dict) else None
         )
 
+        clarify_action = (
+            action_value.get("hermes_clarify_action")
+            if isinstance(action_value, dict) else None
+        )
         if hermes_action:
             return self._handle_approval_card_action(event=event, action_value=action_value, loop=loop)
         if update_prompt_action:
             return self._handle_update_prompt_card_action(
+                event=event,
+                action_value=action_value,
+                loop=loop,
+            )
+        if clarify_action is not None:
+            return self._handle_clarify_card_action(
                 event=event,
                 action_value=action_value,
                 loop=loop,

--- a/tests/gateway/test_feishu_clarify.py
+++ b/tests/gateway/test_feishu_clarify.py
@@ -1,0 +1,393 @@
+"""Tests for Feishu clarify interactive card buttons."""
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _make_adapter():
+    """Create a FeishuAdapter with mocked internals for testing."""
+    from gateway.platforms.feishu import FeishuAdapter
+
+    config = PlatformConfig(
+        enabled=True,
+        extra={
+            "app_id": "test_app",
+            "app_secret": "test_secret",
+            "domain_name": "feishu",
+            "connection_mode": "websocket",
+        },
+    )
+    adapter = FeishuAdapter(config)
+    adapter._client = MagicMock()  # Pretend connected
+    adapter._loop = asyncio.new_event_loop()
+    return adapter
+
+
+class TestBuildClarifyCard:
+    """Tests for _build_clarify_card static method."""
+
+    def test_multi_choice_card_structure(self):
+        from gateway.platforms.feishu import FeishuAdapter
+
+        card = FeishuAdapter._build_clarify_card(
+            question="What color?",
+            choices=["Red", "Blue", "Green"],
+            clarify_id="c-123",
+            clarify_id_int=1,
+        )
+
+        # Header
+        assert card["header"]["template"] == "blue"
+        assert "Clarification" in card["header"]["title"]["content"]
+
+        # Markdown body contains question and choices
+        md = card["elements"][0]["content"]
+        assert "What color?" in md
+        assert "1. Red" in md
+        assert "2. Blue" in md
+        assert "3. Green" in md
+
+        # Actions: 3 choice buttons + 1 "Other" button
+        actions = card["elements"][1]["actions"]
+        assert len(actions) == 4
+        assert actions[0]["type"] == "primary"  # First button highlighted
+        assert actions[1]["type"] == "default"
+        assert actions[2]["type"] == "default"
+        assert "Other" in actions[3]["text"]["content"]
+
+    def test_button_values_contain_clarify_ids(self):
+        from gateway.platforms.feishu import FeishuAdapter
+
+        card = FeishuAdapter._build_clarify_card(
+            question="Pick one",
+            choices=["A", "B"],
+            clarify_id="c-456",
+            clarify_id_int=7,
+        )
+        actions = card["elements"][1]["actions"]
+
+        # First choice button
+        assert actions[0]["value"]["hermes_clarify_action"] == "0"
+        assert actions[0]["value"]["clarify_id"] == "c-456"
+        assert actions[0]["value"]["clarify_id_int"] == 7
+
+        # Second choice button
+        assert actions[1]["value"]["hermes_clarify_action"] == "1"
+
+        # "Other" button
+        assert actions[2]["value"]["hermes_clarify_action"] == "-1"
+
+    def test_single_choice(self):
+        from gateway.platforms.feishu import FeishuAdapter
+
+        card = FeishuAdapter._build_clarify_card(
+            question="Confirm?",
+            choices=["Yes"],
+            clarify_id="c-789",
+            clarify_id_int=1,
+        )
+        actions = card["elements"][1]["actions"]
+        assert len(actions) == 2  # 1 choice + 1 "Other"
+        assert actions[0]["value"]["hermes_clarify_action"] == "0"
+
+
+class TestSendClarify:
+    """Tests for send_clarify override."""
+
+    @pytest.mark.asyncio
+    async def test_open_ended_falls_back_to_base(self):
+        adapter = _make_adapter()
+        with patch.object(
+            type(adapter).__bases__[0], "send_clarify", new_callable=AsyncMock
+        ) as mock_base:
+            mock_base.return_value = MagicMock(success=True)
+            result = await adapter.send_clarify(
+                chat_id="chat1",
+                question="Tell me more",
+                choices=None,
+                clarify_id="c-1",
+                session_key="sess1",
+            )
+            mock_base.assert_awaited_once()
+            assert result.success
+
+    @pytest.mark.asyncio
+    async def test_multi_choice_sends_interactive_card(self):
+        adapter = _make_adapter()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"code": 0, "data": {"message_id": "msg_123"}}
+        adapter._feishu_send_with_retry = AsyncMock(return_value=mock_response)
+        adapter._finalize_send_result = MagicMock(
+            return_value=MagicMock(success=True, message_id="msg_123")
+        )
+
+        result = await adapter.send_clarify(
+            chat_id="chat1",
+            question="Which option?",
+            choices=["A", "B", "C"],
+            clarify_id="c-10",
+            session_key="sess1",
+        )
+
+        assert result.success
+        adapter._feishu_send_with_retry.assert_awaited_once()
+        call_kwargs = adapter._feishu_send_with_retry.call_args
+        assert call_kwargs.kwargs["msg_type"] == "interactive"
+
+        # Verify the card payload is valid JSON with clarify structure
+        payload = json.loads(call_kwargs.kwargs["payload"])
+        assert payload["header"]["template"] == "blue"
+        assert len(payload["elements"][1]["actions"]) == 4  # 3 choices + Other
+
+        # State should be stored
+        assert len(adapter._clarify_state) == 1
+        state = list(adapter._clarify_state.values())[0]
+        assert state["clarify_id"] == "c-10"
+        assert state["session_key"] == "sess1"
+
+    @pytest.mark.asyncio
+    async def test_no_client_returns_error(self):
+        adapter = _make_adapter()
+        adapter._client = None
+        result = await adapter.send_clarify(
+            chat_id="chat1",
+            question="Q?",
+            choices=["A"],
+            clarify_id="c-1",
+            session_key="s1",
+        )
+        assert not result.success
+        assert "Not connected" in result.error
+
+
+class TestHandleClarifyCardAction:
+    """Tests for _handle_clarify_card_action."""
+
+    def _make_event(self, open_id="user_123", chat_id="chat_1"):
+        event = SimpleNamespace()
+        event.operator = SimpleNamespace(open_id=open_id, user_id="uid_1")
+        event.context = SimpleNamespace(open_chat_id=chat_id)
+        return event
+
+    def test_regular_choice_resolves(self):
+        adapter = _make_adapter()
+        loop = adapter._loop
+        adapter._allow_group_message = MagicMock(return_value=True)
+        adapter._get_cached_sender_name = MagicMock(return_value="TestUser")
+        adapter._submit_on_loop = MagicMock(return_value=True)
+
+        # Pre-populate state
+        adapter._clarify_state[1] = {
+            "session_key": "sess1",
+            "clarify_id": "c-10",
+            "message_id": "msg_1",
+            "chat_id": "chat_1",
+        }
+
+        action_value = {
+            "hermes_clarify_action": "0",
+            "clarify_id": "c-10",
+            "clarify_id_int": 1,
+        }
+
+        result = adapter._handle_clarify_card_action(
+            event=self._make_event(),
+            action_value=action_value,
+            loop=loop,
+        )
+
+        # Should have scheduled the resolve coroutine
+        adapter._submit_on_loop.assert_called_once()
+
+    def test_other_button_enters_text_capture(self):
+        adapter = _make_adapter()
+        loop = adapter._loop
+        adapter._allow_group_message = MagicMock(return_value=True)
+        adapter._get_cached_sender_name = MagicMock(return_value="TestUser")
+        adapter._submit_on_loop = MagicMock(return_value=True)
+
+        adapter._clarify_state[2] = {
+            "session_key": "sess1",
+            "clarify_id": "c-20",
+            "message_id": "msg_2",
+            "chat_id": "chat_1",
+        }
+
+        action_value = {
+            "hermes_clarify_action": "-1",
+            "clarify_id": "c-20",
+            "clarify_id_int": 2,
+        }
+
+        result = adapter._handle_clarify_card_action(
+            event=self._make_event(),
+            action_value=action_value,
+            loop=loop,
+        )
+
+        # Should schedule _resolve_clarify_other (not _resolve_clarify)
+        adapter._submit_on_loop.assert_called_once()
+
+    def test_unauthorized_user_rejected(self):
+        adapter = _make_adapter()
+        loop = adapter._loop
+        adapter._allow_group_message = MagicMock(return_value=False)
+
+        adapter._clarify_state[3] = {
+            "session_key": "sess1",
+            "clarify_id": "c-30",
+            "message_id": "msg_3",
+            "chat_id": "chat_1",
+        }
+
+        action_value = {
+            "hermes_clarify_action": "0",
+            "clarify_id": "c-30",
+            "clarify_id_int": 3,
+        }
+
+        result = adapter._handle_clarify_card_action(
+            event=self._make_event(open_id="unauthorized"),
+            action_value=action_value,
+            loop=loop,
+        )
+
+        # Should not have resolved — state still present
+        assert 3 in adapter._clarify_state
+
+    def test_already_resolved_ignored(self):
+        adapter = _make_adapter()
+        loop = adapter._loop
+
+        # No state for clarify_id_int=99
+        action_value = {
+            "hermes_clarify_action": "0",
+            "clarify_id": "c-99",
+            "clarify_id_int": 99,
+        }
+
+        result = adapter._handle_clarify_card_action(
+            event=self._make_event(),
+            action_value=action_value,
+            loop=loop,
+        )
+
+        # Should return empty response, not crash
+        assert result is not None or result is None  # Just no exception
+
+
+class TestResolveClarify:
+    """Tests for _resolve_clarify and _resolve_clarify_other."""
+
+    @pytest.mark.asyncio
+    async def test_resolve_clarify_calls_gateway(self):
+        adapter = _make_adapter()
+        adapter._clarify_state[1] = {
+            "session_key": "sess1",
+            "clarify_id": "c-10",
+            "message_id": "msg_1",
+            "chat_id": "chat_1",
+        }
+
+        with patch("tools.clarify_gateway.resolve_gateway_clarify") as mock_resolve:
+            mock_resolve.return_value = True
+            await adapter._resolve_clarify(1, "c-10", 2, "TestUser")
+            mock_resolve.assert_called_once_with("c-10", "2")
+
+        # State should be popped
+        assert 1 not in adapter._clarify_state
+
+    @pytest.mark.asyncio
+    async def test_resolve_clarify_other_marks_awaiting_text(self):
+        adapter = _make_adapter()
+        adapter._clarify_state[2] = {
+            "session_key": "sess1",
+            "clarify_id": "c-20",
+            "message_id": "msg_2",
+            "chat_id": "chat_1",
+        }
+
+        with patch("tools.clarify_gateway.mark_awaiting_text") as mock_mark:
+            mock_mark.return_value = True
+            await adapter._resolve_clarify_other(2, "c-20", "TestUser")
+            mock_mark.assert_called_once_with("c-20")
+
+        # State should NOT be popped (still awaiting text)
+        assert 2 in adapter._clarify_state
+
+
+class TestResolvedCard:
+    """Tests for _build_resolved_clarify_card."""
+
+    def test_choice_resolved_card(self):
+        from gateway.platforms.feishu import FeishuAdapter
+
+        card = FeishuAdapter._build_resolved_clarify_card(
+            choice_text="✅ Choice 1",
+            user_name="Alice",
+        )
+        assert card["header"]["template"] == "green"
+        assert "Choice 1" in card["header"]["title"]["content"]
+        assert "Alice" in card["elements"][0]["content"]
+
+    def test_waiting_resolved_card(self):
+        from gateway.platforms.feishu import FeishuAdapter
+
+        card = FeishuAdapter._build_resolved_clarify_card(
+            choice_text="✏️ Waiting for your answer...",
+            user_name="Bob",
+        )
+        assert card["header"]["template"] == "blue"
+        assert "Waiting" in card["header"]["title"]["content"]
+
+
+class TestCardActionTriggerRouting:
+    """Tests that _on_card_action_trigger routes clarify actions correctly."""
+
+    def test_clarify_action_routed_to_handler(self):
+        adapter = _make_adapter()
+        adapter._loop_accepts_callbacks = MagicMock(return_value=True)
+        adapter._handle_clarify_card_action = MagicMock(return_value="clarify_response")
+
+        data = SimpleNamespace()
+        data.event = SimpleNamespace(
+            action=SimpleNamespace(
+                value={
+                    "hermes_clarify_action": "0",
+                    "clarify_id": "c-1",
+                    "clarify_id_int": 1,
+                }
+            ),
+            operator=SimpleNamespace(open_id="u1", user_id="uid1"),
+            context=SimpleNamespace(open_chat_id="chat1"),
+        )
+
+        result = adapter._on_card_action_trigger(data)
+        assert result == "clarify_response"
+        adapter._handle_clarify_card_action.assert_called_once()
+
+    def test_approval_action_not_routed_to_clarify(self):
+        adapter = _make_adapter()
+        adapter._loop_accepts_callbacks = MagicMock(return_value=True)
+        adapter._handle_approval_card_action = MagicMock(return_value="approval_response")
+        adapter._handle_clarify_card_action = MagicMock()
+
+        data = SimpleNamespace()
+        data.event = SimpleNamespace(
+            action=SimpleNamespace(
+                value={"hermes_action": "approve_once", "approval_id": 1}
+            ),
+            operator=SimpleNamespace(open_id="u1", user_id="uid1"),
+            context=SimpleNamespace(open_chat_id="chat1"),
+        )
+
+        result = adapter._on_card_action_trigger(data)
+        assert result == "approval_response"
+        adapter._handle_clarify_card_action.assert_not_called()


### PR DESCRIPTION
## Problem

The `clarify` tool renders as plain text on Feishu — users see a numbered list and must type a number or option text to respond. This is inconsistent with other interactive elements (approval buttons, update prompts) which already use Feishu interactive cards with clickable buttons.

## Solution

Override `send_clarify()` in the Feishu adapter to render multi-choice clarify prompts as interactive cards with clickable buttons, following the exact same pattern as `send_exec_approval()` and `send_update_prompt()`.

### How it works

1. **Multi-choice** → Blue-header card with:
   - Question + numbered options in Markdown body
   - One button per choice (first one highlighted as `primary`)
   - Final "✏️ Other (type answer)" button for free-text response
   - Each button carries `hermes_clarify_action` (choice index) and `clarify_id` in its value

2. **Open-ended** (no choices) → Falls back to base class plain text rendering (unchanged behavior)

3. **Button click** → Routes through `_on_card_action_trigger()` → `_handle_clarify_card_action()`:
   - Regular choice → `resolve_gateway_clarify()` unblocks agent thread
   - "Other" → `mark_awaiting_text()` enters text-capture mode
   - Card updates to green "✅ Choice N" resolved state

## Changes

Single file: `gateway/platforms/feishu.py`

| What | Lines |
|------|-------|
| `_clarify_state` / `_clarify_counter` initialization | +4 lines |
| `send_clarify()` override | ~45 lines |
| `_build_clarify_card()` static method | ~40 lines |
| `_handle_clarify_card_action()` | ~65 lines |
| `_resolve_clarify()` | ~20 lines |
| `_resolve_clarify_other()` | ~15 lines |
| `_build_resolved_clarify_card()` | ~15 lines |
| `hermes_clarify_action` routing in `_on_card_action_trigger()` | +8 lines |

**Total: ~250 new lines in feishu.py, zero existing lines modified.**

## Testing

- 16/16 new tests pass (`tests/gateway/test_feishu_clarify.py`)
- Syntax check passes
- Card structure, button values, routing, authorization, resolution all covered

## Notes

- Uses the same card structure as approval/update-prompt (`wide_screen_mode`, Schema 2.0)
- Button value uses choice index (not full text) to stay within Feishu's size limits
- Follows the exact authorization and chat-mismatch checks from `_handle_approval_card_action`
