### PR TITLE
Unify dashboard appearance and chat skins

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -9311,6 +9311,17 @@ def _resolve_chat_argv(
     except Exception:
         _log.debug("Failed to apply terminal config bridge for dashboard chat", exc_info=True)
     env.setdefault("NODE_ENV", "production")
+    # The dashboard PTY is rendered by xterm.js, not by whatever terminal
+    # launched `hermes dashboard`. Codex/CI shells often export TERM=dumb or
+    # NO_COLOR=1, which makes the Ink TUI suppress every skin color in the
+    # browser even though xterm.js supports them. Normalize only this embedded
+    # chat child so native CLI/TUI launches keep honoring the user's shell.
+    env["TERM"] = "xterm-256color"
+    env["COLORTERM"] = "truecolor"
+    env["FORCE_COLOR"] = "3"
+    env["HERMES_TUI_TRUECOLOR"] = "1"
+    env.setdefault("HERMES_TUI_BACKGROUND", "#000000")
+    env.pop("NO_COLOR", None)
     # Browser-embedded chat should prefer stable wheel-based scrollback over
     # native terminal mouse tracking. When mouse tracking is enabled, wheel
     # events are consumed by the TUI and forwarded as terminal input, which

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2530,7 +2530,28 @@ async def get_defaults():
 
 @app.get("/api/config/schema")
 async def get_schema():
-    return {"fields": CONFIG_SCHEMA, "category_order": _CATEGORY_ORDER}
+    return {
+        "fields": _config_schema_with_dynamic_options(),
+        "category_order": _CATEGORY_ORDER,
+    }
+
+
+def _config_schema_with_dynamic_options() -> Dict[str, Dict[str, Any]]:
+    """Return config schema with runtime-discovered appearance options."""
+    fields = {key: dict(value) for key, value in CONFIG_SCHEMA.items()}
+    try:
+        fields["display.skin"]["options"] = [
+            skin["name"] for skin in _available_cli_skins()
+        ]
+    except Exception:
+        _log.debug("Failed to populate dynamic skin schema options", exc_info=True)
+    try:
+        fields["dashboard.theme"]["options"] = [
+            theme["name"] for theme in _available_dashboard_themes()
+        ]
+    except Exception:
+        _log.debug("Failed to populate dynamic dashboard theme schema options", exc_info=True)
+    return fields
 
 
 _EMPTY_MODEL_INFO: dict = {
@@ -9815,6 +9836,128 @@ _BUILTIN_DASHBOARD_THEMES = [
     {"name": "rose",      "label": "Rosé",           "description": "Soft pink and warm ivory — easy on the eyes"},
 ]
 
+_APPEARANCE_PRESETS = [
+    {
+        "id": "hermes-teal",
+        "label": "Hermes Teal",
+        "description": "Canonical dashboard with the default Hermes chat skin",
+        "dashboard_theme": "default",
+        "chat_skin": "default",
+    },
+    {
+        "id": "hermes-teal-large",
+        "label": "Hermes Teal (Large)",
+        "description": "Roomier dashboard with the default Hermes chat skin",
+        "dashboard_theme": "default-large",
+        "chat_skin": "default",
+    },
+    {
+        "id": "nous-blue",
+        "label": "Nous Blue",
+        "description": "Light dashboard paired with the daylight chat skin",
+        "dashboard_theme": "nous-blue",
+        "chat_skin": "daylight",
+    },
+    {
+        "id": "midnight",
+        "label": "Midnight",
+        "description": "Cool dashboard paired with the slate chat skin",
+        "dashboard_theme": "midnight",
+        "chat_skin": "slate",
+    },
+    {
+        "id": "mono",
+        "label": "Mono",
+        "description": "Monochrome dashboard and chat skin",
+        "dashboard_theme": "mono",
+        "chat_skin": "mono",
+    },
+    {
+        "id": "ember",
+        "label": "Ember",
+        "description": "Warm dashboard paired with the Ares chat skin",
+        "dashboard_theme": "ember",
+        "chat_skin": "ares",
+    },
+]
+
+
+def _available_dashboard_themes() -> list:
+    user_themes = _discover_user_themes()
+    seen = set()
+    themes = []
+    for t in _BUILTIN_DASHBOARD_THEMES:
+        seen.add(t["name"])
+        themes.append(dict(t))
+    for t in user_themes:
+        if t["name"] in seen:
+            continue
+        themes.append({
+            "name": t["name"],
+            "label": t["label"],
+            "description": t["description"],
+            "definition": t,
+        })
+        seen.add(t["name"])
+    return themes
+
+
+def _available_cli_skins() -> list:
+    from hermes_cli.skin_engine import list_skins
+
+    skins = []
+    for skin in list_skins():
+        name = str(skin.get("name", "")).strip()
+        if not name:
+            continue
+        skins.append({
+            "name": name,
+            "label": name,
+            "description": skin.get("description", ""),
+            "source": skin.get("source", "builtin"),
+        })
+    return skins
+
+
+def _available_appearance_presets(themes: list, skins: list) -> list:
+    theme_names = {theme["name"] for theme in themes}
+    skin_names = {skin["name"] for skin in skins}
+    presets = []
+    for preset in _APPEARANCE_PRESETS:
+        out = dict(preset)
+        out["available"] = (
+            preset["dashboard_theme"] in theme_names
+            and preset["chat_skin"] in skin_names
+        )
+        presets.append(out)
+    return presets
+
+
+def _active_appearance_preset(
+    dashboard_theme: str,
+    chat_skin: str,
+    presets: list,
+) -> Optional[str]:
+    for preset in presets:
+        if (
+            preset.get("available", True)
+            and preset.get("dashboard_theme") == dashboard_theme
+            and preset.get("chat_skin") == chat_skin
+        ):
+            return str(preset["id"])
+    return None
+
+
+def _broadcast_tui_skin_changed() -> dict:
+    try:
+        from tui_gateway import server as tui_server
+        from tui_gateway.ws import broadcast_event
+
+        return broadcast_event("skin.changed", tui_server.resolve_skin())
+    except Exception:
+        _log.debug("Failed to broadcast TUI skin change", exc_info=True)
+        return {"connected": 0, "sent": 0}
+
 
 def _parse_theme_layer(value: Any, default_hex: str, default_alpha: float = 1.0) -> Optional[Dict[str, Any]]:
     """Normalise a theme layer spec from YAML into `{hex, alpha}` form.
@@ -10064,23 +10207,7 @@ async def get_dashboard_themes():
     """
     config = load_config()
     active = cfg_get(config, "dashboard", "theme", default="default")
-    user_themes = _discover_user_themes()
-    seen = set()
-    themes = []
-    for t in _BUILTIN_DASHBOARD_THEMES:
-        seen.add(t["name"])
-        themes.append(t)
-    for t in user_themes:
-        if t["name"] in seen:
-            continue
-        themes.append({
-            "name": t["name"],
-            "label": t["label"],
-            "description": t["description"],
-            "definition": t,
-        })
-        seen.add(t["name"])
-    return {"themes": themes, "active": active}
+    return {"themes": _available_dashboard_themes(), "active": active}
 
 
 class ThemeSetBody(BaseModel):
@@ -10096,6 +10223,99 @@ async def set_dashboard_theme(body: ThemeSetBody):
     config["dashboard"]["theme"] = body.name
     save_config(config)
     return {"ok": True, "theme": body.name}
+
+
+class AppearanceSetBody(BaseModel):
+    dashboard_theme: Optional[str] = None
+    chat_skin: Optional[str] = None
+
+
+@app.get("/api/appearance")
+async def get_appearance():
+    """Return dashboard theme + CLI/TUI skin choices for the unified picker."""
+    config = load_config()
+    dashboard_theme = cfg_get(config, "dashboard", "theme", default="default")
+    chat_skin = cfg_get(config, "display", "skin", default="default")
+    themes = _available_dashboard_themes()
+    skins = _available_cli_skins()
+    presets = _available_appearance_presets(themes, skins)
+    return {
+        "dashboard_theme": dashboard_theme,
+        "chat_skin": chat_skin,
+        "themes": themes,
+        "skins": skins,
+        "presets": presets,
+        "active_preset": _active_appearance_preset(
+            dashboard_theme,
+            chat_skin,
+            presets,
+        ),
+    }
+
+
+@app.put("/api/appearance")
+async def set_appearance(body: AppearanceSetBody):
+    """Persist dashboard and/or chat appearance settings."""
+    config = load_config()
+    themes = _available_dashboard_themes()
+    skins = _available_cli_skins()
+    theme_names = {theme["name"] for theme in themes}
+    skin_names = {skin["name"] for skin in skins}
+
+    if body.dashboard_theme is None and body.chat_skin is None:
+        raise HTTPException(
+            status_code=400,
+            detail="dashboard_theme or chat_skin required",
+        )
+
+    if body.dashboard_theme is not None and body.dashboard_theme not in theme_names:
+        raise HTTPException(
+            status_code=400,
+            detail=f"unknown dashboard theme: {body.dashboard_theme}",
+        )
+
+    if body.chat_skin is not None and body.chat_skin not in skin_names:
+        raise HTTPException(
+            status_code=400,
+            detail=f"unknown chat skin: {body.chat_skin}",
+        )
+
+    if body.dashboard_theme is not None:
+        dashboard = config.get("dashboard")
+        if not isinstance(dashboard, dict):
+            dashboard = {}
+        dashboard["theme"] = body.dashboard_theme
+        config["dashboard"] = dashboard
+
+    skin_changed = False
+    if body.chat_skin is not None:
+        display = config.get("display")
+        if not isinstance(display, dict):
+            display = {}
+        skin_changed = display.get("skin", "default") != body.chat_skin
+        display["skin"] = body.chat_skin
+        config["display"] = display
+
+    save_config(config)
+
+    skin_broadcast = (
+        _broadcast_tui_skin_changed() if body.chat_skin is not None else None
+    )
+    dashboard_theme = cfg_get(config, "dashboard", "theme", default="default")
+    chat_skin = cfg_get(config, "display", "skin", default="default")
+    presets = _available_appearance_presets(themes, skins)
+    return {
+        "ok": True,
+        "dashboard_theme": dashboard_theme,
+        "chat_skin": chat_skin,
+        "skin_changed": skin_changed,
+        "skin_broadcast": skin_broadcast,
+        "active_preset": _active_appearance_preset(
+            dashboard_theme,
+            chat_skin,
+            presets,
+        ),
+    }
 
 
 # Curated font-override ids. Kept in sync with FONT_CHOICES in

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -701,6 +701,7 @@ class TestAdminEndpointsAuthGate:
             "/api/portal",
             "/api/system/stats",
             "/api/hermes/update/check",
+            "/api/appearance",
         ],
     )
     def test_gated(self, path):
