### PR TITLE
feat(slack): channel join notification + opt-in channel consent gate

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -334,6 +334,21 @@ class PlatformConfig:
     # noise; keep True for back-channels where the operator wants them.
     gateway_restart_notification: bool = True
 
+    # Optional notification when the bot is added to a channel (Slack).
+    # Dict with keys:
+    #   channel: target channel for the notice (id like "C0123…" or "#name")
+    #   message: optional template; placeholders {channel_id}, {inviter_id},
+    #            {channel_ref} (renders as a clickable <#id>), {inviter_ref}
+    # Default None preserves stock behavior (no notification, event ignored).
+    channel_join_notification: Optional[Dict[str, str]] = None
+
+    # Consent gate (Slack): when True, the bot stays dormant in channels it
+    # is newly added to until a human clicks "Activate" on the Block Kit
+    # prompt it posts on join. Channels joined before the gate was enabled
+    # are unaffected (the gate only tracks joins it observed). Default False
+    # preserves stock behavior.
+    channel_consent_gate: bool = False
+
     # Platform-specific settings
     extra: Dict[str, Any] = field(default_factory=dict)
 
@@ -344,6 +359,10 @@ class PlatformConfig:
             "reply_to_mode": self.reply_to_mode,
             "gateway_restart_notification": self.gateway_restart_notification,
         }
+        if self.channel_join_notification:
+            result["channel_join_notification"] = self.channel_join_notification
+        if self.channel_consent_gate:
+            result["channel_consent_gate"] = self.channel_consent_gate
         if self.token:
             result["token"] = self.token
         if self.api_key:
@@ -366,6 +385,26 @@ class PlatformConfig:
         if _grn is None:
             _grn = data.get("extra", {}).get("gateway_restart_notification")
 
+        # channel_join_notification: same dual lookup (top-level or bridged
+        # into extra).  Must be a dict with a non-empty "channel"; anything
+        # else is ignored so a malformed YAML block degrades to stock
+        # behavior instead of crashing the gateway at startup.
+        _cjn = data.get("channel_join_notification")
+        if _cjn is None:
+            _cjn = data.get("extra", {}).get("channel_join_notification")
+        if not isinstance(_cjn, dict) or not str(_cjn.get("channel") or "").strip():
+            _cjn = None
+        else:
+            _cjn = {
+                str(k): str(v)
+                for k, v in _cjn.items()
+                if v is not None
+            }
+
+        _ccg = data.get("channel_consent_gate")
+        if _ccg is None:
+            _ccg = data.get("extra", {}).get("channel_consent_gate")
+
         return cls(
             enabled=_coerce_bool(data.get("enabled"), False),
             token=data.get("token"),
@@ -373,6 +412,8 @@ class PlatformConfig:
             home_channel=home_channel,
             reply_to_mode=data.get("reply_to_mode", "first"),
             gateway_restart_notification=_coerce_bool(_grn, True),
+            channel_join_notification=_cjn,
+            channel_consent_gate=_coerce_bool(_ccg, False),
             extra=data.get("extra", {}),
         )
 
@@ -979,6 +1020,10 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = channel_prompts
                 if "gateway_restart_notification" in platform_cfg:
                     bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
+                if "channel_join_notification" in platform_cfg:
+                    bridged["channel_join_notification"] = platform_cfg["channel_join_notification"]
+                if "channel_consent_gate" in platform_cfg:
+                    bridged["channel_consent_gate"] = platform_cfg["channel_consent_gate"]
                 enabled_was_explicit = _cfg_toplevel and "enabled" in platform_cfg
                 if not bridged and not enabled_was_explicit:
                     continue

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -341,6 +341,9 @@ class SlackAdapter(BasePlatformAdapter):
         # Track pending approval message_ts → resolved flag to prevent
         # double-clicks on approval buttons.
         self._approval_resolved: Dict[str, bool] = {}
+        # Channel consent gate state (channel_consent_gate config). Lazy:
+        # the JSON store is only touched when the gate is enabled.
+        self._consent_store: Optional[Any] = None
         # Track timestamps of messages sent by the bot so we can respond
         # to thread replies even without an explicit @mention.
         self._bot_message_ts: set = set()
@@ -897,6 +900,22 @@ class SlackAdapter(BasePlatformAdapter):
             @self._app.event("assistant_thread_context_changed")
             async def handle_assistant_thread_context_changed(event, say):
                 await self._handle_assistant_thread_lifecycle_event(event)
+
+            # Notify a configured channel when the bot itself is added to a
+            # channel (channel_join_notification in platform config). The
+            # handler is registered unconditionally so Slack doesn't log
+            # "unhandled request" warnings when the workspace subscribes to
+            # member_joined_channel; it no-ops unless configured.
+            @self._app.event("member_joined_channel")
+            async def handle_member_joined_channel(event, say):
+                await self._handle_member_joined_channel(event)
+
+            # Consent gate buttons (channel_consent_gate config).
+            for _action_id in (
+                "hermes_consent_activate",
+                "hermes_consent_decline",
+            ):
+                self._app.action(_action_id)(self._handle_consent_action)
 
             # Register slash command handler(s)
             #
