### PR TITLE
fix(memory): close SQLite in holographic shutdown + header validation (#44037)

### DIFF
--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -251,6 +251,17 @@ class HolographicMemoryProvider(MemoryProvider):
                 logger.debug("Holographic memory_write mirror failed: %s", e)
 
     def shutdown(self) -> None:
+        # IMPORTANT (#44037, same class as #29507): explicitly close the
+        # MemoryStore before dropping the reference so the sqlite3.Connection
+        # is finalized deterministically on the caller's thread.  Leaving it
+        # to refcount/GC would release the DB fd at a non-deterministic time
+        # on a non-deterministic thread, widening the fd-recycle race window
+        # that allows TLS ciphertext to land in the SQLite file.
+        if self._store is not None:
+            try:
+                self._store.close()
+            except Exception:
+                pass
         self._store = None
         self._retriever = None
 


### PR DESCRIPTION
Fixes #44037. The holographic memory provider's shutdown() dropped the MemoryStore reference without closing the SQLite connection, leaving fd finalization to non-deterministic GC. This widened the fd-recycle race window where TLS socket data could be written into memory_store.db (same class as #29507). Two-part fix: (1) explicitly call store.close() in shutdown() before dropping ref, (2) add _validate_sqlite_header() before sqlite3.connect() so corrupt DB files are caught loudly with a backup instead of silently accepted.