### PR TITLE
fix(cron): defer desktop ticker to gateway scheduler owner

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -289,6 +289,34 @@ def _get_lock_paths() -> tuple[Path, Path]:
     return lock_dir, lock_dir / ".tick.lock"
 
 
+def _gateway_scheduler_owner_active() -> bool:
+    """Return True when a gateway process owns the scheduler for this profile.
+
+    The gateway runtime lock is per-HERMES_HOME (i.e. per profile), held for
+    the live gateway's lifetime and released by the OS if that process dies, so
+    a stale lock never lingers. When it is held, the launchd/systemd-managed
+    gateway is the authoritative scheduler owner for the profile.
+
+    This is the ownership signal the ``.tick.lock`` does not provide: the tick
+    lock only gives at-most-once execution, but says nothing about *which*
+    process runs the job. On macOS that distinction is part of the security
+    model — TCC / Full Disk Access provenance depends on the executing process
+    ancestry — so a non-authoritative ticker (e.g. a Desktop dashboard backend)
+    must defer to the gateway rather than run jobs from the wrong ancestry.
+    """
+    try:
+        from gateway.status import is_gateway_runtime_lock_active
+        return is_gateway_runtime_lock_active()
+    except Exception:
+        # If the ownership signal is unavailable, fail open: behave as before
+        # (no owner detected) rather than blocking the only available ticker.
+        logger.debug(
+            "gateway scheduler-owner check failed; assuming no owner",
+            exc_info=True,
+        )
+        return False
+
+
 def _resolve_origin(job: dict) -> Optional[dict]:
     """Extract origin info from a job, preserving any extra routing metadata.
 
@@ -2127,21 +2155,44 @@ def _notify_provider_jobs_changed() -> None:
         logger.debug("on_jobs_changed notify failed: %s", e)
 
 
-def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> int:
+def tick(
+    verbose: bool = True,
+    adapters=None,
+    loop=None,
+    sync: bool = True,
+    *,
+    defer_to_gateway_owner: bool = False,
+) -> int:
     """
     Check and run all due jobs.
-    
+
     Uses a file lock so only one tick runs at a time, even if the gateway's
     in-process ticker and a standalone daemon or manual tick overlap.
-    
+
     Args:
         verbose: Whether to print status messages
         adapters: Optional dict mapping Platform → live adapter (from gateway)
         loop: Optional asyncio event loop (from gateway) for live adapter sends
-    
+        defer_to_gateway_owner: When True, skip execution entirely if a gateway
+            already owns the scheduler for this profile. Non-authoritative
+            tickers (e.g. the Desktop dashboard backend) pass True so that jobs
+            only ever execute from the authorised gateway process ancestry —
+            the ``.tick.lock`` alone gives at-most-once execution but not
+            deterministic provenance, which macOS TCC / Full Disk Access
+            requires. The gateway's own ticker leaves this False so it always
+            runs.
+
     Returns:
-        Number of jobs executed (0 if another tick is already running)
+        Number of jobs executed (0 if another tick is already running, or if
+        deferring to the gateway scheduler owner)
     """
+    if defer_to_gateway_owner and _gateway_scheduler_owner_active():
+        logger.info(
+            "Cron tick skipped — a gateway owns the scheduler for this profile; "
+            "deferring execution to preserve job provenance"
+        )
+        return 0
+
     lock_dir, lock_file = _get_lock_paths()
     lock_dir.mkdir(parents=True, exist_ok=True)
 

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -56,6 +56,7 @@ class CronScheduler(ABC):
         adapters: Any = None,
         loop: Any = None,
         interval: int = 60,
+        defer_to_gateway_owner: bool = False,
     ) -> None:
         """Begin firing due jobs.
 
@@ -63,6 +64,13 @@ class CronScheduler(ABC):
         (it is run inside a daemon thread by the caller, exactly as today).
         An external provider may register a schedule/webhook and return
         immediately; in that case it must still honor stop_event for teardown.
