### PR TITLE
fix: skip ps.exe on Windows to prevent console window popups

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -139,27 +139,28 @@ def _read_process_cmdline(pid: int) -> Optional[str]:
         if raw:
             return raw.replace(b"\x00", b" ").decode("utf-8", errors="ignore").strip()
 
-    try:
-        result = subprocess.run(
-            ["ps", "-p", str(pid), "-o", "command="],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        if result.returncode == 0 and result.stdout.strip():
-            return result.stdout.strip()
-    except (OSError, subprocess.TimeoutExpired):
-        pass
-
-    # Windows fallback: psutil (already used by _pid_exists)
-    try:
-        import psutil  # type: ignore
-        proc = psutil.Process(pid)
-        cmdline_parts = proc.cmdline()
-        if cmdline_parts:
-            return " ".join(cmdline_parts)
-    except Exception:
-        pass
+    # On Windows, skip `ps` (Git's ps.exe pops a console window) and use psutil directly.
+    if sys.platform == "win32":
+        try:
+            import psutil  # type: ignore
+            proc = psutil.Process(pid)
+            cmdline_parts = proc.cmdline()
+            if cmdline_parts:
+                return " ".join(cmdline_parts)
+        except Exception:
+            pass
+    else:
+        try:
+            result = subprocess.run(
+                ["ps", "-p", str(pid), "-o", "command="],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                return result.stdout.strip()
+        except (OSError, subprocess.TimeoutExpired):
+            pass
 
     return None
 


### PR DESCRIPTION
## Problem

On Windows with Git installed, `gateway/status.py`'s `_read_process_cmdline()` calls `subprocess.run(["ps", "-p", ...])` which finds Git's `C:\Program Files\Git\usr\bin\ps.exe` in PATH. Each call spawns a visible console window that flashes on screen.

The gateway checks process status periodically, so users see intermittent ps.exe console window popups as long as the gateway is running.

## Root Cause

The function tries `/proc/<pid>/cmdline` first (fails on Windows), then falls through to the `ps` command — which resolves to Git's ps.exe on Windows. The psutil fallback sits after the `ps` call and is never reached.

## Fix

On `win32`, skip the `ps` subprocess call entirely and use psutil directly (already a dependency). Non-Windows platforms are unchanged.

```
if sys.platform == "win32":
    # use psutil directly
else:
    # existing ps command path
```

## Testing

- Verified fix on Windows 11 with Git installed — no more ps.exe popup windows
- Gateway restarts cleanly and process status checks work via psutil
- No behavior change on Linux/macOS