### PR TITLE
fix(nix): downgrade extraPythonPackages collision check to warning (#43810)

### DIFF
--- a/nix/hermes-agent.nix
+++ b/nix/hermes-agent.nix
@@ -143,10 +143,9 @@ let
                 if line.startswith('Name:'):
                     pkg = canonical(line.split(':', 1)[1].strip())
                     if pkg in core:
-                        print(f'ERROR: plugin package \"{pkg}\" collides with a package in hermes sealed venv', file=sys.stderr)
+                        print(f'WARNING: plugin package \\"{pkg}\\" collides with a package in hermes sealed venv', file=sys.stderr)
                         print(f'  from: {di}', file=sys.stderr)
-                        print(f'  Remove this dependency from extraPythonPackages.', file=sys.stderr)
-                        sys.exit(1)
+                        print(f'  The sealed venv copy will take precedence at runtime.', file=sys.stderr)
                     break
 
     print('No collisions found.')


### PR DESCRIPTION
Fixes #43810. The collision check in checkPackageCollisions hard-failed the Nix build (sys.exit(1)) when an extraPythonPackage transitively depended on a package already in the sealed uv2nix venv. This made practically every non-trivial plugin uninstallable since packages like requests, pillow, certifi, etc. are ubiquitous. Changed the hard error to a warning since the sealed venv copy takes precedence at runtime anyway.