### PR TITLE
feat: persist compaction summary as cross-session checkpoint

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -19,8 +19,10 @@ Improvements over v2:
 import hashlib
 import json
 import logging
+import os
 import re
 import time
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from agent.auxiliary_client import call_llm, _is_connection_error
@@ -1449,6 +1451,8 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             summary = redact_sensitive_text(content.strip())
             # Store for iterative updates on next compaction
             self._previous_summary = summary
+            # Persist to disk for cross-session context
+            self._persist_summary(summary)
             self._summary_failure_cooldown_until = 0.0
             self._summary_model_fallen_back = False
             self._last_summary_error = None
@@ -1905,6 +1909,57 @@ The user has requested that this compaction PRIORITISE preserving all informatio
     # ------------------------------------------------------------------
     # Main compression entry point
     # ------------------------------------------------------------------
+
+
+    # --- Session checkpoint persistence (cross-session context) ---
+    _SESSION_CHECKPOINT_DIR = None
+
+    @classmethod
+    def _get_checkpoint_dir(cls):
+        """Return the session checkpoint directory, creating it if needed."""
+        if cls._SESSION_CHECKPOINT_DIR is None:
+            from hermes_constants import get_hermes_home
+            cls._SESSION_CHECKPOINT_DIR = get_hermes_home() / "session-checkpoints"
+            cls._SESSION_CHECKPOINT_DIR.mkdir(parents=True, exist_ok=True)
+        return cls._SESSION_CHECKPOINT_DIR
+
+    def _persist_summary(self, summary: str) -> None:
+        """Persist compaction summary to disk for cross-session context.
+
+        Writes the structured summary (without the SUMMARY_PREFIX header) to
+        ``<hermes_home>/session-checkpoints/latest.md`` so the next session
+        can inject it into the system prompt as background context.
+        """
+        try:
+            cp_dir = self._get_checkpoint_dir()
+            clean = summary
+            if clean.startswith(SUMMARY_PREFIX):
+                clean = clean[len(SUMMARY_PREFIX):].lstrip("\n")
+            if clean.startswith(LEGACY_SUMMARY_PREFIX):
+                clean = clean[len(LEGACY_SUMMARY_PREFIX):].lstrip("\n")
+            target = cp_dir / "latest.md"
+            target.write_text(clean, encoding="utf-8")
+            logger.info("Session checkpoint persisted to %s (%d chars)", target, len(clean))
+        except Exception as exc:
+            logger.warning("Failed to persist session checkpoint: %s", exc)
+
+    @staticmethod
+    def load_latest_checkpoint():
+        """Load the most recent session checkpoint from disk.
+
+        Returns the summary text (without prefix) or None if not available.
+        Called during system prompt construction to inject cross-session context.
+        """
+        try:
+            from hermes_constants import get_hermes_home
+            cp_file = get_hermes_home() / "session-checkpoints" / "latest.md"
+            if cp_file.exists():
+                text = cp_file.read_text(encoding="utf-8").strip()
+                if text:
+                    return text
+        except Exception:
+            pass
+        return None
 
     def compress(self, messages: List[Dict[str, Any]], current_tokens: int = None, focus_topic: str = None, force: bool = False) -> List[Dict[str, Any]]:
         """Compress conversation messages by summarizing middle turns.

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -358,6 +358,22 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         except Exception:
             pass
 
+    # Session checkpoint -- inject the most recent compaction summary
+    # from the previous session as background context.
+    try:
+        from agent.context_compressor import ContextCompressor
+        _checkpoint_text = ContextCompressor.load_latest_checkpoint()
+        if _checkpoint_text:
+            volatile_parts.append(
+                "## Previous Session Context (auto-loaded checkpoint)\n"
+                "The following is a structured summary from the most recent "
+                "session. Use it to resume context -- do NOT re-do completed "
+                "work.\n\n"
+                + _checkpoint_text
+            )
+    except Exception:
+        pass
+
     from hermes_time import now as _hermes_now
     now = _hermes_now()
     # Date-only (not minute-precision) so the system prompt is byte-stable


### PR DESCRIPTION
## Summary

Persists the context compaction summary to disk and auto-injects it into the next session's system prompt, enabling **cross-session context continuity** with zero additional token cost.

## Problem

When a long conversation triggers context compaction, the structured summary (Active Task, Goal, Completed Actions, Key Decisions, etc.) is lost when the session ends. The next session starts cold — the agent has no memory of what was discussed, and the user must re-explain context.

## Solution

Two small changes:

### 1. `agent/context_compressor.py` — Persist summary after compaction

- `_persist_summary(summary)`: Strips the `SUMMARY_PREFIX` header and writes the clean summary to `<hermes_home>/session-checkpoints/latest.md`
- `load_latest_checkpoint()`: Static method that reads the persisted summary from disk
- Called automatically after each compaction (1 line added to `_generate_summary()`)

### 2. `agent/system_prompt.py` — Inject checkpoint at session start

- In `build_system_prompt_parts()`, after MEMORY.md/USER.md and external memory provider blocks, loads the latest checkpoint and appends it to the volatile tier
- Framed as "Previous Session Context (auto-loaded checkpoint)" with clear instructions to use it as background reference, not active instructions

## Design Decisions

- **Single file, auto-overwrite**: Only `latest.md` is kept — the most recent compaction state. No accumulation of historical checkpoints.
- **Zero token overhead**: Reuses the existing compaction summary that's already generated. No additional LLM calls.
- **Non-breaking**: If no checkpoint exists, the injection is silently skipped. Existing behavior is unchanged.
- **Strips SUMMARY_PREFIX**: The persisted file contains only the clean structured summary, without the runtime instruction header.

## Testing

Applied and running on a live Hermes instance (Docker, v0.16.0). The checkpoint directory is created automatically at `<hermes_home>/session-checkpoints/`.

## Files Changed

- `agent/context_compressor.py` — +55 lines (imports, 3 new methods, 1 call site)
- `agent/system_prompt.py` — +16 lines (checkpoint loading and injection)