### PR TITLE
fix(cli): use rich.Table for resume session list to fix CJK alignment

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6834,15 +6834,25 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         if reason == "history":
             _cli_visible_print("(._.) No messages in the current chat yet — here are recent sessions you can resume:")
         else:
+else:
             _cli_visible_print("  Recent sessions:")
         _cli_visible_print()
-        _cli_visible_print(f"  {'#':<3} {'Title':<32} {'Preview':<40} {'Last Active':<13} {'ID'}")
-        _cli_visible_print(f"  {'─' * 3} {'─' * 32} {'─' * 40} {'─' * 13} {'─' * 24}")
+        from rich.table import Table
+
+        table = Table(show_header=True, header_style="bold", box=None, padding=(0, 1))
+        table.add_column("#", justify="right", width=3, no_wrap=True)
+        table.add_column("Last Active", width=13, no_wrap=True)
+        table.add_column("ID", width=24, no_wrap=True)
+        table.add_column("Title / Preview")
+
         for idx, session in enumerate(sessions, start=1):
             title = session.get("title") or "—"
-            preview = (session.get("preview") or "")[:38]
+            preview = (session.get("preview") or "")[:80]
+            combined = f"{title} — {preview}" if preview else title
             last_active = _relative_time(session.get("last_active"))
-            _cli_visible_print(f"  {idx:<3} {title:<32} {preview:<40} {last_active:<13} {session['id']}")
+            table.add_row(str(idx), last_active, session["id"], combined)
+
+        ChatConsole().print(table)
         _cli_visible_print()
         _cli_visible_print("  Use /resume <number>, /resume <session id>, or /resume <session title> to continue.")
         _cli_visible_print("  Example: /resume 2")

--- a/cli.py
+++ b/cli.py
@@ -6834,7 +6834,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         if reason == "history":
             _cli_visible_print("(._.) No messages in the current chat yet — here are recent sessions you can resume:")
         else:
-else:
+
             _cli_visible_print("  Recent sessions:")
         _cli_visible_print()
         from rich.table import Table

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13985,8 +13985,7 @@ def main():
             if not sessions:
                 print("No sessions found.")
                 return
-
-            # Short workspace label: the repo/dir basename, "—" when unbound. The
+# Short workspace label: the repo/dir basename, "—" when unbound. The
             # Workspace column only appears once at least one session carries one
             # (or when filtering), so all-unbound listings read as before.
             def _ws_label(s):
@@ -13996,44 +13995,57 @@ def main():
             has_ws = bool(_ws_filter) or any(_ws_key(s) for s in sessions)
             has_titles = any(s.get("title") for s in sessions)
 
+            from rich.console import Console
+            from rich.table import Table
+
             if has_ws:
                 if has_titles:
-                    print(f"{'Title':<28} {'Workspace':<18} {'Last Active':<13} {'ID'}")
-                    print("─" * 110)
+                    table = Table(show_header=True, header_style="bold", box=None, padding=(0, 1))
+                    table.add_column("Title", width=28, no_wrap=True)
+                    table.add_column("Workspace", width=18, no_wrap=True)
+                    table.add_column("Last Active", width=13, no_wrap=True)
+                    table.add_column("ID")
                 else:
-                    print(f"{'Preview':<38} {'Workspace':<18} {'Last Active':<13} {'Src':<6} {'ID'}")
-                    print("─" * 100)
+                    table = Table(show_header=True, header_style="bold", box=None, padding=(0, 1))
+                    table.add_column("Preview", width=38, no_wrap=True)
+                    table.add_column("Workspace", width=18, no_wrap=True)
+                    table.add_column("Last Active", width=13, no_wrap=True)
+                    table.add_column("Src", width=6, no_wrap=True)
+                    table.add_column("ID")
                 for s in sessions:
                     last_active = _relative_time(s.get("last_active"))
                     ws = _ws_label(s)[:16]
                     if has_titles:
                         title = (s.get("title") or "—")[:26]
-                        print(f"{title:<28} {ws:<18} {last_active:<13} {s['id']}")
+                        table.add_row(title, ws, last_active, s["id"])
                     else:
                         preview = s.get("preview", "")[:36]
-                        print(f"{preview:<38} {ws:<18} {last_active:<13} {s['source']:<6} {s['id']}")
+                        table.add_row(preview, ws, last_active, s["source"], s["id"])
+                Console().print(table)
                 return
 
