### PR TITLE
fix(security): harden tool and delegation redaction

### DIFF
--- a/agent/redact_fallback.py
+++ b/agent/redact_fallback.py
@@ -1,0 +1,77 @@
+"""Small last-ditch secret redactor for hard safety boundaries.
+
+This module intentionally has no dependency on :mod:`agent.redact`.  Callers use
+it only when the full shared redactor fails; it preserves a minimal set of
+credential guards so model-facing/tool-facing boundaries do not fail open.
+"""
+
+from __future__ import annotations
+
+import re
+
+_SENSITIVE_FIELD_RE = re.compile(
+    r'("(?:api_?key|token|secret|password|access_token|refresh_token|auth_token|bearer|authorization|private_key)")'
+    r'\s*:\s*"([^"]+)"',
+    re.IGNORECASE,
+)
+
+_SECRET_ENV_NAMES = r"(?:API_?KEY|TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIAL|AUTH)"
+_ENV_ASSIGN_RE = re.compile(
+    rf"\b([A-Z0-9_]{{0,50}}{_SECRET_ENV_NAMES}[A-Z0-9_]{{0,50}})\s*=\s*(['\"]?)(\S+)\2",
+    re.IGNORECASE,
+)
+
+_AUTH_HEADER_RE = re.compile(r"(\bAuthorization:\s*Bearer\s+)(\S+)", re.IGNORECASE)
+_BEARER_RE = re.compile(r"(\bBearer\s+)[A-Za-z0-9._\-]{12,}", re.IGNORECASE)
+
+_PREFIX_RE = re.compile(
+    r"(?<![A-Za-z0-9_-])(?:"
+    r"sk-[A-Za-z0-9_-]{10,}"
+    r"|gh[pousr]_[A-Za-z0-9_]{10,}"
+    r"|github_pat_[A-Za-z0-9_]{10,}"
+    r"|xox[baprs]-[A-Za-z0-9-]{10,}"
+    r"|hf_[A-Za-z0-9]{10,}"
+    r"|glpat-[A-Za-z0-9_-]{10,}"
+    r"|AIza[A-Za-z0-9_-]{30,}"
+    r"|pplx-[A-Za-z0-9]{10,}"
+    r"|fal_[A-Za-z0-9_-]{10,}"
+    r"|fc-[A-Za-z0-9]{10,}"
+    r"|bb_live_[A-Za-z0-9_-]{10,}"
+    r"|gAAAA[A-Za-z0-9_=-]{20,}"
+    r"|AKIA[A-Z0-9]{16}"
+    r"|sk_live_[A-Za-z0-9]{10,}"
+    r"|sk_test_[A-Za-z0-9]{10,}"
+    r"|rk_live_[A-Za-z0-9]{10,}"
+    r"|SG\.[A-Za-z0-9_-]{10,}"
+    r"|npm_[A-Za-z0-9]{10,}"
+    r"|pypi-[A-Za-z0-9_-]{10,}"
+    r"|dop_v1_[A-Za-z0-9]{10,}"
+    r"|doo_v1_[A-Za-z0-9]{10,}"
+    r"|am_[A-Za-z0-9_-]{10,}"
+    r"|sk_[A-Za-z0-9_]{10,}"
+    r"|tvly-[A-Za-z0-9]{10,}"
+    r"|exa_[A-Za-z0-9]{10,}"
+    r"|gsk_[A-Za-z0-9]{10,}"
+    r"|hsk-[A-Za-z0-9]{10,}"
+    r"|xai-[A-Za-z0-9]{30,}"
+    r")"
+    r"(?![A-Za-z0-9_-])"
+)
+
+
+def redact_sensitive_text_fallback(text: object) -> str:
+    """Return ``text`` with high-risk secret shapes replaced by ``[REDACTED]``.
+
+    This is deliberately narrower than the canonical redactor.  It catches
+    sensitive JSON fields, env-style assignments, bearer tokens, and common
+    vendor prefixes without trying to preserve debuggability.
+    """
+    redacted = "" if text is None else str(text)
+    if not redacted:
+        return redacted
+    redacted = _SENSITIVE_FIELD_RE.sub(lambda m: f'{m.group(1)}: "[REDACTED]"', redacted)
+    redacted = _ENV_ASSIGN_RE.sub(lambda m: f"{m.group(1)}={m.group(2)}[REDACTED]{m.group(2)}", redacted)
+    redacted = _AUTH_HEADER_RE.sub(lambda m: f"{m.group(1)}[REDACTED]", redacted)
+    redacted = _BEARER_RE.sub(lambda m: f"{m.group(1)}[REDACTED]", redacted)
+    redacted = _PREFIX_RE.sub("[REDACTED]", redacted)
+    return redacted

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -220,8 +220,19 @@ def _gateway_loop_exception_handler(
 
 
 def _redact_gateway_user_facing_secrets(text: str) -> str:
-    """Best-effort secret redaction before text can leave the gateway."""
+    """Redact secrets before gateway text can leave the process."""
     redacted = str(text or "")
+    try:
+        from agent.redact import redact_sensitive_text
+
+        # Gateway chat/status output is an external side-effect boundary, so
+        # force redaction even if verbose local logs have been opted out.
+        redacted = redact_sensitive_text(redacted, force=True)
+    except Exception as exc:
+        logger.warning("Gateway secret redaction failed: %s", exc)
+        from agent.redact_fallback import redact_sensitive_text_fallback
+
+        redacted = redact_sensitive_text_fallback(redacted)
     for pattern in _GATEWAY_SECRET_PATTERNS:
         redacted = pattern.sub(lambda m: (m.group(1) if m.lastindex else "") + "[REDACTED]", redacted)
     return redacted

--- a/model_tools.py
+++ b/model_tools.py
@@ -597,9 +597,12 @@ _TOOL_ERROR_MAX_LEN = 2000
 
 
 def _sanitize_tool_error(error_msg: str) -> str:
-    """Strip structural framing tokens from a tool error before showing it to the model.
+    """Strip unsafe text from a tool error before showing it to the model.
 
-    See _TOOL_ERROR_ROLE_TAG_RE docstring above for rationale.
+    See _TOOL_ERROR_ROLE_TAG_RE docstring above for rationale.  This is also
+    a hard safety boundary: raw tool exceptions may contain credentials from
+    HTTP libraries, SDKs, subprocess stderr, or plugin code, so force the
+    shared secret redactor even when ordinary log redaction is disabled.
     """
     if not error_msg:
         return "[TOOL_ERROR] "
@@ -607,6 +610,15 @@ def _sanitize_tool_error(error_msg: str) -> str:
     sanitized = _TOOL_ERROR_FENCE_OPEN_RE.sub("", sanitized)
     sanitized = _TOOL_ERROR_FENCE_CLOSE_RE.sub("", sanitized)
     sanitized = _TOOL_ERROR_CDATA_RE.sub("", sanitized)
+    try:
+        from agent.redact import redact_sensitive_text
+
+        sanitized = redact_sensitive_text(sanitized, force=True)
+    except Exception as exc:
+        logger.warning("Tool-error secret redaction failed: %s", exc)
+        from agent.redact_fallback import redact_sensitive_text_fallback
+
+        sanitized = redact_sensitive_text_fallback(sanitized)
     if len(sanitized) > _TOOL_ERROR_MAX_LEN:
         sanitized = sanitized[:_TOOL_ERROR_MAX_LEN - 3] + "..."
     return f"[TOOL_ERROR] {sanitized}"

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -1,5 +1,7 @@
 """Telegram-specific gateway filtering for noisy status/error output."""
 
+import logging
+
 from gateway.config import Platform
 from gateway.run import (
     _prepare_gateway_status_message,
@@ -74,6 +76,45 @@ def test_telegram_final_response_redacts_auth_secrets():
     assert "authentication failed" in sanitized.lower()
     assert "check the configured credentials" in sanitized.lower()
     assert "sk-live" not in sanitized
+
+
+def test_telegram_final_response_redacts_opaque_sensitive_fields():
+    """Gateway chat redaction should use the shared redactor, not prefix-only patterns."""
+    raw = 'Diagnostic payload: {"api_key": "opaque-secret-value-1234567890"}'
+
+    sanitized = _sanitize_gateway_final_response(Platform.TELEGRAM, raw)
+
+    assert "opaque-secret-value-1234567890" not in sanitized
+    assert '"api_key"' in sanitized
+    assert "..." in sanitized or "***" in sanitized
+
+
+def test_telegram_final_response_redacts_even_when_global_redaction_disabled(monkeypatch):
+    import agent.redact as redact_module
+
+    monkeypatch.setattr(redact_module, "_REDACT_ENABLED", False)
+    raw = 'Diagnostic payload: {"api_key": "opaque-secret-value-1234567890"}'
+
+    sanitized = _sanitize_gateway_final_response(Platform.TELEGRAM, raw)
+
+    assert "opaque-secret-value-1234567890" not in sanitized
+
+
+def test_telegram_final_response_fallback_redacts_if_shared_redactor_raises(monkeypatch, caplog):
+    import agent.redact as redact_module
+
+    def fail_redaction(*_args, **_kwargs):
+        raise RuntimeError("redactor unavailable")
+
+    monkeypatch.setattr(redact_module, "redact_sensitive_text", fail_redaction)
+    raw = 'Diagnostic payload: {"api_key": "opaque-secret-value-1234567890"}'
+
+    with caplog.at_level(logging.WARNING, logger="gateway.run"):
+        sanitized = _sanitize_gateway_final_response(Platform.TELEGRAM, raw)
+
+    assert "opaque-secret-value-1234567890" not in sanitized
+    assert '"api_key"' in sanitized
+    assert "Gateway secret redaction failed" in caplog.text
 
 
 def test_telegram_final_response_keeps_normal_answers():

--- a/tests/test_sanitize_tool_error.py
+++ b/tests/test_sanitize_tool_error.py
@@ -99,6 +99,41 @@ class TestEnvelope:
         assert msg in out
 
 
+class TestSecretRedaction:
+    def test_redacts_secret_like_values_before_model_context(self):
+        msg = 'Error executing tool: upstream returned {"api_key": "opaque-secret-value-1234567890"}'
+
+        out = _sanitize_tool_error(msg)
+
+        assert "opaque-secret-value-1234567890" not in out
+        assert '"api_key"' in out
+        assert "..." in out or "***" in out
+
+    def test_redacts_even_when_global_redaction_disabled(self, monkeypatch):
+        import agent.redact as redact_module
+
+        monkeypatch.setattr(redact_module, "_REDACT_ENABLED", False)
+        msg = 'Error executing tool: upstream returned {"api_key": "opaque-secret-value-1234567890"}'
+
+        out = _sanitize_tool_error(msg)
+
+        assert "opaque-secret-value-1234567890" not in out
+
+    def test_fallback_redacts_if_shared_redactor_raises(self, monkeypatch):
+        import agent.redact as redact_module
+
+        def fail_redaction(*_args, **_kwargs):
+            raise RuntimeError("redactor unavailable")
+
+        monkeypatch.setattr(redact_module, "redact_sensitive_text", fail_redaction)
+        msg = 'Error executing tool: upstream returned {"api_key": "opaque-secret-value-1234567890"}'
+
+        out = _sanitize_tool_error(msg)
+
+        assert "opaque-secret-value-1234567890" not in out
+        assert '"api_key"' in out
+
+
 class TestHandleFunctionCallIntegration:
     """Verify handle_function_call routes exception-path errors through the sanitizer.
 
@@ -135,3 +170,25 @@ class TestHandleFunctionCallIntegration:
         assert "<tool_call>" not in payload["error"]
         assert "</tool_call>" not in payload["error"]
         assert "boom" in payload["error"]
+
+    def test_exception_path_redacts_secret_material(self):
+        import json
+        from model_tools import handle_function_call
+        from tools.registry import registry as _registry
+
+        def boom(_args, **_kwargs):
+            raise RuntimeError('{"api_key": "opaque-secret-value-1234567890"}')
+
+        all_tools = _registry.get_all_tool_names()
+        assert all_tools, "no tools registered — test environment broken"
+        target = all_tools[0]
+        original = _registry._tools[target].handler
+        _registry._tools[target].handler = boom
+        try:
+            result_str = handle_function_call(target, {})
+        finally:
+            _registry._tools[target].handler = original
+
+        payload = json.loads(result_str)
+        assert "opaque-secret-value-1234567890" not in payload["error"]
+        assert '"api_key"' in payload["error"]

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -148,6 +148,10 @@ class TestStripBlockedTools(unittest.TestCase):
         result = _strip_blocked_tools(["terminal", "file", "delegation", "clarify", "memory", "code_execution"])
         self.assertEqual(sorted(result), ["file", "terminal"])
 
+    def test_removes_messaging_toolset(self):
+        result = _strip_blocked_tools(["terminal", "messaging", "web"])
+        self.assertEqual(sorted(result), ["terminal", "web"])
+
     def test_preserves_allowed_toolsets(self):
         result = _strip_blocked_tools(["terminal", "file", "web", "browser"])
         self.assertEqual(sorted(result), ["browser", "file", "terminal", "web"])

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -709,6 +709,7 @@ def _strip_blocked_tools(toolsets: List[str]) -> List[str]:
         "delegation",
         "clarify",
         "memory",
+        "messaging",
         "code_execution",
     }
     return [t for t in toolsets if t not in blocked_toolset_names]


### PR DESCRIPTION
## Summary
- Force secret redaction on tool exception text before it enters model context.
- Force secret redaction on Telegram gateway final/status output before external delivery.
- Add a dependency-light fallback redactor for hard safety boundaries if the shared redactor raises.
- Strip the `messaging` toolset from delegated subagents so child agents cannot regain `send_message` through toolset requests.

## Verification
- `python -m pytest tests/agent/test_redact.py tests/test_sanitize_tool_error.py tests/gateway/test_telegram_noise_filter.py tests/tools/test_delegate.py -q` — 244 passed.
- `python -m py_compile agent/redact_fallback.py model_tools.py gateway/run.py tools/delegate_tool.py`
- `git diff --check origin/main..HEAD`
- Added-line static scan for secret assignments, shell injection, eval/exec, pickle, and SQL-format injection returned no matches.

## Review
- Independent reviewer found two initial hardening gaps: warning visibility and fallback coverage.
- Follow-up patch added warning-level logs plus fallback redaction at both boundaries.
- Independent follow-up reviewer passed with no blocking findings.

## Notes
- The fallback redactor is intentionally narrower than the canonical redactor and is used only if the canonical redactor fails.
