### PR TITLE
fix(web): guarantee keyless web search/extract works even when plugin discovery doesn't register providers

### DIFF
--- a/tests/tools/test_web_keyless_default_fallback.py
+++ b/tests/tools/test_web_keyless_default_fallback.py
@@ -1,0 +1,100 @@
+"""Regression: the keyless Parallel web default must survive a failed sweep.
+
+``web_search`` / ``web_extract`` are documented to work out of the box with
+zero setup via the bundled keyless Parallel free-MCP backend. That guarantee
+only holds if the bundled ``plugins/web/*`` providers are registered in
+``agent.web_search_registry``. The dispatch triggers the general plugin sweep
+(:func:`hermes_cli.plugins._ensure_plugins_discovered`) to do that — but the
+sweep can finish without registering them (its exception swallowed as a
+warning, a packaged layout where it ran before the bundled tree was
+importable, or a stale empty-discovery cache). When that happened, *both*
+tools dead-ended on "No web {search,extract} provider configured" even though
+no setup should be needed.
+
+These tests pin the invariant that :func:`tools.web_tools._ensure_web_plugins_loaded`
+guarantees the keyless default is registered regardless of the sweep's outcome,
+and that the direct-registration fallback honors an explicit ``plugins.disabled``
+entry. Real imports from the bundled plugin modules — no provider mocking.
+"""
+from __future__ import annotations
+
+import pytest
+
+import agent.web_search_registry as reg
+import hermes_cli.plugins as plugins
+from tools import web_tools
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    reg._reset_for_tests()
+    yield
+    reg._reset_for_tests()
+
+
+def _boom(*_a, **_k):
+    raise RuntimeError("discovery boom")
+
+
+def test_keyless_default_registered_when_discovery_raises(monkeypatch):
+    """A swallowed discovery failure must not strand the keyless default."""
+    monkeypatch.setattr(plugins, "_ensure_plugins_discovered", _boom)
+    assert reg.get_provider("parallel") is None
+
+    web_tools._ensure_web_plugins_loaded()
+
+    parallel = reg.get_provider("parallel")
+    assert parallel is not None, "keyless Parallel default not restored"
+    # It is the universal keyless default precisely because it does both.
+    assert parallel.supports_search()
+    assert parallel.supports_extract()
+
+
+def test_fallback_registers_full_bundled_set(monkeypatch):
+    """The fix covers the whole bundled provider class, not just parallel."""
+    monkeypatch.setattr(plugins, "_ensure_plugins_discovered", _boom)
+
+    web_tools._ensure_web_plugins_loaded()
+
+    names = {p.name for p in reg.list_providers()}
+    # Every bundled backend a user might have configured should be reachable
+    # again, so an explicit ``web.extract_backend: firecrawl`` etc. resolves.
+    for expected in ("parallel", "firecrawl", "tavily", "exa"):
+        assert expected in names, f"{expected} missing after fallback"
+
+
+def test_fallback_honors_explicit_disable(monkeypatch):
+    """A backend the user turned off via plugins.disabled stays off."""
+    monkeypatch.setattr(plugins, "_get_disabled_plugins", lambda: {"web-parallel"})
+
+    web_tools._register_bundled_web_providers_directly()
+
+    names = {p.name for p in reg.list_providers()}
+    assert "parallel" not in names, "explicit disable was ignored"
+    # Other bundled backends are unaffected by the parallel disable.
+    assert "tavily" in names
+
+
+def test_fallback_is_noop_when_discovery_already_registered(monkeypatch):
+    """Healthy path: don't pay for the direct sweep when parallel is present."""
+    # Pretend the general sweep already registered the keyless default.
+    import importlib
+
+    class _Ctx:
+        def register_web_search_provider(self, provider):
+            reg.register_provider(provider)
+
+    importlib.import_module("plugins.web.parallel").register(_Ctx())
+    monkeypatch.setattr(plugins, "_ensure_plugins_discovered", lambda *a, **k: None)
+
+    calls = {"n": 0}
+    real = web_tools._register_bundled_web_providers_directly
+
+    def _spy():
+        calls["n"] += 1
+        real()
+
+    monkeypatch.setattr(web_tools, "_register_bundled_web_providers_directly", _spy)
+    web_tools._ensure_web_plugins_loaded()
+
+    assert calls["n"] == 0, "direct-registration ran on the healthy path"

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -810,6 +810,17 @@ def _ensure_web_plugins_loaded() -> None:
     Mirrors :func:`tools.browser_tool._ensure_browser_plugins_loaded` exactly:
     the underlying discovery call is idempotent and cheap on subsequent
     invocations.
