### PR TITLE
fix(tts): microsecond timestamps for output paths to prevent concurrent collisions

### DIFF
--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2095,7 +2095,7 @@ def text_to_speech_tool(
                 file_path, command_provider_config
             )
     else:
-        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S_%f")
         out_dir = Path(DEFAULT_OUTPUT_DIR)
         out_dir.mkdir(parents=True, exist_ok=True)
         if command_provider_config is not None:


### PR DESCRIPTION
## Summary

`text_to_speech_tool` names output files `tts_<YYYYMMDD_HHMMSS>.<fmt>` with second-level precision. Two concurrent `/api/audio/speak` requests landing in the same second resolve to the same path and race: one caller unlinks the file mid-write of the other, which then surfaces as `TTS provider produced no output` with no other diagnostic. Hit in production with a desktop voice-playback client that fires overlapping synth requests; any concurrent TTS caller can trigger it.

## Fix

Add `%f` (microseconds) to the strftime format so concurrent calls get unique paths. One line; no behavior change other than the filename precision.

## Validation

Running in production since 2026-06-03; the "produced no output" errors stopped with this change and have not recurred under the same concurrent-playback workload.