### PR TITLE
fix(desktop): recover stale session before stop

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
@@ -42,6 +42,7 @@ function sessionInfo(overrides: Partial<SessionInfo> = {}): SessionInfo {
 }
 
 interface HarnessHandle {
+  cancelRun: () => Promise<void>
   steerPrompt: (text: string) => Promise<boolean>
   submitText: (
     text: string,
@@ -102,8 +103,12 @@ function Harness({
   })
 
   useEffect(() => {
-    onReady({ steerPrompt: actions.steerPrompt, submitText: actions.submitText })
-  }, [actions.steerPrompt, actions.submitText, onReady])
+    onReady({
+      cancelRun: actions.cancelRun,
+      steerPrompt: actions.steerPrompt,
+      submitText: actions.submitText
+    })
+  }, [actions.cancelRun, actions.steerPrompt, actions.submitText, onReady])
 
   return null
 }
@@ -629,6 +634,43 @@ describe('usePromptActions sleep/wake session recovery', () => {
     expect(calls[2]?.params).toEqual({ session_id: RECOVERED_SESSION_ID, text: 'message after wake' })
   })
 
+  it('resumes the stored session and retries once when session.interrupt reports "session not found"', async () => {
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+    let interruptAttempts = 0
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+      if (method === 'session.interrupt') {
+        interruptAttempts += 1
+        if (interruptAttempts === 1) {
+          throw new Error('session not found')
+        }
+        return {} as never
+      }
+      if (method === 'session.resume') {
+        return { session_id: RECOVERED_SESSION_ID } as never
+      }
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        storedSessionId={STORED_SESSION_ID}
+      />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await handle!.cancelRun()
+
+    expect(calls.map(c => c.method)).toEqual(['session.interrupt', 'session.resume', 'session.interrupt'])
+    expect(calls[0]?.params).toEqual({ session_id: RUNTIME_SESSION_ID })
+    expect(calls[1]?.params).toEqual({ session_id: STORED_SESSION_ID })
+    expect(calls[2]?.params).toEqual({ session_id: RECOVERED_SESSION_ID })
+  })
+
   it('surfaces the original error (no resume) when the failure is not "session not found"', async () => {
     const calls: string[] = []
     const states: Record<string, unknown>[] = []
@@ -818,4 +860,3 @@ describe('uploadComposerAttachment remote read failures', () => {
     ).rejects.toThrow('ENOENT: no such file')
   })
 })
