### PR TITLE
fix: add .ics, .vcf, .vcs to MEDIA_DELIVERY_EXTS and gateway regex

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1199,6 +1199,8 @@ MEDIA_DELIVERY_EXTS: Tuple[str, ...] = (
     ".zip", ".tar", ".gz", ".tgz", ".bz2", ".xz", ".7z", ".rar", ".apk", ".ipa",
     # Web / rendered output
     ".html", ".htm",
+    # Calendar / contacts
+    ".ics", ".vcf", ".vcs",
 )
 
 # Regex alternation fragment of bare extensions (no leading dot), e.g.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -710,7 +710,7 @@ _TOOL_MEDIA_RE = re.compile(
     r'MEDIA:((?:[A-Za-z]:[/\\]|/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
     r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
     r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
-    r'txt|csv|apk|ipa))',
+    r'txt|csv|apk|ipa|ics|vcf|vcs))',
     re.IGNORECASE,
 )
 
@@ -13983,7 +13983,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             r'MEDIA:((?:[A-Za-z]:[/\\]|/|~\/)\S+\.(?:png|jpe?g|gif|webp|'
                             r'mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|'
                             r'flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|'
-                            r'txt|csv|apk|ipa))',
+                            r'txt|csv|apk|ipa|ics|vcf|vcs))',
                             re.IGNORECASE
                         )
                         for _match in _TOOL_MEDIA_RE.finditer(_hc):


### PR DESCRIPTION
## Problem

Calendar files (.ics) and contact files (.vcf, .vcs) were missing from the allowed file extensions list in `MEDIA_DELIVERY_EXTS`. This caused `MEDIA:/path/to/file.ics` tags in agent responses to be silently ignored and never delivered as file attachments on any platform.

## Fix

Added `.ics`, `.vcf`, and `.vcs` to two locations:

- `gateway/platforms/base.py`: `MEDIA_DELIVERY_EXTS` tuple — the source of truth that drives `MEDIA_TAG_CLEANUP_RE`
- `gateway/run.py`: `_TOOL_MEDIA_RE` regex — mirrors the allowed extensions for tool result scanning

## How it was discovered

A user asked Hermes to create an iCalendar (.ics) file with university course dates and send it via Slack. The `MEDIA:` tag was emitted correctly in the response but never delivered — after debugging, the root cause was the missing extension in `MEDIA_DELIVERY_EXTS`.