### PR TITLE
feat(google-workspace): add scoped auth contexts

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -262,6 +262,10 @@ def get_read_block_error(path: str) -> Optional[str]:
         "auth.lock",
         ".anthropic_oauth.json",
         ".env",
+        "google_token.json",
+        "google_client_secret.json",
+        "google_workspace_auth_contexts.json",
+        "google_oauth_pending.json",
         "webhook_subscriptions.json",
         os.path.join("auth", "google_oauth.json"),
         # Bitwarden Secrets Manager disk cache: stores plaintext secret values
@@ -305,6 +309,26 @@ def get_read_block_error(path: str) -> Optional[str]:
             f"Access denied: {path} is a Hermes MCP token file "
             "and cannot be read directly. (Defense-in-depth — not a "
             "security boundary; the terminal tool can still bypass.)"
+        )
+
+    # Materialized named Google Workspace contexts contain copied OAuth tokens
+    # and OAuth client secrets. Block the whole subtree, not just known
+    # basenames, so new credential artifacts cannot become model-readable.
+    for hd in hermes_dirs:
+        try:
+            google_contexts = (
+                hd / ".cache" / "google-workspace" / "contexts"
+            ).resolve()
+        except Exception:
+            continue
+        try:
+            resolved.relative_to(google_contexts)
+        except ValueError:
+            continue
+        return (
+            f"Access denied: {path} is a materialized Google Workspace "
+            "credential and cannot be read directly. (Defense-in-depth — "
+            "not a security boundary; the terminal tool can still bypass.)"
         )
 
     # Block common secret-bearing project-local .env files anywhere on disk.

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1175,6 +1175,7 @@ def _media_delivery_denied_paths() -> List[Path]:
         # every turn, which defeated the strict-mode recency window) plus the
         # pending-exchange session/verifier file.
         "google_token.json",
+        "google_client_secret.json",
         "google_workspace_auth_contexts.json",
         "google_oauth_pending.json",
         os.path.join("auth", "google_oauth.json"),
@@ -1195,6 +1196,8 @@ def _media_delivery_denied_paths() -> List[Path]:
     _ROOT_CREDENTIAL_DIRS = (
         "pairing",
         "mcp-tokens",
+        # Materialized named Google auth-context tokens and client secrets.
+        os.path.join(".cache", "google-workspace", "contexts"),
     )
     for hermes_root in (_HERMES_HOME, _HERMES_ROOT):
         for rel in _ROOT_CREDENTIAL_FILES:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1175,6 +1175,7 @@ def _media_delivery_denied_paths() -> List[Path]:
         # every turn, which defeated the strict-mode recency window) plus the
         # pending-exchange session/verifier file.
         "google_token.json",
