### PR TITLE
fix(tests): drop --profile from cron create options test (missed in #43956 revert)

### DIFF
--- a/tests/hermes_cli/test_subcommands_cron.py
+++ b/tests/hermes_cli/test_subcommands_cron.py
@@ -50,7 +50,7 @@ def test_cron_create_options():
         "cron", "create", "0 9 * * *", "do the thing",
         "--name", "daily", "--deliver", "origin", "--repeat", "3",
         "--skill", "a", "--skill", "b", "--no-agent",
-        "--workdir", "/tmp/x", "--profile", "work",
+        "--workdir", "/tmp/x",
     ])
     assert ns.schedule == "0 9 * * *"
     assert ns.prompt == "do the thing"
@@ -60,7 +60,6 @@ def test_cron_create_options():
     assert ns.skills == ["a", "b"]
     assert ns.no_agent is True
     assert ns.workdir == "/tmp/x"
-    assert ns.profile == "work"
 
 
 def test_cron_edit_no_agent_tristate():


### PR DESCRIPTION
## Summary
Fixes the red `test (2)` shard on main: PR #43956 (revert of cron per-job profile support) removed the `--profile` flag from the cron parser but missed `test_cron_create_options`, which still passes `--profile work` and fails with `SystemExit: 2`.

## Changes
- `tests/hermes_cli/test_subcommands_cron.py`: drop `--profile work` arg and `ns.profile` assertion

## Validation
| | Before | After |
|---|---|---|
| `test_subcommands_cron.py` | 1 failed (SystemExit: 2) | 6/6 pass |
| main CI test (2) shard | red since #43956 | unblocked |

## Infographic
![infographic](https://v3b.fal.media/files/b/0a9dd22b/UB0Y1wqi3tb8VdHSHhNhV_a1Di1jov.png)
