### PR TITLE
fix(wecom): constant-time callback signature comparison

### DIFF
--- a/gateway/platforms/wecom_crypto.py
+++ b/gateway/platforms/wecom_crypto.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import hmac
 import os
 import secrets
 import socket
@@ -87,7 +88,10 @@ class WXBizMsgCrypt:
 
     def decrypt(self, msg_signature: str, timestamp: str, nonce: str, encrypt: str) -> bytes:
         expected = _sha1_signature(self.token, timestamp, nonce, encrypt)
-        if expected != msg_signature:
+        # Constant-time comparison: a plain ``!=`` leaks how many leading
+        # characters of the signature matched via response timing, letting a
+        # network attacker forge a valid callback signature byte-by-byte.
+        if not hmac.compare_digest(expected, msg_signature or ""):
             raise SignatureError("signature mismatch")
         try:
             cipher_text = base64.b64decode(encrypt)

--- a/tests/gateway/test_wecom_callback.py
+++ b/tests/gateway/test_wecom_callback.py
@@ -53,6 +53,45 @@ class TestWecomCrypto:
         with pytest.raises(SignatureError):
             crypt.decrypt("bad-sig", "1", "n", root.findtext("Encrypt", default=""))
 
+    def test_signature_check_uses_constant_time_compare(self, monkeypatch):
+        """The signature check must go through hmac.compare_digest so an
+        attacker cannot recover the expected signature via timing.
+        """
+        import gateway.platforms.wecom_crypto as crypto_mod
+
+        calls: list[tuple[str, str]] = []
+        real_compare = crypto_mod.hmac.compare_digest
+
+        def _spy(a, b):
+            calls.append((a, b))
+            return real_compare(a, b)
+
+        monkeypatch.setattr(crypto_mod.hmac, "compare_digest", _spy)
+
+        app = _app()
+        crypt = WXBizMsgCrypt(app["token"], app["encoding_aes_key"], app["corp_id"])
+        encrypted_xml = crypt.encrypt("<xml/>", nonce="n", timestamp="1")
+        root = ET.fromstring(encrypted_xml)
+        crypt.decrypt(
+            root.findtext("MsgSignature", default=""),
+            root.findtext("TimeStamp", default=""),
+            root.findtext("Nonce", default=""),
+            root.findtext("Encrypt", default=""),
+        )
+        assert calls, "signature comparison did not use hmac.compare_digest"
+
+    def test_signature_none_does_not_raise_typeerror(self):
+        """A missing/None signature must surface as SignatureError, not a
+        TypeError from comparing str against None.
+        """
+        app = _app()
+        crypt = WXBizMsgCrypt(app["token"], app["encoding_aes_key"], app["corp_id"])
+        encrypted_xml = crypt.encrypt("<xml/>", nonce="n", timestamp="1")
+        root = ET.fromstring(encrypted_xml)
+        from gateway.platforms.wecom_crypto import SignatureError
+        with pytest.raises(SignatureError):
+            crypt.decrypt(None, "1", "n", root.findtext("Encrypt", default=""))
+
 
 class TestWecomCallbackEventConstruction:
     def test_build_event_extracts_text_message(self):


### PR DESCRIPTION
## Summary
WeCom callback signature verification (`gateway/platforms/wecom_crypto.py`) compared the expected SHA1 signature with the attacker-supplied `msg_signature` using a plain `!=` string comparison.

`python
expected = _sha1_signature(self.token, timestamp, nonce, encrypt)
if expected != msg_signature:
    raise SignatureError("signature mismatch")
`

Python's `str.__ne__` short-circuits on the first differing byte, so the verification time is proportional to the number of leading characters that matched. This is a classic **timing side-channel**: a network attacker who controls `timestamp` / `nonce` / `echostr` in a callback request can measure response latency and recover a valid `msg_signature` byte-by-byte, then forge authenticated WeCom callbacks (spoofed inbound messages, URL-verification bypass).

## Fix
- Compare with `hmac.compare_digest` (constant-time), matching the existing pattern in the Feishu (`feishu.py`), LINE (`line.py`), and webhook (`webhook.py`) verifiers.
- Coerce a missing signature to `""` so a `None` value raises a clean `SignatureError` instead of a `TypeError`.

No behavior change for legitimate callers — valid signatures still pass, invalid ones still raise `SignatureError`.

## Tests
`tests/gateway/test_wecom_callback.py`:
- existing roundtrip + mismatch tests still pass
- new: asserts the verification path goes through `hmac.compare_digest`
- new: `None` signature raises `SignatureError` (not `TypeError`)

`.venv/Scripts/python -m pytest tests/gateway/test_wecom_callback.py` → 14 passed.

## Scope
Upstream-only file, no fork-specific code. Distinct from the open WeCom PRs (media attachments / target-ref parsing), which do not touch the crypto verifier.

Made with [Cursor](https://cursor.com)