### PR TITLE
fix: handle Telegram audio file attachments

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -103,6 +103,49 @@ _TELEGRAM_IMAGE_EXT_TO_MIME = {
     ".webp": "image/webp",
     ".gif": "image/gif",
 }
+_TELEGRAM_AUDIO_EXTENSIONS = {
+    ".mp3",
+    ".m4a",
+    ".ogg",
+    ".opus",
+    ".wav",
+    ".flac",
+    ".aac",
+}
+_TELEGRAM_AUDIO_MIME_TO_EXT = {
+    "audio/mpeg": ".mp3",
+    "audio/mp3": ".mp3",
+    "audio/mp4": ".m4a",
+    "audio/x-m4a": ".m4a",
+    "audio/aac": ".aac",
+    "audio/ogg": ".ogg",
+    "audio/opus": ".opus",
+    "audio/wav": ".wav",
+    "audio/x-wav": ".wav",
+    "audio/flac": ".flac",
+}
+
+
+def _telegram_audio_ext(
+    filename: str = "", mime_type: str = "", fallback: str = ".mp3"
+) -> str:
+    """Best-effort audio cache extension from Telegram filename/MIME metadata."""
+    if filename:
+        _, ext = os.path.splitext(filename)
+        ext = ext.lower()
+        if ext in _TELEGRAM_AUDIO_EXTENSIONS:
+            return ext
+    mime = (mime_type or "").lower()
+    return _TELEGRAM_AUDIO_MIME_TO_EXT.get(mime, fallback)
+
+
+def _telegram_audio_mime(ext: str, mime_type: str = "") -> str:
+    """Return a stable audio MIME for cached Telegram audio."""
+    mime = (mime_type or "").lower()
+    if mime.startswith("audio/"):
+        return mime
+    ext_to_mime = {v: k for k, v in _TELEGRAM_AUDIO_MIME_TO_EXT.items()}
+    return ext_to_mime.get(ext, "audio/mpeg")
 
 
 MAX_COMMANDS_PER_SCOPE = 30
@@ -5614,9 +5657,16 @@ class TelegramAdapter(BasePlatformAdapter):
             try:
                 file_obj = await msg.audio.get_file()
                 audio_bytes = await file_obj.download_as_bytearray()
-                cached_path = cache_audio_from_bytes(bytes(audio_bytes), ext=".mp3")
+                audio_name = (
+                    getattr(msg.audio, "file_name", "")
+                    or getattr(file_obj, "file_path", "")
+                    or ""
+                )
+                audio_mime = (getattr(msg.audio, "mime_type", "") or "").lower()
+                ext = _telegram_audio_ext(audio_name, audio_mime)
+                cached_path = cache_audio_from_bytes(bytes(audio_bytes), ext=ext)
                 event.media_urls = [cached_path]
-                event.media_types = ["audio/mp3"]
+                event.media_types = [_telegram_audio_mime(ext, audio_mime)]
                 logger.info("[Telegram] Cached user audio at %s", cached_path)
             except Exception as e:
                 logger.warning("[Telegram] Failed to cache audio: %s", e, exc_info=True)
@@ -5723,6 +5773,22 @@ class TelegramAdapter(BasePlatformAdapter):
                     event.media_types = [SUPPORTED_VIDEO_TYPES[ext]]
                     event.message_type = MessageType.VIDEO
                     logger.info("[Telegram] Cached user video document at %s", cached_path)
