### PR TITLE
Fix/deepsfix(deepseek): omitting tool_choice auto/any and preserving signed thinking blocks for /anthropic endpointeek anthropic compat

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -512,20 +512,29 @@ def _is_deepseek_anthropic_endpoint(base_url: str | None) -> bool:
         The content[].thinking in the thinking mode must be passed back
         to the API.
 
-    Per DeepSeek's published compatibility matrix the blocks are unsigned
-    (no Anthropic-proprietary signature, no ``redacted_thinking`` support),
-    so this endpoint is handled with the same strip-signed / keep-unsigned
-    policy used for Kimi's ``/coding`` endpoint.  The match is pinned to
-    the ``/anthropic`` path so the OpenAI-compatible ``api.deepseek.com``
-    base URL (which never reaches this adapter) is not misclassified.
+    DeepSeek's thinking blocks carry a DeepSeek-owned ``signature`` field
+    (not an Anthropic-proprietary signature), so signed blocks must be
+    preserved for DeepSeek endpoints.  Internal proxies (e.g.
+    ``deepgate.ximalaya.local/deepseek-v4-pro-anthropic/api``) are
+    detected via the URL path containing ``deepseek``.
     See hermes-agent#16748.
     """
-    if not base_url_host_matches(base_url or "", "api.deepseek.com"):
-        return False
     normalized = _normalize_base_url_text(base_url)
     if not normalized:
         return False
-    return "/anthropic" in normalized.rstrip("/").lower()
+    normalized_lower = normalized.rstrip("/").lower()
+    # Official DeepSeek /anthropic endpoint
+    if base_url_host_matches(base_url or "", "api.deepseek.com") and "/anthropic" in normalized_lower:
+        return True
+    # Internal proxies serving DeepSeek's Anthropic-compatible API
+    from urllib.parse import urlparse
+    try:
+        path = urlparse(normalized_lower).path
+    except Exception:
+        path = ""
+    if "deepseek" in path:
+        return True
+    return False
 
 
 def _requires_bearer_auth(base_url: str | None) -> bool:
@@ -1957,12 +1966,16 @@ def _manage_thinking_signatures(
     """
     _THINKING_TYPES = frozenset(("thinking", "redacted_thinking"))
     _is_third_party = _is_third_party_anthropic_endpoint(base_url)
-    # Kimi / DeepSeek share a contract: strip signed Anthropic blocks
-    # (neither upstream can validate Anthropic signatures), preserve unsigned
-    # ones synthesised from reasoning_content.  See #13848, #16748.
+    _is_deepseek = _is_deepseek_anthropic_endpoint(base_url)
+    # Kimi's /coding endpoint enables thinking server-side and requires
+    # unsigned thinking blocks on replayed assistant tool-call messages.
+    # Signed Anthropic blocks must be stripped (Kimi can't validate
+    # Anthropic's signatures).  DeepSeek endpoints preserve ALL thinking
+    # blocks (DeepSeek's own signatures must round-trip).
+    # See hermes-agent#13848 (Kimi) and #16748 (DeepSeek).
     _preserve_unsigned_thinking = (
         _is_kimi_family_endpoint(base_url, model)
-        or _is_deepseek_anthropic_endpoint(base_url)
+        or _is_deepseek
     )
 
     last_assistant_idx = None