+        "google_workspace_auth_contexts.json",
         "google_oauth_pending.json",
         os.path.join("auth", "google_oauth.json"),
         # Webhook subscription HMAC secrets.

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1335,6 +1335,7 @@ _SENSITIVE_MANAGED_FILE_BASENAMES = frozenset({
     "config.yaml",
     ".anthropic_oauth.json",
     "google_token.json",
+    "google_workspace_auth_contexts.json",
     "google_oauth_pending.json",
     "google_oauth.json",
     "webhook_subscriptions.json",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1335,6 +1335,7 @@ _SENSITIVE_MANAGED_FILE_BASENAMES = frozenset({
     "config.yaml",
     ".anthropic_oauth.json",
     "google_token.json",
+    "google_client_secret.json",
     "google_workspace_auth_contexts.json",
     "google_oauth_pending.json",
     "google_oauth.json",

--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -9,9 +9,11 @@ required_credential_files:
   - path: google_workspace_auth_contexts.json
     description: Named Google Workspace OAuth auth contexts (created by setup script)
     alternative_group: named-context
+    readiness_json_path: contexts.*.token.refresh_token
   - path: google_token.json
     description: Legacy Google OAuth2 token (created by setup script)
     alternative_group: legacy
+    readiness_json_path: refresh_token
   - path: google_client_secret.json
     description: Legacy Google OAuth2 client credentials (downloaded from Google Cloud Console)
     alternative_group: legacy

--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -8,13 +8,13 @@ platforms: [linux, macos, windows]
 required_credential_files:
   - path: google_workspace_auth_contexts.json
     description: Named Google Workspace OAuth auth contexts (created by setup script)
-    optional: true
+    alternative_group: named-context
   - path: google_token.json
     description: Legacy Google OAuth2 token (created by setup script)
-    optional: true
+    alternative_group: legacy
   - path: google_client_secret.json
     description: Legacy Google OAuth2 client credentials (downloaded from Google Cloud Console)
-    optional: true
+    alternative_group: legacy
 metadata:
   hermes:
     tags: [Google, Gmail, Calendar, Drive, Sheets, Docs, Contacts, Email, OAuth]

--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -8,10 +8,13 @@ platforms: [linux, macos, windows]
 required_credential_files:
   - path: google_workspace_auth_contexts.json
     description: Named Google Workspace OAuth auth contexts (created by setup script)
+    optional: true
   - path: google_token.json
     description: Legacy Google OAuth2 token (created by setup script)
+    optional: true
   - path: google_client_secret.json
     description: Legacy Google OAuth2 client credentials (downloaded from Google Cloud Console)
+    optional: true
 metadata:
   hermes:
     tags: [Google, Gmail, Calendar, Drive, Sheets, Docs, Contacts, Email, OAuth]
@@ -38,6 +41,8 @@ By default this skill remains backward compatible with the legacy single-token f
 
 - `~/.hermes/google_token.json`
 - `~/.hermes/google_client_secret.json`
+
+The first write to the named-context store snapshots any legacy default token, client secret, and pending auth into `contexts.default`; the store-backed copy is authoritative after that migration.
 
 For least-privilege or multi-account setups, use **auth contexts**. An auth context is a named Google OAuth credential bundle: account hint, OAuth client, requested services/scopes, token, and pending PKCE state. Contexts are stored in `~/.hermes/google_workspace_auth_contexts.json`, a single static credential file that remote terminal backends can mount.
 

--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -9,11 +9,12 @@ required_credential_files:
   - path: google_workspace_auth_contexts.json
     description: Named Google Workspace OAuth auth contexts (created by setup script)
     alternative_group: named-context
-    readiness_json_path: contexts.*.token.refresh_token
+    readiness_json_path: contexts.*.token
+    readiness_json_required_keys: [refresh_token, client_id, client_secret]
   - path: google_token.json
     description: Legacy Google OAuth2 token (created by setup script)
     alternative_group: legacy
-    readiness_json_path: refresh_token
+    readiness_json_required_keys: [refresh_token, client_id, client_secret]
   - path: google_client_secret.json
     description: Legacy Google OAuth2 client credentials (downloaded from Google Cloud Console)
     alternative_group: legacy

--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -6,10 +6,12 @@ author: Nous Research
 license: MIT
 platforms: [linux, macos, windows]
 required_credential_files:
+  - path: google_workspace_auth_contexts.json
+    description: Named Google Workspace OAuth auth contexts (created by setup script)
   - path: google_token.json
-    description: Google OAuth2 token (created by setup script)
+    description: Legacy Google OAuth2 token (created by setup script)
   - path: google_client_secret.json
-    description: Google OAuth2 client credentials (downloaded from Google Cloud Console)
+    description: Legacy Google OAuth2 client credentials (downloaded from Google Cloud Console)
 metadata:
   hermes:
     tags: [Google, Gmail, Calendar, Drive, Sheets, Docs, Contacts, Email, OAuth]
@@ -29,6 +31,54 @@ Gmail, Calendar, Drive, Contacts, Sheets, and Docs — through Hermes-managed OA
 
 - `scripts/setup.py` — OAuth2 setup (run once to authorize)
 - `scripts/google_api.py` — compatibility wrapper CLI. It prefers `gws` for operations when available, while preserving Hermes' existing JSON output contract.
+
+## Auth Contexts
+
+By default this skill remains backward compatible with the legacy single-token files:
+
+- `~/.hermes/google_token.json`
+- `~/.hermes/google_client_secret.json`
+
+For least-privilege or multi-account setups, use **auth contexts**. An auth context is a named Google OAuth credential bundle: account hint, OAuth client, requested services/scopes, token, and pending PKCE state. Contexts are stored in `~/.hermes/google_workspace_auth_contexts.json`, a single static credential file that remote terminal backends can mount.
+
+Auth contexts generalize both multi-account aliases and scoped OAuth. They can represent different Google accounts, or multiple differently scoped OAuth grants for the same Google account.
+
+Common examples:
+
+```bash
+# Gmail read-only context
+$GSETUP --auth-context gmail-readonly --client-secret /path/to/mail-client.json --account-hint mail@example.com
+$GSETUP --auth-context gmail-readonly --services gmail-readonly --auth-url
+$GSETUP --auth-context gmail-readonly --auth-code "THE_REDIRECT_URL"
+$GSETUP --auth-context gmail-readonly --set-default-for gmail
+
+# Drive/Calendar/Docs/Sheets writer context
+$GSETUP --auth-context workspace-writer --client-secret /path/to/workspace-client.json --account-hint workspace@example.com
+$GSETUP --auth-context workspace-writer --services drive,calendar,docs,sheets --auth-url
+$GSETUP --auth-context workspace-writer --auth-code "THE_REDIRECT_URL"
+$GSETUP --auth-context workspace-writer --set-default-for drive,calendar,docs,sheets
+
+# Inspect without starting OAuth
+$GSETUP --services gmail-readonly --print-scopes
+$GSETUP --list-contexts
+```
+
+Then API calls can omit `--auth-context`; `google_api.py` routes by service default:
+
+```bash
+$GAPI gmail search "newer_than:1d"       # gmail-readonly
+$GAPI drive search "renovation"          # workspace-writer
+$GAPI calendar list                       # workspace-writer
+```
+
+You can always override routing explicitly:
+
+```bash
+$GAPI --auth-context gmail-readonly gmail get MESSAGE_ID
+$GAPI --auth-context workspace-writer drive upload report.md
+```
+
+Local scope gates fail early when a context lacks the permission for a command. For example, `gmail send` with a `gmail-readonly` token fails before calling Google.
 
 ## First-Time Setup
 

--- a/skills/productivity/google-workspace/scripts/auth_contexts.py
+++ b/skills/productivity/google-workspace/scripts/auth_contexts.py
@@ -221,6 +221,12 @@ def _load_store(*, strict: bool = False) -> dict[str, Any]:
                     f"Auth context store is unreadable; refusing to overwrite {path}"
                 )
             return _empty_store()
+    if any(not isinstance(entry, dict) for entry in data["contexts"].values()):
+        if strict:
+            raise RuntimeError(
+                f"Auth context store is unreadable; refusing to overwrite {path}"
+            )
+        return _empty_store()
     _merge_legacy_default(data)
     return data
 
@@ -332,7 +338,7 @@ def set_token_payload(context: str, token_payload: dict[str, Any], *, services: 
     if context == "default" and not store_path().exists():
         _write_private_json(legacy_token_path(), token_payload)
         return
-    store = load_store()
+    store = _load_store_for_update()
     entry = _context_entry(store, context)
     entry["token"] = token_payload
     if services is not None:
@@ -361,7 +367,7 @@ def set_client_secret(context: str, payload: dict[str, Any], *, account_hint: st
     if context == "default" and not store_path().exists():
         _write_private_json(legacy_client_secret_path(), payload)
         return
-    store = load_store()
+    store = _load_store_for_update()
     entry = _context_entry(store, context)
     entry["client_secret"] = payload
     if account_hint:
@@ -388,7 +394,7 @@ def set_pending_auth(context: str, payload: dict[str, Any]) -> None:
     if context == "default" and not store_path().exists():
         _write_private_json(legacy_pending_path(), payload)
         return
-    store = load_store()
+    store = _load_store_for_update()
     entry = _context_entry(store, context)
     entry["pending_auth"] = payload
     save_store(store)
@@ -450,7 +456,7 @@ def set_default_for_services(context: str, services_csv: str) -> None:
     unknown = sorted(set(services) - valid_api_services)
     if unknown:
         raise ValueError(f"Unknown API service(s) for defaults: {', '.join(unknown)}")
-    store = load_store()
+    store = _load_store_for_update()
     _context_entry(store, context)
     defaults = store.setdefault("default_contexts", {})
     for service in services:

--- a/skills/productivity/google-workspace/scripts/auth_contexts.py
+++ b/skills/productivity/google-workspace/scripts/auth_contexts.py
@@ -118,6 +118,38 @@ def legacy_pending_path() -> Path:
     return hermes_home() / LEGACY_PENDING_NAME
 
 
+def _read_json_file(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text())
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _merge_legacy_default(data: dict[str, Any]) -> None:
+    """Snapshot legacy credentials into ``contexts.default`` when needed.
+
+    Creating a named context must not make a working legacy default disappear.
+    Once copied, the store-backed default remains authoritative and later
+    changes to stale legacy files are ignored.
+    """
+    legacy_payloads = {
+        "token": _read_json_file(legacy_token_path()),
+        "client_secret": _read_json_file(legacy_client_secret_path()),
+        "pending_auth": _read_json_file(legacy_pending_path()),
+    }
+    if not any(legacy_payloads.values()):
+        return
+    contexts = data.setdefault("contexts", {})
+    default = contexts.setdefault("default", {"name": "default"})
+    default.setdefault("name", "default")
+    for key, payload in legacy_payloads.items():
+        if payload and key not in default:
+            default[key] = payload
+
+
 def validate_context_name(name: str | None) -> str:
     if name is None:
         name = "default"
@@ -146,6 +178,7 @@ def load_store() -> dict[str, Any]:
     data.setdefault("version", 1)
     data.setdefault("default_contexts", {})
     data.setdefault("contexts", {})
+    _merge_legacy_default(data)
     return data
 
 
@@ -172,6 +205,7 @@ def save_store(data: dict[str, Any]) -> None:
     data.setdefault("version", 1)
     data.setdefault("default_contexts", {})
     data.setdefault("contexts", {})
+    _merge_legacy_default(data)
     _write_private_json(store_path(), data)
 
 

--- a/skills/productivity/google-workspace/scripts/auth_contexts.py
+++ b/skills/productivity/google-workspace/scripts/auth_contexts.py
@@ -1,0 +1,419 @@
+"""Named Google Workspace OAuth auth contexts.
+
+An auth context is a named OAuth credential bundle: account hint, requested
+services/scopes, client secret, token, and pending PKCE session. Contexts let one
+Hermes profile route different Google operations through different least-
+privilege grants without splitting agent memory across Hermes profiles.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+from _hermes_home import get_hermes_home
+
+LEGACY_TOKEN_NAME = "google_token.json"
+LEGACY_CLIENT_SECRET_NAME = "google_client_secret.json"
+LEGACY_PENDING_NAME = "google_oauth_pending.json"
+AUTH_CONTEXTS_NAME = "google_workspace_auth_contexts.json"
+
+_CONTEXT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$")
+
+GMAIL_READONLY = "https://www.googleapis.com/auth/gmail.readonly"
+GMAIL_SEND = "https://www.googleapis.com/auth/gmail.send"
+GMAIL_MODIFY = "https://www.googleapis.com/auth/gmail.modify"
+CALENDAR = "https://www.googleapis.com/auth/calendar"
+CALENDAR_READONLY = "https://www.googleapis.com/auth/calendar.readonly"
+DRIVE = "https://www.googleapis.com/auth/drive"
+DRIVE_READONLY = "https://www.googleapis.com/auth/drive.readonly"
+DRIVE_FILE = "https://www.googleapis.com/auth/drive.file"
+CONTACTS_READONLY = "https://www.googleapis.com/auth/contacts.readonly"
+SHEETS = "https://www.googleapis.com/auth/spreadsheets"
+SHEETS_READONLY = "https://www.googleapis.com/auth/spreadsheets.readonly"
+DOCS = "https://www.googleapis.com/auth/documents"
+DOCS_READONLY = "https://www.googleapis.com/auth/documents.readonly"
+
+SERVICE_SCOPE_MAP: dict[str, list[str]] = {
+    "gmail-readonly": [GMAIL_READONLY],
+    "gmail-send": [GMAIL_SEND],
+    "gmail-modify": [GMAIL_MODIFY],
+    # Legacy/default Gmail service remains read/send/modify for backward compatibility.
+    "gmail": [GMAIL_READONLY, GMAIL_SEND, GMAIL_MODIFY],
+    "email": [GMAIL_READONLY, GMAIL_SEND, GMAIL_MODIFY],
+    "calendar-readonly": [CALENDAR_READONLY],
+    "calendar": [CALENDAR],
+    "drive-readonly": [DRIVE_READONLY],
+    "drive-file": [DRIVE_FILE],
+    "drive": [DRIVE],
+    "contacts-readonly": [CONTACTS_READONLY],
+    "contacts": [CONTACTS_READONLY],
+    "sheets-readonly": [SHEETS_READONLY],
+    "sheets": [SHEETS],
+    "docs-readonly": [DOCS_READONLY],
+    "docs": [DOCS],
+}
+
+LEGACY_DEFAULT_SERVICES = ["gmail", "calendar", "drive", "contacts", "sheets", "docs"]
+SCOPES = [scope for service in LEGACY_DEFAULT_SERVICES for scope in SERVICE_SCOPE_MAP[service]]
+
+# Full write scopes imply narrower read scopes for local command gating.
+SCOPE_IMPLICATIONS: dict[str, set[str]] = {
+    GMAIL_MODIFY: {GMAIL_READONLY},
+    CALENDAR: {CALENDAR_READONLY},
+    DRIVE: {DRIVE_READONLY, DRIVE_FILE},
+    SHEETS: {SHEETS_READONLY},
+    DOCS: {DOCS_READONLY},
+}
+
+COMMAND_SCOPE_REQUIREMENTS: dict[tuple[str, str], list[set[str]]] = {
+    ("gmail", "search"): [{GMAIL_READONLY, GMAIL_MODIFY}],
+    ("gmail", "get"): [{GMAIL_READONLY, GMAIL_MODIFY}],
+    ("gmail", "labels"): [{GMAIL_READONLY, GMAIL_MODIFY}],
+    ("gmail", "send"): [{GMAIL_SEND}],
+    ("gmail", "reply"): [{GMAIL_SEND}],
+    ("gmail", "modify"): [{GMAIL_MODIFY}],
+    ("calendar", "list"): [{CALENDAR_READONLY, CALENDAR}],
+    ("calendar", "create"): [{CALENDAR}],
+    ("calendar", "delete"): [{CALENDAR}],
+    ("drive", "search"): [{DRIVE_READONLY, DRIVE_FILE, DRIVE}],
+    ("drive", "get"): [{DRIVE_READONLY, DRIVE_FILE, DRIVE}],
+    ("drive", "download"): [{DRIVE_READONLY, DRIVE_FILE, DRIVE}],
+    ("drive", "upload"): [{DRIVE_FILE, DRIVE}],
+    ("drive", "create-folder"): [{DRIVE_FILE, DRIVE}],
+    ("drive", "share"): [{DRIVE}],
+    ("drive", "delete"): [{DRIVE}],
+    ("contacts", "list"): [{CONTACTS_READONLY}],
+    ("sheets", "get"): [{SHEETS_READONLY, SHEETS}],
+    ("sheets", "create"): [{SHEETS}],
+    ("sheets", "update"): [{SHEETS}],
+    ("sheets", "append"): [{SHEETS}],
+    ("docs", "get"): [{DOCS_READONLY, DOCS}],
+    ("docs", "create"): [{DOCS}],
+    ("docs", "append"): [{DOCS}],
+}
+
+
+def hermes_home() -> Path:
+    return get_hermes_home()
+
+
+def store_path() -> Path:
+    return hermes_home() / AUTH_CONTEXTS_NAME
+
+
+def legacy_token_path() -> Path:
+    return hermes_home() / LEGACY_TOKEN_NAME
+
+
+def legacy_client_secret_path() -> Path:
+    return hermes_home() / LEGACY_CLIENT_SECRET_NAME
+
+
+def legacy_pending_path() -> Path:
+    return hermes_home() / LEGACY_PENDING_NAME
+
+
+def validate_context_name(name: str | None) -> str:
+    if name is None:
+        name = "default"
+    if not isinstance(name, str) or name != name.strip() or not _CONTEXT_RE.fullmatch(name) or name in {".", ".."} or "/" in name or "\\" in name:
+        raise ValueError(
+            "Auth context names must be 1-64 chars: letters, numbers, '.', '_', '-' "
+            "and may not contain path separators"
+        )
+    return name
+
+
+def _empty_store() -> dict[str, Any]:
+    return {"version": 1, "default_contexts": {}, "contexts": {}}
+
+
+def load_store() -> dict[str, Any]:
+    path = store_path()
+    if not path.exists():
+        return _empty_store()
+    try:
+        data = json.loads(path.read_text())
+    except Exception:
+        return _empty_store()
+    if not isinstance(data, dict):
+        return _empty_store()
+    data.setdefault("version", 1)
+    data.setdefault("default_contexts", {})
+    data.setdefault("contexts", {})
+    return data
+
+
+def _write_private_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        path.parent.chmod(0o700)
+    except OSError:
+        pass
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True))
+    try:
+        tmp.chmod(0o600)
+    except OSError:
+        pass
+    os.replace(tmp, path)
+    try:
+        path.chmod(0o600)
+    except OSError:
+        pass
+
+
+def save_store(data: dict[str, Any]) -> None:
+    data.setdefault("version", 1)
+    data.setdefault("default_contexts", {})
+    data.setdefault("contexts", {})
+    _write_private_json(store_path(), data)
+
+
+def _context_entry(store: dict[str, Any], context: str) -> dict[str, Any]:
+    context = validate_context_name(context)
+    contexts = store.setdefault("contexts", {})
+    entry = contexts.setdefault(context, {})
+    entry.setdefault("name", context)
+    return entry
+
+
+def context_exists(context: str = "default") -> bool:
+    context = validate_context_name(context)
+    if context == "default" and (legacy_token_path().exists() or legacy_client_secret_path().exists()):
+        return True
+    return context in load_store().get("contexts", {})
+
+
+def list_contexts() -> list[str]:
+    names = set(load_store().get("contexts", {}).keys())
+    if legacy_token_path().exists() or legacy_client_secret_path().exists():
+        names.add("default")
+    return sorted(names)
+
+
+def scope_list(raw: Any) -> list[str]:
+    if not raw:
+        return []
+    if isinstance(raw, str):
+        return [s.strip() for s in raw.split() if s.strip()]
+    return [str(s).strip() for s in raw if str(s).strip()]
+
+
+def expand_scopes(scopes: list[str]) -> set[str]:
+    expanded = set(scopes)
+    for scope in list(expanded):
+        expanded.update(SCOPE_IMPLICATIONS.get(scope, set()))
+    return expanded
+
+
+def resolve_scopes(*, services: str | None = None, scopes: str | None = None) -> list[str]:
+    if scopes:
+        return sorted(set(scope_list(scopes.replace(",", " "))))
+    selected = (services or "all").strip().lower()
+    service_names = LEGACY_DEFAULT_SERVICES if selected in {"", "all"} else [s.strip().lower() for s in selected.split(",") if s.strip()]
+    unknown = sorted(set(service_names) - set(SERVICE_SCOPE_MAP))
+    if unknown:
+        raise ValueError(f"Unknown Google service preset(s): {', '.join(unknown)}")
+    out: list[str] = []
+    for service in service_names:
+        for scope in SERVICE_SCOPE_MAP[service]:
+            if scope not in out:
+                out.append(scope)
+    return out
+
+
+def get_token_payload(context: str = "default") -> dict[str, Any]:
+    context = validate_context_name(context)
+    store = load_store()
+    token = store.get("contexts", {}).get(context, {}).get("token")
+    if isinstance(token, dict):
+        return dict(token)
+    if context == "default" and legacy_token_path().exists() and not store_path().exists():
+        try:
+            return json.loads(legacy_token_path().read_text())
+        except Exception:
+            return {}
+    return {}
+
+
+def set_token_payload(context: str, token_payload: dict[str, Any], *, services: list[str] | None = None, requested_scopes: list[str] | None = None) -> None:
+    context = validate_context_name(context)
+    if context == "default" and not store_path().exists():
+        _write_private_json(legacy_token_path(), token_payload)
+        return
+    store = load_store()
+    entry = _context_entry(store, context)
+    entry["token"] = token_payload
+    if services is not None:
+        entry["services"] = services
+    if requested_scopes is not None:
+        entry["requested_scopes"] = requested_scopes
+    save_store(store)
+
+
+def get_client_secret(context: str = "default") -> dict[str, Any]:
+    context = validate_context_name(context)
+    store = load_store()
+    secret = store.get("contexts", {}).get(context, {}).get("client_secret")
+    if isinstance(secret, dict):
+        return dict(secret)
+    if context == "default" and legacy_client_secret_path().exists() and not store_path().exists():
+        try:
+            return json.loads(legacy_client_secret_path().read_text())
+        except Exception:
+            return {}
+    return {}
+
+
+def set_client_secret(context: str, payload: dict[str, Any], *, account_hint: str = "") -> None:
+    context = validate_context_name(context)
+    if context == "default" and not store_path().exists():
+        _write_private_json(legacy_client_secret_path(), payload)
+        return
+    store = load_store()
+    entry = _context_entry(store, context)
+    entry["client_secret"] = payload
+    if account_hint:
+        entry["account_hint"] = account_hint
+    save_store(store)
+
+
+def get_pending_auth(context: str = "default") -> dict[str, Any]:
+    context = validate_context_name(context)
+    store = load_store()
+    pending = store.get("contexts", {}).get(context, {}).get("pending_auth")
+    if isinstance(pending, dict):
+        return dict(pending)
+    if context == "default" and legacy_pending_path().exists() and not store_path().exists():
+        try:
+            return json.loads(legacy_pending_path().read_text())
+        except Exception:
+            return {}
+    return {}
+
+
+def set_pending_auth(context: str, payload: dict[str, Any]) -> None:
+    context = validate_context_name(context)
+    if context == "default" and not store_path().exists():
+        _write_private_json(legacy_pending_path(), payload)
+        return
+    store = load_store()
+    entry = _context_entry(store, context)
+    entry["pending_auth"] = payload
+    save_store(store)
+
+
+def clear_pending_auth(context: str = "default") -> None:
+    context = validate_context_name(context)
+    store = load_store()
+    if context in store.get("contexts", {}):
+        store["contexts"][context].pop("pending_auth", None)
+        save_store(store)
+    if context == "default":
+        legacy_pending_path().unlink(missing_ok=True)
+
+
+def delete_token(context: str = "default") -> None:
+    context = validate_context_name(context)
+    store = load_store()
+    if context in store.get("contexts", {}):
+        store["contexts"][context].pop("token", None)
+        store["contexts"][context].pop("pending_auth", None)
+        save_store(store)
+    _materialized_token_path(context).unlink(missing_ok=True)
+    if context == "default":
+        legacy_token_path().unlink(missing_ok=True)
+        legacy_pending_path().unlink(missing_ok=True)
+
+
+def set_default_for_services(context: str, services_csv: str) -> None:
+    context = validate_context_name(context)
+    services = [s.strip().lower() for s in services_csv.split(",") if s.strip()]
+    valid_api_services = {"gmail", "calendar", "drive", "contacts", "sheets", "docs"}
+    unknown = sorted(set(services) - valid_api_services)
+    if unknown:
+        raise ValueError(f"Unknown API service(s) for defaults: {', '.join(unknown)}")
+    store = load_store()
+    _context_entry(store, context)
+    defaults = store.setdefault("default_contexts", {})
+    for service in services:
+        defaults[service] = context
+    save_store(store)
+
+
+def default_context_for_service(service: str) -> str:
+    return load_store().get("default_contexts", {}).get(service, "default")
+
+
+def _materialized_token_path(context: str) -> Path:
+    return hermes_home() / ".cache" / "google-workspace" / "contexts" / context / LEGACY_TOKEN_NAME
+
+
+def _materialized_client_secret_path(context: str) -> Path:
+    return hermes_home() / ".cache" / "google-workspace" / "contexts" / context / LEGACY_CLIENT_SECRET_NAME
+
+
+def materialize_token_file(context: str = "default") -> Path:
+    context = validate_context_name(context)
+    if context == "default" and legacy_token_path().exists() and not store_path().exists():
+        return legacy_token_path()
+    payload = get_token_payload(context)
+    path = _materialized_token_path(context)
+    if not payload:
+        path.unlink(missing_ok=True)
+        return path
+    _write_private_json(path, payload)
+    return path
+
+
+def materialize_client_secret_file(context: str = "default") -> Path:
+    context = validate_context_name(context)
+    if context == "default" and legacy_client_secret_path().exists() and not store_path().exists():
+        return legacy_client_secret_path()
+    payload = get_client_secret(context)
+    path = _materialized_client_secret_path(context)
+    if not payload:
+        path.unlink(missing_ok=True)
+        return path
+    _write_private_json(path, payload)
+    return path
+
+
+def granted_scopes_for_context(context: str = "default") -> list[str]:
+    context = validate_context_name(context)
+    payload = get_token_payload(context)
+    scopes = scope_list(payload.get("scopes") or payload.get("scope"))
+    if scopes:
+        return scopes
+    # Legacy default tokens predate stored scope metadata; preserve compatibility
+    # only for that legacy layout. Named/store-backed contexts fail closed.
+    if context == "default" and legacy_token_path().exists() and not store_path().exists():
+        return list(SCOPES)
+    return []
+
+
+def missing_scopes(payload: dict[str, Any], required_scopes: list[str] | None = None) -> list[str]:
+    required = required_scopes or list(SCOPES)
+    granted = expand_scopes(scope_list(payload.get("scopes") or payload.get("scope")))
+    if not granted:
+        return [] if required_scopes is None else sorted(required)
+    return sorted(scope for scope in required if scope not in granted)
+
+
+def assert_command_allowed(context: str, service: str, action: str) -> None:
+    alternatives = COMMAND_SCOPE_REQUIREMENTS.get((service, action))
+    if not alternatives:
+        return
+    granted = expand_scopes(granted_scopes_for_context(context))
+    if any(granted.intersection(allowed) for allowed in alternatives):
+        return
+    needed = " OR ".join("/".join(sorted(allowed)) for allowed in alternatives)
+    raise PermissionError(
+        f"Auth context '{context}' lacks OAuth scope for {service} {action}. "
+        f"Need one of: {needed}. Granted: {', '.join(sorted(granted)) or '(none)'}"
+    )

--- a/skills/productivity/google-workspace/scripts/auth_contexts.py
+++ b/skills/productivity/google-workspace/scripts/auth_contexts.py
@@ -21,6 +21,7 @@ LEGACY_CLIENT_SECRET_NAME = "google_client_secret.json"
 LEGACY_PENDING_NAME = "google_oauth_pending.json"
 AUTH_CONTEXTS_NAME = "google_workspace_auth_contexts.json"
 _LEGACY_MIGRATION_KEY = "legacy_default_migrated"
+_LEGACY_SUPPRESSED_KEY = "legacy_default_suppressed_fields"
 
 _CONTEXT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$")
 
@@ -146,6 +147,12 @@ def _merge_legacy_default(data: dict[str, Any]) -> None:
     """
     if data.get(_LEGACY_MIGRATION_KEY) is True:
         return
+    suppressed_raw = data.get(_LEGACY_SUPPRESSED_KEY, [])
+    suppressed = (
+        {str(field) for field in suppressed_raw}
+        if isinstance(suppressed_raw, list)
+        else set()
+    )
     legacy_payloads: dict[str, dict[str, Any] | None] = {}
     all_readable = True
     for key, path in (
@@ -153,6 +160,9 @@ def _merge_legacy_default(data: dict[str, Any]) -> None:
         ("client_secret", legacy_client_secret_path()),
         ("pending_auth", legacy_pending_path()),
     ):
+        if key in suppressed:
+            legacy_payloads[key] = None
+            continue
         readable, payload = _read_json_file(path)
         if not readable:
             all_readable = False
@@ -183,21 +193,44 @@ def _empty_store() -> dict[str, Any]:
     return {"version": 1, "default_contexts": {}, "contexts": {}}
 
 
-def load_store() -> dict[str, Any]:
+def _load_store(*, strict: bool = False) -> dict[str, Any]:
     path = store_path()
     if not path.exists():
         return _empty_store()
     try:
-        data = json.loads(path.read_text())
-    except Exception:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        if strict:
+            raise RuntimeError(
+                f"Auth context store is unreadable; refusing to overwrite {path}"
+            ) from exc
         return _empty_store()
     if not isinstance(data, dict):
+        if strict:
+            raise RuntimeError(
+                f"Auth context store is unreadable; refusing to overwrite {path}"
+            )
         return _empty_store()
     data.setdefault("version", 1)
-    data.setdefault("default_contexts", {})
-    data.setdefault("contexts", {})
+    for key in ("default_contexts", "contexts"):
+        if key not in data:
+            data[key] = {}
+        elif not isinstance(data[key], dict):
+            if strict:
+                raise RuntimeError(
+                    f"Auth context store is unreadable; refusing to overwrite {path}"
+                )
+            return _empty_store()
     _merge_legacy_default(data)
     return data
+
+
+def load_store() -> dict[str, Any]:
+    return _load_store()
+
+
+def _load_store_for_update() -> dict[str, Any]:
+    return _load_store(strict=True)
 
 
 def _write_private_json(path: Path, payload: dict[str, Any]) -> None:
@@ -361,20 +394,27 @@ def set_pending_auth(context: str, payload: dict[str, Any]) -> None:
     save_store(store)
 
 
+def _suppress_legacy_fields(store: dict[str, Any], fields: set[str]) -> None:
+    existing = store.get(_LEGACY_SUPPRESSED_KEY, [])
+    suppressed = {str(field) for field in existing} if isinstance(existing, list) else set()
+    store[_LEGACY_SUPPRESSED_KEY] = sorted(suppressed | fields)
+
+
 def clear_pending_auth(context: str = "default") -> None:
     context = validate_context_name(context)
     store_existed = store_path().exists()
+    store = _load_store_for_update() if store_existed else _empty_store()
     if context == "default":
-        # Remove the legacy source before loading/saving the store so a
-        # pre-marker store cannot migrate the pending state back in.
+        # Validate the named store before unlinking anything, then tombstone only
+        # pending auth so unrelated transient legacy files can still migrate.
         legacy_pending_path().unlink(missing_ok=True)
-    store = load_store()
+        if store_existed:
+            _suppress_legacy_fields(store, {"pending_auth"})
     changed = False
     if context in store.get("contexts", {}):
         store["contexts"][context].pop("pending_auth", None)
         changed = True
     if context == "default" and store_existed:
-        store[_LEGACY_MIGRATION_KEY] = True
         changed = True
     if changed:
         save_store(store)
@@ -383,19 +423,20 @@ def clear_pending_auth(context: str = "default") -> None:
 def delete_token(context: str = "default") -> None:
     context = validate_context_name(context)
     store_existed = store_path().exists()
+    store = _load_store_for_update() if store_existed else _empty_store()
     if context == "default":
-        # Destructive intent wins over legacy migration. Unlink sources first
-        # so old stores without the one-time marker cannot resurrect them.
+        # Validate the named store before unlinking anything, then tombstone only
+        # token-bearing fields so unrelated transient legacy files can migrate.
         legacy_token_path().unlink(missing_ok=True)
         legacy_pending_path().unlink(missing_ok=True)
-    store = load_store()
+        if store_existed:
+            _suppress_legacy_fields(store, {"token", "pending_auth"})
     changed = False
     if context in store.get("contexts", {}):
         store["contexts"][context].pop("token", None)
         store["contexts"][context].pop("pending_auth", None)
         changed = True
     if context == "default" and store_existed:
-        store[_LEGACY_MIGRATION_KEY] = True
         changed = True
     if changed:
         save_store(store)

--- a/skills/productivity/google-workspace/scripts/auth_contexts.py
+++ b/skills/productivity/google-workspace/scripts/auth_contexts.py
@@ -119,14 +119,22 @@ def legacy_pending_path() -> Path:
     return hermes_home() / LEGACY_PENDING_NAME
 
 
-def _read_json_file(path: Path) -> dict[str, Any]:
+def _read_json_file(path: Path) -> tuple[bool, dict[str, Any] | None]:
+    """Return ``(readable, payload)`` for an optional legacy JSON source.
+
+    Missing files are readable with no payload. Existing malformed, empty, or
+    non-object files are incomplete and must delay the one-time migration so a
+    concurrent credential rewrite cannot be skipped permanently.
+    """
     if not path.exists():
-        return {}
+        return True, None
     try:
-        payload = json.loads(path.read_text())
+        payload = json.loads(path.read_text(encoding="utf-8"))
     except Exception:
-        return {}
-    return payload if isinstance(payload, dict) else {}
+        return False, None
+    if not isinstance(payload, dict) or not payload:
+        return False, None
+    return True, payload
 
 
 def _merge_legacy_default(data: dict[str, Any]) -> None:
@@ -138,19 +146,26 @@ def _merge_legacy_default(data: dict[str, Any]) -> None:
     """
     if data.get(_LEGACY_MIGRATION_KEY) is True:
         return
-    legacy_payloads = {
-        "token": _read_json_file(legacy_token_path()),
-        "client_secret": _read_json_file(legacy_client_secret_path()),
-        "pending_auth": _read_json_file(legacy_pending_path()),
-    }
-    if any(legacy_payloads.values()):
+    legacy_payloads: dict[str, dict[str, Any] | None] = {}
+    all_readable = True
+    for key, path in (
+        ("token", legacy_token_path()),
+        ("client_secret", legacy_client_secret_path()),
+        ("pending_auth", legacy_pending_path()),
+    ):
+        readable, payload = _read_json_file(path)
+        if not readable:
+            all_readable = False
+        legacy_payloads[key] = payload
+    if any(payload is not None for payload in legacy_payloads.values()):
         contexts = data.setdefault("contexts", {})
         default = contexts.setdefault("default", {"name": "default"})
         default.setdefault("name", "default")
         for key, payload in legacy_payloads.items():
-            if payload and key not in default:
+            if payload is not None and key not in default:
                 default[key] = payload
-    data[_LEGACY_MIGRATION_KEY] = True
+    if all_readable:
+        data[_LEGACY_MIGRATION_KEY] = True
 
 
 def validate_context_name(name: str | None) -> str:
@@ -348,27 +363,41 @@ def set_pending_auth(context: str, payload: dict[str, Any]) -> None:
 
 def clear_pending_auth(context: str = "default") -> None:
     context = validate_context_name(context)
+    store_existed = store_path().exists()
     if context == "default":
         # Remove the legacy source before loading/saving the store so a
         # pre-marker store cannot migrate the pending state back in.
         legacy_pending_path().unlink(missing_ok=True)
     store = load_store()
+    changed = False
     if context in store.get("contexts", {}):
         store["contexts"][context].pop("pending_auth", None)
+        changed = True
+    if context == "default" and store_existed:
+        store[_LEGACY_MIGRATION_KEY] = True
+        changed = True
+    if changed:
         save_store(store)
 
 
 def delete_token(context: str = "default") -> None:
     context = validate_context_name(context)
+    store_existed = store_path().exists()
     if context == "default":
         # Destructive intent wins over legacy migration. Unlink sources first
         # so old stores without the one-time marker cannot resurrect them.
         legacy_token_path().unlink(missing_ok=True)
         legacy_pending_path().unlink(missing_ok=True)
     store = load_store()
+    changed = False
     if context in store.get("contexts", {}):
         store["contexts"][context].pop("token", None)
         store["contexts"][context].pop("pending_auth", None)
+        changed = True
+    if context == "default" and store_existed:
+        store[_LEGACY_MIGRATION_KEY] = True
+        changed = True
+    if changed:
         save_store(store)
     _materialized_token_path(context).unlink(missing_ok=True)
 

--- a/skills/productivity/google-workspace/scripts/auth_contexts.py
+++ b/skills/productivity/google-workspace/scripts/auth_contexts.py
@@ -20,6 +20,7 @@ LEGACY_TOKEN_NAME = "google_token.json"
 LEGACY_CLIENT_SECRET_NAME = "google_client_secret.json"
 LEGACY_PENDING_NAME = "google_oauth_pending.json"
 AUTH_CONTEXTS_NAME = "google_workspace_auth_contexts.json"
+_LEGACY_MIGRATION_KEY = "legacy_default_migrated"
 
 _CONTEXT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$")
 
@@ -129,25 +130,27 @@ def _read_json_file(path: Path) -> dict[str, Any]:
 
 
 def _merge_legacy_default(data: dict[str, Any]) -> None:
-    """Snapshot legacy credentials into ``contexts.default`` when needed.
+    """Snapshot legacy credentials into ``contexts.default`` exactly once.
 
     Creating a named context must not make a working legacy default disappear.
-    Once copied, the store-backed default remains authoritative and later
-    changes to stale legacy files are ignored.
+    Once the store is initialized, it remains authoritative and later changes
+    to stale legacy files are ignored, including after revoke/delete actions.
     """
+    if data.get(_LEGACY_MIGRATION_KEY) is True:
+        return
     legacy_payloads = {
         "token": _read_json_file(legacy_token_path()),
         "client_secret": _read_json_file(legacy_client_secret_path()),
         "pending_auth": _read_json_file(legacy_pending_path()),
     }
-    if not any(legacy_payloads.values()):
-        return
-    contexts = data.setdefault("contexts", {})
-    default = contexts.setdefault("default", {"name": "default"})
-    default.setdefault("name", "default")
-    for key, payload in legacy_payloads.items():
-        if payload and key not in default:
-            default[key] = payload
+    if any(legacy_payloads.values()):
+        contexts = data.setdefault("contexts", {})
+        default = contexts.setdefault("default", {"name": "default"})
+        default.setdefault("name", "default")
+        for key, payload in legacy_payloads.items():
+            if payload and key not in default:
+                default[key] = payload
+    data[_LEGACY_MIGRATION_KEY] = True
 
 
 def validate_context_name(name: str | None) -> str:
@@ -345,25 +348,29 @@ def set_pending_auth(context: str, payload: dict[str, Any]) -> None:
 
 def clear_pending_auth(context: str = "default") -> None:
     context = validate_context_name(context)
+    if context == "default":
+        # Remove the legacy source before loading/saving the store so a
+        # pre-marker store cannot migrate the pending state back in.
+        legacy_pending_path().unlink(missing_ok=True)
     store = load_store()
     if context in store.get("contexts", {}):
         store["contexts"][context].pop("pending_auth", None)
         save_store(store)
-    if context == "default":
-        legacy_pending_path().unlink(missing_ok=True)
 
 
 def delete_token(context: str = "default") -> None:
     context = validate_context_name(context)
+    if context == "default":
+        # Destructive intent wins over legacy migration. Unlink sources first
+        # so old stores without the one-time marker cannot resurrect them.
+        legacy_token_path().unlink(missing_ok=True)
+        legacy_pending_path().unlink(missing_ok=True)
     store = load_store()
     if context in store.get("contexts", {}):
         store["contexts"][context].pop("token", None)
         store["contexts"][context].pop("pending_auth", None)
         save_store(store)
     _materialized_token_path(context).unlink(missing_ok=True)
-    if context == "default":
-        legacy_token_path().unlink(missing_ok=True)
-        legacy_pending_path().unlink(missing_ok=True)
 
 
 def set_default_for_services(context: str, services_csv: str) -> None:

--- a/skills/productivity/google-workspace/scripts/auth_contexts.py
+++ b/skills/productivity/google-workspace/scripts/auth_contexts.py
@@ -69,12 +69,13 @@ SCOPE_IMPLICATIONS: dict[str, set[str]] = {
     DOCS: {DOCS_READONLY},
 }
 
+# Each set is an OR group; multiple groups for one command are conjunctive.
 COMMAND_SCOPE_REQUIREMENTS: dict[tuple[str, str], list[set[str]]] = {
     ("gmail", "search"): [{GMAIL_READONLY, GMAIL_MODIFY}],
     ("gmail", "get"): [{GMAIL_READONLY, GMAIL_MODIFY}],
     ("gmail", "labels"): [{GMAIL_READONLY, GMAIL_MODIFY}],
     ("gmail", "send"): [{GMAIL_SEND}],
-    ("gmail", "reply"): [{GMAIL_SEND}],
+    ("gmail", "reply"): [{GMAIL_SEND}, {GMAIL_READONLY, GMAIL_MODIFY}],
     ("gmail", "modify"): [{GMAIL_MODIFY}],
     ("calendar", "list"): [{CALENDAR_READONLY, CALENDAR}],
     ("calendar", "create"): [{CALENDAR}],
@@ -406,14 +407,17 @@ def missing_scopes(payload: dict[str, Any], required_scopes: list[str] | None = 
 
 
 def assert_command_allowed(context: str, service: str, action: str) -> None:
-    alternatives = COMMAND_SCOPE_REQUIREMENTS.get((service, action))
-    if not alternatives:
+    required_groups = COMMAND_SCOPE_REQUIREMENTS.get((service, action))
+    if not required_groups:
         return
     granted = expand_scopes(granted_scopes_for_context(context))
-    if any(granted.intersection(allowed) for allowed in alternatives):
+    if all(granted.intersection(group) for group in required_groups):
         return
-    needed = " OR ".join("/".join(sorted(allowed)) for allowed in alternatives)
+    needed = " AND ".join(
+        next(iter(group)) if len(group) == 1 else f"({' OR '.join(sorted(group))})"
+        for group in required_groups
+    )
     raise PermissionError(
         f"Auth context '{context}' lacks OAuth scope for {service} {action}. "
-        f"Need one of: {needed}. Granted: {', '.join(sorted(granted)) or '(none)'}"
+        f"Need: {needed}. Granted: {', '.join(sorted(granted)) or '(none)'}"
     )

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 """Google Workspace API CLI for Hermes Agent.
 
 Uses the Google Workspace CLI (`gws`) when available, but preserves the
@@ -37,21 +38,13 @@ if _SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, _SCRIPTS_DIR)
 
 from _hermes_home import get_hermes_home
+import auth_contexts as gauth
 
 HERMES_HOME = get_hermes_home()
 TOKEN_PATH = HERMES_HOME / "google_token.json"
 CLIENT_SECRET_PATH = HERMES_HOME / "google_client_secret.json"
-
-SCOPES = [
-    "https://www.googleapis.com/auth/gmail.readonly",
-    "https://www.googleapis.com/auth/gmail.send",
-    "https://www.googleapis.com/auth/gmail.modify",
-    "https://www.googleapis.com/auth/calendar",
-    "https://www.googleapis.com/auth/drive",
-    "https://www.googleapis.com/auth/contacts.readonly",
-    "https://www.googleapis.com/auth/spreadsheets",
-    "https://www.googleapis.com/auth/documents",
-]
+SCOPES = gauth.SCOPES
+CURRENT_AUTH_CONTEXT = "default"
 
 
 def _normalize_authorized_user_payload(payload: dict) -> dict:
@@ -62,21 +55,14 @@ def _normalize_authorized_user_payload(payload: dict) -> dict:
 
 
 def _ensure_authenticated():
-    if not TOKEN_PATH.exists():
-        print("Not authenticated. Run the setup script first:", file=sys.stderr)
-        print(f"  python {Path(__file__).parent / 'setup.py'}", file=sys.stderr)
+    if not gauth.get_token_payload(CURRENT_AUTH_CONTEXT):
+        print(f"Not authenticated for Google auth context {CURRENT_AUTH_CONTEXT!r}. Run the setup script first:", file=sys.stderr)
+        print(f"  python {Path(__file__).parent / 'setup.py'} --auth-context {CURRENT_AUTH_CONTEXT} --auth-url", file=sys.stderr)
         sys.exit(1)
 
 
 def _stored_token_scopes() -> list[str]:
-    try:
-        data = json.loads(TOKEN_PATH.read_text())
-    except Exception:
-        return list(SCOPES)
-    scopes = data.get("scopes")
-    if isinstance(scopes, list) and scopes:
-        return scopes
-    return list(SCOPES)
+    return gauth.granted_scopes_for_context(CURRENT_AUTH_CONTEXT)
 
 
 def _gws_binary() -> str | None:
@@ -88,7 +74,8 @@ def _gws_binary() -> str | None:
 
 def _gws_env() -> dict[str, str]:
     env = os.environ.copy()
-    env["GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE"] = str(TOKEN_PATH)
+    env["GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE"] = str(gauth.materialize_token_file(CURRENT_AUTH_CONTEXT))
+    env["HERMES_GOOGLE_AUTH_CONTEXT"] = CURRENT_AUTH_CONTEXT
     return env
 
 
@@ -185,15 +172,14 @@ def get_credentials():
     from google.oauth2.credentials import Credentials
     from google.auth.transport.requests import Request
 
-    creds = Credentials.from_authorized_user_file(str(TOKEN_PATH), _stored_token_scopes())
+    creds = Credentials.from_authorized_user_file(str(gauth.materialize_token_file(CURRENT_AUTH_CONTEXT)), _stored_token_scopes())
     if creds.expired and creds.refresh_token:
         creds.refresh(Request())
-        TOKEN_PATH.write_text(
-            json.dumps(
-                _normalize_authorized_user_payload(json.loads(creds.to_json())),
-                indent=2,
-            )
-        )
+        payload = _normalize_authorized_user_payload(json.loads(creds.to_json()))
+        existing_scopes = _stored_token_scopes()
+        if existing_scopes and not (payload.get("scopes") or payload.get("scope")):
+            payload["scopes"] = existing_scopes
+        gauth.set_token_payload(CURRENT_AUTH_CONTEXT, payload)
     if not creds.valid:
         print("Token is invalid. Re-run setup.", file=sys.stderr)
         sys.exit(1)
@@ -1053,6 +1039,7 @@ def _docs_insert_text(doc_id: str, text: str, index: int) -> None:
 
 def main():
     parser = argparse.ArgumentParser(description="Google Workspace API for Hermes Agent")
+    parser.add_argument("--auth-context", default="", help="Named Google OAuth auth context. Defaults by API service, then legacy/default.")
     sub = parser.add_subparsers(dest="service", required=True)
 
     # --- Gmail ---
@@ -1218,6 +1205,14 @@ def main():
     p.set_defaults(func=docs_append)
 
     args = parser.parse_args()
+    global CURRENT_AUTH_CONTEXT
+    try:
+        CURRENT_AUTH_CONTEXT = args.auth_context or gauth.default_context_for_service(args.service)
+        gauth.validate_context_name(CURRENT_AUTH_CONTEXT)
+        gauth.assert_command_allowed(CURRENT_AUTH_CONTEXT, args.service, args.action)
+    except (PermissionError, ValueError) as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(2)
     args.func(args)
 
 

--- a/skills/productivity/google-workspace/scripts/gws_bridge.py
+++ b/skills/productivity/google-workspace/scripts/gws_bridge.py
@@ -16,10 +16,15 @@ if _SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, _SCRIPTS_DIR)
 
 from _hermes_home import get_hermes_home
+import auth_contexts as gauth
+
+CURRENT_AUTH_CONTEXT = os.getenv("HERMES_GOOGLE_AUTH_CONTEXT", "default")
 
 
 def get_token_path() -> Path:
-    return get_hermes_home() / "google_token.json"
+    if CURRENT_AUTH_CONTEXT == "default" and not gauth.store_path().exists():
+        return gauth.legacy_token_path()
+    return gauth.materialize_token_file(CURRENT_AUTH_CONTEXT)
 
 
 def _normalize_authorized_user_payload(payload: dict) -> dict:
@@ -68,9 +73,15 @@ def refresh_token(token_data: dict) -> dict:
         tz=timezone.utc,
     ).isoformat()
 
-    get_token_path().write_text(
-        json.dumps(_normalize_authorized_user_payload(token_data), indent=2)
-    )
+    refreshed = _normalize_authorized_user_payload(token_data)
+    if CURRENT_AUTH_CONTEXT == "default" and gauth.legacy_token_path().exists() and not gauth.store_path().exists():
+        get_token_path().write_text(json.dumps(refreshed, indent=2))
+        try:
+            get_token_path().chmod(0o600)
+        except OSError:
+            pass
+    else:
+        gauth.set_token_payload(CURRENT_AUTH_CONTEXT, refreshed)
     return token_data
 
 
@@ -95,15 +106,25 @@ def get_valid_token() -> str:
 
 def main():
     """Refresh token if needed, then exec gws with remaining args."""
-    if len(sys.argv) < 2:
-        print("Usage: gws_bridge.py <gws args...>", file=sys.stderr)
+    global CURRENT_AUTH_CONTEXT
+    argv = sys.argv[1:]
+    if "--auth-context" in argv:
+        idx = argv.index("--auth-context")
+        try:
+            CURRENT_AUTH_CONTEXT = argv[idx + 1]
+        except IndexError:
+            print("ERROR: --auth-context requires a value", file=sys.stderr)
+            sys.exit(2)
+        del argv[idx:idx + 2]
+    if not argv:
+        print("Usage: gws_bridge.py [--auth-context NAME] <gws args...>", file=sys.stderr)
         sys.exit(1)
 
     access_token = get_valid_token()
     env = os.environ.copy()
     env["GOOGLE_WORKSPACE_CLI_TOKEN"] = access_token
 
-    result = subprocess.run(["gws"] + sys.argv[1:], env=env)
+    result = subprocess.run(["gws"] + argv, env=env)
     sys.exit(result.returncode)
 
 

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -213,18 +213,39 @@ def _ensure_deps():
 
 
 def check_auth_live(auth_context: str = "default"):
-    """Check auth with a real API call to detect disabled_client/account issues."""
+    """Force a real OAuth refresh to detect disabled clients/accounts.
+
+    Refreshing is service-neutral, so least-privilege Gmail-, Drive-, Sheets-,
+    or Docs-only contexts do not need an unrelated Calendar scope merely to
+    validate their OAuth client and account.
+    """
     # quiet=True suppresses the "AUTHENTICATED" print from check_auth so the
     # final status line reflects the live-call outcome (OK or FAILED).
     if not check_auth(quiet=True, auth_context=auth_context):
         return False
     try:
-        from googleapiclient.discovery import build
+        from google.auth.transport.requests import Request
         from google.oauth2.credentials import Credentials
+
+        payload = _token_payload(auth_context)
         creds = Credentials.from_authorized_user_file(str(_token_file(auth_context)))
-        service = build("calendar", "v3", credentials=creds)
-        service.calendarList().list(maxResults=1).execute()
-        print("LIVE_CHECK_OK: Real API call succeeded.")
+        if not creds.refresh_token:
+            print("LIVE_CHECK_FAILED: Stored credentials have no refresh token.")
+            return False
+        creds.refresh(Request())
+        refreshed_payload = _normalize_authorized_user_payload(
+            json.loads(creds.to_json())
+        )
+        existing_scopes = gauth.scope_list(
+            payload.get("scopes") or payload.get("scope")
+        )
+        refreshed_scopes = gauth.scope_list(
+            refreshed_payload.get("scopes") or refreshed_payload.get("scope")
+        )
+        if existing_scopes and not refreshed_scopes:
+            refreshed_payload["scopes"] = existing_scopes
+        _set_token_payload(auth_context, refreshed_payload)
+        print("LIVE_CHECK_OK: OAuth token refresh succeeded.")
         return True
     except Exception as e:
         err_str = str(e).lower()
@@ -510,7 +531,7 @@ def main():
     parser.add_argument("--strict-scopes", action="store_true", help="Fail auth-code exchange if granted scopes miss requested scopes")
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--check", action="store_true", help="Check if auth is valid (exit 0=yes, 1=no)")
-    group.add_argument("--check-live", action="store_true", help="Check auth with a real API call (detects disabled_client)")
+    group.add_argument("--check-live", action="store_true", help="Force a live OAuth refresh (detects disabled_client without requiring a service scope)")
     group.add_argument("--client-secret", metavar="PATH", help="Store OAuth client_secret.json")
     group.add_argument("--auth-url", action="store_true", help="Print OAuth URL for user to visit")
     group.add_argument("--auth-code", metavar="CODE", help="Exchange auth code for token")

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -37,22 +37,13 @@ if _SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, _SCRIPTS_DIR)
 
 from _hermes_home import display_hermes_home, get_hermes_home
+import auth_contexts as gauth
 
 HERMES_HOME = get_hermes_home()
 TOKEN_PATH = HERMES_HOME / "google_token.json"
 CLIENT_SECRET_PATH = HERMES_HOME / "google_client_secret.json"
 PENDING_AUTH_PATH = HERMES_HOME / "google_oauth_pending.json"
-
-SCOPES = [
-    "https://www.googleapis.com/auth/gmail.readonly",
-    "https://www.googleapis.com/auth/gmail.send",
-    "https://www.googleapis.com/auth/gmail.modify",
-    "https://www.googleapis.com/auth/calendar",
-    "https://www.googleapis.com/auth/drive",
-    "https://www.googleapis.com/auth/contacts.readonly",
-    "https://www.googleapis.com/auth/spreadsheets",
-    "https://www.googleapis.com/auth/documents",
-]
+SCOPES = gauth.SCOPES
 
 REQUIRED_PACKAGES = ["google-api-python-client", "google-auth-oauthlib", "google-auth-httplib2"]
 
@@ -69,19 +60,17 @@ def _normalize_authorized_user_payload(payload: dict) -> dict:
     return normalized
 
 
-def _load_token_payload(path: Path = TOKEN_PATH) -> dict:
+def _load_token_payload(path: Path = TOKEN_PATH, auth_context: str = "default") -> dict:
+    if path == TOKEN_PATH:
+        return _token_payload(auth_context)
     try:
         return json.loads(path.read_text())
     except Exception:
         return {}
 
 
-def _missing_scopes_from_payload(payload: dict) -> list[str]:
-    raw = payload.get("scopes") or payload.get("scope")
-    if not raw:
-        return []
-    granted = {s.strip() for s in (raw.split() if isinstance(raw, str) else raw) if s.strip()}
-    return sorted(scope for scope in SCOPES if scope not in granted)
+def _missing_scopes_from_payload(payload: dict, required_scopes: list[str] | None = None) -> list[str]:
+    return gauth.missing_scopes(payload, required_scopes)
 
 
 def _format_missing_scopes(missing_scopes: list[str]) -> str:
@@ -91,6 +80,73 @@ def _format_missing_scopes(missing_scopes: list[str]) -> str:
         f"{bullets}\n"
         "Run the Google Workspace setup again from this same Hermes profile to refresh consent."
     )
+
+
+def _client_secret_payload(auth_context: str = "default") -> dict:
+    if auth_context == "default" and CLIENT_SECRET_PATH.exists() and not gauth.store_path().exists():
+        try:
+            return json.loads(CLIENT_SECRET_PATH.read_text())
+        except Exception:
+            return {}
+    return gauth.get_client_secret(auth_context)
+
+
+def _client_secret_file(auth_context: str = "default") -> Path:
+    if auth_context == "default" and CLIENT_SECRET_PATH.exists() and not gauth.store_path().exists():
+        return CLIENT_SECRET_PATH
+    return gauth.materialize_client_secret_file(auth_context)
+
+
+def _token_payload(auth_context: str = "default") -> dict:
+    if auth_context == "default" and TOKEN_PATH.exists() and not gauth.store_path().exists():
+        try:
+            return json.loads(TOKEN_PATH.read_text())
+        except Exception:
+            return {}
+    return gauth.get_token_payload(auth_context)
+
+
+def _token_file(auth_context: str = "default") -> Path:
+    if auth_context == "default" and TOKEN_PATH.exists() and not gauth.store_path().exists():
+        return TOKEN_PATH
+    return gauth.materialize_token_file(auth_context)
+
+
+def _set_token_payload(auth_context: str, payload: dict, **kwargs):
+    if auth_context == "default" and not gauth.store_path().exists():
+        TOKEN_PATH.write_text(json.dumps(payload, indent=2))
+        try:
+            TOKEN_PATH.chmod(0o600)
+        except OSError:
+            pass
+        return
+    gauth.set_token_payload(auth_context, payload, **kwargs)
+
+
+def _pending_payload(auth_context: str = "default") -> dict:
+    if auth_context == "default" and PENDING_AUTH_PATH.exists() and not gauth.store_path().exists():
+        try:
+            return json.loads(PENDING_AUTH_PATH.read_text())
+        except Exception:
+            return {}
+    return gauth.get_pending_auth(auth_context)
+
+
+def _set_pending_payload(auth_context: str, payload: dict):
+    if auth_context == "default" and not gauth.store_path().exists():
+        PENDING_AUTH_PATH.write_text(json.dumps(payload, indent=2))
+        try:
+            PENDING_AUTH_PATH.chmod(0o600)
+        except OSError:
+            pass
+        return
+    gauth.set_pending_auth(auth_context, payload)
+
+
+def _clear_pending(auth_context: str = "default"):
+    if auth_context == "default":
+        PENDING_AUTH_PATH.unlink(missing_ok=True)
+    gauth.clear_pending_auth(auth_context)
 
 
 def install_deps():
@@ -156,16 +212,16 @@ def _ensure_deps():
             sys.exit(1)
 
 
-def check_auth_live():
+def check_auth_live(auth_context: str = "default"):
     """Check auth with a real API call to detect disabled_client/account issues."""
     # quiet=True suppresses the "AUTHENTICATED" print from check_auth so the
     # final status line reflects the live-call outcome (OK or FAILED).
-    if not check_auth(quiet=True):
+    if not check_auth(quiet=True, auth_context=auth_context):
         return False
     try:
         from googleapiclient.discovery import build
         from google.oauth2.credentials import Credentials
-        creds = Credentials.from_authorized_user_file(str(TOKEN_PATH))
+        creds = Credentials.from_authorized_user_file(str(_token_file(auth_context)))
         service = build("calendar", "v3", credentials=creds)
         service.calendarList().list(maxResults=1).execute()
         print("LIVE_CHECK_OK: Real API call succeeded.")
@@ -182,10 +238,11 @@ def check_auth_live():
         return False
 
 
-def check_auth(quiet: bool = False):
+def check_auth(quiet: bool = False, auth_context: str = "default", required_scopes: list[str] | None = None):
     """Check if stored credentials are valid. Prints status, exits 0 or 1."""
-    if not TOKEN_PATH.exists():
-        print(f"NOT_AUTHENTICATED: No token at {TOKEN_PATH}")
+    token_payload = _token_payload(auth_context)
+    if not token_payload:
+        print(f"NOT_AUTHENTICATED: No token for Google auth context {auth_context!r}")
         return False
 
     _ensure_deps()
@@ -197,38 +254,37 @@ def check_auth(quiet: bool = False):
         # Passing scopes forces google-auth to validate them on refresh,
         # which fails with invalid_scope if the token has fewer scopes
         # than requested.
-        creds = Credentials.from_authorized_user_file(str(TOKEN_PATH))
+        creds = Credentials.from_authorized_user_file(str(_token_file(auth_context)))
     except Exception as e:
         print(f"TOKEN_CORRUPT: {e}")
         return False
 
-    payload = _load_token_payload(TOKEN_PATH)
+    payload = _token_payload(auth_context)
     if creds.valid:
-        missing_scopes = _missing_scopes_from_payload(payload)
+        missing_scopes = _missing_scopes_from_payload(payload, required_scopes)
         if missing_scopes:
             print(f"AUTHENTICATED (partial): Token valid but missing {len(missing_scopes)} scopes:")
             for s in missing_scopes:
                 print(f"  - {s}")
         if not quiet:
-            print(f"AUTHENTICATED: Token valid at {TOKEN_PATH}")
+            print(f"AUTHENTICATED: Token valid for Google auth context {auth_context!r}")
         return True
 
     if creds.expired and creds.refresh_token:
         try:
             creds.refresh(Request())
-            TOKEN_PATH.write_text(
-                json.dumps(
-                    _normalize_authorized_user_payload(json.loads(creds.to_json())),
-                    indent=2,
-                )
-            )
-            missing_scopes = _missing_scopes_from_payload(_load_token_payload(TOKEN_PATH))
+            refreshed_payload = _normalize_authorized_user_payload(json.loads(creds.to_json()))
+            existing_scopes = gauth.scope_list(payload.get("scopes") or payload.get("scope"))
+            if existing_scopes and not gauth.scope_list(refreshed_payload.get("scopes") or refreshed_payload.get("scope")):
+                refreshed_payload["scopes"] = existing_scopes
+            _set_token_payload(auth_context, refreshed_payload)
+            missing_scopes = _missing_scopes_from_payload(_token_payload(auth_context), required_scopes)
             if missing_scopes:
                 print(f"AUTHENTICATED (partial): Token refreshed but missing {len(missing_scopes)} scopes:")
                 for s in missing_scopes:
                     print(f"  - {s}")
             if not quiet:
-                print(f"AUTHENTICATED: Token refreshed at {TOKEN_PATH}")
+                print(f"AUTHENTICATED: Token refreshed for Google auth context {auth_context!r}")
             return True
         except Exception as e:
             err_str = str(e).lower()
@@ -252,7 +308,7 @@ def check_auth(quiet: bool = False):
     return False
 
 
-def store_client_secret(path: str):
+def store_client_secret(path: str, auth_context: str = "default", account_hint: str = ""):
     """Copy and validate client_secret.json to Hermes home."""
     src = Path(path).expanduser().resolve()
     if not src.exists():
@@ -270,35 +326,25 @@ def store_client_secret(path: str):
         print("Download the correct file from: https://console.cloud.google.com/apis/credentials")
         sys.exit(1)
 
-    CLIENT_SECRET_PATH.write_text(json.dumps(data, indent=2))
-    print(f"OK: Client secret saved to {CLIENT_SECRET_PATH}")
+    gauth.set_client_secret(auth_context, data, account_hint=account_hint)
+    print(f"OK: Client secret saved for Google auth context {auth_context!r}")
 
 
-def _save_pending_auth(*, state: str, code_verifier: str):
+def _save_pending_auth(*, state: str, code_verifier: str, auth_context: str = "default", requested_scopes: list[str] | None = None, services: list[str] | None = None):
     """Persist the OAuth session bits needed for a later token exchange."""
-    PENDING_AUTH_PATH.write_text(
-        json.dumps(
-            {
-                "state": state,
-                "code_verifier": code_verifier,
-                "redirect_uri": REDIRECT_URI,
-            },
-            indent=2,
-        )
-    )
+    payload = {"state": state, "code_verifier": code_verifier, "redirect_uri": REDIRECT_URI}
+    if requested_scopes is not None:
+        payload["requested_scopes"] = requested_scopes
+    if services is not None:
+        payload["services"] = services
+    _set_pending_payload(auth_context, payload)
 
 
-def _load_pending_auth() -> dict:
+def _load_pending_auth(auth_context: str = "default") -> dict:
     """Load the pending OAuth session created by get_auth_url()."""
-    if not PENDING_AUTH_PATH.exists():
+    data = _pending_payload(auth_context)
+    if not data:
         print("ERROR: No pending OAuth session found. Run --auth-url first.")
-        sys.exit(1)
-
-    try:
-        data = json.loads(PENDING_AUTH_PATH.read_text())
-    except Exception as e:
-        print(f"ERROR: Could not read pending OAuth session: {e}")
-        print("Run --auth-url again to start a fresh OAuth session.")
         sys.exit(1)
 
     if not data.get("state") or not data.get("code_verifier"):
@@ -326,18 +372,18 @@ def _extract_code_and_state(code_or_url: str) -> tuple[str, str | None]:
     return params["code"][0], state
 
 
-def get_auth_url():
+def get_auth_url(auth_context: str = "default", services: str = "all", scopes: str = ""):
     """Print the OAuth authorization URL. User visits this in a browser."""
-    if not CLIENT_SECRET_PATH.exists():
-        print("ERROR: No client secret stored. Run --client-secret first.")
+    if not _client_secret_payload(auth_context):
+        print(f"ERROR: No client secret stored for Google auth context {auth_context!r}. Run --client-secret first.")
         sys.exit(1)
 
     _ensure_deps()
     from google_auth_oauthlib.flow import Flow
 
     flow = Flow.from_client_secrets_file(
-        str(CLIENT_SECRET_PATH),
-        scopes=SCOPES,
+        str(_client_secret_file(auth_context)),
+        scopes=gauth.resolve_scopes(services=services, scopes=scopes),
         redirect_uri=REDIRECT_URI,
         autogenerate_code_verifier=True,
     )
@@ -345,18 +391,20 @@ def get_auth_url():
         access_type="offline",
         prompt="consent",
     )
-    _save_pending_auth(state=state, code_verifier=flow.code_verifier)
+    requested_scopes = gauth.resolve_scopes(services=services, scopes=scopes)
+    service_list = [s.strip().lower() for s in (services or "all").split(",") if s.strip()]
+    _save_pending_auth(state=state, code_verifier=flow.code_verifier, auth_context=auth_context, requested_scopes=requested_scopes, services=service_list)
     # Print just the URL so the agent can extract it cleanly
     print(auth_url)
 
 
-def exchange_auth_code(code: str):
+def exchange_auth_code(code: str, auth_context: str = "default", strict_scopes: bool = False):
     """Exchange the authorization code for a token and save it."""
-    if not CLIENT_SECRET_PATH.exists():
-        print("ERROR: No client secret stored. Run --client-secret first.")
+    if not _client_secret_payload(auth_context):
+        print(f"ERROR: No client secret stored for Google auth context {auth_context!r}. Run --client-secret first.")
         sys.exit(1)
 
-    pending_auth = _load_pending_auth()
+    pending_auth = _load_pending_auth(auth_context)
     raw_callback = code
     code, returned_state = _extract_code_and_state(code)
     if returned_state and returned_state != pending_auth["state"]:
@@ -368,7 +416,7 @@ def exchange_auth_code(code: str):
     from urllib.parse import parse_qs, urlparse
 
     # Extract granted scopes from the callback URL if the user pasted the full redirect URL.
-    granted_scopes = list(SCOPES)
+    granted_scopes = list(pending_auth.get("requested_scopes") or SCOPES)
     if isinstance(raw_callback, str) and raw_callback.startswith("http"):
         params = parse_qs(urlparse(raw_callback).query)
         scope_val = (params.get("scope") or [""])[0].strip()
@@ -376,7 +424,7 @@ def exchange_auth_code(code: str):
             granted_scopes = scope_val.split()
 
     flow = Flow.from_client_secrets_file(
-        str(CLIENT_SECRET_PATH),
+        str(_client_secret_file(auth_context)),
         scopes=granted_scopes,
         redirect_uri=pending_auth.get("redirect_uri", REDIRECT_URI),
         state=pending_auth["state"],
@@ -405,20 +453,25 @@ def exchange_auth_code(code: str):
         # granted_scopes was extracted from the callback URL
         token_payload["scopes"] = granted_scopes
 
-    missing_scopes = _missing_scopes_from_payload(token_payload)
+    requested_scopes = pending_auth.get("requested_scopes") or list(SCOPES)
+    missing_scopes = _missing_scopes_from_payload(token_payload, requested_scopes)
     if missing_scopes:
-        print(f"WARNING: Token missing some Google Workspace scopes: {', '.join(missing_scopes)}")
+        msg = f"Token missing requested Google Workspace scopes: {', '.join(missing_scopes)}"
+        if strict_scopes:
+            print(f"ERROR: {msg}")
+            sys.exit(1)
+        print(f"WARNING: {msg}")
         print("Some services may not be available.")
 
-    TOKEN_PATH.write_text(json.dumps(token_payload, indent=2))
-    PENDING_AUTH_PATH.unlink(missing_ok=True)
-    print(f"OK: Authenticated. Token saved to {TOKEN_PATH}")
-    print(f"Profile-scoped token location: {display_hermes_home()}/google_token.json")
+    _set_token_payload(auth_context, token_payload, services=pending_auth.get("services"), requested_scopes=requested_scopes)
+    _clear_pending(auth_context)
+    print(f"OK: Authenticated Google auth context {auth_context!r}.")
+    print(f"Profile-scoped context store: {display_hermes_home()}/{gauth.AUTH_CONTEXTS_NAME}")
 
 
-def revoke():
+def revoke(auth_context: str = "default"):
     """Revoke stored token and delete it."""
-    if not TOKEN_PATH.exists():
+    if not _token_payload(auth_context):
         print("No token to revoke.")
         return
 
@@ -427,7 +480,7 @@ def revoke():
     from google.auth.transport.requests import Request
 
     try:
-        creds = Credentials.from_authorized_user_file(str(TOKEN_PATH), SCOPES)
+        creds = Credentials.from_authorized_user_file(str(_token_file(auth_context)), gauth.granted_scopes_for_context(auth_context))
         if creds.expired and creds.refresh_token:
             creds.refresh(Request())
 
@@ -444,13 +497,17 @@ def revoke():
     except Exception as e:
         print(f"Remote revocation failed (token may already be invalid): {e}")
 
-    TOKEN_PATH.unlink(missing_ok=True)
-    PENDING_AUTH_PATH.unlink(missing_ok=True)
-    print(f"Deleted {TOKEN_PATH}")
+    gauth.delete_token(auth_context)
+    print(f"Deleted token for Google auth context {auth_context!r}")
 
 
 def main():
     parser = argparse.ArgumentParser(description="Google Workspace OAuth setup for Hermes")
+    parser.add_argument("--auth-context", default="default", help="Named Google OAuth auth context (default: legacy/default)")
+    parser.add_argument("--services", default="all", help="Comma-separated service presets (e.g. gmail-readonly,calendar,drive) for --auth-url/--check")
+    parser.add_argument("--scopes", default="", help="Comma- or space-separated explicit OAuth scopes; overrides --services")
+    parser.add_argument("--account-hint", default="", help="Optional human account label/email saved with the context")
+    parser.add_argument("--strict-scopes", action="store_true", help="Fail auth-code exchange if granted scopes miss requested scopes")
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--check", action="store_true", help="Check if auth is valid (exit 0=yes, 1=no)")
     group.add_argument("--check-live", action="store_true", help="Check auth with a real API call (detects disabled_client)")
@@ -459,22 +516,41 @@ def main():
     group.add_argument("--auth-code", metavar="CODE", help="Exchange auth code for token")
     group.add_argument("--revoke", action="store_true", help="Revoke and delete stored token")
     group.add_argument("--install-deps", action="store_true", help="Install Python dependencies")
+    group.add_argument("--print-scopes", action="store_true", help="Print scopes resolved from --services/--scopes and exit")
+    group.add_argument("--list-contexts", action="store_true", help="List configured Google auth contexts")
+    group.add_argument("--set-default-for", metavar="SERVICES", help="Comma-separated API services to route to --auth-context by default")
     args = parser.parse_args()
 
+    try:
+        requested_scopes = gauth.resolve_scopes(services=args.services, scopes=args.scopes)
+    except ValueError as e:
+        print(f"ERROR: {e}")
+        sys.exit(1)
+    if args.set_default_for:
+        try:
+            gauth.set_default_for_services(args.auth_context, args.set_default_for)
+        except ValueError as e:
+            print(f"ERROR: {e}")
+            sys.exit(1)
+        print(f"OK: Google auth context {args.auth_context!r} is default for {args.set_default_for}")
     if args.check:
-        sys.exit(0 if check_auth() else 1)
+        sys.exit(0 if check_auth(auth_context=args.auth_context, required_scopes=requested_scopes if args.services != "all" or args.scopes else None) else 1)
     if getattr(args, "check_live", False):
-        sys.exit(0 if check_auth_live() else 1)
+        sys.exit(0 if check_auth_live(auth_context=args.auth_context) else 1)
     elif args.client_secret:
-        store_client_secret(args.client_secret)
+        store_client_secret(args.client_secret, auth_context=args.auth_context, account_hint=args.account_hint)
     elif args.auth_url:
-        get_auth_url()
+        get_auth_url(auth_context=args.auth_context, services=args.services, scopes=args.scopes)
     elif args.auth_code:
-        exchange_auth_code(args.auth_code)
+        exchange_auth_code(args.auth_code, auth_context=args.auth_context, strict_scopes=args.strict_scopes)
     elif args.revoke:
-        revoke()
+        revoke(auth_context=args.auth_context)
     elif args.install_deps:
         sys.exit(0 if install_deps() else 1)
+    elif args.print_scopes:
+        print("\n".join(requested_scopes))
+    elif args.list_contexts:
+        print(json.dumps({"contexts": gauth.list_contexts(), "default_contexts": gauth.load_store().get("default_contexts", {})}, indent=2))
 
 
 if __name__ == "__main__":

--- a/tests/agent/test_context_references.py
+++ b/tests/agent/test_context_references.py
@@ -375,7 +375,9 @@ async def test_blocks_canonical_read_denylist_credential_stores(tmp_path: Path, 
     (hermes_home).mkdir(parents=True)
 
     auth_json = hermes_home / "auth.json"
-    auth_json.write_text('{"openai": "sk-AUTHJSON-SECRET"}\n', encoding="utf-8")
+    auth_json.write_text(
+        '{"openai": "AUTHJSON_SECRET_MARKER"}\n', encoding="utf-8"
+    )
 
     oauth = hermes_home / ".anthropic_oauth.json"
     oauth.write_text('{"access_token": "OAUTH-SECRET"}\n', encoding="utf-8")
@@ -384,13 +386,44 @@ async def test_blocks_canonical_read_denylist_credential_stores(tmp_path: Path, 
     mcp_token.parent.mkdir(parents=True)
     mcp_token.write_text('{"token": "MCP-TOKEN-SECRET"}\n', encoding="utf-8")
 
+    google_token = hermes_home / "google_token.json"
+    google_token.write_text('{"token": "GOOGLE-TOKEN-SECRET"}\n', encoding="utf-8")
+    google_client = hermes_home / "google_client_secret.json"
+    google_client.write_text(
+        '{"installed": {"client_secret": "GOOGLE-CLIENT-SECRET"}}\n',
+        encoding="utf-8",
+    )
+    google_contexts = hermes_home / "google_workspace_auth_contexts.json"
+    google_contexts.write_text(
+        '{"contexts": {"named": {"token": "GOOGLE-CONTEXT-SECRET"}}}\n',
+        encoding="utf-8",
+    )
+    materialized = (
+        hermes_home
+        / ".cache"
+        / "google-workspace"
+        / "contexts"
+        / "named"
+        / "google_token.json"
+    )
+    materialized.parent.mkdir(parents=True)
+    materialized.write_text(
+        '{"refresh_token": "GOOGLE-MATERIALIZED-SECRET"}\n',
+        encoding="utf-8",
+    )
+
     project_env = tmp_path / "project" / ".env"
     project_env.parent.mkdir(parents=True)
     project_env.write_text("DB_PASSWORD=ENV-SECRET\n", encoding="utf-8")
 
     result = await preprocess_context_references_async(
         "inspect @file:.hermes/auth.json and @file:.hermes/.anthropic_oauth.json "
-        "and @file:.hermes/mcp-tokens/github.json and @file:project/.env",
+        "and @file:.hermes/mcp-tokens/github.json "
+        "and @file:.hermes/google_token.json "
+        "and @file:.hermes/google_client_secret.json "
+        "and @file:.hermes/google_workspace_auth_contexts.json "
+        "and @file:.hermes/.cache/google-workspace/contexts/named/google_token.json "
+        "and @file:project/.env",
         cwd=tmp_path,
         allowed_root=tmp_path,
         context_length=100_000,
@@ -398,13 +431,17 @@ async def test_blocks_canonical_read_denylist_credential_stores(tmp_path: Path, 
 
     assert result.expanded
     for secret in (
-        "sk-AUTHJSON-SECRET",
+        "AUTHJSON_SECRET_MARKER",
         "OAUTH-SECRET",
         "MCP-TOKEN-SECRET",
+        "GOOGLE-TOKEN-SECRET",
+        "GOOGLE-CLIENT-SECRET",
+        "GOOGLE-CONTEXT-SECRET",
+        "GOOGLE-MATERIALIZED-SECRET",
         "ENV-SECRET",
     ):
         assert secret not in result.message
-    assert sum("sensitive credential" in warning for warning in result.warnings) == 4
+    assert sum("sensitive credential" in warning for warning in result.warnings) == 8
 
 
 @pytest.mark.asyncio

--- a/tests/agent/test_file_safety_credentials.py
+++ b/tests/agent/test_file_safety_credentials.py
@@ -76,6 +76,35 @@ def test_google_oauth_json_blocked(fake_home):
     assert "credential store" in err
 
 
+@pytest.mark.parametrize(
+    "name",
+    [
+        "google_token.json",
+        "google_client_secret.json",
+        "google_workspace_auth_contexts.json",
+        "google_oauth_pending.json",
+    ],
+)
+def test_google_workspace_root_credentials_blocked(fake_home, name):
+    from agent.file_safety import get_read_block_error
+
+    credential = _create(fake_home, name)
+    err = get_read_block_error(str(credential))
+    assert err is not None
+    assert "credential store" in err
+
+
+def test_materialized_google_workspace_credentials_blocked(fake_home):
+    from agent.file_safety import get_read_block_error
+
+    context_dir = Path(".cache/google-workspace/contexts/named")
+    for name in ("google_token.json", "google_client_secret.json"):
+        credential = _create(fake_home, context_dir / name)
+        err = get_read_block_error(str(credential))
+        assert err is not None
+        assert "credential" in err.lower()
+
+
 def test_arbitrary_hermes_home_file_not_blocked(fake_home):
     """Non-credential files inside HERMES_HOME stay readable."""
     from agent.file_safety import get_read_block_error
@@ -188,6 +217,35 @@ def test_read_file_tool_blocks_nested_google_oauth_path(
     assert "credential store" in out["error"]
     assert "REFRESH_TOKEN_MARKER" not in json.dumps(out)
     assert "ACCESS_TOKEN_MARKER" not in json.dumps(out)
+
+
+def test_read_file_tool_blocks_google_workspace_credentials(
+    fake_home, tmp_path, monkeypatch
+):
+    """Root and materialized Workspace OAuth files must never reach the model."""
+    import json
+
+    import tools.file_tools as ft
+
+    context_store = _create(fake_home, "google_workspace_auth_contexts.json")
+    materialized = _create(
+        fake_home,
+        Path(".cache/google-workspace/contexts/named/google_token.json"),
+    )
+    context_store.write_text("WORKSPACE-CONTEXT-SECRET", encoding="utf-8")
+    materialized.write_text("WORKSPACE-TOKEN-SECRET", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        ft, "_get_live_tracking_cwd", lambda task_id="default": None
+    )
+
+    for path, marker in (
+        (context_store, "WORKSPACE-CONTEXT-SECRET"),
+        (materialized, "WORKSPACE-TOKEN-SECRET"),
+    ):
+        out = json.loads(ft.read_file_tool(str(path), task_id="workspace-credential-test"))
+        assert "error" in out
+        assert marker not in json.dumps(out)
 
 
 def test_search_tool_blocks_direct_auth_json_path(fake_home, monkeypatch):

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1121,6 +1121,27 @@ class TestMediaDeliveryDefaultMode:
 
         assert BasePlatformAdapter.validate_media_delivery_path(str(store)) is None
 
+    def test_denylist_blocks_materialized_google_context_credentials(self, tmp_path, monkeypatch):
+        """Named-context token and client-secret copies live below the cache
+        tree but remain credential material, not deliverable artifacts.
+        """
+        self._patch_roots(monkeypatch)
+
+        fake_home = tmp_path / "home"
+        hermes_dir = fake_home / ".hermes"
+        context_dir = hermes_dir / ".cache" / "google-workspace" / "contexts" / "named"
+        context_dir.mkdir(parents=True)
+        token = context_dir / "google_token.json"
+        client_secret = context_dir / "google_client_secret.json"
+        token.write_text('{"refresh_token": "***"}')
+        client_secret.write_text('{"installed": {"client_secret": "***"}}')
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setattr("gateway.platforms.base._HERMES_HOME", hermes_dir)
+        monkeypatch.setattr("gateway.platforms.base._HERMES_ROOT", hermes_dir)
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(token)) is None
+        assert BasePlatformAdapter.validate_media_delivery_path(str(client_secret)) is None
+
     def test_denylist_blocks_google_token_even_when_freshly_refreshed(self, tmp_path, monkeypatch):
         """The exploit was that the Google integration rewrites
         google_token.json every turn, bumping its mtime to ~now, so the

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1104,6 +1104,23 @@ class TestMediaDeliveryDefaultMode:
 
         assert BasePlatformAdapter.validate_media_delivery_path(str(token)) is None
 
+    def test_denylist_blocks_google_auth_context_store_default_mode(self, tmp_path, monkeypatch):
+        """The named-context vault contains OAuth tokens and client secrets,
+        so it must never be deliverable as a native attachment.
+        """
+        self._patch_roots(monkeypatch)
+
+        fake_home = tmp_path / "home"
+        hermes_dir = fake_home / ".hermes"
+        hermes_dir.mkdir(parents=True)
+        store = hermes_dir / "google_workspace_auth_contexts.json"
+        store.write_text('{"contexts": {"work": {"token": "***"}}}')
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setattr("gateway.platforms.base._HERMES_HOME", hermes_dir)
+        monkeypatch.setattr("gateway.platforms.base._HERMES_ROOT", hermes_dir)
+
+        assert BasePlatformAdapter.validate_media_delivery_path(str(store)) is None
+
     def test_denylist_blocks_google_token_even_when_freshly_refreshed(self, tmp_path, monkeypatch):
         """The exploit was that the Google integration rewrites
         google_token.json every turn, bumping its mtime to ~now, so the

--- a/tests/hermes_cli/test_web_server_files.py
+++ b/tests/hermes_cli/test_web_server_files.py
@@ -593,6 +593,7 @@ def test_other_credential_store_basenames_blocked(forced_files_client):
         "config.yaml",
         ".anthropic_oauth.json",
         "google_token.json",
+        "google_client_secret.json",
         "google_workspace_auth_contexts.json",
         "google_oauth_pending.json",
         "google_oauth.json",
@@ -607,6 +608,22 @@ def test_other_credential_store_basenames_blocked(forced_files_client):
     listing = client.get("/api/files", params={"path": str(root)})
     names = [e["name"] for e in listing.json()["entries"]]
     assert names == []
+
+
+def test_materialized_google_context_credentials_blocked(forced_files_client):
+    client, root = forced_files_client
+    context_dir = root / ".cache" / "google-workspace" / "contexts" / "named"
+    context_dir.mkdir(parents=True)
+    token = context_dir / "google_token.json"
+    client_secret = context_dir / "google_client_secret.json"
+    token.write_text('{"refresh_token": "SECRET"}')
+    client_secret.write_text('{"installed": {"client_secret": "SECRET"}}')
+
+    listing = client.get("/api/files", params={"path": str(context_dir)})
+    assert [entry["name"] for entry in listing.json()["entries"]] == []
+    for path in (token, client_secret):
+        assert client.get("/api/files/read", params={"path": str(path)}).status_code == 403
+        assert client.get("/api/files/download", params={"path": str(path)}).status_code == 403
 
 
 def test_git_credentials_blocked(forced_files_client):

--- a/tests/hermes_cli/test_web_server_files.py
+++ b/tests/hermes_cli/test_web_server_files.py
@@ -593,6 +593,7 @@ def test_other_credential_store_basenames_blocked(forced_files_client):
         "config.yaml",
         ".anthropic_oauth.json",
         "google_token.json",
+        "google_workspace_auth_contexts.json",
         "google_oauth_pending.json",
         "google_oauth.json",
         "webhook_subscriptions.json",

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -435,6 +435,40 @@ def test_api_gmail_reply_reads_headers_case_insensitively_and_uses_conventional_
     assert "\nreferences: " not in raw_text
 
 
+def test_api_main_blocks_send_only_context_from_gmail_reply(api_module, monkeypatch, capsys):
+    api_module.gauth.set_token_payload(
+        "send-only",
+        {"token": "tok", "scopes": [api_module.gauth.GMAIL_SEND]},
+        services=["gmail-send"],
+        requested_scopes=[api_module.gauth.GMAIL_SEND],
+    )
+
+    def should_not_run(_args):
+        raise AssertionError("gmail_reply reached the API path without read scope")
+
+    monkeypatch.setattr(api_module, "gmail_reply", should_not_run)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            str(API_PATH),
+            "--auth-context",
+            "send-only",
+            "gmail",
+            "reply",
+            "message-id",
+            "--body",
+            "hello",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        api_module.main()
+
+    assert exc_info.value.code == 2
+    assert "lacks OAuth scope for gmail reply" in capsys.readouterr().err
+
+
 def test_api_get_credentials_refresh_persists_authorized_user_type(api_module, monkeypatch):
     token_path = api_module.TOKEN_PATH
     _write_token(token_path, token="ya29.old")

--- a/tests/skills/test_google_workspace_auth_contexts.py
+++ b/tests/skills/test_google_workspace_auth_contexts.py
@@ -162,7 +162,9 @@ class TestCommandScopeGate:
         assert auth_contexts.context_exists("default")
         assert "default" in auth_contexts.list_contexts()
 
-        stored_default = auth_contexts.load_store()["contexts"]["default"]
+        store = auth_contexts.load_store()
+        assert store["legacy_default_migrated"] is True
+        stored_default = store["contexts"]["default"]
         assert stored_default["token"]["token"] == "legacy"
         assert stored_default["client_secret"]["installed"]["client_id"] == "legacy"
         assert stored_default["pending_auth"]["state"] == "legacy"
@@ -180,6 +182,41 @@ class TestCommandScopeGate:
         auth_contexts.legacy_token_path().write_text('{"token": "stale"}')
 
         assert auth_contexts.get_token_payload("default")["token"] == "store"
+
+    def test_delete_migrated_default_token_does_not_restore_legacy(self, auth_contexts):
+        auth_contexts.legacy_token_path().write_text('{"token": "legacy"}')
+        auth_contexts.legacy_pending_path().write_text('{"state": "pending"}')
+        auth_contexts.set_client_secret(
+            "named",
+            {"installed": {"client_id": "named"}},
+        )
+        assert auth_contexts.get_token_payload("default")["token"] == "legacy"
+
+        auth_contexts.delete_token("default")
+
+        assert auth_contexts.get_token_payload("default") == {}
+        assert auth_contexts.get_pending_auth("default") == {}
+        assert not auth_contexts.legacy_token_path().exists()
+        assert not auth_contexts.legacy_pending_path().exists()
+        stored_default = auth_contexts.load_store()["contexts"]["default"]
+        assert "token" not in stored_default
+        assert "pending_auth" not in stored_default
+
+    def test_clear_migrated_default_pending_does_not_restore_legacy(self, auth_contexts):
+        auth_contexts.legacy_token_path().write_text('{"token": "legacy"}')
+        auth_contexts.legacy_pending_path().write_text('{"state": "pending"}')
+        auth_contexts.set_client_secret(
+            "named",
+            {"installed": {"client_id": "named"}},
+        )
+        assert auth_contexts.get_pending_auth("default")["state"] == "pending"
+
+        auth_contexts.clear_pending_auth("default")
+
+        assert auth_contexts.get_pending_auth("default") == {}
+        assert auth_contexts.get_token_payload("default")["token"] == "legacy"
+        assert not auth_contexts.legacy_pending_path().exists()
+        assert "pending_auth" not in auth_contexts.load_store()["contexts"]["default"]
 
     def test_full_drive_implies_read(self, auth_contexts):
         auth_contexts.set_token_payload("drive", {"token": "tok", "scopes": [auth_contexts.DRIVE]})

--- a/tests/skills/test_google_workspace_auth_contexts.py
+++ b/tests/skills/test_google_workspace_auth_contexts.py
@@ -1,0 +1,139 @@
+"""Tests for Google Workspace named auth contexts."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT_DIR = Path(__file__).resolve().parents[2] / "skills/productivity/google-workspace/scripts"
+AUTH_CONTEXTS_PATH = SCRIPT_DIR / "auth_contexts.py"
+API_PATH = SCRIPT_DIR / "google_api.py"
+
+
+def load_module(name: str, path: Path, monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir(exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.syspath_prepend(str(SCRIPT_DIR))
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def auth_contexts(monkeypatch, tmp_path):
+    return load_module("auth_contexts_test", AUTH_CONTEXTS_PATH, monkeypatch, tmp_path)
+
+
+class TestContextNames:
+    @pytest.mark.parametrize("name", ["default", "gmail-readonly", "workspace.writer", "x_1"])
+    def test_accepts_path_safe_names(self, auth_contexts, name):
+        assert auth_contexts.validate_context_name(name) == name
+
+    @pytest.mark.parametrize("name", ["", ".", "..", "../x", "x/y", "x\\y", " space"])
+    def test_rejects_unsafe_names(self, auth_contexts, name):
+        with pytest.raises(ValueError):
+            auth_contexts.validate_context_name(name)
+
+
+class TestScopeResolution:
+    def test_gmail_readonly_is_least_privilege(self, auth_contexts):
+        assert auth_contexts.resolve_scopes(services="gmail-readonly") == [
+            "https://www.googleapis.com/auth/gmail.readonly"
+        ]
+
+    def test_workspace_writer_services(self, auth_contexts):
+        assert auth_contexts.resolve_scopes(services="drive,calendar,docs,sheets") == [
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/calendar",
+            "https://www.googleapis.com/auth/documents",
+            "https://www.googleapis.com/auth/spreadsheets",
+        ]
+
+    def test_explicit_scopes_override_services(self, auth_contexts):
+        assert auth_contexts.resolve_scopes(
+            services="all",
+            scopes="https://www.googleapis.com/auth/calendar.readonly,https://www.googleapis.com/auth/drive.file",
+        ) == [
+            "https://www.googleapis.com/auth/calendar.readonly",
+            "https://www.googleapis.com/auth/drive.file",
+        ]
+
+    def test_unknown_service_fails(self, auth_contexts):
+        with pytest.raises(ValueError):
+            auth_contexts.resolve_scopes(services="gmail-readonly,photos")
+
+
+class TestStoreAndDefaults:
+    def test_context_store_round_trip(self, auth_contexts):
+        auth_contexts.set_client_secret("gmail-readonly", {"installed": {"client_id": "id"}}, account_hint="mail@example.com")
+        auth_contexts.set_token_payload(
+            "gmail-readonly",
+            {"token": "tok", "scopes": [auth_contexts.GMAIL_READONLY]},
+            services=["gmail-readonly"],
+            requested_scopes=[auth_contexts.GMAIL_READONLY],
+        )
+        data = json.loads(auth_contexts.store_path().read_text())
+        assert data["contexts"]["gmail-readonly"]["account_hint"] == "mail@example.com"
+        assert auth_contexts.get_token_payload("gmail-readonly")["token"] == "tok"
+
+    def test_default_context_routing(self, auth_contexts):
+        auth_contexts.set_client_secret("workspace-writer", {"installed": {"client_id": "id"}})
+        auth_contexts.set_default_for_services("workspace-writer", "drive,calendar")
+        assert auth_contexts.default_context_for_service("drive") == "workspace-writer"
+        assert auth_contexts.default_context_for_service("calendar") == "workspace-writer"
+        assert auth_contexts.default_context_for_service("gmail") == "default"
+
+    def test_legacy_default_context_reads_old_files(self, auth_contexts):
+        auth_contexts.legacy_token_path().write_text(json.dumps({"token": "legacy"}))
+        auth_contexts.legacy_client_secret_path().write_text(json.dumps({"installed": {"client_id": "id"}}))
+        assert auth_contexts.get_token_payload("default")["token"] == "legacy"
+        assert auth_contexts.materialize_token_file("default") == auth_contexts.legacy_token_path()
+
+
+class TestCommandScopeGate:
+    def test_allows_readonly_gmail_read(self, auth_contexts):
+        auth_contexts.set_token_payload("gmail-readonly", {"token": "tok", "scopes": [auth_contexts.GMAIL_READONLY]})
+        auth_contexts.assert_command_allowed("gmail-readonly", "gmail", "search")
+
+    def test_blocks_gmail_send_with_readonly_context(self, auth_contexts):
+        auth_contexts.set_token_payload("gmail-readonly", {"token": "tok", "scopes": [auth_contexts.GMAIL_READONLY]})
+        with pytest.raises(PermissionError):
+            auth_contexts.assert_command_allowed("gmail-readonly", "gmail", "send")
+
+    def test_blocks_named_context_when_scope_metadata_missing(self, auth_contexts):
+        auth_contexts.set_token_payload("unknown", {"token": "tok"})
+        with pytest.raises(PermissionError):
+            auth_contexts.assert_command_allowed("unknown", "gmail", "send")
+
+    def test_auth_store_is_private(self, auth_contexts):
+        auth_contexts.set_token_payload("gmail-readonly", {"token": "tok", "scopes": [auth_contexts.GMAIL_READONLY]})
+        mode = auth_contexts.store_path().stat().st_mode & 0o777
+        assert mode == 0o600
+
+    def test_delete_token_removes_materialized_cache_file(self, auth_contexts):
+        auth_contexts.set_token_payload("gmail-readonly", {"token": "tok", "scopes": [auth_contexts.GMAIL_READONLY]})
+        path = auth_contexts.materialize_token_file("gmail-readonly")
+        assert path.exists()
+        auth_contexts.delete_token("gmail-readonly")
+        assert not path.exists()
+
+    def test_store_existing_default_does_not_fallback_to_stale_legacy(self, auth_contexts):
+        auth_contexts.legacy_token_path().write_text('{"token": "legacy"}')
+        auth_contexts.legacy_client_secret_path().write_text('{"installed": {"client_id": "legacy"}}')
+        auth_contexts.legacy_pending_path().write_text('{"state": "legacy"}')
+        auth_contexts.set_default_for_services("default", "gmail")
+        assert auth_contexts.get_token_payload("default") == {}
+        assert auth_contexts.get_client_secret("default") == {}
+        assert auth_contexts.get_pending_auth("default") == {}
+
+    def test_full_drive_implies_read(self, auth_contexts):
+        auth_contexts.set_token_payload("drive", {"token": "tok", "scopes": [auth_contexts.DRIVE]})
+        auth_contexts.assert_command_allowed("drive", "drive", "search")

--- a/tests/skills/test_google_workspace_auth_contexts.py
+++ b/tests/skills/test_google_workspace_auth_contexts.py
@@ -218,6 +218,73 @@ class TestCommandScopeGate:
         assert not auth_contexts.legacy_pending_path().exists()
         assert "pending_auth" not in auth_contexts.load_store()["contexts"]["default"]
 
+    def test_migration_waits_for_existing_malformed_legacy_source(self, auth_contexts):
+        auth_contexts.legacy_token_path().write_text("{")
+        auth_contexts.legacy_client_secret_path().write_text(
+            '{"installed": {"client_id": "legacy"}}'
+        )
+
+        auth_contexts.set_client_secret(
+            "named",
+            {"installed": {"client_id": "named"}},
+        )
+        stored = json.loads(auth_contexts.store_path().read_text())
+        assert "legacy_default_migrated" not in stored
+        assert "token" not in stored["contexts"]["default"]
+        assert (
+            stored["contexts"]["default"]["client_secret"]["installed"]["client_id"]
+            == "legacy"
+        )
+
+        auth_contexts.legacy_token_path().write_text('{"token": "repaired"}')
+        auth_contexts.set_default_for_services("named", "gmail")
+
+        stored = json.loads(auth_contexts.store_path().read_text())
+        assert stored["legacy_default_migrated"] is True
+        assert stored["contexts"]["default"]["token"]["token"] == "repaired"
+
+    def test_delete_default_persists_marker_without_default_context(self, auth_contexts):
+        auth_contexts.store_path().write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "default_contexts": {},
+                    "contexts": {"named": {"name": "named", "token": {"token": "n"}}},
+                }
+            )
+        )
+        auth_contexts.legacy_token_path().write_text('{"token": "stale"}')
+
+        auth_contexts.delete_token("default")
+
+        stored = json.loads(auth_contexts.store_path().read_text())
+        assert stored["legacy_default_migrated"] is True
+        auth_contexts.legacy_token_path().write_text(
+            '{"token": "stale-writer-returned"}'
+        )
+        assert auth_contexts.get_token_payload("default") == {}
+
+    def test_clear_pending_persists_marker_without_default_context(self, auth_contexts):
+        auth_contexts.store_path().write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "default_contexts": {},
+                    "contexts": {"named": {"name": "named", "token": {"token": "n"}}},
+                }
+            )
+        )
+        auth_contexts.legacy_pending_path().write_text('{"state": "stale"}')
+
+        auth_contexts.clear_pending_auth("default")
+
+        stored = json.loads(auth_contexts.store_path().read_text())
+        assert stored["legacy_default_migrated"] is True
+        auth_contexts.legacy_pending_path().write_text(
+            '{"state": "stale-writer-returned"}'
+        )
+        assert auth_contexts.get_pending_auth("default") == {}
+
     def test_full_drive_implies_read(self, auth_contexts):
         auth_contexts.set_token_payload("drive", {"token": "tok", "scopes": [auth_contexts.DRIVE]})
         auth_contexts.assert_command_allowed("drive", "drive", "search")

--- a/tests/skills/test_google_workspace_auth_contexts.py
+++ b/tests/skills/test_google_workspace_auth_contexts.py
@@ -285,6 +285,89 @@ class TestCommandScopeGate:
         )
         assert auth_contexts.get_pending_auth("default") == {}
 
+    def test_delete_suppresses_only_token_fields_during_partial_migration(
+        self, auth_contexts
+    ):
+        auth_contexts.store_path().write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "default_contexts": {},
+                    "contexts": {"named": {"name": "named"}},
+                }
+            )
+        )
+        auth_contexts.legacy_token_path().write_text('{"token": "stale"}')
+        auth_contexts.legacy_client_secret_path().write_text("{")
+
+        auth_contexts.delete_token("default")
+
+        stored = json.loads(auth_contexts.store_path().read_text())
+        assert "legacy_default_migrated" not in stored
+        assert set(stored["legacy_default_suppressed_fields"]) == {
+            "pending_auth",
+            "token",
+        }
+
+        auth_contexts.legacy_client_secret_path().write_text(
+            '{"installed": {"client_id": "repaired"}}'
+        )
+        auth_contexts.legacy_token_path().write_text(
+            '{"token": "stale-writer-returned"}'
+        )
+        assert (
+            auth_contexts.get_client_secret("default")["installed"]["client_id"]
+            == "repaired"
+        )
+        assert auth_contexts.get_token_payload("default") == {}
+
+    def test_clear_pending_suppresses_only_pending_during_partial_migration(
+        self, auth_contexts
+    ):
+        auth_contexts.store_path().write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "default_contexts": {},
+                    "contexts": {"named": {"name": "named"}},
+                }
+            )
+        )
+        auth_contexts.legacy_token_path().write_text("{")
+        auth_contexts.legacy_pending_path().write_text('{"state": "stale"}')
+
+        auth_contexts.clear_pending_auth("default")
+
+        stored = json.loads(auth_contexts.store_path().read_text())
+        assert "legacy_default_migrated" not in stored
+        assert stored["legacy_default_suppressed_fields"] == ["pending_auth"]
+
+        auth_contexts.legacy_token_path().write_text('{"token": "repaired"}')
+        auth_contexts.legacy_pending_path().write_text(
+            '{"state": "stale-writer-returned"}'
+        )
+        assert auth_contexts.get_token_payload("default")["token"] == "repaired"
+        assert auth_contexts.get_pending_auth("default") == {}
+
+    def test_destructive_operations_refuse_to_overwrite_malformed_store(
+        self, auth_contexts
+    ):
+        malformed = '{"contexts":{"named":{"client_secret":"named-secret"}'
+        for operation in (
+            auth_contexts.delete_token,
+            auth_contexts.clear_pending_auth,
+        ):
+            auth_contexts.store_path().write_text(malformed)
+            auth_contexts.legacy_token_path().write_text('{"token": "legacy"}')
+            auth_contexts.legacy_pending_path().write_text('{"state": "pending"}')
+
+            with pytest.raises(RuntimeError, match="unreadable"):
+                operation("default")
+
+            assert auth_contexts.store_path().read_text() == malformed
+            assert auth_contexts.legacy_token_path().exists()
+            assert auth_contexts.legacy_pending_path().exists()
+
     def test_full_drive_implies_read(self, auth_contexts):
         auth_contexts.set_token_payload("drive", {"token": "tok", "scopes": [auth_contexts.DRIVE]})
         auth_contexts.assert_command_allowed("drive", "drive", "search")

