### PR TITLE
fix(skills): use os.walk(followlinks=True) in _find_skill for symlinked skill dirs

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -12,6 +12,8 @@ from tools.skill_manager_tool import (
     _validate_category,
     _validate_frontmatter,
     _validate_file_path,
+    _find_skill,
+    _find_skill_in_other_profiles,
     _create_skill,
     _edit_skill,
     _patch_skill,
@@ -196,6 +198,68 @@ class TestValidateFilePath:
         # Only SKILL.md gets the root-level exception, not arbitrary files.
         err = _validate_file_path("README.md")
         assert "File must be under one of:" in err
+
+
+# ---------------------------------------------------------------------------
+# Skill discovery — symlinked skill directories
+# ---------------------------------------------------------------------------
+
+
+class TestSkillDiscovery:
+    @staticmethod
+    def _make_skill(root: Path, name: str) -> Path:
+        skill_dir = root / name
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: A symlink test skill.\n---\n\n"
+            "# Symlink Test\n\nBody.\n"
+        )
+        return skill_dir
+
+    def test_find_skill_follows_direct_skill_symlink(self, tmp_path):
+        source = self._make_skill(tmp_path / "source", "source-skill")
+        link = tmp_path / "direct-skill"
+        try:
+            link.symlink_to(source, target_is_directory=True)
+        except OSError:
+            pytest.skip("Symlinks not supported")
+
+        with _skill_dir(tmp_path):
+            result = _find_skill("direct-skill")
+
+        assert result == {"path": link}
+
+    def test_find_skill_follows_category_skill_symlink(self, tmp_path):
+        source = self._make_skill(tmp_path / "source", "source-skill")
+        link = tmp_path / "category" / "category-skill"
+        link.parent.mkdir()
+        try:
+            link.symlink_to(source, target_is_directory=True)
+        except OSError:
+            pytest.skip("Symlinks not supported")
+
+        with _skill_dir(tmp_path):
+            result = _find_skill("category-skill")
+
+        assert result == {"path": link}
+
+    def test_find_skill_in_other_profiles_follows_skill_symlink(self, tmp_path):
+        hermes_root = tmp_path / "hermes"
+        active_skills = hermes_root / "profiles" / "active" / "skills"
+        other_skills = hermes_root / "profiles" / "other" / "skills"
+        source = self._make_skill(tmp_path / "source", "source-skill")
+        link = other_skills / "category" / "other-skill"
+        link.parent.mkdir(parents=True)
+        try:
+            link.symlink_to(source, target_is_directory=True)
+        except OSError:
+            pytest.skip("Symlinks not supported")
+
+        with patch("tools.skill_manager_tool.SKILLS_DIR", active_skills), \
+             patch("hermes_constants.get_default_hermes_root", return_value=hermes_root):
+            result = _find_skill_in_other_profiles("other-skill")
+
+        assert result == [("other", link)]
 
 
 # ---------------------------------------------------------------------------

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -288,19 +288,13 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     are visible — Python 3.11's rglob does not follow directory symlinks
     (the follow_symlinks parameter was added in 3.12).
     """
-    from agent.skill_utils import get_all_skills_dirs, is_excluded_skill_path
-    import os
+    from agent.skill_utils import get_all_skills_dirs, iter_skill_index_files
     for skills_dir in get_all_skills_dirs():
         if not skills_dir.exists():
             continue
-        for root, _dirs, files in os.walk(skills_dir, followlinks=True):
-            if "SKILL.md" not in files:
-                continue
-            if os.path.basename(root) == name:
-                skill_md_path = Path(root) / "SKILL.md"
-                if is_excluded_skill_path(skill_md_path):
-                    continue
-                return {"path": Path(root)}
+        for skill_md in iter_skill_index_files(skills_dir, "SKILL.md"):
+            if skill_md.parent.name == name:
+                return {"path": skill_md.parent}
     return None
 
 
@@ -316,7 +310,7 @@ def _find_skill_in_other_profiles(name: str) -> List[Tuple[str, Path]]:
     matches: List[Tuple[str, Path]] = []
     try:
         from hermes_constants import get_default_hermes_root
-        from agent.skill_utils import is_excluded_skill_path
+        from agent.skill_utils import iter_skill_index_files
     except Exception:
         return matches
 
@@ -359,9 +353,7 @@ def _find_skill_in_other_profiles(name: str) -> List[Tuple[str, Path]]:
         if not skills_dir.is_dir():
             continue
         try:
-            for skill_md in skills_dir.rglob("SKILL.md"):
-                if is_excluded_skill_path(skill_md):
-                    continue
+            for skill_md in iter_skill_index_files(skills_dir, "SKILL.md"):
                 if skill_md.parent.name == name:
                     matches.append((profile_name, skill_md.parent))
                     break  # one match per profile is enough

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -282,16 +282,25 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     Searches the local skills dir (~/.hermes/skills/) first, then any
     external dirs configured via skills.external_dirs.  Returns
     {"path": Path} or None.
+
+    Uses os.walk with followlinks=True instead of Path.rglob so that
+    symlinked skill directories (e.g. shared skills under ~/.agents/skills/)
+    are visible — Python 3.11's rglob does not follow directory symlinks
+    (the follow_symlinks parameter was added in 3.12).
     """
     from agent.skill_utils import get_all_skills_dirs, is_excluded_skill_path
+    import os
     for skills_dir in get_all_skills_dirs():
         if not skills_dir.exists():
             continue
-        for skill_md in skills_dir.rglob("SKILL.md"):
-            if is_excluded_skill_path(skill_md):
+        for root, _dirs, files in os.walk(skills_dir, followlinks=True):
+            if "SKILL.md" not in files:
                 continue
-            if skill_md.parent.name == name:
-                return {"path": skill_md.parent}
+            if os.path.basename(root) == name:
+                skill_md_path = Path(root) / "SKILL.md"
+                if is_excluded_skill_path(skill_md_path):
+                    continue
+                return {"path": Path(root)}
     return None
 
 


### PR DESCRIPTION
On Python 3.11, Path.rglob does not follow directory symlinks (the
follow_symlinks parameter was added in 3.12). This means skill_manage
cannot see skills that are symlinked into ~/.hermes/skills/ from shared
directories like ~/.agents/skills/.

iter_skill_index_files already uses os.walk(followlinks=True) and
correctly finds these skills. This change aligns _find_skill with that
existing pattern.

### Problem

skill_view(), skills_list(), and the system prompt builder all see
symlinked skills, but skill_manage(action=patch) and all other
skill_manage actions return "Skill X not found in active profile".

Example: read-project-code is a symlink ~/.hermes/skills/read-project-code
→ ~/.agents/skills/read-project-code. It appears in skills_list() and
can be loaded via skill_view(), but skill_manage(action=patch, name=
read-project-code, ...) fails.

### Changes

Replace skills_dir.rglob("SKILL.md") with os.walk(skills_dir,
followlinks=True) in _find_skill(), matching the approach already used
by iter_skill_index_files in agent/skill_utils.py.

### How to test

```bash
pytest tests/tools/test_skill_manager_tool.py -v
# 90 passed
```

Manually:

```python
from tools.skill_manager_tool import _find_skill
_find_skill(read-project-code)
# Before: None
# After: {path: PosixPath(.../.hermes/skills/read-project-code)}
```

### Platforms tested

- macOS 26.5.1, Python 3.11.15