### PR TITLE
fix(model-switch): keep working credentials when reselecting the current model

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -961,10 +961,13 @@ def switch_model(
             # If resolution fell through to "custom" (e.g. named custom provider like
             # "ollama-launch" that resolve_runtime_provider doesn't know), keep existing
             # credentials. Otherwise use the resolved values (picks up credential rotation,
-            # base_url adjustments for OpenCode, etc.).
-            api_key = runtime.get("api_key", "")
-            base_url = runtime.get("base_url", "")
-            api_mode = runtime.get("api_mode", "")
+            # base_url adjustments for OpenCode, etc.).  Empty resolved fields keep the
+            # current values — storing "" would later clobber the working credentials
+            # when the session override is applied, turning a same-model reselect into
+            # a silent dead session (#43866).
+            api_key = runtime.get("api_key", "") or api_key
+            base_url = runtime.get("base_url", "") or base_url
+            api_mode = runtime.get("api_mode", "") or api_mode
         except Exception:
             pass
 

--- a/tests/hermes_cli/test_model_switch_same_model_credentials.py
+++ b/tests/hermes_cli/test_model_switch_same_model_credentials.py
@@ -1,0 +1,85 @@
+"""Regression tests for #43866: reselecting the current model must not wipe credentials.
+
+When the session-level model selector picks the SAME provider+model as the
+global default, ``switch_model()`` takes the provider-unchanged branch and
+re-resolves credentials via ``resolve_runtime_provider()``.  If that
+resolution comes back empty (key lives only in the running agent's config,
+named custom provider the resolver doesn't know, etc.), the result used to
+carry ``api_key=""`` / ``base_url=""``.  The gateway stored those empty
+strings in ``_session_model_overrides`` and applied them over the
+correctly-resolved config defaults on the next message — so the session went
+silently dead: no API call, no response.
+"""
+
+from hermes_cli.model_switch import switch_model
+
+
+_MOCK_VALIDATION = {
+    "accepted": True,
+    "persist": True,
+    "recognized": True,
+    "message": None,
+}
+
+
+def _patch_common(monkeypatch, runtime):
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: runtime,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model", lambda *a, **k: _MOCK_VALIDATION
+    )
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None
+    )
+
+
+def test_same_model_reselect_keeps_current_credentials(monkeypatch):
+    """Empty resolver output must fall back to the working credentials."""
+    _patch_common(
+        monkeypatch, {"api_key": "", "base_url": "", "api_mode": ""}
+    )
+
+    result = switch_model(
+        raw_input="openai/gpt-5.4-mini",
+        current_provider="openrouter",
+        current_model="openai/gpt-5.4-mini",
+        current_base_url="https://openrouter.ai/api/v1",
+        current_api_key="sk-or-live-key",
+        user_providers={},
+        custom_providers=[],
+    )
+
+    assert result.success is True
+    assert result.target_provider == "openrouter"
+    assert result.api_key == "sk-or-live-key"
+    assert result.base_url == "https://openrouter.ai/api/v1"
+
+
+def test_same_provider_reselect_still_picks_up_rotated_credentials(monkeypatch):
+    """Non-empty resolver output must still win (credential rotation)."""
+    _patch_common(
+        monkeypatch,
+        {
+            "api_key": "sk-or-rotated-key",
+            "base_url": "https://openrouter.ai/api/v2",
+            "api_mode": "chat_completions",
+        },
+    )
+
+    result = switch_model(
+        raw_input="openai/gpt-5.4-mini",
+        current_provider="openrouter",
+        current_model="openai/gpt-5.4-mini",
+        current_base_url="https://openrouter.ai/api/v1",
+        current_api_key="sk-or-stale-key",
+        user_providers={},
+        custom_providers=[],
+    )
+
+    assert result.success is True
+    assert result.api_key == "sk-or-rotated-key"
+    assert result.base_url == "https://openrouter.ai/api/v2"
+    assert result.api_mode == "chat_completions"


### PR DESCRIPTION
## Summary

In Hermes Desktop, selecting the **same** model+provider in the session-level model selector as the global default makes the session go silently dead: the message is sent but no API call is ever made (#43866). Selecting a *different* model works.

## Root cause

The session selector goes through `switch_model()` (`hermes_cli/model_switch.py`). With the provider unchanged, the credential-resolution branch re-resolves via `resolve_runtime_provider()` and **unconditionally** overwrites `api_key` / `base_url` / `api_mode` with the resolved values — even when they come back empty (key known only to the running agent's config, named custom provider the resolver doesn't know, etc.). The branch comment already promised "keep existing credentials" on fall-through, but the code never implemented it.

The gateway then stores those empty strings in `_session_model_overrides` (`gateway/slash_commands.py`) and `_apply_session_model_override()` (`gateway/run.py`) applies them over the correctly-resolved config defaults on the next message — empty `api_key`/`base_url`, no request, no response.

## Change

`hermes_cli/model_switch.py` (provider-unchanged branch only): fall back to the current credentials when a resolved field is empty:

```python
api_key = runtime.get("api_key", "") or api_key
base_url = runtime.get("base_url", "") or base_url
api_mode = runtime.get("api_mode", "") or api_mode
```

Non-empty resolved values still win, so credential rotation and OpenCode base-url adjustments keep working. The provider-**changed** path is untouched (it already errors out instead of silently keeping empty credentials), and `_apply_session_model_override()` is deliberately left alone — on cross-provider switches an empty `api_mode` legitimately means "re-detect".

This also fixes the same silent breakage for named custom providers (e.g. `ollama-launch`) whose `base_url` was wiped on a same-provider model switch — the exact case the original comment described.

## Tests

- New `tests/hermes_cli/test_model_switch_same_model_credentials.py`:
  - same provider+model reselect with empty resolver output keeps the working credentials (fails on `main`, passes with this fix)
  - same-provider reselect with non-empty resolver output still picks up rotated credentials
- `pytest tests/hermes_cli -k "model_switch or model_command or user_providers_model"` — 114 passed
- `pytest tests/gateway/test_session_model_override_routing.py tests/gateway/test_model_switch_persistence.py tests/gateway/test_empty_model_recovery.py` — 22 passed

## Platform

Pure-Python logic change, platform-independent (reported on Windows Desktop, reproducible anywhere).

Fixes #43866