--- a/tests/skills/test_google_workspace_auth_contexts.py
+++ b/tests/skills/test_google_workspace_auth_contexts.py
@@ -368,6 +368,51 @@ class TestCommandScopeGate:
             assert auth_contexts.legacy_token_path().exists()
             assert auth_contexts.legacy_pending_path().exists()
 
+    def test_all_store_mutations_refuse_to_overwrite_malformed_store(
+        self, auth_contexts
+    ):
+        malformed = '{"contexts":{"named":{"client_secret":"named-secret"}'
+        operations = (
+            lambda: auth_contexts.set_token_payload("named", {"token": "new"}),
+            lambda: auth_contexts.set_client_secret(
+                "named", {"installed": {"client_id": "new"}}
+            ),
+            lambda: auth_contexts.set_pending_auth("named", {"state": "new"}),
+            lambda: auth_contexts.set_default_for_services("named", "gmail"),
+        )
+        for operation in operations:
+            auth_contexts.store_path().write_text(malformed)
+
+            with pytest.raises(RuntimeError, match="unreadable"):
+                operation()
+
+            assert auth_contexts.store_path().read_text() == malformed
+
+    def test_destructive_operations_validate_context_entries_before_unlink(
+        self, auth_contexts
+    ):
+        malformed_entry = json.dumps(
+            {
+                "version": 1,
+                "default_contexts": {},
+                "contexts": {"default": "malformed-entry"},
+            }
+        )
+        for operation in (
+            auth_contexts.delete_token,
+            auth_contexts.clear_pending_auth,
+        ):
+            auth_contexts.store_path().write_text(malformed_entry)
+            auth_contexts.legacy_token_path().write_text('{"token": "legacy"}')
+            auth_contexts.legacy_pending_path().write_text('{"state": "pending"}')
+
+            with pytest.raises(RuntimeError, match="unreadable"):
+                operation("default")
+
+            assert auth_contexts.store_path().read_text() == malformed_entry
+            assert auth_contexts.legacy_token_path().exists()
+            assert auth_contexts.legacy_pending_path().exists()
+
     def test_full_drive_implies_read(self, auth_contexts):
         auth_contexts.set_token_payload("drive", {"token": "tok", "scopes": [auth_contexts.DRIVE]})
         auth_contexts.assert_command_allowed("drive", "drive", "search")

