### PR TITLE
fix(skills): preserve GitHub binary assets

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1815,6 +1815,66 @@ class TestGitHubFetchFileContent:
         assert content.startswith(b"\x89PNG")
         assert content != resp.text
 
+    @patch("tools.skills_hub.httpx.get")
+    def test_fetch_unknown_suffix_invalid_utf8_returns_raw_bytes(self, mock_get):
+        model_bytes = b"GGUF\x00\xff\xfe\x80weights"
+        resp = MagicMock(status_code=200)
+        resp.content = model_bytes
+        resp.text = model_bytes.decode("utf-8", errors="replace")
+        mock_get.return_value = resp
+
+        content = self._source()._fetch_file_content(
+            "owner/repo", "skill/assets/model.gguf"
+        )
+
+        assert content == model_bytes
+        assert isinstance(content, bytes)
+        assert content != resp.text
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_fetch_extensionless_invalid_utf8_round_trips_through_quarantine(
+        self, mock_get, tmp_path
+    ):
+        import tools.skills_hub as hub
+
+        raw_fixture = b"\x00\xff\xfe\x80extensionless-fixture"
+        responses = {
+            "https://api.github.com/repos/owner/repo/contents/demo-skill/SKILL.md": b"---\nname: demo-skill\n---\n",
+            "https://api.github.com/repos/owner/repo/contents/demo-skill/assets/fixture": raw_fixture,
+        }
+
+        def fake_get(url, **_kwargs):
+            content = responses[url]
+            resp = MagicMock(status_code=200)
+            resp.content = content
+            resp.text = content.decode("utf-8", errors="replace")
+            return resp
+
+        mock_get.side_effect = fake_get
+        src = self._source()
+        src._tree_cache["owner/repo"] = (
+            "main",
+            [
+                {"type": "blob", "path": "demo-skill/SKILL.md"},
+                {"type": "blob", "path": "demo-skill/assets/fixture"},
+            ],
+        )
+        hub_dir = tmp_path / "skills" / ".hub"
+
+        with patch.object(hub, "SKILLS_DIR", tmp_path / "skills"), \
+             patch.object(hub, "HUB_DIR", hub_dir), \
+             patch.object(hub, "LOCK_FILE", hub_dir / "lock.json"), \
+             patch.object(hub, "QUARANTINE_DIR", hub_dir / "quarantine"), \
+             patch.object(hub, "AUDIT_LOG", hub_dir / "audit.log"), \
+             patch.object(hub, "TAPS_FILE", hub_dir / "taps.json"), \
+             patch.object(hub, "INDEX_CACHE_DIR", hub_dir / "index-cache"):
+            bundle = src.fetch("owner/repo/demo-skill")
+            assert bundle is not None
+            assert bundle.files["assets/fixture"] == raw_fixture
+            q_path = quarantine_bundle(bundle)
+
+        assert (q_path / "assets" / "fixture").read_bytes() == raw_fixture
+
 
 # ---------------------------------------------------------------------------
 # GitHubSource._download_directory — tree API + fallback (#2940)

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1779,6 +1779,43 @@ class TestQuarantineBundleBinaryAssets:
         assert not absolute_target.exists()
 
 
+class TestGitHubFetchFileContent:
+    """Tests for preserving text and binary GitHub file content."""
+
+    def _source(self):
+        auth = MagicMock(spec=GitHubAuth)
+        auth.get_headers.return_value = {}
+        return GitHubSource(auth=auth)
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_fetch_text_file_returns_text(self, mock_get):
+        resp = MagicMock(status_code=200)
+        resp.text = "---\nname: demo\n---\n"
+        resp.content = resp.text.encode("utf-8")
+        mock_get.return_value = resp
+
+        content = self._source()._fetch_file_content("owner/repo", "skill/SKILL.md")
+
+        assert content == "---\nname: demo\n---\n"
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_fetch_binary_asset_returns_raw_bytes(self, mock_get):
+        png_bytes = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\xff\xd8"
+        resp = MagicMock(status_code=200)
+        resp.content = png_bytes
+        # Simulate the corruption-prone text view that would replace invalid
+        # binary bytes if callers used resp.text for image assets.
+        resp.text = png_bytes.decode("utf-8", errors="replace")
+        mock_get.return_value = resp
+
+        content = self._source()._fetch_file_content("owner/repo", "skill/assets/reference.png")
+
+        assert content == png_bytes
+        assert isinstance(content, bytes)
+        assert content.startswith(b"\x89PNG")
+        assert content != resp.text
+
+
 # ---------------------------------------------------------------------------
 # GitHubSource._download_directory — tree API + fallback (#2940)
 # ---------------------------------------------------------------------------