@@ -2108,6 +2127,260 @@ class SlackAdapter(BasePlatformAdapter):
         self._cache_assistant_thread_metadata(metadata)
         self._seed_assistant_thread_session(metadata)
 
+    # Default notice when channel_join_notification.message is unset.
+    DEFAULT_CHANNEL_JOIN_MESSAGE = (
+        "I was added to {channel_ref} by {inviter_ref}."
+    )
+
+    async def _handle_member_joined_channel(self, event: dict) -> None:
+        """React to the bot being added to a channel.
+
+        Two independent features hang off this event, both no-ops unless
+        configured:
+          - ``channel_join_notification``: post a notice to a status channel.
+          - ``channel_consent_gate``: mark the new channel dormant and post
+            an Activate/Decline Block Kit prompt into it; the bot ignores
+            the channel's messages until a human clicks Activate.
+
+        Only the bot's OWN join triggers anything (Slack delivers
+        member_joined_channel for every member when subscribed).
+        """
+        joined_user = event.get("user", "")
+        team_id = event.get("team") or ""
+        bot_uid = self._team_bot_user_ids.get(team_id, self._bot_user_id)
+        if not joined_user or not bot_uid or joined_user != bot_uid:
+            return
+
+        channel_id = event.get("channel", "")
+        if not channel_id:
+            return
+        inviter_id = event.get("inviter", "")
+
+        await self._send_channel_join_notification(channel_id, inviter_id)
+
+        if self.config.channel_consent_gate:
+            await self._post_consent_prompt(channel_id, inviter_id)
+
+    async def _send_channel_join_notification(
+        self, channel_id: str, inviter_id: str
+    ) -> None:
+        """Post the channel_join_notification notice, if configured."""
+        cfg = self.config.channel_join_notification
+        if not cfg:
+            return
+
+        target = str(cfg.get("channel", "")).strip()
+        if not target:
+            return
+        # Don't announce joining the announcements channel itself.
+        if channel_id == target or target.lstrip("#") == channel_id:
+            return
+
+        template = cfg.get("message") or self.DEFAULT_CHANNEL_JOIN_MESSAGE
+        inviter_ref = f"<@{inviter_id}>" if inviter_id else "someone"
+        try:
+            text = template.format(
+                channel_id=channel_id,
+                channel_ref=f"<#{channel_id}>",
+                inviter_id=inviter_id or "unknown",
+                inviter_ref=inviter_ref,
+            )
+        except (KeyError, IndexError, ValueError):
+            logger.warning(
+                "[Slack] channel_join_notification message template has "
+                "invalid placeholders; using default. Template: %r",
+                template,
+            )
+            text = self.DEFAULT_CHANNEL_JOIN_MESSAGE.format(
+                channel_ref=f"<#{channel_id}>",
+                inviter_ref=inviter_ref,
+            )
+
+        result = await self.send(target, text)
+        if not result.success:
+            logger.warning(
+                "[Slack] channel_join_notification send to %s failed: %s",
+                target,
+                result.error,
+            )
+
+    # ------------------------------------------------------------------
+    # Channel consent gate (channel_consent_gate config)
+    # ------------------------------------------------------------------
+
+    def _get_consent_store(self):
+        """Lazy-init the persistent consent store."""
+        if self._consent_store is None:
+            from gateway.platforms.slack_consent import ChannelConsentStore
+
+            self._consent_store = ChannelConsentStore()
+        return self._consent_store
+
+    def _is_channel_consent_blocked(self, channel_id: str) -> bool:
+        """True when the consent gate says this channel is dormant."""
+        if not self.config.channel_consent_gate or not channel_id:
+            return False
+        try:
+            return self._get_consent_store().is_dormant(channel_id)
+        except Exception:  # pragma: no cover - defensive
+            logger.warning(
+                "[Slack] Consent store check failed for %s; failing open",
+                channel_id,
+                exc_info=True,
+            )
+            return False
+
+    async def _post_consent_prompt(
+        self, channel_id: str, inviter_id: str
+    ) -> None:
+        """Mark the channel pending and post the Activate/Decline prompt."""
+        try:
+            store = self._get_consent_store()
+            # Re-invites to an already-approved channel shouldn't reset
+            # consent; only start tracking on first sight or after decline.
+            if store.status(channel_id) == "approved":
+                return
+            store.set(channel_id, "pending")
+        except Exception:  # pragma: no cover - defensive
+            logger.warning(
+                "[Slack] Could not persist pending consent for %s",
+                channel_id,
+                exc_info=True,
+            )
+            return
+
+        inviter_ref = f"<@{inviter_id}>" if inviter_id else "someone"
+        prompt = (
+            f"Hi! I was added to this channel by {inviter_ref}. "
+            "I'll stay dormant — not reading or responding to messages — "
+            "until someone confirms I should be active here."
+        )
+        blocks = [
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": prompt},
+            },
+            {
+                "type": "actions",
+                "elements": [
+                    {
+                        "type": "button",
+                        "text": {"type": "plain_text", "text": "✅ Activate"},
+                        "style": "primary",
+                        "action_id": "hermes_consent_activate",
+                        "value": channel_id,
+                    },
+                    {
+                        "type": "button",
+                        "text": {"type": "plain_text", "text": "🚫 Decline"},
+                        "action_id": "hermes_consent_decline",
+                        "value": channel_id,
+                    },
+                ],
+            },
+        ]
+        try:
+            client = self._get_client(channel_id)
+            if client is None:
+                return
+            await client.chat_postMessage(
+                channel=channel_id,
+                text=prompt,  # fallback for notifications/accessibility
+                blocks=blocks,
+            )
+        except Exception:
+            logger.warning(
+                "[Slack] Could not post consent prompt to %s",
+                channel_id,
+                exc_info=True,
+            )
+
+    async def _handle_consent_action(self, ack, body, action) -> None:
+        """Handle Activate/Decline clicks on the consent prompt."""
+        await ack()
+
+        action_id = action.get("action_id", "")
+        channel_id = action.get("value", "") or body.get("channel", {}).get(
+            "id", ""
+        )
+        user_name = body.get("user", {}).get("name", "unknown")
+        user_id = body.get("user", {}).get("id", "")
+        message = body.get("message", {})
+        msg_ts = message.get("ts", "")
+
+        if not channel_id:
+            return
+
+        if not self._is_interactive_user_authorized(
+            user_id,
+            channel_id=channel_id,
+            user_name=user_name,
+        ):
+            logger.warning(
+                "[Slack] Unauthorized consent click by %s (%s) - ignoring",
+                user_name,
+                user_id,
+            )
+            return
+
+        approved = action_id == "hermes_consent_activate"
+        try:
+            self._get_consent_store().set(
+                channel_id,
+                "approved" if approved else "declined",
+                by_user_id=user_id,
+                by_user_name=user_name,
+            )
+        except Exception:  # pragma: no cover - defensive
+            logger.warning(
+                "[Slack] Could not persist consent decision for %s",
+                channel_id,
+                exc_info=True,
+            )
+            return
+
+        decision_text = (
+            f"✅ Activated by <@{user_id}> — I'm now live in this channel."
+            if approved
+            else (
+                f"🚫 Declined by <@{user_id}> — I'll stay dormant here. "
+                "Re-invite me to ask again."
+            )
+        )
+
+        # Replace the prompt (buttons removed) with the decision.
+        try:
+            client = self._get_client(channel_id)
+            if client is not None and msg_ts:
+                await client.chat_update(
+                    channel=channel_id,
+                    ts=msg_ts,
+                    text=decision_text,
+                    blocks=[
+                        {
+                            "type": "section",
+                            "text": {
+                                "type": "mrkdwn",
+                                "text": decision_text,
+                            },
+                        }
+                    ],
+                )
+        except Exception:
+            logger.warning(
+                "[Slack] Could not update consent prompt in %s",
+                channel_id,
+                exc_info=True,
+            )
+
+        logger.info(
+            "[Slack] Channel %s consent %s by %s (%s)",
+            channel_id,
+            "approved" if approved else "declined",
+            user_name,
+            user_id,
+        )
+
     async def _handle_slack_message(self, event: dict) -> None:
         """Handle an incoming Slack message event."""
         # Dedup: Slack Socket Mode can redeliver events after reconnects (#4777)
