### PR TITLE
feat(feishu): add cardkit v1 streaming card support (schema 2.0)

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2042,10 +2042,6 @@ class FeishuAdapter(BasePlatformAdapter):
         if not self._client or not HAS_CARDKIT:
             return None
         try:
-            # Best-effort hydrate bot name on first streaming card use.
-            if not getattr(self, "_bot_name", ""):
-                await self._hydrate_bot_identity()
-
             # --- Card reuse: if this chat already has an active streaming
             # card, update it in-place instead of closing + recreating.
             # This handles the tool-boundary case where stream_consumer
@@ -4679,10 +4675,10 @@ class FeishuAdapter(BasePlatformAdapter):
                             "[Feishu] FEISHU_BOT_NAME differs from /bot/v3/info; using hydrated bot name for group @mention gating."
                         )
                     self._bot_name = bot_name
-                    logger.info("[Feishu] Bot identity hydrated: bot_name=%r open_id=%r", bot_name, open_id[:8] if open_id else "")
-        except Exception as exc:
-            logger.warning(
-                "[Feishu] /bot/v3/info probe failed during hydration: %s", exc,
+        except Exception:
+            logger.debug(
+                "[Feishu] /bot/v3/info probe failed during hydration",
+                exc_info=True,
             )
 
         # Fallback probe for _bot_name only: application info endpoint. Needs

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -156,7 +156,7 @@ _PHASE_TRANSITIONS: Dict[int, set] = {
     _CardPhase.COMPLETED: set(),
     _CardPhase.ABORTED: set(),
     _CardPhase.TERMINATED: set(),
-    _CardPhase.CREATION_FAILED: set(),
+    _CardPhase.CREATION_FAILED: {_CardPhase.IDLE},
 }
 
 # Feishu server auto-closes streaming after ~10 minutes; rotate at ~8 min.
@@ -178,6 +178,7 @@ try:
         UpdateCardRequest,
         UpdateCardRequestBody,
     )
+    from lark_oapi.api.cardkit.v1.model import Card as CardKitCard  # type: ignore[attr-defined]
 
     HAS_CARDKIT = True
 except (ImportError, AttributeError):
@@ -191,6 +192,7 @@ except (ImportError, AttributeError):
     SettingsCardRequestBody = None  # type: ignore[assignment,misc]
     UpdateCardRequest = None  # type: ignore[assignment,misc]
     UpdateCardRequestBody = None  # type: ignore[assignment,misc]
+    CardKitCard = None  # type: ignore[assignment,misc]
 
 FEISHU_WEBSOCKET_AVAILABLE = websockets is not None
 FEISHU_WEBHOOK_AVAILABLE = aiohttp is not None
@@ -2166,13 +2168,9 @@ class FeishuAdapter(BasePlatformAdapter):
                         card_id, card_state.get("sequence"),
                     )
                     return result
-                # Edit failed — fall through to create a new card.
+                # Edit failed — close the stale card before creating new one.
                 logger.warning("[Feishu] Streaming card reuse edit failed; creating new card")
-
-            # Close any previously-open streaming cards for this chat before
-            # creating a new one (only reached when no active card exists or
-            # reuse failed).
-            await self._close_streaming_siblings(chat_id)
+                await self._close_streaming_siblings(chat_id)
 
             if not self._transition_card_phase(chat_id, _CardPhase.CREATING):
                 logger.warning("[Feishu] Cannot create card: invalid phase %s", self._card_phase(chat_id))
@@ -2382,7 +2380,6 @@ class FeishuAdapter(BasePlatformAdapter):
                 bot_name=bot_name, status=status, error_summary=error_summary,
                 last_content=card_state.get("last_content", ""),
             )
-            from lark_oapi.api.cardkit.v1.model import Card as CardKitCard
             card_obj = CardKitCard.builder() \
                 .type("card_json") \
                 .data(card_json) \
@@ -2475,7 +2472,6 @@ class FeishuAdapter(BasePlatformAdapter):
         self._closed_streaming_card_ids[card_id] = None
         if len(self._closed_streaming_card_ids) > 500:
             self._closed_streaming_card_ids.popitem(last=False)
-        self._transition_card_phase(chat_id, target_phase)
         # Reset to IDLE so the next turn can create a new card.
         self._card_phases[chat_id] = _CardPhase.IDLE
 

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -4680,10 +4680,9 @@ class FeishuAdapter(BasePlatformAdapter):
                         )
                     self._bot_name = bot_name
                     logger.info("[Feishu] Bot identity hydrated: bot_name=%r open_id=%r", bot_name, open_id[:8] if open_id else "")
-        except Exception:
-            logger.debug(
-                "[Feishu] /bot/v3/info probe failed during hydration",
-                exc_info=True,
+        except Exception as exc:
+            logger.warning(
+                "[Feishu] /bot/v3/info probe failed during hydration: %s", exc,
             )
 
         # Fallback probe for _bot_name only: application info endpoint. Needs

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -124,6 +124,44 @@ except ImportError:
     FEISHU_DOMAIN = None  # type: ignore[assignment]
     LARK_DOMAIN = None  # type: ignore[assignment]
 
+
+# ---------------------------------------------------------------------------
+# Streaming card phase state machine
+# ---------------------------------------------------------------------------
+
+class _CardPhase(int):
+    """Phase lifecycle for a single streaming card.
+
+    Valid transitions::
+
+        Idle -> Creating -> Streaming -> Completed
+                                  -> Aborted
+                                  -> Terminated
+              Creating -> CreationFailed
+                        -> Terminated
+    """
+    IDLE = 0
+    CREATING = 1
+    STREAMING = 2
+    COMPLETED = 3
+    ABORTED = 4
+    TERMINATED = 5
+    CREATION_FAILED = 6
+
+
+_PHASE_TRANSITIONS: Dict[int, set] = {
+    _CardPhase.IDLE: {_CardPhase.CREATING},
+    _CardPhase.CREATING: {_CardPhase.STREAMING, _CardPhase.CREATION_FAILED, _CardPhase.TERMINATED},
+    _CardPhase.STREAMING: {_CardPhase.COMPLETED, _CardPhase.ABORTED, _CardPhase.TERMINATED},
+    _CardPhase.COMPLETED: set(),
+    _CardPhase.ABORTED: set(),
+    _CardPhase.TERMINATED: set(),
+    _CardPhase.CREATION_FAILED: set(),
+}
+
+# Feishu server auto-closes streaming after ~10 minutes; rotate at ~8 min.
+_STREAM_CARD_TTL_SECONDS = 500
+
 # cardkit v1 is optional — older lark_oapi SDKs may lack it.  When
 # unavailable the streaming-card feature gracefully degrades.
 HAS_CARDKIT = False
@@ -1512,12 +1550,14 @@ class FeishuAdapter(BasePlatformAdapter):
         # by create, so we cache it per message_id.
         self._pending_processing_reactions: "OrderedDict[str, str]" = OrderedDict()
         self._load_seen_message_ids()
-        # Streaming card state: chat_id -> {card_id -> {sequence, message_id}}.
+        # Streaming card state: chat_id -> {card_id -> {sequence, message_id, ...}}.
         # Tracks cardkit v1 cards currently in streaming mode per chat.
         self._streaming_cards: Dict[str, Dict[str, Dict[str, Any]]] = {}
         # Card IDs of streaming cards that have been closed, used to distinguish
         # "card already closed" from "IM message edit failure" in edit_message.
         self._closed_streaming_card_ids: "OrderedDict[str, None]" = OrderedDict()
+        # Per-chat card phase for lifecycle enforcement.
+        self._card_phases: Dict[str, int] = {}
 
     @staticmethod
     def _load_settings(extra: Dict[str, Any]) -> FeishuAdapterSettings:
@@ -1698,6 +1738,7 @@ class FeishuAdapter(BasePlatformAdapter):
         # (e.g. if disconnect raised before reaching the cleanup path).
         self._streaming_cards.clear()
         self._closed_streaming_card_ids.clear()
+        self._card_phases.clear()
 
         if not FEISHU_AVAILABLE:
             logger.error("[Feishu] lark-oapi not installed")
@@ -1976,6 +2017,36 @@ class FeishuAdapter(BasePlatformAdapter):
     # Streaming card helpers (cardkit v1, schema 2.0)
     # =========================================================================
 
+    def _transition_card_phase(self, chat_id: str, to_phase: int) -> bool:
+        """Attempt a phase transition for *chat_id*'s streaming card.
+
+        Returns True on success, False if the transition is invalid.
+        """
+        current = self._card_phases.get(chat_id, _CardPhase.IDLE)
+        allowed = _PHASE_TRANSITIONS.get(current, set())
+        if to_phase not in allowed:
+            logger.warning(
+                "[Feishu] Invalid card phase transition: %s -> %s (chat=%s)",
+                current, to_phase, chat_id,
+            )
+            return False
+        self._card_phases[chat_id] = to_phase
+        return True
+
+    def _card_phase(self, chat_id: str) -> int:
+        return self._card_phases.get(chat_id, _CardPhase.IDLE)
+
+    def _is_card_expired(self, chat_id: str) -> bool:
+        """Check if the active streaming card has exceeded TTL."""
+        cards = self._streaming_cards.get(chat_id)
+        if not cards:
+            return False
+        for card_state in cards.values():
+            created_at = card_state.get("created_at", 0)
+            if created_at and (time.monotonic() - created_at) > _STREAM_CARD_TTL_SECONDS:
+                return True
+        return False
+
     @staticmethod
     def _build_streaming_card_json(
         initial_content: str = "",
@@ -2009,18 +2080,18 @@ class FeishuAdapter(BasePlatformAdapter):
                     {
                         "tag": "text_tag",
                         "text": {"tag": "plain_text", "content": "AI"},
-                        "color": "blue",
+                        "color": "wathet",
                     },
                     {
                         "tag": "text_tag",
                         "text": {"tag": "plain_text", "content": "生成中"},
-                        "color": "blue",
+                        "color": "wathet",
                     },
                 ],
-                "template": "blue",
+                "template": "wathet",
                 "ud_icon": {
                     "token": "larkcommunity_colorful",
-                    "style": {"color": "blue"},
+                    "style": {"color": "wathet"},
                 },
             },
             "config": {
@@ -2060,6 +2131,20 @@ class FeishuAdapter(BasePlatformAdapter):
         if not self._client or not HAS_CARDKIT:
             return None
         try:
+            # --- TTL rotation: close expired card and create fresh one ---
+            if self._is_card_expired(chat_id):
+                logger.info("[Feishu] Streaming card TTL expired for chat=%s, rotating", chat_id)
+                old_msg_id = None
+                old_cards = self._streaming_cards.get(chat_id)
+                if old_cards:
+                    for cs in old_cards.values():
+                        old_msg_id = cs.get("message_id")
+                        break
+                await self._close_streaming_siblings(chat_id)
+                # New card replies to old card's message for threading continuity
+                if old_msg_id and not reply_to:
+                    reply_to = old_msg_id
+
             # --- Card reuse: if this chat already has an active streaming
             # card, update it in-place instead of closing + recreating.
             # This handles the tool-boundary case where stream_consumer
@@ -2089,6 +2174,10 @@ class FeishuAdapter(BasePlatformAdapter):
             # reuse failed).
             await self._close_streaming_siblings(chat_id)
 
+            if not self._transition_card_phase(chat_id, _CardPhase.CREATING):
+                logger.warning("[Feishu] Cannot create card: invalid phase %s", self._card_phase(chat_id))
+                return None
+
             formatted = self.format_message(content)
             truncated = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)[0]
             card_json = self._build_streaming_card_json(truncated, bot_name=self._bot_name)