@@ -1818,6 +1855,31 @@ class TestDownloadDirectoryViaTree:
         assert "references/api.md" in files
         assert "other/file.txt" not in files  # outside target path
         assert len(files) == 3
+
+    @patch.object(GitHubSource, "_fetch_file_content")
+    @patch("tools.skills_hub.httpx.get")
+    def test_tree_api_preserves_binary_asset_bytes(self, mock_get, mock_fetch):
+        """Tree API path carries binary support files through as bytes."""
+        png_bytes = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\xff\xd8"
+        repo_resp = MagicMock(status_code=200, json=lambda: {"default_branch": "main"})
+        tree_resp = MagicMock(status_code=200, json=lambda: {
+            "truncated": False,
+            "tree": [
+                {"type": "blob", "path": "skills/my-skill/SKILL.md"},
+                {"type": "blob", "path": "skills/my-skill/assets/reference.png"},
+            ],
+        })
+        mock_get.side_effect = [repo_resp, tree_resp]
+        mock_fetch.side_effect = lambda repo, path: (
+            png_bytes if path.endswith("reference.png") else "# Skill\n"
+        )
+
+        src = self._source()
+        files = src._download_directory("owner/repo", "skills/my-skill")
+
+        assert files["SKILL.md"] == "# Skill\n"
+        assert files["assets/reference.png"] == png_bytes
+        assert isinstance(files["assets/reference.png"], bytes)
 
     @patch.object(GitHubSource, "_download_directory_recursive", return_value={"SKILL.md": "# ok"})
     @patch("tools.skills_hub.httpx.get")

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -60,6 +60,19 @@ INDEX_CACHE_TTL = 3600  # 1 hour
 
 _REDIRECT_STATUS_CODES = {301, 302, 303, 307, 308}
 _MAX_SKILL_FETCH_REDIRECTS = 5
+_BINARY_SKILL_FILE_SUFFIXES = {
+    # Images
+    ".avif", ".bmp", ".gif", ".heic", ".heif", ".ico", ".jpeg", ".jpg", ".png", ".tif", ".tiff", ".webp",
+    # Audio/video
+    ".aac", ".flac", ".m4a", ".mov", ".mp3", ".mp4", ".ogg", ".wav", ".webm",
+    # Fonts
+    ".eot", ".otf", ".ttf", ".woff", ".woff2",
+    # Model/data/runtime assets
+    ".db", ".duckdb", ".npy", ".npz", ".onnx", ".parquet", ".pickle", ".pkl", ".safetensors", ".sqlite3", ".wasm",
+    # Documents/archives/compiled assets
+    ".7z", ".bin", ".bz2", ".class", ".dmg", ".doc", ".docx", ".gz", ".jar", ".pdf",
+    ".ppt", ".pptx", ".pyc", ".rar", ".sqlite", ".tar", ".tgz", ".xls", ".xlsx", ".xz", ".zip", ".zst",
+}
 
 
 # ---------------------------------------------------------------------------
