### PR TITLE
feat(catalog): add Basic Memory to the optional MCP catalog

### DIFF
--- a/optional-mcps/basic-memory/manifest.yaml
+++ b/optional-mcps/basic-memory/manifest.yaml
@@ -1,0 +1,64 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: basic-memory
+description: Local-first knowledge graph and memory MCP for notes, context, and project recall.
+source: https://github.com/basicmachines-co/basic-memory
+homepage: https://basicmemory.com
+
+transport:
+  type: stdio
+  command: uvx
+  args:
+    - --from
+    - basic-memory
+    - bm
+    - mcp
+    - --transport
+    - stdio
+
+auth:
+  type: none
+
+# Useful default surface, while avoiding destructive and admin-only tools.
+# Users can enable additional tools with:
+#   hermes mcp configure basic-memory
+tools:
+  default_enabled:
+    - search_notes
+    - read_note
+    - write_note
+    - edit_note
+    - move_note
+    - build_context
+    - recent_activity
+    - list_directory
+    - list_memory_projects
+    - list_workspaces
+    - create_memory_project
+    - cloud_info
+    - schema_validate
+    - schema_infer
+    - schema_diff
+
+post_install: |
+  Basic Memory runs locally over stdio — no server process to start.
+
+  For local-first use, configure a project with:
+    bm project add <name> <path>
+    bm project default <name>
+
+  For Basic Memory Cloud, authenticate first:
+    bm cloud login
+    # or:
+    bm cloud api-key save bmc_...
+
+  Then link a project to a cloud workspace:
+    bm project set-cloud <project> --workspace <workspace>
+
+  Restart Hermes or run /reload-mcp so the Basic Memory tools are loaded.
+
+  Note: this catalog entry exposes Basic Memory as ordinary MCP tools.
+  For Hermes-native memory capture, session transcripts, and bm_* tool
+  aliases, use the hermes-basic-memory memory-provider plugin instead.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -297,6 +297,7 @@ locales = ["locales/*.yaml"]
 # catalog iterates over (a shared `optional-mcps/*/*` glob would collapse all
 # manifests into one colliding optional-mcps/manifest.yaml). One target per
 # entry; tests/test_packaging_metadata.py enforces an entry per optional-mcps/<name>.
+"optional-mcps/basic-memory" = ["optional-mcps/basic-memory/manifest.yaml"]
 "optional-mcps/linear" = ["optional-mcps/linear/manifest.yaml"]
 "optional-mcps/n8n" = ["optional-mcps/n8n/manifest.yaml"]
 


### PR DESCRIPTION
## What does this PR do?

Adds [Basic Memory](https://basicmemory.com) ([GitHub](https://github.com/basicmachines-co/basic-memory)) to the optional MCP catalog. Basic Memory is an open-source local-first knowledge graph that lets you store and retrieve notes, entities, and relationships from a semantic markdown knowledge base — essentially persistent memory across AI sessions.

This PR contributes `optional-mcps/basic-memory/manifest.yaml` plus the corresponding `pyproject.toml` data-files registration so the manifest ships in built wheels and sdists.

## Related Issue

Fixes basicmachines-co/basic-memory#864

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `optional-mcps/basic-memory/manifest.yaml` — new catalog entry for Basic Memory MCP server
- `pyproject.toml` — registered `optional-mcps/basic-memory/manifest.yaml` in `[tool.setuptools.data-files]` alongside existing linear and n8n entries

### Manifest highlights

- **Invocation**: `uvx --from basic-memory bm mcp --transport stdio` — self-contained, no PATH dependency on `bm`
- **Auth**: `type: none` — Basic Memory's MCP server requires no credentials at the MCP protocol level; cloud auth is handled separately via the `bm` CLI
- **default_enabled**: 15 tools covering read/write knowledge graph operations and schema tools; destructive tools (`delete_note`, `delete_project`) are deliberately omitted from the default set
- **homepage**: `https://basicmemory.com`

## How to Test

1. `pip install -e .` in this repo
2. `python -c "import importlib.resources; print(list(importlib.resources.files('hermes').joinpath('').iterdir()))"` — verify the manifest is included
3. `pytest tests/hermes_cli/test_mcp_catalog.py -q` — the `TestShippedCatalog.test_all_shipped_manifests_parse` test should pass with the new entry

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass *(sandbox constraints prevented installing the full repo; the manifest was validated structurally against the `test_all_shipped_manifests_parse` schema contract)*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — N/A, catalog entries are covered by the existing `TestShippedCatalog` test

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `uvx` is cross-platform; Basic Memory supports macOS, Linux, Windows
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

N/A — this is a pure catalog/packaging addition with no UI or runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)