### PR TITLE
fix(codex): strip temperature for native backend

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -218,6 +218,13 @@ class ResponsesApiTransport(ProviderTransport):
             kwargs.pop("timeout", None)
 
         if is_codex_backend:
+            # Native ChatGPT Codex backend rejects sampling controls on the
+            # Responses endpoint (HTTP 400 "Unsupported parameter:
+            # temperature"). Other Responses-compatible providers may accept
+            # it, so strip only after request_overrides have been merged and
+            # only for this backend.
+            kwargs.pop("temperature", None)
+
             prompt_cache_key = kwargs.get("prompt_cache_key")
             cache_scope_id = str(prompt_cache_key or session_id or "").strip()
             if cache_scope_id:

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -515,6 +515,52 @@ class TestCodexTransportTimeout:
         assert kw.get("timeout") == 450.0
 
 
+class TestCodexTransportCodexBackendTemperatureStrip:
+    """chatgpt.com/backend-api/codex rejects ``temperature``.
+
+    The generic Responses preflight intentionally preserves temperature for
+    Responses-compatible providers, but the native ``openai-codex`` backend
+    returns HTTP 400 ``Unsupported parameter: temperature`` when the field
+    leaks through request overrides (for example from fallback/compression
+    paths used by cron jobs).  Mirror the existing Codex max_output_tokens
+    guard and strip this only for the native Codex backend.
+    """
+
+    @pytest.fixture
+    def transport(self):
+        from agent.transports.codex import ResponsesApiTransport
+        return ResponsesApiTransport()
+
+    def test_codex_backend_strips_temperature_from_request_overrides(self, transport):
+        kw = transport.build_kwargs(
+            model="gpt-5.5",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            is_codex_backend=True,
+            request_overrides={"temperature": 0.7},
+        )
+        assert "temperature" not in kw
+
+    def test_codex_backend_strips_direct_temperature(self, transport):
+        kw = transport.build_kwargs(
+            model="gpt-5.5",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            is_codex_backend=True,
+            temperature=0.7,
+        )
+        assert "temperature" not in kw
+
+    def test_non_codex_backend_preserves_temperature(self, transport):
+        kw = transport.build_kwargs(
+            model="gpt-5.5",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            request_overrides={"temperature": 0.7},
+        )
+        assert kw.get("temperature") == 0.7
+
+
 class TestCodexTransportXaiServiceTierStrip:
     """xAI Responses API rejects ``service_tier`` (#28490).
 


### PR DESCRIPTION
## Summary
- Strip `temperature` only for the native ChatGPT Codex backend before calling the Responses endpoint.
- Keep `temperature` intact for generic Responses-compatible providers.
- Add regression coverage for `request_overrides` and direct `temperature` inputs.

## Rationale
The native `openai-codex`/ChatGPT Codex backend rejects sampling controls with HTTP 400 (`Unsupported parameter: temperature`). Generic Responses-compatible providers may accept `temperature`, so the guard belongs at the backend-aware `is_codex_backend` branch after `request_overrides` are merged rather than in generic Responses preflight.

## Test plan
- `git diff --check`
- Python smoke check for Codex backend override/direct temperature stripping and generic Responses preservation
- `python -m pytest tests/agent/transports/test_codex_transport.py tests/run_agent/test_run_agent_codex_responses.py::test_build_api_kwargs_codex tests/run_agent/test_run_agent_codex_responses.py::test_preflight_codex_api_kwargs_allows_reasoning_and_temperature -q`
- `python scripts/check-windows-footguns.py --diff upstream/main`

Full `scripts/run_tests.sh` was not run; this PR is covered by the targeted transport/regression tests above.

## Platforms tested
- WSL2/Linux environment, Python 3.11
