### PR TITLE
fix(gateway,agent): persist delivered responses that recovery paths drop from the transcript

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3862,6 +3862,17 @@ def run_conversation(
                         )
                         final_response = _recovered
                         agent._response_was_previewed = True
+                        # Append the recovered text as a real assistant turn
+                        # before breaking. Without this the transcript tail
+                        # ends at the user message: _persist_session writes no
+                        # assistant row for this turn, so the next message
+                        # makes the model re-answer every "unanswered" user
+                        # message in the session (#44100).
+                        _recovered_msg = agent._build_assistant_message(
+                            assistant_message, finish_reason
+                        )
+                        _recovered_msg["content"] = _recovered
+                        messages.append(_recovered_msg)
                         break
 
                     # If the previous turn already delivered real content alongside

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8793,11 +8793,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         _user_entry,
                         skip_db=agent_persisted,
                     )
+                    # The assistant write must NOT be skipped: with an empty
+                    # new-message slice the agent's own DB flush wrote nothing
+                    # this turn, and a response generated this turn cannot
+                    # already be in the loaded history — so there is no
+                    # duplicate risk (#860 / #42039 concern only the user
+                    # entry). With skip_db=agent_persisted this write was a
+                    # no-op (state.db is the canonical transcript store) and
+                    # the delivered response was silently dropped. (#44100)
                     if response:
                         self.session_store.append_to_transcript(
                             session_entry.session_id,
                             {"role": "assistant", "content": response, "timestamp": ts},
-                            skip_db=agent_persisted,
+                            skip_db=False,
                         )
                 else:
                     # Attach the inbound platform message_id to the first user
@@ -8823,7 +8831,36 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             session_entry.session_id, entry,
                             skip_db=agent_persisted,
                         )
-            
+
+                    # Safety net: recovery paths (e.g. partial-stream
+                    # recovery) can deliver a final response without ever
+                    # appending an assistant message to the agent's message
+                    # list. The agent's DB flush then persists only the user
+                    # turn, and because state.db is the canonical transcript
+                    # store, the skip_db writes above cannot backfill it —
+                    # the delivered response is lost and the model re-answers
+                    # every "unanswered" user message next turn (#44100).
+                    # The response provably isn't among the agent-persisted
+                    # messages here, so skip_db=False cannot double-write.
+                    _turn_has_assistant_text = any(
+                        isinstance(m, dict)
+                        and m.get("role") == "assistant"
+                        and not m.get("tool_calls")
+                        and str(m.get("content") or "").strip()
+                        for m in new_messages
+                    )
+                    if response and not _turn_has_assistant_text:
+                        logger.info(
+                            "Delivered response missing from agent transcript "
+                            "— backfilling assistant row for session %s",
+                            session_entry.session_id,
+                        )
+                        self.session_store.append_to_transcript(
+                            session_entry.session_id,
+                            {"role": "assistant", "content": response, "timestamp": ts},
+                            skip_db=False,
+                        )
+
             # Token counts and model are now persisted by the agent directly.
             # Keep only last_prompt_tokens here for context-window tracking and
             # compression decisions.

