### PR TITLE
fix(tools): delete a reaped docker container's sandbox dir to stop the disk leak

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -1314,6 +1314,59 @@ def test_reap_orphan_removes_stale_exited_container(monkeypatch):
     assert "old-cid" in rms[0][0], f"expected rm of old-cid, got {rms[0][0]}"
 
 
+def test_reap_orphan_removes_sandbox_dir(monkeypatch, tmp_path):
+    """Reaping a container also deletes its host-side bind-mount sandbox dir
+    (``<sandbox>/docker/<task-id>/``). ``docker rm`` alone leaves it to leak
+    forever. Regression for #44114."""
+    monkeypatch.setenv("TERMINAL_SANDBOX_DIR", str(tmp_path))
+    from tools.environments.base import get_sandbox_dir
+
+    task_id = "20260610_161415_61bb69"
+    sandbox = get_sandbox_dir() / "docker" / task_id
+    (sandbox / "home").mkdir(parents=True)
+    (sandbox / "workspace").mkdir(parents=True)
+    assert sandbox.is_dir()
+
+    old = _now_iso(offset_seconds=900)
+
+    def _run(cmd, **kwargs):
+        sub = cmd[1] if isinstance(cmd, list) and len(cmd) >= 2 else ""
+        if sub == "ps":
+            return subprocess.CompletedProcess(cmd, 0, stdout="old-cid\n", stderr="")
+        if sub == "inspect":
+            fmt = cmd[3] if len(cmd) > 3 else ""
+            if "hermes-task-id" in fmt:
+                return subprocess.CompletedProcess(cmd, 0, stdout=task_id + "\n", stderr="")
+            return subprocess.CompletedProcess(cmd, 0, stdout=old + "\n", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+
+    removed = docker_env.reap_orphan_containers(
+        max_age_seconds=600, profile_filter="default", docker_exe="/usr/bin/docker",
+    )
+
+    assert removed == 1
+    assert not sandbox.exists(), "reaped container's sandbox dir must be deleted (#44114)"
+
+
+def test_remove_sandbox_dir_refuses_to_escape_sandbox(monkeypatch, tmp_path):
+    """A malformed ``hermes-task-id`` label must never delete anything outside
+    ``<sandbox>/docker/`` — path-traversal guard for the reaper's dir cleanup."""
+    monkeypatch.setenv("TERMINAL_SANDBOX_DIR", str(tmp_path))
+    outside = tmp_path / "secret"
+    outside.mkdir()
+    docker_env._remove_sandbox_dir("../secret")
+    assert outside.is_dir(), "must not delete dirs outside <sandbox>/docker/"
+
+    from tools.environments.base import get_sandbox_dir
+
+    docker_root = get_sandbox_dir() / "docker"
+    docker_root.mkdir(parents=True, exist_ok=True)
+    docker_env._remove_sandbox_dir(".")
+    assert docker_root.is_dir(), "must not wipe the <sandbox>/docker root itself"
+
+
 def test_reap_orphan_spares_recently_exited_container(monkeypatch):
     """A container exited within max_age_seconds must NOT be reaped — that
     container belongs to a Hermes process that just finished and may be

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -207,6 +207,10 @@ def reap_orphan_containers(
         age = (now - finished_at).total_seconds()
         if age < max_age_seconds:
             continue
+        # Resolve the task id before removal so we can drop its sandbox dir
+        # afterwards; docker rm only removes the container, not the host-side
+        # bind mounts it left under <sandbox>/docker/<task-id>/ (#44114).
+        task_id = _container_task_id(docker, cid)
         try:
             result = subprocess.run(
                 [docker, "rm", "-f", cid],
@@ -219,6 +223,8 @@ def reap_orphan_containers(
                     "Reaped orphan container %s (exited %d seconds ago)",
                     cid[:12], int(age),
                 )
+                if task_id:
+                    _remove_sandbox_dir(task_id)
             else:
                 logger.debug(
                     "docker rm -f %s failed: %s",
@@ -262,6 +268,45 @@ def _container_finished_at(docker_exe: str, container_id: str):
     except ValueError as e:
         logger.debug("could not parse FinishedAt %r for %s: %s", raw, container_id[:12], e)
         return None
+
+
+def _container_task_id(docker_exe: str, container_id: str) -> Optional[str]:
+    """Return the container's ``hermes-task-id`` label, or ``None`` if unavailable.
+
+    Used by the reaper to locate (and delete) the container's host-side
+    bind-mount sandbox dir, which ``docker rm`` does not touch (#44114).
+    """
+    try:
+        result = subprocess.run(
+            [docker_exe, "inspect", "--format", '{{index .Config.Labels "hermes-task-id"}}', container_id],
+            capture_output=True, text=True, timeout=10, check=False,
+            stdin=subprocess.DEVNULL,
+        )
+    except (subprocess.TimeoutExpired, OSError) as e:
+        logger.debug("orphan reaper docker inspect task-id %s failed: %s", container_id[:12], e)
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def _remove_sandbox_dir(task_id: str) -> None:
+    """Delete the bind-mount sandbox dir left behind by a reaped container.
+
+    ``docker rm`` removes only the container; the host-side bind mounts under
+    ``<sandbox>/docker/<task-id>/`` would otherwise leak forever (#44114). The
+    target is strictly required to be a direct child of ``<sandbox>/docker`` so a
+    malformed ``hermes-task-id`` label can never escape the sandbox root.
+    """
+    try:
+        from tools.environments.base import get_sandbox_dir
+
+        docker_root = (get_sandbox_dir() / "docker").resolve()
+        target = (docker_root / task_id).resolve()
+        if target.parent == docker_root and target != docker_root and target.is_dir():
+            shutil.rmtree(target, ignore_errors=True)
+    except Exception as e:
+        logger.debug("failed to remove sandbox dir for task %r: %s", task_id, e)
 
 
 def find_docker() -> Optional[str]:


### PR DESCRIPTION
## What does this PR do?

Docker sandbox dirs under `~/.hermes/sandboxes/docker/<task-id>/` were leaking on disk forever. The orphan reaper (`reap_orphan_containers`) `docker rm -f`'d stale containers but never touched their host-side bind-mount dirs, and persist-mode `cleanup()` intentionally keeps the dir for reuse — so once a container was reaped, nothing ever deleted its workspace/home dirs.

This resolves the container's `hermes-task-id` label (via `docker inspect`) before removal and deletes the matching `<sandbox>/docker/<task-id>/` dir after a successful `docker rm`. The target is strictly required to be a direct child of `<sandbox>/docker`, so a malformed label (`..`, `.`, an absolute path) can never escape the sandbox root, and the dir is only removed when the container removal actually succeeds.

Scope is the reaper (the leak path in the issue's example). The optional "sweep all dirs with no matching container" idea is left as a follow-up.

## Related Issue

Fixes #44114

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/environments/docker.py` — added `_container_task_id()` (read the `hermes-task-id` label) and `_remove_sandbox_dir()` (sandbox-scoped `rmtree`); `reap_orphan_containers()` now deletes the reaped container's sandbox dir after a successful `docker rm -f`.
- `tests/tools/test_docker_environment.py` — added `test_reap_orphan_removes_sandbox_dir` and `test_remove_sandbox_dir_refuses_to_escape_sandbox`.

## How to Test

1. Open the TUI/desktop, ask one question (creates `~/.hermes/sandboxes/docker/<task-id>/`).
2. Let the container exit and the orphan reaper run (next startup, container older than `2 × lifetime_seconds`).
3. On `main` the sandbox dir remains; with this change it is deleted along with the container.

Regression tests (CPU-only, no docker daemon needed — `docker` subprocess calls are mocked, `TERMINAL_SANDBOX_DIR` points at a tmp dir):

- `pytest tests/tools/test_docker_environment.py::test_reap_orphan_removes_sandbox_dir` — reaping deletes the dir.
- `pytest tests/tools/test_docker_environment.py::test_remove_sandbox_dir_refuses_to_escape_sandbox` — path-traversal guard.

## Checklist

- [x] Bug fix is non-breaking
- [x] Added regression tests (reaper-deletes-dir + path-traversal safety)
- [x] `ruff check` passes on the changed files
- [x] Dir removal is strictly scoped to `<sandbox>/docker/<task-id>` and only runs on a successful `docker rm`
