### PR TITLE
[verified] add API diagnostics to cron failure notifications

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -444,6 +444,24 @@ def run_conversation(
     compression_attempts = 0
     _turn_exit_reason = "unknown"  # Diagnostic: why the loop ended
 
+    def _build_api_error_context(
+        error: Exception,
+        *,
+        failure_reason: str | None = None,
+        status_code: int | None = None,
+    ) -> dict:
+        return {
+            "provider": str(_provider or ""),
+            "model": str(_model or ""),
+            "base_url": str(_base or ""),
+            "attempt": api_call_count,
+            "context_messages": len(api_messages) if isinstance(api_messages, list) else len(messages),
+            "context_tokens": approx_tokens,
+            "error_type": type(error).__name__,
+            "status_code": status_code,
+            "failure_reason": failure_reason,
+        }
+
     # Optional opt-in runtime: if api_mode == codex_app_server, hand the
     # turn to the codex app-server subprocess (terminal/file ops/patching
     # all run inside Codex). Default Hermes path is bypassed entirely.
@@ -3065,6 +3083,11 @@ def run_conversation(
                             "completed": False,
                             "failed": True,
                             "error": f"content_policy_blocked: {_summary}",
+                            "api_error_context": _build_api_error_context(
+                                api_error,
+                                failure_reason=classified.reason.value,
+                                status_code=status_code,
+                            ),
                         }
                     return {
                         "final_response": None,
@@ -3073,6 +3096,11 @@ def run_conversation(
                         "completed": False,
                         "failed": True,
                         "error": str(api_error),
+                        "api_error_context": _build_api_error_context(
+                            api_error,
+                            failure_reason=classified.reason.value,
+                            status_code=status_code,
+                        ),
                     }
 
                 if retry_count >= max_retries:
@@ -3180,6 +3208,11 @@ def run_conversation(
                         "completed": False,
                         "failed": True,
                         "error": _final_summary,
+                        "api_error_context": _build_api_error_context(
+                            api_error,
+                            failure_reason=classified.reason.value,
+                            status_code=status_code,
+                        ),
                         # Surface the classified reason so callers (notably the
                         # kanban worker path in cli.py) can distinguish a
                         # transient throttle from a real failure and choose a

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -112,6 +112,58 @@ def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
         )
         return None
 
+
+def _api_error_diagnostics_block(info: dict) -> str:
+    """Build a compact, non-secret diagnostics block for cron failure logs."""
+    if not isinstance(info, dict):
+        return ""
+
+    diag = info.get("api_error_context")
+    if not isinstance(diag, dict):
+        return ""
+
+    parts = []
+    provider = (diag.get("provider") or "").strip()
+    if provider:
+        parts.append(f"- Provider: {provider}")
+
+    model = (diag.get("model") or "").strip()
+    if model:
+        parts.append(f"- Model: {model}")
+
+    base_url = (diag.get("base_url") or "").strip()
+    if base_url:
+        parts.append(f"- Base URL: {base_url}")
+
+    attempt = diag.get("attempt") if diag.get("attempt") is not None else diag.get("attempts")
+    if attempt is not None:
+        parts.append(f"- Attempt: {attempt}")
+
+    context_messages = diag.get("context_messages")
+    if context_messages is not None:
+        parts.append(f"- Context messages: {context_messages}")
+
+    context_tokens = diag.get("context_tokens")
+    if context_tokens is not None:
+        parts.append(f"- Approx context tokens: {context_tokens}")
+
+    error_type = (diag.get("error_type") or "").strip()
+    if error_type:
+        parts.append(f"- Error type: {error_type}")
+
+    status_code = diag.get("status_code")
+    if status_code is not None:
+        parts.append(f"- Status: {status_code}")
+
+    reason = (diag.get("failure_reason") or "").strip()
+    if reason:
+        parts.append(f"- Failure reason: {reason}")
+
+    if not parts:
+        return ""
+
+    return "\n\n**API diagnostics:**\n" + "\n".join(parts)
+
 # Valid delivery platforms — used to validate user-supplied platform names
 # in cron delivery targets, preventing env var enumeration via crafted names.
 _KNOWN_DELIVERY_PLATFORMS = frozenset({
@@ -1909,6 +1961,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 or (result.get("final_response") or "").strip()
                 or "agent reported failure"
             )
+            _err_text = f"{_err_text}{_api_error_diagnostics_block(result)}"
             raise RuntimeError(_err_text)
 
         final_response = result.get("final_response", "") or ""

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1205,6 +1205,26 @@ class TestRunJobSessionPersistence:
                 "API call failed",
             ),
             (
+                {
+                    "final_response": None,
+                    "completed": False,
+                    "failed": True,
+                    "error": "api call timed out",
+                    "api_error_context": {
+                        "provider": "openrouter",
+                        "model": "qwen2.5:3b",
+                        "base_url": "https://example.invalid/v1",
+                        "attempt": 2,
+                        "context_messages": 7,
+                        "context_tokens": 256,
+                        "error_type": "TimeoutError",
+                        "status_code": 408,
+                        "failure_reason": "timeout",
+                    },
+                },
+                "api call timed out",
+            ),
+            (
                 {"final_response": None, "completed": False, "failed": True},
                 "agent reported failure",
             ),
@@ -1267,6 +1287,13 @@ class TestRunJobSessionPersistence:
         assert "(FAILED)" in output
         # Ephemeral cron agent must still be closed even on agent-flagged failure.
         mock_agent.close.assert_called_once()
+
+        if agent_result.get("api_error_context"):
+            assert "API diagnostics" in error
+            assert "Provider: openrouter" in error
+            assert "Model: qwen2.5:3b" in error
+            assert "Attempt: 2" in error
+            assert "Approx context tokens: 256" in error
 
     def test_run_job_completed_true_without_failed_flag_succeeds(self, tmp_path):
         """Regression guard: a normal success result (``completed=True``,


### PR DESCRIPTION
## Summary
- Added structured API-failure context on cron execution path so job failures carry actionable diagnostics.
- `agent.conversation_loop` now records an `api_error_context` payload (provider, model, base URL, attempt count, context size, token estimate, error type, status, and failure reason) on API-related failures.
- `cron.scheduler` appends a compact `API diagnostics` block from that payload when `run_job` raises for agent-reported failure.
- Added regression coverage in `tests/cron/test_scheduler.py` to assert diagnostics are surfaced in cron failure errors.

## Validation
- `python3 -m py_compile agent/conversation_loop.py cron/scheduler.py tests/cron/test_scheduler.py`
- `python3 -m ruff check cron/scheduler.py agent/conversation_loop.py tests/cron/test_scheduler.py`
- `python3 -m pytest -o addopts="" -q tests/cron/test_scheduler.py -k "run_job"`
- `python3 -m pytest -o addopts="" -q tests/cron/test_scheduler.py`

Closes #43170