+                    await self.handle_message(event)
+                    return
+
+                if ext in _TELEGRAM_AUDIO_EXTENSIONS or doc_mime.startswith("audio/"):
+                    file_obj = await doc.get_file()
+                    audio_bytes = await file_obj.download_as_bytearray()
+                    audio_ext = _telegram_audio_ext(
+                        original_filename,
+                        doc_mime,
+                        fallback=ext if ext in _TELEGRAM_AUDIO_EXTENSIONS else ".mp3",
+                    )
+                    cached_path = cache_audio_from_bytes(bytes(audio_bytes), ext=audio_ext)
+                    event.media_urls = [cached_path]
+                    event.media_types = [_telegram_audio_mime(audio_ext, doc_mime)]
+                    event.message_type = MessageType.AUDIO
+                    logger.info("[Telegram] Cached user audio document at %s", cached_path)
                     await self.handle_message(event)
                     return
 

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -81,8 +81,8 @@ def _make_document(
     return doc
 
 
-def _make_message(document=None, caption=None, media_group_id=None, photo=None):
-    """Build a mock Telegram Message with the given document/photo."""
+def _make_message(document=None, caption=None, media_group_id=None, photo=None, audio=None):
+    """Build a mock Telegram Message with the given document/photo/audio."""
     msg = MagicMock()
     msg.message_id = 42
     msg.text = caption or ""
@@ -91,7 +91,7 @@ def _make_message(document=None, caption=None, media_group_id=None, photo=None):
     # Media flags — all None except explicit payload
     msg.photo = photo
     msg.video = None
-    msg.audio = None
+    msg.audio = audio
     msg.voice = None
     msg.sticker = None
     msg.document = document
@@ -122,6 +122,14 @@ def _make_video(file_obj=None):
     return video
 
 
+def _make_audio(file_name="track.m4a", mime_type="audio/mp4", file_obj=None):
+    audio = MagicMock()
+    audio.file_name = file_name
+    audio.mime_type = mime_type
+    audio.get_file = AsyncMock(return_value=file_obj or _make_file_obj(b"audio-bytes"))
+    return audio
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -148,6 +156,9 @@ def _redirect_cache(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(
         "gateway.platforms.base.VIDEO_CACHE_DIR", tmp_path / "video_cache"
+    )
+    monkeypatch.setattr(
+        "gateway.platforms.base.AUDIO_CACHE_DIR", tmp_path / "audio_cache"
     )
 
 
@@ -427,6 +438,48 @@ class TestVideoDownloadBlock:
         assert len(event.media_urls) == 1
         assert os.path.exists(event.media_urls[0])
         assert event.media_types == [SUPPORTED_VIDEO_TYPES[".mp4"]]
+
+
+class TestAudioDownloadBlock:
+    @pytest.mark.asyncio
+    async def test_native_audio_preserves_m4a_extension_and_type(self, adapter):
+        file_obj = _make_file_obj(b"fake-m4a")
+        file_obj.file_path = "audio/track.m4a"
+        msg = _make_message(
+            audio=_make_audio(
+                file_name="track.m4a", mime_type="audio/mp4", file_obj=file_obj
+            )
+        )
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.AUDIO
+        assert len(event.media_urls) == 1
+        assert event.media_urls[0].endswith(".m4a")
+        assert os.path.exists(event.media_urls[0])
+        assert event.media_types == ["audio/mp4"]
+
+    @pytest.mark.asyncio
+    async def test_audio_document_is_treated_as_audio_not_unsupported_document(self, adapter):
+        file_obj = _make_file_obj(b"fake-mp3-doc")
+        doc = _make_document(
+            file_name="song.mp3",
+            mime_type="audio/mpeg",
+            file_size=1024,
+            file_obj=file_obj,
+        )
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.AUDIO
+        assert len(event.media_urls) == 1
+        assert event.media_urls[0].endswith(".mp3")
+        assert os.path.exists(event.media_urls[0])
+        assert event.media_types == ["audio/mpeg"]
+        assert "Unsupported document type" not in (event.text or "")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Problem
- Telegram native audio uploads were always cached as `.mp3`/`audio/mp3`, losing `.m4a` metadata.
- Audio files sent via Telegram file/document upload (for example `.mp3` documents) fell through to the generic document allowlist and were rejected as unsupported.

Fix
- Add Telegram audio extension/MIME resolution.
- Preserve native audio upload extension/MIME where Telegram provides it.
- Route audio documents to `MessageType.AUDIO` and cache them as audio attachments instead of unsupported documents.

Testing
- `python -m pytest tests/gateway/test_telegram_documents.py tests/gateway/test_telegram_audio_vs_voice.py -o 'addopts=' -q`\n- `git diff --check`