### PR TITLE
fix(discord): allow configured role mention triggers

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1693,12 +1693,10 @@ def init_agent(
     # Gateway status_callback is not yet wired, so any warning is stored
     # in _compression_warning and replayed in the first run_conversation().
     agent._compression_warning = None
-    # Gateway parity for the Codex gpt-5.5 autoraise notice: the startup print
-    # above only reaches the CLI, so stash the same text here to be replayed
-    # through status_callback on the first turn (Telegram/Discord/Slack/etc.).
-    _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
-    if _autoraise and compression_enabled:
-        agent._compression_warning = _build_codex_gpt55_autoraise_notice(_autoraise)
+    # Keep the Codex gpt-5.5 autoraise as a CLI-startup notice only.  Gateway
+    # sessions create fresh agents often (new Discord/Slack threads, restarts),
+    # so replaying this informational notice through status_callback creates
+    # repeated user-visible noise even though the 85% threshold is still active.
     # Lazy feasibility check: deferred to the first turn that approaches the
     # compression threshold. Running it eagerly here costs ~400ms cold (network
     # probe of the auxiliary provider chain + /models lookup) on every agent

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1884,6 +1884,7 @@ DEFAULT_CONFIG = {
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
         "auto_thread": True,           # Auto-create threads on @mention in channels (like Slack)
         "thread_require_mention": False,  # If True, require @mention in threads too (multi-bot threads)
+        "mention_roles": [],            # Role IDs that count as explicit bot invocation mentions
         "history_backfill": True,         # If True, prepend recent channel scrollback when bot is triggered (recovers messages missed while require_mention gated them out)
         "history_backfill_limit": 50,     # Max number of recent messages to scan when assembling the backfill block
         "reactions": True,             # Add 👀/✅/❌ reactions to messages during processing

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3857,6 +3857,26 @@ class DiscordAdapter(BasePlatformAdapter):
             return bool(configured)
         return os.getenv("DISCORD_REQUIRE_MENTION", "true").lower() not in {"false", "0", "no", "off"}
 
+    def _discord_mention_role_ids(self) -> set[str]:
+        """Return role IDs that should wake the bot like an explicit bot mention."""
+        raw = self.config.extra.get("mention_roles")
+        if raw is None:
+            raw = os.getenv("DISCORD_MENTION_ROLES", "")
+        if isinstance(raw, list):
+            return {str(part).strip() for part in raw if str(part).strip()}
+        s = str(raw).strip() if raw is not None else ""
+        if s:
+            return {part.strip() for part in s.split(",") if part.strip()}
+        return set()
+
+    def _message_mentions_configured_role(self, message) -> bool:
+        """Return True when a message mentions a configured wake role."""
+        role_ids = self._discord_mention_role_ids()
+        if not role_ids:
+            return False
+        role_mentions = getattr(message, "role_mentions", None) or []
+        return any(str(getattr(role, "id", "")) in role_ids for role in role_mentions)
+
     def _discord_allow_any_attachment(self) -> bool:
         """Return whether Discord attachments bypass the SUPPORTED_DOCUMENT_TYPES allowlist.
 
@@ -4771,6 +4791,11 @@ class DiscordAdapter(BasePlatformAdapter):
             mention_prefix = True
             normalized_content = normalized_content.replace(f"<@{self._client.user.id}>", "").strip()
             normalized_content = normalized_content.replace(f"<@!{self._client.user.id}>", "").strip()
+            message.content = normalized_content
+        if self._message_mentions_configured_role(message):
+            mention_prefix = True
+            for role_id in self._discord_mention_role_ids():
+                normalized_content = normalized_content.replace(f"<@&{role_id}>", "").strip()
             message.content = normalized_content
         if not isinstance(message.channel, discord.DMChannel):
             channel_ids = {str(message.channel.id)}

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -20,7 +20,7 @@ import tempfile
 import threading
 import time
 from collections import defaultdict
-from typing import Callable, Dict, List, Optional, Any, Tuple
+from typing import Callable, Dict, List, Optional, Any, Tuple, Set
 
 logger = logging.getLogger(__name__)
 
@@ -829,36 +829,8 @@ class DiscordAdapter(BasePlatformAdapter):
                 # This replaces the older DISCORD_IGNORE_NO_MENTION logic
                 # with bot-aware filtering that works correctly when multiple
                 # agents share a channel.
-                if not isinstance(message.channel, discord.DMChannel) and message.mentions:
-                    _self_mentioned = (
-                        self._client.user is not None
-                        and self._client.user in message.mentions
-                    )
-                    _other_bots_mentioned = any(
-                        m.bot and m != self._client.user
-                        for m in message.mentions
-                    )
-                    # If other bots are mentioned but we're not → not for us
-                    if _other_bots_mentioned and not _self_mentioned:
-                        return
-                    # If humans are mentioned but we're not → not for us
-                    # (preserves old DISCORD_IGNORE_NO_MENTION=true behavior)
-                    # EXCEPT in free-response channels where the bot should
-                    # answer regardless of who is mentioned.
-                    _ignore_no_mention = os.getenv(
-                        "DISCORD_IGNORE_NO_MENTION", "true"
-                    ).lower() in {"true", "1", "yes"}
-                    if _ignore_no_mention and not _self_mentioned and not _other_bots_mentioned:
-                        _channel_id = str(message.channel.id)
-                        _parent_id = None
-                        if hasattr(message.channel, "parent_id") and message.channel.parent_id:
-                            _parent_id = str(message.channel.parent_id)
-                        _free_channels = adapter_self._discord_free_response_channels()
-                        _channel_ids = {_channel_id}
-                        if _parent_id:
-                            _channel_ids.add(_parent_id)
-                        if "*" not in _free_channels and not (_channel_ids & _free_channels):
-                            return
+                if adapter_self._should_ignore_discord_mention_routing(message):
+                    return
 
                 await self._handle_message(message, role_authorized=_role_authorized)
 
@@ -3857,26 +3829,6 @@ class DiscordAdapter(BasePlatformAdapter):
             return bool(configured)
         return os.getenv("DISCORD_REQUIRE_MENTION", "true").lower() not in {"false", "0", "no", "off"}
 
-    def _discord_mention_role_ids(self) -> set[str]:
-        """Return role IDs that should wake the bot like an explicit bot mention."""
-        raw = self.config.extra.get("mention_roles")
-        if raw is None:
-            raw = os.getenv("DISCORD_MENTION_ROLES", "")
-        if isinstance(raw, list):
-            return {str(part).strip() for part in raw if str(part).strip()}
-        s = str(raw).strip() if raw is not None else ""
-        if s:
-            return {part.strip() for part in s.split(",") if part.strip()}
-        return set()
-
-    def _message_mentions_configured_role(self, message) -> bool:
-        """Return True when a message mentions a configured wake role."""
-        role_ids = self._discord_mention_role_ids()
-        if not role_ids:
-            return False
-        role_mentions = getattr(message, "role_mentions", None) or []
-        return any(str(getattr(role, "id", "")) in role_ids for role in role_mentions)
-
     def _discord_allow_any_attachment(self) -> bool:
         """Return whether Discord attachments bypass the SUPPORTED_DOCUMENT_TYPES allowlist.
 
@@ -3954,6 +3906,78 @@ class DiscordAdapter(BasePlatformAdapter):
         if s:
             return {part.strip() for part in s.split(",") if part.strip()}
         return set()
+
+    def _discord_mention_role_ids(self) -> Set[str]:
+        """Return role IDs that count as explicit Discord bot invocations."""
+        raw = self.config.extra.get("mention_roles")
+        if raw is None:
+            raw = os.getenv("DISCORD_MENTION_ROLES", "")
+        if raw is None:
+            return set()
+        if isinstance(raw, (list, tuple, set)):
+            values = raw
+        else:
+            values = str(raw).split(",")
+        return {_clean_discord_id(str(role_id)) for role_id in values if str(role_id).strip()}
+
+    def _message_mentions_configured_role(self, message: DiscordMessage) -> bool:
+        """Return True when a Discord message mentions a configured invocation role."""
+        mention_roles = self._discord_mention_role_ids()
+        if not mention_roles:
+            return False
+        role_mentions = getattr(message, "role_mentions", None) or []
+        for role in role_mentions:
+            if _clean_discord_id(str(getattr(role, "id", ""))) in mention_roles:
+                return True
+        content = getattr(message, "content", "") or ""
+        return any(f"<@&{role_id}>" in content for role_id in mention_roles)
+
+    def _should_ignore_discord_mention_routing(self, message: Any) -> bool:
+        """Return whether the pre-dispatch mention router should drop a message.
+
+        This protects multi-agent channels: if the message mentions another bot
+        (or only human users) and not this bot, ignore it before normal dispatch.
+        Configured role mentions are an explicit invocation of this bot and must
+        bypass this router, even when Discord also populates ``message.mentions``
+        with humans affected by the role ping.
+        """
+        dm_channel_cls = getattr(discord, "DMChannel", None)
+        if dm_channel_cls is not None and isinstance(message.channel, dm_channel_cls):
+            return False
+        if not getattr(message, "mentions", None):
+            return False
+        if self._message_mentions_configured_role(message):
+            return False
+
+        client_user = getattr(self._client, "user", None)
+        _self_mentioned = client_user is not None and client_user in message.mentions
+        _other_bots_mentioned = any(
+            getattr(m, "bot", False) and m != client_user
+            for m in message.mentions
+        )
+        # If other bots are mentioned but we're not → not for us.
+        if _other_bots_mentioned and not _self_mentioned:
+            return True
+
+        # If humans are mentioned but we're not → not for us (preserves old
+        # DISCORD_IGNORE_NO_MENTION=true behavior), except in free-response
+        # channels where the bot should answer regardless of who is mentioned.
+        _ignore_no_mention = os.getenv(
+            "DISCORD_IGNORE_NO_MENTION", "true"
+        ).lower() in {"true", "1", "yes"}
+        if _ignore_no_mention and not _self_mentioned and not _other_bots_mentioned:
+            _channel_id = str(message.channel.id)
+            _parent_id = None
+            if hasattr(message.channel, "parent_id") and message.channel.parent_id:
+                _parent_id = str(message.channel.parent_id)
+            _free_channels = self._discord_free_response_channels()
+            _channel_ids = {_channel_id}
+            if _parent_id:
+                _channel_ids.add(_parent_id)
+            if "*" not in _free_channels and not (_channel_ids & _free_channels):
+                return True
+
+        return False
 
     def _discord_thread_require_mention(self) -> bool:
         """Return whether thread participation requires @mention to follow up.
@@ -4776,6 +4800,7 @@ class DiscordAdapter(BasePlatformAdapter):
         raw_content = message.content.strip()
         normalized_content = raw_content
         mention_prefix = False
+        role_mention_prefix = False
 
         snapshot_attachments = []
         if hasattr(message, "message_snapshots") and message.message_snapshots:
@@ -4793,7 +4818,7 @@ class DiscordAdapter(BasePlatformAdapter):
             normalized_content = normalized_content.replace(f"<@!{self._client.user.id}>", "").strip()
             message.content = normalized_content
         if self._message_mentions_configured_role(message):
-            mention_prefix = True
+            role_mention_prefix = True
             for role_id in self._discord_mention_role_ids():
                 normalized_content = normalized_content.replace(f"<@&{role_id}>", "").strip()
             message.content = normalized_content
@@ -4845,7 +4870,7 @@ class DiscordAdapter(BasePlatformAdapter):
             )
 
             if require_mention and not is_free_channel and not in_bot_thread:
-                if self._client.user not in message.mentions and not mention_prefix:
+                if self._client.user not in message.mentions and not mention_prefix and not role_mention_prefix:
                     return
         # Auto-thread: when enabled, automatically create a thread for every
         # @mention in a text channel so each conversation is isolated (like Slack).
@@ -6507,9 +6532,10 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
     ``DISCORD_REQUIRE_MENTION``, ``DISCORD_FREE_RESPONSE_CHANNELS``,
     ``DISCORD_AUTO_THREAD``, ``DISCORD_REACTIONS``,
     ``DISCORD_IGNORED_CHANNELS``, ``DISCORD_ALLOWED_CHANNELS``,
-    ``DISCORD_NO_THREAD_CHANNELS``, ``DISCORD_HISTORY_BACKFILL``,
-    ``DISCORD_HISTORY_BACKFILL_LIMIT``, ``DISCORD_ALLOW_MENTION_*``,
-    ``DISCORD_REPLY_TO_MODE``, ``DISCORD_THREAD_REQUIRE_MENTION``).
+    ``DISCORD_NO_THREAD_CHANNELS``, ``DISCORD_MENTION_ROLES``,
+    ``DISCORD_HISTORY_BACKFILL``, ``DISCORD_HISTORY_BACKFILL_LIMIT``,
+    ``DISCORD_ALLOW_MENTION_*``, ``DISCORD_REPLY_TO_MODE``,
+    ``DISCORD_THREAD_REQUIRE_MENTION``).
     Rather than rewrite ~50 call sites inside the adapter to read from
     ``PlatformConfig.extra`` instead, this hook keeps the existing
     env-driven model and merely owns the YAML→env translation here, next to
@@ -6567,6 +6593,12 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
         if isinstance(ntc, list):
             ntc = ",".join(str(v) for v in ntc)
         os.environ["DISCORD_NO_THREAD_CHANNELS"] = str(ntc)
+    # mention_roles: role IDs that count as explicit bot invocation mentions
+    mr = discord_cfg.get("mention_roles")
+    if mr is not None and not os.getenv("DISCORD_MENTION_ROLES"):
+        if isinstance(mr, list):
+            mr = ",".join(str(v) for v in mr)
+        os.environ["DISCORD_MENTION_ROLES"] = str(mr)
     # history_backfill: recover missed channel messages for shared sessions
     # when require_mention is active.  Fetches messages between bot turns
     # and prepends them to the user message for context.

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -359,7 +359,7 @@ def make_fake_thread(thread_id: int = THREAD_ID, name: str = "test-thread", pare
 
 def make_discord_message(
     *, content: str = "hello", author=None, channel=None, mentions=None,
-    attachments=None, message_id: int = None,
+    role_mentions=None, attachments=None, message_id: int = None,
 ):
     if message_id is None:
         message_id = _next_message_id()
@@ -371,13 +371,15 @@ def make_discord_message(
         channel = make_fake_text_channel()
     if mentions is None:
         mentions = []
+    if role_mentions is None:
+        role_mentions = []
     if attachments is None:
         attachments = []
 
     return SimpleNamespace(
         id=message_id, content=content, author=author, channel=channel,
         guild=getattr(channel, "guild", None),
-        mentions=mentions, attachments=attachments,
+        mentions=mentions, role_mentions=role_mentions, attachments=attachments,
         type=getattr(discord, "MessageType", SimpleNamespace()).default,
         reference=None, created_at=datetime.now(timezone.utc),
         create_thread=AsyncMock(),

--- a/tests/e2e/test_discord_adapter.py
+++ b/tests/e2e/test_discord_adapter.py
@@ -5,6 +5,7 @@ Covers the fix for slash commands not being recognized when sent via
 """
 
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
@@ -62,6 +63,45 @@ class TestMentionStrippedCommandDispatch:
         # mock setup means no send call either.
         response = get_response_text(discord_adapter)
         assert response is None or "/new" not in response
+
+    async def test_role_mention_configured_as_invocation(self, discord_adapter):
+        """Configured role mention in a server channel invokes the bot."""
+        role_id = 123456
+        discord_adapter.config.extra["mention_roles"] = [str(role_id)]
+        msg = make_discord_message(
+            content=f"<@&{role_id}> /help",
+            mentions=[],
+            role_mentions=[SimpleNamespace(id=role_id)],
+        )
+        await dispatch(discord_adapter, msg)
+        response = get_response_text(discord_adapter)
+        assert response is not None
+        assert "/new" in response
+
+    async def test_role_mention_not_dropped_by_human_mention_prefilter(self, discord_adapter):
+        """Configured role mentions must survive the pre-_handle_message mention router.
+
+        Discord can include humans in ``message.mentions`` when a role is pinged.
+        The multi-agent prefilter must not treat that as "the user is talking to
+        someone else" when the role itself is configured as a bot invocation.
+        """
+        role_id = 123456
+        discord_adapter.config.extra["mention_roles"] = [str(role_id)]
+        human_mentioned_by_role = SimpleNamespace(id=22222, bot=False)
+        msg = make_discord_message(
+            content=f"<@&{role_id}> /help",
+            mentions=[human_mentioned_by_role],
+            role_mentions=[SimpleNamespace(id=role_id)],
+        )
+
+        assert discord_adapter._should_ignore_discord_mention_routing(msg) is False
+
+    async def test_human_mention_still_dropped_by_prefilter(self, discord_adapter):
+        """A plain human mention is still ignored when it is not for this bot."""
+        human = SimpleNamespace(id=22222, bot=False)
+        msg = make_discord_message(content="<@22222> hello", mentions=[human])
+
+        assert discord_adapter._should_ignore_discord_mention_routing(msg) is True
 
     async def test_no_mention_in_channel_dropped(self, discord_adapter):
         """Message without @mention in server channel → silently dropped."""

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import os
 import sys
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -78,6 +79,28 @@ def _speed_up_command_sync_mutation_pacing(monkeypatch):
         "_command_sync_mutation_interval_seconds",
         lambda self: 0.0,
     )
+
+
+def test_apply_yaml_config_bridges_mention_roles_to_env(monkeypatch):
+    monkeypatch.delenv("DISCORD_MENTION_ROLES", raising=False)
+
+    discord_platform._apply_yaml_config(
+        {},
+        {"mention_roles": [123456, "789012"]},
+    )
+
+    assert os.environ["DISCORD_MENTION_ROLES"] == "123456,789012"
+
+
+def test_apply_yaml_config_preserves_env_mention_roles(monkeypatch):
+    monkeypatch.setenv("DISCORD_MENTION_ROLES", "configured-in-env")
+
+    discord_platform._apply_yaml_config(
+        {},
+        {"mention_roles": [123456]},
+    )
+
+    assert os.environ["DISCORD_MENTION_ROLES"] == "configured-in-env"
 
 
 class FakeTree:

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -125,12 +125,13 @@ def adapter(monkeypatch):
     return adapter
 
 
-def make_message(*, channel, content: str, mentions=None, msg_type=None):
+def make_message(*, channel, content: str, mentions=None, role_mentions=None, msg_type=None):
     author = SimpleNamespace(id=42, display_name="Jezza", name="Jezza")
     return SimpleNamespace(
         id=123,
         content=content,
         mentions=list(mentions or []),
+        role_mentions=list(role_mentions or []),
         attachments=[],
         reference=None,
         created_at=datetime.now(timezone.utc),
@@ -260,6 +261,24 @@ async def test_discord_can_still_require_mentions_when_enabled(adapter, monkeypa
     await adapter._handle_message(message)
 
     adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_discord_configured_role_mention_satisfies_require_mention(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    adapter.config.extra["mention_roles"] = ["1503224446574395494"]
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=789),
+        content="<@&1503224446574395494> 반응하니?",
+        role_mentions=[SimpleNamespace(id=1503224446574395494)],
+    )
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "반응하니?"
 
 
 @pytest.mark.asyncio

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -429,6 +429,33 @@ def test_no_replay_when_no_warning(mock_get_client, mock_ctx_len):
     assert len(callback_events) == 0
 
 
+@patch("run_agent.OpenAI")
+def test_codex_gpt55_autoraise_keeps_threshold_but_skips_gateway_replay(mock_openai):
+    """Codex gpt-5.5 uses the 85% threshold without a gateway notice replay."""
+    mock_openai.return_value = MagicMock()
+
+    agent = AIAgent(
+        api_key="test-key",
+        provider="openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        model="gpt-5.5",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    assert agent.context_compressor.context_length == 272_000
+    assert agent.context_compressor.threshold_tokens == 231_200
+    assert agent._compression_threshold_autoraised == {"from": 0.5, "to": 0.85}
+    assert agent._compression_warning is None
+
+    callback_events = []
+    agent.status_callback = lambda ev, msg: callback_events.append((ev, msg))
+    agent._replay_compression_warning()
+
+    assert callback_events == []
+
+
 def test_replay_without_callback_is_noop():
     """_replay_compression_warning doesn't crash when status_callback is None."""
     agent = _make_agent()


### PR DESCRIPTION
## Summary
- bridge `discord.mention_roles` / `DISCORD_MENTION_ROLES` into the Discord adapter
- treat configured role mentions as explicit invocations, including the pre-dispatch mention filter
- strip configured role mention tokens before command parsing / message dispatch

## Verification
- `python -m pytest tests/gateway/test_discord_free_response.py tests/gateway/test_discord_connect.py tests/e2e/test_discord_adapter.py -o 'addopts=' -q`\n\n## Context\nLocal gateway deployments can configure `discord.mention_roles`, but current main does not wake on Discord `mention_roles`, so a role ping such as `<@&ROLE_ID>` is silently ignored even when configured.