### PR TITLE
fix(bedrock): subagent transport routing + retry transient streaming faults

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2925,6 +2925,35 @@ def run_conversation(
                         and "nonetype" in str(api_error).lower()
                         and "not iterable" in str(api_error).lower()
                     )
+                    # Anthropic Bedrock SDK's event-stream decoder
+                    # (anthropic/lib/bedrock/_stream_decoder.py) raises a bare
+                    # ``ValueError("Bad response code, expected 200: {...}")``
+                    # when a streamed event frame carries a non-200 status.
+                    # The embedded ``:exception-type`` is frequently a TRANSIENT
+                    # server fault (internalServerException, modelStreamError,
+                    # throttling, serviceUnavailable, modelTimeout) that AWS
+                    # explicitly tells callers to retry ("Try your request
+                    # again") — but the bare ValueError loses the HTTP status,
+                    # so without this carve-out it falls into the local-bug
+                    # bucket and aborts the turn non-retryably.  Treat the
+                    # transient exception types as retryable so the classifier's
+                    # unknown→retry path runs.  A genuine validationException
+                    # (real client bug) is intentionally NOT excluded and still
+                    # aborts.
+                    and not (
+                        isinstance(api_error, ValueError)
+                        and "bad response code, expected 200" in str(api_error).lower()
+                        and any(
+                            _t in str(api_error).lower()
+                            for _t in (
+                                "internalserverexception",
+                                "modelstreamerrorexception",
+                                "throttlingexception",
+                                "serviceunavailableexception",
+                                "modeltimeoutexception",
+                            )
+                        )
+                    )
                 )
                 # ``FailoverReason.billing`` (HTTP 402) is NOT in this
                 # exclusion set.  By the time we reach this block:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -93,6 +93,17 @@ def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
         return "codex_responses"
     if hostname == "api.openai.com":
         return "codex_responses"
+    # AWS Bedrock — bedrock-runtime.<region>.amazonaws.com speaks the native
+    # Converse protocol, NOT chat/completions. Without this, a delegated
+    # subagent routed to a Bedrock base_url falls through to the
+    # ``chat_completions`` default and POSTs an OpenAI-shaped body to
+    # ``bedrock-runtime/.../chat/completions`` with ``Bearer None`` — which
+    # Bedrock cannot process, surfacing as a persistent ``internalServerException``
+    # 400. Mirror the main agent's auto-detection in agent/agent_init.py.
+    if hostname.startswith("bedrock-runtime.") and base_url_host_matches(
+        normalized, "amazonaws.com"
+    ):
+        return "bedrock_converse"
     if normalized.endswith("/anthropic"):
         return "anthropic_messages"
     if hostname == "api.kimi.com" and "/coding" in normalized:

--- a/tests/hermes_cli/test_detect_api_mode_for_url.py
+++ b/tests/hermes_cli/test_detect_api_mode_for_url.py
@@ -65,6 +65,52 @@ class TestAnthropicMessagesDetection:
         assert _detect_api_mode_for_url("https://api.example.com/anthropic/v1") is None
 
 
+class TestBedrockConverseDetection:
+    """AWS Bedrock runtime endpoints speak the native Converse protocol.
+
+    Without this detection a delegated subagent routed to a Bedrock base_url
+    falls through to the chat_completions default and POSTs an OpenAI-shaped
+    body to bedrock-runtime/.../chat/completions with ``Bearer None``, which
+    Bedrock cannot process — surfacing as a persistent internalServerException
+    400 across all retries.
+    """
+
+    def test_bedrock_us_east_1_returns_converse(self):
+        assert (
+            _detect_api_mode_for_url("https://bedrock-runtime.us-east-1.amazonaws.com")
+            == "bedrock_converse"
+        )
+
+    def test_bedrock_other_region_returns_converse(self):
+        assert (
+            _detect_api_mode_for_url("https://bedrock-runtime.eu-west-1.amazonaws.com/")
+            == "bedrock_converse"
+        )
+
+    def test_bedrock_uppercase_tolerated(self):
+        assert (
+            _detect_api_mode_for_url("https://BEDROCK-RUNTIME.US-EAST-1.AMAZONAWS.COM")
+            == "bedrock_converse"
+        )
+
+    def test_bedrock_lookalike_host_does_not_match(self):
+        # A suffix-spoofing host must NOT be treated as Bedrock.
+        assert (
+            _detect_api_mode_for_url(
+                "https://bedrock-runtime.us-east-1.amazonaws.com.evil.test"
+            )
+            is None
+        )
+
+    def test_bedrock_path_segment_does_not_match(self):
+        assert (
+            _detect_api_mode_for_url(
+                "https://proxy.example.test/bedrock-runtime.us-east-1.amazonaws.com"
+            )
+            is None
+        )
+
+
 class TestDefaultCase:
     def test_generic_url_returns_none(self):
         assert _detect_api_mode_for_url("https://api.together.xyz/v1") is None

