### PR TITLE
Fix _add_path_candidate crash on ~user expanduser() RuntimeError

### DIFF
--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -144,7 +144,10 @@ class SubdirectoryHintTracker:
                 if parent == p:
                     break  # filesystem root
                 p = parent
-        except (OSError, ValueError):
+        except (OSError, ValueError, RuntimeError):
+            # RuntimeError covers Path.expanduser() on a "~user" token whose
+            # user is not a real account ("Could not determine home directory.").
+            # The hint walk is best-effort, so a bad path is skipped, never fatal.
             pass
 
     def _extract_paths_from_command(self, cmd: str, candidates: Set[Path]):


### PR DESCRIPTION
### Problem
`_add_path_candidate` in `agent/subdirectory_hints.py` calls `Path(raw_path).expanduser()` inside `try/except (OSError, ValueError)`. But `Path.expanduser()` raises **`RuntimeError("Could not determine home directory.")`** — not `OSError`/`ValueError` — for a `~user` token whose `user` is not a real account (no `/etc/passwd` entry), even when `$HOME` is set (the `~user` form does a passwd lookup, not a `$HOME` substitution).

Because `RuntimeError` isn't caught, it escapes `_extract_paths_from_command` → `check_tool_call` → `execute_tool_calls_sequential` → `_execute_tool_calls` → `run_conversation` and **aborts the whole agent turn**. On a long-running gateway this fires whenever a model emits a path-like `~name/...` token for a non-existent user (~3×/24h in our deployment; each one kills the turn, e.g. an aborted scheduled run).

### Reproduce
```python
from pathlib import Path
Path("~nonexistent_user/x").expanduser()   # RuntimeError: Could not determine home directory.
```

### Fix
The directory-hint walk is best-effort, so broaden the except to include `RuntimeError` and skip the bad path instead of crashing. Only the `_add_path_candidate` block is changed — the two structurally-identical `except (OSError, ValueError)` blocks in `_is_valid_subdir` / `_load_hints_for_directory` operate on already-resolved Paths (no `expanduser`) and are left untouched.

Fixes #43963
