### PR TITLE
fix(docker): clean up sandbox dirs when reaping orphan containers

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -1243,17 +1243,20 @@ def _now_iso(offset_seconds: int = 0) -> str:
 
 
 def _reaper_run_mock(monkeypatch, ps_ids: list[str], inspect_responses: dict[str, str],
-                      rm_succeeds: bool = True):
+                      rm_succeeds: bool = True, task_id_responses: dict[str, str] | None = None):
     """Build a subprocess.run mock for reaper tests.
 
     * ``ps_ids`` — what ``docker ps -a --filter ... --format '{{.ID}}'`` returns
     * ``inspect_responses[cid]`` — what ``docker inspect ... FinishedAt`` returns
       for each cid; ``""`` means "field unset".
     * ``rm_succeeds`` — whether ``docker rm -f`` returns 0.
+    * ``task_id_responses[cid]`` — what ``docker inspect ... hermes-task-id``
+      returns for each cid; missing cids return ``""``.
 
     Captures every call so tests can assert which containers were rm'd.
     """
     calls = []
+    _task_id_responses = task_id_responses or {}
 
     def _run(cmd, **kwargs):
         calls.append((list(cmd) if isinstance(cmd, list) else cmd, kwargs))
@@ -1265,8 +1268,13 @@ def _reaper_run_mock(monkeypatch, ps_ids: list[str], inspect_responses: dict[str
                 cmd, 0, stdout="\n".join(ps_ids) + ("\n" if ps_ids else ""), stderr="",
             )
         if sub == "inspect":
-            # cmd is [docker, inspect, --format, '{{.State.FinishedAt}}', cid]
+            fmt = cmd[3] if len(cmd) > 3 else ""
             cid = cmd[-1]
+            if "hermes-task-id" in fmt:
+                return subprocess.CompletedProcess(
+                    cmd, 0, stdout=_task_id_responses.get(cid, "") + "\n", stderr="",
+                )
+            # Default: FinishedAt
             return subprocess.CompletedProcess(
                 cmd, 0, stdout=inspect_responses.get(cid, "") + "\n", stderr="",
             )
@@ -1399,6 +1407,52 @@ def test_reap_orphan_handles_docker_ps_failure_gracefully(monkeypatch):
         max_age_seconds=600, profile_filter="default", docker_exe="/usr/bin/docker",
     )
     assert removed == 0
+
+
+
+def test_reap_orphan_cleans_sandbox_dir(monkeypatch, tmp_path):
+    """When the reaper removes a container, it must also delete the
+    bind-mount sandbox dir (issue #44114)."""
+    import shutil
+
+    old = _now_iso(offset_seconds=900)
+    task_dir = tmp_path / "docker" / "test-task-abc"
+    task_dir.mkdir(parents=True)
+    (task_dir / "marker.txt").write_text("hello")
+
+    calls = _reaper_run_mock(
+        monkeypatch, ps_ids=["old-cid"], inspect_responses={"old-cid": old},
+        task_id_responses={"old-cid": "test-task-abc"},
+    )
+    monkeypatch.setattr(docker_env, "get_sandbox_dir", lambda: tmp_path, raising=False)
+
+    # Patch get_sandbox_dir at the import site inside reap_orphan_containers
+    with monkeypatch.context() as m:
+        import tools.environments.base as base_mod
+        m.setattr(base_mod, "get_sandbox_dir", lambda: tmp_path)
+        removed = docker_env.reap_orphan_containers(
+            max_age_seconds=600, profile_filter="default", docker_exe="/usr/bin/docker",
+        )
+
+    assert removed == 1
+    assert not task_dir.exists(), "sandbox dir should be deleted after container reaped"
+
+
+def test_reap_orphan_skips_sandbox_cleanup_on_missing_task_id(monkeypatch, tmp_path):
+    """When the container has no hermes-task-id label, the reaper must not
+    crash — sandbox cleanup is best-effort."""
+    old = _now_iso(offset_seconds=900)
+
+    calls = _reaper_run_mock(
+        monkeypatch, ps_ids=["old-cid"], inspect_responses={"old-cid": old},
+        task_id_responses={},  # no task-id label
+    )
+
+    removed = docker_env.reap_orphan_containers(
+        max_age_seconds=600, profile_filter="default", docker_exe="/usr/bin/docker",
+    )
+
+    assert removed == 1, "container should still be removed even without task-id"
 
 
 def test_reap_orphan_continues_after_individual_rm_failure(monkeypatch):

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -219,6 +219,23 @@ def reap_orphan_containers(
                     "Reaped orphan container %s (exited %d seconds ago)",
                     cid[:12], int(age),
                 )
