### PR TITLE
fix: render Feishu slash confirmations as cards

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -227,6 +227,12 @@ _APPROVAL_LABEL_MAP: Dict[str, str] = {
     "always": "Approved permanently",
     "deny": "Denied",
 }
+_SLASH_CONFIRM_CHOICES = frozenset({"once", "always", "cancel"})
+_SLASH_CONFIRM_LABEL_MAP: Dict[str, str] = {
+    "once": "Approved once",
+    "always": "Always approved",
+    "cancel": "Cancelled",
+}
 _FEISHU_BOT_MSG_TRACK_SIZE = 512                   # LRU size for tracking sent message IDs
 _FEISHU_REPLY_FALLBACK_CODES = frozenset({230011, 231003})  # reply target withdrawn/missing → create fallback
 
@@ -1470,6 +1476,8 @@ class FeishuAdapter(BasePlatformAdapter):
         # Update prompt button state (prompt_id → {session_key, message_id, chat_id})
         self._update_prompt_state: Dict[int, Dict[str, str]] = {}
         self._update_prompt_counter = itertools.count(1)
+        # Slash-confirm button state (confirm_id → {session_key, message_id, chat_id})
+        self._slash_confirm_state: Dict[str, Dict[str, Any]] = {}
         # Feishu reaction deletion requires the opaque reaction_id returned
         # by create, so we cache it per message_id.
         self._pending_processing_reactions: "OrderedDict[str, str]" = OrderedDict()
@@ -1931,6 +1939,91 @@ class FeishuAdapter(BasePlatformAdapter):
             return result
         except Exception as exc:
             logger.warning("[Feishu] send_exec_approval failed: %s", exc)
