### PR TITLE
fix(security): validate inbound Slack file URLs against SSRF

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -3463,6 +3463,18 @@ class SlackAdapter(BasePlatformAdapter):
     ) -> str:
         """Download a Slack file using the bot token for auth, with retry."""
         import httpx
+        from gateway.platforms.base import _ssrf_redirect_guard, safe_url_for_log
+        from tools.url_safety import is_safe_url
+
+        # SSRF guard: the download attaches the bot token, so a URL that
+        # resolves to (or 3xx-redirects into) a private/internal address would
+        # both leak the token and let the server reach internal services
+        # (CWE-918). The outbound send_image() path is already guarded; this
+        # is the inbound sibling that was missing the same protection.
+        if not is_safe_url(url):
+            raise ValueError(
+                f"Blocked unsafe Slack file URL (SSRF protection): {safe_url_for_log(url)}"
+            )
 
         bot_token = (
             self._team_clients[team_id].token
@@ -3470,7 +3482,11 @@ class SlackAdapter(BasePlatformAdapter):
             else self.config.token
         )
 
-        async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+        async with httpx.AsyncClient(
+            timeout=30.0,
+            follow_redirects=True,
+            event_hooks={"response": [_ssrf_redirect_guard]},
+        ) as client:
             for attempt in range(3):
                 try:
                     response = await client.get(
@@ -3519,6 +3535,16 @@ class SlackAdapter(BasePlatformAdapter):
     async def _download_slack_file_bytes(self, url: str, team_id: str = "") -> bytes:
         """Download a Slack file and return raw bytes, with retry."""
         import httpx
+        from gateway.platforms.base import _ssrf_redirect_guard, safe_url_for_log
+        from tools.url_safety import is_safe_url
+
+        # SSRF guard (CWE-918): see _download_slack_file. This sibling path
+        # also attaches the bot token and must validate the destination plus
+        # every redirect hop.
+        if not is_safe_url(url):
+            raise ValueError(
+                f"Blocked unsafe Slack file URL (SSRF protection): {safe_url_for_log(url)}"
+            )
 
         bot_token = (
             self._team_clients[team_id].token
@@ -3526,7 +3552,11 @@ class SlackAdapter(BasePlatformAdapter):
             else self.config.token
         )
 
-        async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+        async with httpx.AsyncClient(
+            timeout=30.0,
+            follow_redirects=True,
+            event_hooks={"response": [_ssrf_redirect_guard]},
+        ) as client:
             for attempt in range(3):
                 try:
                     response = await client.get(

--- a/tests/gateway/test_slack_download_ssrf.py
+++ b/tests/gateway/test_slack_download_ssrf.py
@@ -1,0 +1,104 @@
+"""SSRF regression tests for inbound Slack file downloads.
+
+``_download_slack_file`` / ``_download_slack_file_bytes`` attach the bot
+token and follow redirects, so they must validate the destination (CWE-918)
+exactly like the already-guarded outbound ``send_image`` path: a pre-flight
+``is_safe_url`` check plus a per-redirect guard.
+"""
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.platforms.base import _ssrf_redirect_guard
+from gateway.platforms.slack import SlackAdapter
+
+
+def _fake_adapter():
+    self = SlackAdapter.__new__(SlackAdapter)
+    self.config = SimpleNamespace(token="xoxb-test-token")
+    self._team_clients = {}
+    return self
+
+
+class _NetworkTouched(RuntimeError):
+    pass
+
+
+class _RecordingClient:
+    """Captures AsyncClient kwargs; refuses to perform real I/O."""
+
+    last_kwargs = None
+
+    def __init__(self, **kwargs):
+        type(self).last_kwargs = kwargs
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def get(self, *args, **kwargs):
+        raise _NetworkTouched("network access attempted")
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    ["_download_slack_file", "_download_slack_file_bytes"],
+)
+def test_unsafe_url_blocked_before_network(monkeypatch, method_name):
+    import tools.url_safety as url_safety
+
+    calls = {"checked": []}
+
+    def fake_is_safe_url(url, *a, **k):
+        calls["checked"].append(url)
+        return False
+
+    monkeypatch.setattr(url_safety, "is_safe_url", fake_is_safe_url)
+
+    # If the guard is bypassed, the fake client raises _NetworkTouched; a
+    # correct implementation raises ValueError *before* touching httpx.
+    monkeypatch.setattr("httpx.AsyncClient", _RecordingClient)
+
+    self = _fake_adapter()
+    method = getattr(self, method_name)
+    args = ("http://169.254.169.254/latest/meta-data/", ".jpg") \
+        if method_name == "_download_slack_file" \
+        else ("http://169.254.169.254/latest/meta-data/",)
+
+    with pytest.raises(ValueError):
+        asyncio.run(method(*args))
+
+    assert calls["checked"], "download must call is_safe_url before fetching"
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    ["_download_slack_file", "_download_slack_file_bytes"],
+)
+def test_redirect_guard_is_wired(monkeypatch, method_name):
+    import tools.url_safety as url_safety
+
+    monkeypatch.setattr(url_safety, "is_safe_url", lambda *a, **k: True)
+    monkeypatch.setattr("httpx.AsyncClient", _RecordingClient)
+
+    self = _fake_adapter()
+    method = getattr(self, method_name)
+    args = ("https://files.slack.com/x.jpg", ".jpg") \
+        if method_name == "_download_slack_file" \
+        else ("https://files.slack.com/x.jpg",)
+
+    # The fake client raises when .get() is called; we only care that the
+    # client was constructed with the redirect guard hook.
+    with pytest.raises(_NetworkTouched):
+        asyncio.run(method(*args))
+
+    kwargs = _RecordingClient.last_kwargs
+    assert kwargs is not None
+    hooks = kwargs.get("event_hooks", {})
+    assert _ssrf_redirect_guard in hooks.get("response", []), (
+        "AsyncClient must register _ssrf_redirect_guard to block "
+        "redirect-based SSRF"
+    )


