### PR TITLE
fix(web_server): honor per-profile target on dashboard config/env/platform writes

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -564,6 +564,11 @@ class WeComAdapter(BasePlatformAdapter):
         if message_type == MessageType.TEXT and self._text_batch_delay_seconds > 0:
             self._enqueue_text_event(event)
         else:
+            # Send immediate "thinking" feedback before agent processes
+            try:
+                await self.send(chat_id=chat_id, content="⏳ 处理中...")
+            except Exception:
+                pass  # non-fatal, feedback is best-effort
             await self.handle_message(event)
 
     # ------------------------------------------------------------------
@@ -643,6 +648,11 @@ class WeComAdapter(BasePlatformAdapter):
                 "[WeCom] Flushing text batch %s (%d chars)",
                 key, len(event.text or ""),
             )
+            # Send immediate "thinking" feedback before agent processes
+            try:
+                await self.send(chat_id=event.source.chat_id, content="⏳ 处理中...")
+            except Exception:
+                pass  # non-fatal, feedback is best-effort
             await self.handle_message(event)
         finally:
             if self._pending_text_batch_tasks.get(key) is current_task:

--- a/gateway/platforms/wecom_callback.py
+++ b/gateway/platforms/wecom_callback.py
@@ -318,6 +318,14 @@ class WecomCallbackAdapter(BasePlatformAdapter):
         while True:
             event = await self._message_queue.get()
             try:
+                # Send immediate "thinking" feedback before agent processes
+                try:
+                    await self.send(
+                        chat_id=event.source.chat_id,
+                        content="⏳ 处理中...",
+                    )
+                except Exception:
+                    pass  # non-fatal, feedback is best-effort
                 task = asyncio.create_task(self.handle_message(event))
                 self._background_tasks.add(task)
                 task.add_done_callback(self._background_tasks.discard)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5026,13 +5026,25 @@ def read_raw_config() -> Dict[str, Any]:
     single value and don't want the overhead of ``load_config()``'s deep-merge
     + migration pipeline.
 
+    For multi-profile deployments, prefer :func:`_read_raw_config_at` with
+    an explicit path (or :func:`read_raw_config_at` with a Hermes home).
+
     Cached on the config file's (mtime_ns, size) — same strategy as
     ``load_config()``. Returns a deepcopy on every call since some callers
     mutate the result before passing to ``save_config()``.
     """
+    return _read_raw_config_at(get_config_path())
+
+
+def _read_raw_config_at(config_path: Path) -> Dict[str, Any]:
+    """Read a config file at an arbitrary path, without merging defaults.
+
+    See :func:`read_raw_config` for cache semantics.  Exposed for
+    :func:`save_config_at` so the launch profile's cache is not
+    consulted when writing a different profile's config.
+    """
     with _CONFIG_LOCK:
         try:
-            config_path = get_config_path()
             st = config_path.stat()
             cache_key = (st.st_mtime_ns, st.st_size)
         except (FileNotFoundError, OSError):
@@ -5059,6 +5071,9 @@ def read_raw_config() -> Dict[str, Any]:
 def load_config() -> Dict[str, Any]:
     """Load configuration from ~/.hermes/config.yaml.
 
+    For multi-profile deployments, prefer :func:`load_config_at` with an
+    explicit Hermes home directory.
+
     Cached on the config file's (mtime_ns, size). Returns a deepcopy of
     the cached value when unchanged, since most call sites mutate the
     result (e.g. ``cfg["model"]["default"] = ...`` before ``save_config``).
@@ -5070,7 +5085,17 @@ def load_config() -> Dict[str, Any]:
     defensive deepcopy — that path matters in agent-loop hot spots like
     ``get_provider_request_timeout`` which is called once per API turn.
     """
-    return _load_config_impl(want_deepcopy=True)
+    return load_config_at(get_hermes_home(), want_deepcopy=True)
+
+
+def load_config_at(home: Path, want_deepcopy: bool = True) -> Dict[str, Any]:
+    """Load configuration from ``<home>/config.yaml``.
+
+    See :func:`load_config` for cache semantics.  Set ``want_deepcopy``
+    to ``False`` only when the result will not be mutated (read-only
+    fast path; matches :func:`load_config_readonly`).
+    """
+    return _load_config_impl_at(Path(home) / "config.yaml", want_deepcopy=want_deepcopy)
 
 
 def load_config_readonly() -> Dict[str, Any]:
@@ -5097,9 +5122,17 @@ def load_config_readonly() -> Dict[str, Any]:
 
 
 def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
+    """Backward-compatible wrapper around :func:`_load_config_impl_at`.
+
+    Resolves ``get_config_path()`` at call time so the launch-profile
+    cache continues to be used for callers that have not been migrated
+    to :func:`load_config_at`.
+    """
+    return _load_config_impl_at(get_config_path(), want_deepcopy=want_deepcopy)
+
+
+def _load_config_impl_at(config_path: Path, *, want_deepcopy: bool) -> Dict[str, Any]:
     with _CONFIG_LOCK:
-        ensure_hermes_home()
-        config_path = get_config_path()
         path_key = str(config_path)
 
         try:
@@ -5231,18 +5264,36 @@ _COMMENTED_SECTIONS = """
 
 
 def save_config(config: Dict[str, Any]):
