### PR TITLE
fix(whatsapp): honor group allowlist in bridge

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -173,6 +173,76 @@ class GatewayAuthorizationMixin:
             return any(str(item).strip() for item in sender_allow)
         return False
 
+    def _whatsapp_group_chat_authorized(self, source: SessionSource) -> bool:
+        """Authorize WhatsApp senders by an allowlisted group chat.
+
+        WhatsApp ``WHATSAPP_ALLOWED_USERS`` is the DM/user allowlist, while
+        ``group_policy`` / ``group_allow_from`` are chat-scoped. A participant
+        in an explicitly allowlisted group should not also need DM access.
+        """
+        if (
+            source.platform != Platform.WHATSAPP
+            or source.chat_type not in {"group", "forum"}
+            or not source.chat_id
+        ):
+            return False
+        if not self._adapter_enforces_own_access_policy(source.platform):
+            return False
+
+        adapters = getattr(self, "adapters", None) or {}
+        adapter = adapters.get(source.platform)
+
+        policy = getattr(adapter, "_group_policy", None) if adapter is not None else None
+        allowed = getattr(adapter, "_group_allow_from", None) if adapter is not None else None
+
+        config = getattr(self, "config", None)
+        platform_cfg = (
+            config.platforms.get(source.platform)
+            if config is not None and hasattr(config, "platforms")
+            else None
+        )
+        extra = getattr(platform_cfg, "extra", None) if platform_cfg else None
+        if isinstance(extra, dict):
+            if policy is None:
+                policy = extra.get("group_policy")
+            if allowed is None:
+                allowed = extra.get("group_allow_from") or extra.get("groupAllowFrom")
+
+        if policy is None:
+            policy = os.getenv("WHATSAPP_GROUP_POLICY", "")
+        if allowed is None:
+            allowed = os.getenv("WHATSAPP_GROUP_ALLOWED_USERS", "")
+
+        if str(policy or "").strip().lower() != "allowlist":
+            return False
+
+        is_group_allowed = getattr(adapter, "_is_group_allowed", None)
+        if callable(is_group_allowed):
+            try:
+                return bool(is_group_allowed(source.chat_id))
+            except Exception:
+                pass
+
+        if isinstance(allowed, (set, list, tuple)):
+            allowed_ids = {str(value).strip() for value in allowed if str(value).strip()}
+        else:
+            allowed_ids = {
+                part.strip()
+                for part in str(allowed or "").split(",")
+                if part.strip()
+            }
+
+        if "*" in allowed_ids:
+            return True
+        chat_id = str(source.chat_id).strip()
+        if chat_id in allowed_ids:
+            return True
+        if chat_id.endswith("@g.us") and chat_id[:-5] in allowed_ids:
+            return True
+        if not chat_id.endswith("@g.us") and f"{chat_id}@g.us" in allowed_ids:
+            return True
+        return False
+
     def _is_user_authorized(self, source: SessionSource) -> bool:
         """
         Check if a user is authorized to use the bot.
@@ -220,6 +290,9 @@ class GatewayAuthorizationMixin:
                     }
                     if "*" in allowed_group_ids or source.chat_id in allowed_group_ids:
                         return True
+
+        if self._whatsapp_group_chat_authorized(source):
+            return True
 
         if not user_id:
             return False

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -509,10 +509,14 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             bridge_env["HERMES_IMAGE_CACHE_DIR"] = str(_get_img_dir())
             bridge_env["HERMES_AUDIO_CACHE_DIR"] = str(_get_audio_dir())
             bridge_env["HERMES_DOCUMENT_CACHE_DIR"] = str(_get_doc_dir())
-            bridge_env["WHATSAPP_GROUP_POLICY"] = getattr(self, "_group_policy", "open")
-            bridge_env["WHATSAPP_GROUP_ALLOWED_USERS"] = ",".join(
-                sorted(getattr(self, "_group_allow_from", set()))
+            group_policy = getattr(self, "_group_policy", os.getenv("WHATSAPP_GROUP_POLICY", "open"))
+            group_allow_from = getattr(
+                self,
+                "_group_allow_from",
+                self._coerce_allow_list(os.getenv("WHATSAPP_GROUP_ALLOWED_USERS", "")),
             )
+            bridge_env["WHATSAPP_GROUP_POLICY"] = group_policy
+            bridge_env["WHATSAPP_GROUP_ALLOWED_USERS"] = ",".join(sorted(group_allow_from))
 
             self._bridge_process = subprocess.Popen(
                 [

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -277,7 +277,11 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self._dm_policy = str(config.extra.get("dm_policy") or os.getenv("WHATSAPP_DM_POLICY", "open")).strip().lower()
         self._allow_from = self._coerce_allow_list(config.extra.get("allow_from") or config.extra.get("allowFrom"))
         self._group_policy = str(config.extra.get("group_policy") or os.getenv("WHATSAPP_GROUP_POLICY", "open")).strip().lower()
-        self._group_allow_from = self._coerce_allow_list(config.extra.get("group_allow_from") or config.extra.get("groupAllowFrom"))
+        self._group_allow_from = self._coerce_allow_list(
+            config.extra.get("group_allow_from")
+            or config.extra.get("groupAllowFrom")
+            or os.getenv("WHATSAPP_GROUP_ALLOWED_USERS")
+        )
         self._mention_patterns = self._compile_mention_patterns()
         self._message_queue: asyncio.Queue = asyncio.Queue()
         self._bridge_log_fh = None
@@ -505,6 +509,10 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             bridge_env["HERMES_IMAGE_CACHE_DIR"] = str(_get_img_dir())
             bridge_env["HERMES_AUDIO_CACHE_DIR"] = str(_get_audio_dir())
             bridge_env["HERMES_DOCUMENT_CACHE_DIR"] = str(_get_doc_dir())
+            bridge_env["WHATSAPP_GROUP_POLICY"] = getattr(self, "_group_policy", "open")
+            bridge_env["WHATSAPP_GROUP_ALLOWED_USERS"] = ",".join(
+                sorted(getattr(self, "_group_allow_from", set()))
+            )
 
             self._bridge_process = subprocess.Popen(
                 [

--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -161,7 +161,21 @@ class WhatsAppBehaviorMixin:
         if self._group_policy == "disabled":
             return False
         if self._group_policy == "allowlist":
-            return chat_id in self._group_allow_from
+            allowed_groups = getattr(self, "_group_allow_from", set())
+            normalized = str(chat_id or "").strip()
+            if "*" in allowed_groups:
+                return True
+            if normalized in allowed_groups:
+                return True
+            if normalized.endswith("@g.us") and normalized[:-5] in allowed_groups:
+                return True
+            if (
+                normalized
+                and not normalized.endswith("@g.us")
+                and f"{normalized}@g.us" in allowed_groups
+            ):
+                return True
+            return False
         # "open" — all groups allowed
         return True
 

--- a/scripts/whatsapp-bridge/allowlist.js
+++ b/scripts/whatsapp-bridge/allowlist.js
@@ -18,6 +18,19 @@ export function parseAllowedUsers(rawValue) {
   );
 }
 
+export function matchesAllowedIdentifier(identifier, allowedIdentifiers) {
+  if (!allowedIdentifiers || allowedIdentifiers.size === 0) {
+    return false;
+  }
+
+  if (allowedIdentifiers.has('*')) {
+    return true;
+  }
+
+  const normalized = normalizeWhatsAppIdentifier(identifier);
+  return Boolean(normalized && allowedIdentifiers.has(normalized));
+}
+
 function readMappingFile(sessionDir, identifier, suffix = '') {
   const filePath = path.join(sessionDir, `lid-mapping-${identifier}${suffix}.json`);
   if (!existsSync(filePath)) {

--- a/scripts/whatsapp-bridge/allowlist.test.mjs
+++ b/scripts/whatsapp-bridge/allowlist.test.mjs
@@ -6,6 +6,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 
 import {
   expandWhatsAppIdentifiers,
+  matchesAllowedIdentifier,
   matchesAllowedUser,
   normalizeWhatsAppIdentifier,
   parseAllowedUsers,
@@ -77,4 +78,19 @@ test('matchesAllowedUser rejects everyone when allowlist is empty (#8389)', () =
   } finally {
     rmSync(sessionDir, { recursive: true, force: true });
   }
+});
+
+test('matchesAllowedIdentifier matches explicit group identifiers only', () => {
+  const allowedGroups = parseAllowedUsers('120363001234567890@g.us');
+
+  assert.equal(matchesAllowedIdentifier('120363001234567890@g.us', allowedGroups), true);
+  assert.equal(matchesAllowedIdentifier('120363001234567890', allowedGroups), true);
+  assert.equal(matchesAllowedIdentifier('120363999999999999@g.us', allowedGroups), false);
+  assert.equal(matchesAllowedIdentifier('267383306489914@lid', allowedGroups), false);
+});
+
+test('matchesAllowedIdentifier preserves secure empty-list default and wildcard', () => {
+  assert.equal(matchesAllowedIdentifier('120363001234567890@g.us', parseAllowedUsers('')), false);
+  assert.equal(matchesAllowedIdentifier('120363001234567890@g.us', null), false);
+  assert.equal(matchesAllowedIdentifier('120363001234567890@g.us', parseAllowedUsers('*')), true);
 });

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -29,7 +29,7 @@ import { randomBytes, createHash } from 'crypto';
 import { execSync } from 'child_process';
 import { tmpdir } from 'os';
 import qrcode from 'qrcode-terminal';
-import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
+import { matchesAllowedIdentifier, matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
 
 // Parse CLI args
 const args = process.argv.slice(2);
@@ -71,6 +71,8 @@ try {
 const PAIR_ONLY = args.includes('--pair-only');
 const WHATSAPP_MODE = getArg('mode', process.env.WHATSAPP_MODE || 'self-chat'); // "bot" or "self-chat"
 const ALLOWED_USERS = parseAllowedUsers(process.env.WHATSAPP_ALLOWED_USERS || '');
+const GROUP_POLICY = String(process.env.WHATSAPP_GROUP_POLICY || '').trim().toLowerCase();
+const ALLOWED_GROUPS = parseAllowedUsers(process.env.WHATSAPP_GROUP_ALLOWED_USERS || '');
 const DEFAULT_REPLY_PREFIX = '⚕ *Hermes Agent*\n────────────\n';
 const REPLY_PREFIX = process.env.WHATSAPP_REPLY_PREFIX === undefined
   ? DEFAULT_REPLY_PREFIX
@@ -321,7 +323,31 @@ async function startSocket() {
           } catch {}
           continue;
         }
-        if (!matchesAllowedUser(senderId, ALLOWED_USERS, SESSION_DIR)) {
+        if (isGroup && GROUP_POLICY === 'disabled') {
+          try {
+            console.log(JSON.stringify({
+              event: 'ignored',
+              reason: 'group_policy_disabled',
+              chatId,
+              senderId,
+            }));
+          } catch {}
+          continue;
+        }
+
+        if (isGroup && GROUP_POLICY === 'allowlist') {
+          if (!matchesAllowedIdentifier(chatId, ALLOWED_GROUPS)) {
+            try {
+              console.log(JSON.stringify({
+                event: 'ignored',
+                reason: 'group_allowlist_mismatch',
+                chatId,
+                senderId,
+              }));
+            } catch {}
+            continue;
+          }
+        } else if (!matchesAllowedUser(senderId, ALLOWED_USERS, SESSION_DIR)) {
           try {
             console.log(JSON.stringify({
               event: 'ignored',

--- a/tests/gateway/test_config_driven_access_policy.py
+++ b/tests/gateway/test_config_driven_access_policy.py
@@ -52,6 +52,8 @@ def _clear_auth_env(monkeypatch) -> None:
         "QQ_ALLOWED_USERS",
         "QQ_GROUP_ALLOWED_USERS",
         "WHATSAPP_ALLOWED_USERS",
+        "WHATSAPP_GROUP_ALLOWED_USERS",
+        "WHATSAPP_GROUP_POLICY",
         "TELEGRAM_ALLOWED_USERS",
         "GATEWAY_ALLOWED_USERS",
         "GATEWAY_ALLOW_ALL_USERS",
@@ -285,6 +287,57 @@ def test_env_allowlist_still_takes_precedence_for_own_policy_platform(monkeypatc
     )
     assert runner._is_user_authorized(listed) is True
     assert runner._is_user_authorized(stranger) is False
+
+
+def test_whatsapp_group_allowlist_authorizes_group_sender_even_with_dm_allowlist(monkeypatch):
+    """WhatsApp group allowlist is chat-scoped and must not grant DM access."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "owner-user")
+
+    family_chat = "120363001234567890@g.us"
+    config = GatewayConfig(
+        platforms={
+            Platform.WHATSAPP: PlatformConfig(
+                enabled=True,
+                extra={
+                    "dm_policy": "allowlist",
+                    "allow_from": ["owner-user"],
+                    "group_policy": "allowlist",
+                    "group_allow_from": [family_chat],
+                },
+            )
+        }
+    )
+    runner, adapter = _make_runner(Platform.WHATSAPP, config, enforces=True)
+    adapter._group_policy = "allowlist"
+    adapter._group_allow_from = {family_chat}
+    adapter._is_group_allowed = lambda chat_id: chat_id == family_chat
+
+    group_sender = SessionSource(
+        platform=Platform.WHATSAPP,
+        user_id="other-member@lid",
+        chat_id=family_chat,
+        user_name="member",
+        chat_type="group",
+    )
+    other_group_sender = SessionSource(
+        platform=Platform.WHATSAPP,
+        user_id="other-member@lid",
+        chat_id="120363999999999999@g.us",
+        user_name="member",
+        chat_type="group",
+    )
+    dm_sender = SessionSource(
+        platform=Platform.WHATSAPP,
+        user_id="other-member@lid",
+        chat_id="other-member@lid",
+        user_name="member",
+        chat_type="dm",
+    )
+
+    assert runner._is_user_authorized(group_sender) is True
+    assert runner._is_user_authorized(other_group_sender) is False
+    assert runner._is_user_authorized(dm_sender) is False
 
 
 def test_unknown_adapter_does_not_crash_trust_check(monkeypatch):

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -244,6 +244,38 @@ class TestDataInitialized:
         assert result is True
         assert adapter._running is True
 
