### PR TITLE
fix(gateway): wrap get_model_context_length in asyncio.to_thread to prevent event loop blocking

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8033,7 +8033,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 pass
 
             if _hyg_compression_enabled:
-                _hyg_context_length = get_model_context_length(
+                _hyg_context_length = await asyncio.to_thread(
+                    get_model_context_length,
                     _hyg_model,
                     base_url=_hyg_base_url or "",
                     api_key=_hyg_api_key or "",


### PR DESCRIPTION
## Problem

When using a custom endpoint (e.g. a local proxy), each incoming message triggers `get_model_context_length()` synchronously inside an async handler. This calls `requests.get(url, timeout=10)` — a blocking HTTP call on the asyncio event loop.

If the endpoint is slow or unreachable, the loop freezes up to 10 seconds per message, causing Discord heartbeat timeouts:

```
WARNING discord.gateway: Shard ID None heartbeat blocked for more than 10 seconds.
```

## Fix

Wrap the call in `asyncio.to_thread()` at the call site in `gateway/run.py`:

```python
# Before
_hyg_context_length = get_model_context_length(...)

# After  
_hyg_context_length = await asyncio.to_thread(get_model_context_length, ...)
```

`asyncio` is already imported; `asyncio.to_thread` requires Python 3.9+ (project targets 3.12).