### PR TITLE
add native linear plugin tools for jimmy project records

### DIFF
--- a/plugins/linear_tools/__init__.py
+++ b/plugins/linear_tools/__init__.py
@@ -1,0 +1,171 @@
+"""linear_tools plugin — native Linear project-record tools.
+
+The plugin exposes focused, secret-safe Linear GraphQL helpers as model tools.
+It uses LINEAR_API_KEY only as an HTTP Authorization header and never returns
+credential material, header values, token lengths, or private config details.
+"""
+
+from __future__ import annotations
+
+import os
+
+from plugins.linear_tools import client
+
+
+def check_linear_requirements() -> bool:
+    """Return True when a Linear API key is present, without inspecting it."""
+    return bool(os.environ.get("LINEAR_API_KEY"))
+
+
+_ISSUE_IDENTIFIER = {
+    "type": "object",
+    "properties": {
+        "identifier": {
+            "type": "string",
+            "description": "Linear issue identifier or UUID, e.g. FGD-167.",
+        }
+    },
+    "required": ["identifier"],
+    "additionalProperties": False,
+}
+
+
+def _schema(name: str, description: str, parameters: dict) -> dict:
+    return {"name": name, "description": description, "parameters": parameters}
+
+
+_TOOLS = (
+    (
+        "linear_get_issue",
+        "Read compact metadata for one Linear issue by identifier.",
+        _schema("linear_get_issue", "Read compact metadata for one Linear issue by identifier.", _ISSUE_IDENTIFIER),
+        client.handle_get_issue,
+    ),
+    (
+        "linear_search_issues",
+        "Search Linear issues and return compact metadata.",
+        _schema(
+            "linear_search_issues",
+            "Search Linear issues and return compact metadata.",
+            {
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string", "description": "Search query."},
+                    "limit": {"type": "integer", "minimum": 1, "maximum": 25, "default": 10},
+                },
+                "required": ["query"],
+                "additionalProperties": False,
+            },
+        ),
+        client.handle_search_issues,
+    ),
+    (
+        "linear_add_comment",
+        "Add a comment to one Linear issue and return comment evidence.",
+        _schema(
+            "linear_add_comment",
+            "Add a comment to one Linear issue and return comment evidence.",
+            {
+                "type": "object",
+                "properties": {
+                    "identifier": {"type": "string", "description": "Linear issue identifier or UUID."},
+                    "body": {"type": "string", "description": "Comment body."},
+                },
+                "required": ["identifier", "body"],
+                "additionalProperties": False,
+            },
+        ),
+        client.handle_add_comment,
+    ),
+    (
+        "linear_ensure_comment",
+        "Add a Linear issue comment only if the exact body is not already present.",
+        _schema(
+            "linear_ensure_comment",
+            "Add a Linear issue comment only if the exact body is not already present.",
+            {
+                "type": "object",
+                "properties": {
+                    "identifier": {"type": "string", "description": "Linear issue identifier or UUID."},
+                    "body": {"type": "string", "description": "Comment body to ensure exactly once."},
+                },
+                "required": ["identifier", "body"],
+                "additionalProperties": False,
+            },
+        ),
+        client.handle_ensure_comment,
+    ),
+    (
+        "linear_update_status",
+        "Update one Linear issue's status by exact state name.",
+        _schema(
+            "linear_update_status",
+            "Update one Linear issue's status by exact state name.",
+            {
+                "type": "object",
+                "properties": {
+                    "identifier": {"type": "string", "description": "Linear issue identifier or UUID."},
+                    "state": {"type": "string", "description": "Exact workflow state name, e.g. Done."},
+                },
+                "required": ["identifier", "state"],
+                "additionalProperties": False,
+            },
+        ),
+        client.handle_update_status,
+    ),
+    (
+        "linear_create_issue",
+        "Create a Linear issue in a team by key and return compact issue evidence.",
+        _schema(
+            "linear_create_issue",
+            "Create a Linear issue in a team by key and return compact issue evidence.",
+            {
+                "type": "object",
+                "properties": {
+                    "team": {"type": "string", "description": "Linear team key, e.g. FGD."},
+                    "title": {"type": "string", "description": "Issue title."},
+                    "description": {"type": "string", "description": "Issue description."},
+                    "priority": {"type": "integer", "minimum": 0, "maximum": 4},
+                    "parent": {"type": "string", "description": "Optional parent issue identifier or UUID."},
+                },
+                "required": ["team", "title"],
+                "additionalProperties": False,
+            },
+        ),
+        client.handle_create_issue,
+    ),
+    (
+        "linear_link_issues",
+        "Relate two Linear issues when relation mutation support is implemented.",
+        _schema(
+            "linear_link_issues",
+            "Relate two Linear issues when relation mutation support is implemented.",
+            {
+                "type": "object",
+                "properties": {
+                    "identifier": {"type": "string", "description": "Primary Linear issue identifier."},
+                    "related_identifier": {"type": "string", "description": "Related Linear issue identifier."},
+                    "relation": {"type": "string", "description": "Requested relation type, if known."},
+                },
+                "required": ["identifier", "related_identifier"],
+                "additionalProperties": False,
+            },
+        ),
+        client.handle_link_issues,
+    ),
+)
+
+
+def register(ctx) -> None:
+    """Register Linear tools under the explicit `linear` plugin toolset."""
+    for name, schema, handler in ((item[0], item[2], item[3]) for item in _TOOLS):
+        ctx.register_tool(
+            name=name,
+            toolset="linear",
+            schema=schema,
+            handler=handler,
+            check_fn=check_linear_requirements,
+            requires_env=["LINEAR_API_KEY"],
+            description=schema.get("description", ""),
+            emoji="📐",
+        )