@@ -2283,6 +2556,16 @@ class SlackAdapter(BasePlatformAdapter):
         if not channel_type and channel_id.startswith("D"):
             channel_type = "im"
         is_dm = channel_type in {"im", "mpim"}  # Both 1:1 and group DMs
+
+        # Consent gate: stay fully dormant in channels pending/declined
+        # consent — no processing, no session, no memory. DMs are never
+        # gated (the gate governs channel membership, not direct chats).
+        if not is_dm and self._is_channel_consent_blocked(channel_id):
+            logger.debug(
+                "[Slack] Ignoring message in consent-gated channel %s",
+                channel_id,
+            )
+            return
 
         # Build thread_ts for session keying.
         # In channels: fall back to ts so each top-level @mention starts a

--- a/gateway/platforms/slack_consent.py
+++ b/gateway/platforms/slack_consent.py
@@ -1,0 +1,127 @@
+"""Persistent consent state for the Slack channel consent gate.
+
+When ``channel_consent_gate`` is enabled in the Slack platform config, the
+bot stays dormant in newly joined channels until a human explicitly
+activates it via Block Kit buttons. This module owns the on-disk state:
+a small JSON map of channel_id → consent record.
+
+States:
+  (absent)   — channel predates the gate or gate never saw the join;
+               bot behaves normally (the gate only governs channels it
+               watched the bot join).
+  pending    — bot joined, consent prompt posted, no decision yet → dormant.
+  approved   — a human clicked Activate → bot behaves normally.
+  declined   — a human clicked Decline → dormant.
+
+The file lives at ``$HERMES_HOME/slack_channel_consent.json``. Writes are
+atomic (tmp + rename). All operations are defensive: a corrupt or
+unreadable file degrades to an empty store rather than raising into the
+event pipeline.
+"""
+
+import json
+import logging
+import os
+import tempfile
+import time
+from pathlib import Path
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+PENDING = "pending"
+APPROVED = "approved"
+DECLINED = "declined"
+
+_VALID_STATES = {PENDING, APPROVED, DECLINED}
+
+
+class ChannelConsentStore:
+    """JSON-backed map of Slack channel_id → consent record."""
+
+    def __init__(self, path: Optional[Path] = None):
+        if path is None:
+            from hermes_constants import get_hermes_home
+
+            path = get_hermes_home() / "slack_channel_consent.json"
+        self._path = Path(path)
+        self._data: Dict[str, dict] = {}
+        self._loaded = False
+
+    def _load(self) -> None:
+        if self._loaded:
+            return
+        self._loaded = True
+        try:
+            if self._path.exists():
+                raw = json.loads(self._path.read_text(encoding="utf-8"))
+                if isinstance(raw, dict):
+                    self._data = {
+                        str(k): v
+                        for k, v in raw.items()
+                        if isinstance(v, dict)
+                        and v.get("status") in _VALID_STATES
+                    }
+        except Exception:
+            logger.warning(
+                "[Slack] Could not read channel consent store at %s; "
+                "starting empty",
+                self._path,
+                exc_info=True,
+            )
+            self._data = {}
+
+    def _save(self) -> None:
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            fd, tmp = tempfile.mkstemp(
+                dir=str(self._path.parent), prefix=".consent-", suffix=".tmp"
+            )
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    json.dump(self._data, f, indent=2, sort_keys=True)
+                os.replace(tmp, self._path)
+            finally:
+                if os.path.exists(tmp):
+                    os.unlink(tmp)
+        except Exception:
+            logger.warning(
+                "[Slack] Could not persist channel consent store at %s",
+                self._path,
+                exc_info=True,
+            )
+
+    def status(self, channel_id: str) -> Optional[str]:
+        """Return 'pending' | 'approved' | 'declined', or None if untracked."""
+        self._load()
+        rec = self._data.get(channel_id)
+        return rec.get("status") if rec else None
+
+    def is_dormant(self, channel_id: str) -> bool:
+        """True when the bot must not process messages in this channel."""
+        return self.status(channel_id) in {PENDING, DECLINED}
+
+    def set(
+        self,
+        channel_id: str,
+        status: str,
+        *,
+        by_user_id: str = "",
+        by_user_name: str = "",
+    ) -> None:
+        if status not in _VALID_STATES:
+            raise ValueError(f"invalid consent status: {status!r}")
+        self._load()
+        self._data[str(channel_id)] = {
+            "status": status,
+            "by_user_id": by_user_id,
+            "by_user_name": by_user_name,
+            "updated_at": int(time.time()),
+        }
+        self._save()
+
+    def forget(self, channel_id: str) -> None:
+        """Drop a channel from the store (reverts to untracked/normal)."""
+        self._load()
+        if self._data.pop(str(channel_id), None) is not None:
+            self._save()

