### PR TITLE
Fix/repair on api copy 24187

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -345,7 +345,7 @@ def sanitize_tool_call_arguments(
 
 
 def repair_message_sequence(agent, messages: List[Dict]) -> int:
-    """Collapse malformed role-alternation left in the live history.
+    """Collapse malformed role-alternation in the given message list.
 
     Providers (OpenAI, OpenRouter, Anthropic) expect strict alternation:
     after the system message, user/tool alternates with assistant, with
@@ -358,6 +358,16 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
     most shapes, but external callers (gateway multi-queue replay,
     session resume, cron, explicit conversation_history passed in by
     host code) can feed in already-broken histories.
+
+    IMPORTANT: mutates the list it is handed (and, when merging user
+    turns, the ``content`` key of the surviving dict). Callers must pass
+    the per-call ``api_messages`` copy, never the canonical transcript:
+    shrinking the canonical list desynchronizes the positional
+    persistence cursor in ``_flush_messages_to_session_db``, silently
+    dropping the current turn's assistant/tool rows from SessionDB and
+    triggering a self-reinforcing replay loop (#24187). Consecutive
+    user turns are legal in the canonical transcript; only the wire
+    copy needs strict alternation.
 
     Repairs applied:
       1. Stray ``tool`` messages whose ``tool_call_id`` doesn't match
@@ -438,8 +448,9 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
         merged.append(msg)
 
     if repairs > 0:
-        # Rewrite in place so downstream paths (persistence, return
-        # value, session DB flush) see the repaired sequence.
+        # Rewrite the given list in place so the caller's reference sees
+        # the repaired sequence. The caller passes the per-call API copy
+        # (never the canonical transcript — see docstring / #24187).
         messages[:] = merged
 
     return repairs

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -698,15 +698,11 @@ def run_conversation(
         # empty content on malformed sequences, which would otherwise
         # retrigger the empty-retry loop indefinitely.
         #
-        # Runs on the per-call ``api_messages`` copy only — same
-        # API-call-time-only pattern as the sanitizer and thinking-only
-        # passes above. The canonical ``messages`` list keeps the raw
-        # event sequence (consecutive user turns are legal there).
-        # Mutating ``messages`` in place here shrank the list under the
-        # positional persistence cursor in
-        # ``_flush_messages_to_session_db``, silently dropping the
-        # current turn's assistant/tool rows from SessionDB and causing
-        # a self-reinforcing replay loop (#24187).
+        # Runs on the per-call ``api_messages`` copy, never the canonical
+        # ``messages`` list — same API-call-time pattern as the sanitizer
+        # and thinking-only passes above. Repairing canonical shrinks it
+        # under the persistence cursor and silently drops the turn
+        # (#24187; see the repair_message_sequence docstring).
         repaired_seq = agent._repair_message_sequence(api_messages)
         if repaired_seq > 0:
             request_logger.info(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -588,21 +588,6 @@ def run_conversation(
                 agent.session_id or "-",
             )
 
-        # Defensive: repair malformed role-alternation before API call.
-        # Catches cases where the history got wedged into a
-        # ``tool → user`` or ``user → user`` tail (e.g. after empty-
-        # response scaffolding was stripped and a new user message
-        # landed after an orphan tool result). Most providers return
-        # empty content on malformed sequences, which would otherwise
-        # retrigger the empty-retry loop indefinitely.
-        repaired_seq = agent._repair_message_sequence(messages)
-        if repaired_seq > 0:
-            request_logger.info(
-                "Repaired %s message-alternation violations before request (session=%s)",
-                repaired_seq,
-                agent.session_id or "-",
-            )
-
         api_messages = []
         for idx, msg in enumerate(messages):
             api_msg = msg.copy()
@@ -704,6 +689,31 @@ def run_conversation(
         # stored conversation history keeps the reasoning block for the
         # UI transcript and session persistence.
         api_messages = agent._drop_thinking_only_and_merge_users(api_messages)
+
+        # Defensive: repair malformed role-alternation before the API call.
+        # Catches cases where the history got wedged into a
+        # ``tool → user`` or ``user → user`` tail (e.g. after empty-
+        # response scaffolding was stripped and a new user message
+        # landed after an orphan tool result). Most providers return
+        # empty content on malformed sequences, which would otherwise
+        # retrigger the empty-retry loop indefinitely.
+        #
+        # Runs on the per-call ``api_messages`` copy only — same
+        # API-call-time-only pattern as the sanitizer and thinking-only
+        # passes above. The canonical ``messages`` list keeps the raw
+        # event sequence (consecutive user turns are legal there).
+        # Mutating ``messages`` in place here shrank the list under the
+        # positional persistence cursor in
+        # ``_flush_messages_to_session_db``, silently dropping the
+        # current turn's assistant/tool rows from SessionDB and causing
+        # a self-reinforcing replay loop (#24187).
+        repaired_seq = agent._repair_message_sequence(api_messages)
+        if repaired_seq > 0:
+            request_logger.info(
+                "Repaired %s message-alternation violations in API copy (session=%s)",
+                repaired_seq,
+                agent.session_id or "-",
+            )
 
         # Normalize message whitespace and tool-call JSON for consistent
         # prefix matching.  Ensures bit-perfect prefixes across turns,

--- a/tests/run_agent/test_24187_replay_spiral.py
+++ b/tests/run_agent/test_24187_replay_spiral.py
@@ -5,26 +5,16 @@ Drives the **real** ``run_conversation()`` across a multi-turn gateway loop
 ``hermes_state.SessionDB`` each turn, mocked provider) and proves the
 self-reinforcing replay spiral cannot start.
 
-The function-level contract is pinned in ``test_message_sequence_repair.py``.
-Those tests call ``_repair_message_sequence`` / ``_flush_messages_to_session_db``
-in isolation. This one closes the gap their docstring calls out: nothing
-exercised the bug through the actual ``run_conversation()`` call site and the
-real persistence machinery.
+The function-level contract is pinned in ``test_message_sequence_repair.py``;
+this closes the gap those tests' docstring calls out — nothing exercised the
+bug through the actual ``run_conversation()`` call site.
 
 Production evidence (session 20260609_160142_0c197c39): one interrupted turn
 seeded a user/user alternation violation; from then on normally-paced turns
 lost their assistant replies — 5 replies generated and delivered to Matrix
 with no corresponding rows in state.db, the "Repaired N" counter climbing 1→10.
-
-Before the fix, ``run_conversation`` repaired the canonical ``messages`` list
-in place; merging consecutive user turns shrank it under the positional flush
-cursor in ``_flush_messages_to_session_db``, so each turn's assistant reply was
-silently never written. The unanswered user row then left a fresh user/user
-violation, so the next repair had one more to fix — the spiral. Run against
-that wiring (parent commit a72bb03) this test fails: zero assistant rows
-persist and the repair counter climbs 1,2,3,4,5. Against the shipped fix
-(repair on the per-call ``api_messages`` copy) every reply persists and the
-counter stays flat.
+The test is bug-sensitive: against the pre-fix wiring (repair on the canonical
+list) it fails with zero assistant rows persisted and the counter climbing 1→5.
 """
 
 import tempfile

--- a/tests/run_agent/test_24187_replay_spiral.py
+++ b/tests/run_agent/test_24187_replay_spiral.py
@@ -1,0 +1,133 @@
+"""#24187 — end-to-end reproduction of the SessionDB replay-loop.
+
+Drives the **real** ``run_conversation()`` across a multi-turn gateway loop
+(fresh ``AIAgent`` per inbound message, history reloaded from a real
+``hermes_state.SessionDB`` each turn, mocked provider) and proves the
+self-reinforcing replay spiral cannot start.
+
+The function-level contract is pinned in ``test_message_sequence_repair.py``.
+Those tests call ``_repair_message_sequence`` / ``_flush_messages_to_session_db``
+in isolation. This one closes the gap their docstring calls out: nothing
+exercised the bug through the actual ``run_conversation()`` call site and the
+real persistence machinery.
+
+Production evidence (session 20260609_160142_0c197c39): one interrupted turn
+seeded a user/user alternation violation; from then on normally-paced turns
+lost their assistant replies — 5 replies generated and delivered to Matrix
+with no corresponding rows in state.db, the "Repaired N" counter climbing 1→10.
+
+Before the fix, ``run_conversation`` repaired the canonical ``messages`` list
+in place; merging consecutive user turns shrank it under the positional flush
+cursor in ``_flush_messages_to_session_db``, so each turn's assistant reply was
+silently never written. The unanswered user row then left a fresh user/user
+violation, so the next repair had one more to fix — the spiral. Run against
+that wiring (parent commit a72bb03) this test fails: zero assistant rows
+persist and the repair counter climbs 1,2,3,4,5. Against the shipped fix
+(repair on the per-call ``api_messages`` copy) every reply persists and the
+counter stays flat.
+"""
+
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _mock_provider_response(content):
+    msg = SimpleNamespace(content=content, tool_calls=None, reasoning=None)
+    choice = SimpleNamespace(message=msg, finish_reason="stop")
+    return SimpleNamespace(
+        choices=[choice],
+        model="test/model",
+        usage=SimpleNamespace(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+    )
+
+
+def _make_agent(session_db, session_id, reply):
+    """A real AIAgent wired to a real SessionDB with a canned provider reply.
+
+    Mirrors the gateway: a fresh agent per inbound message (so
+    ``_last_flushed_db_idx`` starts at 0 every turn).
+    """
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            session_db=session_db,
+            session_id=session_id,
+            platform="matrix",
+        )
+    agent.client = MagicMock()
+    agent.client.chat.completions.create.return_value = _mock_provider_response(reply)
+    return agent
+
+
+def test_run_conversation_gateway_loop_persists_every_reply():
+    """The replay spiral never starts when driven through the real loop.
+
+    Seed one user/user violation, then run five normally-paced gateway turns
+    against the real ``run_conversation()``. Every assistant reply must reach
+    SessionDB and the repair counter must stay flat — pre-fix, the replies
+    were dropped and the counter escalated 1→5.
+    """
+    from hermes_state import SessionDB
+
+    repair_counts = []
+    _real_repair = AIAgent._repair_message_sequence
+
+    def _recording_repair(self, msgs):
+        n = _real_repair(self, msgs)
+        repair_counts.append(n)
+        return n
+
+    N = 5
+    with (
+        tempfile.TemporaryDirectory() as tmpdir,
+        patch.object(AIAgent, "_repair_message_sequence", _recording_repair),
+    ):
+        db = SessionDB(db_path=Path(tmpdir) / "state.db")
+        sid = "20260609_replay_spiral"
+        db.create_session(session_id=sid, source="test")
+        # Seed: a turn interrupted before its reply was appended leaves an
+        # orphan user row — the single alternation violation that starts it.
+        db.append_message(session_id=sid, role="user", content="seed (interrupted turn)")
+
+        for i in range(N):
+            # Fresh agent per inbound message; history reloaded from SessionDB.
+            history = [
+                {"role": r["role"], "content": r["content"]}
+                for r in db.get_messages(sid)
+            ]
+            agent = _make_agent(db, sid, reply=f"answer {i}")
+            result = agent.run_conversation(
+                f"question {i}", conversation_history=history
+            )
+            # The model generated and returned the reply every turn (as in
+            # production, where all replies were delivered to Matrix).
+            assert result["final_response"] == f"answer {i}"
+
+        rows = [(r.get("role"), r.get("content")) for r in db.get_messages(sid)]
+        db.close()
+
+    assistant_rows = [c for role, c in rows if role == "assistant"]
+    user_rows = [c for role, c in rows if role == "user"]
+
+    # Every reply persisted, in order — the row the bug silently dropped.
+    assert assistant_rows == [f"answer {i}" for i in range(N)], assistant_rows
+    # User rows: the seed plus one answered question per turn.
+    assert user_rows == ["seed (interrupted turn)"] + [
+        f"question {i}" for i in range(N)
+    ], user_rows
+    # No runaway: the repair counter never climbs past the single seed
+    # violation. Pre-fix it escalated one-per-turn (1, 2, 3, 4, 5).
+    assert max(repair_counts) <= 1, repair_counts
+    assert repair_counts != [1, 2, 3, 4, 5]

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -199,3 +199,127 @@ def test_repair_preserves_system_messages():
     AIAgent._repair_message_sequence(agent, messages)
 
     assert messages == original
+
+
+# ── #24187: repair must not desync SessionDB persistence ───────────────────
+#
+# repair_message_sequence() used to run on the canonical ``messages`` list
+# before the API call. Shrinking that list in place left the positional
+# persistence cursor in _flush_messages_to_session_db() pointing past the
+# end, so the current turn's assistant/tool rows were silently never
+# written to SessionDB. Gateway-style integrations (fresh AIAgent per
+# inbound message, history reloaded from SessionDB each turn) then kept
+# re-loading the same stale history: every lost assistant reply created a
+# new user/user alternation violation, which made the next repair shrink
+# the list further — a self-reinforcing replay loop that persisted until a
+# manual session reset.
+#
+# The fix runs repair on the per-call ``api_messages`` copy only (same
+# pattern as sanitize_api_messages / drop_thinking_only_and_merge_users).
+# These tests pin both halves of the contract.
+
+
+class _FakeSessionDB:
+    def __init__(self):
+        self.rows = []
+
+    def append_message(self, **kwargs):
+        self.rows.append(kwargs)
+
+
+def _flushing_agent(db):
+    agent = _bare_agent()
+    agent._session_db = db
+    agent._session_db_created = True
+    agent._last_flushed_db_idx = 0
+    agent.session_id = "test_24187"
+    return agent
+
+
+def test_repair_on_api_copy_leaves_canonical_transcript_intact():
+    """Repairing the per-call copy must not mutate or shrink the canonical list."""
+    agent = _bare_agent()
+    canonical = [
+        {"role": "user", "content": "question one"},
+        {"role": "user", "content": "question two"},
+        {"role": "user", "content": "question three"},
+    ]
+    api_messages = [m.copy() for m in canonical]
+
+    repairs = AIAgent._repair_message_sequence(agent, api_messages)
+
+    # Wire copy: merged to a single alternation-legal user turn.
+    assert repairs == 2
+    assert len(api_messages) == 1
+    assert "question one" in api_messages[0]["content"]
+    assert "question three" in api_messages[0]["content"]
+    # Canonical transcript: untouched, in length and content.
+    assert len(canonical) == 3
+    assert [m["content"] for m in canonical] == [
+        "question one", "question two", "question three",
+    ]
+
+
+def test_current_turn_persists_when_history_has_violations():
+    """#24187 regression: the current turn must reach SessionDB even when
+    the loaded history contains user/user alternation violations.
+
+    Mirrors the conversation-loop flow: history loaded from SessionDB,
+    current user message appended, repair applied to the API copy (not
+    the canonical list), assistant reply appended, then flush.
+    """
+    db = _FakeSessionDB()
+    agent = _flushing_agent(db)
+
+    # History as reloaded from SessionDB: three orphaned user turns
+    # (their assistant replies were lost by the pre-fix bug).
+    conversation_history = [
+        {"role": "user", "content": "old question A"},
+        {"role": "user", "content": "old question B"},
+        {"role": "user", "content": "old question C"},
+    ]
+    messages = list(conversation_history)
+    messages.append({"role": "user", "content": "current question"})
+
+    # Conversation loop: repair the wire copy only.
+    api_messages = [m.copy() for m in messages]
+    AIAgent._repair_message_sequence(agent, api_messages)
+
+    # Model replies; reply is appended to the canonical list.
+    messages.append({"role": "assistant", "content": "current answer"})
+
+    AIAgent._flush_messages_to_session_db(agent, messages, conversation_history)
+
+    # The current turn (user + assistant) must be persisted. Before the
+    # fix, repair shrank ``messages`` to 2 entries while the flush cursor
+    # stayed at len(conversation_history)=3, so messages[3:] was empty
+    # and ZERO rows were written.
+    flushed = [(r["role"], r["content"]) for r in db.rows]
+    assert ("user", "current question") in flushed
+    assert ("assistant", "current answer") in flushed
+    assert len(db.rows) == 2
+
+
+def test_old_in_place_repair_would_have_dropped_the_turn():
+    """Documents the pre-fix failure shape: repairing the canonical list
+    desyncs the positional flush cursor and silently drops the turn."""
+    db = _FakeSessionDB()
+    agent = _flushing_agent(db)
+
+    conversation_history = [
+        {"role": "user", "content": "old question A"},
+        {"role": "user", "content": "old question B"},
+        {"role": "user", "content": "old question C"},
+    ]
+    messages = list(conversation_history)
+    messages.append({"role": "user", "content": "current question"})
+
+    # The bug: repair applied to the canonical list (4 users -> 1).
+    AIAgent._repair_message_sequence(agent, messages)
+    messages.append({"role": "assistant", "content": "current answer"})
+
+    AIAgent._flush_messages_to_session_db(agent, messages, conversation_history)
+
+    # messages[3:] == [] -> nothing persisted. This is the silent data
+    # loss the fix removes; kept as executable documentation.
+    assert db.rows == []

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -203,20 +203,13 @@ def test_repair_preserves_system_messages():
 
 # ── #24187: repair must not desync SessionDB persistence ───────────────────
 #
-# repair_message_sequence() used to run on the canonical ``messages`` list
-# before the API call. Shrinking that list in place left the positional
-# persistence cursor in _flush_messages_to_session_db() pointing past the
-# end, so the current turn's assistant/tool rows were silently never
-# written to SessionDB. Gateway-style integrations (fresh AIAgent per
-# inbound message, history reloaded from SessionDB each turn) then kept
-# re-loading the same stale history: every lost assistant reply created a
-# new user/user alternation violation, which made the next repair shrink
-# the list further — a self-reinforcing replay loop that persisted until a
-# manual session reset.
-#
-# The fix runs repair on the per-call ``api_messages`` copy only (same
-# pattern as sanitize_api_messages / drop_thinking_only_and_merge_users).
-# These tests pin both halves of the contract.
+# repair_message_sequence() used to run on the canonical ``messages`` list,
+# shrinking it under the positional flush cursor in
+# _flush_messages_to_session_db() so the current turn's assistant/tool rows
+# were silently never written. The fix runs repair on the per-call
+# ``api_messages`` copy only. These tests pin both halves of the contract;
+# the end-to-end gateway replay spiral is reproduced in
+# test_24187_replay_spiral.py.
 
 
 class _FakeSessionDB:


### PR DESCRIPTION
## What does this PR do?

Fixes a silent data-loss bug where assistant replies were never persisted to SessionDB, sending gateway deployments into an hour-long replay loop.

`repair_message_sequence()` ran on the canonical `messages` list before each API call and rewrote it in place (`messages[:] = merged`). When repair shrinks the list — merging consecutive user turns, dropping stray tool results — the positional persistence cursor in `_flush_messages_to_session_db()` (anchored at `len(conversation_history)`) points past the surviving entries, so the current turn's assistant/tool rows are silently never written.

In gateway deployments (fresh `AIAgent` per inbound message, history reloaded from SessionDB each turn) this is **self-reinforcing**: each lost reply leaves a fresh user/user violation, so the next repair shrinks the list further. Observed in production (Matrix gateway): one interrupted turn seeded a single violation, after which every normally-paced turn lost its reply — 5 consecutive `user` rows in `state.db` while the gateway logs show all 5 replies were generated and delivered, the `Repaired N message-alternation violations` counter climbing 1→10, and the agent re-answering hour-old topics until a manual session reset.

**Why this approach:** `conversation_loop.py` already treats every other provider-shape fix as an API-call-time-only projection on the per-call `api_messages` copy (`sanitize_api_messages()`, `drop_thinking_only_and_merge_users()`, whitespace/tool-call normalization). `repair_message_sequence` was the lone pass mutating the canonical list. Moving the repair call onto `api_messages` conforms it to that existing convention: the canonical transcript keeps the raw event sequence (consecutive user turns are legal there; only the wire copy needs strict alternation), the flush cursor can no longer overshoot, and sessions already corrupted on disk self-heal after one turn.

This dissolves the case the other open approaches try to patch around persistence: the cursor clamp (#24326) still yields an empty flush slice; falling back to `_last_flushed_db_idx` (#24196) re-appends the whole history in the fresh-agent flow; the `replace_messages()` rewrite (#24211/#24419) is consistent but canonicalizes the lossy merge into stored history on every pass. Keeping the merge off the canonical list removes the need for any of them.

## Related Issue

Fixes #24187

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/conversation_loop.py` — move the `_repair_message_sequence()` call from the canonical `messages` (pre-copy) to the per-call `api_messages` copy, right after `drop_thinking_only_and_merge_users()`.
- `agent/agent_runtime_helpers.py` — docstring/comments on `repair_message_sequence()`: it mutates the list it is handed; callers must pass the API copy, never the canonical transcript (with the #24187 rationale).
- `tests/run_agent/test_24187_replay_spiral.py` — **new.** End-to-end test driving the real `run_conversation()` across a multi-turn gateway loop against a real `SessionDB`.
- `tests/run_agent/test_message_sequence_repair.py` — 3 function-level regression tests pinning both halves of the contract (canonical untouched; current turn persists with violated history; the pre-fix zero-rows failure as executable documentation).

## How to Test

1. Run the reproduction + contract tests:
   ```
   scripts/run_tests.sh tests/run_agent/test_24187_replay_spiral.py tests/run_agent/test_message_sequence_repair.py
   ```
   → **15 passed.** The end-to-end test seeds one user/user violation in a real `SessionDB`, then runs five normally-paced turns through the real `run_conversation()` (mocked provider); every reply persists and the repair counter stays flat.
2. Confirm the test actually catches the bug: in `conversation_loop.py`, temporarily point the repair call back at the canonical list (`agent._repair_message_sequence(messages)` before the `api_messages` copy is built) and rerun step 1.
3. → the end-to-end test fails with **zero assistant rows persisted** across all five turns and the repair counter climbing 1→5 — the production fingerprint, reproduced through the real loop. Revert the change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(agent):`, `test(agent):`, `docs(agent):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (4 files; verified against the merge-base)
- [ ] I've run `pytest tests/ -q` and all tests pass : multiple unrelated tests fail, settled on running "scripts/run_tests.sh tests/run_agent/    "
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS Tahoe 26.5.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on `repair_message_sequence()` updated; no README/`docs/` impact
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure in-memory list/persistence logic; no platform-specific paths, processes, or filesystem modes)
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

We are not providing real logs with this PR, but added a test that contains steps to trigger the bug.