### PR TITLE
fix(cli): align session tables with CJK content via display-width padding

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6827,7 +6827,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         if not sessions:
             return False
 
-        from hermes_cli.main import _relative_time
+        from hermes_cli.main import _clip_to_width, _pad_to_width, _relative_time
 
         _cli_visible_print()
         if reason == "history":
@@ -6838,10 +6838,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         _cli_visible_print(f"  {'#':<3} {'Title':<32} {'Preview':<40} {'Last Active':<13} {'ID'}")
         _cli_visible_print(f"  {'─' * 3} {'─' * 32} {'─' * 40} {'─' * 13} {'─' * 24}")
         for idx, session in enumerate(sessions, start=1):
+            # Truncate/pad by display columns — CJK characters are
+            # double-width, so str slices / format-spec padding shift
+            # every column to their right (#44199). Titles are padded but
+            # never clipped: they render in full by design (#14082).
             title = session.get("title") or "—"
-            preview = (session.get("preview") or "")[:38]
+            preview = _clip_to_width(session.get("preview") or "", 38)
             last_active = _relative_time(session.get("last_active"))
-            _cli_visible_print(f"  {idx:<3} {title:<32} {preview:<40} {last_active:<13} {session['id']}")
+            _cli_visible_print(
+                f"  {idx:<3} {_pad_to_width(title, 32)} "
+                f"{_pad_to_width(preview, 40)} {last_active:<13} {session['id']}"
+            )
         _cli_visible_print()
         _cli_visible_print("  Use /resume <number>, /resume <session id>, or /resume <session title> to continue.")
         _cli_visible_print("  Example: /resume 2")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -797,6 +797,46 @@ def _relative_time(ts) -> str:
     return datetime.fromtimestamp(ts).strftime("%Y-%m-%d")
 
 
+def _disp_width(text: str) -> int:
+    """Terminal display width of *text* (CJK characters occupy 2 columns).
+
+    ``wcswidth`` returns ``-1`` for control characters; clamp to 0 so a
+    weird character can't poison the column math (same convention as
+    ``agent/markdown_tables.py``).
+    """
+    from wcwidth import wcswidth
+
+    w = wcswidth(text)
+    return w if w > 0 else 0
+
+
+def _clip_to_width(text: str, width: int) -> str:
+    """Truncate *text* to at most *width* display columns.
+
+    A plain slice (``text[:n]``) counts characters, so CJK text can still
+    overflow its column by up to 2x; this never splits a double-width
+    character across the boundary.
+    """
+    if _disp_width(text) <= width:
+        return text
+    from wcwidth import wcwidth
+
+    out = []
+    used = 0
+    for ch in text:
+        w = max(wcwidth(ch), 0)
+        if used + w > width:
+            break
+        out.append(ch)
+        used += w
+    return "".join(out)
+
+
+def _pad_to_width(text: str, width: int) -> str:
+    """Column-aware ``str.ljust`` — pads to *width* display columns."""
+    return text + " " * max(0, width - _disp_width(text))
+
+
 def _has_any_provider_configured() -> bool:
     """Check if at least one inference provider is usable."""
     from hermes_cli.config import get_env_path, get_hermes_home, load_config
@@ -13853,20 +13893,30 @@ def main():
             else:
                 print(f"{'Preview':<50} {'Last Active':<13} {'Src':<6} {'ID'}")
                 print("─" * 95)
+            # Truncate and pad by display columns, not characters — CJK
+            # characters are double-width, so str slices / format-spec
+            # padding shift every column to their right (#44199).
             for s in sessions:
                 last_active = _relative_time(s.get("last_active"))
                 preview = (
-                    s.get("preview", "")[:38]
+                    _clip_to_width(s.get("preview", ""), 38)
                     if has_titles
-                    else s.get("preview", "")[:48]
+                    else _clip_to_width(s.get("preview", ""), 48)
                 )
                 if has_titles:
