### PR TITLE
feat(gateway/dingtalk): add block_dm config with optional auto-reply

### DIFF
--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -23,7 +23,9 @@ Configuration in config.yaml:
         #   - "manager1234"
         extra:
           client_id: "your-app-key"      # or DINGTALK_CLIENT_ID env var
-          client_secret: "your-secret"   # or DINGTALK_CLIENT_SECRET env var
+          client_secret: "your-secret"    # or DINGTALK_CLIENT_SECRET env var
+          block_dm: false                 # block DMs (env: DINGTALK_BLOCK_DM)
+          block_dm_reply: "..."           # auto-reply when DM is blocked (env: DINGTALK_BLOCK_DM_REPLY)
 """
 
 import asyncio
@@ -416,6 +418,25 @@ class DingTalkAdapter(BasePlatformAdapter):
             return {str(part).strip() for part in raw if str(part).strip()}
         return {part.strip() for part in str(raw).split(",") if part.strip()}
 
+    def _dingtalk_block_dm(self) -> bool:
+        """Return whether direct messages should be silently blocked."""
+        configured = self.config.extra.get("block_dm") if self.config.extra else None
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.lower() in {"true", "1", "yes", "on"}
+            return bool(configured)
+        return os.getenv("DINGTALK_BLOCK_DM", "false").lower() in {"true", "1", "yes", "on"}
+
+    def _dingtalk_block_dm_reply(self) -> str:
+        """Return the auto-reply text sent when a DM is blocked.
+
+        Empty string means no reply (silent drop).
+        """
+        reply = self.config.extra.get("block_dm_reply") if self.config.extra else None
+        if reply is None:
+            reply = os.getenv("DINGTALK_BLOCK_DM_REPLY", "")
+        return str(reply).strip() if reply else ""
+
     def _compile_mention_patterns(self) -> List[re.Pattern]:
         """Compile optional regex wake-word patterns for group triggers."""
         patterns = self.config.extra.get("mention_patterns") if self.config.extra else None
@@ -611,6 +632,30 @@ class DingTalkAdapter(BasePlatformAdapter):
                 "[%s] Dropping message from non-allowlisted user staff_id=%s sender_id=%s",
                 self.name, sender_staff_id, sender_id,
             )
+            return
+
+        # DM block gate — when block_dm is enabled, reject DMs and optionally
+        # send a configurable auto-reply so the sender isn't left hanging.
+        if not is_group and self._dingtalk_block_dm():
+            reply_text = self._dingtalk_block_dm_reply()
+            logger.debug(
+                "[%s] Blocking DM from sender_id=%s reply=%r",
+                self.name, sender_id, reply_text[:50] if reply_text else None,
+            )
+            if reply_text:
+                session_webhook = getattr(message, "session_webhook", None) or ""
+                if session_webhook:
+                    try:
+                        await self.send(
+                            chat_id,
+                            reply_text,
+                            metadata={"session_webhook": session_webhook},
+                        )
+                    except Exception as exc:
+                        logger.warning(
+                            "[%s] Failed to send block_dm_reply: %s",
+                            self.name, exc,
+                        )
             return
 
         # Group mention/pattern gate.  DMs pass through unconditionally.

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -777,6 +777,124 @@ class TestShouldProcessMessage:
         assert adapter._should_process_message(msg, "hi", is_group=True, chat_id="grp2") is False
 
 
+class TestBlockDm:
+    """Verify block_dm config reading and DM blocking behavior."""
+
+    def test_block_dm_defaults_false(self, monkeypatch):
+        monkeypatch.delenv("DINGTALK_BLOCK_DM", raising=False)
+        adapter = _make_gating_adapter(monkeypatch)
+        assert adapter._dingtalk_block_dm() is False
+
+    def test_block_dm_from_config_extra(self, monkeypatch):
+        adapter = _make_gating_adapter(monkeypatch, extra={"block_dm": True})
+        assert adapter._dingtalk_block_dm() is True
+
+    def test_block_dm_from_env_var(self, monkeypatch):
+        adapter = _make_gating_adapter(monkeypatch, env={"DINGTALK_BLOCK_DM": "true"})
+        assert adapter._dingtalk_block_dm() is True
+
+    def test_block_dm_string_true(self, monkeypatch):
+        adapter = _make_gating_adapter(monkeypatch, extra={"block_dm": "yes"})
+        assert adapter._dingtalk_block_dm() is True
+
+    def test_block_dm_reply_defaults_empty(self, monkeypatch):
+        monkeypatch.delenv("DINGTALK_BLOCK_DM_REPLY", raising=False)
+        adapter = _make_gating_adapter(monkeypatch)
+        assert adapter._dingtalk_block_dm_reply() == ""
+
+    def test_block_dm_reply_from_config(self, monkeypatch):
+        adapter = _make_gating_adapter(
+            monkeypatch,
+            extra={"block_dm_reply": "DMs are disabled. Please use a group chat."},
+        )
+        assert adapter._dingtalk_block_dm_reply() == "DMs are disabled. Please use a group chat."
+
+    def test_block_dm_reply_from_env(self, monkeypatch):
+        adapter = _make_gating_adapter(
+            monkeypatch, env={"DINGTALK_BLOCK_DM_REPLY": "Use group chat."},
+        )
+        assert adapter._dingtalk_block_dm_reply() == "Use group chat."
+
+    @pytest.mark.asyncio
+    async def test_dm_blocked_when_enabled(self, monkeypatch):
+        """DMs are silently dropped when block_dm is True."""
+        adapter = _make_gating_adapter(monkeypatch, extra={"block_dm": True})
+        msg = _FakeChatbotMessage.from_dict({
+            "msgId": "msg1",
+            "conversationType": "1",  # DM
+            "conversationId": "",
+            "senderId": "user1",
+            "senderNick": "User",
+            "text": "hello",
+            "sessionWebhook": "https://oapi.dingtalk.com/robot/sendBySession?token=abc",
+        })
+        with patch.object(adapter, "handle_message", new_callable=AsyncMock) as mock_handle:
+            await adapter._on_message(msg)
+        mock_handle.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dm_blocked_with_auto_reply(self, monkeypatch):
+        """When block_dm_reply is set, the adapter sends the reply before returning."""
+        adapter = _make_gating_adapter(
+            monkeypatch,
+            extra={"block_dm": True, "block_dm_reply": "Please use a group."},
+        )
+        msg = _FakeChatbotMessage.from_dict({
+            "msgId": "msg2",
+            "conversationType": "1",
+            "conversationId": "",
+            "senderId": "user1",
+            "senderNick": "User",
+            "text": "hello",
+            "sessionWebhook": "https://oapi.dingtalk.com/robot/sendBySession?token=abc",
+        })
+        with patch.object(adapter, "send", new_callable=AsyncMock) as mock_send, \
+             patch.object(adapter, "handle_message", new_callable=AsyncMock) as mock_handle:
+            await adapter._on_message(msg)
+        mock_send.assert_called_once()
+        call_args = mock_send.call_args
+        assert call_args[0][1] == "Please use a group."
+        assert call_args[1]["metadata"]["session_webhook"] == "https://oapi.dingtalk.com/robot/sendBySession?token=abc"
+        mock_handle.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_group_messages_unaffected_by_block_dm(self, monkeypatch):
+        """Group messages are processed normally even when block_dm is True."""
+        adapter = _make_gating_adapter(
+            monkeypatch,
+            extra={"block_dm": True, "require_mention": False},
+        )
+        msg = _FakeChatbotMessage.from_dict({
+            "msgId": "msg3",
+            "conversationType": "2",  # group
+            "conversationId": "grp1",
+            "senderId": "user1",
+            "senderNick": "User",
+            "text": "hello",
+            "sessionWebhook": "https://oapi.dingtalk.com/robot/sendBySession?token=abc",
+        })
+        with patch.object(adapter, "handle_message", new_callable=AsyncMock) as mock_handle:
+            await adapter._on_message(msg)
+        mock_handle.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_dm_passes_through_when_block_dm_disabled(self, monkeypatch):
+        """DMs are processed normally when block_dm is False (default)."""
+        adapter = _make_gating_adapter(monkeypatch)
+        msg = _FakeChatbotMessage.from_dict({
+            "msgId": "msg4",
+            "conversationType": "1",
+            "conversationId": "",
+            "senderId": "user1",
+            "senderNick": "User",
+            "text": "hello",
+            "sessionWebhook": "https://oapi.dingtalk.com/robot/sendBySession?token=abc",
+        })
+        with patch.object(adapter, "handle_message", new_callable=AsyncMock) as mock_handle:
+            await adapter._on_message(msg)
+        mock_handle.assert_called_once()
+
+
 # ---------------------------------------------------------------------------
 # _IncomingHandler.process — session_webhook extraction & fire-and-forget
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

When `block_dm: true` is configured (or will be configured) for DingTalk, private chat (DM) messages are silently dropped. The sender sees "Thinking..." indefinitely with no response, which is confusing.

## Solution

Add two new config options under `platforms.dingtalk.extra`:

- **`block_dm`** (bool, default: `false`) — reject DMs before they reach the agent
- **`block_dm_reply`** (str, default: `""`) — optional auto-reply sent to the sender when a DM is blocked

Both support env var fallbacks (`DINGTALK_BLOCK_DM`, `DINGTALK_BLOCK_DM_REPLY`).

### Config example

```yaml
platforms:
  dingtalk:
    enabled: true
    extra:
      client_id: "your-app-key"
      client_secret: "your-secret"
      block_dm: true
      block_dm_reply: "DMs are disabled. Please mention me in a group chat."
```

### Behavior

| `block_dm` | `block_dm_reply` | DM behavior |
|------------|-------------------|-------------|
| `false` | any | DMs processed normally (default, backward compatible) |
| `true` | `""` | DMs silently dropped |
| `true` | `"text"` | DMs blocked, auto-reply sent to sender |

Group messages are **never affected** by `block_dm`.

## Changes

- `gateway/platforms/dingtalk.py` — +2 helper methods (`_dingtalk_block_dm`, `_dingtalk_block_dm_reply`), block_dm gate in `_on_message`, updated docstring
- `tests/gateway/test_dingtalk.py` — 11 new tests (7 config reading + 4 integration)

## Testing

All 79 DingTalk tests pass (including 11 new ones).

Closes #44113
