### PR TITLE
Regenerate package-lock.json with npm 11 so npm ci validates on a clean checkout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8418,9 +8418,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.13.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.1.tgz",
-      "integrity": "sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==",
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -19659,7 +19659,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19676,7 +19675,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19693,7 +19691,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19710,7 +19707,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19727,7 +19723,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19744,7 +19739,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19761,7 +19755,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19778,7 +19771,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19795,7 +19787,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19812,7 +19803,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19829,7 +19819,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19846,7 +19835,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19863,7 +19851,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19880,7 +19867,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19897,7 +19883,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19914,7 +19899,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19931,7 +19915,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19948,7 +19931,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19965,7 +19947,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19982,7 +19963,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19999,7 +19979,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20016,7 +19995,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20033,7 +20011,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20050,7 +20027,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20067,7 +20043,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20084,7 +20059,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }


### PR DESCRIPTION
## Summary

Fixes #44121

`npm ci` fails with `EUSAGE` on a pristine checkout of `main` under npm 11:

```
Invalid: lock file's @types/node@24.13.1 does not satisfy @types/node@24.13.2
```

The committed `package-lock.json` was generated with an older npm and records `"peer": true` on the esbuild platform packages — metadata npm 11 considers stale, which causes its `ci` validation to re-resolve `@types/node` against the registry instead of trusting the lockfile. When `@types/node@24.13.2` was published (2026-06-10), validation started failing everywhere even though every manifest declares `^24.12.0`, which `24.13.1` satisfies.

Downstream, `hermes update` runs `npm ci`, hits this error on every update, falls back to `npm install`, and leaves users with a rewritten `package-lock.json` / dirty working tree that then triggers the updater's stash/restore path on the next run.

## Change

Single-file change, regenerated with npm 11.16.0:

```
npx npm@11 install --package-lock-only
```

3 insertions, 29 deletions: bumps the `@types/node` lock entry to 24.13.2 and drops the stale `"peer": true` markers from the esbuild platform packages. No manifest changes.

## Verification

On this branch:
- `npx npm@11 ci --dry-run` → passes (was `EUSAGE` on `main`)
- `npm ci --dry-run` with npm **10.9.8** → passes (no regression for older npm)
- Real `npx npm@11 ci` → installs 1337 packages, 0 vulnerabilities, and leaves `package-lock.json` untouched — so `hermes update` no longer dirties the tree

## Follow-up (not in this PR)

The issue suggests a CI job running `npm ci` against the latest Node LTS / npm pairing to catch future drift — happy to do that separately if maintainers want it. This also unblocks #6716 (switching `install.sh` to `npm ci`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)