### PR TITLE
feat(api): add mobile notification inbox endpoints

### DIFF
--- a/gateway/mobile_notifications.py
+++ b/gateway/mobile_notifications.py
@@ -1,0 +1,369 @@
+"""SQLite-backed mobile notification inbox for Hermes WebUI clients."""
+
+import sqlite3
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+
+OPEN_STATUSES = ("unread", "read")
+CLOSED_STATUSES = ("closed", "expired")
+VALID_NOTIFICATION_STATUSES = OPEN_STATUSES + CLOSED_STATUSES
+VALID_ACTION_STATUSES = ("pending", "done", "rejected")
+
+
+class MobileNotificationStore:
+    """Persist mobile notification inbox items and approval-style actions."""
+
+    def __init__(self, db_path: Optional[str] = None):
+        if not db_path:
+            try:
+                from hermes_cli.config import get_hermes_home
+
+                db_path = str(get_hermes_home() / "mobile_notifications.db")
+            except Exception:
+                db_path = ":memory:"
+
+        self._db_path: Optional[str] = db_path if db_path != ":memory:" else None
+        try:
+            self._conn = sqlite3.connect(db_path, check_same_thread=False)
+        except Exception:
+            self._conn = sqlite3.connect(":memory:", check_same_thread=False)
+            self._db_path = None
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA foreign_keys = ON")
+
+        from hermes_state import apply_wal_with_fallback
+
+        apply_wal_with_fallback(self._conn, db_label="mobile_notifications.db")
+        self._init_schema()
+        self._tighten_file_permissions()
+
+    def _init_schema(self) -> None:
+        self._conn.execute(
+            """CREATE TABLE IF NOT EXISTS mobile_notifications (
+                id TEXT PRIMARY KEY,
+                kind TEXT NOT NULL,
+                title TEXT NOT NULL,
+                body TEXT NOT NULL,
+                detail_ref TEXT NOT NULL DEFAULT '',
+                status TEXT NOT NULL DEFAULT 'unread',
+                expires_at REAL,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL
+            )"""
+        )
+        self._conn.execute(
+            """CREATE TABLE IF NOT EXISTS mobile_notification_actions (
+                id TEXT PRIMARY KEY,
+                notification_id TEXT NOT NULL,
+                group_key TEXT NOT NULL,
+                label TEXT NOT NULL,
+                value TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'pending',
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                FOREIGN KEY(notification_id)
+                    REFERENCES mobile_notifications(id)
+                    ON DELETE CASCADE
+            )"""
+        )
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_mobile_notifications_status "
+            "ON mobile_notifications(status, expires_at)"
+        )
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_mobile_notification_actions_parent "
+            "ON mobile_notification_actions(notification_id, group_key, status)"
+        )
+        self._conn.commit()
+
+    def _tighten_file_permissions(self) -> None:
+        if not self._db_path:
+            return
+        for candidate in (
+            Path(self._db_path),
+            Path(f"{self._db_path}-wal"),
+            Path(f"{self._db_path}-shm"),
+        ):
+            try:
+                if candidate.exists():
+                    candidate.chmod(0o600)
+            except OSError:
+                pass
+
+    def upsert_notification(
+        self,
+        notification: Dict[str, Any],
+        actions: Optional[List[Dict[str, Any]]] = None,
+    ) -> Dict[str, Any]:
+        now = time.time()
+        notification_id = self._clean_text(
+            notification.get("id") or f"mn_{uuid.uuid4().hex}", "id", 128
+        )
+        kind = self._clean_text(notification.get("kind") or "general", "kind", 64)
+        title = self._clean_text(notification.get("title"), "title", 200)
+        body = self._clean_text(notification.get("body"), "body", 1000)
+        detail_ref = self._clean_text(
+            notification.get("detail_ref") or "", "detail_ref", 1000, required=False
+        )
+        status = notification.get("status") or "unread"
+        if status not in VALID_NOTIFICATION_STATUSES:
+            raise ValueError("Invalid notification status")
+        expires_at = notification.get("expires_at")
+        if expires_at is not None:
+            expires_at = float(expires_at)
+        created_at = float(notification.get("created_at") or now)
+
+        self._conn.execute(
+            """INSERT INTO mobile_notifications (
+                id, kind, title, body, detail_ref, status, expires_at,
+                created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                kind=excluded.kind,
+                title=excluded.title,
+                body=excluded.body,
+                detail_ref=excluded.detail_ref,
+                status=excluded.status,
+                expires_at=excluded.expires_at,
+                updated_at=excluded.updated_at""",
+            (
+                notification_id,
+                kind,
+                title,
+                body,
+                detail_ref,
+                status,
+                expires_at,
+                created_at,
+                now,
+            ),
+        )
+
+        if actions is not None:
+            self._conn.execute(
+                "DELETE FROM mobile_notification_actions WHERE notification_id = ?",
+                (notification_id,),
+            )
+            for raw_action in actions:
+                action_id = self._clean_text(
+                    raw_action.get("id") or f"act_{uuid.uuid4().hex}", "action_id", 128
+                )
+                group_key = self._clean_text(
+                    raw_action.get("group_key") or "default", "group_key", 128
+                )
+                label = self._clean_text(raw_action.get("label"), "label", 100)
+                value = self._clean_text(raw_action.get("value"), "value", 500)
+                action_status = raw_action.get("status") or "pending"
+                if action_status not in VALID_ACTION_STATUSES:
+                    raise ValueError("Invalid action status")
+                self._conn.execute(
+                    """INSERT INTO mobile_notification_actions (
+                        id, notification_id, group_key, label, value, status,
+                        created_at, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        action_id,
+                        notification_id,
+                        group_key,
+                        label,
+                        value,
+                        action_status,
+                        now,
+                        now,
+                    ),
+                )
+
+        self._conn.commit()
+        self._tighten_file_permissions()
+        return self.get_notification(notification_id) or {}
+
+    def list_notifications(self, status: str = "open", limit: int = 50) -> List[Dict[str, Any]]:
+        self.expire_due()
+        if status == "open":
+            rows = self._conn.execute(
+                """SELECT * FROM mobile_notifications
+                WHERE status IN ('unread', 'read')
+                ORDER BY created_at DESC
+                LIMIT ?""",
+                (limit,),
+            ).fetchall()
+        elif status == "all":
+            rows = self._conn.execute(
+                """SELECT * FROM mobile_notifications
+                ORDER BY created_at DESC
+                LIMIT ?""",
+                (limit,),
+            ).fetchall()
+        else:
+            raise ValueError("Invalid status filter")
+        return [self._row_to_notification(row) for row in rows]
+
+    def get_notification(self, notification_id: str) -> Optional[Dict[str, Any]]:
+        self.expire_due()
+        row = self._conn.execute(
+            "SELECT * FROM mobile_notifications WHERE id = ?",
+            (notification_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return self._row_to_notification(row)
+
+    def mark_read(self, notification_id: str) -> Optional[Dict[str, Any]]:
+        self.expire_due()
+        row = self._conn.execute(
+            "SELECT status FROM mobile_notifications WHERE id = ?",
+            (notification_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        if row["status"] == "unread":
+            self._conn.execute(
+                "UPDATE mobile_notifications SET status = 'read', updated_at = ? WHERE id = ?",
+                (time.time(), notification_id),
+            )
+            self._conn.commit()
+        return self.get_notification(notification_id)
+
+    def resolve_action(
+        self,
+        notification_id: str,
+        action_id: str,
+    ) -> Tuple[str, Optional[Dict[str, Any]]]:
+        self.expire_due()
+        notification = self.get_notification(notification_id)
+        if notification is None:
+            return "not_found", None
+        if notification["status"] == "expired":
+            return "expired", notification
+
+        action_row = self._conn.execute(
+            """SELECT * FROM mobile_notification_actions
+            WHERE notification_id = ? AND id = ?""",
+            (notification_id, action_id),
+        ).fetchone()
+        if action_row is None:
+            return "not_found", notification
+        if action_row["status"] == "done":
+            return "ok", notification
+        if action_row["status"] != "pending":
+            return "conflict", notification
+
+        done_sibling = self._conn.execute(
+            """SELECT id FROM mobile_notification_actions
+            WHERE notification_id = ? AND group_key = ? AND status = 'done'
+            LIMIT 1""",
+            (notification_id, action_row["group_key"]),
+        ).fetchone()
+        if done_sibling is not None:
+            return "conflict", notification
+
+        now = time.time()
+        self._conn.execute(
+            """UPDATE mobile_notification_actions
+            SET status = 'done', updated_at = ?
+            WHERE notification_id = ? AND id = ?""",
+            (now, notification_id, action_id),
+        )
+        self._conn.execute(
+            """UPDATE mobile_notification_actions
+            SET status = 'rejected', updated_at = ?
+            WHERE notification_id = ? AND group_key = ? AND id != ? AND status = 'pending'""",
+            (now, notification_id, action_row["group_key"], action_id),
+        )
+
+        pending = self._conn.execute(
+            """SELECT COUNT(*) FROM mobile_notification_actions
+            WHERE notification_id = ? AND status = 'pending'""",
+            (notification_id,),
+        ).fetchone()[0]
+        if pending == 0:
+            self._conn.execute(
+                "UPDATE mobile_notifications SET status = 'closed', updated_at = ? WHERE id = ?",
+                (now, notification_id),
+            )
+        self._conn.commit()
+        return "ok", self.get_notification(notification_id)
+
+    def expire_due(self, now: Optional[float] = None) -> int:
+        if now is None:
+            now = time.time()
+        rows = self._conn.execute(
+            """SELECT id FROM mobile_notifications
+            WHERE status IN ('unread', 'read') AND expires_at IS NOT NULL AND expires_at <= ?""",
+            (now,),
+        ).fetchall()
+        if not rows:
+            return 0
+        ids = [row["id"] for row in rows]
+        placeholders = ",".join("?" for _ in ids)
+        self._conn.execute(
+            f"UPDATE mobile_notifications SET status = 'expired', updated_at = ? WHERE id IN ({placeholders})",
+            [now] + ids,
+        )
+        self._conn.execute(
+            f"UPDATE mobile_notification_actions SET status = 'rejected', updated_at = ? "
+            f"WHERE notification_id IN ({placeholders}) AND status = 'pending'",
+            [now] + ids,
+        )
+        self._conn.commit()
+        return len(ids)
+
+    def _row_to_notification(self, row: sqlite3.Row) -> Dict[str, Any]:
+        actions = [
+            {
+                "id": action["id"],
+                "group_key": action["group_key"],
+                "label": action["label"],
+                "value": action["value"],
+                "status": action["status"],
+                "created_at": action["created_at"],
+                "updated_at": action["updated_at"],
+            }
+            for action in self._conn.execute(
+                """SELECT * FROM mobile_notification_actions
+                WHERE notification_id = ?
+                ORDER BY created_at ASC, id ASC""",
+                (row["id"],),
+            ).fetchall()
+        ]
+        return {
+            "id": row["id"],
+            "kind": row["kind"],
+            "title": row["title"],
+            "body": row["body"],
+            "detail_ref": row["detail_ref"],
+            "status": row["status"],
+            "expires_at": row["expires_at"],
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+            "actions": actions,
+        }
+
+    def _clean_text(
+        self,
+        value: Any,
+        field_name: str,
+        max_length: int,
+        required: bool = True,
+    ) -> str:
+        if value is None:
+            if required:
+                raise ValueError(f"{field_name} is required")
+            return ""
+        if not isinstance(value, str):
+            value = str(value)
+        value = value.strip()
+        if required and not value:
+            raise ValueError(f"{field_name} is required")
+        if len(value) > max_length:
+            raise ValueError(f"{field_name} exceeds {max_length} chars")
+        return value
+
+    def close(self) -> None:
+        try:
+            self._conn.close()
+        except Exception:
+            pass

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -14,6 +14,9 @@ Exposes an HTTP server with endpoints:
 - GET  /api/sessions/{session_id}/messages — read session message history
 - POST /api/sessions/{session_id}/fork — branch a session using SessionDB lineage
 - POST /api/sessions/{session_id}/chat[/stream] — chat with a persisted session
+- GET  /api/mobile/notifications — list mobile notification inbox items
+- POST /api/mobile/notifications/{notification_id}/read — mark an inbox item read
+- POST /api/mobile/notifications/{notification_id}/actions — resolve an inbox action
 - POST /v1/runs                    — start a run, returns run_id immediately (202)
 - GET  /v1/runs/{run_id}           — retrieve current run status
 - GET  /v1/runs/{run_id}/events    — SSE stream of structured lifecycle events
@@ -53,6 +56,7 @@ except ImportError:
     web = None  # type: ignore[assignment]
 
 from gateway.config import Platform, PlatformConfig
+from gateway.mobile_notifications import MobileNotificationStore
 from gateway.platforms.base import (
     BasePlatformAdapter,
     SendResult,
@@ -766,6 +770,7 @@ class APIServerAdapter(BasePlatformAdapter):
         # in-flight run by run_id.
         self._run_approval_sessions: Dict[str, str] = {}
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
+        self._mobile_notifications: Optional[MobileNotificationStore] = None
 
     @staticmethod
     def _parse_cors_origins(value: Any) -> tuple[str, ...]:
@@ -913,6 +918,12 @@ class APIServerAdapter(BasePlatformAdapter):
             {"error": {"message": "Invalid API key", "type": "invalid_request_error", "code": "invalid_api_key"}},
             status=401,
         )
+
+    def _get_mobile_notifications(self) -> MobileNotificationStore:
+        """Lazy-init the mobile notification inbox store."""
+        if self._mobile_notifications is None:
+            self._mobile_notifications = MobileNotificationStore()
+        return self._mobile_notifications
 
     # ------------------------------------------------------------------
     # Session header helpers
@@ -1162,6 +1173,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "session_chat": True,
                 "session_chat_streaming": True,
                 "session_fork": True,
+                "mobile_notifications": True,
                 "admin_config_rw": False,
                 "jobs_admin": False,
                 "memory_write_api": False,
@@ -1194,8 +1206,89 @@ class APIServerAdapter(BasePlatformAdapter):
                 "session_fork": {"method": "POST", "path": "/api/sessions/{session_id}/fork"},
                 "session_chat": {"method": "POST", "path": "/api/sessions/{session_id}/chat"},
                 "session_chat_stream": {"method": "POST", "path": "/api/sessions/{session_id}/chat/stream"},
+                "mobile_notifications": {"method": "GET", "path": "/api/mobile/notifications"},
+                "mobile_notification_read": {"method": "POST", "path": "/api/mobile/notifications/{notification_id}/read"},
+                "mobile_notification_actions": {"method": "POST", "path": "/api/mobile/notifications/{notification_id}/actions"},
             },
         })
+
+    async def _handle_mobile_notifications(self, request: "web.Request") -> "web.Response":
+        """GET /api/mobile/notifications — list WebUI mobile inbox items."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        status = request.query.get("status", "open")
+        if status not in {"open", "all"}:
+            return web.json_response({"error": "status must be 'open' or 'all'"}, status=400)
+
+        raw_limit = request.query.get("limit", "50")
+        try:
+            limit = int(raw_limit)
+        except (TypeError, ValueError):
+            return web.json_response({"error": "limit must be an integer"}, status=400)
+        if limit < 1 or limit > 100:
+            return web.json_response({"error": "limit must be between 1 and 100"}, status=400)
+
+        notifications = self._get_mobile_notifications().list_notifications(
+            status=status,
+            limit=limit,
+        )
+        return web.json_response({"notifications": notifications})
+
+    async def _handle_mark_mobile_notification_read(self, request: "web.Request") -> "web.Response":
+        """POST /api/mobile/notifications/{id}/read — mark an inbox item read."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        notification_id = request.match_info.get("notification_id", "")
+        if not notification_id:
+            return web.json_response({"error": "notification_id is required"}, status=400)
+
+        notification = self._get_mobile_notifications().mark_read(notification_id)
+        if notification is None:
+            return web.json_response({"error": "Notification not found"}, status=404)
+        return web.json_response({"notification": notification})
+
+    async def _handle_mobile_notification_action(self, request: "web.Request") -> "web.Response":
+        """POST /api/mobile/notifications/{id}/actions — resolve an inbox action."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        notification_id = request.match_info.get("notification_id", "")
+        if not notification_id:
+            return web.json_response({"error": "notification_id is required"}, status=400)
+
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response({"error": "Invalid JSON in request body"}, status=400)
+        if not isinstance(body, dict):
+            return web.json_response({"error": "Request body must be an object"}, status=400)
+
+        action_id = body.get("action_id")
+        if not isinstance(action_id, str) or not action_id.strip():
+            return web.json_response({"error": "action_id is required"}, status=400)
+
+        result, notification = self._get_mobile_notifications().resolve_action(
+            notification_id,
+            action_id.strip(),
+        )
+        if result == "not_found":
+            return web.json_response({"error": "Notification or action not found"}, status=404)
+        if result == "expired":
+            return web.json_response(
+                {"error": "Notification expired", "notification": notification},
+                status=410,
+            )
+        if result == "conflict":
+            return web.json_response(
+                {"error": "Action already resolved", "notification": notification},
+                status=409,
+            )
+        return web.json_response({"notification": notification})
 
     async def _handle_skills(self, request: "web.Request") -> "web.Response":
         """GET /v1/skills — list installed skills visible to the API-server agent.
@@ -4177,6 +4270,10 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_post("/api/sessions/{session_id}/fork", self._handle_fork_session)
             self._app.router.add_post("/api/sessions/{session_id}/chat", self._handle_session_chat)
             self._app.router.add_post("/api/sessions/{session_id}/chat/stream", self._handle_session_chat_stream)
+            # Mobile notification inbox for Hermes WebUI / installed web app clients
+            self._app.router.add_get("/api/mobile/notifications", self._handle_mobile_notifications)
+            self._app.router.add_post("/api/mobile/notifications/{notification_id}/read", self._handle_mark_mobile_notification_read)
+            self._app.router.add_post("/api/mobile/notifications/{notification_id}/actions", self._handle_mobile_notification_action)
             self._app.router.add_post("/v1/chat/completions", self._handle_chat_completions)
             self._app.router.add_post("/v1/responses", self._handle_responses)
             self._app.router.add_get("/v1/responses/{response_id}", self._handle_get_response)
@@ -4285,6 +4382,16 @@ class APIServerAdapter(BasePlatformAdapter):
                 logger.debug(
                     "Failed to close response store for %s", self.name, exc_info=True,
                 )
+        if self._mobile_notifications is not None:
+            try:
+                self._mobile_notifications.close()
+            except Exception:
+                logger.debug(
+                    "Failed to close mobile notification store for %s",
+                    self.name,
+                    exc_info=True,
+                )
+            self._mobile_notifications = None
         if self._site:
             await self._site.stop()
             self._site = None

--- a/tests/gateway/test_api_server_mobile_notifications.py
+++ b/tests/gateway/test_api_server_mobile_notifications.py
@@ -1,0 +1,220 @@
+"""Tests for the Hermes mobile notification inbox API."""
+
+import os
+import stat
+import time
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter, cors_middleware
+
+
+def _make_adapter(api_key: str = "") -> APIServerAdapter:
+    extra = {}
+    if api_key:
+        extra["key"] = api_key
+    config = PlatformConfig(enabled=True, extra=extra)
+    return APIServerAdapter(config)
+
+
+def _create_app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application(middlewares=[cors_middleware])
+    app["api_server_adapter"] = adapter
+    app.router.add_get("/v1/capabilities", adapter._handle_capabilities)
+    app.router.add_get("/api/mobile/notifications", adapter._handle_mobile_notifications)
+    app.router.add_post(
+        "/api/mobile/notifications/{notification_id}/read",
+        adapter._handle_mark_mobile_notification_read,
+    )
+    app.router.add_post(
+        "/api/mobile/notifications/{notification_id}/actions",
+        adapter._handle_mobile_notification_action,
+    )
+    return app
+
+
+@pytest.fixture
+def adapter(tmp_path, monkeypatch):
+    monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: tmp_path)
+    return _make_adapter()
+
+
+@pytest.fixture
+def auth_adapter(tmp_path, monkeypatch):
+    monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: tmp_path)
+    return _make_adapter(api_key="sk-secret")
+
+
+def _seed_approval(adapter: APIServerAdapter, expires_at=None):
+    return adapter._get_mobile_notifications().upsert_notification(
+        {
+            "id": "remember-1",
+            "kind": "memory_approval",
+            "title": "保存候補があります",
+            "body": "2件の候補を確認してください。",
+            "detail_ref": "memory-review:2026-06-11",
+            "expires_at": expires_at,
+        },
+        actions=[
+            {
+                "id": "yes",
+                "group_key": "remember-1",
+                "label": "はい",
+                "value": "approve",
+            },
+            {
+                "id": "no",
+                "group_key": "remember-1",
+                "label": "いいえ",
+                "value": "reject",
+            },
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_mobile_notifications_require_auth(auth_adapter):
+    app = _create_app(auth_adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.get("/api/mobile/notifications")
+        assert resp.status == 401
+
+        resp = await cli.get(
+            "/api/mobile/notifications",
+            headers={"Authorization": "Bearer sk-secret"},
+        )
+        assert resp.status == 200
+
+
+@pytest.mark.asyncio
+async def test_list_mobile_notifications_returns_open_items(adapter):
+    _seed_approval(adapter)
+    adapter._get_mobile_notifications().upsert_notification(
+        {
+            "id": "old-closed",
+            "kind": "memory_approval",
+            "title": "完了済み",
+            "body": "これは表示しません。",
+            "status": "closed",
+        },
+        actions=[],
+    )
+    adapter._get_mobile_notifications().upsert_notification(
+        {
+            "id": "old-expired",
+            "kind": "memory_approval",
+            "title": "期限切れ",
+            "body": "これも表示しません。",
+            "expires_at": time.time() - 1,
+        },
+        actions=[],
+    )
+
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.get("/api/mobile/notifications")
+        assert resp.status == 200
+        data = await resp.json()
+
+    assert [item["id"] for item in data["notifications"]] == ["remember-1"]
+    assert {action["id"] for action in data["notifications"][0]["actions"]} == {"yes", "no"}
+
+
+@pytest.mark.asyncio
+async def test_mark_mobile_notification_read(adapter):
+    _seed_approval(adapter)
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post("/api/mobile/notifications/remember-1/read")
+        assert resp.status == 200
+        data = await resp.json()
+
+    assert data["notification"]["status"] == "read"
+
+
+@pytest.mark.asyncio
+async def test_resolve_mobile_notification_action_closes_group(adapter):
+    _seed_approval(adapter)
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post(
+            "/api/mobile/notifications/remember-1/actions",
+            json={"action_id": "yes"},
+        )
+        assert resp.status == 200
+        data = await resp.json()
+
+        retry = await cli.post(
+            "/api/mobile/notifications/remember-1/actions",
+            json={"action_id": "yes"},
+        )
+        assert retry.status == 200
+
+        conflict = await cli.post(
+            "/api/mobile/notifications/remember-1/actions",
+            json={"action_id": "no"},
+        )
+        assert conflict.status == 409
+
+    assert data["notification"]["status"] == "closed"
+    statuses = {action["id"]: action["status"] for action in data["notification"]["actions"]}
+    assert statuses == {"yes": "done", "no": "rejected"}
+
+
+@pytest.mark.asyncio
+async def test_resolve_expired_mobile_notification_returns_gone(adapter):
+    _seed_approval(adapter, expires_at=time.time() - 1)
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post(
+            "/api/mobile/notifications/remember-1/actions",
+            json={"action_id": "yes"},
+        )
+        data = await resp.json()
+
+    assert resp.status == 410
+    assert data["notification"]["status"] == "expired"
+
+
+@pytest.mark.asyncio
+async def test_mobile_notification_validation_errors(adapter):
+    _seed_approval(adapter)
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        bad_status = await cli.get("/api/mobile/notifications?status=closed")
+        bad_limit = await cli.get("/api/mobile/notifications?limit=0")
+        missing_action = await cli.post(
+            "/api/mobile/notifications/remember-1/actions",
+            json={},
+        )
+
+    assert bad_status.status == 400
+    assert bad_limit.status == 400
+    assert missing_action.status == 400
+
+
+@pytest.mark.asyncio
+async def test_mobile_capabilities_advertise_inbox(adapter):
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.get("/v1/capabilities")
+        assert resp.status == 200
+        data = await resp.json()
+
+    assert data["features"]["mobile_notifications"] is True
+    assert data["endpoints"]["mobile_notifications"]["path"] == "/api/mobile/notifications"
+
+
+def test_mobile_notification_db_is_owner_only(tmp_path, monkeypatch):
+    if os.name == "nt":
+        pytest.skip("POSIX file permissions are not available on Windows")
+    db_path = tmp_path / "mobile_notifications.db"
+    monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: tmp_path)
+    adapter = _make_adapter()
+    _seed_approval(adapter)
+
+    mode = stat.S_IMODE(db_path.stat().st_mode)
+    assert mode == 0o600


### PR DESCRIPTION
## What does this PR do?

Adds a small SQLite-backed mobile notification inbox for Hermes WebUI/mobile clients. This gives external UIs a stable API surface to list notification items, mark them read, and resolve approval-style actions such as yes/no memory-review prompts.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `gateway/mobile_notifications.py` with owner-only SQLite persistence for inbox items and grouped actions.
- Added authenticated API server endpoints:
  - `GET /api/mobile/notifications`
  - `POST /api/mobile/notifications/{notification_id}/read`
  - `POST /api/mobile/notifications/{notification_id}/actions`
- Advertised the mobile notification inbox through `/v1/capabilities`.
- Added API tests for auth, listing, read state, action resolution, expiration, validation, capabilities, and DB permissions.

## How to Test

1. `python -m py_compile gateway/mobile_notifications.py gateway/platforms/api_server.py`
2. `ruff check gateway/mobile_notifications.py gateway/platforms/api_server.py tests/gateway/test_api_server_mobile_notifications.py`
3. `python -m pytest tests/gateway/test_api_server_mobile_notifications.py tests/gateway/test_api_server_jobs.py -q`

Full-suite note: `python -m pytest tests/ -q -x` currently stops before this change area at `tests/acp/test_edit_approval.py::test_write_file_approval_mutates_and_request_includes_diff`, where the temp path under `/private/var/folders/...` is rejected as a sensitive system path.

## Checklist

### Code

- [x] I've read the Contributing Guide / AGENTS guidance for this repo
- [x] My commit messages follow Conventional Commits
- [x] I searched for relevant existing API shape in the codebase before adding this surface
- [x] My PR contains only changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation/docstrings — endpoint list and capabilities metadata updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — SQLite store uses existing WAL fallback pattern and skips POSIX permission assertion on Windows
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Targeted tests pass:

```
48 passed, 47 warnings in 1.48s
```