### PR TITLE
feat(desktop): add GitHub colorblind themes

### DIFF
--- a/apps/desktop/src/themes/presets.ts
+++ b/apps/desktop/src/themes/presets.ts
@@ -307,6 +307,35 @@ const GITHUB_DARK_COLORBLIND_COLORS: DesktopThemeColors = {
   userBubbleBorder: '#30363d'
 }
 
+const GITHUB_LIGHT_COLORBLIND_COLORS: DesktopThemeColors = {
+  background: '#ffffff',
+  foreground: '#24292f',
+  card: '#f6f8fa',
+  cardForeground: '#24292f',
+  muted: '#eaeef2',
+  mutedForeground: '#57606a',
+  popover: '#ffffff',
+  popoverForeground: '#24292f',
+  primary: '#0969da',
+  primaryForeground: '#ffffff',
+  secondary: '#ebecf0',
+  secondaryForeground: '#24292f',
+  accent: '#ddf4ff',
+  accentForeground: '#0969da',
+  border: '#d0d7de',
+  input: '#ffffff',
+  ring: '#0969da',
+  midground: '#0969da',
+  midgroundForeground: '#ffffff',
+  composerRing: '#0969da',
+  destructive: '#b35900',
+  destructiveForeground: '#ffffff',
+  sidebarBackground: '#f6f8fa',
+  sidebarBorder: '#d0d7de',
+  userBubble: '#ddf4ff',
+  userBubbleBorder: '#d0d7de'
+}
+
 /**
  * GitHub Dark Colorblind — faithful desktop clone of the GitHub Theme VS Code
  * extension's `GitHub Dark Colorblind (Beta)` palette. The source theme is MIT
@@ -363,6 +392,62 @@ export const githubDarkColorblindTheme: DesktopTheme = {
   }
 }
 
+/**
+ * GitHub Light Colorblind — faithful desktop clone of the GitHub Theme VS Code
+ * extension's `GitHub Light Colorblind (Beta)` palette. The source theme is MIT
+ * licensed in primer/github-vscode-theme (Copyright © 2020 Primer) and swaps
+ * red/green status colors for orange/blue cues for protanopia/deuteranopia
+ * accessibility.
+ */
+export const githubLightColorblindTheme: DesktopTheme = {
+  name: 'github-light-colorblind',
+  label: 'GitHub Light Colorblind',
+  description: 'GitHub light colorblind palette — blue/orange accessible contrast',
+  colors: GITHUB_LIGHT_COLORBLIND_COLORS,
+  darkColors: GITHUB_LIGHT_COLORBLIND_COLORS,
+  typography: {
+    fontMono: `"Cascadia Code", "JetBrains Mono", ${SYSTEM_MONO}`
+  },
+  terminal: {
+    foreground: '#24292f',
+    black: '#24292f',
+    red: '#b35900',
+    green: '#0550ae',
+    yellow: '#4d2d00',
+    blue: '#0969da',
+    magenta: '#8250df',
+    cyan: '#1b7c83',
+    white: '#6e7781',
+    brightBlack: '#57606a',
+    brightRed: '#8a4600',
+    brightGreen: '#0969da',
+    brightYellow: '#633c01',
+    brightBlue: '#218bff',
+    brightMagenta: '#a475f9',
+    brightCyan: '#3192aa',
+    brightWhite: '#8c959f'
+  },
+  darkTerminal: {
+    foreground: '#24292f',
+    black: '#24292f',
+    red: '#b35900',
+    green: '#0550ae',
+    yellow: '#4d2d00',
+    blue: '#0969da',
+    magenta: '#8250df',
+    cyan: '#1b7c83',
+    white: '#6e7781',
+    brightBlack: '#57606a',
+    brightRed: '#8a4600',
+    brightGreen: '#0969da',
+    brightYellow: '#633c01',
+    brightBlue: '#218bff',
+    brightMagenta: '#a475f9',
+    brightCyan: '#3192aa',
+    brightWhite: '#8c959f'
+  }
+}
+
 export const BUILTIN_THEMES: Record<string, DesktopTheme> = {
   nous: nousTheme,
   midnight: midnightTheme,
@@ -370,7 +455,8 @@ export const BUILTIN_THEMES: Record<string, DesktopTheme> = {
   mono: monoTheme,
   cyberpunk: cyberpunkTheme,
   slate: slateTheme,
-  'github-dark-colorblind': githubDarkColorblindTheme
+  'github-dark-colorblind': githubDarkColorblindTheme,
+  'github-light-colorblind': githubLightColorblindTheme
 }
 
 export const BUILTIN_THEME_LIST = Object.values(BUILTIN_THEMES)

--- a/apps/desktop/src/themes/presets.ts
+++ b/apps/desktop/src/themes/presets.ts
@@ -3,7 +3,7 @@
  * Add new themes here — no code changes needed elsewhere.
  */
 
-import type { DesktopTheme, DesktopThemeTypography } from './types'
+import type { DesktopTheme, DesktopThemeColors, DesktopThemeTypography } from './types'
 
 // Color-emoji fonts to append to every stack as a last resort. None of the UI
 // text/mono fonts carry emoji glyphs, so without this emoji render as tofu
@@ -278,13 +278,99 @@ export const slateTheme: DesktopTheme = {
   }
 }
 
