### PR TITLE
fix(api_server): resolve forward on session_id to prevent forking (#44004)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1817,6 +1817,14 @@ class APIServerAdapter(BasePlatformAdapter):
             try:
                 db = self._ensure_session_db()
                 if db is not None:
+                    # Resolve forward: if the client-supplied session_id was
+                    # superseded by compression (parent → child chain), use
+                    # the latest descendant that actually holds messages.
+                    # Without this, stateless clients (Open WebUI, LibreChat,
+                    # etc.) that re-supply the original session_id on every
+                    # request will fork the ended session on each turn.
+                    # See #44004.
+                    session_id = db.resolve_resume_session_id(session_id)
                     history = db.get_messages_as_conversation(session_id)
             except Exception as e:
                 logger.warning("Failed to load session history for %s: %s", session_id, e)

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -3250,6 +3250,7 @@ class TestSessionIdHeader:
         """When X-Hermes-Session-Id is provided, it's passed to the agent and echoed in the response."""
         mock_result = {"final_response": "Continuing!", "messages": [], "api_calls": 1}
         mock_db = MagicMock()
+        mock_db.resolve_resume_session_id.return_value = "my-session-123"
         mock_db.get_messages_as_conversation.return_value = [
             {"role": "user", "content": "previous message"},
             {"role": "assistant", "content": "previous reply"},
@@ -3280,6 +3281,7 @@ class TestSessionIdHeader:
             {"role": "assistant", "content": "stored reply 1"},
         ]
         mock_db = MagicMock()
+        mock_db.resolve_resume_session_id.return_value = "existing-session"
         mock_db.get_messages_as_conversation.return_value = db_history
         auth_adapter._session_db = mock_db
         app = _create_app(auth_adapter)
@@ -3370,6 +3372,7 @@ class TestSessionKeyHeader:
         """Both headers coexist: key scopes memory, id scopes transcript."""
         mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
         mock_db = MagicMock()
+        mock_db.resolve_resume_session_id.return_value = "transcript-xyz"
         mock_db.get_messages_as_conversation.return_value = []
         auth_adapter._session_db = mock_db
         app = _create_app(auth_adapter)


### PR DESCRIPTION
Fixes #44004. Call resolve_resume_session_id() on the client-supplied X-Hermes-Session-Id in the chat completions endpoint, so that when a session has been superseded by compression (parent-child chain), the latest descendant holding messages is used instead of the ended parent. Without this, stateless OpenAI-compatible clients (Open WebUI, LibreChat, etc.) that re-supply the original session_id on every request fork the ended session on each turn.