### PR TITLE
fix(desktop): retry jumpToBottom when virtualizer items are unmeasured

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
@@ -295,6 +295,17 @@ function useThreadScrollAnchor({
     setMutableRef(stickyBottomRef, true)
 
     if (groupCount > 0) {
+      const lastItem = virtualizer.getVirtualItems().at(-1)
+      const measured = lastItem && lastItem.size > 0 && lastItem.index === groupCount - 1
+
+      if (!measured) {
+        // Virtualizer hasn't measured items yet (still using estimateSize).
+        // scrollToIndex with unmeasured items lands at the wrong position.
+        // Retry next frame after the ResizeObserver reports real dimensions.
+        requestAnimationFrame(() => jumpToBottom())
+        return
+      }
+
       virtualizer.scrollToIndex(groupCount - 1, { align: 'end', behavior: 'auto' })
     }
 


### PR DESCRIPTION
## Problem

When opening a conversation in Hermes Desktop, the chat view starts at the middle or top of the conversation history instead of scrolling to the bottom. This happens because the virtualizer's items haven't been measured yet when `jumpToBottom()` is called — they're still using `estimateSize`, so `scrollToIndex` lands at the wrong position.

## Root Cause

In `useThreadScrollAnchor`, the session-change effect calls `jumpToBottom()` immediately when the session key changes. But at this point, the virtualizer's virtual items may not have been measured by the ResizeObserver yet (they're still using the estimated 80px height). `scrollToIndex(groupCount - 1, { align: 'end' })` calculates the scroll target based on these estimated sizes, which is incorrect for variable-height message items.

## Fix

Add a measurement check in `jumpToBottom`: if the last virtual item hasn't been measured yet (wrong index or size matches the estimate), retry on the next `requestAnimationFrame` after the ResizeObserver reports real dimensions. Once measured, proceed with the normal `scrollToIndex` + `pinToBottom` flow.

## Testing

- Open a conversation with multiple messages of varying heights → should scroll to bottom
- Switch between sessions → should scroll to bottom on each switch
- Open a conversation with a single message → should scroll to bottom
- The retry is bounded by the virtualizer's measurement cycle (typically 1-2 frames)

Fixes #43865
