### PR TITLE
fix(title_generator): strip think blocks from LLM response before extracting title

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -62,7 +62,17 @@ def generate_title(
             timeout=timeout,
             main_runtime=main_runtime,
         )
-        title = (response.choices[0].message.content or "").strip()
+        content = response.choices[0].message.content or ""
+        # Strip thinking/reasoning blocks that some think-enabled models
+        # (MiniMax M2.7, DeepSeek) emit even for simple prompts like title
+        # generation.  Without this the raw <think>...</think> XML leaks
+        # into session titles — see session 20260611_105050_b44345.
+        try:
+            from agent.agent_runtime_helpers import strip_think_blocks
+            content = strip_think_blocks(None, content)
+        except ImportError:
+            pass
+        title = content.strip()
         # Clean up: remove quotes, trailing punctuation, prefixes like "Title: "
         title = title.strip('"\'')
         if title.lower().startswith("title:"):


### PR DESCRIPTION
Title generation (agent/title_generator.py) directly extracts response.choices[0].message.content as the session title without stripping thinking/reasoning blocks that think-enabled models (MiniMax M2.7, DeepSeek) emit even for simple prompts.

The strip_think_blocks() function in agent_runtime_helpers already handles all tag variants (think/thinking/reasoning/thought + unterminated blocks from MiniMax M2.7), but the title generator never called it — unlike the main conversation loop which does.

This caused session titles to be polluted with raw <think> XML, e.g.

Fix: apply strip_think_blocks() to the content before extracting the title. Uses try/except ImportError guard for robustness.

## What does this PR do?

Title generation leaks raw <think> XML from think-enabled
    models into session titles because strip_think_blocks() is
    never called on the LLM response. This PR adds the stripping
    step — one import + one function call — to fix the issue.

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- agent/title_generator.py: apply strip_think_blocks() to
      response content before extracting title text


## How to Test

 1. Run title generation against a think-enabled model (MiniMax M2.7 or DeepSeek)
 2. Verify session title does not contain <think>... XML
 3. Run title generation against a non-thinking model (e.g. gpt-4o-mini) and verify it still produces clean titles (no regression)

## Checklist

- [x] "My commit messages follow Conventional Commits"
- [x] "My PR contains only changes related to this fix"
- [x] Platform: WSL (Ubuntu 24.04)

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL (Ubuntu 24.04)

## Screenshots / Logs

Verified with the polluted title from session 20260611_105050_b44345:

    Before: ""
    After: "Chrome快捷方式突破10栏位限制"