--- a/tests/skills/test_google_workspace_auth_contexts.py
+++ b/tests/skills/test_google_workspace_auth_contexts.py
@@ -108,6 +108,23 @@ class TestCommandScopeGate:
         with pytest.raises(PermissionError):
             auth_contexts.assert_command_allowed("gmail-readonly", "gmail", "send")
 
+    def test_gmail_reply_requires_send_and_read_scopes(self, auth_contexts):
+        auth_contexts.set_token_payload(
+            "send-only",
+            {"token": "tok", "scopes": [auth_contexts.GMAIL_SEND]},
+        )
+        with pytest.raises(PermissionError):
+            auth_contexts.assert_command_allowed("send-only", "gmail", "reply")
+
+        auth_contexts.set_token_payload(
+            "send-and-read",
+            {
+                "token": "tok",
+                "scopes": [auth_contexts.GMAIL_SEND, auth_contexts.GMAIL_READONLY],
+            },
+        )
+        auth_contexts.assert_command_allowed("send-and-read", "gmail", "reply")
+
     def test_blocks_named_context_when_scope_metadata_missing(self, auth_contexts):
         auth_contexts.set_token_payload("unknown", {"token": "tok"})
         with pytest.raises(PermissionError):

--- a/tests/skills/test_google_workspace_auth_contexts.py
+++ b/tests/skills/test_google_workspace_auth_contexts.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -12,6 +13,7 @@ import pytest
 SCRIPT_DIR = Path(__file__).resolve().parents[2] / "skills/productivity/google-workspace/scripts"
 AUTH_CONTEXTS_PATH = SCRIPT_DIR / "auth_contexts.py"
 API_PATH = SCRIPT_DIR / "google_api.py"
