### PR TITLE
fix(api_server): resolve compressed sessions to their live tip for stateless clients

### DIFF
--- a/contributors/emails/AIalliAI@users.noreply.github.com
+++ b/contributors/emails/AIalliAI@users.noreply.github.com
@@ -1,0 +1,2 @@
+AIalliAI
+# new noreply email used after 2026-07-26

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4919,7 +4919,9 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Reuse session from previous_response_id chain so the dashboard
         # groups the entire conversation under one session entry.
-        session_id = stored_session_id or str(uuid.uuid4())
+        # Resolve compression tip so that a rotated session_id (after
+        # context compression) doesn't resume the stale parent (#44004).
+        session_id = self._resolve_session_tip(stored_session_id) or str(uuid.uuid4())
 
         stream = _coerce_request_bool(body.get("stream"), default=False)
         route = self._resolve_route(body.get("model"))

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1946,6 +1946,35 @@ class APIServerAdapter(BasePlatformAdapter):
             logger.debug("SessionDB unavailable for API server: %s", e)
             return None
 
+    def _resolve_session_tip(self, session_id: Optional[str]) -> Optional[str]:
+        """Follow a compression-continuation chain to its live tip.
+
+        Context compression ends the active session and continues in a new
+        child session.  Resident platforms (Discord, TUI) pick up the rotated
+        id in memory, but stateless API clients re-supply the original
+        ``session_id`` on every request; resuming the ended parent forks a
+        fresh lineage on every turn (#44004).  Best-effort: any failure
+        returns the id unchanged.
+
+        Synchronous (uses ``_ensure_session_db``, not the async variant) so it
+        can be called from the request path without an await — the lookup is a
+        single indexed walk over an already-open connection.
+        """
+        if not session_id:
+            return session_id
+        try:
+            db = self._ensure_session_db()
+            if db is None:
+                return session_id
+            resolved = db.get_compression_tip(session_id)
+        except Exception as e:
+            logger.debug("Compression-tip resolution failed for %s: %s", session_id, e)
+            return session_id
+        if isinstance(resolved, str) and resolved and resolved != session_id:
+            logger.debug("Resolved session %s -> compression tip %s", session_id, resolved)
+            return resolved
+        return session_id
+
     # ------------------------------------------------------------------
     # Agent creation helper
     # ------------------------------------------------------------------

--- a/scripts/tool_search_livetest2.py
+++ b/scripts/tool_search_livetest2.py
@@ -187,7 +187,7 @@ def run_one(scenario: Dict[str, Any], mode: str, rep: int, out_dir: Path) -> Dic
         "final_response": base._redact_secrets(final_response)[:500],
     }
     out_path = out_dir / f"{scenario['id']}__{'enabled' if enabled else 'disabled'}__rep{rep}.json"
-    out_path.write_text(json.dumps(rec, indent=1))
+    out_path.write_text(json.dumps(rec, indent=1), encoding="utf-8")
     shutil.rmtree(Path(os.environ["HERMES_HOME"]).parent, ignore_errors=True)
     return rec
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -3089,6 +3089,61 @@ class TestResponsesEndpoint:
             )
             assert resp.status == 400
 
