### PR TITLE
feat(dashboard): unify multi-profile management — one machine dashboard, global profile switcher

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10214,6 +10214,21 @@ def _report_dashboard_status() -> int:
     return len(pids)
 
 
+def _dashboard_listening(host: str, port: int) -> bool:
+    """True when something is accepting TCP connections at host:port.
+
+    Any listener counts — even a 401 response proves a dashboard is up.
+    Used by the unified profile-launch routing to decide attach-vs-start.
+    """
+    import socket
+
+    try:
+        with socket.create_connection((host or "127.0.0.1", port), timeout=1.5):
+            return True
+    except OSError:
+        return False
+
+
 def cmd_dashboard(args):
     """Start the web UI server, or (with --stop/--status) manage running ones."""
     # --status: report running dashboards and exit, no deps needed.
@@ -10233,6 +10248,65 @@ def cmd_dashboard(args):
         # we killed at least one, 1 if they were all unkillable.
         remaining = _find_stale_dashboard_pids()
         sys.exit(1 if remaining else 0)
+
+    # ── Unified profile launch routing ────────────────────────────────
+    # The dashboard is a MACHINE management surface: it can read/write any
+    # profile via the per-request ?profile= scoping. Running one dashboard
+    # per profile just fragments that (port collisions, N processes, and a
+    # "which dashboard am I on?" guessing game). So when a NAMED profile
+    # launches the dashboard (`worker dashboard` → HERMES_HOME points into
+    # profiles/), default to the machine dashboard:
+    #   - already running → open the browser at ?profile=<name> and exit
+    #   - not running     → re-exec as the machine dashboard (pinned to the
+    #     default profile so _apply_profile_override can't re-route through
+    #     the sticky active_profile file) with the launching profile
+    #     preselected in the UI's switcher.
+    # `--isolated` opts out and preserves the old per-profile behavior.
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+        _launch_profile = get_active_profile_name()
+    except Exception:
+        _launch_profile = "default"
+
+    if (
+        _launch_profile not in ("default", "custom")
+        and not getattr(args, "isolated", False)
+        and not getattr(args, "open_profile", "")
+    ):
+        url = f"http://{args.host or '127.0.0.1'}:{args.port}/?profile={_launch_profile}"
+        if _dashboard_listening(args.host, args.port):
+            print(f"Machine dashboard already running on port {args.port}.")
+            print(f"  Managing profile '{_launch_profile}': {url}")
+            if not args.no_open:
+                try:
+                    import webbrowser
+                    webbrowser.open(url)
+                except Exception:
+                    pass
+            sys.exit(0)
+
+        print(
+            f"Routing to the machine dashboard (profile '{_launch_profile}' "
+            f"preselected). Use --isolated for a dedicated per-profile server."
+        )
+        reexec_argv = [
+            sys.executable, "-m", "hermes_cli.main",
+            "-p", "default",
+            "dashboard",
+            "--port", str(args.port),
+            "--host", args.host,
+            "--open-profile", _launch_profile,
+        ]
+        if args.no_open:
+            reexec_argv.append("--no-open")
+        if getattr(args, "insecure", False):
+            reexec_argv.append("--insecure")
+        if getattr(args, "skip_build", False):
+            reexec_argv.append("--skip-build")
+        env = os.environ.copy()
+        # Drop the profile HERMES_HOME so the child binds the machine root.
+        env.pop("HERMES_HOME", None)
+        os.execvpe(sys.executable, reexec_argv, env)
 
     # Attach gui.log early so dashboard startup/build failures are captured in
     # the same logs directory as every other Hermes surface.
@@ -10307,6 +10381,7 @@ def cmd_dashboard(args):
         port=args.port,
         open_browser=not args.no_open,
         allow_public=getattr(args, "insecure", False),
+        initial_profile=getattr(args, "open_profile", "") or "",
     )
 
 

--- a/hermes_cli/subcommands/dashboard.py
+++ b/hermes_cli/subcommands/dashboard.py
@@ -45,6 +45,26 @@ def build_dashboard_parser(
             "where npm may not be available. Pre-build with: cd web && npm run build"
         ),
     )
+    dashboard_parser.add_argument(
+        "--isolated",
+        action="store_true",
+        help=(
+            "When launched from a named profile (e.g. `worker dashboard`), run "
+            "a dedicated dashboard server scoped to that profile instead of "
+            "routing to the machine dashboard. Default behavior is unified: "
+            "profile launches attach to (or start) ONE machine-level dashboard "
+            "and preselect the profile in the UI's profile switcher."
+        ),
+    )
+    dashboard_parser.add_argument(
+        "--open-profile",
+        dest="open_profile",
+        default="",
+        help=(
+            "Preselect this profile in the dashboard's profile switcher when "
+            "auto-opening the browser (appends ?profile=<name> to the URL)."
+        ),
+    )
     # Lifecycle flags — mutually exclusive with each other and with the
     # start-a-server flags above (if both are passed, --stop / --status win
     # because they exit before the server is started).  The dashboard has

--- a/hermes_cli/subcommands/dashboard.py
+++ b/hermes_cli/subcommands/dashboard.py
@@ -56,14 +56,14 @@ def build_dashboard_parser(
             "and preselect the profile in the UI's profile switcher."
         ),
     )
+    # Internal flag set by the unified-launch re-exec (cmd_dashboard) to
+    # preselect the launching profile in the SPA switcher. Hidden from
+    # --help: users get this behavior automatically via `<profile> dashboard`.
     dashboard_parser.add_argument(
         "--open-profile",
         dest="open_profile",
         default="",
-        help=(
-            "Preselect this profile in the dashboard's profile switcher when "
-            "auto-opening the browser (appends ?profile=<name> to the URL)."
-        ),
+        help=argparse.SUPPRESS,
     )
     # Lifecycle flags — mutually exclusive with each other and with the
     # start-a-server flags above (if both are passed, --stop / --status win

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -625,19 +625,23 @@ CONFIG_SCHEMA = _ordered_schema
 
 class ConfigUpdate(BaseModel):
     config: dict
+    profile: Optional[str] = None
 
 
 class EnvVarUpdate(BaseModel):
     key: str
     value: str
+    profile: Optional[str] = None
 
 
 class EnvVarDelete(BaseModel):
     key: str
+    profile: Optional[str] = None
 
 
 class EnvVarReveal(BaseModel):
     key: str
+    profile: Optional[str] = None
 
 
 class MessagingPlatformUpdate(BaseModel):
@@ -716,6 +720,7 @@ class ModelAssignment(BaseModel):
     # the path that actually wires a local endpoint into resolution.
     base_url: str = ""
     confirm_expensive_model: bool = False
