### PR TITLE
feat(session_search): hybrid semantic search (BM25 + sqlite-vec vectors)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1876,7 +1876,30 @@ DEFAULT_CONFIG = {
             # NOTE: no reasoning_effort here by design — see moa_reference above.
         },
     },
-    
+
+    # Session search — hybrid semantic retrieval (#44075). When ``semantic``
+    # is true, session_search discovery queries combine the existing FTS5
+    # BM25 ranking with embedding cosine similarity (sqlite-vec), merged by
+    # weighted reciprocal rank fusion. Requires an OpenAI-compatible
+    # /embeddings endpoint: either a named provider (``embedding_provider``,
+    # resolved through the auxiliary provider chain) or a direct
+    # ``embedding_base_url`` + ``embedding_api_key`` pair (e.g. a local
+    # fastembed/ollama server). When disabled, sqlite-vec is missing, or no
+    # provider resolves, search falls back to FTS5-only — current behavior.
+    # One-time backfill of existing history:
+    #   python scripts/backfill_session_embeddings.py
+    "session_search": {
+        "semantic": False,
+        "embedding_provider": "",   # "" = auto-detect via provider chain
+        "embedding_model": "text-embedding-3-small",
+        "embedding_base_url": "",   # direct OpenAI-compatible endpoint (takes precedence)
+        "embedding_api_key": "",    # API key for embedding_base_url
+        "hybrid_weight_vector": 0.7,  # weight of cosine-similarity ranking
+        "hybrid_weight_bm25": 0.3,    # weight of FTS5 BM25 ranking
+        "min_similarity": 0.25,     # drop vector hits below this cosine similarity
+        "index_batch_size": 96,     # new messages embedded per search call
+    },
+
     "display": {
         "compact": False,
         "personality": "",

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1268,6 +1268,22 @@ CREATE TABLE IF NOT EXISTS async_delegations (
     delivery_claimed_at REAL
 );
 
+CREATE TABLE IF NOT EXISTS message_embeddings (
+    message_id INTEGER PRIMARY KEY REFERENCES messages(id),
+    model TEXT NOT NULL,
+    dim INTEGER NOT NULL,
+    vector BLOB NOT NULL,
+    created_at REAL NOT NULL
+);
+
+CREATE TRIGGER IF NOT EXISTS message_embeddings_delete AFTER DELETE ON messages BEGIN
+    DELETE FROM message_embeddings WHERE message_id = old.id;
+END;
+
+CREATE TRIGGER IF NOT EXISTS message_embeddings_invalidate AFTER UPDATE OF content ON messages BEGIN
+    DELETE FROM message_embeddings WHERE message_id = old.id;
+END;
+
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
 CREATE INDEX IF NOT EXISTS idx_sessions_source_id ON sessions(source, id);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
@@ -8603,6 +8619,211 @@ class SessionDB:
         with self._lock:
             rows = self._conn.execute(sql, params).fetchall()
         return [dict(r) for r in rows]
+
+    # =========================================================================
+    # Semantic (vector) search — #44075
+    # =========================================================================
+    # Embeddings live in the plain ``message_embeddings`` table as little-
+    # endian float32 BLOBs. KNN runs through sqlite-vec's scalar function
+    # ``vec_distance_cosine()`` over that table — deliberately NOT a vec0
+    # virtual table, so a connection that never loads the extension (older
+    # install, sqlite-vec uninstalled, read-only profile DB) can still open,
+    # migrate, and query everything else in state.db without tripping on an
+    # unreadable virtual table.
+
+    # None = not probed yet; probed once per SessionDB instance.
+    _vec_loaded: Optional[bool] = None
+
+    def vector_search_available(self) -> bool:
+        """True when the sqlite-vec extension is importable and loaded on
+        this connection. Lazy and cached; safe to call repeatedly."""
+        if self._vec_loaded is not None:
+            return self._vec_loaded
+        try:
+            import sqlite_vec
+        except ImportError:
+            self._vec_loaded = False
+            return False
+        try:
+            # enable_load_extension is absent on sqlite3 builds compiled
+            # with SQLITE_OMIT_LOAD_EXTENSION (some macOS system pythons).
+            self._conn.enable_load_extension(True)
+            try:
+                sqlite_vec.load(self._conn)
+            finally:
+                self._conn.enable_load_extension(False)
+            with self._lock:
+                self._conn.execute("SELECT vec_version()").fetchone()
+            self._vec_loaded = True
+        except (AttributeError, sqlite3.Error) as exc:
+            logger.warning(
+                "sqlite-vec extension could not be loaded; semantic session "
+                "search disabled for this connection: %s", exc
+            )
+            self._vec_loaded = False
+        return self._vec_loaded
+
+    def upsert_message_embeddings(
+        self, rows: List[Tuple[int, str, int, bytes]]
+    ) -> int:
+        """Insert or replace embeddings. ``rows`` is a list of
+        ``(message_id, model, dim, vector_blob)``. Returns rows written."""
+        if not rows:
+            return 0
+        now = time.time()
+        payload = [(mid, model, dim, vec, now) for mid, model, dim, vec in rows]
+
+        def _write(conn: sqlite3.Connection) -> int:
+            conn.executemany(
+                "INSERT OR REPLACE INTO message_embeddings "
+                "(message_id, model, dim, vector, created_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                payload,
+            )
+            return len(payload)
+
+        return self._execute_write(_write)
+
+    def get_unembedded_messages(
+        self,
+        model: str,
+        limit: int = 128,
+        roles: Tuple[str, ...] = ("user", "assistant"),
+    ) -> List[Dict[str, Any]]:
+        """Active or compaction-archived messages with non-empty text content
+        that have no embedding for ``model`` yet. Newest first, so recent
+        sessions become semantically searchable before deep history is
+        backfilled.
+
+        Includes compacted=1 rows so vector recall matches the FTS5 path:
+        pre-compaction transcript stays discoverable after in-place compaction
+        (#38763, #44093).
+        """
+        role_placeholders = ",".join("?" for _ in roles)
+        with self._lock:
+            cursor = self._conn.execute(
+                f"""
+                SELECT m.id, m.content
+                FROM messages m
+                LEFT JOIN message_embeddings e
+                    ON e.message_id = m.id AND e.model = ?
+                WHERE e.message_id IS NULL
+                  AND (m.active = 1 OR m.compacted = 1)
+                  AND m.role IN ({role_placeholders})
+                  AND m.content IS NOT NULL
+                  AND length(trim(m.content)) > 0
+                ORDER BY m.id DESC
+                LIMIT ?
+                """,
+                (model, *roles, limit),
+            )
+            return [dict(row) for row in cursor.fetchall()]
+
+    def count_message_embeddings(self, model: Optional[str] = None) -> int:
+        """Number of stored embeddings, optionally for one model."""
+        with self._lock:
+            if model is None:
+                row = self._conn.execute(
+                    "SELECT COUNT(*) FROM message_embeddings"
+                ).fetchone()
+            else:
+                row = self._conn.execute(
+                    "SELECT COUNT(*) FROM message_embeddings WHERE model = ?",
+                    (model,),
+                ).fetchone()
+        return row[0] if row else 0
+
+    def search_messages_by_vector(
+        self,
+        query_vector: bytes,
+        model: str,
+        dim: int,
+        role_filter: Optional[List[str]] = None,
+        exclude_sources: Optional[List[str]] = None,
+        limit: int = 20,
+        include_inactive: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """Cosine-distance KNN over stored message embeddings.
+
+        Returns rows shaped like :meth:`_search_messages_impl` results (snippet is
+        a plain content prefix — no FTS5 highlighting) plus a ``distance``
+        key (cosine distance, lower = closer). Returns ``[]`` when sqlite-vec
+        is unavailable. The ``model``/``dim`` filters keep stale embeddings
+        from a previously configured model out of the distance function,
+        which would otherwise error on dimension mismatch.
+
+        The active/inactive predicate mirrors ``_search_messages_impl``:
+        compaction-archived rows (active=0, compacted=1) ARE included by default,
+        matching the FTS5 discovery path (#38763, #44093).
+        """
+        if not self.vector_search_available():
+            return []
+
+        where_clauses = ["e.model = ?", "e.dim = ?"]
+        params: list = [query_vector, model, dim]
+        if not include_inactive:
+            # Match the FTS5 path: (active=1 OR compacted=1), so
+            # pre-compaction transcript stays discoverable after in-place
+            # compaction (#38763).
+            where_clauses.append("(m.active = 1 OR m.compacted = 1)")
+        if exclude_sources is not None:
+            placeholders = ",".join("?" for _ in exclude_sources)
+            where_clauses.append(f"s.source NOT IN ({placeholders})")
+            params.extend(exclude_sources)
+        if role_filter:
+            placeholders = ",".join("?" for _ in role_filter)
+            where_clauses.append(f"m.role IN ({placeholders})")
+            params.extend(role_filter)
+        params.append(limit)
+
+        sql = f"""
+            SELECT
+                m.id,
+                m.session_id,
+                m.role,
+                m.content,
+                m.timestamp,
+                m.tool_name,
+                s.source,
+                s.model,
+                s.started_at AS session_started,
+                vec_distance_cosine(e.vector, ?) AS distance
+            FROM message_embeddings e
+            JOIN messages m ON m.id = e.message_id
+            JOIN sessions s ON s.id = m.session_id
+            WHERE {" AND ".join(where_clauses)}
+            ORDER BY distance ASC
+            LIMIT ?
+        """
+        with self._lock:
+            try:
+                cursor = self._conn.execute(sql, params)
+                matches = [dict(row) for row in cursor.fetchall()]
+            except sqlite3.Error as exc:
+                logger.warning("Vector search failed: %s", exc, exc_info=True)
+                return []
+
+        for match in matches:
+            content_raw = match.pop("content", None)
+            text = ""
+            if isinstance(content_raw, str):
+                text = content_raw
+                # Multimodal content is stored JSON-encoded; surface the text
+                # parts the same way search_messages context previews do.
+                if content_raw.startswith("["):
+                    try:
+                        decoded = json.loads(content_raw)
+                        if isinstance(decoded, list):
+                            parts = [
+                                p.get("text", "") for p in decoded
+                                if isinstance(p, dict) and p.get("type") == "text"
+                            ]
+                            text = " ".join(t for t in parts if t).strip() or content_raw
+                    except (ValueError, TypeError):
+                        pass
+            snippet = " ".join(text.split())
+            match["snippet"] = snippet[:200] + ("..." if len(snippet) > 200 else "")
+        return matches
 
     def search_sessions_by_id(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,7 +156,7 @@ edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 hindsight = ["hindsight-client==0.6.1"]
-dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "mcp==1.26.0", "starlette==1.0.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==81.0.0"]  # starlette: CVE-2026-48710; setuptools: latest <82 (torch >=2.11 caps setuptools<82)
+dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "mcp==1.26.0", "starlette==1.0.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==81.0.0", "sqlite-vec==0.1.9"]  # sqlite-vec: semantic session search tests  # starlette: CVE-2026-48710; setuptools: latest <82 (torch >=2.11 caps setuptools<82)
 messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", "aiohttp==3.14.1", "brotlicffi==1.2.0.1", "slack-bolt==1.29.0", "slack-sdk==3.43.0", "qrcode==7.4.2"]  # aiohttp 3.14.1: CVE-2026-34513/34518/34519/34520/34525 + 34993(RCE)/47265
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt==1.29.0", "slack-sdk==3.43.0", "aiohttp==3.14.1"]
@@ -224,6 +224,11 @@ mistral = ["mistralai==2.4.8"]
 bedrock = ["boto3==1.42.89"]
 vertex = ["google-auth==2.55.1"]
 azure-identity = ["azure-identity==1.25.3"]
+# Semantic session search — sqlite-vec powers the vector half of hybrid
+# session_search retrieval (config: session_search.semantic). Also
+# lazy-installable at runtime via tools/lazy_deps.py ("tool.session_semantic");
+# keep the pin in sync there.
+semantic-search = ["sqlite-vec==0.1.9"]
 termux = [
   # Baseline Android / Termux path for reliable fresh installs.
   "python-telegram-bot[webhooks]==22.6",

--- a/scripts/backfill_session_embeddings.py
+++ b/scripts/backfill_session_embeddings.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""One-time embedding backfill for semantic session search (#44075).
+
+Embeds every active user/assistant message in state.db that has no
+embedding yet, so past conversations become semantically searchable
+immediately instead of converging via the opportunistic per-search batch.
+
+Usage:
+    python scripts/backfill_session_embeddings.py [--db PATH] [--batch-size N]
+
+Requires ``session_search.semantic: true`` plus a working embedding
+provider in config.yaml (see DEFAULT_CONFIG["session_search"]), and the
+sqlite-vec package (``pip install hermes-agent[semantic-search]`` or let
+lazy-install pull it).
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+# Allow running straight from a checkout: scripts/ is not a package.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--db", type=Path, default=None,
+        help="Path to state.db (default: the active profile's database)",
+    )
+    parser.add_argument(
+        "--batch-size", type=int, default=64,
+        help="Messages embedded per provider call (default: 64)",
+    )
+    args = parser.parse_args()
+
+    from hermes_state import DEFAULT_DB_PATH, SessionDB
+    from tools.session_semantic import (
+        backfill,
+        get_semantic_config,
+        semantic_enabled,
+        _ensure_sqlite_vec,
+    )
+
+    db_path = args.db or DEFAULT_DB_PATH
+    if not Path(db_path).exists():
+        print(f"No database at {db_path}", file=sys.stderr)
+        return 1
+
+    cfg = get_semantic_config()
+    if not semantic_enabled(cfg):
+        print(
+            "session_search.semantic is disabled in config.yaml — enable it "
+            "first so searches actually use the embeddings:\n\n"
+            "  session_search:\n    semantic: true\n",
+            file=sys.stderr,
+        )
+        return 1
+    if not _ensure_sqlite_vec():
+        print(
+            "sqlite-vec is not installed and could not be lazy-installed. "
+            "Run: pip install 'hermes-agent[semantic-search]'",
+            file=sys.stderr,
+        )
+        return 1
+
+    db = SessionDB(db_path)
+    if not db.vector_search_available():
+        print(
+            "sqlite-vec extension failed to load on this Python build "
+            "(sqlite3 compiled without extension support?).",
+            file=sys.stderr,
+        )
+        return 1
+
+    pending = len(db.get_unembedded_messages(cfg["embedding_model"], limit=1_000_000))
+    print(f"Model: {cfg['embedding_model']}")
+    print(f"Pending messages: {pending}")
+    if pending == 0:
+        print("Nothing to do.")
+        return 0
+
+    def progress(done: int) -> None:
+        print(f"  embedded {done}/{pending}", flush=True)
+
+    total = backfill(db, cfg, batch_size=args.batch_size, progress=progress)
+    print(f"Done — embedded {total} messages.")
+    if total < pending:
+        print(
+            f"Warning: {pending - total} messages were not embedded "
+            "(provider failure mid-run?). Re-run to resume.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -68,6 +68,7 @@ def test_lazy_installable_extras_excluded_from_all():
         "honcho", "hindsight",
         "supermemory", "mem0",
         "mistral",  # mistralai — Voxtral STT/TTS, lazy-installed (stt.mistral / tts.mistral)
+        "semantic-search",  # sqlite-vec — lazy-installed (tool.session_semantic)
     }
     all_extra_specs = optional_dependencies["all"]
     for extra in lazy_covered_extras:

--- a/tests/tools/test_session_semantic.py
+++ b/tests/tools/test_session_semantic.py
@@ -1,0 +1,328 @@
+"""Tests for hybrid semantic session search (#44075).
+
+Layers covered:
+  - rrf_merge / serialize_f32 — pure functions, no deps
+  - message_embeddings schema — plain table + invalidation triggers,
+    works without sqlite-vec
+  - vector KNN + hybrid end-to-end — require the sqlite-vec extension;
+    skipped when it is not installed or the sqlite3 build cannot load
+    extensions
+
+No live network anywhere: embedding calls are faked with deterministic
+topic-axis vectors.
+"""
+import json
+import re
+import struct
+import time
+
+import pytest
+
+from hermes_state import SessionDB
+import tools.session_semantic as session_semantic
+from tools.session_semantic import rrf_merge, serialize_f32
+from tools.session_search_tool import session_search
+
+
+@pytest.fixture
+def db(tmp_path):
+    return SessionDB(tmp_path / "state.db")
+
+
+def _require_sqlite_vec(db):
+    if not db.vector_search_available():
+        pytest.skip("sqlite-vec extension not available")
+
+
+# A tiny deterministic "embedding space": each axis counts vocabulary hits
+# for one topic, so cosine distance clusters paraphrases without a network
+# call. Axis 3 is the catch-all so no vector is all-zero.
+_TOPIC_AXES = (
+    {"smart", "home", "tuya", "bardi", "bulb", "bulbs", "lights"},
+    {"hr", "talenta", "clock", "attendance", "payroll"},
+    {"modpack", "minecraft", "neoforge", "quest"},
+)
+
+
+def fake_embed_texts(texts, cfg=None):
+    out = []
+    for text in texts:
+        words = set(re.findall(r"\w+", text.lower()))
+        vec = [float(len(words & axis)) for axis in _TOPIC_AXES] + [0.0]
+        if not any(vec):
+            vec[3] = 1.0
+        out.append(serialize_f32(vec))
+    return out
+
+
+_ENABLED_CFG = {
+    "semantic": True,
+    "embedding_provider": "",
+    "embedding_model": "fake-embed",
+    "embedding_base_url": "",
+    "embedding_api_key": "",
+    "hybrid_weight_vector": 0.7,
+    "hybrid_weight_bm25": 0.3,
+    "min_similarity": 0.25,
+    "index_batch_size": 96,
+}
+
+
+def _seed_smart_home_sessions(db):
+    """One session about Tuya bulbs (no 'smart home' wording), one about HR."""
+    now = int(time.time())
+    db.create_session("s_bulbs", source="cli")
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, title = ? WHERE id = ?",
+        (now - 20000, "Bardi bulb setup", "s_bulbs"),
+    )
+    db.append_message("s_bulbs", role="user", content="Set up my Bardi Tuya bulbs")
+    db.append_message("s_bulbs", role="assistant", content="Paired both Tuya bulbs and added schedules.")
+
+    db.create_session("s_hr", source="cli")
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, title = ? WHERE id = ?",
+        (now - 10000, "Talenta automation", "s_hr"),
+    )
+    db.append_message("s_hr", role="user", content="Automate Talenta clock attendance")
+    db.append_message("s_hr", role="assistant", content="Talenta clock automation scripted.")
+    db._conn.commit()
+
+
+# =========================================================================
+# Pure functions
+# =========================================================================
+
+class TestSerializeF32:
+    def test_roundtrip(self):
+        vec = [0.25, -1.5, 3.0]
+        blob = serialize_f32(vec)
+        assert len(blob) == 12
+        assert list(struct.unpack("<3f", blob)) == vec
+
+
+class TestRRFMerge:
+    def test_dedupes_and_tags_both(self):
+        fts = [{"id": 1, "snippet": ">>>hit<<<"}, {"id": 2, "snippet": "b"}]
+        vec = [{"id": 1, "snippet": "plain"}, {"id": 3, "snippet": "c"}]
+        merged = rrf_merge(fts, vec, weight_bm25=0.5, weight_vector=0.5)
+        by_id = {row["id"]: row for row in merged}
+        assert set(by_id) == {1, 2, 3}
+        assert by_id[1]["match_type"] == "both"
+        assert by_id[2]["match_type"] == "keyword"
+        assert by_id[3]["match_type"] == "semantic"
+        # FTS row wins field content on dedupe — keeps the highlighted snippet
+        assert by_id[1]["snippet"] == ">>>hit<<<"
+        # A row in both lists outranks single-source rows
+        assert merged[0]["id"] == 1
+
+    def test_weights_bias_ranking(self):
+        fts = [{"id": 10}]
+        vec = [{"id": 20}]
+        vec_heavy = rrf_merge(fts, vec, weight_bm25=0.1, weight_vector=0.9)
+        assert vec_heavy[0]["id"] == 20
+        bm25_heavy = rrf_merge(fts, vec, weight_bm25=0.9, weight_vector=0.1)
+        assert bm25_heavy[0]["id"] == 10
+
+    def test_empty_inputs(self):
+        assert rrf_merge([], [], 0.3, 0.7) == []
+        only_vec = rrf_merge([], [{"id": 5}], 0.3, 0.7)
+        assert only_vec[0]["match_type"] == "semantic"
+
+
+# =========================================================================
+# Schema: plain table + triggers (no sqlite-vec needed)
+# =========================================================================
+
+class TestEmbeddingSchema:
+    def test_upsert_and_count(self, db):
+        db.create_session("s1", source="cli")
+        mid = db.append_message("s1", role="user", content="hello world")
+        written = db.upsert_message_embeddings(
+            [(mid, "fake-embed", 4, serialize_f32([1, 0, 0, 0]))]
+        )
+        assert written == 1
+        assert db.count_message_embeddings() == 1
+        assert db.count_message_embeddings("fake-embed") == 1
+        assert db.count_message_embeddings("other-model") == 0
+        # Replace, not duplicate
+        db.upsert_message_embeddings(
+            [(mid, "fake-embed", 4, serialize_f32([0, 1, 0, 0]))]
+        )
+        assert db.count_message_embeddings() == 1
+
+    def test_unembedded_selection(self, db):
+        db.create_session("s1", source="cli")
+        m1 = db.append_message("s1", role="user", content="first")
+        db.append_message("s1", role="tool", content="tool output", tool_name="t")
+        db.append_message("s1", role="user", content="   ")
+        m4 = db.append_message("s1", role="assistant", content="second")
+
+        pending = db.get_unembedded_messages("fake-embed", limit=10)
+        # Tool role and whitespace-only content excluded; newest first
+        assert [row["id"] for row in pending] == [m4, m1]
+
+        db.upsert_message_embeddings([(m4, "fake-embed", 4, serialize_f32([1, 0, 0, 0]))])
+        assert [r["id"] for r in db.get_unembedded_messages("fake-embed", limit=10)] == [m1]
+        # A different model still sees both rows as pending
+        assert len(db.get_unembedded_messages("other-model", limit=10)) == 2
+
+    def test_delete_trigger_removes_embedding(self, db):
+        db.create_session("s1", source="cli")
+        mid = db.append_message("s1", role="user", content="ephemeral")
+        db.upsert_message_embeddings([(mid, "fake-embed", 4, serialize_f32([1, 0, 0, 0]))])
+        db._conn.execute("DELETE FROM messages WHERE id = ?", (mid,))
+        db._conn.commit()
+        assert db.count_message_embeddings() == 0
+
+    def test_content_update_invalidates_embedding(self, db):
+        db.create_session("s1", source="cli")
+        mid = db.append_message("s1", role="user", content="original")
+        db.upsert_message_embeddings([(mid, "fake-embed", 4, serialize_f32([1, 0, 0, 0]))])
+        db._conn.execute("UPDATE messages SET content = 'edited' WHERE id = ?", (mid,))
+        db._conn.commit()
+        assert db.count_message_embeddings() == 0
+        # Non-content updates (e.g. rewind toggling active) keep the embedding
+        mid2 = db.append_message("s1", role="user", content="kept")
+        db.upsert_message_embeddings([(mid2, "fake-embed", 4, serialize_f32([1, 0, 0, 0]))])
+        db._conn.execute("UPDATE messages SET active = 0 WHERE id = ?", (mid2,))
+        db._conn.commit()
+        assert db.count_message_embeddings() == 1
+
+
+# =========================================================================
+# Fallback gating — hybrid_search must return None (FTS-only behaviour)
+# =========================================================================
+
+class TestFallbackGating:
+    def test_disabled_by_default(self, db):
+        # Fresh HERMES_HOME (autouse fixture) → default config → semantic off
+        assert session_semantic.hybrid_search(db, query="anything") is None
+
+    def test_empty_query(self, db, monkeypatch):
+        monkeypatch.setattr(session_semantic, "get_semantic_config", lambda: dict(_ENABLED_CFG))
+        assert session_semantic.hybrid_search(db, query="   ") is None
+
+    def test_sqlite_vec_missing(self, db, monkeypatch):
+        monkeypatch.setattr(session_semantic, "get_semantic_config", lambda: dict(_ENABLED_CFG))
+        monkeypatch.setattr(session_semantic, "_ensure_sqlite_vec", lambda: False)
+        assert session_semantic.hybrid_search(db, query="smart home") is None
+
+    def test_embedding_failure(self, db, monkeypatch):
+        monkeypatch.setattr(session_semantic, "get_semantic_config", lambda: dict(_ENABLED_CFG))
+        monkeypatch.setattr(session_semantic, "_ensure_sqlite_vec", lambda: True)
+        monkeypatch.setattr(db.__class__, "vector_search_available", lambda self: True)
+        monkeypatch.setattr(session_semantic, "embed_texts", lambda texts, cfg=None: None)
+        assert session_semantic.hybrid_search(db, query="smart home") is None
+
+    def test_discover_falls_back_to_fts(self, db):
+        """With semantic off, the tool answers exactly like before (search_mode fts)."""
+        _seed_smart_home_sessions(db)
+        result = json.loads(session_search(query="Tuya", db=db))
+        assert result["success"] is True
+        assert result["search_mode"] == "fts"
+        assert result["count"] == 1
+
+    def test_index_pending_survives_readonly_db(self, monkeypatch):
+        """Cross-profile DBs open read-only; indexing must not raise."""
+        monkeypatch.setattr(session_semantic, "embed_texts", fake_embed_texts)
+        import sqlite3
+
+        class _RoDB:
+            def get_unembedded_messages(self, model, limit=128, roles=("user", "assistant")):
+                return [{"id": 1, "content": "tuya bulbs"}]
+
+            def upsert_message_embeddings(self, rows):
+                raise sqlite3.OperationalError("attempt to write a readonly database")
+
+        assert session_semantic.index_pending(_RoDB(), dict(_ENABLED_CFG)) == 0
+
+
+# =========================================================================
+# Vector KNN + hybrid end-to-end (need sqlite-vec)
+# =========================================================================
+
+class TestVectorSearch:
+    def test_knn_orders_by_cosine_distance(self, db):
+        _require_sqlite_vec(db)
+        _seed_smart_home_sessions(db)
+        monkeypatch_rows = db.get_unembedded_messages("fake-embed", limit=50)
+        blobs = fake_embed_texts([r["content"] for r in monkeypatch_rows])
+        db.upsert_message_embeddings(
+            [(r["id"], "fake-embed", 4, b) for r, b in zip(monkeypatch_rows, blobs)]
+        )
+
+        query_blob = fake_embed_texts(["what did we do about smart home lights"])[0]
+        rows = db.search_messages_by_vector(query_blob, model="fake-embed", dim=4, limit=10)
+        assert rows, "expected vector hits"
+        assert rows[0]["session_id"] == "s_bulbs"
+        assert rows[0]["distance"] < rows[-1]["distance"] or len(rows) == 1
+        assert "snippet" in rows[0] and "content" not in rows[0]
+
+        # Model/dim mismatch returns nothing instead of erroring
+        assert db.search_messages_by_vector(query_blob, model="other", dim=4) == []
+        assert db.search_messages_by_vector(serialize_f32([1.0]), model="fake-embed", dim=1) == []
+
+    def test_role_and_source_filters(self, db):
+        _require_sqlite_vec(db)
+        _seed_smart_home_sessions(db)
+        rows = db.get_unembedded_messages("fake-embed", limit=50)
+        blobs = fake_embed_texts([r["content"] for r in rows])
+        db.upsert_message_embeddings(
+            [(r["id"], "fake-embed", 4, b) for r, b in zip(rows, blobs)]
+        )
+        query_blob = fake_embed_texts(["tuya bulbs"])[0]
+        user_only = db.search_messages_by_vector(
+            query_blob, model="fake-embed", dim=4, role_filter=["user"], limit=10
+        )
+        assert user_only and all(r["role"] == "user" for r in user_only)
+        excluded = db.search_messages_by_vector(
+            query_blob, model="fake-embed", dim=4, exclude_sources=["cli"], limit=10
+        )
+        assert excluded == []
+
+
+class TestHybridEndToEnd:
+    @pytest.fixture
+    def semantic_db(self, db, monkeypatch):
+        _require_sqlite_vec(db)
+        _seed_smart_home_sessions(db)
+        monkeypatch.setattr(session_semantic, "get_semantic_config", lambda: dict(_ENABLED_CFG))
+        monkeypatch.setattr(session_semantic, "embed_texts", fake_embed_texts)
+        return db
+
+    def test_semantic_recall_without_keyword_overlap(self, semantic_db):
+        """The motivating case from #44075: 'smart home' finds the Tuya
+        bulbs session even though no message contains those words."""
+        merged = session_semantic.hybrid_search(semantic_db, query="smart home")
+        assert merged, "hybrid search returned no rows"
+        assert merged[0]["session_id"] == "s_bulbs"
+        assert merged[0]["match_type"] == "semantic"
+
+    def test_keyword_and_semantic_agree(self, semantic_db):
+        merged = session_semantic.hybrid_search(semantic_db, query="Tuya bulbs")
+        assert merged[0]["session_id"] == "s_bulbs"
+        assert merged[0]["match_type"] == "both"
+
+    def test_opportunistic_indexing_runs_on_search(self, semantic_db):
+        assert semantic_db.count_message_embeddings() == 0
+        session_semantic.hybrid_search(semantic_db, query="smart home")
+        assert semantic_db.count_message_embeddings("fake-embed") == 4
+
+    def test_discover_tool_reports_hybrid(self, semantic_db):
+        result = json.loads(session_search(query="smart home", db=semantic_db))
+        assert result["success"] is True
+        assert result["search_mode"] == "hybrid"
+        assert result["count"] == 1
+        assert result["results"][0]["session_id"] == "s_bulbs"
+        assert result["results"][0]["match_type"] == "semantic"
+
+    def test_sort_newest_biases_time(self, semantic_db):
+        # Both sessions hit (hr via keyword-ish vocab? no — use a query
+        # touching both topics) and newest-first ordering applies.
+        merged = session_semantic.hybrid_search(
+            semantic_db, query="tuya bulbs talenta clock", sort="newest"
+        )
+        assert len(merged) >= 2
+        timestamps = [row.get("timestamp") or 0 for row in merged]
+        assert timestamps == sorted(timestamps, reverse=True)

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -242,6 +242,10 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     ),
     # HF Agent Trace Viewer upload (hermes trace upload / /upload-trace).
     "tool.trace_upload": ("huggingface-hub==1.2.3",),
