### PR TITLE
fix(skills): follow directory symlinks in SKILL.md discovery

### DIFF
--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -49,7 +49,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from hermes_constants import get_hermes_home
-from agent.skill_utils import is_excluded_skill_path
+from agent.skill_utils import iter_skill_index_files
 
 logger = logging.getLogger(__name__)
 
@@ -181,9 +181,7 @@ def get_keep() -> int:
 
 def _count_skill_files(base: Path) -> int:
     try:
-        return sum(
-            1 for p in base.rglob("SKILL.md") if not is_excluded_skill_path(p)
-        )
+        return sum(1 for _ in iter_skill_index_files(base, "SKILL.md"))
     except OSError:
         return 0
 

--- a/agent/learning_graph.py
+++ b/agent/learning_graph.py
@@ -75,9 +75,11 @@ def _category(fm: dict[str, Any], skill_md: Path) -> str:
 
 
 def _iter_skill_files(roots: list[tuple[str, Path]]):
+    from agent.skill_utils import iter_skill_index_files
+
     for source, root in roots:
         if root.exists():
-            for path in root.rglob("SKILL.md"):
+            for path in iter_skill_index_files(root, "SKILL.md"):
                 yield source, path
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2754,16 +2754,14 @@ def _check_unavailable_skill(command_name: str) -> str | None:
     normalized = command_name.lower().replace("_", "-")
     try:
         from tools.skills_tool import _get_disabled_skill_names
-        from agent.skill_utils import get_all_skills_dirs, is_excluded_skill_path
+        from agent.skill_utils import get_all_skills_dirs, iter_skill_index_files
         disabled = _get_disabled_skill_names()
 
         # Check disabled skills across all dirs (local + external)
         for skills_dir in get_all_skills_dirs():
             if not skills_dir.exists():
                 continue
-            for skill_md in skills_dir.rglob("SKILL.md"):
-                if is_excluded_skill_path(skill_md):
-                    continue
+            for skill_md in iter_skill_index_files(skills_dir, "SKILL.md"):
                 slug, declared_name = _skill_slug_from_frontmatter(skill_md)
                 if not slug or not declared_name:
                     continue
@@ -2780,9 +2778,7 @@ def _check_unavailable_skill(command_name: str) -> str | None:
         repo_root = Path(__file__).resolve().parent.parent
         optional_dir = get_optional_skills_dir(repo_root / "optional-skills")
         if optional_dir.exists():
-            for skill_md in optional_dir.rglob("SKILL.md"):
-                if is_excluded_skill_path(skill_md):
-                    continue
+            for skill_md in iter_skill_index_files(optional_dir, "SKILL.md"):
                 slug, _declared = _skill_slug_from_frontmatter(skill_md)
                 if not slug:
                     continue

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from hermes_cli.config import get_hermes_home, get_env_path, get_project_root, load_config
 from hermes_cli.env_loader import load_hermes_dotenv
 from hermes_constants import display_hermes_home
-from agent.skill_utils import is_excluded_skill_path
+from agent.skill_utils import iter_skill_index_files
 
 
 def _dotenv_key_names() -> set[str]:
@@ -146,12 +146,7 @@ def _count_skills(hermes_home: Path) -> int:
     skills_dir = hermes_home / "skills"
     if not skills_dir.is_dir():
         return 0
-    count = 0
-    for item in skills_dir.rglob("SKILL.md"):
-        if is_excluded_skill_path(item):
-            continue
-        count += 1
-    return count
+    return sum(1 for _ in iter_skill_index_files(skills_dir, "SKILL.md"))
 
 
 def _count_mcp_servers(config: dict) -> int:

--- a/hermes_cli/profile_describer.py
+++ b/hermes_cli/profile_describer.py
@@ -34,7 +34,7 @@ from pathlib import Path
 from typing import Optional
 
 from hermes_cli import profiles as profiles_mod
