### PR TITLE
feat(desktop): auto-detect RTL paragraph direction in chat

### DIFF
--- a/apps/desktop/src/components/assistant-ui/user-message-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/user-message-text.tsx
@@ -127,7 +127,9 @@ const InlineSegmentView: FC<{ text: string }> = ({ text }) => {
   const nodes = useMemo(() => splitInlineCode(text), [text])
 
   return (
-    <span className="wrap-anywhere block whitespace-pre-line">
+    // data-slot is the styles.css hook for per-line bidi direction (#44150);
+    // whitespace-pre-line makes each newline a UAX#9 paragraph boundary.
+    <span className="wrap-anywhere block whitespace-pre-line" data-slot="aui_user-inline-text">
       {nodes.map((node, nodeIndex) =>
         node.kind === 'inline-code' ? (
           <code

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -823,6 +823,34 @@ canvas {
    content's --message-text-indent). No extra prose indent — a single gutter
    reads cleaner than a ragged tool-vs-reply column. */
 
+/* RTL / bidirectional text (#44150). Each paragraph-level block resolves its
+   base direction from its own first strong character (UAX#9 plaintext
+   heuristic): Arabic/Hebrew/Persian/Urdu paragraphs read right-to-left —
+   `text-align: start` follows the resolved direction, so they right-align
+   too — while English paragraphs stay LTR, and mixed conversations resolve
+   per paragraph. Covers assistant prose, user bubbles, and both composers
+   (main + edit share the composer-rich-input slot). List markers and indent
+   stay on the left: `direction` is deliberately untouched so RTL list items
+   reorder and right-align without mirroring the surrounding layout. */
+[data-slot='aui_assistant-message-content'] .aui-md :where(p, h1, h2, h3, h4, h5, h6, li, blockquote),
+[data-slot='aui_user-inline-text'],
+[data-slot='composer-rich-input'] {
+  unicode-bidi: plaintext;
+}
+
+/* Code stays left-to-right regardless of the surrounding paragraph: inline
+   code inside an RTL sentence renders as an isolated LTR run instead of
+   having its neutrals (dots, slashes, dashes) reordered by the bidi
+   algorithm. Fenced blocks (CodeCard / Shiki / user fences) already keep the
+   document's LTR `direction` — nothing above changes `direction`. KaTeX
+   output is pinned LTR too; math layout assumes it. */
+[data-slot='aui_assistant-message-content'] .aui-md :where(:not(pre) > code),
+[data-slot='aui_user-inline-code'],
+[data-slot='aui_assistant-message-content'] .aui-md .katex {
+  direction: ltr;
+  unicode-bidi: isolate;
+}
+
 [data-slot='aui_user-message-root'] {
   top: var(--sticky-human-top);
 }


### PR DESCRIPTION
Fixes #44150

## Problem

Arabic (and Hebrew/Persian/Urdu) text in the desktop chat renders left-to-right: RTL paragraphs read backwards-feeling and left-aligned, and mixed Arabic/English technical conversations — the normal case, per the issue — become genuinely hard to follow.

## Approach

Pure CSS, exactly the behavior proposed in the issue (first-strong-character paragraph detection), with one `data-slot` hook added to the user-message renderer:

- `unicode-bidi: plaintext` on assistant prose blocks (`p`, headings, `li`, `blockquote`), user message text, and both composers (main + edit share the `composer-rich-input` slot). Each paragraph-level block resolves its base direction from its own first strong character (UAX#9), and `text-align: start` follows the resolved direction — so Arabic paragraphs read *and align* right-to-left while English ones stay LTR, per paragraph. In the user bubble and composer, each line is its own bidi paragraph (`whitespace-pre-line` / `pre-wrap`).
- Inline code and KaTeX output are pinned `direction: ltr; unicode-bidi: isolate`, so commands, flags, and file paths embedded in an RTL sentence keep their internal character order instead of having their neutrals (dots, slashes, dashes) reordered.
- Fenced code blocks (CodeCard/Shiki, user fences) are untouched and keep the document's LTR direction — `direction` is never changed anywhere, so layout, list indent, and the rest of the UI stay LTR as the issue requests ("do not force the whole app UI to RTL").

No config knob in this iteration: plaintext auto-detection covers `auto` semantics with zero configuration. A `chat_text_direction: auto | ltr | rtl` override can be layered on later if maintainers want it.

## Verification

Rendered the compiled rules against mixed Arabic/English fixtures (assistant prose with inline code, lists, fenced block; multi-line user message; composer):

- Arabic paragraph → RTL, right-aligned, `npm run dev --host 127.0.0.1` intact as an LTR run
- English paragraph → unchanged
- User message → line 1 (Arabic) RTL with `main.py` isolated, line 2 (English) LTR
- Composer → follows typed text direction, `deploy.sh` intact
- Fenced block → LTR

`npm run typecheck`, eslint, and the desktop vitest suite pass (the 6 failing tests on this branch fail identically on clean `main` — pre-existing, unrelated areas).

## Notes / scope

This covers the **desktop app chat** (`apps/desktop`), which is where HTML rendering makes bidi fixable. The dashboard's embedded `/chat` page is an xterm.js terminal (`web/src/pages/ChatPage.tsx`) — xterm.js has no bidi support upstream (xtermjs/xterm.js#701), so the terminal canvas can't be fixed at this layer; that part would need upstream terminal support and is left out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)