+const GITHUB_DARK_COLORBLIND_COLORS: DesktopThemeColors = {
+  background: '#0d1117',
+  foreground: '#c9d1d9',
+  card: '#010409',
+  cardForeground: '#c9d1d9',
+  muted: '#161b22',
+  mutedForeground: '#8b949e',
+  popover: '#161b22',
+  popoverForeground: '#c9d1d9',
+  primary: '#58a6ff',
+  primaryForeground: '#0d1117',
+  secondary: '#1f6feb',
+  secondaryForeground: '#ffffff',
+  accent: '#18273e',
+  accentForeground: '#c9d1d9',
+  border: '#30363d',
+  input: '#0d1117',
+  ring: '#58a6ff',
+  midground: '#58a6ff',
+  midgroundForeground: '#0d1117',
+  composerRing: '#58a6ff',
+  destructive: '#d47616',
+  destructiveForeground: '#ffffff',
+  sidebarBackground: '#010409',
+  sidebarBorder: '#30363d',
+  userBubble: '#0e1c32',
+  userBubbleBorder: '#30363d'
+}
+
+/**
+ * GitHub Dark Colorblind — faithful desktop clone of the GitHub Theme VS Code
+ * extension's `GitHub Dark Colorblind (Beta)` palette. The source theme is MIT
+ * licensed in primer/github-vscode-theme (Copyright © 2020 Primer) and swaps
+ * red/green status colors for orange/blue cues for protanopia/deuteranopia
+ * accessibility.
+ */
+export const githubDarkColorblindTheme: DesktopTheme = {
+  name: 'github-dark-colorblind',
+  label: 'GitHub Dark Colorblind',
+  description: 'GitHub dark colorblind palette — blue/orange accessible contrast',
+  colors: GITHUB_DARK_COLORBLIND_COLORS,
+  darkColors: GITHUB_DARK_COLORBLIND_COLORS,
+  typography: {
+    fontMono: `"Cascadia Code", "JetBrains Mono", ${SYSTEM_MONO}`
+  },
+  terminal: {
+    foreground: '#c9d1d9',
+    black: '#484f58',
+    red: '#ec8e2c',
+    green: '#58a6ff',
+    yellow: '#d29922',
+    blue: '#58a6ff',
+    magenta: '#bc8cff',
+    cyan: '#39c5cf',
+    white: '#b1bac4',
+    brightBlack: '#6e7681',
+    brightRed: '#fdac54',
+    brightGreen: '#79c0ff',
+    brightYellow: '#e3b341',
+    brightBlue: '#79c0ff',
+    brightMagenta: '#d2a8ff',
+    brightCyan: '#56d4dd',
+    brightWhite: '#ffffff'
+  },
+  darkTerminal: {
+    foreground: '#c9d1d9',
+    black: '#484f58',
+    red: '#ec8e2c',
+    green: '#58a6ff',
+    yellow: '#d29922',
+    blue: '#58a6ff',
+    magenta: '#bc8cff',
+    cyan: '#39c5cf',
+    white: '#b1bac4',
+    brightBlack: '#6e7681',
+    brightRed: '#fdac54',
+    brightGreen: '#79c0ff',
+    brightYellow: '#e3b341',
+    brightBlue: '#79c0ff',
+    brightMagenta: '#d2a8ff',
+    brightCyan: '#56d4dd',
+    brightWhite: '#ffffff'
+  }
+}
+
 export const BUILTIN_THEMES: Record<string, DesktopTheme> = {
   nous: nousTheme,
   midnight: midnightTheme,
   ember: emberTheme,
   mono: monoTheme,
   cyberpunk: cyberpunkTheme,
-  slate: slateTheme
+  slate: slateTheme,
+  'github-dark-colorblind': githubDarkColorblindTheme
 }
 
 export const BUILTIN_THEME_LIST = Object.values(BUILTIN_THEMES)


### PR DESCRIPTION
## What does this PR do?

Adds the GitHub Dark Colorblind and GitHub Light Colorblind palettes as built-in Hermes Desktop themes. The palettes are adapted from the MIT-licensed `primer/github-vscode-theme` GitHub Colorblind themes and preserve the blue/orange status cues intended for protanopia/deuteranopia accessibility.

## Related Issue

No issue; small accessibility/theme addition.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `github-dark-colorblind` and `github-light-colorblind` built-in desktop themes in `apps/desktop/src/themes/presets.ts`.
- Included matching terminal ANSI palettes for both themes.
- Registered both themes in `BUILTIN_THEMES` so they appear in Appearance settings, `/skin`, and existing theme surfaces.

## How to Test

1. `cd apps/desktop`
2. Run the checks below.
3. Select `GitHub Dark Colorblind` or `GitHub Light Colorblind` in Settings → Appearance, or use `/skin github-dark-colorblind` / `/skin github-light-colorblind`.

## Local Validation

| Check | Result |
|---|---|
| `npm run typecheck` | PASS |
| `npx vitest run --environment jsdom src/themes/presets.test.ts src/themes/user-themes.test.ts src/themes/vscode.test.ts src/themes/profile-theme.test.ts src/themes/install.test.ts` | PASS — 5 files / 45 tests |
| `npx eslint src/themes/presets.ts` | PASS |
| `npm run build` | PASS — `dist/index.html + assets present` |

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — not run; change is limited to Desktop TypeScript theme presets
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — existing theme registry tests cover built-in theme invariants
- [x] I've tested on my platform: WSL2 / Linux desktop build checks

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — theme-only Desktop change
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A — this PR does not add a skill.

## Screenshots / Logs

No screenshots attached. Local build and focused desktop theme checks passed as listed above.

## AI-Assisted Disclosure

AI tools were used to inspect the Desktop theme registry, adapt the GitHub Colorblind palettes, and run local validation. The final diff is intentionally scoped to `apps/desktop/src/themes/presets.ts` and was reviewed before submission.