+
+        ``defer_to_gateway_owner``: a non-authoritative ticker (e.g. the Desktop
+        dashboard backend) passes True so it skips execution while a gateway
+        already owns the scheduler for this profile — the tick lock gives
+        at-most-once execution but not deterministic process provenance, which
+        macOS TCC / Full Disk Access requires. The gateway's own ticker leaves
+        it False. Providers that manage their own provenance may ignore it.
         """
 
     def stop(self) -> None:
@@ -163,7 +171,7 @@ class InProcessCronScheduler(CronScheduler):
     def name(self) -> str:
         return "builtin"
 
-    def start(self, stop_event, *, adapters=None, loop=None, interval=60):
+    def start(self, stop_event, *, adapters=None, loop=None, interval=60, defer_to_gateway_owner=False):
         import logging
         from cron.scheduler import tick as cron_tick
 
@@ -171,7 +179,13 @@ class InProcessCronScheduler(CronScheduler):
         logger.info("In-process cron scheduler started (interval=%ds)", interval)
         while not stop_event.is_set():
             try:
-                cron_tick(verbose=False, adapters=adapters, loop=loop, sync=False)
+                cron_tick(
+                    verbose=False,
+                    adapters=adapters,
+                    loop=loop,
+                    sync=False,
+                    defer_to_gateway_owner=defer_to_gateway_owner,
+                )
             except Exception as e:
                 logger.debug("Cron tick error: %s", e)
             stop_event.wait(interval)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -129,16 +129,20 @@ def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60
     scheduler provider here (no live adapters; delivery falls back to the
     per-platform send path).
 
-    Cross-process safe: the built-in provider's ``cron.scheduler.tick`` takes
-    the ``cron/.tick.lock`` file lock, so this never double-fires alongside a
-    real gateway on the same HERMES_HOME — whichever process grabs the lock
-    first wins the tick.
+    Defers to the gateway: ``cron/.tick.lock`` only gives at-most-once
+    execution — whichever process grabs it first runs the tick — which is not
+    enough on macOS, where TCC / Full Disk Access provenance depends on the
+    executing process ancestry. So we pass ``defer_to_gateway_owner=True``:
+    when a gateway already owns the scheduler for this profile, this ticker
+    skips execution and lets the authorised gateway process chain run the job.
+    Only when no gateway is running (a desktop-only setup) does this ticker
+    execute jobs itself.
     """
     from cron.scheduler_provider import resolve_cron_scheduler
 
     provider = resolve_cron_scheduler()
     _log.info("Desktop cron scheduler started (provider=%s, interval=%ds)", provider.name, interval)
-    provider.start(stop_event, interval=interval)
+    provider.start(stop_event, interval=interval, defer_to_gateway_owner=True)
 
 
 @asynccontextmanager

--- a/plugins/cron/chronos/__init__.py
+++ b/plugins/cron/chronos/__init__.py
@@ -100,11 +100,15 @@ class ChronosCronScheduler(CronScheduler):
 
     # -- lifecycle --------------------------------------------------------
 
-    def start(self, stop_event, *, adapters=None, loop=None, interval=60):
+    def start(self, stop_event, *, adapters=None, loop=None, interval=60, defer_to_gateway_owner=False):
         """Arm all enabled jobs via NAS, then RETURN immediately.
 
         Does NOT block and does NOT spawn a 60s wake (DQ-1) — that is the whole
         point of scale-to-zero. The machine wakes only on a NAS→agent fire.
+
+        ``defer_to_gateway_owner`` is accepted for interface parity but ignored:
+        an external scheduler owns execution provenance via the NAS→agent fire
+        chain, so there is no local non-authoritative ticker to defer.
         """
         try:
             self.reconcile()