-                    title = (s.get("title") or "—")[:30]
+                    title = _clip_to_width(s.get("title") or "—", 30)
                     sid = s["id"]
-                    print(f"{title:<32} {preview:<40} {last_active:<13} {sid}")
+                    print(
+                        f"{_pad_to_width(title, 32)} "
+                        f"{_pad_to_width(preview, 40)} "
+                        f"{last_active:<13} {sid}"
+                    )
                 else:
                     sid = s["id"]
-                    print(f"{preview:<50} {last_active:<13} {s['source']:<6} {sid}")
+                    print(
+                        f"{_pad_to_width(preview, 50)} "
+                        f"{last_active:<13} {s['source']:<6} {sid}"
+                    )
 
         elif action == "export":
             from hermes_cli.session_filters import (

--- a/tests/cli/test_cli_resume_command.py
+++ b/tests/cli/test_cli_resume_command.py
@@ -71,6 +71,31 @@ class TestCliResumeCommand:
         printed = "\n".join(call.args[0] for call in mock_cprint.call_args_list)
         assert "Conversation History" in printed
         assert "Hello" in printed
+    def test_show_recent_sessions_aligns_cjk_titles(self, capsys):
+        # CJK characters are double-width in terminals; padding by character
+        # count shifts every column to their right (#44199). The ID column
+        # must start at the same display column in every row.
+        from wcwidth import wcswidth
+
+        cli_obj = _make_cli()
+        cli_obj._list_recent_sessions = MagicMock(return_value=[
+            {"id": "sess_002", "title": "整理论文和更新README #4",
+             "preview": "我更新了paper/和其他文件", "last_active": None},
+            {"id": "sess_001", "title": "Research", "preview": "read docs",
+             "last_active": None},
+        ])
+
+        shown = cli_obj._show_recent_sessions(reason="resume")
+        output = capsys.readouterr().out
+
+        assert shown is True
+        id_columns = {
+            wcswidth(line.split(sid)[0])
+            for line in output.splitlines()
+            for sid in ("sess_001", "sess_002")
+            if sid in line
+        }
+        assert len(id_columns) == 1
 
     def test_handle_resume_by_index_switches_to_numbered_session(self):
         cli_obj = _make_cli()

--- a/tests/hermes_cli/test_session_table_width.py
+++ b/tests/hermes_cli/test_session_table_width.py
@@ -1,0 +1,61 @@
+"""Display-width helpers for the session list tables (#44199).
+
+CJK characters occupy two terminal columns, so ``str`` slices and
+format-spec padding (which count characters) misalign every column to
+the right of CJK content. ``_clip_to_width`` / ``_pad_to_width`` count
+display columns instead.
+"""
+
+from hermes_cli.main import _clip_to_width, _disp_width, _pad_to_width
+
+
+class TestDispWidth:
+    def test_ascii_counts_one_column_per_char(self):
+        assert _disp_width("hello") == 5
+
+    def test_cjk_counts_two_columns_per_char(self):
+        assert _disp_width("整理论文") == 8
+
+    def test_mixed_content(self):
+        assert _disp_width("更新README") == 10  # 2*2 + 6
+
+    def test_control_chars_clamp_to_zero(self):
+        # wcswidth() returns -1 for control chars; must not go negative.
+        assert _disp_width("a\x07b") == 0
+
+    def test_empty_string(self):
+        assert _disp_width("") == 0
+
+
+class TestClipToWidth:
+    def test_ascii_clips_like_slice(self):
+        assert _clip_to_width("abcdefgh", 5) == "abcde"
+
+    def test_short_text_unchanged(self):
+        assert _clip_to_width("abc", 10) == "abc"
+
+    def test_cjk_clips_by_columns_not_chars(self):
+        # 4 chars = 8 columns; only 3 chars (6 columns) fit in 6.
+        assert _clip_to_width("整理论文", 6) == "整理论"
+
+    def test_never_splits_a_double_width_char(self):
+        # 5 columns can hold 2 CJK chars (4 cols); the 3rd (2 cols)
+        # would straddle the boundary and must be dropped entirely.
+        assert _clip_to_width("整理论文", 5) == "整理"
+
+    def test_clipped_result_fits_width(self):
+        for width in range(0, 12):
+            assert _disp_width(_clip_to_width("整理论文和更新", width)) <= width
+
+
+class TestPadToWidth:
+    def test_ascii_matches_ljust(self):
+        assert _pad_to_width("abc", 8) == "abc".ljust(8)
+
+    def test_cjk_pads_by_display_columns(self):
+        # 2 CJK chars = 4 columns -> 4 spaces to reach 8 columns.
+        assert _pad_to_width("整理", 8) == "整理    "
+        assert _disp_width(_pad_to_width("整理", 8)) == 8
+
+    def test_overlong_text_not_truncated(self):
+        assert _pad_to_width("abcdef", 3) == "abcdef"


### PR DESCRIPTION
Fixes #44199

## Problem

The `/resume` inline list (`HermesCLI._show_recent_sessions`, cli.py) and the `hermes sessions list` table (`cmd_sessions`, hermes_cli/main.py) pad cells with `str.format` width specs (`{var:<32}`) and truncate with `str` slices (`[:38]`). Both count **characters**, but CJK characters occupy **two** terminal columns, so any title or preview containing them shifts every column to its right:

```
  #   Title                            Preview                                  Last Active   ID
  ─── ──────────────────────────────── ──────────────────────────────────────── ───────────── ────────────────────────
  2   整理论文和更新README #4                 我更新了paper/和 …   6d ago        20260604_195221_254cc9
```

## Fix

Rather than switching these renderers to `rich.table.Table`, this adds three small display-width helpers to `hermes_cli/main.py` — `_disp_width` / `_clip_to_width` / `_pad_to_width` — using the same `wcwidth`-based approach (including the clamp-negative-to-zero convention) that `agent/markdown_tables.py` already uses for exactly this problem. Both renderers now truncate and pad by terminal columns. `_clip_to_width` never splits a double-width character across the column boundary.

This keeps the diff minimal and the output **byte-identical for pure-ASCII rows**, so nothing depending on the current format changes. `wcwidth` is already imported unconditionally by `agent/markdown_tables.py` and is guaranteed present transitively via the pinned `prompt_toolkit`.

After:

```
  #   Title                            Preview                                  Last Active   ID
  ─── ──────────────────────────────── ──────────────────────────────────────── ───────────── ────────────────────────
  1   整理论文和更新README #4          我更新了paper/和 README，整理了所有章    6d ago        20260604_195221_254cc9
  2   Refactor session storage         moved sqlite schema into hermes_state    ?             20260603_101512_aa11bb
```

## Notes on scope

- Titles in the `/resume` table are padded but deliberately **not** clipped: #14082 made long titles render in full there (enforced by `test_resume_list_shows_full_long_titles`), so an over-long title still trades alignment for visibility, exactly as on main. Only the preview is clipped — now by columns instead of characters.
- `cmd_sessions` keeps its existing `[:30]` title truncation semantics, just measured in columns.
- The issue's suggestion to move Last Active/ID to the left is a layout change beyond the alignment bug, so it's left out of this fix.

## Tests

- `tests/hermes_cli/test_session_table_width.py` (new): unit coverage for the three helpers — CJK widths, never splitting a double-width char at the boundary, negative-`wcswidth` clamping, ASCII equivalence with `str.ljust`.
- `tests/cli/test_cli_resume_command.py`: new test asserting the ID column starts at the same display column for a CJK row and an ASCII row.
- Full `tests/cli/` suite passes (the one failure, `test_resume_quiet_stderr.py::test_session_not_found_goes_to_stdout_in_full_mode`, is a pre-existing test-ordering flake that fails identically on pristine `origin/main` when the whole directory runs together, and passes in isolation both there and on this branch).
