### PR TITLE
fix(title): strip reasoning-tag blocks from auto-generated session titles

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -5,6 +5,7 @@ adds latency to the user-facing reply.
 """
 
 import logging
+import re
 import threading
 from typing import Callable, Optional
 
@@ -24,6 +25,53 @@ _TITLE_PROMPT = (
     "following exchange. The title should capture the main topic or intent. "
     "Return ONLY the title text, nothing else. No quotes, no punctuation at the end, no prefixes."
 )
+
+# ---- Reasoning-tag scrub for auto-titles --------------------------------
+# Reasoning models (notably MiniMax-M3) emit their chain-of-thought inline
+# in the ``content`` field when the structured ``reasoning_content`` field
+# isn't populated — which is exactly what happens for the auxiliary
+# title-generation call.  Without scrubbing, the raw thinking prose gets
+# saved as the session title and surfaces in:
+#   * the desktop session list
+#   * the Telegram topic/thread name (via ``_rename_telegram_topic_for_session_title``)
+#   * ``/sessions`` output
+# Mirrors ``agent.agent_runtime_helpers.strip_think_blocks`` but is
+# self-contained so this module doesn't pull in the agent runtime.
+_THINK_CLOSED_RE = re.compile(
+    r"<think>.*?</think>"
+    r"|<thinking>.*?</thinking>"
+    r"|<reasoning>.*?</reasoning>"
+    r"|<REASONING_SCRATCHPAD>.*?</REASONING_SCRATCHPAD>"
+    r"|<thought>.*?</thought>",
+    re.DOTALL | re.IGNORECASE,
+)
+# Unterminated open tag at a block boundary (start of string or after
+# newline).  Catches the case where the title was truncated at 80 chars
+# before the closing tag could appear, leaving a bare ``<think>…`` prefix.
+_THINK_UNTERMINATED_RE = re.compile(
+    r"(?:^|\n)[ \t]*<(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)\b[^>]*>.*$",
+    re.DOTALL | re.IGNORECASE,
+)
+# Stray orphan opening/closing tags that slipped past the two passes above.
+_THINK_ORPHAN_RE = re.compile(
+    r"</?(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)>\s*",
+    re.IGNORECASE,
+)
+
+
+def _strip_reasoning_tags_for_title(content: str) -> str:
+    """Remove inline reasoning/thinking blocks from a title-generation response.
+
+    Returns the cleaned content (possibly empty).  Empty results are
+    handled by ``generate_title`` returning ``None`` so the session simply
+    stays untitled rather than getting a polluted string.
+    """
+    if not content:
+        return ""
+    s = _THINK_CLOSED_RE.sub("", content)
+    s = _THINK_UNTERMINATED_RE.sub("", s)
+    s = _THINK_ORPHAN_RE.sub("", s)
+    return s.strip()
 
 
 def generate_title(
@@ -62,7 +110,12 @@ def generate_title(
             timeout=timeout,
             main_runtime=main_runtime,
         )
-        title = (response.choices[0].message.content or "").strip()
+        # Reasoning models (e.g. MiniMax-M3) may emit their chain-of-thought
+        # inline in ``content`` when ``reasoning_content`` isn't populated —
+        # strip those blocks before treating the response as a title.
+        title = _strip_reasoning_tags_for_title(
+            response.choices[0].message.content or ""
+        )
         # Clean up: remove quotes, trailing punctuation, prefixes like "Title: "
         title = title.strip('"\'')
         if title.lower().startswith("title:"):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10017,7 +10017,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     def _sanitize_telegram_topic_title(self, title: str) -> str:
         """Return a Bot API-safe forum topic name from a generated session title."""
-        cleaned = re.sub(r"\s+", " ", str(title or "")).strip()
+        # Defensive: if a polluted title (raw ``<think>`` block from a reasoning
+        # model) somehow reaches this layer — e.g. from a code path that
+        # bypasses ``agent.title_generator._strip_reasoning_tags_for_title``
+        # — strip it here too so it never surfaces as a Telegram topic name.
+        # Mirrors the regex family in ``agent/title_generator.py``.
+        title = re.sub(
+            r"<think>.*?</think>|<thinking>.*?</thinking>"
+            r"|<reasoning>.*?</reasoning>"
+            r"|<REASONING_SCRATCHPAD>.*?</REASONING_SCRATCHPAD>"
+            r"|<thought>.*?</thought>",
+            "",
+            str(title or ""),
+            flags=re.DOTALL | re.IGNORECASE,
+        )
+        title = re.sub(
+            r"(?:^|\n)[ \t]*<(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)\b[^>]*>.*$",
+            "",
+            title,
+            flags=re.DOTALL | re.IGNORECASE,
+        )
+        title = re.sub(
+            r"</?(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)>\s*",
+            "",
+            title,
+            flags=re.IGNORECASE,
+        )
+        cleaned = re.sub(r"\s+", " ", title).strip()
         if not cleaned:
             return "Hermes Chat"
         # Telegram forum topic names are short (currently 1-128 chars). Keep

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -2,12 +2,78 @@
 
 from unittest.mock import MagicMock, patch
 
-
 from agent.title_generator import (
+    _strip_reasoning_tags_for_title,
     generate_title,
     auto_title_session,
     maybe_auto_title,
 )
+
+
+class TestStripReasoningTagsForTitle:
+    """Unit tests for _strip_reasoning_tags_for_title()."""
+
+    def test_strips_closed_think_block(self):
+        # Most common case: model emits ``<think>reasoning</think>Actual title``
+        out = _strip_reasoning_tags_for_title(
+            "<think>Let me think about this.</think>TTS-Server Setup"
+        )
+        assert out == "TTS-Server Setup"
+
+    def test_strips_unterminated_think_block(self):
+        # The real-world polluter: title is truncated to 80 chars before
+        # the closing tag appears, leaving a bare ``<think>…`` prefix.
+        out = _strip_reasoning_tags_for_title(
+            "<think> The user wants a short descriptive title (3-7 words) for a conversati... #2"
+        )
+        assert out == ""
+
+    def test_strips_only_thinking_returns_empty(self):
+        out = _strip_reasoning_tags_for_title("<think>reasoning only</think>")
+        assert out == ""
+
+    def test_strips_multiple_think_blocks(self):
+        out = _strip_reasoning_tags_for_title(
+            "Multi <think>block 1</think> middle <think>block 2</think> tail"
+        )
+        assert out == "Multi  middle  tail"
+
+    def test_handles_thinking_and_reasoning_variants(self):
+        for tag in ("thinking", "reasoning", "REASONING_SCRATCHPAD", "thought"):
+            out = _strip_reasoning_tags_for_title(
+                f"<{tag}>internal scratch</{tag}>Visible Title"
+            )
+            assert out == "Visible Title", f"failed for {tag}: {out!r}"
+
+    def test_handles_case_insensitivity(self):
+        for tag in ("THINK", "Think", "ThInKiNg"):
+            out = _strip_reasoning_tags_for_title(
+                f"<{tag}>internal</{tag}>Visible"
+            )
+            assert out == "Visible", f"failed for {tag}: {out!r}"
+
+    def test_passes_through_normal_text(self):
+        out = _strip_reasoning_tags_for_title("Normal title without think blocks")
+        assert out == "Normal title without think blocks"
+
+    def test_strips_orphan_close_tag(self):
+        out = _strip_reasoning_tags_for_title("A title </think> leaked")
+        assert out == "A title  leaked"
+
+    def test_empty_input_returns_empty(self):
+        assert _strip_reasoning_tags_for_title("") == ""
+        assert _strip_reasoning_tags_for_title(None) == ""
+
+    def test_strips_unterminated_think_after_newline(self):
+        out = _strip_reasoning_tags_for_title(
+            "Lead text\n<think>unterminated block\nmore reasoning"
+        )
+        assert out == "Lead text"
+
+    def test_preserves_prose_mention_of_tag_word(self):
+        # Don't over-strip: bare word "think" without a tag must survive.
+        out = _strip_reasoning_tags_for_title("Let me think about the title")
+        assert out == "Let me think about the title"
 
 
 class TestGenerateTitle:
@@ -57,6 +123,35 @@ class TestGenerateTitle:
 
         with patch("agent.title_generator.call_llm", return_value=mock_response):
             assert generate_title("question", "answer") is None
+
+    def test_strips_think_block_from_response(self):
+        """Regression: MiniMax-M3 returns thinking inline in content."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        # Real-world polluter: closed think block followed by a clean title.
+        mock_response.choices[0].message.content = (
+            "<think>The user wants a short title. The topic is a TTS server.</think>"
+            "TTS-Server Setup"
+        )
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            assert generate_title("help with tts", "sure") == "TTS-Server Setup"
+
+    def test_strips_unterminated_think_block_returns_none(self):
+        """Regression: title truncated at 80 chars before closing tag.
+
+        When the response is just truncated thinking prose, the session
+        stays untitled instead of being polluted.
+        """
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        # Real-world polluter: bare ``<think>`` prefix from truncation.
+        mock_response.choices[0].message.content = (
+            "<think> The user wants a short descriptive title (3-7 words) for a conversati... #2"
+        )
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            assert generate_title("q", "a") is None
 
     def test_returns_none_on_exception(self):
         with patch("agent.title_generator.call_llm", side_effect=RuntimeError("no provider")):