@@ -2109,15 +2198,16 @@ class FeishuAdapter(BasePlatformAdapter):
                     "[Feishu] cardkit create failed: %s",
                     getattr(create_response, "msg", "unknown"),
                 )
+                self._transition_card_phase(chat_id, _CardPhase.CREATION_FAILED)
                 return None
 
             card_id = self._extract_response_field(create_response, "card_id")
             if not card_id:
                 logger.warning("[Feishu] cardkit create returned no card_id")
+                self._transition_card_phase(chat_id, _CardPhase.CREATION_FAILED)
                 return None
 
             # Step 2: Send interactive message referencing the card entity.
-            # Use _feishu_send_with_retry for reply_to/thread support and retry.
             interactive_content = json.dumps(
                 {"type": "card", "data": {"card_id": card_id}},
                 ensure_ascii=False,
@@ -2134,6 +2224,7 @@ class FeishuAdapter(BasePlatformAdapter):
                     "[Feishu] Interactive card message send failed: %s",
                     getattr(msg_response, "msg", "unknown"),
                 )
+                self._transition_card_phase(chat_id, _CardPhase.CREATION_FAILED)
                 return None
 
             # Track streaming state (sequence starts at 1 — the initial
@@ -2142,12 +2233,15 @@ class FeishuAdapter(BasePlatformAdapter):
                 "sequence": 1,
                 "message_id": self._extract_response_field(msg_response, "message_id"),
                 "last_content": truncated,
+                "created_at": time.monotonic(),
             }
+            self._transition_card_phase(chat_id, _CardPhase.STREAMING)
 
             logger.info("[Feishu] Streaming card created: card_id=%s msg_id=%s", card_id, self._extract_response_field(msg_response, "message_id"))
             return SendResult(success=True, message_id=card_id)
 
         except Exception as exc:
+            self._transition_card_phase(chat_id, _CardPhase.CREATION_FAILED)
             logger.warning(
                 "[Feishu] Streaming card send failed: %s", exc, exc_info=True,
             )
@@ -2220,18 +2314,26 @@ class FeishuAdapter(BasePlatformAdapter):
         """Build a card JSON with status-appropriate header for post-stream update."""
         _display_name = bot_name or "Hermes"
         if status == "error":
-            template = "red"
-            icon_color = "red"
+            template = "grey"
+            icon_color = "grey"
             tags = [
-                {"tag": "text_tag", "text": {"tag": "plain_text", "content": "AI"}, "color": "red"},
-                {"tag": "text_tag", "text": {"tag": "plain_text", "content": "错误"}, "color": "red"},
+                {"tag": "text_tag", "text": {"tag": "plain_text", "content": "AI"}, "color": "grey"},
+                {"tag": "text_tag", "text": {"tag": "plain_text", "content": "错误"}, "color": "grey"},
             ]
             subtitle = {"tag": "plain_text", "content": error_summary[:80]} if error_summary else None
-        else:
-            template = "turquoise"
-            icon_color = "turquoise"
+        elif status == "aborted":
+            template = "grey"
+            icon_color = "grey"
             tags = [
-                {"tag": "text_tag", "text": {"tag": "plain_text", "content": "AI"}, "color": "turquoise"},
+                {"tag": "text_tag", "text": {"tag": "plain_text", "content": "AI"}, "color": "grey"},
+                {"tag": "text_tag", "text": {"tag": "plain_text", "content": "已中止"}, "color": "grey"},
+            ]
+            subtitle = None
+        else:
+            template = "blue"
+            icon_color = "blue"
+            tags = [
+                {"tag": "text_tag", "text": {"tag": "plain_text", "content": "AI"}, "color": "blue"},
             ]
             subtitle = None
 
@@ -2315,6 +2417,7 @@ class FeishuAdapter(BasePlatformAdapter):
         ``_close_streaming_siblings``).  When omitted the state is read
         from ``self._streaming_cards``.
         """
+        target_phase = _CardPhase.ABORTED if status == "aborted" else _CardPhase.COMPLETED
         if HAS_CARDKIT:
             try:
                 if card_state is None:
@@ -2370,6 +2473,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._closed_streaming_card_ids[card_id] = None
         if len(self._closed_streaming_card_ids) > 500:
             self._closed_streaming_card_ids.popitem(last=False)
+        self._transition_card_phase(chat_id, target_phase)
 
     async def _close_streaming_siblings(self, chat_id: str) -> None:
         """Finalize all open streaming cards for *chat_id*.

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1919,6 +1919,20 @@ class FeishuAdapter(BasePlatformAdapter):
                 finalize=finalize,
             )
 
+        # When streaming cards are enabled, the message_id may be a card_id
+        # that was already closed by a prior finalize call (e.g. the
+        # stream_consumer's got_done path first edits with finalize=True
+        # in the mid-stream update, then attempts a second finalize in the
+        # dedicated got_done block).  Returning success here prevents the
+        # caller from treating the missing card as an edit failure and
+        # falling back to a full send, which would duplicate the response.
+        if self._streaming_card_enabled and finalize:
+            logger.debug(
+                "[Feishu] Streaming card %s already closed; treating finalize as success",
+                message_id,
+            )
+            return SendResult(success=True, message_id=message_id)
+
         # --- Existing IM v1 update path --------------------------------------
         content = self.format_message(content)
         try:
@@ -1947,49 +1961,44 @@ class FeishuAdapter(BasePlatformAdapter):
     # Streaming card helpers (cardkit v1, schema 2.0)
     # =========================================================================
 
+    @staticmethod
     def _build_streaming_card_json(
-        self,
         initial_content: str = "",
-        model_name: str = "",
-        context_pct: Optional[int] = None,
     ) -> str:
         """Build a cardkit v1 schema-2.0 JSON string with streaming enabled.
 
-        *model_name* and *context_pct* are displayed in the card header's
-        subtitle when provided, giving users visibility into which model
-        is responding and how much of the context window is consumed.
+        The ``summary.content`` is populated from the first ~60 characters of
+        *initial_content* so that the Feishu conversation list shows a
+        meaningful preview instead of the default ``[生成中...]``.
         """
