### PR TITLE
fix(tui-gateway): grant the WS orphan-reap grace in awake time so sleep/wake doesn't kill the Desktop session

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1382,6 +1382,112 @@ def test_ws_orphan_reap_disabled_when_grace_zero(monkeypatch):
     assert fired["timer"] is False
 
 
+def test_ws_orphan_reap_rearms_after_system_sleep(monkeypatch):
+    """A reap timer the host slept through re-arms instead of reaping.
+
+    Regression for #44183: threading.Timer's wait elapses in wall-clock time
+    on macOS, so closing the lid for longer than the grace made the timer
+    fire at the instant of wake — before the Desktop app could reconnect —
+    and every >20s sleep/wake cycle 404'd the open session. The reap must
+    grant the full grace window in *awake* (monotonic) time.
+    """
+    timers = []
+
+    class _Timer:
+        def __init__(self, interval, function):
+            self.interval = interval
+            self.function = function
+            timers.append(self)
+
+        def start(self):
+            pass
+
+    closed = []
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 20.0)
+    monkeypatch.setattr(server.threading, "Timer", _Timer)
+    monkeypatch.setattr(server.time, "monotonic", lambda: clock["now"])
+    monkeypatch.setattr(
+        server,
+        "_close_session_by_id",
+        lambda sid, *, end_reason: closed.append((sid, end_reason)) or True,
+    )
+
+    server._sessions["slept-sid"] = _session(
+        transport=server._detached_ws_transport, running=False
+    )
+    try:
+        server._schedule_ws_orphan_reap("slept-sid")
+        assert len(timers) == 1
+        assert timers[0].interval == 20.0
+
+        # Host sleeps 2s into the grace: the wall-clock wait expires during
+        # the sleep and the timer fires at wake with only 2s of awake time
+        # elapsed — spared, re-armed for the remaining 18s.
+        clock["now"] += 2.0
+        timers[0].function()
+        assert closed == []
+        assert len(timers) == 2
+        assert abs(timers[1].interval - 18.0) < 1e-9
+
+        # The re-armed timer runs its full remainder awake: reap proceeds.
+        clock["now"] += 18.0
+        timers[1].function()
+        assert closed == [("slept-sid", "ws_orphan_reap")]
+        assert len(timers) == 2
+    finally:
+        server._sessions.pop("slept-sid", None)
+
+
+def test_ws_orphan_reap_rearm_spares_post_wake_reconnect(monkeypatch):
+    """A session that reconnects within the post-wake grace is not reaped."""
+    timers = []
+
+    class _Timer:
+        def __init__(self, interval, function):
+            self.interval = interval
+            self.function = function
+            timers.append(self)
+
+        def start(self):
+            pass
+
+    class _LiveTransport:
+        def write(self, *a, **k):
+            return True
+
+    closed = []
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 20.0)
+    monkeypatch.setattr(server.threading, "Timer", _Timer)
+    monkeypatch.setattr(server.time, "monotonic", lambda: clock["now"])
+    monkeypatch.setattr(
+        server,
+        "_close_session_by_id",
+        lambda sid, *, end_reason: closed.append((sid, end_reason)) or True,
+    )
+
+    server._sessions["woke-sid"] = _session(
+        transport=server._detached_ws_transport, running=False
+    )
+    try:
+        server._schedule_ws_orphan_reap("woke-sid")
+        clock["now"] += 2.0
+        timers[0].function()
+        assert len(timers) == 2  # slept through the wait — re-armed
+
+        # Desktop reconnects (session.resume re-binds a live transport)
+        # before the re-armed remainder elapses: the reap is a no-op and
+        # the chain stops.
+        server._sessions["woke-sid"]["transport"] = _LiveTransport()
+        clock["now"] += 18.0
+        timers[1].function()
+        assert closed == []
+        assert len(timers) == 2
+    finally:
+        server._sessions.pop("woke-sid", None)
+
+
 def test_init_session_fires_reset_hook(monkeypatch):
     hooks = []
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -160,6 +160,11 @@ try:
 except (ValueError, TypeError):
     _ws_orphan_reap_grace = 20.0
 _WS_ORPHAN_REAP_GRACE_S = max(0.0, _ws_orphan_reap_grace)
+# If the reap timer fires with more than this much of the grace still
+# unelapsed on the monotonic clock, the host slept through the wait —
+# re-arm instead of reaping (#44183). Big enough to ignore timer jitter
+# and wall-clock NTP nudges, small relative to any real sleep.
+_WS_ORPHAN_REAP_SLEEP_SLACK_S = 0.5
 _DETAIL_SECTION_NAMES = ("thinking", "tools", "subagents", "activity")
 _DETAIL_MODES = frozenset({"hidden", "collapsed", "expanded"})
 
