### PR TITLE
fix(gateway): suppress codex autoraise status noise

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -68,6 +68,14 @@ _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 
+# Pure informational startup notices that are useful in CLI logs but too noisy
+# as standalone gateway chat messages. Real compression warnings still pass
+# through the status rail below.
+_GATEWAY_INFO_ONLY_STATUS_RE = re.compile(
+    r"codex\s+gpt-5\.5\s+caps\s+context\s+at\s+272k,\s+so\s+auto-compaction\s+was\s+raised",
+    re.IGNORECASE,
+)
+
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"("  # transient/auxiliary status that should stay in logs, not Telegram chat
     r"auxiliary\s+.+\s+failed"
@@ -362,6 +370,8 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
     """Filter/sanitize agent status callbacks before platform delivery."""
     text = str(message or "").strip()
     if not text:
+        return None
+    if event_type == "lifecycle" and _GATEWAY_INFO_ONLY_STATUS_RE.search(text):
         return None
     if _gateway_platform_value(platform) != "telegram":
         return text

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -36,6 +36,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 
@@ -152,6 +153,69 @@ def _should_fall_back(code: int, detail: str) -> bool:
 
 def _is_access_denied(detail: str) -> bool:
     return bool(_ACCESS_DENIED_PATTERN.search(detail or ""))
+
+
+def _replace_or_insert_xml_setting(xml: str, tag: str, value: str) -> str:
+    """Return ``xml`` with a top-level Task Settings child set to ``value``.
+
+    Windows' ``schtasks /Create /SC ONLOGON`` applies workstation defaults that
+    are unsafe for a long-lived gateway on laptops: stop on battery and a finite
+    execution time limit.  We harden the generated task by querying its XML and
+    re-importing it with explicit daemon-safe settings.
+    """
+    replacement = f"<{tag}>{value}</{tag}>"
+    pattern = re.compile(rf"<{re.escape(tag)}>.*?</{re.escape(tag)}>", re.DOTALL)
+    if pattern.search(xml):
+        return pattern.sub(replacement, xml, count=1)
+    settings_match = re.search(r"</Settings>", xml)
+    if not settings_match:
+        return xml
+    indent = "    "
+    return xml[: settings_match.start()] + f"{indent}{replacement}\n" + xml[settings_match.start() :]
+
+
+def _harden_scheduled_task_settings(task_name: str) -> tuple[bool, str]:
+    """Patch a Scheduled Task's XML so it behaves like a daemon.
+
+    ``schtasks``' simple ``/Create /SC ONLOGON`` path is convenient but leaves
+    power-management and lifetime defaults up to Windows.  The observed Hifumi
+    gateway log had repeated fresh starts with no traceback and no clean
+    shutdown record; the installed task XML also had ``StopIfGoingOnBatteries``
+    enabled and the default 72-hour execution limit.  Re-importing explicit XML
+    makes the task robust across battery transitions and long uptimes.
+    """
+    code, out, err = _exec_schtasks(["/Query", "/TN", task_name, "/XML"])
+    if code != 0 or not out.strip():
+        return (False, f"schtasks /Query /XML failed (code {code}): {(err or out).strip()}")
+
+    xml = out
+    for tag, value in (
+        ("DisallowStartIfOnBatteries", "false"),
+        ("StopIfGoingOnBatteries", "false"),
+        ("StartWhenAvailable", "true"),
+        ("AllowStartOnDemand", "true"),
+        ("RunOnlyIfIdle", "false"),
+        ("ExecutionTimeLimit", "PT0S"),
+    ):
+        xml = _replace_or_insert_xml_setting(xml, tag, value)
+    xml = _replace_or_insert_xml_setting(xml, "StopOnIdleEnd", "false")
+
+    tmp_name = None
+    try:
+        with tempfile.NamedTemporaryFile("w", suffix=".xml", delete=False, encoding="utf-16", newline="") as fh:
+            tmp_name = fh.name
+            fh.write(xml)
+        import_code, import_out, import_err = _exec_schtasks(["/Create", "/F", "/TN", task_name, "/XML", tmp_name])
+    finally:
+        if tmp_name:
+            try:
+                Path(tmp_name).unlink()
+            except OSError:
+                pass
+
+    if import_code != 0:
+        return (False, f"schtasks /Create /XML failed (code {import_code}): {(import_err or import_out).strip()}")
+    return (True, f"Hardened Scheduled Task {task_name!r} power/lifetime settings")
 
 
 def _is_running_as_admin() -> bool:
