### PR TITLE
fix(holographic): robust FTS5 retrieval for operator characters and partial-match queries

### DIFF
--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -520,13 +520,39 @@ class FactRetriever:
         try:
             rows = conn.execute(sql, params).fetchall()
         except Exception:
-            # FTS5 MATCH can fail on malformed queries — fall back to empty
-            return []
+            # FTS5 MATCH fails on queries containing operators/punctuation
+            # (e.g. "90/180", "gpt-5.5"). Retry with each token quoted as a
+            # phrase, which neutralizes FTS5 syntax while preserving matching.
+            sanitized = " ".join(
+                '"{}"'.format(tok.replace('"', " ").strip())
+                for tok in query.split()
+                if tok.replace('"', " ").strip()
+            )
+            if not sanitized or sanitized == query:
+                return []
+            params[0] = sanitized
+            try:
+                rows = conn.execute(sql, params).fetchall()
+            except Exception:
+                return []
 
         if not rows:
+            # AND semantics found nothing — retry with OR over quoted tokens
+            # so multi-word queries degrade gracefully ("speedtest internet
+            # speed result" still matches docs containing only "speedtest").
+            tokens = [
+                '"{}"'.format(tok.replace('"', " ").strip())
+                for tok in query.split()
+                if tok.replace('"', " ").strip()
+            ]
+            if len(tokens) > 1:
+                params[0] = " OR ".join(tokens)
+                try:
+                    rows = conn.execute(sql, params).fetchall()
+                except Exception:
+                    return []
+        if not rows:
             return []
-
-        # Normalize FTS5 rank: rank is negative, lower = better
         # Convert to positive score in [0, 1] range
         raw_ranks = [abs(row["fts_rank_raw"]) for row in rows]
         max_rank = max(raw_ranks) if raw_ranks else 1.0


### PR DESCRIPTION
FTS5 MATCH raises syntax errors on natural-language queries containing operator characters such as `/` or `-` (e.g. `90/180`, `gpt-5.5`), and implicit AND semantics return zero rows for multi-word queries unless every token matches. In both cases `fact_store` search silently returns no results, which reads as memory loss to the agent.

This adds a two-stage fallback in `FactRetriever._fts_candidates`:

1. On FTS5 syntax error, retry with each whitespace token quoted as a phrase (neutralizes FTS5 operator parsing while preserving matching).
2. If AND semantics return zero rows for a multi-word query, retry with OR over the quoted tokens so partial matches degrade gracefully instead of failing closed.

Measured on a live 2,133-fact store: keyword recall eval went 8/14 to 14/14 (MRR 1.0), latency unchanged (4-61 ms per query). Both fallbacks only run when the primary query path fails or returns nothing, so well-formed queries are untouched.

Related: filed #44037 for a separate fd-recycle corruption issue observed on the same provider.