### PR TITLE
fix(agent): exclude Bedrock transient faults from local-validation-error classification

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -152,6 +152,25 @@ def _ollama_context_limit_error(agent: Any, request_tokens: int) -> Optional[str
     )
 
 
+_BEDROCK_TRANSIENT_EXCEPTIONS = frozenset({
+    "internalserverexception",
+    "modelstreamerrorexception",
+    "throttlingexception",
+    "serviceunavailableexception",
+    "modeltimeoutexception",
+})
+
+
+def _is_bedrock_transient_fault(exc: Exception) -> bool:
+    if not isinstance(exc, ValueError):
+        return False
+    msg = str(exc)
+    if "Bad response code, expected 200" not in msg:
+        return False
+    msg_lower = msg.lower()
+    return any(tag in msg_lower for tag in _BEDROCK_TRANSIENT_EXCEPTIONS)
+
+
 def _ra():
     """Lazy reference to ``run_agent`` so callers can patch
     ``run_agent.handle_function_call`` / ``run_agent._set_interrupt`` /
@@ -3744,6 +3763,7 @@ def run_conversation(
                         and "nonetype" in str(api_error).lower()
                         and "not iterable" in str(api_error).lower()
                     )
+                    and not _is_bedrock_transient_fault(api_error)
                 )
                 # ``FailoverReason.billing`` (HTTP 402) is NOT in this
                 # exclusion set.  By the time we reach this block:

--- a/tests/run_agent/test_bedrock_transient_retry.py
+++ b/tests/run_agent/test_bedrock_transient_retry.py
@@ -1,0 +1,89 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent import conversation_loop
+from run_agent import AIAgent
+
+
+@pytest.fixture
+def agent():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        instance = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    instance.client = MagicMock()
+    instance._cached_system_prompt = "You are helpful."
+    instance._use_prompt_caching = False
+    instance.tool_delay = 0
+    instance.compression_enabled = False
+    instance.save_trajectories = False
+    instance._fallback_chain = []
+    instance._api_max_retries = 2
+    return instance
+
+
+def _response(content):
+    message = SimpleNamespace(content=content, tool_calls=None)
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+@pytest.mark.parametrize(
+    "exception_type",
+    [
+        "internalServerException",
+        "modelStreamErrorException",
+        "throttlingException",
+        "serviceUnavailableException",
+        "modelTimeoutException",
+    ],
+)
+def test_bedrock_transient_value_error_retries(agent, exception_type):
+    error = ValueError(
+        "Bad response code, expected 200: "
+        f"{{':event-type': 'exception', ':exception-type': '{exception_type}'}}"
+    )
+    with (
+        patch.object(
+            agent,
+            "_interruptible_api_call",
+            side_effect=[error, _response("Recovered")],
+        ) as api_call,
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+        patch.object(conversation_loop, "jittered_backoff", return_value=0.0),
+    ):
+        result = agent.run_conversation("hello")
+    assert api_call.call_count == 2
+    assert result["completed"] is True
+    assert result["final_response"] == "Recovered"
+
+
+def test_bedrock_validation_error_does_not_retry(agent):
+    error = ValueError(
+        "Bad response code, expected 200: "
+        "{':event-type': 'exception', ':exception-type': 'validationException'}"
+    )
+    with (
+        patch.object(agent, "_interruptible_api_call", side_effect=error) as api_call,
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+        patch.object(agent, "_dump_api_request_debug"),
+    ):
+        result = agent.run_conversation("hello")
+    assert api_call.call_count == 1
+    assert result["completed"] is False
+    assert result["failed"] is True
+    assert "validationException" in result["error"]


### PR DESCRIPTION
## Problem

Transient AWS Bedrock streaming server faults abort the turn instead of retrying.

When Bedrock encounters an `internalServerException`, `throttlingException`, or similar transient fault during streaming, it sends the error inside an event-stream frame with `status_code=400` but `:exception-type=internalServerException` (a 5xx-class fault). AWS's own message says "Try your request again."

The Anthropic SDK's Bedrock decoder raises a bare `ValueError("Bad response code, expected 200: ...")` that **drops the HTTP status** — the agent sees `HTTP None`. The `is_local_validation_error` predicate treats all bare `ValueError` as local programming bugs (non-retryable), so a recoverable hiccup kills the turn.

## Fix

Add `_is_bedrock_transient_fault()` that matches the decoder's error message pattern and checks for known transient `:exception-type` values:

| Exception type | Transient? |
|---|---|
| `internalServerException` | ✅ Yes |
| `modelStreamErrorException` | ✅ Yes |
| `throttlingException` | ✅ Yes |
| `serviceUnavailableException` | ✅ Yes |
| `modelTimeoutException` | ✅ Yes |
| `validationException` | ❌ No (real client bug) |

Only `ValueError` instances matching "Bad response code, expected 200" AND containing a known transient exception-type are excluded from `is_local_validation_error`. A genuine `validationException` is intentionally not matched and still aborts.

## Tests

- [x] Verified the focused regression tests fail for all five transient cases on `main`
- [x] Verified all five transient exception types retry and recover through `run_conversation()`
- [x] Verified `validationException` remains non-retryable with one API attempt
- [x] `scripts/run_tests.sh tests/run_agent/ -q` — 1993 passed
- [x] `uv run ruff check .`

Closes #43915
