### PR TITLE
fix(security): harden curator rollback tar extraction (symlink/abs-path escape)

### DIFF
--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -45,7 +45,7 @@ import re
 import shutil
 import tarfile
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_constants import get_hermes_home
@@ -526,6 +526,48 @@ def _restore_cron_skill_links(snapshot_dir: Path) -> Dict[str, Any]:
 
 
 
+def _is_unsafe_archive_path(name: str) -> bool:
+    """True if *name* would escape the extraction root.
+
+    Catches POSIX absolute paths, Windows absolute / drive-letter / UNC
+    paths (``C:/x``, ``\\\\server\\share``) and any ``..`` traversal
+    component. ``Path(name).parts`` alone misses the Windows cases on a
+    POSIX host and the drive case on Windows, so we check both flavours
+    explicitly.
+    """
+    if not name:
+        return True
+    normalized = name.replace("\\", "/")
+    posix = PurePosixPath(normalized)
+    windows = PureWindowsPath(name)
+    if posix.is_absolute() or windows.is_absolute() or windows.drive:
+        return True
+    return any(part == ".." for part in posix.parts)
+
+
+def _assert_safe_member(member: "tarfile.TarInfo") -> None:
+    """Reject tar members that could escape the skills dir on extract.
+
+    Defense-in-depth for the Python < 3.12 fallback path, which has no
+    ``filter="data"`` and would otherwise honour a symlink/hardlink member
+    whose target points outside the destination (then write a later member
+    *through* that link). The original guard only inspected ``member.name``;
+    a link member's traversal lives in ``member.linkname``, and Windows
+    absolute paths slipped past the POSIX-only check entirely.
+    """
+    if _is_unsafe_archive_path(member.name):
+        raise tarfile.TarError(
+            f"refusing to extract unsafe path: {member.name!r}"
+        )
+    if member.issym() or member.islnk():
+        link = member.linkname or ""
+        if not link or _is_unsafe_archive_path(link):
+            raise tarfile.TarError(
+                "refusing to extract link with unsafe target: "
+                f"{member.name!r} -> {link!r}"
+            )
+
+
 def rollback(backup_id: Optional[str] = None) -> Tuple[bool, str, Optional[Path]]:
     """Restore ``~/.hermes/skills/`` from a snapshot.
 
@@ -604,13 +646,10 @@ def rollback(backup_id: Optional[str] = None) -> Tuple[bool, str, Optional[Path]
         with tarfile.open(archive, "r:gz") as tf:
             # Python 3.12+ supports filter='data' for safer extraction.
             # Fall back to the unfiltered call for older interpreters but
-            # still reject absolute paths and .. components defensively.
+            # still reject absolute paths, .. components AND unsafe link
+            # targets defensively (the fallback honours symlink members).
             for member in tf.getmembers():
-                name = member.name
-                if name.startswith("/") or ".." in Path(name).parts:
-                    raise tarfile.TarError(
-                        f"refusing to extract unsafe path: {name!r}"
-                    )
+                _assert_safe_member(member)
             try:
                 tf.extractall(str(skills), filter="data")  # type: ignore[call-arg]
             except TypeError:

--- a/tests/agent/test_curator_backup.py
+++ b/tests/agent/test_curator_backup.py
@@ -259,6 +259,62 @@ def test_rollback_rejects_unsafe_tarball(backup_env, monkeypatch):
     assert "unsafe" in msg.lower() or "refus" in msg.lower() or "extract" in msg.lower()
 
 
+def test_is_unsafe_archive_path_variants(backup_env):
+    """The path guard must catch POSIX abs, Windows abs/drive/UNC, and ..."""
+    cb = backup_env["cb"]
+    unsafe = [
+        "",
+        "/etc/passwd",
+        "../escape",
+        "a/../../b",
+        "C:/Windows/System32/evil.dll",
+        "C:\\Windows\\evil.dll",
+        "\\\\server\\share\\evil",
+    ]
+    for p in unsafe:
+        assert cb._is_unsafe_archive_path(p), f"{p!r} should be unsafe"
+
+    safe = ["alpha/SKILL.md", "beta/scripts/run.py", "./gamma/x"]
+    for p in safe:
+        assert not cb._is_unsafe_archive_path(p), f"{p!r} should be safe"
+
+
+def test_rollback_rejects_symlink_escape(backup_env):
+    """A symlink member whose target escapes the tree must be refused.
+
+    The pre-3.12 fallback (no ``filter='data'``) would otherwise create the
+    link and let a later member write through it. The original name-only
+    guard never inspected ``linkname``.
+    """
+    cb = backup_env["cb"]
+    skills = backup_env["skills"]
+    _write_skill(skills, "alpha")
+    cb.snapshot_skills(reason="legit")
+
+    rows = cb.list_backups()
+    snap_dir = Path(rows[0]["path"])
+    mal = snap_dir / "skills.tar.gz"
+    mal.unlink()
+    with tarfile.open(mal, "w:gz") as tf:
+        info = tarfile.TarInfo(name="alpha/link")
+        info.type = tarfile.SYMTYPE
+        info.linkname = "/etc/cron.d"  # absolute escape target
+        tf.addfile(info)
+
+    ok, msg, _ = cb.rollback()
+    assert not ok
+    assert "unsafe" in msg.lower() or "link" in msg.lower() or "refus" in msg.lower()
+
+
+def test_assert_safe_member_allows_in_tree_symlink(backup_env):
+    """A relative, in-tree symlink target is allowed (no degradation)."""
+    cb = backup_env["cb"]
+    info = tarfile.TarInfo(name="alpha/link")
+    info.type = tarfile.SYMTYPE
+    info.linkname = "SKILL.md"
+    cb._assert_safe_member(info)  # must not raise
+
+
 # ---------------------------------------------------------------------------
 # Integration with run_curator_review
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`agent/curator_backup.py::rollback()` extracts a snapshot tarball back into
`~/.hermes/skills/`. Before extraction it validated only `member.name` with a
POSIX-absolute / `..` check, then fell back to a plain `tf.extractall()` on
Python < 3.12 (where `filter="data"` is unavailable). That leaves two escape
vectors if an attacker can plant a crafted `skills.tar.gz` in
`.curator_backups/`:

1. **Symlink / hardlink members** — the traversal lives in `member.linkname`,
   which was never inspected. The pre-3.12 fallback creates the link, and a
   later member can then be written *through* it, outside `skills/`.
2. **Windows absolute / drive-letter / UNC paths** (`C:/x`, `C:\x`,
   `\\server\share`) — the POSIX-only `startswith("/")` check lets these
   through, and `Path(name).parts` shows no `..` for them.

## Fix

- Add `_assert_safe_member()` (with helper `_is_unsafe_archive_path()`) that
  rejects unsafe member **names** (POSIX abs, Windows abs/drive/UNC, `..`)
  **and** unsafe **link targets**, mirroring the secure extraction pattern
  already used in `hermes_cli/profiles.py::_safe_extract_profile_archive`.
- The `filter="data"` path on Python 3.12+ is unchanged.
- Relative, in-tree symlinks still extract, so legitimate snapshots are
  unaffected (no functional degradation).

## Test plan

- [x] `tests/agent/test_curator_backup.py` — new tests:
  - `test_is_unsafe_archive_path_variants` (POSIX abs, Windows abs/drive/UNC, `..`)
  - `test_rollback_rejects_symlink_escape` (symlink with absolute target is refused)
  - `test_assert_safe_member_allows_in_tree_symlink` (relative in-tree link allowed)
- [x] Existing `test_rollback_rejects_unsafe_tarball` still passes.
- [x] All 28 tests in the file pass locally.
