### PR TITLE
fix(tools): strip the null branch from multi-variant nullable anyOf/oneOf unions

### DIFF
--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -649,6 +649,40 @@ class TestConvertTools:
         }
         assert result[0]["input_schema"]["required"] == ["command"]
 
+    def test_strips_null_branch_from_multivariant_union(self):
+        """Optional[Union[str, int]] keeps a {"type": "null"} branch that the
+        single-branch collapse misses; Anthropic rejects it, so the null
+        branch must be dropped while the remaining union is preserved."""
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "run",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "value": {
+                                "anyOf": [
+                                    {"type": "string"},
+                                    {"type": "integer"},
+                                    {"type": "null"},
+                                ],
+                            },
+                        },
+                    },
+                },
+            }
+        ]
+
+        result = convert_tools_to_anthropic(tools)
+
+        prop = result[0]["input_schema"]["properties"]["value"]
+        variant_types = {v.get("type") for v in prop["anyOf"]}
+        assert variant_types == {"string", "integer"}
+        assert "null" not in variant_types
+        # Anthropic path uses keep_nullable_hint=False → no OpenAPI nullable key.
+        assert "nullable" not in prop
+
 
 # ---------------------------------------------------------------------------
 # Message conversion

--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -98,6 +98,107 @@ def test_anyof_nested_objects_sanitized():
     assert variants[1] == {"type": "string"}
 
 
+# ─────────────────────────────────────────────────────────────────────────
+# Nullable anyOf/oneOf unions. The single-non-null case collapses to that
+# branch; the multi-non-null case (Optional[Union[str, int]]) must still
+# drop the {"type": "null"} branch Anthropic rejects while keeping the rest
+# of the union intact.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_multivariant_nullable_anyof_drops_null_keeps_union():
+    """Optional[Union[str, int]] → null branch dropped, both types preserved."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "value": {
+                "anyOf": [
+                    {"type": "string"},
+                    {"type": "integer"},
+                    {"type": "null"},
+                ],
+            },
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    prop = out[0]["function"]["parameters"]["properties"]["value"]
+    assert all(v.get("type") != "null" for v in prop["anyOf"])
+    assert {v["type"] for v in prop["anyOf"]} == {"string", "integer"}
+    # keep_nullable_hint=True on this path → optionality still signalled so
+    # runtime coercion can map a model-emitted "null" to Python None.
+    assert prop.get("nullable") is True
+
+
+def test_multivariant_nullable_oneof_drops_null_keeps_union():
+    """Same as above but for oneOf."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "value": {
+                "oneOf": [
+                    {"type": "string"},
+                    {"type": "integer"},
+                    {"type": "null"},
+                ],
+            },
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    prop = out[0]["function"]["parameters"]["properties"]["value"]
+    assert all(v.get("type") != "null" for v in prop["oneOf"])
+    assert {v["type"] for v in prop["oneOf"]} == {"string", "integer"}
+    assert prop.get("nullable") is True
+
+
+def test_multivariant_nullable_union_stripped_in_nested_items():
+    """A nullable union nested under array items is also cleaned."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "bag": {
+                "type": "array",
+                "items": {
+                    "anyOf": [
+                        {"type": "string"},
+                        {"type": "integer"},
+                        {"type": "null"},
+                    ],
+                },
+            },
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    items = out[0]["function"]["parameters"]["properties"]["bag"]["items"]
+    assert all(v.get("type") != "null" for v in items["anyOf"])
+    assert {v["type"] for v in items["anyOf"]} == {"string", "integer"}
+
+
+def test_null_less_multivariant_union_left_untouched():
+    """A union with no null branch is meaningful — leave it (and don't add nullable)."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "value": {
+                "anyOf": [{"type": "string"}, {"type": "integer"}],
+            },
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    prop = out[0]["function"]["parameters"]["properties"]["value"]
+    assert {v["type"] for v in prop["anyOf"]} == {"string", "integer"}
+    assert "nullable" not in prop
+
+
+def test_strip_nullable_unions_multivariant_keep_hint_false():
+    """keep_nullable_hint=False (the Anthropic path) drops null without a hint."""
+    from tools.schema_sanitizer import strip_nullable_unions
+
+    schema = {"anyOf": [{"type": "string"}, {"type": "integer"}, {"type": "null"}]}
+    out = strip_nullable_unions(schema, keep_nullable_hint=False)
+    assert {v["type"] for v in out["anyOf"]} == {"string", "integer"}
+    assert "nullable" not in out
+
+
 def test_missing_parameters_gets_default_object_schema():
     tools = [{"type": "function", "function": {"name": "t"}}]
     out = sanitize_tool_schemas(tools)

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -17,9 +17,11 @@ The failure modes we've seen in the wild:
   (malformed MCP server output, e.g. ``additionalProperties: "object"``).
 * ``"type": ["string", "null"]`` array types — many converters only accept
   single-string ``type``.
