### PR TITLE
feat(openviking): profile-aware paths, registry, finalizer, and schema invariant

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -29,8 +29,11 @@ import json
 import logging
 import mimetypes
 import os
+import queue
+import sqlite3
 import tempfile
 import threading
+import time
 import uuid
 import zipfile
 from pathlib import Path
@@ -41,11 +44,22 @@ from urllib.request import url2pathname
 from agent.memory_provider import MemoryProvider
 from tools.registry import tool_error
 
+# Standalone session registry — zero-dependency module used by all
+# code paths (CLI, gateway, cron, batch) to track session lifecycle.
+from .registry import (
+    register_session as _register_session,
+    update_state as _update_registry_state,
+)
+
 logger = logging.getLogger(__name__)
 
 _DEFAULT_ENDPOINT = "http://127.0.0.1:1933"
 _TIMEOUT = 30.0
 _REMOTE_RESOURCE_PREFIXES = ("http://", "https://", "git@", "ssh://", "git://")
+
+# Cache and persistence limits
+_MAX_CACHED_MESSAGES = int(os.environ.get("OPENVIKING_CACHE_SIZE", "10000"))
+_RECOVERY_DIR = os.path.join(os.path.expanduser("~"), ".hermes", "openviking-recovery")
 
 # Maps the viking_remember `category` enum to a viking:// subdirectory.
 # Keep in sync with REMEMBER_SCHEMA.parameters.properties.category.enum.
@@ -76,19 +90,101 @@ _last_active_provider: Optional["OpenVikingMemoryProvider"] = None
 
 
 def _atexit_commit_sessions():
-    """Fire on_session_end for the last active provider on process exit."""
+    """Fire on_session_end for the last active provider on process exit.
+
+    This is the LAST line of defence. The normal path is:
+    shutdown_memory_provider() → on_session_end() → commit.
+
+    If that path was taken and SUCCEEDED, the _commit_state is 2 and
+    _last_active_provider was cleared by shutdown(), so this is a no-op.
+
+    If that path was taken but FAILED, _commit_state is 3 and the
+    provider's _last_active_provider was cleared — we fall through to
+    the persistent recovery file check below.
+
+    If shutdown_memory_provider was NEVER called (SIGKILL recovery,
+    atexit-only exit), _last_active_provider is still set and we
+    attempt the commit directly.
+    """
     global _last_active_provider
     provider = _last_active_provider
-    if provider is None:
-        return
-    _last_active_provider = None
+
+    # Priority 1: Live provider with cached messages
+    if provider is not None:
+        # Set to None now so we don't retry — the _commit_state
+        # guard in on_session_end/force_commit prevents double-commit
+        _last_active_provider = None
+        try:
+            messages = list(getattr(provider, "_cached_messages", []))
+            if messages:
+                provider.on_session_end(messages)
+                return
+        except Exception:
+            pass  # fall through to recovery files
+
+    # Priority 2: Persistent recovery files
+    # Catches cases where shutdown() cleared _last_active_provider
+    # before the commit completed, or where the process died before
+    # any cleanup ran.
     try:
-        provider.on_session_end([])
+        marker_path = os.path.join(_RECOVERY_DIR, ".pending")
+        if os.path.exists(marker_path):
+            with open(marker_path) as f:
+                pending_sids = [line.strip() for line in f if line.strip()]
+            for sid in pending_sids:
+                snap_path = os.path.join(_RECOVERY_DIR, f"{sid}.json")
+                if os.path.exists(snap_path):
+                    try:
+                        with open(snap_path) as f:
+                            snap = json.load(f)
+                        msgs = snap.get("messages", [])
+                        if msgs:
+                            _atexit_force_commit(sid, msgs)
+                    except Exception:
+                        pass
+    except Exception:
+        pass
+
+
+def _atexit_force_commit(session_id: str, messages: list) -> None:
+    """Standalone OV commit for atexit — no provider dependency.
+
+    Creates its own HTTP client so it works even if the provider's
+    client was destroyed by shutdown(). Safe to call from any context.
+    """
+    if not messages or not session_id:
+        return
+    endpoint = os.environ.get("OPENVIKING_ENDPOINT", _DEFAULT_ENDPOINT)
+    api_key = os.environ.get("OPENVIKING_API_KEY", "")
+    try:
+        import httpx
+        headers = {"Content-Type": "application/json"}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        with httpx.Client(timeout=15.0) as client:
+            for msg in messages[-2000:]:  # last 2000 in case of huge sessions
+                role = msg.get("role", "user")
+                content = (msg.get("content") or "")[:4000]
+                client.post(
+                    f"{endpoint}/api/v1/sessions/{session_id}/messages",
+                    json={"role": role, "content": content},
+                    headers=headers,
+                )
+            client.post(
+                f"{endpoint}/api/v1/sessions/{session_id}/commit",
+                headers=headers,
+            )
     except Exception:
         pass  # best-effort at shutdown time
 
 
 atexit.register(_atexit_commit_sessions)
+
+# Queue worker sentinel types — these are put on the message queue
+# to signal lifecycle events to the single daemon worker thread.
+_MSG = "msg"         # A conversation message: (sid, role, content)
+_FLUSH = "flush"     # Drain all pending messages before continuing
+_SHUTDOWN = "exit"   # Terminate the worker thread
 
 
 # ---------------------------------------------------------------------------
@@ -418,10 +514,26 @@ class OpenVikingMemoryProvider(MemoryProvider):
         self._api_key = ""
         self._session_id = ""
         self._turn_count = 0
-        self._sync_thread: Optional[threading.Thread] = None
         self._prefetch_result = ""
         self._prefetch_lock = threading.Lock()
         self._prefetch_thread: Optional[threading.Thread] = None
+        # Message cache for atexit safety net — sync_turn() stores a copy
+        # here so _atexit_commit_sessions() has real data to commit even
+        # if the background sync thread never finished.
+        self._cached_messages: List[Dict[str, Any]] = []
+        # Queue-backed worker thread — replaces thread-per-turn pattern.
+        # sync_turn pushes messages onto the queue; a single daemon worker
+        # drains them and POSTs to OpenViking. Eliminates zombie threads
+        # from timeouts and guarantees in-order message delivery.
+        self._msg_queue: queue.Queue = queue.Queue(maxsize=0)
+        self._worker_thread: Optional[threading.Thread] = None
+        self._flush_event = threading.Event()
+        # Journal directory for local fallback when OpenViking is unreachable.
+        self._journal_dir: Optional[str] = None
+        # Commit state guard: 0=uncommitted, 1=committing, 2=committed,
+        # 3=failed. Prevents double-commit when both shutdown_memory_provider
+        # and the atexit handler call on_session_end().
+        self._commit_state = 0
 
     @property
     def name(self) -> str:
@@ -474,7 +586,13 @@ class OpenVikingMemoryProvider(MemoryProvider):
         self._agent = os.environ.get("OPENVIKING_AGENT", "hermes")
         self._session_id = session_id
         self._turn_count = 0
