### PR TITLE
fix(runtime): strip trailing /v1 from anthropic_messages custom provider base_url

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -155,6 +155,30 @@ def _resolve_plain_custom_api_mode(model_cfg: Dict[str, Any], base_url: str) -> 
     return configured_mode or detected_mode or "chat_completions"
 
 
+def _strip_anthropic_v1_suffix(base_url: str, api_mode: Optional[str]) -> str:
+    """Drop a trailing ``/v1`` from Anthropic-style base URLs.
+
+    The Anthropic SDK appends ``/v1/messages`` to the base_url itself, so a
+    configured ``http://gateway:3001/v1`` would send requests to
+    ``/v1/v1/messages`` — a 404 on every gateway, surfaced only as an opaque
+    auth/probe failure.  The opencode and azure-foundry resolvers already
+    normalise this; routing custom providers through the same rule lets a
+    ``custom_providers`` entry with ``api_mode: anthropic_messages`` share
+    the ``/v1`` base_url of its OpenAI-compatible siblings on the same
+    gateway.  Refs #44181.
+    """
+    if api_mode != "anthropic_messages" or not base_url:
+        return base_url
+    stripped = re.sub(r"/v1/?$", "", base_url)
+    if stripped != base_url:
+        logger.debug(
+            "anthropic_messages base_url '%s' ends with /v1 — stripped to "
+            "'%s' (the Anthropic SDK appends /v1/messages itself)",
+            base_url, stripped,
+        )
+    return stripped
+
+
 def _host_derived_api_key(base_url: str) -> str:
     """Look up `<VENDOR>_API_KEY` in the env, derived from the base URL host.
 
@@ -571,10 +595,11 @@ def _try_resolve_from_custom_pool(
         pool_api_key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")
         if not pool_api_key:
             return None
+        api_mode = api_mode_override or _detect_api_mode_for_url(base_url) or "chat_completions"
         return {
             "provider": provider_label,
-            "api_mode": api_mode_override or _detect_api_mode_for_url(base_url) or "chat_completions",
-            "base_url": base_url,
+            "api_mode": api_mode,
+            "base_url": _strip_anthropic_v1_suffix(base_url, api_mode),
             "api_key": pool_api_key,
             "source": f"pool:{pool_key}",
             "credential_pool": pool,
@@ -1015,12 +1040,15 @@ def _resolve_named_custom_runtime(
     ]
     api_key = next((candidate for candidate in api_key_candidates if has_usable_secret(candidate)), "")
 
+    api_mode = (
+        custom_provider.get("api_mode")
+        or _detect_api_mode_for_url(base_url)
+        or "chat_completions"
+    )
     result = {
         "provider": "custom",
-        "api_mode": custom_provider.get("api_mode")
-        or _detect_api_mode_for_url(base_url)
-        or "chat_completions",
-        "base_url": base_url,
+        "api_mode": api_mode,
+        "base_url": _strip_anthropic_v1_suffix(base_url, api_mode),
         "api_key": api_key or "no-key-required",
         "source": f"custom_provider:{custom_provider.get('name', requested_provider)}",
     }
@@ -1169,14 +1197,17 @@ def _resolve_openrouter_runtime(
     if effective_provider == "custom" and not api_key and not _is_openrouter_url:
         api_key = "no-key-required"
 
-    return {
-        "provider": effective_provider,
-        "api_mode": _resolve_plain_custom_api_mode(model_cfg, base_url)
+    api_mode = (
+        _resolve_plain_custom_api_mode(model_cfg, base_url)
         if effective_provider == "custom"
         else _parse_api_mode(model_cfg.get("api_mode"))
         or _detect_api_mode_for_url(base_url)
-        or "chat_completions",
-        "base_url": base_url,
+        or "chat_completions"
+    )
+    return {
+        "provider": effective_provider,
+        "api_mode": api_mode,
+        "base_url": _strip_anthropic_v1_suffix(base_url, api_mode),
         "api_key": api_key,
         "source": source,
     }

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -3375,3 +3375,134 @@ def test_resolve_named_custom_runtime_pool_result_includes_extra_headers(monkeyp
     }
     assert resolved["api_key"] == "pooled-key"
     assert resolved["source"] == "pool:lmstudio-pool"
+
+
+# ---------------------------------------------------------------------------
+# anthropic_messages /v1 suffix normalization for custom providers (#44181)
+# ---------------------------------------------------------------------------
+# The Anthropic SDK appends /v1/messages to base_url itself, so a configured
+# trailing /v1 produces /v1/v1/messages requests (a 404).  Custom providers
+# must get the same strip the opencode / azure-foundry resolvers already do.
+
+
+def test_named_custom_provider_anthropic_messages_strips_v1_suffix(monkeypatch):
+    """A custom_providers entry can share its gateway's /v1 base_url across protocols."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "custom_providers": [
+                {
+                    "name": "aiapi-claude",
+                    "base_url": "http://192.168.8.11:3001/v1",
+                    "api_key": "gateway-key",
+                    "api_mode": "anthropic_messages",
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError(
+                "resolve_provider should not be called for named custom providers"
+            )
+        ),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="custom:aiapi-claude")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["api_mode"] == "anthropic_messages"
+    # /v1 stripped — the SDK appends /v1/messages, yielding .../v1/messages
+    assert resolved["base_url"] == "http://192.168.8.11:3001"
+    assert resolved["api_key"] == "gateway-key"
+
+
+def test_named_custom_provider_chat_completions_keeps_v1_suffix(monkeypatch):
+    """OpenAI-wire custom providers must keep their /v1 base_url untouched."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "custom_providers": [
+                {
+                    "name": "aiapi-completions",
+                    "base_url": "http://192.168.8.11:3001/v1",
+                    "api_key": "gateway-key",
+                    "api_mode": "chat_completions",
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError(
+                "resolve_provider should not be called for named custom providers"
+            )
+        ),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="custom:aiapi-completions")
+
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["base_url"] == "http://192.168.8.11:3001/v1"
+
+
+def test_bare_custom_anthropic_messages_strips_v1_suffix(monkeypatch):
+    """model.api_mode: anthropic_messages with a /v1 base_url gets the same strip."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "custom")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "custom",
+            "base_url": "http://127.0.0.1:3001/v1",
+            "api_mode": "anthropic_messages",
+            "default": "claude-opus-4-8",
+        },
+    )
+    monkeypatch.delenv("CUSTOM_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="custom")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["base_url"] == "http://127.0.0.1:3001"
+
+
+def test_custom_pool_anthropic_messages_strips_v1_suffix(monkeypatch):
+    """Pooled credentials for an anthropic_messages custom endpoint strip /v1 too."""
+
+    class _Entry:
+        access_token = "pool-token"
+        source = "pool"
+
+    class _Pool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return _Entry()
+
+    monkeypatch.setattr(rp, "get_custom_provider_pool_key", lambda *a, **k: "custom:gw")
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+
+    resolved = rp._try_resolve_from_custom_pool(
+        "http://192.168.8.11:3001/v1", "custom", "anthropic_messages"
+    )
+
+    assert resolved is not None
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["base_url"] == "http://192.168.8.11:3001"
+    assert resolved["api_key"] == "pool-token"

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1194,6 +1194,8 @@ custom_providers:
     api_mode: anthropic_messages  # for Anthropic-compatible proxies
 ```
 
+For `api_mode: anthropic_messages` entries, a trailing `/v1` on `base_url` is stripped automatically: the Anthropic SDK appends `/v1/messages` to the base URL itself, so `http://gateway:3001/v1` would otherwise request `/v1/v1/messages` and 404. Several entries pointing at the same multi-protocol gateway can therefore share the gateway's `/v1` URL — OpenAI-wire entries use it as-is, Anthropic-wire entries normalize it.
+
 Some OpenAI-compatible endpoints need provider-specific request body fields. Add an `extra_body` map to the matching custom provider and Hermes will merge it into each chat-completions request for that endpoint:
 
 ```yaml


### PR DESCRIPTION
## Problem

A `custom_providers` / `providers:` entry with `api_mode: anthropic_messages` and a base URL ending in `/v1` (the natural choice when several entries share one multi-protocol gateway) fails silently: the Anthropic SDK appends `/v1/messages` to the base_url itself, so requests go to `http://host:3001/v1/v1/messages` — a 404 that surfaces only as an opaque auth / model-detection failure.

The opencode-zen/go resolver (`runtime_provider.py` ~L406) and the azure-foundry resolver (~L369, ~L1001) already strip the trailing `/v1` for exactly this reason — custom providers were the remaining gap.

## Fix

Adds a `_strip_anthropic_v1_suffix()` helper and applies it on the three custom-provider return paths where `api_mode` can be explicitly configured:

- named `custom_providers` / `providers:` entries (`_resolve_named_custom_runtime`)
- the custom credential-pool path (`_try_resolve_from_custom_pool`)
- bare `provider: custom` with `model.api_mode` (openrouter/custom fallback resolver)

The strip is gated on `api_mode == "anthropic_messages"` — OpenAI-wire entries keep their `/v1` untouched. A debug log records the rewrite. This is Option B from the issue (auto-normalize), matching the existing in-repo precedent rather than a docs-only fix.

Also documents the behavior in the custom-providers section of `website/docs/integrations/providers.md`.

Note on the issue's repro: the reported config uses a `protocol:` key, which isn't part of the schema (the recognized field is `api_mode` / `transport`; unknown keys are ignored with a logged warning). The underlying double-`/v1` failure mode is real for `api_mode: anthropic_messages`, which this PR fixes.

## Tests

4 new regression tests in `tests/hermes_cli/test_runtime_provider_resolution.py` (named entry strips, chat_completions keeps `/v1`, bare-custom strips, pool path strips). Full file: 133 passed.

Fixes #44181
