### PR TITLE
fix(profiles): skip large extensionless files in alias lookup

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -452,6 +452,14 @@ def find_alias_for_profile(profile_name: str) -> Optional[str]:
             continue
         if not is_windows and entry.suffix:
             continue
+        # Skip large files — Hermes wrappers are tiny shell/batch scripts.
+        # Large extensionless binaries in ~/.local/bin would be expensive to
+        # read and decode as text (issue #44032).
+        try:
+            if entry.stat().st_size > 65536:
+                continue
+        except OSError:
+            continue
         try:
             content = entry.read_text()
         except (OSError, UnicodeDecodeError):

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -756,6 +756,30 @@ class TestFindAliasForProfile:
         (wrapper_dir / "pip").write_text("#!/bin/sh\nexec python -m pip \"$@\"\n")
         assert find_alias_for_profile("steve") is None
 
+    def test_skips_large_extensionless_files(self, profile_env, monkeypatch):
+        # Large extensionless binaries in ~/.local/bin should not be read as
+        # text — only small wrapper scripts are inspected (issue #44032).
+        monkeypatch.setattr("sys.platform", "darwin")
+        from hermes_cli.profiles import _get_wrapper_dir, find_alias_for_profile
+        wrapper_dir = _get_wrapper_dir()
+        wrapper_dir.mkdir(parents=True, exist_ok=True)
+        # Write a large file (> 64 KiB) that contains the needle — it must be
+        # skipped entirely, so it must NOT match.
+        large_content = b"\x00" * 70000 + b"hermes -p steve"
+        (wrapper_dir / "some-large-binary").write_bytes(large_content)
+        assert find_alias_for_profile("steve") is None
+
+    def test_reads_small_extensionless_wrappers(self, profile_env, monkeypatch):
+        # Small wrapper scripts must still be read and matched normally.
+        monkeypatch.setattr("sys.platform", "darwin")
+        from hermes_cli.profiles import _get_wrapper_dir, find_alias_for_profile
+        wrapper_dir = _get_wrapper_dir()
+        wrapper_dir.mkdir(parents=True, exist_ok=True)
+        (wrapper_dir / "mysteve").write_text(
+            "#!/bin/sh\nexec hermes -p steve \"$@\"\n"
+        )
+        assert find_alias_for_profile("steve") == "mysteve"
+
     def test_custom_alias_on_windows(self, profile_env, monkeypatch):
         monkeypatch.setattr("sys.platform", "win32")
         from hermes_cli.profiles import create_wrapper_script, find_alias_for_profile


### PR DESCRIPTION
## What does this PR do?

Adds a size guard to `find_alias_for_profile()` so that large extensionless binaries in `~/.local/bin` are skipped instead of being read and decoded as text. This prevents CPU burn and latency spikes when the wrapper directory contains unrelated native executables.

## Related Issue

Fixes #44032

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/profiles.py`: Added a 64 KiB `stat().st_size` guard before `read_text()` in `find_alias_for_profile()` — files larger than typical wrapper scripts are skipped early.
- `tests/hermes_cli/test_profiles.py`: Added `test_skips_large_extensionless_files` (70 KB binary with needle is ignored) and `test_reads_small_extensionless_wrappers` (small wrapper still matches normally).

## How to Test

1. Run `python -m pytest tests/hermes_cli/test_profiles.py::TestFindAliasForProfile -v` — all 8 tests pass.
2. Create a large extensionless binary in the wrapper directory (e.g., `dd if=/dev/zero of=~/.local/bin/bigtool bs=1k count=100`), then run `hermes profile list` — it should complete quickly without reading the binary.
3. Verify that normal profile aliases still work: `hermes profile create testprof`, then `hermes profile list` should show the alias.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_profiles.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `find_alias_for_profile` (callers: 2 in profiles.py — `list_profiles`, profile display path)
- Blast radius: LOW — size guard is additive, existing behavior preserved for small files
- Related patterns: `entry.read_text()` with `UnicodeDecodeError` catch is the existing error-handling pattern; the size guard is a cheaper early-exit before the I/O