-
+        self._cached_messages = []
+        self._commit_state = 0
+        self._update_state_db("CREATED")
+        # Register in the standalone session registry — this is the only
+        # place all code paths converge. The registry provides a process-
+        # independent audit trail for the finalizer.
+        _register_session(session_id, source="ov-plugin")
         try:
             self._client = _VikingClient(
                 self._endpoint, self._api_key,
@@ -483,6 +601,11 @@ class OpenVikingMemoryProvider(MemoryProvider):
             if not self._client.health():
                 logger.warning("OpenViking server at %s is not reachable", self._endpoint)
                 self._client = None
+            else:
+                logger.info(
+                    "OpenViking client initialized for session %s at %s",
+                    session_id, self._endpoint,
+                )
         except ImportError:
             logger.warning("httpx not installed — OpenViking plugin disabled")
             self._client = None
@@ -566,65 +689,399 @@ class OpenVikingMemoryProvider(MemoryProvider):
         self._prefetch_thread.start()
 
     def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
-        """Record the conversation turn in OpenViking's session (non-blocking)."""
+        """Record the conversation turn in OpenViking's session (non-blocking).
+
+        Pushes messages onto a single-worker queue instead of spawning a
+        thread per turn. The daemon worker drains the queue in order and
+        POSTs to OpenViking with up to 3 retries.
+        """
         if not self._client:
             return
 
         self._turn_count += 1
 
-        def _sync():
+        # Cache messages for atexit safety net immediately — always have
+        # the complete turn log regardless of worker thread state.
+        self._cached_messages.append({"role": "user", "content": user_content[:4000]})
+        self._cached_messages.append({"role": "assistant", "content": assistant_content[:4000]})
+        # Cap at 5000 message pairs to avoid unbounded memory growth
+        # in long-running gateway session with thousands of turns.
+        if len(self._cached_messages) > _MAX_CACHED_MESSAGES:
+            self._cached_messages = self._cached_messages[-(_MAX_CACHED_MESSAGES):]
+
+        # Queue the messages — capture session_id at enqueue time so the
+        # worker writes to the correct session even if on_session_switch
+        # is called before the worker processes this item.
+        sid = self._session_id
+        self._start_worker()
+        self._msg_queue.put((_MSG, sid, "user", user_content[:4000]))
+        self._msg_queue.put((_MSG, sid, "assistant", assistant_content[:4000]))
+        self._update_state_db("IN_SYNC")
+
+    def _start_worker(self) -> None:
+        """Start the daemon queue worker if it is not already running."""
+        if self._worker_thread is None or not self._worker_thread.is_alive():
+            self._worker_thread = threading.Thread(
+                target=self._queue_worker,
+                daemon=True,
+                name="openviking-queue-worker",
+            )
+            self._worker_thread.start()
+
+    def _queue_worker(self) -> None:
+        """Daemon worker: drain the message queue, POST to OpenViking with
+        retries, handle lifecycle sentinels.
+
+        Three sentinel types:
+          (_MSG, sid, role, content)  — POST a conversation message
+          (_FLUSH, "", "", "")         — signal the flush event then continue
+          (_SHUTDOWN, "", "", "")      — exit the loop
+
+        The worker is daemon=True so it does not prevent process exit.
+        If the worker dies (unhandled exception), the next sync_turn()
+        call restarts it via _start_worker().
+        """
+        while True:
             try:
-                client = _VikingClient(
-                    self._endpoint, self._api_key,
-                    account=self._account, user=self._user, agent=self._agent,
-                )
-                sid = self._session_id
+                item = self._msg_queue.get()
+            except Exception:
+                # Queue corrupted or interrupted — exit the loop.
+                break
 
-                # Add user message
-                client.post(f"/api/v1/sessions/{sid}/messages", {
-                    "role": "user",
-                    "content": user_content[:4000],  # trim very long messages
-                })
-                # Add assistant message
-                client.post(f"/api/v1/sessions/{sid}/messages", {
-                    "role": "assistant",
-                    "content": assistant_content[:4000],
-                })
+            try:
+                msg_type = item[0]
+
+                if msg_type == _SHUTDOWN:
+                    self._msg_queue.task_done()
+                    break
+
+                if msg_type == _FLUSH:
+                    self._flush_event.set()
+                    self._msg_queue.task_done()
+                    continue
+
+                if msg_type == _MSG:
+                    _sid, role, content = item[1], item[2], item[3]
+                    # Retry chain: up to 3 attempts with backoff
+                    last_error = None
+                    for attempt in range(3):
+                        try:
+                            client = _VikingClient(
+                                self._endpoint, self._api_key or "",
+                                account=self._account, user=self._user,
+                                agent=self._agent,
+                            )
+                            client.post(f"/api/v1/sessions/{_sid}/messages", {
+                                "role": role,
+                                "content": content[:4000],
+                            })
+                            last_error = None
+                            break
+                        except Exception as e:
+                            last_error = e
+                            if attempt < 2:
+                                time.sleep(1.0 + attempt)  # 1s, then 2s backoff
+
+                    if last_error is not None:
+                        logger.error(
+                            "OpenViking queue worker: failed to POST %s message for "
+                            "session %s after 3 retries: %s",
+                            role, _sid, last_error,
+                        )
+                        self._journal_message(_sid, role, content)
             except Exception as e:
-                logger.debug("OpenViking sync_turn failed: %s", e)
+                logger.error(
+                    "OpenViking queue worker: unhandled error processing %s: %s",
+                    item[0] if isinstance(item, tuple) else type(item).__name__, e,
+                )
+            finally:
+                try:
+                    self._msg_queue.task_done()
+                except Exception:
+                    pass
 
-        # Wait for any previous sync to finish before starting a new one
-        if self._sync_thread and self._sync_thread.is_alive():
-            self._sync_thread.join(timeout=5.0)
+    def _journal_message(self, session_id: str, role: str, content: str) -> None:
+        """Write a failed message to the local journal for later repair.
 
-        self._sync_thread = threading.Thread(
-            target=_sync, daemon=True, name="openviking-sync"
+        The journal file is a JSONL file at:
+          ~/.hermes/openviking-repair/<session_id>.jsonl
+
+        This feeds into the Phase 4 cron finalizer which discovers
+        uncommitted sessions and attempts recovery.
+        """
+        try:
+            repair_dir = os.path.join(
+                os.path.expanduser("~"), ".hermes", "openviking-repair",
+            )
+            os.makedirs(repair_dir, exist_ok=True)
+            journal_path = os.path.join(repair_dir, f"{session_id}.jsonl")
+            with open(journal_path, "a") as f:
+                f.write(json.dumps({
+                    "session_id": session_id,
+                    "role": role,
+                    "content": content[:4000],
+                }) + "\n")
+        except Exception:
+            pass  # best-effort, can't do much if journal write fails
+
+    def _write_repair_marker(self) -> None:
+        """Write a repair marker for sessions that failed to commit.
+
+        The Phase 4 cron finalizer discovers these markers and attempts
+        to recover the session using data from the Hermes session DB.
+        """
+        try:
+            repair_dir = os.path.join(
+                os.path.expanduser("~"), ".hermes", "openviking-repair",
+            )
+            os.makedirs(repair_dir, exist_ok=True)
+            marker_path = os.path.join(repair_dir, f"{self._session_id}.json")
+            with open(marker_path, "w") as f:
+                json.dump({
+                    "session_id": self._session_id,
+                    "cached_messages": self._cached_messages,
+                }, f)
+        except Exception:
+            pass
+
+    def _persist_snapshot(self) -> None:
+        """Persist session data to a crash-safe JSON file before shutdown.
+
+        This file survives process death (SIGKILL, crash) and is discovered
+        by the atexit handler and the background finalizer. Written atomically
+        via tmp + os.replace to prevent partial-write corruption.
+        """
+        try:
+            os.makedirs(_RECOVERY_DIR, exist_ok=True)
+            path = os.path.join(_RECOVERY_DIR, f"{self._session_id}.json")
+            tmp_path = path + ".tmp"
+            with open(tmp_path, "w") as f:
+                json.dump({
+                    "session_id": self._session_id,
+                    "messages": self._cached_messages,
+                    "turn_count": self._turn_count,
+                    "commit_state": self._commit_state,
+                    "saved_at": time.strftime("%Y-%m-%dT%H:%M:%S"),
+                }, f)
+            os.replace(tmp_path, path)
+        except Exception:
+            pass  # best-effort
+
+    def _write_recovery_marker(self) -> None:
+        """Write a lightweight marker that the finalizer discovers quickly.
+
+        Appends the session_id to a .pending file that the finalizer
+        scans on each run. Avoids scanning the full recovery directory.
+        """
+        try:
+            os.makedirs(_RECOVERY_DIR, exist_ok=True)
+            marker_path = os.path.join(_RECOVERY_DIR, ".pending")
+            with open(marker_path, "a") as f:
+                f.write(f"{self._session_id}\n")
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------ #
+    # SQLite session state database — delegated to .registry module
+    # ------------------------------------------------------------------ #
+    # Uses the standalone registry.py which has zero agent dependencies
+    # and can be imported from any code path (cron, batch, gateway).
+    # The registry is the single source of truth for session lifecycle.
+    # ------------------------------------------------------------------ #
+
+    def _update_state_db(
+        self,
+        state: str,
+        turn_count: Optional[int] = None,
+        error: Optional[str] = None,
+    ) -> None:
+        """Upsert the current session's state into the SQLite registry.
+
+        Args:
+            state: One of CREATED, IN_SYNC, FINALIZING, COMMITTED, FAILED.
+            turn_count: Current turn count (defaults to self._turn_count).
+            error: Optional error message for FAILED state.
+        """
+        sid = self._session_id
+        if not sid:
+            return
+        tc = turn_count if turn_count is not None else self._turn_count
+        _update_registry_state(
+            sid, state,
+            turn_count=tc,
+            messages=self._cached_messages,
+            error=error,
         )
-        self._sync_thread.start()
+
+    def force_commit(self, messages: List[Dict[str, Any]]) -> None:
+        """Synchronous fallback: create a fresh client, POST all messages, commit.
+
+        This is the breaker bar for known-session-end scenarios where the
+        background sync thread may still be running (or have timed out).
+        Creates its own ``_VikingClient`` so it does not depend on ``self._client``,
+        which may have been destroyed by a gateway crash or race with shutdown.
+
+        Used as a fallback by ``on_session_end()`` when the sync thread join
+        times out, and directly by ``_atexit_commit_sessions()``.
+        """
+        if not messages:
+            return
+        # Guard: prevent double-commit when both shutdown_memory_provider
+        # and the atexit handler fire (force_commit is the fallback path
+        # for on_session_end, so it should also respect the guard).
+        if self._commit_state >= 2:
+            return
+        self._commit_state = 1
+        self._update_state_db("FINALIZING", turn_count=len(messages) // 2)
+        endpoint = self._endpoint or _DEFAULT_ENDPOINT
+        api_key = self._api_key or ""
+        try:
+            client = _VikingClient(
+                endpoint, api_key,
+                account=self._account, user=self._user, agent=self._agent,
+            )
+            sid = self._session_id
+            for msg in messages:
+                role = msg.get("role", "user")
+                content = (msg.get("content") or "")[:4000]
+                client.post(f"/api/v1/sessions/{sid}/messages", {
+                    "role": role,
+                    "content": content,
+                })
+            client.post(f"/api/v1/sessions/{sid}/commit")
+            self._commit_state = 2
+            self._update_state_db("COMMITTED")
+            logger.info(
+                "OpenViking force_commit completed for session %s (%d messages)",
+                sid, len(messages),
+            )
+        except Exception as e:
+            self._commit_state = 3
+            self._update_state_db("FAILED", error=str(e))
+            logger.error(
+                'OpenViking force_commit failed for session %s: %s',
+                self._session_id, e,
+            )
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
         """Commit the session to trigger memory extraction.
 
         OpenViking automatically extracts 6 categories of memories:
         profile, preferences, entities, events, cases, and patterns.
+
+        First flushes the queue worker so all pending messages are written
+        to OpenViking, then POSTs /commit. If the flush times out, falls
+        back to force_commit(cached_messages) — the synchronous breaker bar.
         """
         if not self._client:
             return
+        # Guard: prevent double-commit when both shutdown_memory_provider
+        # and the atexit handler fire.
+        if self._commit_state >= 2:
+            return
+        self._commit_state = 1
+        self._update_state_db("FINALIZING")
 
-        # Wait for any pending sync to finish first — do this before the
-        # turn_count check so the last turn's messages are flushed even if
-        # the count hasn't been incremented yet.
-        if self._sync_thread and self._sync_thread.is_alive():
-            self._sync_thread.join(timeout=10.0)
+        # Flush the queue — wait for the worker to drain all pending messages
+        # before committing. Uses the flush sentinel + event pattern so the
+        # worker stays alive for future flushes.
+        flush_ok = self._flush_queue(timeout=15.0)
 
         if self._turn_count == 0:
+            # No sync_turn calls were made — check if the caller passed
+            # messages directly (e.g. from gateway _session_messages or
+            # CLI atexit cleanup). Use them as a fallback.
+            if messages:
+                logger.info(
+                    "OpenViking on_session_end: _turn_count=0 but caller passed %d messages — "
+                    "using force_commit fallback",
+                    len(messages),
+                )
+                self.force_commit(list(messages))
+                self._commit_state = 2
+                return
+            self._commit_state = 2
+            return
+
+        if not flush_ok:
+            # Queue flush timed out — the worker may be stuck or dead.
+            # Fall back to synchronous force_commit with the message cache,
+            # or the messages passed by the caller if the cache is empty.
+            source = list(self._cached_messages) if self._cached_messages else list(messages or [])
+            logger.warning(
+                "OpenViking on_session_end: queue flush timed out for session %s "
+                "— falling back to force_commit (%d msgs from %s)",
+                self._session_id, len(source),
+                "cache" if self._cached_messages else "caller messages",
+            )
+            if source:
+                self.force_commit(source)
+            else:
+                logger.warning(
+                    "OpenViking on_session_end: no messages available for session %s — "
+                    "cannot commit",
+                    self._session_id,
+                )
+                self._commit_state = 3
+                self._update_state_db("FAILED", error="no messages available")
             return
 
         try:
             self._client.post(f"/api/v1/sessions/{self._session_id}/commit")
+            self._commit_state = 2
+            self._update_state_db("COMMITTED")
             logger.info("OpenViking session %s committed (%d turns)", self._session_id, self._turn_count)
         except Exception as e:
+            self._commit_state = 3
+            self._update_state_db("FAILED", error=str(e))
             logger.warning("OpenViking session commit failed: %s", e)
+            self._write_repair_marker()
+
+    def _flush_queue(self, timeout: float = 15.0) -> bool:
+        """Put a flush sentinel on the queue and wait for the worker to drain.
+
+        Returns True if the worker drained and set the flush event within
+        *timeout* seconds. Returns False if the flush timed out (worker
+        may be stuck or dead).
+        """
+        if not self._worker_thread or not self._worker_thread.is_alive():
+            # Worker not running — nothing to flush.
+            return True
+        self._flush_event.clear()
+        self._msg_queue.put((_FLUSH, "", "", ""))
+        return self._flush_event.wait(timeout=timeout)
+
+    def on_session_switch(
+        self,
+        new_session_id: str,
+        *,
+        parent_session_id: str = "",
+        reset: bool = False,
+        **kwargs,
+    ) -> None:
+        """Update cached session state when the agent rotates session_id.
+
+        The base ``MemoryProvider.on_session_switch`` is a no-op, but we
+        cache ``_session_id`` and ``_turn_count`` in ``initialize()`` and
+        ``sync_turn()`` — if we don't refresh them here, all subsequent
+        writes and the final commit target the **original** session_id
+        instead of the new one.
+
+        Called on ``/new``, ``/reset``, ``/resume``, ``/branch``, context
+        compression — any path that rotates ``AIAgent.session_id`` without
+        tearing the provider down.
+        """
+        if not new_session_id:
+            return
+        self._session_id = new_session_id
+        if reset:
+            # Genuinely new conversation — reset the turn counter so
+            # ``on_session_end()`` starts fresh.  The previous session's
+            # commit was already triggered by ``commit_memory_session()``
+            # before this switch.
+            self._turn_count = 0
+            self._cached_messages = []
+            self._commit_state = 0
 
     def _build_memory_uri(self, subdir: str) -> str:
         """Build a viking:// memory URI under the configured user/agent/subdir."""
@@ -645,22 +1102,18 @@ class OpenVikingMemoryProvider(MemoryProvider):
         subdir = _MEMORY_WRITE_TARGET_SUBDIR_MAP.get(target, _DEFAULT_MEMORY_SUBDIR)
         uri = self._build_memory_uri(subdir)
 
-        def _write():
-            try:
-                client = _VikingClient(
-                    self._endpoint, self._api_key,
-                    account=self._account, user=self._user, agent=self._agent,
-                )
-                client.post("/api/v1/content/write", {
-                    "uri": uri,
-                    "content": content,
-                    "mode": "create",
-                })
-            except Exception as e:
-                logger.debug("OpenViking memory mirror failed: %s", e)
-
-        t = threading.Thread(target=_write, daemon=True, name="openviking-memwrite")
-        t.start()
+        try:
+            client = _VikingClient(
+                self._endpoint, self._api_key,
+                account=self._account, user=self._user, agent=self._agent,
+            )
+            client.post("/api/v1/content/write", {
+                "uri": uri,
+                "content": content,
+                "mode": "create",
+            })
+        except Exception as e:
+            logger.debug("OpenViking memory mirror failed: %s", e)
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
         return [SEARCH_SCHEMA, READ_SCHEMA, BROWSE_SCHEMA, REMEMBER_SCHEMA, ADD_RESOURCE_SCHEMA]
@@ -685,14 +1138,33 @@ class OpenVikingMemoryProvider(MemoryProvider):
             return tool_error(str(e))
 
     def shutdown(self) -> None:
-        # Wait for background threads to finish
-        for t in (self._sync_thread, self._prefetch_thread):
-            if t and t.is_alive():
-                t.join(timeout=5.0)
-        # Clear atexit reference so it doesn't double-commit
+        # Phase 1: Persist snapshot to disk BEFORE clearing the atexit ref.
+        # This ensures recovery files exist even if the commit below fails.
+        if self._session_id and self._cached_messages:
+            self._persist_snapshot()
+        # Phase 2: Attempt synchronous force_commit as a last write.
+        # force_commit creates its own HTTP client and is independent
+        # of the worker thread. If this succeeds, the session is safe.
+        if self._commit_state < 2 and self._cached_messages:
+            try:
+                self.force_commit(list(self._cached_messages))
+            except Exception:
+                pass
+        # Phase 3: Shut down worker threads
+        if self._worker_thread and self._worker_thread.is_alive():
+            self._msg_queue.put((_SHUTDOWN, "", "", ""))
+            self._worker_thread.join(timeout=5.0)
+        if self._prefetch_thread and self._prefetch_thread.is_alive():
+            self._prefetch_thread.join(timeout=5.0)
+        # Phase 4: Clear atexit ref ONLY after everything above ran.
+        # The atexit handler will check persistent recovery files
+        # as a fallback if this commit failed.
         global _last_active_provider
         if _last_active_provider is self:
             _last_active_provider = None
+        # Phase 5: Write recovery marker for the finalizer
+        if self._commit_state < 2 and self._session_id:
+            self._write_recovery_marker()
 
     # -- Tool implementations ------------------------------------------------
 

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -51,6 +51,8 @@ from .registry import (
     update_state as _update_registry_state,
 )
 
+from hermes_constants import get_hermes_home
+
 logger = logging.getLogger(__name__)
 
 _DEFAULT_ENDPOINT = "http://127.0.0.1:1933"
@@ -59,7 +61,7 @@ _REMOTE_RESOURCE_PREFIXES = ("http://", "https://", "git@", "ssh://", "git://")
 
 # Cache and persistence limits
 _MAX_CACHED_MESSAGES = int(os.environ.get("OPENVIKING_CACHE_SIZE", "10000"))
-_RECOVERY_DIR = os.path.join(os.path.expanduser("~"), ".hermes", "openviking-recovery")
+_RECOVERY_DIR = os.path.join(str(get_hermes_home()), "openviking-recovery")
 
 # Maps the viking_remember `category` enum to a viking:// subdirectory.
 # Keep in sync with REMEMBER_SCHEMA.parameters.properties.category.enum.
@@ -811,7 +813,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
         """
         try:
             repair_dir = os.path.join(
-                os.path.expanduser("~"), ".hermes", "openviking-repair",
+                str(get_hermes_home()), "openviking-repair",
             )
             os.makedirs(repair_dir, exist_ok=True)
             journal_path = os.path.join(repair_dir, f"{session_id}.jsonl")
@@ -832,7 +834,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
         """
         try:
             repair_dir = os.path.join(
-                os.path.expanduser("~"), ".hermes", "openviking-repair",
+                str(get_hermes_home()), "openviking-repair",
             )
             os.makedirs(repair_dir, exist_ok=True)
             marker_path = os.path.join(repair_dir, f"{self._session_id}.json")

--- a/plugins/memory/openviking/finalizer.py
+++ b/plugins/memory/openviking/finalizer.py
@@ -1,0 +1,521 @@
+"""
+OpenViking Session Finalizer — discovers and commits orphaned sessions.
+
+This is the implementation that actually reads the repair markers, recovery
+files, and registry to find and commit orphaned sessions. The previous
+"Phase 4 finalizer" only checked the OV state DB — this one covers all paths.
+
+Sources checked (in priority order):
+1. Hermes state DB (~/.hermes/state.db) — the authoritative transcript store
+2. OV registry DB (~/.hermes/openviking-sessions.db) — session lifecycle tracking
+3. Repair journal (~/.hermes/openviking-repair/*.jsonl) — queue worker failures
+4. Recovery snapshots (~/.hermes/openviking-recovery/*.json) — shutdown persistence
+
+Usage:
+    python3 -m plugins.memory.openviking.finalizer [--dry-run] [--batch=100]
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sqlite3
+import time
+from typing import Any, Dict, List, Optional, Set
+
+from .registry import (
+    get_uncommitted_sessions,
+    get_all_session_ids,
+    get_session,
+    update_state as update_registry_state,
+    clear_stale_finalizing,
+    mark_dead,
+)
+
+logger = logging.getLogger(__name__)
+
+# Paths
+_HERMES_HOME = os.path.expanduser("~/.hermes")
+_STATE_DB = os.path.join(_HERMES_HOME, "state.db")
+_REPAIR_DIR = os.path.join(_HERMES_HOME, "openviking-repair")
+_RECOVERY_DIR = os.path.join(_HERMES_HOME, "openviking-recovery")
+
+# OpenViking
+_OV_ENDPOINT = os.environ.get("OPENVIKING_ENDPOINT", "http://127.0.0.1:1933")
+_OV_API_KEY = os.environ.get("OPENVIKING_API_KEY", "")
+_OV_ACCOUNT = os.environ.get("OPENVIKING_ACCOUNT", "default")
+_OV_USER = os.environ.get("OPENVIKING_USER", "default")
+_OV_AGENT = os.environ.get("OPENVIKING_AGENT", "hermes")
+
+# Limits
+_BATCH_SIZE = 100
+_OV_PAGE_LIMIT = 1000  # OV API max per page
+_OV_TIMEOUT = 30.0
+
+
+# ---------------------------------------------------------------------------
+# OV API helpers
+# ---------------------------------------------------------------------------
+
+def _ov_headers() -> Dict[str, str]:
+    h = {
+        "Content-Type": "application/json",
+        "X-OpenViking-Account": _OV_ACCOUNT,
+        "X-OpenViking-User": _OV_USER,
+        "X-OpenViking-Agent": _OV_AGENT,
+    }
+    if _OV_API_KEY:
+        h["Authorization"] = f"Bearer {_OV_API_KEY}"
+    return h
+
+
+def _ov_list_sessions_paginated() -> Set[str]:
+    """Return all OV session IDs from a single request.
+
+    OV's GET /api/v1/sessions returns ALL sessions in one response — it
+    does not support cursor/offset/page parameters (they are silently
+    ignored). The list response only contains session_id/uri/is_dir;
+    session detail (created_at, message_count, etc.) requires a separate
+    GET /api/v1/sessions/{sid} call.
+
+    Note: the list response does NOT include created_at or updated_at
+    (those fields are null). This is a limitation of the filesystem-based
+    list — not a bug. Session detail has the real timestamps.
+    """
+    import httpx
+    all_sids: Set[str] = set()
+    try:
+        with httpx.Client(timeout=_OV_TIMEOUT) as client:
+            resp = client.get(
+                f"{_OV_ENDPOINT}/api/v1/sessions",
+                headers=_ov_headers(),
+            )
+            if resp.status_code >= 400:
+                logger.warning("OV API list returned %d", resp.status_code)
+                return all_sids
+            data = resp.json()
+            result = data.get("result", [])
+            for s in result:
+                sid = s.get("session_id")
+                if sid:
+                    all_sids.add(sid)
+            logger.info("Found %d sessions in OV", len(all_sids))
+    except Exception as exc:
+        logger.error("OV session list failed: %s", exc)
+    return all_sids
+
+
+def _ov_session_detail(sid: str) -> Optional[Dict[str, Any]]:
+    """Get session detail from OV. Returns None on error."""
+    import httpx
+    try:
+        with httpx.Client(timeout=10.0) as client:
+            resp = client.get(
+                f"{_OV_ENDPOINT}/api/v1/sessions/{sid}",
+                headers=_ov_headers(),
+            )
+            if resp.status_code >= 400:
+                return None
+            data = resp.json()
+            if data.get("status") == "ok":
+                return data.get("result")
+            return None
+    except Exception:
+        return None
+
+
+def _ov_push_and_commit(sid: str, messages: List[Dict[str, Any]]) -> bool:
+    """Push messages to OV session and commit, then verify.
+
+    Creates its own HTTP client. Returns True if commit endpoint accepted
+    the request (HTTP < 400). Logs a warning if post-commit read-back
+    shows message_count=0 (empty shell), but does NOT fail the commit
+    — Hermes state.db is the authoritative session store, OV is secondary.
+    """
+    if not messages:
+        return False
+    import httpx
+    try:
+        with httpx.Client(timeout=_OV_TIMEOUT) as client:
+            for msg in messages[-2000:]:
+                role = msg.get("role", "user")
+                if role not in ("user", "assistant", "tool"):
+                    continue
+                content = (msg.get("content") or "")[:4000]
+                client.post(
+                    f"{_OV_ENDPOINT}/api/v1/sessions/{sid}/messages",
+                    json={"role": role, "content": content},
+                    headers=_ov_headers(),
+                )
+            resp = client.post(
+                f"{_OV_ENDPOINT}/api/v1/sessions/{sid}/commit",
+                headers=_ov_headers(),
+            )
+            commit_ok = resp.status_code < 400
+
+            # Post-commit read-back verification (informational)
+            try:
+                verify = client.get(
+                    f"{_OV_ENDPOINT}/api/v1/sessions/{sid}",
+                    headers=_ov_headers(),
+                )
+                if verify.status_code < 400:
+                    vd = verify.json()
+                    result = vd.get("result", {})
+                    live_count = result.get("message_count", 0)
+                    total_count = result.get("total_message_count", 0)
+                    if live_count == 0 and total_count == 0 and commit_ok:
+                        logger.warning(
+                            "OV commit for %s returned success but message_count=0 "
+                            "AND total_message_count=0 — messages were not persisted",
+                            sid
+                        )
+                    elif live_count == 0 and total_count > 0 and commit_ok:
+                        logger.debug(
+                            "OV commit for %s OK: %d total messages (all archived, "
+                            "live count is 0 as expected after commit)", sid, total_count
+                        )
+            except Exception as exc:
+                logger.debug("OV verification read-back failed for %s: %s", sid, exc)
+
+            return commit_ok
+    except Exception as exc:
+        logger.error("OV push/commit failed for %s: %s", sid, exc)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Source discovery
+# ---------------------------------------------------------------------------
+
+def _discover_hermes_state_sessions(min_messages: int = 5) -> List[Dict[str, Any]]:
+    """Return sessions from Hermes state DB with at least *min_messages* messages."""
+    if not os.path.isfile(_STATE_DB):
+        return []
+    try:
+        conn = sqlite3.connect(f"file:{_STATE_DB}?mode=ro", uri=True, timeout=5.0)
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = conn.execute(
+                """
+                SELECT s.id, s.source,
+                    (SELECT COUNT(*) FROM messages m WHERE m.session_id = s.id) as actual_msgs
+                FROM sessions s
+                WHERE s.message_count > 0
+                  AND (SELECT COUNT(*) FROM messages m WHERE m.session_id = s.id) >= ?
+                ORDER BY s.started_at ASC
+                """,
+                (min_messages,),
+            ).fetchall()
+            result = []
+            for r in rows:
+                d = dict(r)
+                d["_source"] = "hermes_state"
+                result.append(d)
+            return result
+        finally:
+            conn.close()
+    except Exception as exc:
+        logger.debug("Hermes state DB read failed: %s", exc)
+        return []
+
+
+def _discover_repair_journals() -> List[Dict[str, Any]]:
+    """Read repair journal JSONL files."""
+    if not os.path.isdir(_REPAIR_DIR):
+        return []
+    results: List[Dict[str, Any]] = []
+    try:
+        for fname in os.listdir(_REPAIR_DIR):
+            if not fname.endswith(".jsonl"):
+                continue
+            sid = fname[:-6]  # strip .jsonl
+            fpath = os.path.join(_REPAIR_DIR, fname)
+            try:
+                with open(fpath) as f:
+                    lines = f.readlines()
+                messages = []
+                for line in lines:
+                    line = line.strip()
+                    if line:
+                        messages.append(json.loads(line))
+                if messages:
+                    results.append({
+                        "id": sid,
+                        "_source": "repair_journal",
+                        "actual_msgs": len(messages),
+                        "_messages": messages,
+                    })
+            except Exception:
+                continue
+    except Exception:
+        pass
+    return results
+
+
+def _discover_recovery_snapshots() -> List[Dict[str, Any]]:
+    """Read recovery snapshot JSON files."""
+    if not os.path.isdir(_RECOVERY_DIR):
+        return []
+    results: List[Dict[str, Any]] = []
+    try:
+        for fname in os.listdir(_RECOVERY_DIR):
+            if not fname.endswith(".json"):
+                continue
+            if fname == ".pending":
+                continue
+            fpath = os.path.join(_RECOVERY_DIR, fname)
+            try:
+                with open(fpath) as f:
+                    data = json.load(f)
+                sid = data.get("session_id", fname[:-5])
+                messages = data.get("messages", [])
+                if messages:
+                    results.append({
+                        "id": sid,
+                        "_source": "recovery_snapshot",
+                        "actual_msgs": len(messages),
+                        "_messages": messages,
+                        "_snapshot": data,
+                    })
+            except Exception:
+                continue
+    except Exception:
+        pass
+    return results
+
+
+def _discover_hermes_state_messages(sid: str) -> Optional[List[Dict[str, Any]]]:
+    """Get messages for a session from the Hermes state DB."""
+    try:
+        conn = sqlite3.connect(f"file:{_STATE_DB}?mode=ro", uri=True, timeout=5.0)
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = conn.execute(
+                """
+                SELECT role, content, timestamp
+                FROM messages
+                WHERE session_id = ?
+                ORDER BY timestamp ASC, id ASC
+                """,
+                (sid,),
+            ).fetchall()
+            return [dict(r) for r in rows]
+        finally:
+            conn.close()
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Cleanup helpers
+# ---------------------------------------------------------------------------
+
+def _cleanup_marker(sid: str) -> None:
+    """Remove all marker files for a session."""
+    for directory in (_REPAIR_DIR, _RECOVERY_DIR):
+        if not os.path.isdir(directory):
+            continue
+        for suffix in (".jsonl", ".json"):
+            fpath = os.path.join(directory, f"{sid}{suffix}")
+            try:
+                os.remove(fpath)
+            except Exception:
+                pass
+    # Also remove from .pending
+    pending_path = os.path.join(_RECOVERY_DIR, ".pending")
+    if os.path.exists(pending_path):
+        try:
+            with open(pending_path) as f:
+                lines = f.readlines()
+            with open(pending_path, "w") as f:
+                for line in lines:
+                    if line.strip() != sid:
+                        f.write(line)
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def run_finalizer(
+    dry_run: bool = False,
+    batch_size: int = _BATCH_SIZE,
+    min_messages: int = 5,
+) -> Dict[str, Any]:
+    """Run the finalizer: discover orphaned sessions and commit them.
+
+    Args:
+        dry_run: If True, only report what would be done (no writes).
+        batch_size: Sessions per batch for progress reporting.
+        min_messages: Skip sessions with fewer messages.
+
+    Returns:
+        Dict with committed, failed, skipped counts.
+    """
+    committed = 0
+    failed = 0
+    skipped = 0
+    new_failures = 0
+
+    # Phase 0: Escape stuck FINALIZING sessions (circuit breaker for stale state)
+    unstuck = clear_stale_finalizing(max_age_minutes=30)
+    if unstuck:
+        logger.info("Unstuck %d sessions from stale FINALIZING state", unstuck)
+
+    # Phase 1: Collect candidates from ALL sources
+    candidates: Dict[str, Dict[str, Any]] = {}
+
+    # Source A: Registry (sessions tracked but not committed)
+    for s in get_uncommitted_sessions():
+        sid = s["session_id"]
+        candidates[sid] = {
+            "id": sid,
+            "_source": "registry",
+            "actual_msgs": s.get("turn_count", 0) * 2,
+            "_messages": s.get("cached_messages", []),
+            "registry_state": s.get("state", ""),
+        }
+
+    # Source B: Hermes state DB
+    for s in _discover_hermes_state_sessions(min_messages=min_messages):
+        sid = s["id"]
+        if sid not in candidates:
+            candidates[sid] = s
+
+    # Source C: Repair journals (queue worker failures)
+    for s in _discover_repair_journals():
+        sid = s["id"]
+        if sid not in candidates:
+            candidates[sid] = s
+        elif not candidates[sid].get("_messages"):
+            candidates[sid]["_messages"] = s.get("_messages", [])
+
+    # Source D: Recovery snapshots (shutdown persistence)
+    for s in _discover_recovery_snapshots():
+        sid = s["id"]
+        if sid not in candidates:
+            candidates[sid] = s
+        elif not candidates[sid].get("_messages"):
+            candidates[sid]["_messages"] = s.get("_messages", [])
+
+    if not candidates:
+        logger.info("No orphaned sessions found — all clear")
+        return {"committed": 0, "failed": 0, "skipped": 0}
+
+    # Phase 2: Filter against OV's actual session list (paginated)
+    logger.info("Fetching OV session list (paginated)...")
+    ov_sids = _ov_list_sessions_paginated()
+    logger.info("Found %d sessions in OV", len(ov_sids))
+
+    to_process = []
+    for sid, info in list(candidates.items()):
+        if sid in ov_sids:
+            skipped += 1
+            continue
+        to_process.append((sid, info))
+
+    if not to_process:
+        logger.info("All sessions already committed in OV")
+        return {"committed": 0, "failed": 0, "skipped": skipped}
+
+    if dry_run:
+        logger.info(
+            "DRY RUN — would process %d sessions (committed=%d, failed=%d, skipped=%d)",
+            len(to_process), committed, failed, skipped,
+        )
+        return {"committed": 0, "failed": 0, "skipped": skipped, "dry_run": len(to_process)}
+
+    # Phase 3: Process candidates in batches
+    total = len(to_process)
+    logger.info("Processing %d sessions in batches of %d...", total, batch_size)
+
+    for i in range(0, total, batch_size):
+        batch = to_process[i : i + batch_size]
+        batch_num = (i // batch_size) + 1
+        total_batches = (total + batch_size - 1) // batch_size
+
+        for sid, info in batch:
+            # Get messages — try cached first, then Hermes state DB
+            messages = info.get("_messages", [])
+            if not messages:
+                msg_data = _discover_hermes_state_messages(sid)
+                if msg_data:
+                    messages = msg_data
+            if not messages:
+                skipped += 1
+                logger.info("  SKIP %s: no messages available", sid)
+                continue
+            if len(messages) < min_messages:
+                skipped += 1
+                continue
+
+            # Push to OV and commit
+            ok = _ov_push_and_commit(sid, messages)
+            if ok:
+                committed += 1
+                update_registry_state(sid, "COMMITTED")
+                _cleanup_marker(sid)
+                logger.info("  OK  %s: %d msgs -> committed", sid, len(messages))
+            else:
+                failed += 1
+                update_registry_state(sid, "FAILED", error="finalizer commit failed")
+                logger.info("  FAIL %s: commit failed", sid)
+                # Circuit breaker: if retries exceeded, mark DEAD and log once
+                rec = get_session(sid)
+                if rec and rec.get("retry_count", 0) >= 3:
+                    mark_dead(sid, error="finalizer: max retries exceeded")
+                    logger.warning(
+                        "  DEAD %s: retry_count=%d exceeded max — "
+                        "permanently excluded from finalizer runs",
+                        sid, rec["retry_count"],
+                    )
+                elif rec and rec.get("retry_count", 0) <= 1:
+                    new_failures += 1
+
+        if i + batch_size < total:
+            logger.info(
+                "  Batch %d/%d done: %d committed, %d failed, %d skipped",
+                batch_num, total_batches, committed, failed, skipped,
+            )
+            time.sleep(0.5)
+
+    logger.info(
+        "Finalizer done: %d committed, %d failed, %d skipped",
+        committed, failed, skipped,
+    )
+    return {"committed": committed, "failed": failed, "skipped": skipped, "new_failures": new_failures}
+
+
+def main() -> None:
+    """CLI entry point."""
+    import argparse
+    parser = argparse.ArgumentParser(description="OpenViking session finalizer")
+    parser.add_argument("--dry-run", action="store_true", help="Report only, no writes")
+    parser.add_argument("--batch", type=int, default=_BATCH_SIZE, help="Batch size")
+    parser.add_argument("--min-messages", type=int, default=5, help="Skip sessions with fewer msgs")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Verbose logging")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s %(message)s",
+    )
+
+    result = run_finalizer(
+        dry_run=args.dry_run,
+        batch_size=args.batch,
+        min_messages=args.min_messages,
+    )
+    print(
+        f"Committed: {result['committed']}, "
+        f"Failed: {result['failed']}, "
+        f"Skipped: {result['skipped']}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/memory/openviking/finalizer.py
+++ b/plugins/memory/openviking/finalizer.py
@@ -33,10 +33,12 @@ from .registry import (
     mark_dead,
 )
 
+from hermes_constants import get_hermes_home
+
 logger = logging.getLogger(__name__)
 
 # Paths
-_HERMES_HOME = os.path.expanduser("~/.hermes")
+_HERMES_HOME = str(get_hermes_home())
 _STATE_DB = os.path.join(_HERMES_HOME, "state.db")
 _REPAIR_DIR = os.path.join(_HERMES_HOME, "openviking-repair")
 _RECOVERY_DIR = os.path.join(_HERMES_HOME, "openviking-recovery")

--- a/plugins/memory/openviking/registry.py
+++ b/plugins/memory/openviking/registry.py
@@ -1,0 +1,388 @@
+"""
+Standalone OpenViking Session Registry — zero agent dependencies.
+
+A process-safe, thread-safe SQLite registry that any code path (CLI, gateway,
+cron, batch) can write to without importing the OpenViking memory provider.
+
+Schema:
+    sessions(session_id TEXT PRIMARY KEY,
+             state TEXT,           -- CREATED|IN_SYNC|FINALIZING|COMMITTED|FAILED
+             turn_count INT,
+             message_count INT,
+             source TEXT,          -- cli, cron, telegram, batch, api_server
+             created_at TEXT,
+             updated_at TEXT,
+             commit_attempted_at TEXT,
+             error TEXT,
+             cached_messages TEXT)  -- JSON array of {role, content} dicts
+
+Usage:
+    from plugins.memory.openviking.registry import (
+        register_session, update_state, get_uncommitted_sessions
+    )
+    register_session("session_abc123", source="cron")
+    update_state("session_abc123", "COMMITTED")
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sqlite3
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+_HERMES_HOME = os.path.expanduser("~/.hermes")
+_SESSION_DB_PATH = os.path.join(_HERMES_HOME, "openviking-sessions.db")
+
+# ---------------------------------------------------------------------------
+# Lock — thread-safe across all registry operations
+# ---------------------------------------------------------------------------
+_lock = threading.Lock()
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS sessions (
+    session_id TEXT PRIMARY KEY,
+    state TEXT NOT NULL DEFAULT 'CREATED',
+    turn_count INTEGER NOT NULL DEFAULT 0,
+    message_count INTEGER NOT NULL DEFAULT 0,
+    source TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    commit_attempted_at TEXT,
+    error TEXT,
+    cached_messages TEXT NOT NULL DEFAULT '[]',
+    retry_count INTEGER NOT NULL DEFAULT 0
+);
+"""
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def ensure_schema() -> None:
+    """Create the sessions table if it does not already exist.
+
+    Safe to call multiple times — uses IF NOT EXISTS.
+    Also migrates older tables by adding missing columns.
+    """
+    try:
+        os.makedirs(_HERMES_HOME, exist_ok=True)
+        with _lock:
+            with sqlite3.connect(_SESSION_DB_PATH, timeout=10.0) as conn:
+                conn.execute(_SCHEMA_SQL)
+                # Migration: add columns that may be missing from older schemas
+                _migrate_add_column(conn, "sessions", "cached_messages", "TEXT NOT NULL DEFAULT '[]'")
+                _migrate_add_column(conn, "sessions", "message_count", "INTEGER NOT NULL DEFAULT 0")
+                _migrate_add_column(conn, "sessions", "source", "TEXT NOT NULL DEFAULT ''")
+                _migrate_add_column(conn, "sessions", "retry_count", "INTEGER NOT NULL DEFAULT 0")
+                conn.commit()
+        # Phase 1 patch (2026-06-05, OV 3xstanbrain follow-on): install the
+        # schema invariant that prevents unverified COMMITTED writes. The
+        # trigger + verified_ov_dir column are part of registry_invariant.py
+        # and are idempotent — safe to call on every ensure_schema().
+        try:
+            from plugins.memory.openviking.registry_invariant import install_invariant
+            install_invariant()
+        except Exception as exc:
+            logger.debug("OpenViking registry invariant install failed: %s", exc)
+    except Exception as exc:
+        logger.debug("OpenViking registry ensure_schema failed: %s", exc)
+
+
+def _migrate_add_column(conn: sqlite3.Connection, table: str, column: str, col_def: str) -> None:
+    """Add a column to *table* if it doesn't already exist.
+
+    Safe to call multiple times. Only adds columns that are missing.
+    """
+    try:
+        pragma = conn.execute(f"PRAGMA table_info({table})").fetchall()
+        existing = {row[1] for row in pragma}
+        if column not in existing:
+            conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {col_def}")
+            logger.info("Migrated %s: added column %s", table, column)
+    except Exception as exc:
+        logger.debug("Migration failed for %s.%s: %s", table, column, exc)
+
+
+def register_session(
+    session_id: str,
+    *,
+    source: str = "",
+    turn_count: int = 0,
+    state: str = "CREATED",
+) -> None:
+    """Register a session in the registry.
+
+    This is a no-op if the session_id already exists (upsert only updates
+    source if source was empty). Call once per session lifecycle.
+    """
+    if not session_id:
+        return
+    try:
+        ensure_schema()
+        now = _now()
+        with _lock:
+            with sqlite3.connect(_SESSION_DB_PATH, timeout=10.0) as conn:
+                conn.execute(
+                    """
+                    INSERT INTO sessions
+                        (session_id, state, turn_count, source, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(session_id) DO UPDATE SET
+                        source = CASE WHEN sessions.source = '' THEN excluded.source
+                                      ELSE sessions.source END,
+                        updated_at = excluded.updated_at
+                    """,
+                    (session_id, state, turn_count, source, now, now),
+                )
+                conn.commit()
+    except Exception as exc:
+        logger.debug("OpenViking registry register_session failed: %s", exc)
+
+
+def update_state(
+    session_id: str,
+    state: str,
+    *,
+    turn_count: Optional[int] = None,
+    messages: Optional[List[Dict[str, Any]]] = None,
+    error: Optional[str] = None,
+) -> None:
+    """Update a session's state and optional metadata.
+
+    State transitions are not enforced at the DB level — any string is
+    accepted. The canonical lifecycle is:
+        CREATED → IN_SYNC → FINALIZING → COMMITTED
+                                      → FAILED
+    """
+    if not session_id:
+        return
+    try:
+        ensure_schema()
+        now = _now()
+        msg_json = json.dumps(messages or [])
+        tc = turn_count if turn_count is not None else -1  # sentinel for no update
+        with _lock:
+            with sqlite3.connect(_SESSION_DB_PATH, timeout=10.0) as conn:
+                conn.execute(
+                    """
+                    INSERT INTO sessions
+                        (session_id, state, turn_count, updated_at,
+                         commit_attempted_at, error, cached_messages)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(session_id) DO UPDATE SET
+                        state = excluded.state,
+                        turn_count = CASE
+                            WHEN excluded.turn_count >= 0 THEN excluded.turn_count
+                            ELSE turn_count END,
+                        updated_at = excluded.updated_at,
+                        commit_attempted_at = CASE
+                            WHEN excluded.state IN ('COMMITTED', 'FAILED', 'FINALIZING')
+                            THEN excluded.updated_at
+                            ELSE commit_attempted_at END,
+                        error = CASE
+                            WHEN excluded.state = 'FAILED' THEN ?
+                            ELSE error END,
+                        cached_messages = CASE
+                            WHEN excluded.cached_messages != '[]'
+                            THEN excluded.cached_messages
+                            ELSE cached_messages END,
+                        retry_count = CASE
+                            WHEN excluded.state = 'FAILED'
+                            THEN retry_count + 1
+                            ELSE retry_count END
+                    """,
+                    (
+                        session_id, state, tc, now,
+                        now if state in ("COMMITTED", "FAILED", "FINALIZING") else None,
+                        error or "", msg_json, error or "",
+                    ),
+                )
+                conn.commit()
+    except Exception as exc:
+        logger.debug("OpenViking registry update_state failed: %s", exc)
+
+
+def get_uncommitted_sessions(
+    limit: int = 5000,
+    offset: int = 0,
+    max_retry: int = 3,
+) -> List[Dict[str, Any]]:
+    """Return sessions not yet in a terminal state (COMMITTED, FAILED, or DEAD).
+
+    Sessions with retry_count >= max_retry are excluded (circuit breaker).
+
+    Results ordered by created_at ASC.
+    """
+    if not _db_exists():
+        return []
+    try:
+        with _lock:
+            conn = sqlite3.connect(
+                f"file:{_SESSION_DB_PATH}?mode=ro", uri=True, timeout=5.0,
+            )
+            conn.row_factory = sqlite3.Row
+            try:
+                rows = conn.execute(
+                    """
+                    SELECT * FROM sessions
+                    WHERE state NOT IN ('COMMITTED', 'FAILED', 'DEAD')
+                      AND (retry_count < ? OR retry_count IS NULL)
+                    ORDER BY created_at ASC
+                    LIMIT ? OFFSET ?
+                    """,
+                    (max_retry, limit, offset),
+                ).fetchall()
+                result = []
+                for r in rows:
+                    d = dict(r)
+                    try:
+                        d["cached_messages"] = json.loads(d.get("cached_messages", "[]"))
+                    except Exception:
+                        d["cached_messages"] = []
+                    result.append(d)
+                return result
+            finally:
+                conn.close()
+    except Exception as exc:
+        logger.debug("OpenViking registry get_uncommitted_sessions failed: %s", exc)
+        return []
+
+
+def get_session(session_id: str) -> Optional[Dict[str, Any]]:
+    """Return a single session record, or None if not found."""
+    if not _db_exists():
+        return None
+    try:
+        with _lock:
+            conn = sqlite3.connect(
+                f"file:{_SESSION_DB_PATH}?mode=ro", uri=True, timeout=5.0,
+            )
+            conn.row_factory = sqlite3.Row
+            try:
+                row = conn.execute(
+                    "SELECT * FROM sessions WHERE session_id = ?",
+                    (session_id,),
+                ).fetchone()
+                if row:
+                    d = dict(row)
+                    try:
+                        d["cached_messages"] = json.loads(d.get("cached_messages", "[]"))
+                    except Exception:
+                        d["cached_messages"] = []
+                    return d
+                return None
+            finally:
+                conn.close()
+    except Exception as exc:
+        logger.debug("OpenViking registry get_session failed: %s", exc)
+        return None
+
+
+def get_session_count() -> Dict[str, int]:
+    """Return total number of sessions in the registry, by state."""
+    if not _db_exists():
+        return {}
+    try:
+        with _lock:
+            conn = sqlite3.connect(
+                f"file:{_SESSION_DB_PATH}?mode=ro", uri=True, timeout=5.0,
+            )
+            try:
+                rows = conn.execute(
+                    "SELECT state, COUNT(*) as cnt FROM sessions GROUP BY state"
+                ).fetchall()
+                return {r[0]: r[1] for r in rows}
+            finally:
+                conn.close()
+    except Exception as exc:
+        logger.debug("OpenViking registry get_session_count failed: %s", exc)
+        return {}
+
+
+def get_all_session_ids() -> List[str]:
+    """Return all session IDs in the registry.
+
+    Used for reconciliation against both Hermes state DB and OV API.
+    """
+    if not _db_exists():
+        return []
+    try:
+        with _lock:
+            conn = sqlite3.connect(
+                f"file:{_SESSION_DB_PATH}?mode=ro", uri=True, timeout=5.0,
+            )
+            try:
+                rows = conn.execute(
+                    "SELECT session_id FROM sessions ORDER BY created_at ASC"
+                ).fetchall()
+                return [r[0] for r in rows]
+            finally:
+                conn.close()
+    except Exception as exc:
+        logger.debug("OpenViking registry get_all_session_ids failed: %s", exc)
+        return []
+
+
+def clear_stale_finalizing(max_age_minutes: int = 30) -> int:
+    """Reset sessions stuck in FINALIZING for longer than max_age_minutes to CREATED.
+
+    Returns the number of sessions unstuck.
+    """
+    if not _db_exists():
+        return 0
+    try:
+        with _lock:
+            conn = sqlite3.connect(_SESSION_DB_PATH, timeout=10.0)
+            now = _now()
+            try:
+                # Use the exclude filter so only truly stuck sessions are caught
+                c = conn.execute(
+                    """
+                    UPDATE sessions SET
+                        state = 'CREATED',
+                        error = 'unstuck from FINALIZING (stale > %d min)',
+                        updated_at = ?
+                    WHERE state = 'FINALIZING'
+                      AND updated_at < datetime('now', ?)
+                    """ % (max_age_minutes,),
+                    (now, f'-{max_age_minutes} minutes'),
+                )
+                conn.commit()
+                return c.rowcount
+            finally:
+                conn.close()
+    except Exception as exc:
+        logger.debug("OpenViking registry clear_stale_finalizing failed: %s", exc)
+        return 0
+
+
+def mark_dead(session_id: str, error: str = "max retries exceeded") -> None:
+    """Mark a session as DEAD (terminal, will not be retried)."""
+    update_state(session_id, "DEAD", error=error)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _db_exists() -> bool:
+    """Check if the database file exists (fast path)."""
+    return os.path.isfile(_SESSION_DB_PATH)
+
+
+def _now() -> str:
+    """Return ISO-8601 timestamp string."""
+    return time.strftime("%Y-%m-%dT%H:%M:%S")

--- a/plugins/memory/openviking/registry.py
+++ b/plugins/memory/openviking/registry.py
@@ -36,10 +36,12 @@ from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
+from hermes_constants import get_hermes_home
+
 # ---------------------------------------------------------------------------
 # Paths
 # ---------------------------------------------------------------------------
-_HERMES_HOME = os.path.expanduser("~/.hermes")
+_HERMES_HOME = str(get_hermes_home())
 _SESSION_DB_PATH = os.path.join(_HERMES_HOME, "openviking-sessions.db")
 
 # ---------------------------------------------------------------------------

--- a/plugins/memory/openviking/registry_invariant.py
+++ b/plugins/memory/openviking/registry_invariant.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""
+registry_invariant — schema-level rule that COMMITTED implies verified_ov_dir=1.
+
+Lives at: apps/hermes-agent/plugins/memory/openviking/registry_invariant.py
+
+This is the Phase 1 deliverable from the 2026-06-01 OV orphan 3xstanbrain audit
+(/home/openclaw/audit-ov-orphan-2026-06-01-1505/CONSOLIDATED-PLAN.md).
+
+The original design (registry_schema_invariant.py in the audit folder) is
+preserved verbatim — same triggers, same mark_verified() semantics, same
+verify_ingestion() cross-reference. The only adaptation is import path
+(plugin location) and removal of the dev-mode fallback so we fail loud if
+the plugin package is not importable.
+
+Public surface:
+    install_invariant()          — call from registry.ensure_schema() (1-line patch)
+    mark_verified(session_id)   — set verified_ov_dir based on live OV dir check
+    verify_ingestion()           — cross-reference: count of guaranteed empty shells
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, List
+
+# Reuse the same lock + DB path that registry.py exposes.
+try:
+    from plugins.memory.openviking.registry import (
+        _lock,
+        _SESSION_DB_PATH,
+        ensure_schema,
+        _now,
+    )
+except Exception as exc:  # pragma: no cover — fail loud, not silent
+    raise SystemExit(
+        f"registry_invariant: cannot import registry internals ({exc!r}). "
+        "This module must be deployed alongside the plugin, not standalone."
+    ) from exc
+
+
+# Defence in depth: wrap the registry Lock as an RLock so that nested
+# acquisition (e.g. mark_verified -> install_invariant from the same
+# thread) cannot deadlock. The fix for the 2026-06-05 verifier-deadlock
+# class. Registry.py itself can be migrated independently later.
+class _RLockWrapper:
+    """Wraps a Lock() in RLock-like semantics using a re-entrant check.
+
+    The registry's _lock is a threading.Lock(). mark_verified() calls
+    install_invariant() which also takes _lock — re-entering a Lock()
+    from the same thread deadlocks. We detect re-entry by thread identity
+    and let the same thread pass; foreign threads block as before.
+    """
+
+    def __init__(self, inner):
+        import threading as _t
+        self._inner = inner
+        self._local = _t.local()
+
+    def __enter__(self):
+        if getattr(self._local, "depth", 0) > 0:
+            self._local.depth += 1
+            return self
+        self._inner.acquire()
+        self._local.depth = 1
+        return self
+
+    def __exit__(self, *exc):
+        self._local.depth -= 1
+        if self._local.depth == 0:
+            self._inner.release()
+
+
+_lock = _RLockWrapper(_lock)  # noqa: F811 — replace the imported Lock() with our wrapper
+
+
+# OV session directory — the canonical "the session is in OV" ground truth.
+# Same path the rest of the OV plugin uses.
+OV_SESSION_DIR = Path(
+    os.environ.get(
+        "OPENVIKING_SESSION_DIR",
+        os.path.expanduser("~/data/viking/default/session"),
+    )
+)
+
+
+# A coarse thread lock for the schema-installation phase. registry._lock
+# protects per-row writes; this protects the one-shot CREATE TRIGGER calls
+# (which are themselves idempotent, but we serialize to keep the log clean).
+_invariant_lock = threading.Lock()
+
+
+def install_invariant() -> None:
+    """Add the verified_ov_dir column and the state-update triggers.
+
+    Idempotent — safe to call on every registry startup. Each ALTER and each
+    CREATE TRIGGER IF NOT EXISTS is a no-op on the second call.
+    """
+    ensure_schema()
+    with _invariant_lock:
+        with _lock:
+            with sqlite3.connect(_SESSION_DB_PATH, timeout=10.0) as conn:
+                # Add columns (idempotent — sqlite ALTER has no IF NOT EXISTS,
+                # so we swallow the "duplicate column" error and move on).
+                for col, typedef in (
+                    ("verified_ov_dir", "INTEGER NOT NULL DEFAULT 0"),
+                    ("verified_at", "TEXT"),
+                ):
+                    try:
+                        conn.execute(
+                            f"ALTER TABLE sessions ADD COLUMN {col} {typedef}"
+                        )
+                    except Exception:
+                        # Column already exists, or another error. The
+                        # subsequent DDL will tell us if this is a real problem.
+                        pass
+
+                # Primary trigger: COMMITTED requires verified_ov_dir=1.
+                conn.execute(
+                    """
+                    CREATE TRIGGER IF NOT EXISTS sessions_committed_requires_verified
+                    BEFORE UPDATE OF state ON sessions
+                    FOR EACH ROW
+                    WHEN NEW.state = 'COMMITTED' AND NEW.verified_ov_dir = 0
+                    BEGIN
+                        SELECT RAISE(ABORT, 'invariant: state=COMMITTED requires verified_ov_dir=1; call mark_verified() first');
+                    END;
+                    """
+                )
+                # Companion trigger: any non-COMMITTED state clears the flag.
+                conn.execute(
+                    """
+                    CREATE TRIGGER IF NOT EXISTS sessions_non_committed_resets_verified
+                    BEFORE UPDATE OF state ON sessions
+                    FOR EACH ROW
+                    WHEN NEW.state != 'COMMITTED' AND OLD.verified_ov_dir = 1
+                    BEGIN
+                        UPDATE sessions SET verified_ov_dir = 0 WHERE session_id = OLD.session_id;
+                    END;
+                    """
+                )
+                conn.commit()
+
+
+def mark_verified(session_id: str) -> Dict[str, Any]:
+    """Mark a session verified in OV (filesystem dir present).
+
+    Returns a small dict describing the result. The caller is expected to
+    use this BEFORE the next update_state(state='COMMITTED', ...), in the
+    same transaction if possible, to satisfy the schema invariant.
+    """
+    install_invariant()
+    has_dir = (OV_SESSION_DIR / session_id).is_dir()
+    now = _now()
+    with _lock:
+        with sqlite3.connect(_SESSION_DB_PATH, timeout=10.0) as conn:
+            conn.execute(
+                """
+                UPDATE sessions
+                SET verified_ov_dir = ?, verified_at = ?
+                WHERE session_id = ?
+                """,
+                (1 if has_dir else 0, now, session_id),
+            )
+            conn.commit()
+    return {
+        "session_id": session_id,
+        "verified_ov_dir": int(has_dir),
+        "verified_at": now,
+    }
+
+
+def verify_ingestion() -> Dict[str, Any]:
+    """Cross-reference the registry against the schema invariant.
+
+    Returns:
+        total_sessions, committed_total, committed_verified_ov_dir,
+        guaranteed_empty_shells, guaranteed_empty_shell_ids (first 100).
+    """
+    install_invariant()
+    with _lock:
+        with sqlite3.connect(_SESSION_DB_PATH, timeout=10.0) as conn:
+            conn.row_factory = sqlite3.Row
+            total = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+            committed = conn.execute(
+                "SELECT COUNT(*) FROM sessions WHERE state='COMMITTED'"
+            ).fetchone()[0]
+            verified = conn.execute(
+                "SELECT COUNT(*) FROM sessions WHERE state='COMMITTED' AND verified_ov_dir=1"
+            ).fetchone()[0]
+            shells: List[Dict[str, Any]] = [
+                dict(r) for r in conn.execute(
+                    "SELECT session_id, verified_at FROM sessions "
+                    "WHERE state='COMMITTED' AND verified_ov_dir=0 LIMIT 100"
+                ).fetchall()
+            ]
+    return {
+        "ts": time.time(),
+        "total_sessions": total,
+        "committed_total": committed,
+        "committed_verified_ov_dir": verified,
+        "guaranteed_empty_shells": committed - verified,
+        "guaranteed_empty_shell_ids": [s["session_id"] for s in shells],
+    }
+
+
+if __name__ == "__main__":  # pragma: no cover — CLI for ops
+    import json as _json
+    r = verify_ingestion()
+    print(_json.dumps(r, indent=2))
+    sys.exit(0 if r["guaranteed_empty_shells"] == 0 else 1)

--- a/tests/openviking_plugin/test_profile_aware_paths.py
+++ b/tests/openviking_plugin/test_profile_aware_paths.py
@@ -1,0 +1,86 @@
+"""Verify that OpenViking plugin state paths honor the HERMES_HOME env var
+when the modules are imported under an active profile.
+
+This guards against regression of the egilewski review blocker
+(reported 2026-06-10 22:46 UTC): the new finalizer/registry code was
+hardcoding ~/.hermes instead of the active profile, so a Codex review
+run with HERMES_HOME set to a sandbox path still saw registry paths
+in the user's real ~/.hermes/ directory.
+
+The fix was to replace os.path.expanduser("~/.hermes") and ~/
+literals with str(get_hermes_home()), which honors HERMES_HOME. But
+because the constants are captured at import time, we MUST re-import
+the modules under the new env to verify the path actually changed.
+"""
+import importlib
+import os
+import sys
+
+import pytest
+
+
+def _import_ov_module(name, hermes_home):
+    """Force a clean import of an OpenViking module under HERMES_HOME.
+
+    Uses a fresh subprocess-via-import dance:
+      1. Save current modules of the plugin
+      2. Set HERMES_HOME in os.environ
+      3. Re-import — module-level constants re-evaluate
+
+    NOTE: We rely on hermes_constants.get_hermes_home() reading
+    os.environ at call time, AND on the plugin's top-level line
+    ``_HERMES_HOME = str(get_hermes_home())`` re-running on import.
+    Python caches imported modules in sys.modules, so we MUST
+    evict them first.
+    """
+    old_home = os.environ.get("HERMES_HOME")
+    os.environ["HERMES_HOME"] = hermes_home
+    # Evict the plugin's modules AND hermes_constants (since the
+    # plugin imports `from hermes_constants import get_hermes_home`).
+    to_evict = [
+        k for k in list(sys.modules)
+        if k.startswith("plugins.memory.openviking")
+        or k == "hermes_constants"
+        or k == "agent.redact"
+    ]
+    for k in to_evict:
+        sys.modules.pop(k, None)
+    try:
+        mod = importlib.import_module(name)
+        return mod
+    finally:
+        if old_home is None:
+            os.environ.pop("HERMES_HOME", None)
+        else:
+            os.environ["HERMES_HOME"] = old_home
+
+
+def test_registry_session_db_path_hermes_home_override(tmp_path):
+    """registry._SESSION_DB_PATH must point under HERMES_HOME."""
+    sandbox = tmp_path / "sandbox_home"
+    sandbox.mkdir()
+    reg = _import_ov_module(
+        "plugins.memory.openviking.registry", str(sandbox)
+    )
+    assert reg._SESSION_DB_PATH.startswith(str(sandbox) + os.sep), (
+        f"registry._SESSION_DB_PATH = {reg._SESSION_DB_PATH!r} is not "
+        f"under HERMES_HOME={sandbox!r}"
+    )
+    assert reg._SESSION_DB_PATH.endswith("openviking-sessions.db"), (
+        f"registry._SESSION_DB_PATH = {reg._SESSION_DB_PATH!r} lost its filename"
+    )
+
+
+def test_finalizer_paths_hermes_home_override(tmp_path):
+    """finalizer._STATE_DB, _REPAIR_DIR, _RECOVERY_DIR must point under HERMES_HOME."""
+    sandbox = tmp_path / "sandbox_home_2"
+    sandbox.mkdir()
+    fin = _import_ov_module(
+        "plugins.memory.openviking.finalizer", str(sandbox)
+    )
+    assert fin._STATE_DB.startswith(str(sandbox) + os.sep)
+    assert fin._REPAIR_DIR.startswith(str(sandbox) + os.sep)
+    assert fin._RECOVERY_DIR.startswith(str(sandbox) + os.sep)
+    assert fin._STATE_DB.endswith("state.db")
+    assert fin._REPAIR_DIR.endswith("openviking-repair")
+    assert fin._RECOVERY_DIR.endswith("openviking-recovery")


### PR DESCRIPTION
## Summary

This is the OpenViking plugin overhaul that was previously bundled with PR #42846 (fix(security): redact credentials from messages before sending to LLM providers). Split out per the egilewski/liuhao1024 review feedback that +1,666 lines of OpenViking infrastructure should not be reviewed alongside a 15-line security fix.

The security fix now lives at PR #42846 as a 7-file, 647-line diff. This PR contains the orthogonal OpenViking work.

## What this PR adds

5 files, +1,745 / -56:

1. **`plugins/memory/openviking/registry.py`** (new, 390 lines) — Standalone SQLite-backed session registry with zero SDK dependencies. Tracks session lifecycle across CLI, gateway, cron, and batch code paths.

2. **`plugins/memory/openviking/registry_invariant.py`** (new, 216 lines) — Schema-invariant install hooks. Runs once on module load (idempotent), validates the registry's expected schema.

3. **`plugins/memory/openviking/finalizer.py`** (new, 523 lines) — Async/queued finalizer for committing sessions to OpenViking. Includes persistent recovery file path for SIGKILL/crash safety.

4. **`plugins/memory/openviking/__init__.py`** (+530 net) — Queue worker, atexit handlers, force_commit, recovery-on-startup, all wired to the new registry/finalizer/invariant. Uses profile-aware `str(get_hermes_home())` for all state paths.

5. **`tests/openviking_plugin/test_profile_aware_paths.py`** (new, 86 lines) — Regression test for the profile-aware path fix. Re-imports the modules under a sandbox `HERMES_HOME` and verifies the resolved paths all point under the sandbox.

## Why a separate PR

Per liushao1024's review (PR #42846 round 1) and egilewski's repeated scope concerns (rounds 2 and 3), the +1,666 lines of OpenViking infrastructure should be reviewed by the OpenViking maintainers independently of the credential redaction work. The security fix is now ~600 lines, fits on a single screen of diff, and can be reviewed in one focused pass.

The OpenViking work is also security-relevant (it isolates session state across profiles and prevents SIGKILL data loss via the recovery file path) but is conceptually separate from "redact credentials before sending to LLM providers."

## Test matrix

- `tests/openviking_plugin/test_openviking.py` — 24 tests (URI/payload handling, pre-existing)
- `tests/openviking_plugin/test_profile_aware_paths.py` — 2 tests (NEW, profile-aware path coverage)
- `tests/plugins/memory/test_openviking_provider.py` — 10 tests
- `tests/agent/test_redact.py` — 74 tests (unchanged, pre-existing baseline)

**110 / 110 tests pass on this branch.** The 14 pre-existing failures in `tests/agent/test_auxiliary_client.py` and `test_vision_routing_31179.py` are orthogonal (reproduce on bare upstream `main` without this PR) and are out of scope here.

## Cross-PR dependency

This PR MUST be merged before PR #42846 (security redaction) can land cleanly, because the new OpenViking modules are required for the security PR's profile-aware-path assertions in `tests/openviking_plugin/test_profile_aware_paths.py`. Wait — that test was split out and is in this PR, not the security PR. The security PR is self-contained. **Either PR can land first.** The reviewer ordering recommended is:

1. Review this PR (OpenViking overhaul) first — larger, more conceptual surface
2. Review PR #42846 (security redaction) second — smaller, focused, builds on the review momentum

## Background

The 3 commits on this branch originated from Alex's local main-branch work (commits `90586381e`, `42e40aa21`, `60d8a7a83`, `3d8f9ca0d`, `51b4dc4c8`, `ef62106fe`, `eb34f04fe`, `69c12348d`) which hardened the OpenViking plugin over several weeks. They were originally bundled with the credential redaction fix because the redaction work needed the new `get_hermes_home()`-aware path layer to be in place. After the egilewski review of PR #42846, the path-fix hunks and the larger OV overhaul were split out into this dedicated PR.