### PR TITLE
fix: add bounds checking in _parse_status git status parsing

### DIFF
--- a/agent/coding_context.py
+++ b/agent/coding_context.py
@@ -576,13 +576,17 @@ def _parse_status(porcelain: str) -> tuple[dict[str, str], dict[str, int]]:
             branch["upstream"] = line.split(maxsplit=2)[-1]
         elif line.startswith("# branch.ab"):
             parts = line.split()
-            branch["ahead"], branch["behind"] = parts[2].lstrip("+"), parts[3].lstrip("-")
+            if len(parts) >= 4:
+                branch["ahead"], branch["behind"] = parts[2].lstrip("+"), parts[3].lstrip("-")
         elif line.startswith(("1 ", "2 ")):
-            xy = line.split(maxsplit=2)[1]
-            if xy[0] != ".":
-                counts["staged"] += 1
-            if xy[1] != ".":
-                counts["modified"] += 1
+            parts = line.split(maxsplit=2)
+            if len(parts) >= 2:
+                xy = parts[1]
+                if len(xy) >= 2:
+                    if xy[0] != ".":
+                        counts["staged"] += 1
+                    if xy[1] != ".":
+                        counts["modified"] += 1
         elif line.startswith("u "):
             counts["conflicts"] += 1
         elif line.startswith("? "):


### PR DESCRIPTION
## Summary

Previously, `_parse_status()` in `coding_context.py` accessed array indices without checking if enough elements existed, which could raise `IndexError` on malformed or unexpected git status output.

This PR adds proper bounds checking to make the parser more robust against unexpected git status formats or edge cases.

## Changes

- Check `len(parts) >= 4` before accessing `parts[2]` and `parts[3]` for branch ahead/behind counts
- Check `len(parts) >= 2` before accessing `parts[1]` for status flags
- Check `len(xy) >= 2` before accessing `xy[0]` and `xy[1]` for staged/modified indicators

## Test Plan

- [ ] Unit tests pass
- [ ] Git status parsing works correctly with normal output
- [ ] No crash on malformed git status output

## Related Issues

Addresses Bug #6 from codebase analysis: Potential IndexError in git status parsing