+SETUP_PATH = SCRIPT_DIR / "setup.py"
 
 
 def load_module(name: str, path: Path, monkeypatch, tmp_path):
@@ -142,15 +144,124 @@ class TestCommandScopeGate:
         auth_contexts.delete_token("gmail-readonly")
         assert not path.exists()
 
-    def test_store_existing_default_does_not_fallback_to_stale_legacy(self, auth_contexts):
+    def test_named_store_migrates_and_preserves_legacy_default(self, auth_contexts):
         auth_contexts.legacy_token_path().write_text('{"token": "legacy"}')
-        auth_contexts.legacy_client_secret_path().write_text('{"installed": {"client_id": "legacy"}}')
+        auth_contexts.legacy_client_secret_path().write_text(
+            '{"installed": {"client_id": "legacy"}}'
+        )
         auth_contexts.legacy_pending_path().write_text('{"state": "legacy"}')
-        auth_contexts.set_default_for_services("default", "gmail")
-        assert auth_contexts.get_token_payload("default") == {}
-        assert auth_contexts.get_client_secret("default") == {}
-        assert auth_contexts.get_pending_auth("default") == {}
+
+        auth_contexts.set_client_secret(
+            "named",
+            {"installed": {"client_id": "named"}},
+        )
+
+        assert auth_contexts.get_token_payload("default")["token"] == "legacy"
+        assert auth_contexts.get_client_secret("default")["installed"]["client_id"] == "legacy"
+        assert auth_contexts.get_pending_auth("default")["state"] == "legacy"
+        assert auth_contexts.context_exists("default")
+        assert "default" in auth_contexts.list_contexts()
+
+        stored_default = auth_contexts.load_store()["contexts"]["default"]
+        assert stored_default["token"]["token"] == "legacy"
+        assert stored_default["client_secret"]["installed"]["client_id"] == "legacy"
+        assert stored_default["pending_auth"]["state"] == "legacy"
+
+    def test_store_backed_default_remains_authoritative_after_migration(self, auth_contexts):
+        auth_contexts.legacy_token_path().write_text('{"token": "legacy"}')
+        auth_contexts.set_client_secret(
+            "named",
+            {"installed": {"client_id": "named"}},
+        )
+        auth_contexts.set_token_payload(
+            "default",
+            {"token": "store", "scopes": [auth_contexts.GMAIL_READONLY]},
+        )
+        auth_contexts.legacy_token_path().write_text('{"token": "stale"}')
+
+        assert auth_contexts.get_token_payload("default")["token"] == "store"
 
     def test_full_drive_implies_read(self, auth_contexts):
         auth_contexts.set_token_payload("drive", {"token": "tok", "scopes": [auth_contexts.DRIVE]})
         auth_contexts.assert_command_allowed("drive", "drive", "search")