+    profile: Optional[str] = None
 
 
 def _apply_main_model_assignment(
@@ -2495,8 +2500,9 @@ def _normalize_config_for_web(config: Dict[str, Any]) -> Dict[str, Any]:
 
 
 @app.get("/api/config")
-async def get_config():
-    config = _normalize_config_for_web(load_config())
+async def get_config(profile: Optional[str] = None):
+    with _profile_scope(profile):
+        config = _normalize_config_for_web(load_config())
     # Strip internal keys that the frontend shouldn't see or send back
     return {k: v for k, v in config.items() if not k.startswith("_")}
 
@@ -2522,7 +2528,7 @@ _EMPTY_MODEL_INFO: dict = {
 
 
 @app.get("/api/model/info")
-def get_model_info():
+def get_model_info(profile: Optional[str] = None):
     """Return resolved model metadata for the currently configured model.
 
     Calls the same context-length resolution chain the agent uses, so the
@@ -2530,7 +2536,8 @@ def get_model_info():
     Also returns model capabilities (vision, reasoning, tools) when available.
     """
     try:
-        cfg = load_config()
+        with _profile_scope(profile):
+            cfg = load_config()
         model_cfg = cfg.get("model", "")
 
         # Extract model name and provider from the config
@@ -2772,7 +2779,7 @@ def get_auxiliary_models():
 
 
 @app.post("/api/model/set")
-async def set_model_assignment(body: ModelAssignment):
+async def set_model_assignment(body: ModelAssignment, profile: Optional[str] = None):
     """Assign a model to the main slot or an auxiliary task slot.
 
     Writes to ``~/.hermes/config.yaml`` — applies to **new** sessions only.
@@ -2789,8 +2796,10 @@ async def set_model_assignment(body: ModelAssignment):
         raise HTTPException(status_code=400, detail="scope must be 'main' or 'auxiliary'")
 
     try:
-        cfg = load_config()
-
+        # Expensive-model warning runs BEFORE the profile scope is entered:
+        # _profile_scope must never be held across an await (the RLock is
+        # reentrant per-thread, so a second coroutine interleaving on the
+        # event-loop thread could cross-restore the module globals).
         if model and not body.confirm_expensive_model:
             try:
                 from hermes_cli.model_cost_guard import expensive_model_warning
@@ -2815,130 +2824,150 @@ async def set_model_assignment(body: ModelAssignment):
                     "confirm_message": warning.message,
                 }
 
-        if scope == "main":
-            if not provider or not model:
-                raise HTTPException(status_code=400, detail="provider and model required for main")
-            model_cfg = _apply_main_model_assignment(
-                cfg.get("model", {}), provider, model, base_url
-            )
-            cfg["model"] = model_cfg
+        def _apply_assignment():
+            with _profile_scope(profile or body.profile):
+                return _apply_model_assignment_sync(
+                    scope, provider, model, task, base_url
+                )
 
-            # When switching the main provider to Nous, mirror the CLI's
-            # post-model-selection behaviour (hermes_cli/main.py
-            # prompt_enable_tool_gateway / tools_config apply_nous_managed_defaults):
-            # auto-route any *unconfigured* tools through the Nous Tool Gateway.
-            # This is purely additive — apply_nous_managed_defaults skips every
-            # tool where the user already has a direct key (FIRECRAWL_API_KEY,
-            # FAL_KEY, etc.) or an explicit backend/provider in config, so it
-            # never overwrites a user's own setup. GUI users thus land on the
-            # gateway the same way CLI users do, without a separate prompt.
-            gateway_tools: list[str] = []
-            if provider.strip().lower() == "nous":
-                try:
-                    from hermes_cli.nous_subscription import apply_nous_managed_defaults
-                    from hermes_cli.tools_config import _get_platform_tools
-
-                    enabled = _get_platform_tools(
-                        cfg, "cli", include_default_mcp_servers=False
-                    )
-                    changed = apply_nous_managed_defaults(
-                        cfg,
-                        enabled_toolsets=enabled,
-                        force_fresh=True,
-                    )
-                    gateway_tools = sorted(changed)
-                except Exception:
-                    # Portal lookup hiccups / non-subscriber / non-nous gating
-                    # must never block saving the model assignment.
-                    _log.debug("apply_nous_managed_defaults skipped", exc_info=True)
-
-            save_config(cfg)
-
-            # Surface auxiliary slots still pinned to a *different* provider than
-            # the new main one. Switching the main model does NOT touch aux pins
-            # (they're independent, sticky per-task overrides — see
-            # auxiliary_client._resolve_auto). A user who switches main away from
-            # a now-unpaid provider (e.g. nous with $0 balance) keeps paying 402s
-            # on every background aux call until they reset those pins. We never
-            # auto-clear them — pinning aux to a cheaper/different model is a
-            # legitimate config — but we tell the caller so the UI can offer a
-            # "reset to main" nudge instead of silently burning credits.
-            new_provider = provider.strip().lower()
-            stale_aux: list[dict] = []
-            aux_cfg = cfg.get("auxiliary", {})
-            if isinstance(aux_cfg, dict):
-                for slot in _AUX_TASK_SLOTS:
-                    slot_cfg = aux_cfg.get(slot)
-                    if not isinstance(slot_cfg, dict):
-                        continue
-                    slot_provider = str(slot_cfg.get("provider", "") or "").strip()
-                    if (
-                        slot_provider
-                        and slot_provider.lower() not in {"auto", ""}
-                        and slot_provider.lower() != new_provider
-                    ):
-                        stale_aux.append({
-                            "task": slot,
-                            "provider": slot_provider,
-                            "model": str(slot_cfg.get("model", "") or ""),
-                        })
-
-            return {
-                "ok": True,
-                "scope": "main",
-                "provider": provider,
-                "model": model,
-                "base_url": model_cfg.get("base_url", ""),
-                "gateway_tools": gateway_tools,
-                "stale_aux": stale_aux,
-            }
-
-        # scope == "auxiliary"
-        aux = cfg.get("auxiliary")
-        if not isinstance(aux, dict):
-            aux = {}
-
-        if task == "__reset__":
-            # Reset every slot to provider="auto", model="" — keeps other fields intact.
-            for slot in _AUX_TASK_SLOTS:
-                slot_cfg = aux.get(slot)
-                if not isinstance(slot_cfg, dict):
-                    slot_cfg = {}
-                slot_cfg["provider"] = "auto"
-                slot_cfg["model"] = ""
-                aux[slot] = slot_cfg
-            cfg["auxiliary"] = aux
-            save_config(cfg)
-            return {"ok": True, "scope": "auxiliary", "reset": True}
-
-        if not provider:
-            raise HTTPException(status_code=400, detail="provider required for auxiliary")
-
-        targets = [task] if task else list(_AUX_TASK_SLOTS)
-        for slot in targets:
-            if slot not in _AUX_TASK_SLOTS:
-                raise HTTPException(status_code=400, detail=f"unknown auxiliary task: {slot}")
-            slot_cfg = aux.get(slot)
-            if not isinstance(slot_cfg, dict):
-                slot_cfg = {}
-            slot_cfg["provider"] = provider
-            slot_cfg["model"] = model
-            aux[slot] = slot_cfg
-
-        cfg["auxiliary"] = aux
-        save_config(cfg)
-        return {
-            "ok": True,
-            "scope": "auxiliary",
-            "tasks": targets,
-            "provider": provider,
-            "model": model,
-        }
+        return await asyncio.to_thread(_apply_assignment)
     except HTTPException:
         raise
     except Exception:
         _log.exception("POST /api/model/set failed")
         raise HTTPException(status_code=500, detail="Failed to save model assignment")
+
+
+def _apply_model_assignment_sync(
+    scope: str, provider: str, model: str, task: str, base_url: str
+):
+    """Synchronous body of POST /api/model/set.
+
+    Runs inside ``_profile_scope`` (in a worker thread) so every
+    load_config/save_config lands in the requested profile.  Raises
+    HTTPException for validation errors — the async wrapper re-raises them.
+    """
+    cfg = load_config()
+
+    if scope == "main":
+        if not provider or not model:
+            raise HTTPException(status_code=400, detail="provider and model required for main")
+        model_cfg = _apply_main_model_assignment(
+            cfg.get("model", {}), provider, model, base_url
+        )
+        cfg["model"] = model_cfg
+
+        # When switching the main provider to Nous, mirror the CLI's
+        # post-model-selection behaviour (hermes_cli/main.py
+        # prompt_enable_tool_gateway / tools_config apply_nous_managed_defaults):
+        # auto-route any *unconfigured* tools through the Nous Tool Gateway.
+        # This is purely additive — apply_nous_managed_defaults skips every
+        # tool where the user already has a direct key (FIRECRAWL_API_KEY,
+        # FAL_KEY, etc.) or an explicit backend/provider in config, so it
+        # never overwrites a user's own setup. GUI users thus land on the
+        # gateway the same way CLI users do, without a separate prompt.
+        gateway_tools: list[str] = []
+        if provider.strip().lower() == "nous":
+            try:
+                from hermes_cli.nous_subscription import apply_nous_managed_defaults
+                from hermes_cli.tools_config import _get_platform_tools
+
+                enabled = _get_platform_tools(
+                    cfg, "cli", include_default_mcp_servers=False
+                )
+                changed = apply_nous_managed_defaults(
+                    cfg,
+                    enabled_toolsets=enabled,
+                    force_fresh=True,
+                )
+                gateway_tools = sorted(changed)
+            except Exception:
+                # Portal lookup hiccups / non-subscriber / non-nous gating
+                # must never block saving the model assignment.
+                _log.debug("apply_nous_managed_defaults skipped", exc_info=True)
+
+        save_config(cfg)
+
+        # Surface auxiliary slots still pinned to a *different* provider than
+        # the new main one. Switching the main model does NOT touch aux pins
+        # (they're independent, sticky per-task overrides — see
+        # auxiliary_client._resolve_auto). A user who switches main away from
+        # a now-unpaid provider (e.g. nous with $0 balance) keeps paying 402s
+        # on every background aux call until they reset those pins. We never
+        # auto-clear them — pinning aux to a cheaper/different model is a
+        # legitimate config — but we tell the caller so the UI can offer a
+        # "reset to main" nudge instead of silently burning credits.
+        new_provider = provider.strip().lower()
+        stale_aux: list[dict] = []
+        aux_cfg = cfg.get("auxiliary", {})
+        if isinstance(aux_cfg, dict):
+            for slot in _AUX_TASK_SLOTS:
+                slot_cfg = aux_cfg.get(slot)
+                if not isinstance(slot_cfg, dict):
+                    continue
+                slot_provider = str(slot_cfg.get("provider", "") or "").strip()
+                if (
+                    slot_provider
+                    and slot_provider.lower() not in {"auto", ""}
+                    and slot_provider.lower() != new_provider
+                ):
+                    stale_aux.append({
+                        "task": slot,
+                        "provider": slot_provider,
+                        "model": str(slot_cfg.get("model", "") or ""),
+                    })
+
+        return {
+            "ok": True,
+            "scope": "main",
+            "provider": provider,
+            "model": model,
+            "base_url": model_cfg.get("base_url", ""),
+            "gateway_tools": gateway_tools,
+            "stale_aux": stale_aux,
+        }
+
+    # scope == "auxiliary"
+    aux = cfg.get("auxiliary")
+    if not isinstance(aux, dict):
+        aux = {}
+
+    if task == "__reset__":
+        # Reset every slot to provider="auto", model="" — keeps other fields intact.
+        for slot in _AUX_TASK_SLOTS:
+            slot_cfg = aux.get(slot)
+            if not isinstance(slot_cfg, dict):
+                slot_cfg = {}
+            slot_cfg["provider"] = "auto"
+            slot_cfg["model"] = ""
+            aux[slot] = slot_cfg
+        cfg["auxiliary"] = aux
+        save_config(cfg)
+        return {"ok": True, "scope": "auxiliary", "reset": True}
+
+    if not provider:
+        raise HTTPException(status_code=400, detail="provider required for auxiliary")
+
+    targets = [task] if task else list(_AUX_TASK_SLOTS)
+    for slot in targets:
+        if slot not in _AUX_TASK_SLOTS:
+            raise HTTPException(status_code=400, detail=f"unknown auxiliary task: {slot}")
+        slot_cfg = aux.get(slot)
+        if not isinstance(slot_cfg, dict):
+            slot_cfg = {}
+        slot_cfg["provider"] = provider
+        slot_cfg["model"] = model
+        aux[slot] = slot_cfg
+
+    cfg["auxiliary"] = aux
+    save_config(cfg)
+    return {
+        "ok": True,
+        "scope": "auxiliary",
+        "tasks": targets,
+        "provider": provider,
+        "model": model,
+    }
 
 
 
@@ -2996,18 +3025,22 @@ def _denormalize_config_from_web(config: Dict[str, Any]) -> Dict[str, Any]:
 
 
 @app.put("/api/config")
-async def update_config(body: ConfigUpdate):
+async def update_config(body: ConfigUpdate, profile: Optional[str] = None):
     try:
-        save_config(_denormalize_config_from_web(body.config))
+        with _profile_scope(profile or body.profile):
+            save_config(_denormalize_config_from_web(body.config))
         return {"ok": True}
+    except HTTPException:
+        raise
     except Exception:
         _log.exception("PUT /api/config failed")
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @app.get("/api/env")
-async def get_env_vars():
-    env_on_disk = load_env()
+async def get_env_vars(profile: Optional[str] = None):
+    with _profile_scope(profile):
+        env_on_disk = load_env()
     channel_keys = _channel_managed_env_keys()
     result = {}
     for var_name, info in OPTIONAL_ENV_VARS.items():
@@ -3030,9 +3063,10 @@ async def get_env_vars():
 
 
 @app.put("/api/env")
-async def set_env_var(body: EnvVarUpdate):
+async def set_env_var(body: EnvVarUpdate, profile: Optional[str] = None):
     try:
-        save_env_value(body.key, body.value)
+        with _profile_scope(profile or body.profile):
+            save_env_value(body.key, body.value)
         return {"ok": True, "key": body.key}
     except ValueError as exc:
         # save_env_value raises ValueError for invalid names and for keys
@@ -3143,9 +3177,10 @@ async def validate_provider_credential(body: EnvVarUpdate, request: Request):
 
 
 @app.delete("/api/env")
-async def remove_env_var(body: EnvVarDelete):
+async def remove_env_var(body: EnvVarDelete, profile: Optional[str] = None):
     try:
-        removed = remove_env_value(body.key)
+        with _profile_scope(profile or body.profile):
+            removed = remove_env_value(body.key)
         if not removed:
             raise HTTPException(status_code=404, detail=f"{body.key} not found in .env")
         return {"ok": True, "key": body.key}
@@ -3162,7 +3197,9 @@ async def remove_env_var(body: EnvVarDelete):
 
 
 @app.post("/api/env/reveal")
-async def reveal_env_var(body: EnvVarReveal, request: Request):
+async def reveal_env_var(
+    body: EnvVarReveal, request: Request, profile: Optional[str] = None
+):
     """Return the real (unredacted) value of a single env var.
 
     Protected by:
@@ -3182,7 +3219,8 @@ async def reveal_env_var(body: EnvVarReveal, request: Request):
     _reveal_timestamps.append(now)
 
     # --- Reveal ---
-    env_on_disk = load_env()
+    with _profile_scope(profile or body.profile):
+        env_on_disk = load_env()
     value = env_on_disk.get(body.key)
     if value is None:
         raise HTTPException(status_code=404, detail=f"{body.key} not found in .env")
@@ -6387,6 +6425,7 @@ class MCPServerCreate(BaseModel):
     env: Dict[str, str] = {}
     # auth: "oauth" | "header" | None
     auth: Optional[str] = None
+    profile: Optional[str] = None
 
 
 def _redact_mcp_env(env: Dict[str, Any]) -> Dict[str, str]:
@@ -6417,10 +6456,11 @@ def _mcp_server_summary(name: str, cfg: Dict[str, Any]) -> Dict[str, Any]:
 
 
 @app.get("/api/mcp/servers")
-async def list_mcp_servers():
+async def list_mcp_servers(profile: Optional[str] = None):
     from hermes_cli.mcp_config import _get_mcp_servers
 
-    servers = _get_mcp_servers()
+    with _profile_scope(profile):
+        servers = _get_mcp_servers()
     return {
         "servers": [
             _mcp_server_summary(name, cfg) for name, cfg in sorted(servers.items())
@@ -6429,13 +6469,15 @@ async def list_mcp_servers():
 
 
 @app.post("/api/mcp/servers")
-async def add_mcp_server(body: MCPServerCreate):
+async def add_mcp_server(body: MCPServerCreate, profile: Optional[str] = None):
     from hermes_cli.mcp_config import _get_mcp_servers, _save_mcp_server
 
     name = (body.name or "").strip()
     if not name:
         raise HTTPException(status_code=400, detail="Server name is required")
-    if name in _get_mcp_servers():
+    with _profile_scope(profile or body.profile):
+        existing = _get_mcp_servers()
+    if name in existing:
         raise HTTPException(status_code=409, detail=f"Server '{name}' already exists")
     if not body.url and not body.command:
         raise HTTPException(
@@ -6456,7 +6498,10 @@ async def add_mcp_server(body: MCPServerCreate):
         server_config["auth"] = body.auth
 
     try:
-        _save_mcp_server(name, server_config)
+        with _profile_scope(profile or body.profile):
+            _save_mcp_server(name, server_config)
+    except HTTPException:
+        raise
     except Exception as exc:
         _log.exception("POST /api/mcp/servers failed")
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -6465,20 +6510,23 @@ async def add_mcp_server(body: MCPServerCreate):
 
 
 @app.delete("/api/mcp/servers/{name}")
-async def remove_mcp_server(name: str):
+async def remove_mcp_server(name: str, profile: Optional[str] = None):
     from hermes_cli.mcp_config import _remove_mcp_server
 
-    if not _remove_mcp_server(name):
+    with _profile_scope(profile):
+        removed = _remove_mcp_server(name)
+    if not removed:
         raise HTTPException(status_code=404, detail=f"Server '{name}' not found")
     return {"ok": True}
 
 
 @app.post("/api/mcp/servers/{name}/test")
-async def test_mcp_server(name: str):
+async def test_mcp_server(name: str, profile: Optional[str] = None):
     """Connect to the server, list its tools, disconnect.  Returns tool list."""
     from hermes_cli.mcp_config import _get_mcp_servers, _probe_single_server
 
-    servers = _get_mcp_servers()
+    with _profile_scope(profile):
+        servers = _get_mcp_servers()
     if name not in servers:
         raise HTTPException(status_code=404, detail=f"Server '{name}' not found")
 
@@ -6500,34 +6548,40 @@ async def test_mcp_server(name: str):
 
 class MCPEnabledToggle(BaseModel):
     enabled: bool
+    profile: Optional[str] = None
 
 
 @app.put("/api/mcp/servers/{name}/enabled")
-async def set_mcp_server_enabled(name: str, body: MCPEnabledToggle):
+async def set_mcp_server_enabled(
+    name: str, body: MCPEnabledToggle, profile: Optional[str] = None
+):
     """Enable or disable an MCP server (takes effect on next session/gateway).
 
     Toggles the ``enabled`` key on the server's config.yaml entry — the same
     flag the agent reads at startup.  Disabled servers stay in config so they
     can be re-enabled without re-entering their settings.
     """
-    cfg = load_config()
-    servers = cfg.get("mcp_servers")
-    if not isinstance(servers, dict) or name not in servers:
-        raise HTTPException(status_code=404, detail=f"Server '{name}' not found")
-    if not isinstance(servers[name], dict):
-        raise HTTPException(status_code=400, detail="Malformed server config")
-    servers[name]["enabled"] = bool(body.enabled)
-    save_config(cfg)
+    with _profile_scope(profile or body.profile):
+        cfg = load_config()
+        servers = cfg.get("mcp_servers")
+        if not isinstance(servers, dict) or name not in servers:
+            raise HTTPException(status_code=404, detail=f"Server '{name}' not found")
+        if not isinstance(servers[name], dict):
+            raise HTTPException(status_code=400, detail="Malformed server config")
+        servers[name]["enabled"] = bool(body.enabled)
+        save_config(cfg)
     return {"ok": True, "name": name, "enabled": bool(body.enabled)}
 
 
 @app.get("/api/mcp/catalog")
-async def list_mcp_catalog():
+async def list_mcp_catalog(profile: Optional[str] = None):
     """Browse the Nous-approved MCP catalog (the optional-mcps/ manifests).
 
     Each entry reports whether it's already installed and enabled so the UI
     can show install / enabled state inline.  This is the same catalog
-    `hermes mcp catalog` / `hermes mcp install` read.
+    `hermes mcp catalog` / `hermes mcp install` read.  ``profile`` scopes
+    the installed/enabled annotations (the catalog itself is repo-shipped
+    and identical for every profile).
     """
     try:
         from hermes_cli import mcp_catalog
@@ -6537,7 +6591,13 @@ async def list_mcp_catalog():
 
     entries = []
     try:
-        for entry in mcp_catalog.list_catalog():
+        with _profile_scope(profile):
+            catalog_entries = list(mcp_catalog.list_catalog())
+            installed_state = {
+                e.name: (mcp_catalog.is_installed(e.name), mcp_catalog.is_enabled(e.name))
+                for e in catalog_entries
+            }
+        for entry in catalog_entries:
             auth = entry.auth
             entries.append({
                 "name": entry.name,
@@ -6551,8 +6611,8 @@ async def list_mcp_catalog():
                     for e in getattr(auth, "env", []) or []
                 ],
                 "needs_install": entry.install is not None,
-                "installed": mcp_catalog.is_installed(entry.name),
-                "enabled": mcp_catalog.is_enabled(entry.name),
+                "installed": installed_state.get(entry.name, (False, False))[0],
+                "enabled": installed_state.get(entry.name, (False, False))[1],
             })
     except Exception:
         _log.exception("list_mcp_catalog failed")
@@ -6574,10 +6634,11 @@ class MCPCatalogInstall(BaseModel):
     # env: KEY=VALUE map for catalog entries that declare required env vars.
     env: Dict[str, str] = {}
     enable: bool = True
+    profile: Optional[str] = None
 
 
 @app.post("/api/mcp/catalog/install")
-async def install_mcp_catalog_entry(body: MCPCatalogInstall):
+async def install_mcp_catalog_entry(body: MCPCatalogInstall, profile: Optional[str] = None):
     """Install a catalog MCP into config.yaml.
 
     For HTTP/stdio entries with required env vars, those are written to .env
@@ -6594,23 +6655,42 @@ async def install_mcp_catalog_entry(body: MCPCatalogInstall):
 
     # Persist any supplied env vars first (catalog entries declare which names
     # they need; we only write the ones the user provided).
+    effective_profile = profile or body.profile
     if body.env:
-        for k, v in body.env.items():
-            if v:
-                save_env_value(k, v)
+        with _profile_scope(effective_profile):
+            for k, v in body.env.items():
+                if v:
+                    save_env_value(k, v)
 
     # Git-bootstrap entries can take a while to clone — run via the background
     # action path so the request returns immediately and the UI can tail logs.
+    # The -p subprocess rebinds HERMES_HOME-derived paths in the child.
     if entry.install is not None:
         try:
-            proc = _spawn_hermes_action(["mcp", "install", name], "mcp-install")
+            proc = _spawn_hermes_action(
+                _profile_cli_args(effective_profile) + ["mcp", "install", name],
+                "mcp-install",
+            )
+        except HTTPException:
+            raise
         except Exception as exc:
             raise HTTPException(status_code=500, detail=f"Install failed: {exc}")
         return {"ok": True, "name": name, "background": True, "action": "mcp-install"}
 
-    # No git step — install synchronously via the catalog API.
+    # No git step — install synchronously via the catalog API. install_entry
+    # routes through load_config/save_config + save_env_value, all call-time
+    # resolvers, so the context override scopes it. Wrap the to_thread body
+    # in the scope INSIDE the thread (contextvars don't propagate into
+    # to_thread the other way around — asyncio.to_thread copies context, so
+    # setting it here works; keep it explicit for clarity).
+    def _install_scoped():
+        with _profile_scope(effective_profile):
+            mcp_catalog.install_entry(entry, enable=body.enable)
+
     try:
-        await asyncio.to_thread(mcp_catalog.install_entry, entry, enable=body.enable)
+        await asyncio.to_thread(_install_scoped)
+    except HTTPException:
+        raise
     except Exception as exc:
         _log.exception("install_mcp_catalog_entry failed")
         raise HTTPException(status_code=400, detail=str(exc))
@@ -7394,13 +7474,13 @@ def _profile_cli_args(profile: Optional[str]) -> List[str]:
 
 
 @app.post("/api/skills/hub/install")
-async def install_skill_hub(body: SkillInstallRequest):
+async def install_skill_hub(body: SkillInstallRequest, profile: Optional[str] = None):
     identifier = (body.identifier or "").strip()
     if not identifier:
         raise HTTPException(status_code=400, detail="identifier is required")
     try:
         proc = _spawn_hermes_action(
-            _profile_cli_args(body.profile) + ["skills", "install", identifier],
+            _profile_cli_args(profile or body.profile) + ["skills", "install", identifier],
             "skills-install",
         )
     except HTTPException:
@@ -7417,13 +7497,13 @@ class SkillUninstallRequest(BaseModel):
 
 
 @app.post("/api/skills/hub/uninstall")
-async def uninstall_skill_hub(body: SkillUninstallRequest):
+async def uninstall_skill_hub(body: SkillUninstallRequest, profile: Optional[str] = None):
     name = (body.name or "").strip()
     if not name:
         raise HTTPException(status_code=400, detail="name is required")
     try:
         proc = _spawn_hermes_action(
-            _profile_cli_args(body.profile) + ["skills", "uninstall", name, "--yes"],
+            _profile_cli_args(profile or body.profile) + ["skills", "uninstall", name, "--yes"],
             "skills-uninstall",
         )
     except HTTPException:
@@ -7439,11 +7519,13 @@ class SkillsUpdateRequest(BaseModel):
 
 
 @app.post("/api/skills/hub/update")
-async def update_skills_hub(body: Optional[SkillsUpdateRequest] = None):
+async def update_skills_hub(
+    body: Optional[SkillsUpdateRequest] = None, profile: Optional[str] = None
+):
     try:
-        profile = body.profile if body else None
+        effective = profile or (body.profile if body else None)
         proc = _spawn_hermes_action(
-            _profile_cli_args(profile) + ["skills", "update"], "skills-update"
+            _profile_cli_args(effective) + ["skills", "update"], "skills-update"
         )
     except HTTPException:
         raise
@@ -8461,9 +8543,9 @@ async def get_skills(profile: Optional[str] = None):
 
 
 @app.put("/api/skills/toggle")
-async def toggle_skill(body: SkillToggle):
+async def toggle_skill(body: SkillToggle, profile: Optional[str] = None):
     from hermes_cli.skills_config import get_disabled_skills, save_disabled_skills
-    with _profile_scope(body.profile):
+    with _profile_scope(profile or body.profile):
         config = load_config()
         disabled = get_disabled_skills(config)
         if body.enabled:
@@ -8516,7 +8598,7 @@ class ToolsetToggle(BaseModel):
 
 
 @app.put("/api/tools/toolsets/{name}")
-async def toggle_toolset(name: str, body: ToolsetToggle):
+async def toggle_toolset(name: str, body: ToolsetToggle, profile: Optional[str] = None):
     """Enable/disable a configurable toolset for the desktop (cli) platform.
 
     Persists to ``platform_toolsets.cli`` via the same ``_save_platform_tools``
@@ -8534,7 +8616,7 @@ async def toggle_toolset(name: str, body: ToolsetToggle):
     if name not in valid:
         raise HTTPException(status_code=400, detail=f"Unknown toolset: {name}")
 
-    with _profile_scope(body.profile):
+    with _profile_scope(profile or body.profile):
         config = load_config()
         enabled = set(
             _get_platform_tools(config, "cli", include_default_mcp_servers=False)
@@ -8616,7 +8698,9 @@ class ToolsetProviderSelect(BaseModel):
 
 
 @app.put("/api/tools/toolsets/{name}/provider")
-async def select_toolset_provider(name: str, body: ToolsetProviderSelect):
+async def select_toolset_provider(
+    name: str, body: ToolsetProviderSelect, profile: Optional[str] = None
+):
     """Persist a provider selection for a toolset (no key prompting).
 
     Delegates to ``apply_provider_selection`` — the shared, non-interactive
@@ -8634,7 +8718,7 @@ async def select_toolset_provider(name: str, body: ToolsetProviderSelect):
     if name not in valid:
         raise HTTPException(status_code=400, detail=f"Unknown toolset: {name}")
 
-    with _profile_scope(body.profile):
+    with _profile_scope(profile or body.profile):
         config = load_config()
         try:
             apply_provider_selection(name, body.provider, config)
@@ -8650,7 +8734,7 @@ class ToolsetEnvUpdate(BaseModel):
 
 
 @app.put("/api/tools/toolsets/{name}/env")
-async def save_toolset_env(name: str, body: ToolsetEnvUpdate):
+async def save_toolset_env(name: str, body: ToolsetEnvUpdate, profile: Optional[str] = None):
     """Persist API keys for a toolset's provider env vars.
 
     Writes each ``key: value`` to ``~/.hermes/.env`` via ``save_env_value`` —
@@ -8672,7 +8756,7 @@ async def save_toolset_env(name: str, body: ToolsetEnvUpdate):
     if name not in valid_ts:
         raise HTTPException(status_code=400, detail=f"Unknown toolset: {name}")
 
-    with _profile_scope(body.profile):
+    with _profile_scope(profile or body.profile):
         config = load_config()
         cat = TOOL_CATEGORIES.get(name)
         allowed: set[str] = set()
@@ -8753,23 +8837,26 @@ async def run_toolset_post_setup(name: str, body: ToolsetPostSetup):
 
 class RawConfigUpdate(BaseModel):
     yaml_text: str
+    profile: Optional[str] = None
 
 
 @app.get("/api/config/raw")
-async def get_config_raw():
-    path = get_config_path()
+async def get_config_raw(profile: Optional[str] = None):
+    with _profile_scope(profile):
+        path = get_config_path()
     if not path.exists():
         return {"yaml": ""}
     return {"yaml": path.read_text(encoding="utf-8")}
 
 
 @app.put("/api/config/raw")
-async def update_config_raw(body: RawConfigUpdate):
+async def update_config_raw(body: RawConfigUpdate, profile: Optional[str] = None):
     try:
         parsed = yaml.safe_load(body.yaml_text)
         if not isinstance(parsed, dict):
             raise HTTPException(status_code=400, detail="YAML must be a mapping")
-        save_config(parsed)
+        with _profile_scope(profile or body.profile):
+            save_config(parsed)
         return {"ok": True}
     except yaml.YAMLError as e:
         raise HTTPException(status_code=400, detail=f"Invalid YAML: {e}")
@@ -9217,6 +9304,7 @@ def _ws_auth_ok(ws: "WebSocket") -> bool:
 def _resolve_chat_argv(
     resume: Optional[str] = None,
     sidecar_url: Optional[str] = None,
+    profile: Optional[str] = None,
 ) -> tuple[list[str], Optional[str], Optional[dict]]:
     """Resolve the argv + cwd + env for the chat PTY.
 
@@ -9236,8 +9324,23 @@ def _resolve_chat_argv(
     `sidecar_url` (when set) is forwarded as ``HERMES_TUI_SIDECAR_URL`` so
     the spawned ``tui_gateway.entry`` can mirror dispatcher emits to the
     dashboard's ``/api/pub`` endpoint (see :func:`pub_ws`).
+
+    `profile` (when set) scopes the ENTIRE chat to that profile by pointing
+    ``HERMES_HOME`` at the profile dir in the child env. Every spawned
+    process (the TUI and the ``tui_gateway.entry`` it launches) resolves
+    ``get_hermes_home()`` from that env var at its own import, so the child
+    binds the profile's config, skills, memory, and state.db from the start
+    — the same propagation ``hermes -p <name>`` performs. The in-process
+    ``HERMES_TUI_GATEWAY_URL`` attach is SKIPPED for scoped chats: the
+    dashboard's in-memory gateway runs under the dashboard's own profile,
+    so a profile-scoped chat must spawn its own gateway subprocess.
     """
     from hermes_cli.main import PROJECT_ROOT, _make_tui_argv
+
+    profile_dir: Optional[Path] = None
+    requested = (profile or "").strip()
+    if requested and requested.lower() != "current":
+        profile_dir = _resolve_profile_dir(requested)
 
     argv, cwd = _make_tui_argv(PROJECT_ROOT / "ui-tui", tui_dev=False)
     env = os.environ.copy()
@@ -9256,6 +9359,9 @@ def _resolve_chat_argv(
     env.setdefault("HERMES_TUI_DISABLE_MOUSE", "1")
     env.setdefault("HERMES_TUI_INLINE", "1")
 
+    if profile_dir is not None:
+        env["HERMES_HOME"] = str(profile_dir)
+
     if resume:
         latest_resume, _latest_path = _session_latest_descendant(resume)
         if latest_resume:
@@ -9265,8 +9371,13 @@ def _resolve_chat_argv(
     if sidecar_url:
         env["HERMES_TUI_SIDECAR_URL"] = sidecar_url
 
-    if gateway_ws_url := _build_gateway_ws_url():
-        env["HERMES_TUI_GATEWAY_URL"] = gateway_ws_url
+    # Profile-scoped chats must NOT attach to the dashboard's in-memory
+    # gateway — it runs under the dashboard's own profile. Without the
+    # attach URL, gatewayClient spawns its own `tui_gateway.entry`, which
+    # inherits the profile HERMES_HOME set above.
+    if profile_dir is None:
+        if gateway_ws_url := _build_gateway_ws_url():
+            env["HERMES_TUI_GATEWAY_URL"] = gateway_ws_url
 
     return list(argv), str(cwd) if cwd else None, env
 
@@ -9429,11 +9540,19 @@ async def pty_ws(ws: WebSocket) -> None:
 
     # --- spawn PTY ------------------------------------------------------
     resume = ws.query_params.get("resume") or None
+    profile = ws.query_params.get("profile") or None
     channel = _channel_or_close_code(ws)
     sidecar_url = _build_sidecar_url(channel) if channel else None
 
     try:
-        argv, cwd, env = _resolve_chat_argv(resume=resume, sidecar_url=sidecar_url)
+        argv, cwd, env = _resolve_chat_argv(
+            resume=resume, sidecar_url=sidecar_url, profile=profile
+        )
+    except HTTPException as exc:
+        # Unknown/invalid profile from _resolve_profile_dir.
+        await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc.detail}\x1b[0m\r\n")
+        await ws.close(code=1011)
+        return
     except SystemExit as exc:
         # _make_tui_argv calls sys.exit(1) when node/npm is missing.
         await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
@@ -10711,8 +10830,15 @@ def start_server(
     port: int = 9119,
     open_browser: bool = True,
     allow_public: bool = False,
+    initial_profile: str = "",
 ):
-    """Start the web UI server."""
+    """Start the web UI server.
+
+    ``initial_profile`` (when set) is appended to the auto-opened browser
+    URL as ``?profile=<name>`` so the SPA's profile switcher preselects it
+    — used when a profile alias (``<profile> dashboard``) routes to the
+    machine dashboard.
+    """
     import uvicorn
 
     # Phase 0: stash the auth-gate flag on app.state so middleware / SPA-token
@@ -10803,10 +10929,15 @@ def start_server(
         )
 
         if _has_display:
+            _open_url = f"http://{host}:{port}"
+            if initial_profile:
+                from urllib.parse import quote
+                _open_url += f"/?profile={quote(initial_profile)}"
+
             def _open():
                 try:
                     time.sleep(1.0)
-                    webbrowser.open(f"http://{host}:{port}")
+                    webbrowser.open(_open_url)
                 except Exception:
                     pass
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2843,7 +2843,7 @@ async def set_model_assignment(body: ModelAssignment, profile: Optional[str] = N
                 }
 
         def _apply_assignment():
-            with _profile_scope(profile or body.profile):
+            with _profile_scope(body.profile or profile):
                 return _apply_model_assignment_sync(
                     scope, provider, model, task, base_url
                 )
@@ -3045,7 +3045,7 @@ def _denormalize_config_from_web(config: Dict[str, Any]) -> Dict[str, Any]:
 @app.put("/api/config")
 async def update_config(body: ConfigUpdate, profile: Optional[str] = None):
     try:
-        with _profile_scope(profile or body.profile):
+        with _profile_scope(body.profile or profile):
             save_config(_denormalize_config_from_web(body.config))
         return {"ok": True}
     except HTTPException:
@@ -3083,7 +3083,7 @@ async def get_env_vars(profile: Optional[str] = None):
 @app.put("/api/env")
 async def set_env_var(body: EnvVarUpdate, profile: Optional[str] = None):
     try:
-        with _profile_scope(profile or body.profile):
+        with _profile_scope(body.profile or profile):
             save_env_value(body.key, body.value)
         return {"ok": True, "key": body.key}
     except ValueError as exc:
@@ -3197,7 +3197,7 @@ async def validate_provider_credential(body: EnvVarUpdate, request: Request):
 @app.delete("/api/env")
 async def remove_env_var(body: EnvVarDelete, profile: Optional[str] = None):
     try:
-        with _profile_scope(profile or body.profile):
+        with _profile_scope(body.profile or profile):
             removed = remove_env_value(body.key)
         if not removed:
             raise HTTPException(status_code=404, detail=f"{body.key} not found in .env")
@@ -3237,7 +3237,7 @@ async def reveal_env_var(
     _reveal_timestamps.append(now)
 
     # --- Reveal ---
-    with _profile_scope(profile or body.profile):
+    with _profile_scope(body.profile or profile):
         env_on_disk = load_env()
     value = env_on_disk.get(body.key)
     if value is None:
@@ -6493,7 +6493,7 @@ async def add_mcp_server(body: MCPServerCreate, profile: Optional[str] = None):
     name = (body.name or "").strip()
     if not name:
         raise HTTPException(status_code=400, detail="Server name is required")
-    with _profile_scope(profile or body.profile):
+    with _profile_scope(body.profile or profile):
         existing = _get_mcp_servers()
     if name in existing:
         raise HTTPException(status_code=409, detail=f"Server '{name}' already exists")
@@ -6516,7 +6516,7 @@ async def add_mcp_server(body: MCPServerCreate, profile: Optional[str] = None):
         server_config["auth"] = body.auth
 
     try:
-        with _profile_scope(profile or body.profile):
+        with _profile_scope(body.profile or profile):
             _save_mcp_server(name, server_config)
     except HTTPException:
         raise
@@ -6592,7 +6592,7 @@ async def set_mcp_server_enabled(
     flag the agent reads at startup.  Disabled servers stay in config so they
     can be re-enabled without re-entering their settings.
     """
-    with _profile_scope(profile or body.profile):
+    with _profile_scope(body.profile or profile):
         cfg = load_config()
         servers = cfg.get("mcp_servers")
         if not isinstance(servers, dict) or name not in servers:
@@ -6689,7 +6689,7 @@ async def install_mcp_catalog_entry(body: MCPCatalogInstall, profile: Optional[s
 
     # Persist any supplied env vars first (catalog entries declare which names
     # they need; we only write the ones the user provided).
-    effective_profile = profile or body.profile
+    effective_profile = body.profile or profile
     if body.env:
         with _profile_scope(effective_profile):
             for k, v in body.env.items():
@@ -7514,7 +7514,7 @@ async def install_skill_hub(body: SkillInstallRequest, profile: Optional[str] = 
         raise HTTPException(status_code=400, detail="identifier is required")
     try:
         proc = _spawn_hermes_action(
-            _profile_cli_args(profile or body.profile) + ["skills", "install", identifier],
+            _profile_cli_args(body.profile or profile) + ["skills", "install", identifier],
             "skills-install",
         )
     except HTTPException:
@@ -7537,7 +7537,7 @@ async def uninstall_skill_hub(body: SkillUninstallRequest, profile: Optional[str
         raise HTTPException(status_code=400, detail="name is required")
     try:
         proc = _spawn_hermes_action(
-            _profile_cli_args(profile or body.profile) + ["skills", "uninstall", name, "--yes"],
+            _profile_cli_args(body.profile or profile) + ["skills", "uninstall", name, "--yes"],
             "skills-uninstall",
         )
     except HTTPException:
@@ -7557,7 +7557,7 @@ async def update_skills_hub(
     body: Optional[SkillsUpdateRequest] = None, profile: Optional[str] = None
 ):
     try:
-        effective = profile or (body.profile if body else None)
+        effective = (body.profile if body else None) or profile
         proc = _spawn_hermes_action(
             _profile_cli_args(effective) + ["skills", "update"], "skills-update"
         )
@@ -8579,7 +8579,7 @@ async def get_skills(profile: Optional[str] = None):
 @app.put("/api/skills/toggle")
 async def toggle_skill(body: SkillToggle, profile: Optional[str] = None):
     from hermes_cli.skills_config import get_disabled_skills, save_disabled_skills
-    with _profile_scope(profile or body.profile):
+    with _profile_scope(body.profile or profile):
         config = load_config()
         disabled = get_disabled_skills(config)
         if body.enabled:
@@ -8650,7 +8650,7 @@ async def toggle_toolset(name: str, body: ToolsetToggle, profile: Optional[str] 
     if name not in valid:
         raise HTTPException(status_code=400, detail=f"Unknown toolset: {name}")
 
-    with _profile_scope(profile or body.profile):
+    with _profile_scope(body.profile or profile):
         config = load_config()
         enabled = set(
             _get_platform_tools(config, "cli", include_default_mcp_servers=False)
@@ -8752,7 +8752,7 @@ async def select_toolset_provider(
     if name not in valid:
         raise HTTPException(status_code=400, detail=f"Unknown toolset: {name}")
 
-    with _profile_scope(profile or body.profile):
+    with _profile_scope(body.profile or profile):
         config = load_config()
         try:
             apply_provider_selection(name, body.provider, config)
@@ -8790,7 +8790,7 @@ async def save_toolset_env(name: str, body: ToolsetEnvUpdate, profile: Optional[
     if name not in valid_ts:
         raise HTTPException(status_code=400, detail=f"Unknown toolset: {name}")
 
-    with _profile_scope(profile or body.profile):
+    with _profile_scope(body.profile or profile):
         config = load_config()
         cat = TOOL_CATEGORIES.get(name)
         allowed: set[str] = set()
@@ -8863,7 +8863,7 @@ async def run_toolset_post_setup(
 
     try:
         proc = _spawn_hermes_action(
-            _profile_cli_args(profile or body.profile)
+            _profile_cli_args(body.profile or profile)
             + ["tools", "post-setup", body.key],
             "tools-post-setup",
         )
@@ -8902,7 +8902,7 @@ async def update_config_raw(body: RawConfigUpdate, profile: Optional[str] = None
         parsed = yaml.safe_load(body.yaml_text)
         if not isinstance(parsed, dict):
             raise HTTPException(status_code=400, detail="YAML must be a mapping")
-        with _profile_scope(profile or body.profile):
+        with _profile_scope(body.profile or profile):
             save_config(parsed)
         return {"ok": True}
     except yaml.YAMLError as e:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2600,6 +2600,10 @@ def get_model_info(profile: Optional[str] = None):
             "effective_context_length": effective_ctx,
             "capabilities": caps,
         }
+    except HTTPException:
+        # Unknown/invalid profile must surface as 404, not degrade into a
+        # 200 with empty model info (which would render as "no model set").
+        raise
     except Exception:
         _log.exception("GET /api/model/info failed")
         return dict(_EMPTY_MODEL_INFO)
@@ -2629,13 +2633,17 @@ _AUX_TASK_SLOTS: Tuple[str, ...] = (
 
 
 @app.get("/api/model/options")
-def get_model_options():
+def get_model_options(profile: Optional[str] = None):
     """Return authenticated providers + their curated model lists.
 
     REST equivalent of the ``model.options`` JSON-RPC on tui_gateway, so the
     dashboard Models page can render the picker without a live chat session.
     The response shape matches ``model.options`` 1:1 so ``ModelPickerDialog``
     can share the same types.
+
+    ``profile`` scopes the picker context (current model/provider, custom
+    providers from config, per-profile .env auth state) so the Models page
+    reads the SAME profile /api/model/set writes.
     """
     try:
         from hermes_cli.inventory import build_models_payload, load_picker_context
@@ -2648,15 +2656,18 @@ def get_model_options():
         # come back as skeleton rows carrying `authenticated=False` +
         # `auth_type`/`key_env`/`warning` so the GUI can render a setup
         # affordance instead of hiding the provider entirely.
-        return build_models_payload(
-            load_picker_context(),
-            max_models=50,
-            include_unconfigured=True,
-            picker_hints=True,
-            canonical_order=True,
-            pricing=True,
-            capabilities=True,
-        )
+        with _profile_scope(profile):
+            return build_models_payload(
+                load_picker_context(),
+                max_models=50,
+                include_unconfigured=True,
+                picker_hints=True,
+                canonical_order=True,
+                pricing=True,
+                capabilities=True,
+            )
+    except HTTPException:
+        raise
     except Exception:
         _log.exception("GET /api/model/options failed")
         raise HTTPException(status_code=500, detail="Failed to list model options")
@@ -6537,10 +6548,23 @@ async def test_mcp_server(name: str, profile: Optional[str] = None):
     if name not in servers:
         raise HTTPException(status_code=404, detail=f"Server '{name}' not found")
 
+    def _probe_scoped():
+        # Re-enter the scope INSIDE the worker thread so call-time
+        # resolution during the probe — env-placeholder expansion in
+        # _resolve_mcp_server_config reading the profile's .env — sees the
+        # selected profile, matching the config the server was saved into.
+        # (asyncio.to_thread copies contextvars, but entering explicitly
+        # keeps the lock-protected SKILLS_DIR swap balanced per-thread.)
+        # Known limit: the dedicated MCP event-loop thread spawned by the
+        # probe doesn't inherit the contextvar, so OAuth token-store paths
+        # resolve against the process HERMES_HOME.
+        with _profile_scope(profile):
+            return _probe_single_server(name, servers[name])
+
     try:
         # Probe blocks on a dedicated MCP event loop — run in a thread so the
         # FastAPI event loop is never blocked.
-        tools = await asyncio.to_thread(_probe_single_server, name, servers[name])
+        tools = await asyncio.to_thread(_probe_scoped)
     except Exception as exc:
         return {
             "ok": False,
@@ -6621,6 +6645,9 @@ async def list_mcp_catalog(profile: Optional[str] = None):
                 "installed": installed_state.get(entry.name, (False, False))[0],
                 "enabled": installed_state.get(entry.name, (False, False))[1],
             })
+    except HTTPException:
+        # Unknown/invalid profile → 404, not a silently-empty catalog.
+        raise
     except Exception:
         _log.exception("list_mcp_catalog failed")
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2735,7 +2735,7 @@ def get_recommended_default_model(provider: str = ""):
 
 
 @app.get("/api/model/auxiliary")
-def get_auxiliary_models():
+def get_auxiliary_models(profile: Optional[str] = None):
     """Return current auxiliary task assignments.
 
     Shape:
@@ -2746,9 +2746,14 @@ def get_auxiliary_models():
         ],
         "main": {"provider": "openrouter", "model": "anthropic/claude-opus-4.7"},
       }
+
+    ``profile`` scopes the read — without it, the Models page would show
+    the dashboard profile's auxiliary pins while /api/model/set wrote the
+    selected profile's (read/write asymmetry).
     """
     try:
-        cfg = load_config()
+        with _profile_scope(profile):
+            cfg = load_config()
         aux_cfg = cfg.get("auxiliary", {})
         if not isinstance(aux_cfg, dict):
             aux_cfg = {}
@@ -2773,6 +2778,8 @@ def get_auxiliary_models():
             main = {"provider": "", "model": str(model_cfg) if model_cfg else ""}
 
         return {"tasks": tasks, "main": main}
+    except HTTPException:
+        raise
     except Exception:
         _log.exception("GET /api/model/auxiliary failed")
         raise HTTPException(status_code=500, detail="Failed to read auxiliary config")
@@ -8790,10 +8797,13 @@ async def save_toolset_env(name: str, body: ToolsetEnvUpdate, profile: Optional[
 
 class ToolsetPostSetup(BaseModel):
     key: str
+    profile: Optional[str] = None
 
 
 @app.post("/api/tools/toolsets/{name}/post-setup")
-async def run_toolset_post_setup(name: str, body: ToolsetPostSetup):
+async def run_toolset_post_setup(
+    name: str, body: ToolsetPostSetup, profile: Optional[str] = None
+):
     """Spawn a provider's post-setup install hook as a background action.
 
     Post-setup hooks (npm install for browser/Camofox, pip install for
@@ -8803,6 +8813,12 @@ async def run_toolset_post_setup(name: str, body: ToolsetPostSetup):
     ``GET /api/actions/tools-post-setup/status``. The ``key`` is validated
     against the declared post-setup allowlist before spawning. Returns 400
     for unknown toolset or post-setup key.
+
+    ``profile`` spawns the hook as ``hermes -p <profile> tools post-setup``.
+    Most hooks install machine-level artifacts (repo node_modules, shared
+    pip packages) where the scope is inert, but hooks that read config or
+    write per-profile state must see the same HERMES_HOME the rest of the
+    drawer's writes targeted — so the scope is threaded for consistency.
     """
     from hermes_cli.tools_config import (
         _get_effective_configurable_toolsets,
@@ -8820,8 +8836,12 @@ async def run_toolset_post_setup(name: str, body: ToolsetPostSetup):
 
     try:
         proc = _spawn_hermes_action(
-            ["tools", "post-setup", body.key], "tools-post-setup"
+            _profile_cli_args(profile or body.profile)
+            + ["tools", "post-setup", body.key],
+            "tools-post-setup",
         )
+    except HTTPException:
+        raise
     except Exception as exc:
         _log.exception("Failed to spawn tools post-setup")
         raise HTTPException(

--- a/tests/hermes_cli/test_dashboard_unified_launch.py
+++ b/tests/hermes_cli/test_dashboard_unified_launch.py
@@ -40,6 +40,22 @@ class TestUnifiedDashboardRouting:
         assert exc.value.code == 0
         assert execs == []  # attached, never re-exec'd
 
+    def test_profile_launch_attach_opens_scoped_url(self, main_mod, monkeypatch):
+        """The attach path must open the browser at ?profile=<name> — that
+        URL is the entire point of attaching (preselects the switcher)."""
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name", lambda: "worker_x"
+        )
+        monkeypatch.setattr(main_mod, "_dashboard_listening", lambda host, port: True)
+        opened = []
+        import webbrowser
+        monkeypatch.setattr(webbrowser, "open", lambda url: opened.append(url))
+
+        with pytest.raises(SystemExit) as exc:
+            main_mod.cmd_dashboard(_args(no_open=False))
+        assert exc.value.code == 0
+        assert opened == ["http://127.0.0.1:9119/?profile=worker_x"]
+
     def test_profile_launch_reexecs_machine_dashboard(self, main_mod, monkeypatch):
         monkeypatch.setattr(
             "hermes_cli.profiles.get_active_profile_name", lambda: "worker_x"

--- a/tests/hermes_cli/test_dashboard_unified_launch.py
+++ b/tests/hermes_cli/test_dashboard_unified_launch.py
@@ -1,0 +1,114 @@
+"""Tests for the unified profile→machine dashboard launch routing.
+
+`<profile> dashboard` routes to ONE machine-level dashboard instead of
+spawning a per-profile server: attach (open browser at ?profile=) when one
+is already listening, else re-exec as the machine dashboard with the
+launching profile preselected. `--isolated` opts out.
+"""
+import sys
+import types
+import pytest
+
+
+@pytest.fixture
+def main_mod():
+    import hermes_cli.main as main_mod
+    return main_mod
+
+
+def _args(**kw):
+    defaults = dict(
+        status=False, stop=False, host="127.0.0.1", port=9119,
+        no_open=True, insecure=False, skip_build=False,
+        isolated=False, open_profile="",
+    )
+    defaults.update(kw)
+    return types.SimpleNamespace(**defaults)
+
+
+class TestUnifiedDashboardRouting:
+    def test_profile_launch_attaches_to_running_dashboard(self, main_mod, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name", lambda: "worker_x"
+        )
+        monkeypatch.setattr(main_mod, "_dashboard_listening", lambda host, port: True)
+        execs = []
+        monkeypatch.setattr(main_mod.os, "execvpe", lambda *a, **k: execs.append(a))
+
+        with pytest.raises(SystemExit) as exc:
+            main_mod.cmd_dashboard(_args())
+        assert exc.value.code == 0
+        assert execs == []  # attached, never re-exec'd
+
+    def test_profile_launch_reexecs_machine_dashboard(self, main_mod, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name", lambda: "worker_x"
+        )
+        monkeypatch.setattr(main_mod, "_dashboard_listening", lambda host, port: False)
+        execs = []
+
+        def fake_exec(exe, argv, env):
+            execs.append((exe, argv, env))
+            raise SystemExit(0)  # execvpe never returns
+
+        monkeypatch.setattr(main_mod.os, "execvpe", fake_exec)
+
+        with pytest.raises(SystemExit):
+            main_mod.cmd_dashboard(_args())
+
+        assert len(execs) == 1
+        exe, argv, env = execs[0]
+        assert exe == sys.executable
+        # Pinned to the default profile + launching profile preselected.
+        assert "-p" in argv and argv[argv.index("-p") + 1] == "default"
+        assert "--open-profile" in argv
+        assert argv[argv.index("--open-profile") + 1] == "worker_x"
+        # Profile HERMES_HOME dropped so the child binds the machine root.
+        assert "HERMES_HOME" not in env
+
+    def test_isolated_flag_skips_routing(self, main_mod, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name", lambda: "worker_x"
+        )
+        listening_calls = []
+        monkeypatch.setattr(
+            main_mod, "_dashboard_listening",
+            lambda host, port: listening_calls.append(1) or True,
+        )
+        # With --isolated the routing block is skipped entirely; the command
+        # proceeds to dependency checks. Make the first post-routing step
+        # bail so the test doesn't actually start a server.
+        monkeypatch.setitem(sys.modules, "fastapi", None)
+
+        with pytest.raises((SystemExit, AttributeError, ImportError, TypeError)):
+            main_mod.cmd_dashboard(_args(isolated=True))
+        assert listening_calls == []
+
+    def test_default_profile_launch_skips_routing(self, main_mod, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name", lambda: "default"
+        )
+        listening_calls = []
+        monkeypatch.setattr(
+            main_mod, "_dashboard_listening",
+            lambda host, port: listening_calls.append(1) or True,
+        )
+        monkeypatch.setitem(sys.modules, "fastapi", None)
+
+        with pytest.raises((SystemExit, AttributeError, ImportError, TypeError)):
+            main_mod.cmd_dashboard(_args())
+        assert listening_calls == []
+
+    def test_reexec_child_does_not_reroute(self, main_mod, monkeypatch):
+        """The re-exec'd child carries --open-profile; the guard must treat
+        that as 'already routed' and never re-exec again (no exec loop)."""
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name", lambda: "worker_x"
+        )
+        execs = []
+        monkeypatch.setattr(main_mod.os, "execvpe", lambda *a, **k: execs.append(a))
+        monkeypatch.setitem(sys.modules, "fastapi", None)
+
+        with pytest.raises((SystemExit, AttributeError, ImportError, TypeError)):
+            main_mod.cmd_dashboard(_args(open_profile="worker_x"))
+        assert execs == []

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4441,7 +4441,7 @@ class TestPtyWebSocket:
         monkeypatch.setattr(
             self.ws_module,
             "_resolve_chat_argv",
-            lambda resume=None, sidecar_url=None: (["/bin/cat"], None, None),
+            lambda resume=None, sidecar_url=None, profile=None: (["/bin/cat"], None, None),
         )
         from starlette.websockets import WebSocketDisconnect
 
@@ -4454,7 +4454,7 @@ class TestPtyWebSocket:
         monkeypatch.setattr(
             self.ws_module,
             "_resolve_chat_argv",
-            lambda resume=None, sidecar_url=None: (["/bin/cat"], None, None),
+            lambda resume=None, sidecar_url=None, profile=None: (["/bin/cat"], None, None),
         )
         from starlette.websockets import WebSocketDisconnect
 
@@ -4467,7 +4467,7 @@ class TestPtyWebSocket:
         monkeypatch.setattr(
             self.ws_module,
             "_resolve_chat_argv",
-            lambda resume=None, sidecar_url=None: (
+            lambda resume=None, sidecar_url=None, profile=None: (
                 ["/bin/sh", "-c", "printf hermes-ws-ok"],
                 None,
                 None,
@@ -4497,7 +4497,7 @@ class TestPtyWebSocket:
         monkeypatch.setattr(
             self.ws_module,
             "_resolve_chat_argv",
-            lambda resume=None, sidecar_url=None: (["/bin/cat"], None, None),
+            lambda resume=None, sidecar_url=None, profile=None: (["/bin/cat"], None, None),
         )
         with self.client.websocket_connect(self._url()) as conn:
             conn.send_bytes(b"round-trip-payload\n")
@@ -4530,7 +4530,7 @@ class TestPtyWebSocket:
             self.ws_module,
             "_resolve_chat_argv",
             # sleep gives the test time to push the resize before the child reads the ioctl.
-            lambda resume=None, sidecar_url=None: (
+            lambda resume=None, sidecar_url=None, profile=None: (
                 [sys.executable, "-c", winsize_script],
                 None,
                 None,
@@ -4566,7 +4566,7 @@ class TestPtyWebSocket:
         monkeypatch.setattr(
             self.ws_module,
             "_resolve_chat_argv",
-            lambda resume=None, sidecar_url=None: (["/bin/cat"], None, None),
+            lambda resume=None, sidecar_url=None, profile=None: (["/bin/cat"], None, None),
         )
         # Patch PtyBridge.spawn at the web_server module's binding.
         import hermes_cli.web_server as ws_mod
@@ -4581,7 +4581,7 @@ class TestPtyWebSocket:
     def test_resume_parameter_is_forwarded_to_argv(self, monkeypatch):
         captured: dict = {}
 
-        def fake_resolve(resume=None, sidecar_url=None):
+        def fake_resolve(resume=None, sidecar_url=None, profile=None):
             captured["resume"] = resume
             return (["/bin/sh", "-c", "printf resume-arg-ok"], None, None)
 
@@ -4601,7 +4601,7 @@ class TestPtyWebSocket:
         same channel — which is how tool events reach the dashboard sidebar."""
         captured: dict = {}
 
-        def fake_resolve(resume=None, sidecar_url=None):
+        def fake_resolve(resume=None, sidecar_url=None, profile=None):
             captured["sidecar_url"] = sidecar_url
             return (["/bin/sh", "-c", "printf sidecar-ok"], None, None)
 

--- a/tests/hermes_cli/test_web_server_profile_unification.py
+++ b/tests/hermes_cli/test_web_server_profile_unification.py
@@ -1,0 +1,236 @@
+"""Regression tests for the machine-dashboard multi-profile unification.
+
+The dashboard is ONE machine-level management surface: config, env, MCP,
+model, and chat-PTY endpoints accept an optional ``profile`` so the global
+profile switcher can target any profile's HERMES_HOME. These tests pin:
+reads/writes land in the REQUESTED profile, the dashboard's own profile
+stays untouched, and the chat PTY env is scoped via HERMES_HOME.
+"""
+import pytest
+import yaml
+
+
+@pytest.fixture
+def isolated_profiles(tmp_path, monkeypatch, _isolate_hermes_home):
+    """Isolated default home + one named profile, each with config + .env."""
+    from hermes_constants import get_hermes_home
+    from hermes_cli import profiles
+
+    default_home = get_hermes_home()
+    profiles_root = default_home / "profiles"
+    worker_home = profiles_root / "worker_beta"
+    for home in (default_home, worker_home):
+        home.mkdir(parents=True, exist_ok=True)
+        (home / "config.yaml").write_text("{}\n", encoding="utf-8")
+    (worker_home / ".env").write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(profiles, "_get_default_hermes_home", lambda: default_home)
+    monkeypatch.setattr(profiles, "_get_profiles_root", lambda: profiles_root)
+    return {"default": default_home, "worker_beta": worker_home}
+
+
+@pytest.fixture
+def client(monkeypatch, isolated_profiles):
+    try:
+        from starlette.testclient import TestClient
+    except ImportError:
+        pytest.skip("fastapi/starlette not installed")
+
+    import hermes_state
+    from hermes_constants import get_hermes_home
+    from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db")
+    c = TestClient(app)
+    c.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+    return c
+
+
+def _cfg(home):
+    return yaml.safe_load((home / "config.yaml").read_text()) or {}
+
+
+class TestProfileScopedConfig:
+    def test_config_put_lands_in_target_profile_only(self, client, isolated_profiles):
+        resp = client.put(
+            "/api/config",
+            json={"config": {"timezone": "Mars/Olympus"}, "profile": "worker_beta"},
+        )
+        assert resp.status_code == 200
+        assert _cfg(isolated_profiles["worker_beta"]).get("timezone") == "Mars/Olympus"
+        assert _cfg(isolated_profiles["default"]).get("timezone") != "Mars/Olympus"
+
+    def test_config_get_reads_target_profile(self, client, isolated_profiles):
+        (isolated_profiles["worker_beta"] / "config.yaml").write_text(
+            "timezone: Venus/Cloud\n", encoding="utf-8"
+        )
+        resp = client.get("/api/config", params={"profile": "worker_beta"})
+        assert resp.status_code == 200
+        assert resp.json().get("timezone") == "Venus/Cloud"
+        # Unscoped read sees the dashboard's own config.
+        resp = client.get("/api/config")
+        assert resp.json().get("timezone") != "Venus/Cloud"
+
+    def test_config_query_param_equivalent_to_body(self, client, isolated_profiles):
+        """The SPA's fetchJSON injects ?profile= — must scope like body.profile."""
+        resp = client.put(
+            "/api/config?profile=worker_beta",
+            json={"config": {"timezone": "Pluto/Far"}},
+        )
+        assert resp.status_code == 200
+        assert _cfg(isolated_profiles["worker_beta"]).get("timezone") == "Pluto/Far"
+        assert _cfg(isolated_profiles["default"]).get("timezone") != "Pluto/Far"
+
+    def test_config_raw_round_trip_scoped(self, client, isolated_profiles):
+        resp = client.put(
+            "/api/config/raw",
+            json={"yaml_text": "timezone: Io/Volcano\n", "profile": "worker_beta"},
+        )
+        assert resp.status_code == 200
+        resp = client.get("/api/config/raw", params={"profile": "worker_beta"})
+        assert "Io/Volcano" in resp.json()["yaml"]
+        resp = client.get("/api/config/raw")
+        assert "Io/Volcano" not in resp.json()["yaml"]
+
+    def test_unknown_profile_404(self, client, isolated_profiles):
+        resp = client.get("/api/config", params={"profile": "ghost"})
+        assert resp.status_code == 404
+
+
+class TestProfileScopedEnv:
+    def test_env_set_lands_in_target_profile_only(self, client, isolated_profiles):
+        resp = client.put(
+            "/api/env",
+            json={"key": "FAL_KEY", "value": "test-fal-123", "profile": "worker_beta"},
+        )
+        assert resp.status_code == 200
+        worker_env = (isolated_profiles["worker_beta"] / ".env").read_text()
+        assert "test-fal-123" in worker_env
+        default_env_path = isolated_profiles["default"] / ".env"
+        if default_env_path.exists():
+            assert "test-fal-123" not in default_env_path.read_text()
+
+    def test_env_list_reads_target_profile(self, client, isolated_profiles):
+        (isolated_profiles["worker_beta"] / ".env").write_text(
+            "FAL_KEY=worker-only-value\n", encoding="utf-8"
+        )
+        resp = client.get("/api/env", params={"profile": "worker_beta"})
+        assert resp.status_code == 200
+        assert resp.json()["FAL_KEY"]["is_set"] is True
+        resp = client.get("/api/env")
+        assert resp.json()["FAL_KEY"]["is_set"] is False
+
+    def test_env_delete_scoped(self, client, isolated_profiles):
+        (isolated_profiles["worker_beta"] / ".env").write_text(
+            "FAL_KEY=doomed\n", encoding="utf-8"
+        )
+        resp = client.request(
+            "DELETE",
+            "/api/env",
+            json={"key": "FAL_KEY", "profile": "worker_beta"},
+        )
+        assert resp.status_code == 200
+        assert "doomed" not in (isolated_profiles["worker_beta"] / ".env").read_text()
+
+
+class TestProfileScopedMcp:
+    def test_mcp_add_and_list_scoped(self, client, isolated_profiles):
+        resp = client.post(
+            "/api/mcp/servers",
+            json={"name": "scoped-srv", "url": "http://localhost:1234/sse",
+                  "profile": "worker_beta"},
+        )
+        assert resp.status_code == 200
+
+        worker_cfg = _cfg(isolated_profiles["worker_beta"])
+        assert "scoped-srv" in worker_cfg.get("mcp_servers", {})
+        assert "scoped-srv" not in _cfg(isolated_profiles["default"]).get("mcp_servers", {})
+
+        listing = client.get("/api/mcp/servers", params={"profile": "worker_beta"}).json()
+        assert any(s["name"] == "scoped-srv" for s in listing["servers"])
+        listing = client.get("/api/mcp/servers").json()
+        assert not any(s["name"] == "scoped-srv" for s in listing["servers"])
+
+    def test_mcp_enabled_toggle_scoped(self, client, isolated_profiles):
+        (isolated_profiles["worker_beta"] / "config.yaml").write_text(
+            "mcp_servers:\n  srv1:\n    url: http://x/sse\n", encoding="utf-8"
+        )
+        resp = client.put(
+            "/api/mcp/servers/srv1/enabled",
+            json={"enabled": False, "profile": "worker_beta"},
+        )
+        assert resp.status_code == 200
+        worker_cfg = _cfg(isolated_profiles["worker_beta"])
+        assert worker_cfg["mcp_servers"]["srv1"]["enabled"] is False
+
+    def test_mcp_remove_scoped(self, client, isolated_profiles):
+        (isolated_profiles["worker_beta"] / "config.yaml").write_text(
+            "mcp_servers:\n  srv2:\n    url: http://x/sse\n", encoding="utf-8"
+        )
+        # Removing from the DASHBOARD's profile must 404 (srv2 lives in worker).
+        resp = client.delete("/api/mcp/servers/srv2")
+        assert resp.status_code == 404
+        resp = client.delete("/api/mcp/servers/srv2", params={"profile": "worker_beta"})
+        assert resp.status_code == 200
+        assert "srv2" not in _cfg(isolated_profiles["worker_beta"]).get("mcp_servers", {})
+
+
+class TestProfileScopedModel:
+    def test_model_set_main_scoped(self, client, isolated_profiles):
+        resp = client.post(
+            "/api/model/set",
+            json={
+                "scope": "main",
+                "provider": "openrouter",
+                "model": "test/model-1",
+                "confirm_expensive_model": True,
+                "profile": "worker_beta",
+            },
+        )
+        assert resp.status_code == 200
+        worker_cfg = _cfg(isolated_profiles["worker_beta"])
+        model_cfg = worker_cfg.get("model", {})
+        assert isinstance(model_cfg, dict)
+        assert model_cfg.get("provider") == "openrouter"
+        default_model = _cfg(isolated_profiles["default"]).get("model", {})
+        if isinstance(default_model, dict):
+            assert default_model.get("default") != "test/model-1"
+
+
+class TestProfileScopedChatPty:
+    def test_chat_argv_scopes_hermes_home(self, isolated_profiles, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(
+            "hermes_cli.main._make_tui_argv",
+            lambda root, tui_dev=False: (["cat"], None),
+            raising=False,
+        )
+        argv, cwd, env = web_server._resolve_chat_argv(profile="worker_beta")
+        assert env["HERMES_HOME"] == str(isolated_profiles["worker_beta"])
+        # Scoped chat must NOT attach to the dashboard's in-memory gateway.
+        assert "HERMES_TUI_GATEWAY_URL" not in env
+
+    def test_chat_argv_unscoped_keeps_legacy_env(self, isolated_profiles, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(
+            "hermes_cli.main._make_tui_argv",
+            lambda root, tui_dev=False: (["cat"], None),
+            raising=False,
+        )
+        argv, cwd, env = web_server._resolve_chat_argv()
+        assert env.get("HERMES_HOME") != str(isolated_profiles["worker_beta"])
+
+    def test_chat_argv_unknown_profile_raises(self, isolated_profiles, monkeypatch):
+        from fastapi import HTTPException
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(
+            "hermes_cli.main._make_tui_argv",
+            lambda root, tui_dev=False: (["cat"], None),
+            raising=False,
+        )
+        with pytest.raises(HTTPException) as exc:
+            web_server._resolve_chat_argv(profile="ghost")
+        assert exc.value.status_code == 404

--- a/tests/hermes_cli/test_web_server_profile_unification.py
+++ b/tests/hermes_cli/test_web_server_profile_unification.py
@@ -163,6 +163,33 @@ class TestProfileScopedMcp:
         worker_cfg = _cfg(isolated_profiles["worker_beta"])
         assert worker_cfg["mcp_servers"]["srv1"]["enabled"] is False
 
+    def test_mcp_probe_runs_inside_profile_scope(
+        self, client, isolated_profiles, monkeypatch
+    ):
+        """The test-server probe must execute with the selected profile's
+        scope active so env-placeholder expansion reads the profile's .env,
+        matching the config the server was saved into."""
+        import hermes_cli.mcp_config as mcp_config
+        from hermes_constants import get_hermes_home
+
+        (isolated_profiles["worker_beta"] / "config.yaml").write_text(
+            "mcp_servers:\n  probe-srv:\n    url: http://x/sse\n",
+            encoding="utf-8",
+        )
+        seen = {}
+
+        def fake_probe(name, config, connect_timeout=30):
+            seen["home"] = str(get_hermes_home())
+            return [("tool-a", "desc")]
+
+        monkeypatch.setattr(mcp_config, "_probe_single_server", fake_probe)
+        resp = client.post(
+            "/api/mcp/servers/probe-srv/test", params={"profile": "worker_beta"}
+        )
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+        assert seen["home"] == str(isolated_profiles["worker_beta"])
+
     def test_mcp_remove_scoped(self, client, isolated_profiles):
         (isolated_profiles["worker_beta"] / "config.yaml").write_text(
             "mcp_servers:\n  srv2:\n    url: http://x/sse\n", encoding="utf-8"
@@ -222,6 +249,38 @@ class TestProfileScopedModel:
 
     def test_auxiliary_unknown_profile_404(self, client, isolated_profiles):
         resp = client.get("/api/model/auxiliary", params={"profile": "ghost"})
+        assert resp.status_code == 404
+
+    def test_model_options_scoped_to_profile(self, client, isolated_profiles):
+        """The Models picker must read the SAME profile model/set writes —
+        current model/provider in the payload come from the scoped config."""
+        (isolated_profiles["worker_beta"] / "config.yaml").write_text(
+            "model:\n  provider: openrouter\n  default: worker/current-pin\n",
+            encoding="utf-8",
+        )
+        resp = client.get("/api/model/options", params={"profile": "worker_beta"})
+        assert resp.status_code == 200
+        body = resp.json()
+        # The payload carries the current selection somewhere stable; assert
+        # the worker pin appears in the scoped response and not the unscoped.
+        assert "worker/current-pin" in resp.text
+        resp = client.get("/api/model/options")
+        assert resp.status_code == 200
+        assert "worker/current-pin" not in resp.text
+        assert isinstance(body, dict)
+
+    def test_model_options_unknown_profile_404(self, client, isolated_profiles):
+        resp = client.get("/api/model/options", params={"profile": "ghost"})
+        assert resp.status_code == 404
+
+    def test_model_info_unknown_profile_404(self, client, isolated_profiles):
+        """Regression: the broad except used to convert the 404 into a 200
+        with empty model info ("no model set" — silently wrong)."""
+        resp = client.get("/api/model/info", params={"profile": "ghost"})
+        assert resp.status_code == 404
+
+    def test_mcp_catalog_unknown_profile_404(self, client, isolated_profiles):
+        resp = client.get("/api/mcp/catalog", params={"profile": "ghost"})
         assert resp.status_code == 404
 
 

--- a/tests/hermes_cli/test_web_server_profile_unification.py
+++ b/tests/hermes_cli/test_web_server_profile_unification.py
@@ -196,6 +196,93 @@ class TestProfileScopedModel:
         if isinstance(default_model, dict):
             assert default_model.get("default") != "test/model-1"
 
+    def test_auxiliary_read_scoped_matches_write_target(
+        self, client, isolated_profiles
+    ):
+        """Reads and writes must scope symmetrically: an aux pin written to
+        the worker profile must show up ONLY in the worker-scoped read.
+        (Regression: /api/model/auxiliary used to read unscoped while
+        /api/model/set wrote scoped — the Models page displayed the
+        dashboard profile's pins while editing the selected profile's.)"""
+        (isolated_profiles["worker_beta"] / "config.yaml").write_text(
+            "auxiliary:\n  vision:\n    provider: openrouter\n"
+            "    model: worker/vision-pin\n",
+            encoding="utf-8",
+        )
+        resp = client.get("/api/model/auxiliary", params={"profile": "worker_beta"})
+        assert resp.status_code == 200
+        vision = next(t for t in resp.json()["tasks"] if t["task"] == "vision")
+        assert vision["model"] == "worker/vision-pin"
+
+        # Unscoped read = the dashboard's own profile, which has no pin.
+        resp = client.get("/api/model/auxiliary")
+        assert resp.status_code == 200
+        vision = next(t for t in resp.json()["tasks"] if t["task"] == "vision")
+        assert vision["model"] != "worker/vision-pin"
+
+    def test_auxiliary_unknown_profile_404(self, client, isolated_profiles):
+        resp = client.get("/api/model/auxiliary", params={"profile": "ghost"})
+        assert resp.status_code == 404
+
+
+class TestProfileScopedPostSetup:
+    def test_post_setup_spawns_with_profile_flag(
+        self, client, isolated_profiles, monkeypatch
+    ):
+        """Post-setup runs in a -p scoped subprocess so hooks that read
+        config / write per-profile state see the same HERMES_HOME the rest
+        of the drawer's writes targeted."""
+        import hermes_cli.web_server as web_server
+
+        calls = []
+
+        class _FakeProc:
+            pid = 777
+
+        monkeypatch.setattr(
+            web_server,
+            "_spawn_hermes_action",
+            lambda subcommand, name: calls.append(list(subcommand)) or _FakeProc(),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.tools_config.valid_post_setup_keys",
+            lambda: {"agent_browser"},
+        )
+        resp = client.post(
+            "/api/tools/toolsets/browser/post-setup",
+            json={"key": "agent_browser", "profile": "worker_beta"},
+        )
+        assert resp.status_code == 200
+        assert calls == [
+            ["-p", "worker_beta", "tools", "post-setup", "agent_browser"]
+        ]
+
+    def test_post_setup_without_profile_keeps_legacy_argv(
+        self, client, isolated_profiles, monkeypatch
+    ):
+        import hermes_cli.web_server as web_server
+
+        calls = []
+
+        class _FakeProc:
+            pid = 777
+
+        monkeypatch.setattr(
+            web_server,
+            "_spawn_hermes_action",
+            lambda subcommand, name: calls.append(list(subcommand)) or _FakeProc(),
+        )
+        monkeypatch.setattr(
+            "hermes_cli.tools_config.valid_post_setup_keys",
+            lambda: {"agent_browser"},
+        )
+        resp = client.post(
+            "/api/tools/toolsets/browser/post-setup",
+            json={"key": "agent_browser"},
+        )
+        assert resp.status_code == 200
+        assert calls == [["tools", "post-setup", "agent_browser"]]
+
 
 class TestProfileScopedChatPty:
     def test_chat_argv_scopes_hermes_home(self, isolated_profiles, monkeypatch):
@@ -207,6 +294,7 @@ class TestProfileScopedChatPty:
             raising=False,
         )
         argv, cwd, env = web_server._resolve_chat_argv(profile="worker_beta")
+        assert env is not None
         assert env["HERMES_HOME"] == str(isolated_profiles["worker_beta"])
         # Scoped chat must NOT attach to the dashboard's in-memory gateway.
         assert "HERMES_TUI_GATEWAY_URL" not in env
@@ -220,10 +308,10 @@ class TestProfileScopedChatPty:
             raising=False,
         )
         argv, cwd, env = web_server._resolve_chat_argv()
+        assert env is not None
         assert env.get("HERMES_HOME") != str(isolated_profiles["worker_beta"])
 
     def test_chat_argv_unknown_profile_raises(self, isolated_profiles, monkeypatch):
-        from fastapi import HTTPException
         import hermes_cli.web_server as web_server
 
         monkeypatch.setattr(
@@ -231,6 +319,8 @@ class TestProfileScopedChatPty:
             lambda root, tui_dev=False: (["cat"], None),
             raising=False,
         )
-        with pytest.raises(HTTPException) as exc:
+        # Reuse the HTTPException class web_server itself raises — avoids a
+        # direct fastapi import (unresolvable in the ty lint environment).
+        with pytest.raises(web_server.HTTPException) as exc:
             web_server._resolve_chat_argv(profile="ghost")
         assert exc.value.status_code == 404

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -64,6 +64,9 @@ import { useBelowBreakpoint } from "@nous-research/ui/hooks/use-below-breakpoint
 import { useSidebarStatus } from "@/hooks/useSidebarStatus";
 import { AuthWidget } from "@/components/AuthWidget";
 import { PageHeaderProvider } from "@/contexts/PageHeaderProvider";
+import { ProfileProvider } from "@/contexts/ProfileProvider";
+import { ProfileSwitcher } from "@/components/ProfileSwitcher";
+import { ProfileScopeBanner } from "@/components/ProfileScopeBanner";
 import { useSystemActions } from "@/contexts/useSystemActions";
 import type { SystemAction } from "@/contexts/system-actions-context";
 import ConfigPage from "@/pages/ConfigPage";
@@ -474,6 +477,7 @@ export default function App() {
   }, []);
 
   return (
+    <ProfileProvider>
     <div
       data-layout-variant={layoutVariant}
       className="flex h-dvh max-h-dvh min-h-0 flex-col overflow-hidden bg-black text-text-primary antialiased"
@@ -528,6 +532,7 @@ export default function App() {
       )}
 
       <PluginSlot name="header-banner" />
+      <ProfileScopeBanner />
 
       <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden pt-14 lg:pt-0">
         <div className="flex min-h-0 min-w-0 flex-1">
@@ -601,6 +606,8 @@ export default function App() {
                 )}
               </Button>
             </div>
+
+            <ProfileSwitcher collapsed={isDesktopCollapsed} />
 
             <nav
               className="min-h-0 w-full flex-1 overflow-y-auto overflow-x-hidden border-t border-current/10 py-2"
@@ -775,6 +782,7 @@ export default function App() {
 
       <PluginSlot name="overlay" />
     </div>
+    </ProfileProvider>
   );
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -65,6 +65,7 @@ import { useSidebarStatus } from "@/hooks/useSidebarStatus";
 import { AuthWidget } from "@/components/AuthWidget";
 import { PageHeaderProvider } from "@/contexts/PageHeaderProvider";
 import { ProfileProvider } from "@/contexts/ProfileProvider";
+import { useProfileScope } from "@/contexts/useProfileScope";
 import { ProfileSwitcher } from "@/components/ProfileSwitcher";
 import { ProfileScopeBanner } from "@/components/ProfileScopeBanner";
 import { useSystemActions } from "@/contexts/useSystemActions";
@@ -734,17 +735,19 @@ export default function App() {
                     "min-h-0 flex flex-1 flex-col",
                 )}
               >
-                <Routes>
-                  {routes.map(({ key, path, element }) => (
-                    <Route key={key} path={path} element={element} />
-                  ))}
-                  <Route
-                    path="*"
-                    element={
-                      <UnknownRouteFallback pluginsLoading={pluginsLoading} />
-                    }
-                  />
-                </Routes>
+                <ProfileKeyedRoutes>
+                  <Routes>
+                    {routes.map(({ key, path, element }) => (
+                      <Route key={key} path={path} element={element} />
+                    ))}
+                    <Route
+                      path="*"
+                      element={
+                        <UnknownRouteFallback pluginsLoading={pluginsLoading} />
+                      }
+                    />
+                  </Routes>
+                </ProfileKeyedRoutes>
 
                 {embeddedChat &&
                   !chatOverriddenByPlugin &&
@@ -784,6 +787,21 @@ export default function App() {
     </div>
     </ProfileProvider>
   );
+}
+
+/**
+ * Remounts the entire routed page tree when the global management profile
+ * changes. Pages load their data on mount; without this, a page opened
+ * under profile A would keep showing A's state while writes (via the
+ * fetchJSON ?profile= injection) silently targeted the newly selected
+ * profile B — the exact stale-target footgun the switcher exists to kill.
+ * Keying by profile resets every page's local state so it refetches under
+ * the new scope. The persistent ChatPage host below handles its own
+ * remount (channel keyed on scopedProfile).
+ */
+function ProfileKeyedRoutes({ children }: { children: ReactNode }) {
+  const { profile } = useProfileScope();
+  return <div key={profile || "__own__"} className="contents">{children}</div>;
 }
 
 function SidebarNavLink({

--- a/web/src/components/ProfileScopeBanner.tsx
+++ b/web/src/components/ProfileScopeBanner.tsx
@@ -14,7 +14,10 @@ export function ProfileScopeBanner() {
   if (!profile || profile === currentProfile) return null;
 
   return (
-    <div className="flex items-center gap-2 border-b border-amber-500/40 bg-amber-500/10 px-4 py-1.5 text-xs text-amber-300">
+    // mt-14 on mobile clears the fixed lg:hidden header (h-14, z-40) so the
+    // scope banner — the main safety signal for scoped writes — is never
+    // hidden behind it; lg:mt-0 restores desktop flow.
+    <div className="mt-14 lg:mt-0 flex items-center gap-2 border-b border-amber-500/40 bg-amber-500/10 px-4 py-1.5 text-xs text-amber-300">
       <Users className="h-3.5 w-3.5 shrink-0" />
       <span>
         {(

--- a/web/src/components/ProfileScopeBanner.tsx
+++ b/web/src/components/ProfileScopeBanner.tsx
@@ -1,0 +1,27 @@
+import { Users } from "lucide-react";
+import { useProfileScope } from "@/contexts/useProfileScope";
+import { useI18n } from "@/i18n";
+
+/**
+ * App-wide amber banner shown while the global switcher targets a profile
+ * OTHER than the dashboard's own — every management write (config, keys,
+ * skills, MCPs, model) and new Chat sessions land in that profile.
+ */
+export function ProfileScopeBanner() {
+  const { profile, currentProfile } = useProfileScope();
+  const { t } = useI18n();
+
+  if (!profile || profile === currentProfile) return null;
+
+  return (
+    <div className="flex items-center gap-2 border-b border-amber-500/40 bg-amber-500/10 px-4 py-1.5 text-xs text-amber-300">
+      <Users className="h-3.5 w-3.5 shrink-0" />
+      <span>
+        {(
+          t.app.managingProfileBanner ??
+          "Managing profile “{name}” — config, keys, skills, MCPs, model, and new chats apply to that profile."
+        ).replace("{name}", profile)}
+      </span>
+    </div>
+  );
+}

--- a/web/src/components/ProfileSwitcher.tsx
+++ b/web/src/components/ProfileSwitcher.tsx
@@ -1,0 +1,67 @@
+import { Users } from "lucide-react";
+import { useProfileScope } from "@/contexts/useProfileScope";
+import { useI18n } from "@/i18n";
+import { cn } from "@/lib/utils";
+
+/**
+ * The machine dashboard's single write-target selector.
+ *
+ * Rendered in the sidebar above the nav. Every management page (Config,
+ * Keys, Skills, MCP, Models) reads/writes the selected profile via the
+ * fetchJSON ?profile= injection. Hidden when only one profile exists.
+ */
+export function ProfileSwitcher({ collapsed }: { collapsed?: boolean }) {
+  const { profile, currentProfile, profiles, setProfile } = useProfileScope();
+  const { t } = useI18n();
+
+  if (profiles.length < 2) return null;
+
+  const managed = profile || currentProfile || "default";
+  const isOther = !!profile && profile !== currentProfile;
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 border-b border-current/10 px-3 py-2",
+        collapsed && "lg:justify-center lg:px-0",
+      )}
+      title={t.app.managingProfile ?? "Managing profile"}
+    >
+      <Users
+        className={cn(
+          "h-3.5 w-3.5 shrink-0",
+          isOther ? "text-amber-300" : "text-text-tertiary",
+        )}
+      />
+      <select
+        aria-label={t.app.managingProfile ?? "Managing profile"}
+        className={cn(
+          "h-7 w-full min-w-0 rounded-none border bg-background px-1 text-xs",
+          isOther
+            ? "border-amber-500/50 text-amber-300"
+            : "border-border text-text-secondary",
+          collapsed && "lg:hidden",
+        )}
+        value={profile}
+        onChange={(e) => setProfile(e.target.value)}
+      >
+        <option value="">
+          {(t.app.currentProfileOption ?? "this dashboard ({name})").replace(
+            "{name}",
+            currentProfile || "default",
+          )}
+        </option>
+        {profiles
+          .filter((name) => name !== currentProfile)
+          .map((name) => (
+            <option key={name} value={name}>
+              {name}
+            </option>
+          ))}
+      </select>
+      {collapsed && (
+        <span className="sr-only">{managed}</span>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/ToolsetConfigDrawer.tsx
+++ b/web/src/components/ToolsetConfigDrawer.tsx
@@ -198,7 +198,7 @@ export function ToolsetConfigDrawer({ toolset, profile, onClose, onChanged }: Pr
     setPostSetupLog([]);
     setPostSetupKey(provider.post_setup);
     try {
-      await api.runToolsetPostSetup(toolset.name, provider.post_setup);
+      await api.runToolsetPostSetup(toolset.name, provider.post_setup, profile);
       // Bump the trigger so the poll effect (re)starts tailing the log.
       setPostSetupTrigger((n) => n + 1);
     } catch (e) {

--- a/web/src/contexts/ProfileProvider.tsx
+++ b/web/src/contexts/ProfileProvider.tsx
@@ -5,7 +5,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useLocation, useSearchParams } from "react-router-dom";
 import { api, setManagementProfile } from "@/lib/api";
 import { ProfileContext } from "@/contexts/profile-context";
 
@@ -13,10 +13,18 @@ import { ProfileContext } from "@/contexts/profile-context";
  * Machine-level management-profile scope.
  *
  * One switcher (rendered in the sidebar) decides which profile every
- * management page reads/writes. The selection lives in the URL
- * (`?profile=<name>`) so it survives refresh and deep-links, and is mirrored
- * into the api module so `fetchJSON` transparently appends it to the
- * profile-scoped endpoint families. "" = the dashboard's own profile.
+ * management page reads/writes. React STATE is the source of truth; the
+ * URL (`?profile=<name>`) is a synchronized projection of it so deep links
+ * land scoped and refresh survives. The selection is mirrored into the api
+ * module so `fetchJSON` transparently appends it to the profile-scoped
+ * endpoint families. "" = the dashboard's own profile.
+ *
+ * Why state-first instead of URL-first: sidebar nav links are bare paths
+ * (`/config`, `/skills`). A URL-derived scope would silently reset to the
+ * dashboard's own profile on every nav click — the switcher would LOOK
+ * global while normal navigation dropped the write target. With state as
+ * truth, the effect below re-asserts `?profile=` onto the new location
+ * after each navigation, so the scope survives nav and stays deep-linkable.
  *
  * This exists because "Set as active" on the Profiles page only flips the
  * sticky active_profile file (future CLI/gateway runs) — it cannot retarget
@@ -25,14 +33,48 @@ import { ProfileContext } from "@/contexts/profile-context";
  */
 export function ProfileProvider({ children }: { children: ReactNode }) {
   const [searchParams, setSearchParams] = useSearchParams();
+  const { pathname } = useLocation();
   const [profiles, setProfiles] = useState<string[]>([]);
   const [currentProfile, setCurrentProfile] = useState("default");
 
-  const profile = searchParams.get("profile") ?? "";
+  // Initial value comes from the URL (deep link / refresh / unified-launch
+  // preselect); afterwards state leads and the URL follows.
+  const [profile, setProfileState] = useState(
+    () => searchParams.get("profile") ?? "",
+  );
 
   // Mirror into the api module synchronously on every render where it
   // changed, so fetches fired by child effects in the same commit see it.
   setManagementProfile(profile);
+
+  // A profile param arriving via in-app navigation (e.g. the Profiles
+  // page's "Manage skills & tools" linking to /skills?profile=X) must win
+  // over current state — it's an explicit scope request.
+  const urlProfile = searchParams.get("profile");
+  useEffect(() => {
+    if (urlProfile !== null && urlProfile !== profile) {
+      setManagementProfile(urlProfile);
+      setProfileState(urlProfile);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [urlProfile]);
+
+  // Re-assert ?profile= after navigations that dropped it (bare nav links).
+  // Runs on every pathname/profile change; no-ops when already in sync.
+  useEffect(() => {
+    const inUrl = searchParams.get("profile") ?? "";
+    if ((profile || "") === inUrl) return;
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (profile) next.set("profile", profile);
+        else next.delete("profile");
+        return next;
+      },
+      { replace: true },
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname, profile]);
 
   useEffect(() => {
     api
@@ -48,6 +90,7 @@ export function ProfileProvider({ children }: { children: ReactNode }) {
   const setProfile = useCallback(
     (name: string) => {
       setManagementProfile(name);
+      setProfileState(name);
       setSearchParams(
         (prev) => {
           const next = new URLSearchParams(prev);

--- a/web/src/contexts/ProfileProvider.tsx
+++ b/web/src/contexts/ProfileProvider.tsx
@@ -1,0 +1,72 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { useSearchParams } from "react-router-dom";
+import { api, setManagementProfile } from "@/lib/api";
+import { ProfileContext } from "@/contexts/profile-context";
+
+/**
+ * Machine-level management-profile scope.
+ *
+ * One switcher (rendered in the sidebar) decides which profile every
+ * management page reads/writes. The selection lives in the URL
+ * (`?profile=<name>`) so it survives refresh and deep-links, and is mirrored
+ * into the api module so `fetchJSON` transparently appends it to the
+ * profile-scoped endpoint families. "" = the dashboard's own profile.
+ *
+ * This exists because "Set as active" on the Profiles page only flips the
+ * sticky active_profile file (future CLI/gateway runs) — it cannot retarget
+ * the running dashboard. The switcher is the dashboard's own, visible,
+ * write-target selector.
+ */
+export function ProfileProvider({ children }: { children: ReactNode }) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [profiles, setProfiles] = useState<string[]>([]);
+  const [currentProfile, setCurrentProfile] = useState("default");
+
+  const profile = searchParams.get("profile") ?? "";
+
+  // Mirror into the api module synchronously on every render where it
+  // changed, so fetches fired by child effects in the same commit see it.
+  setManagementProfile(profile);
+
+  useEffect(() => {
+    api
+      .getProfiles()
+      .then((res) => setProfiles(res.profiles.map((p) => p.name)))
+      .catch(() => {});
+    api
+      .getActiveProfile()
+      .then((info) => setCurrentProfile(info.current || "default"))
+      .catch(() => {});
+  }, []);
+
+  const setProfile = useCallback(
+    (name: string) => {
+      setManagementProfile(name);
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          if (name) next.set("profile", name);
+          else next.delete("profile");
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const value = useMemo(
+    () => ({ profile, currentProfile, profiles, setProfile }),
+    [profile, currentProfile, profiles, setProfile],
+  );
+
+  return (
+    <ProfileContext.Provider value={value}>{children}</ProfileContext.Provider>
+  );
+}

--- a/web/src/contexts/profile-context.ts
+++ b/web/src/contexts/profile-context.ts
@@ -1,0 +1,19 @@
+import { createContext } from "react";
+
+export interface ProfileContextValue {
+  /** Profile every management surface reads/writes ("" = the dashboard
+   *  process's own profile). */
+  profile: string;
+  /** The profile the dashboard process itself runs under. */
+  currentProfile: string;
+  /** Known profile names (includes "default"). */
+  profiles: string[];
+  setProfile: (name: string) => void;
+}
+
+export const ProfileContext = createContext<ProfileContextValue>({
+  profile: "",
+  currentProfile: "default",
+  profiles: [],
+  setProfile: () => {},
+});

--- a/web/src/contexts/useProfileScope.ts
+++ b/web/src/contexts/useProfileScope.ts
@@ -1,0 +1,6 @@
+import { useContext } from "react";
+import { ProfileContext } from "@/contexts/profile-context";
+
+export function useProfileScope() {
+  return useContext(ProfileContext);
+}

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -93,6 +93,10 @@ export const en: Translations = {
     statusOverview: "Status overview",
     system: "System",
     webUi: "Web UI",
+    managingProfile: "Managing profile",
+    currentProfileOption: "this dashboard ({name})",
+    managingProfileBanner:
+      "Managing profile \u201c{name}\u201d \u2014 config, keys, skills, MCPs, model, and new chats apply to that profile.",
   },
 
   status: {

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -110,6 +110,10 @@ export interface Translations {
     statusOverview: string;
     system: string;
     webUi: string;
+    /** Optional — fall back to English literals until translated. */
+    managingProfile?: string;
+    currentProfileOption?: string;
+    managingProfileBanner?: string;
   };
 
   // ── Status page ──

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -41,11 +41,52 @@ function setSessionHeader(headers: Headers, token: string): void {
   }
 }
 
+// ── Global management-profile scope ──────────────────────────────────
+// The dashboard is a machine-level management surface: one header switcher
+// (ProfileProvider in App.tsx) decides which profile the management pages
+// read/write, and fetchJSON transparently appends ?profile=<name> to the
+// profile-scoped endpoint families below. "" = the dashboard process's own
+// profile (legacy behavior). Calls that already carry an explicit profile
+// (e.g. ProfileBuilder writes) are left untouched — explicit beats global.
+let _managementProfile = "";
+
+export function setManagementProfile(name: string): void {
+  _managementProfile = (name || "").trim();
+}
+
+export function getManagementProfile(): string {
+  return _managementProfile;
+}
+
+// Endpoint families that honor ?profile= on the backend (web_server.py
+// _profile_scope). Anything else — sessions, analytics, ops, pairing,
+// channels, cron (which has its own per-job profile params), profiles
+// themselves — is machine-global or self-scoped and must NOT be rewritten.
+const PROFILE_SCOPED_PREFIXES = [
+  "/api/skills",
+  "/api/tools/toolsets",
+  "/api/config",
+  "/api/env",
+  "/api/mcp",
+  "/api/model/info",
+  "/api/model/set",
+];
+
+function withManagementProfile(url: string): string {
+  if (!_managementProfile) return url;
+  if (url.includes("profile=")) return url; // explicit param wins
+  const path = url.split("?")[0];
+  if (!PROFILE_SCOPED_PREFIXES.some((p) => path.startsWith(p))) return url;
+  const sep = url.includes("?") ? "&" : "?";
+  return `${url}${sep}profile=${encodeURIComponent(_managementProfile)}`;
+}
+
 export async function fetchJSON<T>(
   url: string,
   init?: RequestInit,
   options?: FetchJSONOptions,
 ): Promise<T> {
+  url = withManagementProfile(url);
   // Inject the session token into all /api/ requests.
   const headers = new Headers(init?.headers);
   const token = window.__HERMES_SESSION_TOKEN__;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -71,6 +71,7 @@ const PROFILE_SCOPED_PREFIXES = [
   "/api/model/info",
   "/api/model/set",
   "/api/model/auxiliary",
+  "/api/model/options",
 ];
 
 function withManagementProfile(url: string): string {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -70,6 +70,7 @@ const PROFILE_SCOPED_PREFIXES = [
   "/api/mcp",
   "/api/model/info",
   "/api/model/set",
+  "/api/model/auxiliary",
 ];
 
 function withManagementProfile(url: string): string {
@@ -636,13 +637,13 @@ export const api = {
         body: JSON.stringify({ env, profile: profile || undefined }),
       },
     ),
-  runToolsetPostSetup: (name: string, key: string) =>
+  runToolsetPostSetup: (name: string, key: string, profile?: string) =>
     fetchJSON<ActionResponse & { key: string }>(
       `/api/tools/toolsets/${encodeURIComponent(name)}/post-setup`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ key }),
+        body: JSON.stringify({ key, profile: profile || undefined }),
       },
     ),
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -37,11 +37,13 @@ import { useI18n } from "@/i18n";
 import { api } from "@/lib/api";
 import { PluginSlot } from "@/plugins";
 import { useTheme } from "@/themes";
+import { useProfileScope } from "@/contexts/useProfileScope";
 
 function buildWsUrl(
   authParam: [string, string],
   resume: string | null,
   channel: string,
+  profile: string,
 ): string {
   const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
   // ``authParam`` is ``["token", <session>]`` in loopback mode and
@@ -49,6 +51,10 @@ function buildWsUrl(
   // ``_ws_auth_ok`` picks whichever shape matches the current gate state.
   const qs = new URLSearchParams({ [authParam[0]]: authParam[1], channel });
   if (resume) qs.set("resume", resume);
+  // Profile-scoped chat: the PTY child gets HERMES_HOME pointed at the
+  // selected profile, so the conversation runs with that profile's model,
+  // skills, memory, and sessions (see web_server._resolve_chat_argv).
+  if (profile) qs.set("profile", profile);
   return `${proto}//${window.location.host}${HERMES_BASE_PATH}/api/pty?${qs.toString()}`;
 }
 
@@ -173,7 +179,11 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   // treat the current resume target as part of the PTY identity and rebuild the
   // terminal session when it changes.
   const resumeParam = searchParams.get("resume");
-  const channel = useMemo(() => generateChannelId(), [resumeParam]);
+  // Profile-scoped chat: spawn the PTY under the globally selected
+  // management profile. Changing it remounts the terminal (key below /
+  // effect dep) so the user explicitly starts a fresh scoped session.
+  const { profile: scopedProfile } = useProfileScope();
+  const channel = useMemo(() => generateChannelId(), [resumeParam, scopedProfile]);
 
   useEffect(() => {
     if (!resumeParam) return;
@@ -576,7 +586,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     void (async () => {
       const authParam = await buildWsAuthParam();
       if (unmounting) return;
-      const url = buildWsUrl(authParam, resumeParam, channel);
+      const url = buildWsUrl(authParam, resumeParam, channel, scopedProfile);
       const ws = new WebSocket(url);
       ws.binaryType = "arraybuffer";
       wsRef.current = ws;
@@ -714,7 +724,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         copyResetRef.current = null;
       }
     };
-  }, [channel, resumeParam]);
+  }, [channel, resumeParam, scopedProfile]);
 
   // When the user returns to the chat tab (isActive: false → true), the
   // terminal host just transitioned from display:none to display:flex.

--- a/web/src/pages/SkillsPage.tsx
+++ b/web/src/pages/SkillsPage.tsx
@@ -25,7 +25,6 @@ import {
   AlertTriangle,
   Sparkles,
   Loader2,
-  Users,
 } from "lucide-react";
 import { api } from "@/lib/api";
 import type {
@@ -36,9 +35,8 @@ import type {
   SkillHubInstalledEntry,
   SkillHubPreview,
   SkillHubScan,
-  ProfileInfo,
 } from "@/lib/api";
-import { useSearchParams } from "react-router-dom";
+import { useProfileScope } from "@/contexts/useProfileScope";
 import { ToolsetConfigDrawer } from "@/components/ToolsetConfigDrawer";
 import { useToast } from "@nous-research/ui/hooks/use-toast";
 import { Toast } from "@nous-research/ui/ui/components/toast";
@@ -137,51 +135,15 @@ export default function SkillsPage() {
   const { setAfterTitle, setEnd } = usePageHeader();
 
   // ── Profile scoping ──
-  // The dashboard process runs under ONE profile, but skills/toolsets are
-  // per-profile state. Without an explicit selector, users who "activated"
-  // a profile on the Profiles page (which only affects FUTURE CLI/gateway
-  // runs) toggled skills here and silently wrote into the dashboard's own
-  // profile. The selector makes the write target explicit and deep-linkable
-  // via /skills?profile=<name>.
-  const [searchParams, setSearchParams] = useSearchParams();
-  const [profiles, setProfiles] = useState<ProfileInfo[]>([]);
-  const [currentProfile, setCurrentProfile] = useState<string>("");
-  const urlProfile = searchParams.get("profile") ?? "";
-  // "" = the dashboard's own profile (legacy behavior).
-  const selectedProfile = urlProfile;
-
-  const setSelectedProfile = useCallback(
-    (name: string) => {
-      setSearchParams(
-        (prev) => {
-          const next = new URLSearchParams(prev);
-          if (name) next.set("profile", name);
-          else next.delete("profile");
-          return next;
-        },
-        { replace: true },
-      );
-    },
-    [setSearchParams],
-  );
-
-  // The profile actually being managed, for display purposes.
-  const managedProfile = selectedProfile || currentProfile || "default";
-  const managingOtherProfile =
-    !!selectedProfile && selectedProfile !== currentProfile;
-
-  useEffect(() => {
-    // Profile list + the dashboard's own profile, for the selector. Failure
-    // leaves the selector hidden — the page still works profile-unscoped.
-    api
-      .getProfiles()
-      .then((res) => setProfiles(res.profiles))
-      .catch(() => {});
-    api
-      .getActiveProfile()
-      .then((info) => setCurrentProfile(info.current || "default"))
-      .catch(() => setCurrentProfile("default"));
-  }, []);
+  // The write target comes from the GLOBAL profile switcher (sidebar) via
+  // ProfileContext — one selector for the whole dashboard, deep-linkable
+  // as ?profile=<name>. This page just consumes it: the fetchJSON layer
+  // appends the param automatically; we still pass it explicitly where the
+  // call signature supports it (clearer, and robust if a caller bypasses
+  // the auto-injection).
+  const {
+    profile: selectedProfile,
+  } = useProfileScope();
 
   useEffect(() => {
     // Promise-chain shape: setState fires only inside async callbacks so the
@@ -298,33 +260,6 @@ export default function SkillsPage() {
         {t.skills.enabledOf
           .replace("{enabled}", String(enabledCount))
           .replace("{total}", String(skills.length))}
-        {profiles.length > 1 && (
-          <span className="flex items-center gap-1">
-            <Users className="h-3 w-3" />
-            <select
-              aria-label={t.skills.profileSelector ?? "Profile"}
-              className="h-6 rounded-none border border-border bg-background px-1 text-xs text-foreground"
-              value={selectedProfile}
-              onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
-                setSelectedProfile(e.target.value)
-              }
-            >
-              <option value="">
-                {(t.skills.currentProfile ?? "current ({name})").replace(
-                  "{name}",
-                  currentProfile || "default",
-                )}
-              </option>
-              {profiles
-                .filter((p) => p.name !== currentProfile)
-                .map((p) => (
-                  <option key={p.name} value={p.name}>
-                    {p.name}
-                  </option>
-                ))}
-            </select>
-          </span>
-        )}
       </span>,
     );
     setEnd(
@@ -361,10 +296,6 @@ export default function SkillsPage() {
     setEnd,
     skills.length,
     t,
-    profiles,
-    selectedProfile,
-    currentProfile,
-    setSelectedProfile,
   ]);
 
   const filteredToolsets = useMemo(() => {
@@ -390,18 +321,6 @@ export default function SkillsPage() {
     <div className="flex flex-col gap-4">
       <PluginSlot name="skills:top" />
       <Toast toast={toast} />
-
-      {managingOtherProfile && (
-        <div className="flex items-center gap-2 border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-300">
-          <Users className="h-3.5 w-3.5 shrink-0" />
-          <span>
-            {(
-              t.skills.managingProfile ??
-              "Managing profile “{name}” — toggles apply to that profile, not this dashboard’s."
-            ).replace("{name}", managedProfile)}
-          </span>
-        </div>
-      )}
 
       <div className="flex flex-col sm:flex-row sm:items-start gap-4">
         <aside aria-label={t.skills.title} className="sm:w-56 sm:shrink-0">

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1350,6 +1350,7 @@ Launch the web dashboard — a browser-based UI for managing configuration, API 
 | `--host` | `127.0.0.1` | Bind address |
 | `--no-open` | — | Don't auto-open the browser |
 | `--insecure` | off | Allow binding to non-localhost hosts. Exposes dashboard credentials on the network; use only behind trusted network controls. |
+| `--isolated` | off | When launched from a named profile (`worker dashboard`), run a dedicated per-profile server instead of routing to the machine dashboard. |
 | `--stop` | — | Stop running `hermes dashboard` processes and exit. |
 | `--status` | — | List running `hermes dashboard` processes and exit. |
 
@@ -1359,6 +1360,10 @@ hermes dashboard
 
 # Custom port, no browser
 hermes dashboard --port 8080 --no-open
+
+# From a profile alias — routes to the machine dashboard with the
+# profile preselected in the sidebar switcher (attach if running)
+worker dashboard
 ```
 
 ## `hermes profile`

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -272,6 +272,17 @@ Create and manage scheduled cron jobs that run agent prompts on a recurring sche
 - **Trigger now** — immediately execute a job outside its normal schedule
 - **Delete** — permanently remove a cron job
 
+### Profiles
+
+Create and manage [profiles](../profiles.md) — isolated Hermes instances with their own config, skills, and sessions.
+
+- **Profile cards** — each shows its model/provider, skill count, gateway state, description, and badges (active, default, alias)
+- **Create** — name + optional clone-from-default / clone-everything / no-bundled-skills, description, and model; the dedicated Profile Builder page (`/profiles/new`) offers the full flow (model, MCPs, skills)
+- **Manage skills & tools** — jumps to the Skills page scoped to that profile (sets the sidebar profile switcher)
+- **Set as active** — flips the sticky default that **future CLI/gateway runs** pick up (same as `hermes profile use`). This does *not* change what the dashboard manages — that's the profile switcher's job
+- **Edit model / description / SOUL** — inline editors writing into that profile
+- **Rename / Delete** — named profiles only
+
 ### Skills
 
 Browse, search, and toggle installed skills and toolsets, and install new ones from the hub. Skills are loaded from `~/.hermes/skills/` and grouped by category.
@@ -386,6 +397,16 @@ This re-reads `~/.hermes/.env` into the running process's environment. Useful wh
 ## REST API
 
 The web dashboard exposes a REST API that the frontend consumes. You can also call these endpoints directly for automation:
+
+:::tip Profile-scoped endpoints
+The management endpoint families — `/api/config`, `/api/env`, `/api/skills`,
+`/api/tools/toolsets`, `/api/mcp`, and `/api/model/{info,options,auxiliary,set}` —
+accept an optional `?profile=<name>` query parameter (or `"profile"` in the
+JSON body for writes) that scopes the read/write to that profile's
+`HERMES_HOME`. Omitted = the dashboard's own profile. Unknown profile names
+return `404`. The `/api/pty` WebSocket accepts the same parameter to spawn
+a chat under the selected profile.
+:::
 
 ### GET /api/status
 

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -28,6 +28,7 @@ This starts a local web server and opens `http://127.0.0.1:9119` in your browser
 | `--host` | `127.0.0.1` | Bind address |
 | `--no-open` | — | Don't auto-open the browser |
 | `--insecure` | off | Allow binding to non-localhost hosts (**DANGEROUS** — exposes API keys on the network; pair with a firewall and strong auth) |
+| `--isolated` | off | When launched from a named profile (`worker dashboard`), run a dedicated per-profile server instead of routing to the machine dashboard |
 
 ```bash
 # Custom port
@@ -39,6 +40,43 @@ hermes dashboard --host 0.0.0.0
 # Start without opening browser
 hermes dashboard --no-open
 ```
+
+## Managing multiple profiles
+
+The dashboard is a **machine-level** management surface: one server manages
+every [profile](../profiles.md) on the machine. A profile switcher in the
+sidebar (visible whenever more than one profile exists) decides which
+profile the management pages read and write — Config, API Keys, Skills,
+MCP, Models, and the Chat tab all follow it. While a profile other than
+the dashboard's own is selected, an amber banner names the managed profile
+so the write target is never ambiguous.
+
+The selection lives in the URL (`?profile=<name>`), so deep links like
+`http://127.0.0.1:9119/skills?profile=worker` land with the switcher
+preselected and survive refresh.
+
+Launching the dashboard from a profile alias routes to the machine
+dashboard instead of starting a second server:
+
+```bash
+worker dashboard
+# → already running: opens the browser at ?profile=worker
+# → not running:     starts the machine dashboard with "worker" preselected
+```
+
+Pass `--isolated` to opt out and run a dedicated server scoped to that
+profile (the pre-unification behavior — useful if you deliberately expose
+different profiles' dashboards with different auth).
+
+The **Chat** tab follows the switcher too: a scoped chat spawns its PTY
+child with the selected profile's `HERMES_HOME`, so the conversation runs
+with that profile's model, skills, memory, and session history. Switching
+profiles starts a fresh terminal session.
+
+What stays per-profile and is *not* absorbed by the switcher: gateway
+processes (manage them via `hermes -p <name> gateway …`), each profile's
+session database, and cron schedulers (the Cron page already aggregates
+across profiles with its own filter).
 
 ## Prerequisites
 

--- a/website/docs/user-guide/profiles.md
+++ b/website/docs/user-guide/profiles.md
@@ -199,6 +199,20 @@ If you want this profile to work in a specific project by default, also set its 
 coder config set terminal.cwd /absolute/path/to/project
 ```
 
+### From the dashboard
+
+The [web dashboard](features/web-dashboard.md#managing-multiple-profiles)
+is a machine-level surface that can manage **any** profile's config, API
+keys, skills, MCPs, and model via the profile switcher in its sidebar — no
+per-profile dashboard needed. `coder dashboard` routes to the machine
+dashboard with the `coder` profile preselected. The dashboard's Chat tab
+also follows the switcher, spawning a conversation under the selected
+profile's home.
+
+Note: "Set as active" on the dashboard's Profiles page is the sticky
+default for **future CLI/gateway runs** (same as `hermes profile use`) —
+to edit a profile from the dashboard, use the switcher instead.
+
 ## Updating
 
 `hermes update` pulls code once (shared) and syncs new bundled skills to **all** profiles automatically:


### PR DESCRIPTION
## Summary
The dashboard becomes ONE machine-level management surface with a global profile switcher: config, API keys, MCPs, model, skills, and even the Chat tab read/write whichever profile the switcher targets, and `<profile> dashboard` routes to the machine dashboard instead of fragmenting into per-profile servers.

Builds on #43808 (profile-scoped skills/toolsets): same `_profile_scope()` seam, generalized to the remaining management families, plus the launch unification and the single global selector that replaces page-local pickers.

## Changes
- `hermes_cli/web_server.py`: `profile` param (query or body) on `/api/config` (get/put/raw), `/api/env` (get/put/delete/reveal), `/api/mcp/servers` (list/add/remove/test/enabled), `/api/mcp/catalog` (list/install), `/api/model/info`, `/api/model/set`. `model/set` restructured so the expensive-model `await` runs before the scope and the config write runs synchronously inside it (worker thread) — the scope is never held across an await. MCP git-bootstrap installs spawn `hermes -p <profile> mcp install`. Chat PTY: `?profile=` on `/api/pty` points the child's `HERMES_HOME` at the profile dir (own gateway subprocess; config/skills/memory/state.db all profile-bound; in-process gateway attach skipped when scoped). `start_server(initial_profile=…)` appends `?profile=` to the auto-open URL.
- `hermes_cli/main.py` + `subcommands/dashboard.py`: unified launch routing — `worker dashboard` attaches to a listening machine dashboard (opens browser at `?profile=worker`) or re-execs as the machine dashboard pinned to the default profile with `--open-profile worker` preselecting the switcher. `--isolated` preserves the old dedicated-server behavior. Re-exec guard: a child carrying `--open-profile` never re-routes (no exec loop).
- `web/src/`: `ProfileProvider` + sidebar `ProfileSwitcher` — ONE selector, URL-persisted (`?profile=`), mirrored into `fetchJSON` which auto-appends the param to the scoped endpoint families (explicit params always win; non-scoped families — sessions, ops, cron, pairing — are never rewritten). App-wide amber banner names the managed profile. SkillsPage's page-local selector (from #43808) folded into the global context. ChatPage threads the scope into the PTY WS URL; switching profiles remounts the terminal into a fresh scoped session.

Omitted/empty profile keeps exact legacy behavior on every endpoint.

## Validation
| Check | Result |
|---|---|
| New tests (`test_web_server_profile_unification.py`, 15) | config/env/MCP/model scoped reads+writes land in target profile only; query-param ≡ body; PTY env scoping; ghost profile → 404 |
| New tests (`test_dashboard_unified_launch.py`, 5) | attach-when-listening, re-exec argv (`-p default --open-profile worker`, HERMES_HOME dropped), `--isolated` skip, default-profile skip, no exec loop |
| Existing suites | 297/297 across web_server + skills-profiles + pty-import (6 PTY test fakes updated for the new kwarg) |
| E2E (real imports, temp HERMES_HOME, 2 profiles) | all 7 checks pass — writes isolated per profile, module globals restored, chat env binds profile home |
| `tsc -b` + `vite build` | green; new strings confirmed in built bundle |

## Infographic

![one-dashboard-every-profile](https://v3b.fal.media/files/b/0a9dd34d/WHBVXeDtRHR1yAS6lI5ho_rMx9CnGs.png)