+    @pytest.mark.asyncio
+    async def test_previous_response_id_resolves_compression_tip(self, adapter, tmp_path):
+        """previous_response_id chaining must resolve compressed-away session to the live tip (#44004)."""
+        from hermes_state import SessionDB
+
+        db_path = tmp_path / "test_state.db"
+        sdb = SessionDB(db_path)
+        sdb.create_session("stale-parent", "api_server")
+        sdb.append_message("stale-parent", "user", "before compression")
+        sdb.end_session("stale-parent", "compression")
+        sdb.create_session("live-child", "api_server", parent_session_id="stale-parent")
+        sdb.append_message("live-child", "user", "compressed summary")
+        sdb.append_message("live-child", "assistant", "post-compression reply")
+
+        # Pre-store a response whose stored_session_id points at the stale parent.
+        # Previous_response_id chaining would normally create this in a prior turn.
+        resp0_id = "resp_stale_parent_store"
+        adapter._response_store.put(resp0_id, {
+            "response": {"id": resp0_id, "object": "response", "status": "completed"},
+            "conversation_history": [{"role": "user", "content": "old turn"}],
+            "session_id": "stale-parent",
+        })
+
+        mock_result = {
+            "final_response": "continuing on tip",
+            "messages": [{"role": "assistant", "content": "continuing on tip"}],
+            "api_calls": 1,
+        }
+        usage = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run,
+                patch.object(adapter, "_ensure_session_db", return_value=sdb),
+            ):
+                mock_run.return_value = (mock_result, usage)
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "continue here",
+                        "previous_response_id": resp0_id,
+                    },
+                )
+
+        assert resp.status == 200, await resp.text()
+        agent_session_id = mock_run.call_args.kwargs["session_id"]
+        assert agent_session_id == "live-child", (
+            f"Expected session_id to resolve to 'live-child', got {agent_session_id!r}"
+        )
+
+        # Verify the response header also carries the resolved session_id
+        assert resp.headers.get("X-Hermes-Session-Id") == "live-child"
+
 
 class TestResponsesStreaming:
     @pytest.mark.asyncio

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -257,47 +257,6 @@ async def test_session_chat_loads_history_and_preserves_session_headers(auth_ada
     ]
 
 
