### PR TITLE
fix(whatsapp): bump Baileys to v7.0.0-rc13 for LID group support (#43830)

### DIFF
--- a/scripts/whatsapp-bridge/package.json
+++ b/scripts/whatsapp-bridge/package.json
@@ -8,7 +8,7 @@
     "start": "node bridge.js"
   },
   "dependencies": {
-    "@whiskeysockets/baileys": "WhiskeySockets/Baileys#01047debd81beb20da7b7779b08edcb06aa03770",
+    "@whiskeysockets/baileys": "WhiskeySockets/Baileys#8053b086ecc97ec3f78299561de11959bab05d39",
     "express": "^4.21.0",
     "qrcode-terminal": "^0.12.0",
     "pino": "^9.0.0"


### PR DESCRIPTION
Fixes #43830. Bump Baileys from commit 01047de (v7.0.0-rc.9 era) to v7.0.0-rc13 (8053b08). The old pin silently failed to deliver outbound messages to WhatsApp groups fully migrated to LID addressing: sendMessage resolved successfully but messages never reached the group. v7.0.0-rc13 includes the LID addressing fix.