--- a/tests/cron/test_scheduler_ownership.py
+++ b/tests/cron/test_scheduler_ownership.py
@@ -1,0 +1,101 @@
+"""Scheduler-ownership guard tests.
+
+A non-authoritative cron ticker (e.g. the Desktop dashboard backend) must
+defer to a gateway that already owns the scheduler for a profile, so jobs only
+ever execute from the authorised process ancestry. The ``.tick.lock`` alone
+gives at-most-once execution but not deterministic provenance, which macOS
+TCC / Full Disk Access depends on.
+"""
+
+import logging
+
+import pytest
+
+import cron.scheduler as sched
+
+
+def _make_job(job_id="job1"):
+    return {
+        "id": job_id, "name": job_id, "prompt": "test",
+        "schedule": "every 5m", "enabled": True,
+        "next_run_at": "2020-01-01T00:00:00", "deliver": "local",
+    }
+
+
+def _patch_run_path(monkeypatch, due):
+    """Patch the execution path so a due job runs end-to-end without I/O."""
+    monkeypatch.setattr(sched, "get_due_jobs", lambda: due)
+    monkeypatch.setattr(sched, "advance_next_run", lambda *_a, **_kw: None)
+    monkeypatch.setattr(sched, "save_job_output", lambda *_a, **_kw: "/tmp/out")
+    monkeypatch.setattr(sched, "mark_job_run", lambda *_a, **_kw: None)
+    monkeypatch.setattr(sched, "_deliver_result", lambda *_a, **_kw: None)
+    monkeypatch.setattr(sched, "run_job", lambda j: (True, "out", "resp", None))
+
+
+@pytest.fixture
+def reset_pools():
+    sched._parallel_pool = None
+    sched._parallel_pool_max_workers = None
+    sched._sequential_pool = None
+    sched._running_job_ids.clear()
+    yield
+    sched._shutdown_parallel_pool()
+    sched._running_job_ids.clear()
+
+
+class TestSchedulerOwnershipGuard:
+    def test_defer_when_gateway_owner_active_skips_execution(self, monkeypatch):
+        """defer_to_gateway_owner=True + a gateway owner → no jobs, no lock."""
+        monkeypatch.setattr(sched, "_gateway_scheduler_owner_active", lambda: True)
+
+        due_jobs_called = []
+        monkeypatch.setattr(
+            sched, "get_due_jobs",
+            lambda: due_jobs_called.append(True) or [_make_job()],
+        )
+
+        ran = sched.tick(verbose=False, defer_to_gateway_owner=True)
+
+        assert ran == 0
+        assert not due_jobs_called, "deferred tick must not inspect/run jobs"
+
+    def test_runs_when_no_gateway_owner(self, monkeypatch, reset_pools):
+        """defer_to_gateway_owner=True but no owner → ticker runs the job."""
+        monkeypatch.setattr(sched, "_gateway_scheduler_owner_active", lambda: False)
+        _patch_run_path(monkeypatch, [_make_job()])
+
+        ran = sched.tick(verbose=False, defer_to_gateway_owner=True)
+
+        assert ran == 1
+
+    def test_gateway_ticker_runs_even_when_owner_active(self, monkeypatch, reset_pools):
+        """The gateway's own ticker (defer flag False) ignores the owner guard."""
+        # Owner "active" here would be the gateway itself; the guard must not
+        # apply to the default (gateway-ticker) call path.
+        monkeypatch.setattr(sched, "_gateway_scheduler_owner_active", lambda: True)
+        _patch_run_path(monkeypatch, [_make_job()])
+
+        ran = sched.tick(verbose=False)  # defer_to_gateway_owner defaults False
+
+        assert ran == 1
+
+
+class TestGatewaySchedulerOwnerActive:
+    def test_delegates_to_runtime_lock(self, monkeypatch):
+        import gateway.status as status
+
+        monkeypatch.setattr(status, "is_gateway_runtime_lock_active", lambda: True)
+        assert sched._gateway_scheduler_owner_active() is True
+
+        monkeypatch.setattr(status, "is_gateway_runtime_lock_active", lambda: False)
+        assert sched._gateway_scheduler_owner_active() is False
+
+    def test_fails_open_on_error(self, monkeypatch, caplog):
+        import gateway.status as status
+
+        def _boom():
+            raise RuntimeError("lock backend unavailable")
+
+        monkeypatch.setattr(status, "is_gateway_runtime_lock_active", _boom)
+        with caplog.at_level(logging.DEBUG, logger=sched.logger.name):
+            assert sched._gateway_scheduler_owner_active() is False

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -153,6 +153,30 @@ def test_inprocess_provider_ticks_and_stops():
     assert calls[0].get("sync") is False
 
 