+            table = Table(show_header=True, header_style="bold", box=None, padding=(0, 1))
+            table.add_column("Last Active", width=13, no_wrap=True)
+            table.add_column("ID", width=24, no_wrap=True)
             if has_titles:
-                print(f"{'Title':<32} {'Preview':<40} {'Last Active':<13} {'ID'}")
-                print("─" * 110)
+                table.add_column("Title", width=32, no_wrap=True)
+                table.add_column("Preview")
             else:
-                print(f"{'Preview':<50} {'Last Active':<13} {'Src':<6} {'ID'}")
-                print("─" * 95)
+                table.add_column("Preview")
+                table.add_column("Src", width=6, no_wrap=True)
+
             for s in sessions:
                 last_active = _relative_time(s.get("last_active"))
-                preview = (
-                    s.get("preview", "")[:38]
-                    if has_titles
-                    else s.get("preview", "")[:48]
-                )
+                sid = s["id"]
                 if has_titles:
                     title = (s.get("title") or "—")[:30]
-                    sid = s["id"]
-                    print(f"{title:<32} {preview:<40} {last_active:<13} {sid}")
+                    preview = (s.get("preview", "") or "")[:80]
+                    table.add_row(last_active, sid, title, preview)
                 else:
-                    sid = s["id"]
-                    print(f"{preview:<50} {last_active:<13} {s['source']:<6} {sid}")
+                    preview = (s.get("preview", "") or "")[:80]
+                    table.add_row(last_active, sid, preview, s["source"])
+
+            Console().print(table)
 
         elif action == "export":
             from hermes_cli.session_filters import (

--- a/tests/cli/test_cli_resume_command.py
+++ b/tests/cli/test_cli_resume_command.py
@@ -351,3 +351,32 @@ class TestResumeFlushesBeforeEndSession:
             [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "hi"}]
         )
         cli_obj._session_db.end_session.assert_called_once()
+
+
+class TestCjkAlignment:
+    """CJK character alignment in _show_recent_sessions output."""
+
+    def test_cjk_titles_render_through_cprint(self):
+        cli_obj = _make_cli()
+        cli_obj._list_recent_sessions = MagicMock(return_value=[
+            {
+                "id": "sess_cn",
+                "title": "整理论文和更新README #4",
+                "preview": "我更新了paper/和README，整理了参考文献",
+                "last_active": None,
+            },
+        ])
+
+        running_app = SimpleNamespace(_is_running=True)
+        with (
+            patch("prompt_toolkit.application.get_app_or_none", return_value=running_app),
+            patch("cli._cprint") as mock_cprint,
+        ):
+            shown = cli_obj._show_recent_sessions(reason="resume")
+
+        assert shown is True
+        printed = "\n".join(call.args[0] for call in mock_cprint.call_args_list)
+        # CJK characters should appear in the output (Rich handles double-width)
+        assert "整理论文" in printed or "论文" in printed
+        assert "README" in printed
+        assert "sess_cn" in printed


### PR DESCRIPTION
## Summary

Replace `str.format()` fixed-width table rendering with `rich.table.Table` in the `/resume` inline session list and `hermes sessions list` command. Fixes CJK (Chinese/Japanese/Korean) character alignment by using Rich's Unicode-aware column width handling.

### Before

```
  #   Title                            Preview                                  Last Active   ID
  ─── ──────────────────────────────── ──────────────────────────────────────── ───────────── ────────────────────────
  2   整理论文和更新README #4                 我更新了paper/和 …   6d ago        20260604_195221_254cc9
```

### After

```
  #  Last Active    ID                        Title / Preview
  1  ?              sess_002                  整理论文和更新README #4 — 我更新了paper/和README
```

## Changes

### `cli.py` — `_show_recent_sessions()`
- Replace `print(f"{'#':<3} {'Title':<32} ...")` with `rich.table.Table`
- Columns reordered: **# | Last Active | ID | Title / Preview**
- Title and Preview merged into one column to prevent width bleed
- Preview limit increased from 38 to 80 chars

### `hermes_cli/main.py` — `cmd_sessions()` list action
- Same `rich.table.Table` migration
- Columns reordered: **Last Active | ID | Title | Preview** (with titles) or **Last Active | ID | Preview | Src** (no titles)
- Preview limit increased from 38/48 to 80 chars

## Validation

- Verified output with CJK titles renders correctly (Rich handles double-width chars)
- Existing test assertions (`test_show_recent_sessions_includes_indexes_and_resume_hint`, `test_resume_list_shows_full_long_titles`) confirmed compatible

Closes #44199