+    @pytest.mark.asyncio
+    async def test_bridge_group_env_falls_back_when_adapter_attrs_missing(self, monkeypatch):
+        """Bare adapters still forward env-only group allowlists to the bridge.
+
+        Some tests and recovery paths construct ``WhatsAppAdapter`` via
+        ``__new__`` and bypass ``__init__``. In that shape, connect() must not
+        silently downgrade group policy to open/empty when the operator supplied
+        ``WHATSAPP_GROUP_POLICY`` / ``WHATSAPP_GROUP_ALLOWED_USERS`` in env.
+        """
+        monkeypatch.setenv("WHATSAPP_GROUP_POLICY", "allowlist")
+        monkeypatch.setenv("WHATSAPP_GROUP_ALLOWED_USERS", "group-123@g.us")
+
+        adapter = _make_adapter()
+        assert not hasattr(adapter, "_group_policy")
+        assert not hasattr(adapter, "_group_allow_from")
+
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        # Return non-connected health so connect() starts a fresh subprocess
+        # instead of reusing an already-running bridge before building env.
+        mock_client_cls = _mock_aiohttp(status=200, json_data={"status": "starting"})
+        mock_fh = MagicMock()
+        patches = _connect_patches(mock_proc, mock_fh, mock_client_cls)
+
+        with patches[0], patches[1], patches[2], patches[3], patches[4] as mock_popen,              patches[5], patches[6], patches[7], patches[8],              patch.object(type(adapter), "_poll_messages", return_value=MagicMock()):
+            result = await adapter.connect()
+
+        assert result is True
+        bridge_env = mock_popen.call_args.kwargs["env"]
+        assert bridge_env["WHATSAPP_GROUP_POLICY"] == "allowlist"
+        assert bridge_env["WHATSAPP_GROUP_ALLOWED_USERS"] == "group-123@g.us"
+
 
 # ---------------------------------------------------------------------------
 # File handle cleanup on error paths

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -146,6 +146,68 @@ class TestCloseBridgeLog:
 
 
 # ---------------------------------------------------------------------------
