### PR TITLE
fix(markdown): split table rows on unescaped pipes so "\|" cells aren't broken

### DIFF
--- a/agent/markdown_tables.py
+++ b/agent/markdown_tables.py
@@ -62,15 +62,58 @@ def _pad_to_width(s: str, target: int) -> str:
     return s + " " * max(0, target - _disp_width(s))
 
 
+def _split_cells(s: str) -> List[str]:
+    r"""Split ``s`` on unescaped ``|`` separators, keeping ``\|`` in the cell.
+
+    GFM treats a backslash-escaped pipe (``\|``) as a literal pipe in cell
+    content, not a column separator. A bare ``str.split("|")`` tears such a
+    cell apart (``int \| None`` → ``int \`` + ``None``), desyncing the column
+    count so the realigner rebuilds the table with a phantom column. We walk
+    the string so an escaped pipe — or an escaped backslash (``\\``) — never
+    acts as a separator. The escape sequence itself is left intact: the
+    rebuilt rows are fed back through a Markdown renderer in ``render`` mode,
+    where the backslash must survive (unescaping here would re-introduce the
+    very ambiguity this split resolves).
+    """
+
+    cells: List[str] = []
+    buf: List[str] = []
+    i, n = 0, len(s)
+    while i < n:
+        ch = s[i]
+        if ch == "\\" and i + 1 < n:
+            # Keep the backslash with the char it escapes so an escaped pipe
+            # (or escaped backslash) is never mistaken for a separator.
+            buf.append(s[i : i + 2])
+            i += 2
+        elif ch == "|":
+            cells.append("".join(buf))
+            buf = []
+            i += 1
+        else:
+            buf.append(ch)
+            i += 1
+    cells.append("".join(buf))
+    return cells
+
+
 def split_table_row(row: str) -> List[str]:
-    """Split ``| a | b | c |`` into ``["a", "b", "c"]`` with trims."""
+    r"""Split ``| a | b | c |`` into ``["a", "b", "c"]`` with trims.
+
+    Honors GFM pipe escaping: a ``\|`` inside a cell is a literal pipe, not a
+    column separator, so an ``int \| None`` union-type cell stays one cell
+    instead of being torn into ``int \`` and ``None``.
+    """
 
     s = row.strip()
     if s.startswith("|"):
         s = s[1:]
-    if s.endswith("|"):
-        s = s[:-1]
-    return [c.strip() for c in s.split("|")]
+    cells = _split_cells(s)
+    # Drop the empty cell produced by the closing border pipe. A trailing
+    # escaped ``\|`` does not yield an empty cell, so it is preserved.
+    if len(cells) > 1 and not cells[-1].strip():
+        cells.pop()
+    return [c.strip() for c in cells]
 
 
 def is_table_divider(row: str) -> bool:

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -218,14 +218,54 @@ def _is_table_row(line: str) -> bool:
     return bool(stripped) and '|' in stripped
 
 
+def _split_table_cells(s: str) -> list[str]:
+    r"""Split ``s`` on unescaped ``|`` separators, keeping ``\|`` in the cell.
+
+    GFM treats a backslash-escaped pipe (``\|``) as a literal pipe in cell
+    content, not a column separator. A bare ``str.split("|")`` tears such a
+    cell apart (``int \| None`` → ``int \`` + ``None``), which desyncs the
+    cell count and invents a phantom column. Walk the string so an escaped
+    pipe — or an escaped backslash (``\\``) — is never a separator.
+    """
+    cells: list[str] = []
+    buf: list[str] = []
+    i, n = 0, len(s)
+    while i < n:
+        ch = s[i]
+        if ch == "\\" and i + 1 < n:
+            buf.append(s[i : i + 2])
+            i += 2
+        elif ch == "|":
+            cells.append("".join(buf))
+            buf = []
+            i += 1
+        else:
+            buf.append(ch)
+            i += 1
+    cells.append("".join(buf))
+    return cells
+
+
 def _split_markdown_table_row(line: str) -> list[str]:
-    """Split a simple GFM table row into stripped cell values."""
+    r"""Split a GFM table row into stripped cell values.
+
+    Honors GFM pipe escaping: a ``\|`` is a literal pipe inside a cell, not a
+    column separator, so an ``int \| None`` cell is kept whole instead of
+    being torn into ``int \`` and ``None`` (which invents a phantom column and
+    scrambles the per-row bullets). The table-pipe escape is then resolved to
+    a bare ``|`` for display: these cells become Telegram bullet text rather
+    than a re-parsed pipe table, and ``_escape_mdv2`` re-escapes the pipe for
+    MarkdownV2 on the way out.
+    """
     stripped = line.strip()
     if stripped.startswith("|"):
         stripped = stripped[1:]
-    if stripped.endswith("|"):
-        stripped = stripped[:-1]
-    return [cell.strip() for cell in stripped.split("|")]
+    cells = _split_table_cells(stripped)
+    # Drop the empty cell from the closing border pipe; a trailing escaped
+    # ``\|`` yields no empty cell, so it survives.
+    if len(cells) > 1 and not cells[-1].strip():
+        cells.pop()
+    return [cell.strip().replace(r"\|", "|") for cell in cells]
 
 
 def _render_table_block_for_telegram(table_block: list[str]) -> str:

--- a/tests/agent/test_markdown_tables.py
+++ b/tests/agent/test_markdown_tables.py
@@ -43,6 +43,17 @@ def test_split_strips_outer_pipes_and_trims():
     assert split_table_row("a | b | c") == ["a", "b", "c"]
 
 
