### PR TITLE
fix(dashboard): don't force /opt/data files root for remote requests on host installs

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1280,6 +1280,12 @@ def _managed_files_policy(request: Request, *, create_root: bool = True) -> Mana
         return ManagedFilesPolicy(default_path=root, locked_root=root, can_change_path=False)
 
     home = _canonical_path(Path.home())
+    if not _local_dashboard_request(request):
+        # Remote / auth-gated clients on a host install stay confined to the
+        # dashboard user's home. /opt/data only exists in the hosted (Docker)
+        # filesystem layout, which is detected via HERMES_HOME above — forcing
+        # it here 500s on plain host installs reached over the LAN (#44116).
+        return ManagedFilesPolicy(default_path=home, locked_root=home, can_change_path=False)
     return ManagedFilesPolicy(default_path=home, locked_root=None, can_change_path=True)
 
 

--- a/tests/hermes_cli/test_web_server_files.py
+++ b/tests/hermes_cli/test_web_server_files.py
@@ -436,3 +436,70 @@ def test_stream_upload_large_file_under_cap_succeeds(forced_files_client, monkey
     assert created.status_code == 200
     assert file_path.stat().st_size == len(payload)
     assert file_path.read_bytes() == payload
+
+
+def _remote_request():
+    return SimpleNamespace(
+        app=web_server.app,
+        client=SimpleNamespace(host="192.168.1.50"),
+        url=SimpleNamespace(hostname="192.168.1.10"),
+    )
+
+
+def test_hosted_policy_locks_remote_requests_to_opt_data(monkeypatch):
+    monkeypatch.delenv("HERMES_DASHBOARD_FILES_ROOT", raising=False)
+    monkeypatch.setenv("HERMES_HOME", "/opt/data")
+    client, prev_auth_required, prev_bound_host = _client_with_app_state()
+    try:
+        policy = web_server._managed_files_policy(_remote_request(), create_root=False)
+    finally:
+        _restore_app_state(prev_auth_required, prev_bound_host)
+        client.close()
+
+    assert str(policy.locked_root) == "/opt/data"
+    assert policy.can_change_path is False
+
+
+def test_remote_request_on_host_install_locks_to_home(monkeypatch, tmp_path):
+    """Regression test for #44116: LAN access to a non-Docker install must not
+    force the Docker-only /opt/data root."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.delenv("HERMES_DASHBOARD_FILES_ROOT", raising=False)
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setenv("HOME", str(home))
+
+    client, prev_auth_required, prev_bound_host = _client_with_app_state()
+    try:
+        policy = web_server._managed_files_policy(_remote_request(), create_root=False)
+    finally:
+        _restore_app_state(prev_auth_required, prev_bound_host)
+        client.close()
+
+    assert policy.locked_root == home.resolve()
+    assert policy.default_path == home.resolve()
+    assert policy.can_change_path is False
+
+
+def test_auth_required_on_host_install_locks_to_home(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.delenv("HERMES_DASHBOARD_FILES_ROOT", raising=False)
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setenv("HOME", str(home))
+
+    client, prev_auth_required, prev_bound_host = _client_with_app_state()
+    web_server.app.state.auth_required = True
+    try:
+        request = SimpleNamespace(
+            app=web_server.app,
+            client=SimpleNamespace(host="127.0.0.1"),
+            url=SimpleNamespace(hostname="127.0.0.1"),
+        )
+        policy = web_server._managed_files_policy(request, create_root=False)
+    finally:
+        _restore_app_state(prev_auth_required, prev_bound_host)
+        client.close()
+
+    assert policy.locked_root == home.resolve()
+    assert policy.can_change_path is False


### PR DESCRIPTION
## Summary

Fixes #44116

On a non-Docker host install, opening the dashboard **Files** tab from another machine on the LAN returned a 500:

```json
{"detail":"Managed files root is unavailable: [Errno 13] Permission denied: '/opt/data'"}
```

`_managed_files_policy` treated **any** non-local request (remote client, or `auth_required` set) as a hosted deployment and locked the managed-files root to `/opt/data` — a path that only exists in the Docker/hosted filesystem layout.

## Change

- The `/opt/data` lock now applies only when the install actually uses the hosted layout, detected via the existing `_default_hermes_root_is_opt_data()` check (`HERMES_HOME` resolving to `/opt/data`, which the official Docker setup sets).
- Remote and auth-gated requests on plain host installs keep a **locked root** — the dashboard user's home (`locked_root=home`, `can_change_path=False`) — so the previous confinement posture for non-local clients is preserved, just no longer pointing at a Docker-only path. Local requests keep the existing unlocked home policy.
- `HERMES_DASHBOARD_FILES_ROOT` continues to override everything, so the workaround from the issue keeps working.

## Tests

Added to `tests/hermes_cli/test_web_server_files.py`:
- remote request on a host install (no `HERMES_HOME`) → policy locks to home, no 500
- `auth_required=True` on a host install → policy locks to home
- remote request with `HERMES_HOME=/opt/data` → still locked to `/opt/data` (hosted behavior unchanged)

`pytest tests/hermes_cli/ -k web_server`: 306 passed; the one failure (`test_skills_list_without_profile_uses_dashboard_home`) is a pre-existing test-ordering flake that also fails on unmodified `main` and passes in isolation.