### PR TITLE
fix(npm): add allowScripts to suppress npm 11 install-script warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,5 +40,16 @@
   },
   "engines": {
     "node": ">=20.0.0"
+  },
+  "allowScripts": {
+    "agent-browser@0.26.0": true,
+    "electron@40.9.3": true,
+    "electron-winstaller@5.4.0": true,
+    "esbuild@0.25.12": true,
+    "esbuild@0.27.7": true,
+    "esbuild@0.28.0": true,
+    "fsevents@2.3.3": true,
+    "node-pty@1.1.0": true,
+    "unicode-animations@1.0.3": true
   }
 }


### PR DESCRIPTION
## Problem

`hermes update` emits npm 11 `allow-scripts` warnings because the repo does not declare which dependency install scripts have been reviewed/approved. These warnings are noisy during routine updates and obscure real failures.

npm says this field is currently advisory, but future releases may block unreviewed install scripts when `strict-allow-scripts` is enabled.

## Solution

Add version-pinned `allowScripts` entries to the root `package.json` for all flagged dependencies:

- `agent-browser@0.26.0`
- `electron@40.9.3`
- `electron-winstaller@5.4.0`
- `esbuild@0.25.12`, `@0.27.7`, `@0.28.0`
- `fsevents@2.3.3`
- `node-pty@1.1.0`
- `unicode-animations@1.0.3`

These are all dependencies Hermes explicitly depends on and expects to use. The entries are version-pinned to match the current lockfile; if dependency bumps add new install-script packages, `npm approve-scripts --allow-scripts-pending` can extend the list.

## Testing

```bash
# Before: warnings emitted
npm install --dry-run --no-fund --no-audit --progress=false --workspaces=false 2>&1 | grep -c "allow-scripts"
# (returns > 0)

# After: no warnings
npm install --dry-run --no-fund --no-audit --progress=false --workspaces=false 2>&1 | grep -c "allow-scripts"
# (returns 0)
```

Closes #43997