+            return SendResult(success=False, error=str(exc))
+
+    @staticmethod
+    def _build_slash_confirm_card(*, title: str, message: str, confirm_id: str) -> Dict[str, Any]:
+        preview = message[:3800] + "..." if len(message) > 3800 else message
+
+        def _btn(label: str, choice: str, btn_type: str = "default") -> dict:
+            return {
+                "tag": "button",
+                "text": {"tag": "plain_text", "content": label},
+                "type": btn_type,
+                "value": {
+                    "hermes_slash_confirm_action": choice,
+                    "slash_confirm_id": confirm_id,
+                },
+            }
+
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": title or "⚠️ Confirmation Required", "tag": "plain_text"},
+                "template": "orange",
+            },
+            "elements": [
+                {"tag": "markdown", "content": preview},
+                {
+                    "tag": "action",
+                    "actions": [
+                        _btn("✅ Approve Once", "once", "primary"),
+                        _btn("🔒 Always Approve", "always"),
+                        _btn("❌ Cancel", "cancel", "danger"),
+                    ],
+                },
+            ],
+        }
+
+    async def send_slash_confirm(
+        self,
+        chat_id: str,
+        title: str,
+        message: str,
+        session_key: str,
+        confirm_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a generic slash-command confirmation as a Feishu card."""
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        confirm_id = str(confirm_id)
+        self._prune_slash_confirm_state()
+        state = {
+            "session_key": session_key,
+            "message_id": "",
+            "chat_id": chat_id,
+            "metadata": dict(metadata or {}),
+            "created_at": time.time(),
+        }
+        # Pre-register before sending so a very fast callback cannot race the
+        # API response. Failure paths remove the entry and let the gateway use
+        # its text fallback.
+        self._slash_confirm_state[confirm_id] = state
+
+        try:
+            payload = json.dumps(
+                self._build_slash_confirm_card(title=title, message=message, confirm_id=confirm_id),
+                ensure_ascii=False,
+            )
+            response = await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="interactive",
+                payload=payload,
+                reply_to=None,
+                metadata=metadata,
+            )
+
+            result = self._finalize_send_result(response, "send_slash_confirm failed")
+            if result.success:
+                state["message_id"] = result.message_id or ""
+                return result
+            self._slash_confirm_state.pop(confirm_id, None)
+            return result
+        except Exception as exc:
+            self._slash_confirm_state.pop(confirm_id, None)
+            logger.warning("[Feishu] send_slash_confirm failed: %s", exc)
             return SendResult(success=False, error=str(exc))
 
     @staticmethod
@@ -2540,11 +2633,21 @@ class FeishuAdapter(BasePlatformAdapter):
             action_value.get("hermes_update_prompt_action")
             if isinstance(action_value, dict) else None
         )
+        slash_confirm_action = (
+            action_value.get("hermes_slash_confirm_action")
+            if isinstance(action_value, dict) else None
+        )
 
         if hermes_action:
             return self._handle_approval_card_action(event=event, action_value=action_value, loop=loop)
         if update_prompt_action:
             return self._handle_update_prompt_card_action(
+                event=event,
+                action_value=action_value,
+                loop=loop,
+            )
+        if slash_confirm_action:
+            return self._handle_slash_confirm_card_action(
                 event=event,
                 action_value=action_value,
                 loop=loop,
@@ -2583,6 +2686,155 @@ class FeishuAdapter(BasePlatformAdapter):
         if not allowed_ids:
             return True
         return "*" in allowed_ids or normalized in allowed_ids
+
+    def _prune_slash_confirm_state(self) -> None:
+        """Drop Feishu slash-confirm state older than the core pending timeout."""
+        try:
+            from tools import slash_confirm as _slash_confirm_mod
+            ttl = float(getattr(_slash_confirm_mod, "DEFAULT_TIMEOUT_SECONDS", 300))
+        except Exception:
+            ttl = 300.0
+        now = time.time()
+        stale = [
+            confirm_id for confirm_id, state in self._slash_confirm_state.items()
+            if now - float(state.get("created_at", 0) or 0) > ttl
+        ]
+        for confirm_id in stale:
+            self._slash_confirm_state.pop(confirm_id, None)
+
+    @staticmethod
+    def _build_resolved_slash_confirm_card(*, choice: str, user_name: str) -> Dict[str, Any]:
+        expired = choice == "expired"
+        if expired:
+            title = "⌛ Confirmation expired"
+            template = "grey"
+            content = "This confirmation was already handled, superseded, or expired."
+        else:
+            icon = "❌" if choice == "cancel" else "✅"
+            label = _SLASH_CONFIRM_LABEL_MAP.get(choice, "Resolved")
+            title = f"{icon} {label}"
+            template = "red" if choice == "cancel" else "green"
+            content = f"{icon} **{label}** by {user_name}"
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": title, "tag": "plain_text"},
+                "template": template,
+            },
+            "elements": [{"tag": "markdown", "content": content}],
+        }
+
+    def _slash_confirm_pending_matches(self, *, session_key: str, confirm_id: str) -> bool:
+        try:
+            from tools import slash_confirm as _slash_confirm_mod
+            _slash_confirm_mod.clear_if_stale(session_key)
+            pending = _slash_confirm_mod.get_pending(session_key)
+        except Exception:
+            logger.debug("[Feishu] Failed to inspect slash-confirm pending state", exc_info=True)
+            return True
+        return bool(pending and str(pending.get("confirm_id", "")) == str(confirm_id))
+
+    def _slash_confirm_operator_allowed(
+        self,
+        *,
+        state: Dict[str, Any],
+        open_id: str,
+        user_id: str,
+        chat_id: str,
+    ) -> bool:
+        operator_ids = {str(v).strip() for v in (open_id, user_id) if str(v or "").strip()}
+        if not operator_ids:
+            return False
+        metadata_value = state.get("metadata")
+        metadata = metadata_value if isinstance(metadata_value, dict) else {}
+        requester_ids = {
+            str(metadata.get("slash_confirm_requester_user_id", "")).strip(),
+            str(metadata.get("slash_confirm_requester_user_id_alt", "")).strip(),
+        } - {""}
+        if requester_ids:
+            if operator_ids & requester_ids:
+                return True
+            if operator_ids & set(self._admins):
+                return True
+            return False
+        sender_id = SimpleNamespace(open_id=open_id, user_id=user_id)
+        return self._allow_group_message(sender_id, chat_id, is_bot=False)
+
+    def _handle_slash_confirm_card_action(self, *, event: Any, action_value: Dict[str, Any], loop: Any) -> Any:
+        """Schedule slash-confirm resolution and build the synchronous callback response."""
+        confirm_id = str(action_value.get("slash_confirm_id", "") or "")
+        if not confirm_id:
+            logger.debug("[Feishu] Card action missing slash_confirm_id, ignoring")
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+        self._prune_slash_confirm_state()
+        state = self._slash_confirm_state.get(confirm_id)
+        if not state:
+            logger.debug("[Feishu] Slash confirm %s already resolved or unknown", confirm_id)
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        choice = str(action_value.get("hermes_slash_confirm_action", "") or "").strip().lower()
+        if choice not in _SLASH_CONFIRM_CHOICES:
+            logger.debug("[Feishu] Card action has invalid slash confirm choice=%r", choice)
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        session_key = str(state.get("session_key", "") or "")
+        if not self._slash_confirm_pending_matches(session_key=session_key, confirm_id=confirm_id):
+            self._slash_confirm_state.pop(confirm_id, None)
+            if P2CardActionTriggerResponse is None:
+                return None
+            response = P2CardActionTriggerResponse()
+            if CallBackCard is not None:
+                card = CallBackCard()
+                card.type = "raw"
+                card.data = self._build_resolved_slash_confirm_card(choice="expired", user_name="")
+                response.card = card
+            return response
+
+        operator = getattr(event, "operator", None)
+        open_id = str(getattr(operator, "open_id", "") or "")
+        user_id = str(getattr(operator, "user_id", "") or "")
+        callback_chat_id = str(getattr(getattr(event, "context", None), "open_chat_id", "") or "")
+        expected_chat_id = str(state.get("chat_id", "") or "")
+        if not callback_chat_id or not expected_chat_id or callback_chat_id != expected_chat_id:
+            logger.warning(
+                "[Feishu] Slash confirm callback chat mismatch for %s (expected=%s, got=%s)",
+                confirm_id,
+                expected_chat_id,
+                callback_chat_id,
+            )
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+        if not self._slash_confirm_operator_allowed(
+            state=state,
+            open_id=open_id,
+            user_id=user_id,
+            chat_id=expected_chat_id,
+        ):
+            logger.warning("[Feishu] Unauthorized slash confirm click by %s", open_id or user_id or "<unknown>")
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        user_name = self._get_cached_sender_name(open_id) or open_id or user_id
+        if not self._submit_on_loop(
+            loop,
+            self._resolve_slash_confirm(
+                confirm_id,
+                choice,
+                user_name,
+                open_id=open_id,
+                user_id=user_id,
+                chat_id=callback_chat_id,
+            ),
+        ):
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        if P2CardActionTriggerResponse is None:
+            return None
+        response = P2CardActionTriggerResponse()
+        if CallBackCard is not None:
+            card = CallBackCard()
+            card.type = "raw"
+            card.data = self._build_resolved_slash_confirm_card(choice=choice, user_name=user_name)
+            response.card = card
+        return response
 
     def _handle_approval_card_action(self, *, event: Any, action_value: Dict[str, Any], loop: Any) -> Any:
         """Schedule approval resolution and build the synchronous callback response."""
@@ -2696,6 +2948,66 @@ class FeishuAdapter(BasePlatformAdapter):
             card.data = self._build_resolved_update_prompt_card(answer=answer, user_name=user_name)
             response.card = card
         return response
+
+    async def _resolve_slash_confirm(
+        self,
+        confirm_id: str,
+        choice: str,
+        user_name: str,
+        *,
+        open_id: str = "",
+        user_id: str = "",
+        chat_id: str = "",
+    ) -> None:
+        """Resolve a Feishu slash-confirm button click through the core primitive."""
+        state = self._slash_confirm_state.get(confirm_id)
+        if not state:
+            logger.debug("[Feishu] Slash confirm %s already resolved or unknown", confirm_id)
+            return
+        expected_chat_id = str(state.get("chat_id", "") or "")
+        if expected_chat_id and chat_id and expected_chat_id != chat_id:
+            logger.warning(
+                "[Feishu] Slash confirm %s chat mismatch (expected=%s, got=%s)",
+                confirm_id,
+                expected_chat_id,
+                chat_id,
+            )
+            return
+        if not self._slash_confirm_operator_allowed(
+            state=state,
+            open_id=open_id,
+            user_id=user_id,
+            chat_id=expected_chat_id,
+        ):
+            logger.warning(
+                "[Feishu] Unauthorized slash confirm click by %s for confirm %s",
+                open_id or user_id or "<unknown>",
+                confirm_id,
+            )
+            return
+
+        state = self._slash_confirm_state.pop(confirm_id, None)
+        if not state:
+            logger.debug("[Feishu] Slash confirm %s already resolved while validating callback", confirm_id)
+            return
+
+        session_key = str(state.get("session_key", "") or "")
+        metadata = state.get("metadata") if isinstance(state.get("metadata"), dict) else None
+        try:
+            from tools import slash_confirm as _slash_confirm_mod
+            result_text = await _slash_confirm_mod.resolve(session_key, confirm_id, choice)
+            logger.info(
+                "Feishu slash confirm resolved for session %s (choice=%s, user=%s)",
+                session_key, choice, user_name,
+            )
+            if result_text:
+                await self.send(
+                    chat_id=str(state.get("chat_id", "") or expected_chat_id),
+                    content=result_text,
+                    metadata=metadata,
+                )
+        except Exception as exc:
+            logger.error("Failed to resolve Feishu slash confirm: %s", exc)
 
     async def _resolve_approval(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6611,24 +6611,37 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.info("STOP for session %s — agent interrupted, session lock released", _quick_key)
                 return EphemeralReply(t("gateway.stop.stopped"))
 
-            # /reset and /new must bypass the running-agent guard so they
-            # actually dispatch as commands instead of being queued as user
-            # text (which would be fed back to the agent with the same
-            # broken history — #2170).  Interrupt the agent first, then
-            # clear the adapter's pending queue so the stale "/reset" text
-            # doesn't get re-processed as a user message after the
-            # interrupt completes.
+            # /reset and /new must bypass the generic running-agent guard so
+            # they actually dispatch as commands instead of being queued as
+            # user text (which would be fed back to the agent with the same
+            # broken history — #2170).  They are still destructive session
+            # boundary operations, so route through the same slash-confirm
+            # gate used on the cold path; only interrupt/reset after the user
+            # approves the card/text prompt.
             if _cmd_def_inner and _cmd_def_inner.name == "new":
-                # Clear any pending messages so the old text doesn't replay
-                await self._interrupt_and_clear_session(
-                    _quick_key,
-                    source,
-                    interrupt_reason=_INTERRUPT_REASON_RESET,
-                    invalidation_reason="new_command",
+                async def _do_interrupt_and_reset():
+                    # Clear any pending messages so the old text doesn't replay.
+                    await self._interrupt_and_clear_session(
+                        _quick_key,
+                        source,
+                        interrupt_reason=_INTERRUPT_REASON_RESET,
+                        invalidation_reason="new_command",
+                    )
+                    # Clean up the running agent entry so the reset handler
+                    # doesn't think an agent is still active.
+                    return await self._handle_reset_command(event)
+
+                return await self._maybe_confirm_destructive_slash(
+                    event=event,
+                    command="new",
+                    title="/new",
+                    detail=(
+                        "This interrupts the currently running task, starts a "
+                        "fresh session, and discards the current conversation "
+                        "history."
+                    ),
+                    execute=_do_interrupt_and_reset,
                 )
-                # Clean up the running agent entry so the reset handler
-                # doesn't think an agent is still active.
-                return await self._handle_reset_command(event)
 
             # /queue <prompt> — queue without interrupting.
             # Semantics: each /queue invocation produces its own full agent

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10697,6 +10697,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         adapter = self.adapters.get(source.platform)
         metadata = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
+        metadata = dict(metadata or {})
+        if getattr(source, "user_id", None):
+            metadata["slash_confirm_requester_user_id"] = str(source.user_id)
+        if getattr(source, "user_id_alt", None):
+            metadata["slash_confirm_requester_user_id_alt"] = str(source.user_id_alt)
 
         used_buttons = False
         if adapter is not None:

--- a/tests/gateway/test_destructive_slash_confirm.py
+++ b/tests/gateway/test_destructive_slash_confirm.py
@@ -64,6 +64,7 @@ def _make_runner():
     runner.session_store.rewrite_transcript = MagicMock()
 
     runner._running_agents = {}
+    runner._running_agents_ts = {}
     runner._pending_messages = {}
     import itertools as _it
     runner._slash_confirm_counter = _it.count(1)
@@ -286,3 +287,54 @@ async def test_resolve_always_persists_opt_out_and_runs_execute(monkeypatch):
     assert resolved is not None
     assert "✨ fresh" in resolved
     assert "config.yaml" in resolved
+
+
+@pytest.mark.asyncio
+async def test_active_new_requests_confirm_before_interrupting_or_resetting():
+    """When /new arrives while an agent is running, it must still use the
+    destructive slash-confirm gate.  The running agent is interrupted only
+    after the user approves the card/text prompt, not when the command first
+    arrives.
+    """
+    from tools import slash_confirm as _slash_confirm_mod
+
+    runner = _make_runner()
+    source = _make_source()
+    session_key = build_session_key(source)
+    event = MessageEvent(text="/new", source=source, message_id="m-active-new")
+
+    runner._session_key_for_source = lambda source: session_key
+    runner._is_user_authorized = lambda source: True
+    runner._check_slash_access = lambda source, canonical_cmd: None
+    runner._read_user_config = lambda: {"approvals": {"destructive_slash_confirm": True}}
+    runner.adapters[Platform.TELEGRAM].send_slash_confirm = AsyncMock(
+        return_value=SimpleNamespace(success=True)
+    )
+    runner._running_agents = {session_key: object()}
+    runner._running_agents_ts = {}
+    runner._interrupt_and_clear_session = AsyncMock()
+    runner._handle_reset_command = AsyncMock(return_value="✨ reset after approval")
+    _slash_confirm_mod.clear(session_key)
+
+    result = await runner._handle_message(event)
+
+    assert result is None
+    runner._interrupt_and_clear_session.assert_not_awaited()
+    runner._handle_reset_command.assert_not_awaited()
+    pending = _slash_confirm_mod.get_pending(session_key)
+    assert pending is not None
+    assert pending["command"] == "new"
+
+    resolved = await _slash_confirm_mod.resolve(
+        session_key, pending["confirm_id"], "once",
+    )
+
+    runner._interrupt_and_clear_session.assert_awaited_once_with(
+        session_key,
+        source,
+        interrupt_reason="Session reset requested",
+        invalidation_reason="new_command",
+    )
+    runner._handle_reset_command.assert_awaited_once_with(event)
+    assert resolved == "✨ reset after approval"
+    _slash_confirm_mod.clear(session_key)

--- a/tests/gateway/test_destructive_slash_confirm.py
+++ b/tests/gateway/test_destructive_slash_confirm.py
@@ -153,6 +153,33 @@ async def test_gate_on_pending_confirm_registered(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_button_path_passes_requester_metadata_without_text_fallback():
+    """Button-capable adapters get requester metadata for callback auth and
+    suppress the text fallback when card delivery succeeds."""
+    runner = _make_runner()
+    runner._read_user_config = lambda: {"approvals": {"destructive_slash_confirm": True}}
+    session_key = build_session_key(_make_source())
+    runner._session_key_for_source = lambda src: session_key
+    runner.adapters[Platform.TELEGRAM].send_slash_confirm = AsyncMock(
+        return_value=SimpleNamespace(success=True)
+    )
+
+    execute = AsyncMock(return_value="reset done")
+    result = await runner._maybe_confirm_destructive_slash(
+        event=_make_event("/new"),
+        command="new",
+        title="/new",
+        detail="Discards history.",
+        execute=execute,
+    )
+
+    assert result is None
+    execute.assert_not_awaited()
+    kwargs = runner.adapters[Platform.TELEGRAM].send_slash_confirm.call_args.kwargs
+    assert kwargs["metadata"]["slash_confirm_requester_user_id"] == "u1"
+
+
+@pytest.mark.asyncio
 async def test_resolve_once_runs_execute_and_returns_result():
     """Resolving the pending confirm with 'once' runs the destructive
     action and returns its output."""

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -51,6 +51,10 @@ def _make_adapter() -> FeishuAdapter:
     config = PlatformConfig(enabled=True)
     adapter = FeishuAdapter(config)
     adapter._client = MagicMock()
+    # Keep callback authorization tests deterministic regardless of the
+    # developer machine's FEISHU_GROUP_POLICY environment.
+    adapter._group_policy = "allowlist"
+    adapter._default_group_policy = "allowlist"
     return adapter
 
 
@@ -58,6 +62,7 @@ def _make_card_action_data(
     action_value: dict,
     chat_id: str = "oc_12345",
     open_id: str = "ou_user1",
+    user_id: str = "",
     token: str = "tok_abc",
 ) -> SimpleNamespace:
     """Create a mock Feishu card action callback data object."""
@@ -65,7 +70,7 @@ def _make_card_action_data(
         event=SimpleNamespace(
             token=token,
             context=SimpleNamespace(open_chat_id=chat_id),
-            operator=SimpleNamespace(open_id=open_id),
+            operator=SimpleNamespace(open_id=open_id, user_id=user_id),
             action=SimpleNamespace(
                 tag="button",
                 value=action_value,
@@ -301,6 +306,112 @@ class TestFeishuUpdatePrompt:
 
         assert result.success is False
         assert "timed out" in (result.error or "")
+
+
+# ===========================================================================
+# send_slash_confirm — generic slash confirmation card
+# ===========================================================================
+
+class TestFeishuSlashConfirm:
+    """Test generic slash-confirm Feishu cards."""
+
+    @pytest.mark.asyncio
+    async def test_sends_interactive_card_and_stores_state(self):
+        adapter = _make_adapter()
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_sc_001"),
+        )
+
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_send:
+            result = await adapter.send_slash_confirm(
+                chat_id="oc_12345",
+                title="⚠️ Confirm /new",
+                message="Proceed with **/new**?",
+                session_key="sess-sc-1",
+                confirm_id="confirm-1",
+                metadata={"thread_id": "th_1", "slash_confirm_requester_user_id": "ou_owner"},
+            )
+
+        assert result.success is True
+        assert result.message_id == "msg_sc_001"
+        kwargs = mock_send.call_args[1]
+        assert kwargs["chat_id"] == "oc_12345"
+        assert kwargs["msg_type"] == "interactive"
+        assert kwargs["metadata"] == {"thread_id": "th_1", "slash_confirm_requester_user_id": "ou_owner"}
+
+        card = json.loads(kwargs["payload"])
+        assert card["header"]["title"]["content"] == "⚠️ Confirm /new"
+        assert "Proceed with **/new**?" in card["elements"][0]["content"]
+        actions = card["elements"][1]["actions"]
+        assert [a["value"]["hermes_slash_confirm_action"] for a in actions] == ["once", "always", "cancel"]
+        assert [a["value"]["slash_confirm_id"] for a in actions] == ["confirm-1"] * 3
+        assert all("session_key" not in a["value"] for a in actions)
+
+        state = adapter._slash_confirm_state["confirm-1"]
+        assert state["session_key"] == "sess-sc-1"
+        assert state["message_id"] == "msg_sc_001"
+        assert state["chat_id"] == "oc_12345"
+        assert state["metadata"]["slash_confirm_requester_user_id"] == "ou_owner"
+
+    @pytest.mark.asyncio
+    async def test_send_failure_cleans_state_for_gateway_text_fallback(self):
+        adapter = _make_adapter()
+        with patch.object(
+            adapter, "_feishu_send_with_retry", new_callable=AsyncMock,
+            side_effect=TimeoutError("timed out"),
+        ):
+            result = await adapter.send_slash_confirm(
+                chat_id="oc_12345",
+                title="Confirm",
+                message="Proceed?",
+                session_key="sess-sc-2",
+                confirm_id="confirm-2",
+            )
+
+        assert result.success is False
+        assert "timed out" in (result.error or "")
+        assert "confirm-2" not in adapter._slash_confirm_state
+
+    @pytest.mark.asyncio
+    async def test_resolve_calls_core_and_sends_followup(self):
+        from tools import slash_confirm
+
+        adapter = _make_adapter()
+        adapter._allowed_group_users = {"ou_owner"}
+        adapter._slash_confirm_state["confirm-3"] = {
+            "session_key": "sess-sc-3",
+            "message_id": "msg_sc_003",
+            "chat_id": "oc_12345",
+            "metadata": {"thread_id": "th_3", "slash_confirm_requester_user_id": "ou_owner"},
+            "created_at": 9999999999,
+        }
+
+        async def _handler(choice):
+            return f"resolved:{choice}"
+
+        slash_confirm.register("sess-sc-3", "confirm-3", "new", _handler)
+        try:
+            with patch.object(adapter, "send", new_callable=AsyncMock) as mock_send:
+                await adapter._resolve_slash_confirm(
+                    "confirm-3",
+                    "once",
+                    "Owner",
+                    open_id="ou_owner",
+                    chat_id="oc_12345",
+                )
+        finally:
+            slash_confirm.clear("sess-sc-3")
+
+        assert "confirm-3" not in adapter._slash_confirm_state
+        mock_send.assert_awaited_once_with(
+            chat_id="oc_12345",
+            content="resolved:once",
+            metadata={"thread_id": "th_3", "slash_confirm_requester_user_id": "ou_owner"},
+        )
 
 
 # ===========================================================================
@@ -801,6 +912,104 @@ class TestCardActionCallbackResponse:
         assert response is not None
         assert response.card is None
         assert 8 in adapter._update_prompt_state
+        mock_submit.assert_not_called()
+
+    def test_returns_card_for_slash_confirm_once(self, _patch_callback_card_types):
+        from tools import slash_confirm
+
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_bob"}
+        adapter._slash_confirm_state["sc-1"] = {
+            "session_key": "sess-sc-1",
+            "message_id": "msg_sc_001",
+            "chat_id": "oc_12345",
+            "metadata": {"slash_confirm_requester_user_id": "ou_bob"},
+            "created_at": 9999999999,
+        }
+        slash_confirm.register("sess-sc-1", "sc-1", "new", AsyncMock(return_value="done"))
+        data = _make_card_action_data(
+            {"hermes_slash_confirm_action": "once", "slash_confirm_id": "sc-1"},
+            open_id="ou_bob",
+        )
+        adapter._sender_name_cache["ou_bob"] = ("Bob", 9999999999)
+
+        try:
+            with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro) as mock_submit:
+                response = adapter._on_card_action_trigger(data)
+        finally:
+            slash_confirm.clear("sess-sc-1")
+
+        assert response is not None
+        assert response.card is not None
+        mock_submit.assert_called_once()
+        card = response.card.data
+        assert card["header"]["template"] == "green"
+        assert "Approved once" in card["header"]["title"]["content"]
+        assert "Bob" in card["elements"][0]["content"]
+
+    def test_rejects_slash_confirm_click_from_non_requester(self, _patch_callback_card_types):
+        from tools import slash_confirm
+
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._allowed_group_users = {"ou_owner", "ou_intruder"}
+        adapter._slash_confirm_state["sc-2"] = {
+            "session_key": "sess-sc-2",
+            "message_id": "msg_sc_002",
+            "chat_id": "oc_12345",
+            "metadata": {"slash_confirm_requester_user_id": "ou_owner"},
+            "created_at": 9999999999,
+        }
+        slash_confirm.register("sess-sc-2", "sc-2", "new", AsyncMock(return_value="done"))
+        data = _make_card_action_data(
+            {"hermes_slash_confirm_action": "always", "slash_confirm_id": "sc-2"},
+            open_id="ou_intruder",
+        )
+
+        try:
+            with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+                response = adapter._on_card_action_trigger(data)
+        finally:
+            slash_confirm.clear("sess-sc-2")
+
+        assert response is not None
+        assert response.card is None
+        assert "sc-2" in adapter._slash_confirm_state
+        mock_submit.assert_not_called()
+
+    def test_slash_confirm_superseded_card_returns_expired_state(self, _patch_callback_card_types):
+        from tools import slash_confirm
+
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._slash_confirm_state["old"] = {
+            "session_key": "sess-sc-3",
+            "message_id": "msg_old",
+            "chat_id": "oc_12345",
+            "metadata": {"slash_confirm_requester_user_id": "ou_owner"},
+            "created_at": 9999999999,
+        }
+        slash_confirm.register("sess-sc-3", "new", "new", AsyncMock(return_value="new"))
+        data = _make_card_action_data(
+            {"hermes_slash_confirm_action": "once", "slash_confirm_id": "old"},
+            open_id="ou_owner",
+        )
+
+        try:
+            with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+                response = adapter._on_card_action_trigger(data)
+        finally:
+            slash_confirm.clear("sess-sc-3")
+
+        assert response is not None
+        assert response.card is not None
+        assert response.card.data["header"]["template"] == "grey"
+        assert "expired" in response.card.data["header"]["title"]["content"].lower()
+        assert "old" not in adapter._slash_confirm_state
         mock_submit.assert_not_called()
 
 


### PR DESCRIPTION
## Summary
- Implement Feishu/Lark `send_slash_confirm` so generic slash-command confirmations render as interactive cards instead of text fallback.
- Route Feishu slash-confirm card callbacks through `tools.slash_confirm.resolve(...)`, send follow-up results back to the original chat/thread, and update the card inline after button clicks.
- Add callback safety checks for pending-confirm match, chat mismatch, requester/admin authorization, stale/superseded cards, and send-failure fallback.
- Pass requester metadata from the gateway slash-confirm primitive to button-capable adapters for platform callback authorization.

## Test Plan
- `./venv/bin/python -m py_compile gateway/platforms/feishu.py gateway/run.py tests/gateway/test_feishu_approval_buttons.py tests/gateway/test_destructive_slash_confirm.py`
- `./venv/bin/python -m pytest tests/gateway/test_feishu_approval_buttons.py tests/gateway/test_destructive_slash_confirm.py tests/tools/test_slash_confirm.py -q -o 'addopts='`

## Notes
This makes Feishu consistent with other button-capable platforms: button UI is used when card delivery succeeds, and the existing text fallback remains available if card delivery fails.