### PR TITLE
fix(windows): hide console-window flash on gateway-runtime subprocess spawns

### DIFF
--- a/agent/coding_context.py
+++ b/agent/coding_context.py
@@ -60,6 +60,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
 
+from hermes_cli._subprocess_compat import windows_hide_flags
+
 logger = logging.getLogger("hermes.coding_context")
 
 CODING_TOOLSET = "coding"
@@ -594,6 +596,7 @@ def _git(cwd: Path, *args: str) -> str:
             capture_output=True,
             text=True,
             timeout=_GIT_TIMEOUT,
+            creationflags=windows_hide_flags(),
         )
     except (OSError, subprocess.SubprocessError):
         return ""

--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Awaitable, Callable
 
 from agent.model_metadata import estimate_tokens_rough
+from hermes_cli._subprocess_compat import windows_hide_flags
 
 _QUOTED_REFERENCE_VALUE = r'(?:`[^`\n]+`|"[^"\n]+"|\'[^\'\n]+\')'
 REFERENCE_PATTERN = re.compile(
@@ -298,6 +299,7 @@ def _expand_git_reference(
             text=True,
             timeout=30,
             stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
         )
     except subprocess.TimeoutExpired:
         return f"{ref.raw}: git command timed out (30s)", None
@@ -491,6 +493,7 @@ def _rg_files(path: Path, cwd: Path, limit: int) -> list[Path] | None:
             text=True,
             timeout=10,
             stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
         )
     except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
         return None

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -70,6 +70,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Tuple
 
+from hermes_cli._subprocess_compat import windows_hide_flags
+
 try:
     import fcntl  # POSIX only; Windows falls back to best-effort without flock.
 except ImportError:  # pragma: no cover
@@ -397,6 +399,7 @@ def _spawn(spec: ShellHookSpec, stdin_json: str) -> Dict[str, Any]:
             timeout=spec.timeout,
             text=True,
             shell=False,
+            creationflags=windows_hide_flags(),
         )
     except subprocess.TimeoutExpired:
         result["timed_out"] = True

--- a/agent/skill_preprocessing.py
+++ b/agent/skill_preprocessing.py
@@ -5,6 +5,8 @@ import re
 import subprocess
 from pathlib import Path
 
+from hermes_cli._subprocess_compat import windows_hide_flags
+
 logger = logging.getLogger(__name__)
 
 # Matches ${HERMES_SKILL_DIR} / ${HERMES_SESSION_ID} tokens in SKILL.md.
@@ -75,6 +77,7 @@ def run_inline_shell(command: str, cwd: Path | None, timeout: int) -> str:
             timeout=max(1, int(timeout)),
             check=False,
             stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
         )
     except subprocess.TimeoutExpired:
         return f"[inline-shell timeout after {timeout}s: {command}]"

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Any, Optional
 from utils import atomic_json_write
+from hermes_cli._subprocess_compat import windows_hide_flags
 
 if sys.platform == "win32":
     import msvcrt
@@ -86,6 +87,7 @@ def terminate_pid(pid: int, *, force: bool = False) -> None:
                 capture_output=True,
                 text=True,
                 timeout=10,
+                creationflags=windows_hide_flags(),
             )
         except FileNotFoundError:
             os.kill(pid, signal.SIGTERM)

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -364,7 +364,7 @@ class TestTerminatePid:
         calls = []
         monkeypatch.setattr(status, "_IS_WINDOWS", True)
 
-        def fake_run(cmd, capture_output=False, text=False, timeout=None):
+        def fake_run(cmd, capture_output=False, text=False, timeout=None, **kwargs):
             calls.append((cmd, capture_output, text, timeout))
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -4,6 +4,7 @@ import subprocess
 
 import pytest
 
+from hermes_cli._subprocess_compat import windows_hide_flags
 from tools.environments import docker as docker_env
 
 
@@ -110,6 +111,7 @@ def test_ensure_docker_available_uses_resolved_executable(monkeypatch):
             "text": True,
             "timeout": 5,
             "stdin": subprocess.DEVNULL,
+            "creationflags": windows_hide_flags(),
         })
     ]
 

--- a/tests/tools/test_windows_native_support.py
+++ b/tests/tools/test_windows_native_support.py
@@ -1007,3 +1007,101 @@ class TestGatewayDetachedWatcherWindowsFlags:
             "CreateProcess and retry without the breakaway bit, matching "
             "gateway_windows._spawn_detached's fallback pattern."
         )
