### PR TITLE
fix(feishu): ignore thread_id in DM quoted replies to prevent isolated sessions

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -3123,6 +3123,10 @@ class FeishuAdapter(BasePlatformAdapter):
                 text = f"{hint}\n\n{text}" if text else hint
 
         thread_id = getattr(message, "thread_id", None) or getattr(message, "root_id", None) or None
+        # Feishu DMs do not support real threads; quoted replies populate
+        # thread_id/root_id but should not create isolated sessions.
+        if chat_type == "p2p":
+            thread_id = None
         reply_to_message_id = (
             getattr(message, "parent_id", None)
             or getattr(message, "upper_message_id", None)

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1465,6 +1465,95 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(event.text, "/help test")
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_p2p_quoted_reply_ignores_thread_id(self):
+        """Feishu DMs do not support real threads; quoted replies that
+        populate thread_id/root_id must not create isolated sessions."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._dispatch_inbound_event = AsyncMock()
+        adapter.get_chat_info = AsyncMock(
+            return_value={"chat_id": "oc_dm", "name": "Feishu DM", "type": "dm"}
+        )
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={"user_id": "ou_user", "user_name": "张三", "user_id_alt": None}
+        )
+        adapter._fetch_message_text = AsyncMock(return_value="original message")
+
+        # Simulate a quoted reply in a DM: Lark SDK populates thread_id/root_id
+        message = SimpleNamespace(
+            chat_id="oc_dm",
+            thread_id="om_thread_parent",
+            root_id="om_thread_parent",
+            parent_id="om_parent",
+            upper_message_id=None,
+            message_type="text",
+            content='{"text":"reply to you"}',
+            message_id="om_reply",
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=SimpleNamespace(event=SimpleNamespace(message=message)),
+                message=message,
+                sender_id=SimpleNamespace(open_id="ou_user", user_id=None, union_id=None),
+                is_bot=False,
+                chat_type="p2p",
+                message_id="om_reply",
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.await_args.args[0]
+        self.assertIsNone(event.source.thread_id, "thread_id must be None in DM (p2p) chats")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_group_quoted_reply_preserves_thread_id(self):
+        """Group messages with thread_id/root_id must still create
+        thread-scoped sessions (real Feishu group threads)."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._dispatch_inbound_event = AsyncMock()
+        adapter.get_chat_info = AsyncMock(
+            return_value={"chat_id": "oc_group", "name": "Team Chat", "type": "group"}
+        )
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={"user_id": "ou_user", "user_name": "张三", "user_id_alt": None}
+        )
+        adapter._fetch_message_text = AsyncMock(return_value="original message")
+
+        message = SimpleNamespace(
+            chat_id="oc_group",
+            thread_id="om_thread_parent",
+            root_id="om_thread_parent",
+            parent_id="om_parent",
+            upper_message_id=None,
+            message_type="text",
+            content='{"text":"reply in thread"}',
+            message_id="om_reply",
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=SimpleNamespace(event=SimpleNamespace(message=message)),
+                message=message,
+                sender_id=SimpleNamespace(open_id="ou_user", user_id=None, union_id=None),
+                is_bot=False,
+                chat_type="group",
+                message_id="om_reply",
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.await_args.args[0]
+        self.assertEqual(
+            event.source.thread_id,
+            "om_thread_parent",
+            "thread_id must be preserved in group chats",
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_extract_text_file_injects_content(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where Feishu/Lark DM quoted replies (引用回复) create isolated sessions, causing the agent to lose all conversation context. When a user quotes/replies to a message in a DM, the Lark SDK populates `thread_id`/`root_id`, which then flows into the session key and creates a brand new empty session instead of continuing the existing DM conversation.

## Related Issue

Fixes #44028

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/feishu.py`: In `_process_inbound_message`, clear `thread_id` when `chat_type == "p2p"` (DM), since Feishu DMs do not support real threads — only group chats do. (+4 lines)
- `tests/gateway/test_feishu.py`: Add two regression tests — `test_p2p_quoted_reply_ignores_thread_id` verifies DM quoted replies get `thread_id=None`, and `test_group_quoted_reply_preserves_thread_id` verifies group thread routing is unaffected. (+89 lines)

## How to Test

1. `python -m pytest tests/gateway/test_feishu.py -k "test_p2p_quoted_reply_ignores_thread_id or test_group_quoted_reply_preserves_thread_id" -v` — both new tests should pass
2. `python -m pytest tests/gateway/test_feishu.py -q` — all 162 tests pass, 45 skipped (no regressions)
3. Manual: send a quoted reply in a Feishu DM to a Hermes bot — the reply should stay in the same session as regular DM messages (no session isolation)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `_process_inbound_message` in `gateway/platforms/feishu.py` (line 3098); `build_source` → `build_session_key` flow for DM session key construction
- Blast radius: LOW — change only affects Feishu p2p (DM) chat type; group chat threading is explicitly preserved
- Related patterns: Same `chat_type == "p2p"` guard pattern used elsewhere in feishu.py (e.g., line 3891)
