### PR TITLE
fix(cron): clarify local delivery behavior

### DIFF
--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -557,7 +557,7 @@ function CronJobDetail({
                 <div className="flex flex-wrap items-center gap-2">
                   <h3 className="text-xl font-semibold tracking-tight">{jobTitle(job)}</h3>
                   <StatePill tone={STATE_TONE[state] ?? 'muted'}>{c.states[state] ?? state}</StatePill>
-                  {deliver && deliver !== DEFAULT_DELIVER && (
+                  {deliver && (
                     <StatePill tone="muted">{c.deliveryLabels[deliver] ?? deliver}</StatePill>
                   )}
                 </div>

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -939,7 +939,7 @@ export const en: Translations = {
       completed: 'completed'
     },
     deliveryLabels: {
-      local: 'This desktop',
+      local: 'Local (save only)',
       telegram: 'Telegram',
       discord: 'Discord',
       slack: 'Slack',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1071,7 +1071,7 @@ export const ja = defineLocale({
       completed: '完了'
     },
     deliveryLabels: {
-      local: 'このデスクトップ',
+      local: 'ローカルに保存のみ',
       telegram: 'Telegram',
       discord: 'Discord',
       slack: 'Slack',

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1038,7 +1038,7 @@ export const zhHant = defineLocale({
       completed: '已完成'
     },
     deliveryLabels: {
-      local: '此桌面',
+      local: '僅本機儲存',
       telegram: 'Telegram',
       discord: 'Discord',
       slack: 'Slack',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1126,7 +1126,7 @@ export const zh: Translations = {
       completed: '已完成'
     },
     deliveryLabels: {
-      local: '此桌面',
+      local: '仅本地保存',
       telegram: 'Telegram',
       discord: 'Discord',
       slack: 'Slack',

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1128,18 +1128,36 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                 # silent skip — do not pollute the prompt with error messages
 
     # Always prepend cron execution guidance so the agent knows how
-    # delivery works and can suppress delivery when appropriate.
-    cron_hint = (
-        "[IMPORTANT: You are running as a scheduled cron job. "
-        "DELIVERY: Your final response will be automatically delivered "
-        "to the user — do NOT use send_message or try to deliver "
-        "the output yourself. Just produce your report/output as your "
-        "final response and the system handles the rest. "
-        "SILENT: If there is genuinely nothing new to report, respond "
-        "with exactly \"[SILENT]\" (nothing else) to suppress delivery. "
-        "Never combine [SILENT] with content — either report your "
-        "findings normally, or say [SILENT] and nothing more.]\n\n"
-    )
+    # delivery works and can suppress delivery when appropriate.  Local-only
+    # jobs are persisted to run history/output files but are intentionally not
+    # sent to a chat target, so avoid telling the agent that delivery will
+    # happen automatically.
+    if _normalize_deliver_value(job.get("deliver", "local")).strip().lower() == "local":
+        cron_hint = (
+            "[IMPORTANT: You are running as a scheduled cron job. "
+            "DELIVERY: This job is configured for local-only output. "
+            "Your final response will be saved to the cron run history/output file; "
+            "it will not be sent as a chat or platform message. "
+            "Do not use send_message unless the user's prompt explicitly asks you "
+            "to notify a separate destination. Put the primary content directly "
+            "in your final response so it is visible when the user opens the run. "
+            "SILENT: If there is genuinely nothing new to report, respond "
+            "with exactly \"[SILENT]\" (nothing else) to suppress delivery. "
+            "Never combine [SILENT] with content — either report your "
+            "findings normally, or say [SILENT] and nothing more.]\n\n"
+        )
+    else:
+        cron_hint = (
+            "[IMPORTANT: You are running as a scheduled cron job. "
+            "DELIVERY: Your final response will be automatically delivered "
+            "to the user — do NOT use send_message or try to deliver "
+            "the output yourself. Just produce your report/output as your "
+            "final response and the system handles the rest. "
+            "SILENT: If there is genuinely nothing new to report, respond "
+            "with exactly \"[SILENT]\" (nothing else) to suppress delivery. "
+            "Never combine [SILENT] with content — either report your "
+            "findings normally, or say [SILENT] and nothing more.]\n\n"
+        )
     prompt = cron_hint + prompt
     if skills is None:
         legacy = job.get("skill")

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1990,18 +1990,26 @@ class TestBuildJobPromptSilentHint:
         result = _build_job_prompt(job)
         assert "[SILENT]" in result
 
-    def test_delivery_guidance_present(self):
+    def test_delivery_guidance_present_for_delivery_targets(self):
         """Cron hint tells agents their final response is auto-delivered."""
-        job = {"prompt": "Generate a report"}
+        job = {"prompt": "Generate a report", "deliver": "origin"}
         result = _build_job_prompt(job)
         assert "do NOT use send_message" in result
         assert "automatically delivered" in result
+
+    def test_local_delivery_guidance_says_saved_locally(self):
+        """Local-only jobs are saved, not delivered as chat messages."""
+        job = {"prompt": "Generate a report", "deliver": "local"}
+        result = _build_job_prompt(job)
+        assert "local-only output" in result
+        assert "saved to the cron run history/output file" in result
+        assert "automatically delivered" not in result
 
     def test_delivery_guidance_precedes_user_prompt(self):
         """System guidance appears before the user's prompt text."""
         job = {"prompt": "My custom prompt"}
         result = _build_job_prompt(job)
-        system_pos = result.index("do NOT use send_message")
+        system_pos = result.index("DELIVERY:")
         prompt_pos = result.index("My custom prompt")
         assert system_pos < prompt_pos
 

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -256,7 +256,7 @@ When scheduling jobs, you specify where the output goes:
 | `"telegram,discord"` | Fan out to a specific set of channels | Comma-separated list |
 | `"origin,all"` | Deliver to the origin **plus** every other connected channel | Combine any tokens |
 
-The agent's final response is automatically delivered. You do not need to call `send_message` in the cron prompt.
+For non-local delivery targets, the agent's final response is automatically delivered. You do not need to call `send_message` in the cron prompt. `deliver="local"` is save-only: output is written to local cron history/output files, but no chat or platform message is sent.
 
 ### Routing intent (`all`)
 
@@ -431,7 +431,7 @@ This means cron jobs that run at high frequency or during peak hours are more re
 
 ## Schedule formats
 
-The agent's final response is automatically delivered — you do **not** need to include `send_message` in the cron prompt for that same destination. If a cron run calls `send_message` to the exact target the scheduler will already deliver to, Hermes skips that duplicate send and tells the model to put the user-facing content in the final response instead. Use `send_message` only for additional or different targets.
+For non-local delivery targets, the agent's final response is automatically delivered — you do **not** need to include `send_message` in the cron prompt for that same destination. If a cron run calls `send_message` to the exact target the scheduler will already deliver to, Hermes skips that duplicate send and tells the model to put the user-facing content in the final response instead. `deliver="local"` saves output locally only; use `send_message` only when the user's task explicitly asks for an additional or different target.
 
 ### Relative delays (one-shot)
 


### PR DESCRIPTION
## Summary
- distinguish `deliver=local` cron jobs in the runtime prompt as save-only instead of saying they will be automatically delivered
- relabel Desktop cron's local destination as `Local (save only)` and show the delivery pill for local jobs
- update cron docs and regression tests so local delivery semantics stay explicit

## Test plan
- `python -m pytest tests/cron/test_scheduler.py -q -o 'addopts='`
- `python -m pytest -q -o 'addopts=' tests/cron/test_scheduler.py::TestBuildJobPromptSilentHint tests/cron/test_scheduler.py::TestResolveDeliveryTarget tests/cron/test_scheduler.py::TestDeliverResultErrorReturns`
- `npx eslint src/app/cron/index.tsx src/i18n/en.ts src/i18n/ja.ts src/i18n/zh-hant.ts src/i18n/zh.ts`
- `npm run typecheck --workspace apps/desktop`
- `npm run test:ui --workspace apps/desktop -- src/i18n/runtime.test.ts`
