### PR TITLE
feat(memory): add WARNING-level logging for Hindsight sync/prefetch failures

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -36,6 +36,7 @@ import logging
 import os
 import queue
 import threading
+import time
 
 from datetime import datetime, timezone
 from typing import Any, Dict, List
@@ -548,6 +549,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._prefetch_result = ""
         self._prefetch_lock = threading.Lock()
         self._prefetch_thread = None
+        self._last_prefetch_warn = 0.0
         # Single-writer model for retain. sync_turn() enqueues; the writer
         # thread drains sequentially. Avoids spawning ad-hoc threads that
         # can race the interpreter shutdown and emit "cannot schedule new
@@ -1363,7 +1365,12 @@ class HindsightMemoryProvider(MemoryProvider):
                     with self._prefetch_lock:
                         self._prefetch_result = text
             except Exception as e:
-                logger.debug("Hindsight prefetch failed: %s", e, exc_info=True)
+                now = time.monotonic()
+                if now - self._last_prefetch_warn > 300:
+                    self._last_prefetch_warn = now
+                    logger.warning("Hindsight prefetch failed: %s", e, exc_info=True)
+                else:
+                    logger.debug("Hindsight prefetch failed: %s", e, exc_info=True)
 
         self._prefetch_thread = threading.Thread(target=_run, daemon=True, name="hindsight-prefetch")
         self._prefetch_thread.start()

--- a/run_agent.py
+++ b/run_agent.py
@@ -2990,21 +2990,26 @@ class AIAgent:
             return
         if not (self._memory_manager and final_response and original_user_message):
             return
+        sync_kwargs = {"session_id": self.session_id or ""}
+        if messages is not None:
+            sync_kwargs["messages"] = messages
         try:
-            sync_kwargs = {"session_id": self.session_id or ""}
-            if messages is not None:
-                sync_kwargs["messages"] = messages
             self._memory_manager.sync_all(
                 original_user_message,
                 final_response,
                 **sync_kwargs,
             )
+        except Exception as e:
+            logger.warning("External memory sync failed: %s", e)
+            logger.debug("External memory sync failed", exc_info=True)
+        try:
             self._memory_manager.queue_prefetch_all(
                 original_user_message,
                 session_id=self.session_id or "",
             )
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning("External memory prefetch queue failed: %s", e)
+            logger.debug("External memory prefetch queue failed", exc_info=True)
 
     def release_clients(self) -> None:
         """Release LLM client resources WITHOUT tearing down session tool state.

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -6,14 +6,32 @@ turn counting, tags), and schema completeness.
 """
 
 import json
+import logging
+import logging.handlers
 import os
 import re
 import stat
 import sys
