### PR TITLE
desktop: un-truncate the active slash row so long descriptions stay readable

### DIFF
--- a/apps/desktop/src/app/chat/composer/trigger-popover.tsx
+++ b/apps/desktop/src/app/chat/composer/trigger-popover.tsx
@@ -136,9 +136,24 @@ export function ComposerTriggerPopover({
               >
                 {isSlash ? (
                   <>
-                    <span className="truncate text-[0.8125rem] font-medium leading-snug text-foreground">{display}</span>
+                    {/* Active row (keyboard nav or hover) un-truncates inline so
+                        long command names / descriptions stay readable without a
+                        floating tooltip. */}
+                    <span
+                      className={cn(
+                        'text-[0.8125rem] font-medium leading-snug text-foreground',
+                        active ? 'whitespace-normal break-words' : 'truncate'
+                      )}
+                    >
+                      {display}
+                    </span>
                     {description && (
-                      <span className="truncate text-[0.6875rem] leading-snug text-(--ui-text-tertiary)">
+                      <span
+                        className={cn(
+                          'text-[0.6875rem] leading-snug text-(--ui-text-tertiary)',
+                          active ? 'whitespace-normal break-words' : 'truncate'
+                        )}
+                      >
                         {description}
                       </span>
                     )}


### PR DESCRIPTION
## Summary

Follow-up to #42351.

In the desktop composer's slash popover, each row renders the command label and description with `truncate`. Skill commands and longer blurbs were clipped with an ellipsis and no way to read the rest.

Instead of a floating tooltip (which overlaps the popover, fights its `overflow-y-auto`/z-index, and only helps mouse users), the **active row un-truncates inline**:

- The active row is the one reached by keyboard arrows *or* hover — `onMouseEnter` already calls `onHover(index)` which sets `activeIndex` — so this covers both navigation modes with the flag the component already computes.
- Active row drops `truncate` for `whitespace-normal break-words`, wrapping the full label/description within the existing `w-80` drawer (which already scrolls).
- Idle rows stay single-line/truncated, so the list reads compact.

No new component, measurement hook, or portal.

## Test plan

- [x] `apps/desktop` `npm run typecheck` clean
- [x] `eslint` on touched file — 0 errors
- [x] Manual: open `/` popover, arrow through / hover rows — active row expands to full text, others stay truncated