### PR TITLE
fix: preserve Responses API function call outputs

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2836,12 +2836,39 @@ class APIServerAdapter(BasePlatformAdapter):
                 if isinstance(item, str):
                     input_messages.append({"role": "user", "content": item})
                 elif isinstance(item, dict):
-                    role = item.get("role", "user")
-                    try:
-                        content = _normalize_multimodal_content(item.get("content", ""))
-                    except ValueError as exc:
-                        return _multimodal_validation_error(exc, param=f"input[{idx}].content")
-                    input_messages.append({"role": role, "content": content})
+                    item_type = str(item.get("type") or "").strip().lower()
+                    if item_type == "function_call":
+                        call_id = item.get("call_id") or item.get("tool_call_id") or item.get("id") or ""
+                        arguments = item.get("arguments", "")
+                        if not isinstance(arguments, str):
+                            arguments = json.dumps(arguments, default=str)
+                        input_messages.append({
+                            "role": "assistant",
+                            "tool_calls": [
+                                {
+                                    "id": str(call_id),
+                                    "function": {
+                                        "name": str(item.get("name") or ""),
+                                        "arguments": arguments,
+                                    },
+                                }
+                            ],
+                        })
+                    elif item_type == "function_call_output":
+                        call_id = item.get("call_id") or item.get("tool_call_id") or ""
+                        output = item.get("output", item.get("content", ""))
+                        input_messages.append({
+                            "role": "tool",
+                            "tool_call_id": str(call_id),
+                            "content": _normalize_chat_content(output),
+                        })
+                    else:
+                        role = item.get("role", "user")
+                        try:
+                            content = _normalize_multimodal_content(item.get("content", ""))
+                        except ValueError as exc:
+                            return _multimodal_validation_error(exc, param=f"input[{idx}].content")
+                        input_messages.append({"role": role, "content": content})
         else:
             return web.json_response(_openai_error("'input' must be a string or array"), status=400)
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1604,6 +1604,57 @@ class TestResponsesEndpoint:
             assert len(call_kwargs["conversation_history"]) == 1
 
     @pytest.mark.asyncio
+    async def test_responses_input_preserves_function_call_output_items(self, adapter):
+        """Client-side Responses history must keep tool-call outputs."""
+        mock_result = {"final_response": "Done", "messages": [], "api_calls": 1}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": [
+                            {"role": "user", "content": "Read /tmp/example.txt"},
+                            {
+                                "type": "function_call",
+                                "call_id": "call_read",
+                                "name": "read_file",
+                                "arguments": '{"path":"/tmp/example.txt"}',
+                            },
+                            {
+                                "type": "function_call_output",
+                                "call_id": "call_read",
+                                "output": [{"type": "input_text", "text": '{"content":"hello"}'}],
+                            },
+                            {"role": "user", "content": "What did the file say?"},
+                        ],
+                    },
+                )
+
+            assert resp.status == 200
+            call_kwargs = mock_run.call_args.kwargs
+            assert call_kwargs["user_message"] == "What did the file say?"
+            assert call_kwargs["conversation_history"] == [
+                {"role": "user", "content": "Read /tmp/example.txt"},
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": "call_read",
+                            "function": {
+                                "name": "read_file",
+                                "arguments": '{"path":"/tmp/example.txt"}',
+                            },
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call_read", "content": '{"content":"hello"}'},
+            ]
+
+    @pytest.mark.asyncio
     async def test_instructions_as_ephemeral_prompt(self, adapter):
         """The instructions field maps to ephemeral_system_prompt."""
         mock_result = {"final_response": "Ahoy!", "messages": [], "api_calls": 1}


### PR DESCRIPTION
## Summary
- Preserve Responses API `function_call` items as assistant tool calls when parsing client-provided input history
- Preserve `function_call_output` items as tool messages so tool results survive across turns
- Add a regression test covering client-managed Responses history with tool output items

## Test Plan
- `.venv/bin/python -m pytest tests/gateway/test_api_server.py::TestResponsesEndpoint::test_responses_input_preserves_function_call_output_items tests/gateway/test_api_server.py::TestResponsesEndpoint -q`
- `.venv/bin/python -m pytest tests/gateway/test_api_server.py -q`

Closes #43757