+
+    Triggering discovery is necessary but not *sufficient*: the sweep can
+    finish without registering the bundled web providers (its exception
+    swallowed below as a warning, a packaged layout where discovery ran before
+    the bundled tree was importable, or a stale empty-discovery cache). When
+    that happens the registry is empty and *both* web_search and web_extract
+    dead-end on "No web {search,extract} provider configured" — even though the
+    keyless Parallel default is supposed to work with zero setup. So after
+    discovery we verify the keyless default landed and, if not, register the
+    bundled providers directly (see
+    :func:`_register_bundled_web_providers_directly`).
     """
     try:
         from hermes_cli.plugins import _ensure_plugins_discovered
@@ -821,6 +832,87 @@ def _ensure_web_plugins_loaded() -> None:
         # configured" error this helper is meant to eliminate, with no
         # clue in normal logs about the real cause.
         logger.warning("Web plugin discovery failed (non-fatal): %s", exc)
+
+    # Belt-and-suspenders: guarantee the keyless Parallel default (the
+    # documented zero-setup backend for both web_search and web_extract) is
+    # actually registered. The lookup is a cheap dict hit on the healthy path
+    # (discovery already registered it → no-op); only an empty registry pays
+    # for the direct-registration sweep.
+    try:
+        from agent.web_search_registry import get_provider
+
+        if get_provider("parallel") is None:
+            _register_bundled_web_providers_directly()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Bundled web provider fallback check failed: %s", exc)
+
+
+def _register_bundled_web_providers_directly() -> None:
+    """Register the repo's bundled web providers without the plugin manager.
+
+    The normal path is the general plugin sweep
+    (:func:`hermes_cli.plugins._ensure_plugins_discovered`), which auto-loads
+    every ``plugins/web/<name>`` backend (they are ``kind: backend``). This
+    fallback exists for the runtimes where that sweep does not leave the web
+    registry populated — so the keyless Parallel default (and any bundled
+    backend the user explicitly configured) keeps working instead of
+    surfacing a misleading "No web provider configured" error.
+
+    Imports each bundled ``plugins/web/<name>`` package and calls its
+    ``register()`` directly against :mod:`agent.web_search_registry`. Idempotent
+    (re-register overwrites) and honors an explicit ``plugins.disabled`` entry
+    so a backend the user turned off stays off.
+    """
+    try:
+        from hermes_cli.plugins import (
+            _get_disabled_plugins,
+            get_bundled_plugins_dir,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Bundled web provider fallback unavailable: %s", exc)
+        return
+
+    web_dir = get_bundled_plugins_dir() / "web"
+    if not web_dir.is_dir():
+        return
+
+    disabled = _get_disabled_plugins()
+
+    from agent.web_search_provider import WebSearchProvider
+    from agent.web_search_registry import register_provider
+
+    class _DirectRegistrationCtx:
+        """Minimal plugin ctx exposing only web-provider registration."""
+
+        def register_web_search_provider(self, provider) -> None:
+            if isinstance(provider, WebSearchProvider):
+                register_provider(provider)
+
+    ctx = _DirectRegistrationCtx()
+    import importlib
+
+    for child in sorted(web_dir.iterdir()):
+        if not child.is_dir():
+            continue
+        if not (child / "plugin.yaml").exists() and not (child / "plugin.yml").exists():
+            continue
+        # Respect an explicit disable — match discover_and_load's key/name
+        # check (key ``web/<dir>``; manifest name ``web-<dir-with-dashes>``).
+        if (
+            f"web/{child.name}" in disabled
+            or f"web-{child.name.replace('_', '-')}" in disabled
+        ):
+            continue
+        try:
+            module = importlib.import_module(f"plugins.web.{child.name}")
+            register_fn = getattr(module, "register", None)
+            if callable(register_fn):
+                register_fn(ctx)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "Direct registration of bundled web provider '%s' failed: %s",
+                child.name, exc,
+            )
 
 
 def web_search_tool(query: str, limit: int = 5) -> str:


### PR DESCRIPTION
## Summary

A user reported (dashboard logs) that the agent can't do web search or extract — **both** tools fail:

```
web_search  → {"success": false, "error": "No web search provider configured. Run hermes tools to set one up."}
web_extract → {"success": false, "error": "No web extract provider configured. Set web.extract_backend to firecrawl, tavily, exa, or parallel."}
```

`web_search` / `web_extract` are documented to work with **zero setup** via the bundled keyless **Parallel free-MCP** backend (`plugins/web/parallel`, `badge: free`, "no key needed"). That guarantee only holds when the bundled `plugins/web/*` providers are registered in `agent.web_search_registry`.

The dispatch relied entirely on the general plugin sweep (`_ensure_plugins_discovered`) to register them. When that sweep finishes **without** registering the web backends — its exception swallowed as a warning by `_ensure_web_plugins_loaded`, a packaged layout where it ran before the bundled tree was importable, or a stale empty-discovery cache — the registry is empty. Then both `get_provider("parallel")` and the active-provider walk return `None` (keyless Parallel reports `is_available() == False` without a key), so both tools dead-end on the misleading errors above, even though no setup should be required.

`_ensure_web_plugins_loaded` was originally added (#27580) to prevent exactly this misleading error, but it only *triggers* discovery — it doesn't *guarantee* registration.

## Fix

After triggering discovery, `_ensure_web_plugins_loaded` now checks whether the keyless Parallel default actually landed and, if not, registers the bundled `plugins/web/*` providers **directly** against the registry.

- Idempotent; a **no-op on the healthy path** (a single dict lookup when discovery already registered the providers).
- Covers the whole bundled provider class (so an explicit `web.extract_backend: firecrawl` etc. resolves too), not just parallel.
- Honors an explicit `plugins.disabled` entry — a backend the user turned off stays off.

## Test plan

- [x] `tests/tools/test_web_keyless_default_fallback.py` (4 tests, real plugin imports):
  - keyless Parallel default is restored when discovery raises;
  - the full bundled set is restored (firecrawl/tavily/exa/parallel);
  - the fallback honors `plugins.disabled`;
  - the fallback is a no-op on the healthy path.
- [x] Existing `tests/plugins/web/test_web_search_provider_plugins.py` still passes. (The 2 pre-existing `TestParallelClientConfig` failures in `test_web_tools_config.py` require the real Parallel SDK/key and fail on clean `main` too — unrelated to this change.)