### PR TITLE
fix: add logging to swallowed exceptions in conversation_loop.py

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -138,6 +138,7 @@ def _nous_entitlement_message(capability: str) -> str:
         )
         return message or ""
     except Exception:
+        logger.debug("_nous_entitlement_message failed", exc_info=True)
         return ""
 
 
@@ -219,6 +220,7 @@ def _try_refresh_nous_paid_entitlement_credentials(agent) -> bool:
             force=True,
         )
     except Exception:
+        logger.debug("_try_refresh_nous_client_credentials failed", exc_info=True)
         return False
 
 
@@ -549,7 +551,7 @@ def run_conversation(
                             blocks.append({"type": "text", "text": marker})
                             _sm["content"] = blocks
                         except Exception:
-                            pass
+                            logger.debug("Failed to inject steer into multimodal content blocks", exc_info=True)
                     _injected = True
                     logger.debug(
                         "Pre-API-call steer drain: injected into tool msg at index %d",
@@ -731,6 +733,7 @@ def run_conversation(
                             ),
                         }}
                     except Exception:
+                        logger.debug("Tool call argument normalization failed, falling back to repair", exc_info=True)
                         tc["function"]["arguments"] = _repair_tool_call_arguments(
                             tc["function"]["arguments"],
                             tc["function"].get("name", "?"),
@@ -765,7 +768,7 @@ def run_conversation(
             try:
                 agent.iteration_budget.refund()
             except Exception:
-                pass
+                logger.debug("iteration_budget.refund() failed", exc_info=True)
             break
         
         # Thinking spinner for quiet mode (animated during API call)
@@ -855,7 +858,7 @@ def run_conversation(
                 except ImportError:
                     pass
                 except Exception:
-                    pass  # Never let rate guard break the agent loop
+                    logger.debug("nous_rate_guard check failed (fail-open)", exc_info=True)  # Never let rate guard break the agent loop
 
             try:
                 agent._reset_stream_delivery_tracking()
@@ -892,6 +895,7 @@ def run_conversation(
                     _original_api_kwargs = _llm_request_mw.original_payload
                     _llm_middleware_trace = _llm_request_mw.trace
                 except Exception:
+                    logger.debug("LLM request middleware failed, using fallback", exc_info=True)
                     _original_api_kwargs = dict(api_kwargs)
                     _llm_middleware_trace = []
 
@@ -950,7 +954,7 @@ def run_conversation(
                             request=_request_payload,
                         )
                 except Exception:
-                    pass
+                    logger.debug("API request logging hook failed", exc_info=True)
 
                 if env_var_enabled("HERMES_DUMP_REQUESTS"):
                     agent._dump_api_request_debug(api_kwargs, reason="preflight")
@@ -1716,7 +1720,7 @@ def run_conversation(
                         from agent.nous_rate_guard import clear_nous_rate_limit
                         clear_nous_rate_limit()
                     except Exception:
-                        pass
+                        logger.debug("clear_nous_rate_limit failed", exc_info=True)
                 agent._touch_activity(f"API call #{api_call_count} completed")
                 break  # Success, exit retry loop
 
@@ -1927,7 +1931,7 @@ def run_conversation(
                                     getattr(api_error, "message", None) or
                                     str(api_error))
                 except Exception:
-                    pass
+                    logger.debug("Failed to extract API error body", exc_info=True)
                 _err_status = getattr(api_error, "status_code", None)
                 _IMAGE_REJECTION_PHRASES = (
                     "only 'text' content type is supported",


### PR DESCRIPTION
## Summary

Previously, many exception handlers in `conversation_loop.py` silently swallowed errors with bare `except Exception: pass` or `return ""`. This makes debugging difficult because failures are hidden.

This PR adds `logger.debug()` calls with `exc_info=True` to all these locations so errors are visible when debug logging is enabled, while preserving the existing fail-open behavior.

## Changes

- `_nous_entitlement_message`: log credential message failures
- `_try_refresh_nous_paid_entitlement_credentials`: log refresh failures  
- Steer injection: log multimodal content block failures
- Tool call normalization: log argument repair fallbacks
- `iteration_budget.refund()`: log budget refund failures
- `nous_rate_guard`: log rate guard check failures
- LLM request middleware: log middleware failures
- API request logging: log hook failures
- `clear_nous_rate_limit`: log rate limit clear failures
- API error body extraction: log extraction failures

## Test Plan

- [ ] Unit tests pass
- [ ] Debug logging shows errors when they occur
- [ ] No behavior change in normal operation

## Related Issues

Addresses Bug #1 from codebase analysis: Broad Exception Handling (Swallowed Errors)