### PR TITLE
test(desktop): mark pane resizable in PaneShell widthOverride test

### DIFF
--- a/apps/desktop/src/components/pane-shell/pane-shell.test.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.test.tsx
@@ -153,7 +153,7 @@ describe('PaneShell composition', () => {
 
     const rendered = render(
       <PaneShell>
-        <Pane id="files" side="left" width="240px">
+        <Pane id="files" resizable side="left" width="240px">
           files
         </Pane>
         <PaneMain>main</PaneMain>
@@ -161,6 +161,22 @@ describe('PaneShell composition', () => {
     )
 
     expect(getColumnTemplate(gridContainer(rendered))).toEqual(['320px', 'minmax(0,1fr)'])
+  })
+
+  it('ignores widthOverride for non-resizable panes', () => {
+    setPaneOpen('files', true)
+    setPaneWidthOverride('files', 320)
+
+    const rendered = render(
+      <PaneShell>
+        <Pane id="files" side="left" width="240px">
+          files
+        </Pane>
+        <PaneMain>main</PaneMain>
+      </PaneShell>
+    )
+
+    expect(getColumnTemplate(gridContainer(rendered))).toEqual(['240px', 'minmax(0,1fr)'])
   })
 
   it('preserves CSS-string widths verbatim (clamp, var, etc.)', () => {


### PR DESCRIPTION
## Problem

`pane-shell.test.tsx` > "PaneShell composition > uses widthOverride from the store when set" fails on pristine main:

```
expected ['240px', 'minmax(0,1fr)'] to deeply equal ['320px', 'minmax(0,1fr)']
```

Repro: `npx vitest run --environment jsdom src/components/pane-shell/` from `apps/desktop`.

## Analysis — the test is wrong, not the component

`trackForPane` only applies a stored `widthOverride` when the pane is `resizable`:

```ts
const override = pane.resizable ? states[pane.id]?.widthOverride : undefined
```

This gating is deliberate: `widthOverride` is written exclusively by the drag-resize handler, which only renders for resizable panes, and #41670 later duplicated the exact same `resizable ? widthOverride : undefined` pattern for the hover-reveal overlay width. A non-resizable pane should keep its declared width even if a stale override is persisted in the store.

The test renders its pane **without** `resizable`, so the override is (correctly) ignored and the declared `240px` wins. Both the test and the gating shipped in the same commit (#20059), so the test has been failing since it was introduced — a stale expectation, not a regression.

## Fix

- Add `resizable` to the pane in the existing test so the override applies (now passes, asserting `320px`).
- Add an inverse test, "ignores widthOverride for non-resizable panes", pinning the intended gating behavior (asserts `240px`).

## Verification

`npx vitest run --environment jsdom src/components/pane-shell/` — 17/17 pass (was 15/16).
