### PR TITLE
fix(api): continue compressed sessions for stateless clients

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1353,6 +1353,19 @@ class APIServerAdapter(BasePlatformAdapter):
             logger.warning("Failed to load session history for %s: %s", session_id, exc)
             return []
 
+    def _resolve_continuation_session_id(self, session_id: Optional[str]) -> Optional[str]:
+        """Map a stale compression parent id to the current continuation session."""
+        if not session_id:
+            return session_id
+        db = self._ensure_session_db()
+        if db is None:
+            return session_id
+        try:
+            return db.resolve_compression_continuation_session_id(session_id)
+        except Exception as exc:
+            logger.warning("Failed to resolve continuation session for %s: %s", session_id, exc)
+            return session_id
+
     async def _handle_list_sessions(self, request: "web.Request") -> "web.Response":
         """GET /api/sessions — list persisted Hermes sessions."""
         auth_err = self._check_auth(request)
@@ -1547,6 +1560,7 @@ class APIServerAdapter(BasePlatformAdapter):
         _, err = self._get_existing_session_or_404(session_id)
         if err:
             return err
+        session_id = self._resolve_continuation_session_id(session_id)
         body, err = await self._read_json_body(request)
         if err:
             return err
@@ -1591,6 +1605,7 @@ class APIServerAdapter(BasePlatformAdapter):
         _, err = self._get_existing_session_or_404(session_id)
         if err:
             return err
+        session_id = self._resolve_continuation_session_id(session_id)
         body, err = await self._read_json_body(request)
         if err:
             return err
@@ -1817,6 +1832,7 @@ class APIServerAdapter(BasePlatformAdapter):
             try:
                 db = self._ensure_session_db()
                 if db is not None:
+                    session_id = self._resolve_continuation_session_id(session_id)
                     history = db.get_messages_as_conversation(session_id)
             except Exception as e:
                 logger.warning("Failed to load session history for %s: %s", session_id, e)
@@ -2897,7 +2913,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Reuse session from previous_response_id chain so the dashboard
         # groups the entire conversation under one session entry.
-        session_id = stored_session_id or str(uuid.uuid4())
+        session_id = self._resolve_continuation_session_id(stored_session_id) if stored_session_id else str(uuid.uuid4())
 
         stream = _coerce_request_bool(body.get("stream"), default=False)
         if stream:
@@ -3051,20 +3067,18 @@ class APIServerAdapter(BasePlatformAdapter):
             },
         }
 
-        # Store the complete response object for future chaining / GET retrieval
+        effective_session_id = result.get("session_id", session_id) if isinstance(result, dict) else session_id
         if store:
             self._response_store.put(response_id, {
                 "response": response_data,
                 "conversation_history": full_history,
                 "instructions": instructions,
-                "session_id": session_id,
+                "session_id": effective_session_id,
             })
-            # Update conversation mapping so the next request with the same
-            # conversation name automatically chains to this response
             if conversation:
                 self._response_store.set_conversation(conversation, response_id)
 
-        response_headers = {"X-Hermes-Session-Id": session_id}
+        response_headers = {"X-Hermes-Session-Id": effective_session_id}
         if gateway_session_key:
             response_headers["X-Hermes-Session-Key"] = gateway_session_key
         return web.json_response(response_data, headers=response_headers)
@@ -3701,7 +3715,8 @@ class APIServerAdapter(BasePlatformAdapter):
                     conversation_history.append({"role": msg["role"], "content": str(content)})
 
         run_id = f"run_{uuid.uuid4().hex}"
-        session_id = body.get("session_id") or stored_session_id or run_id
+        requested_session_id = body.get("session_id") or stored_session_id or run_id
+        session_id = self._resolve_continuation_session_id(requested_session_id)
         approval_session_key = gateway_session_key or session_id or run_id
         ephemeral_system_prompt = instructions
         loop = asyncio.get_running_loop()
@@ -3833,18 +3848,21 @@ class APIServerAdapter(BasePlatformAdapter):
                     )
                 else:
                     final_response = result.get("final_response", "") if isinstance(result, dict) else ""
