### PR TITLE
fix(gateway): don't restore a bare billing provider as the resumed session's provider

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -971,6 +971,35 @@ def test_session_resume_passes_stored_runtime_to_agent(monkeypatch):
     assert server._sessions[runtime_sid]["model_override"] == captured["model_override"]
 
 
+def test_stored_session_runtime_overrides_skips_bare_billing_provider():
+    """A bare billing bucket ("custom"/"auto"/"openrouter") must not be restored as the
+    provider identity on resume. A custom endpoint that never used `/model` persists only
+    `billing_provider="custom"`; restoring that broke `session.resume` with "No LLM provider
+    configured" (agent_init treats it as non-routable). A real provider, or an explicit
+    `model_config.provider`, is still restored.
+    """
+    # Bare "custom" bucket, no explicit model_config.provider: no provider override restored.
+    ov = server._stored_session_runtime_overrides({"model": "my-model", "billing_provider": "custom"})
+    assert "provider_override" not in ov
+    assert ov["model_override"]["provider"] is None
+
+    for bare in ("auto", "openrouter", "custom"):
+        ov = server._stored_session_runtime_overrides({"model": "m", "billing_provider": bare})
+        assert "provider_override" not in ov
+
+    # A real provider in billing_provider is still restored.
+    ov = server._stored_session_runtime_overrides({"model": "m", "billing_provider": "anthropic"})
+    assert ov["provider_override"] == "anthropic"
+    assert ov["model_override"]["provider"] == "anthropic"
+
+    # An explicit routable provider in model_config wins over the bare billing bucket.
+    ov = server._stored_session_runtime_overrides(
+        {"model": "m", "billing_provider": "custom", "model_config": {"provider": "custom:myendpoint"}}
+    )
+    assert ov["provider_override"] == "custom:myendpoint"
+    assert ov["model_override"]["provider"] == "custom:myendpoint"
+
+
 def test_persist_live_session_runtime_preserves_resume_metadata(monkeypatch):
     updates = {}
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1438,6 +1438,11 @@ def _resolve_startup_runtime() -> tuple[str, str | None]:
     return model, None
 
 
+# Bare billing buckets are not routable provider identities (kept in parity with the
+# provider gate in agent_init). Restoring one as a session provider override breaks resume.
+_BARE_BILLING_PROVIDERS = {"auto", "openrouter", "custom"}
+
+
 def _stored_session_runtime_overrides(row: dict | None) -> dict:
     """Return runtime fields persisted with a stored session.
 
@@ -1464,12 +1469,18 @@ def _stored_session_runtime_overrides(row: dict | None) -> dict:
 
     overrides: dict = {}
     model = str(row.get("model") or model_config.get("model") or "").strip()
-    provider = str(
-        model_config.get("provider")
-        or model_config.get("billing_provider")
-        or row.get("billing_provider")
-        or ""
+    # ``billing_provider`` is only the billing bucket — for a custom endpoint it is the
+    # bare class ``"custom"``, which agent_init treats as non-routable, so restoring it as
+    # the provider override makes ``session.resume`` fail with "No LLM provider configured".
+    # Only restore an explicit provider; otherwise leave it unset so resume falls back to
+    # the configured default, matching the working CLI path.
+    explicit_provider = str(model_config.get("provider") or "").strip()
+    billing_provider = str(
+        model_config.get("billing_provider") or row.get("billing_provider") or ""
     ).strip()
+    provider = explicit_provider
+    if not provider and billing_provider.lower() not in _BARE_BILLING_PROVIDERS:
+        provider = billing_provider
     base_url = str(model_config.get("base_url") or "").strip()
     api_mode = str(model_config.get("api_mode") or "").strip()
     reasoning_config = model_config.get("reasoning_config")


### PR DESCRIPTION
## What does this PR do?

Resuming an older chat in the desktop/TUI gateway failed with `resume failed: No LLM provider configured` whenever the session had only ever run normal turns (no `/model` switch) against a `custom:<name>` endpoint — even though new chats and `hermes chat --resume <id>` from the CLI work fine for the same sessions.

Root cause: `_stored_session_runtime_overrides` (`tui_gateway/server.py`) restored the session provider from `billing_provider` when `model_config` had no explicit `provider`. For a custom endpoint, the only thing persisted on a normal turn is `billing_provider`, and its value is the bare billing *bucket* `"custom"` (not the routable `custom:<name>` identity). That bare class was then set as the resumed session's `provider_override` / `model_override.provider`, and `agent_init` treats a bare `auto`/`openrouter`/`custom` as non-routable, so provider resolution returned no client and raised `No LLM provider configured`. The CLI is unaffected because it does not go through the session-scoped runtime-restore path.

Fix: only restore an explicit `model_config.provider`; skip a bare billing bucket so resume falls back to the configured default provider, matching the working CLI path. A real provider stored in `billing_provider` (e.g. `anthropic`) is still restored. Introduced by #43702.

## Related Issue

Fixes #44022

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py` — `_stored_session_runtime_overrides`: split provider resolution so a bare billing bucket (`auto`/`openrouter`/`custom`, mirrored from the gate in `agent_init`) is no longer restored as the session provider; only an explicit `model_config.provider` (or a non-bare `billing_provider`) is.
- `tests/test_tui_gateway_server.py` — added `test_stored_session_runtime_overrides_skips_bare_billing_provider`.

## How to Test

1. Configure a `custom_providers` endpoint as the default (`model.provider: custom:<name>`, `api_mode: anthropic_messages`).
2. In the desktop/TUI app start a chat and send a couple of messages **without** using `/model` (so the row persists only `billing_provider="custom"`).
3. Reopen that chat: on `main` it fails with `No LLM provider configured`; with this change it resumes against the configured default.

Regression test: `pytest tests/test_tui_gateway_server.py::test_stored_session_runtime_overrides_skips_bare_billing_provider` (fails before, passes after). The existing `test_session_resume_passes_stored_runtime_to_agent` (a non-bare `billing_provider`) still passes, confirming real providers are still restored.

## Checklist

- [x] Bug fix is non-breaking
- [x] Added a regression test that fails before and passes after
- [x] `ruff check` passes on the changed files