+
+
+# ---------------------------------------------------------------------------
+# Gateway-runtime subprocess spawns hide their console window (#43848)
+# ---------------------------------------------------------------------------
+
+
+class TestGatewayRuntimeSpawnsHideConsole:
+    """Per-agent-call subprocess spawns must pass CREATE_NO_WINDOW.
+
+    When the gateway runs without a console on Windows (Desktop app,
+    service), every console child it spawns — git/rg context probes,
+    shell hooks, runtime pip installs, taskkill, backend version probes —
+    opens a *visible* conhost window that flickers and steals focus on
+    each agent call (issue #43848).
+
+    Each test simulates Windows by flipping ``IS_WINDOWS`` in
+    ``hermes_cli._subprocess_compat`` (which ``windows_hide_flags()``
+    consults at call time) and asserts the CREATE_NO_WINDOW bit
+    (0x08000000) reaches ``subprocess.run``.
+    """
+
+    CREATE_NO_WINDOW = 0x08000000
+
+    @pytest.fixture(autouse=True)
+    def _simulate_windows(self, monkeypatch):
+        from hermes_cli import _subprocess_compat as sc
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+
+    def _capture_run(self, monkeypatch):
+        import subprocess as sp
+        captured = {}
+
+        def fake_run(*args, **kwargs):
+            captured["kwargs"] = kwargs
+            return sp.CompletedProcess(args[0] if args else [], 0, "", "")
+
+        monkeypatch.setattr(sp, "run", fake_run)
+        return captured
+
+    def _assert_hidden(self, captured):
+        kwargs = captured["kwargs"]
+        assert kwargs.get("creationflags", 0) & self.CREATE_NO_WINDOW, (
+            "subprocess.run call is missing CREATE_NO_WINDOW — on a "
+            "console-less Windows gateway this child would open a visible "
+            "conhost window (#43848)."
+        )
+
+    def test_coding_context_git_probe(self, monkeypatch, tmp_path):
+        from agent import coding_context
+        captured = self._capture_run(monkeypatch)
+        coding_context._git(tmp_path, "status", "--porcelain")
+        self._assert_hidden(captured)
+
+    def test_context_references_rg_files(self, monkeypatch, tmp_path):
+        from agent import context_references
+        captured = self._capture_run(monkeypatch)
+        context_references._rg_files(tmp_path / "src", tmp_path, 5)
+        self._assert_hidden(captured)
+
+    def test_skill_inline_shell(self, monkeypatch):
+        from agent import skill_preprocessing
+        captured = self._capture_run(monkeypatch)
+        skill_preprocessing.run_inline_shell("echo hi", None, 5)
+        self._assert_hidden(captured)
+
+    def test_env_probe_run(self, monkeypatch):
+        from tools import env_probe
+        captured = self._capture_run(monkeypatch)
+        env_probe._run(["echo", "hi"])
+        self._assert_hidden(captured)
+
+    def test_gateway_status_taskkill(self, monkeypatch):
+        from gateway import status as gw_status
+        captured = self._capture_run(monkeypatch)
+        monkeypatch.setattr(gw_status, "_IS_WINDOWS", True)
+        gw_status.terminate_pid(987654, force=True)
+        self._assert_hidden(captured)
+
+    def test_tts_process_tree_taskkill(self, monkeypatch):
+        from tools import tts_tool
+        captured = self._capture_run(monkeypatch)
+        monkeypatch.setattr(os, "name", "nt")
+        proc = MagicMock()
+        proc.poll.return_value = None
+        proc.pid = 987654
+        tts_tool._terminate_command_tts_process_tree(proc)
+        self._assert_hidden(captured)
+
+    def test_transcription_process_tree_taskkill(self, monkeypatch):
+        from tools import transcription_tools
+        captured = self._capture_run(monkeypatch)
+        monkeypatch.setattr(os, "name", "nt")
+        proc = MagicMock()
+        proc.poll.return_value = None
+        proc.pid = 987654
+        transcription_tools._terminate_command_stt_process_tree(proc)
+        self._assert_hidden(captured)

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -61,6 +61,7 @@ from hermes_constants import get_hermes_home
 from typing import Dict, List, Optional, Set, Tuple
 
 from utils import env_int
+from hermes_cli._subprocess_compat import windows_hide_flags
 
 logger = logging.getLogger(__name__)
 
@@ -308,6 +309,7 @@ def _run_git(
             env=env,
             cwd=str(normalized_working_dir),
             stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
         )
         ok = result.returncode == 0
         stdout = result.stdout.strip()
