### PR TITLE
fix(tui-gateway): resolve React #301 infinite render loop + WebSocket unavailable for Node.js < v22

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1574,6 +1574,26 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
             sys.exit(1)
         return path
 
+    node = _node_bin("node")
+    node_flags = ["--expose-gc"]
+    try:
+        ws_check = subprocess.run(
+            [node, "-e", "process.exit(typeof WebSocket === 'undefined' ? 1 : 0)"],
+            capture_output=True,
+            text=True
+        )
+        if ws_check.returncode != 0:
+            exp_check = subprocess.run(
+                [node, "--experimental-websocket", "-e", "process.exit(typeof WebSocket === 'undefined' ? 1 : 0)"],
+                capture_output=True,
+                text=True
+            )
+            if exp_check.returncode == 0:
+                node_flags.append("--experimental-websocket")
+                os.environ["NODE_OPTIONS"] = (os.environ.get("NODE_OPTIONS", "") + " --experimental-websocket").strip()
+    except Exception:
+        pass
+
     # Footgun: --dev against a prebuilt bundle that has no source/node_modules.
     ext_dir = os.environ.get("HERMES_TUI_DIR")
     if tui_dev and ext_dir:
@@ -1590,14 +1610,12 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
         if ext_dir:
             p = Path(ext_dir)
             if (p / "dist" / "entry.js").is_file():
-                node = _node_bin("node")
-                return [node, "--expose-gc", str(p / "dist" / "entry.js")], p
+                return [node] + node_flags + [str(p / "dist" / "entry.js")], p
 
         # 1b. Bundled in wheel (pip install)
         bundled = _find_bundled_tui()
         if bundled is not None:
-            node = _node_bin("node")
-            return [node, "--expose-gc", str(bundled)], bundled.parent
+            return [node] + node_flags + [str(bundled)], bundled.parent
 
     # 2. Normal flow: npm install if needed, always esbuild, then node dist/entry.js.
     #    --dev flow: npm install if needed, then tsx src/entry.tsx.
@@ -1708,8 +1726,7 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
                 print(preview)
             sys.exit(1)
 
-    node = _node_bin("node")
-    return [node, "--expose-gc", str(tui_dir / "dist" / "entry.js")], tui_dir
+    return [node] + node_flags + [str(tui_dir / "dist" / "entry.js")], tui_dir
 
 
 def _normalize_tui_toolsets(toolsets: object) -> list[str]:

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -270,6 +270,34 @@ export function useMainApp(gw: GatewayClient) {
   })
 
   const { actions: composerActions, refs: composerRefs, state: composerState } = composer
