### PR TITLE
feat(gateway): per-platform overrides for lifecycle notification texts

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -334,6 +334,21 @@ class PlatformConfig:
     # noise; keep True for back-channels where the operator wants them.
     gateway_restart_notification: bool = True
 
+    # Optional overrides for the gateway lifecycle notification texts.
+    # Keys (all optional; missing keys fall back to the built-in defaults):
+    #   restarting    — sent to active chats/home channels when the gateway
+    #                   begins a restart
+    #   shutting_down — sent to active chats/home channels on plain shutdown
+    #   restarted     — sent to the chat that initiated /restart once the
+    #                   gateway is back
+    #   online        — sent to home channels on startup
+    # Example YAML:
+    #   slack:
+    #     gateway_restart_messages:
+    #       restarting: "Singularity is restarting — back in a moment."
+    #       online: "Singularity is back online."
+    gateway_restart_messages: Dict[str, str] = field(default_factory=dict)
+
     # Platform-specific settings
     extra: Dict[str, Any] = field(default_factory=dict)
 
@@ -344,6 +359,8 @@ class PlatformConfig:
             "reply_to_mode": self.reply_to_mode,
             "gateway_restart_notification": self.gateway_restart_notification,
         }
+        if self.gateway_restart_messages:
+            result["gateway_restart_messages"] = self.gateway_restart_messages
         if self.token:
             result["token"] = self.token
         if self.api_key:
@@ -366,6 +383,15 @@ class PlatformConfig:
         if _grn is None:
             _grn = data.get("extra", {}).get("gateway_restart_notification")
 
+        # Same dual lookup for the message-text overrides.
+        _grm = data.get("gateway_restart_messages")
+        if _grm is None:
+            _grm = data.get("extra", {}).get("gateway_restart_messages")
+        if not isinstance(_grm, dict):
+            _grm = {}
+        else:
+            _grm = {str(k): str(v) for k, v in _grm.items() if v is not None}
+
         return cls(
             enabled=_coerce_bool(data.get("enabled"), False),
             token=data.get("token"),
@@ -373,6 +399,7 @@ class PlatformConfig:
             home_channel=home_channel,
             reply_to_mode=data.get("reply_to_mode", "first"),
             gateway_restart_notification=_coerce_bool(_grn, True),
+            gateway_restart_messages=_grm,
             extra=data.get("extra", {}),
         )
 
@@ -979,6 +1006,8 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = channel_prompts
                 if "gateway_restart_notification" in platform_cfg:
                     bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
+                if "gateway_restart_messages" in platform_cfg:
+                    bridged["gateway_restart_messages"] = platform_cfg["gateway_restart_messages"]
                 enabled_was_explicit = _cfg_toplevel and "enabled" in platform_cfg
                 if not bridged and not enabled_was_explicit:
                     continue

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1440,6 +1440,19 @@ _INTERRUPT_REASON_SSE_DISCONNECT = "SSE client disconnected"
 _INTERRUPT_REASON_GATEWAY_SHUTDOWN = "Gateway shutting down"
 _INTERRUPT_REASON_GATEWAY_RESTART = "Gateway restarting"
 
