### PR TITLE
fix(cron): require exact silent marker for delivery suppression

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2146,7 +2146,7 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
                 # responses: do not deliver a blank message, and let the
                 # empty-response guard below mark the run as a soft failure.
                 should_deliver = bool(deliver_content.strip())
-                if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
+                if should_deliver and success and deliver_content.strip().upper() == SILENT_MARKER.upper():
                     logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
                     should_deliver = False
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1897,37 +1897,52 @@ class TestSilentDelivery:
         deliver_mock.assert_not_called()
         assert any(SILENT_MARKER in r.message for r in caplog.records)
 
-    def test_silent_with_note_suppresses_delivery(self):
+    def test_silent_with_note_is_delivered(self):
+        """Only an exact [SILENT] response suppresses delivery."""
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
              patch("cron.scheduler.run_job", return_value=(True, "# output", "[SILENT] No changes detected", None)), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
              patch("cron.scheduler._deliver_result") as deliver_mock, \
              patch("cron.scheduler.mark_job_run"):
+            deliver_mock.return_value = None
             from cron.scheduler import tick
             tick(verbose=False)
-        deliver_mock.assert_not_called()
+        deliver_mock.assert_called_once()
 
-    def test_silent_trailing_suppresses_delivery(self):
-        """Agent appended [SILENT] after explanation text — must still suppress."""
+    def test_silent_trailing_after_content_is_delivered(self):
+        """Agents must not combine report content with a delivery-suppression marker."""
         response = "2 deals filtered out (like<10, reply<15).\n\n[SILENT]"
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
              patch("cron.scheduler.run_job", return_value=(True, "# output", response, None)), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
              patch("cron.scheduler._deliver_result") as deliver_mock, \
              patch("cron.scheduler.mark_job_run"):
+            deliver_mock.return_value = None
             from cron.scheduler import tick
             tick(verbose=False)
-        deliver_mock.assert_not_called()
+        deliver_mock.assert_called_once()
 
-    def test_silent_is_case_insensitive(self):
+    def test_silent_exact_match_is_case_insensitive(self):
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
-             patch("cron.scheduler.run_job", return_value=(True, "# output", "[silent] nothing new", None)), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", "[silent]", None)), \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
              patch("cron.scheduler._deliver_result") as deliver_mock, \
              patch("cron.scheduler.mark_job_run"):
             from cron.scheduler import tick
             tick(verbose=False)
         deliver_mock.assert_not_called()
+
+    def test_incidental_silent_marker_in_normal_response_is_delivered(self):
+        response = "The [SILENT] suppression path is configured correctly."
+        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", response, None)), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler.mark_job_run"):
+            deliver_mock.return_value = None
+            from cron.scheduler import tick
+            tick(verbose=False)
+        deliver_mock.assert_called_once()
 
     def test_failed_job_always_delivers(self):
         """Failed jobs deliver regardless of [SILENT] in output."""


### PR DESCRIPTION
## Summary
- Require the cron delivery suppression response to be exactly `[SILENT]`, not merely contain that substring.
- Update the regression test so explanatory text mentioning `[SILENT]` is delivered rather than suppressed.
- Keep the existing exact-marker suppression behavior intact.

## Verification
- `PYTHONPATH=$WT python -m pytest tests/cron/test_scheduler.py::TestSilentDelivery tests/cron/test_scheduler.py::TestBuildJobPromptSilentHint tests/cron/test_cron_no_agent.py -q` → 31 passed, 1 unrelated `audioop` deprecation warning.
- `git diff --check origin/main..HEAD`
- Public/privacy gate: neutral author/committer metadata and no secret/private identifier blockers.

## Notes
- Clean branch rebuilt from current `origin/main` after upstream advanced; excludes unrelated local work.