-* ``anyOf`` / ``oneOf`` unions whose only purpose is to permit ``null`` for
-  optional fields (common Pydantic/MCP shape). Anthropic rejects these at
-  the top of ``input_schema``; collapse them to the non-null branch.
+* ``anyOf`` / ``oneOf`` unions carrying a ``{"type": "null"}`` branch for
+  optional fields (common Pydantic/MCP shape). Anthropic rejects the null
+  branch; we drop it — collapsing to the lone non-null variant, or, for a
+  genuine multi-type union (``Optional[Union[str, int]]``), keeping the
+  remaining non-null branches.
 * Unconstrained ``additionalProperties`` on objects with empty properties.
 
 This module walks the final tool schema tree (after MCP-level normalization
@@ -133,7 +135,7 @@ def strip_nullable_unions(
     *,
     keep_nullable_hint: bool = True,
 ) -> Any:
-    """Collapse ``anyOf`` / ``oneOf`` nullable unions to the non-null branch.
+    """Strip the ``null`` branch from ``anyOf`` / ``oneOf`` nullable unions.
 
     MCP / Pydantic optional fields commonly arrive as::
 
@@ -141,10 +143,16 @@ def strip_nullable_unions(
 
     Anthropic's tool input-schema validator rejects the null branch. Tool
     optionality is already represented by the parent object's ``required``
-    array, so we collapse the union to the single non-null variant.
+    array, so the null branch is always removed:
 
-    Metadata (``title``, ``description``, ``default``, ``examples``) on the
-    outer union node is carried over to the replacement variant.
+    * **One** non-null branch survives (``Optional[str]``) → collapse the
+      union to that single variant. Metadata (``title``, ``description``,
+      ``default``, ``examples``) on the outer union node is carried over to
+      the replacement variant.
+    * **Two or more** non-null branches survive
+      (``Optional[Union[str, int]]`` → ``anyOf: [str, int, null]``) → keep
+      the union but drop only the null branch, leaving ``anyOf: [str, int]``.
+      The union itself is meaningful, so it is preserved rather than collapsed.
 
     Args:
         schema: JSON-Schema fragment (dict, list, or scalar).
@@ -176,10 +184,13 @@ def strip_nullable_unions(
             item for item in variants
             if not (isinstance(item, dict) and item.get("type") == "null")
         ]
-        # Only collapse when we actually dropped a null branch AND exactly
-        # one non-null branch survives (otherwise the union is meaningful
-        # and we leave it alone).
-        if len(non_null) == 1 and len(non_null) != len(variants):
+        # Nothing to do when there is no null branch to drop, or when the
+        # union is *only* null branches (degenerate — leave it untouched).
+        if len(non_null) == len(variants) or not non_null:
+            continue
+        if len(non_null) == 1:
+            # Single surviving branch → collapse the union down to it and
+            # carry the outer node's metadata onto the replacement.
             replacement = dict(non_null[0]) if isinstance(non_null[0], dict) else {}
             if keep_nullable_hint:
                 replacement.setdefault("nullable", True)
@@ -187,6 +198,17 @@ def strip_nullable_unions(
                 if meta_key in stripped and meta_key not in replacement:
                     replacement[meta_key] = stripped[meta_key]
             return strip_nullable_unions(replacement, keep_nullable_hint=keep_nullable_hint)
+        # Two or more surviving branches → the union is meaningful, so keep
+        # it as a union but drop just the null branch (which Anthropic
+        # rejects). Optionality is still carried by the parent ``required``
+        # array; preserve the ``nullable: true`` hint when requested so
+        # runtime coercion (``model_tools._schema_allows_null``) can still
+        # map a model-emitted ``"null"`` string to Python ``None``.
+        rebuilt = dict(stripped)
+        rebuilt[key] = non_null
+        if keep_nullable_hint:
+            rebuilt.setdefault("nullable", True)
+        return strip_nullable_unions(rebuilt, keep_nullable_hint=keep_nullable_hint)
     return stripped
 
 


### PR DESCRIPTION
## What does this PR do?

`strip_nullable_unions` is the shared helper that strips the `{"type": "null"}`
branch from optional-field unions before tool schemas reach a provider. It only
dropped the null branch when **exactly one** non-null branch survived. For
`Optional[Union[A, B]]` — which Pydantic/MCP emit as `anyOf: [A, B, null]` — two
non-null branches remain, so the null branch was left in place and sent to
Anthropic's tool-schema validator, which rejects it with HTTP 400.

The same helper feeds the global sanitizer, the MCP ingestion path, and the
Anthropic adapter, so all three leaked the null branch on multi-type optional
unions.

The fix drops the null branch in every case:
- one non-null branch → collapse to it (unchanged behavior)
- two or more → keep the union of the remaining non-null branches

The `nullable: true` hint is still preserved (when requested) so runtime
coercion (`model_tools._schema_allows_null`) keeps mapping a model-emitted
`"null"` to Python `None`.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/schema_sanitizer.py` — `strip_nullable_unions`: when 2+ non-null
  branches remain, rebuild the `anyOf`/`oneOf` without the null branch instead
  of leaving the union untouched; single-branch collapse unchanged. Docstrings
  updated.
- `tests/tools/test_schema_sanitizer.py` — multi-variant `anyOf`/`oneOf`,
  nested `items`, null-less union left untouched, `keep_nullable_hint=False`.
- `tests/agent/test_anthropic_adapter.py` — null branch dropped on the
  Anthropic conversion path with no `nullable` key added.

## How to Test

Before the fix, a tool parameter typed `Optional[Union[str, int]]` produced
`anyOf: [str, int, null]` and the `{"type": "null"}` branch survived in the
schema sent to Anthropic (HTTP 400). After the fix it becomes
`anyOf: [str, int]`, with optionality still carried by the parent `required`
array.

Affected test suites:

```
pytest tests/tools/test_schema_sanitizer.py \
       tests/agent/test_anthropic_adapter.py \
       tests/run_agent/test_tool_arg_coercion.py \
       tests/tools/test_mcp_tool.py \
       tests/agent/test_moonshot_schema.py -q
```

Result: **497 passed, 1 skipped**.

## Checklist

- [x] Commit messages follow Conventional Commits (`fix(tools): …`)
- [x] PR contains only changes related to this fix
- [x] Added tests for the change (multi-variant + Anthropic path)
- [x] Affected test suites pass