### PR DESCRIPTION
## Summary

Reasoning models (notably **MiniMax-M3**, also observed on **GLM-5.1** on some endpoints) emit their chain-of-thought **inline in the `content` field** for non-streaming auxiliary calls where the structured `reasoning_content` field isn't populated. The title generator took the raw content as-is, so the model's thinking prose got saved as the session title and surfaced in:

- the desktop session list
- the **Telegram forum-topic name** (via `_rename_telegram_topic_for_session_title` → Telegram Bot API `editForumTopic`)
- the `/sessions` command output

Real-world impact from a user DB: **10 out of 10** auto-titled Telegram sessions on `MiniMax-M3` had polluted titles like:

> `<think> The user wants a short descriptive title (3-7 words) for a conversati... #2`

(All unterminated, because the 80-char truncation at `generate_title()` line 71-72 cut the response before the closing `</think>` could appear.)

## Repro

1. Set `model.default: <any reasoning model that puts CoT inline in content>` (e.g. MiniMax-M3 via minimax provider, or GLM-5.1 on endpoints that don't populate `reasoning_content`)
2. Start a new session in Telegram
3. After the first exchange, observe the Telegram topic name and the desktop session title

## Fix

Two layers of defense:

**`agent/title_generator.py`** — new `_strip_reasoning_tags_for_title()` helper that runs three regex passes on the title response before any other cleanup:

1. Closed tag pairs: `<think>…</think>`, `<thinking>…</thinking>`, `<reasoning>…</reasoning>`, `<REASONING_SCRATCHPAD>…</REASONING_SCRATCHPAD>`, `<thought>…</thought>` (case-insensitive)
2. Unterminated open tag at a block boundary (start of string or after newline) — catches the real-world 80-char-truncation case
3. Stray orphan open/close tags

If the response is only thinking prose (no actual title produced), the function returns `None` and the session stays untitled rather than getting a polluted string. Mirrors the logic of `agent.agent_runtime_helpers.strip_think_blocks` but is self-contained so `title_generator` doesn't pull in the agent runtime.

**`gateway/run.py:_sanitize_telegram_topic_title`** — defensive backup. If a polluted title somehow reaches this layer (e.g. via a code path that bypasses the title generator), it's scrubbed before the Bot API sees it.

## Test Plan

- [ ] New `TestStripReasoningTagsForTitle` class in `tests/agent/test_title_generator.py` (10 unit tests)
- [ ] Two new regression tests in `TestGenerateTitle` that exercise the exact real-world polluted strings from the user DB
- [ ] Existing tests still pass

Test coverage:
- Closed `<think>…</think>` block followed by a real title → strips, returns the title
- Unterminated `<think>` at start of string (the actual DB sample) → strips, returns `None`
- Unterminated `<think>` after a newline → strips from the tag to end
- Multiple blocks in one response → strips all
- All 5 tag variants (`think`, `thinking`, `reasoning`, `REASONING_SCRATCHPAD`, `thought`)
- Case-insensitive (`THINK`, `Think`, `ThInKiNg`)
- Prose mention of the word "think" without a tag → preserved
- Empty / `None` input → returns `""`

Manual validation against the 10 real polluted samples from the user DB:

```
POLLUTED INPUT -> SCRUBBED OUTPUT (all should be empty or clean):
  [OK] '<think> The user wants a short descriptive title (3-7 w' -> ''
  [OK] '<think> The user wants a short, descriptive title (3-7 ' -> ''
  [OK] '<think> The user is asking me to generate a short title' -> ''
  [OK] '<think> The user wants a short descriptive title (3-7 w' -> ''
  [OK] '<think> The user is asking me to generate a short, desc' -> ''
  [OK] '<think> The user is asking in German about a TTS (text-' -> ''
  [OK] '<think> The user is asking for a short, descriptive tit' -> ''
  [OK] '<think> The user sent "test" and the assistant responde' -> ''
  [OK] '<think> The user is asking about whether Hermes is now ' -> ''
  [OK] '<think> The user is asking about MCP server support, an' -> ''

CLEAN INPUT -> UNCHANGED OUTPUT:
  [OK] 'Casual Greeting and Catch Up' -> 'Casual Greeting and Catch Up'
  [OK] 'Verlorene Chats nach Update' -> 'Verlorene Chats nach Update'
  [OK] 'TTS-Server Setup' -> 'TTS-Server Setup'
  [OK] 'Debugging Python Import Errors' -> 'Debugging Python Import Errors'
```

Also ran a one-shot DB cleanup script on the user install — 10 polluted titles cleared, 2 clean titles preserved.

## Notes

- This is a defensive fix on the Hermes side; the underlying model behavior is correct (it IS using `reasoning_content` on streaming calls and on the main conversation path — only the auxiliary title-generation call doesn't get that treatment). No model change is required.
- The `_sanitize_telegram_topic_title` defensive layer is intentionally a near-duplicate of the regex family in `title_generator.py` rather than importing from it, to keep the gateway module's import surface narrow. If a shared helper is preferred, happy to refactor.

## Related

- File touched: `agent/title_generator.py` (the bug), `gateway/run.py` (defensive depth), `tests/agent/test_title_generator.py` (coverage)
- Discovered while investigating session-title pollution on a user install with `model=MiniMax-M3` and `provider=minimax` at base URL `https://api.minimax.io/v1`
