### PR TITLE
fix(oneshot): close session DB row after oneshot completes

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -364,7 +364,17 @@ def _run_agent(
     agent.stream_delta_callback = None
     agent.tool_gen_callback = None
 
-    return agent.chat(prompt) or ""
+    try:
+        return agent.chat(prompt) or ""
+    finally:
+        # Oneshot sessions are one-and-done.  Without this, the session row
+        # stays ended_at=NULL forever and piles up in "active sessions" UIs.
+        sid = getattr(agent, "session_id", None)
+        if session_db and sid:
+            try:
+                session_db.end_session(sid, "oneshot_complete")
+            except Exception:
+                pass
 
 
 def _oneshot_clarify_callback(question: str, choices=None) -> str:


### PR DESCRIPTION
## Problem

`hermes -z` (oneshot mode) creates a session row in the SQLite database via `SessionDB` but never calls `end_session()`. The interactive CLI path does this in `cli.py` (~line 13074, `"cli_close"`), but `oneshot.py` bypasses that entirely.

Every cron-triggered `hermes -z` call leaves a dead session with `ended_at=NULL`. Over hours/days, this accumulates — on my instance, 11 stale CLI sessions piled up in a single morning before I noticed. Any dashboard or query filtering on `ended_at IS NULL` shows these as "active" forever.

## Fix

A `try/finally` block in `_run_agent()` calls `session_db.end_session()` after `agent.chat()` returns, mirroring the interactive CLI behavior. Uses `getattr(agent, "session_id", None)` so test mocks without a `session_id` attribute work unchanged.

## Testing

- All 46 existing tests in `tests/hermes_cli/test_tui_resume_flow.py` pass (including 14 oneshot-specific tests)
- Verified live: ran `hermes -z "say hello"` and confirmed the new session row has `ended_at` set while older stale sessions remain unchanged
- Exception path tested implicitly via `try/finally` — `end_session()` call is defensive (wrapped in its own try/except)

## Checklist

- [x] No new model tools or core surface added (pure session lifecycle fix)
- [x] Cache-safe — doesn't touch the conversation loop
- [x] No new env vars or config options