### PR TITLE
Default dashboard initial load to chat

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -97,7 +97,7 @@ import { api } from "@/lib/api";
 import type { StatusResponse } from "@/lib/api";
 
 function RootRedirect() {
-  return <Navigate to="/sessions" replace />;
+  return <Navigate to="/chat" replace />;
 }
 
 function UnknownRouteFallback({ pluginsLoading }: { pluginsLoading: boolean }) {


### PR DESCRIPTION

## Summary
- change the dashboard root route from `/sessions` to `/chat`
- keeps direct `/sessions` navigation and unknown-route fallback behavior unchanged

## Root Cause
Initial dashboard loads were landing users on Recent Sessions even though the primary working surface is Chat.

## Validation
- `npm run build --workspace web`

## Notes
- `npm --workspace web exec eslint -- src/App.tsx` is currently blocked by pre-existing React compiler lint findings in sidebar tooltip ref usage elsewhere in `App.tsx`; this PR only changes `RootRedirect`.

Fixes NS-448.