@@ -1976,15 +1989,15 @@ def _manage_thinking_signatures(
             continue
 
         if _preserve_unsigned_thinking:
-            # Kimi / DeepSeek: strip signed, preserve unsigned.
             new_content = []
             for b in m["content"]:
                 if not isinstance(b, dict) or b.get("type") not in _THINKING_TYPES:
                     new_content.append(b)
                     continue
-                if b.get("signature") or b.get("data"):
-                    # Signed (or redacted-with-data) — upstream can't validate, strip.
+                if not _is_deepseek and (b.get("signature") or b.get("data")):
+                    # Anthropic-signed block on Kimi — upstream can't validate, strip
                     continue
+                # Unsigned thinking (Kimi), or DeepSeek-signed thinking — keep it.
                 new_content.append(b)
             m["content"] = new_content or [{"type": "text", "text": "(empty)"}]
         elif _is_third_party or idx != last_assistant_idx:

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2282,8 +2282,21 @@ def build_anthropic_kwargs(
 
     if anthropic_tools:
         kwargs["tools"] = anthropic_tools
-        # Map OpenAI tool_choice to Anthropic format
-        if tool_choice == "auto" or tool_choice is None:
+        # Map OpenAI tool_choice to Anthropic format.
+        # DeepSeek's /anthropic endpoint only accepts
+        #   {"type": "function", "function": {"name": "..."}}
+        # and rejects Anthropic-native {"type": "auto"} / {"type": "any"}.
+        # Omit tool_choice for "auto" (defaults to auto) and for "required"
+        # (DeepSeek has no equivalent); only emit for a specific tool name.
+        _is_deepseek = _is_deepseek_anthropic_endpoint(base_url)
+        if _is_deepseek:
+            if isinstance(tool_choice, str) and tool_choice not in ("auto", "required", "none"):
+                # Specific tool name — DeepSeek supports this variant.
+                kwargs["tool_choice"] = {"type": "function", "function": {"name": tool_choice}}
+            elif tool_choice == "none":
+                kwargs.pop("tools", None)
+            # else: "auto"/None/"required" — omit tool_choice, default is auto.
+        elif tool_choice == "auto" or tool_choice is None:
             kwargs["tool_choice"] = {"type": "auto"}
         elif tool_choice == "required":
             kwargs["tool_choice"] = {"type": "any"}

--- a/tests/agent/test_deepseek_anthropic_thinking.py
+++ b/tests/agent/test_deepseek_anthropic_thinking.py
@@ -119,11 +119,11 @@ class TestDeepSeekAnthropicPreservesThinking:
             assert len(thinking) == 1
             assert thinking[0]["thinking"] == expected
 
-    def test_signed_anthropic_thinking_block_is_stripped(self) -> None:
-        """Anthropic-signed blocks (that leaked through) must still be stripped.
+    def test_signed_thinking_block_preserved_on_deepseek(self) -> None:
+        """DeepSeek-signed thinking blocks must be preserved.
 
-        DeepSeek issues its own signatures and cannot validate Anthropic's —
-        the strip-signed / keep-unsigned split matches the Kimi policy.
+        DeepSeek issues its own signatures and requires thinking blocks to
+        round-trip on subsequent requests — stripping them triggers HTTP 400.
         """
         from agent.anthropic_adapter import convert_messages_to_anthropic
 
@@ -134,8 +134,8 @@ class TestDeepSeekAnthropicPreservesThinking:
                 "content": [
                     {
                         "type": "thinking",
-                        "thinking": "anthropic-signed payload",
-                        "signature": "anthropic-sig-xyz",
+                        "thinking": "deepseek-signed payload",
+                        "signature": "deepseek-sig-xyz",
                     },
                     {"type": "text", "text": "hello"},
                 ],
@@ -151,10 +151,12 @@ class TestDeepSeekAnthropicPreservesThinking:
             b for b in assistant_msg["content"]
             if isinstance(b, dict) and b.get("type") == "thinking"
         ]
-        assert thinking_blocks == [], (
-            "Signed Anthropic thinking blocks must be stripped on DeepSeek — "
-            "DeepSeek cannot validate Anthropic-proprietary signatures."
+        assert len(thinking_blocks) == 1, (
+            "Signed DeepSeek thinking blocks must be preserved — "
+            "DeepSeek requires its own signatures to round-trip."
         )
+        assert thinking_blocks[0]["thinking"] == "deepseek-signed payload"
+        assert thinking_blocks[0]["signature"] == "deepseek-sig-xyz"
 
     def test_cache_control_stripped_from_thinking_block(self) -> None:
         """cache_control must still be stripped even when the block is preserved.


### PR DESCRIPTION
## What does this PR do?

Fixes two compatibility issues when using DeepSeek's Anthropic-compatible `/anthropic` endpoint:

1. **Preserving signed thinking blocks** — DeepSeek issues its own signatures on thinking blocks and requires them to round-trip on subsequent requests. The old code stripped all signed blocks assuming they were Anthropic-proprietary, causing HTTP 400 errors.

2. **Omitting `tool_choice: {"type": "auto"}` / `{"type": "any"}`** — DeepSeek's `/anthropic` endpoint only accepts `{"type": "function", "function": {"name": "..."}}` and rejects the Anthropic-native variants with HTTP 400.

Also expands `_is_deepseek_anthropic_endpoint()` to detect internal proxy URLs (e.g. `deepgate.ximalaya.local/deepseek-v4-pro-anthropic/api`) by matching `"deepseek"` in the URL path.

## Related Issue

Fixes #16748

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `agent/anthropic_adapter.py`:
  - `_is_deepseek_anthropic_endpoint()`: detect internal proxies by URL path in addition to `api.deepseek.com`
  - `_manage_thinking_signatures()`: preserve DeepSeek-signed thinking blocks instead of stripping them
  - `build_anthropic_kwargs()`: omit `tool_choice` for `"auto"`/`"required"` on DeepSeek endpoints; translate specific tool names to `{"type": "function", ...}` format
- `tests/agent/test_deepseek_anthropic_thinking.py`: update test expectations for signed block preservation

## How to Test

```bash
# Verify no {"type": "auto"} is sent to DeepSeek endpoints
python -c "
from agent.anthropic_adapter import build_anthropic_kwargs
kwargs = build_anthropic_kwargs(
    model='deepseek-v4-pro',
    messages=[{'role': 'user', 'content': 'hello'}],
    tools=[{'name': 'search', 'description': 'search', 'input_schema': {'type': 'object', 'properties': {}}}],
    max_tokens=4096,
    reasoning_config=None,
    tool_choice='auto',
    base_url='http://deepgate.ximalaya.local/deepseek-v4-pro-anthropic/api',
)
assert kwargs.get('tool_choice') is None  # omitted, defaults to auto
print('OK')
"

# Run tests
pytest tests/agent/test_deepseek_anthropic_thinking.py -v

Checklist

Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run pytest tests/ -q and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated cli-config.yaml.example — N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md — N/A
- [x] I've considered cross-platform impact — N/A
- [x] I've updated tool descriptions/schemas — N/A

Screenshots / Logs

Before (HTTP 400 error):
tool_choice: field `type`: unknown variant `auto`, expected `function`

After: request succeeds with tool_choice omitted (defaults to auto).

---