### PR TITLE
fix(update): skip npm ci when lockfiles haven't changed

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2357,6 +2357,12 @@ DEFAULT_CONFIG = {
         #               ignored paths — node_modules, venv, build outputs —
         #               are never touched.
         "non_interactive_local_changes": "stash",
+        # Skip Node.js dependency installation (``npm ci``) during
+        # ``hermes update`` even when lockfiles have changed.  Useful
+        # on Windows where ``npm ci`` is very slow (NTFS + antivirus
+        # overhead).  The web UI build and desktop rebuild still run
+        # when their own staleness checks trigger.
+        "skip_node_deps": False,
     },
 
     # Language Server Protocol — semantic diagnostics from real

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -190,6 +190,7 @@ def _config_overrides(config: dict) -> dict[str, str]:
         ("display", "show_reasoning"),
         ("privacy", "redact_pii"),
         ("tts", "provider"),
+        ("updates", "skip_node_deps"),
     ]
 
     for section, key in interesting_paths:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7380,12 +7380,50 @@ def _ensure_uv_for_termux(pip_cmd: list[str]) -> str | None:
     return resolve_uv() or shutil.which("uv")
 
 
+def _node_deps_install_needed() -> bool:
+    """Return True if ``npm ci`` should run because lockfiles changed.
+
+    Compares the mtime of ``package-lock.json`` against
+    ``node_modules/.package-lock.json`` (written by npm after every
+    successful ``ci``/``install``).  When the lockfile is *not* newer
+    than the marker the tree is already in sync and the expensive
+    install can be skipped.
+
+    Also honours the ``updates.skip_node_deps`` config flag — when set
+    the install is unconditionally skipped (useful on Windows where
+    ``npm ci`` takes several minutes even for an up-to-date tree).
+    """
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        if cfg.get("updates", {}).get("skip_node_deps"):
+            return False
+    except Exception:
+        pass
+
+    lockfile = PROJECT_ROOT / "package-lock.json"
+    if not lockfile.exists():
+        # No lockfile — let npm handle it (will likely fail anyway).
+        return True
+
+    marker = PROJECT_ROOT / "node_modules" / ".package-lock.json"
+    if not marker.exists():
+        # No marker — node_modules never installed.
+        return True
+
+    return lockfile.stat().st_mtime > marker.stat().st_mtime
+
+
 def _update_node_dependencies() -> None:
     npm = shutil.which("npm")
     if not npm:
         return
 
     if not (PROJECT_ROOT / "package.json").exists():
+        return
+
+    if not _node_deps_install_needed():
+        print("→ Node.js dependencies up to date (skipping npm ci)")
         return
 
     # With a single workspace lockfile the root install would cover ALL