+def test_split_keeps_escaped_pipe_in_cell():
+    r"""A GFM-escaped pipe (``\|``) is a literal pipe inside the cell, not a
+    column separator, so the cell is kept whole and the escape preserved."""
+    # The reported case: an ``int \| None`` union type in a cell.
+    assert split_table_row(r"| value | int \| None |") == ["value", r"int \| None"]
+    # An escaped backslash (``\\``) before a real separator still splits.
+    assert split_table_row(r"| a\\ | b |") == [r"a\\", "b"]
+    # A row that ends with an escaped pipe (no closing border) keeps it.
+    assert split_table_row(r"| a | b \|") == ["a", r"b \|"]
+
+
 def test_is_table_divider_handles_alignment_colons():
     assert is_table_divider("|---|---|")
     assert is_table_divider("| :--- | ---: | :---: |")
@@ -72,6 +83,28 @@ def test_no_op_on_text_without_tables():
 def test_no_op_when_pipes_but_no_divider():
     text = "echo a | grep b\necho c | wc -l\n"
     assert realign_markdown_tables(text) == text
+
+
+def test_escaped_pipe_does_not_create_phantom_column():
+    r"""Realigning a two-column table whose cell holds an escaped pipe
+    (``int \| None``) must keep it two columns — the escaped pipe stays in
+    the cell instead of being treated as a separator and spawning a third
+    column with a dangling ``int \`` fragment."""
+    src = dedent(
+        """\
+        | param | type |
+        |-------|------|
+        | x | int \\| None |
+        | y | str |
+        """
+    )
+    out = realign_markdown_tables(src).rstrip("\n").split("\n")
+    # Every rebuilt row parses back to exactly two cells.
+    counts = {len(split_table_row(row)) for row in out}
+    assert counts == {2}, "phantom column:\n" + "\n".join(out)
+    # The escaped pipe survives intact in the body — preserved so the
+    # downstream Markdown renderer still emits a literal pipe.
+    assert any(r"int \| None" in row for row in out)
 
 
 def test_cjk_table_pipes_align_across_rows():

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -38,6 +38,7 @@ _ensure_telegram_mock()
 from gateway.platforms.telegram import (  # noqa: E402
     TelegramAdapter,
     _escape_mdv2,
+    _split_markdown_table_row,
     _strip_mdv2,
     _wrap_markdown_tables,
 )
@@ -717,6 +718,31 @@ class TestWrapMarkdownTables:
         assert "• Score: 150" in out
         assert "• Rank: 1" in out
         assert "**Alice**\n• Score: 150\n• Rank: 1" in out
+
+    def test_escaped_pipe_in_cell_kept_whole(self):
+        r"""A GFM-escaped pipe (``\|``, e.g. an ``int \| None`` union type) is
+        a literal pipe inside the cell, not a column separator.  It must stay
+        in one cell — not spawn a phantom column or a dangling ``int \``
+        bullet — and resolve to a bare pipe for display."""
+        text = (
+            "| name | type |\n"
+            "|------|------|\n"
+            "| x | int \\| None |\n"
+        )
+        out = _wrap_markdown_tables(text)
+        # Heading is the real first cell; the escaped-pipe cell maps to the
+        # right column, kept whole, with the escape resolved for display.
+        assert "**x**" in out
+        assert "• type: int | None" in out
+        # No torn cell leaks a dangling backslash fragment.
+        assert "int \\" not in out.replace("int | None", "")
+
+    def test_split_markdown_table_row_honors_escaped_pipe(self):
+        r"""Unit: the row splitter ignores ``\|`` as a separator and resolves
+        it to a literal pipe for the rendered cell."""
+        assert _split_markdown_table_row(r"| x | int \| None |") == ["x", "int | None"]
+        # A bare separator still splits; surrounding cells are unaffected.
+        assert _split_markdown_table_row(r"| a | b | c |") == ["a", "b", "c"]
 
 
 class TestFormatMessageTables:


### PR DESCRIPTION
## What does this PR do?

Markdown tables broke when a cell held a GFM-escaped pipe (`\|`, e.g. an
`int \| None` union type). `split_table_row` and Telegram's
`_split_markdown_table_row` split on every `|`, so `int \| None` was torn
into `int \` + `None`: the CLI realigner rebuilt the table with a phantom
column, and the Telegram renderer scrambled the per-row bullets. Rows now
split only on **unescaped** pipes.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/markdown_tables.py` — escape-aware `_split_cells` / `split_table_row`.
  The `\|` escape is **preserved** so the downstream Markdown renderer still
  emits a literal pipe (no `render`-mode regression).
- `gateway/platforms/telegram.py` — escape-aware `_split_table_cells` /
  `_split_markdown_table_row`; `\|` resolves to a bare `|` for bullet text.
- Tests added for both sites.

## How to Test

Realign a 2-column table whose cell holds `int \| None`: before it became 3
columns with a dangling `int \`; now it stays 2 columns.

```
$ pytest tests/agent/test_markdown_tables.py tests/gateway/test_telegram_format.py -q
120 passed
```

Wider regression across markdown/table paths (agent, telegram, cli, weixin,
yuanbao): **252 passed**.

## Checklist

- [x] Conventional Commits (`fix(markdown): …`)
- [x] PR contains only changes related to this fix
- [x] Added tests for the fix
- [x] All tests pass