### PR TITLE
fix(desktop): recover stale session before stop

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
@@ -42,6 +42,7 @@ function sessionInfo(overrides: Partial<SessionInfo> = {}): SessionInfo {
 }
 
 interface HarnessHandle {
+  cancelRun: () => Promise<void>
   steerPrompt: (text: string) => Promise<boolean>
   submitText: (
     text: string,
@@ -102,8 +103,12 @@ function Harness({
   })
 
   useEffect(() => {
-    onReady({ steerPrompt: actions.steerPrompt, submitText: actions.submitText })
-  }, [actions.steerPrompt, actions.submitText, onReady])
+    onReady({
+      cancelRun: actions.cancelRun,
+      steerPrompt: actions.steerPrompt,
+      submitText: actions.submitText
+    })
+  }, [actions.cancelRun, actions.steerPrompt, actions.submitText, onReady])
 
   return null
 }
@@ -629,6 +634,43 @@ describe('usePromptActions sleep/wake session recovery', () => {
     expect(calls[2]?.params).toEqual({ session_id: RECOVERED_SESSION_ID, text: 'message after wake' })
   })
 
+  it('resumes the stored session and retries once when session.interrupt reports "session not found"', async () => {
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+    let interruptAttempts = 0
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+      if (method === 'session.interrupt') {
+        interruptAttempts += 1
+        if (interruptAttempts === 1) {
+          throw new Error('session not found')
+        }
+        return {} as never
+      }
+      if (method === 'session.resume') {
+        return { session_id: RECOVERED_SESSION_ID } as never
+      }
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        storedSessionId={STORED_SESSION_ID}
+      />
+    )
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await handle!.cancelRun()
+
+    expect(calls.map(c => c.method)).toEqual(['session.interrupt', 'session.resume', 'session.interrupt'])
+    expect(calls[0]?.params).toEqual({ session_id: RUNTIME_SESSION_ID })
+    expect(calls[1]?.params).toEqual({ session_id: STORED_SESSION_ID })
+    expect(calls[2]?.params).toEqual({ session_id: RECOVERED_SESSION_ID })
+  })
+
   it('surfaces the original error (no resume) when the failure is not "session not found"', async () => {
     const calls: string[] = []
     const states: Record<string, unknown>[] = []
@@ -818,4 +860,3 @@ describe('uploadComposerAttachment remote read failures', () => {
     ).rejects.toThrow('ENOENT: no such file')
   })
 })
-

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -108,6 +108,12 @@ function inlineErrorMessage(error: unknown, fallback: string): string {
   return (raw.match(/Error invoking remote method '[^']+': Error: (.+)$/)?.[1] ?? raw).replace(/^Error:\s*/, '').trim()
 }
 
+function isSessionNotFoundError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+
+  return /session not found/i.test(message)
+}
+
 function base64FromDataUrl(dataUrl: string): string {
   const comma = dataUrl.indexOf(',')
 
@@ -661,9 +667,7 @@ export function usePromptActions({
         try {
           await requestGateway('prompt.submit', { session_id: sessionId, text })
         } catch (firstErr) {
-          const firstMsg = firstErr instanceof Error ? firstErr.message : String(firstErr)
-
-          if (/session not found/i.test(firstMsg) && selectedStoredSessionIdRef.current) {
+          if (isSessionNotFoundError(firstErr) && selectedStoredSessionIdRef.current) {
             // Re-register the session in the gateway and get a fresh live ID.
             const resumed = await requestGateway<{ session_id: string }>('session.resume', {
               session_id: selectedStoredSessionIdRef.current
@@ -1273,11 +1277,39 @@ export function usePromptActions({
     try {
       await requestGateway('session.interrupt', { session_id: sessionId })
     } catch (err) {
+      let stopError = err
+
+      if (isSessionNotFoundError(err) && selectedStoredSessionIdRef.current) {
+        try {
+          const resumed = await requestGateway<{ session_id: string }>('session.resume', {
+            session_id: selectedStoredSessionIdRef.current
+          })
+          const recoveredId = resumed?.session_id
+
+          if (recoveredId) {
+            activeSessionIdRef.current = recoveredId
+            await requestGateway('session.interrupt', { session_id: recoveredId })
+
+            return
+          }
+        } catch (resumeErr) {
+          stopError = resumeErr
+        }
+      }
+
       setMutableRef(busyRef, false)
       setBusy(false)
-      notifyError(err, copy.stopFailed)
+      notifyError(stopError, copy.stopFailed)
     }
-  }, [activeSessionId, activeSessionIdRef, busyRef, copy.stopFailed, requestGateway, updateSessionState])
+  }, [
+    activeSessionId,
+    activeSessionIdRef,
+    busyRef,
+    copy.stopFailed,
+    requestGateway,
+    selectedStoredSessionIdRef,
+    updateSessionState
+  ])
 
   // Steer = nudge the live turn without interrupting: the gateway appends the
   // text to the next tool result so the model reads it on its next iteration


### PR DESCRIPTION
## What does this PR do?

Salvages the desktop stop-recovery fix from #43941 onto current `main`, dropping the unrelated `package-lock.json` / `nix/lib.nix` churn that was failing CI.

Desktop already recovers from a stale runtime session id when `prompt.submit` returns `session not found` after a gateway restart or sleep/wake. The stop path did not have the same recovery: `cancelRun` called `session.interrupt` once with the stale runtime id, then surfaced `Stop failed / session not found`.

This makes stop/cancel mirror the prompt recovery path. If `session.interrupt` reports `session not found` and the selected stored session id is available, Desktop resumes that durable session, updates the active runtime ref with the recovered id, and retries `session.interrupt` once against the recovered runtime id.

## Why this is a salvage rather than the original PR

The original #43941 also bumped `@types/node` 24.13.1 → 24.13.2 in `package-lock.json` and updated the `npmDepsHash` in `nix/lib.nix`. That bump is **not** required:

- It is a local **npm 11** re-resolution artifact (`npm install` re-resolves the `^24.12.0` range to the newest patch). The repo's CI runs **node 22 / npm 10**, where `npm ci` installs the lockfile deterministically.
- `main` is green at `@types/node@24.13.1`, and the desktop typecheck + UI tests pass against the unchanged lockfile (verified locally).
- The committed `npmDepsHash` in #43941 was also wrong, which is what turned the `nix (ubuntu-latest)` check red.

Keeping only the two `apps/desktop` files makes this single-concern and CI-clean.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-prompt-actions.ts`: extract shared `isSessionNotFoundError` detection and retry `session.interrupt` through `session.resume` when a stale runtime id is recoverable.
- `apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx`: add coverage for the stale-session stop recovery path.

## How to Test

1. `npm install -w apps/desktop --include=dev`
2. `npm --workspace apps/desktop run test:ui -- src/app/session/hooks/use-prompt-actions.test.tsx`
3. `npm --workspace apps/desktop run typecheck`

## Verification (local, on the actual artifact)

- UI tests: `use-prompt-actions.test.tsx` — **26/26 passed** (incl. the new stop-recovery test).
- `tsc -p apps/desktop --noEmit` — **clean (exit 0)**.
- `package-lock.json` and `nix/lib.nix` are byte-identical to `main`.

## Checklist

- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I have added tests for my changes
- [x] I have tested on my platform: macOS desktop workspace npm toolchain

Co-authored-by: helix4u <4317663+helix4u@users.noreply.github.com>