@@ -428,6 +430,7 @@ def _init_store(store: Path, working_dir: str) -> Optional[str]:
             capture_output=True, text=True,
             env=init_env, timeout=_GIT_TIMEOUT,
             stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
         )
         if result.returncode != 0:
             return f"Shadow store init failed: {result.stderr.strip()}"

--- a/tools/env_probe.py
+++ b/tools/env_probe.py
@@ -37,6 +37,8 @@ import sys
 import threading
 from typing import Optional
 
+from hermes_cli._subprocess_compat import windows_hide_flags
+
 logger = logging.getLogger(__name__)
 
 # Module-level cache.  The probe result is deterministic for the
@@ -66,6 +68,7 @@ def _run(cmd: list[str], timeout: float = 3.0) -> tuple[int, str, str]:
             timeout=timeout,
             check=False,
             stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
         )
         return result.returncode, (result.stdout or "").strip(), (result.stderr or "").strip()
     except FileNotFoundError:

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -20,6 +20,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import IO, Callable, Protocol
 
+from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_constants import get_hermes_home
 from tools.interrupt import is_interrupted
 
@@ -140,7 +141,12 @@ def _popen_bash(
     If *stdin_data* is provided, writes it asynchronously via :func:`_pipe_stdin`.
     Backends with special Popen needs (e.g. local's ``preexec_fn``) can bypass
     this and call :func:`_pipe_stdin` directly.
+
+    On Windows the child gets ``CREATE_NO_WINDOW`` so console helpers
+    (``docker exec``, ``ssh``) don't flash a console window when Hermes
+    runs under a GUI host (issue #43848).
     """
+    kwargs.setdefault("creationflags", windows_hide_flags())
     proc = subprocess.Popen(
         cmd,
         stdout=subprocess.PIPE,

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -16,6 +16,7 @@ import uuid
 from pathlib import Path
 from typing import Optional
 
+from hermes_cli._subprocess_compat import windows_hide_flags
 from tools.environments.base import BaseEnvironment, _popen_bash
 from tools.environments.local import _HERMES_PROVIDER_ENV_BLOCKLIST
 
@@ -178,6 +179,7 @@ def reap_orphan_containers(
             [docker, "ps", "-a", *filters, "--format", "{{.ID}}"],
             capture_output=True, text=True, timeout=15, check=False,
             stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
         )
     except (subprocess.TimeoutExpired, OSError) as e:
         logger.debug("orphan reaper docker ps failed: %s", e)
@@ -212,6 +214,7 @@ def reap_orphan_containers(
                 [docker, "rm", "-f", cid],
                 capture_output=True, text=True, timeout=30,
                 stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
             )
             if result.returncode == 0:
                 removed += 1
@@ -242,6 +245,7 @@ def _container_finished_at(docker_exe: str, container_id: str):
             [docker_exe, "inspect", "--format", "{{.State.FinishedAt}}", container_id],
             capture_output=True, text=True, timeout=10, check=False,
             stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
         )
     except (subprocess.TimeoutExpired, OSError) as e:
         logger.debug("orphan reaper docker inspect %s failed: %s", container_id[:12], e)
@@ -385,6 +389,7 @@ def _image_uses_init_entrypoint(docker_exe: str, image: str) -> bool:
             text=True,
             timeout=15,
             stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
         )
     except (subprocess.SubprocessError, OSError) as e:
         logger.debug("Docker: could not inspect entrypoint for %s: %s", image, e)
@@ -458,6 +463,7 @@ def _ensure_docker_available() -> None:
             text=True,
             timeout=5,
             stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
         )
     except FileNotFoundError:
         logger.error(
@@ -839,6 +845,7 @@ class DockerEnvironment(BaseEnvironment):
                             timeout=30,
                             check=True,
                             stdin=subprocess.DEVNULL,
+                            creationflags=windows_hide_flags(),
                         )
                     except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
                         logger.warning(
@@ -878,6 +885,7 @@ class DockerEnvironment(BaseEnvironment):
                     timeout=120,  # image pull may take a while
                     check=True,
                     stdin=subprocess.DEVNULL,
+                    creationflags=windows_hide_flags(),
                 )
             except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
                 # Docker may create the container object before `docker run`
@@ -895,6 +903,7 @@ class DockerEnvironment(BaseEnvironment):
                     [self._docker_exe, "rm", "-f", container_name],
                     capture_output=True, timeout=10,
                     stdin=subprocess.DEVNULL,
+                    creationflags=windows_hide_flags(),
                 )
                 raise
             self._container_id = result.stdout.strip()
@@ -1006,6 +1015,7 @@ class DockerEnvironment(BaseEnvironment):
                         [self._docker_exe, "start", cid],
                         capture_output=True, text=True, timeout=30, check=True,
                         stdin=subprocess.DEVNULL,
+                        creationflags=windows_hide_flags(),
                     )
                     self._container_id = cid
                     logger.info("Recovery: restarted container %s", cid[:12])
@@ -1037,6 +1047,7 @@ class DockerEnvironment(BaseEnvironment):
                 result = subprocess.run(
                     run_cmd, capture_output=True, text=True, timeout=120, check=True,
                     stdin=subprocess.DEVNULL,
+                    creationflags=windows_hide_flags(),
                 )
                 self._container_id = result.stdout.strip()
                 self._container_name = new_name
@@ -1092,6 +1103,7 @@ class DockerEnvironment(BaseEnvironment):
                 [docker, "info", "--format", "{{.Driver}}"],
                 capture_output=True, text=True, timeout=10,
                 stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
             )
             driver = result.stdout.strip().lower()
             if driver != "overlay2":
@@ -1103,6 +1115,7 @@ class DockerEnvironment(BaseEnvironment):
                 [docker, "create", "--storage-opt", "size=1m", "hello-world"],
                 capture_output=True, text=True, timeout=15,
                 stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
             )
             if probe.returncode == 0:
                 # Clean up the created container
@@ -1110,7 +1123,8 @@ class DockerEnvironment(BaseEnvironment):
                 if container_id:
                     subprocess.run([docker, "rm", container_id],
                                    capture_output=True, timeout=5,
-                                   stdin=subprocess.DEVNULL)
+                                   stdin=subprocess.DEVNULL,
+                                   creationflags=windows_hide_flags())
                 _storage_opt_ok = True
             else:
                 _storage_opt_ok = False
@@ -1146,6 +1160,7 @@ class DockerEnvironment(BaseEnvironment):
                 timeout=10,
                 check=False,
                 stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
             )
         except (subprocess.TimeoutExpired, OSError) as e:
             logger.debug("docker ps probe failed: %s — will start a fresh container", e)
@@ -1263,6 +1278,7 @@ class DockerEnvironment(BaseEnvironment):
                         [docker_exe, "stop", "-t", "10", container_id],
                         capture_output=True, timeout=30,
                         stdin=subprocess.DEVNULL,
+                        creationflags=windows_hide_flags(),
                     )
                 except (subprocess.TimeoutExpired, OSError) as e:
                     logger.warning("docker stop %s timed out / failed: %s", log_id, e)
@@ -1272,6 +1288,7 @@ class DockerEnvironment(BaseEnvironment):
                         [docker_exe, "rm", "-f", container_id],
                         capture_output=True, timeout=30,
                         stdin=subprocess.DEVNULL,
+                        creationflags=windows_hide_flags(),
                     )
                 except (subprocess.TimeoutExpired, OSError) as e:
                     logger.warning("docker rm -f %s failed: %s", log_id, e)

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -9,6 +9,7 @@ import subprocess
 import tempfile
 from pathlib import Path
 
+from hermes_cli._subprocess_compat import windows_hide_flags
 from tools.environments.base import BaseEnvironment, _popen_bash
 from tools.environments.file_sync import (
     FileSyncManager,
@@ -107,6 +108,7 @@ class SSHEnvironment(BaseEnvironment):
                 text=True,
                 timeout=15,
                 stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
             )
             if result.returncode != 0:
                 error_msg = result.stderr.strip() or result.stdout.strip()
@@ -125,6 +127,7 @@ class SSHEnvironment(BaseEnvironment):
                 text=True,
                 timeout=10,
                 stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
             )
             home = result.stdout.strip()
             if home and result.returncode == 0:
@@ -152,6 +155,7 @@ class SSHEnvironment(BaseEnvironment):
             text=True,
             timeout=10,
             stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
         )
 
     # _get_sync_files provided via iter_sync_files in FileSyncManager init
@@ -167,6 +171,7 @@ class SSHEnvironment(BaseEnvironment):
             text=True,
             timeout=10,
             stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
         )
 
         scp_cmd = ["scp", "-o", f"ControlPath={self.control_socket}"]
@@ -181,6 +186,7 @@ class SSHEnvironment(BaseEnvironment):
             text=True,
             timeout=30,
             stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
         )
         if result.returncode != 0:
             raise RuntimeError(f"scp failed: {result.stderr.strip()}")
@@ -210,6 +216,7 @@ class SSHEnvironment(BaseEnvironment):
                 text=True,
                 timeout=30,
                 stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
             )
             if result.returncode != 0:
                 raise RuntimeError(f"remote mkdir failed: {result.stderr.strip()}")
@@ -255,6 +262,7 @@ class SSHEnvironment(BaseEnvironment):
             tar_proc = subprocess.Popen(
                 tar_cmd,
                 stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             )
@@ -262,6 +270,7 @@ class SSHEnvironment(BaseEnvironment):
                 ssh_proc = subprocess.Popen(
                     ssh_cmd, stdin=tar_proc.stdout, stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
+                    creationflags=windows_hide_flags(),
                 )
             except Exception:
                 tar_proc.kill()
@@ -311,6 +320,7 @@ class SSHEnvironment(BaseEnvironment):
             result = subprocess.run(
                 ssh_cmd,
                 stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
                 stdout=f,
                 stderr=subprocess.PIPE,
                 timeout=120,
@@ -328,6 +338,7 @@ class SSHEnvironment(BaseEnvironment):
             text=True,
             timeout=10,
             stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
         )
         if result.returncode != 0:
             raise RuntimeError(f"remote rm failed: {result.stderr.strip()}")
@@ -366,6 +377,7 @@ class SSHEnvironment(BaseEnvironment):
                     capture_output=True,
                     timeout=5,
                     stdin=subprocess.DEVNULL,
+                    creationflags=windows_hide_flags(),
                 )
             except (OSError, subprocess.SubprocessError):
                 pass

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -61,6 +61,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Optional
 
+from hermes_cli._subprocess_compat import windows_hide_flags
+
 logger = logging.getLogger(__name__)
 
 
@@ -372,6 +374,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                 [uv_bin, "pip", "install", *specs],
                 capture_output=True, text=True, timeout=timeout, env=uv_env,
                 stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
             )
             if r.returncode == 0:
                 return _InstallResult(True, r.stdout or "", r.stderr or "")
@@ -386,6 +389,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
             pip_cmd + ["--version"],
             capture_output=True, text=True, timeout=15,
             stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
         )
         if probe.returncode != 0:
             raise FileNotFoundError("pip not in venv")
@@ -395,6 +399,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                 [sys.executable, "-m", "ensurepip", "--upgrade", "--default-pip"],
                 capture_output=True, text=True, timeout=120, check=True,
                 stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
             )
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             return _InstallResult(False, "",
@@ -405,6 +410,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
             pip_cmd + ["install", *specs],
             capture_output=True, text=True, timeout=timeout,
             stdin=subprocess.DEVNULL,
+            creationflags=windows_hide_flags(),
         )
         return _InstallResult(r.returncode == 0, r.stdout or "", r.stderr or "")
     except subprocess.TimeoutExpired as e:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -46,6 +46,7 @@ from pathlib import Path
 from typing import Optional, Dict, Any, List
 
 from utils import env_var_enabled
+from hermes_cli._subprocess_compat import windows_hide_flags
 
 logger = logging.getLogger(__name__)
 
@@ -578,6 +579,7 @@ def _sudo_nopasswd_works() -> bool:
             stderr=subprocess.DEVNULL,
             timeout=3,
             check=False,
+            creationflags=windows_hide_flags(),
         )
         return probe.returncode == 0
     except Exception:
@@ -2480,13 +2482,25 @@ def check_terminal_requirements() -> bool:
             if not docker:
                 logger.error("Docker executable not found in PATH or common install locations")
                 return False
-            result = subprocess.run([docker, "version"], capture_output=True, timeout=5, stdin=subprocess.DEVNULL)
+            result = subprocess.run(
+                [docker, "version"],
+                capture_output=True,
+                timeout=5,
+                stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
+            )
             return result.returncode == 0
 
         elif env_type == "singularity":
             executable = shutil.which("apptainer") or shutil.which("singularity")
             if executable:
-                result = subprocess.run([executable, "--version"], capture_output=True, timeout=5, stdin=subprocess.DEVNULL)
+                result = subprocess.run(
+                    [executable, "--version"],
+                    capture_output=True,
+                    timeout=5,
+                    stdin=subprocess.DEVNULL,
+                    creationflags=windows_hide_flags(),
+                )
                 return result.returncode == 0
             return False
 

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -38,6 +38,7 @@ from typing import Optional, Dict, Any
 from urllib.parse import urljoin
 
 from utils import is_truthy_value
+from hermes_cli._subprocess_compat import windows_hide_flags
 from tools.managed_tool_gateway import resolve_managed_tool_gateway
 from tools.tool_backend_helpers import (
     managed_nous_tools_enabled,
@@ -491,6 +492,7 @@ def _terminate_command_stt_process_tree(proc: subprocess.Popen) -> None:
                 stderr=subprocess.DEVNULL,
                 timeout=5,
                 stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
             )
         except Exception:
             proc.kill()

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -53,6 +53,7 @@ from typing import Callable, Dict, Any, Optional
 from urllib.parse import urljoin
 
 from hermes_constants import display_hermes_home
+from hermes_cli._subprocess_compat import windows_hide_flags
 
 logger = logging.getLogger(__name__)
 def get_env_value(name, default=None):
@@ -713,6 +714,7 @@ def _terminate_command_tts_process_tree(proc: subprocess.Popen) -> None:
                 stderr=subprocess.DEVNULL,
                 timeout=5,
                 stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
             )
         except Exception:
             proc.kill()


### PR DESCRIPTION
## Summary

On Windows, when the gateway runs without a console (Desktop app / background service), every console child process it spawns opens a **visible conhost window** that flickers and steals focus — the behavior reported in #43848.

The main terminal-tool execution path already hides its window via `windows_hide_flags()` (`tools/environments/local.py`), and the same convention exists in `tools/process_registry.py` and `cron/scheduler.py` — but a number of spawn sites reachable during a normal agent turn were missed. The most user-visible ones run on **every message** (git workspace probes during prompt building) or on every file edit (checkpoint git calls), which is what makes the flicker so noticeable.

## Change

Pass `creationflags=windows_hide_flags()` (`CREATE_NO_WINDOW`; returns `0` on POSIX, so non-Windows behavior is unchanged) at the gateway-runtime spawn sites:

**Per agent turn**
- `agent/coding_context.py` — git workspace probes during prompt building (several per message)
- `agent/context_references.py` — `@git`/`@diff` reference git calls and `rg --files` listing
- `tools/checkpoint_manager.py` — shadow-store git calls on every checkpointed file edit
- `agent/shell_hooks.py` — user-configured hook commands
- `agent/skill_preprocessing.py` — SKILL.md inline-shell snippets

**Terminal tool probes** (first commit)
- `tools/terminal_tool.py` — `sudo -n true` probe (Windows 11 ships a `sudo`), `docker version` / `apptainer --version` backend probes

**Process cleanup** (`taskkill` tree-kills, Windows-only branches)
- `gateway/status.py::terminate_pid`, `tools/tts_tool.py`, `tools/transcription_tools.py`

**Runtime installs / probes**
- `tools/lazy_deps.py` — `uv pip` / `pip` / `ensurepip` runtime dependency installs (these otherwise show a console window for the whole install)
- `tools/env_probe.py` — interpreter/binary version probes

**Container/remote backends**
- `tools/environments/base.py` — `_popen_bash` now defaults `creationflags` to `windows_hide_flags()` (via `setdefault`, so callers can still override), covering the shared `docker exec` / `ssh` per-command spawn path
- `tools/environments/docker.py` — container lifecycle and probe spawns (`docker ps/rm/inspect/run/start/stop/info/create`)
- `tools/environments/ssh.py` — control-master setup, scp/tar sync, and remote command spawns

Sites intentionally left alone: macOS-only spawns (`security`, `scutil`), interactive flows that must keep the console (`claude setup-token`), and the interactive CLI (a console already exists there, so nothing flashes).

## Testing

- New regression tests in `tests/tools/test_windows_native_support.py` (`TestGatewayRuntimeSpawnsHideConsole`) simulate Windows by flipping `IS_WINDOWS` in `_subprocess_compat` and assert the `CREATE_NO_WINDOW` bit reaches `subprocess.run` for the per-turn probes, taskkill paths, and inline-shell helper. Verified they fail against unpatched modules.
- Existing suites for all touched modules pass: 348 tests across `test_coding_context`, `test_context_references`, `test_shell_hooks`, `test_checkpoint_manager`, `test_env_probe`, `test_lazy_deps`, `test_windows_native_support`, `test_status`, plus the terminal-tool suites (220 more).

Fixes #43848