@@ -228,6 +241,11 @@ def _guarded_http_get(url: str, *, timeout: int = 20) -> Optional[httpx.Response
 
 def _validate_bundle_rel_path(rel_path: str) -> str:
     return _normalize_bundle_path(rel_path, field_name="bundle file path", allow_nested=True)
+
+
+def _is_binary_skill_file(path_value: str) -> bool:
+    """Return True when a skill support file should be preserved as raw bytes."""
+    return Path(path_value).suffix.lower() in _BINARY_SKILL_FILE_SUFFIXES
 
 
 # ---------------------------------------------------------------------------
@@ -513,7 +531,7 @@ class GitHubSource(SkillSource):
         skill_md_path = f"{skill_path}/SKILL.md"
 
         content = self._fetch_file_content(repo, skill_md_path)
-        if not content:
+        if not content or isinstance(content, bytes):
             return None
 
         fm = self._parse_frontmatter_quick(content)
@@ -729,8 +747,8 @@ class GitHubSource(SkillSource):
         return last_resp
 
 
-    def _download_directory(self, repo: str, path: str) -> Dict[str, str]:
-        """Recursively download all text files from a GitHub directory.
+    def _download_directory(self, repo: str, path: str) -> Dict[str, Union[str, bytes]]:
+        """Recursively download all files from a GitHub directory.
 
         Uses the Git Trees API first (single call for the entire tree) to
         avoid per-directory rate limiting that causes silent subdirectory
@@ -743,7 +761,7 @@ class GitHubSource(SkillSource):
         logger.debug("Tree API unavailable for %s/%s, falling back to Contents API", repo, path)
         return self._download_directory_recursive(repo, path)
 
-    def _download_directory_via_tree(self, repo: str, path: str) -> Optional[Dict[str, str]]:
+    def _download_directory_via_tree(self, repo: str, path: str) -> Optional[Dict[str, Union[str, bytes]]]:
         """Download an entire directory using the Git Trees API (single request).
 
         Returns:
@@ -770,7 +788,7 @@ class GitHubSource(SkillSource):
             return {}
 
         # Filter to blobs under our target path and fetch content
-        files: Dict[str, str] = {}
+        files: Dict[str, Union[str, bytes]] = {}
         for item in tree_entries:
             if item.get("type") != "blob":
                 continue
@@ -786,7 +804,7 @@ class GitHubSource(SkillSource):
 
         return files if files else None
 
-    def _download_directory_recursive(self, repo: str, path: str) -> Dict[str, str]:
+    def _download_directory_recursive(self, repo: str, path: str) -> Dict[str, Union[str, bytes]]:
         """Recursively download via Contents API (fallback)."""
         url = f"https://api.github.com/repos/{repo}/contents/{path.rstrip('/')}"
         try:
@@ -801,7 +819,7 @@ class GitHubSource(SkillSource):
         if not isinstance(entries, list):
             return {}
 
-        files: Dict[str, str] = {}
+        files: Dict[str, Union[str, bytes]] = {}
         for entry in entries:
             name = entry.get("name", "")
             entry_type = entry.get("type", "")
@@ -846,14 +864,16 @@ class GitHubSource(SkillSource):
 
         return None
 
-    def _fetch_file_content(self, repo: str, path: str) -> Optional[str]:
-        """Fetch a single file's content from GitHub."""
+    def _fetch_file_content(self, repo: str, path: str) -> Optional[Union[str, bytes]]:
+        """Fetch a single file's content from GitHub without corrupting binary assets."""
         url = f"https://api.github.com/repos/{repo}/contents/{path}"
         resp = self._github_get(
             url,
             headers={**self.auth.get_headers(), "Accept": "application/vnd.github.v3.raw"},
         )
         if resp is not None and resp.status_code == 200:
+            if _is_binary_skill_file(path):
+                return resp.content
             return resp.text
         return None
 
@@ -878,7 +898,7 @@ class GitHubSource(SkillSource):
             return self._skillsh_groupings[repo]
 
         content = self._fetch_file_content(repo, "skills.sh.json")
-        groupings = self._parse_skillsh_groupings(content) if content else None
+        groupings = self._parse_skillsh_groupings(content) if isinstance(content, str) else None
         self._skillsh_groupings[repo] = groupings
         return groupings
 

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -874,7 +874,10 @@ class GitHubSource(SkillSource):
         if resp is not None and resp.status_code == 200:
             if _is_binary_skill_file(path):
                 return resp.content
-            return resp.text
+            try:
+                return resp.content.decode("utf-8")
+            except UnicodeDecodeError:
+                return resp.content
         return None
 
     def _get_skillsh_groupings(self, repo: str) -> Optional[Dict[str, str]]:


### PR DESCRIPTION
## Summary

- Preserve GitHub skill binary support files as raw bytes instead of decoding every file through `resp.text`
- Widen GitHub directory-download bundle typing to `str | bytes`, matching `SkillBundle.files`
- Add regression coverage for text files, PNG-like binary assets, and tree API binary propagation

Fixes #44046

## Problem

GitHub-backed skill installs currently fetch every file through `_fetch_file_content()` using `resp.text`. For binary assets such as PNG/JPEG files, that decodes invalid UTF-8 bytes into replacement characters (`U+FFFD`). Quarantine then writes the resulting string as UTF-8, corrupting and inflating the installed asset.

`SkillBundle.files` and the quarantine writer already support byte values, so this patch keeps known binary support-file extensions as `bytes` at fetch time.

## Verification

- `uv run --with pytest python -m pytest -o addopts= tests/tools/test_skills_hub.py -q`
  - `146 passed`
- `uv run --with ruff ruff check tools/skills_hub.py tests/tools/test_skills_hub.py`
  - `All checks passed!`
- `git diff --check origin/main...HEAD`
  - clean
- Manual byte-preservation smoke test: mocked a GitHub PNG response, fetched via `GitHubSource._fetch_file_content()`, wrote through `quarantine_bundle()`, and verified the file bytes matched exactly.