@@ -709,6 +710,10 @@ class TestAdminEndpointsAuthGate:
 
     def test_webhooks_enable_post_gated(self):
         resp = self.client.post("/api/webhooks/enable")
+        assert resp.status_code in (401, 403)
+
+    def test_appearance_put_gated(self):
+        resp = self.client.put("/api/appearance", json={"dashboard_theme": "mono"})
         assert resp.status_code in (401, 403)
 
 
@@ -1042,3 +1047,101 @@ class TestToolsConfigEndpoints:
                 kwargs["json"] = payload
             r = fn(path, **kwargs)
             assert r.status_code == 401, f"{method} {path} not gated"
+
+
+class TestAppearanceEndpoints:
+    @pytest.fixture(autouse=True)
+    def _setup(self, _isolate_hermes_home):
+        self.client, self.header = _client()
+
+    def test_get_appearance_lists_presets_themes_skins_and_custom_entries(self):
+        from hermes_constants import get_hermes_home
+
+        home = get_hermes_home()
+        (home / "skins").mkdir(parents=True, exist_ok=True)
+        (home / "skins" / "ocean-chat.yaml").write_text(
+            "name: ocean-chat\ndescription: Custom ocean skin\n",
+            encoding="utf-8",
+        )
+        (home / "dashboard-themes").mkdir(parents=True, exist_ok=True)
+        (home / "dashboard-themes" / "ocean.yaml").write_text(
+            "name: ocean\nlabel: Ocean\ndescription: Custom ocean dashboard\n"
+            "palette:\n  background: '#001122'\n  midground: '#aaddff'\n",
+            encoding="utf-8",
+        )
+
+        r = self.client.get("/api/appearance")
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["dashboard_theme"] == "default"
+        assert body["chat_skin"] == "default"
+        assert "hermes-teal" in {preset["id"] for preset in body["presets"]}
+        assert "ocean" in {theme["name"] for theme in body["themes"]}
+        assert "ocean-chat" in {skin["name"] for skin in body["skins"]}
+
+    def test_set_appearance_writes_theme_and_skin(self, monkeypatch):
+        import hermes_cli.web_server as ws
+        from hermes_cli.config import load_config
+
+        monkeypatch.setattr(
+            ws,
+            "_broadcast_tui_skin_changed",
+            lambda: {"connected": 1, "sent": 1},
+        )
+
+        r = self.client.put(
+            "/api/appearance",
+            json={"dashboard_theme": "mono", "chat_skin": "ares"},
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["dashboard_theme"] == "mono"
+        assert body["chat_skin"] == "ares"
+        assert body["skin_broadcast"] == {"connected": 1, "sent": 1}
+
+        cfg = load_config()
+        assert cfg["dashboard"]["theme"] == "mono"
+        assert cfg["display"]["skin"] == "ares"
+
+    def test_set_appearance_rejects_invalid_values_without_corrupting_config(self):
+        from hermes_cli.config import load_config
+
+        ok = self.client.put(
+            "/api/appearance",
+            json={"dashboard_theme": "mono", "chat_skin": "mono"},
+        )
+        assert ok.status_code == 200, ok.text
+
+        r = self.client.put(
+            "/api/appearance",
+            json={"dashboard_theme": "missing-theme", "chat_skin": "ares"},
+        )
+        assert r.status_code == 400
+
+        cfg = load_config()
+        assert cfg["dashboard"]["theme"] == "mono"
+        assert cfg["display"]["skin"] == "mono"
+
+    def test_config_schema_uses_dynamic_theme_and_skin_options(self):
+        from hermes_constants import get_hermes_home
+
+        home = get_hermes_home()
+        (home / "skins").mkdir(parents=True, exist_ok=True)
+        (home / "skins" / "custom-chat.yaml").write_text(
+            "name: custom-chat\ndescription: Custom chat skin\n",
+            encoding="utf-8",
+        )
+        (home / "dashboard-themes").mkdir(parents=True, exist_ok=True)
+        (home / "dashboard-themes" / "custom-dashboard.yaml").write_text(
+            "name: custom-dashboard\nlabel: Custom Dashboard\n"
+            "palette:\n  background: '#101010'\n  midground: '#eeeeee'\n",
+            encoding="utf-8",
+        )
+
+        r = self.client.get("/api/config/schema")
+        assert r.status_code == 200, r.text
+        fields = r.json()["fields"]
+        assert "custom-chat" in fields["display.skin"]["options"]
+        assert "custom-dashboard" in fields["dashboard.theme"]["options"]
+        assert "default-large" in fields["dashboard.theme"]["options"]
+        assert "charizard" in fields["display.skin"]["options"]

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4384,6 +4384,10 @@ class TestPtyWebSocket:
         """Dashboard chat runs the TUI in browser-scrollback mode."""
         import hermes_cli.main as main_mod
 
+        monkeypatch.setenv("TERM", "dumb")
+        monkeypatch.setenv("NO_COLOR", "1")
+        monkeypatch.setenv("FORCE_COLOR", "0")
+        monkeypatch.delenv("COLORTERM", raising=False)
         monkeypatch.setattr(
             main_mod,
             "_make_tui_argv",
@@ -4394,6 +4398,12 @@ class TestPtyWebSocket:
 
         assert env["HERMES_TUI_INLINE"] == "1"
         assert env["HERMES_TUI_DISABLE_MOUSE"] == "1"
+        assert env["TERM"] == "xterm-256color"
+        assert env["COLORTERM"] == "truecolor"
+        assert env["FORCE_COLOR"] == "3"
+        assert env["HERMES_TUI_TRUECOLOR"] == "1"
+        assert env["HERMES_TUI_BACKGROUND"] == "#000000"
+        assert "NO_COLOR" not in env
 
     def test_resolve_chat_argv_applies_terminal_backend_config(
         self, monkeypatch, _isolate_hermes_home

--- a/tests/tui_gateway/test_ws_broadcast.py
+++ b/tests/tui_gateway/test_ws_broadcast.py
@@ -1,0 +1,58 @@
+"""Tests for dashboard WebSocket broadcast helpers."""
+
+
+class _FakeTransport:
+    def __init__(self, ok=True):
+        self.ok = ok
+        self.frames = []
+
+    def write(self, frame):
+        self.frames.append(frame)
+        return self.ok
+
+
+def test_broadcast_event_reaches_connected_transports_and_prunes_dead_ones():
+    from tui_gateway import ws
+
+    live = _FakeTransport(ok=True)
+    dead = _FakeTransport(ok=False)
+
+    with ws._TRANSPORTS_LOCK:
+        ws._TRANSPORTS.clear()
+        ws._TRANSPORTS.add(live)
+        ws._TRANSPORTS.add(dead)
+
+    try:
+        result = ws.broadcast_event("skin.changed", {"name": "mono"})
+
+        assert result == {"connected": 2, "sent": 1}
+        assert live.frames == [
+            {
+                "jsonrpc": "2.0",
+                "method": "event",
+                "params": {
+                    "type": "skin.changed",
+                    "session_id": "",
+                    "payload": {"name": "mono"},
+                },
+            }
+        ]
+        assert dead.frames
+        with ws._TRANSPORTS_LOCK:
+            assert live in ws._TRANSPORTS
+            assert dead not in ws._TRANSPORTS
+    finally:
+        with ws._TRANSPORTS_LOCK:
+            ws._TRANSPORTS.clear()
+
+
+def test_broadcast_event_is_safe_with_no_transports():
+    from tui_gateway import ws
+
+    with ws._TRANSPORTS_LOCK:
+        ws._TRANSPORTS.clear()
+
+    assert ws.broadcast_event("skin.changed", {"name": "default"}) == {
+        "connected": 0,
+        "sent": 0,
+    }

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -27,6 +27,7 @@ import asyncio
 import json
 import logging
 import socket
+import threading
 from typing import Any
 
 from tui_gateway import server
@@ -128,6 +129,46 @@ class WSTransport:
         self._closed = True
 
 
+_TRANSPORTS_LOCK = threading.Lock()
+_TRANSPORTS: set[WSTransport] = set()
+
+
+def _register_transport(transport: WSTransport) -> None:
+    with _TRANSPORTS_LOCK:
+        _TRANSPORTS.add(transport)
+
+
+def _unregister_transport(transport: WSTransport) -> None:
+    with _TRANSPORTS_LOCK:
+        _TRANSPORTS.discard(transport)
+
+
+def broadcast_event(event: str, payload: dict | None = None, *, session_id: str = "") -> dict[str, int]:
+    """Broadcast a global event to every connected WebSocket transport."""
+    params = {"type": event, "session_id": session_id}
+    if payload is not None:
+        params["payload"] = payload
+    frame = {"jsonrpc": "2.0", "method": "event", "params": params}
+
+    with _TRANSPORTS_LOCK:
+        transports = list(_TRANSPORTS)
+
+    sent = 0
+    dropped: list[WSTransport] = []
+    for transport in transports:
+        if transport.write(frame):
+            sent += 1
+        else:
+            dropped.append(transport)
+
+    if dropped:
+        with _TRANSPORTS_LOCK:
+            for transport in dropped:
+                _TRANSPORTS.discard(transport)
+
+    return {"connected": len(transports), "sent": sent}
+
+
 def _ws_peer_label(ws: Any) -> str:
     """Return ``host:port`` when available, else a stable placeholder."""
     client = getattr(ws, "client", None)
@@ -175,6 +216,7 @@ async def handle_ws(ws: Any) -> None:
         _log.info("ws accepted peer=%s", peer)
 
         transport = WSTransport(ws, asyncio.get_running_loop(), peer=peer)
+        _register_transport(transport)
 
         ready_ok = await transport.write_async(
             {
@@ -286,6 +328,7 @@ async def handle_ws(ws: Any) -> None:
         reaped_sessions = 0
         detached_sessions = 0
         if transport is not None:
+            _unregister_transport(transport)
             transport.close()
 
             # Reap sessions this transport owned (close_on_disconnect sidecar

--- a/web/src/components/ThemeSwitcher.tsx
+++ b/web/src/components/ThemeSwitcher.tsx
@@ -1,6 +1,13 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
 import { createPortal } from "react-dom";
-import { Palette, Check, Type } from "lucide-react";
+import { Check, Layers, Palette, Terminal, Type } from "lucide-react";
 import { Button } from "@nous-research/ui/ui/components/button";
 import { ListItem } from "@nous-research/ui/ui/components/list-item";
 import { BottomSheet } from "@nous-research/ui/ui/components/bottom-sheet";
@@ -8,6 +15,7 @@ import { Typography } from "@nous-research/ui/ui/components/typography/index";
 import { useBelowBreakpoint } from "@nous-research/ui/hooks/use-below-breakpoint";
 import { BUILTIN_THEMES, THEME_DEFAULT_FONT_ID, useTheme } from "@/themes";
 import type { DashboardTheme, FontChoice, ThemeListEntry } from "@/themes";
+import type { AppearancePreset, ChatSkinSummary } from "@/lib/api";
 import { useI18n } from "@/i18n";
 import { cn } from "@/lib/utils";
 
@@ -25,13 +33,26 @@ import { cn } from "@/lib/utils";
  * the sidebar (same idea as a responsive Drawer).
  */
 export function ThemeSwitcher({ collapsed = false, dropUp = false }: ThemeSwitcherProps) {
-  const { themeName, availableThemes, setTheme, fontId, fontChoices, setFont } = useTheme();
+  const {
+    appearancePresets,
+    availableSkins,
+    availableThemes,
+    chatSkin,
+    fontChoices,
+    fontId,
+    setAppearance,
+    setChatSkin,
+    setFont,
+    setTheme,
+    themeName,
+  } = useTheme();
   const { t } = useI18n();
   const [open, setOpen] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const narrowViewport = useBelowBreakpoint(640);
   const useMobileSheet = Boolean(dropUp && narrowViewport);
+  const [dropUpStyle, setDropUpStyle] = useState<CSSProperties | undefined>();
 
   const close = useCallback(() => setOpen(false), []);
 
@@ -56,9 +77,41 @@ export function ThemeSwitcher({ collapsed = false, dropUp = false }: ThemeSwitch
     return () => document.removeEventListener("mousedown", onMouseDown);
   }, [open, close, useMobileSheet]);
 
-  const current = availableThemes.find((th) => th.name === themeName);
-  const label = current?.label ?? themeName;
-  const sheetTitle = t.theme?.title ?? "Theme";
+  useEffect(() => {
+    if (!open || !dropUp || useMobileSheet) {
+      return;
+    }
+
+    let raf = 0;
+    const sync = () => {
+      raf = 0;
+      const rect = wrapperRef.current?.getBoundingClientRect();
+      setDropUpStyle(
+        rect
+          ? { bottom: window.innerHeight - rect.top + 4, left: rect.left }
+          : undefined,
+      );
+    };
+
+    raf = window.requestAnimationFrame(sync);
+    window.addEventListener("resize", sync);
+    return () => {
+      if (raf) window.cancelAnimationFrame(raf);
+      window.removeEventListener("resize", sync);
+    };
+  }, [dropUp, open, useMobileSheet]);
+
+  const currentTheme = availableThemes.find((th) => th.name === themeName);
+  const currentSkin = availableSkins.find((skin) => skin.name === chatSkin);
+  const activePreset = appearancePresets.find(
+    (preset) =>
+      preset.available &&
+      preset.dashboard_theme === themeName &&
+      preset.chat_skin === chatSkin,
+  );
+  const label = activePreset?.label ?? "Custom";
+  const detail = `${currentTheme?.label ?? themeName} / ${currentSkin?.label ?? chatSkin}`;
+  const sheetTitle = t.theme?.title ?? "Appearance";
 
   return (
     <div ref={wrapperRef} className="relative">
@@ -71,8 +124,8 @@ export function ThemeSwitcher({ collapsed = false, dropUp = false }: ThemeSwitch
             ? "text-text-secondary hover:text-foreground hover:bg-transparent"
             : "px-2 py-1 normal-case tracking-normal font-normal text-xs text-text-secondary hover:text-foreground",
         )}
-        title={`${t.theme?.switchTheme ?? "Switch theme"}: ${label}`}
-        aria-label={t.theme?.switchTheme ?? "Switch theme"}
+        title={`${t.theme?.switchTheme ?? "Switch appearance"}: ${detail}`}
+        aria-label={t.theme?.switchTheme ?? "Switch appearance"}
         aria-expanded={open}
         aria-haspopup="listbox"
       >
@@ -98,11 +151,25 @@ export function ThemeSwitcher({ collapsed = false, dropUp = false }: ThemeSwitch
           title={sheetTitle}
         >
           <div aria-label={sheetTitle} role="listbox">
+            <PresetSection
+              availableThemes={availableThemes}
+              chatSkin={chatSkin}
+              close={close}
+              presets={appearancePresets}
+              setAppearance={setAppearance}
+              themeName={themeName}
+            />
             <ThemeSwitcherOptions
               availableThemes={availableThemes}
               close={close}
               setTheme={setTheme}
               themeName={themeName}
+            />
+            <ChatSkinSection
+              chatSkin={chatSkin}
+              close={close}
+              setChatSkin={setChatSkin}
+              skins={availableSkins}
             />
             <FontSection
               fontChoices={fontChoices}
@@ -114,23 +181,18 @@ export function ThemeSwitcher({ collapsed = false, dropUp = false }: ThemeSwitch
       )}
 
       {open && !useMobileSheet && (() => {
-        const rect = wrapperRef.current?.getBoundingClientRect();
         const dropdown = (
           <div
             ref={dropdownRef}
             aria-label={sheetTitle}
             className={cn(
-              "min-w-[240px] max-h-[70dvh] overflow-y-auto",
+              "min-w-[280px] max-h-[70dvh] overflow-y-auto",
               "border border-current/20 bg-background-base/95 backdrop-blur-sm",
               "shadow-[0_12px_32px_-8px_rgba(0,0,0,0.6)]",
               dropUp ? "fixed z-[100]" : "absolute z-50 right-0 top-full mt-1",
             )}
             role="listbox"
-            style={
-              dropUp && rect
-                ? { bottom: window.innerHeight - rect.top + 4, left: rect.left }
-                : undefined
-            }
+            style={dropUp ? dropUpStyle : undefined}
           >
             <div className="border-b border-current/20 px-3 py-2">
               <Typography
@@ -141,11 +203,25 @@ export function ThemeSwitcher({ collapsed = false, dropUp = false }: ThemeSwitch
               </Typography>
             </div>
 
+            <PresetSection
+              availableThemes={availableThemes}
+              chatSkin={chatSkin}
+              close={close}
+              presets={appearancePresets}
+              setAppearance={setAppearance}
+              themeName={themeName}
+            />
             <ThemeSwitcherOptions
               availableThemes={availableThemes}
               close={close}
               setTheme={setTheme}
               themeName={themeName}
+            />
+            <ChatSkinSection
+              chatSkin={chatSkin}
+              close={close}
+              setChatSkin={setChatSkin}
+              skins={availableSkins}
             />
             <FontSection
               fontChoices={fontChoices}
@@ -160,6 +236,72 @@ export function ThemeSwitcher({ collapsed = false, dropUp = false }: ThemeSwitch
   );
 }
 
+function PresetSection({
+  availableThemes,
+  chatSkin,
+  close,
+  presets,
+  setAppearance,
+  themeName,
+}: PresetSectionProps) {
+  const availablePresets = presets.filter((preset) => preset.available);
+  if (availablePresets.length === 0) return null;
+
+  return (
+    <>
+      <SectionHeader icon={<Layers className="h-3 w-3" />} label="Linked" />
+      {availablePresets.map((preset) => {
+        const isActive =
+          preset.dashboard_theme === themeName && preset.chat_skin === chatSkin;
+        const theme = availableThemes.find((th) => th.name === preset.dashboard_theme);
+        const paletteTheme = BUILTIN_THEMES[preset.dashboard_theme] ?? theme?.definition;
+
+        return (
+          <ListItem
+            active={isActive}
+            aria-selected={isActive}
+            className="gap-3"
+            key={preset.id}
+            onClick={() => {
+              setAppearance({
+                dashboardTheme: preset.dashboard_theme,
+                chatSkin: preset.chat_skin,
+              });
+              close();
+            }}
+            role="option"
+          >
+            {paletteTheme ? (
+              <ThemeSwatch theme={paletteTheme} />
+            ) : (
+              <PlaceholderSwatch />
+            )}
+
+            <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+              <Typography
+                mondwest
+                className="truncate text-display text-xs tracking-wide"
+              >
+                {preset.label}
+              </Typography>
+              <Typography className="truncate text-xs tracking-normal text-text-tertiary">
+                {preset.description}
+              </Typography>
+            </div>
+
+            <Check
+              className={cn(
+                "h-3 w-3 shrink-0 text-midground",
+                isActive ? "opacity-100" : "opacity-0",
+              )}
+            />
+          </ListItem>
+        );
+      })}
+    </>
+  );
+}
+
 function ThemeSwitcherOptions({
   availableThemes,
   close,
@@ -168,6 +310,7 @@ function ThemeSwitcherOptions({
 }: ThemeSwitcherOptionsProps) {
   return (
     <>
+      <SectionHeader icon={<Palette className="h-3 w-3" />} label="Dashboard theme" />
       {availableThemes.map((th) => {
         const isActive = th.name === themeName;
         const paletteTheme = BUILTIN_THEMES[th.name] ?? th.definition;
@@ -217,6 +360,61 @@ function ThemeSwitcherOptions({
   );
 }
 
+function ChatSkinSection({
+  chatSkin,
+  close,
+  setChatSkin,
+  skins,
+}: ChatSkinSectionProps) {
+  return (
+    <>
+      <SectionHeader icon={<Terminal className="h-3 w-3" />} label="Chat skin" />
+      {skins.map((skin) => {
+        const isActive = skin.name === chatSkin;
+
+        return (
+          <ListItem
+            active={isActive}
+            aria-selected={isActive}
+            className="gap-3"
+            key={skin.name}
+            onClick={() => {
+              setChatSkin(skin.name);
+              close();
+            }}
+            role="option"
+          >
+            <span aria-hidden className="h-4 w-9 shrink-0 text-center text-xs text-text-tertiary">
+              {skin.source === "user" ? "usr" : "cli"}
+            </span>
+
+            <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+              <Typography
+                mondwest
+                className="truncate text-display text-xs tracking-wide"
+              >
+                {skin.label}
+              </Typography>
+              {skin.description && (
+                <Typography className="truncate text-xs tracking-normal text-text-tertiary">
+                  {skin.description}
+                </Typography>
+              )}
+            </div>
+
+            <Check
+              className={cn(
+                "h-3 w-3 shrink-0 text-midground",
+                isActive ? "opacity-100" : "opacity-0",
+              )}
+            />
+          </ListItem>
+        );
+      })}
+    </>
+  );
+}
+
 const FONT_CATEGORY_LABEL_KEY: Record<FontChoice["category"], "fontSans" | "fontSerif" | "fontMono"> = {
   sans: "fontSans",
   serif: "fontSerif",
@@ -231,17 +429,10 @@ function FontSection({ fontChoices, fontId, setFont }: FontSectionProps) {
   const order: FontChoice["category"][] = ["sans", "serif", "mono"];
   return (
     <>
-      <div className="mt-1 border-t border-current/20 px-3 pb-1 pt-2">
-        <span className="inline-flex items-center gap-1.5">
-          <Type className="h-3 w-3 text-text-tertiary" />
-          <Typography
-            mondwest
-            className="text-display text-xs tracking-[0.12em] text-text-tertiary"
-          >
-            {t.theme?.fontTitle ?? "Font"}
-          </Typography>
-        </span>
-      </div>
+      <SectionHeader
+        icon={<Type className="h-3 w-3" />}
+        label={t.theme?.fontTitle ?? "Font"}
+      />
 
       {/* Theme-default (clears the override). */}
       <ListItem
@@ -316,6 +507,22 @@ function FontSection({ fontChoices, fontId, setFont }: FontSectionProps) {
   );
 }
 
+function SectionHeader({ icon, label }: SectionHeaderProps) {
+  return (
+    <div className="mt-1 border-t border-current/20 px-3 pb-1 pt-2 first:mt-0 first:border-t-0">
+      <span className="inline-flex items-center gap-1.5 text-text-tertiary">
+        {icon}
+        <Typography
+          mondwest
+          className="text-display text-xs tracking-[0.12em] text-text-tertiary"
+        >
+          {label}
+        </Typography>
+      </span>
+    </div>
+  );
+}
+
 function ThemeSwatch({ theme }: { theme: DashboardTheme }) {
   // Inverted themes (Nous Blue / future lens themes) author their palette
   // pre-inversion — `#FFAC02` reads as `#0053FD` blue once the foreground-
@@ -354,6 +561,27 @@ interface ThemeSwitcherOptionsProps {
   close: () => void;
   setTheme: (name: string) => void;
   themeName: string;
+}
+
+interface PresetSectionProps {
+  availableThemes: ThemeListEntry[];
+  chatSkin: string;
+  close: () => void;
+  presets: AppearancePreset[];
+  setAppearance: (appearance: { chatSkin?: string; dashboardTheme?: string }) => void;
+  themeName: string;
+}
+
+interface ChatSkinSectionProps {
+  chatSkin: string;
+  close: () => void;
+  setChatSkin: (name: string) => void;
+  skins: ChatSkinSummary[];
+}
+
+interface SectionHeaderProps {
+  icon: ReactNode;
+  label: string;
 }
 
 interface FontSectionProps {

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -520,8 +520,8 @@ export const en: Translations = {
   },
 
   theme: {
-    title: "Theme",
-    switchTheme: "Switch theme",
+    title: "Appearance",
+    switchTheme: "Switch appearance",
     fontTitle: "Font",
     fontDefault: "Theme default",
     fontDefaultHint: "Use the active theme's font",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -792,6 +792,14 @@ export const api = {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name }),
     }),
+  getAppearance: () =>
+    fetchJSON<AppearanceResponse>("/api/appearance"),
+  setAppearance: (body: AppearanceSetRequest) =>
+    fetchJSON<AppearanceSetResponse>("/api/appearance", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
   getFontPref: () =>
     fetchJSON<DashboardFontResponse>("/api/dashboard/font"),
   setFontPref: (font: string) =>
@@ -1982,6 +1990,46 @@ export interface DashboardThemeSummary {
 export interface DashboardThemesResponse {
   active: string;
   themes: DashboardThemeSummary[];
+}
+
+export interface ChatSkinSummary {
+  description: string;
+  label: string;
+  name: string;
+  source: "builtin" | "user" | string;
+}
+
+export interface AppearancePreset {
+  active?: boolean;
+  available: boolean;
+  chat_skin: string;
+  dashboard_theme: string;
+  description: string;
+  id: string;
+  label: string;
+}
+
+export interface AppearanceResponse {
+  active_preset?: string | null;
+  chat_skin: string;
+  dashboard_theme: string;
+  presets: AppearancePreset[];
+  skins: ChatSkinSummary[];
+  themes: DashboardThemeSummary[];
+}
+
+export interface AppearanceSetRequest {
+  chat_skin?: string;
+  dashboard_theme?: string;
+}
+
+export interface AppearanceSetResponse {
+  active_preset?: string | null;
+  chat_skin: string;
+  dashboard_theme: string;
+  ok: boolean;
+  skin_broadcast?: { connected: number; sent: number } | null;
+  skin_changed?: boolean;
 }
 
 export interface DashboardFontResponse {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -63,18 +63,25 @@ function generateChannelId(): string {
   return `chat-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`;
 }
 
-// Colors for the terminal body.  Matches the dashboard's dark teal canvas
-// with cream foreground — we intentionally don't pick monokai or a loud
-// theme, because the TUI's skin engine already paints the content; the
-// terminal chrome just needs to sit quietly inside the dashboard.
-// `background` is omitted here — it's supplied dynamically from the active
-// theme's `terminalBackground` field so users can control it via YAML themes.
+// Colors for the terminal body. The TUI skin engine paints the content; xterm
+// only supplies the neutral canvas underneath it. Keep this independent of the
+// dashboard theme so "Dashboard theme" choices don't visually mutate the chat
+// skin through the browser embed.
 const TERMINAL_THEME_STATIC = {
   foreground: "#f0e6d2",
   cursor: "#f0e6d2",
   cursorAccent: "#0d2626",
   selectionBackground: "#f0e6d244",
 };
+
+const LIGHT_CHAT_SKIN_BACKGROUNDS: Record<string, string> = {
+  daylight: "#f8fafc",
+  "warm-lightmode": "#f5f0e8",
+};
+
+function terminalBackgroundForChatSkin(skinName: string): string {
+  return LIGHT_CHAT_SKIN_BACKGROUNDS[skinName] ?? "#000000";
+}
 
 /**
  * CSS width for xterm font tiers.
@@ -159,8 +166,9 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       : false,
   );
 
-  const { theme } = useTheme();
-  const terminalBg = theme.terminalBackground ?? "#000000";
+  const { chatSkin, theme } = useTheme();
+  const terminalBg = terminalBackgroundForChatSkin(chatSkin);
+  const cancelDashboardInversion = (theme.palette.foreground.alpha ?? 0) > 0.01;
   const terminalTheme = useMemo(
     () => ({ ...TERMINAL_THEME_STATIC, background: terminalBg }),
     [terminalBg],
@@ -761,8 +769,8 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     };
   }, [isActive]);
 
-  // Keep the live xterm theme in sync when the active theme's terminal
-  // background changes (e.g. user switches to a custom YAML theme mid-session).
+  // Keep the live xterm theme in sync when the selected chat skin changes
+  // between dark-terminal and light-terminal skins.
   useEffect(() => {
     const term = termRef.current;
     if (!term) return;
@@ -877,6 +885,8 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
           )}
           style={{
             backgroundColor: terminalBg,
+            filter: cancelDashboardInversion ? "invert(1)" : undefined,
+            isolation: "isolate",
             boxShadow: "0 8px 32px rgba(0, 0, 0, 0.4)",
           }}
         >

--- a/web/src/themes/context.tsx
+++ b/web/src/themes/context.tsx
@@ -29,6 +29,7 @@ import type {
   ThemeTypography,
 } from "./types";
 import { api } from "@/lib/api";
+import type { AppearancePreset, ChatSkinSummary } from "@/lib/api";
 
 /** LocalStorage key — pre-applied before the React tree mounts to avoid
  *  a visible flash of the default palette on theme-overridden installs. */
@@ -50,6 +51,14 @@ const THEME_NAME_ALIASES: Record<string, string> = {
   // Renamed during the LENS_5I port + Nous-blue rebrand.
   "lens-5i": "nous-blue",
 };
+
+const DEFAULT_CHAT_SKINS: ChatSkinSummary[] = [
+  { name: "default", label: "default", description: "Classic Hermes — gold and kawaii", source: "builtin" },
+  { name: "ares", label: "ares", description: "War-god theme — crimson and bronze", source: "builtin" },
+  { name: "mono", label: "mono", description: "Monochrome — clean grayscale", source: "builtin" },
+  { name: "slate", label: "slate", description: "Cool blue — developer-focused", source: "builtin" },
+  { name: "daylight", label: "daylight", description: "Light theme for bright terminals", source: "builtin" },
+];
 
 function migrateThemeName(name: string): string {
   return THEME_NAME_ALIASES[name] ?? name;
@@ -430,6 +439,10 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     })),
   );
 
+  const [chatSkin, setChatSkinState] = useState("default");
+  const [availableSkins, setAvailableSkins] = useState<ChatSkinSummary[]>(DEFAULT_CHAT_SKINS);
+  const [appearancePresets, setAppearancePresets] = useState<AppearancePreset[]>([]);
+
   /** Full definitions for user themes keyed by name — the API provides
    *  these so custom YAMLs apply without a client-side stub. */
   const [userThemeDefs, setUserThemeDefs] = useState<
@@ -468,11 +481,13 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     applyTheme(resolveTheme(themeName));
   }, [themeName, resolveTheme, fontId]);
 
-  // Load server-side themes (built-ins + user YAMLs) once on mount.
+  // Load server-side appearance choices (dashboard themes + CLI/TUI skins)
+  // once on mount. The richer endpoint keeps the picker in sync with custom
+  // YAMLs from both ~/.hermes/dashboard-themes and ~/.hermes/skins.
   useEffect(() => {
     let cancelled = false;
     api
-      .getThemes()
+      .getAppearance()
       .then((resp) => {
         if (cancelled) return;
         if (resp.themes?.length) {
@@ -491,10 +506,17 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
               defs[entry.name] = entry.definition;
             }
           }
-          if (Object.keys(defs).length > 0) setUserThemeDefs(defs);
+          setUserThemeDefs(defs);
         }
-        if (resp.active) {
-          const migratedActive = migrateThemeName(resp.active);
+        if (resp.skins?.length) {
+          setAvailableSkins(resp.skins);
+        }
+        setAppearancePresets(resp.presets ?? []);
+        if (resp.chat_skin) {
+          setChatSkinState(resp.chat_skin);
+        }
+        if (resp.dashboard_theme) {
+          const migratedActive = migrateThemeName(resp.dashboard_theme);
           if (migratedActive !== themeName) {
             setThemeName(migratedActive);
             window.localStorage.setItem(STORAGE_KEY, migratedActive);
@@ -502,8 +524,8 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
           // If the server is still persisting the stale key, push the
           // migrated value back so it converges too — otherwise every
           // future page load would re-trigger this branch.
-          if (migratedActive !== resp.active) {
-            api.setTheme(migratedActive).catch(() => {});
+          if (migratedActive !== resp.dashboard_theme) {
+            api.setAppearance({ dashboard_theme: migratedActive }).catch(() => {});
           }
         }
       })
@@ -551,9 +573,60 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       if (typeof window !== "undefined") {
         window.localStorage.setItem(STORAGE_KEY, next);
       }
-      api.setTheme(next).catch(() => {});
+      api.setAppearance({ dashboard_theme: next }).catch(() => {
+        api.setTheme(next).catch(() => {});
+      });
     },
     [availableThemes, userThemeDefs],
+  );
+
+  const setChatSkin = useCallback(
+    (name: string) => {
+      const knownNames = new Set<string>([
+        "default",
+        ...availableSkins.map((skin) => skin.name),
+      ]);
+      const next = knownNames.has(name) ? name : "default";
+      setChatSkinState(next);
+      api.setAppearance({ chat_skin: next }).catch(() => {});
+    },
+    [availableSkins],
+  );
+
+  const setAppearance = useCallback(
+    ({ dashboardTheme, chatSkin: nextSkin }: AppearanceSelection) => {
+      let nextTheme: string | undefined;
+      if (dashboardTheme) {
+        const knownThemes = new Set<string>([
+          ...Object.keys(BUILTIN_THEMES),
+          ...availableThemes.map((t) => t.name),
+          ...Object.keys(userThemeDefs),
+        ]);
+        nextTheme = knownThemes.has(dashboardTheme) ? dashboardTheme : "default";
+        setThemeName(nextTheme);
+        if (typeof window !== "undefined") {
+          window.localStorage.setItem(STORAGE_KEY, nextTheme);
+        }
+      }
+
+      let resolvedSkin: string | undefined;
+      if (nextSkin) {
+        const knownSkins = new Set<string>([
+          "default",
+          ...availableSkins.map((skin) => skin.name),
+        ]);
+        resolvedSkin = knownSkins.has(nextSkin) ? nextSkin : "default";
+        setChatSkinState(resolvedSkin);
+      }
+
+      api
+        .setAppearance({
+          dashboard_theme: nextTheme,
+          chat_skin: resolvedSkin,
+        })
+        .catch(() => {});
+    },
+    [availableThemes, availableSkins, userThemeDefs],
   );
 
   const setFont = useCallback((id: string) => {
@@ -571,16 +644,34 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       themeName,
       availableThemes,
       setTheme,
+      chatSkin,
+      availableSkins,
+      setChatSkin,
+      appearancePresets,
+      setAppearance,
       fontId,
       fontChoices: FONT_CHOICES,
       setFont,
     }),
-    [themeName, availableThemes, setTheme, resolveTheme, fontId, setFont],
+    [
+      themeName,
+      availableThemes,
+      setTheme,
+      resolveTheme,
+      chatSkin,
+      availableSkins,
+      setChatSkin,
+      appearancePresets,
+      setAppearance,
+      fontId,
+      setFont,
+    ],
   );
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function useTheme(): ThemeContextValue {
   return useContext(ThemeContext);
 }
@@ -594,13 +685,28 @@ const ThemeContext = createContext<ThemeContextValue>({
     description: t.description,
   })),
   setTheme: () => {},
+  chatSkin: "default",
+  availableSkins: DEFAULT_CHAT_SKINS,
+  setChatSkin: () => {},
+  appearancePresets: [],
+  setAppearance: () => {},
   fontId: THEME_DEFAULT_FONT_ID,
   fontChoices: FONT_CHOICES,
   setFont: () => {},
 });
 
+interface AppearanceSelection {
+  chatSkin?: string;
+  dashboardTheme?: string;
+}
+
 interface ThemeContextValue {
+  appearancePresets: AppearancePreset[];
+  availableSkins: ChatSkinSummary[];
   availableThemes: ThemeListEntry[];
+  chatSkin: string;
+  setAppearance: (appearance: AppearanceSelection) => void;
+  setChatSkin: (name: string) => void;
   setTheme: (name: string) => void;
   theme: DashboardTheme;
   themeName: string;

--- a/website/docs/user-guide/features/extending-the-dashboard.md
+++ b/website/docs/user-guide/features/extending-the-dashboard.md
@@ -14,7 +14,7 @@ The Hermes web dashboard (`hermes dashboard`) is built to be reskinned and exten
 
 All three are **drop-in at runtime**: no repo clone, no `npm run build`, no patching the dashboard source. This page is the canonical reference for all three.
 
-If you just want to use the dashboard, see [Web Dashboard](./web-dashboard). If you want to reskin the terminal CLI (not the web dashboard), see [Skins & Themes](./skins) — the CLI skin system is unrelated to dashboard themes.
+If you just want to use the dashboard, see [Web Dashboard](./web-dashboard). If you want to reskin the terminal CLI or the embedded dashboard chat, see [Skins & Themes](./skins). Dashboard themes and CLI/TUI skins use separate YAML formats, but the dashboard Appearance picker can set linked built-in pairs so the web chrome and chat surface stay in step.
 
 :::note How the pieces compose
 Themes and plugins are independent but synergistic. A theme can stand alone (just a YAML file). A plugin can stand alone (just a tab). Together they let you build a complete visual reskin with custom HUDs — the example `strike-freedom-cockpit` demo (lives in the `hermes-example-plugins` companion repo — see [Combined theme + plugin demo](#combined-theme--plugin-demo) for install steps) does exactly that.
@@ -73,7 +73,7 @@ palette:
   midground: "#ff00ff"
 ```
 
-Refresh the dashboard. Click the palette icon in the header and pick **Neon**. The background goes black, text and accents go magenta, and every derived color (card, border, muted, ring, etc.) is recomputed from that 2-color triplet via `color-mix()` in CSS.
+Refresh the dashboard. Click the palette icon in the header, open **Dashboard theme**, and pick **Neon**. The background goes black, text and accents go magenta, and every derived color (card, border, muted, ring, etc.) is recomputed from that 2-color triplet via `color-mix()` in CSS.
 
 That's the whole onboarding: one file, two colors. Everything below is optional refinement.
 
@@ -133,8 +133,8 @@ typography:
 
 ##### Changing the font from the UI (no YAML)
 
-The theme picker in the dashboard header has a **Font** section below the
-theme list. Pick any font there and it overrides the body font of whatever
+The Appearance picker in the dashboard header has a **Font** section below the
+theme and chat-skin lists. Pick any font there and it overrides the body font of whatever
 theme is active — the choice is independent of the theme and persists across
 theme switches (stored in `config.yaml` under `dashboard.font`). Choose
 **Theme default** to clear the override and fall back to the active theme's
@@ -351,7 +351,7 @@ customCSS: |
   /* Any additional selector-level tweaks */
 ```
 
-Refresh the dashboard after creating the file. Switch themes live from the header bar — click the palette icon. Selection persists to `config.yaml` under `dashboard.theme` and is restored on reload.
+Refresh the dashboard after creating the file. Switch themes live from the header bar — click the palette icon and use **Dashboard theme**. Selection persists to `config.yaml` under `dashboard.theme` and is restored on reload.
 
 ---
 
@@ -872,6 +872,7 @@ Read the plugin source (`strike-freedom-cockpit/dashboard/dist/index.js` in the 
 |----------|--------|-------------|
 | `/api/dashboard/themes` | GET | List available themes + active name. Built-ins return `{name, label, description}`; user themes also include a `definition` field with the full normalised theme object. |
 | `/api/dashboard/theme` | PUT | Set active theme. Body: `{"name": "midnight"}`. Persists to `config.yaml` under `dashboard.theme`. |
+| `/api/appearance` | GET/PUT | Unified dashboard appearance surface. Lists dashboard themes, CLI/TUI skins, and linked presets. PUT accepts `dashboard_theme` and/or `chat_skin`, persists `dashboard.theme` / `display.skin`, and broadcasts a live `skin.changed` event to embedded chat when the skin changes. |
 
 ### Plugin endpoints
 

--- a/website/docs/user-guide/features/skins.md
+++ b/website/docs/user-guide/features/skins.md
@@ -6,7 +6,7 @@ description: "Customize the Hermes CLI with built-in and user-defined skins"
 
 # Skins & Themes
 
-Skins control the **visual presentation** of the Hermes CLI: banner colors, spinner faces and verbs, response-box labels, branding text, and the tool activity prefix.
+Skins control the **visual presentation** of the Hermes CLI and the TUI embedded in dashboard chat: banner colors, spinner faces and verbs, response-box labels, branding text, and the tool activity prefix.
 
 Conversational style and visual style are separate concepts:
 
@@ -27,6 +27,12 @@ Or set the default skin in `~/.hermes/config.yaml`:
 display:
   skin: default
 ```
+
+In the web dashboard, click the palette icon in the header to open
+**Appearance**. Linked presets set both the dashboard theme and this
+`display.skin` value together; the **Chat skin** section lists built-in and
+custom skins from `~/.hermes/skins/` when you want to choose the TUI skin
+independently.
 
 ## Built-in skins
 
@@ -266,6 +272,7 @@ Hermes Mod respects the `HERMES_HOME` environment variable, so it works with [pr
 - Built-in skins load from `hermes_cli/skin_engine.py`.
 - Unknown skins automatically fall back to `default`.
 - `/skin` updates the active CLI theme immediately for the current session.
+- The dashboard Appearance picker persists `display.skin` and broadcasts the change to embedded chat sessions.
 - User skins in `~/.hermes/skins/` take precedence over built-in skins with the same name.
 - Skin changes via `/skin` are session-only. To make a skin your permanent default, set it in `config.yaml`.
 - The `banner_logo` and `banner_hero` fields support Rich console markup (e.g., `[bold #FF0000]text[/]`) for colored ASCII art.

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -1017,13 +1017,13 @@ The frontend is built with React 19, TypeScript, Tailwind CSS v4, and shadcn/ui-
 
 When you run `hermes update`, the web frontend is automatically rebuilt if `npm` is available. This keeps the dashboard in sync with code updates. If `npm` isn't installed, the update skips the frontend build and `hermes dashboard` will build it on first launch.
 
-## Themes & plugins
+## Appearance, themes & plugins
 
-The dashboard ships with six built-in themes and can be extended with user-defined themes, plugin tabs, and backend API routes — all drop-in, no repo clone needed.
+The dashboard ships with built-in appearance presets, dashboard themes, and CLI/TUI chat skins. It can also be extended with user-defined dashboard themes, custom CLI skins, plugin tabs, and backend API routes — all drop-in, no repo clone needed.
 
-**Switch themes live** from the header bar — click the palette icon next to the language switcher. Selection persists to `config.yaml` under `dashboard.theme` and is restored on page load.
+**Switch appearance live** from the header bar — click the palette icon next to the language switcher. Linked presets update both the dashboard theme (`dashboard.theme`) and embedded chat/TUI skin (`display.skin`). The separate **Dashboard theme** and **Chat skin** sections let you choose custom or unmapped options independently.
 
-**Change the font independently** from the same picker — the **Font** section below the theme list overrides the UI font of whatever theme is active. The choice persists across theme switches (`config.yaml` → `dashboard.font`); pick **Theme default** to clear it and return to the active theme's own font.
+**Change the font independently** from the same picker — the **Font** section overrides the UI font of whatever theme is active. The choice persists across theme switches (`config.yaml` → `dashboard.font`); pick **Theme default** to clear it and return to the active theme's own font.
 
 Built-in themes:
 
@@ -1031,6 +1031,7 @@ Built-in themes:
 |-------|-----------|
 | **Hermes Teal** (`default`) | Dark teal + cream, system fonts, comfortable spacing |
 | **Hermes Teal (Large)** (`default-large`) | Same as default with 18px text and roomier spacing |
+| **Nous Blue** (`nous-blue`) | Light mode with vivid Nous-blue accents |
 | **Midnight** (`midnight`) | Deep blue-violet, Inter + JetBrains Mono |
 | **Ember** (`ember`) | Warm crimson + bronze, Spectral serif + IBM Plex Mono |
 | **Mono** (`mono`) | Grayscale, IBM Plex, compact |


### PR DESCRIPTION
## Summary
- add a unified `/api/appearance` surface for dashboard themes and CLI/TUI chat skins
- add linked appearance presets while preserving independent dashboard theme, chat skin, and font controls
- broadcast `skin.changed` to connected TUI websocket clients and refresh config schema options dynamically
- document the linked Appearance picker and the separate custom theme/skin asset paths

## Validation
- `.venv/bin/python -m pytest tests/hermes_cli/test_dashboard_admin_endpoints.py::TestAppearanceEndpoints tests/hermes_cli/test_dashboard_admin_endpoints.py::TestAdminEndpointsAuthGate tests/hermes_cli/test_dashboard_auth_middleware.py::test_other_public_api_paths_are_public_under_gate tests/tui_gateway/test_ws_broadcast.py`
- `npx eslint src/components/ThemeSwitcher.tsx src/themes/context.tsx src/lib/api.ts`
- `npm run build --workspace web`
- Browser smoke: temp `HERMES_HOME` on `127.0.0.1:9124`; linked Mono wrote both `dashboard.theme=mono` and `display.skin=mono`; unmapped Cyberpunk left the chat skin unchanged