--- a/plugins/linear_tools/client.py
+++ b/plugins/linear_tools/client.py
@@ -1,0 +1,296 @@
+"""Secret-safe Linear GraphQL client and native tool handlers."""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from typing import Any
+
+API_URL = "https://api.linear.app/graphql"
+_UNSUPPORTED_LINK_REASON = "Linear relation/link mutation shape deferred for a later gate."
+
+
+def _json(obj: Any) -> str:
+    return json.dumps(obj, ensure_ascii=False, sort_keys=True)
+
+
+def _error(message: str) -> str:
+    # Deliberately compact and sanitized: no headers, token values, token length,
+    # env paths, config paths, logs, sessions, cookies, cache, or database detail.
+    return _json({"ok": False, "error": message})
+
+
+def _require_str(args: dict[str, Any], key: str) -> str:
+    value = str(args.get(key, "")).strip()
+    if not value:
+        raise ValueError(f"missing required field: {key}")
+    return value
+
+
+def _limit(args: dict[str, Any], default: int = 10, maximum: int = 25) -> int:
+    try:
+        value = int(args.get("limit", default))
+    except (TypeError, ValueError):
+        value = default
+    return max(1, min(maximum, value))
+
+
+def gql(query: str, variables: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Execute a Linear GraphQL operation.
+
+    The API key is used only as the Authorization header and is never returned.
+    Raised errors are sanitized by the public tool handlers.
+    """
+    key = os.environ.get("LINEAR_API_KEY", "")
+    if not key:
+        raise RuntimeError("Linear API key unavailable")
+
+    body = json.dumps({"query": query, "variables": variables or {}}).encode("utf-8")
+    req = urllib.request.Request(
+        API_URL,
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": key,
+            "User-Agent": "hermes-agent-linear-tools/0.1",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        # Do not include body: Linear/API errors may echo request details.
+        raise RuntimeError(f"Linear API request failed with HTTP {exc.code}") from exc
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        raise RuntimeError("Linear API request failed") from exc
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("Linear API returned invalid JSON") from exc
+
+    if payload.get("errors"):
+        raise RuntimeError("Linear API returned GraphQL errors")
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        raise RuntimeError("Linear API returned no data")
+    return data
+
+
+def _compact_state(state: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(state, dict):
+        return {}
+    compact = {"name": state.get("name")}
+    if state.get("type") is not None:
+        compact["type"] = state.get("type")
+    return {k: v for k, v in compact.items() if v is not None}
+
+
+def _compact_team(team: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(team, dict):
+        return {}
+    return {k: team.get(k) for k in ("key", "name") if team.get(k) is not None}
+
+
+def _compact_issue(issue: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(issue, dict):
+        return {}
+    compact = {
+        "id": issue.get("id"),
+        "identifier": issue.get("identifier"),
+        "title": issue.get("title"),
+        "url": issue.get("url"),
+        "state": _compact_state(issue.get("state")),
+        "team": _compact_team(issue.get("team")),
+    }
+    return {k: v for k, v in compact.items() if v not in (None, {}, [])}
+
+
+ISSUE_QUERY = """query($id: String!) {
+  issue(id: $id) {
+    id identifier title url
+    state { name type }
+    team { id key name }
+  }
+}"""
+
+ISSUE_WITH_COMMENTS_QUERY = """query($id: String!) {
+  issue(id: $id) {
+    id identifier title url
+    state { name type }
+    team { id key name }
+    comments(first: 100) { nodes { id body createdAt } }
+  }
+}"""
+
+
+def _get_issue(identifier: str, *, comments: bool = False) -> dict[str, Any]:
+    query = ISSUE_WITH_COMMENTS_QUERY if comments else ISSUE_QUERY
+    issue = gql(query, {"id": identifier}).get("issue")
+    if not isinstance(issue, dict):
+        raise RuntimeError("Linear issue not found")
+    return issue
+
+
+def handle_get_issue(args: dict[str, Any], **_: Any) -> str:
+    try:
+        identifier = _require_str(args, "identifier")
+        return _json({"ok": True, "issue": _compact_issue(_get_issue(identifier))})
+    except Exception as exc:
+        return _error(str(exc))
+
+
+def handle_search_issues(args: dict[str, Any], **_: Any) -> str:
+    try:
+        query = _require_str(args, "query")
+        first = _limit(args)
+        data = gql(
+            """query($term: String!, $first: Int!) {
+              searchIssues(term: $term, first: $first) {
+                nodes { id identifier title url state { name type } team { id key name } }
+              }
+            }""",
+            {"term": query, "first": first},
+        )
+        nodes = data.get("searchIssues", {}).get("nodes", [])
+        return _json({"ok": True, "issues": [_compact_issue(node) for node in nodes]})
+    except Exception as exc:
+        return _error(str(exc))
+
+
+def _create_comment(issue_id: str, body: str) -> dict[str, Any]:
+    data = gql(
+        """mutation($input: CommentCreateInput!) {
+          commentCreate(input: $input) {
+            success comment { id createdAt }
+          }
+        }""",
+        {"input": {"issueId": issue_id, "body": body}},
+    )
+    payload = data.get("commentCreate", {})
+    if not payload.get("success"):
+        raise RuntimeError("Linear comment create failed")
+    comment = payload.get("comment")
+    if not isinstance(comment, dict):
+        raise RuntimeError("Linear comment create returned no comment")
+    return {"id": comment.get("id"), "createdAt": comment.get("createdAt")}
+
+
+def handle_add_comment(args: dict[str, Any], **_: Any) -> str:
+    try:
+        identifier = _require_str(args, "identifier")
+        body = _require_str(args, "body")
+        issue = _get_issue(identifier)
+        comment = _create_comment(issue["id"], body)
+        return _json({"ok": True, "issue": _compact_issue(issue), "comment": comment})
+    except Exception as exc:
+        return _error(str(exc))
+
+
+def handle_ensure_comment(args: dict[str, Any], **_: Any) -> str:
+    try:
+        identifier = _require_str(args, "identifier")
+        body = _require_str(args, "body")
+        issue = _get_issue(identifier, comments=True)
+        comments = issue.get("comments", {}).get("nodes", [])
+        for comment in comments:
+            if isinstance(comment, dict) and comment.get("body") == body:
+                return _json(
+                    {
+                        "ok": True,
+                        "created": False,
+                        "issue": _compact_issue(issue),
+                        "comment": {
+                            "id": comment.get("id"),
+                            "createdAt": comment.get("createdAt"),
+                        },
+                    }
+                )
+        comment = _create_comment(issue["id"], body)
+        return _json({"ok": True, "created": True, "issue": _compact_issue(issue), "comment": comment})
+    except Exception as exc:
+        return _error(str(exc))
+
+
+def _workflow_states_for_team(team_id: str) -> list[dict[str, Any]]:
+    data = gql(
+        """query($teamId: ID!) {
+          workflowStates(filter: { team: { id: { eq: $teamId } } }, first: 100) {
+            nodes { id name type }
+          }
+        }""",
+        {"teamId": team_id},
+    )
+    nodes = data.get("workflowStates", {}).get("nodes", [])
+    return [node for node in nodes if isinstance(node, dict)]
+
+
+def handle_update_status(args: dict[str, Any], **_: Any) -> str:
+    try:
+        identifier = _require_str(args, "identifier")
+        state_name = _require_str(args, "state")
+        issue = _get_issue(identifier)
+        team = issue.get("team") or {}
+        team_id = team.get("id")
+        if not team_id:
+            raise RuntimeError("Linear issue has no team id")
+        matches = [s for s in _workflow_states_for_team(team_id) if s.get("name") == state_name]
+        if len(matches) != 1:
+            raise RuntimeError("Linear workflow state not found or ambiguous")
+        before = _compact_state(issue.get("state"))
+        data = gql(
+            """mutation($id: String!, $input: IssueUpdateInput!) {
+              issueUpdate(id: $id, input: $input) {
+                success issue { id identifier title url state { name type } team { id key name } }
+              }
+            }""",
+            {"id": issue["id"], "input": {"stateId": matches[0]["id"]}},
+        )
+        payload = data.get("issueUpdate", {})
+        if not payload.get("success"):
+            raise RuntimeError("Linear issue update failed")
+        updated = payload.get("issue")
+        return _json({"ok": True, "issue": _compact_issue(updated), "before": before, "after": _compact_state(updated.get("state") if isinstance(updated, dict) else None)})
+    except Exception as exc:
+        return _error(str(exc))
+
+
+def _resolve_team_id(team_key: str) -> str:
+    data = gql("query { teams(first: 100) { nodes { id key name } } }")
+    for team in data.get("teams", {}).get("nodes", []):
+        if isinstance(team, dict) and team.get("key") == team_key:
+            return team["id"]
+    raise RuntimeError("Linear team not found")
+
+
+def handle_create_issue(args: dict[str, Any], **_: Any) -> str:
+    try:
+        team_key = _require_str(args, "team")
+        title = _require_str(args, "title")
+        issue_input: dict[str, Any] = {"teamId": _resolve_team_id(team_key), "title": title}
+        description = str(args.get("description", "")).strip()
+        if description:
+            issue_input["description"] = description
+        if args.get("priority") is not None:
+            issue_input["priority"] = int(args["priority"])
+        parent = str(args.get("parent", "")).strip()
+        if parent:
+            issue_input["parentId"] = parent
+        data = gql(
+            """mutation($input: IssueCreateInput!) {
+              issueCreate(input: $input) {
+                success issue { id identifier title url state { name type } team { id key name } }
+              }
+            }""",
+            {"input": issue_input},
+        )
+        payload = data.get("issueCreate", {})
+        if not payload.get("success"):
+            raise RuntimeError("Linear issue create failed")
+        return _json({"ok": True, "issue": _compact_issue(payload.get("issue"))})
+    except Exception as exc:
+        return _error(str(exc))
+
+
+def handle_link_issues(args: dict[str, Any], **_: Any) -> str:
+    return _json({"ok": False, "unsupported": True, "reason": _UNSUPPORTED_LINK_REASON})

--- a/plugins/linear_tools/plugin.yaml
+++ b/plugins/linear_tools/plugin.yaml
@@ -1,0 +1,13 @@
+name: linear_tools
+version: 0.1.0
+description: "Native Linear project-record tools for issue reads, comments, status updates, issue creation, and guarded project evidence markers."
+author: NousResearch
+kind: standalone
+provides_tools:
+  - linear_get_issue
+  - linear_search_issues
+  - linear_add_comment
+  - linear_ensure_comment
+  - linear_update_status
+  - linear_create_issue
+  - linear_link_issues

--- a/tests/plugins/test_linear_tools_plugin.py
+++ b/tests/plugins/test_linear_tools_plugin.py
@@ -1,0 +1,336 @@
+import json
+import os
+import urllib.error
+
+import pytest
+
+
+def _loads(result):
+    assert isinstance(result, str)
+    return json.loads(result)
+
+
+def test_register_wires_linear_tools_with_auth_check():
+    import plugins.linear_tools as plugin
+
+    calls = []
+
+    class _Ctx:
+        def register_tool(self, **kw):
+            calls.append(kw)
+
+    plugin.register(_Ctx())
+
+    names = {call["name"] for call in calls}
+    assert names == {
+        "linear_get_issue",
+        "linear_search_issues",
+        "linear_add_comment",
+        "linear_ensure_comment",
+        "linear_update_status",
+        "linear_create_issue",
+        "linear_link_issues",
+    }
+    assert {call["toolset"] for call in calls} == {"linear"}
+    assert all(call["check_fn"] is plugin.check_linear_requirements for call in calls)
+    assert all(call["requires_env"] == ["LINEAR_API_KEY"] for call in calls)
+
+
+def test_check_linear_requirements_uses_presence_only(monkeypatch):
+    import plugins.linear_tools as plugin
+
+    monkeypatch.delenv("LINEAR_API_KEY", raising=False)
+    assert plugin.check_linear_requirements() is False
+
+    monkeypatch.setenv("LINEAR_API_KEY", "lin_api_secret_value")
+    assert plugin.check_linear_requirements() is True
+
+
+def test_get_issue_returns_compact_issue(monkeypatch):
+    from plugins.linear_tools import client
+
+    def fake_gql(query, variables=None):
+        assert variables == {"id": "FGD-167"}
+        return {
+            "issue": {
+                "id": "uuid-1",
+                "identifier": "FGD-167",
+                "title": "Build native Linear tools",
+                "url": "https://linear.app/issue/FGD-167",
+                "state": {"name": "In Progress", "type": "started"},
+                "team": {"id": "team-1", "key": "FGD", "name": "FGD"},
+            }
+        }
+
+    monkeypatch.setattr(client, "gql", fake_gql)
+
+    result = _loads(client.handle_get_issue({"identifier": "FGD-167"}))
+
+    assert result == {
+        "ok": True,
+        "issue": {
+            "id": "uuid-1",
+            "identifier": "FGD-167",
+            "title": "Build native Linear tools",
+            "url": "https://linear.app/issue/FGD-167",
+            "state": {"name": "In Progress", "type": "started"},
+            "team": {"key": "FGD", "name": "FGD"},
+        },
+    }
+
+
+def test_search_issues_returns_compact_issues(monkeypatch):
+    from plugins.linear_tools import client
+
+    def fake_gql(query, variables=None):
+        assert variables == {"term": "native linear", "first": 2}
+        return {
+            "searchIssues": {
+                "nodes": [
+                    {
+                        "id": "uuid-1",
+                        "identifier": "FGD-167",
+                        "title": "Build native Linear tools",
+                        "url": "u",
+                        "state": {"name": "Todo", "type": "unstarted"},
+                        "team": {"id": "team-1", "key": "FGD", "name": "FGD"},
+                    }
+                ]
+            }
+        }
+
+    monkeypatch.setattr(client, "gql", fake_gql)
+
+    result = _loads(client.handle_search_issues({"query": "native linear", "limit": 2}))
+
+    assert result["ok"] is True
+    assert result["issues"] == [
+        {
+            "id": "uuid-1",
+            "identifier": "FGD-167",
+            "title": "Build native Linear tools",
+            "url": "u",
+            "state": {"name": "Todo", "type": "unstarted"},
+            "team": {"key": "FGD", "name": "FGD"},
+        }
+    ]
+
+
+def test_add_comment_returns_comment_evidence(monkeypatch):
+    from plugins.linear_tools import client
+
+    calls = []
+
+    def fake_gql(query, variables=None):
+        calls.append(variables)
+        if "issue(id:" in query:
+            return {"issue": {"id": "issue-uuid", "identifier": "FGD-167", "title": "T", "url": "u", "state": {"name": "Todo"}, "team": {"key": "FGD"}}}
+        return {
+            "commentCreate": {
+                "success": True,
+                "comment": {"id": "comment-1", "createdAt": "2026-06-11T00:00:00Z"},
+            }
+        }
+
+    monkeypatch.setattr(client, "gql", fake_gql)
+
+    result = _loads(client.handle_add_comment({"identifier": "FGD-167", "body": "marker"}))
+
+    assert result["ok"] is True
+    assert result["comment"] == {"id": "comment-1", "createdAt": "2026-06-11T00:00:00Z"}
+    assert calls[-1] == {"input": {"issueId": "issue-uuid", "body": "marker"}}
+
+
+def test_ensure_comment_reuses_existing_exact_body(monkeypatch):
+    from plugins.linear_tools import client
+
+    created = []
+
+    def fake_gql(query, variables=None):
+        if "comments(first:" in query:
+            return {
+                "issue": {
+                    "id": "issue-uuid",
+                    "identifier": "FGD-167",
+                    "title": "T",
+                    "url": "u",
+                    "state": {"name": "Todo"},
+                    "team": {"key": "FGD"},
+                    "comments": {
+                        "nodes": [
+                            {"id": "comment-existing", "body": "marker", "createdAt": "2026-06-11T00:00:00Z"}
+                        ]
+                    },
+                }
+            }
+        created.append(variables)
+        return {"commentCreate": {"success": True, "comment": {"id": "new", "createdAt": "later"}}}
+
+    monkeypatch.setattr(client, "gql", fake_gql)
+
+    result = _loads(client.handle_ensure_comment({"identifier": "FGD-167", "body": "marker"}))
+
+    assert result["ok"] is True
+    assert result["created"] is False
+    assert result["comment"]["id"] == "comment-existing"
+    assert created == []
+
+
+def test_ensure_comment_creates_when_absent(monkeypatch):
+    from plugins.linear_tools import client
+
+    def fake_gql(query, variables=None):
+        if "comments(first:" in query:
+            return {
+                "issue": {
+                    "id": "issue-uuid",
+                    "identifier": "FGD-167",
+                    "title": "T",
+                    "url": "u",
+                    "state": {"name": "Todo"},
+                    "team": {"key": "FGD"},
+                    "comments": {"nodes": []},
+                }
+            }
+        return {
+            "commentCreate": {
+                "success": True,
+                "comment": {"id": "comment-new", "createdAt": "2026-06-11T00:00:00Z"},
+            }
+        }
+
+    monkeypatch.setattr(client, "gql", fake_gql)
+
+    result = _loads(client.handle_ensure_comment({"identifier": "FGD-167", "body": "marker"}))
+
+    assert result["ok"] is True
+    assert result["created"] is True
+    assert result["comment"]["id"] == "comment-new"
+
+
+def test_update_status_resolves_team_scoped_state(monkeypatch):
+    from plugins.linear_tools import client
+
+    def fake_gql(query, variables=None):
+        if "issue(id:" in query:
+            return {
+                "issue": {
+                    "id": "issue-uuid",
+                    "identifier": "FGD-167",
+                    "title": "T",
+                    "url": "u",
+                    "state": {"name": "Todo", "type": "unstarted"},
+                    "team": {"id": "team-1", "key": "FGD", "name": "FGD"},
+                }
+            }
+        if "workflowStates" in query:
+            return {"workflowStates": {"nodes": [{"id": "state-done", "name": "Done", "type": "completed"}]}}
+        return {
+            "issueUpdate": {
+                "success": True,
+                "issue": {
+                    "id": "issue-uuid",
+                    "identifier": "FGD-167",
+                    "title": "T",
+                    "url": "u",
+                    "state": {"name": "Done", "type": "completed"},
+                    "team": {"key": "FGD"},
+                },
+            }
+        }
+
+    monkeypatch.setattr(client, "gql", fake_gql)
+
+    result = _loads(client.handle_update_status({"identifier": "FGD-167", "state": "Done"}))
+
+    assert result["ok"] is True
+    assert result["before"] == {"name": "Todo", "type": "unstarted"}
+    assert result["after"] == {"name": "Done", "type": "completed"}
+
+
+def test_create_issue_resolves_team_and_returns_created_issue(monkeypatch):
+    from plugins.linear_tools import client
+
+    def fake_gql(query, variables=None):
+        if "teams(first:" in query:
+            return {"teams": {"nodes": [{"id": "team-1", "key": "FGD", "name": "FGD"}]}}
+        return {
+            "issueCreate": {
+                "success": True,
+                "issue": {
+                    "id": "issue-new",
+                    "identifier": "FGD-200",
+                    "title": "New issue",
+                    "url": "u",
+                    "state": {"name": "Todo", "type": "unstarted"},
+                    "team": {"key": "FGD", "name": "FGD"},
+                },
+            }
+        }
+
+    monkeypatch.setattr(client, "gql", fake_gql)
+
+    result = _loads(client.handle_create_issue({"team": "FGD", "title": "New issue", "description": "Body", "priority": 3}))
+
+    assert result["ok"] is True
+    assert result["issue"]["identifier"] == "FGD-200"
+    assert result["issue"]["title"] == "New issue"
+
+
+def test_link_issues_returns_clean_unsupported_result():
+    from plugins.linear_tools import client
+
+    result = _loads(client.handle_link_issues({"identifier": "FGD-167", "related_identifier": "FGD-145"}))
+
+    assert result == {
+        "ok": False,
+        "unsupported": True,
+        "reason": "Linear relation/link mutation shape deferred for a later gate.",
+    }
+
+
+def test_graphql_client_uses_authorization_header_without_returning_secret(monkeypatch):
+    from plugins.linear_tools import client
+
+    seen = {}
+
+    class _Resp:
+        def __enter__(self):
+            return self
+        def __exit__(self, *args):
+            return False
+        def read(self):
+            return b'{"data":{"viewer":{"name":"Jimmy"}}}'
+
+    def fake_urlopen(req, timeout):
+        seen["auth"] = req.headers.get("Authorization")
+        return _Resp()
+
+    monkeypatch.setenv("LINEAR_API_KEY", "lin_api_super_secret_value")
+    monkeypatch.setattr(client.urllib.request, "urlopen", fake_urlopen)
+
+    result = client.gql("query { viewer { name } }")
+
+    assert seen["auth"] == "lin_api_super_secret_value"
+    assert result == {"viewer": {"name": "Jimmy"}}
+    assert "lin_api_super_secret_value" not in json.dumps(result)
+
+
+def test_errors_do_not_include_token_value_or_length(monkeypatch):
+    from plugins.linear_tools import client
+
+    secret = "lin_api_super_secret_value"
+    monkeypatch.setenv("LINEAR_API_KEY", secret)
+
+    def fake_urlopen(req, timeout):
+        raise urllib.error.URLError("network down")
+
+    monkeypatch.setattr(client.urllib.request, "urlopen", fake_urlopen)
+
+    result = _loads(client.handle_get_issue({"identifier": "FGD-167"}))
+
+    dumped = json.dumps(result)
+    assert result["ok"] is False
+    assert secret not in dumped
+    assert str(len(secret)) not in dumped
+    assert "Authorization" not in dumped


### PR DESCRIPTION
FGD-167 native Linear tool route implementation.

Summary:
Adds bundled standalone linear plugin toolset.
Implements native Linear project-record tools:
linear_get_issue
linear_search_issues
linear_add_comment
linear_ensure_comment
linear_update_status
linear_create_issue
linear_link_issues as deferred/unsupported until relation shape is separately approved
Uses LINEAR_API_KEY only inside request headers.
Gates availability on key presence only.
Does not return token values, token lengths, prefixes/suffixes, headers, .env, private config, logs, sessions, cookies, cache, database, or secret-bearing material.
Adds mocked tests for registration, auth gating, request behavior, comment idempotence, status update resolution, issue creation, deferred linking, and secret-safety.

Validation:
python -m pytest tests/plugins/test_linear_tools_plugin.py -q
12 passed in 0.11s

Safety:
No real Linear API calls in tests.
No live Linear mutation.
No gateway restart.
No config edits.
No package-lock change.
Dirty main repo untouched.