### PR TITLE
fix(agent): catch RuntimeError from expanduser() with ~nonexistent_user (#43963)

### DIFF
--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -144,7 +144,9 @@ class SubdirectoryHintTracker:
                 if parent == p:
                     break  # filesystem root
                 p = parent
-        except (OSError, ValueError):
+        except (OSError, ValueError, RuntimeError):
+            # RuntimeError is raised by Path.expanduser() when a ~user token
+            # references a non-existent account (passwd lookup fails).
             pass
 
     def _extract_paths_from_command(self, cmd: str, candidates: Set[Path]):


### PR DESCRIPTION
Fixes #43963. Path.expanduser() raises RuntimeError (not OSError/ValueError) when a ~user token references a non-existent account via passwd lookup. Added RuntimeError to the except tuple in _add_path_candidate so it degrades gracefully instead of crashing the agent turn.