+                    effective_session_id = result.get("session_id", session_id) if isinstance(result, dict) else session_id
                     q.put_nowait({
                         "event": "run.completed",
                         "run_id": run_id,
                         "timestamp": time.time(),
                         "output": final_response,
                         "usage": usage,
+                        "session_id": effective_session_id,
                     })
                     self._set_run_status(
                         run_id,
                         "completed",
                         output=final_response,
                         usage=usage,
+                        session_id=effective_session_id,
                         last_event="run.completed",
                     )
             except asyncio.CancelledError:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2744,6 +2744,57 @@ class SessionDB:
                 current = child_id
         return session_id
 
+    def resolve_compression_continuation_session_id(self, session_id: str) -> str:
+        """Follow compression-created descendants to the current live session.
+
+        Compression ends the current session with ``end_reason='compression'``
+        and creates a child continuation session. Stateless API clients may
+        keep resubmitting the original id, so callers that want "continue this
+        conversation" semantics need to walk that chain forward before loading
+        history or appending new messages.
+
+        Only sessions ended by compression are followed. Other lineage shapes
+        such as explicit forks or branches keep their original ids so callers
+        do not silently hop across intentional conversation splits.
+        """
+        if not session_id:
+            return session_id
+
+        with self._lock:
+            current = session_id
+            seen = {current}
+            for _ in range(32):
+                try:
+                    row = self._conn.execute(
+                        "SELECT end_reason FROM sessions WHERE id = ?",
+                        (current,),
+                    ).fetchone()
+                except Exception:
+                    return session_id
+                if row is None:
+                    return session_id
+                end_reason = row["end_reason"] if hasattr(row, "keys") else row[0]
+                if end_reason != "compression":
+                    return current
+                try:
+                    child_row = self._conn.execute(
+                        "SELECT id FROM sessions "
+                        "WHERE parent_session_id = ? "
+                        "ORDER BY started_at DESC, id DESC LIMIT 1",
+                        (current,),
+                    ).fetchone()
+                except Exception:
+                    return session_id
+                if child_row is None:
+                    return current
+                child_id = child_row["id"] if hasattr(child_row, "keys") else child_row[0]
+                if not child_id or child_id in seen:
+                    return current
+                seen.add(child_id)
+                current = child_id
+
+        return session_id
+
     def get_messages_as_conversation(
         self,
         session_id: str,

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -34,6 +34,7 @@ from gateway.platforms.api_server import (
     cors_middleware,
     security_headers_middleware,
 )
+from hermes_state import SessionDB
 
 
 # ---------------------------------------------------------------------------
@@ -3306,6 +3307,37 @@ class TestSessionIdHeader:
             # History must come from DB, not from the request body
             assert call_kwargs["conversation_history"] == db_history
             assert call_kwargs["user_message"] == "new question"
+
+    @pytest.mark.asyncio
+    async def test_provided_session_id_resolves_compression_child_before_turn(self, auth_adapter, tmp_path):
+        """A stale compression parent should continue on the live child session."""
+        db = SessionDB(tmp_path / "state.db")
+        db.create_session("parent", source="api_server")
+        db.append_message("parent", role="user", content="before compression")
+        db.end_session("parent", "compression")
+        db.create_session("child", source="api_server", parent_session_id="parent")
+        db.append_message("child", role="assistant", content="compressed summary")
+
+        auth_adapter._session_db = db
+        mock_result = {"final_response": "Still here", "messages": [], "api_calls": 1, "session_id": "child"}
+        request = MagicMock()
+        request.headers = {"X-Hermes-Session-Id": "parent", "Authorization": "Bearer sk-secret"}
+        request.json = AsyncMock(return_value={
+            "model": "hermes-agent",
+            "messages": [{"role": "user", "content": "Continue"}],
+        })
+
+        with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+            resp = await auth_adapter._handle_chat_completions(request)
+
+        assert resp.status == 200
+        assert resp.headers.get("X-Hermes-Session-Id") == "child"
+        call_kwargs = mock_run.call_args.kwargs
+        assert call_kwargs["session_id"] == "child"
+        assert call_kwargs["conversation_history"] == [
+            {"role": "assistant", "content": "compressed summary"},
+        ]
 
     @pytest.mark.asyncio
     async def test_db_failure_falls_back_to_empty_history(self, auth_adapter):

--- a/tests/hermes_state/test_resolve_resume_session_id.py
+++ b/tests/hermes_state/test_resolve_resume_session_id.py
@@ -94,3 +94,29 @@ def test_prefers_most_recent_child_when_fork_exists(db):
     ])
     db.append_message("newer_fork", role="user", content="x")
     assert db.resolve_resume_session_id("parent") == "newer_fork"
