### PR TITLE
Add Nix desktop launcher entry

### DIFF
--- a/nix/desktop.nix
+++ b/nix/desktop.nix
@@ -13,6 +13,16 @@ let
   packageJson = builtins.fromJSON (builtins.readFile (npm.src + "/apps/desktop/package.json"));
   version = packageJson.version;
 
+  desktopItem = pkgs.makeDesktopItem {
+    name = "hermes-desktop";
+    desktopName = "Hermes";
+    comment = "Native desktop shell for Hermes Agent";
+    exec = "hermes-desktop";
+    icon = "hermes-desktop";
+    categories = [ "Development" ];
+    startupNotify = true;
+  };
+
   # Build the renderer (dist/ + electron/ + package.json).
   renderer = pkgs.buildNpmPackage (npm // {
     pname = "hermes-desktop-renderer";
@@ -78,8 +88,16 @@ stdenv.mkDerivation {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/share/hermes-desktop $out/bin
+    mkdir -p \
+      $out/share/hermes-desktop \
+      $out/share/applications \
+      $out/share/icons/hicolor/512x512/apps \
+      $out/share/pixmaps \
+      $out/bin
     cp -r ${renderer}/* $out/share/hermes-desktop/
+    cp ${desktopItem}/share/applications/* $out/share/applications/
+    cp ${npm.src}/apps/desktop/assets/icon.png $out/share/icons/hicolor/512x512/apps/hermes-desktop.png
+    cp ${npm.src}/apps/desktop/assets/icon.png $out/share/pixmaps/hermes-desktop.png
 
     # Wrap the nixpkgs electron binary to launch our app.  Set
     # HERMES_DESKTOP_HERMES to the absolute path of the nix-built `hermes`


### PR DESCRIPTION
## Summary
- add a Linux desktop entry to the Nix desktop package
- install the Hermes desktop icon under hicolor 512x512 and pixmaps lookup paths

## Why
The Nix flake provides the Electron GUI app, but profile installs did not expose a launcher entry to desktop environments. KDE also did not resolve the original 1024x1024-only icon path reliably.

## Validation
- nix eval .#packages.x86_64-linux.desktop.drvPath --raw
- nix profile add .#desktop
- kbuildsycoca6 --noincremental --menutest --desktopfile hermes-desktop.desktop
- kiconfinder6 hermes-desktop