### PR TITLE
fix(tests): drop --profile assertions missed by cron profile revert

### DIFF
--- a/tests/hermes_cli/test_subcommands_cron.py
+++ b/tests/hermes_cli/test_subcommands_cron.py
@@ -50,7 +50,7 @@ def test_cron_create_options():
         "cron", "create", "0 9 * * *", "do the thing",
         "--name", "daily", "--deliver", "origin", "--repeat", "3",
         "--skill", "a", "--skill", "b", "--no-agent",
-        "--workdir", "/tmp/x", "--profile", "work",
+        "--workdir", "/tmp/x",
     ])
     assert ns.schedule == "0 9 * * *"
     assert ns.prompt == "do the thing"
@@ -60,7 +60,6 @@ def test_cron_create_options():
     assert ns.skills == ["a", "b"]
     assert ns.no_agent is True
     assert ns.workdir == "/tmp/x"
-    assert ns.profile == "work"
 
 
 def test_cron_edit_no_agent_tristate():


### PR DESCRIPTION
## Summary
Restores green CI on main: PR #43956 (revert of cron per-job profile support) removed the `--profile` flag from `hermes cron create` but left `test_cron_create_options` still passing `--profile work` to the parser, so every run since fails with `SystemExit: 2 — unrecognized arguments: --profile work`.

## Changes
- `tests/hermes_cli/test_subcommands_cron.py`: drop the orphaned `--profile work` arg and `ns.profile` assertion.

## Validation
| | Before | After |
|---|---|---|
| tests/hermes_cli/test_subcommands_cron.py | 1 failed, 5 passed | 6 passed |
| main CI (run 27322395835) | red on this test | n/a — fix pending |

## Infographic
![Stale test assertion swept infographic](https://v3b.fal.media/files/b/0a9dd1fa/sYSEONL6o9CoLjzbAnSue_qUU6zmGp.png)
