### PR TITLE
feat(tui): add 's' as alias for /steer

### DIFF
--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -549,6 +549,7 @@ export const coreCommands: SlashCommand[] = [
   },
 
   {
+    aliases: ['s'],
     help: 'inject a message after the next tool call (no interrupt)',
     name: 'steer',
     run: (arg, ctx) => {


### PR DESCRIPTION
## Summary

Adds `s` as a single-character alias for the TUI `/steer` slash command. `/steer` injects a message after the next tool call without interrupting, so it is typed mid-turn where speed matters most; a one-character alias removes most of the friction.

Uses the existing `aliases` field on `SlashCommand` (`registry.ts` already flat-maps `[cmd.name, ...cmd.aliases]` into the lookup), so this is one line with no dispatch changes.

## Collision check

No existing command or alias is named `s` across the slash command files; nearest neighbors are `sb` on `/steerback` and `q` on `/queue` (per the alias hygiene established in 064ac28cb).

## Validation

`slashParity.test.ts` passes; `npm run build` clean; alias confirmed present in the compiled `dist/entry.js`. Running in daily use since 2026-06-04.