### PR TITLE
feat(providers): add Weights & Biases Inference provider plugin

### DIFF
--- a/plugins/model-providers/coreweave/__init__.py
+++ b/plugins/model-providers/coreweave/__init__.py
@@ -1,0 +1,42 @@
+"""CoreWeave Serverless Inference provider profile.
+
+CoreWeave Serverless Inference (formerly W&B Inference) is a standard
+OpenAI-compatible endpoint serving leading open models on CoreWeave. API-key
+auth via ``COREWEAVE_API_KEY``; the ``/v1/models`` catalog is live so the picker
+fetches models automatically.
+
+The endpoint also accepts an optional ``openai-project`` header (``team/project``)
+for usage attribution. It is only required for accounts whose default project
+lacks Inference access. Because the value is per-user we do not ship a static
+``default_headers`` for it; users that need it supply it via
+``model.default_headers`` in ``config.yaml`` (see the provider docs), which
+``_apply_user_default_headers`` merges onto both the main and auxiliary clients.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+coreweave = ProviderProfile(
+    name="coreweave",
+    aliases=("coreweave-inference", "coreweave-serverless"),
+    display_name="CoreWeave Serverless Inference",
+    description="CoreWeave Serverless Inference — open models on CoreWeave",
+    signup_url="https://wandb.ai/settings",  # where Inference API keys are issued
+    # env_vars: 1st = API key, 2nd = optional base-url override
+    env_vars=("COREWEAVE_API_KEY", "COREWEAVE_BASE_URL"),
+    base_url="https://api.inference.wandb.ai/v1",
+    auth_type="api_key",
+    default_aux_model="meta-llama/Llama-3.1-8B-Instruct",
+    fallback_models=(
+        # Safety net only — the picker fetches the live /v1/models catalog.
+        # Only tool-calling / agentic models belong here.
+        "deepseek-ai/DeepSeek-V3.1",
+        "Qwen/Qwen3-235B-A22B-Instruct-2507",
+        "moonshotai/Kimi-K2-Instruct",
+        "zai-org/GLM-4.5",
+        "openai/gpt-oss-120b",
+        "meta-llama/Llama-3.1-8B-Instruct",
+    ),
+)
+
+register_provider(coreweave)

--- a/plugins/model-providers/coreweave/plugin.yaml
+++ b/plugins/model-providers/coreweave/plugin.yaml
@@ -1,0 +1,5 @@
+name: coreweave-provider
+kind: model-provider
+version: 1.0.0
+description: CoreWeave Serverless Inference (open models on CoreWeave)
+author: Nous Research

--- a/tests/providers/test_profile_wiring.py
+++ b/tests/providers/test_profile_wiring.py
@@ -294,3 +294,13 @@ class TestRequestOverridesParity:
             request_overrides={"top_p": 0.9},
         )
         assert kw["top_p"] == 0.9
+
+
+def test_coreweave_profile_resolves():
+    """CoreWeave Serverless Inference fast-path plugin resolves by id and aliases."""
+    p = get_provider_profile("coreweave")
+    assert p is not None
+    assert p.base_url == "https://api.inference.wandb.ai/v1"
+    assert "COREWEAVE_API_KEY" in p.env_vars
+    for alias in ("coreweave-inference", "coreweave-serverless"):
+        assert get_provider_profile(alias) is p

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -26,6 +26,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **Kimi / Moonshot (China)** | `KIMI_CN_API_KEY` in `~/.hermes/.env` (provider: `kimi-coding-cn`; aliases: `kimi-cn`, `moonshot-cn`) |
 | **Arcee AI** | `ARCEEAI_API_KEY` in `~/.hermes/.env` (provider: `arcee`; aliases: `arcee-ai`, `arceeai`) |
 | **GMI Cloud** | `GMI_API_KEY` in `~/.hermes/.env` (provider: `gmi`; aliases: `gmi-cloud`, `gmicloud`) |
+| **CoreWeave Serverless Inference** | `COREWEAVE_API_KEY` in `~/.hermes/.env` (provider: `coreweave`; aliases: `coreweave-inference`, `coreweave-serverless`) |
 | **MiniMax** | `MINIMAX_API_KEY` in `~/.hermes/.env` (provider: `minimax`) |
 | **MiniMax China** | `MINIMAX_CN_API_KEY` in `~/.hermes/.env` (provider: `minimax-cn`) |
 | **xAI (Grok) — Responses API** | `XAI_API_KEY` in `~/.hermes/.env` (provider: `xai`) |
@@ -258,6 +259,10 @@ hermes chat --provider arcee --model trinity-large-thinking
 # Use the exact model ID returned by GMI's /v1/models endpoint.
 hermes chat --provider gmi --model zai-org/GLM-5.1-FP8
 # Requires: GMI_API_KEY in ~/.hermes/.env
+
+# CoreWeave Serverless Inference
+hermes chat --provider coreweave --model meta-llama/Llama-3.1-8B-Instruct
+# Requires: COREWEAVE_API_KEY in ~/.hermes/.env
 ```
 
 Or set the provider permanently in `config.yaml`:
@@ -267,7 +272,7 @@ model:
   default: "zai-org/GLM-5.1-FP8"
 ```
 
-Base URLs can be overridden with `NOVITA_BASE_URL`, `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, `DASHSCOPE_BASE_URL`, `XIAOMI_BASE_URL`, `GMI_BASE_URL`, or `TOKENHUB_BASE_URL` environment variables.
+Base URLs can be overridden with `NOVITA_BASE_URL`, `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, `DASHSCOPE_BASE_URL`, `XIAOMI_BASE_URL`, `GMI_BASE_URL`, `COREWEAVE_BASE_URL`, or `TOKENHUB_BASE_URL` environment variables.
 
 :::note Z.AI Endpoint Auto-Detection
 When using the Z.AI / GLM provider, Hermes automatically probes multiple endpoints (global, China, coding variants) to find one that accepts your API key. You don't need to set `GLM_BASE_URL` manually — the working endpoint is detected and cached automatically.
@@ -487,6 +492,36 @@ model:
 ```
 
 The base URL can be overridden with `GMI_BASE_URL` (default: `https://api.gmi-serving.com/v1`).
+
+### CoreWeave Serverless Inference
+
+Open models served via [CoreWeave Serverless Inference](https://www.coreweave.com/solutions/ai-inference) (formerly W&B Inference) — OpenAI-compatible API, API key authentication. The model catalog is fetched live from `/v1/models`.
+
+```bash
+# CoreWeave Serverless Inference
+hermes chat --provider coreweave --model meta-llama/Llama-3.1-8B-Instruct
+# Requires: COREWEAVE_API_KEY in ~/.hermes/.env
+```
+
+Or set it permanently in `config.yaml`:
+```yaml
+model:
+  provider: "coreweave"
+  default: "meta-llama/Llama-3.1-8B-Instruct"
+```
+
+Get your API key at [wandb.ai/settings](https://wandb.ai/settings) (CoreWeave Inference keys are still issued there). The base URL can be overridden with `COREWEAVE_BASE_URL` (default: `https://api.inference.wandb.ai/v1`).
+
+:::note Project attribution header
+Most accounts work as-is. Accounts whose default project lacks Inference access must supply the `openai-project` header (`team/project`) — add it under `model.default_headers` in `config.yaml`:
+
+```yaml
+model:
+  provider: "coreweave"
+  default_headers:
+    openai-project: "your-team/your-project"
+```
+:::
 
 ### StepFun
 


### PR DESCRIPTION
W&B Inference is a standard OpenAI-compatible endpoint (serverless inference hosted on CoreWeave). Adds it via the fast-path plugin pattern (zero core edits): a ProviderProfile under plugins/model-providers/wandb/ with WANDB_API_KEY auth, base URL https://api.inference.wandb.ai/v1, and live /v1/models catalog.

The optional openai-project header (only required for personal W&B accounts) is handled via the existing model.default_headers config escape hatch, documented in the provider docs. Un-ignores the plugin dir in .gitignore (the wandb/ rule targets the W&B SDK run-output dir, not this plugin).

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

Adds **W&B Inference** (Weights & Biases serverless inference, hosted on
CoreWeave) as a first-class model provider via the documented fast-path plugin
pattern — a declarative `ProviderProfile` under `plugins/model-providers/wandb/`
with **zero core edits**. It's a standard OpenAI-compatible endpoint, so it
auto-wires into credential resolution, the `--provider` flag, the `/model`
picker, `provider:model` alias syntax, and `hermes setup`. The `/v1/models`
catalog is fetched live; `fallback_models` is only a safety net.

First-class treatment (vs. the generic `custom` path) is justified by the
picker entry, alias syntax, and live catalog — matching how Novita/GMI are
integrated. Providers are an explicitly welcomed "edge" contribution per
AGENTS.md.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #43964

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `plugins/model-providers/wandb/__init__.py` — new `ProviderProfile`
  (id `wandb`; aliases `weights-and-biases`, `wandb-inference`, `wnb`;
  `WANDB_API_KEY` auth; base URL `https://api.inference.wandb.ai/v1`)
- `plugins/model-providers/wandb/plugin.yaml` — plugin manifest
- `website/docs/integrations/providers.md` — table row, dedicated section,
  `WANDB_BASE_URL` override note, and personal-vs-team account guidance for the
  optional `openai-project` header (set via `model.default_headers` in
  `config.yaml` — not a new env var)
- `tests/providers/test_profile_wiring.py` — resolution + alias invariant test
- `.gitignore` — added `!plugins/model-providers/wandb/` so the plugin dir is
  tracked. The existing `wandb/` ignore rule targets the W&B SDK's run-output
  directory, which would otherwise swallow this plugin.

No core files touched (`auth.py`, `runtime_provider.py`, `run_agent.py`, etc.).
No new dependencies — reuses the existing `openai` client.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Discovery/aliases (no key needed):
   `python -c "from providers import get_provider_profile as g; p=g('wandb'); assert g('wnb') is p and g('wandb-inference') is p; print(p.base_url)"`
2. `scripts/run_tests.sh tests/providers/` → 107 passed
3. Live (needs `WANDB_API_KEY` in `~/.hermes/.env`):
   `hermes model` shows "W&B Inference"; `hermes chat --provider wandb --model meta-llama/Llama-3.1-8B-Instruct`

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->
<img width="1612" height="1266" alt="image" src="https://github.com/user-attachments/assets/e51d982a-ee47-4279-9cb7-e5a1dee17791" />
<img width="3084" height="466" alt="image" src="https://github.com/user-attachments/assets/cd7e9e33-4de5-4af0-93d1-7f0157e4eb5f" />
<img width="720" height="579" alt="image" src="https://github.com/user-attachments/assets/dbf5a82e-0c4a-4c15-b2d0-d17362cef326" />
<img width="3072" height="2022" alt="image" src="https://github.com/user-attachments/assets/f587ac52-e8f7-4e9a-858f-f13a861cbaf5" />

