### PR TITLE
feat(gateway): add runtime identity prefix

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8518,26 +8518,42 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         display_reasoning = last_reasoning.strip()
                     response = f"💭 **Reasoning:**\n```\n{display_reasoning}\n```\n\n{response}"
 
-            # Runtime-metadata footer — only on the FINAL message of the turn.
-            # Off by default (display.runtime_footer.enabled=false).  When
-            # streaming already delivered the body, we can't mutate the sent
-            # text, so we fire a separate trailing send below.
+            # Runtime identity prefix + metadata footer — only on the FINAL
+            # message of the turn. Both are off by default. When streaming
+            # already delivered the body, we can't mutate the sent text, so the
+            # footer is handled as a trailing send below and the prefix is skipped.
             _footer_line = ""
+            _identity_prefix = ""
             try:
-                from gateway.runtime_footer import build_footer_line as _bfl
+                from gateway.runtime_footer import (
+                    build_footer_line as _bfl,
+                    build_identity_prefix as _bip,
+                )
+                _runtime_cfg = _load_gateway_config()
+                _platform_key = _platform_config_key(source.platform)
+                _identity_prefix = _bip(
+                    user_config=_runtime_cfg,
+                    platform_key=_platform_key,
+                    provider=agent_result.get("provider"),
+                    model=agent_result.get("model"),
+                )
                 _footer_line = _bfl(
-                    user_config=_load_gateway_config(),
-                    platform_key=_platform_config_key(source.platform),
+                    user_config=_runtime_cfg,
+                    platform_key=_platform_key,
                     model=agent_result.get("model"),
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
                     cwd=os.environ.get("TERMINAL_CWD", ""),
                 )
-            except Exception as _footer_err:
-                logger.debug("runtime_footer build failed: %s", _footer_err)
+            except Exception as _runtime_meta_err:
+                logger.debug("runtime metadata build failed: %s", _runtime_meta_err)
                 _footer_line = ""
