### PR TITLE
feat(desktop): per-message automatic RTL/bidi text direction

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -1604,6 +1604,7 @@ export function ChatBar({
         contentEditable={!disabled}
         data-placeholder={placeholder}
         data-slot={RICH_INPUT_SLOT}
+        dir="auto"
         onBlur={() => window.setTimeout(closeTrigger, 80)}
         onCompositionEnd={event => {
           composingRef.current = false

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -7,7 +7,17 @@ import {
   type SyntaxHighlighterProps
 } from '@assistant-ui/react-streamdown'
 import { code } from '@streamdown/code'
-import { type ComponentProps, memo, type ReactNode, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  type ComponentProps,
+  isValidElement,
+  memo,
+  type ReactNode,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
 
 import { PreviewAttachment } from '@/components/chat/preview-attachment'
 import { SyntaxHighlighter } from '@/components/chat/shiki-highlighter'
@@ -26,6 +36,7 @@ import {
   mediaStreamUrl
 } from '@/lib/media'
 import { previewTargetFromMarkdownHref } from '@/lib/preview-targets'
+import { textDirection } from '@/lib/text-direction'
 import { cn } from '@/lib/utils'
 
 // Math rendering plugin (KaTeX). Configured once at module scope — the
@@ -162,6 +173,40 @@ function MediaAttachment({ path }: { path: string }) {
       {failed ? `Open ${name}` : `Loading ${name}...`}
     </a>
   )
+}
+
+// Block direction comes from the block's prose: code spans and math don't
+// get a vote, so a paragraph that *starts* with `./script.sh` or `npm ...`
+// still right-aligns when the sentence around it is Hebrew/Arabic. Blocks
+// with no prose at all fall back to dir="auto" (plain first-strong).
+function proseText(node: ReactNode): string {
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node)
+  }
+
+  if (Array.isArray(node)) {
+    return node.map(proseText).join('')
+  }
+
+  if (isValidElement(node)) {
+    const props = node.props as { children?: ReactNode; className?: string; node?: { tagName?: string } }
+
+    if (
+      node.type === 'code' ||
+      props.node?.tagName === 'code' ||
+      (typeof props.className === 'string' && props.className.includes('katex'))
+    ) {
+      return ''
+    }
+
+    return proseText(props.children)
+  }
+
+  return ''
+}
+
+function proseDir(children: ReactNode): 'auto' | 'ltr' | 'rtl' {
+  return textDirection(proseText(children)) ?? 'auto'
 }
 
 function childrenToText(children: unknown): string {
@@ -386,40 +431,67 @@ function MarkdownTextSurface({ containerClassName, containerProps }: MarkdownTex
     () =>
       ({
         h1: ({ className, ...props }: ComponentProps<'h1'>) => (
-          <h1 className={cn('my-1 font-semibold', HEADING_SIZES.h1, className)} {...props} />
+          <h1
+            className={cn('my-1 font-semibold text-start', HEADING_SIZES.h1, className)}
+            dir={proseDir(props.children)}
+            {...props}
+          />
         ),
         h2: ({ className, ...props }: ComponentProps<'h2'>) => (
-          <h2 className={cn('my-1 font-semibold', HEADING_SIZES.h2, className)} {...props} />
+          <h2
+            className={cn('my-1 font-semibold text-start', HEADING_SIZES.h2, className)}
+            dir={proseDir(props.children)}
+            {...props}
+          />
         ),
         h3: ({ className, ...props }: ComponentProps<'h3'>) => (
-          <h3 className={cn('my-1 font-semibold', HEADING_SIZES.h3, className)} {...props} />
+          <h3
+            className={cn('my-1 font-semibold text-start', HEADING_SIZES.h3, className)}
+            dir={proseDir(props.children)}
+            {...props}
+          />
         ),
         h4: ({ className, ...props }: ComponentProps<'h4'>) => (
-          <h4 className={cn('my-1 font-semibold', HEADING_SIZES.h4, className)} {...props} />
+          <h4
+            className={cn('my-1 font-semibold text-start', HEADING_SIZES.h4, className)}
+            dir={proseDir(props.children)}
+            {...props}
+          />
         ),
         p: ({ className, ...props }: ComponentProps<'p'>) => (
           // Vertical rhythm is owned by styles.css (`--paragraph-gap`), which
           // must out-specify Tailwind Typography's `prose` margins — so no
-          // `my-*` here on purpose.
-          <p className={cn('wrap-anywhere leading-(--dt-line-height)', className)} {...props} />
+          // `my-*` here on purpose. Direction + `text-start` let each
+          // paragraph right-align when its prose is RTL without affecting
+          // LTR content (see proseDir).
+          <p
+            className={cn('wrap-anywhere text-start leading-(--dt-line-height)', className)}
+            dir={proseDir(props.children)}
+            {...props}
+          />
         ),
         a: MarkdownLink,
         // `---` as quiet spacing, not a heavy full-width rule.
         hr: (_props: ComponentProps<'hr'>) => <div aria-hidden className="my-3" />,
         blockquote: ({ className, ...props }: ComponentProps<'blockquote'>) => (
           <blockquote
-            className={cn('border-l-2 border-border pl-3 text-muted-foreground italic', className)}
+            className={cn('border-s-2 border-border ps-3 text-start text-muted-foreground italic', className)}
+            dir={proseDir(props.children)}
             {...props}
           />
         ),
         ul: ({ className, ...props }: ComponentProps<'ul'>) => (
-          <ul className={cn('my-1 gap-0', className)} {...props} />
+          <ul className={cn('my-1 gap-0', className)} dir={proseDir(props.children)} {...props} />
         ),
         ol: ({ className, ...props }: ComponentProps<'ol'>) => (
-          <ol className={cn('my-1 gap-0', className)} {...props} />
+          <ol className={cn('my-1 gap-0', className)} dir={proseDir(props.children)} {...props} />
         ),
         li: ({ className, ...props }: ComponentProps<'li'>) => (
-          <li className={cn('leading-(--dt-line-height)', className)} {...props} />
+          <li
+            className={cn('text-start leading-(--dt-line-height)', className)}
+            dir={proseDir(props.children)}
+            {...props}
+          />
         ),
         table: ({ className, ...props }: ComponentProps<'table'>) => (
           <div className="aui-md-table my-2 max-w-full overflow-x-auto rounded-[0.375rem] border border-border">

--- a/apps/desktop/src/components/assistant-ui/message-direction.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/message-direction.test.tsx
@@ -1,0 +1,143 @@
+// Message text must resolve its direction from its own prose so RTL
+// scripts (Hebrew, Arabic) render right-aligned and correctly ordered per
+// block, while code stays LTR. Code spans don't get a vote: a technical
+// RTL message often *starts* with a command, which would flip plain
+// first-strong detection to LTR. jsdom does not compute visual direction,
+// so these tests pin the contract that drives it in the browser: prose
+// blocks carry the resolved dir attribute, code blocks never carry one.
+import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { Thread } from './thread'
+
+const createdAt = new Date('2026-05-01T00:00:00.000Z')
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal('ResizeObserver', TestResizeObserver)
+vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
+  window.setTimeout(() => callback(performance.now()), 0)
+)
+vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id))
+
+Element.prototype.scrollTo = function scrollTo() {}
+
+function stubOffsetDimension(
+  prop: 'offsetHeight' | 'offsetWidth',
+  clientProp: 'clientHeight' | 'clientWidth',
+  fallback: number
+) {
+  const previous = Object.getOwnPropertyDescriptor(HTMLElement.prototype, prop)
+
+  Object.defineProperty(HTMLElement.prototype, prop, {
+    configurable: true,
+    get() {
+      return previous?.get?.call(this) || (this as HTMLElement)[clientProp] || fallback
+    }
+  })
+}
+
+stubOffsetDimension('offsetWidth', 'clientWidth', 800)
+stubOffsetDimension('offsetHeight', 'clientHeight', 600)
+
+function userMessage(text: string): ThreadMessage {
+  return {
+    id: 'user-1',
+    role: 'user',
+    content: [{ type: 'text', text }],
+    attachments: [],
+    createdAt,
+    metadata: { custom: {} }
+  } as ThreadMessage
+}
+
+function assistantMessage(text: string): ThreadMessage {
+  return {
+    id: 'assistant-1',
+    role: 'assistant',
+    content: [{ type: 'text', text }],
+    status: { type: 'complete', reason: 'stop' },
+    createdAt,
+    metadata: {
+      unstable_state: null,
+      unstable_annotations: [],
+      unstable_data: [],
+      steps: [],
+      custom: {}
+    }
+  } as ThreadMessage
+}
+
+function Harness({ messages }: { messages: ThreadMessage[] }) {
+  const runtime = useExternalStoreRuntime<ThreadMessage>({
+    messages,
+    isRunning: false,
+    onNew: async () => {}
+  })
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread />
+    </AssistantRuntimeProvider>
+  )
+}
+
+describe('message text direction', () => {
+  it('user message text resolves direction from content while fences stay LTR', async () => {
+    render(<Harness messages={[userMessage('שלום עולם\n```\nnpm run dev\n```')]} />)
+
+    const text = await screen.findByText(/שלום עולם/)
+
+    expect(text.closest('[dir]')?.getAttribute('dir')).toBe('rtl')
+
+    const code = screen.getByText(/npm run dev/)
+
+    expect(code.closest('pre')).not.toBeNull()
+    expect(code.closest('[dir]')).toBeNull()
+  })
+
+  it('user message starting with inline code still follows its prose', async () => {
+    render(<Harness messages={[userMessage('`./scripts/run.sh -v` מה הפקודה הזאת עושה?')]} />)
+
+    const text = await screen.findByText(/מה הפקודה הזאת עושה/)
+
+    expect(text.closest('[dir]')?.getAttribute('dir')).toBe('rtl')
+  })
+
+  it('assistant prose blocks resolve direction per block', async () => {
+    render(<Harness messages={[userMessage('hi'), assistantMessage('שלום לכולם\n\n- פריט ראשון\n- second item')]} />)
+
+    const paragraph = await screen.findByText(/שלום לכולם/)
+
+    expect(paragraph.closest('p')?.getAttribute('dir')).toBe('rtl')
+
+    const item = await screen.findByText(/פריט ראשון/)
+
+    expect(item.closest('li')?.getAttribute('dir')).toBe('rtl')
+    expect(item.closest('ul')?.getAttribute('dir')).toBe('rtl')
+  })
+
+  it('assistant paragraphs starting with inline code follow their prose', async () => {
+    render(
+      <Harness
+        messages={[
+          userMessage('hi'),
+          assistantMessage('`npm run dev` מפעיל את סביבת הפיתוח.\n\n`npm run dev` starts the dev environment.')
+        ]}
+      />
+    )
+
+    const rtl = await screen.findByText(/מפעיל את סביבת הפיתוח/)
+
+    expect(rtl.closest('p')?.getAttribute('dir')).toBe('rtl')
+
+    const ltr = await screen.findByText(/starts the dev environment/)
+
+    expect(ltr.closest('p')?.getAttribute('dir')).toBe('ltr')
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread.tsx
@@ -1530,7 +1530,7 @@ const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sessionId }
               aria-label={copy.editMessage}
               autoFocus
               className={cn(
-                'ui-prompt-input-editor__input max-h-48 w-full resize-none bg-transparent p-0 pr-7 text-[length:var(--conversation-text-font-size)] leading-(--dt-line-height) text-foreground/95 outline-none',
+                'ui-prompt-input-editor__input max-h-48 w-full resize-none bg-transparent p-0 pr-7 text-start text-[length:var(--conversation-text-font-size)] leading-(--dt-line-height) text-foreground/95 outline-none',
                 'empty:before:content-[attr(data-placeholder)] empty:before:text-muted-foreground/60',
                 '**:data-ref-text:cursor-default',
                 expanded ? 'min-h-16' : 'min-h-[1.25rem]'
@@ -1538,6 +1538,7 @@ const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sessionId }
               contentEditable
               data-placeholder={copy.editMessage}
               data-slot={RICH_INPUT_SLOT}
+              dir="auto"
               onBlur={() => window.setTimeout(closeTrigger, 80)}
               onDragOver={handleDragOver}
               onDrop={handleDrop}

--- a/apps/desktop/src/components/assistant-ui/user-message-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/user-message-text.tsx
@@ -2,6 +2,7 @@ import type { FC } from 'react'
 import { Fragment, useMemo } from 'react'
 
 import { DirectiveContent } from '@/components/assistant-ui/directive-text'
+import { textDirection } from '@/lib/text-direction'
 import { cn } from '@/lib/utils'
 
 // User messages should render the bare-minimum of markdown: backtick `code`
@@ -126,8 +127,23 @@ export const UserMessageText: FC<UserMessageTextProps> = ({ className, text }) =
 const InlineSegmentView: FC<{ text: string }> = ({ text }) => {
   const nodes = useMemo(() => splitInlineCode(text), [text])
 
+  // Direction comes from the segment's prose; inline code doesn't get a
+  // vote, so a message that *starts* with a command still right-aligns
+  // when the sentence around it is Hebrew/Arabic. `text-start` follows the
+  // resolved direction (the bubble itself is `text-left`); fences stay LTR.
+  const dir = useMemo(
+    () =>
+      textDirection(
+        nodes
+          .filter(node => node.kind === 'inline-text')
+          .map(node => node.text)
+          .join('')
+      ) ?? 'auto',
+    [nodes]
+  )
+
   return (
-    <span className="wrap-anywhere block whitespace-pre-line">
+    <span className="wrap-anywhere block whitespace-pre-line text-start" dir={dir}>
       {nodes.map((node, nodeIndex) =>
         node.kind === 'inline-code' ? (
           <code

--- a/apps/desktop/src/lib/text-direction.ts
+++ b/apps/desktop/src/lib/text-direction.ts
@@ -1,0 +1,18 @@
+// First-strong direction detection, same heuristic as dir="auto" but over a
+// caller-chosen slice of the text. Callers strip code spans before asking:
+// a technical RTL message usually *starts* with a command or identifier,
+// which would flip first-strong to LTR even though the sentence is
+// Hebrew/Arabic. U+0590-U+08FF is RTL scripts end to end (Hebrew, Arabic,
+// Syriac, Thaana, NKo, Samaritan, Mandaic and their extensions).
+const RTL_CHAR = /[\u0590-\u08FF\uFB1D-\uFDFF\uFE70-\uFEFF]/
+const FIRST_LETTER = /\p{L}/u
+
+export function textDirection(text: string): 'ltr' | 'rtl' | null {
+  const first = text.match(FIRST_LETTER)
+
+  if (!first) {
+    return null
+  }
+
+  return RTL_CHAR.test(first[0]) ? 'rtl' : 'ltr'
+}

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1053,6 +1053,24 @@ canvas {
   color: var(--ui-inline-code-foreground);
 }
 
+/* Inside a direction-resolved block (the dir attribute is only ever set on
+   message blocks and the composer), inline code and KaTeX math keep their
+   internal LTR order: their neutrals (dots, slashes, dashes) would
+   otherwise be reordered by an RTL paragraph's bidi run. `isolate` stops
+   the run from leaking into the sentence around it. */
+[dir] :is(code, .katex) {
+  direction: ltr;
+  unicode-bidi: isolate;
+}
+
+/* Code blocks are LTR surfaces even when they sit inside an RTL list item
+   or blockquote: pin them so the card chrome and code lines don't mirror. */
+[data-slot='code-card'],
+[data-streamdown='code-block'],
+[data-slot='aui_user-fence'] {
+  direction: ltr;
+}
+
 [data-slot='aui_assistant-message-content'] .aui-md :where(.aui-shiki, .aui-shiki > pre) {
   margin: 0 !important;
 }


### PR DESCRIPTION
## What does this PR do?

Adds automatic bidirectional text support to the desktop app. Hebrew, Arabic and other RTL-script messages currently render left-aligned with mangled punctuation order, because nothing in the renderer sets a text direction: the user bubble hardcodes `text-left` (thread.tsx, `USER_BUBBLE_BASE_CLASS`), the markdown surface inherits LTR, and the composer is a plain LTR contenteditable.

The fix resolves direction per block with the first-strong-character heuristic, applied to the block's prose:

- every prose block in assistant markdown (`p`, `h1`-`h4`, `li`, `ul`/`ol`, `blockquote`) and every user message text segment gets a `dir` attribute resolved from its own text, so mixed Hebrew/English answers render each paragraph correctly
- code spans and math don't get a vote: a technical RTL message often *starts* with a command (`./run.sh ...` followed by an Arabic/Hebrew explanation), and plain first-strong would flip that whole block to LTR; blocks with no prose at all fall back to `dir="auto"`
- inline `code` and KaTeX output inside resolved blocks are pinned to an isolated LTR run, so their neutrals (dots, slashes, dashes) keep their order inside RTL sentences; fenced code blocks keep LTR entirely
- both composers (main and inline edit) carry `dir="auto"` and re-resolve on every input, so the box flips as you type
- `text-start` accompanies the `dir` attribute where an ancestor pins `text-align` (the user bubble's `text-left`), so RTL blocks actually right-align
- the blockquote border moves from `border-l-2`/`pl-3` to the logical `border-s-2`/`ps-3`, and list markers already follow direction because Tailwind Typography uses `padding-inline-start`

LTR content resolves to LTR, so English-only users see no change. No new dependencies, no settings, no locale work. App chrome stays LTR.

## Related Issue

Fixes #44150 (filed shortly after this PR was opened; requests exactly this behavior).

Related work on other surfaces, no overlap with this PR:
- #29047 reports the same symptom class (Arabic renders LTR, no bidi) in the web dashboard chat pane; this PR fixes the desktop renderer only
- #41462 (open) adds RTL/bidi to the TUI
- #29795 (open) adds an Arabic locale to the web dashboard

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/lib/text-direction.ts`: first-strong direction detection over a caller-chosen slice of text
- `apps/desktop/src/components/assistant-ui/markdown-text.tsx`: prose block component overrides resolve `dir` from their prose (code spans and math excluded) with `text-start`; logical border/padding on blockquote
- `apps/desktop/src/components/assistant-ui/user-message-text.tsx`: same per text segment, from the segment's non-code text; fences untouched so code stays LTR
- `apps/desktop/src/components/assistant-ui/thread.tsx`: `dir="auto"` + `text-start` on the inline edit composer's contenteditable
- `apps/desktop/src/app/chat/composer/index.tsx`: `dir="auto"` on the main composer contenteditable
- `apps/desktop/src/components/assistant-ui/message-direction.test.tsx`: pins the contract for user and assistant messages: prose blocks carry the resolved direction, code-first blocks follow their prose, code blocks never carry one
- `apps/desktop/src/styles.css`: inline `code` and KaTeX output inside direction-resolved blocks are pinned to an isolated LTR run, so their neutrals (dots, slashes, dashes) keep their order inside RTL sentences; fenced code cards are pinned LTR so their chrome and code lines don't mirror when they sit inside an RTL list item

## How to Test

1. `cd apps/desktop && npx vitest run --environment jsdom src/components/assistant-ui/message-direction.test.tsx` - 4 passed
2. `npm run typecheck` - clean
3. `npx eslint` on the touched files - clean (repo-wide `npm run lint` has pre-existing findings on main, none in these files)
4. Manual: run the desktop app, send a Hebrew message such as `מה שלומך?` - the bubble right-aligns; ask for a Hebrew answer with a list and a code block - paragraphs, headings and bullets right-align with markers on the right, the code block stays LTR
5. Send a message that starts with code, e.g. `` `./scripts/run.sh -v` מה הפקודה הזאת עושה? `` - the block still right-aligns (code doesn't vote on direction) and the chip keeps its internal order
6. Type Hebrew in the composer - it right-aligns as you type; delete it and type English - it flips back
7. Click an existing Hebrew user bubble to edit it - the edit box opens right-aligned
8. Send English messages - rendering is visually identical to main (LTR prose resolves to LTR)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (renderer-only change; desktop vitest suite run instead, failures on main are unchanged)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, dev build (`npm run dev`)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (rendering only, no platform code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before / after on the same conversation (Hebrew answer with heading, list and code block; English follow-up unchanged):

Before:
<img width="952" height="800" alt="before-final2-pr" src="https://github.com/user-attachments/assets/bf4b2a84-9cad-4bef-b5e3-c5c88e0cfa6c" />

After:
<img width="952" height="800" alt="after-final2-pr" src="https://github.com/user-attachments/assets/ac2709d5-c787-45de-805f-a4ee0a0701b4" />

Composer auto-directing while typing Hebrew:
<img width="952" height="240" alt="composer-rtl-pr" src="https://github.com/user-attachments/assets/1860db6b-c513-4a16-9485-09a8cf6a7cca" />

A Hebrew paragraph that starts with code: plain first-strong would resolve it LTR (before); resolved from prose it follows the sentence, and the chips keep their internal order (after):

Before:
<img width="1480" height="140" alt="rtl-codefirst-before" src="https://github.com/user-attachments/assets/fdd7df18-9218-4a40-baf4-ac5a4af1932a" />


After:
<img width="1480" height="140" alt="rtl-codefirst-after" src="https://github.com/user-attachments/assets/5b3e5330-70fc-4ec2-b7a2-aee0d4f7cda2" />