+
+
+def test_live_check_uses_scope_neutral_oauth_refresh(monkeypatch, tmp_path, capsys):
+    setup_script = load_module("google_workspace_setup_live_test", SETUP_PATH, monkeypatch, tmp_path)
+    token_file = tmp_path / "token.json"
+    token_file.write_text("{}")
+    monkeypatch.setattr(setup_script, "check_auth", lambda **_kwargs: True)
+    monkeypatch.setattr(setup_script, "_token_file", lambda _context: token_file)
+    monkeypatch.setattr(
+        setup_script,
+        "_token_payload",
+        lambda _context: {
+            "token": "old",
+            "refresh_token": "refresh",
+            "scopes": [setup_script.gauth.GMAIL_SEND],
+        },
+    )
+    saved = {}
+    monkeypatch.setattr(
+        setup_script,
+        "_set_token_payload",
+        lambda context, payload, **_kwargs: saved.update(
+            {"context": context, "payload": payload}
+        ),
+    )
+
+    class FakeCredentials:
+        refresh_token = "refresh"
+
+        @classmethod
+        def from_authorized_user_file(cls, filename):
+            assert filename == str(token_file)
+            return cls()
+
+        def refresh(self, _request):
+            self.refreshed = True
+
+        def to_json(self):
+            assert self.refreshed
+            return json.dumps(
+                {
+                    "token": "refreshed",
+                    "refresh_token": "refresh",
+                    "token_uri": "https://oauth2.googleapis.com/token",
+                    "client_id": "client",
+                    "client_secret": "secret",
+                }
+            )
+
+    google_module = types.ModuleType("google")
+    oauth2_module = types.ModuleType("google.oauth2")
+    credentials_module = types.ModuleType("google.oauth2.credentials")
+    setattr(credentials_module, "Credentials", FakeCredentials)
+    auth_module = types.ModuleType("google.auth")
+    transport_module = types.ModuleType("google.auth.transport")
+    requests_module = types.ModuleType("google.auth.transport.requests")
+    setattr(requests_module, "Request", lambda: object())
+    googleapiclient_module = types.ModuleType("googleapiclient")
+    discovery_module = types.ModuleType("googleapiclient.discovery")
+
+    def reject_service_specific_call(*_args, **_kwargs):
+        raise AssertionError("live check must not require a Calendar or other service scope")
+
+    setattr(discovery_module, "build", reject_service_specific_call)
+    for name, module in {
+        "google": google_module,
+        "google.oauth2": oauth2_module,
+        "google.oauth2.credentials": credentials_module,
+        "google.auth": auth_module,
+        "google.auth.transport": transport_module,
+        "google.auth.transport.requests": requests_module,
+        "googleapiclient": googleapiclient_module,
+        "googleapiclient.discovery": discovery_module,
+    }.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    assert setup_script.check_auth_live("gmail-send") is True
+    assert saved["context"] == "gmail-send"
+    assert saved["payload"]["token"] == "refreshed"
+    assert saved["payload"]["scopes"] == [setup_script.gauth.GMAIL_SEND]
+    assert "LIVE_CHECK_OK" in capsys.readouterr().out

--- a/tests/skills/test_google_workspace_credential_files.py
+++ b/tests/skills/test_google_workspace_credential_files.py
@@ -59,18 +59,31 @@ class TestGoogleWorkspaceCredentialFiles:
             entries_by_path["google_workspace_auth_contexts.json"][
                 "readiness_json_path"
             ]
-            == "contexts.*.token.refresh_token"
+            == "contexts.*.token"
+        )
+        required_token_keys = ["refresh_token", "client_id", "client_secret"]
+        assert (
+            entries_by_path["google_workspace_auth_contexts.json"][
+                "readiness_json_required_keys"
+            ]
+            == required_token_keys
         )
         assert (
-            entries_by_path["google_token.json"]["readiness_json_path"]
-            == "refresh_token"
+            entries_by_path["google_token.json"]["readiness_json_required_keys"]
+            == required_token_keys
         )
 
     def test_entries_are_registered_when_files_exist(self, tmp_path):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
         (hermes_home / "google_token.json").write_text(
-            json.dumps({"refresh_token": "refresh"})
+            json.dumps(
+                {
+                    "refresh_token": "refresh",
+                    "client_id": "client-id",
+                    "client_secret": "client-secret",
+                }
+            )
         )
         (hermes_home / "google_client_secret.json").write_text("{}")
         (hermes_home / "google_workspace_auth_contexts.json").write_text("{}")
@@ -105,7 +118,13 @@ class TestGoogleWorkspaceCredentialFiles:
             json.dumps(
                 {
                     "contexts": {
-                        "named": {"token": {"refresh_token": "refresh"}}
+                        "named": {
+                            "token": {
+                                "refresh_token": "refresh",
+                                "client_id": "client-id",
+                                "client_secret": "client-secret",
+                            }
+                        }
                     }
                 }
             )
@@ -140,7 +159,13 @@ class TestGoogleWorkspaceCredentialFiles:
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
         (hermes_home / "google_token.json").write_text(
-            json.dumps({"refresh_token": "refresh"})
+            json.dumps(
+                {
+                    "refresh_token": "refresh",
+                    "client_id": "client-id",
+                    "client_secret": "client-secret",
+                }
+            )
         )
         (hermes_home / "google_client_secret.json").write_text("{}")
 
@@ -220,6 +245,35 @@ class TestGoogleWorkspaceCredentialFiles:
             assert result["setup_needed"] is True
             assert result["readiness_status"] == "setup_needed"
             assert result["missing_credential_files"]
