### PR TITLE
fix(agent): add Chinese reasoning tags to think block filters (#43827)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -487,6 +487,11 @@ def strip_think_blocks(agent, content: str) -> str:
     content = re.sub(r'<reasoning>.*?</reasoning>', '', content, flags=re.DOTALL | re.IGNORECASE)
     content = re.sub(r'<REASONING_SCRATCHPAD>.*?</REASONING_SCRATCHPAD>', '', content, flags=re.DOTALL | re.IGNORECASE)
     content = re.sub(r'<thought>.*?</thought>', '', content, flags=re.DOTALL | re.IGNORECASE)
+    # 1a. Chinese reasoning tokens used by MiniMax M3 (#43827).
+    #     These are plain-text markers (no angle brackets) used alongside
+    #     or instead of the English <think> family.
+    for _cn_tag in ("思考", "反思", "推理", "推敲"):
+        content = content.replace(_cn_tag, "")
     # 1b. Tool-call XML blocks (openclaw/openclaw#67318). Handle the
     #     generic tag names first — they have no attribute gating since
     #     a literal <tool_call> in prose is already vanishingly rare.

--- a/cli.py
+++ b/cli.py
@@ -188,6 +188,11 @@ _REASONING_TAGS = (
     "thinking",
     "reasoning",
     "thought",
+    # Chinese reasoning tokens used by MiniMax M3 (#43827)
+    "思考",
+    "反思",
+    "推理",
+    "推敲",
 )
 
 
@@ -4661,8 +4666,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # suppress them during streaming too — unless show_reasoning is
         # enabled, in which case we route the inner content to the
         # reasoning display box instead of discarding it.
-        _OPEN_TAGS = ("<REASONING_SCRATCHPAD>", "<think>", "<reasoning>", "<THINKING>", "<thinking>", "<thought>")
-        _CLOSE_TAGS = ("</REASONING_SCRATCHPAD>", "</think>", "</reasoning>", "</THINKING>", "</thinking>", "</thought>")
+        _OPEN_TAGS = ("<REASONING_SCRATCHPAD>", "<think>", "<reasoning>", "<THINKING>", "<thinking>", "<thought>", "思考", "反思", "推理", "推敲")
+        _CLOSE_TAGS = ("</REASONING_SCRATCHPAD>", "</think>", "</reasoning>", "</THINKING>", "</thinking>", "</thought>", "思考", "反思", "推理", "推敲")
 
         # Append to a pre-filter buffer first
         self._stream_prefilt = getattr(self, "_stream_prefilt", "") + text

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -101,10 +101,13 @@ class GatewayStreamConsumer:
     _OPEN_THINK_TAGS = (
         "<REASONING_SCRATCHPAD>", "<think>", "<reasoning>",
         "<THINKING>", "<thinking>", "<thought>",
+        # Chinese reasoning tokens used by MiniMax M3 (#43827)
+        "思考", "反思", "推理", "推敲",
     )
     _CLOSE_THINK_TAGS = (
         "</REASONING_SCRATCHPAD>", "</think>", "</reasoning>",
         "</THINKING>", "</thinking>", "</thought>",
+        "思考", "反思", "推理", "推敲",
     )
 
     # Class-wide monotonic counter for native-streaming draft ids.  Telegram


### PR DESCRIPTION
Fixes #43827. MiniMax M3 emits Chinese reasoning tokens (思考/反思/推理/推敲) that were never added to the three hard-coded tag filter lists consulted by all consumer code paths (agent_runtime_helpers.py strip_think_blocks, cli.py streaming filter, gateway/stream_consumer.py). Added the Chinese tokens to all three locations so they are stripped during streaming and from final responses, matching the existing English tag filtering behavior.