### PR TITLE
fix: reduce skills prompt context

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1277,11 +1277,10 @@ def build_skills_system_prompt(
     else:
         index_lines = []
         for category in sorted(skills_by_category.keys()):
-            cat_desc = category_descriptions.get(category, "")
-            if cat_desc:
-                index_lines.append(f"  {category}: {cat_desc}")
-            else:
-                index_lines.append(f"  {category}:")
+            # Keep categories as navigation labels only. Category DESCRIPTION.md
+            # text is useful in docs/UI, but duplicative in the model prompt
+            # because every listed skill already carries its own description.
+            index_lines.append(f"  {category}:")
             # Deduplicate and sort skills within each category
             seen = set()
             for name, desc in sorted(skills_by_category[category], key=lambda x: x[0]):
@@ -1295,31 +1294,16 @@ def build_skills_system_prompt(
 
         result = (
             "## Skills (mandatory)\n"
-            "Before replying, scan the skills below. If a skill matches or is even partially relevant "
-            "to your task, you MUST load it with skill_view(name) and follow its instructions. "
-            "Err on the side of loading — it is always better to have context you don't need "
-            "than to miss critical steps, pitfalls, or established workflows. "
-            "Skills contain specialized knowledge — API endpoints, tool-specific commands, "
-            "and proven workflows that outperform general-purpose approaches. Load the skill "
-            "even if you think you could handle the task with basic tools like web_search or terminal. "
-            "Skills also encode the user's preferred approach, conventions, and quality standards "
-            "for tasks like code review, planning, and testing — load them even for tasks you "
-            "already know how to do, because the skill defines how it should be done here.\n"
-            "Whenever the user asks you to configure, set up, install, enable, disable, modify, "
-            "or troubleshoot Hermes Agent itself — its CLI, config, models, providers, tools, "
-            "skills, voice, gateway, plugins, or any feature — load the `hermes-agent` skill "
-            "first. It has the actual commands (e.g. `hermes config set …`, `hermes tools`, "
-            "`hermes setup`) so you don't have to guess or invent workarounds.\n"
-            "If a skill has issues, fix it with skill_manage(action='patch').\n"
-            "After difficult/iterative tasks, offer to save as a skill. "
-            "If a skill you loaded was missing steps, had wrong commands, or needed "
-            "pitfalls you discovered, update it before finishing.\n"
-            "\n"
+            "Scan this index before replying. If a listed skill matches or is even partly "
+            "relevant, load it with skill_view(name) and follow it. Skills contain task-specific "
+            "commands, pitfalls, and local conventions that override generic guesses. For Hermes "
+            "Agent setup/config/troubleshooting, load `hermes-agent` first. If a loaded skill is "
+            "wrong or incomplete, patch it with skill_manage. After difficult/iterative work, "
+            "offer to save the workflow as a skill.\n\n"
             "<available_skills>\n"
             + "\n".join(index_lines) + "\n"
-            "</available_skills>\n"
-            "\n"
-            "Only proceed without loading a skill if genuinely none are relevant to the task."
+            "</available_skills>\n\n"
+            "Only skip skill loading when none are genuinely relevant."
         )
 
     # ── Store in LRU cache ────────────────────────────────────────────

--- a/scripts/measure_prompt_context.py
+++ b/scripts/measure_prompt_context.py
@@ -1,0 +1,46 @@
+"""Measure high-level Hermes system-prompt context sections.
+
+This is intentionally lightweight and approximate: character counts plus an
+OpenAI-style token estimate (chars / 4). It avoids model/provider calls and is
+safe to run in local checkouts.
+"""
+
+from __future__ import annotations
+
+from agent.prompt_builder import (
+    HERMES_AGENT_HELP_GUIDANCE,
+    KANBAN_GUIDANCE,
+    MEMORY_GUIDANCE,
+    OPENAI_MODEL_EXECUTION_GUIDANCE,
+    SKILLS_GUIDANCE,
+    TASK_COMPLETION_GUIDANCE,
+    TOOL_USE_ENFORCEMENT_GUIDANCE,
+    build_environment_hints,
+    build_skills_system_prompt,
+)
+
+
+def estimate_tokens(text: str) -> int:
+    return (len(text) + 3) // 4
+
+
+def main() -> None:
+    sections = {
+        "skills_index": build_skills_system_prompt(),
+        "environment_hints": build_environment_hints(),
+        "hermes_help_guidance": HERMES_AGENT_HELP_GUIDANCE,
+        "memory_guidance": MEMORY_GUIDANCE,
+        "skills_guidance": SKILLS_GUIDANCE,
+        "kanban_guidance": KANBAN_GUIDANCE,
+        "task_completion_guidance": TASK_COMPLETION_GUIDANCE,
+        "tool_use_enforcement": TOOL_USE_ENFORCEMENT_GUIDANCE,
+        "execution_discipline": OPENAI_MODEL_EXECUTION_GUIDANCE,
+    }
+    for name, text in sections.items():
+        print(f"{name}\tchars={len(text)}\test_tokens={estimate_tokens(text)}")
+    total_chars = sum(len(text) for text in sections.values())
+    print(f"measured_total\tchars={total_chars}\test_tokens={estimate_tokens(''.join(sections.values()))}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -264,6 +264,26 @@ class TestBuildSkillsSystemPrompt:
         assert "python-debug" in result
         assert "Debug Python scripts" in result
         assert "available_skills" in result
+        assert "skill_view(name)" in result
+
+    def test_omits_category_descriptions_from_index(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        category_dir = tmp_path / "skills" / "coding"
+        category_dir.mkdir(parents=True)
+        (category_dir / "DESCRIPTION.md").write_text(
+            "---\ndescription: Long category prose that duplicates the skill list\n---\n"
+        )
+        skill_dir = category_dir / "python-debug"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: python-debug\ndescription: Debug Python scripts\n---\n"
+        )
+
+        result = build_skills_system_prompt()
+
+        assert "  coding:" in result
+        assert "Long category prose" not in result
+        assert "python-debug: Debug Python scripts" in result
 
     def test_deduplicates_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))


### PR DESCRIPTION
## Summary
- compact the mandatory skills index guidance while preserving the skill_view/patch/save workflow instructions
- omit category DESCRIPTION.md prose from the system-prompt skills index because per-skill descriptions already carry selection context
- add a lightweight prompt-context measurement script and regression coverage for category description omission

## Measurements
Measured with: python scripts/measure_prompt_context.py

Before:
- skills_index: 10,686 chars / ~2,672 tokens
- measured static subset total: 22,136 chars / ~5,534 tokens

After:
- skills_index: 7,445 chars / ~1,862 tokens
- measured static subset total: 18,895 chars / ~4,724 tokens

Reduction:
- skills_index: -3,241 chars / ~810 tokens (-30.3%)
- measured static subset total: -3,241 chars / ~810 tokens (-14.6%)

## Tests
- python -m pytest tests/agent/test_prompt_builder.py -q
- python scripts/measure_prompt_context.py