+
+  const composerActionsRef = useRef(composerActions)
+  composerActionsRef.current = composerActions
+
+  const stableComposerActions = useMemo(() => {
+    const obj = {} as any
+    const keys: Array<keyof typeof composerActions> = [
+      'clearIn',
+      'dequeue',
+      'enqueue',
+      'handleTextPaste',
+      'openEditor',
+      'pushHistory',
+      'removeQueue',
+      'replaceQueue',
+      'setCompIdx',
+      'setHistoryIdx',
+      'setInput',
+      'setInputBuf',
+      'setPasteSnips',
+      'setQueueEdit',
+      'syncQueue'
+    ]
+    for (const key of keys) {
+      obj[key] = (...args: any[]) => (composerActionsRef.current[key] as any)(...args)
+    }
+    return obj as typeof composerActions
+  }, [])
   const empty = !historyItems.some(msg => msg.kind !== 'intro')
 
   useEffect(() => {
@@ -405,7 +433,11 @@ export function useMainApp(gw: GatewayClient) {
   )
 
   const appendMessage = useCallback(
-    (msg: Msg) => setHistoryItems(prev => capHistory(appendTranscriptMessage(prev, msg))),
+    (msg: Msg) => {
+      queueMicrotask(() => {
+        setHistoryItems(prev => capHistory(appendTranscriptMessage(prev, msg)))
+      })
+    },
     []
   )
 
@@ -483,7 +515,7 @@ export function useMainApp(gw: GatewayClient) {
 
   const session = useSessionLifecycle({
     colsRef,
-    composerActions,
+    composerActions: stableComposerActions,
     gw,
     panel,
     rpc,
@@ -668,7 +700,7 @@ export function useMainApp(gw: GatewayClient) {
 
   const { dispatchSubmission, send, sendQueued, submit } = useSubmission({
     appendMessage,
-    composerActions,
+    composerActions: stableComposerActions,
     composerRefs,
     composerState,
     gw,
@@ -694,13 +726,13 @@ export function useMainApp(gw: GatewayClient) {
       return
     }
 
-    const next = composerActions.dequeue()
+    const next = stableComposerActions.dequeue()
 
     if (next) {
       patchUiState({ busy: true, status: 'running…' })
       sendQueued(next)
     }
-  }, [ui.sid, ui.busy, composerActions, composerRefs, sendQueued])
+  }, [ui.sid, ui.busy, stableComposerActions, composerRefs, sendQueued])
 
   const { pagerPageSize } = useInputHandlers({
     actions: {
@@ -712,7 +744,7 @@ export function useMainApp(gw: GatewayClient) {
       newSession: session.newSession,
       sys
     },
-    composer: { actions: composerActions, refs: composerRefs, state: composerState },
+    composer: { actions: stableComposerActions, refs: composerRefs, state: composerState },
     gateway,
     terminal: { hasSelection, scrollRef, scrollWithSelection, selection, stdout },
     voice: {
@@ -730,7 +762,7 @@ export function useMainApp(gw: GatewayClient) {
   const onEvent = useMemo(
     () =>
       createGatewayEventHandler({
-        composer: { setInput: composerActions.setInput },
+        composer: { setInput: stableComposerActions.setInput },
         gateway,
         session: {
           STARTUP_RESUME_ID,
@@ -755,7 +787,7 @@ export function useMainApp(gw: GatewayClient) {
       appendMessage,
       bellOnComplete,
       clearSelection,
-      composerActions.setInput,
+      stableComposerActions.setInput,
       gateway,
       panel,
       session.newSession,
@@ -826,12 +858,12 @@ export function useMainApp(gw: GatewayClient) {
     () =>
       createSlashHandler({
         composer: {
-          enqueue: composerActions.enqueue,
+          enqueue: stableComposerActions.enqueue,
           hasSelection,
           paste,
           queueRef: composerRefs.queueRef,
           selection,
-          setInput: composerActions.setInput
+          setInput: stableComposerActions.setInput
         },
         gateway,
         local: {
@@ -858,7 +890,7 @@ export function useMainApp(gw: GatewayClient) {
       }),
     [
       catalog,
-      composerActions,
+      stableComposerActions,
       composerRefs,
       die,
       gateway,
@@ -1062,17 +1094,17 @@ export function useMainApp(gw: GatewayClient) {
       compIdx: composerState.compIdx,
       completions: composerState.completions,
       empty,
-      handleTextPaste: composerActions.handleTextPaste,
+      handleTextPaste: stableComposerActions.handleTextPaste,
       input: composerState.input,
       inputBuf: composerState.inputBuf,
       pagerPageSize,
       queueEditIdx: composerState.queueEditIdx,
       queuedDisplay: composerState.queuedDisplay,
       submit,
-      updateInput: composerActions.setInput,
+      updateInput: stableComposerActions.setInput,
       voiceRecordKey
     }),
-    [cols, composerActions, composerState, empty, pagerPageSize, submit, voiceRecordKey]
+    [cols, stableComposerActions, composerState, empty, pagerPageSize, submit, voiceRecordKey]
   )
 
   // Pass current progress through unfrozen — streaming update throttling


### PR DESCRIPTION
### Problem

When TUI chat runs on Node.js < v22 (e.g., v20.20.2), it crashes with:
* React error #301 (too many re-renders) when gateway connection state changes
* gateway websocket unavailable errors due to missing global WebSocket class

### Root Causes

1. **React #301 loop**: composerActions changed on every input keystroke (due to openEditor), causing onEvent handler to recreate infinitely during gateway disconnect, triggering >25 synchronous re-renders.
2. **WebSocket unavailable**: Node.js < v22 requires `--experimental-websocket` flag to enable global WebSocket class; without it, `typeof WebSocket === 'undefined'` and gateway exits.

### Solution

1. **Stabilize composerActions reference** in `useMainApp.ts` using useRef + useMemo proxy pattern (`stableComposerActions`) to prevent hook dependency churn.
2. **Auto-detect WebSocket availability** in `_make_tui_argv()` and inject `--experimental-websocket` flag when needed for Node.js < v22.
3. **Batch state updates** in `appendMessage` via `queueMicrotask` to avoid React render queue overflow.

### Testing

* Verified on Node.js v20.20.2 with `--experimental-websocket`
* Chat no longer crashes with React #301
* WebSocket connections establish successfully
* Messages flow through gateway without hanging

Fixes: gateway exited / gateway websocket unavailable / React error #301 in TUI chat