### PR TITLE
fix(gateway): flush in-flight sends before cancelling on planned restart

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4603,17 +4603,38 @@ class BasePlatformAdapter(ABC):
                     del self._session_tasks[session_key]
                     self._release_session_guard(session_key, guard=interrupt_event)
     
-    async def cancel_background_tasks(self) -> None:
+    async def cancel_background_tasks(self, grace_seconds: float = 0.0) -> None:
         """Cancel any in-flight background message-processing tasks.
 
         Used during gateway shutdown/replacement so active sessions from the old
         process do not keep running after adapters are being torn down.
+
+        ``grace_seconds`` lets in-flight tasks finish naturally before any
+        cancellation.  The planned-restart path passes a small grace so the
+        reply the /restart handler just queued (the "Restarting gateway"
+        ack) isn't cancelled mid-send — the handler returns ~50ms before
+        teardown reaches this method, well inside one HTTPS round trip, so
+        without a grace the ack is reliably lost whenever no active agents
+        force a longer drain.  Tasks still pending after the grace window
+        are cancelled as usual.
 
         Each cancelled task is awaited with a 5s bound so a wedged finally
         (typing-task cleanup, on_processing_complete hook) can't stall the
         whole shutdown path.  Stragglers are released from our tracking and
         allowed to finish unwinding on their own.
         """
+        if grace_seconds > 0:
+            pending = [t for t in self._background_tasks if not t.done()]
+            if pending:
+                _done, still_pending = await asyncio.wait(
+                    pending, timeout=grace_seconds
+                )
+                if still_pending:
+                    logger.debug(
+                        "[%s] %d background task(s) still pending after "
+                        "%.1fs grace; cancelling",
+                        self.name, len(still_pending), grace_seconds,
+                    )
         # Loop until no new tasks appear.  Without this, a message
         # arriving during the `await asyncio.gather` below would spawn
         # a fresh _process_message_background task (added to

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5815,7 +5815,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             for platform, adapter in list(self.adapters.items()):
                 _adapter_started_at = time.monotonic()
                 try:
-                    await adapter.cancel_background_tasks()
+                    # On a planned restart, give in-flight sends a moment to
+                    # flush so the /restart ack the handler just queued isn't
+                    # cancelled mid-send (it starts ~50ms before teardown
+                    # reaches here — far less than one HTTPS round trip).
+                    await adapter.cancel_background_tasks(
+                        grace_seconds=2.0 if self._restart_requested else 0.0
+                    )
                 except Exception as e:
                     logger.debug("✗ %s background-task cancel error: %s", platform.value, e)
                 try:

--- a/tests/gateway/test_restart_ack_grace.py
+++ b/tests/gateway/test_restart_ack_grace.py
@@ -1,0 +1,72 @@
+"""Tests for the grace window in ``cancel_background_tasks``.
+
+The /restart handler queues its ack reply and ``request_restart`` begins
+teardown ~50ms later.  Teardown's ``cancel_background_tasks`` used to
+cancel the in-flight ``_process_message_background`` task mid-send, so
+the "Restarting gateway" ack was reliably lost whenever no active agents
+forced a longer drain (the send needs a full HTTPS round trip).  The
+planned-restart path now passes ``grace_seconds`` so in-flight tasks can
+finish naturally before cancellation.
+"""
+import asyncio
+
+import pytest
+
+from tests.gateway.restart_test_helpers import RestartTestAdapter
+
+
+def _track(adapter, coro):
+    task = asyncio.get_event_loop().create_task(coro)
+    adapter._background_tasks.add(task)
+    task.add_done_callback(adapter._background_tasks.discard)
+    return task
+
+
+@pytest.mark.asyncio
+async def test_grace_lets_inflight_send_finish():
+    """A task that completes inside the grace window is not cancelled."""
+    adapter = RestartTestAdapter()
+    delivered = asyncio.Event()
+
+    async def fake_send():
+        await asyncio.sleep(0.05)  # simulated network round trip
+        delivered.set()
+
+    task = _track(adapter, fake_send())
+    await adapter.cancel_background_tasks(grace_seconds=2.0)
+
+    assert delivered.is_set()
+    assert not task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_no_grace_cancels_inflight_send():
+    """Without a grace window the in-flight task is cancelled (old behavior)."""
+    adapter = RestartTestAdapter()
+    delivered = asyncio.Event()
+
+    async def fake_send():
+        await asyncio.sleep(0.5)
+        delivered.set()
+
+    task = _track(adapter, fake_send())
+    await adapter.cancel_background_tasks()
+
+    assert not delivered.is_set()
+    assert task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_grace_expiry_still_cancels():
+    """A task that outlives the grace window is cancelled; the call stays bounded."""
+    adapter = RestartTestAdapter()
+
+    async def slow_task():
+        await asyncio.sleep(30)
+
+    task = _track(adapter, slow_task())
+    await asyncio.wait_for(
+        adapter.cancel_background_tasks(grace_seconds=0.1), timeout=6.0
+    )
+
+    assert task.cancelled()


### PR DESCRIPTION
## Summary

The `/restart` ack ("♻ Restarting gateway. If you aren't notified within 60 seconds, restart from the console with `hermes gateway restart`.") never reaches the chat on a quiet restart. The handler queues the reply and `request_restart()` begins `stop()` 50ms later; with no active agents the drain phase takes 0.00s, and `cancel_background_tasks()` cancels the in-flight `_process_message_background` task mid-send, well inside one HTTPS round trip. `CancelledError` propagates silently: no failure log, no retry. The user sees only the post-boot confirmation, or, if the restart fails to come back, nothing at all. That last case is the painful one: the ack's text is the recovery instruction for restart failures (#43475 / #43888), so the race eats it exactly when it matters.

Reproduced 3/3 on launchd-managed gateways (log signature: `Sending response (119 chars)` followed ~50ms later by `Stopping gateway for restart...`, then no delivery and no error). The ack only survives when active agents force a multi-second drain before teardown reaches the cancel.

## Fix

`cancel_background_tasks()` gains a `grace_seconds` parameter (default `0.0`: existing behavior is unchanged for every other caller). The planned-restart teardown passes `2.0` so in-flight tasks can finish naturally before cancellation. Tasks that outlive the grace are cancelled exactly as before.

## Relationship to other open work

- **#8008** fixes the same race class for Discord's `_pending_text_batch_tasks`, which were dropped because they are not tracked in `_background_tasks`. This PR covers the complementary case: tasks that *are* tracked get `task.cancel()` immediately, so being tracked does not save them either. The flush-with-deadline-then-cancel shape matches #8008's fix.
- **#36913** bounds shutdown awaits so a wedged platform cannot hang teardown. This grace window is compatible with that concern: it is strictly bounded (2s, then the existing 5s cancel bound applies), restart-scoped, and adds no unbounded await.
- **#43888** is where this was found, while verifying that fix in production.

## Tests

`tests/gateway/test_restart_ack_grace.py`: an in-flight task completes inside the grace window without cancellation; no grace preserves the old immediate-cancel behavior; a task that outlives the grace is still cancelled and the call stays bounded.

## Production validation

Running on two launchd-managed gateways since 2026-06-10. Before the patch the ack was lost on every quiet restart (3/3 that evening, same 50ms log signature each time); after it, both messages deliver and the restart completes in roughly 12 seconds end to end.