### PR TITLE
test(gateway): cover fallback key env aliases

### DIFF
--- a/tests/gateway/test_runtime_config_env_expansion.py
+++ b/tests/gateway/test_runtime_config_env_expansion.py
@@ -118,3 +118,62 @@ def test_gateway_runtime_loaders_expand_env_var_templates(
     loader = getattr(gateway_run.GatewayRunner, loader_name)
 
     assert loader() == expected
+
+
+@pytest.mark.parametrize("key_field", ["key_env", "api_key_env"])
+def test_gateway_fallback_provider_resolves_key_env_aliases(monkeypatch, gateway_home, key_field):
+    """Gateway runtime fallback should match init-time fallback key resolution."""
+    _write_config(
+        gateway_home,
+        "fallback_providers:\n"
+        "  - provider: custom:test-fallback\n"
+        "    base_url: https://fallback.example.invalid/v1\n"
+        f"    {key_field}: GATEWAY_FALLBACK_TEST_KEY\n"
+        "    model: test-fallback-model\n",
+    )
+    monkeypatch.setenv("GATEWAY_FALLBACK_TEST_KEY", "env-fallback-key")
+
+    calls = []
+
+    def fake_resolve_runtime_provider(*, requested=None, explicit_base_url=None, explicit_api_key=None):
+        calls.append(
+            {
+                "requested": requested,
+                "explicit_base_url": explicit_base_url,
+                "explicit_api_key": explicit_api_key,
+            }
+        )
+        return {
+            "api_key": explicit_api_key,
+            "base_url": explicit_base_url,
+            "provider": requested,
+            "api_mode": "chat_completions",
+            "command": None,
+            "args": [],
+            "credential_pool": None,
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        fake_resolve_runtime_provider,
+    )
+
+    resolved = gateway_run._try_resolve_fallback_provider()
+
+    assert calls == [
+        {
+            "requested": "custom:test-fallback",
+            "explicit_base_url": "https://fallback.example.invalid/v1",
+            "explicit_api_key": "env-fallback-key",
+        }
+    ]
+    assert resolved == {
+        "api_key": "env-fallback-key",
+        "base_url": "https://fallback.example.invalid/v1",
+        "provider": "custom:test-fallback",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+        "model": "test-fallback-model",
+    }


### PR DESCRIPTION
## Summary
- Add regression coverage for gateway runtime fallback providers using both `key_env` and `api_key_env`.
- Assert the env-resolved key is passed to runtime provider resolution as `explicit_api_key`.
- Preserve the fallback entry model while exercising the direct runtime gateway path.

## Verification
- `PYTHONPATH=$WT python -m pytest tests/gateway/test_runtime_config_env_expansion.py -q` → 11 passed.
- `git diff --check origin/main..HEAD`
- Public/privacy gate: neutral author/committer metadata and no secret/private identifier blockers; schema key-name mentions are expected test field names only.

## Notes
- Clean branch rebuilt from current `origin/main` after upstream advanced; excludes unrelated local work.