+        finally:
+            clear_credential_files()
+
+    def test_named_refresh_token_without_client_fields_requires_setup(self, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "google_workspace_auth_contexts.json").write_text(
+            json.dumps(
+                {
+                    "contexts": {
+                        "named": {"token": {"refresh_token": "refresh"}}
+                    }
+                }
+            )
+        )
+
+        from tools.credential_files import clear_credential_files
+        from tools.skills_tool import skill_view
+
+        clear_credential_files()
+        try:
+            with (
+                patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+                patch("tools.skills_tool.SKILLS_DIR", SKILL_MD.parents[2]),
+            ):
+                result = json.loads(skill_view("google-workspace"))
+
+            assert result["setup_needed"] is True
+            assert result["readiness_status"] == "setup_needed"
         finally:
             clear_credential_files()
 

--- a/tests/skills/test_google_workspace_credential_files.py
+++ b/tests/skills/test_google_workspace_credential_files.py
@@ -52,11 +52,26 @@ class TestGoogleWorkspaceCredentialFiles:
             "google_token.json": "legacy",
             "google_client_secret.json": "legacy",
         }
+        entries_by_path = {
+            entry["path"]: entry for entry in entries if isinstance(entry, dict)
+        }
+        assert (
+            entries_by_path["google_workspace_auth_contexts.json"][
+                "readiness_json_path"
+            ]
+            == "contexts.*.token.refresh_token"
+        )
+        assert (
+            entries_by_path["google_token.json"]["readiness_json_path"]
+            == "refresh_token"
+        )
 
     def test_entries_are_registered_when_files_exist(self, tmp_path):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
-        (hermes_home / "google_token.json").write_text("{}")
+        (hermes_home / "google_token.json").write_text(
+            json.dumps({"refresh_token": "refresh"})
+        )
         (hermes_home / "google_client_secret.json").write_text("{}")
         (hermes_home / "google_workspace_auth_contexts.json").write_text("{}")
 
@@ -86,7 +101,15 @@ class TestGoogleWorkspaceCredentialFiles:
     def test_named_context_only_is_available_and_mounted(self, tmp_path):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
