### PR TITLE
fix(tui-gateway): re-arm WS orphan reap while a detached session is mid-turn

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1382,6 +1382,94 @@ def test_ws_orphan_reap_disabled_when_grace_zero(monkeypatch):
     assert fired["timer"] is False
 
 
+def test_ws_orphan_reap_rearms_while_detached_session_is_mid_turn(monkeypatch):
+    """A detached mid-turn session re-arms the reap timer instead of leaking.
+
+    Regression for #44045: the disconnect-path reap timer was one-shot, so a
+    turn that outlived the grace window (long tool calls, context compression,
+    the post-turn background review pass) was spared once and then never
+    re-checked — the session stayed parked on the drop transport with its DB
+    row un-ended, visible as a separate "active" Desktop chat.
+    """
+    timers = []
+
+    class _Timer:
+        def __init__(self, interval, function):
+            self.interval = interval
+            self.function = function
+            timers.append(self)
+
+        def start(self):
+            pass
+
+    closed = []
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0.01)
+    monkeypatch.setattr(server.threading, "Timer", _Timer)
+    monkeypatch.setattr(
+        server,
+        "_close_session_by_id",
+        lambda sid, *, end_reason: closed.append((sid, end_reason)) or True,
+    )
+
+    server._sessions["mid-turn-sid"] = _session(
+        transport=server._detached_ws_transport, running=True
+    )
+    try:
+        server._schedule_ws_orphan_reap("mid-turn-sid")
+        assert len(timers) == 1
+
+        # Grace expires while the turn is still running: spared, but re-armed.
+        timers[0].function()
+        assert closed == []
+        assert len(timers) == 2
+
+        # Turn finishes; the re-armed timer fires and the session is reaped.
+        server._sessions["mid-turn-sid"]["running"] = False
+        timers[1].function()
+        assert closed == [("mid-turn-sid", "ws_orphan_reap")]
+        # Reaped — no further re-arm.
+        assert len(timers) == 2
+    finally:
+        server._sessions.pop("mid-turn-sid", None)
+
+
+def test_ws_orphan_reap_does_not_rearm_after_reattach(monkeypatch):
+    """A mid-turn session that re-binds a live transport cancels the reap chain."""
+    timers = []
+
+    class _Timer:
+        def __init__(self, interval, function):
+            self.function = function
+            timers.append(self)
+
+        def start(self):
+            pass
+
+    class _LiveTransport:
+        def write(self, *a, **k):
+            return True
+
+    closed = []
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0.01)
+    monkeypatch.setattr(server.threading, "Timer", _Timer)
+    monkeypatch.setattr(
+        server,
+        "_close_session_by_id",
+        lambda sid, *, end_reason: closed.append((sid, end_reason)) or True,
+    )
+
+    server._sessions["reattached-sid"] = _session(
+        transport=_LiveTransport(), running=True
+    )
+    try:
+        server._schedule_ws_orphan_reap("reattached-sid")
+        timers[0].function()
+        assert closed == []
+        assert len(timers) == 1  # live transport — chain stops
+    finally:
+        server._sessions.pop("reattached-sid", None)
+
+
 def test_init_session_fires_reset_hook(monkeypatch):
     hooks = []
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -527,7 +527,27 @@ def _schedule_ws_orphan_reap(sid: str) -> None:
         # guard with _sessions_lock). _sessions_lock is an RLock and the global
         # ordering is always resume_lock -> sessions_lock, so nesting is safe.
         with _session_resume_lock:
-            if not _ws_session_is_orphaned(_sessions.get(sid)):
+            session = _sessions.get(sid)
+            if not _ws_session_is_orphaned(session):
+                # A detached session that is still mid-turn is spared by the
+                # orphan check, but the turn keeps running in the background
+                # (long tool calls, context compression, the post-turn
+                # review pass can outlive the grace window). The timer used
+                # to be one-shot, so nothing re-checked after the turn
+                # finished: the session stayed parked on the drop transport
+                # with its DB row un-ended until the multi-hour idle reaper,
+                # showing up as a separate "active" Desktop chat (#44045).
+                # Re-arm so the reap happens once the in-flight turn ends —
+                # unless a reconnect re-bound a live transport meanwhile.
+                if (
+                    session is not None
+                    and not session.get("_finalized")
+                    and session.get("running")
+                    and session.get("transport") is _detached_ws_transport
+                ):
+                    rearm = threading.Timer(_WS_ORPHAN_REAP_GRACE_S, _reap)
+                    rearm.daemon = True
+                    rearm.start()
                 return
             _close_session_by_id(sid, end_reason="ws_orphan_reap")
 


### PR DESCRIPTION
## Summary

The Desktop/TUI websocket disconnect path parks a detached session on the drop transport and schedules a **one-shot** grace timer (`_schedule_ws_orphan_reap`). `_ws_session_is_orphaned` deliberately spares sessions that are mid-turn — but when the in-flight turn outlives the grace window (long tool calls, **context compression, the post-turn background review pass**), the timer fired once, saw `running=True`, returned, and nothing ever re-checked. The session then sat detached with its DB row un-ended until the multi-hour idle reaper (`_SESSION_TTL_S` = 6h default), so the compression continuation child showed up as a separate "active" Desktop chat alongside the user's real workflow — the exact `ended_at = NULL` ghost row in the report.

`_reap` now re-arms itself while the session is detached, un-finalized, and still running. A reconnect or `session.resume` that re-binds a live transport still cancels the chain exactly as before, and since `_finalize_session` already ends `agent.session_id` (the rotated continuation id, #20001), the reap lands on the right DB row with `end_reason=ws_orphan_reap`.

Fixes #44045

## Why this addresses the reported shape

- parent `end_reason='compression'`, child `ended_at=NULL`: compression rotates the session id mid-turn; the client had already disconnected, so the spared-once reap never came back for the continuation.
- gateway `active_sessions: 1`: the ghost is not running anything — it's only parked in `_sessions` and projected as active via its un-ended DB row.

## Testing

Two new tests in `tests/test_tui_gateway_server.py` (pattern-matched to the existing orphan-reap tests, no real timers):
- `test_ws_orphan_reap_rearms_while_detached_session_is_mid_turn` — grace expires mid-turn → spared **and re-armed**; turn ends → re-armed timer reaps with `ws_orphan_reap`; no further re-arm. **Fails on `main`** (timer never re-arms), passes with the fix.
- `test_ws_orphan_reap_does_not_rearm_after_reattach` — a mid-turn session that re-bound a live transport stops the chain (guards the reconnect behavior).

`tests/test_tui_gateway_server.py` + `tests/test_tui_gateway_ws.py`: 260 passed, 1 pre-existing environment-dependent failure (`test_browser_manage_connect_default_local_reports_launch_hint`, fails identically on clean `main`).