@@ -484,7 +548,10 @@ def _install_scheduled_task(task_name: str, script_path: Path) -> tuple[bool, st
     for argv in variants:
         code, out, err = _exec_schtasks(argv)
         if code == 0:
-            return (True, f"Created Scheduled Task {task_name!r}")
+            hardened, harden_detail = _harden_scheduled_task_settings(task_name)
+            if hardened:
+                return (True, f"Created Scheduled Task {task_name!r}; {harden_detail}")
+            return (True, f"Created Scheduled Task {task_name!r}; warning: {harden_detail}")
         last_code, last_err = code, (err or out or "")
     if delete_detail and "cannot find" not in delete_detail.lower():
         last_err = f"{last_err.strip()} (delete detail: {delete_detail})"

--- a/tests/gateway/test_status_message_filter.py
+++ b/tests/gateway/test_status_message_filter.py
@@ -1,0 +1,23 @@
+from gateway.run import _prepare_gateway_status_message
+from gateway.platforms.base import Platform
+
+
+def test_codex_gpt55_autoraise_notice_is_not_sent_to_discord_status():
+    notice = (
+        "ℹ Codex gpt-5.5 caps context at 272K, so auto-compaction was raised "
+        "to 85% (from 50%) to use more of the window before summarizing.\n"
+        "  Opt back out: hermes config set compression.codex_gpt55_autoraise false"
+    )
+
+    assert _prepare_gateway_status_message(Platform.DISCORD, "lifecycle", notice) is None
+
+
+def test_non_autoraise_compression_warning_still_sent_to_discord_status():
+    warning = (
+        "⚠ Compression model small-model (openrouter) context is 80,000 tokens, "
+        "but the main model gpt-5.5 (openai-codex)'s compression threshold was "
+        "136,000 tokens. Auto-lowered this session's threshold to 80,000 tokens "
+        "so compression can run."
+    )
+
+    assert _prepare_gateway_status_message(Platform.DISCORD, "lifecycle", warning) == warning

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -239,6 +239,12 @@ def test_install_scheduled_task_recreates_instead_of_change(monkeypatch, tmp_pat
     """Install must delete+create so stale minute-repeat task settings are not preserved."""
     calls = []
     script_path = tmp_path / "Hermes_Gateway_alice.cmd"
+    task_xml = """<?xml version=\"1.0\"?>
+<Task><Settings>
+<DisallowStartIfOnBatteries>true</DisallowStartIfOnBatteries>
+<StopIfGoingOnBatteries>true</StopIfGoingOnBatteries>
+<ExecutionTimeLimit>PT72H</ExecutionTimeLimit>
+</Settings></Task>"""
 
     monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
 
@@ -246,6 +252,8 @@ def test_install_scheduled_task_recreates_instead_of_change(monkeypatch, tmp_pat
         calls.append(tuple(args))
         if args[0] == "/Delete":
             return (0, "SUCCESS", "")
+        if args[:3] == ["/Query", "/TN", "Hermes_Gateway_alice"]:
+            return (0, task_xml, "")
         if args[0] == "/Create":
             return (0, "SUCCESS", "")
         raise AssertionError(f"unexpected schtasks args: {args}")
@@ -259,6 +267,42 @@ def test_install_scheduled_task_recreates_instead_of_change(monkeypatch, tmp_pat
     assert calls[1][0] == "/Create"
     assert "/SC" in calls[1]
     assert "ONLOGON" in calls[1]
+    assert calls[2] == ("/Query", "/TN", "Hermes_Gateway_alice", "/XML")
+    assert calls[3][0:4] == ("/Create", "/F", "/TN", "Hermes_Gateway_alice")
+    assert "/XML" in calls[3]
+    assert "Hardened Scheduled Task" in detail
+
+
+def test_harden_scheduled_task_settings_reimports_daemon_safe_xml(monkeypatch):
+    imported = {}
+    original_xml = """<?xml version=\"1.0\"?>
+<Task><Settings>
+<DisallowStartIfOnBatteries>true</DisallowStartIfOnBatteries>
+<StopIfGoingOnBatteries>true</StopIfGoingOnBatteries>
+<ExecutionTimeLimit>PT72H</ExecutionTimeLimit>
+</Settings></Task>"""
+
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+
+    def fake_schtasks(args):
+        if args == ["/Query", "/TN", "Hermes_Gateway", "/XML"]:
+            return (0, original_xml, "")
+        if args[:4] == ["/Create", "/F", "/TN", "Hermes_Gateway"]:
+            xml_path = Path(args[-1])
+            imported["xml"] = xml_path.read_text(encoding="utf-16")
+            return (0, "SUCCESS", "")
+        raise AssertionError(f"unexpected schtasks args: {args}")
+
+    monkeypatch.setattr(gateway_windows, "_exec_schtasks", fake_schtasks)
+
+    ok, detail = gateway_windows._harden_scheduled_task_settings("Hermes_Gateway")
+
+    assert ok is True
+    assert "Hardened Scheduled Task" in detail
+    assert "<DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>" in imported["xml"]
+    assert "<StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>" in imported["xml"]
+    assert "<ExecutionTimeLimit>PT0S</ExecutionTimeLimit>" in imported["xml"]
+    assert "<StartWhenAvailable>true</StartWhenAvailable>" in imported["xml"]
 
 
 def test_install_scheduled_task_success_start_now_uses_direct_spawn_not_task_run(monkeypatch, tmp_path, capsys):


### PR DESCRIPTION
## Summary
- suppress the Codex gpt-5.5 auto-compaction autoraise notice on gateway status delivery
- keep real compression warnings flowing to Discord/gateway status messages
- add regression coverage for the gateway status filter

## Test Plan
- python -m pytest tests/run_agent/test_compression_feasibility.py tests/gateway/test_status_message_filter.py tests/gateway/test_telegram_status_update.py -q

Root cause: agent_init.py stores the Codex gpt-5.5 threshold autoraise notice in _compression_warning. Gateway turns replay that through status_callback, and gateway/run.py only filtered noisy status for Telegram, so Discord received the informational startup notice as a standalone status message whenever a fresh agent/session replay occurred.