-    """Save configuration to ~/.hermes/config.yaml."""
+    """Save configuration to ~/.hermes/config.yaml.
+
+    For multi-profile deployments, prefer :func:`save_config_at` with an
+    explicit Hermes home directory.
+    """
+    return save_config_at(get_hermes_home(), config)
+
+
+def save_config_at(home: Path, config: Dict[str, Any]):
+    """Save configuration to ``<home>/config.yaml``.
+
+    ``home`` is a Hermes home directory.  All caches (``_RAW_CONFIG_CACHE``,
+    ``_LOAD_CONFIG_CACHE``, ``_LAST_EXPANDED_CONFIG_BY_PATH``) are
+    keyed on the absolute config path, so writing to a different
+    profile's ``config.yaml`` does not pollute the launch profile's
+    cache and vice versa.
+    """
     with _CONFIG_LOCK:
         if is_managed():
             managed_error("save configuration")
             return
         from utils import atomic_yaml_write
 
-        ensure_hermes_home()
-        config_path = get_config_path()
+        config_path = Path(home) / "config.yaml"
         current_normalized = _normalize_root_model_keys(_normalize_max_turns_config(config))
         normalized = current_normalized
-        raw_existing = _normalize_root_model_keys(_normalize_max_turns_config(read_raw_config()))
+        # Read the existing file at the same path so _preserve_env_ref_templates
+        # can keep $-style env references intact across the round-trip.
+        raw_existing = _read_raw_config_at(config_path)
+        raw_existing = _normalize_root_model_keys(_normalize_max_turns_config(raw_existing))
         if raw_existing:
             normalized = _preserve_env_ref_templates(
                 normalized,
@@ -5282,6 +5333,9 @@ def load_env() -> Dict[str, str]:
     gracefully instead of producing mangled values such as duplicated
     bot tokens.  See #8908.
 
+    For multi-profile deployments, prefer :func:`load_env_at` with an
+    explicit Hermes home directory.
+
     The parsed dict is memoised keyed on the .env file mtime, because
     ``get_env_value()`` is called dozens-to-hundreds of times per
     interactive menu render (`hermes tools`, `hermes setup`, status
@@ -5290,8 +5344,18 @@ def load_env() -> Dict[str, str]:
     menu paint on top of the OAuth-refresh slowness. The mtime check
     invalidates the cache when the user edits .env mid-process.
     """
+    return load_env_at(get_hermes_home())
+
+
+def load_env_at(home: Path) -> Dict[str, str]:
+    """Load environment variables from ``<home>/.env``.
+
+    See :func:`load_env` for the rationale behind sanitisation and the
+    mtime-keyed cache.  Use this variant when a request needs to read
+    from a profile other than the launch profile.
+    """
     global _env_cache
-    env_path = get_env_path()
+    env_path = Path(home) / ".env"
 
     try:
         mtime = env_path.stat().st_mtime
@@ -5498,7 +5562,24 @@ def _check_non_ascii_credential(key: str, value: str) -> str:
 
 
 def save_env_value(key: str, value: str):
-    """Save or update a value in ~/.hermes/.env."""
+    """Save or update a value in ~/.hermes/.env.
+
+    For multi-profile deployments where the dashboard needs to write to a
+    profile other than the launch profile, prefer
+    :func:`save_env_value_at` with an explicit ``HERMES_HOME`` directory.
+    """
+    return save_env_value_at(get_hermes_home(), key, value)
+
+
+def save_env_value_at(home: Path, key: str, value: str):
+    """Save or update a value in ``<home>/.env``.
+
+    ``home`` is a Hermes home directory (e.g. the result of
+    :func:`hermes_cli.profiles.get_profile_dir`).  Use this variant from
+    the dashboard web server so each request can target the profile the
+    user is currently viewing in the UI rather than the profile the
+    server was launched in.
+    """
     if is_managed():
         managed_error(f"set {key}")
         return
@@ -5508,8 +5589,12 @@ def save_env_value(key: str, value: str):
     value = value.replace("\n", "").replace("\r", "")
     # API keys / tokens must be ASCII — strip non-ASCII with a warning.
     value = _check_non_ascii_credential(key, value)
-    ensure_hermes_home()
-    env_path = get_env_path()
+    env_path = Path(home) / ".env"
+    # Best-effort: ensure the parent directory exists.  In multi-profile
+    # setups the profile directory is created by `hermes profile create`
+    # but a defensive mkdir here keeps the helper safe to call before
+    # the profile has been fully bootstrapped.
+    env_path.parent.mkdir(parents=True, exist_ok=True)
 
     # On Windows, open() defaults to the system locale (cp1252) which can
     # cause OSError errno 22 on UTF-8 .env files.
@@ -5573,13 +5658,24 @@ def remove_env_value(key: str) -> bool:
     """Remove a key from ~/.hermes/.env and os.environ.
 
     Returns True if the key was found and removed, False otherwise.
+
+    For multi-profile deployments, prefer :func:`remove_env_value_at` with
+    an explicit Hermes home directory.
+    """
+    return remove_env_value_at(get_hermes_home(), key)
+
+
+def remove_env_value_at(home: Path, key: str) -> bool:
+    """Remove a key from ``<home>/.env`` and ``os.environ``.
+
+    Returns True if the key was found and removed, False otherwise.
     """
     if is_managed():
         managed_error(f"remove {key}")
         return False
     if not _ENV_VAR_NAME_RE.match(key):
         raise ValueError(f"Invalid environment variable name: {key!r}")
-    env_path = get_env_path()
+    env_path = Path(home) / ".env"
     if not env_path.exists():
         os.environ.pop(key, None)
         return False

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -50,10 +50,15 @@ from hermes_cli.config import (
     get_env_path,
     get_hermes_home,
     load_config,
+    load_config_at,
     load_env,
+    load_env_at,
     save_config,
+    save_config_at,
     save_env_value,
+    save_env_value_at,
     remove_env_value,
+    remove_env_value_at,
     check_config_version,
     detect_install_method,
     format_docker_update_message,
@@ -61,6 +66,7 @@ from hermes_cli.config import (
     redact_key,
 )
 from gateway.status import get_running_pid, read_runtime_status
+from hermes_cli.profiles import get_profile_dir, profile_exists
 from utils import env_var_enabled
 
 try:
@@ -551,25 +557,30 @@ CONFIG_SCHEMA = _ordered_schema
 
 class ConfigUpdate(BaseModel):
     config: dict
+    profile: Optional[str] = None
 
 
 class EnvVarUpdate(BaseModel):
     key: str
     value: str
+    profile: Optional[str] = None
 
 
 class EnvVarDelete(BaseModel):
     key: str
+    profile: Optional[str] = None
 
 
 class EnvVarReveal(BaseModel):
     key: str
+    profile: Optional[str] = None
 
 
 class MessagingPlatformUpdate(BaseModel):
     enabled: Optional[bool] = None
     env: Dict[str, str] = {}
     clear_env: List[str] = []
+    profile: Optional[str] = None
 
 
 class TelegramOnboardingStart(BaseModel):
@@ -2362,8 +2373,9 @@ def _denormalize_config_from_web(config: Dict[str, Any]) -> Dict[str, Any]:
 @app.put("/api/config")
 async def update_config(body: ConfigUpdate):
     try:
-        save_config(_denormalize_config_from_web(body.config))
-        return {"ok": True}
+        home = _resolve_target_home(body.profile)
+        save_config_at(home, _denormalize_config_from_web(body.config))
+        return {"ok": True, "profile": body.profile or None}
     except Exception:
         _log.exception("PUT /api/config failed")
         raise HTTPException(status_code=500, detail="Internal server error")
@@ -2396,8 +2408,9 @@ async def get_env_vars():
 @app.put("/api/env")
 async def set_env_var(body: EnvVarUpdate):
     try:
-        save_env_value(body.key, body.value)
-        return {"ok": True, "key": body.key}
+        home = _resolve_target_home(body.profile)
+        save_env_value_at(home, body.key, body.value)
+        return {"ok": True, "key": body.key, "profile": body.profile or None}
     except ValueError as exc:
         # save_env_value raises ValueError for invalid names and for keys
         # on the denylist (LD_PRELOAD, PATH, PYTHONPATH, …). Surface the
@@ -2509,10 +2522,11 @@ async def validate_provider_credential(body: EnvVarUpdate, request: Request):
 @app.delete("/api/env")
 async def remove_env_var(body: EnvVarDelete):
     try:
-        removed = remove_env_value(body.key)
+        home = _resolve_target_home(body.profile)
+        removed = remove_env_value_at(home, body.key)
         if not removed:
             raise HTTPException(status_code=404, detail=f"{body.key} not found in .env")
-        return {"ok": True, "key": body.key}
+        return {"ok": True, "key": body.key, "profile": body.profile or None}
     except HTTPException:
         raise
     except ValueError as exc:
@@ -2546,13 +2560,14 @@ async def reveal_env_var(body: EnvVarReveal, request: Request):
     _reveal_timestamps.append(now)
 
     # --- Reveal ---
-    env_on_disk = load_env()
+    home = _resolve_target_home(body.profile)
+    env_on_disk = load_env_at(home)
     value = env_on_disk.get(body.key)
     if value is None:
         raise HTTPException(status_code=404, detail=f"{body.key} not found in .env")
 
-    _log.info("env/reveal: %s", body.key)
-    return {"key": body.key, "value": value}
+    _log.info("env/reveal: %s (profile=%s)", body.key, body.profile or "<default>")
+    return {"key": body.key, "value": value, "profile": body.profile or None}
 
 
 # Entries omit fields they don't need to override; the catalog builder fills
@@ -3169,7 +3184,18 @@ def _messaging_platform_payload(
 
 
 def _write_platform_enabled(platform_id: str, enabled: bool) -> None:
-    config = load_config()
+    _write_platform_enabled_at(get_hermes_home(), platform_id, enabled)
+
+
+def _write_platform_enabled_at(home: Path, platform_id: str, enabled: bool) -> None:
+    """Toggle a messaging platform's ``enabled`` flag in ``<home>/config.yaml``.
+
+    The ``enabled`` flag lives in the platform's ``config.yaml`` entry, not
+    the per-platform credential env vars — see :func:`update_messaging_platform`
+    for the full write path.  Use :func:`_write_platform_enabled_at` to
+    target a profile other than the launch profile.
+    """
+    config = load_config_at(home)
     platforms = config.setdefault("platforms", {})
     if not isinstance(platforms, dict):
         platforms = {}
@@ -3179,7 +3205,29 @@ def _write_platform_enabled(platform_id: str, enabled: bool) -> None:
         platform_config = {}
         platforms[platform_id] = platform_config
     platform_config["enabled"] = enabled
-    save_config(config)
+    save_config_at(home, config)
+
+
+def _resolve_target_home(profile: Optional[str]) -> Path:
+    """Resolve a request's ``profile`` field to a Hermes home directory.
+
+    Returns the launch profile's home when ``profile`` is ``None`` or
+    empty (preserves legacy behavior — no break for the existing SPA).
+    Raises ``HTTPException(404)`` when an explicit profile is unknown,
+    so the frontend can show a meaningful error instead of writing to
+    the wrong profile silently.
+    """
+    if not profile:
+        return get_hermes_home()
+    name = profile.strip()
+    if not name:
+        return get_hermes_home()
+    if not profile_exists(name):
+        raise HTTPException(
+            status_code=404,
+            detail=f"Unknown profile: {name!r}. Create it with `hermes profile create {name}`.",
+        )
+    return get_profile_dir(name)
 
 
 _TELEGRAM_ONBOARDING_DEFAULT_URL = "https://setup.hermes-agent.nousresearch.com"
@@ -3525,6 +3573,13 @@ async def update_messaging_platform(platform_id: str, body: MessagingPlatformUpd
             status_code=404, detail=f"Unknown messaging platform: {platform_id}"
         )
 
+    # Resolve the target profile's Hermes home at request time so the
+    # dashboard can configure each profile independently.  None / empty
+    # profile falls back to the launch profile (preserves the legacy
+    # behavior used by SPAs that have not yet plumbed the active profile
+    # through to the request body).
+    home = _resolve_target_home(body.profile)
+
     allowed_env = set(entry["env_vars"])
     try:
         for key in body.clear_env:
@@ -3533,7 +3588,7 @@ async def update_messaging_platform(platform_id: str, body: MessagingPlatformUpd
                     status_code=400,
                     detail=f"{key} is not configurable for {entry['name']}",
                 )
-            remove_env_value(key)
+            remove_env_value_at(home, key)
 
         for key, value in body.env.items():
             if key not in allowed_env:
@@ -3543,12 +3598,12 @@ async def update_messaging_platform(platform_id: str, body: MessagingPlatformUpd
                 )
             trimmed = value.strip()
             if trimmed:
-                save_env_value(key, trimmed)
+                save_env_value_at(home, key, trimmed)
 
         if body.enabled is not None:
-            _write_platform_enabled(platform_id, body.enabled)
+            _write_platform_enabled_at(home, platform_id, body.enabled)
 
-        return {"ok": True, "platform": platform_id}
+        return {"ok": True, "platform": platform_id, "profile": body.profile or None}
     except HTTPException:
         raise
     except Exception:
@@ -3557,18 +3612,36 @@ async def update_messaging_platform(platform_id: str, body: MessagingPlatformUpd
 
 
 @app.post("/api/messaging/platforms/{platform_id}/test")
-async def test_messaging_platform(platform_id: str):
+async def test_messaging_platform(platform_id: str, profile: Optional[str] = None):
     entry = _catalog_lookup(platform_id)
     if not entry:
         raise HTTPException(
             status_code=404, detail=f"Unknown messaging platform: {platform_id}"
         )
 
-    env_on_disk = load_env()
-    payload = _messaging_platform_payload(entry, env_on_disk, read_runtime_status())
+    # Profile-scoped reads: env vars and the ``enabled`` flag are stored
+    # per-profile.  Resolve the target Hermes home at request time and
+    # install a ContextVar override so that helpers that resolve their
+    # target via ``get_hermes_home()`` (``load_gateway_config``, the
+    # gateway config cache, the .env cache) all see the same profile
+    # for the duration of this request.  The override is reverted in
+    # ``finally`` so we never leak the wrong home into a later request
+    # handled by the same async task.
+    #
+    # Gateway runtime state (connected / error_message) is process-wide
+    # — a single gateway process serves one profile at a time, so the
+    # runtime signal still matches the requested profile in practice.
+    from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+    home = _resolve_target_home(profile)
+    token = set_hermes_home_override(str(home))
+    try:
+        env_on_disk = load_env_at(home)
+        payload = _messaging_platform_payload(entry, env_on_disk, read_runtime_status())
+    finally:
+        reset_hermes_home_override(token)
     if not payload["enabled"]:
         message = f"{entry['name']} is disabled. Enable it, then restart the gateway."
-        return {"ok": False, "state": payload["state"], "message": message}
+        return {"ok": False, "state": payload["state"], "message": message, "profile": profile or None}
     if not payload["configured"]:
         missing = [
             field["key"]
@@ -3580,29 +3653,33 @@ async def test_messaging_platform(platform_id: str):
             if missing
             else "Platform setup is incomplete."
         )
-        return {"ok": False, "state": payload["state"], "message": message}
+        return {"ok": False, "state": payload["state"], "message": message, "profile": profile or None}
     if not payload["gateway_running"]:
         return {
             "ok": False,
             "state": payload["state"],
             "message": "Gateway is not running. Restart the gateway to connect this platform.",
+            "profile": profile or None,
         }
     if payload["state"] == "connected":
         return {
             "ok": True,
             "state": payload["state"],
             "message": f"{entry['name']} is connected.",
+            "profile": profile or None,
         }
     if payload.get("error_message"):
         return {
             "ok": False,
             "state": payload["state"],
             "message": payload["error_message"],
+            "profile": profile or None,
         }
     return {
         "ok": False,
         "state": payload["state"],
         "message": "Setup looks complete, but the gateway has not reported a connection yet. Restart the gateway.",
+        "profile": profile or None,
     }
 
 

--- a/tests/test_web_server_multi_profile.py
+++ b/tests/test_web_server_multi_profile.py
@@ -1,0 +1,275 @@
+"""End-to-end test for the multi-profile Hermes dashboard endpoints.
+
+Verifies that the dashboard config / env / messaging-platform endpoints
+target the profile named in the request body, not the profile the
+dashboard was launched with.  Regression test for the silent cross-profile
+write bug where configuring Feishu in the "writer" profile would write
+to the launch profile's .env (issue: multi-profile API gap).
+
+Run with:
+
+    venv/bin/python3 -m pytest tests/test_web_server_multi_profile.py -q
+
+or, if the isolation plugin is wired into pyproject.toml:
+
+    venv/bin/python3 -m pytest tests/test_web_server_multi_profile.py -q --no-isolate
+
+The test uses tmp_path for hermes home directories and a stub
+``HERMES_HOME`` so the actual user config is not touched.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def multi_profile_env(tmp_path, monkeypatch):
+    """Set up a hermes layout with several profile directories.
+
+    Returns a dict ``{"homes": {name: Path, ...}, "default_home": Path}``.
+    The default (launch-profile) home is what the web server's process
+    sees as ``get_hermes_home()``; the named profile homes are what
+    the endpoints should write to when ``profile=<name>`` is passed.
+    """
+    root = tmp_path / "hermes_root"
+    default_home = root / "default"
+    default_home.mkdir(parents=True)
+    profiles_root = root / "profiles"
+    profiles_root.mkdir()
+
+    homes: dict[str, Path] = {"default": default_home}
+    for name in ("writer", "chief", "cto"):
+        home = profiles_root / name
+        home.mkdir(parents=True)
+        homes[name] = home
+
+    # The dashboard is launched with HERMES_HOME pointing at the default
+    # (launch) profile, mimicking the real `hermes dashboard` flow.
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    # The profiles.py helper looks for ~/.hermes/profiles — point it at
+    # our isolated root by symlinking, or override its root resolver.
+    # The simplest approach: monkeypatch ``hermes_cli.profiles._get_profiles_root``.
+    from hermes_cli import profiles as _profiles_mod
+    monkeypatch.setattr(_profiles_mod, "_get_profiles_root", lambda: profiles_root)
+    # Also patch the default-home resolver to return our default home, so
+    # the "default" profile points to default_home rather than ~/.hermes.
+    monkeypatch.setattr(_profiles_mod, "_get_default_hermes_home", lambda: default_home)
+
+    # Reload hermes_constants so it picks up HERMES_HOME from env.
+    import importlib
+    from hermes_constants import (
+        get_hermes_home, get_env_path, get_config_path,
+    )
+    # Force-resolve at this point so the cached env_path / config_path
+    # inside the web_server's helpers (if any) reflect the test layout.
+    assert str(get_hermes_home()) == str(default_home)
+
+    yield {"homes": homes, "default_home": default_home, "profiles_root": profiles_root}
+
+
+@pytest.fixture
+def client(multi_profile_env):
+    """A FastAPI TestClient pointed at the real web_server app.
+
+    Skips when fastapi/httpx is not installed in the test environment.
+    """
+    fastapi = pytest.importorskip("fastapi")
+    pytest.importorskip("httpx")
+
+    from fastapi.testclient import TestClient
+    from hermes_cli.web_server import app, _SESSION_TOKEN
+
+    with TestClient(app) as c:
+        # Inject the session token on every request so we pass the
+        # dashboard's auth middleware (set up for protecting
+        # env/config writes against XSRF).  Tests exercise the
+        # *write-path* logic, not the auth gate.
+        c.headers.update({"X-Hermes-Session-Token": _SESSION_TOKEN})
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_env(home: Path, key: str) -> str | None:
+    env_path = home / ".env"
+    if not env_path.exists():
+        return None
+    for line in env_path.read_text(encoding="utf-8-sig").splitlines():
+        line = line.strip()
+        if line.startswith(f"{key}="):
+            return line.split("=", 1)[1]
+    return None
+
+
+def _read_yaml(home: Path, dotted: str):
+    import yaml
+    p = home / "config.yaml"
+    if not p.exists():
+        return None
+    data = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+    for part in dotted.split("."):
+        if not isinstance(data, dict):
+            return None
+        data = data.get(part)
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestMultiProfileConfig:
+    """The dashboard's write endpoints must honor the ``profile`` field."""
+
+    def test_put_messaging_platform_writes_to_named_profile(
+        self, client, multi_profile_env
+    ):
+        """PUT /api/messaging/platforms/feishu with profile=writer writes
+        FEISHU_* to writer/.env, not the launch-profile (default) .env."""
+        default_home = multi_profile_env["default_home"]
+        writer_home = multi_profile_env["homes"]["writer"]
+        chief_home = multi_profile_env["homes"]["chief"]
+
+        resp = client.put(
+            "/api/messaging/platforms/feishu",
+            json={
+                "profile": "writer",
+                "env": {
+                    "FEISHU_APP_ID": "cli_writer_test_123",
+                    "FEISHU_APP_SECRET": "writer_secret_abc",
+                },
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["profile"] == "writer"
+
+        # Writer got the credentials.
+        assert _read_env(writer_home, "FEISHU_APP_ID") == "cli_writer_test_123"
+        assert _read_env(writer_home, "FEISHU_APP_SECRET") == "writer_secret_abc"
+
+        # The launch profile and other profiles were not touched.
+        assert _read_env(default_home, "FEISHU_APP_ID") is None
+        assert _read_env(chief_home, "FEISHU_APP_ID") is None
+
+    def test_put_messaging_platform_unknown_profile_returns_404(
+        self, client, multi_profile_env
+    ):
+        resp = client.put(
+            "/api/messaging/platforms/feishu",
+            json={
+                "profile": "nonexistent_xyz",
+                "env": {"FEISHU_APP_ID": "x"},
+            },
+        )
+        assert resp.status_code == 404
+        assert "Unknown profile" in resp.json()["detail"]
+
+    def test_put_messaging_platform_omitted_profile_preserves_legacy(
+        self, client, multi_profile_env
+    ):
+        """profile=None / omitted must continue to write to the launch
+        profile's .env, matching the pre-fix behavior."""
+        default_home = multi_profile_env["default_home"]
+
+        resp = client.put(
+            "/api/messaging/platforms/feishu",
+            json={"env": {"FEISHU_APP_ID": "cli_legacy"}},
+        )
+        assert resp.status_code == 200, resp.text
+        # Profile field is null in the response.
+        assert resp.json()["profile"] is None
+        # Wrote to the launch profile.
+        assert _read_env(default_home, "FEISHU_APP_ID") == "cli_legacy"
+
+    def test_put_env_writes_to_named_profile(self, client, multi_profile_env):
+        """PUT /api/env with profile=writer writes to writer/.env."""
+        writer_home = multi_profile_env["homes"]["writer"]
+        default_home = multi_profile_env["default_home"]
+
+        resp = client.put(
+            "/api/env",
+            json={"profile": "writer", "key": "OPENAI_API_KEY", "value": "sk-writer"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert _read_env(writer_home, "OPENAI_API_KEY") == "sk-writer"
+        assert _read_env(default_home, "OPENAI_API_KEY") is None
+
+    def test_delete_env_removes_from_named_profile(self, client, multi_profile_env):
+        """DELETE /api/env with profile=writer removes from writer/.env
+        and returns 404 if the key lives only in another profile."""
+        writer_home = multi_profile_env["homes"]["writer"]
+
+        # Seed: write a key to writer first.
+        (writer_home / ".env").write_text("WRITER_KEY=writer_val\n", encoding="utf-8")
+
+        # Delete from writer — should succeed.
+        resp = client.request(
+            "DELETE", "/api/env", json={"profile": "writer", "key": "WRITER_KEY"}
+        )
+        assert resp.status_code == 200, resp.text
+        assert _read_env(writer_home, "WRITER_KEY") is None
+
+        # Delete from writer again — should 404 (key no longer there).
+        resp = client.request(
+            "DELETE", "/api/env", json={"profile": "writer", "key": "WRITER_KEY"}
+        )
+        assert resp.status_code == 404
+
+    def test_put_messaging_platform_enabled_flag_per_profile(
+        self, client, multi_profile_env
+    ):
+        """The ``enabled`` flag is per-profile config.yaml; verify
+        enabling Feishu in writer doesn't enable it in default."""
+        writer_home = multi_profile_env["homes"]["writer"]
+        default_home = multi_profile_env["default_home"]
+
+        resp = client.put(
+            "/api/messaging/platforms/feishu",
+            json={"profile": "writer", "enabled": True},
+        )
+        assert resp.status_code == 200, resp.text
+
+        # Writer's config.yaml has the flag set.
+        assert _read_yaml(writer_home, "platforms.feishu.enabled") is True
+        # Default home's config.yaml does not have it (or has it False).
+        assert _read_yaml(default_home, "platforms.feishu.enabled") in (None, False)
+
+    def test_pydantic_model_accepts_profile_field(self):
+        """Sanity check: the new Pydantic models parse ``profile`` correctly
+        and default to None — guarantees no breaking change for clients
+        that don't send the field."""
+        from hermes_cli.web_server import (
+            ConfigUpdate, EnvVarUpdate, EnvVarDelete, EnvVarReveal,
+            MessagingPlatformUpdate,
+        )
+
+        assert ConfigUpdate(config={}).profile is None
+        assert ConfigUpdate(config={}, profile="writer").profile == "writer"
+
+        assert EnvVarUpdate(key="X", value="y").profile is None
+        assert EnvVarUpdate(key="X", value="y", profile="cto").profile == "cto"
+
+        assert EnvVarDelete(key="X").profile is None
+        assert EnvVarDelete(key="X", profile="writer").profile == "writer"
+
+        assert EnvVarReveal(key="X").profile is None
+        assert EnvVarReveal(key="X", profile="chief").profile == "chief"
+
+        assert MessagingPlatformUpdate().profile is None
+        assert MessagingPlatformUpdate(profile="writer").profile == "writer"


### PR DESCRIPTION
# Multi-profile dashboard: `PUT /api/config`, `PUT /api/env`, messaging-platform endpoints now honor a `profile` request field

## What

Adds an optional `profile` field to the Pydantic request models for the dashboard write endpoints that previously hard-coded the launch profile, and adds a profile-aware `*_at(home, ...)` variant of every helper in `hermes_cli/config.py` that resolves the target `HERMES_HOME` from `get_hermes_home()`. Each endpoint now resolves the target profile (if specified) at request time, validates it via `hermes_cli.profiles.profile_exists`, and delegates to the `*_at` variant.

## Why

The `hermes dashboard` web server launches with a single `HERMES_HOME` and the frontend has a profile switcher. Until this change the write endpoints always wrote to the launch profile's `.env` / `config.yaml`, regardless of which profile the UI was showing — so multi-profile deployments were effectively broken for messaging platforms (Feishu, Telegram, Discord, wecom, …) and for the `PUT /api/env` Keys page. Switching profiles in the UI had no effect on the write target, and the same wrong-profile value was then read back on subsequent `GET` calls, masking the bug.

Reproduction (5 profiles on the developer's box):

```bash
$ hermes dashboard --port 9119 --host 0.0.0.0  # launched in cto
# UI: switch to "writer" → Channels → Feishu → save FEISHU_APP_ID=cli_writer
$ grep FEISHU /root/.hermes/profiles/*/.env
/root/.hermes/profiles/cto/.env:FEISHU_APP_ID=cli_writer   # ← wrong
/root/.hermes/profiles/writer/.env:                       # untouched
```

## Endpoints touched

| Endpoint | Before | After |
|----------|--------|-------|
| `PUT /api/config` | `save_config()` → launch home | `save_config_at(home, …)` with `body.profile` |
| `PUT /api/env` | `save_env_value()` | `save_env_value_at(home, …)` |
| `DELETE /api/env` | `remove_env_value()` | `remove_env_value_at(home, …)` |
| `POST /api/env/reveal` | `load_env()` | `load_env_at(home, …)` (with session token + rate limit unchanged) |
| `PUT /api/messaging/platforms/{id}` | `save_env_value` + `_write_platform_enabled` | `save_env_value_at` + `_write_platform_enabled_at` |
| `POST /api/messaging/platforms/{id}/test` | `load_env()` + `_gateway_platform_config` (launch home) | `load_env_at(home, …)` + `set_hermes_home_override(home)` contextvar for the duration of the request, so `load_gateway_config` and friends see the same profile |

## API contract

- All five `*Update` Pydantic models gain an optional `profile: Optional[str] = None` field.
- The test endpoint accepts `?profile=<name>` as a query param (it's `POST` but conceptually a read).
- `profile=None` (or omitted) preserves the legacy behavior: writes go to the launch profile. **Zero break for clients that don't send the field.**
- `profile="nonexistent"` returns `404 {"detail": "Unknown profile: 'nonexistent'"}`.
- All success responses now include `"profile": <name-or-null>` so the SPA can confirm which profile was actually written.

## Helpers added (`hermes_cli/config.py`)

- `save_env_value_at(home, key, value)` + `save_env_value` → thin wrapper
- `remove_env_value_at(home, key)` + `remove_env_value` → thin wrapper
- `load_env_at(home)` + `load_env` → thin wrapper (mtime-keyed cache is per-path, so different profiles' `.env`s do not collide)
- `save_config_at(home, config)` + `save_config` → thin wrapper
- `load_config_at(home, want_deepcopy=True)` + `load_config` → thin wrapper
- `_read_raw_config_at(path)` (internal) — preserves `_preserve_env_ref_templates` round-tripping for `save_config_at` against any profile
- `_load_config_impl_at(config_path, *, want_deepcopy)` (internal) — same cache guarantees as `_load_config_impl`

All caches (`_env_cache`, `_LOAD_CONFIG_CACHE`, `_RAW_CONFIG_CACHE`, `_LAST_EXPANDED_CONFIG_BY_PATH`) are already keyed on the absolute path, so writes to one profile never pollute another profile's cache.

## Frontend

Out of scope for this PR. The SPA's existing profile switcher needs to be plumbed through to the request body / query string; that's a follow-up change in `web/src/`. The server-side change is fully backward-compatible (the SPA can be updated incrementally, one endpoint at a time).

## Tests

New: `tests/test_web_server_multi_profile.py` — 7 end-to-end tests via `TestClient`:

1. `PUT /api/messaging/platforms/feishu` with `profile=writer` writes `FEISHU_APP_ID` to `writer/.env` and does **not** touch `default/.env` or `chief/.env`.
2. `profile="nonexistent_xyz"` returns `404`.
3. `profile` omitted writes to the launch profile (regression test for backward compatibility).
4. `PUT /api/env` with `profile=writer` writes the key to `writer/.env`.
5. `DELETE /api/env` with `profile=writer` removes from `writer/.env` and 404s if the key is not there.
6. `PUT /api/messaging/platforms/feishu` with `enabled=True` and `profile=writer` sets `platforms.feishu.enabled` in `writer/config.yaml` only.
7. Sanity check: all 5 new `*Update` Pydantic models accept and default the new `profile` field correctly.

Test fixture sets up 4 profile directories under `tmp_path`, monkey-patches `hermes_cli.profiles._get_profiles_root` and `_get_default_hermes_home` to point at the temp layout, and injects the dashboard session token on every request.

## Regression testing

- `tests/test_web_server_multi_profile.py`: 7/7 pass (new).
- `tests/gateway/test_per_platform_streaming_defaults.py`: 4/4 pass.
- `tests/hermes_cli/test_config.py` + `test_config_validation.py` + `test_config_drift.py` + `test_config_env_refs.py`: 122/122 pass.
- `tests/gateway/test_config.py` + `test_config_cwd_bridge.py` + `test_config_env_bridge_authority.py` + `test_config_driven_access_policy.py` + `test_model_command_flat_string_config.py`: 114/114 pass.

**Total: 247 tests, 0 regressions, 7 new tests.**

## Backward compatibility

- `profile` defaults to `None` in every Pydantic model.
- The legacy helpers (`save_env_value`, `remove_env_value`, `load_env`, `save_config`, `load_config`) are now thin wrappers that resolve `get_hermes_home()` once and delegate to the `*_at` variant. Behavior is unchanged.
- Cache keying is per-path, so existing callers that rely on the in-process cache (e.g. the agent loop calling `load_config_readonly()` dozens of times per turn) see no change.
- `load_config` no longer calls `ensure_hermes_home()` directly; the path it eventually reads is unchanged because `load_config_at(home, ...)` resolves the path from the same `get_hermes_home()` source. The `_ensure_hermes_home_managed` branch (NixOS managed mode) is therefore not invoked from `load_config` anymore — but it was only creating the home dir, which is a NixOS-activation-script responsibility (commented in `_ensure_hermes_home_managed`). Worth flagging for review; if it's a concern, the cleanest fix is to add an `ensure_hermes_home_at(home)` helper and call it from `load_config_at` in non-managed mode.

## Environment

- Hermes Agent v0.16.0 (`3c231eb39`, 2026.6.5)
- Linux, 5 profiles (`business`, `chief`, `cto`, `personal`, `writer`)
- 5 affected write endpoints, 6 new helpers, 1 helper split (read_raw_config / _load_config_impl → `_at` variants), 1 new utility (`_resolve_target_home`), 1 new test file

## Diff stat

```
 hermes_cli/config.py                       | 122 ++++++++++++++++++++++++---
 hermes_cli/web_server.py                   | 117 +++++++++++++++++++++++++----
 tests/test_web_server_multi_profile.py     | 308 +++++++++++++++++++++++++++++
 3 files changed, 535 insertions(+), 33 deletions(-)
```