--- a/hermes_cli/slack_cli.py
+++ b/hermes_cli/slack_cli.py
@@ -88,6 +88,7 @@ def _build_full_manifest(bot_name: str, bot_description: str) -> dict:
                     "app_mention",
                     "assistant_thread_context_changed",
                     "assistant_thread_started",
+                    "member_joined_channel",
                     "message.channels",
                     "message.groups",
                     "message.im",

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -71,6 +71,70 @@ class TestPlatformConfigRoundtrip:
         restored = PlatformConfig.from_dict({"gateway_restart_notification": "false"})
         assert restored.gateway_restart_notification is False
 
+    def test_channel_join_notification_defaults_none(self):
+        assert PlatformConfig().channel_join_notification is None
+        assert PlatformConfig.from_dict({}).channel_join_notification is None
+
+    def test_channel_join_notification_roundtrip(self):
+        cjn = {"channel": "#singularity-status", "message": "joined {channel_ref}"}
+        pc = PlatformConfig(enabled=True, channel_join_notification=cjn)
+        restored = PlatformConfig.from_dict(pc.to_dict())
+        assert restored.channel_join_notification == cjn
+
+    def test_channel_join_notification_from_extra(self):
+        restored = PlatformConfig.from_dict(
+            {"extra": {"channel_join_notification": {"channel": "C0123"}}}
+        )
+        assert restored.channel_join_notification == {"channel": "C0123"}
+
+    def test_channel_join_notification_rejects_malformed(self):
+        # Not a dict
+        assert (
+            PlatformConfig.from_dict(
+                {"channel_join_notification": "yes"}
+            ).channel_join_notification
+            is None
+        )
+        # Dict missing channel
+        assert (
+            PlatformConfig.from_dict(
+                {"channel_join_notification": {"message": "hi"}}
+            ).channel_join_notification
+            is None
+        )
+        # Blank channel
+        assert (
+            PlatformConfig.from_dict(
+                {"channel_join_notification": {"channel": "  "}}
+            ).channel_join_notification
+            is None
+        )
+
+    def test_channel_join_notification_drops_none_values(self):
+        restored = PlatformConfig.from_dict(
+            {"channel_join_notification": {"channel": "C0123", "message": None}}
+        )
+        assert restored.channel_join_notification == {"channel": "C0123"}
+
+    def test_channel_consent_gate_defaults_false(self):
+        assert PlatformConfig().channel_consent_gate is False
+        assert PlatformConfig.from_dict({}).channel_consent_gate is False
+
+    def test_channel_consent_gate_roundtrip_true(self):
+        pc = PlatformConfig(enabled=True, channel_consent_gate=True)
+        restored = PlatformConfig.from_dict(pc.to_dict())
+        assert restored.channel_consent_gate is True
+
+    def test_channel_consent_gate_from_extra(self):
+        restored = PlatformConfig.from_dict(
+            {"extra": {"channel_consent_gate": True}}
+        )
+        assert restored.channel_consent_gate is True
+
+    def test_channel_consent_gate_coerces_quoted_true(self):
+        restored = PlatformConfig.from_dict({"channel_consent_gate": "true"})
+        assert restored.channel_consent_gate is True
+
 
 class TestGetConnectedPlatforms:
     def test_returns_enabled_with_token(self):