-@pytest.mark.asyncio
-async def test_session_chat_resumes_compression_tip_instead_of_forking(auth_adapter, session_db):
-    """Chatting against a compressed-away session must continue its live tip (#44004).
-
-    Stateless clients re-supply the original session_id every turn; without
-    forward resolution each turn resumes the ended parent and forks a fresh
-    lineage from it.
-    """
-    source_id = session_db.create_session("stale-parent", "api_server")
-    session_db.append_message(source_id, "user", "before compression")
-    session_db.end_session(source_id, "compression")
-    session_db.create_session("live-tip", "api_server", parent_session_id=source_id)
-    session_db.append_message("live-tip", "user", "compressed summary")
-    session_db.append_message("live-tip", "assistant", "post-compression reply")
-
-    mock_run = AsyncMock(return_value=({"final_response": "continuing", "session_id": "live-tip"}, {"total_tokens": 2}))
-    app = _create_session_app(auth_adapter)
-    with patch.object(auth_adapter, "_run_agent", mock_run):
-        async with TestClient(TestServer(app)) as cli:
-            resp = await cli.post(
-                f"/api/sessions/{source_id}/chat",
-                json={"message": "next turn"},
-                headers={"Authorization": "Bearer sk-test"},
-            )
-            assert resp.status == 200, await resp.text()
-            payload = await resp.json()
-
-    _, kwargs = mock_run.call_args
-    # The run must target the live continuation, not the ended parent...
-    assert kwargs["session_id"] == "live-tip"
-    # ...and history must come from the tip (compressed context), not the parent.
-    history = kwargs["conversation_history"]
-    assert len(history) == 2
-    assert isinstance(history[0].pop("timestamp"), (int, float))
-    assert isinstance(history[1].pop("timestamp"), (int, float))
-    assert history == [
-        {"role": "user", "content": "compressed summary"},
-        {"role": "assistant", "content": "post-compression reply"},
-    ]
-    assert payload["session_id"] == "live-tip"
-    assert resp.headers["X-Hermes-Session-Id"] == "live-tip"
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -258,6 +258,49 @@ async def test_session_chat_loads_history_and_preserves_session_headers(auth_ada
 
 
 @pytest.mark.asyncio
+async def test_session_chat_resumes_compression_tip_instead_of_forking(auth_adapter, session_db):
+    """Chatting against a compressed-away session must continue its live tip (#44004).
+
+    Stateless clients re-supply the original session_id every turn; without
+    forward resolution each turn resumes the ended parent and forks a fresh
+    lineage from it.
+    """
+    source_id = session_db.create_session("stale-parent", "api_server")
+    session_db.append_message(source_id, "user", "before compression")
+    session_db.end_session(source_id, "compression")
+    session_db.create_session("live-tip", "api_server", parent_session_id=source_id)
+    session_db.append_message("live-tip", "user", "compressed summary")
+    session_db.append_message("live-tip", "assistant", "post-compression reply")
+
+    mock_run = AsyncMock(return_value=({"final_response": "continuing", "session_id": "live-tip"}, {"total_tokens": 2}))
+    app = _create_session_app(auth_adapter)
+    with patch.object(auth_adapter, "_run_agent", mock_run):
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/api/sessions/{source_id}/chat",
+                json={"message": "next turn"},
+                headers={"Authorization": "Bearer sk-test"},
+            )
+            assert resp.status == 200, await resp.text()
+            payload = await resp.json()
+
+    _, kwargs = mock_run.call_args
+    # The run must target the live continuation, not the ended parent...
+    assert kwargs["session_id"] == "live-tip"
+    # ...and history must come from the tip (compressed context), not the parent.
+    history = kwargs["conversation_history"]
+    assert len(history) == 2
+    assert isinstance(history[0].pop("timestamp"), (int, float))
+    assert isinstance(history[1].pop("timestamp"), (int, float))
+    assert history == [
+        {"role": "user", "content": "compressed summary"},
+        {"role": "assistant", "content": "post-compression reply"},
+    ]
+    assert payload["session_id"] == "live-tip"
+    assert resp.headers["X-Hermes-Session-Id"] == "live-tip"
+
+
+@pytest.mark.asyncio
 async def test_session_chat_accepts_multimodal_message(auth_adapter, session_db):
     session_id = session_db.create_session("image-session", "api_server")
     image_payload = [


### PR DESCRIPTION
Fixes #44004

## Problem

Context compression ends the active session and continues in a new child session (`agent/conversation_compression.py`). Resident platforms (Discord, TUI) pick up the rotated `session_id` in memory, but **stateless OpenAI-compatible clients** (Open WebUI, LibreChat, custom apps) re-supply the original `session_id` on every request. The API server resumes the ended parent each turn and forks a fresh lineage from it — the agent "forgets what we just said" after every compaction (the issue reporter observed 4 child lineages from one session_id within 8 minutes).

## Fix

`APIServerAdapter._resolve_session_tip()` projects the session id stored for a client-supplied `previous_response_id` to its compression-chain tip on the `/v1/responses` continuation path, using the existing `SessionDB.get_compression_tip()` primitive — the same canonicalization `gateway/run.py` and the Desktop session list already use. Resolution is strictly best-effort: missing DB, unknown/new ids, or lookup failures leave the supplied id unchanged, so first-contact ids and ephemeral run ids behave exactly as before.

Scope note for reviewers: earlier revisions of this branch resolved the tip at five intake points (`/v1/chat/completions`, `/api/sessions/{id}/chat`, `/chat/stream`, `/v1/runs`) and surfaced mid-run rotation in `/v1/runs` status. That was deliberately narrowed to the `/v1/responses` path — the reporter's actual setup — to keep the change reviewable; the remaining intake points can follow as a separate PR if wanted. The helper is intentionally synchronous (`_ensure_session_db`, not the async variant): the call site has no `await`, and the lookup is a single indexed walk on an already-open connection.

## Tests

- `test_api_server.py::TestResponsesEndpoint::test_previous_response_id_resolves_compression_tip` — a `previous_response_id` whose session was compressed away resolves to the live tip instead of forking a fresh lineage
- Touched gateway suites green: `test_api_server.py` (254), `test_api_server_runs.py` (37), `test_session_api.py` (33), `test_api_server_jobs.py` (41), `test_api_server_multiplex_secret_scope.py` (3)
