### PR TITLE
fix(desktop): keep silent profile turns alive past idle reap

### DIFF
--- a/apps/desktop/src/store/session-watchdog.test.ts
+++ b/apps/desktop/src/store/session-watchdog.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { $workingSessionIds, setSessionWorking } from './session'
+
+describe('session working watchdog', () => {
+  afterEach(() => {
+    setSessionWorking('background-profile-session', false)
+    vi.useRealTimers()
+    $workingSessionIds.set([])
+  })
+
+  it('keeps a silent running turn alive through the desktop backend idle window', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    $workingSessionIds.set([])
+
+    setSessionWorking('background-profile-session', true)
+
+    // Electron's pooled profile backend idle reaper fires at 10 minutes. A
+    // legitimate long-running command can be silent for that whole window, so
+    // the renderer watchdog must not drop the working flag before the backend
+    // gets another keepalive tick.
+    vi.advanceTimersByTime(10 * 60 * 1000)
+
+    expect($workingSessionIds.get()).toContain('background-profile-session')
+  })
+})

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -156,11 +156,13 @@ export const setModelPickerOpen = (next: Updater<boolean>) => updateAtom($modelP
 
 // Watchdog tracking — when does a "working" session count as stuck?
 // Long-running tool calls (LLM inference, long shell commands, web fetches)
-// can take a few minutes legitimately. We allow 8 minutes of complete
-// silence on the stream before clearing the working flag; in practice this
-// catches gateway hangs and dropped streams without false-positive-clearing
-// real long turns.
-const SESSION_WATCHDOG_TIMEOUT_MS = 8 * 60 * 1000
+// can take a few minutes legitimately. Keep this longer than Electron's
+// pooled-backend idle reaper (10 minutes): a silent-but-still-running
+// background profile must keep its secondary socket open long enough for the
+// renderer keepalive to spare the backend. Otherwise the watchdog drops the
+// working flag, pruning closes the socket, and Electron later SIGTERMs the
+// profile backend mid-turn.
+const SESSION_WATCHDOG_TIMEOUT_MS = 12 * 60 * 1000
 const sessionWatchdogTimers = new Map<string, ReturnType<typeof setTimeout>>()
 
 function armSessionWatchdog(sessionId: string) {


### PR DESCRIPTION
## Summary
- keep the desktop renderer's working-session watchdog alive past Electron's 10-minute pooled profile backend idle reaper
- add a focused watchdog regression test for silent background profile turns

Fixes #43953

## Verification
- `npm --prefix apps/desktop run test:ui -- src/store/session-watchdog.test.ts`
- `npm --prefix apps/desktop run type-check`