+
+
+def test_resolve_compression_continuation_walks_to_live_descendant(db):
+    _make_chain(db, [
+        ("root", None),
+        ("child", "root"),
+        ("grandchild", "child"),
+    ])
+    db.append_message("root", role="user", content="before compression")
+    db.append_message("child", role="assistant", content="compressed summary")
+    db.append_message("grandchild", role="user", content="latest turn")
+    db.end_session("root", "compression")
+    db.end_session("child", "compression")
+
+    assert db.resolve_compression_continuation_session_id("root") == "grandchild"
+    assert db.resolve_compression_continuation_session_id("child") == "grandchild"
+
+
+def test_resolve_compression_continuation_does_not_cross_branch_session(db):
+    _make_chain(db, [
+        ("root", None),
+        ("forked", "root"),
+    ])
+    db.end_session("root", "branched")
+
+    assert db.resolve_compression_continuation_session_id("root") == "root"


### PR DESCRIPTION
## What does this PR do?

Fixes stateless API-session continuity after conversation compaction. When a client keeps sending an old `session_id` after Hermes rotates that session during compression, the API server now resolves the compression lineage forward to the current live descendant before loading history or starting the next turn. The API server also persists and emits the effective post-rotation `session_id` in response/run paths that were still holding the stale id.

## Related Issue

Fixes #44004

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_state.py`: added `resolve_compression_continuation_session_id()` to follow only compression-created descendants, without crossing explicit branch/fork splits.
- `gateway/platforms/api_server.py`: normalized continuation `session_id`s for chat/session/responses/runs flows before history reload and agent execution; propagated the effective session id through response headers, stored response chaining state, and `run.completed` status/events.
- `tests/hermes_state/test_resolve_resume_session_id.py`: added regression coverage for compression-lineage continuation and a guard that branched sessions do not auto-hop.
- `tests/gateway/test_api_server.py`: added a direct handler regression test proving a stale compressed parent header resolves to the live child before the turn starts.

## How to Test

1. Run the fix-specific regression subset:
   `pytest tests/hermes_state/test_resolve_resume_session_id.py::test_resolve_compression_continuation_walks_to_live_descendant tests/hermes_state/test_resolve_resume_session_id.py::test_resolve_compression_continuation_does_not_cross_branch_session tests/gateway/test_api_server.py::TestSessionIdHeader::test_provided_session_id_resolves_compression_child_before_turn -q -x --timeout=60`
2. Run scoped static checks:
   `ruff check gateway/platforms/api_server.py hermes_state.py tests/gateway/test_api_server.py tests/hermes_state/test_resolve_resume_session_id.py`
   `python scripts/check-windows-footguns.py --diff $(git merge-base origin/main HEAD)`
   `git diff --check`
3. In a fully provisioned test environment, rerun the repo command:
   `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh`
   In this shared worker environment it stops during collection with `ModuleNotFoundError: No module named 'fastapi'` from `tests/hermes_cli/test_dashboard_auth_401_reauth.py` before reaching the whole suite.

## What platforms tested on

- macOS 15 / darwin-arm64 (local worker sandbox)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 / darwin-arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Broad suite note: `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh` stops during collection in this environment because `fastapi` is unavailable for `tests/hermes_cli/test_dashboard_auth_401_reauth.py`.
- Green covering subset: `3 passed in 0.69s` for the compression-continuation regression tests listed above.

<!-- autocontrib:worker-id=issue-new-16839dda kind=pr-open -->