-            if _footer_line and response and not agent_result.get("already_sent"):
-                response = f"{response}\n\n{_footer_line}"
+                _identity_prefix = ""
+            if response and not agent_result.get("already_sent"):
+                if _identity_prefix and not response.startswith(_identity_prefix):
+                    response = f"{_identity_prefix}{response}"
+                if _footer_line:
+                    response = f"{response}\n\n{_footer_line}"
 
             # Emit agent:end hook
             await self.hooks.emit("agent:end", {

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -1,8 +1,12 @@
-"""Gateway runtime-metadata footer.
+"""Gateway runtime-metadata footer and identity prefix.
 
 Renders a compact footer showing runtime state (model, context %, cwd) and
 appends it to the FINAL message of an agent turn when enabled.  Off by default
 to keep replies minimal.
+
+The optional runtime identity prefix prepends the active provider/model route
+to the FINAL message, e.g. ``(openai-codex/gpt-5.5) Done``.  It is also off by
+default and shares the same global + per-platform config shape as the footer.
 
 Config (``~/.hermes/config.yaml``)::
 
@@ -10,10 +14,15 @@ Config (``~/.hermes/config.yaml``)::
       runtime_footer:
         enabled: true                       # off by default
         fields: [model, context_pct, cwd]   # order shown; drop any to hide
+      runtime_identity_prefix:
+        enabled: true                       # off by default
+        fields: [provider, model]           # renders (provider/model)
+        separator: "/"
 
-Per-platform overrides live under ``display.platforms.<platform>.runtime_footer``.
-Users can toggle the global setting with ``/footer on|off`` from both the CLI
-and any gateway platform.
+Per-platform overrides live under ``display.platforms.<platform_key>.runtime_footer``
+and ``display.platforms.<platform_key>.runtime_identity_prefix``. Users can
+toggle the global footer setting with ``/footer on|off`` from both the CLI and
+any gateway platform.
 
 The footer is appended to the final response text in ``gateway/run.py`` right
 before returning the response to the adapter send path — so it only lands on
@@ -29,7 +38,9 @@ import os
 from typing import Any, Iterable, Optional
 
 _DEFAULT_FIELDS: tuple[str, ...] = ("model", "context_pct", "cwd")
+_DEFAULT_PREFIX_FIELDS: tuple[str, ...] = ("provider", "model")
 _SEP = " · "
+_PREFIX_SEP = "/"
 
 
 def _home_relative_cwd(cwd: str) -> str:
@@ -51,6 +62,13 @@ def _model_short(model: Optional[str]) -> str:
     if not model:
         return ""
     return model.rsplit("/", 1)[-1]
+
+
+def _identity_part(value: Optional[str]) -> str:
+    """Return a single-line provider/model identifier safe for inline display."""
+    if not value:
+        return ""
+    return " ".join(str(value).strip().split())
 
 
 def resolve_footer_config(
@@ -84,6 +102,46 @@ def resolve_footer_config(
                     resolved["enabled"] = bool(plat_footer.get("enabled"))
                 if isinstance(plat_footer.get("fields"), list) and plat_footer["fields"]:
                     resolved["fields"] = [str(f) for f in plat_footer["fields"]]
+
+    return resolved
+
+
+def resolve_identity_prefix_config(
+    user_config: dict[str, Any] | None,
+    platform_key: str | None = None,
+) -> dict[str, Any]:
+    """Resolve effective runtime identity-prefix config for *platform_key*.
+
+    Merge order mirrors :func:`resolve_footer_config`:
+        1. Built-in defaults (enabled=False)
+        2. ``display.runtime_identity_prefix``
+        3. ``display.platforms.<platform_key>.runtime_identity_prefix``
+    """
+    resolved = {
+        "enabled": False,
+        "fields": list(_DEFAULT_PREFIX_FIELDS),
+        "separator": _PREFIX_SEP,
+    }
+    cfg = (user_config or {}).get("display") or {}
+
+    def _apply(prefix_cfg: Any) -> None:
+        if not isinstance(prefix_cfg, dict):
+            return
+        if "enabled" in prefix_cfg:
+            resolved["enabled"] = bool(prefix_cfg.get("enabled"))
+        if isinstance(prefix_cfg.get("fields"), list) and prefix_cfg["fields"]:
+            resolved["fields"] = [str(f) for f in prefix_cfg["fields"]]
+        if "separator" in prefix_cfg:
+            sep = str(prefix_cfg.get("separator") or "")
+            resolved["separator"] = sep if sep else _PREFIX_SEP
+
+    _apply(cfg.get("runtime_identity_prefix"))
+
+    if platform_key:
+        platforms = cfg.get("platforms") or {}
+        plat_cfg = platforms.get(platform_key)
+        if isinstance(plat_cfg, dict):
+            _apply(plat_cfg.get("runtime_identity_prefix"))
 
     return resolved
 
@@ -122,6 +180,32 @@ def format_runtime_footer(
     return _SEP.join(parts)
 
 
+def format_runtime_identity_prefix(
+    *,
+    provider: Optional[str],
+    model: Optional[str],
+    fields: Iterable[str] = _DEFAULT_PREFIX_FIELDS,
+    separator: str = _PREFIX_SEP,
+) -> str:
+    """Render an inline identity prefix, or return "" if no fields have data."""
+    parts: list[str] = []
+    for field in fields:
+        if field == "provider":
+            part = _identity_part(provider)
+            if part:
+                parts.append(part)
+        elif field == "model":
+            part = _identity_part(model)
+            if part:
+                parts.append(part)
+        # Unknown field names are silently ignored.
+
+    if not parts:
+        return ""
+    sep = separator if separator else _PREFIX_SEP
+    return f"({sep.join(parts)}) "
+
+
 def build_footer_line(
     *,
     user_config: dict[str, Any] | None,
@@ -146,4 +230,23 @@ def build_footer_line(
         context_length=context_length,
         cwd=cwd,
         fields=cfg.get("fields") or _DEFAULT_FIELDS,
+    )
+
+
+def build_identity_prefix(
+    *,
+    user_config: dict[str, Any] | None,
+    platform_key: str | None,
+    provider: Optional[str],
+    model: Optional[str],
+) -> str:
+    """Top-level identity-prefix entry point used by gateway/run.py."""
+    cfg = resolve_identity_prefix_config(user_config, platform_key)
+    if not cfg.get("enabled"):
+        return ""
+    return format_runtime_identity_prefix(
+        provider=provider,
+        model=model,
+        fields=cfg.get("fields") or _DEFAULT_PREFIX_FIELDS,
+        separator=str(cfg.get("separator") or _PREFIX_SEP),
     )

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1466,6 +1466,15 @@ DEFAULT_CONFIG = {
             "enabled": False,
             "fields": ["model", "context_pct", "cwd"],  # Order shown; drop any to hide
         },
+        # Gateway runtime identity prefix prepended to the FINAL message of a
+        # turn (disabled by default). When enabled, renders e.g.
+        # `(openai-codex/gpt-5.5) response text`. Per-platform overrides go
+        # under display.platforms.<platform>.runtime_identity_prefix.
+        "runtime_identity_prefix": {
+            "enabled": False,
+            "fields": ["provider", "model"],
+            "separator": "/",
+        },
         "copy_shortcut": "auto",  # "auto" (platform default) | "ctrl_c" | "ctrl_shift_c" | "disabled"
     },
 

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -11,8 +11,11 @@ from gateway.runtime_footer import (
     _home_relative_cwd,
     _model_short,
     build_footer_line,
+    build_identity_prefix,
     format_runtime_footer,
+    format_runtime_identity_prefix,
     resolve_footer_config,
+    resolve_identity_prefix_config,
 )
 
 
@@ -147,6 +150,42 @@ def test_format_footer_unknown_field_silently_ignored():
     assert out == "gpt-5.4 · 50%"
 
 
+def test_format_identity_prefix_provider_and_model():
+    out = format_runtime_identity_prefix(
+        provider="openai-codex",
+        model="gpt-5.5",
+        fields=("provider", "model"),
+    )
+    assert out == "(openai-codex/gpt-5.5) "
+
+
+def test_format_identity_prefix_custom_separator_and_order():
+    out = format_runtime_identity_prefix(
+        provider="local-claude",
+        model="claude-opus-4-8",
+        fields=("model", "provider"),
+        separator=" via ",
+    )
+    assert out == "(claude-opus-4-8 via local-claude) "
+
+
+def test_format_identity_prefix_sanitizes_newlines():
+    out = format_runtime_identity_prefix(
+        provider="openai-codex\nextra",
+        model="gpt-5.5",
+    )
+    assert out == "(openai-codex extra/gpt-5.5) "
+
+
+def test_format_identity_prefix_empty_when_fields_missing():
+    out = format_runtime_identity_prefix(
+        provider="",
+        model=None,
+        fields=("provider", "model", "bogus"),
+    )
+    assert out == ""
+
+
 # ---------------------------------------------------------------------------
 # resolve_footer_config
 # ---------------------------------------------------------------------------
@@ -202,6 +241,39 @@ def test_resolve_ignores_malformed_config():
     assert cfg["enabled"] is False
 
 
+def test_resolve_identity_prefix_defaults_off_empty_config():
+    cfg = resolve_identity_prefix_config({}, "telegram")
+    assert cfg == {
+        "enabled": False,
+        "fields": ["provider", "model"],
+        "separator": "/",
+    }
+
+
+def test_resolve_identity_prefix_platform_override_wins():
+    user = {
+        "display": {
+            "runtime_identity_prefix": {"enabled": True, "fields": ["provider"]},
+            "platforms": {
+                "slack": {
+                    "runtime_identity_prefix": {
+                        "fields": ["provider", "model"],
+                        "separator": " | ",
+                    },
+                },
+            },
+        },
+    }
+    tg = resolve_identity_prefix_config(user, "telegram")
+    assert tg["enabled"] is True
+    assert tg["fields"] == ["provider"]
+    assert tg["separator"] == "/"
+    slack = resolve_identity_prefix_config(user, "slack")
+    assert slack["enabled"] is True
+    assert slack["fields"] == ["provider", "model"]
+    assert slack["separator"] == " | "
+
+
 # ---------------------------------------------------------------------------
 # build_footer_line — top-level entry point used by gateway/run.py
 # ---------------------------------------------------------------------------
@@ -246,6 +318,44 @@ def test_build_footer_per_platform_off_suppresses():
         cwd="/tmp",
     )
     assert out == ""
+
+
+def test_build_identity_prefix_empty_when_disabled():
+    out = build_identity_prefix(
+        user_config={},
+        platform_key="slack",
+        provider="openai-codex",
+        model="gpt-5.5",
+    )
+    assert out == ""
+
+
+def test_build_identity_prefix_returns_rendered_when_enabled():
+    out = build_identity_prefix(
+        user_config={"display": {"runtime_identity_prefix": {"enabled": True}}},
+        platform_key="slack",
+        provider="openai-codex",
+        model="gpt-5.5",
+    )
+    assert out == "(openai-codex/gpt-5.5) "
+
+
+def test_build_identity_prefix_per_platform_override():
+    user = {
+        "display": {
+            "runtime_identity_prefix": {"enabled": True, "fields": ["provider", "model"]},
+            "platforms": {
+                "slack": {"runtime_identity_prefix": {"fields": ["provider"]}},
+            },
+        },
+    }
+    out = build_identity_prefix(
+        user_config=user,
+        platform_key="slack",
+        provider="openai-codex",
+        model="gpt-5.5",
+    )
+    assert out == "(openai-codex) "
 
 
 def test_build_footer_no_data_returns_empty_even_when_enabled():


### PR DESCRIPTION
## Summary
- add an opt-in gateway `display.runtime_identity_prefix` setting
- render final gateway replies with a provider/model prefix like `(openai-codex/gpt-5.5) ` when enabled
- preserve existing runtime footer behavior and keep both features disabled by default

## Configuration
```yaml
display:
  runtime_identity_prefix:
    enabled: true
    fields: [provider, model]
    separator: "/"
```

Per-platform overrides are supported under `display.platforms.<platform>.runtime_identity_prefix`.

## Test Plan
- `python -m pytest tests/gateway/test_runtime_footer.py -q -o 'addopts='`
