### PR TITLE
fix(feifix(feishu): prevent isolated thread sessions in DMs (#44028)

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -3123,6 +3123,8 @@ class FeishuAdapter(BasePlatformAdapter):
                 text = f"{hint}\n\n{text}" if text else hint
 
         thread_id = getattr(message, "thread_id", None) or getattr(message, "root_id", None) or None
+        if getattr(message, "chat_type", None) == "p2p":
+            thread_id = None
         reply_to_message_id = (
             getattr(message, "parent_id", None)
             or getattr(message, "upper_message_id", None)


### PR DESCRIPTION
### Description
Fixes an issue where a user sending a quoted reply (`引用回复`) in a Feishu/Lark DM conversation is routed to an isolated session instead of the normal DM session, causing the agent to lose conversation context.

### Root Cause
When a user quotes/replies to a message in a Feishu DM, the Lark SDK populates `message.thread_id` (or `message.root_id`). While this is correct for group threads, Feishu DMs do not support real threads. This causes `build_session_key()` to generate an isolated session key (e.g., `agent:main:feishu:dm:oc_xxx:om_yyy`) instead of the main DM session key.

### Changes Made
- Added a check for `chat_type == "p2p"` in `_process_inbound_message` to clear the `thread_id` when the message is from a direct message conversation.
- This ensures quoted replies in DMs stay within the same session and maintain proper context.

Fixes #44028