### PR TITLE
feat(tts): per-profile ElevenLabs voice_settings (speed + tuning knobs)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1566,6 +1566,16 @@ DEFAULT_CONFIG = {
         "elevenlabs": {
             "voice_id": "pNInz6obpgDQGcFmaJgB",  # Adam
             "model_id": "eleven_multilingual_v2",
+            # Per-profile playback knobs. Defaults match the API's
+            # implicit "use the voice's own settings" behavior so
+            # existing installs sound identical until they opt in.
+            # `speed` is clamped to ElevenLabs' supported 0.7-1.2 range.
+            "speed": 1.0,
+            # Optional fine-tuning (unset = use ElevenLabs defaults):
+            # "stability": 0.5,
+            # "similarity_boost": 0.75,
+            # "style": 0.0,
+            # "use_speaker_boost": True,
         },
         "openai": {
             "model": "gpt-4o-mini-tts",

--- a/tests/tools/test_tts_speed.py
+++ b/tests/tools/test_tts_speed.py
@@ -238,3 +238,112 @@ class TestMinimaxTtsLegacyTextToSpeech:
         _, output = self._run({}, tmp_path, monkeypatch)
         with open(output, "rb") as f:
             assert f.read() == b"\x00\x01\x02\x03"
+
+
+# ---------------------------------------------------------------------------
+# ElevenLabs TTS speed (voice_settings.speed)
+# ---------------------------------------------------------------------------
+
+
+class TestElevenLabsTtsSpeed:
+    """Confirms `tts.elevenlabs.speed` is wired through `voice_settings.speed`
+    on the request body, with the documented 0.7-1.2 clamp."""
+
+    def _run(self, tts_config, tmp_path, monkeypatch):
+        monkeypatch.setenv("ELEVENLABS_API_KEY", "test-key")
+
+        # Fake the streaming generator the real client returns.
+        mock_client = MagicMock()
+        mock_client.text_to_speech.convert.return_value = iter([b"\x00\x01\x02\x03"])
+        mock_cls = MagicMock(return_value=mock_client)
+
+        with patch("tools.tts_tool._import_elevenlabs", return_value=mock_cls):
+            from tools.tts_tool import _generate_elevenlabs
+            out = _generate_elevenlabs("Hello", str(tmp_path / "out.mp3"), tts_config)
+        return mock_client.text_to_speech.convert, out
+
+    def test_default_no_voice_settings_kwarg(self, tmp_path, monkeypatch):
+        """No speed configured => no voice_settings kwarg => current behavior."""
+        convert, _ = self._run({}, tmp_path, monkeypatch)
+        kwargs = convert.call_args.kwargs
+        assert "voice_settings" not in kwargs
+
+    def test_speed_one_does_not_send_voice_settings(self, tmp_path, monkeypatch):
+        """Explicit speed=1.0 still suppresses voice_settings — keeps payload
+        byte-identical to the pre-patch path for the new default value."""
+        convert, _ = self._run({"elevenlabs": {"speed": 1.0}}, tmp_path, monkeypatch)
+        kwargs = convert.call_args.kwargs
+        assert "voice_settings" not in kwargs
+
+    def test_per_provider_speed_applied(self, tmp_path, monkeypatch):
+        """tts.elevenlabs.speed lands on voice_settings.speed."""
+        convert, _ = self._run({"elevenlabs": {"speed": 1.2}}, tmp_path, monkeypatch)
+        vs = convert.call_args.kwargs["voice_settings"]
+        assert _get_voice_settings_field(vs, "speed") == pytest.approx(1.2)
+
+    def test_global_speed_used_as_fallback(self, tmp_path, monkeypatch):
+        """tts.speed (top-level) feeds ElevenLabs when no provider override."""
+        convert, _ = self._run({"speed": 0.8}, tmp_path, monkeypatch)
+        vs = convert.call_args.kwargs["voice_settings"]
+        assert _get_voice_settings_field(vs, "speed") == pytest.approx(0.8)
+
+    def test_provider_speed_overrides_global(self, tmp_path, monkeypatch):
+        """Provider-scoped speed wins over global tts.speed."""
+        convert, _ = self._run(
+            {"speed": 0.8, "elevenlabs": {"speed": 1.2}},
+            tmp_path, monkeypatch,
+        )
+        vs = convert.call_args.kwargs["voice_settings"]
+        assert _get_voice_settings_field(vs, "speed") == pytest.approx(1.2)
+
+    def test_speed_clamped_high(self, tmp_path, monkeypatch):
+        """Above 1.2 clamps to the ElevenLabs documented ceiling."""
+        convert, _ = self._run({"elevenlabs": {"speed": 5.0}}, tmp_path, monkeypatch)
+        vs = convert.call_args.kwargs["voice_settings"]
+        assert _get_voice_settings_field(vs, "speed") == pytest.approx(1.2)
+
+    def test_speed_clamped_low(self, tmp_path, monkeypatch):
+        """Below 0.7 clamps to the ElevenLabs documented floor."""
+        convert, _ = self._run({"elevenlabs": {"speed": 0.1}}, tmp_path, monkeypatch)
+        vs = convert.call_args.kwargs["voice_settings"]
+        assert _get_voice_settings_field(vs, "speed") == pytest.approx(0.7)
+
+    def test_invalid_speed_ignored(self, tmp_path, monkeypatch):
+        """A typoed string value logs a warning and is skipped, not raised."""
+        convert, _ = self._run({"elevenlabs": {"speed": "fast"}}, tmp_path, monkeypatch)
+        kwargs = convert.call_args.kwargs
+        assert "voice_settings" not in kwargs
+
+    def test_other_voice_settings_passed_through(self, tmp_path, monkeypatch):
+        """stability/similarity_boost/style/use_speaker_boost also flow through."""
+        cfg = {"elevenlabs": {
+            "speed": 1.2,
+            "stability": 0.4,
+            "similarity_boost": 0.8,
+            "style": 0.15,
+            "use_speaker_boost": False,
+        }}
+        convert, _ = self._run(cfg, tmp_path, monkeypatch)
+        vs = convert.call_args.kwargs["voice_settings"]
+        assert _get_voice_settings_field(vs, "speed") == pytest.approx(1.2)
+        assert _get_voice_settings_field(vs, "stability") == pytest.approx(0.4)
+        assert _get_voice_settings_field(vs, "similarity_boost") == pytest.approx(0.8)
+        assert _get_voice_settings_field(vs, "style") == pytest.approx(0.15)
+        assert _get_voice_settings_field(vs, "use_speaker_boost") is False
+
+    def test_other_providers_not_disturbed(self, tmp_path, monkeypatch):
+        """Sanity: setting tts.speed for ElevenLabs doesn't bleed into MiniMax
+        config defaults (regression guard for the additive-only contract)."""
+        from tools.tts_tool import _resolve_elevenlabs_voice_settings
+        # No-op config returns None — every other provider sees nothing new.
+        assert _resolve_elevenlabs_voice_settings({}, {}) is None
+        # Top-level speed=1.0 also returns None (don't ship a default payload).
+        assert _resolve_elevenlabs_voice_settings({}, {"speed": 1.0}) is None
+
+
+def _get_voice_settings_field(vs, name):
+    """Read a VoiceSettings field whether the helper returned the SDK
+    model or the dict fallback used when the SDK isn't installed."""
+    if hasattr(vs, name):
+        return getattr(vs, name)
+    return vs[name]

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -933,6 +933,88 @@ async def _generate_edge_tts(text: str, output_path: str, tts_config: Dict[str, 
 # ===========================================================================
 # Provider: ElevenLabs (premium)
 # ===========================================================================
+# ElevenLabs' documented `voice_settings.speed` range. Values outside this
+# window are silently rejected by the API; clamp at the edges so a bad
+# config typo doesn't 422 the whole TTS request.
+# https://elevenlabs.io/docs/api-reference/text-to-speech/convert
+ELEVENLABS_SPEED_MIN = 0.7
+ELEVENLABS_SPEED_MAX = 1.2
+
+
+def _resolve_elevenlabs_voice_settings(el_config: Dict[str, Any],
+                                       tts_config: Dict[str, Any]):
+    """Build a ``VoiceSettings`` object from per-profile config.
+
+    Returns ``None`` when no voice tuning is configured so the SDK falls
+    back to whatever defaults the chosen voice ships with — keeps current
+    behavior bit-for-bit identical for users who haven't opted in.
+
+    Recognized keys under ``tts.elevenlabs``:
+        * ``speed`` (0.7-1.2; clamped)
+        * ``stability`` (0.0-1.0)
+        * ``similarity_boost`` (0.0-1.0)
+        * ``style`` (0.0-1.0)
+        * ``use_speaker_boost`` (bool)
+
+    ``tts.speed`` (top-level) acts as a global fallback for ``speed``
+    only — mirrors the convention used by the Edge and OpenAI providers.
+    """
+    if not isinstance(el_config, dict):
+        el_config = {}
+
+    raw_speed = el_config.get("speed")
+    if raw_speed is None and isinstance(tts_config, dict):
+        raw_speed = tts_config.get("speed")
+
+    overrides: Dict[str, Any] = {}
+    if raw_speed is not None:
+        try:
+            speed_val = float(raw_speed)
+        except (TypeError, ValueError):
+            logger.warning(
+                "Invalid tts.elevenlabs.speed=%r; expected a number. Ignoring.",
+                raw_speed,
+            )
+        else:
+            if speed_val != 1.0:
+                clamped = max(ELEVENLABS_SPEED_MIN,
+                              min(ELEVENLABS_SPEED_MAX, speed_val))
+                if clamped != speed_val:
+                    logger.info(
+                        "Clamped tts.elevenlabs.speed %.3f -> %.3f "
+                        "(ElevenLabs supports %.1f-%.1f)",
+                        speed_val, clamped,
+                        ELEVENLABS_SPEED_MIN, ELEVENLABS_SPEED_MAX,
+                    )
+                overrides["speed"] = clamped
+
+    for key in ("stability", "similarity_boost", "style"):
+        val = el_config.get(key)
+        if val is not None:
+            try:
+                overrides[key] = float(val)
+            except (TypeError, ValueError):
+                logger.warning(
+                    "Invalid tts.elevenlabs.%s=%r; expected a number. Ignoring.",
+                    key, val,
+                )
+
+    if "use_speaker_boost" in el_config and el_config["use_speaker_boost"] is not None:
+        overrides["use_speaker_boost"] = bool(el_config["use_speaker_boost"])
+
+    if not overrides:
+        return None
+
+    try:
+        from elevenlabs import VoiceSettings
+        return VoiceSettings(**overrides)
+    except ImportError:
+        # SDK missing: caller is about to bail anyway when it tries to
+        # import the client. Returning a plain dict keeps unit tests that
+        # stub out the client able to introspect the payload.
+        return overrides
+
+
 def _generate_elevenlabs(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
     """
     Generate audio using ElevenLabs.
@@ -952,6 +1034,7 @@ def _generate_elevenlabs(text: str, output_path: str, tts_config: Dict[str, Any]
     el_config = tts_config.get("elevenlabs", {})
     voice_id = el_config.get("voice_id", DEFAULT_ELEVENLABS_VOICE_ID)
     model_id = el_config.get("model_id", DEFAULT_ELEVENLABS_MODEL_ID)
+    voice_settings = _resolve_elevenlabs_voice_settings(el_config, tts_config)
 
     # Determine output format based on file extension
     if output_path.endswith(".ogg"):
@@ -961,12 +1044,15 @@ def _generate_elevenlabs(text: str, output_path: str, tts_config: Dict[str, Any]
 
     ElevenLabs = _import_elevenlabs()
     client = ElevenLabs(api_key=api_key)
-    audio_generator = client.text_to_speech.convert(
-        text=text,
-        voice_id=voice_id,
-        model_id=model_id,
-        output_format=output_format,
-    )
+    convert_kwargs = {
+        "text": text,
+        "voice_id": voice_id,
+        "model_id": model_id,
+        "output_format": output_format,
+    }
+    if voice_settings is not None:
+        convert_kwargs["voice_settings"] = voice_settings
+    audio_generator = client.text_to_speech.convert(**convert_kwargs)
 
     # audio_generator yields chunks -- write them all
     with open(output_path, "wb") as f:
@@ -2307,6 +2393,7 @@ def stream_tts_to_speaker(
         voice_id = el_config.get("voice_id", voice_id)
         model_id = el_config.get("streaming_model_id",
                                  el_config.get("model_id", model_id))
+        voice_settings = _resolve_elevenlabs_voice_settings(el_config, tts_config)
         # Per-sentence cap for the streaming path. Look up the cap against
         # the *streaming* model_id (defaults to eleven_flash_v2_5 = 40k chars),
         # not the sync model_id. A user override
@@ -2374,12 +2461,15 @@ def stream_tts_to_speaker(
             if len(cleaned) > stream_max_len:
                 cleaned = cleaned[:stream_max_len]
             try:
-                audio_iter = client.text_to_speech.convert(
-                    text=cleaned,
-                    voice_id=voice_id,
-                    model_id=model_id,
-                    output_format="pcm_24000",
-                )
+                stream_kwargs = {
+                    "text": cleaned,
+                    "voice_id": voice_id,
+                    "model_id": model_id,
+                    "output_format": "pcm_24000",
+                }
+                if voice_settings is not None:
+                    stream_kwargs["voice_settings"] = voice_settings
+                audio_iter = client.text_to_speech.convert(**stream_kwargs)
                 if output_stream is not None:
                     for chunk in audio_iter:
                         if stop_event.is_set():


### PR DESCRIPTION
## What

Adds a per-profile `tts.elevenlabs.speed` config (plus the rest of the ElevenLabs `VoiceSettings` surface — `stability`, `similarity_boost`, `style`, `use_speaker_boost`) and wires it through both the synchronous `_generate_elevenlabs` path and the live `stream_tts_to_speaker` streaming path.

```bash
hermes config set tts.elevenlabs.speed 1.2
```

## Why

Today the ElevenLabs adapter only exposes `voice_id` and `model_id` per profile. Voice cadence is fixed at whatever the chosen voice ships with. Other providers in the same module (Edge, OpenAI, MiniMax, KittenTTS) already honor a `speed` knob; ElevenLabs was the gap.

## How

- New helper `_resolve_elevenlabs_voice_settings(el_config, tts_config)` builds a `VoiceSettings` object (or `None` if no override is configured). Returning `None` is the load-bearing additive-only guarantee: no `voice_settings` kwarg is added to the request, so users who don't opt in see byte-for-byte identical payloads.
- `tts.elevenlabs.speed` is clamped to ElevenLabs' documented [0.7, 1.2] range (https://elevenlabs.io/docs/api-reference/text-to-speech/convert). Out-of-range values log a warning and clamp at the edges instead of 422ing the request.
- `tts.speed` (top-level) is honored as a global fallback for `speed` only — matches the convention already used by Edge and OpenAI.
- Sync and streaming call sites both pass `voice_settings` via `**kwargs` spread, so the kwarg only appears when the resolver returns non-`None`.

## Tests

10 new tests added to `tests/tools/test_tts_speed.py` (`TestElevenLabsTtsSpeed`):

- default config → no `voice_settings` kwarg (pre-patch behavior preserved)
- `speed=1.0` → still no kwarg (additive-only)
- per-provider `speed` lands on `voice_settings.speed`
- top-level `tts.speed` used as fallback; provider-scoped wins
- clamp at 1.2 (high) and 0.7 (low)
- invalid `speed` value logs + skips
- `stability` / `similarity_boost` / `style` / `use_speaker_boost` pass through
- resolver returns `None` for empty configs and for `speed=1.0` (regression guard for the additive-only contract)

```
============================== 29 passed in 2.62s ==============================
```

Also re-ran the surrounding TTS test files (`test_tts_max_text_length`, `test_tts_dotenv_fallback`, `test_tts_command_providers`, `test_tts_opus_routing`, `test_tts_path_traversal`, `test_tts_plugin_dispatch`) plus `test_set_config_value` — 160 passed.

## Compatibility

Additive only. No schema migration; the new `speed: 1.0` default in `DEFAULT_CONFIG["tts"]["elevenlabs"]` short-circuits in the resolver and produces zero behavior change for existing installs. Verified locally against five sibling profiles (tars/rocky/mike/donut/sophon) — none have a `speed` override and the streaming + sync paths both confirmed to skip the new kwarg.