+                # Also remove the bind-mount sandbox dir if one was allocated.
+                task_id = _container_task_id(docker, cid)
+                if task_id:
+                    try:
+                        from tools.environments.base import get_sandbox_dir
+                        sandbox = get_sandbox_dir() / "docker" / task_id
+                        if sandbox.is_dir():
+                            import shutil
+                            shutil.rmtree(sandbox, ignore_errors=True)
+                            logger.info(
+                                "Reaped sandbox dir for task %s", task_id,
+                            )
+                    except Exception as e:
+                        logger.debug(
+                            "sandbox dir cleanup for %s failed: %s",
+                            task_id, e,
+                        )
             else:
                 logger.debug(
                     "docker rm -f %s failed: %s",
@@ -263,6 +280,24 @@ def _container_finished_at(docker_exe: str, container_id: str):
         logger.debug("could not parse FinishedAt %r for %s: %s", raw, container_id[:12], e)
         return None
 
+
+
+def _container_task_id(docker_exe: str, container_id: str) -> str | None:
+    """Return the ``hermes-task-id`` label value for *container_id*, or None."""
+    try:
+        result = subprocess.run(
+            [docker_exe, "inspect", "--format",
+             '{{index .Config.Labels "hermes-task-id"}}', container_id],
+            capture_output=True, text=True, timeout=10, check=False,
+            stdin=subprocess.DEVNULL,
+        )
+    except (subprocess.TimeoutExpired, OSError) as e:
+        logger.debug("orphan reaper inspect task-id %s failed: %s", container_id[:12], e)
+        return None
+    if result.returncode != 0:
+        return None
+    raw = result.stdout.strip()
+    return raw if raw else None
 
 def find_docker() -> Optional[str]:
     """Locate the docker (or podman) CLI binary.


### PR DESCRIPTION
## What does this PR do?

Cleans up orphaned Docker sandbox directories (`~/.hermes/sandboxes/docker/<task-id>/`) when the orphan reaper removes stale containers. Previously, `reap_orphan_containers()` removed containers via `docker rm -f` but left their bind-mount directories on disk indefinitely.

## Related Issue

Fixes #44114

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/environments/docker.py`: Added `_container_task_id()` helper to inspect the `hermes-task-id` Docker label. After successful container removal, the reaper now deletes the matching sandbox directory under `get_sandbox_dir() / "docker" / task_id`. Cleanup is best-effort — failures are logged at debug level.
- `tests/tools/test_docker_environment.py`: Updated `_reaper_run_mock` to support `task_id_responses` for the new inspect call. Added `test_reap_orphan_cleans_sandbox_dir` (verifies sandbox dir is deleted) and `test_reap_orphan_skips_sandbox_cleanup_on_missing_task_id` (verifies graceful handling when label is absent).

## How to Test

1. Run `pytest tests/tools/test_docker_environment.py -x -q` — all 73 tests should pass (71 existing + 2 new)
2. The new tests verify: (a) sandbox dir is deleted after container reaping, (b) missing `hermes-task-id` label doesn't crash the reaper
3. Existing reaper tests confirm no regression in container removal behavior

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `tools/environments/docker.py::reap_orphan_containers` (callers: 1 — `terminal_tool._maybe_reap_docker_orphans`)
- Analyzed: `tools/environments/docker.py::_container_task_id` (new helper, pattern mirrors `_container_finished_at`)
- Blast radius: LOW — sandbox cleanup is best-effort, failures don't affect container removal
- Related patterns: `_container_finished_at` uses the same `docker inspect --format` approach
