### PR TITLE
fix(desktop): disabling a provider's last model no longer re-enables all toggles

### DIFF
--- a/apps/desktop/src/app/shell/model-menu-panel.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.tsx
@@ -21,6 +21,7 @@ import { useI18n } from '@/i18n'
 import { displayModelName, modelDisplayParts, reasoningEffortLabel } from '@/lib/model-status-label'
 import { cn } from '@/lib/utils'
 import {
+  $knownProviders,
   $visibleModels,
   collapseModelFamilies,
   DEFAULT_VISIBLE_PER_PROVIDER,
@@ -64,6 +65,7 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
   const currentProvider = useStore($currentProvider)
   const currentReasoningEffort = useStore($currentReasoningEffort)
   const visibleModels = useStore($visibleModels)
+  const knownProviders = useStore($knownProviders)
 
   const modelOptions = useQuery({
     queryKey: ['model-options', activeSessionId || 'global'],
@@ -88,8 +90,8 @@ export function ModelMenuPanel({ gateway, onSelectModel, requestGateway }: Model
 
   const providers = modelOptions.data?.providers
   const effectiveVisibleModels = useMemo(
-    () => effectiveVisibleKeys(visibleModels, providers ?? []),
-    [visibleModels, providers]
+    () => effectiveVisibleKeys(visibleModels, providers ?? [], knownProviders),
+    [visibleModels, providers, knownProviders]
   )
 
   const switchTo = (model: string, provider: string) =>

--- a/apps/desktop/src/components/model-visibility-dialog.tsx
+++ b/apps/desktop/src/components/model-visibility-dialog.tsx
@@ -11,6 +11,7 @@ import { getGlobalModelOptions } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { displayModelName, modelDisplayParts } from '@/lib/model-status-label'
 import {
+  $knownProviders,
   $visibleModels,
   collapseModelFamilies,
   effectiveVisibleKeys,
@@ -38,6 +39,7 @@ export function ModelVisibilityDialog({
   const copy = t.modelVisibility
   const [search, setSearch] = useState('')
   const stored = useStore($visibleModels)
+  const known = useStore($knownProviders)
 
   const modelOptions = useQuery({
     queryKey: ['model-options', sessionId || 'global'],
@@ -56,10 +58,10 @@ export function ModelVisibilityDialog({
     [modelOptions.data]
   )
 
-  const visible = effectiveVisibleKeys(stored, providers)
+  const visible = effectiveVisibleKeys(stored, providers, known)
 
   const toggle = (provider: ModelOptionProvider, model: string) => {
-    const next = new Set(effectiveVisibleKeys($visibleModels.get(), providers))
+    const next = new Set(effectiveVisibleKeys($visibleModels.get(), providers, $knownProviders.get()))
     const key = modelVisibilityKey(provider.slug, model)
 
     if (next.has(key)) {
@@ -68,7 +70,12 @@ export function ModelVisibilityDialog({
       next.add(key)
     }
 
-    setVisibleModels(next)
+    // Record every provider currently on screen as customized so emptying one
+    // (hiding its last model) keeps it empty instead of snapping back to all-on.
+    setVisibleModels(
+      next,
+      providers.map(p => p.slug)
+    )
   }
 
   const q = search.trim().toLowerCase()

--- a/apps/desktop/src/store/model-visibility.test.ts
+++ b/apps/desktop/src/store/model-visibility.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { ModelOptionProvider } from '@/types/hermes'
 
-import { effectiveVisibleKeys, modelVisibilityKey } from './model-visibility'
+import { $knownProviders, $visibleModels, effectiveVisibleKeys, modelVisibilityKey, setVisibleModels } from './model-visibility'
 
 const provider = (slug: string, models: string[]): ModelOptionProvider => ({
   models,
@@ -33,5 +33,67 @@ describe('model visibility', () => {
 
     expect(visible.has(modelVisibilityKey('local-ollama', 'qwen3:latest'))).toBe(true)
     expect(visible.has(modelVisibilityKey('local-ollama', 'llama3.2:latest'))).toBe(false)
+  })
+
+  it('keeps a known provider empty after its last model is hidden (no snap-back)', () => {
+    // The user disabled every anthropic model down to the last one, so the
+    // stored set no longer contains any `anthropic::` key — but anthropic is in
+    // the known set because the user customized it. It must stay empty rather
+    // than resurrecting all of anthropic's defaults (the reported bug).
+    const stored = new Set([modelVisibilityKey('openai', 'gpt-5')])
+    const known = new Set(['anthropic', 'openai'])
+
+    const visible = effectiveVisibleKeys(
+      stored,
+      [
+        provider('anthropic', ['haiku-4.5', 'sonnet-4.6', 'opus-4.8']),
+        provider('openai', ['gpt-5'])
+      ],
+      known
+    )
+
+    expect(visible.has(modelVisibilityKey('anthropic', 'haiku-4.5'))).toBe(false)
+    expect(visible.has(modelVisibilityKey('anthropic', 'sonnet-4.6'))).toBe(false)
+    expect(visible.has(modelVisibilityKey('anthropic', 'opus-4.8'))).toBe(false)
+    expect(visible.has(modelVisibilityKey('openai', 'gpt-5'))).toBe(true)
+  })
+
+  it('still seeds a genuinely new provider absent from the known set', () => {
+    // The user has customized anthropic, but `gemini` only appeared afterwards
+    // (e.g. a new key). It was never customized, so it should show by default.
+    const stored = new Set([modelVisibilityKey('anthropic', 'haiku-4.5')])
+    const known = new Set(['anthropic'])
+
+    const visible = effectiveVisibleKeys(
+      stored,
+      [
+        provider('anthropic', ['haiku-4.5', 'opus-4.8']),
+        provider('gemini', ['gemini-3-pro', 'gemini-3-flash'])
+      ],
+      known
+    )
+
+    // anthropic keeps its single explicit choice (opus stays hidden)...
+    expect(visible.has(modelVisibilityKey('anthropic', 'opus-4.8'))).toBe(false)
+    // ...while the brand-new gemini provider is seeded visible.
+    expect(visible.has(modelVisibilityKey('gemini', 'gemini-3-pro'))).toBe(true)
+    expect(visible.has(modelVisibilityKey('gemini', 'gemini-3-flash'))).toBe(true)
+  })
+
+  it('setVisibleModels unions known provider slugs across customizations', () => {
+    $visibleModels.set(null)
+    $knownProviders.set(null)
+
+    setVisibleModels(new Set([modelVisibilityKey('anthropic', 'haiku-4.5')]), ['anthropic'])
+    expect($knownProviders.get()).toEqual(new Set(['anthropic']))
+
+    // A later customization made while only `openai` is on screen must not drop
+    // anthropic from the known set.
+    setVisibleModels(new Set([modelVisibilityKey('openai', 'gpt-5')]), ['openai'])
+    expect($knownProviders.get()).toEqual(new Set(['anthropic', 'openai']))
+
+    // Omitting the slugs (non-customization writes) leaves the known set intact.
+    setVisibleModels(new Set())
+    expect($knownProviders.get()).toEqual(new Set(['anthropic', 'openai']))
   })
 })

--- a/apps/desktop/src/store/model-visibility.ts
+++ b/apps/desktop/src/store/model-visibility.ts
@@ -5,6 +5,12 @@ import type { ModelOptionProvider } from '@/types/hermes'
 
 const STORAGE_KEY = 'hermes.desktop.visible-models'
 
+/** Providers the user has already customized. A provider in this set with zero
+ *  visible keys means the user deliberately hid all of its models — we must NOT
+ *  resurrect its defaults. A provider absent from this set is genuinely new and
+ *  still gets seeded so it shows up by default after an update adds it. */
+const KNOWN_PROVIDERS_KEY = 'hermes.desktop.known-model-providers'
+
 /** Models shown per provider in the status-bar dropdown before the user has
  *  customized the list. Backend `models` are already relevance-ordered. */
 export const DEFAULT_VISIBLE_PER_PROVIDER = 50
@@ -71,11 +77,41 @@ function loadVisible(): Set<string> | null {
  *  hasn't customized — in which case the curated default applies. */
 export const $visibleModels = atom<Set<string> | null>(loadVisible())
 
+/** Provider slugs the user has customized at least once. Seeded lazily by
+ *  {@link setVisibleModels}; null until the first customization. */
+export const $knownProviders = atom<Set<string> | null>(loadKnownProviders())
+
 export const $modelVisibilityOpen = atom(false)
 
-export function setVisibleModels(keys: Set<string>): void {
+function loadKnownProviders(): Set<string> | null {
+  const raw = storedString(KNOWN_PROVIDERS_KEY)
+
+  if (!raw) {
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(raw)
+
+    return Array.isArray(parsed) ? new Set(parsed.filter((x): x is string => typeof x === 'string')) : null
+  } catch {
+    return null
+  }
+}
+
+/** Persist the visible key set. Pass `knownProviderSlugs` (the provider slugs
+ *  currently on screen) whenever the change is a user customization so a
+ *  provider the user empties stays empty instead of being re-seeded. The known
+ *  set is unioned so transient/partial provider lists never drop a slug. */
+export function setVisibleModels(keys: Set<string>, knownProviderSlugs?: Iterable<string>): void {
   $visibleModels.set(new Set(keys))
   persistString(STORAGE_KEY, JSON.stringify([...keys]))
+
+  if (knownProviderSlugs !== undefined) {
+    const known = new Set([...($knownProviders.get() ?? []), ...knownProviderSlugs])
+    $knownProviders.set(known)
+    persistString(KNOWN_PROVIDERS_KEY, JSON.stringify([...known]))
+  }
 }
 
 export function setModelVisibilityOpen(open: boolean): void {
@@ -102,7 +138,8 @@ export function defaultVisibleKeys(providers: readonly ModelOptionProvider[]): S
  *  configured, otherwise the curated default for the given providers. */
 export function effectiveVisibleKeys(
   stored: Set<string> | null,
-  providers: readonly ModelOptionProvider[]
+  providers: readonly ModelOptionProvider[],
+  known?: Set<string> | null
 ): Set<string> {
   if (!stored) {
     return defaultVisibleKeys(providers)
@@ -119,6 +156,14 @@ export function effectiveVisibleKeys(
     const hasStoredProvider = [...stored].some(key => key.startsWith(providerPrefix))
 
     if (hasStoredProvider) {
+      continue
+    }
+
+    // Zero stored keys for this provider. Seed its curated defaults only when
+    // the provider is genuinely new (never customized). If the user has already
+    // customized it — i.e. they hid every model down to the last one — keep it
+    // empty rather than resurrecting every toggle they just turned off.
+    if (known?.has(provider.slug)) {
       continue
     }
 


### PR DESCRIPTION
## Summary

In the desktop **Models** visibility dialog, disabling the *last* enabled model of a provider (e.g. the final Anthropic model) made every toggle for that provider snap back **on**. As reported, this happens for any provider — emptying one resets it to all-visible.

### Root cause

`effectiveVisibleKeys` re-seeds a provider's curated defaults whenever the stored visible-set has **zero keys** for that provider:

```ts
const hasStoredProvider = [...stored].some(key => key.startsWith(providerPrefix))
if (hasStoredProvider) continue
// ...seed this provider's default models...
```

That heuristic exists for a good reason — to surface a *genuinely new* provider by default after an update adds it. But it can't tell a new provider apart from one the user **intentionally emptied**: both look like "zero stored keys." So hiding a provider's last model drops it to zero keys → next render re-seeds all of its defaults → every toggle flips back on.

### Fix

Track the providers the user has already customized in a new `$knownProviders` set (persisted alongside the visible set, unioned so a partial/transient provider list never drops a slug). `effectiveVisibleKeys` now seeds a zero-key provider's defaults **only when it is not known**:

- **Known** provider with zero visible keys → user deliberately hid everything → stays empty (the bug).
- **New** provider absent from the known set → still seeded visible (feature preserved).

The dialog and the status-bar model menu both pass the known set through; the toggle handler records the on-screen providers as known on every customization.

## Test plan

`apps/desktop/src/store/model-visibility.test.ts` (run via repo-root `vitest`):

- [x] Existing: new provider with stale stored choices stays visible.
- [x] Existing: a provider with stored choices isn't re-seeded.
- [x] New: a **known** provider whose last model was hidden stays empty (no snap-back).
- [x] New: a brand-new provider absent from the known set is still seeded visible.
- [x] New: `setVisibleModels` unions known provider slugs across customizations.

```
vitest run --config apps/desktop/vite.config.ts apps/desktop/src/store/model-visibility.test.ts
# Test Files 1 passed (1) — Tests 5 passed (5)
tsc --noEmit -p apps/desktop/tsconfig.json   # 0 errors
```