--- a/tests/run_agent/test_bedrock_stream_transient_retryable.py
+++ b/tests/run_agent/test_bedrock_stream_transient_retryable.py
@@ -1,0 +1,139 @@
+"""Regression guard: Anthropic Bedrock streaming transient faults must not be
+classified as local validation errors by the main agent loop.
+
+The Anthropic SDK's Bedrock event-stream decoder
+(``anthropic/lib/bedrock/_stream_decoder.py``) raises a *bare* ``ValueError``
+when a streamed event frame carries a non-200 status:
+
+    raise ValueError(f"Bad response code, expected 200: {response_dict}")
+
+The embedded ``:exception-type`` is frequently a TRANSIENT server fault
+(``internalServerException``, ``modelStreamErrorException``,
+``throttlingException``, ``serviceUnavailableException``,
+``modelTimeoutException``) that AWS explicitly tells callers to retry
+("The system encountered an unexpected error during processing. Try your
+request again.").  Because the SDK raises a bare ValueError, the HTTP status
+is lost (the agent sees ``HTTP None``), and the agent loop's non-retryable
+classifier treats every ``ValueError`` / ``TypeError`` as a local programming
+bug — aborting the turn instead of retrying.
+
+This test mirrors the exact predicate shape used in
+``agent/conversation_loop.py`` so any future refactor must preserve:
+
+    internalServerException ValueError  → NOT local validation (retryable)
+    throttlingException ValueError      → NOT local validation (retryable)
+    validationException ValueError      → IS local validation (real client bug)
+    bare ValueError                     → IS local validation (programming bug)
+"""
+from __future__ import annotations
+
+import json
+
+
+def _mirror_agent_predicate(err: BaseException) -> bool:
+    """Exact shape of agent/conversation_loop.py's is_local_validation_error.
+
+    Kept in lock-step with the source. If you change one, change both.
+    """
+    import ssl
+
+    return (
+        isinstance(err, (ValueError, TypeError))
+        and not isinstance(err, (UnicodeEncodeError, json.JSONDecodeError))
+        and not isinstance(err, ssl.SSLError)
+        and not (
+            isinstance(err, TypeError)
+            and "nonetype" in str(err).lower()
+            and "not iterable" in str(err).lower()
+        )
+        # Bedrock streaming transient-fault carve-out.
+        and not (
+            isinstance(err, ValueError)
+            and "bad response code, expected 200" in str(err).lower()
+            and any(
+                _t in str(err).lower()
+                for _t in (
+                    "internalserverexception",
+                    "modelstreamerrorexception",
+                    "throttlingexception",
+                    "serviceunavailableexception",
+                    "modeltimeoutexception",
+                )
+            )
+        )
+    )
+
+
+def _stream_decoder_error(exception_type: str) -> ValueError:
+    """Build a ValueError matching the exact shape raised by
+    anthropic/lib/bedrock/_stream_decoder.py for a non-200 event frame."""
+    response_dict = {
+        "status_code": 400,
+        "headers": {
+            ":exception-type": exception_type,
+            ":content-type": "application/json",
+            ":message-type": "exception",
+        },
+        "body": b'{"message":"The system encountered an unexpected error during processing. Try your request again."}',
+    }
+    return ValueError(f"Bad response code, expected 200: {response_dict}")
+
+
+class TestBedrockStreamTransientIsRetryable:
+
+    def test_internal_server_exception_is_not_local_validation(self):
+        """internalServerException is a transient AWS fault — must retry."""
+        assert not _mirror_agent_predicate(
+            _stream_decoder_error("internalServerException")
+        )
+
+    def test_throttling_exception_is_not_local_validation(self):
+        assert not _mirror_agent_predicate(
+            _stream_decoder_error("throttlingException")
+        )
+
+    def test_model_stream_error_exception_is_not_local_validation(self):
+        assert not _mirror_agent_predicate(
+            _stream_decoder_error("modelStreamErrorException")
+        )
+
+    def test_service_unavailable_exception_is_not_local_validation(self):
+        assert not _mirror_agent_predicate(
+            _stream_decoder_error("serviceUnavailableException")
+        )
+
+    def test_model_timeout_exception_is_not_local_validation(self):
+        assert not _mirror_agent_predicate(
+            _stream_decoder_error("modelTimeoutException")
+        )
+
+    def test_validation_exception_is_still_local_validation(self):
+        """A genuine validationException is a real client bug — retrying
+        reproduces it. Must remain classified as non-retryable."""
+        assert _mirror_agent_predicate(
+            _stream_decoder_error("validationException")
+        )
+
+    def test_bare_value_error_is_still_local_validation(self):
+        """The carve-out must be narrow: an unrelated bare ValueError is
+        still a programming bug."""
+        assert _mirror_agent_predicate(ValueError("bad arg"))
+
+
+class TestAgentLoopSourceStillHasCarveOut:
+    """Belt-and-suspenders: the production source must actually include the
+    Bedrock transient-stream carve-out. Protects against an accidental revert
+    that happens to leave the test file intact."""
+
+    def test_conversation_loop_excludes_bedrock_transient_stream_faults(self):
+        import inspect
+        from agent import conversation_loop
+
+        src = inspect.getsource(conversation_loop)
+        assert "is_local_validation_error" in src
+        assert "bad response code, expected 200" in src.lower(), (
+            "agent/conversation_loop.py must carve out the Anthropic Bedrock "
+            "stream decoder's transient-fault ValueError from the "
+            "is_local_validation_error classification."
+        )
+        assert "internalserverexception" in src.lower()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2517,7 +2517,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
 
         # Explicit delegation.api_mode in config always wins. Lets users force
         # a transport for non-standard endpoints the URL heuristic can't detect.