+    # Semantic session search — sqlite-vec powers the vector half of hybrid
+    # BM25 + cosine retrieval (config: session_search.semantic). Matches the
+    # ``semantic-search`` extra in pyproject.toml; keep the pin in sync there.
+    "tool.session_semantic": ("sqlite-vec==0.1.9",),
 }
 
 

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -656,25 +656,56 @@ def _discover(
     current_session_id: str = None,
     link_profile: str = None,
 ) -> str:
-    """Discovery shape: FTS5 + anchored window + bookends per hit. Single call."""
+    """Discovery shape: FTS5 + hybrid (BM25 + vector) + anchored window + bookends per hit.
+
+    When ``session_search.semantic`` is enabled and the vector extension is
+    available, this first tries hybrid BM25 + vector retrieval via
+    :func:`~tools.session_semantic.hybrid_search`. If hybrid is unavailable
+    (disabled, missing sqlite-vec, no provider), it falls back to the existing
+    FTS5-only path, preserving current behavior exactly.
+    """
     role_list = role_filter if role_filter else ["user", "assistant"]
     current_lineage_root = _resolve_lineage(db, current_session_id) if current_session_id else None
     title_result = _title_match_result(db, query, current_lineage_root)
 
+    # Hybrid (BM25 + vector) search — returns None when unavailable, in which
+    # case the FTS5-only fallback runs below.
+    raw_results = None
+    search_mode = "fts"
     try:
