### PR TITLE
fix(security): block SSRF in yuanbao download_url

### DIFF
--- a/gateway/platforms/yuanbao_media.py
+++ b/gateway/platforms/yuanbao_media.py
@@ -31,6 +31,31 @@ import httpx
 
 logger = logging.getLogger(__name__)
 
+
+def _safe_url_for_log(url: str, max_len: int = 80) -> str:
+    """Truncate a URL for safe logging (avoid leaking long query strings)."""
+    if len(url) <= max_len:
+        return url
+    return f"{url[:max_len - 3]}..."
+
+
+async def _ssrf_redirect_guard(response: "httpx.Response") -> None:
+    """Re-validate each redirect target to block redirect-based SSRF.
+
+    Without this, an attacker can host a public URL that 30x-redirects to
+    http://169.254.169.254/ (cloud metadata) or http://127.0.0.1/ and bypass
+    the pre-flight ``is_safe_url`` check on the initial URL.
+    """
+    if response.is_redirect and response.next_request is not None:
+        from tools.url_safety import is_safe_url
+
+        redirect_url = str(response.next_request.url)
+        if not is_safe_url(redirect_url):
+            raise ValueError(
+                "Blocked redirect to private/internal address: "
+                f"{_safe_url_for_log(redirect_url)}"
+            )
+
 # ============ 常量 ============
 
 UPLOAD_INFO_PATH = "/api/resource/genUploadInfo"
@@ -218,7 +243,23 @@ async def download_url(
         httpx.HTTPError: 网络/HTTP 错误
     """
     max_bytes = max_size_mb * 1024 * 1024
-    async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+
+    # SSRF protection: the URL originates from model/agent output (e.g. an
+    # ``![alt](url)`` image link in a reply), so it is attacker-influenceable.
+    # Reject private/internal/metadata targets up front, and re-validate every
+    # redirect hop (see ``_ssrf_redirect_guard``).
+    from tools.url_safety import is_safe_url
+
+    if not is_safe_url(url):
+        raise ValueError(
+            f"Blocked unsafe URL (SSRF protection): {_safe_url_for_log(url)}"
+        )
+
+    async with httpx.AsyncClient(
+        timeout=30.0,
+        follow_redirects=True,
+        event_hooks={"response": [_ssrf_redirect_guard]},
+    ) as client:
         # 先 HEAD 检查大小
         try:
             head = await client.head(url)

--- a/tests/gateway/platforms/test_yuanbao_media_ssrf.py
+++ b/tests/gateway/platforms/test_yuanbao_media_ssrf.py
@@ -1,0 +1,67 @@
+"""SSRF protection tests for gateway.platforms.yuanbao_media.download_url.
+
+The download URL comes from model/agent output (e.g. an ``![alt](url)`` image
+link in a reply that the gateway resolves and sends back). Without a guard, an
+agent could make the gateway fetch internal services or the cloud metadata
+endpoint, so ``download_url`` must reject private/internal targets and must
+re-validate redirect hops.
+"""
+
+import pytest
+
+from gateway.platforms import yuanbao_media
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+        "http://127.0.0.1:8080/admin",
+        "http://localhost/secret",
+        "http://[::1]/secret",
+        "http://10.0.0.5/internal",
+    ],
+)
+async def test_download_url_blocks_private_targets(url):
+    with pytest.raises(ValueError, match="SSRF"):
+        await yuanbao_media.download_url(url)
+
+
+class _Resp:
+    def __init__(self, redirect, next_url):
+        self.is_redirect = redirect
+        if next_url is None:
+            self.next_request = None
+        else:
+            self.next_request = type("R", (), {"url": next_url})()
+
+
+@pytest.mark.asyncio
+async def test_redirect_guard_blocks_unsafe_redirect(monkeypatch):
+    """A 30x redirect whose target fails is_safe_url must be rejected."""
+    # Deterministic stub so the test does not depend on live DNS resolution.
+    monkeypatch.setattr(
+        "tools.url_safety.is_safe_url",
+        lambda u: "evil-internal" not in u,
+    )
+
+    with pytest.raises(ValueError, match="private/internal"):
+        await yuanbao_media._ssrf_redirect_guard(
+            _Resp(True, "http://evil-internal/latest/meta-data/")
+        )
+
+
+@pytest.mark.asyncio
+async def test_redirect_guard_allows_safe_redirect(monkeypatch):
+    monkeypatch.setattr("tools.url_safety.is_safe_url", lambda u: True)
+    # Safe redirect -> no raise.
+    await yuanbao_media._ssrf_redirect_guard(
+        _Resp(True, "https://cdn.example.com/image.png")
+    )
+
+
+@pytest.mark.asyncio
+async def test_redirect_guard_noop_on_non_redirect():
+    # A non-redirect response is a no-op even without next_request.
+    await yuanbao_media._ssrf_redirect_guard(_Resp(False, None))


### PR DESCRIPTION
## Summary

`gateway/platforms/yuanbao_media.py::download_url()` fetched arbitrary URLs
with **no SSRF protection**. The URL is attacker-influenceable: it originates
from model/agent output (e.g. an `![alt](url)` image link in a reply that the
Yuanbao gateway resolves and downloads to re-upload). A crafted URL could make
the gateway issue requests to:

- the cloud metadata endpoint (`http://169.254.169.254/…`) to steal IAM creds,
- loopback/admin services (`http://127.0.0.1:…`),
- private RFC1918 ranges (`http://10.0.0.0/8`, etc.).

Because `follow_redirects=True` was set with no per-hop check, even a *public*
URL could 30x-redirect to an internal target and bypass any naive front check.

## Fix

- Reject private/internal/metadata targets up front via the existing
  `tools.url_safety.is_safe_url` helper (the same one used elsewhere in the
  gateway, e.g. `gateway/platforms/base.py`).
- Re-validate **every redirect hop** with an `httpx` response event hook
  (`_ssrf_redirect_guard`) so a redirect to an internal address is blocked
  mid-flight.
- Truncate URLs in error messages to avoid leaking long query strings.

No behavior change for legitimate public media URLs.

## Test plan

- [x] `tests/gateway/platforms/test_yuanbao_media_ssrf.py` — new regression tests:
  - private/internal/metadata targets are rejected (`169.254.169.254`,
    `127.0.0.1`, `localhost`, `::1`, `10.0.0.5`)
  - redirect guard blocks an unsafe redirect, allows a safe one, and is a
    no-op on non-redirect responses
- [x] All 8 tests pass locally.