+from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+
+
+@contextmanager
+def _capture_logs(logger_name: str, level: int = logging.DEBUG):
+    """Capture log records from *logger_name* at *level* or above."""
+    lg = logging.getLogger(logger_name)
+    handler = logging.handlers.MemoryHandler(capacity=100)
+    handler.setLevel(level)
+    records: list[logging.LogRecord] = []
+    handler.emit = records.append  # type: ignore[assignment]
+    lg.addHandler(handler)
+    try:
+        yield records
+    finally:
+        lg.removeHandler(handler)
 
 from plugins.memory.hindsight import (
     HindsightMemoryProvider,
@@ -664,6 +682,50 @@ class TestPrefetch:
         assert call_kwargs["tags"] == ["t1"]
         assert call_kwargs["tags_match"] == "all"
         assert call_kwargs["types"] == ["world"]
+
+    def test_prefetch_failure_logs_warning_on_first_failure(self, provider):
+        """First prefetch failure should log at WARNING level (#44055)."""
+        import logging
+        from unittest.mock import patch as mock_patch
+
+        p = provider
+        p._prefetch_method = "recall"
+        # Make arecall raise to trigger the failure path
+        p._client.arecall = AsyncMock(side_effect=RuntimeError("connection refused"))
+
+        with _capture_logs("plugins.memory.hindsight", logging.WARNING) as records:
+            p.queue_prefetch("test query")
+            if p._prefetch_thread:
+                p._prefetch_thread.join(timeout=5.0)
+
+        assert any("Hindsight prefetch failed" in r.getMessage() for r in records)
+
+    def test_prefetch_failure_rate_limits_warnings(self, provider):
+        """Subsequent prefetch failures within 5 minutes should log at
+        DEBUG, not WARNING (#44055)."""
+        import logging
+
+        p = provider
+        p._prefetch_method = "recall"
+        p._client.arecall = AsyncMock(side_effect=RuntimeError("connection refused"))
+
+        # First failure — WARNING
+        with _capture_logs("plugins.memory.hindsight", logging.WARNING) as records:
+            p.queue_prefetch("query 1")
+            if p._prefetch_thread:
+                p._prefetch_thread.join(timeout=5.0)
+
+        first_warnings = [r for r in records if "Hindsight prefetch failed" in r.getMessage()]
+        assert len(first_warnings) >= 1
+
+        # Second failure immediately after — should NOT produce WARNING
+        with _capture_logs("plugins.memory.hindsight", logging.WARNING) as records:
+            p.queue_prefetch("query 2")
+            if p._prefetch_thread:
+                p._prefetch_thread.join(timeout=5.0)
+
+        second_warnings = [r for r in records if "Hindsight prefetch failed" in r.getMessage()]
+        assert len(second_warnings) == 0, "Rate-limited: no WARNING expected within 5 min"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/run_agent/test_memory_sync_interrupted.py
+++ b/tests/run_agent/test_memory_sync_interrupted.py
@@ -17,9 +17,27 @@ These tests exercise the helper directly on a bare ``AIAgent`` built
 via ``__new__`` so the full ``run_conversation`` machinery isn't needed
 — the method is pure logic and three state arguments.
 """
+from contextlib import contextmanager
 from unittest.mock import MagicMock
+import logging
+import logging.handlers
 
 import pytest
+
+
+@contextmanager
+def _capture_logs(logger_name: str, level: int = logging.DEBUG):
+    """Capture log records from *logger_name* at *level* or above."""
+    lg = logging.getLogger(logger_name)
+    handler = logging.handlers.MemoryHandler(capacity=100)
+    handler.setLevel(level)
+    records: list[logging.LogRecord] = []
+    handler.emit = records.append  # type: ignore[assignment]
+    lg.addHandler(handler)
+    try:
+        yield records
+    finally:
+        lg.removeHandler(handler)
 
 
 def _bare_agent():
@@ -189,6 +207,40 @@ class TestSyncExternalMemoryForTurn:
         )
         # sync_all was attempted.
         agent._memory_manager.sync_all.assert_called_once()
+        # queue_prefetch_all is still attempted (independent failure domain).
+        agent._memory_manager.queue_prefetch_all.assert_called_once()
+
+    def test_sync_exception_logs_warning(self):
+        """sync_all failure must produce a WARNING log so that silent
+        failures are visible at default log level (#44055)."""
+        import logging
+        agent = _bare_agent()
+        agent._memory_manager.sync_all.side_effect = RuntimeError("boom")
+
+        with _capture_logs("run_agent", logging.WARNING) as records:
+            agent._sync_external_memory_for_turn(
+                original_user_message="hi",
+                final_response="hey",
+                interrupted=False,
+            )
+
+        assert any("External memory sync failed" in r.getMessage() for r in records)
+
+    def test_prefetch_exception_logs_warning(self):
+        """queue_prefetch_all failure must produce a WARNING log
+        (#44055)."""
+        import logging
+        agent = _bare_agent()
+        agent._memory_manager.queue_prefetch_all.side_effect = RuntimeError("dead")
+
+        with _capture_logs("run_agent", logging.WARNING) as records:
+            agent._sync_external_memory_for_turn(
+                original_user_message="hi",
+                final_response="hey",
+                interrupted=False,
+            )
+
+        assert any("External memory prefetch queue failed" in r.getMessage() for r in records)
 
     def test_prefetch_exception_is_swallowed(self):
         """Same best-effort contract applies to the prefetch step — a


### PR DESCRIPTION
## Problem

The Hindsight memory provider has two silent failure modes that turn a 30-second log check into a 2-hour forensic investigation:

1. **`_sync_external_memory_for_turn`** wraps both `sync_all` and `queue_prefetch_all` in a single `try/except Exception: pass`. If `sync_all` fails (network, auth, schema change), the exception silently cancels `queue_prefetch_all` as well — one subsystem's failure mutes the other. No log is emitted at any level.

2. **Hindsight prefetch thread** catches exceptions at `logger.debug` only. Users at the default INFO level never see that recall is failing. The symptom is "memory doesn't work" with no log trail.

This continues the same silent-failure pattern from #7718 and #8038.

## Changes

### `run_agent.py` — Independent failure domains for sync/prefetch

- Split the monolithic `try/except: pass` into two separate `try/except` blocks so `sync_all` and `queue_prefetch_all` have independent failure domains
- Both blocks now log at `WARNING` with a `DEBUG`-level traceback for forensics
- `queue_prefetch_all` is still attempted even when `sync_all` fails

### `plugins/memory/hindsight/__init__.py` — Rate-limited WARNING for prefetch failures

- First prefetch failure logs at `WARNING` with full `exc_info`
- Subsequent failures within 5 minutes log at `DEBUG` with `exc_info` (forensic trail stays alive)
- Added `self._last_prefetch_warn = 0.0` to track rate limiting

### Tests

- `test_sync_exception_logs_warning` — verifies sync failure produces WARNING log
- `test_prefetch_exception_logs_warning` — verifies prefetch failure produces WARNING log
- `test_sync_exception_is_swallowed` — updated to verify `queue_prefetch_all` is still called after sync failure
- `test_prefetch_failure_logs_warning_on_first_failure` — Hindsight-specific: first failure is WARNING
- `test_prefetch_failure_rate_limits_warnings` — Hindsight-specific: second failure within 5 min is DEBUG

## Test Plan

```
python -m pytest tests/run_agent/test_memory_sync_interrupted.py tests/plugins/memory/test_hindsight_provider.py -v
```

123 tests pass (19 in memory_sync, 104 in hindsight_provider), including 4 new regression tests.

Closes #44055
