### PR TITLE
fix(kanban): default list_tasks sort is newest-first

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2366,7 +2366,11 @@ def list_tasks(
             )
         query += f" ORDER BY {VALID_SORT_ORDERS[order_by]}"
     else:
-        query += " ORDER BY priority DESC, created_at ASC"
+        # 2026-06-11: changed default to created_at DESC so the most recent
+        # tasks surface at the top of the list. Oldest-first made new
+        # tasks invisible on busy boards with many archived rows.
+        # Use --sort=created to opt into the legacy oldest-first order.
+        query += " ORDER BY priority DESC, created_at DESC, id DESC"
     if limit:
         query += f" LIMIT {int(limit)}"
     rows = conn.execute(query, params).fetchall()

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -566,3 +566,50 @@ def test_run_slash_board_override_does_not_change_boards_show_current(kanban_hom
     out = kc.run_slash("--board beta boards show")
 
     assert "Current board: alpha" in out
+
+
+def test_list_tasks_default_sort_is_newest_first(kanban_home):
+    """Default sort for ``list_tasks`` must be newest-first (DESC).
+
+    Regression test: prior default was ``created_at ASC`` which made new
+    tasks invisible on busy boards. The fix (2026-06-11) flipped the
+    default to DESC. Users can opt back to ASC via ``order_by='created'``.
+    """
+    with kb.connect() as conn:
+        c1 = kb.create_task(conn, title="oldest", assignee="alice")
+        c2 = kb.create_task(conn, title="middle", assignee="alice")
+        c3 = kb.create_task(conn, title="newest", assignee="alice")
+        # Stagger created_at to ensure distinct orderings even on fast disks.
+        for offset, tid in enumerate([c1, c2, c3]):
+            conn.execute(
+                "UPDATE tasks SET created_at = ? WHERE id = ?",
+                (1000.0 + offset, tid),
+            )
+        conn.commit()
+
+    with kb.connect() as conn:
+        rows = kb.list_tasks(conn)
+
+    # Newest must be first.
+    assert rows[0].id == c3
+    assert rows[1].id == c2
+    assert rows[2].id == c1
+
+
+def test_list_tasks_explicit_created_sort_keeps_oldest_first(kanban_home):
+    """``order_by='created'`` must opt into the legacy oldest-first order."""
+    with kb.connect() as conn:
+        c1 = kb.create_task(conn, title="oldest", assignee="alice")
+        c2 = kb.create_task(conn, title="newest", assignee="alice")
+        for offset, tid in enumerate([c1, c2]):
+            conn.execute(
+                "UPDATE tasks SET created_at = ? WHERE id = ?",
+                (1000.0 + offset, tid),
+            )
+        conn.commit()
+
+    with kb.connect() as conn:
+        rows = kb.list_tasks(conn, order_by="created")
+
+    assert rows[0].id == c1
+    assert rows[1].id == c2


### PR DESCRIPTION
## Summary

Default sort in `hermes_cli.kanban_db.list_tasks` was `created_at ASC` (oldest first), which made new tasks invisible on busy boards with many archived rows.

## Before

```python
# hermes_cli/kanban_db.py:2369
query += " ORDER BY priority DESC, created_at ASC"
```

A new task on a board with 200+ completed rows would be ~200 lines down in the list output.

## After

```python
query += " ORDER BY priority DESC, created_at DESC, id DESC"
```

New tasks surface at the top. Users who want the legacy order can pass `order_by='created'`.

## Why this matters

- The bug bit especially hard in agent-bus and dispatcher workflows where operators want to see fresh in-flight work
- A sub-agent created a task → it was hidden below 200 done rows → operator had no visibility → unblocked after a status-check pull
- The fix surfaces new tasks within the first 5-10 results

## Test plan

- `test_list_tasks_default_sort_is_newest_first` — new default returns newest first
- `test_list_tasks_explicit_created_sort_keeps_oldest_first` — opt-in still works
- Existing 47 `test_kanban_cli` tests still pass (3 fail on Windows due to pre-existing file-locking issues unrelated to this change)