--- a/tests/gateway/test_slack_channel_consent_gate.py
+++ b/tests/gateway/test_slack_channel_consent_gate.py
@@ -1,0 +1,275 @@
+"""Tests for the Slack channel consent gate (channel_consent_gate config).
+
+Contract:
+  - Gate disabled (default) → join posts no prompt, messages flow (stock).
+  - Gate enabled → bot join marks the channel pending + posts the
+    Activate/Decline Block Kit prompt; messages in pending/declined
+    channels are dropped before any processing.
+  - Activate click → approved, messages flow; Decline → stays dormant.
+  - Re-invite to an approved channel does NOT reset consent.
+  - DMs are never gated.
+  - Untracked channels (joined before the gate existed) are never gated.
+"""
+import json
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.slack import SlackAdapter
+from gateway.platforms.slack_consent import ChannelConsentStore
+
+
+# ---------------------------------------------------------------------------
+# ChannelConsentStore
+# ---------------------------------------------------------------------------
+
+
+class TestChannelConsentStore:
+    def test_untracked_channel_is_not_dormant(self, tmp_path):
+        store = ChannelConsentStore(tmp_path / "consent.json")
+        assert store.status("C1") is None
+        assert store.is_dormant("C1") is False
+
+    def test_pending_and_declined_are_dormant_approved_is_not(self, tmp_path):
+        store = ChannelConsentStore(tmp_path / "consent.json")
+        store.set("C1", "pending")
+        assert store.is_dormant("C1") is True
+        store.set("C1", "approved", by_user_id="U1", by_user_name="jake")
+        assert store.is_dormant("C1") is False
+        store.set("C1", "declined")
+        assert store.is_dormant("C1") is True
+
+    def test_persists_across_instances(self, tmp_path):
+        path = tmp_path / "consent.json"
+        ChannelConsentStore(path).set("C1", "approved", by_user_id="U1")
+        store2 = ChannelConsentStore(path)
+        assert store2.status("C1") == "approved"
+
+    def test_corrupt_file_degrades_to_empty(self, tmp_path):
+        path = tmp_path / "consent.json"
+        path.write_text("{not json", encoding="utf-8")
+        store = ChannelConsentStore(path)
+        assert store.status("C1") is None
+        # And writes still work afterwards
+        store.set("C1", "pending")
+        assert ChannelConsentStore(path).status("C1") == "pending"
+
+    def test_invalid_states_in_file_are_dropped(self, tmp_path):
+        path = tmp_path / "consent.json"
+        path.write_text(
+            json.dumps({"C1": {"status": "bogus"}, "C2": {"status": "pending"}}),
+            encoding="utf-8",
+        )
+        store = ChannelConsentStore(path)
+        assert store.status("C1") is None
+        assert store.status("C2") == "pending"
+
+    def test_set_rejects_invalid_status(self, tmp_path):
+        store = ChannelConsentStore(tmp_path / "consent.json")
+        with pytest.raises(ValueError):
+            store.set("C1", "maybe")
+
+    def test_forget_reverts_to_untracked(self, tmp_path):
+        path = tmp_path / "consent.json"
+        store = ChannelConsentStore(path)
+        store.set("C1", "declined")
+        store.forget("C1")
+        assert store.is_dormant("C1") is False
+        assert ChannelConsentStore(path).status("C1") is None
+
+
+# ---------------------------------------------------------------------------
+# SlackAdapter integration
+# ---------------------------------------------------------------------------
+
+
+def make_adapter(tmp_path, gate=True, cjn=None):
+    config = PlatformConfig(
+        enabled=True,
+        token="***",
+        channel_consent_gate=gate,
+        channel_join_notification=cjn,
+    )
+    a = SlackAdapter(config)
+    a._app = MagicMock()
+    client = AsyncMock()
+    a._app.client = client
+    a._bot_user_id = "U_BOT"
+    a._running = True
+    a._consent_store = ChannelConsentStore(tmp_path / "consent.json")
+    a.handle_message = AsyncMock()
+    return a, client
+
+
+def join_event(user="U_BOT", channel="C_NEW", inviter="U_HUMAN"):
+    return {
+        "type": "member_joined_channel",
+        "user": user,
+        "channel": channel,
+        "team": "T1",
+        "inviter": inviter,
+    }
+
+
+def consent_click(action_id, channel="C_NEW", user_id="U_HUMAN"):
+    body = {
+        "channel": {"id": channel},
+        "user": {"id": user_id, "name": "jake"},
+        "message": {"ts": "123.456"},
+    }
+    action = {"action_id": action_id, "value": channel}
+    return body, action
+
+
+@pytest.mark.asyncio
+async def test_gate_disabled_join_posts_no_prompt(tmp_path):
+    a, client = make_adapter(tmp_path, gate=False)
+    await a._handle_member_joined_channel(join_event())
+    client.chat_postMessage.assert_not_awaited()
+    assert a._consent_store.status("C_NEW") is None
+
+
+@pytest.mark.asyncio
+async def test_join_marks_pending_and_posts_prompt(tmp_path):
+    a, client = make_adapter(tmp_path)
+    await a._handle_member_joined_channel(join_event())
+    assert a._consent_store.status("C_NEW") == "pending"
+    client.chat_postMessage.assert_awaited_once()
+    kwargs = client.chat_postMessage.await_args.kwargs
+    assert kwargs["channel"] == "C_NEW"
+    action_ids = {
+        el["action_id"]
+        for b in kwargs["blocks"]
+        if b["type"] == "actions"
+        for el in b["elements"]
+    }
+    assert action_ids == {"hermes_consent_activate", "hermes_consent_decline"}
+
+
+@pytest.mark.asyncio
+async def test_other_member_join_does_not_trigger_gate(tmp_path):
+    a, client = make_adapter(tmp_path)
+    await a._handle_member_joined_channel(join_event(user="U_SOMEONE"))
+    client.chat_postMessage.assert_not_awaited()
+    assert a._consent_store.status("C_NEW") is None
+
+
+@pytest.mark.asyncio
+async def test_reinvite_to_approved_channel_keeps_approval(tmp_path):
+    a, client = make_adapter(tmp_path)
+    a._consent_store.set("C_NEW", "approved", by_user_id="U_HUMAN")
+    await a._handle_member_joined_channel(join_event())
+    client.chat_postMessage.assert_not_awaited()
+    assert a._consent_store.status("C_NEW") == "approved"
+
+
+@pytest.mark.asyncio
+async def test_pending_channel_messages_are_dropped(tmp_path):
+    a, _ = make_adapter(tmp_path)
+    a._consent_store.set("C_NEW", "pending")
+    await a._handle_slack_message(
+        {
+            "type": "message",
+            "user": "U_HUMAN",
+            "channel": "C_NEW",
+            "channel_type": "channel",
+            "team": "T1",
+            "ts": "1.0",
+            "text": "<@U_BOT> hello",
+        }
+    )
+    a.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_untracked_channel_messages_flow(tmp_path):
+    a, _ = make_adapter(tmp_path)
+    await a._handle_slack_message(
+        {
+            "type": "message",
+            "user": "U_HUMAN",
+            "channel": "C_OLD",
+            "channel_type": "channel",
+            "team": "T1",
+            "ts": "2.0",
+            "text": "<@U_BOT> hello",
+        }
+    )
+    a.handle_message.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dms_are_never_gated(tmp_path):
+    a, _ = make_adapter(tmp_path)
+    a._consent_store.set("D_DM", "pending")  # nonsensical, but must not gate
+    await a._handle_slack_message(
+        {
+            "type": "message",
+            "user": "U_HUMAN",
+            "channel": "D_DM",
+            "channel_type": "im",
+            "team": "T1",
+            "ts": "3.0",
+            "text": "hello",
+        }
+    )
+    a.handle_message.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_activate_click_approves_and_unblocks(tmp_path):
+    a, client = make_adapter(tmp_path)
+    a._is_interactive_user_authorized = MagicMock(return_value=True)
+    a._consent_store.set("C_NEW", "pending")
+
+    body, action = consent_click("hermes_consent_activate")
+    await a._handle_consent_action(AsyncMock(), body, action)
+
+    assert a._consent_store.status("C_NEW") == "approved"
+    assert a._is_channel_consent_blocked("C_NEW") is False
+    client.chat_update.assert_awaited_once()  # prompt replaced, buttons gone
+
+
+@pytest.mark.asyncio
+async def test_decline_click_keeps_dormant(tmp_path):
+    a, client = make_adapter(tmp_path)
+    a._is_interactive_user_authorized = MagicMock(return_value=True)
+    a._consent_store.set("C_NEW", "pending")
+
+    body, action = consent_click("hermes_consent_decline")
+    await a._handle_consent_action(AsyncMock(), body, action)
+
+    assert a._consent_store.status("C_NEW") == "declined"
+    assert a._is_channel_consent_blocked("C_NEW") is True
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_click_is_ignored(tmp_path):
+    a, client = make_adapter(tmp_path)
+    a._is_interactive_user_authorized = MagicMock(return_value=False)
+    a._consent_store.set("C_NEW", "pending")
+
+    body, action = consent_click("hermes_consent_activate", user_id="U_RANDO")
+    await a._handle_consent_action(AsyncMock(), body, action)
+
+    assert a._consent_store.status("C_NEW") == "pending"
+    client.chat_update.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_join_notification_and_gate_both_fire(tmp_path):
+    from gateway.platforms.base import SendResult
+
+    a, client = make_adapter(
+        tmp_path, cjn={"channel": "C_STATUS"}
+    )
+    a.send = AsyncMock(return_value=SendResult(success=True))
+    await a._handle_member_joined_channel(join_event())
+    # Status ping sent
+    a.send.assert_awaited_once()
+    assert a.send.await_args.args[0] == "C_STATUS"
+    # Consent prompt posted into the joined channel
+    client.chat_postMessage.assert_awaited_once()
+    assert a._consent_store.status("C_NEW") == "pending"

