### PR TITLE
fix(cli): model-aware reasoning controls — report reasoning as uncontrollable on fixed-thinking routes

### DIFF
--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -263,6 +263,8 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
                   effFast
                 )
 
+                // No effort label on models whose reasoning Hermes cannot
+                // steer — it would mirror the placebo dial (#44030).
                 const meta = [
                   fastControl.kind !== 'none' && fastControl.on ? copy.fast : null,
                   (caps?.reasoning ?? true) ? reasoningEffortLabel(effEffort) || copy.medium : null

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -251,12 +251,26 @@ def build_models_payload(
     }
 
 
+# Direct routes where the runtime never sends reasoning controls — no
+# extra_body.reasoning, no reasoning_effort, no thinking toggle (see
+# run_agent._supports_reasoning_extra_body and the transport kwargs
+# builders in agent/transports/). On these providers the thinking mode is
+# fixed by model choice (DeepSeek maps deepseek-chat / deepseek-reasoner
+# to the non-thinking / thinking modes of deepseek-v4-flash), so a picker
+# Thinking toggle or effort dial would be a placebo control (#44030).
+# models.dev still reports such models as `reasoning: true` because they
+# *do* reason — the question here is whether Hermes can steer it.
+_REASONING_FIXED_PROVIDERS = frozenset({"deepseek"})
+
+
 def _apply_capabilities(rows: list[dict]) -> None:
     """Attach a ``{model: {fast, reasoning}}`` map to each provider row.
 
     `fast` mirrors ``model_supports_fast_mode`` (the same gate the runtime
-    enforces). `reasoning` comes from the models.dev catalog when known and
-    defaults to True otherwise — the effort dial is broadly accepted and a
+    enforces). `reasoning` means "the runtime can steer reasoning for this
+    model": False for ``_REASONING_FIXED_PROVIDERS`` routes that never
+    receive reasoning controls, otherwise from the models.dev catalog when
+    known, defaulting to True — the effort dial is broadly accepted and a
     no-op on models that ignore it, whereas hiding it from a capable-but-
     uncatalogued model is the worse failure.
     """
@@ -272,8 +286,8 @@ def _apply_capabilities(rows: list[dict]) -> None:
         caps: dict[str, dict[str, bool]] = {}
 
         for model in row.get("models") or []:
-            reasoning = True
-            if get_model_capabilities is not None and slug:
+            reasoning = slug not in _REASONING_FIXED_PROVIDERS
+            if reasoning and get_model_capabilities is not None and slug:
                 try:
                     meta = get_model_capabilities(slug, model)
                     if meta is not None:

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -945,3 +945,62 @@ def test_list_authenticated_providers_refresh_busts_cache():
         assert clear.call_count == 0
         model_switch.list_authenticated_providers(refresh=True)
         assert clear.call_count == 1
+
+
+# ─── capabilities (#44030) ─────────────────────────────────────────────
+
+
+def _provider_row(slug: str, models: list[str]) -> dict:
+    return {
+        "slug": slug,
+        "name": slug.title(),
+        "models": models,
+        "total_models": len(models),
+        "is_current": True,
+        "is_user_defined": False,
+        "source": "built-in",
+    }
+
+
+def _capabilities_for(rows: list[dict], models_dev_meta) -> dict:
+    """Run build_models_payload(capabilities=True) with models.dev mocked."""
+    ctx = _empty_ctx()
+    with _list_auth_returning(rows), patch(
+        "agent.models_dev.get_model_capabilities",
+        return_value=models_dev_meta,
+    ):
+        payload = build_models_payload(ctx, capabilities=True)
+    return {row["slug"]: row["capabilities"] for row in payload["providers"]}
+
+
+def test_capabilities_reasoning_fixed_provider_is_false():
+    """Direct DeepSeek never receives reasoning controls from the runtime
+    (thinking mode is fixed by model choice), so the capability map must
+    report reasoning=False even though models.dev catalogs the models as
+    reasoning-capable — otherwise pickers show placebo controls (#44030).
+    """
+    from agent.models_dev import ModelCapabilities
+
+    rows = [_provider_row("deepseek", ["deepseek-v4-flash", "deepseek-chat"])]
+    caps = _capabilities_for(rows, ModelCapabilities(supports_reasoning=True))
+    assert caps["deepseek"]["deepseek-v4-flash"]["reasoning"] is False
+    assert caps["deepseek"]["deepseek-chat"]["reasoning"] is False
+
+
+def test_capabilities_reasoning_from_models_dev_when_steerable():
+    """On steerable routes the models.dev catalog still gates reasoning."""
+    from agent.models_dev import ModelCapabilities
+
+    rows = [_provider_row("openrouter", ["some/non-reasoning-model"])]
+    caps = _capabilities_for(rows, ModelCapabilities(supports_reasoning=False))
+    assert caps["openrouter"]["some/non-reasoning-model"]["reasoning"] is False
+
+
+def test_capabilities_reasoning_defaults_true_when_uncatalogued():
+    """Unknown models on steerable routes keep the permissive default —
+    hiding the dial from a capable-but-uncatalogued model is the worse
+    failure (the dial is a no-op on models that ignore it).
+    """
+    rows = [_provider_row("openrouter", ["unknown/model"])]
+    caps = _capabilities_for(rows, None)
+    assert caps["openrouter"]["unknown/model"]["reasoning"] is True


### PR DESCRIPTION
## What does this PR do?

Makes the Desktop model picker's **Thinking toggle and reasoning-effort dial model-aware**, as requested in #44030.

The Desktop submenu already gates those controls on the `capabilities` map from `build_models_payload(capabilities=True)` — but `_apply_capabilities()` in `hermes_cli/inventory.py` answered the wrong question: *"does this model reason?"* (models.dev `reasoning` flag) instead of *"can Hermes steer its reasoning?"*.

On the direct DeepSeek route the runtime never sends reasoning controls — no `extra_body.reasoning`, no `reasoning_effort`, no thinking toggle (see `run_agent._supports_reasoning_extra_body()` and the transport kwargs builders in `agent/transports/chat_completions.py`). Thinking mode there is fixed by model choice (`deepseek-chat` vs `deepseek-reasoner` / `deepseek-v4-flash`). models.dev still catalogs those models as reasoning-capable (they *do* reason), so the picker offered a placebo toggle and effort dial — exactly the behavior reported: `show_reasoning=false` has no effect and effort levels are ignored.

With `reasoning: false` in the capability map, the existing Desktop gating (`ModelEditSubmenu`'s `reasoning` prop) hides the toggle and dial and shows "No options", matching the issue's expected behavior ("gray out or hide controls that the current model doesn't support"). The TUI picker consumes the same map and benefits equally.

## Related Issue

Fixes #44030

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/inventory.py` — add `_REASONING_FIXED_PROVIDERS` (currently `deepseek`) and report `reasoning: false` for those routes in `_apply_capabilities()`, before the models.dev fallback. Steerable routes keep the existing models.dev gating and the permissive default for uncatalogued models.
- `apps/desktop/src/app/shell/model-menu-panel.tsx` — skip the reasoning-effort meta label ("Medium" etc.) on the current-model row when `caps.reasoning` is false, so the row doesn't claim an effort level the route ignores.
- `tests/hermes_cli/test_inventory.py` — regression tests: DeepSeek models report `reasoning=false` even when models.dev says `supports_reasoning=true`; steerable routes still follow models.dev; uncatalogued models keep the permissive `true` default.

## How to Test

1. `pytest tests/hermes_cli/test_inventory.py -q` — 26 passed (3 new).
2. Configure the direct DeepSeek provider with `deepseek-v4-flash`, open the Desktop model menu → the model's Edit submenu no longer offers the Thinking toggle / effort dial, and the current-model row no longer shows an effort label.
3. Any OpenRouter/Nous reasoning model → toggle and dial still present, unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (`tests/hermes_cli/`: 2368 passed; one pre-existing, unrelated failure in `test_gateway_service.py::TestSystemdServiceRefresh` that also fails on clean `main` on this machine)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5 (Darwin 25.5.0); desktop change verified with `tsc -p . --noEmit` and eslint

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — `_apply_capabilities` docstring updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config changes)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure capability-map / UI-gating change, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