-from agent.skill_utils import is_excluded_skill_path
+from agent.skill_utils import iter_skill_index_files
 
 logger = logging.getLogger(__name__)
 
@@ -108,9 +108,7 @@ def _collect_skills(profile_dir: Path) -> list[str]:
     if not skills_dir.is_dir():
         return []
     names: list[str] = []
-    for md in skills_dir.rglob("SKILL.md"):
-        if is_excluded_skill_path(md):
-            continue
+    for md in iter_skill_index_files(skills_dir, "SKILL.md"):
         try:
             rel = md.relative_to(skills_dir)
         except ValueError:
@@ -199,8 +197,7 @@ def describe_profile(
     skill_names = _collect_skills(profile_dir)
     skill_list = "\n".join(f"  - {n}" for n in skill_names) or "  (no skills installed)"
     skill_count = sum(
-        1 for _ in (profile_dir / "skills").rglob("SKILL.md")
-        if not is_excluded_skill_path(_)
+        1 for _ in iter_skill_index_files(profile_dir / "skills", "SKILL.md")
     ) if (profile_dir / "skills").is_dir() else 0
 
     # Read model + provider from the profile's config.

--- a/hermes_cli/profile_distribution.py
+++ b/hermes_cli/profile_distribution.py
@@ -70,7 +70,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-from agent.skill_utils import is_excluded_skill_path
+from agent.skill_utils import iter_skill_index_files
 from hermes_cli._subprocess_compat import noninteractive_git_env
 
 
@@ -482,9 +482,7 @@ def _count_skills(staged: Path) -> int:
     skills_dir = staged / "skills"
     if not skills_dir.is_dir():
         return 0
-    return sum(
-        1 for p in skills_dir.rglob("SKILL.md") if not is_excluded_skill_path(p)
-    )
+    return sum(1 for _ in iter_skill_index_files(skills_dir, "SKILL.md"))
 
 
 def plan_install(

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -32,7 +32,7 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import List, Optional, Tuple
 
-from agent.skill_utils import is_excluded_skill_path
+from agent.skill_utils import iter_skill_index_files
 
 _PROFILE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
 
@@ -730,7 +730,7 @@ def _check_gateway_running(profile_dir: Path) -> bool:
         return False
 
 
-# In-process cache for skill counts. Walking ``skills_dir.rglob("SKILL.md")``
+# In-process cache for skill counts. Walking ``iter_skill_index_files``
 # recurses the entire skill tree (each skill carries references/scripts/assets
 # sub-trees); the default profile alone has ~270 skills, and ``list_profiles``
 # calls this for EVERY profile (16+), so an uncached scan costs ~6s — long
@@ -786,11 +786,7 @@ def _count_skills(profile_dir: Path) -> int:
     ):
         return cached[2]
 
-    count = 0
-    for md in skills_dir.rglob("SKILL.md"):
-        if is_excluded_skill_path(md):
-            continue
-        count += 1
+    count = sum(1 for _ in iter_skill_index_files(skills_dir, "SKILL.md"))
     _SKILL_COUNT_CACHE[key] = (signature, now, count)
     return count
 

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -23,7 +23,7 @@ from rich.table import Table
 # Lazy imports to avoid circular dependencies and slow startup.
 # tools.skills_hub and tools.skills_guard are imported inside functions.
 from hermes_constants import display_hermes_home
-from agent.skill_utils import is_excluded_skill_path
+from agent.skill_utils import iter_skill_index_files
 
 _console = Console()
 
@@ -197,10 +197,7 @@ def _existing_categories() -> List[str]:
                 continue
             # Has at least one nested SKILL.md (excluding dependency/cache dirs)?
             try:
-                if any(
-                    not is_excluded_skill_path(p)
-                    for p in entry.rglob("SKILL.md")
-                ):
+                if next(iter_skill_index_files(entry, "SKILL.md"), None):
                     out.append(entry.name)
             except OSError:
                 continue

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -13231,7 +13231,9 @@ def _disable_unselected_skills(profile_dir: Path, keep: List[str]) -> int:
         installed: List[str] = []
         skills_root = profile_dir / "skills"
         if skills_root.is_dir():
-            for md in skills_root.rglob("SKILL.md"):
+            from agent.skill_utils import iter_skill_index_files
+
+            for md in iter_skill_index_files(skills_root, "SKILL.md"):
                 installed.append(md.parent.name)
         cfg = load_config()
         disabled = get_disabled_skills(cfg)

--- a/tests/agent/test_learning_graph.py
+++ b/tests/agent/test_learning_graph.py
@@ -8,6 +8,8 @@ change-detector.
 
 from __future__ import annotations
 
+import pytest
+
 from agent import learning_graph
 from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 
@@ -79,3 +81,27 @@ def test_full_payload_shape_and_edge_integrity(tmp_path):
     assert graph["stats"]["nodes"] == len(skill_nodes)
     assert graph["stats"]["memory_nodes"] == len(graph["memory"])
     assert all("timestamp" in n for n in graph["nodes"])
+
+
+def test_iter_skill_files_follows_directory_symlinks(tmp_path):
+    """Skill dirs symlinked in from an external vault must reach the graph.
+
+    ``_iter_skill_files`` is the graph's own discovery path; a plain rglob
+    walk stops at directory symlinks and silently drops those skills.
+    """
+    vault = tmp_path / "vault" / "linked-skill"
+    vault.mkdir(parents=True)
+    (vault / "SKILL.md").write_text("---\nname: linked-skill\n---\n", encoding="utf-8")
+
+    root = tmp_path / "skills"
+    real = root / "real-skill"
+    real.mkdir(parents=True)
+    (real / "SKILL.md").write_text("---\nname: real-skill\n---\n", encoding="utf-8")
+    try:
+        (root / "linked-skill").symlink_to(vault)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+    found = {p.parent.name for _source, p in learning_graph._iter_skill_files([("local", root)])}
+
+    assert found == {"real-skill", "linked-skill"}

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -302,3 +302,34 @@ class TestBOMToleranceSiblingSites:
         assert fm is not None
         assert fm.get("name") == "bp"
 
+    def test_skills_hub_parsers_accept_bom(self):
+        from tools.skills_hub import GitHubSource, OptionalSkillSource
+
+        for parser in (
+            GitHubSource._parse_frontmatter_quick,
+            OptionalSkillSource._parse_frontmatter,
+        ):
+            fm = parser("\ufeff" + self.SKILL)
+            assert fm.get("name") == "bom-skill", parser.__qualname__
+
+
+def test_iter_skill_index_files_follows_directory_symlinks(tmp_path):
+    """Symlinked skill dirs (e.g. managed by external skill managers) are
+    discovered, matching the runtime loader's followlinks behavior."""
+    vault = tmp_path / "vault" / "linked-skill"
+    vault.mkdir(parents=True)
+    (vault / "SKILL.md").write_text("---\nname: linked-skill\n---\n", encoding="utf-8")
+
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    real = skills_dir / "real-skill"
+    real.mkdir()
+    (real / "SKILL.md").write_text("---\nname: real-skill\n---\n", encoding="utf-8")
+    (skills_dir / "linked-skill").symlink_to(vault)
+
+    found = list(iter_skill_index_files(skills_dir, "SKILL.md"))
+
+    assert found == [
+        skills_dir / "linked-skill" / "SKILL.md",
+        real / "SKILL.md",
+    ]

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from agent.skill_utils import (
     extract_skill_config_vars,
     extract_skill_conditions,
@@ -325,7 +327,10 @@ def test_iter_skill_index_files_follows_directory_symlinks(tmp_path):
     real = skills_dir / "real-skill"
     real.mkdir()
     (real / "SKILL.md").write_text("---\nname: real-skill\n---\n", encoding="utf-8")
-    (skills_dir / "linked-skill").symlink_to(vault)
+    try:
+        (skills_dir / "linked-skill").symlink_to(vault)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
 
     found = list(iter_skill_index_files(skills_dir, "SKILL.md"))
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -817,3 +817,42 @@ class TestProfilesToServe:
 
 
 
+    def test_on_no_named_profiles_returns_just_default(self, profile_env):
+        serve = profiles_to_serve(multiplex=True)
+        assert [n for n, _ in serve] == ["default"]
+
+
+class TestCountSkills:
+    """_count_skills must see symlinked skill dirs (external skill managers)."""
+
+    def test_counts_real_and_symlinked_skills(self, tmp_path):
+        from hermes_cli.profiles import _count_skills
+
+        profile_dir = tmp_path / "profile"
+        skills_dir = profile_dir / "skills"
+        skills_dir.mkdir(parents=True)
+
+        real = skills_dir / "real-skill"
+        real.mkdir()
+        (real / "SKILL.md").write_text("---\nname: real-skill\n---\n", encoding="utf-8")
+
+        vault = tmp_path / "vault" / "linked-skill"
+        vault.mkdir(parents=True)
+        (vault / "SKILL.md").write_text("---\nname: linked-skill\n---\n", encoding="utf-8")
+        (skills_dir / "linked-skill").symlink_to(vault)
+
+        assert _count_skills(profile_dir) == 2
+
+    def test_excluded_dirs_not_counted(self, tmp_path):
+        from hermes_cli.profiles import _count_skills
+
+        profile_dir = tmp_path / "profile"
+        skills_dir = profile_dir / "skills"
+        dep = skills_dir / "some-skill" / "node_modules" / "dep"
+        dep.mkdir(parents=True)
+        (dep / "SKILL.md").write_text("---\nname: dep\n---\n", encoding="utf-8")
+        (skills_dir / "some-skill" / "SKILL.md").write_text(
+            "---\nname: some-skill\n---\n", encoding="utf-8"
+        )
+
+        assert _count_skills(profile_dir) == 1

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -839,7 +839,10 @@ class TestCountSkills:
         vault = tmp_path / "vault" / "linked-skill"
         vault.mkdir(parents=True)
         (vault / "SKILL.md").write_text("---\nname: linked-skill\n---\n", encoding="utf-8")
-        (skills_dir / "linked-skill").symlink_to(vault)
+        try:
+            (skills_dir / "linked-skill").symlink_to(vault)
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"symlink creation unavailable: {exc}")
 
         assert _count_skills(profile_dir) == 2
 

--- a/tests/tools/test_skill_usage.py
+++ b/tests/tools/test_skill_usage.py
@@ -364,3 +364,42 @@ def test_adopt_rejects_empty_name(skills_home):
 
     assert adopt_skill("")[0] is False
 
+    rows = {r["name"]: r for r in usage_report()}
+    assert set(rows) == {"bundled-one", "hub-one", "mine"}
+    assert rows["bundled-one"]["provenance"] == "bundled"
+    assert rows["hub-one"]["provenance"] == "hub"
+    assert rows["mine"]["provenance"] == "agent"
+    # All carry real usage now.
+    for n in rows:
+        assert rows[n]["use_count"] == 1
+        assert rows[n]["_persisted"] is True
+
+
+def test_find_external_skill_dir_follows_directory_symlinks(skills_home, monkeypatch, tmp_path):
+    """External skill lookup must descend symlinked skill dirs.
+
+    ``_find_external_skill_dir`` resolves a skill by frontmatter name across
+    the configured external dirs; without a symlink-aware walk a vault-linked
+    skill is reported missing even though the loader can see it.
+    """
+    from tools.skill_usage import _find_external_skill_dir
+
+    vault = tmp_path / "vault" / "external-skill"
+    vault.mkdir(parents=True)
+    (vault / "SKILL.md").write_text("---\nname: external-skill\n---\n", encoding="utf-8")
+
+    external = tmp_path / "external"
+    external.mkdir()
+    try:
+        (external / "external-skill").symlink_to(vault)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+    monkeypatch.setattr(
+        "agent.skill_utils.get_all_skills_dirs",
+        lambda: [skills_home / "skills", external],
+    )
+
+    found = _find_external_skill_dir("external-skill")
+    assert found is not None
+    assert found.name == "external-skill"

--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -922,3 +922,31 @@ class TestUpdateBackupRecovery:
             result2 = sync_skills(quiet=True)
         assert "old-skill" in result2["updated"]
         assert result2["user_modified"] == []
+
+
+class TestExternalSkillIndexSymlinks:
+    """External dirs are commonly a tree of symlinks into a user's vault.
+
+    A raw rglob walk does not descend directory symlinks, so those skills
+    stayed invisible to shadow detection and sync_skills happily wrote a
+    bundled copy over the top of the delegated one.
+    """
+
+    def test_symlinked_external_skill_is_indexed(self, tmp_path):
+        from tools.skills_sync import _build_external_skill_index
+
+        vault = tmp_path / "vault" / "clair-qa"
+        vault.mkdir(parents=True)
+        (vault / "SKILL.md").write_text("---\nname: clair-qa\n---\n", encoding="utf-8")
+
+        ext_dir = tmp_path / "external"
+        ext_dir.mkdir()
+        try:
+            (ext_dir / "clair-qa").symlink_to(vault)
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"symlink creation unavailable: {exc}")
+
+        with patch("agent.skill_utils.get_external_skills_dirs", return_value=[ext_dir]):
+            names = _build_external_skill_index()
+
+        assert "clair-qa" in names

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -650,13 +650,11 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     external dirs configured via skills.external_dirs.  Returns
     {"path": Path} or None.
     """
-    from agent.skill_utils import get_all_skills_dirs, is_excluded_skill_path
+    from agent.skill_utils import get_all_skills_dirs, iter_skill_index_files
     for skills_dir in get_all_skills_dirs():
         if not skills_dir.exists():
             continue
-        for skill_md in skills_dir.rglob("SKILL.md"):
-            if is_excluded_skill_path(skill_md):
-                continue
+        for skill_md in iter_skill_index_files(skills_dir, "SKILL.md"):
             if skill_md.parent.name == name:
                 return {"path": skill_md.parent}
     return None
@@ -749,7 +747,7 @@ def _find_skill_in_other_profiles(name: str) -> List[Tuple[str, Path]]:
     matches: List[Tuple[str, Path]] = []
     try:
         from hermes_constants import get_default_hermes_root
-        from agent.skill_utils import is_excluded_skill_path
+        from agent.skill_utils import iter_skill_index_files
     except Exception:
         return matches
 
@@ -793,9 +791,7 @@ def _find_skill_in_other_profiles(name: str) -> List[Tuple[str, Path]]:
         if not skills_dir.is_dir():
             continue
         try:
-            for skill_md in skills_dir.rglob("SKILL.md"):
-                if is_excluded_skill_path(skill_md):
-                    continue
+            for skill_md in iter_skill_index_files(skills_dir, "SKILL.md"):
                 if skill_md.parent.name == name:
                     matches.append((profile_name, skill_md.parent))
                     break  # one match per profile is enough

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -34,7 +34,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from hermes_constants import get_hermes_home
-from agent.skill_utils import is_excluded_skill_path, is_external_skill_path
+from agent.skill_utils import is_external_skill_path, iter_skill_index_files
 
 logger = logging.getLogger(__name__)
 
@@ -356,10 +356,7 @@ def list_agent_created_skill_names() -> List[str]:
 
     names: List[str] = []
     # Top-level SKILL.md files (flat layout) AND nested category/skill/SKILL.md
-    for skill_md in base.rglob("SKILL.md"):
-        # Skip Hermes metadata, VCS, virtualenv/dependency, and cache dirs
-        if is_excluded_skill_path(skill_md):
-            continue
+    for skill_md in iter_skill_index_files(base, "SKILL.md"):
         # External skill dirs can be mounted below the local skills tree.
         # Discovery may see them, but autonomous lifecycle curation must not.
         if is_external_skill_path(skill_md):
@@ -1020,7 +1017,6 @@ def _find_skill_dir(skill_name: str) -> Optional[Path]:
     base = _skills_dir()
     if not base.exists():
         return None
-    from agent.skill_utils import iter_skill_index_files
 
     for skill_md in iter_skill_index_files(base, "SKILL.md"):
         if is_external_skill_path(skill_md):
@@ -1037,9 +1033,7 @@ def _find_external_skill_dir(skill_name: str) -> Optional[Path]:
     for base in get_all_skills_dirs()[1:]:
         if not base.exists():
             continue
-        for skill_md in base.rglob("SKILL.md"):
-            if is_excluded_skill_path(skill_md):
-                continue
+        for skill_md in iter_skill_index_files(base, "SKILL.md"):
             if _read_skill_name(skill_md, fallback=skill_md.parent.name) == skill_name:
                 return skill_md.parent
     return None
@@ -1120,9 +1114,7 @@ def usage_report() -> List[Dict[str, Any]]:
     data = load_usage()
     rows: List[Dict[str, Any]] = []
     seen: set = set()
-    for skill_md in base.rglob("SKILL.md"):
-        if is_excluded_skill_path(skill_md):
-            continue
+    for skill_md in iter_skill_index_files(base, "SKILL.md"):
         name = _read_skill_name(skill_md, fallback=skill_md.parent.name)
         if name in seen:
             continue

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -27,7 +27,7 @@ from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from hermes_constants import get_hermes_home
 from hermes_cli._subprocess_compat import windows_hide_flags
-from agent.skill_utils import is_excluded_skill_path
+from agent.skill_utils import iter_skill_index_files
 from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import unquote, urljoin, urlparse, urlsplit, urlunparse
 
@@ -3172,11 +3172,7 @@ class OptionalSkillSource(SkillSource):
         """Find a skill directory by name anywhere in optional-skills/."""
         if not self._optional_dir.is_dir():
             return None
-        for skill_md in self._optional_dir.rglob("SKILL.md"):
-            if is_excluded_skill_path(
-                skill_md.relative_to(self._optional_dir), root=self._optional_dir
-            ):
-                continue
+        for skill_md in iter_skill_index_files(self._optional_dir, "SKILL.md"):
             if skill_md.parent.name == name:
                 return skill_md.parent
         return None
@@ -3187,11 +3183,7 @@ class OptionalSkillSource(SkillSource):
             return []
 
         results: List[SkillMeta] = []
-        for skill_md in sorted(self._optional_dir.rglob("SKILL.md")):
-            if is_excluded_skill_path(
-                skill_md.relative_to(self._optional_dir), root=self._optional_dir
-            ):
-                continue
+        for skill_md in iter_skill_index_files(self._optional_dir, "SKILL.md"):
             parent = skill_md.parent
 
             try:

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -46,7 +46,7 @@ for _stream in (sys.stdout, sys.stderr):
         except (ValueError, TypeError):
             pass
 from hermes_constants import get_bundled_skills_dir, get_hermes_home, get_optional_skills_dir
-from agent.skill_utils import is_excluded_skill_path
+from agent.skill_utils import iter_skill_index_files, is_excluded_skill_path
 from typing import Dict, List, Optional, Set, Tuple
 from utils import atomic_replace
 
@@ -97,9 +97,7 @@ def _build_external_skill_index() -> Set[str]:
 
     external_names: Set[str] = set()
     for ext_dir in get_external_skills_dirs():
-        for skill_md in ext_dir.rglob("SKILL.md"):
-            if is_excluded_skill_path(skill_md):
-                continue
+        for skill_md in iter_skill_index_files(ext_dir, "SKILL.md"):
             skill_dir = skill_md.parent
             # Index by directory name (how _find_skill resolves skills)
             external_names.add(skill_dir.name)
@@ -226,15 +224,7 @@ def _discover_bundled_skills(bundled_dir: Path) -> List[Tuple[str, Path]]:
     if not bundled_dir.exists():
         return skills
 
-    for skill_md in bundled_dir.rglob("SKILL.md"):
-        # Exclusions apply inside the bundled tree. The install prefix itself
-        # may legitimately contain names such as ``venv`` or ``site-packages``;
-        # treating those parent components as skill content makes every wheel
-        # install discover zero bundled skills.
-        if is_excluded_skill_path(
-            skill_md.relative_to(bundled_dir), root=bundled_dir
-        ):
-            continue
+    for skill_md in iter_skill_index_files(bundled_dir, "SKILL.md"):
         skill_dir = skill_md.parent
         skill_name = _read_skill_name(skill_md, skill_dir.name)
         skills.append((skill_name, skill_dir))
@@ -308,11 +298,7 @@ def _optional_skill_index() -> Dict[str, Tuple[str, str, Path]]:
     index: Dict[str, Tuple[str, str, Path]] = {}
     if not optional_dir.exists():
         return index
-    for skill_md in sorted(optional_dir.rglob("SKILL.md")):
-        if is_excluded_skill_path(
-            skill_md.relative_to(optional_dir), root=optional_dir
-        ):
-            continue
+    for skill_md in iter_skill_index_files(optional_dir, "SKILL.md"):
         src = skill_md.parent
         try:
             install_path = _safe_rel_install_path(src, optional_dir)
@@ -373,9 +359,7 @@ def restore_official_optional_skill(name: str, *, restore: bool = False) -> dict
         src_frontmatter = _read_skill_name(src / "SKILL.md", folder_name)
         matches: List[Path] = []
         if SKILLS_DIR.exists():
-            for skill_md in sorted(SKILLS_DIR.rglob("SKILL.md")):
-                if is_excluded_skill_path(skill_md):
-                    continue
+            for skill_md in iter_skill_index_files(SKILLS_DIR, "SKILL.md"):
                 candidate = skill_md.parent
                 try:
                     candidate.relative_to(SKILLS_DIR)
@@ -480,9 +464,7 @@ def _backfill_optional_provenance(quiet: bool = False) -> List[str]:
     backfilled: List[str] = []
     changed = False
     installed_dir_index: Optional[Dict[str, List[Path]]] = None
-    for skill_md in sorted(optional_dir.rglob("SKILL.md")):
-        if is_excluded_skill_path(skill_md):
-            continue
+    for skill_md in iter_skill_index_files(optional_dir, "SKILL.md"):
         src = skill_md.parent
         try:
             install_path = _safe_rel_install_path(src, optional_dir)


### PR DESCRIPTION
I manage some skills with an external tool that symlinks them from a central vault into each agent's skills folder. They load and run fine — the runtime loader walks with `followlinks=True` — but everything else sees a different reality: the profile list undercounts skills, usage tracking misses them, curator backups skip them, and the dashboard's skills views don't know they exist. Turns out the loader is the only place that follows symlinks; the other discovery sites all use `rglob("SKILL.md")`, which never descends into symlinked dirs (on any Python version — 3.13's `recurse_symlinks` is opt-in).

Fix: swapped every discovery site to the `iter_skill_index_files()` helper you already have, so there's one canonical answer to "what skills are installed". Nice side effects: the shared exclusion set now applies uniformly (one endpoint scanned without it), and ordering is deterministic everywhere.

Tests: added symlink coverage for `iter_skill_index_files()` and `_count_skills()`; the test files for all touched modules pass (448 tests). The full suite shows 45 failures on my machine, but they're identical on a clean checkout of main (auth/systemd/environment-specific) — happy to dig into any of them if they look unexpected on your side.