### PR TITLE
fix(kanban): validate --skill against the worker profile's skill registry at create time

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1302,6 +1302,24 @@ def _cmd_assignees(args: argparse.Namespace) -> int:
     return 0
 
 
+def _assignee_hermes_home(assignee: Optional[str]) -> Optional[str]:
+    """HERMES_HOME the dispatched worker would run under.
+
+    Mirrors the dispatcher's resolution in ``kanban_db._default_spawn``:
+    profile-scoped home via ``resolve_profile_env``, falling back to the
+    current process home when no assignee is set or the profile dir
+    doesn't exist yet (the dispatcher defers to ``HERMES_PROFILE`` then).
+    """
+    if assignee:
+        from hermes_cli.profiles import normalize_profile_name, resolve_profile_env
+
+        try:
+            return resolve_profile_env(normalize_profile_name(assignee))
+        except (FileNotFoundError, ValueError):
+            pass
+    return os.environ.get("HERMES_HOME")
+
+
 def _cmd_create(args: argparse.Namespace) -> int:
     try:
         ws_kind, ws_path = _parse_workspace_flag(args.workspace)
@@ -1325,6 +1343,25 @@ def _cmd_create(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
+    skills = getattr(args, "skills", None) or []
+    if skills:
+        unknown = kb.unresolvable_task_skills(
+            skills, _assignee_hermes_home(args.assignee)
+        )
+        if unknown:
+            scope = (
+                f"profile '{args.assignee}'" if args.assignee
+                else "the worker profile"
+            )
+            print(
+                f"kanban: unknown skill(s) for {scope}: {', '.join(unknown)}\n"
+                "Workers preload --skill values at startup and crash on "
+                "unknown names, burning the task's retry budget (see "
+                "#44072). Check the name with `hermes skills list` or "
+                "install the skill into that profile first.",
+                file=sys.stderr,
+            )
+            return 2
     with kb.connect_closing() as conn:
         task_id = kb.create_task(
             conn,

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1353,15 +1353,29 @@ def _cmd_create(args: argparse.Namespace) -> int:
                 f"profile '{args.assignee}'" if args.assignee
                 else "the worker profile"
             )
-            print(
-                f"kanban: unknown skill(s) for {scope}: {', '.join(unknown)}\n"
-                "Workers preload --skill values at startup and crash on "
-                "unknown names, burning the task's retry budget (see "
-                "#44072). Check the name with `hermes skills list` or "
-                "install the skill into that profile first.",
-                file=sys.stderr,
-            )
-            return 2
+            if len(unknown) == len(skills):
+                # Every requested skill is unresolvable — the worker would
+                # crash on startup. Reject hard (exit 2) so the task never
+                # enters the board to burn retries.
+                print(
+                    f"kanban: unknown skill(s) for {scope}: {', '.join(unknown)}\n"
+                    "Workers preload --skill values at startup and crash on "
+                    "unknown names, burning the task's retry budget (see "
+                    "#44072). Check the name with `hermes skills list` or "
+                    "install the skill into that profile first.",
+                    file=sys.stderr,
+                )
+                return 2
+            else:
+                # Mixed: some skills resolve, some don't. Current main
+                # (commit 018009bc) skips unknown entries and continues
+                # with whatever loaded. Accept the task — the worker will
+                # log a warning for the unresolvable ones.
+                print(
+                    f"kanban: some skills unresolvable for {scope}, "
+                    f"skipping: {', '.join(unknown)}",
+                    file=sys.stderr,
+                )
     with kb.connect_closing() as conn:
         task_id = kb.create_task(
             conn,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7613,6 +7613,152 @@ def _resolve_hermes_argv() -> list[str]:
     return _module_hermes_argv()
 
 
+def _kanban_worker_skill_available(hermes_home: Optional[str]) -> bool:
+    """True if the bundled ``kanban-worker`` skill resolves for the home the
+    spawned worker will run under.
+
+    The dispatcher injects ``--skills kanban-worker`` into every worker. When
+    the worker activates a profile (``hermes -p <name>``), its ``SKILLS_DIR``
+    becomes ``<profile_home>/skills`` — which on many profiles does NOT contain
+    the bundled skill (it ships in the *default* root home, not every
+    profile-scoped skills dir). Preloading a missing skill is fatal at CLI
+    startup (``ValueError: Unknown skill(s): kanban-worker``), aborting the
+    worker before the agent loop runs. Gate the flag on actual resolvability;
+    the kanban lifecycle contract is still injected via ``KANBAN_GUIDANCE``, so
+    omitting the flag only drops the supplementary pattern library.
+    """
+    from pathlib import Path as _Path
+
+    # An unset HERMES_HOME means the worker falls back to the default root
+    # home (``~/.hermes``), which ships the bundled skill.
+    base = _Path(hermes_home) if hermes_home else (_Path.home() / ".hermes")
+    skills_root = base / "skills"
+    if not skills_root.is_dir():
+        return False
+    # Canonical bundled location first (cheap), then a bounded scan for
+    # profiles that have it nested elsewhere.
+    if (skills_root / "devops" / "kanban-worker" / "SKILL.md").is_file():
+        return True
+    try:
+        for skill_md in skills_root.rglob("kanban-worker/SKILL.md"):
+            if skill_md.is_file():
+                return True
+    except OSError:
+        pass
+    return False
+
+
+def _skill_search_roots(hermes_home: Optional[str]) -> list:
+    """Skill directories a worker spawned under *hermes_home* would search.
+
+    Mirrors the roots ``skill_view()`` scans: ``<home>/skills`` plus any
+    ``skills.external_dirs`` from that home's ``config.yaml``. The config is
+    read directly (not via the in-process loader) because the validating CLI
+    may be running under a *different* HERMES_HOME than the worker will.
+    """
+    from pathlib import Path as _Path
+
+    base = _Path(hermes_home) if hermes_home else (_Path.home() / ".hermes")
+    roots = []
+    skills_root = base / "skills"
+    if skills_root.is_dir():
+        roots.append(skills_root)
+    config_path = base / "config.yaml"
+    if config_path.is_file():
+        try:
+            import yaml
+
+            with open(config_path, "r", encoding="utf-8") as fh:
+                cfg = yaml.safe_load(fh) or {}
+            external = (cfg.get("skills") or {}).get("external_dirs") or []
+            for raw in external:
+                if not isinstance(raw, str) or not raw.strip():
+                    continue
+                ext = _Path(os.path.expandvars(raw)).expanduser()
+                if ext.is_dir():
+                    roots.append(ext)
+        except Exception:
+            # Unreadable/malformed config — validate against <home>/skills
+            # only rather than failing the create.
+            pass
+    return roots
+
+
+_SKILL_FRONTMATTER_NAME = re.compile(r"^name:\s*['\"]?([^'\"\n]+?)['\"]?\s*$", re.MULTILINE)
+
+
+def unresolvable_task_skills(
+    skills: Iterable[str],
+    hermes_home: Optional[str] = None,
+) -> list:
+    """Return the subset of *skills* that won't resolve for a worker under
+    *hermes_home* (``None`` → the default root home).
+
+    Best-effort mirror of ``skill_view()``'s lookup so ``kanban create`` can
+    reject tasks whose force-loaded skills would crash the worker at startup
+    (``ValueError: Unknown skill(s): ...``) and burn the retry budget (#44072).
+
+    Deliberately conservative — a name is only reported when *every* cheap
+    strategy misses: directory named ``<name>`` containing ``SKILL.md`` (at
+    the root or nested), relative-path form ``cat/name``, legacy flat
+    ``<name>.md``, and frontmatter ``name:`` aliases. Names this function
+    can't reliably check cross-profile are given the benefit of the doubt:
+    plugin-qualified ``namespace:skill`` names (plugin registries are
+    per-home state) and the built-in ``kanban-worker`` (the dispatcher
+    already gates it on resolvability and drops it when absent).
+    """
+    roots = _skill_search_roots(hermes_home)
+    missing = []
+    seen = set()
+    for raw in skills or ():
+        name = (raw or "").strip()
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        if name == "kanban-worker" or ":" in name:
+            continue
+        if not roots:
+            # No skills dir at all — every concrete name is unresolvable.
+            missing.append(name)
+            continue
+        if not _skill_resolves(name, roots):
+            missing.append(name)
+    return missing
+
+
+def _skill_resolves(name: str, roots: list) -> bool:
+    """True if *name* matches any skill under any of *roots*."""
+    for root in roots:
+        direct = root / name
+        try:
+            if (direct / "SKILL.md").is_file():
+                return True
+            if direct.with_suffix(".md").is_file():
+                return True
+        except (OSError, ValueError):
+            continue
+        # Bare-name lookups: nested dir name, frontmatter alias, flat .md.
+        if "/" in name or "\\" in name:
+            continue
+        try:
+            for skill_md in root.rglob("SKILL.md"):
+                if skill_md.parent.name == name:
+                    return True
+                try:
+                    head = skill_md.read_text(encoding="utf-8", errors="replace")[:4096]
+                except OSError:
+                    continue
+                match = _SKILL_FRONTMATTER_NAME.search(head)
+                if match and match.group(1).strip() == name:
+                    return True
+            for flat_md in root.rglob(f"{name}.md"):
+                if flat_md.name != "SKILL.md" and flat_md.is_file():
+                    return True
+        except OSError:
+            continue
+    return False
+
+
 def _worker_terminal_timeout_env(
     max_runtime_seconds: Optional[int],
     current_timeout: Optional[str],

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7675,6 +7675,12 @@ def _skill_search_roots(hermes_home: Optional[str]) -> list:
                 if not isinstance(raw, str) or not raw.strip():
                     continue
                 ext = _Path(os.path.expandvars(raw)).expanduser()
+                # Resolve relative paths against HERMES_HOME (not cwd),
+                # matching get_external_skills_dirs() in agent/skill_utils.py.
+                if not ext.is_absolute():
+                    ext = (base / ext).resolve()
+                else:
+                    ext = ext.resolve()
                 if ext.is_dir():
                     roots.append(ext)
         except Exception:
@@ -7727,36 +7733,74 @@ def unresolvable_task_skills(
 
 
 def _skill_resolves(name: str, roots: list) -> bool:
-    """True if *name* matches any skill under any of *roots*."""
+    """True if *name* matches exactly one skill across all *roots*.
+
+    Uses ``iter_skill_index_files`` (the same walk ``skill_view()`` uses)
+    so excluded paths (VCS, venv, node_modules, cache dirs, skill support
+    dirs) are not counted. Returns False when multiple candidates match
+    the same name across different roots — matching ``skill_view()``'s
+    ambiguity rejection.
+    """
+    # Lazy imports — these are profile-aware lookups that may pull in
+    # a large module chain, and the validating CLI may be running under
+    # a different HERMES_HOME than the worker will.
+    from agent.skill_utils import (
+        is_skill_support_path as _is_skill_support_path,
+        iter_skill_index_files as _iter_skill_index_files,
+    )
+
+    candidates: list[str] = []
+
     for root in roots:
         direct = root / name
         try:
             if (direct / "SKILL.md").is_file():
-                return True
+                candidates.append(str(direct))
+                if len(candidates) > 1:
+                    return False
+                continue
             if direct.with_suffix(".md").is_file():
-                return True
+                candidates.append(str(direct))
+                if len(candidates) > 1:
+                    return False
+                continue
         except (OSError, ValueError):
             continue
+
         # Bare-name lookups: nested dir name, frontmatter alias, flat .md.
         if "/" in name or "\\" in name:
             continue
         try:
-            for skill_md in root.rglob("SKILL.md"):
+            for skill_md in _iter_skill_index_files(root, "SKILL.md"):
                 if skill_md.parent.name == name:
-                    return True
+                    candidates.append(str(skill_md))
+                    if len(candidates) > 1:
+                        return False
+                    continue
                 try:
-                    head = skill_md.read_text(encoding="utf-8", errors="replace")[:4096]
+                    head = skill_md.read_text(
+                        encoding="utf-8", errors="replace"
+                    )[:4096]
                 except OSError:
                     continue
                 match = _SKILL_FRONTMATTER_NAME.search(head)
                 if match and match.group(1).strip() == name:
-                    return True
+                    candidates.append(str(skill_md))
+                    if len(candidates) > 1:
+                        return False
             for flat_md in root.rglob(f"{name}.md"):
-                if flat_md.name != "SKILL.md" and flat_md.is_file():
-                    return True
+                if (
+                    flat_md.name != "SKILL.md"
+                    and flat_md.is_file()
+                    and not _is_skill_support_path(flat_md)
+                ):
+                    candidates.append(str(flat_md))
+                    if len(candidates) > 1:
+                        return False
         except OSError:
             continue
-    return False
+
+    return len(candidates) == 1
 
 
 def _worker_terminal_timeout_env(

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -3126,8 +3126,20 @@ def test_default_spawn_passes_task_skills_verbatim(kanban_home, monkeypatch):
     )
 
 
+def _install_test_skill(home: Path, name: str) -> None:
+    """Drop a minimal skill into <home>/skills so create-time skill
+    validation (#44072) resolves it."""
+    skill_dir = home / "skills" / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\n---\n# {name}\n", encoding="utf-8"
+    )
+
+
 def test_cli_create_skill_flag_repeatable(kanban_home):
     """`hermes kanban create --skill a --skill b` persists the list."""
+    _install_test_skill(kanban_home, "translation")
+    _install_test_skill(kanban_home, "github-code-review")
     out = run_slash(
         "create 'multi-skill' --assignee linguist "
         "--skill translation --skill github-code-review --json"
@@ -3150,6 +3162,7 @@ def test_cli_create_without_skill_flag_leaves_none(kanban_home):
 
 def test_cli_show_renders_skills(kanban_home):
     """`hermes kanban show <id>` prints a skills row when present."""
+    _install_test_skill(kanban_home, "translation")
     out = run_slash(
         "create 'show-test' --assignee x "
         "--skill translation --json"

--- a/tests/hermes_cli/test_kanban_create_skill_validation.py
+++ b/tests/hermes_cli/test_kanban_create_skill_validation.py
@@ -1,0 +1,158 @@
+"""Regression tests for #44072: ``kanban create --skill`` must validate
+skill names at dispatch time.
+
+Workers preload ``--skill`` values at CLI startup and crash with
+``ValueError: Unknown skill(s): <name>`` on unknown names — burning the
+task's retry budget and completing with an empty result. ``kanban create``
+now rejects tasks whose force-loaded skills won't resolve for the worker's
+profile home, before the task is enqueued.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban as kc
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _install_skill(root: Path, rel_dir: str, frontmatter_name: str | None = None) -> None:
+    skill_dir = root / "skills" / rel_dir
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    name = frontmatter_name or rel_dir.rsplit("/", 1)[-1]
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: test skill\n---\n\n# {name}\n",
+        encoding="utf-8",
+    )
+
+
+def _task_count() -> int:
+    with kb.connect() as conn:
+        return len(kb.list_tasks(conn))
+
+
+# ---------------------------------------------------------------------------
+# unresolvable_task_skills (unit)
+# ---------------------------------------------------------------------------
+
+def test_unknown_skill_reported(kanban_home):
+    _install_skill(kanban_home, "devops/real-skill")
+    missing = kb.unresolvable_task_skills(
+        ["real-skill", "no-such-skill"], str(kanban_home)
+    )
+    assert missing == ["no-such-skill"]
+
+
+def test_relative_path_form_resolves(kanban_home):
+    _install_skill(kanban_home, "devops/nested-skill")
+    assert kb.unresolvable_task_skills(
+        ["devops/nested-skill"], str(kanban_home)
+    ) == []
+
+
+def test_frontmatter_name_alias_resolves(kanban_home):
+    # Dir is "short-alias" but the frontmatter name is what skills_list
+    # exposes — skill_view accepts it, so the validator must too.
+    _install_skill(kanban_home, "cat/short-alias", frontmatter_name="long-public-name")
+    assert kb.unresolvable_task_skills(
+        ["long-public-name"], str(kanban_home)
+    ) == []
+
+
+def test_legacy_flat_md_resolves(kanban_home):
+    flat = kanban_home / "skills" / "misc"
+    flat.mkdir(parents=True)
+    (flat / "oldstyle.md").write_text("# oldstyle\n", encoding="utf-8")
+    assert kb.unresolvable_task_skills(["oldstyle"], str(kanban_home)) == []
+
+
+def test_kanban_worker_and_plugin_names_get_benefit_of_doubt(kanban_home):
+    # kanban-worker is gated by the dispatcher itself (dropped when absent,
+    # never fatal); plugin registries are per-home state we can't inspect
+    # cross-profile — neither may be rejected here.
+    (kanban_home / "skills").mkdir()
+    assert kb.unresolvable_task_skills(
+        ["kanban-worker", "someplugin:some-skill"], str(kanban_home)
+    ) == []
+
+
+def test_external_dirs_from_config_are_searched(kanban_home, tmp_path):
+    ext = tmp_path / "external-skills"
+    (ext / "shipped-elsewhere").mkdir(parents=True)
+    (ext / "shipped-elsewhere" / "SKILL.md").write_text(
+        "---\nname: shipped-elsewhere\n---\n", encoding="utf-8"
+    )
+    (kanban_home / "skills").mkdir()
+    (kanban_home / "config.yaml").write_text(
+        f"skills:\n  external_dirs:\n    - {ext.as_posix()}\n", encoding="utf-8"
+    )
+    assert kb.unresolvable_task_skills(
+        ["shipped-elsewhere"], str(kanban_home)
+    ) == []
+
+
+def test_missing_skills_root_rejects_concrete_names(kanban_home):
+    # No <home>/skills at all → preloading any skill is fatal at worker
+    # startup ("Skills directory does not exist yet").
+    assert kb.unresolvable_task_skills(["anything"], str(kanban_home)) == ["anything"]
+
+
+# ---------------------------------------------------------------------------
+# kanban create wiring (end-to-end via run_slash)
+# ---------------------------------------------------------------------------
+
+def test_create_rejects_unknown_skill(kanban_home):
+    _install_skill(kanban_home, "devops/real-skill")
+    out = kc.run_slash("create 'doomed task' --skill some-unknown-skill")
+    assert "unknown skill(s)" in out.lower()
+    assert "some-unknown-skill" in out
+    assert "Created" not in out
+    assert _task_count() == 0
+
+
+def test_create_accepts_installed_skill(kanban_home):
+    _install_skill(kanban_home, "devops/real-skill")
+    out = kc.run_slash("create 'good task' --skill real-skill")
+    assert "Created" in out
+    with kb.connect() as conn:
+        task = kb.list_tasks(conn)[0]
+    assert list(task.skills) == ["real-skill"]
+
+
+def test_create_validates_against_assignee_profile_home(kanban_home):
+    # Skill installed ONLY in the assignee profile's home — the root home
+    # doesn't have it. Create must validate against the profile the worker
+    # will actually run under, not the creator's home.
+    profile_home = kanban_home / "profiles" / "coder"
+    _install_skill(profile_home, "devops/profile-only-skill")
+    out = kc.run_slash(
+        "create 'profile task' --assignee coder --skill profile-only-skill"
+    )
+    assert "Created" in out
+
+    # And the inverse: the skill is in the creator's root home but NOT in
+    # the assignee's profile home — exactly the failure in #44072.
+    _install_skill(kanban_home, "devops/root-only-skill")
+    out = kc.run_slash(
+        "create 'doomed profile task' --assignee coder --skill root-only-skill"
+    )
+    assert "unknown skill(s)" in out.lower()
+    assert "root-only-skill" in out
+
+
+def test_create_without_skills_skips_validation(kanban_home):
+    # No --skill → no validation, even with no skills dir present.
+    out = kc.run_slash("create 'plain task' --assignee alice")
+    assert "Created" in out

--- a/tests/hermes_cli/test_kanban_create_skill_validation.py
+++ b/tests/hermes_cli/test_kanban_create_skill_validation.py
@@ -103,6 +103,95 @@ def test_external_dirs_from_config_are_searched(kanban_home, tmp_path):
     ) == []
 
 
+def test_relative_external_dirs_resolved_against_hermes_home(kanban_home):
+    """Relative skills.external_dirs are resolved against HERMES_HOME,
+    matching how get_external_skills_dirs() in agent/skill_utils.py
+    resolves them (not against the creator cwd)."""
+    ext_rel = kanban_home / "my-external-skills"
+    (ext_rel / "rel-skill").mkdir(parents=True)
+    (ext_rel / "rel-skill" / "SKILL.md").write_text(
+        "---\nname: rel-skill\n---\n", encoding="utf-8"
+    )
+    (kanban_home / "skills").mkdir()
+    # Use a relative path in config.yaml — must resolve against kanban_home
+    (kanban_home / "config.yaml").write_text(
+        "skills:\n  external_dirs:\n    - my-external-skills\n",
+        encoding="utf-8",
+    )
+    assert kb.unresolvable_task_skills(
+        ["rel-skill"], str(kanban_home)
+    ) == []
+
+
+def test_ambiguity_rejected_across_roots(kanban_home, tmp_path):
+    """Same bare skill name in multiple search roots => unresolvable."""
+    ext = tmp_path / "external-skills"
+    (ext / "common-name").mkdir(parents=True)
+    (ext / "common-name" / "SKILL.md").write_text(
+        "---\nname: common-name\n---\n", encoding="utf-8"
+    )
+    # Also in the local skills dir
+    (kanban_home / "skills" / "common-name").mkdir(parents=True)
+    (kanban_home / "skills" / "common-name" / "SKILL.md").write_text(
+        "---\nname: common-name\n---\n", encoding="utf-8"
+    )
+    (kanban_home / "config.yaml").write_text(
+        f"skills:\n  external_dirs:\n    - {ext.as_posix()}\n",
+        encoding="utf-8",
+    )
+    # Ambiguous across roots — _skill_resolves returns False
+    assert kb.unresolvable_task_skills(
+        ["common-name"], str(kanban_home)
+    ) == ["common-name"]
+
+
+def test_excluded_paths_not_counted(kanban_home):
+    """A SKILL.md under .venv or node_modules should not be found."""
+    (kanban_home / "skills" / "real-skill").mkdir(parents=True)
+    (kanban_home / "skills" / "real-skill" / "SKILL.md").write_text(
+        "---\nname: real-skill\n---\n", encoding="utf-8"
+    )
+    # Excluded dirs that should be ignored
+    (kanban_home / "skills" / ".venv" / "real-skill").mkdir(parents=True)
+    (kanban_home / "skills" / ".venv" / "real-skill" / "SKILL.md").write_text(
+        "---\nname: real-skill\n---\n", encoding="utf-8"
+    )
+    assert kb.unresolvable_task_skills(
+        ["real-skill"], str(kanban_home)
+    ) == []
+
+
+def test_mixed_valid_invalid_allows_create(kanban_home):
+    """When SOME skills resolve, the task is accepted (main commits 018009bc
+    skips unknown entries and continues with whatever loaded)."""
+    _install_skill(kanban_home, "devops/valid-skill")
+    out = kc.run_slash(
+        "create 'mixed task' --skill valid-skill --skill missing-skill"
+    )
+    # Should accept the task even though one skill is missing
+    assert "Created" in out or "skipping" in out.lower()
+    with kb.connect() as conn:
+        tasks = kb.list_tasks(conn)
+    # At minimum the task was created
+    assert len(tasks) >= 1
+
+
+def test_skill_support_dirs_not_resolved(kanban_home):
+    """Skills nested under references/ of another skill are not counted."""
+    (kanban_home / "skills" / "real-skill").mkdir(parents=True)
+    (kanban_home / "skills" / "real-skill" / "SKILL.md").write_text(
+        "---\nname: real-skill\n---\n", encoding="utf-8"
+    )
+    # Support dir of real-skill with its own SKILL.md
+    (kanban_home / "skills" / "real-skill" / "references" / "child").mkdir(
+        parents=True
+    )
+    (kanban_home / "skills" / "real-skill" / "references" / "child" / "SKILL.md").write_text(
+        "---\nname: child\n---\n", encoding="utf-8"
+    )
+    assert kb.unresolvable_task_skills(["child"], str(kanban_home)) == ["child"]
+
+
 def test_missing_skills_root_rejects_concrete_names(kanban_home):
     # No <home>/skills at all → preloading any skill is fatal at worker
     # startup ("Skills directory does not exist yet").


### PR DESCRIPTION
## Summary

`hermes kanban create --skill <name>` accepted any string. Unknown names only surfaced when the spawned worker crashed at CLI startup (`ValueError: Unknown skill(s): <name>`) — burning the task's retry budget and completing with an empty result.

This validates at create time and rejects the task with exit 2 and a descriptive error before it is enqueued.

Fixes #44072

## How it works

- **`kanban_db.unresolvable_task_skills(skills, hermes_home)`** — best-effort mirror of `skill_view()`'s lookup strategies (directory named `<name>` containing `SKILL.md` at the root or nested, relative-path form `cat/name`, frontmatter `name:` alias, legacy flat `<name>.md`) against the skills roots the worker will actually see: `<home>/skills` **plus** `skills.external_dirs` from that home's `config.yaml` (read directly, since the validating CLI may run under a different `HERMES_HOME` than the worker).
- **`_cmd_create`** resolves the assignee profile's `HERMES_HOME` the same way the dispatcher's `_default_spawn` does (`resolve_profile_env`), so validation runs against the *worker's* registry, not the creator's — the exact failure mode in the issue ("a profile dispatching a skill not installed in the target assignee's profile").

### Deliberately conservative

A name is only rejected when every cheap strategy misses. Names that can't be reliably checked cross-profile get the benefit of the doubt:

- plugin-qualified `namespace:skill` names (plugin registries are per-home state), and
- the built-in `kanban-worker` (the dispatcher already gates it on resolvability and silently drops it when absent — never fatal).

So a false *accept* degrades to today's behavior, while a reject is always a real startup crash avoided.

## Error output

```
$ hermes kanban create "some task" --assignee coder --skill some-unknown-skill
kanban: unknown skill(s) for profile 'coder': some-unknown-skill
Workers preload --skill values at startup and crash on unknown names, burning the
task's retry budget (see #44072). Check the name with `hermes skills list` or
install the skill into that profile first.
```

## Tests

- New `tests/hermes_cli/test_kanban_create_skill_validation.py` (11 tests): unit coverage for every resolution strategy (direct dir, relative path, frontmatter alias, legacy flat .md, external_dirs, missing skills root) and end-to-end `run_slash` coverage including the assignee-profile-home case in both directions (skill only in profile home → accepted; skill only in root home → rejected).
- Updated `test_cli_create_skill_flag_repeatable` / `test_cli_show_renders_skills` to install the skills they reference (they test persistence/rendering, not resolution).
- Full `tests/hermes_cli -k kanban` selection produces a failure set identical to `origin/main` baseline (the handful of pre-existing ordering/environment-dependent failures are untouched).
