### PR TITLE
fix(desktop): trust bundled venv install without marker (#43913)

### DIFF
--- a/apps/desktop/electron/active-install.cjs
+++ b/apps/desktop/electron/active-install.cjs
@@ -1,0 +1,41 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+function fileExists(target) {
+  try {
+    return fs.statSync(target).isFile()
+  } catch {
+    return false
+  }
+}
+
+function directoryExists(target) {
+  try {
+    return fs.statSync(target).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+function getVenvPython(venvRoot, platform = process.platform) {
+  return platform === 'win32'
+    ? path.join(venvRoot, 'Scripts', 'python.exe')
+    : path.join(venvRoot, 'bin', 'python')
+}
+
+function isHermesSourceRoot(root) {
+  return directoryExists(root) && fileExists(path.join(root, 'hermes_cli', 'main.py'))
+}
+
+function hasUsableActiveInstall(activeRoot, venvRoot, options = {}) {
+  const platform = options.platform || process.platform
+  return isHermesSourceRoot(activeRoot) && fileExists(getVenvPython(venvRoot, platform))
+}
+
+module.exports = {
+  fileExists,
+  directoryExists,
+  getVenvPython,
+  isHermesSourceRoot,
+  hasUsableActiveInstall
+}

--- a/apps/desktop/electron/active-install.test.cjs
+++ b/apps/desktop/electron/active-install.test.cjs
@@ -1,0 +1,53 @@
+/**
+ * Tests for desktop active install detection.
+ *
+ * Run with: node --test apps/desktop/electron/active-install.test.cjs
+ */
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+const { getVenvPython, hasUsableActiveInstall } = require('./active-install.cjs')
+
+function makeTempInstall() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-active-install-'))
+  const activeRoot = path.join(root, 'hermes-agent')
+  const venvRoot = path.join(activeRoot, 'venv')
+  fs.mkdirSync(path.join(activeRoot, 'hermes_cli'), { recursive: true })
+  fs.writeFileSync(path.join(activeRoot, 'hermes_cli', 'main.py'), '# hermes cli entrypoint\n')
+  fs.mkdirSync(path.dirname(getVenvPython(venvRoot, 'darwin')), { recursive: true })
+  fs.writeFileSync(getVenvPython(venvRoot, 'darwin'), '#!/usr/bin/env python3\n')
+  return { root, activeRoot, venvRoot }
+}
+
+test('valid canonical install is usable even when bootstrap marker is missing', () => {
+  const { root, activeRoot, venvRoot } = makeTempInstall()
+  try {
+    assert.equal(hasUsableActiveInstall(activeRoot, venvRoot, { platform: 'darwin' }), true)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('active install readiness still requires a venv python', () => {
+  const { root, activeRoot, venvRoot } = makeTempInstall()
+  try {
+    fs.rmSync(getVenvPython(venvRoot, 'darwin'), { force: true })
+    assert.equal(hasUsableActiveInstall(activeRoot, venvRoot, { platform: 'darwin' }), false)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('active install readiness still requires hermes_cli source root', () => {
+  const { root, activeRoot, venvRoot } = makeTempInstall()
+  try {
+    fs.rmSync(path.join(activeRoot, 'hermes_cli'), { recursive: true, force: true })
+    assert.equal(hasUsableActiveInstall(activeRoot, venvRoot, { platform: 'darwin' }), false)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -28,6 +28,7 @@ const { detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment } = requ
 const { runBootstrap } = require('./bootstrap-runner.cjs')
 const { buildSessionWindowUrl, createSessionWindowRegistry } = require('./session-windows.cjs')
 const { canImportHermesCli, verifyHermesCli } = require('./backend-probes.cjs')
+const { hasUsableActiveInstall } = require('./active-install.cjs')
 const { probeGatewayWebSocket } = require('./gateway-ws-probe.cjs')
 const { serializeJsonBody, setJsonRequestHeaders } = require('./oauth-net-request.cjs')
 const { fetchMarketplaceThemes, searchMarketplaceThemes } = require('./vscode-marketplace.cjs')
@@ -1891,23 +1892,20 @@ function readJson(filePath) {
 //     completedAt:  "<ISO 8601>",
 //     desktopVersion: "<app.getVersion()>"  // for forensics
 //   }
-function readBootstrapMarker() {
-  return readJson(BOOTSTRAP_COMPLETE_MARKER)
-}
-
 function isBootstrapComplete() {
-  const marker = readBootstrapMarker()
-  if (!marker || typeof marker !== 'object') return false
-  if (marker.schemaVersion !== BOOTSTRAP_MARKER_SCHEMA_VERSION) return false
-  if (typeof marker.pinnedCommit !== 'string' || marker.pinnedCommit.length < 7) return false
   // We DELIBERATELY do NOT verify that the checkout is currently at the
   // pinned commit -- users update via the in-app update path or `hermes
   // update`, which moves HEAD legitimately. The marker just attests "we
-  // ran the bootstrap successfully at least once." We DO additionally require
-  // a runnable venv: an interrupted or split-home install can leave the marker
-  // + checkout without a venv, and trusting that spawns a dead backend
-  // ("gateway offline") instead of re-running bootstrap to repair it.
-  return isHermesSourceRoot(ACTIVE_HERMES_ROOT) && fileExists(getVenvPython(VENV_ROOT))
+  // ran the bootstrap successfully at least once."
+  //
+  // Also treat a canonical source root + bundled venv as ready even when the
+  // marker is missing or stale. The bootstrap stages are idempotent, but on
+  // macOS a missing marker can make the launcher fall past the valid venv and
+  // probe /usr/bin/python3 instead; that Python is 3.9 on stock macOS and
+  // cannot import Hermes' PEP-604 syntax, causing an endless reinstall loop.
+  // We still require both source files and the venv python so broken or
+  // half-installed checkouts continue through bootstrap repair.
+  return hasUsableActiveInstall(ACTIVE_HERMES_ROOT, VENV_ROOT)
 }
 
 function writeBootstrapMarker(payload) {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -35,7 +35,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/windows-child-process.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-probes.test.cjs electron/active-install.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/windows-child-process.test.cjs",
     "typecheck": "tsc -p . --noEmit",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",


### PR DESCRIPTION
## Summary

- Treat the canonical `~/.hermes/hermes-agent` checkout plus bundled venv Python as a usable desktop active install, even when `.hermes-bootstrap-complete` is missing or stale.
- Keep broken/partial installs repairable by requiring both `hermes_cli/main.py` and the venv interpreter before skipping bootstrap.
- Add Electron-free regression coverage for valid missing-marker installs and the broken source/venv edge cases.

## Why

On stock macOS, `/usr/bin/python3` is often Python 3.9. After a successful desktop bootstrap, a missing/stale bootstrap marker made relaunch fall past the bundled venv and probe system Python instead. That interpreter cannot import current Hermes Python syntax (`str | None`), so Desktop re-entered bootstrap forever instead of opening the chat UI.

## Verification

- `node --test electron/active-install.test.cjs` — 3/3 pass
- `npm run test:desktop:platforms` — 122/122 pass
- `git rev-list --left-right --count upstream/main...HEAD` — `0 1`
- Duplicate/competitor checks: no open Tranquil-Flow PRs for `#43913` or `fix/43913*`; no open PRs found for `43913 in:title,body` or distinctive desktop install-loop/system-python/venv keywords.

Auto-published by Moonsong via Path B automated pipeline.
