### PR TITLE
fix(provider): fallback to model.base_url when provider is "custom" without explicit_base_url

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -690,15 +690,25 @@ def _resolve_named_custom_runtime(
                 requested_norm = "custom"
         except Exception:
             pass
-    if requested_norm == "custom" and explicit_base_url:
-        base_url = explicit_base_url.strip().rstrip("/")
+    if requested_norm == "custom":
+        base_url = (explicit_base_url or "").strip().rstrip("/")
+        if not base_url:
+            # Path C: fallback to model.base_url from config.yaml when
+            # explicit_base_url is not provided (e.g. CLI `hermes chat`).
+            model_cfg = _get_model_config()
+            cfg_base_url = (model_cfg.get("base_url") or "").strip().rstrip("/")
+            if _config_base_url_trustworthy_for_bare_custom(
+                cfg_base_url, requested_norm
+            ):
+                base_url = cfg_base_url
         # Check credential pool first — mirrors the named-custom-provider path
         # so bare `provider: custom` with a configured custom_providers entry
         # also gets its api_key from the pool instead of env var fallbacks.
-        pool_result = _try_resolve_from_custom_pool(base_url, "custom", None)
-        if pool_result:
-            pool_result["source"] = "direct-alias"
-            return pool_result
+        if base_url:
+            pool_result = _try_resolve_from_custom_pool(base_url, "custom", None)
+            if pool_result:
+                pool_result["source"] = "direct-alias"
+                return pool_result
         _da_is_openai_url   = base_url_host_matches(base_url, "openai.com") or base_url_host_matches(base_url, "openai.azure.com")
         _da_is_openrouter   = base_url_host_matches(base_url, "openrouter.ai")
         api_key_candidates = [


### PR DESCRIPTION
What does this PR do?
    
When provider: "custom" is set in config and the user runs hermes chat
(or any CLI command that doesn't pass explicit_base_url), the resolver
returns an empty base URL and fails with:

    ⚠️ Provider resolver returned an empty base URL. Check your provider
       config or run: hermes setup

The root cause is in _resolve_named_custom_runtime() at
hermes_cli/runtime_provider.py:693. The entire custom-provider block was
guarded by and explicit_base_url, so CLI invocations (which never pass
explicit_base_url) fell through to _resolve_openrouter_runtime() and
produced the error.

This PR removes the explicit_base_url guard and adds a fallback: when
explicit_base_url is missing, the resolver reads model.base_url from
config.yaml and validates it with
_config_base_url_trustworthy_for_bare_custom() before using it. This
preserves the existing safety check that prevents stale OpenRouter URLs
from being silently reused (GitHub #14676).

Related Issue

Fixes #

Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

Changes Made

- hermes_cli/runtime_provider.py: In _resolve_named_custom_runtime(),
  remove the and explicit_base_url guard. When explicit_base_url is
  not provided, fall back to model.base_url from config and validate it
  via _config_base_url_trustworthy_for_bare_custom() before using it.
  If fallback yields an empty URL, the original behavior (continue to
  _resolve_openrouter_runtime) is preserved.

How to Test

1. Set config to model: { provider: "custom", base_url: "http://localhost:8081/v1" }
2. Run hermes chat -q "你好" (no --provider flag, no explicit base URL)
3. Verify the request reaches the local endpoint instead of failing with an empty base URL error

Checklist

Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (fix(scope):, feat(scope):, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run pytest tests/ -q and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A