### PR TITLE
fix(desktop): pin @icons-pack/react-simple-icons below its node>=24 releases

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -53,7 +53,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@hermes/shared": "file:../shared",
-    "@icons-pack/react-simple-icons": "^13.13.0",
+    "@icons-pack/react-simple-icons": ">=13.0.0 <13.11.2",
     "@nanostores/react": "^1.1.0",
     "@nous-research/ui": "^0.13.0",
     "@radix-ui/react-slot": "^1.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@hermes/shared": "file:../shared",
-        "@icons-pack/react-simple-icons": "^13.13.0",
+        "@icons-pack/react-simple-icons": ">=13.0.0 <13.11.2",
         "@nanostores/react": "^1.1.0",
         "@nous-research/ui": "^0.13.0",
         "@radix-ui/react-slot": "^1.2.4",
@@ -159,6 +159,15 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "apps/desktop/node_modules/@icons-pack/react-simple-icons": {
+      "version": "13.11.1",
+      "resolved": "https://registry.npmjs.org/@icons-pack/react-simple-icons/-/react-simple-icons-13.11.1.tgz",
+      "integrity": "sha512-WbwN/o7dUHEjDCJh2p3RvDZ4kZ8nhfUSkUSm0bWuPTXIsoKgDJpwD5UkMCG22R/5kZH6lHAZXwuHWsKNtX7fYA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.13 || ^17 || ^18 || ^19"
       }
     },
     "apps/desktop/node_modules/@nous-research/ui": {
@@ -2552,19 +2561,6 @@
         "@antfu/install-pkg": "^1.1.0",
         "@iconify/types": "^2.0.0",
         "mlly": "^1.8.2"
-      }
-    },
-    "node_modules/@icons-pack/react-simple-icons": {
-      "version": "13.13.0",
-      "resolved": "https://registry.npmjs.org/@icons-pack/react-simple-icons/-/react-simple-icons-13.13.0.tgz",
-      "integrity": "sha512-B5HhQMIpcSH4z8IZ8HFhD59CboHceKYMpPC9kAwGyKntvPdyJJv26DLu4Z1wAjcCLyrJhf11tMhiQGom9Rxb9g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=24",
-        "pnpm": ">=10"
-      },
-      "peerDependencies": {
-        "react": "^16.13 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/@isaacs/fs-minipass": {


### PR DESCRIPTION
## Summary

A WSL user (Node v22.22.3) reported a noisy desktop launch:

```
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: '@icons-pack/react-simple-icons@13.13.0',
npm warn EBADENGINE   required: { node: '>=24', pnpm: '>=10' },
npm warn EBADENGINE   current: { node: 'v22.22.3', npm: '10.9.8' }
npm warn EBADENGINE }
```

`apps/desktop/package.json` declares it supports Node `^20.19.0 || >=22.12.0`, but `@icons-pack/react-simple-icons` bumped its **own** `engines.node` to `>=24` starting at **13.11.2** (13.11.1 and earlier have no Node floor). With the old `^13.13.0` range, every install on the project's supported Node 20/22 range prints the `EBADENGINE` warning — and would hard-fail under `engine-strict` / `npm ci --engine-strict`.

## Fix

Cap the range at `<13.11.2` (`">=13.0.0 <13.11.2"`), which resolves to **13.11.1** — the last release before the Node-24 floor. The package works fine on Node 22; only its declared engine was over-tightened.

Verified every brand glyph the app imports (`platform-icon.tsx`: Telegram, Discord, Matrix, Signal, WhatsApp, Apple, Gmail, HomeAssistant, Mattermost, QQ, WeChat, Bilibili) is present in 13.11.1 — icon-identical, no behavior change.

Lockfile diff is minimal: the resolved version moves to 13.11.1 and the old 13.13.0 entry (with `engines.node: ">=24"`) is dropped; no other packages churn.

## Test plan

- [x] Confirmed via the npm registry that `13.11.2`+ carry `engines.node: ">=24"` and `13.11.1` does not.
- [x] Confirmed all 12 imported `Si*` icon modules exist in `@icons-pack/react-simple-icons@13.11.1`.
- [x] `package-lock.json` regenerated with `npm install --package-lock-only`; diff limited to this one dependency.

> Note: this clears the `EBADENGINE` warning from the report. The reporter's separate "can't click the top two left-sidebar options" symptom looks WSL/WSLg-display-specific and is tracked separately.