+def test_inprocess_provider_forwards_defer_to_gateway_owner():
+    """A non-authoritative caller (Desktop dashboard) passes
+    defer_to_gateway_owner=True; the built-in must forward it to tick() so the
+    ownership guard actually engages. The gateway's own ticker forwards False."""
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    for flag in (True, False):
+        calls = []
+        stop = threading.Event()
+        with patch("cron.scheduler.tick", side_effect=lambda *a, **k: calls.append(k) or 0):
+            t = threading.Thread(
+                target=InProcessCronScheduler().start,
+                args=(stop,),
+                kwargs={"interval": 0, "defer_to_gateway_owner": flag},
+                daemon=True,
+            )
+            t.start()
+            time.sleep(0.2)
+            stop.set()
+            t.join(timeout=5)
+        assert calls, "provider never called tick()"
+        assert calls[0].get("defer_to_gateway_owner") is flag
+
+
 def test_inprocess_provider_stop_is_noop():
     """The default stop() hook is a safe no-op (the stop_event is the real
     stop signal for the built-in)."""


### PR DESCRIPTION
Fixes #43965

## Problem

The Desktop dashboard backend (`HERMES_DESKTOP=1`) runs its own cron ticker, sharing only `cron/.tick.lock` with the launchd gateway ticker. That lock gives *at-most-once* execution but not *deterministic ownership* — whichever process wins the lock runs the job. On macOS, TCC / Full Disk Access depends on process ancestry, so a job that fired under the dashboard ancestry lost access to protected local data that the same job could read when run by the launchd gateway chain.

Observed with a launchd-managed gateway (`ai.hermes.gateway-<profile>`) and Desktop-spawned dashboard backends alive for the same profile: the dashboard ticker sometimes won `cron/.tick.lock` and executed an hourly job without the gateway's FDA provenance. After terminating the dashboard backends, the same job succeeded from the gateway ancestry.

Related: #25737 (durable server-side cron runner), #40684 (added the desktop ticker, relying on the tick lock), #43652 (tick-lock release semantics).

## Steps to reproduce

1. macOS, profile with a launchd-managed gateway: `hermes --profile <p> gateway run --replace`
2. A cron job for that profile that reads TCC/FDA-protected local data
3. Open Hermes Desktop so dashboard backends (`HERMES_DESKTOP=1`) are alive for the same profile
4. Wait for the job — when the dashboard ticker wins the lock, the job runs without FDA provenance and fails to read protected data

## Fix

Use the gateway's per-profile runtime lock (`gateway.status.is_gateway_runtime_lock_active`, held for the live gateway's lifetime, OS-released on death — never stale) as the scheduler-ownership signal:

- `cron/scheduler.py`: new `_gateway_scheduler_owner_active()` helper (lazy import, fails open if the signal is unavailable) and a keyword-only `defer_to_gateway_owner=False` parameter on `tick()`. When set and a gateway owns the scheduler, the tick returns 0 before taking the tick lock or inspecting jobs.
- `hermes_cli/web_server.py`: the desktop ticker passes `defer_to_gateway_owner=True` and the docstring no longer claims the tick lock alone makes it cross-process safe.
- The gateway's own ticker (`gateway/run.py`) keeps the default `False`, so it always runs.

Net effect: with a gateway running, only the gateway executes jobs (correct provenance). With no gateway (desktop-only setup), the dashboard ticker keeps firing jobs exactly as before.

## Tests

New `tests/cron/test_scheduler_ownership.py` (5 tests): deferral when a gateway owner is active (no job inspection, no lock taken), normal execution when no owner, gateway ticker unaffected by the guard, helper delegation to `gateway.status`, fail-open on error.

Ran via `scripts/run_tests.sh` on macOS: new file plus `tests/cron/test_scheduler.py`, `tests/cron/test_parallel_pool.py`, `tests/test_web_server.py`, `tests/gateway/test_status.py` — 207 tests, all passing. Platforms tested: macOS (the bug is macOS-specific; the guard itself is platform-neutral and a no-op when no gateway lock is held).
