### PR TITLE
fix(sessions): archive compressed conversation lineages

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -866,6 +866,12 @@ export function useSessionActions({
 
       try {
         await setSessionArchived(storedSessionId, true, archived?.profile)
+        // A sidebar refresh can race the optimistic removal while the PATCH is
+        // in flight and briefly reinsert the still-unarchived backend row. Win
+        // that race after the mutation succeeds so right-click → Archive does
+        // not appear to do nothing until the next full refresh.
+        setSessions(prev => prev.filter(s => s.id !== storedSessionId))
+        $pinnedSessionIds.set($pinnedSessionIds.get().filter(id => id !== storedSessionId && id !== archivedPinId))
         notify({ durationMs: 2_000, kind: 'success', message: copy.archived })
       } catch (err) {
         if (archived) {

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1715,15 +1715,51 @@ class SessionDB:
         """Archive or unarchive a session.
 
         Archived sessions are hidden from the default session list but keep all
-        their messages — this is a soft hide, not a delete. Returns True when a
-        row was updated.
+        their messages — this is a soft hide, not a delete. For compression
+        chains, archive the whole logical conversation. Desktop lists compression
+        roots projected forward to their latest continuation; updating only the
+        displayed tip lets the still-unarchived root resurrect it on refresh.
+        Returns True when at least one row was updated.
         """
         def _do(conn):
             cursor = conn.execute(
-                "UPDATE sessions SET archived = ? WHERE id = ?",
-                (1 if archived else 0, session_id),
+                """
+                WITH RECURSIVE
+                  ancestors(id) AS (
+                    SELECT ?
+                    UNION
+                    SELECT parent.id
+                    FROM ancestors a
+                    JOIN sessions child ON child.id = a.id
+                    JOIN sessions parent ON parent.id = child.parent_session_id
+                    WHERE parent.end_reason = 'compression'
+                      AND child.started_at >= parent.ended_at
+                  ),
+                  descendants(id) AS (
+                    SELECT ?
+                    UNION
+                    SELECT child.id
+                    FROM descendants d
+                    JOIN sessions parent ON parent.id = d.id
+                    JOIN sessions child ON child.parent_session_id = parent.id
+                    WHERE parent.end_reason = 'compression'
+                      AND child.started_at >= parent.ended_at
+                  ),
+                  lineage(id) AS (
+                    SELECT id FROM ancestors
+                    UNION
+                    SELECT id FROM descendants
+                  )
+                UPDATE sessions
+                SET archived = ?
+                WHERE id IN (SELECT id FROM lineage)
+                """,
+                (session_id, session_id, 1 if archived else 0),
             )
-            return cursor.rowcount
+            rowcount = cursor.rowcount
+            if rowcount is None or rowcount < 0:
+                rowcount = conn.execute("SELECT changes()").fetchone()[0]
+            return rowcount
         rowcount = self._execute_write(_do)
         return rowcount > 0
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1515,6 +1515,7 @@ AUTHOR_MAP = {
     "josephjohnson.joel@gmail.com": "JoelJJohnson",  # PR #39913 salvage (Windows ConPTY dashboard chat bridge)
     "andreas@schwarz-ketsch.de": "Nea74",  # PR #40022 co-author credit (same Windows ConPTY bridge design)
     "chanhokyim@gmail.com": "joel611",  # PR #33958 salvage (DISCORD_ALLOWED_ROLES role_authorized gateway flag)
+    "desg38@gmail.com": "dschnurbusch",  # PR #42373 salvage (archive compressed conversation lineages)
 }
 
 

--- a/tests/hermes_state/test_session_archiving.py
+++ b/tests/hermes_state/test_session_archiving.py
@@ -1,0 +1,51 @@
+import time
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    database = SessionDB(tmp_path / "state.db")
+    try:
+        yield database
+    finally:
+        database.close()
+
+
+def _compression_pair(db: SessionDB):
+    base = time.time() - 100
+    db.create_session("root", source="cli")
+    db.create_session("tip", source="cli", parent_session_id="root")
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, ended_at = ?, end_reason = 'compression', message_count = 1 WHERE id = 'root'",
+        (base, base + 10),
+    )
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, message_count = 1 WHERE id = 'tip'",
+        (base + 20,),
+    )
+    db._conn.commit()
+
+
+def test_archiving_compression_tip_archives_projected_root(db):
+    _compression_pair(db)
+
+    assert db.set_session_archived("tip", True) is True
+
+    assert db.get_session("root")["archived"] == 1
+    assert db.get_session("tip")["archived"] == 1
+    assert [s["id"] for s in db.list_sessions_rich(order_by_last_active=True)] == []
+    assert [s["id"] for s in db.list_sessions_rich(order_by_last_active=True, archived_only=True)] == ["tip"]
+
+
+def test_unarchiving_compression_tip_unarchives_projected_root(db):
+    _compression_pair(db)
+    db.set_session_archived("tip", True)
+
+    assert db.set_session_archived("tip", False) is True
+
+    assert db.get_session("root")["archived"] == 0
+    assert db.get_session("tip")["archived"] == 0
+    assert [s["id"] for s in db.list_sessions_rich(order_by_last_active=True)] == ["tip"]


### PR DESCRIPTION
## Summary
Archive/unarchive entire compression lineages so projected compressed sessions stay hidden after a full Desktop refresh.

This salvages the archiving fix from #42373 onto current `main` as a focused, single-concern PR. **Original work by @dschnurbusch** — credit preserved on the commit author. I've dropped the unrelated cron/recents change that was also bundled in #42373 (it reverts the deliberate cron exclusion from #42537 and belongs in its own PR); that's noted on the original PR.

## What this does
- `set_session_archived` now archives the whole compression lineage via a recursive CTE (ancestors + descendants) instead of only the visible tip. Desktop lists compression roots projected forward to their latest continuation, so archiving only the tip left the unarchived root eligible for the normal list — Cmd-R then resurrected the archived tip.
- Win the optimistic-removal race after the archive PATCH succeeds in `use-session-actions.ts`, so right-click → Archive doesn't appear to do nothing until the next full refresh.
- Adds regression coverage for archiving and unarchiving compressed session tips.

## Why it's correct
The CTE's compression-edge guard (`end_reason='compression' AND child.started_at >= parent.ended_at`) is identical to the `is_compression_edge` projection predicate the list path already uses (`hermes_cli/web_server.py`), so archiving hides exactly the set the Desktop projects as a single row. Non-compression branches and unrelated sessions are correctly left untouched.

## Verification
- `./venv/bin/python -m pytest tests/hermes_state/test_session_archiving.py -q` — 2/2 pass
- Regression: existing archiving coverage in `tests/test_hermes_state.py` (7) and `tests/hermes_cli/test_web_server.py` (6) all green
- `cd apps/desktop && npm run typecheck` — clean (0 errors)
- Standalone repro driving a 3-segment chain + a non-compression branch confirms archiving from tip or root sweeps the full lineage and leaves branches/unrelated sessions alone.
