### PR TITLE
fix(security): use constant-time comparison for BlueBubbles webhook auth

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -9,6 +9,7 @@ downloading from PR #4588 (YuhangLin).
 """
 
 import asyncio
+import hmac
 import json
 import logging
 import os
@@ -870,7 +871,14 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             or request.headers.get("x-guid")
             or request.headers.get("x-bluebubbles-guid")
         )
-        if token != self.password:
+        # Constant-time comparison so the webhook secret cannot be recovered
+        # via a response-timing side channel (CWE-208). A plain ``!=`` short-
+        # circuits on the first differing byte, leaking the matched prefix
+        # length. ``token`` may be ``None`` when no credential header/param is
+        # present, so coerce to a string before encoding.
+        if not hmac.compare_digest(
+            (token or "").encode("utf-8"), self.password.encode("utf-8")
+        ):
             return web.json_response({"error": "unauthorized"}, status=401)
         try:
             raw = await request.read()

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -830,3 +830,54 @@ class TestBlueBubblesWebhookRegistration:
             adapter._unregister_webhook()
         )
         assert ok is False
+
+
+class _FakeWebhookRequest:
+    """Minimal stand-in for an aiohttp request used by _handle_webhook."""
+
+    def __init__(self, query=None, headers=None, body=b"{}"):
+        self.query = query or {}
+        self.headers = headers or {}
+        self._body = body
+
+    async def read(self):
+        return self._body
+
+
+class TestBlueBubblesWebhookAuth:
+    """Webhook credential check must be timing-safe (CWE-208)."""
+
+    def test_wrong_password_rejected(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        req = _FakeWebhookRequest(query={"password": "wrong"})
+        resp = asyncio.run(adapter._handle_webhook(req))
+        assert resp.status == 401
+
+    def test_missing_credential_rejected(self, monkeypatch):
+        # token resolves to None when no query param / header is present;
+        # the comparison must not raise and must still reject.
+        adapter = _make_adapter(monkeypatch)
+        req = _FakeWebhookRequest()
+        resp = asyncio.run(adapter._handle_webhook(req))
+        assert resp.status == 401
+
+    def test_auth_uses_constant_time_compare(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        import gateway.platforms.bluebubbles as bb
+
+        calls = []
+
+        def spy(a, b):
+            calls.append((a, b))
+            return False  # short-circuit before payload processing
+
+        monkeypatch.setattr(bb.hmac, "compare_digest", spy)
+        req = _FakeWebhookRequest(query={"password": "secret"})
+        resp = asyncio.run(adapter._handle_webhook(req))
+
+        assert resp.status == 401
+        # The supplied token AND the configured secret must both flow through
+        # the constant-time comparator (no plain == fast path remains).
+        assert calls, "webhook auth must use hmac.compare_digest"
+        assert calls[0][0] == b"secret"
+        assert calls[0][1] == b"secret"


### PR DESCRIPTION
## Summary

The BlueBubbles webhook handler authenticated inbound requests with a plain string inequality check against the configured shared password. A plain `!=` comparison short-circuits on the first differing byte, so the time taken to reject a request correlates with how many leading bytes of the supplied credential matched. This is a classic timing side channel (CWE-208) that, over many requests, can let an attacker recover the secret byte-by-byte.

## Root cause

`gateway/platforms/bluebubbles.py` — `_handle_webhook`:

`python
token = request.query.get(password) or ... or request.headers.get(x-bluebubbles-guid)
if token != self.password:
    return web.json_response({error: unauthorized}, status=401)
`

## Fix

Compare with `hmac.compare_digest` (constant-time). `token` may be `None` when no credential is supplied, so it is coerced to an empty string before encoding; unauthenticated requests are still rejected and no exception is raised.

## Tests

`tests/gateway/test_bluebubbles.py::TestBlueBubblesWebhookAuth` — wrong credential rejected, missing credential rejected (no exception), and an invariant test asserting both operands flow through `hmac.compare_digest` (i.e. no plain `==` fast path remains). Full existing `test_bluebubbles.py` suite (59 tests) still passes.

## Impact

Inbound webhook authentication only. No change to message handling, config, prompt cache, or role alternation. Behavior is identical for valid/invalid credentials apart from the comparison being constant-time.