### PR TITLE
fix(install/windows): repair stale winget registration + refresh/merge PATH after every package manager

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -893,19 +893,39 @@ function Test-Node {
 }
 
 function Update-ProcessPathForPackages {
-    # Rebuild the current process PATH from the persisted User+Machine hives plus
-    # winget's alias-shim directory, so a freshly-installed shim (rg.exe,
-    # ffmpeg.exe) becomes visible to Get-Command in THIS process without
-    # spawning a new shell. Called after every package-manager attempt
-    # (winget/choco/scoop): previously PATH was only refreshed inside the winget
-    # branch, so a successful choco/scoop fallback -- or any install on a box
-    # without winget -- could be misreported as "not installed".
-    $envPath = [Environment]::GetEnvironmentVariable("Path", "User") + ";" + [Environment]::GetEnvironmentVariable("Path", "Machine")
+    # Make freshly-installed shims (rg.exe, ffmpeg.exe) visible to Get-Command in
+    # THIS process without spawning a new shell, by folding the persisted
+    # User+Machine hives plus winget's alias-shim directory into $env:Path.
+    # Called after every package-manager attempt (winget/choco/scoop): previously
+    # PATH was only refreshed inside the winget branch, so a successful
+    # choco/scoop fallback -- or any install on a box without winget -- could be
+    # misreported as "not installed".
+    #
+    # MERGE rather than overwrite: start from the existing process PATH so any
+    # process-only entries added earlier in this installer run survive, then
+    # APPEND hive/winget-Links entries not already present (case-insensitive,
+    # order-preserving dedupe). A wholesale replace would silently drop those
+    # process-only entries.
+    $candidates = @()
+    $candidates += $env:Path
+    $candidates += [Environment]::GetEnvironmentVariable("Path", "User")
+    $candidates += [Environment]::GetEnvironmentVariable("Path", "Machine")
     $wingetLinks = Join-Path $env:LOCALAPPDATA "Microsoft\WinGet\Links"
     if (Test-Path $wingetLinks) {
-        $envPath = "$envPath;$wingetLinks"
+        $candidates += $wingetLinks
     }
-    $env:Path = $envPath
+    $seen = New-Object System.Collections.Generic.HashSet[string] ([StringComparer]::OrdinalIgnoreCase)
+    $ordered = New-Object System.Collections.Generic.List[string]
+    foreach ($chunk in $candidates) {
+        if ([string]::IsNullOrEmpty($chunk)) { continue }
+        foreach ($entry in $chunk.Split(';')) {
+            $trimmed = $entry.Trim()
+            if ($trimmed -and $seen.Add($trimmed)) {
+                $ordered.Add($trimmed)
+            }
+        }
+    }
+    $env:Path = [string]::Join(';', $ordered)
 }
 
 function Install-SystemPackages {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -892,6 +892,22 @@ function Test-Node {
     return $true
 }
 
+function Update-ProcessPathForPackages {
+    # Rebuild the current process PATH from the persisted User+Machine hives plus
+    # winget's alias-shim directory, so a freshly-installed shim (rg.exe,
+    # ffmpeg.exe) becomes visible to Get-Command in THIS process without
+    # spawning a new shell. Called after every package-manager attempt
+    # (winget/choco/scoop): previously PATH was only refreshed inside the winget
+    # branch, so a successful choco/scoop fallback -- or any install on a box
+    # without winget -- could be misreported as "not installed".
+    $envPath = [Environment]::GetEnvironmentVariable("Path", "User") + ";" + [Environment]::GetEnvironmentVariable("Path", "Machine")
+    $wingetLinks = Join-Path $env:LOCALAPPDATA "Microsoft\WinGet\Links"
+    if (Test-Path $wingetLinks) {
+        $envPath = "$envPath;$wingetLinks"
+    }
+    $env:Path = $envPath
+}
+
 function Install-SystemPackages {
     $script:HasRipgrep = $false
     $script:HasFfmpeg = $false
@@ -961,25 +977,33 @@ function Install-SystemPackages {
             try {
                 $output = winget install --exact --id $pkg --source winget --silent `
                     --accept-package-agreements --accept-source-agreements 2>&1
+                $code = $LASTEXITCODE
                 $output | Out-File -FilePath $log -Encoding utf8
-                "winget exit: $LASTEXITCODE" | Out-File -FilePath $log -Encoding utf8 -Append
+                "winget exit: $code" | Out-File -FilePath $log -Encoding utf8 -Append
+                # 0x8A15002B (-1978335189) = APPINSTALLER_CLI_ERROR_UPDATE_NOT_APPLICABLE.
+                # winget treats `install` on a package it already has registered as
+                # an *upgrade*, finds no newer version, and bails with this code --
+                # even when the binary is gone from disk/PATH (stale registration,
+                # files removed outside winget, or a missing alias shim). We KNOW the
+                # command was missing (that's why we're here), so a plain install
+                # dead-ends forever. Force a reinstall to repair the registration so
+                # the shim reappears.
+                if ($code -eq -1978335189) {
+                    "-> already-installed/no-upgrade; retrying with --force" | Out-File -FilePath $log -Encoding utf8 -Append
+                    $output = winget install --exact --id $pkg --source winget --silent --force `
+                        --accept-package-agreements --accept-source-agreements 2>&1
+                    $output | Out-File -FilePath $log -Encoding utf8 -Append
+                    "winget exit (force): $LASTEXITCODE" | Out-File -FilePath $log -Encoding utf8 -Append
+                }
             } catch {
                 $_ | Out-File -FilePath $log -Encoding utf8 -Append
                 "winget exit: <exception>" | Out-File -FilePath $log -Encoding utf8 -Append
             }
         }
-        # Refresh PATH from both env-var hives AND winget's alias shim directory.
-        # winget exposes packages via "command line aliases" in %LOCALAPPDATA%\
-        # Microsoft\WinGet\Links, which is added to PATH by the AppExecutionAlias
-        # machinery only in *newly-spawned* shells -- not the current process.
-        # Without this addition, Get-Command rg below would falsely return null
-        # immediately after a successful install.
-        $wingetLinks = Join-Path $env:LOCALAPPDATA "Microsoft\WinGet\Links"
-        $envPath = [Environment]::GetEnvironmentVariable("Path", "User") + ";" + [Environment]::GetEnvironmentVariable("Path", "Machine")
-        if (Test-Path $wingetLinks) {
-            $envPath = "$envPath;$wingetLinks"
-        }
-        $env:Path = $envPath
+        # Refresh PATH so packages winget exposed via "command line aliases" in
+        # %LOCALAPPDATA%\Microsoft\WinGet\Links (added to PATH only in
+        # newly-spawned shells, not this process) are visible to Get-Command below.
+        Update-ProcessPathForPackages
         if ($needRipgrep -and (Get-Command rg -ErrorAction SilentlyContinue)) {
             Write-Success "ripgrep installed"
             $script:HasRipgrep = $true
@@ -1005,6 +1029,7 @@ function Install-SystemPackages {
         foreach ($pkg in $chocoPkgs) {
             try { choco install $pkg -y 2>&1 | Out-Null } catch { }
         }
+        Update-ProcessPathForPackages
         if ($needRipgrep -and (Get-Command rg -ErrorAction SilentlyContinue)) {
             Write-Success "ripgrep installed via chocolatey"
             $script:HasRipgrep = $true
@@ -1023,6 +1048,7 @@ function Install-SystemPackages {
         foreach ($pkg in $scoopPkgs) {
             try { scoop install $pkg 2>&1 | Out-Null } catch { }
         }
+        Update-ProcessPathForPackages
         if ($needRipgrep -and (Get-Command rg -ErrorAction SilentlyContinue)) {
             Write-Success "ripgrep installed via scoop"
             $script:HasRipgrep = $true


### PR DESCRIPTION
## Summary

Builds on @xxxigm's #43511 (Windows installer winget stale-registration fix) and adds one follow-up hardening commit. The original change is carried verbatim with authorship preserved; this PR supersedes #43511.

### Commit 1 (@xxxigm, from #43511)
A Windows user saw ripgrep/ffmpeg silently end up uninstalled even though winget reported the package present. Root cause: `winget install <id>` on a package winget already has **registered** is treated as an *upgrade*; finding no newer version it bails with `-1978335189` (`0x8A15002B`, `APPINSTALLER_CLI_ERROR_UPDATE_NOT_APPLICABLE`) **without verifying the binary is on disk/PATH**. A stale registration then became a permanent dead-end.

- Detect that exit code and retry once with `winget install --force` to repair the stale registration so the shim reappears.
- Extract the PATH-refresh into `Update-ProcessPathForPackages` and call it after **every** package manager (winget/choco/scoop), not just winget — so a successful choco/scoop fallback (or any install on a box without winget) is no longer misreported as "not installed".

### Commit 2 (follow-up)
`Update-ProcessPathForPackages` rebuilt `$env:Path` **wholesale** from the persisted User+Machine hives plus winget's Links dir, discarding any process-only PATH entries added earlier in the installer run. Now that the helper runs after *every* package manager, that wholesale replace is more likely to clobber a process-local entry than the original winget-branch-only version was.

- Merge instead of overwrite: seed from the current process PATH, then append hive/winget-Links entries not already present, with a **case-insensitive, order-preserving dedupe**.
- Clean-box behaviour is unchanged (hive entries are simply appended); the only difference is pre-existing process-only entries now survive the refresh.

## Verification
- `[System.Management.Automation.Language.Parser]::ParseFile` → **no syntax errors** (pwsh 7.7).
- Functional test of the merge logic: process-only entry survives ✓, case-insensitive dedupe (`System32` appears once) ✓, order preserved (process PATH first) ✓.

## Test plan (from #43511, unchanged)
- [ ] Stale `BurntSushi.ripgrep.MSVC` registration → confirm the `--force` retry restores `rg`.
- [ ] Choco-but-no-winget box → confirm choco-installed `rg`/`ffmpeg` is detected (PATH refreshed).
- [ ] Happy path (clean machine) unchanged.

Co-authored-by: xxxigm <tuancanhnguyen706@gmail.com>
