### PR TITLE
fix(status): show plugin-registered platforms in hermes status

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -460,6 +460,13 @@ def show_status(args):
 
     # Plugin-registered platforms
     try:
+        # Populate the registry so plugin platforms are visible. Idempotent.
+        from hermes_cli.plugins import discover_plugins
+
+        discover_plugins()
+    except Exception:
+        pass
+    try:
         from gateway.platform_registry import platform_registry
         for entry in platform_registry.plugin_entries():
             configured = entry.check_fn()

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -351,3 +351,32 @@ class TestShowStatusXaiOAuth:
 
         assert "xAI OAuth" in out
         assert "not logged in (run: hermes auth add xai-oauth)" in out
+
+
+def test_show_status_discovers_plugin_platforms(monkeypatch, capsys, tmp_path):
+    """show_status must run plugin discovery so plugin-registered platforms
+    appear in the Messaging Platforms section (#44119)."""
+    import hermes_cli.plugins as plugins_mod
+    from gateway.platform_registry import PlatformEntry, platform_registry
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    def _fake_discover(force=False):
+        platform_registry.register(
+            PlatformEntry(
+                name="testchat-44119",
+                label="TestChat",
+                adapter_factory=lambda cfg: None,
+                check_fn=lambda: True,
+            )
+        )
+
+    monkeypatch.setattr(plugins_mod, "discover_plugins", _fake_discover)
+    try:
+        show_status(SimpleNamespace(all=False, deep=False))
+    finally:
+        platform_registry.unregister("testchat-44119")
+
+    output = capsys.readouterr().out
+    assert "TestChat" in output
+    assert "configured (plugin)" in output


### PR DESCRIPTION
## Summary

`hermes status` never showed plugin-registered messaging platforms (Google Chat, IRC, LINE, Mattermost, ntfy, etc.) — the Messaging Platforms section only listed built-ins.

**Root cause:** `show_status()` in `hermes_cli/status.py` reads `platform_registry.plugin_entries()`, but nothing on the `hermes status` code path ever runs plugin discovery, so the registry is always empty and the plugin loop prints nothing. Every other consumer of the registry (`hermes_cli/gateway.py` platform enumeration, `gateway/config.py`, `cron/scheduler.py`) calls the idempotent `discover_plugins()` before reading it.

**Fix:** apply the same pattern in `status.py` — call `discover_plugins()` (wrapped in try/except like the existing block) right before reading `plugin_entries()`.

## Before / after

Before (plugin platforms silently omitted):
```
  QQBot         ✗ not configured
  Yuanbao       ✗ not configured

◆ Gateway Service
```

After:
```
  QQBot         ✗ not configured
  Yuanbao       ✗ not configured
  Discord       ✓ configured (plugin)
  Google Chat   ✗ not configured (plugin)
  Home Assistant  ✗ not configured (plugin)
  IRC           ✗ not configured (plugin)
  ...
```

## Testing

- Added `test_show_status_discovers_plugin_platforms` — stubs `discover_plugins` to register a fake `PlatformEntry` and asserts it shows up with `(plugin)`. Fails on main, passes with the fix.
- `tests/hermes_cli/test_status.py`: 18 passed.
- Manually verified `hermes status` on a machine with bundled platform plugins: 10 plugin platforms now listed (0 before).

Fixes #44119