+# bridge subprocess environment
+# ---------------------------------------------------------------------------
+
+class TestBridgeEnvironment:
+    """Verify config-derived routing policy reaches the Node bridge."""
+
+    @pytest.mark.asyncio
+    async def test_passes_group_policy_to_node_bridge_env(self):
+        adapter = _make_adapter()
+        adapter._group_policy = "allowlist"
+        adapter._group_allow_from = {"120363001234567890@g.us"}
+
+        mock_proc = MagicMock()
+        mock_proc.pid = 12345
+        mock_proc.poll.return_value = None
+        mock_fh = MagicMock()
+
+        class _ClientSessionFactory:
+            def __init__(self):
+                self.calls = 0
+
+            def __call__(self):
+                factory = self
+
+                class _Session:
+                    async def __aenter__(self):
+                        return self
+
+                    async def __aexit__(self, *exc):
+                        return False
+
+                    def get(self, *args, **kwargs):
+                        factory.calls += 1
+                        if factory.calls == 1:
+                            raise RuntimeError("no existing bridge")
+                        mock_resp = MagicMock()
+                        mock_resp.status = 200
+                        mock_resp.json = AsyncMock(return_value={"status": "connected"})
+                        return _AsyncCM(mock_resp)
+
+                return _Session()
+
+        mock_client_cls = _ClientSessionFactory()
+
+        with patch("gateway.platforms.whatsapp.check_whatsapp_requirements", return_value=True), \
+             patch.object(Path, "exists", return_value=True), \
+             patch.object(Path, "mkdir", return_value=None), \
+             patch("subprocess.run", return_value=MagicMock(returncode=0)), \
+             patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \
+             patch("builtins.open", return_value=mock_fh), \
+             patch("gateway.platforms.whatsapp.asyncio.sleep", new_callable=AsyncMock), \
+             patch("gateway.platforms.whatsapp.asyncio.create_task"), \
+             patch("aiohttp.ClientSession", mock_client_cls):
+            result = await adapter.connect()
+
+        assert result is True
+        bridge_env = mock_popen.call_args.kwargs["env"]
+        assert bridge_env["WHATSAPP_GROUP_POLICY"] == "allowlist"
+        assert bridge_env["WHATSAPP_GROUP_ALLOWED_USERS"] == "120363001234567890@g.us"
+
+
+# ---------------------------------------------------------------------------
 # data variable initialization
 # ---------------------------------------------------------------------------
 

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -236,6 +236,26 @@ def test_group_policy_allowlist_allows_listed_group():
     assert adapter._should_process_message(_group_message("agus test")) is True
 
 