-        # Build subtitle from runtime info when available
-        subtitle_parts: list[str] = []
-        if model_name:
-            subtitle_parts.append(model_name)
-        if context_pct is not None:
-            subtitle_parts.append(f"ctx {context_pct}%")
-        subtitle = " · ".join(subtitle_parts) if subtitle_parts else ""
-
-        header: Dict[str, Any] = {
-            "title": {
-                "tag": "plain_text",
-                "content": "Hermes",
-            },
-            "template": "blue",
-            "ud_icon": {
-                "token": "larkco...rful",
-                "style": {"color": "blue"},
-            },
-        }
-        if subtitle:
-            header["subtitle"] = {
-                "tag": "plain_text",
-                "content": subtitle,
-            }
+        # Strip markdown formatting for the chat-list preview.
+        import re as _re
+        preview_text = _re.sub(r"[#*`_~\[\]()>|]", "", initial_content).strip()
+        preview_text = preview_text.replace("\n", " ")[:60].strip()
 
         card: Dict[str, Any] = {
             "schema": "2.0",
-            "header": header,
+            "header": {
+                "title": {
+                    "tag": "lark_md",
+                    "content": "🪶 Hermes",
+                },
+                "text_tag_list": [
+                    {
+                        "tag": "text_tag",
+                        "text": {"tag": "plain_text", "content": "AI"},
+                        "color": "blue",
+                    },
+                ],
+                "template": "blue",
+                "ud_icon": {
+                    "token": "larkcommunity_colorful",
+                    "style": {"color": "blue"},
+                },
+            },
             "config": {
                 "streaming_mode": True,
-                "summary": {"content": ""},
+                "summary": {"content": preview_text},
                 "streaming_config": {
                     "print_frequency_ms": {"default": 70},
                     "print_step": {"default": 1},
@@ -2031,25 +2040,7 @@ class FeishuAdapter(BasePlatformAdapter):
 
             formatted = self.format_message(content)
             truncated = formatted[: self.MAX_MESSAGE_LENGTH]
-
-            # Resolve runtime info for the card header subtitle.
-            # model_name: try metadata first, then read from gateway config.
-            # context_pct: from metadata if the caller injected it.
-            model_name = ""
-            context_pct: Optional[int] = None
-            if metadata:
-                model_name = metadata.get("_model", "")
-                context_pct = metadata.get("_context_pct")
-            if not model_name:
-                try:
-                    from gateway.run import _resolve_gateway_model
-                    model_name = _resolve_gateway_model()
-                except Exception:
-                    pass
-
-            card_json = self._build_streaming_card_json(
-                truncated, model_name=model_name, context_pct=context_pct,
-            )
+            card_json = self._build_streaming_card_json(truncated)
 
             # Step 1: Create card entity via cardkit v1
             create_body = CreateCardRequestBody.builder() \

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1889,8 +1889,11 @@ class FeishuAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         # --- Streaming card path (cardkit v1, schema 2.0) --------------------
-        # Only used when enabled AND we have the cardkit SDK available.
-        if self._streaming_card_enabled and HAS_CARDKIT:
+        # Only used when enabled AND the caller explicitly requests it via
+        # metadata["streaming_card"] == True.  This gate prevents auto-sent
+        # messages (runtime footer, commentary, tool progress, etc.) from
+        # creating orphaned streaming cards that never get closed.
+        if self._streaming_card_enabled and HAS_CARDKIT and metadata and metadata.get("streaming_card"):
             result = await self._send_streaming_card(
                 chat_id=chat_id,
                 content=content,

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -124,6 +124,32 @@ except ImportError:
     FEISHU_DOMAIN = None  # type: ignore[assignment]
     LARK_DOMAIN = None  # type: ignore[assignment]
 
+# cardkit v1 is optional — older lark_oapi SDKs may lack it.  When
+# unavailable the streaming-card feature gracefully degrades.
+HAS_CARDKIT = False
+try:
+    from lark_oapi.api.cardkit.v1 import (  # type: ignore[attr-defined]
+        Config,
+        CreateCardRequest,
+        CreateCardRequestBody,
+        ContentCardElementRequest,
+        ContentCardElementRequestBody,
+        Settings,
+        SettingsCardRequest,
+        SettingsCardRequestBody,
+    )
+
+    HAS_CARDKIT = True
+except (ImportError, AttributeError):
+    Config = None  # type: ignore[assignment,misc]
+    CreateCardRequest = None  # type: ignore[assignment,misc]
+    CreateCardRequestBody = None  # type: ignore[assignment,misc]
+    ContentCardElementRequest = None  # type: ignore[assignment,misc]
+    ContentCardElementRequestBody = None  # type: ignore[assignment,misc]
+    Settings = None  # type: ignore[assignment,misc]
+    SettingsCardRequest = None  # type: ignore[assignment,misc]
+    SettingsCardRequestBody = None  # type: ignore[assignment,misc]
+
 FEISHU_WEBSOCKET_AVAILABLE = websockets is not None
 FEISHU_WEBHOOK_AVAILABLE = aiohttp is not None
 
@@ -395,6 +421,9 @@ class FeishuAdapterSettings:
     group_rules: Dict[str, FeishuGroupRule] = field(default_factory=dict)
     allow_bots: str = "none"  # "none" | "mentions" | "all"
     require_mention: bool = True
+    # When True, outgoing text messages use Feishu cardkit v1 streaming cards
+    # (schema 2.0) for typewriter-effect streaming instead of post/text + edit.
+    streaming_card_enabled: bool = False
 
 
 @dataclass
@@ -1411,6 +1440,11 @@ class FeishuAdapter(BasePlatformAdapter):
 
     supports_code_blocks = True  # Feishu renders fenced code blocks
 
+    # When True, outgoing messages use cardkit v1 streaming cards (schema 2.0)
+    # so the stream_consumer can perform card-level streaming updates instead
+    # of progressive post/text edits.  Set dynamically from settings.
+    REQUIRES_EDIT_FINALIZE: bool = False
+
     MAX_MESSAGE_LENGTH = 8000
     # Max distinct chat IDs retained in _chat_locks before LRU eviction kicks in.
     CHAT_LOCK_MAX_SIZE: int = 1000
@@ -1474,6 +1508,9 @@ class FeishuAdapter(BasePlatformAdapter):
         # by create, so we cache it per message_id.
         self._pending_processing_reactions: "OrderedDict[str, str]" = OrderedDict()
         self._load_seen_message_ids()
+        # Streaming card state: chat_id -> {card_id -> {sequence, message_id, streaming}}.
+        # Tracks cardkit v1 cards currently in streaming mode per chat.
+        self._streaming_cards: Dict[str, Dict[str, Dict[str, Any]]] = {}
 
     @staticmethod
     def _load_settings(extra: Dict[str, Any]) -> FeishuAdapterSettings:
@@ -1575,6 +1612,9 @@ class FeishuAdapter(BasePlatformAdapter):
             require_mention=_to_boolean(
                 extra.get("require_mention", os.getenv("FEISHU_REQUIRE_MENTION", "true"))
             ),
+            streaming_card_enabled=_to_boolean(
+                extra.get("streaming_card_enabled", os.getenv("FEISHU_STREAMING_CARD_ENABLED", "false"))
+            ),
         )
 
     def _apply_settings(self, settings: FeishuAdapterSettings) -> None:
@@ -1607,6 +1647,8 @@ class FeishuAdapter(BasePlatformAdapter):
         self._ws_ping_timeout = settings.ws_ping_timeout
         self._allow_bots = settings.allow_bots
         self._require_mention = settings.require_mention
+        self._streaming_card_enabled = settings.streaming_card_enabled
+        self.REQUIRES_EDIT_FINALIZE = self._streaming_card_enabled
 
     def _build_event_handler(self) -> Any:
         if EventDispatcherHandler is None:
@@ -1693,6 +1735,12 @@ class FeishuAdapter(BasePlatformAdapter):
     async def disconnect(self) -> None:
         """Disconnect from Feishu/Lark."""
         self._running = False
+
+        # Finalize any open streaming cards before tearing down the connection
+        # so they don't get stuck in streaming mode after disconnect.
+        for chat_id in list(self._streaming_cards):
+            await self._close_streaming_siblings(chat_id)
+
         await self._cancel_pending_tasks(self._pending_text_batch_tasks)
         await self._cancel_pending_tasks(self._pending_media_batch_tasks)
         self._reset_batch_buffers()
@@ -1782,6 +1830,21 @@ class FeishuAdapter(BasePlatformAdapter):
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
+        # --- Streaming card path (cardkit v1, schema 2.0) --------------------
+        # Only used when enabled AND we have the cardkit SDK available.
+        if self._streaming_card_enabled and HAS_CARDKIT:
+            result = await self._send_streaming_card(
+                chat_id=chat_id,
+                content=content,
+                reply_to=reply_to,
+                metadata=metadata,
+            )
+            if result is not None:
+                return result
+            # Streaming card failed — fall through to post/text below.
+            logger.warning("[Feishu] Streaming card send failed; falling back to post/text")
+
+        # --- Existing post/text path -----------------------------------------
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
         last_response = None
@@ -1836,10 +1899,27 @@ class FeishuAdapter(BasePlatformAdapter):
         *,
         finalize: bool = False,
     ) -> SendResult:
-        """Edit a previously sent Feishu text/post message."""
+        """Edit a previously sent Feishu text/post message.
+
+        When streaming cards are active and *message_id* corresponds to a
+        card_id tracked in ``_streaming_cards``, the edit is routed through
+        the cardkit element-content API instead of the IM v1 message update.
+        """
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
+        # --- Streaming card edit path ----------------------------------------
+        card_state = self._streaming_cards.get(chat_id, {}).get(message_id)
+        if card_state is not None:
+            return await self._edit_streaming_card(
+                chat_id=chat_id,
+                card_id=message_id,
+                content=content,
+                card_state=card_state,
+                finalize=finalize,
+            )
+
+        # --- Existing IM v1 update path --------------------------------------
         content = self.format_message(content)
         try:
             msg_type, payload = self._build_outbound_payload(content)
@@ -1862,6 +1942,304 @@ class FeishuAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.error("[Feishu] Failed to edit message %s: %s", message_id, exc, exc_info=True)
             return SendResult(success=False, error=str(exc))
+
+    # =========================================================================
+    # Streaming card helpers (cardkit v1, schema 2.0)
+    # =========================================================================
+
+    def _build_streaming_card_json(
+        self,
+        initial_content: str = "",
+        model_name: str = "",
+        context_pct: Optional[int] = None,
+    ) -> str:
+        """Build a cardkit v1 schema-2.0 JSON string with streaming enabled.
+
+        *model_name* and *context_pct* are displayed in the card header's
+        subtitle when provided, giving users visibility into which model
+        is responding and how much of the context window is consumed.
+        """
+        # Build subtitle from runtime info when available
+        subtitle_parts: list[str] = []
+        if model_name:
+            subtitle_parts.append(model_name)
+        if context_pct is not None:
+            subtitle_parts.append(f"ctx {context_pct}%")
+        subtitle = " · ".join(subtitle_parts) if subtitle_parts else ""
+
+        header: Dict[str, Any] = {
+            "title": {
+                "tag": "plain_text",
+                "content": "Hermes",
+            },
+            "template": "blue",
+            "ud_icon": {
+                "token": "larkco...rful",
+                "style": {"color": "blue"},
+            },
+        }
+        if subtitle:
+            header["subtitle"] = {
+                "tag": "plain_text",
+                "content": subtitle,
+            }
+
+        card: Dict[str, Any] = {
+            "schema": "2.0",
+            "header": header,
+            "config": {
+                "streaming_mode": True,
+                "summary": {"content": ""},
+                "streaming_config": {
+                    "print_frequency_ms": {"default": 70},
+                    "print_step": {"default": 1},
+                    "print_strategy": "fast",
+                },
+            },
+            "body": {
+                "elements": [
+                    {
+                        "tag": "markdown",
+                        "content": initial_content,
+                        "element_id": "markdown_1",
+                    }
+                ]
+            },
+        }
+        return json.dumps(card, ensure_ascii=False)
+
+    async def _send_streaming_card(
+        self,
+        *,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[SendResult]:
+        """Create a streaming card, send it, and write initial content.
+
+        Returns a SendResult on success, or None to signal the caller should
+        fall back to the post/text path.
+        """
+        if not self._client or not HAS_CARDKIT:
+            return None
+        try:
+            # Close any previously-open streaming cards for this chat before
+            # creating a new one (handles tool-progress → final-response
+            # handoff; mirrors dingtalk's _close_streaming_siblings).
+            await self._close_streaming_siblings(chat_id)
+
+            formatted = self.format_message(content)
+            truncated = formatted[: self.MAX_MESSAGE_LENGTH]
+
+            # Resolve runtime info for the card header subtitle.
+            # model_name: try metadata first, then read from gateway config.
+            # context_pct: from metadata if the caller injected it.
+            model_name = ""
+            context_pct: Optional[int] = None
+            if metadata:
+                model_name = metadata.get("_model", "")
+                context_pct = metadata.get("_context_pct")
+            if not model_name:
+                try:
+                    from gateway.run import _resolve_gateway_model
+                    model_name = _resolve_gateway_model()
+                except Exception:
+                    pass
+
+            card_json = self._build_streaming_card_json(
+                truncated, model_name=model_name, context_pct=context_pct,
+            )
+
+            # Step 1: Create card entity via cardkit v1
+            create_body = CreateCardRequestBody.builder() \
+                .type("card_json") \
+                .data(card_json) \
+                .build()
+            create_request = CreateCardRequest.builder() \
+                .request_body(create_body) \
+                .build()
+            create_response = await asyncio.to_thread(
+                self._client.cardkit.v1.card.create, create_request,
+            )
+            if not self._response_succeeded(create_response):
+                logger.warning(
+                    "[Feishu] cardkit create failed: %s",
+                    getattr(create_response, "msg", "unknown"),
+                )
+                return None
+
+            card_id = self._extract_response_field(create_response, "card_id")
+            if not card_id:
+                logger.warning("[Feishu] cardkit create returned no card_id")
+                return None
+
+            # Step 2: Send interactive message referencing the card entity
+            interactive_content = json.dumps(
+                {"type": "card", "data": {"card_id": card_id}},
+                ensure_ascii=False,
+            )
+
+            # Determine receive_id for the message
+            receive_id = chat_id
+            receive_id_type = "chat_id"
+            if chat_id.startswith("feishu_user_id:"):
+                receive_id = chat_id.split(":", 1)[1]
+                receive_id_type = "user_id"
+            elif chat_id.startswith("ou_"):
+                receive_id_type = "open_id"
+
+            msg_body = self._build_create_message_body(
+                receive_id=receive_id,
+                msg_type="interactive",
+                content=interactive_content,
+                uuid_value=str(uuid.uuid4()),
+            )
+            msg_request = self._build_create_message_request(receive_id_type, msg_body)
+            msg_response = await asyncio.to_thread(
+                self._client.im.v1.message.create, msg_request,
+            )
+            if not self._response_succeeded(msg_response):
+                logger.warning(
+                    "[Feishu] Interactive card message send failed: %s",
+                    getattr(msg_response, "msg", "unknown"),
+                )
+                return None
+
+            # Track streaming state (sequence starts at 1 — the initial
+            # content was already baked into the card JSON).
+            self._streaming_cards.setdefault(chat_id, {})[card_id] = {
+                "sequence": 1,
+                "message_id": self._extract_response_field(msg_response, "message_id"),
+                "streaming": True,
+            }
+
+            logger.debug("[Feishu] Streaming card created: card_id=%s", card_id)
+            return SendResult(success=True, message_id=card_id)
+
+        except Exception as exc:
+            logger.warning(
+                "[Feishu] Streaming card send failed: %s", exc, exc_info=True,
+            )
+            return None
+
+    async def _edit_streaming_card(
+        self,
+        *,
+        chat_id: str,
+        card_id: str,
+        content: str,
+        card_state: Dict[str, Any],
+        finalize: bool = False,
+    ) -> SendResult:
+        """Push updated text content to a streaming card element.
+
+        Uses the cardkit v1 element-content API with an incrementing sequence
+        number.  On ``finalize=True`` the streaming mode is closed.
+        """
+        if not HAS_CARDKIT:
+            return SendResult(success=False, error="cardkit SDK not available")
+        try:
+            formatted = self.format_message(content)
+            truncated = formatted[: self.MAX_MESSAGE_LENGTH]
+            sequence = card_state.get("sequence", 0) + 1
+
+            body = ContentCardElementRequestBody.builder() \
+                .content(truncated) \
+                .sequence(sequence) \
+                .uuid(str(uuid.uuid4())) \
+                .build()
+            request = ContentCardElementRequest.builder() \
+                .card_id(card_id) \
+                .element_id("markdown_1") \
+                .request_body(body) \
+                .build()
+            response = await asyncio.to_thread(
+                self._client.cardkit.v1.card_element.content, request,
+            )
+            if not self._response_succeeded(response):
+                logger.warning(
+                    "[Feishu] Streaming card content update failed: %s",
+                    getattr(response, "msg", "unknown"),
+                )
+                return SendResult(success=False, error="card content update failed")
+
+            # Update tracked sequence
+            card_state["sequence"] = sequence
+
+            if finalize:
+                await self._close_streaming_card(chat_id, card_id)
+
+            return SendResult(success=True, message_id=card_id)
+
+        except Exception as exc:
+            logger.warning(
+                "[Feishu] Streaming card edit failed: %s", exc, exc_info=True,
+            )
+            return SendResult(success=False, error=str(exc))
+
+    async def _close_streaming_card(
+        self,
+        chat_id: str,
+        card_id: str,
+        *,
+        card_state: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Close a card's streaming mode and remove it from tracking.
+
+        *card_state* can be passed directly when the caller has already
+        popped the cards dict from ``_streaming_cards`` (e.g.
+        ``_close_streaming_siblings``).  When omitted the state is read
+        from ``self._streaming_cards``.
+        """
+        if HAS_CARDKIT:
+            try:
+                # Get the current sequence for this card (need strict increment)
+                if card_state is None:
+                    card_state = self._streaming_cards.get(chat_id, {}).get(card_id, {})
+                seq = card_state.get("sequence", 0) + 1
+
+                config = Config.builder() \
+                    .streaming_mode(False) \
+                    .build()
+                settings = Settings.builder() \
+                    .config(config) \
+                    .build()
+                settings_body = SettingsCardRequestBody.builder() \
+                    .settings(settings) \
+                    .sequence(seq) \
+                    .uuid(str(uuid.uuid4())) \
+                    .build()
+                settings_request = SettingsCardRequest.builder() \
+                    .card_id(card_id) \
+                    .request_body(settings_body) \
+                    .build()
+                await asyncio.to_thread(
+                    self._client.cardkit.v1.card.settings, settings_request,
+                )
+            except Exception as exc:
+                logger.debug(
+                    "[Feishu] Streaming card close failed (non-fatal): %s", exc,
+                )
+        # Remove from tracking
+        self._streaming_cards.get(chat_id, {}).pop(card_id, None)
+        if not self._streaming_cards.get(chat_id):
+            self._streaming_cards.pop(chat_id, None)
+
+    async def _close_streaming_siblings(self, chat_id: str) -> None:
+        """Finalize all open streaming cards for *chat_id*.
+
+        Called before creating a new card so that tool-progress or commentary
+        cards don't linger in streaming state.
+        """
+        cards = self._streaming_cards.pop(chat_id, None)
+        if not cards:
+            return
+        # We already popped the cards dict from _streaming_cards, so we
+        # must pass the saved state directly to _close_streaming_card
+        # rather than letting it re-read from the (now-empty) tracking dict.
+        for card_id, card_state in cards.items():
+            await self._close_streaming_card(chat_id, card_id, card_state=card_state)
 
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str,

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1440,10 +1440,10 @@ class FeishuAdapter(BasePlatformAdapter):
 
     supports_code_blocks = True  # Feishu renders fenced code blocks
 
-    # When True, outgoing messages use cardkit v1 streaming cards (schema 2.0)
-    # so the stream_consumer can perform card-level streaming updates instead
-    # of progressive post/text edits.  Set dynamically from settings.
-    REQUIRES_EDIT_FINALIZE: bool = False
+    @property
+    def REQUIRES_EDIT_FINALIZE(self) -> bool:
+        """Whether the adapter needs explicit finalize calls for streaming cards."""
+        return self._streaming_card_enabled and HAS_CARDKIT
 
     MAX_MESSAGE_LENGTH = 8000
     # Max distinct chat IDs retained in _chat_locks before LRU eviction kicks in.
@@ -1508,9 +1508,12 @@ class FeishuAdapter(BasePlatformAdapter):
         # by create, so we cache it per message_id.
         self._pending_processing_reactions: "OrderedDict[str, str]" = OrderedDict()
         self._load_seen_message_ids()
-        # Streaming card state: chat_id -> {card_id -> {sequence, message_id, streaming}}.
+        # Streaming card state: chat_id -> {card_id -> {sequence, message_id}}.
         # Tracks cardkit v1 cards currently in streaming mode per chat.
         self._streaming_cards: Dict[str, Dict[str, Dict[str, Any]]] = {}
+        # Card IDs of streaming cards that have been closed, used to distinguish
+        # "card already closed" from "IM message edit failure" in edit_message.
+        self._closed_streaming_card_ids: "OrderedDict[str, None]" = OrderedDict()
 
     @staticmethod
     def _load_settings(extra: Dict[str, Any]) -> FeishuAdapterSettings:
@@ -1648,7 +1651,6 @@ class FeishuAdapter(BasePlatformAdapter):
         self._allow_bots = settings.allow_bots
         self._require_mention = settings.require_mention
         self._streaming_card_enabled = settings.streaming_card_enabled
-        self.REQUIRES_EDIT_FINALIZE = self._streaming_card_enabled
         logger.info(
             "[Feishu] Streaming card config: enabled=%s HAS_CARDKIT=%s REQUIRES_EDIT_FINALIZE=%s bot_name=%r",
             self._streaming_card_enabled, HAS_CARDKIT, self.REQUIRES_EDIT_FINALIZE, getattr(self, '_bot_name', '?'),
@@ -1688,6 +1690,11 @@ class FeishuAdapter(BasePlatformAdapter):
 
     async def connect(self) -> bool:
         """Connect to Feishu/Lark."""
+        # Clear stale streaming card state from a prior connection lifecycle
+        # (e.g. if disconnect raised before reaching the cleanup path).
+        self._streaming_cards.clear()
+        self._closed_streaming_card_ids.clear()
+
         if not FEISHU_AVAILABLE:
             logger.error("[Feishu] lark-oapi not installed")
             return False
@@ -1924,14 +1931,13 @@ class FeishuAdapter(BasePlatformAdapter):
                 finalize=finalize,
             )
 
-        # When streaming cards are enabled, the message_id may be a card_id
-        # that was already closed by a prior finalize call (e.g. the
-        # stream_consumer's got_done path first edits with finalize=True
-        # in the mid-stream update, then attempts a second finalize in the
-        # dedicated got_done block).  Returning success here prevents the
-        # caller from treating the missing card as an edit failure and
-        # falling back to a full send, which would duplicate the response.
-        if self._streaming_card_enabled and finalize:
+        # When a streaming card_id was already closed by a prior finalize call
+        # (e.g. the stream_consumer's got_done path double-finalizes), return
+        # success to prevent the caller from duplicating the response with a
+        # full send.  We only do this for known card_ids so that real IM v1
+        # edit failures for non-card messages (e.g. progress messages, fallback
+        # post/text) are not silently swallowed.
+        if finalize and message_id in self._closed_streaming_card_ids:
             logger.info(
                 "[Feishu] Streaming card %s already closed; treating finalize as success",
                 message_id,
@@ -1979,8 +1985,7 @@ class FeishuAdapter(BasePlatformAdapter):
         meaningful preview instead of the default ``[生成中...]``.
         """
         # Strip markdown formatting for the chat-list preview.
-        import re as _re
-        preview_text = _re.sub(r"[#*`_~\[\]()>|]", "", initial_content).strip()
+        preview_text = re.sub(r"[#*`_~\[\]()>|]", "", initial_content).strip()
         preview_text = preview_text.replace("\n", " ")[:60].strip()
 
         _display_name = bot_name or "Hermes"
@@ -2072,7 +2077,7 @@ class FeishuAdapter(BasePlatformAdapter):
             await self._close_streaming_siblings(chat_id)
 
             formatted = self.format_message(content)
-            truncated = formatted[: self.MAX_MESSAGE_LENGTH]
+            truncated = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)[0]
             card_json = self._build_streaming_card_json(truncated, bot_name=self._bot_name)
 
             # Step 1: Create card entity via cardkit v1
@@ -2098,30 +2103,18 @@ class FeishuAdapter(BasePlatformAdapter):
                 logger.warning("[Feishu] cardkit create returned no card_id")
                 return None
 
-            # Step 2: Send interactive message referencing the card entity
+            # Step 2: Send interactive message referencing the card entity.
+            # Use _feishu_send_with_retry for reply_to/thread support and retry.
             interactive_content = json.dumps(
                 {"type": "card", "data": {"card_id": card_id}},
                 ensure_ascii=False,
             )
-
-            # Determine receive_id for the message
-            receive_id = chat_id
-            receive_id_type = "chat_id"
-            if chat_id.startswith("feishu_user_id:"):
-                receive_id = chat_id.split(":", 1)[1]
-                receive_id_type = "user_id"
-            elif chat_id.startswith("ou_"):
-                receive_id_type = "open_id"
-
-            msg_body = self._build_create_message_body(
-                receive_id=receive_id,
+            msg_response = await self._feishu_send_with_retry(
+                chat_id=chat_id,
                 msg_type="interactive",
-                content=interactive_content,
-                uuid_value=str(uuid.uuid4()),
-            )
-            msg_request = self._build_create_message_request(receive_id_type, msg_body)
-            msg_response = await asyncio.to_thread(
-                self._client.im.v1.message.create, msg_request,
+                payload=interactive_content,
+                reply_to=reply_to,
+                metadata=metadata,
             )
             if not self._response_succeeded(msg_response):
                 logger.warning(
@@ -2135,7 +2128,6 @@ class FeishuAdapter(BasePlatformAdapter):
             self._streaming_cards.setdefault(chat_id, {})[card_id] = {
                 "sequence": 1,
                 "message_id": self._extract_response_field(msg_response, "message_id"),
-                "streaming": True,
             }
 
             logger.info("[Feishu] Streaming card created: card_id=%s msg_id=%s", card_id, self._extract_response_field(msg_response, "message_id"))
@@ -2165,7 +2157,7 @@ class FeishuAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="cardkit SDK not available")
         try:
             formatted = self.format_message(content)
-            truncated = formatted[: self.MAX_MESSAGE_LENGTH]
+            truncated = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)[0]
             sequence = card_state.get("sequence", 0) + 1
 
             body = ContentCardElementRequestBody.builder() \
@@ -2192,7 +2184,7 @@ class FeishuAdapter(BasePlatformAdapter):
             card_state["sequence"] = sequence
 
             if finalize:
-                await self._close_streaming_card(chat_id, card_id)
+                await self._close_streaming_card(chat_id, card_id, card_state=card_state)
 
             return SendResult(success=True, message_id=card_id)
 
@@ -2245,10 +2237,13 @@ class FeishuAdapter(BasePlatformAdapter):
                 logger.debug(
                     "[Feishu] Streaming card close failed (non-fatal): %s", exc,
                 )
-        # Remove from tracking
+        # Remove from tracking and record as closed
         self._streaming_cards.get(chat_id, {}).pop(card_id, None)
         if not self._streaming_cards.get(chat_id):
             self._streaming_cards.pop(chat_id, None)
+        self._closed_streaming_card_ids[card_id] = None
+        if len(self._closed_streaming_card_ids) > 500:
+            self._closed_streaming_card_ids.popitem(last=False)
 
     async def _close_streaming_siblings(self, chat_id: str) -> None:
         """Finalize all open streaming cards for *chat_id*.

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2141,6 +2141,7 @@ class FeishuAdapter(BasePlatformAdapter):
             self._streaming_cards.setdefault(chat_id, {})[card_id] = {
                 "sequence": 1,
                 "message_id": self._extract_response_field(msg_response, "message_id"),
+                "last_content": truncated,
             }
 
             logger.info("[Feishu] Streaming card created: card_id=%s msg_id=%s", card_id, self._extract_response_field(msg_response, "message_id"))
@@ -2246,7 +2247,7 @@ class FeishuAdapter(BasePlatformAdapter):
         card: Dict[str, Any] = {
             "schema": "2.0",
             "header": header,
-            "config": {"streaming_mode": True},
+            "config": {"streaming_mode": False},
             "body": {
                 "elements": [
                     {
@@ -2296,7 +2297,7 @@ class FeishuAdapter(BasePlatformAdapter):
             )
             card_state["sequence"] = seq
         except Exception as exc:
-            logger.debug("[Feishu] Card header update failed (non-fatal): %s", exc)
+            logger.warning("[Feishu] Card header update failed (non-fatal): %s", exc)
 
     async def _close_streaming_card(
         self,
@@ -2316,16 +2317,13 @@ class FeishuAdapter(BasePlatformAdapter):
         """
         if HAS_CARDKIT:
             try:
-                # Get the current sequence for this card (need strict increment)
                 if card_state is None:
                     card_state = self._streaming_cards.get(chat_id, {}).get(card_id, {})
-                # Update header to reflect completion/error status
-                await self._update_card_header(
-                    card_id, card_state,
-                    bot_name=self._bot_name, status=status, error_summary=error_summary,
-                )
-                seq = card_state.get("sequence", 0) + 1
 
+                # Step 1: Close streaming mode FIRST (settings API).
+                # This freezes the card body so no more element-content
+                # updates can race with the header update below.
+                seq = card_state.get("sequence", 0) + 1
                 config = Config.builder() \
                     .streaming_mode(False) \
                     .build()
@@ -2344,9 +2342,26 @@ class FeishuAdapter(BasePlatformAdapter):
                 await asyncio.to_thread(
                     self._client.cardkit.v1.card.settings, settings_request,
                 )
+                card_state["sequence"] = seq
+
+                # Step 2: Update header (card.update PUT).
+                # Only attempt if we have content to preserve — otherwise
+                # skip to avoid wiping the card body with empty content.
+                last_content = card_state.get("last_content", "")
+                if last_content:
+                    await self._update_card_header(
+                        card_id, card_state,
+                        bot_name=self._bot_name, status=status,
+                        error_summary=error_summary,
+                    )
+                else:
+                    logger.debug(
+                        "[Feishu] Skipping header update for card %s: no last_content",
+                        card_id,
+                    )
             except Exception as exc:
-                logger.debug(
-                    "[Feishu] Streaming card close failed (non-fatal): %s", exc,
+                logger.warning(
+                    "[Feishu] Streaming card close failed: %s", exc,
                 )
         # Remove from tracking and record as closed
         self._streaming_cards.get(chat_id, {}).pop(card_id, None)

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2193,8 +2193,9 @@ class FeishuAdapter(BasePlatformAdapter):
                 )
                 return SendResult(success=False, error="card content update failed")
 
-            # Update tracked sequence
+            # Update tracked sequence and last content
             card_state["sequence"] = sequence
+            card_state["last_content"] = truncated
 
             if finalize:
                 await self._close_streaming_card(chat_id, card_id, card_state=card_state)
@@ -2213,6 +2214,7 @@ class FeishuAdapter(BasePlatformAdapter):
         bot_name: str = "Hermes",
         status: str = "completed",
         error_summary: str = "",
+        last_content: str = "",
     ) -> str:
         """Build a card JSON with status-appropriate header for post-stream update."""
         _display_name = bot_name or "Hermes"
@@ -2245,7 +2247,15 @@ class FeishuAdapter(BasePlatformAdapter):
             "schema": "2.0",
             "header": header,
             "config": {"streaming_mode": True},
-            "body": {"elements": []},
+            "body": {
+                "elements": [
+                    {
+                        "tag": "markdown",
+                        "content": last_content,
+                        "element_id": "markdown_1",
+                    }
+                ]
+            },
         }
         return json.dumps(card, ensure_ascii=False)
 
@@ -2265,6 +2275,7 @@ class FeishuAdapter(BasePlatformAdapter):
             seq = card_state.get("sequence", 0) + 1
             card_json = self._build_finalized_header_json(
                 bot_name=bot_name, status=status, error_summary=error_summary,
+                last_content=card_state.get("last_content", ""),
             )
             from lark_oapi.api.cardkit.v1.model import Card as CardKitCard
             card_obj = CardKitCard.builder() \

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2476,6 +2476,8 @@ class FeishuAdapter(BasePlatformAdapter):
         if len(self._closed_streaming_card_ids) > 500:
             self._closed_streaming_card_ids.popitem(last=False)
         self._transition_card_phase(chat_id, target_phase)
+        # Reset to IDLE so the next turn can create a new card.
+        self._card_phases[chat_id] = _CardPhase.IDLE
 
     async def _close_streaming_siblings(self, chat_id: str) -> None:
         """Finalize all open streaming cards for *chat_id*.

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2342,9 +2342,11 @@ class FeishuAdapter(BasePlatformAdapter):
             "text_tag_list": tags,
             "template": template,
             "ud_icon": {"token": "larkcommunity_colorful", "style": {"color": icon_color}},
+            # Always include subtitle — explicitly clears the "正在思考..."
+            # placeholder from the streaming header.  Omitting the field
+            # causes the Feishu PUT to preserve the old subtitle value.
+            "subtitle": subtitle if subtitle else {"tag": "plain_text", "content": ""},
         }
-        if subtitle:
-            header["subtitle"] = subtitle
 
         card: Dict[str, Any] = {
             "schema": "2.0",

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1649,6 +1649,10 @@ class FeishuAdapter(BasePlatformAdapter):
         self._require_mention = settings.require_mention
         self._streaming_card_enabled = settings.streaming_card_enabled
         self.REQUIRES_EDIT_FINALIZE = self._streaming_card_enabled
+        logger.info(
+            "[Feishu] Streaming card config: enabled=%s HAS_CARDKIT=%s REQUIRES_EDIT_FINALIZE=%s bot_name=%r",
+            self._streaming_card_enabled, HAS_CARDKIT, self.REQUIRES_EDIT_FINALIZE, getattr(self, '_bot_name', '?'),
+        )
 
     def _build_event_handler(self) -> Any:
         if EventDispatcherHandler is None:
@@ -2038,6 +2042,10 @@ class FeishuAdapter(BasePlatformAdapter):
         if not self._client or not HAS_CARDKIT:
             return None
         try:
+            # Best-effort hydrate bot name on first streaming card use.
+            if not getattr(self, "_bot_name", ""):
+                await self._hydrate_bot_identity()
+
             # --- Card reuse: if this chat already has an active streaming
             # card, update it in-place instead of closing + recreating.
             # This handles the tool-boundary case where stream_consumer
@@ -4671,6 +4679,7 @@ class FeishuAdapter(BasePlatformAdapter):
                             "[Feishu] FEISHU_BOT_NAME differs from /bot/v3/info; using hydrated bot name for group @mention gating."
                         )
                     self._bot_name = bot_name
+                    logger.info("[Feishu] Bot identity hydrated: bot_name=%r open_id=%r", bot_name, open_id[:8] if open_id else "")
         except Exception:
             logger.debug(
                 "[Feishu] /bot/v3/info probe failed during hydration",

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1840,6 +1840,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 metadata=metadata,
             )
             if result is not None:
+                logger.info("[Feishu] send() → streaming card path: success=%s msg_id=%s", result.success, result.message_id)
                 return result
             # Streaming card failed — fall through to post/text below.
             logger.warning("[Feishu] Streaming card send failed; falling back to post/text")
@@ -1927,7 +1928,7 @@ class FeishuAdapter(BasePlatformAdapter):
         # caller from treating the missing card as an edit failure and
         # falling back to a full send, which would duplicate the response.
         if self._streaming_card_enabled and finalize:
-            logger.debug(
+            logger.info(
                 "[Feishu] Streaming card %s already closed; treating finalize as success",
                 message_id,
             )
@@ -2105,7 +2106,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 "streaming": True,
             }
 
-            logger.debug("[Feishu] Streaming card created: card_id=%s", card_id)
+            logger.info("[Feishu] Streaming card created: card_id=%s msg_id=%s", card_id, self._extract_response_field(msg_response, "message_id"))
             return SendResult(success=True, message_id=card_id)
 
         except Exception as exc:

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1965,6 +1965,8 @@ class FeishuAdapter(BasePlatformAdapter):
     @staticmethod
     def _build_streaming_card_json(
         initial_content: str = "",
+        *,
+        bot_name: str = "Hermes",
     ) -> str:
         """Build a cardkit v1 schema-2.0 JSON string with streaming enabled.
 
@@ -1977,12 +1979,14 @@ class FeishuAdapter(BasePlatformAdapter):
         preview_text = _re.sub(r"[#*`_~\[\]()>|]", "", initial_content).strip()
         preview_text = preview_text.replace("\n", " ")[:60].strip()
 
+        _display_name = bot_name or "Hermes"
+
         card: Dict[str, Any] = {
             "schema": "2.0",
             "header": {
                 "title": {
                     "tag": "lark_md",
-                    "content": "🪶 Hermes",
+                    "content": f"🪶 {_display_name}",
                 },
                 "text_tag_list": [
                     {
@@ -2034,14 +2038,38 @@ class FeishuAdapter(BasePlatformAdapter):
         if not self._client or not HAS_CARDKIT:
             return None
         try:
+            # --- Card reuse: if this chat already has an active streaming
+            # card, update it in-place instead of closing + recreating.
+            # This handles the tool-boundary case where stream_consumer
+            # resets _message_id to None (got_segment_break), causing
+            # send() to be called again within the same turn.
+            existing = self._streaming_cards.get(chat_id)
+            if existing:
+                card_id, card_state = next(iter(existing.items()))
+                result = await self._edit_streaming_card(
+                    chat_id=chat_id,
+                    card_id=card_id,
+                    content=content,
+                    card_state=card_state,
+                    finalize=False,
+                )
+                if result.success:
+                    logger.info(
+                        "[Feishu] Reused existing streaming card: card_id=%s seq=%s",
+                        card_id, card_state.get("sequence"),
+                    )
+                    return result
+                # Edit failed — fall through to create a new card.
+                logger.warning("[Feishu] Streaming card reuse edit failed; creating new card")
+
             # Close any previously-open streaming cards for this chat before
-            # creating a new one (handles tool-progress → final-response
-            # handoff; mirrors dingtalk's _close_streaming_siblings).
+            # creating a new one (only reached when no active card exists or
+            # reuse failed).
             await self._close_streaming_siblings(chat_id)
 
             formatted = self.format_message(content)
             truncated = formatted[: self.MAX_MESSAGE_LENGTH]
-            card_json = self._build_streaming_card_json(truncated)
+            card_json = self._build_streaming_card_json(truncated, bot_name=self._bot_name)
 
             # Step 1: Create card entity via cardkit v1
             create_body = CreateCardRequestBody.builder() \

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -151,11 +151,11 @@ class _CardPhase(int):
 
 _PHASE_TRANSITIONS: Dict[int, set] = {
     _CardPhase.IDLE: {_CardPhase.CREATING},
-    _CardPhase.CREATING: {_CardPhase.STREAMING, _CardPhase.CREATION_FAILED, _CardPhase.TERMINATED},
+    _CardPhase.CREATING: {_CardPhase.STREAMING, _CardPhase.CREATION_FAILED, _CardPhase.TERMINATED, _CardPhase.IDLE},
     _CardPhase.STREAMING: {_CardPhase.COMPLETED, _CardPhase.ABORTED, _CardPhase.TERMINATED},
-    _CardPhase.COMPLETED: set(),
-    _CardPhase.ABORTED: set(),
-    _CardPhase.TERMINATED: set(),
+    _CardPhase.COMPLETED: {_CardPhase.IDLE},
+    _CardPhase.ABORTED: {_CardPhase.IDLE},
+    _CardPhase.TERMINATED: {_CardPhase.IDLE},
     _CardPhase.CREATION_FAILED: {_CardPhase.IDLE},
 }
 
@@ -311,6 +311,7 @@ _FEISHU_REACTION_FAILURE = "CrossMark"
 # delete-failures, not a capacity plan.
 _FEISHU_PROCESSING_REACTION_CACHE_SIZE = 1024
 _FEISHU_MESSAGE_TEXT_CACHE_SIZE = 512       # LRU cap for reply-context message text lookups
+_FEISHU_CLOSED_CARD_CACHE_SIZE = 500       # max tracked closed streaming card IDs (dedup)
 
 # QR onboarding constants
 _ONBOARD_ACCOUNTS_URLS = {
@@ -1906,6 +1907,14 @@ class FeishuAdapter(BasePlatformAdapter):
             # Streaming card failed — fall through to post/text below.
             logger.warning("[Feishu] Streaming card send failed; falling back to post/text")
 
+        # --- Close any orphaned streaming card before post/text ----------------
+        # If a streaming card is still open for this chat (e.g. fallback path
+        # after edit failures, or CancelledError), close it so it doesn't get
+        # stuck in loading state alongside the new post/text message.
+        if self._streaming_card_enabled and self._streaming_cards.get(chat_id):
+            logger.info("[Feishu] Closing orphaned streaming card for chat=%s before post/text send", chat_id)
+            await self._close_streaming_siblings(chat_id)
+
         # --- Existing post/text path -----------------------------------------
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
@@ -1960,6 +1969,7 @@ class FeishuAdapter(BasePlatformAdapter):
         content: str,
         *,
         finalize: bool = False,
+        is_turn_final: bool = True,
     ) -> SendResult:
         """Edit a previously sent Feishu text/post message.
 
@@ -1973,12 +1983,14 @@ class FeishuAdapter(BasePlatformAdapter):
         # --- Streaming card edit path ----------------------------------------
         card_state = self._streaming_cards.get(chat_id, {}).get(message_id)
         if card_state is not None:
+            real_card_id = card_state.get("card_id", message_id)
             return await self._edit_streaming_card(
                 chat_id=chat_id,
-                card_id=message_id,
+                card_id=real_card_id,
                 content=content,
                 card_state=card_state,
                 finalize=finalize,
+                is_turn_final=is_turn_final,
             )
 
         # When a streaming card_id was already closed by a prior finalize call
@@ -2157,10 +2169,11 @@ class FeishuAdapter(BasePlatformAdapter):
             # send() to be called again within the same turn.
             existing = self._streaming_cards.get(chat_id)
             if existing:
-                card_id, card_state = next(iter(existing.items()))
+                _, card_state = next(iter(existing.items()))
+                real_card_id = card_state.get("card_id", next(iter(existing)))
                 result = await self._edit_streaming_card(
                     chat_id=chat_id,
-                    card_id=card_id,
+                    card_id=real_card_id,
                     content=content,
                     card_state=card_state,
                     finalize=False,
@@ -2168,7 +2181,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 if result.success:
                     logger.info(
                         "[Feishu] Reused existing streaming card: card_id=%s seq=%s",
-                        card_id, card_state.get("sequence"),
+                        real_card_id, card_state.get("sequence"),
                     )
                     return result
                 # Edit failed — close the stale card before creating new one.
@@ -2199,13 +2212,13 @@ class FeishuAdapter(BasePlatformAdapter):
                     "[Feishu] cardkit create failed: %s",
                     getattr(create_response, "msg", "unknown"),
                 )
-                self._transition_card_phase(chat_id, _CardPhase.CREATION_FAILED)
+                self._transition_card_phase(chat_id, _CardPhase.IDLE)
                 return None
 
             card_id = self._extract_response_field(create_response, "card_id")
             if not card_id:
                 logger.warning("[Feishu] cardkit create returned no card_id")
-                self._transition_card_phase(chat_id, _CardPhase.CREATION_FAILED)
+                self._transition_card_phase(chat_id, _CardPhase.IDLE)
                 return None
 
             # Step 2: Send interactive message referencing the card entity.
@@ -2225,24 +2238,32 @@ class FeishuAdapter(BasePlatformAdapter):
                     "[Feishu] Interactive card message send failed: %s",
                     getattr(msg_response, "msg", "unknown"),
                 )
-                self._transition_card_phase(chat_id, _CardPhase.CREATION_FAILED)
+                self._transition_card_phase(chat_id, _CardPhase.IDLE)
                 return None
 
             # Track streaming state (sequence starts at 1 — the initial
             # content was already baked into the card JSON).
-            self._streaming_cards.setdefault(chat_id, {})[card_id] = {
+            im_message_id = self._extract_response_field(msg_response, "message_id")
+            card_state = {
+                "card_id": card_id,
                 "sequence": 1,
-                "message_id": self._extract_response_field(msg_response, "message_id"),
+                "message_id": im_message_id,
                 "last_content": truncated,
                 "created_at": time.monotonic(),
             }
+            cards_dict = self._streaming_cards.setdefault(chat_id, {})
+            cards_dict[card_id] = card_state
+            # Also index by IM message_id so edit_message can find the card
+            # when stream_consumer passes the IM message_id back.
+            if im_message_id and im_message_id != card_id:
+                cards_dict[im_message_id] = card_state
             self._transition_card_phase(chat_id, _CardPhase.STREAMING)
 
-            logger.info("[Feishu] Streaming card created: card_id=%s msg_id=%s", card_id, self._extract_response_field(msg_response, "message_id"))
-            return SendResult(success=True, message_id=card_id)
+            logger.info("[Feishu] Streaming card created: card_id=%s msg_id=%s", card_id, im_message_id)
+            return SendResult(success=True, message_id=im_message_id or card_id)
 
         except Exception as exc:
-            self._transition_card_phase(chat_id, _CardPhase.CREATION_FAILED)
+            self._transition_card_phase(chat_id, _CardPhase.IDLE)
             logger.warning(
                 "[Feishu] Streaming card send failed: %s", exc, exc_info=True,
             )
@@ -2256,11 +2277,14 @@ class FeishuAdapter(BasePlatformAdapter):
         content: str,
         card_state: Dict[str, Any],
         finalize: bool = False,
+        is_turn_final: bool = True,
     ) -> SendResult:
         """Push updated text content to a streaming card element.
 
         Uses the cardkit v1 element-content API with an incrementing sequence
-        number.  On ``finalize=True`` the streaming mode is closed.
+        number.  On ``finalize=True AND is_turn_final=True`` the streaming
+        mode is closed.  Segment-break finalizes (tool boundaries) keep the
+        card open for reuse by the next segment.
         """
         if not HAS_CARDKIT:
             return SendResult(success=False, error="cardkit SDK not available")
@@ -2293,7 +2317,7 @@ class FeishuAdapter(BasePlatformAdapter):
             card_state["sequence"] = sequence
             card_state["last_content"] = truncated
 
-            if finalize:
+            if finalize and is_turn_final:
                 await self._close_streaming_card(chat_id, card_id, card_state=card_state)
 
             return SendResult(success=True, message_id=card_id)
@@ -2469,14 +2493,22 @@ class FeishuAdapter(BasePlatformAdapter):
                     "[Feishu] Streaming card close failed: %s", exc,
                 )
         # Remove from tracking and record as closed
-        self._streaming_cards.get(chat_id, {}).pop(card_id, None)
-        if not self._streaming_cards.get(chat_id):
-            self._streaming_cards.pop(chat_id, None)
+        chat_cards = self._streaming_cards.get(chat_id)
+        if chat_cards:
+            # Remove both the card_id key and the IM message_id alias.
+            im_msg_id = card_state.get("message_id") if card_state else None
+            chat_cards.pop(card_id, None)
+            if im_msg_id and im_msg_id != card_id:
+                chat_cards.pop(im_msg_id, None)
+            if not chat_cards:
+                self._streaming_cards.pop(chat_id, None)
         self._closed_streaming_card_ids[card_id] = None
-        if len(self._closed_streaming_card_ids) > 500:
+        if im_msg_id and im_msg_id != card_id:
+            self._closed_streaming_card_ids[im_msg_id] = None
+        while len(self._closed_streaming_card_ids) > _FEISHU_CLOSED_CARD_CACHE_SIZE:
             self._closed_streaming_card_ids.popitem(last=False)
         # Reset to IDLE so the next turn can create a new card.
-        self._card_phases[chat_id] = _CardPhase.IDLE
+        self._transition_card_phase(chat_id, _CardPhase.IDLE)
 
     async def _close_streaming_siblings(self, chat_id: str) -> None:
         """Finalize all open streaming cards for *chat_id*.
@@ -2487,11 +2519,16 @@ class FeishuAdapter(BasePlatformAdapter):
         cards = self._streaming_cards.pop(chat_id, None)
         if not cards:
             return
-        # We already popped the cards dict from _streaming_cards, so we
-        # must pass the saved state directly to _close_streaming_card
-        # rather than letting it re-read from the (now-empty) tracking dict.
-        for card_id, card_state in cards.items():
-            await self._close_streaming_card(chat_id, card_id, card_state=card_state)
+        # Dedup: multiple keys (card_id + IM message_id) may point to the
+        # same card_state object.  Close each unique card_state once.
+        seen_states = set()
+        for key, card_state in cards.items():
+            state_id = id(card_state)
+            if state_id in seen_states:
+                continue
+            seen_states.add(state_id)
+            real_card_id = card_state.get("card_id", key)
+            await self._close_streaming_card(chat_id, real_card_id, card_state=card_state)
 
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str,

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2508,7 +2508,12 @@ class FeishuAdapter(BasePlatformAdapter):
         while len(self._closed_streaming_card_ids) > _FEISHU_CLOSED_CARD_CACHE_SIZE:
             self._closed_streaming_card_ids.popitem(last=False)
         # Reset to IDLE so the next turn can create a new card.
-        self._transition_card_phase(chat_id, _CardPhase.IDLE)
+        # Two-step transition: current → COMPLETED/ABORTED → IDLE.
+        if not self._transition_card_phase(chat_id, target_phase):
+            # Already in a terminal state or IDLE; force to IDLE directly.
+            self._card_phases[chat_id] = _CardPhase.IDLE
+        else:
+            self._transition_card_phase(chat_id, _CardPhase.IDLE)
 
     async def _close_streaming_siblings(self, chat_id: str) -> None:
         """Finalize all open streaming cards for *chat_id*.

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -137,6 +137,8 @@ try:
         Settings,
         SettingsCardRequest,
         SettingsCardRequestBody,
+        UpdateCardRequest,
+        UpdateCardRequestBody,
     )
 
     HAS_CARDKIT = True
@@ -149,6 +151,8 @@ except (ImportError, AttributeError):
     Settings = None  # type: ignore[assignment,misc]
     SettingsCardRequest = None  # type: ignore[assignment,misc]
     SettingsCardRequestBody = None  # type: ignore[assignment,misc]
+    UpdateCardRequest = None  # type: ignore[assignment,misc]
+    UpdateCardRequestBody = None  # type: ignore[assignment,misc]
 
 FEISHU_WEBSOCKET_AVAILABLE = websockets is not None
 FEISHU_WEBHOOK_AVAILABLE = aiohttp is not None
@@ -1995,12 +1999,21 @@ class FeishuAdapter(BasePlatformAdapter):
             "header": {
                 "title": {
                     "tag": "lark_md",
-                    "content": f"🪶 {_display_name}",
+                    "content": f"\U0001f916 {_display_name}",
+                },
+                "subtitle": {
+                    "tag": "plain_text",
+                    "content": "正在思考...",
                 },
                 "text_tag_list": [
                     {
                         "tag": "text_tag",
                         "text": {"tag": "plain_text", "content": "AI"},
+                        "color": "blue",
+                    },
+                    {
+                        "tag": "text_tag",
+                        "text": {"tag": "plain_text", "content": "生成中"},
                         "color": "blue",
                     },
                 ],
@@ -2194,14 +2207,96 @@ class FeishuAdapter(BasePlatformAdapter):
             )
             return SendResult(success=False, error=str(exc))
 
+    @staticmethod
+    def _build_finalized_header_json(
+        *,
+        bot_name: str = "Hermes",
+        status: str = "completed",
+        error_summary: str = "",
+    ) -> str:
+        """Build a card JSON with status-appropriate header for post-stream update."""
+        _display_name = bot_name or "Hermes"
+        if status == "error":
+            template = "red"
+            icon_color = "red"
+            tags = [
+                {"tag": "text_tag", "text": {"tag": "plain_text", "content": "AI"}, "color": "red"},
+                {"tag": "text_tag", "text": {"tag": "plain_text", "content": "错误"}, "color": "red"},
+            ]
+            subtitle = {"tag": "plain_text", "content": error_summary[:80]} if error_summary else None
+        else:
+            template = "turquoise"
+            icon_color = "turquoise"
+            tags = [
+                {"tag": "text_tag", "text": {"tag": "plain_text", "content": "AI"}, "color": "turquoise"},
+            ]
+            subtitle = None
+
+        header: Dict[str, Any] = {
+            "title": {"tag": "lark_md", "content": f"\U0001f916 {_display_name}"},
+            "text_tag_list": tags,
+            "template": template,
+            "ud_icon": {"token": "larkcommunity_colorful", "style": {"color": icon_color}},
+        }
+        if subtitle:
+            header["subtitle"] = subtitle
+
+        card: Dict[str, Any] = {
+            "schema": "2.0",
+            "header": header,
+            "config": {"streaming_mode": True},
+            "body": {"elements": []},
+        }
+        return json.dumps(card, ensure_ascii=False)
+
+    async def _update_card_header(
+        self,
+        card_id: str,
+        card_state: Dict[str, Any],
+        *,
+        bot_name: str = "Hermes",
+        status: str = "completed",
+        error_summary: str = "",
+    ) -> None:
+        """Update the streaming card header to reflect completion/error status."""
+        if not HAS_CARDKIT:
+            return
+        try:
+            seq = card_state.get("sequence", 0) + 1
+            card_json = self._build_finalized_header_json(
+                bot_name=bot_name, status=status, error_summary=error_summary,
+            )
+            from lark_oapi.api.cardkit.v1.model import Card as CardKitCard
+            card_obj = CardKitCard.builder() \
+                .type("card_json") \
+                .data(card_json) \
+                .build()
+            body = UpdateCardRequestBody.builder() \
+                .card(card_obj) \
+                .sequence(seq) \
+                .uuid(str(uuid.uuid4())) \
+                .build()
+            request = UpdateCardRequest.builder() \
+                .card_id(card_id) \
+                .request_body(body) \
+                .build()
+            await asyncio.to_thread(
+                self._client.cardkit.v1.card.update, request,
+            )
+            card_state["sequence"] = seq
+        except Exception as exc:
+            logger.debug("[Feishu] Card header update failed (non-fatal): %s", exc)
+
     async def _close_streaming_card(
         self,
         chat_id: str,
         card_id: str,
         *,
         card_state: Optional[Dict[str, Any]] = None,
+        status: str = "completed",
+        error_summary: str = "",
     ) -> None:
-        """Close a card's streaming mode and remove it from tracking.
+        """Close a card's streaming mode and update header, then remove from tracking.
 
         *card_state* can be passed directly when the caller has already
         popped the cards dict from ``_streaming_cards`` (e.g.
@@ -2213,6 +2308,11 @@ class FeishuAdapter(BasePlatformAdapter):
                 # Get the current sequence for this card (need strict increment)
                 if card_state is None:
                     card_state = self._streaming_cards.get(chat_id, {}).get(card_id, {})
+                # Update header to reflect completion/error status
+                await self._update_card_header(
+                    card_id, card_state,
+                    bot_name=self._bot_name, status=status, error_summary=error_summary,
+                )
                 seq = card_state.get("sequence", 0) + 1
 
                 config = Config.builder() \

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -1386,11 +1386,13 @@ class GatewayStreamConsumer:
             else:
                 # First message — send new, threaded to the original user message
                 # so it lands in the correct topic/thread.
+                meta = dict(self.metadata) if self.metadata else {}
+                meta["streaming_card"] = True
                 result = await self.adapter.send(
                     chat_id=self.chat_id,
                     content=text,
                     reply_to=self._initial_reply_to_id,
-                    metadata=self.metadata,
+                    metadata=meta,
                 )
                 if result.success:
                     if result.message_id:

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -729,6 +729,7 @@ class GatewayStreamConsumer:
             return reply_to_id
         try:
             meta = dict(self.metadata) if self.metadata else {}
+            meta["streaming_card"] = True
             result = await self.adapter.send(
                 chat_id=self.chat_id,
                 content=text,

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -172,6 +172,18 @@ class GatewayStreamConsumer:
             getattr(adapter, "REQUIRES_EDIT_FINALIZE", False) is True
         )
 
+        # Cache adapter edit_message signature so we don't call
+        # inspect.signature on every edit (~14/sec during streaming).
+        try:
+            sig = inspect.signature(self.adapter.edit_message)
+            self._edit_params = sig.parameters
+            self._edit_has_var_keyword = any(
+                p.kind is inspect.Parameter.VAR_KEYWORD for p in self._edit_params.values()
+            )
+        except (TypeError, ValueError):
+            self._edit_params = {}
+            self._edit_has_var_keyword = False
+
         # Think-block filter state (mirrors CLI's _stream_delta tag suppression)
         self._in_think_block = False
         self._think_buffer = ""
@@ -217,6 +229,7 @@ class GatewayStreamConsumer:
         message_id: str,
         content: str,
         finalize: bool = False,
+        is_turn_final: bool = True,
     ):
         """Edit via the adapter, passing routing metadata when supported."""
         kwargs = {
@@ -228,16 +241,11 @@ class GatewayStreamConsumer:
         # must accept finalize= even when it is False (guarded by tests).
         kwargs["finalize"] = finalize
 
-        if self.metadata:
-            try:
-                params = inspect.signature(self.adapter.edit_message).parameters
-                if "metadata" in params or any(
-                    param.kind is inspect.Parameter.VAR_KEYWORD
-                    for param in params.values()
-                ):
-                    kwargs["metadata"] = self.metadata
-            except (TypeError, ValueError):
-                pass
+        # Only pass is_turn_final / metadata to adapters that accept them.
+        if self._edit_has_var_keyword or "is_turn_final" in self._edit_params:
+            kwargs["is_turn_final"] = is_turn_final
+        if self.metadata and (self._edit_has_var_keyword or "metadata" in self._edit_params):
+            kwargs["metadata"] = self.metadata
         return await self.adapter.edit_message(**kwargs)
 
     def on_segment_break(self) -> None:
@@ -728,8 +736,12 @@ class GatewayStreamConsumer:
         if not text.strip():
             return reply_to_id
         try:
+            # NOTE: Do NOT set streaming_card=True here.  Overflow split
+            # chunks each go through send() independently; if the Feishu
+            # streaming-card reuse path fires, it replaces (not appends)
+            # the card's markdown element, causing all but the last chunk
+            # to be lost.  Overflow chunks should use plain post/text.
             meta = dict(self.metadata) if self.metadata else {}
-            meta["streaming_card"] = True
             result = await self.adapter.send(
                 chat_id=self.chat_id,
                 content=text,
@@ -1281,6 +1293,7 @@ class GatewayStreamConsumer:
                         message_id=self._message_id,
                         content=text,
                         finalize=finalize,
+                        is_turn_final=is_turn_final,
                     )
                     if result.success:
                         self._already_sent = True

--- a/tests/gateway/test_stream_consumer_thread_routing.py
+++ b/tests/gateway/test_stream_consumer_thread_routing.py
@@ -103,7 +103,8 @@ class TestInitialReplyToId:
         await consumer._send_or_edit("Test")
 
         call_kwargs = adapter.send.call_args[1]
-        assert call_kwargs["metadata"] == metadata
+        assert call_kwargs["metadata"]["thread_id"] == "omt_topic789"
+        assert call_kwargs["metadata"]["streaming_card"] is True
 
 
 class TestOverflowFirstMessage:


### PR DESCRIPTION
## Summary

Implement Feishu streaming cards using the cardkit v1 API with schema 2.0, enabling typewriter-effect streaming output for AI responses in Feishu chats.

Closes #44184

## Changes

- **`send()`**: When `streaming_card_enabled=true`, creates a cardkit v1 card entity (schema 2.0, `streaming_mode: true`) → sends as `interactive` message → writes initial content. Falls back to `post`/`text` on any failure.
- **`edit_message()`**: Routes through cardkit `card_element.content` API with incrementing `sequence` for tracked streaming cards. Falls back to IM v1 `message.update` for non-card messages.
- **`REQUIRES_EDIT_FINALIZE`**: Dynamically set to `true` when streaming cards are enabled, so `stream_consumer` issues a final close call.
- **`disconnect()`**: Finalizes all open streaming cards before connection teardown.
- **`_streaming_cards`**: Per-chat state tracking (card_id → {sequence, message_id, streaming}).

## Architecture

Mirrors the DingTalk AI Card implementation (`gateway/platforms/dingtalk.py`, commit `4459913f4`):

```
send() → _send_streaming_card()
  ├── Step 1: POST cardkit/v1/cards (create card entity)
  ├── Step 2: POST im/v1/messages (interactive message with card_id)
  └── Track in _streaming_cards[chat_id][card_id]

edit_message() → _edit_streaming_card()
  ├── PUT cardkit/v1/cards/:id/elements/:id/content (full text + sequence++)
  └── On finalize: _close_streaming_card() (settings streaming_mode=false)

disconnect() → _close_streaming_siblings() for all chats
```

## Configuration

```yaml
feishu:
  streaming_card_enabled: true  # default: false
```

Or env var: `FEISHU_STREAMING_CARD_ENABLED=true`

## Test Plan

- [ ] Unit tests for `_build_streaming_card_json()` output
- [ ] Unit tests for `_streaming_cards` state tracking
- [ ] Integration test: streaming card send → edit → finalize lifecycle
- [ ] Integration test: fallback to post/text when cardkit fails
- [ ] Integration test: fallback to post/text when using user identity
- [ ] Integration test: disconnect cleans up open streaming cards
- [ ] Manual test: typewriter effect in Feishu client

## Key Constraints

- cardkit only supports `tenant_access_token` (bot identity)
- `sequence` must strictly increment across all cardkit operations
- Streaming mode has server-side timeout (~120s); auto-closes on expiry
- Requires Feishu client ≥ 7.20 for schema 2.0 rendering

## Files Changed

- `gateway/platforms/feishu.py` (+297 lines)