--- a/tests/cli/test_node_deps_staleness.py
+++ b/tests/cli/test_node_deps_staleness.py
@@ -1,0 +1,139 @@
+"""Tests for _node_deps_install_needed() — staleness check before npm ci."""
+
+import os
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_tree(root: Path, *, lockfile: bool = True, marker: bool = True,
+               lockfile_mtime: float | None = None,
+               marker_mtime: float | None = None) -> None:
+    """Create a minimal PROJECT_ROOT with package-lock.json and node_modules marker."""
+    (root / "package.json").write_text("{}")
+    if lockfile:
+        lf = root / "package-lock.json"
+        lf.write_text("{}")
+        if lockfile_mtime is not None:
+            os.utime(lf, (lockfile_mtime, lockfile_mtime))
+    if marker:
+        nm = root / "node_modules"
+        nm.mkdir(exist_ok=True)
+        mk = nm / ".package-lock.json"
+        mk.write_text("{}")
+        if marker_mtime is not None:
+            os.utime(mk, (marker_mtime, marker_mtime))
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestNodeDepsInstallNeeded:
+    """Test _node_deps_install_needed() staleness logic."""
+
+    def test_returns_true_when_lockfile_newer(self, tmp_path):
+        """Lockfile modified after marker → install needed."""
+        _make_tree(tmp_path, lockfile_mtime=200, marker_mtime=100)
+        with patch("hermes_cli.main.PROJECT_ROOT", tmp_path):
+            from hermes_cli.main import _node_deps_install_needed
+            assert _node_deps_install_needed() is True
+
+    def test_returns_false_when_marker_newer(self, tmp_path):
+        """Marker modified after lockfile → already installed."""
+        _make_tree(tmp_path, lockfile_mtime=100, marker_mtime=200)
+        with patch("hermes_cli.main.PROJECT_ROOT", tmp_path):
+            from hermes_cli.main import _node_deps_install_needed
+            assert _node_deps_install_needed() is False
+
+    def test_returns_false_when_same_mtime(self, tmp_path):
+        """Same mtime → already installed (lockfile NOT newer)."""
+        _make_tree(tmp_path, lockfile_mtime=100, marker_mtime=100)
+        with patch("hermes_cli.main.PROJECT_ROOT", tmp_path):
+            from hermes_cli.main import _node_deps_install_needed
+            assert _node_deps_install_needed() is False
+
+    def test_returns_true_when_no_marker(self, tmp_path):
+        """No node_modules marker → install needed."""
+        _make_tree(tmp_path, marker=False)
+        with patch("hermes_cli.main.PROJECT_ROOT", tmp_path):
+            from hermes_cli.main import _node_deps_install_needed
+            assert _node_deps_install_needed() is True
+
+    def test_returns_true_when_no_lockfile(self, tmp_path):
+        """No lockfile → install needed (let npm handle it)."""
+        _make_tree(tmp_path, lockfile=False, marker=False)
+        with patch("hermes_cli.main.PROJECT_ROOT", tmp_path):
+            from hermes_cli.main import _node_deps_install_needed
+            assert _node_deps_install_needed() is True
+
+    def test_skip_node_deps_config_overrides(self, tmp_path):
+        """Config updates.skip_node_deps=True → always skip."""
+        _make_tree(tmp_path, lockfile_mtime=200, marker_mtime=100)
+        mock_cfg = {"updates": {"skip_node_deps": True}}
+        with patch("hermes_cli.main.PROJECT_ROOT", tmp_path), \
+             patch("hermes_cli.config.load_config", return_value=mock_cfg):
+            from hermes_cli.main import _node_deps_install_needed
+            assert _node_deps_install_needed() is False
+
+    def test_skip_node_deps_false_does_not_skip(self, tmp_path):
+        """Config updates.skip_node_deps=False → normal staleness check."""
+        _make_tree(tmp_path, lockfile_mtime=200, marker_mtime=100)
+        mock_cfg = {"updates": {"skip_node_deps": False}}
+        with patch("hermes_cli.main.PROJECT_ROOT", tmp_path), \
+             patch("hermes_cli.config.load_config", return_value=mock_cfg):
+            from hermes_cli.main import _node_deps_install_needed
+            assert _node_deps_install_needed() is True
+
+    def test_config_load_failure_does_not_crash(self, tmp_path):
+        """If load_config raises, fall through to mtime check."""
+        _make_tree(tmp_path, lockfile_mtime=100, marker_mtime=200)
+        with patch("hermes_cli.main.PROJECT_ROOT", tmp_path), \
+             patch("hermes_cli.config.load_config", side_effect=Exception("broken")):
+            from hermes_cli.main import _node_deps_install_needed
+            assert _node_deps_install_needed() is False
+
+
+class TestUpdateNodeDepsSkipsWhenFresh:
+    """Test that _update_node_dependencies() prints skip message and returns early."""
+
+    def test_skips_npm_ci_when_deps_fresh(self, tmp_path, capsys):
+        """When _node_deps_install_needed returns False, npm is never called."""
+        _make_tree(tmp_path, lockfile_mtime=100, marker_mtime=200)
+        with patch("hermes_cli.main.PROJECT_ROOT", tmp_path), \
+             patch("hermes_cli.main._node_deps_install_needed", return_value=False), \
+             patch("shutil.which", return_value="/usr/bin/npm"):
+            from hermes_cli.main import _update_node_dependencies
+            _update_node_dependencies()
+        captured = capsys.readouterr()
+        assert "skipping npm ci" in captured.out
+
+    def test_runs_npm_ci_when_deps_stale(self, tmp_path, capsys):
+        """When _node_deps_install_needed returns True, npm ci runs."""
+        _make_tree(tmp_path, lockfile_mtime=200, marker_mtime=100)
+        import subprocess
+        mock_result = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        with patch("hermes_cli.main.PROJECT_ROOT", tmp_path), \
+             patch("hermes_cli.main._node_deps_install_needed", return_value=True), \
+             patch("shutil.which", return_value="/usr/bin/npm"), \
+             patch("hermes_cli.main._run_npm_install_deterministic", return_value=mock_result) as mock_npm, \
+             patch("hermes_cli.main._nixos_build_env", return_value=None):
+            from hermes_cli.main import _update_node_dependencies
+            _update_node_dependencies()
+        assert mock_npm.call_count == 2  # root + workspace install
+
+
+class TestDefaultConfigHasSkipNodeDeps:
+    """Verify the config key exists in DEFAULT_CONFIG."""
+
+    def test_skip_node_deps_in_default_config(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+        updates = DEFAULT_CONFIG.get("updates", {})
+        assert "skip_node_deps" in updates
+        assert updates["skip_node_deps"] is False


### PR DESCRIPTION
## Problem

`hermes update` runs `_update_node_dependencies()` unconditionally on every update, executing two `npm ci` commands even when `package.json` / `package-lock.json` haven't changed. On Windows, this takes ~8 minutes due to NTFS + antivirus overhead on the 1.5 GB `node_modules` tree.

The web UI build (`_build_web_ui`) already has a smart staleness check via `_web_ui_build_needed()`, but the Node.js dependency install has no equivalent guard.

## Solution

Added `_node_deps_install_needed()` — a staleness check that compares `package-lock.json` mtime against `node_modules/.package-lock.json` (written by npm after every successful `ci`/`install`). When the lockfile is not newer, the function returns `False` and `_update_node_dependencies()` prints a skip message and returns early.

Also added `updates.skip_node_deps` config flag for unconditional opt-out (useful on Windows where even the mtime check is fast but the user wants to guarantee no npm ci runs).

## Changes

- `hermes_cli/main.py` — Added `_node_deps_install_needed()` function and guard at the top of `_update_node_dependencies()`
- `hermes_cli/config.py` — Added `updates.skip_node_deps` config key (default: `False`)
- `hermes_cli/dump.py` — Added `skip_node_deps` to `interesting_paths` for `hermes config display`
- `tests/cli/test_node_deps_staleness.py` — 11 tests covering all paths

## Testing

```
tests/cli/test_node_deps_staleness.py::TestNodeDepsInstallNeeded::test_returns_true_when_lockfile_newer PASSED
tests/cli/test_node_deps_staleness.py::TestNodeDepsInstallNeeded::test_returns_false_when_marker_newer PASSED
tests/cli/test_node_deps_staleness.py::TestNodeDepsInstallNeeded::test_returns_false_when_same_mtime PASSED
tests/cli/test_node_deps_staleness.py::TestNodeDepsInstallNeeded::test_returns_true_when_no_marker PASSED
tests/cli/test_node_deps_staleness.py::TestNodeDepsInstallNeeded::test_returns_true_when_no_lockfile PASSED
tests/cli/test_node_deps_staleness.py::TestNodeDepsInstallNeeded::test_skip_node_deps_config_overrides PASSED
tests/cli/test_node_deps_staleness.py::TestNodeDepsInstallNeeded::test_skip_node_deps_false_does_not_skip PASSED
tests/cli/test_node_deps_staleness.py::TestNodeDepsInstallNeeded::test_config_load_failure_does_not_crash PASSED
tests/cli/test_node_deps_staleness.py::TestUpdateNodeDepsSkipsWhenFresh::test_skips_npm_ci_when_deps_fresh PASSED
tests/cli/test_node_deps_staleness.py::TestUpdateNodeDepsSkipsWhenFresh::test_runs_npm_ci_when_deps_stale PASSED
tests/cli/test_node_deps_staleness.py::TestDefaultConfigHasSkipNodeDeps::test_skip_node_deps_in_default_config PASSED
11 passed
```

Fixes #43837
