### PR TITLE
fix(kanban): catch RuntimeError from expanduser() in workspace root resolver

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3779,7 +3779,7 @@ def _is_managed_scratch_path(p: Path) -> bool:
     if override:
         try:
             roots.append(Path(override).expanduser().resolve(strict=False))
-        except OSError:
+        except (OSError, RuntimeError):
             pass
     try:
         home = kanban_home()

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2146,6 +2146,18 @@ def test_is_managed_scratch_path_rejects_kanban_metadata_subtrees(kanban_home):
     assert kb._is_managed_scratch_path(task_dir)
 
 
+def test_is_managed_scratch_path_tilde_user_env_does_not_crash(kanban_home, monkeypatch):
+    """``HERMES_KANBAN_WORKSPACES_ROOT`` with ``~nonexistent_user`` must not crash.
+
+    ``Path.expanduser()`` raises ``RuntimeError`` for ``~user`` tokens where
+    ``user`` is not a real account.  The workspace-root resolver must swallow
+    this just like it swallows ``OSError``.
+    """
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACES_ROOT", "~nonexistent_user/workspace")
+    # Must not raise — the path is simply skipped.
+    assert not kb._is_managed_scratch_path(Path("/tmp"))
+
+
 # ---------------------------------------------------------------------------
 # Tenancy
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes a `RuntimeError` crash in `_is_managed_scratch_path()` when the `HERMES_KANBAN_WORKSPACES_ROOT` environment variable contains a `~user` path where `user` is not a real account (e.g. `~nonexistent_user/workspace`).

`Path.expanduser()` raises `RuntimeError("Could not determine home directory.")` for the `~user` form with a non-existent user — this is distinct from `$HOME`-based `~` expansion and is not caught by `except OSError`. The workspace-root resolver now catches `RuntimeError` alongside `OSError` so invalid overrides are silently skipped instead of crashing the kanban subsystem.

This is the same bug pattern as #43963 (`_add_path_candidate` in `agent/subdirectory_hints.py`), applied to a sibling call site that was not covered by PR #43970.

## Related Issue

Same pattern as #43963

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py`: Broadened `except OSError` to `except (OSError, RuntimeError)` on the `expanduser().resolve()` call inside `_is_managed_scratch_path()`'s `HERMES_KANBAN_WORKSPACES_ROOT` resolver.
- `tests/hermes_cli/test_kanban_db.py`: Added `test_is_managed_scratch_path_tilde_user_env_does_not_crash` — sets the env var to `~nonexistent_user/workspace` and asserts the function returns `False` instead of raising.

## How to Test

1. Set `HERMES_KANBAN_WORKSPACES_ROOT=~nonexistent_user/workspace` in your environment
2. Run any kanban operation that calls `_is_managed_scratch_path()` — it should not crash
3. Run the specific test: `pytest tests/hermes_cli/test_kanban_db.py::test_is_managed_scratch_path_tilde_user_env_does_not_crash -v`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `_is_managed_scratch_path` in `hermes_cli/kanban_db.py` (callers: `_cleanup_workspace`, workspace management)
- Blast radius: LOW — single except clause broadening, no control flow change
- Related patterns: Same `expanduser()` RuntimeError pattern as #43963 / PR #43970 (`agent/subdirectory_hints.py`)
