### PR TITLE
fix(hindsight): add lazy_ensure to API client path for ModuleNotFoundError

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -925,6 +925,13 @@ class HindsightMemoryProvider(MemoryProvider):
                 kwargs["idle_timeout"] = idle_timeout
                 self._client = HindsightEmbedded(**kwargs)
             else:
+                try:
+                    from tools.lazy_deps import ensure as _lazy_ensure
+                    _lazy_ensure("memory.hindsight", prompt=False)
+                except ImportError:
+                    pass
+                except Exception as _e:
+                    raise ImportError(str(_e))
                 from hindsight_client import Hindsight
                 timeout = self._timeout or _DEFAULT_TIMEOUT
                 kwargs = {"base_url": self._api_url, "timeout": float(timeout)}


### PR DESCRIPTION
## Problem

HindsightMemoryProvider in API mode (`mode: \"api\"`) raises `ModuleNotFoundError: No module named 'hindsight_client'` after a fresh `uv sync --extra all --locked` (e.g. after `hermes update`).

## Root Cause

Hindsight is deliberately excluded from the curated `[all]` extra (see `pyproject.toml`'s `[all]` policy comment, 2026-05-12). The local\_embedded path already handles this with a `_lazy_ensure('memory.hindsight')` call that triggers venv-scoped pip install at first use. The API client path (line 928) had no such guard.

## Fix

Added the same `_lazy_ensure('memory.hindsight')` pattern to the API client branch, matching the existing local\_embedded pattern at lines 897-902.

## Testing

- `lazy_ensure('memory.hindsight')` runs successfully with hindsight-client already installed
- `HindsightMemoryProvider` imports cleanly after the patch
- Syntax-verified (ruff/lint passed)