--- a/tests/gateway/test_44100_assistant_backfill.py
+++ b/tests/gateway/test_44100_assistant_backfill.py
@@ -1,0 +1,265 @@
+"""Gateway-side tests for issue #44100 — delivered responses must reach state.db.
+
+``state.db`` is the canonical transcript store (spec 002), so
+``append_to_transcript(..., skip_db=True)`` is a complete no-op. When an
+agent recovery path delivers a final response without appending an
+assistant message to its message list, the agent's own DB flush writes
+only the user turn — and the gateway's fallback writes were all skipped
+via ``skip_db=agent_persisted``. The delivered response was silently
+dropped, and the model re-answered every "unanswered" user message on
+the next turn.
+
+Pins the contract:
+
+1. When the turn's new messages contain no assistant text, the gateway
+   backfills the delivered response with ``skip_db=False``.
+2. When the turn DID produce an assistant message, no backfill happens
+   (the #860 / #42039 duplicate-write protection stays intact).
+3. The ``not new_messages`` fallback writes the assistant response with
+   ``skip_db=False`` (a response generated this turn cannot already be
+   in the loaded history).
+"""
+
+import sys
+import types
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource
+
+
+def _bootstrap(monkeypatch, tmp_path):
+    """Minimal GatewayRunner setup (mirrors test_42039_duplicate_user_message)."""
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    config = GatewayConfig()
+    runner = gateway_run.GatewayRunner(config)
+    runner.adapters = {}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._handle_active_session_busy_message = AsyncMock(return_value=False)
+    runner._session_db = MagicMock()
+    runner._recover_telegram_topic_thread_id = lambda _source: None
+    runner._cache_session_source = lambda _key, _source: None
+    runner._is_session_run_current = lambda _key, _gen: True
+    runner._begin_session_run_generation = lambda _key: 1
+    runner._reply_anchor_for_event = lambda _event: None
+    runner._get_guild_id = lambda _event: None
+    runner._should_send_voice_reply = lambda *_a, **_kw: False
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key="agent:main:telegram:group:-1001:12345",
+        session_id="sess-44100",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+    )
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"}
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100_000,
+    )
+    return runner
+
+
+def _event():
+    return MessageEvent(
+        text="hello world",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1001",
+            chat_type="group",
+            user_id="12345",
+        ),
+        message_id="msg-44100",
+    )
+
+
+def _source():
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        user_id="12345",
+    )
+
+
+def _assistant_calls(calls):
+    out = []
+    for call in calls:
+        args = call.args
+        if len(args) >= 2 and isinstance(args[1], dict):
+            if args[1].get("role") == "assistant":
+                out.append(call)
+    return out
+
+
+@pytest.mark.asyncio
+async def test_backfill_when_turn_has_no_assistant_message(monkeypatch, tmp_path):
+    """Recovery turn: agent delivered a response but its message list ends
+    at the user message. The gateway must persist the response itself."""
+    runner = _bootstrap(monkeypatch, tmp_path)
+
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "Recovered streamed answer.",
+            "messages": [{"role": "user", "content": "hello world"}],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    calls = _assistant_calls(
+        runner.session_store.append_to_transcript.call_args_list
+    )
+    backfills = [
+        c for c in calls
+        if c.kwargs.get("skip_db", False) is False
+        and c.args[1].get("content") == "Recovered streamed answer."
+    ]
+    assert len(backfills) == 1, (
+        "Delivered response missing from the agent transcript must be "
+        "backfilled with skip_db=False — skip_db=True writes are no-ops "
+        "now that state.db is the canonical store (#44100). "
+        f"assistant calls: {[(c.args[1].get('content'), c.kwargs) for c in calls]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_backfill_when_assistant_message_present(monkeypatch, tmp_path):
+    """Normal turn: the agent persisted the assistant message itself.
+    No skip_db=False assistant write may happen (#860 / #42039)."""
+    runner = _bootstrap(monkeypatch, tmp_path)
+
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "Hello!",
+            "messages": [
+                {"role": "user", "content": "hello world"},
+                {"role": "assistant", "content": "Hello!"},
+            ],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    calls = _assistant_calls(
+        runner.session_store.append_to_transcript.call_args_list
+    )
+    assert calls, "expected the assistant message to be written to the transcript"
+    for call in calls:
+        assert call.kwargs.get("skip_db", False) is True, (
+            "When the agent already persisted the assistant message, the "
+            "gateway must not double-write it (#860 / #42039). "
+            f"kwargs: {call.kwargs}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_backfill_in_tool_turn_without_final_assistant_text(
+    monkeypatch, tmp_path
+):
+    """Recovery in a tool-calling turn: assistant(tool_calls) + tool result
+    but no final assistant text → response must still be backfilled."""
+    runner = _bootstrap(monkeypatch, tmp_path)
+
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "Recovered after tools.",
+            "messages": [
+                {"role": "user", "content": "hello world"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [{"id": "c1", "function": {"name": "x", "arguments": "{}"}}],
+                },
+                {"role": "tool", "content": "result", "tool_call_id": "c1"},
+            ],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    calls = _assistant_calls(
+        runner.session_store.append_to_transcript.call_args_list
+    )
+    backfills = [
+        c for c in calls
+        if c.kwargs.get("skip_db", False) is False
+        and c.args[1].get("content") == "Recovered after tools."
+    ]
+    assert len(backfills) == 1, (
+        "A tool-call assistant message with no text does not carry the "
+        "delivered response — the gateway must still backfill it. "
+        f"assistant calls: {[(c.args[1].get('content'), c.kwargs) for c in calls]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_not_new_messages_fallback_persists_assistant(monkeypatch, tmp_path):
+    """``not new_messages`` edge case: the assistant response was generated
+    this turn and cannot be in loaded history — it must be written with
+    skip_db=False (the user entry keeps its #42039 protection)."""
+    runner = _bootstrap(monkeypatch, tmp_path)
+
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "Hello!",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [],
+            "history_offset": 1,  # equals len(messages) → new_messages=[]
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    calls = _assistant_calls(
+        runner.session_store.append_to_transcript.call_args_list
+    )
+    assert calls, "expected an assistant fallback write"
+    for call in calls:
+        assert call.kwargs.get("skip_db", True) is False, (
+            "The not-new-messages assistant fallback must not skip the DB "
+            "write — the response was never persisted by the agent (#44100). "
+            f"kwargs: {call.kwargs}"
+        )

--- a/tests/run_agent/test_44100_partial_recovery_persistence.py
+++ b/tests/run_agent/test_44100_partial_recovery_persistence.py
@@ -1,0 +1,116 @@
+"""Regression tests for issue #44100 — delivered responses must be persisted.
+
+The partial-stream recovery path (empty final message but content already
+streamed to the user) used to set ``final_response`` and break WITHOUT
+appending an assistant message to ``messages``. ``_persist_session`` then
+wrote no assistant row for the turn, so the session DB accumulated
+consecutive user messages and the model re-answered all of them on the
+next turn.
+
+Pins the contract: when partial-stream recovery fires, the recovered text
+is appended to ``messages`` as a real assistant turn before the loop exits,
+so it reaches the session DB and the transcript keeps role alternation.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def loop_agent():
+    """AIAgent with a mocked OpenAI client (mirrors test_run_agent's fixture)."""
+    from run_agent import AIAgent
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        a.client = MagicMock()
+        a._cached_system_prompt = "You are helpful."
+        a._use_prompt_caching = False
+        a.tool_delay = 0
+        a.compression_enabled = False
+        a.save_trajectories = False
+        return a
+
+
+class TestPartialStreamRecoveryPersistence:
+    def test_recovered_response_is_appended_as_assistant_message(self, loop_agent):
+        """Empty final message + streamed content → recovery must leave the
+        recovered text in ``messages`` so _persist_session writes it (#44100)."""
+        from tests.run_agent.test_run_agent import _mock_response
+
+        # The aggregated final message is empty, but text was already
+        # streamed (and delivered) to the platform. The accumulator is
+        # reset before each API call, so populate it from inside the
+        # mocked call — when stream deltas would actually arrive.
+        def _create(*_a, **_kw):
+            loop_agent._record_streamed_assistant_text(
+                "Here is the streamed answer."
+            )
+            return _mock_response(content="", finish_reason="stop")
+
+        loop_agent.client.chat.completions.create.side_effect = _create
+
+        persisted = {}
+
+        def _capture(messages, conversation_history=None):
+            persisted["messages"] = list(messages)
+
+        with (
+            patch.object(loop_agent, "_persist_session", side_effect=_capture),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            result = loop_agent.run_conversation("hi")
+
+        assert result["final_response"] == "Here is the streamed answer."
+        assert result["turn_exit_reason"] == "partial_stream_recovery"
+
+        messages = persisted["messages"]
+        last = messages[-1]
+        assert last.get("role") == "assistant", (
+            "Partial-stream recovery must append the recovered text as an "
+            "assistant message — otherwise the turn is never persisted and "
+            "the model re-answers old messages next turn (#44100)."
+        )
+        assert last.get("content") == "Here is the streamed answer."
+
+    def test_normal_turn_unaffected(self, loop_agent):
+        """Control: a normal text response still ends with one assistant
+        message carrying the response."""
+        from tests.run_agent.test_run_agent import _mock_response
+
+        loop_agent.client.chat.completions.create.side_effect = [
+            _mock_response(content="Plain answer.", finish_reason="stop"),
+        ]
+
+        persisted = {}
+
+        def _capture(messages, conversation_history=None):
+            persisted["messages"] = list(messages)
+
+        with (
+            patch.object(loop_agent, "_persist_session", side_effect=_capture),
+            patch.object(loop_agent, "_save_trajectory"),
+            patch.object(loop_agent, "_cleanup_task_resources"),
+        ):
+            result = loop_agent.run_conversation("hi")
+
+        assert result["final_response"] == "Plain answer."
+        assistants = [
+            m for m in persisted["messages"]
+            if isinstance(m, dict) and m.get("role") == "assistant"
+        ]
+        assert len(assistants) == 1
+        assert assistants[0].get("content") == "Plain answer."


### PR DESCRIPTION
## Problem

Gateway delivers assistant responses to the platform (confirmed in gateway.log), but the session DB ends up with **no assistant rows between the user messages**. When the next message arrives, the model loads a transcript full of "unanswered" user messages and re-answers all of them in one turn.

## Root cause

Two pieces interact:

1. **Agent — partial-stream recovery drops the assistant turn.** In `agent/conversation_loop.py`, when the final assembled assistant message has no visible content but text was already streamed to the user, the recovery path sets `final_response` from the streamed text and `break`s **without appending an assistant message to `messages`**. The turn-end `_persist_session()` then flushes a transcript whose tail is the user message — the user row survives (written by the turn-start crash-resilience flush), the assistant row never exists. This matches the issue's evidence exactly: `response ready (…, 48 chars)` logs a non-empty `final_response` while the DB has zero assistant rows.

2. **Gateway — every fallback write is a silent no-op.** Since state.db became the canonical transcript store (spec 002), `append_to_transcript(..., skip_db=True)` does nothing at all. The gateway skips all post-turn DB writes via `skip_db=agent_persisted` to avoid the #860/#42039 duplicate-write bug — correct for messages the agent flushed, but it means the gateway cannot backfill anything the agent's flush missed. The delivered response is silently dropped with no error anywhere.

## Fix

One invariant, enforced at both layers: **a delivered `final_response` must end up in the session transcript.**

- `agent/conversation_loop.py`: the partial-stream recovery path appends the recovered text as a real assistant turn before breaking, so `_persist_session()` writes it and role alternation is preserved.
- `gateway/run.py`: when the turn's new messages contain no assistant text but a response was delivered, the gateway backfills the assistant row with `skip_db=False`. A response generated this turn cannot already be in the loaded history, so this cannot double-write; the #860/#42039 protections for user entries and agent-flushed messages are untouched (pinned by regression tests). Same reasoning for the existing `not new_messages` fallback branch, whose assistant write was also a no-op.

The gateway backfill also covers the `fallback_prior_turn_content` recovery (response sourced from an earlier tool-call turn's content, transcript tail ends at a `tool` message) and any future agent path that returns a response without representing it in `messages` — with an INFO log so occurrences are visible instead of silent.

## Tests

- `tests/run_agent/test_44100_partial_recovery_persistence.py` — partial-stream recovery appends the recovered assistant turn; normal turns unchanged (exactly one assistant message).
- `tests/gateway/test_44100_assistant_backfill.py` — backfill fires when the turn has no assistant text (plain and tool-call turns), does NOT fire when the agent persisted the message itself (#860/#42039 protection intact), and the `not new_messages` fallback writes with `skip_db=False`.

`tests/gateway/` + the neighboring `run_agent` persistence/streaming suites pass; the handful of failures present are identical with and without this diff (pre-existing, environment-dependent: shutdown forensics/systemd, Telegram MarkdownV2 escaping).

## Related

Canonical issue: #43849 (#44100 is the Telegram-specific duplicate). This applies the gateway backfill proposed in #43853 **and** the agent-side root-cause fix a gateway-only backfill can't reach — the partial-stream recovery path that returns a delivered response without ever appending it to `messages`. Happy to consolidate onto whichever thread maintainers prefer to track.

Fixes #44100
