### PR TITLE
fix(cli): tokenized dashboard cmdline matcher — detect global flags before the subcommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ scripts/out/
 # stores the published notes. They are not a build artifact and must never be
 # committed to the repo root. See the hermes-release skill.
 RELEASE_v*.md
+.venv_test/

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5314,6 +5314,77 @@ def cmd_gui(args: argparse.Namespace):
     sys.exit(launch_result.returncode)
 
 
+_DASHBOARD_FLAG_ARITY_CACHE: dict[str, bool] | None = None
+
+
+def _dashboard_global_flag_arity() -> dict[str, bool]:
+    """Map of top-level flags to whether they consume a value token.
+
+    Built by introspecting the real top-level parser (same approach as
+    ``hermes_cli.relaunch``) plus the pre-argparse ``--profile``/``-p``
+    flags, so the dashboard cmdline matcher below never drifts out of
+    sync with the CLI's actual global options.
+    """
+    global _DASHBOARD_FLAG_ARITY_CACHE
+    if _DASHBOARD_FLAG_ARITY_CACHE is None:
+        from hermes_cli._parser import (
+            PRE_ARGPARSE_INHERITED_FLAGS,
+            build_top_level_parser,
+        )
+
+        flags: dict[str, bool] = dict(PRE_ARGPARSE_INHERITED_FLAGS)
+        parser, _subparsers, _chat_parser = build_top_level_parser()
+        for action in parser._actions:
+            takes_value = action.nargs != 0  # store_true/false set nargs=0
+            for opt in action.option_strings:
+                flags[opt] = takes_value
+        _DASHBOARD_FLAG_ARITY_CACHE = flags
+    return _DASHBOARD_FLAG_ARITY_CACHE
+
+
+def _is_dashboard_cmdline(command: str) -> bool:
+    """Return True when *command* is a ``hermes dashboard`` invocation.
+
+    Tokenizes instead of substring-matching so global flags between the
+    entrypoint and the subcommand are still detected — e.g.
+    ``python -m hermes_cli.main --profile work dashboard`` (#44035).
+    Only known top-level flags may appear before ``dashboard``; the first
+    unrecognized token bails out, so cmdlines that merely *mention*
+    dashboard (``hermes -z "fix my dashboard"``) never match.
+    """
+    tokens = [t.strip('"') for t in command.split()]
+
+    entry_idx: int | None = None
+    for i, tok in enumerate(tokens):
+        norm = tok.replace("\\", "/")
+        base = norm.rsplit("/", 1)[-1].lower()
+        if (
+            base in ("hermes", "hermes.exe")
+            or tok == "hermes_cli.main"
+            or norm.endswith("hermes_cli/main.py")
+        ):
+            entry_idx = i
+            break
+    if entry_idx is None:
+        return False
+
+    flag_arity = _dashboard_global_flag_arity()
+    i = entry_idx + 1
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok == "dashboard":
+            return True
+        if not tok.startswith("-"):
+            return False  # a different subcommand or free-text argument
+        if "=" in tok:  # --profile=work
+            i += 1
+            continue
+        if tok not in flag_arity:
+            return False  # unknown flag — don't guess at its arity
+        i += 2 if flag_arity[tok] else 1
+    return False
+
+
 def _find_stale_dashboard_pids(
     *,
     exclude_pids: set[int] | None = None,
@@ -5343,11 +5414,6 @@ def _find_stale_dashboard_pids(
 
     Returns an empty list on any scan error (missing ps/wmic, timeout, etc.).
     """
-    patterns = [
-        "hermes dashboard",
-        "hermes_cli.main dashboard",
-        "hermes_cli/main.py dashboard",
-    ]
     self_pid = os.getpid()
     dashboard_pids: list[int] = []
 
@@ -5377,18 +5443,16 @@ def _find_stale_dashboard_pids(
                     current_cmd = line[len("CommandLine=") :]
                 elif line.startswith("ProcessId="):
                     pid_str = line[len("ProcessId=") :]
-                    if (
-                        any(p in current_cmd for p in patterns)
-                        and int(pid_str) != self_pid
-                    ):
-                        try:
-                            dashboard_pids.append(int(pid_str))
-                        except ValueError:
-                            pass
+                    try:
+                        pid = int(pid_str)
+                    except ValueError:
+                        continue
+                    if _is_dashboard_cmdline(current_cmd) and pid != self_pid:
+                        dashboard_pids.append(pid)
         else:
-            # Linux / macOS: scan the process table via ps and match against
-            # the same explicit patterns list used on Windows.  Using ps
-            # (rather than `pgrep -f "hermes.*dashboard"`) keeps us consistent
+            # Linux / macOS: scan the process table via ps and match with
+            # the same cmdline matcher used on Windows.  Using ps (rather
+            # than `pgrep -f "hermes.*dashboard"`) keeps us consistent
             # with `hermes_cli.gateway._scan_gateway_pids` and avoids the
             # greedy regex matching unrelated cmdlines that merely contain
             # both words (e.g. a chat session discussing "dashboard").
@@ -5411,7 +5475,7 @@ def _find_stale_dashboard_pids(
                     except ValueError:
                         continue
                     command = parts[1]
-                    if any(p in command for p in patterns) and pid != self_pid:
+                    if _is_dashboard_cmdline(command) and pid != self_pid:
                         dashboard_pids.append(pid)
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return []

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5314,19 +5314,21 @@ def cmd_gui(args: argparse.Namespace):
     sys.exit(launch_result.returncode)
 
 
-_DASHBOARD_FLAG_ARITY_CACHE: dict[str, bool] | None = None
+_SERVER_CMDLINE_FLAG_ARITY_CACHE: dict[str, bool] | None = None
+
+_SERVER_SUBCOMMANDS = frozenset({"dashboard", "serve"})
 
 
-def _dashboard_global_flag_arity() -> dict[str, bool]:
+def _server_cmdline_flag_arity() -> dict[str, bool]:
     """Map of top-level flags to whether they consume a value token.
 
     Built by introspecting the real top-level parser (same approach as
     ``hermes_cli.relaunch``) plus the pre-argparse ``--profile``/``-p``
-    flags, so the dashboard cmdline matcher below never drifts out of
+    flags, so the server cmdline matcher below never drifts out of
     sync with the CLI's actual global options.
     """
-    global _DASHBOARD_FLAG_ARITY_CACHE
-    if _DASHBOARD_FLAG_ARITY_CACHE is None:
+    global _SERVER_CMDLINE_FLAG_ARITY_CACHE
+    if _SERVER_CMDLINE_FLAG_ARITY_CACHE is None:
         from hermes_cli._parser import (
             PRE_ARGPARSE_INHERITED_FLAGS,
             build_top_level_parser,
@@ -5338,19 +5340,19 @@ def _dashboard_global_flag_arity() -> dict[str, bool]:
             takes_value = action.nargs != 0  # store_true/false set nargs=0
             for opt in action.option_strings:
                 flags[opt] = takes_value
-        _DASHBOARD_FLAG_ARITY_CACHE = flags
-    return _DASHBOARD_FLAG_ARITY_CACHE
+        _SERVER_CMDLINE_FLAG_ARITY_CACHE = flags
+    return _SERVER_CMDLINE_FLAG_ARITY_CACHE
 
 
-def _is_dashboard_cmdline(command: str) -> bool:
-    """Return True when *command* is a ``hermes dashboard`` invocation.
+def _is_server_cmdline(command: str) -> bool:
+    """Return True when *command* is a ``hermes dashboard`` or ``hermes serve`` invocation.
 
     Tokenizes instead of substring-matching so global flags between the
     entrypoint and the subcommand are still detected — e.g.
     ``python -m hermes_cli.main --profile work dashboard`` (#44035).
-    Only known top-level flags may appear before ``dashboard``; the first
-    unrecognized token bails out, so cmdlines that merely *mention*
-    dashboard (``hermes -z "fix my dashboard"``) never match.
+    Only known top-level flags may appear before the subcommand; the first
+    unrecognized token bails out, so cmdlines that merely *mention* a
+    server subcommand (``hermes -z "fix my dashboard"``) never match.
     """
     tokens = [t.strip('"') for t in command.split()]
 
@@ -5368,15 +5370,25 @@ def _is_dashboard_cmdline(command: str) -> bool:
     if entry_idx is None:
         return False
 
-    flag_arity = _dashboard_global_flag_arity()
+    # Reject shell-wrapped cmdlines like ``sh -c hermes dashboard --status``
+    # whose parent shell is the real process (#44035).
+    if entry_idx > 0 and tokens[entry_idx - 1] == "-c":
+        return False
+
+    flag_arity = _server_cmdline_flag_arity()
     i = entry_idx + 1
     while i < len(tokens):
         tok = tokens[i]
-        if tok == "dashboard":
+        if tok in _SERVER_SUBCOMMANDS:
             return True
         if not tok.startswith("-"):
             return False  # a different subcommand or free-text argument
         if "=" in tok:  # --profile=work
+            flag_name = tok.split("=", 1)[0]
+            arity = flag_arity.get(flag_name)
+            if arity is not True:
+                # Unknown flag or boolean flag with =value — bail out.
+                return False
             i += 1
             continue
         if tok not in flag_arity:
@@ -5389,10 +5401,10 @@ def _find_stale_dashboard_pids(
     *,
     exclude_pids: set[int] | None = None,
 ) -> list[int]:
-    """Return PIDs of ``hermes dashboard`` processes other than ourselves.
+    """Return PIDs of ``hermes dashboard``/``hermes serve`` processes other than ourselves.
 
-    ``hermes dashboard`` is a long-lived server process commonly started and
-    forgotten.  When ``hermes update`` replaces files on disk, the running
+    ``hermes dashboard`` and ``hermes serve`` are long-lived server processes
+    commonly started and forgotten.  When ``hermes update`` replaces files on disk, the running
     process keeps the old Python backend in memory while the JS bundle on
     disk is updated, causing a silent frontend/backend mismatch (e.g. new
     auth headers the old backend doesn't recognise → every API call 401s).
@@ -5447,7 +5459,7 @@ def _find_stale_dashboard_pids(
                         pid = int(pid_str)
                     except ValueError:
                         continue
-                    if _is_dashboard_cmdline(current_cmd) and pid != self_pid:
+                    if _is_server_cmdline(current_cmd) and pid != self_pid:
                         dashboard_pids.append(pid)
         else:
             # Linux / macOS: scan the process table via ps and match with
@@ -5475,7 +5487,7 @@ def _find_stale_dashboard_pids(
                     except ValueError:
                         continue
                     command = parts[1]
-                    if _is_dashboard_cmdline(command) and pid != self_pid:
+                    if _is_server_cmdline(command) and pid != self_pid:
                         dashboard_pids.append(pid)
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return []
@@ -5615,8 +5627,8 @@ def _format_time_ago(iso_ts: str) -> str:
 def _kill_stale_dashboard_processes(
     reason: str = "the running backend no longer matches the updated frontend",
 ) -> None:
-    """Kill running ``hermes dashboard`` processes.
-
+    """Kill running ``hermes dashboard``/``hermes serve`` processes.
+ 
     Called at the end of ``hermes update`` (default ``reason``) and also
     from ``hermes dashboard --stop`` (which overrides ``reason``).  The
     dashboard has no service manager, so after a code update the running
@@ -10248,7 +10260,7 @@ def _render_distribution_plan(plan) -> None:
 
 
 def _report_dashboard_status() -> int:
-    """Print ``hermes dashboard`` PIDs and return the count.
+    """Print ``hermes dashboard``/``hermes serve`` PIDs and return the count.
 
     Uses the same detection logic as ``_find_stale_dashboard_pids`` (the
     current process is excluded, but since ``hermes dashboard --status``

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -228,6 +228,59 @@ class TestFindStaleDashboardPids:
         assert pids == []
 
 
+class TestGlobalFlagsBeforeSubcommand:
+    """Detection must survive global flags between entrypoint and subcommand.
+
+    Regression tests for #44035: ``python -m hermes_cli.main --profile work
+    dashboard ...`` was invisible to the fixed substring patterns, so
+    ``hermes dashboard --status``/``--stop`` and the post-update cleanup
+    all treated the profile-scoped dashboard as not running.
+    """
+
+    def _scan(self, *cmdlines: str) -> list[int]:
+        stdout = "\n".join(
+            _ps_line(10000 + i, cmd) for i, cmd in enumerate(cmdlines)
+        ) + "\n"
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=stdout, stderr="")
+            return _find_stale_dashboard_pids()
+
+    def test_profile_flag_before_dashboard_module_form(self):
+        """The exact shape from #44035 (LaunchAgent-supervised dashboard)."""
+        pids = self._scan(
+            "/home/u/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main "
+            "--profile work dashboard --host 0.0.0.0 --insecure --port 9119 --no-open --skip-build"
+        )
+        assert pids == [10000]
+
+    def test_short_profile_flag_before_dashboard(self):
+        assert self._scan("hermes -p work dashboard --port 9119") == [10000]
+
+    def test_profile_equals_form_before_dashboard(self):
+        assert self._scan("hermes --profile=work dashboard") == [10000]
+
+    def test_boolean_global_flag_before_dashboard(self):
+        assert self._scan("hermes --ignore-user-config dashboard") == [10000]
+
+    def test_script_path_form_with_profile(self):
+        assert self._scan("python /home/x/hermes_cli/main.py -p work dashboard") == [10000]
+
+    def test_profile_flag_before_other_subcommand_not_matched(self):
+        assert self._scan("hermes --profile work chat") == []
+
+    def test_oneshot_prompt_mentioning_dashboard_not_matched(self):
+        """`hermes -z 'fix hermes dashboard'` used to false-positive on the
+        old substring patterns; the tokenized matcher must not kill it."""
+        assert self._scan("hermes -z fix hermes dashboard") == []
+
+    def test_profile_value_named_dashboard_not_matched(self):
+        assert self._scan("hermes -p dashboard chat") == []
+
+    def test_unknown_flag_before_dashboard_not_matched(self):
+        """Unknown flags have unknown arity — bail out rather than guess."""
+        assert self._scan("hermes --some-future-flag dashboard") == []
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX kill semantics")
 class TestKillStaleDashboardPosix:
     """Kill path on Linux / macOS: SIGTERM then SIGKILL any survivors."""

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -280,6 +280,18 @@ class TestGlobalFlagsBeforeSubcommand:
         """Unknown flags have unknown arity — bail out rather than guess."""
         assert self._scan("hermes --some-future-flag dashboard") == []
 
+    def test_unknown_equals_flag_before_dashboard_not_matched(self):
+        """Equals-form unknown flags must also be rejected (#44165 review)."""
+        assert self._scan("hermes --future-flag=x dashboard") == []
+
+    def test_profile_flag_before_serve_matched(self):
+        """``hermes serve`` with --profile before subcommand must be detected."""
+        assert self._scan("hermes --profile work serve --port 9119") == [10000]
+
+    def test_shell_wrapper_not_matched(self):
+        """``sh -c hermes dashboard --status`` is the shell, not hermes."""
+        assert self._scan("sh -c hermes dashboard --status") == []
+
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX kill semantics")
 class TestKillStaleDashboardPosix:


### PR DESCRIPTION
## Problem

`_find_stale_dashboard_pids()` matches fixed substrings (`"hermes dashboard"`, `"hermes_cli.main dashboard"`, `"hermes_cli/main.py dashboard"`), so any invocation with global options between the entrypoint and the subcommand —

```
python -m hermes_cli.main --profile work dashboard --host 0.0.0.0 --port 9119 --no-open --skip-build
```

— is invisible to `hermes dashboard --status`, `hermes dashboard --stop`, and the post-update stale-backend cleanup. After `hermes update`, a profile-scoped dashboard keeps serving the old Python backend against the freshly-built JS bundle.

## Fix

Replace the substring patterns with a tokenized matcher (`_is_dashboard_cmdline`):

1. Find the hermes entrypoint token — `hermes`/`hermes.exe` basename, `hermes_cli.main` (after `-m`), or a `hermes_cli/main.py` script path.
2. Walk forward over **known** top-level flags until the first positional; match only if it is exactly `dashboard`.

Flag arity (does `--profile` consume a value? is `--tui` boolean?) is introspected from the real top-level parser plus `PRE_ARGPARSE_INHERITED_FLAGS` — the same approach `hermes_cli.relaunch` uses for its inherited-flag table — so the matcher can't drift out of sync as global options are added.

Unknown flags and free-text arguments bail out. This matters because the scan feeds a SIGTERM/SIGKILL pass: `ps` output does not preserve shell quoting, so a looser "both words appear" match would kill `hermes -z "summarize my dashboard"` mid-session during `hermes update`. The matcher is strictly tighter than the old patterns on this front — the old `"hermes dashboard"` substring already false-matched cmdlines like `hermes -z fix hermes dashboard`, which now stays alive (covered by a regression test).

Relation to #44048: alternative implementation. That PR's helper accepts any cmdline where an entrypoint substring appears anywhere (including e.g. paths containing `.hermes/`) and `dashboard` appears as a whitespace-delimited word anywhere — which false-positive-kills oneshot/chat sessions that mention "dashboard", since real `ps` output strips the quotes its guard relies on. Happy to converge the two PRs either way.

Both detection consumers are covered (`--status`/`--stop` via `_report_dashboard_status`/`_kill_stale_dashboard_processes`, update cleanup via the same kill helper), Windows wmic and POSIX ps branches share the matcher.

## Tests

- 9 new regression tests: the exact #44035 LaunchAgent shape, `-p`, `--profile=`, boolean flags, script-path form, plus negative cases (other subcommands, prompts mentioning "dashboard", profile literally named `dashboard`, unknown flags).
- `tests/hermes_cli/test_update_stale_dashboard.py` + `test_dashboard_lifecycle_flags.py`: 41/41 pass.
- Full `tests/hermes_cli/` suite: failure set identical to `origin/main` baseline on the same machine (161 pre-existing environment failures, zero new), 9 more tests passing.

Fixes #44035