-

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -108,6 +108,12 @@ function inlineErrorMessage(error: unknown, fallback: string): string {
   return (raw.match(/Error invoking remote method '[^']+': Error: (.+)$/)?.[1] ?? raw).replace(/^Error:\s*/, '').trim()
 }
 
+function isSessionNotFoundError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+
+  return /session not found/i.test(message)
+}
+
 function base64FromDataUrl(dataUrl: string): string {
   const comma = dataUrl.indexOf(',')
 
@@ -661,9 +667,7 @@ export function usePromptActions({
         try {
           await requestGateway('prompt.submit', { session_id: sessionId, text })
         } catch (firstErr) {
-          const firstMsg = firstErr instanceof Error ? firstErr.message : String(firstErr)
-
-          if (/session not found/i.test(firstMsg) && selectedStoredSessionIdRef.current) {
+          if (isSessionNotFoundError(firstErr) && selectedStoredSessionIdRef.current) {
             // Re-register the session in the gateway and get a fresh live ID.
             const resumed = await requestGateway<{ session_id: string }>('session.resume', {
               session_id: selectedStoredSessionIdRef.current
@@ -1273,11 +1277,39 @@ export function usePromptActions({
     try {
       await requestGateway('session.interrupt', { session_id: sessionId })
     } catch (err) {
+      let stopError = err
+
+      if (isSessionNotFoundError(err) && selectedStoredSessionIdRef.current) {
+        try {
+          const resumed = await requestGateway<{ session_id: string }>('session.resume', {
+            session_id: selectedStoredSessionIdRef.current
+          })
+          const recoveredId = resumed?.session_id
+
+          if (recoveredId) {
+            activeSessionIdRef.current = recoveredId
+            await requestGateway('session.interrupt', { session_id: recoveredId })
+
+            return
+          }
+        } catch (resumeErr) {
+          stopError = resumeErr
+        }
+      }
+
       setMutableRef(busyRef, false)
       setBusy(false)
-      notifyError(err, copy.stopFailed)
+      notifyError(stopError, copy.stopFailed)
     }
-  }, [activeSessionId, activeSessionIdRef, busyRef, copy.stopFailed, requestGateway, updateSessionState])
+  }, [
+    activeSessionId,
+    activeSessionIdRef,
+    busyRef,
+    copy.stopFailed,
+    requestGateway,
+    selectedStoredSessionIdRef,
+    updateSessionState
+  ])
 
   // Steer = nudge the live turn without interrupting: the gateway appends the
   // text to the next tool result so the model reads it on its next iteration

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -21,7 +21,7 @@ let
 
   # Single npm deps fetch from the workspace root lockfile.
   # All workspace packages share this derivation.
-  npmDepsHash = "sha256-mVWPJLIYa4EA0iNPiSVLAPzjjnWdky2HbG5mwApy1lo=";
+  npmDepsHash = "sha256-eBok1pSkNwCqBgxevEkDhm0Hu635sJYGi2J/UJWhVto=";
 
   npmDeps = pkgs.fetchNpmDeps {
     inherit src;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8418,9 +8418,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.13.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.1.tgz",
-      "integrity": "sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==",
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## What does this PR do?

Desktop already recovers from a stale runtime session id when `prompt.submit` returns `session not found` after a gateway restart or sleep/wake. The stop path did not have the same recovery: `cancelRun` called `session.interrupt` once with the stale runtime id, then surfaced `Stop failed / session not found`.

This makes stop/cancel mirror the prompt recovery path. If `session.interrupt` reports `session not found` and the selected stored session id is available, Desktop resumes that durable session, updates the active runtime ref with the recovered id, and retries `session.interrupt` once against the recovered runtime id.

The PR also syncs `package-lock.json` from `@types/node@24.13.1` to `24.13.2`, which is required for npm 11 to install the desktop workspace because `apps/desktop/package.json` allows `^24.12.0` and npm resolves that range to `24.13.2`.

## Related Issue

Discord support thread: https://discord.com/channels/1053877538025386074/1514454639142244372

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-prompt-actions.ts`: share `session not found` detection and retry `session.interrupt` through `session.resume` when a stale runtime id is recoverable.
- `apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx`: add coverage for the stale-session stop recovery path.
- `package-lock.json`: sync `@types/node` to `24.13.2` so npm 11 `ci` can install the desktop workspace from the current dependency range.

## How to Test

1. `npm ci --workspace apps/desktop --no-fund --no-audit --progress=false`
2. `npm --workspace apps/desktop run test:ui -- src/app/session/hooks/use-prompt-actions.test.tsx`
3. `npm --workspace apps/desktop run typecheck`

## Checklist

### Code

- [ ] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I have run `pytest tests/ -q` and all tests pass
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: WSL/Linux checkout with the desktop workspace npm toolchain

### Documentation & Housekeeping

- [x] I have updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I have updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I have updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I have considered cross-platform impact (Windows, macOS) per the compatibility guide — recovery is in shared Desktop renderer logic
- [x] I have updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Focused validation passed locally:

- `npm ci --workspace apps/desktop --no-fund --no-audit --progress=false`
- `npm --workspace apps/desktop run test:ui -- src/app/session/hooks/use-prompt-actions.test.tsx` — 1 file / 26 tests passed
- `npm --workspace apps/desktop run typecheck`

Full Python test suite not run in this operator environment.