+# Default texts for gateway lifecycle notifications. Each can be overridden
+# per platform via ``gateway_restart_messages`` in the platform config
+# (see PlatformConfig.gateway_restart_messages in gateway/config.py).
+_GATEWAY_LIFECYCLE_MESSAGE_DEFAULTS: Dict[str, str] = {
+    "restarting": (
+        "⚠️ Gateway restarting — Your current task will be interrupted. "
+        "Send any message after restart and I'll try to resume where you left off."
+    ),
+    "shutting_down": "⚠️ Gateway shutting down — Your current task will be interrupted.",
+    "restarted": "♻ Gateway restarted successfully. Your session continues.",
+    "online": "♻️ Gateway online — Hermes is back and ready.",
+}
+
 _CONTROL_INTERRUPT_MESSAGES = frozenset(
     {
         _INTERRUPT_REASON_STOP.lower(),
@@ -3857,6 +3870,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception as e:
                 logger.debug("Failed interrupting agent during shutdown: %s", e)
 
+    def _lifecycle_message(self, platform: Optional["Platform"], key: str) -> str:
+        """Resolve a gateway lifecycle notification text for a platform.
+
+        Looks up ``gateway_restart_messages[key]`` on the platform config and
+        falls back to the built-in default. ``platform=None`` returns the
+        default (used when no platform context is available).
+        """
+        default = _GATEWAY_LIFECYCLE_MESSAGE_DEFAULTS[key]
+        if platform is None:
+            return default
+        platform_cfg = self.config.platforms.get(platform)
+        if platform_cfg is None:
+            return default
+        overrides = getattr(platform_cfg, "gateway_restart_messages", None) or {}
+        text = overrides.get(key)
+        return text if text else default
+
     async def _notify_active_sessions_of_shutdown(self) -> None:
         """Send shutdown/restart notifications to active chats and home channels.
 
@@ -3867,14 +3897,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         active = self._snapshot_running_agents()
         restart_source = self._restart_command_source if self._restart_requested else None
 
-        action = "restarting" if self._restart_requested else "shutting down"
-        hint = (
-            "Your current task will be interrupted. "
-            "Send any message after restart and I'll try to resume where you left off."
-            if self._restart_requested
-            else "Your current task will be interrupted."
-        )
-        msg = f"⚠️ Gateway {action} — {hint}"
+        msg_key = "restarting" if self._restart_requested else "shutting_down"
 
         notified: set[tuple[str, str, Optional[str]]] = set()
         for session_key in active:
@@ -3949,7 +3972,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     adapter=adapter,
                 )
 
-                result = await adapter.send(chat_id, msg, metadata=metadata)
+                result = await adapter.send(chat_id, self._lifecycle_message(platform, msg_key), metadata=metadata)
                 if result is not None and getattr(result, "success", True) is False:
                     logger.debug(
                         "Failed to send shutdown notification to %s:%s: %s",
@@ -3997,6 +4020,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 continue
 
             try:
+                shutdown_msg = self._lifecycle_message(platform, msg_key)
                 metadata = self._thread_metadata_for_target(
                     platform,
                     home.chat_id,
@@ -4004,9 +4028,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     adapter=adapter,
                 )
                 if metadata:
-                    result = await adapter.send(str(home.chat_id), msg, metadata=metadata)
+                    result = await adapter.send(str(home.chat_id), shutdown_msg, metadata=metadata)
                 else:
-                    result = await adapter.send(str(home.chat_id), msg)
+                    result = await adapter.send(str(home.chat_id), shutdown_msg)
                 if result is not None and getattr(result, "success", True) is False:
                     logger.debug(
                         "Failed to send shutdown notification to home channel %s:%s: %s",
@@ -11239,7 +11263,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             result = await adapter.send(
                 str(chat_id),
-                "♻ Gateway restarted successfully. Your session continues.",
+                self._lifecycle_message(platform, "restarted"),
                 metadata=metadata,
             )
             # adapter.send() catches provider errors (e.g. "Chat not found")
@@ -11280,7 +11304,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         delivered: set[tuple[str, str, Optional[str]]] = set()
         skipped = skip_targets or set()
-        message = "♻️ Gateway online — Hermes is back and ready."
 
         for platform, adapter in self.adapters.items():
             home = self.config.get_home_channel(platform)
@@ -11300,6 +11323,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 continue
 
             try:
+                message = self._lifecycle_message(platform, "online")
                 metadata = self._thread_metadata_for_target(
                     platform,
                     home.chat_id,

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -71,6 +71,26 @@ class TestPlatformConfigRoundtrip:
         restored = PlatformConfig.from_dict({"gateway_restart_notification": "false"})
         assert restored.gateway_restart_notification is False
 
+    def test_gateway_restart_messages_default_empty(self):
+        assert PlatformConfig().gateway_restart_messages == {}
+        assert PlatformConfig.from_dict({}).gateway_restart_messages == {}
+
+    def test_gateway_restart_messages_roundtrip(self):
+        msgs = {"online": "Back online!", "restarting": "Brb."}
+        pc = PlatformConfig(enabled=True, gateway_restart_messages=msgs)
+        restored = PlatformConfig.from_dict(pc.to_dict())
+        assert restored.gateway_restart_messages == msgs
+
+    def test_gateway_restart_messages_from_extra(self):
+        restored = PlatformConfig.from_dict(
+            {"extra": {"gateway_restart_messages": {"online": "Hi"}}}
+        )
+        assert restored.gateway_restart_messages == {"online": "Hi"}
+
+    def test_gateway_restart_messages_ignores_non_dict(self):
+        restored = PlatformConfig.from_dict({"gateway_restart_messages": "oops"})
+        assert restored.gateway_restart_messages == {}
+
 
 class TestGetConnectedPlatforms:
     def test_returns_enabled_with_token(self):

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -584,6 +584,54 @@ async def test_send_home_channel_startup_notification_default_flag_true(
 
 
 @pytest.mark.asyncio
+async def test_send_home_channel_startup_notification_custom_message(
+    tmp_path, monkeypatch
+):
+    """gateway_restart_messages['online'] overrides the startup text."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    runner.config.platforms[Platform.TELEGRAM].gateway_restart_messages = {
+        "online": "Singularity is back online."
+    }
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="home"))
+
+    delivered = await runner._send_home_channel_startup_notifications()
+
+    assert delivered == {("telegram", "home-42", None)}
+    adapter.send.assert_called_once_with(
+        "home-42",
+        "Singularity is back online.",
+    )
+
+
+def test_lifecycle_message_fallbacks():
+    """Missing/blank overrides fall back to built-in defaults per key."""
+    runner, _adapter = make_restart_runner()
+
+    # No overrides configured → defaults.
+    assert "Gateway online" in runner._lifecycle_message(Platform.TELEGRAM, "online")
+    assert "Gateway restarting" in runner._lifecycle_message(Platform.TELEGRAM, "restarting")
+
+    # Partial overrides: only the provided key changes.
+    runner.config.platforms[Platform.TELEGRAM].gateway_restart_messages = {
+        "restarting": "Custom restart text",
+        "shutting_down": "",  # blank → fall back to default
+    }
+    assert runner._lifecycle_message(Platform.TELEGRAM, "restarting") == "Custom restart text"
+    assert "Gateway shutting down" in runner._lifecycle_message(Platform.TELEGRAM, "shutting_down")
+    assert "Gateway online" in runner._lifecycle_message(Platform.TELEGRAM, "online")
+
+    # Unknown platform / None → defaults.
+    assert "Gateway online" in runner._lifecycle_message(None, "online")
+
+
+@pytest.mark.asyncio
 async def test_send_restart_notification_skipped_when_flag_disabled(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION

## Summary

Adds an optional `gateway_restart_messages` dict to `PlatformConfig` so deployers can
customize the gateway lifecycle notification texts per platform. The four texts were
previously hardcoded in `gateway/run.py`:

| key | message |
|-----|---------|
| `restarting` | "⚠️ Gateway restarting — Your current task will be interrupted. Send any message after restart and I'll try to resume where you left off." |
| `shutting_down` | "⚠️ Gateway shutting down — Your current task will be interrupted." |
| `restarted` | "♻ Gateway restarted successfully. Your session continues." |
| `online` | "♻️ Gateway online — Hermes is back and ready." |

They are now consolidated into `_GATEWAY_LIFECYCLE_MESSAGE_DEFAULTS` and resolved via a
small `_lifecycle_message(platform, key)` helper. Any missing or blank key falls back to
the built-in default, so partial overrides work and **default behavior is byte-for-byte
unchanged** when the new key is absent.

## Motivation

White-labeled or end-user-facing deployments (e.g. a branded assistant on a company
Slack) currently have only a binary choice: keep the operator-flavored "Gateway
restarting" copy, or mute lifecycle notifications entirely with
`gateway_restart_notification: false`. This adds the middle option — keep the (useful)
notifications, but with deployment-appropriate wording.

## Usage

```yaml
slack:
  gateway_restart_messages:
    restarting: "MyBot is restarting — back in a moment. Send any message after restart and I'll pick up where we left off."
    online: "MyBot is back online and ready."
```

All keys optional; the new field follows the same shared-key YAML bridging as
`gateway_restart_notification`, so it works as a top-level key under the platform block
without a separate `platforms:` section.

## Changes

- `gateway/config.py`: new `PlatformConfig.gateway_restart_messages` field (default `{}`),
  to_dict/from_dict round-trip (incl. extra-dict lookup), shared-key bridging in
  `load_gateway_config()`. Non-dict YAML values are ignored safely.
- `gateway/run.py`: `_GATEWAY_LIFECYCLE_MESSAGE_DEFAULTS` + `_lifecycle_message()` helper;
  the four send sites (active-session shutdown ping, home-channel shutdown ping,
  post-restart reply, home-channel online ping) resolve text per platform through it.
- Tests: config defaults/round-trip/extra-bridging/non-dict guard; custom online-message
  delivery; per-key fallback behavior for partial and blank overrides.

## Test Plan

- [x] `pytest tests/gateway/test_restart_notification.py tests/gateway/test_gateway_shutdown.py tests/gateway/test_config.py tests/gateway/test_restart_drain.py tests/gateway/test_restart_resume_pending.py` — 197 passed (existing 123 + new coverage)
- [x] Manually verified config load on a live deployment profile: overrides parse and resolve; absent key → stock text

## Platforms tested

- Linux (Amazon Linux 2023, aarch64). Change is pure-Python string/config plumbing in the gateway — no file I/O, process, or terminal handling touched.

---

*Note: supersedes #43884 — same commit; the head branch was renamed to match the CONTRIBUTING.md `feat/` naming convention, which auto-closed the original PR.*