-        if configured_api_mode in {"chat_completions", "codex_responses", "anthropic_messages"}:
+        if configured_api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse"}:
             api_mode = configured_api_mode
 
         return {


### PR DESCRIPTION
Closes #43915.

Two related Bedrock fixes surfaced while running `global.anthropic.claude-fable-5` with delegated subagents. The main agent worked; every `delegate_task` subagent died with a Bedrock 400.

---

## Fix 1 — Subagent transport routing (the actual cause of the failure)

A delegated subagent whose runtime resolves to a Bedrock base_url (`bedrock-runtime.<region>.amazonaws.com`) was routed through the `chat_completions` transport, because `_detect_api_mode_for_url()` recognized OpenAI/xAI/Anthropic endpoints but **not** Bedrock — so it fell through to the default.

The subagent then POSTed an OpenAI-shaped body to `bedrock-runtime/.../chat/completions` with `Authorization: Bearer None` (no SigV4). Bedrock can't process this and returns a **persistent** `internalServerException` 400 — failing identically across all retries.

```
url: https://bedrock-runtime.us-east-1.amazonaws.com/chat/completions
Authorization: Bearer None      ← wrong protocol + no auth
```

**Fix:**
- `runtime_provider._detect_api_mode_for_url()` returns `bedrock_converse` for Bedrock runtime URLs, mirroring the main agent's auto-detection in `agent/agent_init.py`. Includes a suffix-spoof guard (`…amazonaws.com.evil.test` → not matched).
- `delegate_tool`: add `bedrock_converse` to the explicit api_mode override allowlist.

## Fix 2 — Retry transient streaming faults

The Anthropic SDK's Bedrock event-stream decoder (`anthropic/lib/bedrock/_stream_decoder.py:58`) raises a bare `ValueError("Bad response code, expected 200: {...}")` for non-200 event frames, dropping the HTTP status (agent sees `HTTP None`). When the embedded `:exception-type` is a **transient** fault (`internalServerException`, `modelStreamErrorException`, `throttlingException`, `serviceUnavailableException`, `modelTimeoutException`), the `is_local_validation_error` predicate misclassified it as a non-retryable local bug.

**Fix:** narrow carve-out so those transient types are retryable, while a genuine `validationException` still aborts. Mirrors the existing `JSONDecodeError` (#14782) and NoneType-not-iterable (#33136) carve-outs.

---

## Tests

```
$ pytest tests/hermes_cli/test_detect_api_mode_for_url.py \
         tests/run_agent/test_bedrock_stream_transient_retryable.py -q
29 passed
```

- 5 new detection tests (region variants, uppercase, lookalike host, path-segment spoof)
- 8 retry-classification tests (transient types retryable; validationException + bare ValueError still abort)
- sibling `test_jsondecodeerror_retryable.py` unchanged (9 passed)