### PR TITLE
fix(gateway): detect launchd in the /restart service-manager probe

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -787,7 +787,15 @@ class GatewaySlashCommandsMixin:
         # us.  The detached subprocess approach (setsid + bash) doesn't work
         # under systemd (KillMode=mixed kills the cgroup) or Docker (tini
         # exits when the gateway dies, taking the detached helper with it).
-        _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
+        # systemd sets INVOCATION_ID; launchd sets XPC_SERVICE_NAME to the
+        # job label.  Without the launchd check, macOS /restart takes the
+        # detached path and exits 0, which KeepAlive.SuccessfulExit=false
+        # treats as a deliberate stop — the gateway stays dead until next
+        # login.  Interactive macOS shells inherit XPC_SERVICE_NAME=0, so
+        # "0" must count as not-under-launchd.
+        _under_service = bool(os.environ.get("INVOCATION_ID")) or os.environ.get(
+            "XPC_SERVICE_NAME", "0"
+        ) not in ("", "0")
         _in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
         if _under_service or _in_container:
             self.request_restart(detached=False, via_service=True)

--- a/tests/gateway/test_restart_service_detection.py
+++ b/tests/gateway/test_restart_service_detection.py
@@ -1,0 +1,85 @@
+"""Tests for /restart service-manager detection (launchd vs interactive).
+
+The /restart handler routes through ``request_restart(via_service=True)``
+when a service manager supervises the gateway, so the process exits with
+the service-restart code and the manager relaunches it.  Under macOS
+launchd the plist uses ``KeepAlive.SuccessfulExit=false`` — a clean exit 0
+is treated as a deliberate stop and the gateway stays dead (#43475) — so
+launchd must be detected here in the handler, not only at the exit-code
+site (which never runs unless ``via_service=True`` is already set).
+
+launchd sets ``XPC_SERVICE_NAME`` to the job label for processes it
+spawns.  Interactive macOS shells inherit ``XPC_SERVICE_NAME=0`` (a
+truthy string), so the probe must treat ``"0"`` as not-under-launchd:
+routing an unsupervised interactive gateway to the service path would
+make it exit non-zero with nothing to revive it.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.platforms.base import MessageEvent, MessageType
+from tests.gateway.restart_test_helpers import make_restart_runner, make_restart_source
+
+
+def _make_restart_event(update_id: int | None = 100) -> MessageEvent:
+    return MessageEvent(
+        text="/restart",
+        message_type=MessageType.TEXT,
+        source=make_restart_source(),
+        message_id="m1",
+        platform_update_id=update_id,
+    )
+
+
+def _make_runner_with_mock_restart(tmp_path, monkeypatch):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+    monkeypatch.delenv("XPC_SERVICE_NAME", raising=False)
+    runner, _adapter = make_restart_runner()
+    runner.request_restart = MagicMock(return_value=True)
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_restart_under_launchd_uses_service_path(tmp_path, monkeypatch):
+    """launchd job label in XPC_SERVICE_NAME routes /restart via the service path."""
+    runner = _make_runner_with_mock_restart(tmp_path, monkeypatch)
+    monkeypatch.setenv("XPC_SERVICE_NAME", "ai.hermes.gateway")
+
+    await runner._handle_restart_command(_make_restart_event())
+
+    runner.request_restart.assert_called_once_with(detached=False, via_service=True)
+
+
+@pytest.mark.asyncio
+async def test_restart_in_interactive_macos_shell_uses_detached_path(tmp_path, monkeypatch):
+    """XPC_SERVICE_NAME=0 (inherited by interactive macOS shells) is NOT a service."""
+    runner = _make_runner_with_mock_restart(tmp_path, monkeypatch)
+    monkeypatch.setenv("XPC_SERVICE_NAME", "0")
+
+    await runner._handle_restart_command(_make_restart_event())
+
+    runner.request_restart.assert_called_once_with(detached=True, via_service=False)
+
+
+@pytest.mark.asyncio
+async def test_restart_without_service_env_uses_detached_path(tmp_path, monkeypatch):
+    """No service-manager env at all falls back to the detached restart."""
+    runner = _make_runner_with_mock_restart(tmp_path, monkeypatch)
+
+    await runner._handle_restart_command(_make_restart_event())
+
+    runner.request_restart.assert_called_once_with(detached=True, via_service=False)
+
+
+@pytest.mark.asyncio
+async def test_restart_under_systemd_uses_service_path(tmp_path, monkeypatch):
+    """INVOCATION_ID (systemd) still routes via the service path."""
+    runner = _make_runner_with_mock_restart(tmp_path, monkeypatch)
+    monkeypatch.setenv("INVOCATION_ID", "abc123")
+
+    await runner._handle_restart_command(_make_restart_event())
+
+    runner.request_restart.assert_called_once_with(detached=False, via_service=True)


### PR DESCRIPTION
**Fixes #43475.**

On a launchd-managed gateway (macOS), `/restart` stops the gateway and never relaunches it. The handler's service-manager probe checks only `INVOCATION_ID` (systemd) and container markers, so under launchd it takes the detached path and exits 0. The generated plist uses `KeepAlive.SuccessfulExit=false`, which treats a clean exit as a deliberate stop, so the gateway stays silently dead until a manual `launchctl kickstart`.

The fix detects launchd via `XPC_SERVICE_NAME`, which launchd sets to the job label. Two details distinguish it from the earlier attempts:

1. **`XPC_SERVICE_NAME=0` must not count as launchd.** Interactive macOS shells inherit `XPC_SERVICE_NAME=0`, a truthy string. The bare `bool()` probe in #19940/#33393 would route an unsupervised interactive gateway to the service path, where it exits 75 and nothing revives it. This probe excludes `""` and `"0"` (verified: launchd jobs see the real label via `ps eww`; interactive shells see `0`).
2. **Route via `via_service=True` rather than forcing a non-zero exit on the detached path** (the #43498/#43596 approach). The detached path spawns a relaunch helper; exiting non-zero there means the helper and launchd both respawn the gateway, and two instances then race for the same bot tokens, which Telegram and Discord reject (one connection per bot). The service path spawns no helper, so launchd is the single respawner.

This also targets the current handler location in `gateway/slash_commands.py`; the older probe PRs predate the move out of `gateway/run.py`.

**Tests:** `tests/gateway/test_restart_service_detection.py` pins all four routings (launchd job label, interactive `=0`, no service env, systemd `INVOCATION_ID`), built on the existing restart test helpers.

**Production validation:** running on two launchd-managed gateways since 2026-06-10; an earlier version of the same probe ran from 2026-06-03 (noted on #33393).