-        (hermes_home / "google_workspace_auth_contexts.json").write_text("{}")
+        (hermes_home / "google_workspace_auth_contexts.json").write_text(
+            json.dumps(
+                {
+                    "contexts": {
+                        "named": {"token": {"refresh_token": "refresh"}}
+                    }
+                }
+            )
+        )
 
         from tools.credential_files import (
             clear_credential_files,
@@ -116,7 +139,9 @@ class TestGoogleWorkspaceCredentialFiles:
     def test_legacy_only_is_available_and_mounted(self, tmp_path):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
-        (hermes_home / "google_token.json").write_text("{}")
+        (hermes_home / "google_token.json").write_text(
+            json.dumps({"refresh_token": "refresh"})
+        )
         (hermes_home / "google_client_secret.json").write_text("{}")
 
         from tools.credential_files import (
@@ -148,6 +173,38 @@ class TestGoogleWorkspaceCredentialFiles:
     def test_no_credentials_requires_setup(self, tmp_path):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
+
+        from tools.credential_files import clear_credential_files
+        from tools.skills_tool import skill_view
+
+        clear_credential_files()
+        try:
+            with (
+                patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+                patch("tools.skills_tool.SKILLS_DIR", SKILL_MD.parents[2]),
+            ):
+                result = json.loads(skill_view("google-workspace"))
+
+            assert result["setup_needed"] is True
+            assert result["readiness_status"] == "setup_needed"
+            assert result["missing_credential_files"]
+        finally:
+            clear_credential_files()
+
+    def test_named_context_without_token_requires_setup(self, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "google_workspace_auth_contexts.json").write_text(
+            json.dumps(
+                {
+                    "contexts": {
+                        "named": {
+                            "client_secret": {"installed": {"client_id": "client"}}
+                        }
+                    }
+                }
+            )
+        )
 
         from tools.credential_files import clear_credential_files
         from tools.skills_tool import skill_view

--- a/tests/skills/test_google_workspace_credential_files.py
+++ b/tests/skills/test_google_workspace_credential_files.py
@@ -42,10 +42,16 @@ class TestGoogleWorkspaceCredentialFiles:
         assert _EXPECTED_PATHS <= paths, (
             f"Missing entries in required_credential_files: {_EXPECTED_PATHS - paths}"
         )
-        assert all(
-            isinstance(entry, dict) and entry.get("optional") is True
+        groups = {
+            entry["path"]: entry.get("alternative_group")
             for entry in entries
-        ), "Alternative Google credential layouts must not require every file at once"
+            if isinstance(entry, dict)
+        }
+        assert groups == {
+            "google_workspace_auth_contexts.json": "named-context",
+            "google_token.json": "legacy",
+            "google_client_secret.json": "legacy",
+        }
 
     def test_entries_are_registered_when_files_exist(self, tmp_path):
         hermes_home = tmp_path / ".hermes"
@@ -136,5 +142,48 @@ class TestGoogleWorkspaceCredentialFiles:
                 "/root/.hermes/google_token.json",
                 "/root/.hermes/google_client_secret.json",
             }
+        finally:
+            clear_credential_files()
+
+    def test_no_credentials_requires_setup(self, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+
+        from tools.credential_files import clear_credential_files
+        from tools.skills_tool import skill_view
+
+        clear_credential_files()
+        try:
+            with (
+                patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+                patch("tools.skills_tool.SKILLS_DIR", SKILL_MD.parents[2]),
+            ):
+                result = json.loads(skill_view("google-workspace"))
+
+            assert result["setup_needed"] is True
+            assert result["readiness_status"] == "setup_needed"
+            assert result["missing_credential_files"]
+        finally:
+            clear_credential_files()
+
+    def test_incomplete_legacy_layout_requires_setup(self, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "google_client_secret.json").write_text("{}")
+
+        from tools.credential_files import clear_credential_files
+        from tools.skills_tool import skill_view
+
+        clear_credential_files()
+        try:
+            with (
+                patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+                patch("tools.skills_tool.SKILLS_DIR", SKILL_MD.parents[2]),
+            ):
+                result = json.loads(skill_view("google-workspace"))
+
+            assert result["setup_needed"] is True
+            assert result["readiness_status"] == "setup_needed"
+            assert result["missing_credential_files"]
         finally:
             clear_credential_files()

--- a/tests/skills/test_google_workspace_credential_files.py
+++ b/tests/skills/test_google_workspace_credential_files.py
@@ -7,6 +7,7 @@ prevents the regression from silently reappearing.
 
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 from unittest.mock import patch
@@ -41,6 +42,10 @@ class TestGoogleWorkspaceCredentialFiles:
         assert _EXPECTED_PATHS <= paths, (
             f"Missing entries in required_credential_files: {_EXPECTED_PATHS - paths}"
         )
+        assert all(
+            isinstance(entry, dict) and entry.get("optional") is True
+            for entry in entries
+        ), "Alternative Google credential layouts must not require every file at once"
 
     def test_entries_are_registered_when_files_exist(self, tmp_path):
         hermes_home = tmp_path / ".hermes"
@@ -72,31 +77,64 @@ class TestGoogleWorkspaceCredentialFiles:
         finally:
             clear_credential_files()
 
-    def test_missing_token_is_reported(self, tmp_path):
-        """google_token.json absent (first-time setup) — reported as missing, client secret still mounts."""
+    def test_named_context_only_is_available_and_mounted(self, tmp_path):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
+        (hermes_home / "google_workspace_auth_contexts.json").write_text("{}")
+
+        from tools.credential_files import (
+            clear_credential_files,
+            get_credential_file_mounts,
+        )
+        from tools.skills_tool import skill_view
+
+        clear_credential_files()
+        try:
+            with (
+                patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+                patch("tools.skills_tool.SKILLS_DIR", SKILL_MD.parents[2]),
+            ):
+                result = json.loads(skill_view("google-workspace"))
+
+            assert result["setup_needed"] is False
+            assert result["missing_credential_files"] == []
+            container_paths = {
+                mount["container_path"] for mount in get_credential_file_mounts()
+            }
+            assert container_paths == {
+                "/root/.hermes/google_workspace_auth_contexts.json"
+            }
+        finally:
+            clear_credential_files()
+
+    def test_legacy_only_is_available_and_mounted(self, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "google_token.json").write_text("{}")
         (hermes_home / "google_client_secret.json").write_text("{}")
 
         from tools.credential_files import (
             clear_credential_files,
             get_credential_file_mounts,
-            register_credential_files,
         )
+        from tools.skills_tool import skill_view
 
         clear_credential_files()
         try:
-            content = SKILL_MD.read_text(encoding="utf-8")
-            fm = _parse_frontmatter(content)
-            entries = fm.get("required_credential_files", [])
+            with (
+                patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+                patch("tools.skills_tool.SKILLS_DIR", SKILL_MD.parents[2]),
+            ):
+                result = json.loads(skill_view("google-workspace"))
 
-            with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
-                missing = register_credential_files(entries)
-
-            assert "google_token.json" in missing
-            mounts = get_credential_file_mounts()
-            container_paths = {m["container_path"] for m in mounts}
-            assert "/root/.hermes/google_client_secret.json" in container_paths
-            assert "/root/.hermes/google_token.json" not in container_paths
+            assert result["setup_needed"] is False
+            assert result["missing_credential_files"] == []
+            container_paths = {
+                mount["container_path"] for mount in get_credential_file_mounts()
+            }
+            assert container_paths == {
+                "/root/.hermes/google_token.json",
+                "/root/.hermes/google_client_secret.json",
+            }
         finally:
             clear_credential_files()

--- a/tests/skills/test_google_workspace_credential_files.py
+++ b/tests/skills/test_google_workspace_credential_files.py
@@ -17,7 +17,7 @@ SKILL_MD = (
     / "skills/productivity/google-workspace/SKILL.md"
 )
 
-_EXPECTED_PATHS = {"google_token.json", "google_client_secret.json"}
+_EXPECTED_PATHS = {"google_token.json", "google_client_secret.json", "google_workspace_auth_contexts.json"}
 
 
 def _parse_frontmatter(content: str) -> dict:
@@ -47,6 +47,7 @@ class TestGoogleWorkspaceCredentialFiles:
         hermes_home.mkdir()
         (hermes_home / "google_token.json").write_text("{}")
         (hermes_home / "google_client_secret.json").write_text("{}")
+        (hermes_home / "google_workspace_auth_contexts.json").write_text("{}")
 
         from tools.credential_files import (
             clear_credential_files,

--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -110,6 +110,41 @@ class TestRegisterCredentialFiles:
         assert missing == []
         assert get_credential_file_mounts()[0]["container_path"] == "/root/.hermes/optional.json"
 
+    def test_alternative_group_is_ready_when_one_complete_layout_exists(self, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "legacy-token.json").write_text("{}")
+        (hermes_home / "legacy-secret.json").write_text("{}")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            missing = register_credential_files(
+                [
+                    {"path": "named-store.json", "alternative_group": "named"},
+                    {"path": "legacy-token.json", "alternative_group": "legacy"},
+                    {"path": "legacy-secret.json", "alternative_group": "legacy"},
+                ]
+            )
+
+        assert missing == []
+        assert len(get_credential_file_mounts()) == 2
+
+    def test_alternative_groups_report_setup_when_none_complete(self, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "legacy-secret.json").write_text("{}")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            missing = register_credential_files(
+                [
+                    {"path": "named-store.json", "alternative_group": "named"},
+                    {"path": "legacy-token.json", "alternative_group": "legacy"},
+                    {"path": "legacy-secret.json", "alternative_group": "legacy"},
+                ]
+            )
+
+        assert missing
+        assert get_credential_file_mounts()[0]["container_path"] == "/root/.hermes/legacy-secret.json"
+
     def test_path_takes_precedence_over_name(self, tmp_path):
         """When both path and name are present, path wins."""
         hermes_home = tmp_path / ".hermes"

--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -1,5 +1,6 @@
 """Tests for credential file passthrough and skills directory mounting."""
 
+import json
 import os
 from pathlib import Path
 from unittest.mock import patch
@@ -144,6 +145,47 @@ class TestRegisterCredentialFiles:
 
         assert missing
         assert get_credential_file_mounts()[0]["container_path"] == "/root/.hermes/legacy-secret.json"
+
+    def test_readiness_json_path_requires_truthy_nested_value(self, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        store = hermes_home / "contexts.json"
+        store.write_text(json.dumps({"contexts": {"named": {"client_secret": {}}}}))
+        entry = {
+            "path": "contexts.json",
+            "readiness_json_path": "contexts.*.token",
+        }
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            missing = register_credential_files([entry])
+
+        assert missing == ["contexts.json"]
+        assert len(get_credential_file_mounts()) == 1
+
+        store.write_text(
+            json.dumps({"contexts": {"named": {"token": {"refresh_token": "r"}}}})
+        )
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            missing = register_credential_files([entry])
+        assert missing == []
+
+    def test_readiness_json_path_rejects_malformed_json(self, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "contexts.json").write_text("{")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            missing = register_credential_files(
+                [
+                    {
+                        "path": "contexts.json",
+                        "readiness_json_path": "contexts.*.token",
+                    }
+                ]
+            )
+
+        assert missing == ["contexts.json"]
+        assert len(get_credential_file_mounts()) == 1
 
     def test_path_takes_precedence_over_name(self, tmp_path):
         """When both path and name are present, path wins."""

--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -187,6 +187,58 @@ class TestRegisterCredentialFiles:
         assert missing == ["contexts.json"]
         assert len(get_credential_file_mounts()) == 1
 
+    def test_readiness_json_required_keys_must_share_one_object(self, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        store = hermes_home / "contexts.json"
+        entry = {
+            "path": "contexts.json",
+            "readiness_json_path": "contexts.*.token",
+            "readiness_json_required_keys": [
+                "refresh_token",
+                "client_id",
+                "client_secret",
+            ],
+        }
+        store.write_text(
+            json.dumps(
+                {
+                    "contexts": {
+                        "a": {
+                            "token": {
+                                "refresh_token": "r",
+                                "client_id": "id",
+                            }
+                        },
+                        "b": {"token": {"client_secret": "secret"}},
+                    }
+                }
+            )
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            missing = register_credential_files([entry])
+        assert missing == ["contexts.json"]
+
+        store.write_text(
+            json.dumps(
+                {
+                    "contexts": {
+                        "a": {
+                            "token": {
+                                "refresh_token": "r",
+                                "client_id": "id",
+                                "client_secret": "secret",
+                            }
+                        }
+                    }
+                }
+            )
+        )
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            missing = register_credential_files([entry])
+        assert missing == []
+
     def test_path_takes_precedence_over_name(self, tmp_path):
         """When both path and name are present, path wins."""
         hermes_home = tmp_path / ".hermes"

--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -85,6 +85,31 @@ class TestRegisterCredentialFiles:
         assert "does_not_exist.json" in missing
         assert get_credential_file_mounts() == []
 
+    def test_optional_missing_file_is_not_reported(self, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            missing = register_credential_files([
+                {"path": "optional.json", "optional": True},
+            ])
+
+        assert missing == []
+        assert get_credential_file_mounts() == []
+
+    def test_optional_existing_file_is_still_registered(self, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "optional.json").write_text("{}")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            missing = register_credential_files([
+                {"path": "optional.json", "optional": True},
+            ])
+
+        assert missing == []
+        assert get_credential_file_mounts()[0]["container_path"] == "/root/.hermes/optional.json"
+
     def test_path_takes_precedence_over_name(self, tmp_path):
         """When both path and name are present, path wins."""
         hermes_home = tmp_path / ".hermes"

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -20,6 +20,7 @@ creation time and before each command (for resync on Modal).
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import posixpath
@@ -104,6 +105,36 @@ def register_credential_file(
     return True
 
 
+def _json_path_has_truthy_value(path: Path, expression: str) -> bool:
+    """Return whether a dotted JSON path resolves to any truthy value.
+
+    ``*`` expands mapping values or list items, allowing declarations such as
+    ``contexts.*.token`` without embedding service-specific readiness logic.
+    """
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return False
+
+    candidates = [payload]
+    for segment in expression.split("."):
+        if not segment:
+            return False
+        next_candidates = []
+        for candidate in candidates:
+            if segment == "*":
+                if isinstance(candidate, dict):
+                    next_candidates.extend(candidate.values())
+                elif isinstance(candidate, list):
+                    next_candidates.extend(candidate)
+            elif isinstance(candidate, dict) and segment in candidate:
+                next_candidates.append(candidate[segment])
+        candidates = next_candidates
+        if not candidates:
+            return False
+    return any(bool(candidate) for candidate in candidates)
+
+
 def register_credential_files(
     entries: list,
     container_base: str = "/root/.hermes",
@@ -111,7 +142,9 @@ def register_credential_files(
     """Register credential files and return unsatisfied requirements.
 
     Existing files are always registered. Missing entries with ``optional:
-    true`` do not affect readiness. Entries sharing an ``alternative_group``
+    true`` do not affect readiness. ``readiness_json_path`` can require a
+    truthy value at a dotted JSON path (with ``*`` wildcards) while still
+    mounting an incomplete file. Entries sharing an ``alternative_group``
     form an AND-layout, while the named groups are alternatives: satisfying
     every non-optional file in any one group satisfies all grouped entries.
     Ungrouped non-optional entries remain independently required.
@@ -121,12 +154,14 @@ def register_credential_files(
     for entry in entries:
         optional = False
         alternative_group = ""
+        readiness_json_path = ""
         if isinstance(entry, str):
             rel_path = entry.strip()
         elif isinstance(entry, dict):
             rel_path = (entry.get("path") or entry.get("name") or "").strip()
             optional = entry.get("optional") is True
             alternative_group = str(entry.get("alternative_group") or "").strip()
+            readiness_json_path = str(entry.get("readiness_json_path") or "").strip()
         else:
             continue
         if not rel_path:
@@ -134,7 +169,13 @@ def register_credential_files(
         if alternative_group:
             group_missing.setdefault(alternative_group, [])
         registered = register_credential_file(rel_path, container_base)
-        if registered or optional:
+        ready = registered
+        if registered and readiness_json_path:
+            ready = _json_path_has_truthy_value(
+                (_resolve_hermes_home() / rel_path).resolve(),
+                readiness_json_path,
+            )
+        if ready or optional:
             continue
         if alternative_group:
             group_missing[alternative_group].append(rel_path)

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -105,11 +105,15 @@ def register_credential_file(
     return True
 
 
-def _json_path_has_truthy_value(path: Path, expression: str) -> bool:
-    """Return whether a dotted JSON path resolves to any truthy value.
+def _json_path_has_truthy_value(
+    path: Path,
+    expression: str,
+    required_keys: list[str] | None = None,
+) -> bool:
+    """Return whether a JSON path resolves to a semantically ready value.
 
-    ``*`` expands mapping values or list items, allowing declarations such as
-    ``contexts.*.token`` without embedding service-specific readiness logic.
+    ``*`` expands mapping values or list items. When ``required_keys`` is set,
+    every key must be truthy on the same resolved object.
     """
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
@@ -117,22 +121,35 @@ def _json_path_has_truthy_value(path: Path, expression: str) -> bool:
         return False
 
     candidates = [payload]
-    for segment in expression.split("."):
-        if not segment:
-            return False
-        next_candidates = []
-        for candidate in candidates:
-            if segment == "*":
-                if isinstance(candidate, dict):
-                    next_candidates.extend(candidate.values())
-                elif isinstance(candidate, list):
-                    next_candidates.extend(candidate)
-            elif isinstance(candidate, dict) and segment in candidate:
-                next_candidates.append(candidate[segment])
-        candidates = next_candidates
-        if not candidates:
-            return False
-    return any(bool(candidate) for candidate in candidates)
+    if expression:
+        for segment in expression.split("."):
+            if not segment:
+                return False
+            next_candidates = []
+            for candidate in candidates:
+                if segment == "*":
+                    if isinstance(candidate, dict):
+                        next_candidates.extend(candidate.values())
+                    elif isinstance(candidate, list):
+                        next_candidates.extend(candidate)
+                elif isinstance(candidate, dict) and segment in candidate:
+                    next_candidates.append(candidate[segment])
+            candidates = next_candidates
+            if not candidates:
+                return False
+
+    required = required_keys or []
+    return any(
+        bool(candidate)
+        and (
+            not required
+            or (
+                isinstance(candidate, dict)
+                and all(bool(candidate.get(key)) for key in required)
+            )
+        )
+        for candidate in candidates
+    )
 
 
 def register_credential_files(
@@ -142,12 +159,14 @@ def register_credential_files(
     """Register credential files and return unsatisfied requirements.
 
     Existing files are always registered. Missing entries with ``optional:
-    true`` do not affect readiness. ``readiness_json_path`` can require a
-    truthy value at a dotted JSON path (with ``*`` wildcards) while still
-    mounting an incomplete file. Entries sharing an ``alternative_group``
-    form an AND-layout, while the named groups are alternatives: satisfying
-    every non-optional file in any one group satisfies all grouped entries.
-    Ungrouped non-optional entries remain independently required.
+    true`` do not affect readiness. ``readiness_json_path`` can select a
+    truthy JSON value (with ``*`` wildcards), and
+    ``readiness_json_required_keys`` can require fields on that same object,
+    while still mounting an incomplete file. Entries sharing an
+    ``alternative_group`` form an AND-layout, while the named groups are
+    alternatives: satisfying every non-optional file in any one group
+    satisfies all grouped entries. Ungrouped non-optional entries remain
+    independently required.
     """
     missing: List[str] = []
     group_missing: Dict[str, List[str]] = {}
@@ -155,6 +174,7 @@ def register_credential_files(
         optional = False
         alternative_group = ""
         readiness_json_path = ""
+        readiness_json_required_keys: list[str] = []
         if isinstance(entry, str):
             rel_path = entry.strip()
         elif isinstance(entry, dict):
@@ -162,6 +182,11 @@ def register_credential_files(
             optional = entry.get("optional") is True
             alternative_group = str(entry.get("alternative_group") or "").strip()
             readiness_json_path = str(entry.get("readiness_json_path") or "").strip()
+            raw_required_keys = entry.get("readiness_json_required_keys", [])
+            if isinstance(raw_required_keys, list):
+                readiness_json_required_keys = [
+                    str(key).strip() for key in raw_required_keys if str(key).strip()
+                ]
         else:
             continue
         if not rel_path:
@@ -170,10 +195,11 @@ def register_credential_files(
             group_missing.setdefault(alternative_group, [])
         registered = register_credential_file(rel_path, container_base)
         ready = registered
-        if registered and readiness_json_path:
+        if registered and (readiness_json_path or readiness_json_required_keys):
             ready = _json_path_has_truthy_value(
                 (_resolve_hermes_home() / rel_path).resolve(),
                 readiness_json_path,
+                readiness_json_required_keys,
             )
         if ready or optional:
             continue

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -111,20 +111,23 @@ def register_credential_files(
     """Register multiple credential files from skill frontmatter entries.
 
     Each entry is either a string (relative path) or a dict with a ``path``
-    key.  Returns the list of relative paths that were NOT found on the host
-    (i.e. missing files).
+    key. Existing files are always registered. A missing dict entry with
+    ``optional: true`` is not reported as a setup requirement. Returns the
+    list of required relative paths that were not found on the host.
     """
     missing = []
     for entry in entries:
+        optional = False
         if isinstance(entry, str):
             rel_path = entry.strip()
         elif isinstance(entry, dict):
             rel_path = (entry.get("path") or entry.get("name") or "").strip()
+            optional = entry.get("optional") is True
         else:
             continue
         if not rel_path:
             continue
-        if not register_credential_file(rel_path, container_base):
+        if not register_credential_file(rel_path, container_base) and not optional:
             missing.append(rel_path)
     return missing
 

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -108,27 +108,43 @@ def register_credential_files(
     entries: list,
     container_base: str = "/root/.hermes",
 ) -> List[str]:
-    """Register multiple credential files from skill frontmatter entries.
+    """Register credential files and return unsatisfied requirements.
 
-    Each entry is either a string (relative path) or a dict with a ``path``
-    key. Existing files are always registered. A missing dict entry with
-    ``optional: true`` is not reported as a setup requirement. Returns the
-    list of required relative paths that were not found on the host.
+    Existing files are always registered. Missing entries with ``optional:
+    true`` do not affect readiness. Entries sharing an ``alternative_group``
+    form an AND-layout, while the named groups are alternatives: satisfying
+    every non-optional file in any one group satisfies all grouped entries.
+    Ungrouped non-optional entries remain independently required.
     """
-    missing = []
+    missing: List[str] = []
+    group_missing: Dict[str, List[str]] = {}
     for entry in entries:
         optional = False
+        alternative_group = ""
         if isinstance(entry, str):
             rel_path = entry.strip()
         elif isinstance(entry, dict):
             rel_path = (entry.get("path") or entry.get("name") or "").strip()
             optional = entry.get("optional") is True
+            alternative_group = str(entry.get("alternative_group") or "").strip()
         else:
             continue
         if not rel_path:
             continue
-        if not register_credential_file(rel_path, container_base) and not optional:
+        if alternative_group:
+            group_missing.setdefault(alternative_group, [])
+        registered = register_credential_file(rel_path, container_base)
+        if registered or optional:
+            continue
+        if alternative_group:
+            group_missing[alternative_group].append(rel_path)
+        else:
             missing.append(rel_path)
+
+    if group_missing and not any(not paths for paths in group_missing.values()):
+        # Report the closest satisfiable layout, preserving frontmatter order
+        # on ties so setup_needed stays deterministic.
+        missing.extend(min(group_missing.values(), key=len))
     return missing
 
 

--- a/website/docs/developer-guide/creating-skills.md
+++ b/website/docs/developer-guide/creating-skills.md
@@ -251,8 +251,9 @@ required_credential_files:
 Each entry supports:
 - `path` (required) — file path relative to `~/.hermes/`
 - `description` (optional) — explains what the file is and how it's created
+- `optional` (optional, default `false`) — mount the file when present without marking the skill `setup_needed` when it is absent; use this for alternative or backward-compatible credential layouts
 
-When loaded, Hermes checks if these files exist. Missing files trigger `setup_needed`. Existing files are automatically:
+When loaded, Hermes checks if these files exist. Missing non-optional files trigger `setup_needed`. Existing files, including optional ones, are automatically:
 - **Mounted into Docker** containers as read-only bind mounts
 - **Synced into Modal** sandboxes (at creation + before each command, so mid-session OAuth works)
 - Available on **local** backend without any special handling

--- a/website/docs/developer-guide/creating-skills.md
+++ b/website/docs/developer-guide/creating-skills.md
@@ -253,9 +253,10 @@ Each entry supports:
 - `description` (optional) — explains what the file is and how it's created
 - `optional` (optional, default `false`) — mount the file when present without marking the skill `setup_needed` when it is absent
 - `alternative_group` (optional) — entries in the same named group are required together, but satisfying any one alternative group satisfies all grouped credential requirements; use this for layouts such as one named-context store **or** a legacy token/client-secret pair
-- `readiness_json_path` (optional) — require any truthy value at a dotted JSON path before the file satisfies readiness; `*` expands object values or list items (for example, `contexts.*.token.refresh_token`); the file is still mounted when incomplete
+- `readiness_json_path` (optional) — select a truthy value at a dotted JSON path before the file satisfies readiness; `*` expands object values or list items (for example, `contexts.*.token`); the file is still mounted when incomplete
+- `readiness_json_required_keys` (optional) — list fields that must all be truthy on the same object selected by `readiness_json_path`, or on the JSON root when no path is declared
 
-When loaded, Hermes checks whether these files exist and satisfy any declared JSON readiness path. Missing or semantically incomplete ungrouped non-optional files trigger `setup_needed`; grouped files trigger it only when no alternative group is complete. Existing files, including optional and incomplete-group files, are automatically:
+When loaded, Hermes checks whether these files exist and satisfy any declared JSON readiness constraints. Missing or semantically incomplete ungrouped non-optional files trigger `setup_needed`; grouped files trigger it only when no alternative group is complete. Existing files, including optional and incomplete-group files, are automatically:
 - **Mounted into Docker** containers as read-only bind mounts
 - **Synced into Modal** sandboxes (at creation + before each command, so mid-session OAuth works)
 - Available on **local** backend without any special handling

--- a/website/docs/developer-guide/creating-skills.md
+++ b/website/docs/developer-guide/creating-skills.md
@@ -251,9 +251,10 @@ required_credential_files:
 Each entry supports:
 - `path` (required) — file path relative to `~/.hermes/`
 - `description` (optional) — explains what the file is and how it's created
-- `optional` (optional, default `false`) — mount the file when present without marking the skill `setup_needed` when it is absent; use this for alternative or backward-compatible credential layouts
+- `optional` (optional, default `false`) — mount the file when present without marking the skill `setup_needed` when it is absent
+- `alternative_group` (optional) — entries in the same named group are required together, but satisfying any one alternative group satisfies all grouped credential requirements; use this for layouts such as one named-context store **or** a legacy token/client-secret pair
 
-When loaded, Hermes checks if these files exist. Missing non-optional files trigger `setup_needed`. Existing files, including optional ones, are automatically:
+When loaded, Hermes checks if these files exist. Missing ungrouped non-optional files trigger `setup_needed`; grouped files trigger it only when no alternative group is complete. Existing files, including optional and incomplete-group files, are automatically:
 - **Mounted into Docker** containers as read-only bind mounts
 - **Synced into Modal** sandboxes (at creation + before each command, so mid-session OAuth works)
 - Available on **local** backend without any special handling

--- a/website/docs/developer-guide/creating-skills.md
+++ b/website/docs/developer-guide/creating-skills.md
@@ -253,8 +253,9 @@ Each entry supports:
 - `description` (optional) — explains what the file is and how it's created
 - `optional` (optional, default `false`) — mount the file when present without marking the skill `setup_needed` when it is absent
 - `alternative_group` (optional) — entries in the same named group are required together, but satisfying any one alternative group satisfies all grouped credential requirements; use this for layouts such as one named-context store **or** a legacy token/client-secret pair
+- `readiness_json_path` (optional) — require any truthy value at a dotted JSON path before the file satisfies readiness; `*` expands object values or list items (for example, `contexts.*.token.refresh_token`); the file is still mounted when incomplete
 
-When loaded, Hermes checks if these files exist. Missing ungrouped non-optional files trigger `setup_needed`; grouped files trigger it only when no alternative group is complete. Existing files, including optional and incomplete-group files, are automatically:
+When loaded, Hermes checks whether these files exist and satisfy any declared JSON readiness path. Missing or semantically incomplete ungrouped non-optional files trigger `setup_needed`; grouped files trigger it only when no alternative group is complete. Existing files, including optional and incomplete-group files, are automatically:
 - **Mounted into Docker** containers as read-only bind mounts
 - **Synced into Modal** sandboxes (at creation + before each command, so mid-session OAuth works)
 - Available on **local** backend without any special handling

--- a/website/docs/user-guide/skills/google-workspace.md
+++ b/website/docs/user-guide/skills/google-workspace.md
@@ -20,7 +20,7 @@ The setup is fully agent-driven — ask Hermes to set up Google Workspace and it
 3. **Authorize** — Hermes generates an auth URL, you approve in the browser, paste back the redirect URL
 4. **Done** — token auto-refreshes from that point on
 
-Hermes remains backward compatible with the legacy single-token files (`~/.hermes/google_token.json` and `~/.hermes/google_client_secret.json`). For least-privilege or multi-account setups, use **auth contexts**: named OAuth credential bundles stored in `~/.hermes/google_workspace_auth_contexts.json`.
+Hermes remains backward compatible with the legacy single-token files (`~/.hermes/google_token.json` and `~/.hermes/google_client_secret.json`). When the named-context store is first created, any legacy default credentials are copied into its `default` context; the store-backed copy is authoritative after that migration. For least-privilege or multi-account setups, use **auth contexts**: named OAuth credential bundles stored in `~/.hermes/google_workspace_auth_contexts.json`.
 
 Auth contexts let one Hermes profile route different Google APIs through different tokens without splitting the agent's memory/session context. A context can represent a different Google account, or a separately scoped grant for the same account.
 

--- a/website/docs/user-guide/skills/google-workspace.md
+++ b/website/docs/user-guide/skills/google-workspace.md
@@ -20,6 +20,30 @@ The setup is fully agent-driven — ask Hermes to set up Google Workspace and it
 3. **Authorize** — Hermes generates an auth URL, you approve in the browser, paste back the redirect URL
 4. **Done** — token auto-refreshes from that point on
 
+Hermes remains backward compatible with the legacy single-token files (`~/.hermes/google_token.json` and `~/.hermes/google_client_secret.json`). For least-privilege or multi-account setups, use **auth contexts**: named OAuth credential bundles stored in `~/.hermes/google_workspace_auth_contexts.json`.
+
+Auth contexts let one Hermes profile route different Google APIs through different tokens without splitting the agent's memory/session context. A context can represent a different Google account, or a separately scoped grant for the same account.
+
+```bash
+# Gmail read-only context
+$GSETUP --auth-context gmail-readonly --client-secret /path/to/mail-client.json --account-hint mail@example.com
+$GSETUP --auth-context gmail-readonly --services gmail-readonly --auth-url
+$GSETUP --auth-context gmail-readonly --auth-code "THE_REDIRECT_URL"
+$GSETUP --auth-context gmail-readonly --set-default-for gmail
+
+# Drive/Calendar/Docs/Sheets writer context
+$GSETUP --auth-context workspace-writer --client-secret /path/to/workspace-client.json --account-hint workspace@example.com
+$GSETUP --auth-context workspace-writer --services drive,calendar,docs,sheets --auth-url
+$GSETUP --auth-context workspace-writer --auth-code "THE_REDIRECT_URL"
+$GSETUP --auth-context workspace-writer --set-default-for drive,calendar,docs,sheets
+
+# Inspect scopes without starting OAuth
+$GSETUP --services gmail-readonly --print-scopes
+$GSETUP --list-contexts
+```
+
+API commands use service defaults when `--auth-context` is omitted, and they fail locally if the selected context lacks the scope required for a write/send/delete/share operation.
+
 :::tip Email-only users
 If you only need email (no Calendar/Drive/Sheets), use the **himalaya** skill instead — it works with a Gmail App Password and takes 2 minutes. No Google Cloud project needed.
 :::


### PR DESCRIPTION
## Summary

This PR adds named Google Workspace auth contexts: reusable OAuth credential bundles with explicit service/scope metadata. Auth contexts generalize both multi-account aliases and scoped OAuth, allowing one Hermes profile to route Gmail, Drive, Calendar, Docs, and Sheets through different least-privilege tokens without splitting agent memory across Hermes profiles.

An auth context can represent:

- a different Google account
- the same Google account with a different OAuth grant/scope set
- a different OAuth client for the same or different account

The legacy single-token flow remains backward compatible.

## What changed

- Add `scripts/auth_contexts.py` for named Google OAuth credential bundles.
- Add setup support for:
  - `--auth-context NAME`
  - `--services ...`
  - `--scopes ...`
  - `--account-hint ...`
  - `--print-scopes`
  - `--list-contexts`
  - `--set-default-for gmail,drive,...`
  - `--strict-scopes`
- Add service-default routing in `google_api.py` when `--auth-context` is omitted.
- Add local command/scope gates before Gmail send/modify, Drive writes, Calendar writes, Docs writes, Sheets writes, etc.
- Add `gws_bridge.py --auth-context` and `HERMES_GOOGLE_AUTH_CONTEXT` support.
- Register `google_workspace_auth_contexts.json` as a static credential file for remote-backend mounting.
- Update skill and website docs with least-privilege examples.
- Add regression tests for auth-context names, scope resolution, routing, fail-closed behavior, private credential file permissions, legacy/store precedence, and cache cleanup.

## Storage model

New auth-context credentials are stored in one static file:

```text
~/.hermes/google_workspace_auth_contexts.json
```

That file is intended to be mount-friendly for remote terminal backends. Legacy files continue to work when no auth-context store exists:

```text
~/.hermes/google_token.json
~/.hermes/google_client_secret.json
~/.hermes/google_oauth_pending.json
```

When the auth-context store exists, store-backed default context data is authoritative and stale legacy files are ignored for default-context lookups.

Credential/cache writes are private/atomic where this PR writes them, and deleting a token also removes the materialized token cache file.

## Example

```bash
# Gmail read-only context
python setup.py --auth-context gmail-readonly --client-secret /path/to/mail-client.json --account-hint mail@example.com
python setup.py --auth-context gmail-readonly --services gmail-readonly --auth-url
python setup.py --auth-context gmail-readonly --auth-code "THE_REDIRECT_URL"
python setup.py --auth-context gmail-readonly --set-default-for gmail

# Drive/Calendar/Docs/Sheets writer context
python setup.py --auth-context workspace-writer --client-secret /path/to/workspace-client.json --account-hint workspace@example.com
python setup.py --auth-context workspace-writer --services drive,calendar,docs,sheets --auth-url
python setup.py --auth-context workspace-writer --auth-code "THE_REDIRECT_URL"
python setup.py --auth-context workspace-writer --set-default-for drive,calendar,docs,sheets

# Routed by service defaults
python google_api.py gmail search "newer_than:1d"
python google_api.py drive search "project notes"
python google_api.py calendar list
```

A read-only Gmail context will fail locally before calling Google if asked to run `gmail send`.

## Relationship to existing issues/PRs

This is intended as a unifying implementation rather than a parallel one-off:

- Addresses/overlaps #15602 — multi-account Google Workspace support.
- Addresses/overlaps #37900 — Google Workspace read-only / scoped mode.
- Generalizes the account-alias direction in #40675 into auth contexts.
- Incorporates the scoped-service direction from #17087 and #21774.
- Preserves a static credential-file shape relevant to #16452 remote credential mounting.
- Centralizes scope definitions to reduce scope drift concerns such as #43770.
- Does not preclude #21984 integrated Google OAuth; auth contexts define how multiple Google grants are represented/routed once obtained.

## Verification

Ran:

```bash
python3 -m py_compile \
  skills/productivity/google-workspace/scripts/auth_contexts.py \
  skills/productivity/google-workspace/scripts/setup.py \
  skills/productivity/google-workspace/scripts/google_api.py \
  skills/productivity/google-workspace/scripts/gws_bridge.py

/Users/hermes-personal/.hermes/hermes-agent/venv/bin/python -m pytest -o addopts='' \
  tests/skills/test_google_workspace_auth_contexts.py \
  tests/skills/test_google_oauth_setup.py \
  tests/skills/test_google_workspace_api.py \
  tests/skills/test_google_workspace_credential_files.py -q
# 65 passed

/Users/hermes-personal/.hermes/hermes-agent/venv/bin/python -m pytest -o addopts='' tests/skills -q
# 227 passed

git diff --check
# passed
```

Also ran an independent pre-commit review pass; final verdict passed with no blocking security or logic issues.
