### PR TITLE
fix(desktop): dedupe compressed session tips in sidebar merge

### DIFF
--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -140,6 +140,20 @@ describe('mergeSessionPage', () => {
 
     expect(merged.map(s => s.id)).toEqual(['tip', 'other'])
   })
+
+  it('drops a kept compression root when the server returns its projected tip', () => {
+    // A refresh can arrive after auto-compression rotates root -> tip while the
+    // old root is still in keepIds (working, recently-settled, or pinned). The
+    // incoming tip is the fresh server row for that same conversation, so the
+    // stale root must not survive beside it as a duplicate sidebar entry.
+    const previous = [session({ id: 'root', title: 'Old root copy' })]
+    const incoming = [session({ id: 'tip', _lineage_root_id: 'root', title: 'Fresh tip row' })]
+
+    const merged = mergeSessionPage(previous, incoming, ['root'])
+
+    expect(merged.map(s => s.id)).toEqual(['tip'])
+    expect(merged[0]?.title).toBe('Fresh tip row')
+  })
 })
 
 describe('workspaceCwdForNewSession', () => {

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -124,11 +124,20 @@ export function mergeSessionPage(
     return incoming
   }
 
-  const incomingIds = new Set(incoming.map(session => session.id))
+  const incomingConversationIds = new Set<string>()
+
+  for (const session of incoming) {
+    incomingConversationIds.add(session.id)
+
+    if (session._lineage_root_id != null) {
+      incomingConversationIds.add(session._lineage_root_id)
+    }
+  }
 
   const survivors = previous.filter(
     session =>
-      !incomingIds.has(session.id) &&
+      !incomingConversationIds.has(session.id) &&
+      (session._lineage_root_id == null || !incomingConversationIds.has(session._lineage_root_id)) &&
       (keep.has(session.id) || (session._lineage_root_id != null && keep.has(session._lineage_root_id)))
   )
 


### PR DESCRIPTION
## Summary
- make the Desktop session-page merge lineage-aware when preserving working/recently-settled/pinned rows
- drop a stale compression root if the fresh server page already contains its projected compression tip
- add a regression test for the duplicate root+tip sidebar case

## Why
`mergeSessionPage()` keeps rows that the server omitted when they are still working, recently settled, or pinned. That is correct for in-flight chats and old pins, but auto-compression rotates a conversation from a root id to a tip id while retaining `_lineage_root_id`.

Before this change, if `keepIds` still contained the root id and the next refresh returned the projected tip, the stale root survived beside the fresh tip because dedupe only compared incoming live ids. The sidebar could therefore show the same compressed conversation twice until a harder refresh.

## Test Plan
- `npm --workspace apps/desktop run test:ui -- src/store/session.test.ts`
- `npm --workspace apps/desktop exec eslint -- src/store/session.ts src/store/session.test.ts`
- `npm --workspace apps/desktop run typecheck`