@@ -516,7 +521,26 @@ def _schedule_ws_orphan_reap(sid: str) -> None:
     if _WS_ORPHAN_REAP_GRACE_S <= 0:
         return
 
+    # time.monotonic() (mach_absolute_time / CLOCK_MONOTONIC) does not advance
+    # while the host is asleep, so this deadline measures *awake* time.
+    deadline = time.monotonic() + _WS_ORPHAN_REAP_GRACE_S
+
     def _reap() -> None:
+        # threading.Timer's wait elapses in wall-clock time on platforms
+        # without a monotonic condvar (macOS lacks pthread_condattr_setclock),
+        # so a system sleep makes the timer fire "early" in awake-time terms:
+        # closing a MacBook lid for >20s reaped the parked session at the
+        # instant of wake, before the Desktop app's WS reconnect or
+        # session.resume could re-bind a transport — every sleep/wake cycle
+        # 404'd the open chat (#44183). If the monotonic (awake-time) clock
+        # says the grace hasn't actually elapsed, re-arm for the remainder
+        # so the Desktop gets the full grace of awake time to reconnect.
+        remaining = deadline - time.monotonic()
+        if remaining > _WS_ORPHAN_REAP_SLEEP_SLACK_S:
+            rearm = threading.Timer(remaining, _reap)
+            rearm.daemon = True
+            rearm.start()
+            return
         # Serialize the orphan re-check against session.resume (which re-binds a
         # live transport under _session_resume_lock and would make this session
         # non-orphaned). The actual pop + teardown then goes through the shared


### PR DESCRIPTION
## Problem

#44183: when a Mac sleeps with Hermes Desktop open, the WS connection drops and the gateway parks the session behind the 20s orphan-reap grace (`HERMES_TUI_WS_ORPHAN_REAP_GRACE_S`). After any sleep longer than the grace, the session is reaped at the instant of wake — before the Desktop can reconnect or `session.resume` — so actions on the open chat 404 with "session not found".

## Root cause

`threading.Timer`'s wait elapses in **wall-clock** time on macOS: CPython's lock wait uses `pthread_cond_timedwait` with a `CLOCK_REALTIME` deadline because macOS has no `pthread_condattr_setclock`. The wall clock keeps running while the host sleeps, so the timer's deadline expires *during* the sleep and `_reap` fires immediately at wake — the reap always wins the race against the Desktop's reconnect.

`time.monotonic()` (`mach_absolute_time` on macOS, `CLOCK_MONOTONIC` on Linux) does **not** advance during sleep, which gives a clean way to distinguish "20s of awake time elapsed" from "the host slept through the wait".

## Fix

`_schedule_ws_orphan_reap` records a `time.monotonic()` deadline at schedule time. When `_reap` fires, it first checks the monotonic clock: if more than a small slack (0.5s) of the grace is still unelapsed in awake time, the host slept through the wait — re-arm a timer for the remainder instead of reaping. The Desktop therefore gets the full grace of *awake* time after wake to re-bind a transport (which cancels the reap exactly as before).

- The default grace stays 20s, so genuinely orphaned sessions (browser refresh, the #38591 leak this reaper exists for) are reaped on the same schedule as today.
- Repeated sleep cycles just keep re-arming until 20 cumulative seconds of awake time pass without a reconnect.
- On platforms where the timer wait already pauses during suspend, the monotonic check is a no-op (fires with `remaining <= 0`), so behaviour is unchanged.
- The 0.5s slack absorbs timer jitter and forward NTP steps without re-arming spuriously; normal (no-sleep) firings have `remaining <= 0`.

Related: #44102 re-arms this same timer while a detached session is mid-turn — independent condition, trivially composable if both land.

## Tests

- `test_ws_orphan_reap_rearms_after_system_sleep` — timer fires with only 2s of 20s elapsed on a fake monotonic clock → spared and re-armed for 18s; the re-armed timer then reaps after a full awake remainder.
- `test_ws_orphan_reap_rearm_spares_post_wake_reconnect` — Desktop re-binds a live transport within the post-wake remainder → reap is a no-op and the chain stops.

`pytest tests/test_tui_gateway_server.py`: 258 passed, 1 failed — `test_browser_manage_connect_default_local_reports_launch_hint`, which also fails on clean `main` (85503dc) and is unrelated.

Fixes #44183