+def test_group_policy_allowlist_accepts_bare_group_ids():
+    adapter = _make_adapter(
+        group_policy="allowlist",
+        group_allow_from=["120363001234567890"],
+        require_mention=False,
+    )
+
+    assert adapter._should_process_message(_group_message("hello")) is True
+
+
+def test_group_policy_allowlist_accepts_wildcard():
+    adapter = _make_adapter(
+        group_policy="allowlist",
+        group_allow_from=["*"],
+        require_mention=False,
+    )
+
+    assert adapter._should_process_message(_group_message("hello")) is True
+
+
 def test_group_policy_open_allows_all_groups():
     adapter = _make_adapter(group_policy="open", require_mention=True)
 
@@ -272,6 +292,19 @@ def test_config_bridges_whatsapp_dm_and_group_policy(monkeypatch, tmp_path):
     assert __import__("os").environ["WHATSAPP_DM_POLICY"] == "disabled"
     assert __import__("os").environ["WHATSAPP_GROUP_POLICY"] == "allowlist"
     assert __import__("os").environ["WHATSAPP_GROUP_ALLOWED_USERS"] == "120363001234567890@g.us"
+
+
+def test_adapter_reads_group_allowlist_from_env(monkeypatch):
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+
+    monkeypatch.setenv("WHATSAPP_GROUP_POLICY", "allowlist")
+    monkeypatch.setenv("WHATSAPP_GROUP_ALLOWED_USERS", "120363001234567890@g.us")
+
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={}))
+
+    assert adapter._group_policy == "allowlist"
+    assert adapter._group_allow_from == {"120363001234567890@g.us"}
+    assert adapter._should_process_message(_group_message("hello")) is True
 
 
 def test_config_bridges_whatsapp_allow_from(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- pass WhatsApp group allowlist policy from the Python adapter into the Node bridge
- let explicitly allowlisted group messages pass the bridge without allowlisting every sender for DMs
- keep DMs and self-chat protected by the existing sender/self-chat gates
- align Node/Python group ID matching, including bare group IDs and wildcard allowlists

## Test Plan
- node --check scripts/whatsapp-bridge/allowlist.js
- node --check scripts/whatsapp-bridge/bridge.js
- node --test scripts/whatsapp-bridge/allowlist.test.mjs
- python3 -m py_compile gateway/platforms/whatsapp.py tests/gateway/test_whatsapp_connect.py tests/gateway/test_whatsapp_group_gating.py
- python3 -m pytest -q tests/gateway/test_whatsapp_connect.py tests/gateway/test_whatsapp_group_gating.py
