### PR TITLE
fix(agent): elevate compression feasibility error to WARNING and make user-visible

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -245,7 +245,13 @@ def check_compression_model_feasibility(agent: Any) -> None:
         # so the session refuses to start.
         raise
     except Exception as exc:
-        logger.debug(
+        msg = (
+            "⚠ Compression feasibility check failed — context compression "
+            f"may not work this session: {exc}"
+        )
+        agent._compression_warning = msg
+        agent._emit_status(msg)
+        logger.warning(
             "Compression feasibility check failed (non-fatal): %s", exc
         )
 

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -249,7 +249,13 @@ def check_compression_model_feasibility(agent: Any) -> None:
             "⚠ Compression feasibility check failed — context compression "
             f"may not work this session: {exc}"
         )
-        agent._compression_warning = msg
+        # When the agent has a wired status_callback (gateway agents deliver
+        # via _emit_status immediately), deferring to the next-turn replay
+        # produces a duplicate delivery. Only queue the warning when there
+        # is no live callback to surface it now — turn_context.py:159-161
+        # replays and clears the stored value once.
+        if not getattr(agent, "status_callback", None):
+            agent._compression_warning = msg
         agent._emit_status(msg)
         logger.warning(
             "Compression feasibility check failed (non-fatal): %s", exc

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -320,8 +320,8 @@ def test_skips_check_when_compression_disabled():
 
 
 @patch("agent.auxiliary_client.get_text_auxiliary_client")
-def test_exception_does_not_crash(mock_get_client):
-    """Exceptions in the check are caught — never blocks startup."""
+def test_exception_is_logged_and_user_visible(mock_get_client):
+    """Exceptions in the check are caught, logged at WARNING, and surfaced to user."""
     agent = _make_agent()
     mock_get_client.side_effect = RuntimeError("boom")
 
@@ -331,8 +331,10 @@ def test_exception_does_not_crash(mock_get_client):
     # Should not raise
     agent._check_compression_model_feasibility()
 
-    # No user-facing message (error is debug-logged)
-    assert len(messages) == 0
+    # User-facing warning is now emitted (previously was debug-only)
+    assert len(messages) == 1
+    assert "Compression feasibility check failed" in messages[0]
+    assert "may not work this session" in messages[0]
 
 
 @patch("agent.model_metadata.get_model_context_length", return_value=100_000)

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -337,6 +337,62 @@ def test_exception_is_logged_and_user_visible(mock_get_client):
     assert "may not work this session" in messages[0]
 
 
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_exception_with_status_callback_emits_only_once(mock_get_client):
+    """Live status_callback → immediate delivery + NO replay queue.
+    Regression test for teknium1 review on PR #44200: gateway agents wire
+    status_callback, so the next-turn replay in turn_context.py:159-161
+    would duplicate the warning. The fix only sets _compression_warning
+    when there is no live callback to surface it now.
+    """
+    agent = _make_agent()
+    mock_get_client.side_effect = RuntimeError("boom")
+
+    # Capture only the lifecycle status_callback invocations (what the gateway
+    # sends to the user interface). Keep _emit_status on the real impl so
+    # its internal status_callback dispatch path runs unchanged.
+    callback_messages = []
+
+    def _live_cb(event_type: str, message: str) -> None:
+        callback_messages.append((event_type, message))
+
+    agent.status_callback = _live_cb
+    # Quiet vprint to keep pytest clean
+    agent.quiet_mode = True
+
+    agent._check_compression_model_feasibility()
+
+    # Live callback fired exactly once via _emit_status — no replay double-fire here
+    assert len(callback_messages) == 1
+    assert callback_messages[0][0] == "lifecycle"
+    assert "Compression feasibility check failed" in callback_messages[0][1]
+    assert "may not work this session" in callback_messages[0][1]
+    # _compression_warning was NOT queued because the live callback already delivered
+    assert agent._compression_warning is None
+
+
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_exception_without_status_callback_queues_for_next_turn_replay(mock_get_client):
+    """No status_callback → _compression_warning is queued for next-turn replay.
+    Companion to the live-callback test: when there is no callback to deliver
+    the message immediately, the stored value persists so turn_context.py can
+    surface it on the next turn (and then clear it exactly once).
+    """
+    agent = _make_agent()
+    mock_get_client.side_effect = RuntimeError("boom")
+
+    messages = []
+    agent._emit_status = lambda msg: messages.append(msg)
+
+    agent._check_compression_model_feasibility()
+
+    assert len(messages) == 1
+    assert "may not work this session" in messages[0]
+    # Without a callback, queue the warning so turn_context.py replays it on the next turn.
+    assert agent._compression_warning is not None
+    assert "may not work this session" in agent._compression_warning
+
+
 @patch("agent.model_metadata.get_model_context_length", return_value=100_000)
 @patch("agent.auxiliary_client.get_text_auxiliary_client")
 def test_exact_threshold_boundary_no_warning(mock_get_client, mock_ctx_len):


### PR DESCRIPTION
## Summary

`check_compression_model_feasibility` caught generic exceptions from auxiliary model resolution but only logged them at `DEBUG` level, silently swallowing failures that meant context compression would not work. This fix elevates those failures to `WARNING` level and surfaces them via `agent._emit_status`, making them visible across all platforms (CLI, Telegram, Discord, etc.) — consistent with the existing threshold-auto-lower and no-auxiliary-provider warnings.

---

## Changes

**File:** `agent/conversation_compression.py`
- Changed the generic exception handler from `logger.debug` to `logger.warning` + `agent._emit_status` + `agent._compression_warning` storage for gateway replay.

**File:** `tests/run_agent/test_compression_feasibility.py`
- Updated `test_exception_is_logged_and_user_visible` to assert user-visible warning is emitted.

---

## How to Test

```bash
# Primary
python -m pytest tests/run_agent/test_compression_feasibility.py -o "addopts="
# ✅ 16/16

# Related compression tests
python -m pytest \
  tests/run_agent/test_413_compression.py \
  tests/agent/test_compression_logging_session_context.py \
  -o "addopts="
# ✅ 25/25
```

✅ 41/41 compression-related tests pass

---

## Checklist

- [x] Tests pass — 41/41
- [x] Existing test updated to cover new behavior
- [x] Tested on Ubuntu 24.04 (WSL)
- [x] Cross-platform impact considered — warning surfaces on CLI, Telegram, Discord via `_emit_status`
- [x] Follows Contributing Guide and Conventional Commits
- [x] No duplicate PRs; changes scoped to this fix only
- [x] Documentation / schemas / `cli-config.yaml.example` reviewed — N/A

---

## Risk & Impact

**Low.** No behavioral change to compression logic itself — only the visibility of pre-existing failures is improved. Users who previously saw silent compression failures will now receive an actionable warning.

**Type:** 🐛 Bug fix