--- a/tests/gateway/test_slack_channel_join_notification.py
+++ b/tests/gateway/test_slack_channel_join_notification.py
@@ -1,0 +1,132 @@
+"""Tests for channel_join_notification — a configurable notice posted when
+the bot is added to a Slack channel (member_joined_channel event).
+
+Behavior contract:
+  - No config → handler is a silent no-op (stock behavior preserved).
+  - Only the bot's OWN join triggers the notice; other members joining are
+    ignored (Slack fires member_joined_channel for every member).
+  - The notice is never posted about the target channel itself (avoids a
+    self-referential ping when the bot is first invited to the status
+    channel).
+  - Message template supports {channel_id}/{channel_ref}/{inviter_id}/
+    {inviter_ref}; an invalid template falls back to the default rather
+    than raising.
+"""
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import SendResult
+from gateway.platforms.slack import SlackAdapter
+
+
+def make_adapter(cjn=None):
+    config = PlatformConfig(
+        enabled=True,
+        token="***",
+        channel_join_notification=cjn,
+    )
+    a = SlackAdapter(config)
+    a._app = MagicMock()
+    a._app.client = AsyncMock()
+    a._bot_user_id = "U_BOT"
+    a._running = True
+    a.send = AsyncMock(return_value=SendResult(success=True))
+    return a
+
+
+def make_event(user="U_BOT", channel="C_NEW", inviter="U_HUMAN", team="T1"):
+    return {
+        "type": "member_joined_channel",
+        "user": user,
+        "channel": channel,
+        "channel_type": "C",
+        "team": team,
+        "inviter": inviter,
+    }
+
+
+@pytest.mark.asyncio
+async def test_noop_without_config():
+    a = make_adapter(cjn=None)
+    await a._handle_member_joined_channel(make_event())
+    a.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_posts_default_message_on_bot_join():
+    a = make_adapter(cjn={"channel": "C_STATUS"})
+    await a._handle_member_joined_channel(make_event())
+    a.send.assert_awaited_once()
+    target, text = a.send.await_args.args
+    assert target == "C_STATUS"
+    assert "<#C_NEW>" in text
+    assert "<@U_HUMAN>" in text
+
+
+@pytest.mark.asyncio
+async def test_ignores_other_members_joining():
+    a = make_adapter(cjn={"channel": "C_STATUS"})
+    await a._handle_member_joined_channel(make_event(user="U_SOMEONE"))
+    a.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ignores_join_of_target_channel_itself():
+    a = make_adapter(cjn={"channel": "C_STATUS"})
+    await a._handle_member_joined_channel(make_event(channel="C_STATUS"))
+    a.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_custom_template_placeholders():
+    a = make_adapter(
+        cjn={
+            "channel": "C_STATUS",
+            "message": "Added to {channel_ref} ({channel_id}) by {inviter_ref}",
+        }
+    )
+    await a._handle_member_joined_channel(make_event())
+    _, text = a.send.await_args.args
+    assert text == "Added to <#C_NEW> (C_NEW) by <@U_HUMAN>"
+
+
+@pytest.mark.asyncio
+async def test_invalid_template_falls_back_to_default():
+    a = make_adapter(
+        cjn={"channel": "C_STATUS", "message": "bad {nonexistent_placeholder}"}
+    )
+    await a._handle_member_joined_channel(make_event())
+    a.send.assert_awaited_once()
+    _, text = a.send.await_args.args
+    assert "<#C_NEW>" in text  # default template used
+
+
+@pytest.mark.asyncio
+async def test_missing_inviter_renders_someone():
+    a = make_adapter(cjn={"channel": "C_STATUS"})
+    event = make_event()
+    del event["inviter"]
+    await a._handle_member_joined_channel(event)
+    _, text = a.send.await_args.args
+    assert "someone" in text
+
+
+@pytest.mark.asyncio
+async def test_multiworkspace_uses_team_bot_id():
+    a = make_adapter(cjn={"channel": "C_STATUS"})
+    a._team_bot_user_ids = {"T2": "U_BOT_T2"}
+    # Bot id in workspace T2 differs from the primary _bot_user_id
+    await a._handle_member_joined_channel(
+        make_event(user="U_BOT_T2", team="T2")
+    )
+    a.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_send_failure_is_swallowed():
+    a = make_adapter(cjn={"channel": "C_STATUS"})
+    a.send = AsyncMock(return_value=SendResult(success=False, error="boom"))
+    # Must not raise
+    await a._handle_member_joined_channel(make_event())


