### PR TITLE
fix(agent): catch RuntimeError from expanduser() in subdirectory hint loader

### DIFF
--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -144,7 +144,10 @@ class SubdirectoryHintTracker:
                 if parent == p:
                     break  # filesystem root
                 p = parent
-        except (OSError, ValueError):
+        except (OSError, ValueError, RuntimeError):
+            # RuntimeError: Path("~nonexistentuser/...").expanduser() raises it
+            # when the ~user passwd lookup fails. Hints are best-effort —
+            # skip the candidate rather than aborting the agent turn.
             pass
 
     def _extract_paths_from_command(self, cmd: str, candidates: Set[Path]):

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -291,6 +291,36 @@ class TestPermissionErrorHandling:
             assert result is None or isinstance(result, str)
 
 
+class TestExpanduserRuntimeError:
+    """Regression tests for RuntimeError from Path.expanduser() (ref #43963)."""
+
+    def test_add_path_candidate_unknown_user_tilde(self, tmp_path):
+        """~user for a non-existent account raises RuntimeError — must be swallowed."""
+        tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
+        candidates = set()
+        tracker._add_path_candidate("~hermes_no_such_user_43963/notes.md", candidates)
+        assert candidates == set()
+
+    def test_add_path_candidate_expanduser_runtimeerror(self, tmp_path):
+        """Same path with expanduser patched, independent of the host passwd db."""
+        tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
+        candidates = set()
+        with patch.object(
+            Path, "expanduser",
+            side_effect=RuntimeError("Could not determine home directory."),
+        ):
+            tracker._add_path_candidate("~foo/bar", candidates)
+        assert candidates == set()
+
+    def test_check_tool_call_survives_unknown_user_tilde_in_command(self, project):
+        """A ~nonexistentuser token in a terminal command must not abort the turn."""
+        tracker = SubdirectoryHintTracker(working_dir=str(project))
+        result = tracker.check_tool_call(
+            "terminal", {"command": "cat ~hermes_no_such_user_43963/config.yaml"}
+        )
+        assert result is None or isinstance(result, str)
+
+
 class TestOutsideWorkspaceRejection:
     """Direct tests for _is_valid_subdir rejecting outside-workspace paths."""
 


### PR DESCRIPTION
## Summary

`SubdirectoryHintTracker._add_path_candidate` wraps `Path(raw_path).expanduser()` in `except (OSError, ValueError)`, but `expanduser()` raises **`RuntimeError("Could not determine home directory.")`** when a `~user` token references a non-existent account (the `~user` form does a passwd lookup and ignores `$HOME`). The exception escaped `check_tool_call` and aborted the entire agent turn whenever a model emitted a path-like token such as `~foo/bar` in a tool-call argument — per the issue report, ~3×/24h on a long-running gateway.

The hint walk is purely advisory/best-effort, so the bad candidate is now skipped: the except tuple gains `RuntimeError`, with a comment explaining why.

The two other `except (OSError, ValueError)` sites in this module wrap `is_relative_to()`, not `expanduser()`, and are unaffected. The sibling call site in `hermes_cli/kanban_db.py` noted in the issue comments is already addressed by #44005.

Fixes #43963

## Testing

Added `TestExpanduserRuntimeError` with three regression tests:
- `_add_path_candidate` with a real `~nonexistentuser/...` token (exercises the actual passwd-lookup failure)
- same with `expanduser` patched to raise `RuntimeError`, independent of the host passwd db
- full `check_tool_call` with the token inside a `terminal` command

All three fail on `main` and pass with the fix; the full `tests/agent/test_subdirectory_hints.py` suite passes (28 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)