-        raw_results = db.search_messages(
+        from tools.session_semantic import hybrid_search
+        hybrid_results = hybrid_search(
+            db,
             query=query,
             role_filter=role_list,
             exclude_sources=list(_HIDDEN_SESSION_SOURCES),
-            limit=_DISCOVER_SCAN_LIMIT,  # widen so dedup-by-lineage can find
-            # distinct sessions AND so interactive matches buried under a wall
-            # of cron rows are still in hand for the demotion pass below.
-            offset=0,
+            limit=_DISCOVER_SCAN_LIMIT,
             sort=sort,
         )
+        if hybrid_results is not None:
+            raw_results = hybrid_results
+            search_mode = "hybrid"
     except Exception as e:
-        logging.error("FTS5 search failed: %s", e, exc_info=True)
-        return tool_error(f"Search failed: {e}", success=False)
+        logging.warning(
+            "Hybrid search failed; falling back to FTS5: %s", e, exc_info=True
+        )
+        raw_results = None
+
+    if raw_results is None:
+        try:
+            raw_results = db.search_messages(
+                query=query,
+                role_filter=role_list,
+                exclude_sources=list(_HIDDEN_SESSION_SOURCES),
+                limit=_DISCOVER_SCAN_LIMIT,  # widen so dedup-by-lineage can find
+                # distinct sessions AND so interactive matches buried under a wall
+                # of cron rows are still in hand for the demotion pass below.
+                offset=0,
+                sort=sort,
+            )
+        except Exception as e:
+            logging.error("FTS5 search failed: %s", e, exc_info=True)
+            return tool_error(f"Search failed: {e}", success=False)
 
     # Demote automation (cron) rows below interactive ones before dedup, so a
     # high-volume cron corpus can't starve the user's own sessions out of the
@@ -686,6 +717,7 @@ def _discover(
         _empty_payload = {
             "success": True,
             "mode": "discover",
+            "search_mode": search_mode,
             "query": query,
             "results": [],
             "count": 0,
@@ -787,6 +819,8 @@ def _discover(
         }
         if lineage_root and lineage_root != hit_sid:
             entry["parent_session_id"] = lineage_root
+        if match_info.get("match_type"):
+            entry["match_type"] = match_info["match_type"]
         results.append(entry)
 
     for entry in results:
@@ -795,6 +829,7 @@ def _discover(
     _final_payload = {
         "success": True,
         "mode": "discover",
+        "search_mode": search_mode,
         "query": query,
         "results": results,
         "count": len(results),

--- a/tools/session_semantic.py
+++ b/tools/session_semantic.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""
+Semantic (hybrid BM25 + vector) retrieval for session_search — #44075.
+
+FTS5 keyword search only finds past conversations when the query shares
+exact words with them ("smart home" never finds the Tuya-bulbs session).
+This module adds an optional vector half:
+
+    query ──► embedding ──► cosine KNN over message_embeddings (sqlite-vec)
+          └─► FTS5 BM25 (existing search_messages)
+                          └─► weighted Reciprocal Rank Fusion ──► ranked rows
+
+Everything is opt-in and degrades to the existing FTS5-only behaviour:
+``hybrid_search()`` returns ``None`` — caller falls back — whenever
+
+  - ``session_search.semantic`` is false in config.yaml (the default),
+  - sqlite-vec is not installed and cannot be lazy-installed,
+  - no embedding provider resolves, or
+  - the embedding call fails (network, auth, unsupported endpoint).
+
+Embeddings are generated outside the message-write hot path: a bounded
+batch of pending messages is embedded opportunistically per search call
+(``index_pending``), and ``scripts/backfill_session_embeddings.py`` does
+the one-time full backfill. Embedding providers reuse the auxiliary
+provider resolution (any OpenAI-compatible ``/embeddings`` endpoint).
+"""
+
+import logging
+import struct
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Defaults mirrored in hermes_cli/config.py DEFAULT_CONFIG["session_search"].
+_DEFAULTS: Dict[str, Any] = {
+    "semantic": False,
+    "embedding_provider": "",          # "" = auto-detect via provider chain
+    "embedding_model": "text-embedding-3-small",
+    "embedding_base_url": "",          # direct OpenAI-compatible endpoint
+    "embedding_api_key": "",           # key for embedding_base_url
+    "hybrid_weight_vector": 0.7,
+    "hybrid_weight_bm25": 0.3,
+    "min_similarity": 0.25,            # drop vector hits below this cosine similarity
+    "index_batch_size": 96,            # pending messages embedded per search
+}
+
+# Embedding endpoints reject over-long inputs (text-embedding-3-* caps at
+# 8191 tokens). Truncating loses tail content of giant messages but keeps
+# the request valid; the FTS5 half still matches the full text.
+_MAX_EMBED_CHARS = 8000
+
+_RRF_K = 60  # standard reciprocal-rank-fusion damping constant
+
+# Warn-once flags so a misconfigured provider logs one line per process,
+# not one per search call.
+_warned_no_client = False
+_warned_embed_failed = False
+
+_client_cache: Dict[tuple, Any] = {}
+
+
+def get_semantic_config() -> Dict[str, Any]:
+    """``session_search`` section of config.yaml merged over defaults."""
+    cfg = dict(_DEFAULTS)
+    try:
+        from hermes_cli.config import load_config_readonly
+        section = load_config_readonly().get("session_search") or {}
+        if isinstance(section, dict):
+            for key in cfg:
+                if section.get(key) is not None and key in section:
+                    cfg[key] = section[key]
+    except Exception as exc:
+        logger.debug("Could not load session_search config: %s", exc)
+    return cfg
+
+
+def semantic_enabled(cfg: Optional[Dict[str, Any]] = None) -> bool:
+    cfg = cfg or get_semantic_config()
+    return bool(cfg.get("semantic"))
+
+
+def _ensure_sqlite_vec() -> bool:
+    """Import sqlite-vec, lazy-installing it if the user allows that."""
+    try:
+        import sqlite_vec  # noqa: F401
+        return True
+    except ImportError:
+        pass
+    try:
+        from tools.lazy_deps import ensure
+        # prompt=False: never raise a blocking input() prompt mid-session.
+        ensure("tool.session_semantic", prompt=False)
+        import sqlite_vec  # noqa: F401
+        return True
+    except Exception as exc:
+        logger.debug("sqlite-vec unavailable: %s", exc)
+        return False
+
+
+def _get_embedding_client(cfg: Dict[str, Any]):
+    """Resolve an OpenAI-compatible client exposing ``.embeddings``.
+
+    Reuses the auxiliary provider router; an explicit
+    ``embedding_base_url``/``embedding_api_key`` pair takes precedence over
+    the named provider, matching the auxiliary.<task> slot convention.
+    Returns None when nothing resolves (caller falls back to FTS-only).
+    """
+    cache_key = (
+        cfg.get("embedding_provider") or "auto",
+        cfg.get("embedding_model"),
+        cfg.get("embedding_base_url") or "",
+    )
+    if cache_key in _client_cache:
+        return _client_cache[cache_key]
+
+    client = None
+    try:
+        from agent.auxiliary_client import resolve_provider_client
+        # Empty strings mean "unset" — resolve_provider_client truthy-checks
+        # both explicit_* params, so "" routes the same as None.
+        client, _model = resolve_provider_client(
+            str(cfg.get("embedding_provider") or "auto"),
+            model=str(cfg.get("embedding_model") or ""),
+            explicit_base_url=str(cfg.get("embedding_base_url") or ""),
+            explicit_api_key=str(cfg.get("embedding_api_key") or ""),
+        )
+    except Exception as exc:
+        logger.debug("Embedding provider resolution failed: %s", exc)
+    # Codex/Responses adapters only expose chat completions — an embeddings
+    # endpoint is mandatory here.
+    if client is not None and not hasattr(client, "embeddings"):
+        logger.debug(
+            "Resolved provider client has no embeddings endpoint; "
+            "semantic session search needs an OpenAI-compatible /embeddings."
+        )
+        client = None
+    _client_cache[cache_key] = client
+    return client
+
+
+def serialize_f32(vector: List[float]) -> bytes:
+    """Pack a float list into the little-endian float32 BLOB sqlite-vec reads."""
+    return struct.pack(f"<{len(vector)}f", *vector)
+
+
+def embed_texts(
+    texts: List[str], cfg: Optional[Dict[str, Any]] = None
+) -> Optional[List[bytes]]:
+    """Embed texts, returning float32 BLOBs in input order, or None on any
+    failure (missing provider, network error, unsupported endpoint)."""
+    global _warned_no_client, _warned_embed_failed
+    if not texts:
+        return []
+    cfg = cfg or get_semantic_config()
+    client = _get_embedding_client(cfg)
+    if client is None:
+        if not _warned_no_client:
+            _warned_no_client = True
+            logger.warning(
+                "session_search.semantic is enabled but no embedding provider "
+                "resolved — falling back to keyword-only search. Configure "
+                "session_search.embedding_provider or embedding_base_url."
+            )
+        return None
+    try:
+        response = client.embeddings.create(
+            model=cfg["embedding_model"],
+            input=[t[:_MAX_EMBED_CHARS] for t in texts],
+        )
+        ordered = sorted(response.data, key=lambda d: d.index)
+        if len(ordered) != len(texts):
+            raise ValueError(
+                f"embedding count mismatch: sent {len(texts)}, got {len(ordered)}"
+            )
+        return [serialize_f32(d.embedding) for d in ordered]
+    except Exception as exc:
+        if not _warned_embed_failed:
+            _warned_embed_failed = True
+            logger.warning(
+                "Embedding call failed (%s) — session search falling back to "
+                "keyword-only. Further failures logged at debug level.", exc
+            )
+        else:
+            logger.debug("Embedding call failed: %s", exc)
+        return None
+
+
+def index_pending(
+    db,
+    cfg: Optional[Dict[str, Any]] = None,
+    budget: Optional[int] = None,
+) -> int:
+    """Embed up to ``budget`` messages that have no embedding yet.
+
+    Returns rows written. Read-only DB handles (cross-profile search opens
+    other profiles' state.db with mode=ro) make the upsert fail — that is
+    swallowed so searching existing embeddings still works.
+    """
+    cfg = cfg or get_semantic_config()
+    model = cfg["embedding_model"]
+    limit = budget if budget is not None else int(cfg["index_batch_size"])
+    if limit <= 0:
+        return 0
+    rows = db.get_unembedded_messages(model, limit=limit)
+    if not rows:
+        return 0
+    blobs = embed_texts([r["content"] for r in rows], cfg)
+    if blobs is None:
+        return 0
+    payload = []
+    for row, blob in zip(rows, blobs):
+        dim = len(blob) // 4
+        if dim:
+            payload.append((row["id"], model, dim, blob))
+    try:
+        return db.upsert_message_embeddings(payload)
+    except Exception as exc:
+        logger.debug("Embedding upsert skipped (read-only DB?): %s", exc)
+        return 0
+
+
+def rrf_merge(
+    fts_rows: List[Dict[str, Any]],
+    vector_rows: List[Dict[str, Any]],
+    weight_bm25: float,
+    weight_vector: float,
+    k: int = _RRF_K,
+) -> List[Dict[str, Any]]:
+    """Weighted Reciprocal Rank Fusion of two ranked result lists.
+
+    score(msg) = w_bm25 / (k + rank_fts) + w_vec / (k + rank_vec)
+
+    Rank-based fusion sidesteps normalising BM25 (unbounded, lower=better
+    via FTS5 ``rank``) against cosine distance — the two scales never meet.
+    Rows are deduped by message id; the FTS row wins ties for field content
+    (it carries the highlighted snippet) and each surviving row is annotated
+    with ``match_type``: "keyword", "semantic", or "both".
+    """
+    scores: Dict[Any, float] = {}
+    merged: Dict[Any, Dict[str, Any]] = {}
+    sources: Dict[Any, set] = {}
+
+    for rank, row in enumerate(fts_rows):
+        mid = row.get("id")
+        scores[mid] = scores.get(mid, 0.0) + weight_bm25 / (k + rank + 1)
+        merged.setdefault(mid, row)
+        sources.setdefault(mid, set()).add("keyword")
+
+    for rank, row in enumerate(vector_rows):
+        mid = row.get("id")
+        scores[mid] = scores.get(mid, 0.0) + weight_vector / (k + rank + 1)
+        merged.setdefault(mid, row)
+        sources.setdefault(mid, set()).add("semantic")
+
+    out = []
+    for mid, row in merged.items():
+        entry = dict(row)
+        kinds = sources[mid]
+        entry["match_type"] = "both" if len(kinds) == 2 else next(iter(kinds))
+        out.append((scores[mid], entry))
+    out.sort(key=lambda pair: pair[0], reverse=True)
+    return [entry for _score, entry in out]
+
+
+def hybrid_search(
+    db,
+    query: str,
+    role_filter: Optional[List[str]] = None,
+    exclude_sources: Optional[List[str]] = None,
+    limit: int = 20,
+    sort: Optional[str] = None,
+) -> Optional[List[Dict[str, Any]]]:
+    """Hybrid BM25 + vector search over session messages.
+
+    Returns merged rows shaped like ``SessionDB.search_messages()`` output,
+    or ``None`` whenever the semantic path is unavailable — the caller then
+    runs the existing FTS5-only search, preserving current behaviour
+    exactly.
+    """
+    cfg = get_semantic_config()
+    if not semantic_enabled(cfg):
+        return None
+    if not query or not query.strip():
+        return None
+    if not _ensure_sqlite_vec() or not db.vector_search_available():
+        return None
+
+    # Keep the index converging toward full coverage — bounded batch so a
+    # search is never blocked behind a deep-history backfill.
+    try:
+        index_pending(db, cfg)
+    except Exception as exc:
+        logger.debug("Opportunistic embedding indexing failed: %s", exc)
+
+    query_blobs = embed_texts([query.strip()], cfg)
+    if not query_blobs:
+        return None
+    query_blob = query_blobs[0]
+
+    fts_rows: List[Dict[str, Any]] = []
+    try:
+        fts_rows = db.search_messages(
+            query=query,
+            role_filter=role_filter,
+            exclude_sources=exclude_sources,
+            limit=limit,
+        )
+    except Exception as exc:
+        logger.warning("FTS half of hybrid search failed: %s", exc)
+
+    vector_rows = db.search_messages_by_vector(
+        query_blob,
+        model=cfg["embedding_model"],
+        dim=len(query_blob) // 4,
+        role_filter=role_filter,
+        exclude_sources=exclude_sources,
+        limit=limit,
+    )
+    # KNN always returns the nearest rows no matter how far they are — an
+    # off-topic database would answer every query. Keep only hits above the
+    # similarity floor so "no semantic match" stays expressible.
+    min_similarity = float(cfg.get("min_similarity", 0.25))
+    vector_rows = [
+        row for row in vector_rows
+        if (1.0 - (row.get("distance") or 0.0)) >= min_similarity
+    ]
+    if not vector_rows and not fts_rows:
+        return []
+
+    merged = rrf_merge(
+        fts_rows,
+        vector_rows,
+        weight_bm25=float(cfg["hybrid_weight_bm25"]),
+        weight_vector=float(cfg["hybrid_weight_vector"]),
+    )
+    # `sort` biases by time like the FTS-only path: timestamp primary,
+    # fused relevance (already the list order) as tiebreaker.
+    if sort in ("newest", "oldest"):
+        merged.sort(
+            key=lambda r: r.get("timestamp") or 0,
+            reverse=(sort == "newest"),
+        )
+    return merged[:limit]
+
+
+def backfill(
+    db,
+    cfg: Optional[Dict[str, Any]] = None,
+    batch_size: int = 64,
+    progress: Optional[Any] = None,
+) -> int:
+    """Embed every pending message in batches. Returns total rows embedded.
+
+    Used by scripts/backfill_session_embeddings.py; stops cleanly when the
+    provider starts failing (index_pending returns 0) rather than spinning.
+    """
+    cfg = cfg or get_semantic_config()
+    total = 0
+    while True:
+        written = index_pending(db, cfg, budget=batch_size)
+        if written == 0:
+            break
+        total += written
+        if progress is not None:
+            progress(total)
+    return total

--- a/uv.lock
+++ b/uv.lock
@@ -1596,6 +1596,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "ruff" },
     { name = "setuptools" },
+    { name = "sqlite-vec" },
     { name = "starlette" },
     { name = "ty" },
 ]
@@ -1668,6 +1669,9 @@ nemo-relay = [
 ]
 parallel-web = [
     { name = "parallel-web" },
+]
+semantic-search = [
+    { name = "sqlite-vec" },
 ]
 slack = [
     { name = "aiohttp" },
@@ -1841,6 +1845,8 @@ requires-dist = [
     { name = "slack-sdk", marker = "extra == 'messaging'", specifier = "==3.43.0" },
     { name = "slack-sdk", marker = "extra == 'slack'", specifier = "==3.43.0" },
     { name = "sounddevice", marker = "extra == 'voice'", specifier = "==0.5.5" },
+    { name = "sqlite-vec", marker = "extra == 'dev'", specifier = "==0.1.9" },
+    { name = "sqlite-vec", marker = "extra == 'semantic-search'", specifier = "==0.1.9" },
     { name = "starlette", marker = "extra == 'computer-use'", specifier = "==1.0.1" },
     { name = "starlette", marker = "extra == 'dev'", specifier = "==1.0.1" },
     { name = "starlette", marker = "extra == 'mcp'", specifier = "==1.0.1" },
@@ -1855,7 +1861,7 @@ requires-dist = [
     { name = "websockets", specifier = "==15.0.1" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "bedrock", "vertex", "azure-identity", "semantic-search", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
 
 [[package]]
 name = "hf-xet"
@@ -3976,6 +3982,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/94/df/de669c7054cd47c4439ac34b1b2ee8b804a794791fbb10720e997a2c87c7/sqlalchemy-2.0.51-cp313-cp313-win32.whl", hash = "sha256:b93ab07b5292dbe7e6b8da89475275e7042744283921344b56105f3eeb0f828b", size = 2117721, upload-time = "2026-06-15T16:23:12.36Z" },
     { url = "https://files.pythonhosted.org/packages/d0/8a/403c51d064196bae20a0bc2476577f83a3f8dd299719a97417086b7f2ec5/sqlalchemy-2.0.51-cp313-cp313-win_amd64.whl", hash = "sha256:0f053118c30e53161857a953e4de667d90e274980dccbe5dd3829bbbeece72a5", size = 2143615, upload-time = "2026-06-15T16:23:13.906Z" },
     { url = "https://files.pythonhosted.org/packages/e2/22/dbf013a12ec759e54a34a119e9e217435b3f71b2dd5c61a7ade0a25dae87/sqlalchemy-2.0.51-py3-none-any.whl", hash = "sha256:bb024d8b621d0be75f4f44ecc7c950450026e76d66dc8f791bb5331d7fed59d5", size = 1944334, upload-time = "2026-06-15T16:09:22.418Z" },
+]
+
+[[package]]
+name = "sqlite-vec"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/85/9fad0045d8e7c8df3e0fa5a56c630e8e15ad6e5ca2e6106fceb666aa6638/sqlite_vec-0.1.9-py3-none-macosx_10_6_x86_64.whl", hash = "sha256:1b62a7f0a060d9475575d4e599bbf94a13d85af896bc1ce86ee80d1b5b48e5fb", size = 131171, upload-time = "2026-03-31T08:02:31.717Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/3d/3677e0cd2f92e5ebc43cd29fbf565b75582bff1ccfa0b8327c7508e1084f/sqlite_vec-0.1.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1d52e30513bae4cc9778ddbf6145610434081be4c3afe57cd877893bad9f6b6c", size = 165434, upload-time = "2026-03-31T08:02:32.712Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d4/f2b936d3bdc38eadcbd2a87875815db36430fab0363182ba5d12cd8e0b51/sqlite_vec-0.1.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e921e592f24a5f9a18f590b6ddd530eb637e2d474e3b1972f9bbeb773aa3cb9", size = 160076, upload-time = "2026-03-31T08:02:33.796Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ad/6afd073b0f817b3e03f9e37ad626ae341805891f23c74b5292818f49ac63/sqlite_vec-0.1.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux1_x86_64.whl", hash = "sha256:1515727990b49e79bcaf75fdee2ffc7d461f8b66905013231251f1c8938e7786", size = 163388, upload-time = "2026-03-31T08:02:34.888Z" },
+    { url = "https://files.pythonhosted.org/packages/42/89/81b2907cda14e566b9bf215e2ad82fc9b349edf07d2010756ffdb902f328/sqlite_vec-0.1.9-py3-none-win_amd64.whl", hash = "sha256:4a28dc12fa4b53d7b1dced22da2488fade444e96b5d16fd2d698cd670675cf32", size = 292804, upload-time = "2026-03-31T08:02:36.035Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #44075

## What

`session_search` discovery is FTS5-keyword-only, so recall fails whenever the query doesn't share exact words with the past conversation ("what did we do about smart home" misses the Tuya-bulbs session). This adds the hybrid retrieval proposed in the issue:

```
query ─► embedding ─► cosine KNN over message_embeddings (sqlite-vec)
      └► FTS5 BM25 (existing search_messages, unchanged)
                     └► weighted reciprocal rank fusion ─► ranked rows
```

Opt-in via a new top-level config block (default **off** — zero behavior change until enabled):

```yaml
session_search:
  semantic: true
  embedding_provider: ""            # "" = auto via the aux provider chain
  embedding_model: text-embedding-3-small
  embedding_base_url: ""            # direct OpenAI-compatible endpoint (local fastembed/ollama)
  embedding_api_key: ""
  hybrid_weight_vector: 0.7
  hybrid_weight_bm25: 0.3
  min_similarity: 0.25              # KNN relevance floor
  index_batch_size: 96
```

## Design decisions

- **Plain table, not vec0.** Embeddings are float32 BLOBs in a regular `message_embeddings` table (declarative `SCHEMA_SQL`, no version-gated migration); KNN uses sqlite-vec's `vec_distance_cosine()` scalar function. A vec0 virtual table would error on every connection that doesn't load the extension — older installs, read-only cross-profile DBs, sqlite3 builds without `enable_load_extension`. With a plain table those connections are untouched. SQL triggers drop embedding rows when a message is deleted or its content edited.
- **No network in the message-write hot path.** Instead of embed-on-insert, a bounded batch of pending messages (newest first) is embedded opportunistically per search call, and `scripts/backfill_session_embeddings.py` does the one-time full backfill the issue asks for. Model/dim are stored per row, so switching embedding models re-indexes cleanly instead of crashing the distance function.
- **Provider reuse.** Embedding clients come from the existing `resolve_provider_client()` router (any OpenAI-compatible `/embeddings` endpoint), with `embedding_base_url`/`embedding_api_key` direct overrides matching the `auxiliary.<task>` slot convention.
- **Weighted RRF, not score normalisation.** BM25 rank (unbounded, lower=better) and cosine distance never share a scale; reciprocal rank fusion with the issue's configured weights is robust to both. A `min_similarity` floor keeps KNN from "matching" every query with the nearest off-topic rows. `sort=newest/oldest` still applies time-primary ordering with fused relevance as tiebreaker.
- **Graceful fallback everywhere.** `semantic: false`, sqlite-vec missing (lazy-installable as `tool.session_semantic`, mirrored in the `[semantic-search]` extra), no provider resolving, or a failed embedding call → `hybrid_search()` returns `None` and the existing FTS5-only path runs verbatim. The tool response now reports `search_mode: fts|hybrid` and per-result `match_type: keyword|semantic|both` so you can see which half found a hit.

## Narrow-waist note

No new model tool and no tool-schema growth — this rides inside the existing `session_search` discovery shape, so nothing changes on the per-call API surface, and per-conversation prompt caching is unaffected.

## Tests

`tests/tools/test_session_semantic.py` — 21 tests, no live network (embeddings faked with deterministic topic-axis vectors):
- `rrf_merge`/`serialize_f32` pure-function tests
- schema/trigger tests that run without sqlite-vec
- vector KNN + hybrid end-to-end (the motivating case: "smart home" finds the Tuya-bulbs session with `match_type: semantic`), skipped cleanly when sqlite-vec can't load
- fallback gating: disabled config, missing extension, embedding failure, read-only profile DB

sqlite-vec is added to the `[dev]` extra (and `uv.lock`) so CI exercises the vector path. Regression suites pass: `test_session_search.py`, `test_state_db_malformed_repair.py`, `test_project_metadata.py`, `test_lazy_deps.py`, config validation/drift suites (`scripts/run_tests.sh`, 488 tests). `ruff` clean; only new `ty` diagnostics are `unresolved-import sqlite_vec`, the standard optional-dep class.

## Relation to other issues

This targets `session_search` only — it does not build the general embedding infrastructure of #675 or the memory system of #10355; the provider hookup is deliberately thin so it can later be swapped to a shared embedding layer if #675 lands.