### PR DESCRIPTION
## Summary

When Hermes receives a file on Slack it downloads the bytes server-side using the bot token. The two inbound download helpers followed redirects without validating the destination, while the outbound `send_image` path in the same adapter already validates URLs and re-checks every redirect hop. Because the request carries an `Authorization: Bearer <bot-token>` header and `follow_redirects=True`, a URL that resolves to — or 3xx-redirects into — a private/internal address could be used to reach internal services and/or egress the bot token to a non-Slack host (CWE-918, SSRF).

## Root cause

`gateway/platforms/slack.py` — `_download_slack_file` and `_download_slack_file_bytes`:

```python
async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
    response = await client.get(url, headers={"Authorization": f"Bearer {bot_token}"})
```

No `is_safe_url` pre-flight and no redirect guard, unlike the guarded outbound path and `base.cache_image_from_url`.

## Fix

Apply the existing, canonical pattern to both inbound sibling paths:
- `is_safe_url(url)` pre-flight (raises `ValueError` before any network I/O when the target is private/internal),
- `event_hooks={"response": [_ssrf_redirect_guard]}` so each redirect hop is re-validated.

This reuses `tools.url_safety.is_safe_url` and `gateway.platforms.base._ssrf_redirect_guard` — the same helpers the outbound path uses — so behavior stays consistent across the adapter.

## Tests

`tests/gateway/test_slack_download_ssrf.py` (parametrized over both helpers):
- unsafe/internal URL is rejected with `ValueError` *before* any HTTP client call,
- the `AsyncClient` is constructed with `_ssrf_redirect_guard` registered on the response hook.

## Impact

Legitimate Slack file URLs (`files.slack.com` etc.) are unaffected. Only requests targeting private/internal/metadata addresses or redirecting into them are blocked. No change to prompt cache, role alternation, or config.
