### PR TITLE
feat(state): persist sender device attribution

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message.tsx
@@ -144,6 +144,15 @@ export const UserMessage: FC<{
     return messageAttachmentRefs(custom.attachmentRefs)
   })
 
+  // F-003 sender attribution: which device this message was typed on. The
+  // session is the channel; the device nickname is the sender identity until
+  // user accounts exist.
+  const senderDevice = useAuiState(s => {
+    const custom = (s.message.metadata?.custom ?? {}) as { senderDevice?: unknown }
+
+    return typeof custom.senderDevice === 'string' && custom.senderDevice.trim() ? custom.senderDevice.trim() : null
+  })
+
   // Sticky human bubbles clamp to ~2 lines with a soft fade so a long prompt
   // doesn't dominate the viewport while the response streams underneath; the
   // clamp lifts on hover / focus (see styles.css). We measure the *unclamped*
@@ -223,21 +232,32 @@ export const UserMessage: FC<{
     'border-(--ui-stroke-tertiary) hover:border-(--ui-stroke-secondary)'
   )
 
-  const bubbleContent = hasBody && (
-    // Render the user's text through a minimal markdown pipeline:
-    // backtick `code` and ``` fenced ``` blocks, with directive chips
-    // (`@file:` etc.) still resolved inside the plain-text spans.
-    <div
-      className={cn(clampActive && 'sticky-human-clamp')}
-      data-clamped={clampActive && bodyClamped ? 'true' : undefined}
-    >
-      {/* Match the edit composer's collapsed line box (min-h-[1.25rem]) so
-          clicking to edit can't grow the bubble by a sub-pixel and reflow the
-          turn 1px. */}
-      <div className="min-h-[1.25rem]" ref={clampInnerRef}>
-        <UserMessageText className="wrap-anywhere" text={messageText} />
-      </div>
-    </div>
+  const bubbleContent = (senderDevice || hasBody) && (
+    <>
+      {/* Channels: surface who sent this message when it arrived from another
+          participant's device. */}
+      {senderDevice && (
+        <span className="-mb-0.5 block truncate text-[0.625rem] font-medium leading-none text-(--ui-text-tertiary)">
+          {senderDevice}
+        </span>
+      )}
+      {hasBody && (
+        // Render the user's text through a minimal markdown pipeline:
+        // backtick `code` and ``` fenced ``` blocks, with directive chips
+        // (`@file:` etc.) still resolved inside the plain-text spans.
+        <div
+          className={cn(clampActive && 'sticky-human-clamp')}
+          data-clamped={clampActive && bodyClamped ? 'true' : undefined}
+        >
+          {/* Match the edit composer's collapsed line box (min-h-[1.25rem]) so
+              clicking to edit can't grow the bubble by a sub-pixel and reflow the
+              turn 1px. */}
+          <div className="min-h-[1.25rem]" ref={clampInnerRef}>
+            <UserMessageText className="wrap-anywhere" text={messageText} />
+          </div>
+        </div>
+      )}
+    </>
   )
 
   return (

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -335,6 +335,18 @@ describe('toChatMessages', () => {
     expect(read).not.toThrow()
     expect(chatMessageText(read()[0])).toBe(expected)
   })
+
+  it('maps sender_device onto user chat messages only', () => {
+    const messages = toChatMessages([
+      { role: 'user', content: 'hello', sender_device: ' ko-mac ', timestamp: 1 },
+      { role: 'assistant', content: 'hi', sender_device: 'server', timestamp: 2 },
+      { role: 'user', content: 'blank sender', sender_device: '   ', timestamp: 3 }
+    ])
+
+    expect(messages[0].senderDevice).toBe('ko-mac')
+    expect(messages[1].senderDevice).toBeUndefined()
+    expect(messages[2].senderDevice).toBeUndefined()
+  })
 })
 
 describe('renderMediaTags', () => {

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -25,6 +25,8 @@ export type ChatMessage = {
   interim?: boolean
   /** Composer attachment ref strings (`@file:...`, `@image:...`) sent with this user message. */
   attachmentRefs?: string[]
+  /** Device a user message was typed on. */
+  senderDevice?: string
 }
 
 export type GatewayEventPayload = {
@@ -1044,12 +1046,18 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
       flushPendingTools(index)
     }
 
+    const senderDevice =
+      message.role === 'user' && typeof message.sender_device === 'string' && message.sender_device.trim()
+        ? message.sender_device.trim()
+        : undefined
+
     result.push({
       id: `${message.timestamp || Date.now()}-${index}-${displayRole}`,
       role: displayRole,
       parts,
       timestamp: message.timestamp,
-      ...(extractedAttachmentRefs ? { attachmentRefs: extractedAttachmentRefs } : {})
+      ...(extractedAttachmentRefs ? { attachmentRefs: extractedAttachmentRefs } : {}),
+      ...(senderDevice ? { senderDevice } : {})
     })
 
     activeAssistantIndex = message.role === 'assistant' ? result.length - 1 : null

--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -9,7 +9,8 @@ import {
   messageCreatedAt,
   optimisticAttachmentRef,
   parseCommandDispatch,
-  parseSlashCommand
+  parseSlashCommand,
+  toRuntimeMessage
 } from './chat-runtime'
 
 const DATA_URL = 'data:image/png;base64,iVBORw0KGgoAAAANS'
@@ -198,5 +199,23 @@ describe('messageCreatedAt', () => {
   it('treats a zero / non-finite timestamp as absent', () => {
     expect(messageCreatedAt({ timestamp: 0 }, NOW).getTime()).toBe(NOW)
     expect(messageCreatedAt({ timestamp: Number.NaN }, NOW).getTime()).toBe(NOW)
+  })
+})
+
+describe('toRuntimeMessage', () => {
+  it('carries sender device in user metadata custom fields', () => {
+    const runtimeMessage = toRuntimeMessage({
+      attachmentRefs: ['@file:src/a.ts'],
+      id: 'user-1',
+      parts: [{ text: 'hello', type: 'text' }],
+      role: 'user',
+      senderDevice: 'ko-mac',
+      timestamp: 42
+    })
+
+    expect(runtimeMessage.metadata?.custom).toMatchObject({
+      attachmentRefs: ['@file:src/a.ts'],
+      senderDevice: 'ko-mac'
+    })
   })
 })

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -394,7 +394,12 @@ export function toRuntimeMessage(message: ChatMessage): ThreadMessage {
       content: message.parts.filter((part): part is Extract<ChatMessagePart, { type: 'text' }> => part.type === 'text'),
       attachments: [],
       createdAt,
-      metadata: { custom: { attachmentRefs: message.attachmentRefs ?? [] } }
+      metadata: {
+        custom: {
+          attachmentRefs: message.attachmentRefs ?? [],
+          ...(message.senderDevice ? { senderDevice: message.senderDevice } : {})
+        }
+      }
     } as ThreadMessage
   }
 

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -525,6 +525,8 @@ export interface SessionMessage {
    */
   display_metadata?: string | TimelineDisplayMetadata
   role: 'assistant' | 'system' | 'tool' | 'user'
+  /** Device a user message was typed on. */
+  sender_device?: null | string
   text?: unknown
   timestamp?: number
   tool_call_id?: null | string

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -4,8 +4,10 @@ Import-safe module with no dependencies — can be imported from anywhere
 without risk of circular imports.
 """
 
+import json
 import os
 import shutil
+import socket
 import stat
 import sys
 from contextvars import ContextVar, Token
@@ -1162,6 +1164,183 @@ def get_config_path() -> Path:
     in 7+ files (skill_utils.py, hermes_logging.py, hermes_time.py, etc.).
     """
     return get_hermes_home() / "config.yaml"
+
+
+_DEVICE_NAME_CACHE: str | None = None
+
+
+def _resolve_meshboard_device_name() -> str | None:
+    """Resolve this device's friendly name from MeshBoard, if available."""
+    import platform
+    import re
+    import subprocess
+
+    hostname = (platform.node() or "").rstrip(".").lower()
+    hostname_base = hostname.replace(".local", "").replace(".lan", "")
+
+    local_ips: set[str] = set()
+    try:
+        result = subprocess.run(
+            ["hostname", "-I"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            local_ips = set(result.stdout.split())
+    except Exception:
+        pass
+
+    if not local_ips:
+        try:
+            result = subprocess.run(
+                ["ifconfig"],
+                capture_output=True,
+                text=True,
+                timeout=2,
+                check=False,
+            )
+            if result.returncode == 0:
+                for match in re.finditer(r"inet (\d+\.\d+\.\d+\.\d+)", result.stdout):
+                    local_ips.add(match.group(1))
+        except Exception:
+            pass
+
+    mesh_roots = [Path.home() / "Workspaces" / ".mesh"]
+    if os.environ.get("MESHBOARD_RUNTIME"):
+        mesh_roots.append(Path(os.environ["MESHBOARD_RUNTIME"]).expanduser())
+
+    for mesh_root in mesh_roots:
+        devices_path = mesh_root / "registry" / "devices.json"
+        if not devices_path.exists():
+            continue
+
+        try:
+            data = json.loads(devices_path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+
+        devices = data.get("devices", []) or []
+
+        marker = mesh_root / "host-id"
+        if marker.exists():
+            try:
+                host_id = marker.read_text(encoding="utf-8").strip()
+            except Exception:
+                host_id = ""
+            if host_id:
+                for device in devices:
+                    if str(device.get("id", "")) == host_id:
+                        label = device.get("label")
+                        if isinstance(label, str) and label.strip():
+                            return label.strip()
+
+        env_host = os.environ.get("MESHBOARD_LOCAL_HOST", "").strip()
+        if env_host:
+            for device in devices:
+                if str(device.get("id", "")) == env_host:
+                    label = device.get("label")
+                    if isinstance(label, str) and label.strip():
+                        return label.strip()
+
+        for device in devices:
+            lan_hint = str(device.get("lan_hint", "")).strip()
+            if lan_hint and lan_hint in local_ips:
+                label = device.get("label")
+                if isinstance(label, str) and label.strip():
+                    return label.strip()
+
+        for device in devices:
+            ssh_alias = str(device.get("ssh_alias", "")).strip().lower()
+            if ssh_alias and (ssh_alias == hostname or ssh_alias == hostname_base):
+                label = device.get("label")
+                if isinstance(label, str) and label.strip():
+                    return label.strip()
+
+        for device in devices:
+            device_id = str(device.get("id", "")).strip().lower()
+            if device_id and (device_id == hostname or device_id == hostname_base):
+                label = device.get("label")
+                if isinstance(label, str) and label.strip():
+                    return label.strip()
+
+    return None
+
+
+def _resolve_tailscale_device_name() -> str | None:
+    """Resolve this device's Tailscale hostname, if Tailscale is available."""
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["tailscale", "status", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        if result.returncode != 0:
+            return None
+
+        data = json.loads(result.stdout)
+        hostname = data.get("Self", {}).get("HostName")
+        if isinstance(hostname, str) and hostname.strip():
+            return hostname.strip()
+    except Exception:
+        pass
+    return None
+
+
+def get_device_name() -> str:
+    """Return a stable, human-friendly name for this device."""
+    global _DEVICE_NAME_CACHE
+    if _DEVICE_NAME_CACHE is not None:
+        return _DEVICE_NAME_CACHE
+
+    try:
+        config_path = get_config_path()
+        if config_path.exists():
+            import yaml
+
+            config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+            device_config = config.get("device")
+            if isinstance(device_config, dict):
+                name = device_config.get("name")
+                if isinstance(name, str) and name.strip():
+                    _DEVICE_NAME_CACHE = name.strip()
+                    return _DEVICE_NAME_CACHE
+            elif isinstance(device_config, str) and device_config.strip():
+                _DEVICE_NAME_CACHE = device_config.strip()
+                return _DEVICE_NAME_CACHE
+    except Exception:
+        pass
+
+    try:
+        meshboard_name = _resolve_meshboard_device_name()
+        if meshboard_name:
+            _DEVICE_NAME_CACHE = meshboard_name
+            return _DEVICE_NAME_CACHE
+    except Exception:
+        pass
+
+    try:
+        tailscale_name = _resolve_tailscale_device_name()
+        if tailscale_name:
+            _DEVICE_NAME_CACHE = tailscale_name
+            return _DEVICE_NAME_CACHE
+    except Exception:
+        pass
+
+    try:
+        hostname = socket.gethostname()
+        if hostname.endswith(".local"):
+            hostname = hostname[:-6]
+        _DEVICE_NAME_CACHE = hostname or "unknown"
+    except Exception:
+        _DEVICE_NAME_CACHE = "unknown"
+
+    return _DEVICE_NAME_CACHE
 
 
 def get_skills_dir() -> Path:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -37,7 +37,7 @@ from agent.skill_commands import (
     SKILL_SCAFFOLD_SQL_LIKE,
     describe_skill_invocation,
 )
-from hermes_constants import get_hermes_home
+from hermes_constants import get_device_name, get_hermes_home
 from hermes_cli.sqlite_runtime import (
     is_sqlite_wal_reset_vulnerable as _is_sqlite_wal_reset_vulnerable,
 )
@@ -5154,6 +5154,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         display_kind: Optional[str] = None,
         display_metadata: Optional[Dict[str, Any]] = None,
         compression_lock_holder: Optional[str] = None,
+        sender_device: str = None,
     ) -> int:
         """
         Append a message to a session. Returns the message row ID.
@@ -5174,7 +5175,19 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         (which sqlite3 cannot bind and which the conversation loop scrubs
         from every outgoing payload anyway, so the scrubbed form IS the
         wire bytes).
+
+        ``sender_device`` attributes a user message to the device it was
+        typed on. When omitted, local user rows are stamped with this
+        device's resolved name so shared sessions can distinguish human
+        senders without requiring every call site to pass a value. Agent
+        and tool rows remain NULL.
         """
+        if sender_device is None and role == "user":
+            try:
+                sender_device = get_device_name()
+            except Exception:
+                sender_device = None
+
         # Display metadata is presentation-only and never changes the model
         # context role/content replayed to providers.
         display_metadata_json = self._encode_display_metadata(display_metadata)
@@ -5246,8 +5259,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items, platform_message_id, observed, active, api_content, display_kind, display_metadata)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   codex_message_items, platform_message_id, sender_device, observed, active, api_content,
+                   display_kind, display_metadata)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -5265,6 +5279,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     codex_items_json,
                     codex_message_items_json,
                     platform_message_id,
+                    sender_device,
                     1 if observed else 0,
                     1,
                     _scrub_surrogates(api_content) if isinstance(api_content, str) else None,
@@ -5387,8 +5402,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items, platform_message_id, observed, active, api_content, display_kind, display_metadata)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   codex_message_items, platform_message_id, sender_device, observed, active, api_content,
+                   display_kind, display_metadata)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -5406,6 +5422,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     codex_items_json,
                     codex_message_items_json,
                     platform_msg_id,
+                    msg.get("sender_device"),
                     1 if msg.get("observed") else 0,
                     1,
                     _scrub_surrogates(api_content) if isinstance(api_content, str) else None,

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -207,6 +207,7 @@ CREATE TABLE IF NOT EXISTS messages (
     codex_reasoning_items TEXT,
     codex_message_items TEXT,
     platform_message_id TEXT,
+    sender_device TEXT,
     observed INTEGER DEFAULT 0,
     active INTEGER NOT NULL DEFAULT 1,
     compacted INTEGER NOT NULL DEFAULT 0,

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -600,6 +600,7 @@ LEGACY_AUTHOR_MAP = {
     "saeed919@pm.me": "falasi",
     "chrisdlc119@outlook.com": "chdlc",
     "omar@techdeveloper.site": "nycomar",
+    "omar@kostudios.io": "OmarB97",
     "qiyin.zuo@pcitc.com": "qiyin-code",
     "mr.aashiz@gmail.com": "aashizpoudel",
     "adityargadgil@gmail.com": "AdityaRajeshGadgil",

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -14,6 +14,7 @@ from hermes_constants import (
     find_node_executable,
     find_node_executable_on_path,
     get_default_hermes_root,
+    get_device_name,
     get_hermes_dir,
     get_hermes_home,
     get_process_hermes_home,
@@ -353,6 +354,44 @@ class TestNodeToolRunnable:
         monkeypatch.setenv("PATH", str(system_bin))
 
         assert find_node_executable("npm") == str(managed_npm)
+
+
+class TestGetDeviceName:
+    """Tests for local device display-name resolution."""
+
+    def test_uses_config_device_name_first(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(hermes_constants, "_DEVICE_NAME_CACHE", None)
+        monkeypatch.setattr(hermes_constants, "_resolve_meshboard_device_name", lambda: "meshboard-name")
+        monkeypatch.setattr(hermes_constants, "_resolve_tailscale_device_name", lambda: "tailscale-name")
+        (tmp_path / "config.yaml").write_text("device:\n  name: ko-mac\n", encoding="utf-8")
+
+        assert get_device_name() == "ko-mac"
+
+    def test_falls_back_to_meshboard_then_caches(self, tmp_path, monkeypatch):
+        calls = {"meshboard": 0}
+
+        def _meshboard_name():
+            calls["meshboard"] += 1
+            return "meshboard-name"
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(hermes_constants, "_DEVICE_NAME_CACHE", None)
+        monkeypatch.setattr(hermes_constants, "_resolve_meshboard_device_name", _meshboard_name)
+        monkeypatch.setattr(hermes_constants, "_resolve_tailscale_device_name", lambda: "tailscale-name")
+
+        assert get_device_name() == "meshboard-name"
+        assert get_device_name() == "meshboard-name"
+        assert calls["meshboard"] == 1
+
+    def test_hostname_fallback_strips_local_suffix(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(hermes_constants, "_DEVICE_NAME_CACHE", None)
+        monkeypatch.setattr(hermes_constants, "_resolve_meshboard_device_name", lambda: None)
+        monkeypatch.setattr(hermes_constants, "_resolve_tailscale_device_name", lambda: None)
+        monkeypatch.setattr(hermes_constants.socket, "gethostname", lambda: "ko-mac.local")
+
+        assert get_device_name() == "ko-mac"
 
 
 class TestIsContainer:

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1527,6 +1527,65 @@ class TestMessageStorage:
         assert next(m for m in conv if m["role"] == "user").get("message_id") == "ext-1"
         assert "message_id" not in next(m for m in conv if m["role"] == "assistant")
 
+    def test_user_message_sender_device_is_local_metadata(self, db, monkeypatch):
+        """User rows get local attribution without changing prompt replay."""
+        monkeypatch.setattr("hermes_state.get_device_name", lambda: "ko-mac")
+        db.create_session(session_id="s_sender", source="desktop")
+        db.append_message("s_sender", role="user", content="hello")
+        db.append_message("s_sender", role="assistant", content="hi")
+        db.append_message("s_sender", role="tool", content="ok", tool_name="terminal")
+
+        msgs = db.get_messages("s_sender")
+        assert msgs[0]["sender_device"] == "ko-mac"
+        assert msgs[1]["sender_device"] is None
+        assert msgs[2]["sender_device"] is None
+
+        conv = db.get_messages_as_conversation("s_sender")
+        assert "sender_device" not in conv[0]
+        # Upstream's conversation projection now stamps a replay timestamp on
+        # every row; the invariant this guards is that sender attribution stays
+        # local metadata and never leaks into prompt replay.
+        assert {key: value for key, value in conv[0].items() if key != "timestamp"} == {
+            "role": "user",
+            "content": "hello",
+        }
+
+    def test_append_message_sender_device_override_and_failure(self, db, monkeypatch):
+        """Explicit sender attribution wins; resolver failures stay non-fatal."""
+        db.create_session(session_id="s_sender_override", source="desktop")
+        monkeypatch.setattr("hermes_state.get_device_name", lambda: "ko-mac")
+        db.append_message(
+            "s_sender_override",
+            role="user",
+            content="from the phone",
+            sender_device="iphone",
+        )
+
+        def _boom():
+            raise RuntimeError("device resolver unavailable")
+
+        monkeypatch.setattr("hermes_state.get_device_name", _boom)
+        db.append_message("s_sender_override", role="user", content="fallback")
+
+        msgs = db.get_messages("s_sender_override")
+        assert msgs[0]["sender_device"] == "iphone"
+        assert msgs[1]["sender_device"] is None
+
+    def test_replace_messages_preserves_sender_device(self, db):
+        """Transcript rewrites keep sender attribution for user rows."""
+        db.create_session(session_id="s_sender_replace", source="desktop")
+        db.replace_messages(
+            "s_sender_replace",
+            [
+                {"role": "user", "content": "typed elsewhere", "sender_device": "iphone"},
+                {"role": "assistant", "content": "ack"},
+            ],
+        )
+
+        msgs = db.get_messages("s_sender_replace")
+        assert msgs[0]["sender_device"] == "iphone"
+        assert msgs[1]["sender_device"] is None
+
     def test_get_messages_as_conversation_includes_ancestor_chain(self, db):
         db.create_session("root", "tui")
         db.append_message("root", role="user", content="first prompt")
@@ -4488,11 +4547,12 @@ class TestSchemaInit:
             for r in migrated_db._conn.execute("PRAGMA table_info(messages)").fetchall()
         }
         assert "reasoning_content" in msg_cols
+        assert "sender_device" in msg_cols
 
         # The query that used to crash must now work
         cursor = migrated_db._conn.execute(
             "SELECT role, content, reasoning, reasoning_content, "
-            "reasoning_details, codex_reasoning_items "
+            "reasoning_details, codex_reasoning_items, sender_device "
             "FROM messages WHERE session_id = ?",
             ("s1",),
         )
@@ -4500,6 +4560,7 @@ class TestSchemaInit:
         assert row is not None
         assert row[0] == "assistant"
         assert row[3] is None  # reasoning_content NULL for old rows
+        assert row[6] is None  # sender_device NULL for old rows
 
         migrated_db.close()
 


### PR DESCRIPTION
## Why

Shared desktop/cloud sessions need to show where a human user message was typed without changing the model replay transcript. Upstream already has desktop cloud-channel UI that can consume `sender_device`, but the state schema and desktop hydration path do not persist or display it yet.

## What

- Add a `sender_device` column to `messages` and bump the state schema version.
- Resolve a stable local device name from `config.yaml`, MeshBoard registry, Tailscale, then hostname, with caching and non-fatal fallback.
- Auto-stamp local user rows only; assistant/tool rows stay `NULL`, and `get_messages_as_conversation()` remains unchanged for prompt-cache stability.
- Preserve sender attribution through `replace_messages()` and surface it in the desktop user bubble metadata path.

## Verification

- `python3 -m pytest tests/test_hermes_constants.py::TestGetDeviceName tests/test_hermes_state.py::TestMessageStorage::test_user_message_sender_device_is_local_metadata tests/test_hermes_state.py::TestMessageStorage::test_append_message_sender_device_override_and_failure tests/test_hermes_state.py::TestMessageStorage::test_replace_messages_preserves_sender_device tests/test_hermes_state.py::TestSchemaInit::test_reconciliation_adds_missing_columns -q`
- `python3 -m pytest tests/test_hermes_constants.py tests/test_hermes_state.py -q`
- `python3 -m pytest tests/gateway/test_session_api.py tests/hermes_cli/test_web_server.py tests/tools/test_session_search.py -q`
- `python3 -m py_compile hermes_constants.py hermes_state.py`
- `npm --prefix apps/desktop run test:ui -- src/lib/chat-messages.test.ts src/lib/chat-runtime.test.ts`
- `npm --prefix apps/desktop run typecheck`
- `git diff --check`

Also ran `npm --prefix apps/desktop run test:ui -- src`; it currently fails in unrelated upstream-main suites (`pane-shell`, `use-gateway-boot`, `model-settings`, `streaming`, `toolset-config-panel`). The focused sender-device UI tests and type-check pass.

MeshBoard: `hermes-upstream-ports-desktop-lane-20260609`