### PR DESCRIPTION
## Motivation

When a Slack bot is invited to a channel today, the gateway silently starts processing everything there. Two opt-in features around the `member_joined_channel` event give operators visibility and control:

1. **`channel_join_notification`** — post a notice to a configured status channel whenever the bot is added somewhere. Useful for operators running a shared bot who want an audit trail of where it lives.
2. **`channel_consent_gate`** — the bot stays dormant in newly joined channels until a human clicks **Activate** on a Block Kit prompt posted on join. Useful for privacy-sensitive deployments: being invited by one person no longer means the bot immediately reads a channel nobody else agreed to.

## Behavior

Both features are **default-off**; stock behavior is byte-identical when unconfigured.

```yaml
slack:
  channel_join_notification:
    channel: "#bot-status"   # id or #name
    message: "I was added to {channel_ref} by {inviter_ref}."  # optional
  channel_consent_gate: true
```

- Only the bot's **own** join triggers anything (Slack fires `member_joined_channel` for every member when subscribed).
- Notification template supports `{channel_id}`/`{channel_ref}`/`{inviter_id}`/`{inviter_ref}`; invalid templates fall back to a default instead of raising. The status channel's own join is never announced (no self-referential ping).
- Consent gate: pending/declined channels drop messages **before any processing** — no session, no memory writes. DMs are never gated. Channels joined before the gate was enabled are unaffected (the gate only tracks joins it observed). Re-invites to an approved channel don't reset consent; re-invites after a decline re-prompt. Decisions persist in `$HERMES_HOME/slack_channel_consent.json` (atomic writes, corrupt file degrades to empty). Button clicks go through `_is_interactive_user_authorized` like the existing approval buttons.
- The event handler is registered unconditionally so workspaces subscribed to `member_joined_channel` don't get noisy unhandled-request warnings.

## Manifest

`hermes slack manifest` now includes `member_joined_channel` in `bot_events`. Existing apps must add it under **Event Subscriptions** manually — without it Slack never delivers the event (no new OAuth scope needed; `channels:read` covers it).

## Tests

- `tests/gateway/test_config.py` — round-trip, extra-bridging, malformed-input, and coercion tests for both new config fields
- `tests/gateway/test_slack_channel_join_notification.py` — 9 tests: own-join filter, template placeholders, invalid-template fallback, multi-workspace bot ids, send-failure swallowing
- `tests/gateway/test_slack_channel_consent_gate.py` — 18 tests: store persistence/corruption, dormant-message dropping, DM exemption, activate/decline/unauthorized clicks, re-invite semantics, coexistence with the join notification

All existing gateway tests pass unchanged.