### PR TITLE
feat(skills): read profile descriptions in kanban orchestrator Step 0

### DIFF
--- a/skills/devops/kanban-orchestrator/SKILL.md
+++ b/skills/devops/kanban-orchestrator/SKILL.md
@@ -28,7 +28,9 @@ Use one of these:
 - `kanban_list(assignee="<some-name>")` — sanity-check a single name. Returns an empty list (rather than an error) for an unknown assignee, so this only confirms a name you're already considering.
 - **Just ask the user.** "What profiles do you have set up?" is a fine first turn when the goal needs more than one specialist.
 
-Cache the result in your working memory for the rest of the conversation. Re-asking every turn wastes a tool call.
+After listing profiles, read each profile's description with `hermes profile describe <profile-name>`. Descriptions convey the intended role and capabilities of each profile — use them to match tasks with the right specialist. If no description exists, infer the role from the profile name.
+
+Cache both the profile names and their descriptions in your working memory for the rest of the conversation. Re-asking every turn wastes a tool call.
 
 ## When to use the board (vs. just doing the work)
 


### PR DESCRIPTION
## Summary

Update the kanban-orchestrator skill's Step 0 to read profile descriptions after listing profiles. This helps the orchestrator match tasks with the right specialist based on their declared role and capabilities.

## Problem

The orchestrator skill's Step 0 instructs the agent to discover available profiles (`hermes profile list`), but never reads their descriptions. The web UI states that profile descriptions are "used to route kanban tasks by role" — without reading them, the orchestrator can only guess at profile capabilities from names alone.

## Solution

Add an instruction to read each profile's description with `hermes profile describe <profile-name>` after listing profiles. Cache both names and descriptions in working memory for the rest of the conversation.

**Before:**
```
Cache the result in your working memory for the rest of the conversation.
```

**After:**
```
After listing profiles, read each profile's description with
`hermes profile describe <profile-name>`. Descriptions convey the intended
role and capabilities of each profile — use them to match tasks with the
right specialist. If no description exists, infer the role from the profile name.

Cache both the profile names and their descriptions in your working memory
for the rest of the conversation.
```

Fixes #43935
