### PR TITLE
fix(state): neutralize leading/trailing/standalone "." and "-" in _sanitize_fts5_query

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3021,6 +3021,9 @@ class SessionDB:
         - Wrap unquoted hyphenated and dotted terms in quotes so FTS5
           matches them as exact phrases instead of splitting on the
           hyphen/dot (e.g. ``chat-send``, ``P2.2``, ``my-app.config.ts``)
+        - Neutralise leading/trailing/standalone dots and hyphens that the
+          wrap step leaves behind (e.g. ``.env``, ``config.``, ``rm -rf``,
+          ``--force``) so they don't leak into MATCH as a syntax error
         """
         # Step 1: Extract balanced double-quoted phrases and protect them
         # from further processing via numbered placeholders.
@@ -3056,6 +3059,27 @@ class SessionDB:
         # double-quoting bug that would occur if dotted, hyphenated and underscored
         # patterns were applied sequentially (e.g. ``my-app.config``).
         sanitized = re.sub(r"\b(\w+(?:[._-]\w+)+)\b", r'"\1"', sanitized)
+
+        # Step 5b: Neutralise any '.' or '-' the quoting step did not wrap.
+        # Step 5 only quotes separators flanked by word characters on BOTH
+        # sides (``a.b``, ``a-b``).  Leading, trailing and standalone dots and
+        # hyphens — ``.env``, ``config.``, ``rm -rf``, ``git push -f``,
+        # ``--force`` — survive and leak into MATCH as invalid FTS5 syntax
+        # (``syntax error near "."`` or ``no such column: ...``), which the
+        # execute site swallows into silent zero results even though the term
+        # is present in the conversation.  Replace them with a space, but only
+        # OUTSIDE quoted spans so wrapped terms like ``"chat-send"`` keep their
+        # separators.  Every ``"`` remaining here is part of a balanced pair
+        # added by Step 5 — Step 2 already stripped any stray quotes — so the
+        # quoted-span alternative matches reliably.
+        sanitized = re.sub(
+            r'("[^"]*")|[.\-]',
+            lambda m: m.group(1) if m.group(1) else " ",
+            sanitized,
+        )
+        # Replacing a '.'/'-' next to a wildcard can strand it (``deploy.*`` →
+        # ``deploy *``); re-drop any now-leading '*' so it can't re-break MATCH.
+        sanitized = re.sub(r"(^|\s)\*", r"\1", sanitized)
 
         # Step 6: Restore preserved quoted phrases
         for i, quoted in enumerate(_quoted_parts):

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1071,6 +1071,88 @@ class TestFTS5Search:
         assert '"sp_new"' in result
         assert '血管瘤' in result
 
+    def test_sanitize_fts5_neutralizes_edge_dots_and_hyphens(self):
+        """Leading/trailing/standalone '.' and '-' must not survive into MATCH.
+
+        The wrap step (Step 5) only quotes separators flanked by word chars on
+        both sides (``a.b``, ``a-b``). Edge dots/hyphens — ``.env``, ``config.``,
+        ``rm -rf``, ``--force`` — used to leak through and raise
+        sqlite3.OperationalError at the execute site. They must collapse to
+        spaces, while genuinely paired terms stay quoted.
+        """
+        from hermes_state import SessionDB
+        s = SessionDB._sanitize_fts5_query
+
+        # Leading dot/hyphen dropped
+        assert s('.env') == 'env'
+        assert s('.gitignore') == 'gitignore'
+        assert s('--force') == 'force'
+        # Trailing dot/hyphen dropped (inner pair, if any, stays quoted)
+        assert s('config.') == 'config'
+        assert s('foo-bar-') == '"foo-bar"'
+        # Standalone hyphen between words → both terms survive, no '-' leaks
+        assert s('rm -rf').split() == ['rm', 'rf']
+        assert s('git push -f').split() == ['git', 'push', 'f']
+        assert s('node -v').split() == ['node', 'v']
+        # Lone / repeated punctuation collapses to empty — no crash, no operator
+        assert s('.') == ''
+        assert s('-') == ''
+        assert s('...') == ''
+        # A dot/hyphen next to a wildcard must not strand the '*'
+        assert s('deploy.*') == 'deploy'
+        # Properly paired terms keep their quoting (unchanged behavior)
+        assert s('chat-send') == '"chat-send"'
+        assert s('a.b.c') == '"a.b.c"'
+        # No bare '.'/'-' token leaks: any survivor must sit inside a quote
+        for q in ('.env', 'config.', 'rm -rf', '--force', 'e.g.', 'foo-bar-'):
+            out = s(q)
+            assert all(
+                tok.startswith('"')
+                for tok in out.split()
+                if ('.' in tok or '-' in tok)
+            ), f"stray '.'/'-' leaked in {out!r} for {q!r}"
+
+    def test_search_everyday_dot_dash_terms_find_content(self, db):
+        """Everyday terms with edge dots/hyphens must FIND content, not silently
+        return [].
+
+        '.env', 'rm -rf', 'git push -f', '--force' and friends are among the
+        most common things a user searches their history for. Before the fix a
+        leading/trailing/standalone '.'/'-' leaked into FTS5 MATCH, raised
+        OperationalError, and the execute site swallowed it into zero results —
+        so search looked broken for exactly the inputs people reach for most.
+        Regression for that silent-empty bug.
+        """
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user",
+                          content="edit the .env file and the .gitignore too")
+        db.append_message("s1", role="assistant",
+                          content="i ran rm -rf build then git push -f")
+        db.append_message("s1", role="user",
+                          content="check node -v and pass --force to override")
+        db.append_message("s1", role="assistant",
+                          content="e.g. the config. value was wrong")
+
+        # query -> a substring that must appear in the matched snippet
+        cases = {
+            ".env": "env",
+            ".gitignore": "gitignore",
+            "rm -rf": "rm",
+            "git push -f": "push",
+            "node -v": "node",
+            "--force": "force",
+            "config.": "config",
+            "e.g.": "e.g",
+        }
+        for query, needle in cases.items():
+            results = db.search_messages(query)
+            assert isinstance(results, list), f"{query!r} did not return a list"
+            assert len(results) >= 1, f"{query!r} silently returned zero results"
+            assert any(
+                needle in (r.get("snippet") or r.get("content", "")).lower()
+                for r in results
+            ), f"{query!r} matched but snippet missing {needle!r}"
+
 
 # =========================================================================
 # CJK (Chinese/Japanese/Korean) LIKE fallback


### PR DESCRIPTION
## What does this PR do?

Fixes session search silently returning **zero results** for very common
queries like `.env`, `.gitignore`, `rm -rf`, `git push -f`, `node -v`,
`--force`, `config.` and `e.g.`.

`_sanitize_fts5_query` only quoted separators that had a word character on
**both** sides (`a.b`, `a-b`). Leading, trailing and standalone dots/hyphens
slipped through into FTS5 `MATCH` as invalid syntax (`syntax error near "."`,
`no such column: ...`). `search_messages` catches `OperationalError` and
returns `[]`, so the term looked absent even when it was in the conversation
— `8.8.8.8` matched while `.env` did not, a clear inconsistency.

The fix replaces those stray dots/hyphens with spaces **outside quoted spans**
after the wrap step (and re-drops any wildcard the replacement strands, e.g.
`deploy.*`). Wrapped terms like `chat-send` and all valid queries are
unaffected, and no previously-working query can regress.

## Related Issue

No existing issue — found while testing session search.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py` — `_sanitize_fts5_query`: add a post-wrap step that
  neutralizes dots/hyphens left outside quoted spans, plus a wildcard
  re-clean; docstring updated.
- `tests/test_hermes_state.py` — add regression tests under `TestFTS5Search`.

## How to Test

Before: searching history for `.env` or `rm -rf` returns nothing even when
those terms are present. After: they return the matching messages.

```
python -m pytest tests/test_hermes_state.py::TestFTS5Search -q
python -m pytest tests/test_hermes_state.py \
  tests/tools/test_session_search.py \
  tests/hermes_cli/test_web_server_session_search.py -q
```

Results:

- `TestFTS5Search` (including the 2 new tests): **21 passed**
- state + session-search + web-server search suites: **311 passed, 0 failed**

New tests:

- `test_sanitize_fts5_neutralizes_edge_dots_and_hyphens` — the sanitizer no
  longer leaks edge `.`/`-` into `MATCH`.
- `test_search_everyday_dot_dash_terms_find_content` — `.env`, `rm -rf`,
  `git push -f`, `--force`, `config.`, `e.g.` now return matches, not `[]`.

## Checklist

- [x] Commit message follows Conventional Commits (`fix(state): …`)
- [x] PR contains only changes related to this fix
- [x] Added regression tests for the bug
- [x] Relevant test suites pass (commands + results above)