### PR TITLE
fix(desktop): inset hover-reveal trigger past the adjacent scrollbar

### DIFF
--- a/apps/desktop/src/components/pane-shell/pane-shell.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.tsx
@@ -80,9 +80,12 @@ const HOVER_REVEAL_EASE = 'cubic-bezier(0.32,0.72,0,1)'
 // Offset shadow lifting the revealed panel off the content (same both sides;
 // the mirror axis is offset-x, which is 0). Same color on light + dark.
 const HOVER_REVEAL_SHADOW = '0px -18px 18px -5px #00000012'
-// Edge trigger strip, inset past the OS window-resize grab area.
+// Edge trigger strip, inset past the OS window-resize grab area AND the
+// adjacent pane's scrollbar (0.5rem, .scrollbar-dt) — the strip overlays the
+// neighboring scroller's edge, so any overlap makes the scrollbar reveal the
+// pane on hover and swallow its clicks (#44140).
 const HOVER_REVEAL_TRIGGER_WIDTH = 14
-const HOVER_REVEAL_EDGE_GUTTER = 6
+const HOVER_REVEAL_EDGE_GUTTER = 'calc(0.5rem + 2px)'
 
 // Fired (window CustomEvent<{ id }>) to toggle a force-collapsed pane's reveal
 // from the keyboard, since its store-open toggle is a no-op while collapsed.


### PR DESCRIPTION
Part of #44140 (item 2 — scrollbar made unusable by the right-edge hover reveal).

## Root cause

When the rail panes are collapsed, the chat scroller extends to the window edge, so its 8px `.scrollbar-dt` scrollbar occupies the rightmost `0.5rem`. The collapsed file browser's hover-reveal trigger strip (`pane-shell.tsx`: 14px wide, inset 6px) overlapped that band:

- hovering the scrollbar's left edge counted as hover intent and slid the file browser out **over the scrollbar** (which stays open while the pointer is on it, since the revealed panel itself is the hover target), and
- clicks in the overlapped band hit the trigger div instead of the scrollbar thumb.

The issue attributes this to the preview rail, but the preview pane has no hover reveal — the panel popping up is the file browser (`desktop-controller.tsx`, `hoverReveal` + `defaultOpen={false}`, rightmost column).

## Fix

Widen `HOVER_REVEAL_EDGE_GUTTER` from `6` to `calc(0.5rem + 2px)` so the trigger strip starts clear of the scrollbar. Expressed in rem so it stays coupled to the `.scrollbar-dt` width (`styles.css`), and still covers the original purpose of the gutter (insetting past the OS window-resize grab area). Hovering or clicking the scrollbar can no longer reveal the pane; the deliberate pure-CSS hover-intent design is untouched.

## Testing

- `npm run typecheck`, `eslint` — clean
- `vitest src/components/pane-shell/` — 15/16 pass; the one failure (`uses widthOverride from the store when set`) also fails on pristine `main` at 955fa40 and is unrelated.
