### PR TITLE
feat(desktop): native OS notifications for background process completions

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-hermes-config.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.ts
@@ -2,6 +2,7 @@ import { type MutableRefObject, useCallback, useState } from 'react'
 
 import { getHermesConfig, getHermesConfigDefaults } from '@/hermes'
 import { BUILTIN_PERSONALITIES, normalizePersonalityValue, personalityNamesFromConfig } from '@/lib/chat-runtime'
+import { setProcessNotificationsMode } from '@/store/process-notifications'
 import {
   $currentCwd,
   setAvailablePersonalities,
@@ -65,6 +66,7 @@ export function useHermesConfig({ activeSessionIdRef, refreshProjectBranch }: He
 
       setVoiceMaxRecordingSeconds(recordingLimit(config.voice?.max_recording_seconds))
       setSttEnabled(config.stt?.enabled !== false)
+      setProcessNotificationsMode(config.display?.background_process_notifications)
     } catch {
       // Config is nice-to-have; chat still works without it.
     }

--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -34,6 +34,7 @@ import { $gateway } from '@/store/gateway'
 import { dispatchNativeNotification } from '@/store/native-notifications'
 import { notify } from '@/store/notifications'
 import { requestDesktopOnboarding } from '@/store/onboarding'
+import { $processNotificationsMode, processCompletionToast } from '@/store/process-notifications'
 import { clearAllPrompts, setApprovalRequest, setSecretRequest, setSudoRequest } from '@/store/prompts'
 import {
   setCurrentBranch,
@@ -1076,10 +1077,24 @@ export function useMessageStream({
         if (sessionId && payload?.kind === 'compacting') {
           setSessionCompacting(sessionId, true)
           compactedTurnRef.current.add(sessionId)
-        } else if (sessionId && payload?.kind === 'process') {
-          // The gateway's notification poller announces background process
-          // completions / watch matches here — re-sync the status stack.
-          void refreshBackgroundProcesses(sessionId)
+        } else if (payload?.kind === 'process') {
+          // Background process lifecycle from the gateway's notification poller
+          // (tui_gateway/server.py). Re-sync the status stack so the composer
+          // reflects the completion/watch-match.
+          if (sessionId) {
+            void refreshBackgroundProcesses(sessionId)
+          }
+
+          // The poller also chains an agent turn that surfaces the text
+          // in-chat; the native toast covers the hands-off case (#44201) —
+          // window hidden, or the process belongs to a chat the user isn't
+          // looking at. Gated by the same config the messaging gateways
+          // honor: display.background_process_notifications.
+          const toast = processCompletionToast(payload, $processNotificationsMode.get())
+
+          if (toast && (document.hidden || sessionId !== activeSessionIdRef.current)) {
+            void window.hermesDesktop?.notify(toast)
+          }
         }
       } else if (event.type === 'review.summary') {
         // Self-improvement background review saved something to memory/skills

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -67,8 +67,11 @@ export type GatewayEventPayload = {
   // terminal.read.request (GUI agent reading the in-app terminal pane)
   start?: number
   count?: number
-  // status.update (kind=process → background process completion/watch-match)
+  // status.update (kind=process → background process completion/watch-match,
+  // consumed by the native notification poller)
   kind?: string
+  event_type?: string
+  exit_code?: null | number
 }
 
 export function textPart(text: string): ChatMessagePart {

--- a/apps/desktop/src/store/process-notifications.test.ts
+++ b/apps/desktop/src/store/process-notifications.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  normalizeProcessNotificationMode,
+  processCompletionToast
+} from './process-notifications'
+
+describe('normalizeProcessNotificationMode', () => {
+  it('maps false to off (config allows boolean false)', () => {
+    expect(normalizeProcessNotificationMode(false)).toBe('off')
+  })
+
+  it('accepts known modes case-insensitively', () => {
+    expect(normalizeProcessNotificationMode('All')).toBe('all')
+    expect(normalizeProcessNotificationMode(' result ')).toBe('result')
+    expect(normalizeProcessNotificationMode('ERROR')).toBe('error')
+    expect(normalizeProcessNotificationMode('off')).toBe('off')
+  })
+
+  it('defaults unknown values to all (mirrors gateway/run.py)', () => {
+    expect(normalizeProcessNotificationMode(undefined)).toBe('all')
+    expect(normalizeProcessNotificationMode('sometimes')).toBe('all')
+    expect(normalizeProcessNotificationMode(42)).toBe('all')
+    expect(normalizeProcessNotificationMode(true)).toBe('all')
+  })
+})
+
+describe('processCompletionToast', () => {
+  const completion = {
+    kind: 'process',
+    event_type: 'completion',
+    command: 'npm run build',
+    exit_code: 0,
+    text: '[IMPORTANT: Background process proc_1 completed]'
+  }
+
+  it('builds a success toast for a zero exit code', () => {
+    expect(processCompletionToast(completion, 'all')).toEqual({
+      title: 'Background process finished',
+      body: 'npm run build'
+    })
+  })
+
+  it('builds a failure toast with the exit code', () => {
+    expect(processCompletionToast({ ...completion, exit_code: 2 }, 'all')).toEqual({
+      title: 'Background process failed (exit 2)',
+      body: 'npm run build'
+    })
+  })
+
+  it('treats a payload without event_type as a completion (older gateways)', () => {
+    expect(processCompletionToast({ ...completion, event_type: undefined }, 'result')).not.toBeNull()
+  })
+
+  it('returns null when mode is off', () => {
+    expect(processCompletionToast(completion, 'off')).toBeNull()
+  })
+
+  it('in error mode only notifies for non-zero exit codes', () => {
+    expect(processCompletionToast(completion, 'error')).toBeNull()
+    expect(processCompletionToast({ ...completion, exit_code: 1 }, 'error')).not.toBeNull()
+    expect(processCompletionToast({ ...completion, exit_code: null }, 'error')).toBeNull()
+  })
+
+  it('never notifies for watch matches (they can fire many times)', () => {
+    expect(processCompletionToast({ ...completion, event_type: 'watch_match' }, 'all')).toBeNull()
+  })
+
+  it('falls back to the formatted text when command is empty, truncated', () => {
+    const toast = processCompletionToast({ ...completion, command: '', text: 'x'.repeat(300) }, 'all')
+
+    expect(toast?.body).toHaveLength(140)
+  })
+})

--- a/apps/desktop/src/store/process-notifications.ts
+++ b/apps/desktop/src/store/process-notifications.ts
@@ -1,0 +1,58 @@
+import { atom } from 'nanostores'
+
+import type { GatewayEventPayload } from '@/lib/chat-messages'
+
+/**
+ * Notification mode for background process completions, mirroring the
+ * gateway's display.background_process_notifications semantics
+ * (gateway/run.py): `false` → off, unknown values → all.
+ */
+export type ProcessNotificationMode = 'all' | 'error' | 'off' | 'result'
+
+const MODES = new Set<ProcessNotificationMode>(['all', 'error', 'off', 'result'])
+
+export function normalizeProcessNotificationMode(raw: unknown): ProcessNotificationMode {
+  if (raw === false) {
+    return 'off'
+  }
+
+  const mode = typeof raw === 'string' ? raw.trim().toLowerCase() : ''
+
+  return MODES.has(mode as ProcessNotificationMode) ? (mode as ProcessNotificationMode) : 'all'
+}
+
+/** Synced from hermes config (display.background_process_notifications). */
+export const $processNotificationsMode = atom<ProcessNotificationMode>('all')
+
+export const setProcessNotificationsMode = (raw: unknown) =>
+  $processNotificationsMode.set(normalizeProcessNotificationMode(raw))
+
+const BODY_MAX_CHARS = 140
+
+/**
+ * Native-toast content for a status.update (kind=process) gateway event, or
+ * null when the mode/event combination shouldn't notify. Only completion
+ * events surface as OS notifications — watch matches stay in-chat (they can
+ * fire many times per process and would spam the notification center).
+ */
+export function processCompletionToast(
+  payload: GatewayEventPayload,
+  mode: ProcessNotificationMode
+): { body: string; title: string } | null {
+  if (mode === 'off' || (payload.event_type ?? 'completion') !== 'completion') {
+    return null
+  }
+
+  const failed = typeof payload.exit_code === 'number' && payload.exit_code !== 0
+
+  if (mode === 'error' && !failed) {
+    return null
+  }
+
+  const command = (payload.command ?? '').trim()
+
+  return {
+    title: failed ? `Background process failed (exit ${payload.exit_code})` : 'Background process finished',
+    body: (command || payload.text || '').slice(0, BODY_MAX_CHARS)
+  }
+}

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -175,6 +175,7 @@ export interface HermesConfig {
     service_tier?: string
   }
   display?: {
+    background_process_notifications?: boolean | string
     personality?: string
     skin?: string
   }

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -6946,10 +6946,14 @@ def test_notification_poller_delivers_completion(monkeypatch):
     try:
         server._notification_poller_loop(stop, "sid_poll", sess)
 
-        # Should have emitted a status.update with kind=process
+        # Should have emitted a status.update with kind=process, carrying the
+        # structured fields GUI clients use for native notifications (#44201)
         status_calls = [a for a in emitted if a[0] == "status.update"]
         assert len(status_calls) >= 1
         assert status_calls[0][2]["kind"] == "process"
+        assert status_calls[0][2]["event_type"] == "completion"
+        assert status_calls[0][2]["command"] == "echo hello"
+        assert status_calls[0][2]["exit_code"] == 0
 
         # Should have triggered an agent turn
         assert len(turns) == 1

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5951,6 +5951,23 @@ def _notification_event_dedup_key(evt: dict) -> tuple:
     return (evt_sid, evt_type)
 
 
+def _process_status_payload(evt: dict, text: str) -> dict:
+    """Build the status.update payload for a process notification event.
+
+    Besides the agent-facing formatted text, include the structured fields
+    (event type, command, exit code) so GUI clients can render their own
+    surfaces — e.g. the desktop app's native OS notifications (#44201) —
+    without parsing the [IMPORTANT: ...] prose.
+    """
+    return {
+        "kind": "process",
+        "text": text,
+        "event_type": evt.get("type", "completion"),
+        "command": evt.get("command", ""),
+        "exit_code": evt.get("exit_code"),
+    }
+
+
 def _notification_poller_loop(
     stop_event: threading.Event, sid: str, session: dict
 ) -> None:
@@ -5998,7 +6015,7 @@ def _notification_poller_loop(
         # visible independently.
         _dedup_key = _notification_event_dedup_key(evt)
         if _dedup_key not in _emitted:
-            _emit("status.update", sid, {"kind": "process", "text": text})
+            _emit("status.update", sid, _process_status_payload(evt, text))
             _emitted.add(_dedup_key)
 
         with session["history_lock"]:
@@ -6041,7 +6058,7 @@ def _notification_poller_loop(
 
         _dedup_key = _notification_event_dedup_key(evt)
         if _dedup_key not in _emitted:
-            _emit("status.update", sid, {"kind": "process", "text": text})
+            _emit("status.update", sid, _process_status_payload(evt, text))
             _emitted.add(_dedup_key)
 
         with session["history_lock"]:


### PR DESCRIPTION
## Summary

When a background process started with `terminal(background=true, notify_on_complete=true)` finishes, the desktop app now fires a **native OS notification** (Windows toast / macOS notification center), so hands-off background execution no longer requires keeping the chat window open.

Fixes #44201

## How it works

The pieces were mostly already there — this PR connects them:

- The Electron main process already exposes a native-notification IPC bridge (`hermes:notify` in `electron/main.cjs`, surfaced as `window.hermesDesktop.notify`).
- The gateway's notification poller (`tui_gateway/server.py`) already emits a `status.update` (`kind=process`) WS event on completion — but the renderer ignored it, and the payload carried only the agent-facing `[IMPORTANT: ...]` prose.

**Gateway**: the `status.update` payload now also carries the structured fields (`event_type`, `command`, `exit_code`) via a small `_process_status_payload()` helper, so GUI clients don't parse prose. Backward compatible — `kind` and `text` are unchanged.

**Desktop**: a new `store/process-notifications.ts` mirrors the gateway's `display.background_process_notifications` semantics from `gateway/run.py` (`all`/`result`/`error`/`off`, `false` → `off`, unknown → `all`, env-independent) and builds the toast content; `use-message-stream.ts` routes the event through the existing IPC bridge. The mode is synced from hermes config in `use-hermes-config.ts`, so the same config key the messaging gateways honor now governs OS toasts — exactly what the issue asked for.

## Behavior decisions

- The toast fires only when the user can't see the in-chat message: window hidden (`document.hidden`, same gate as the existing "Hermes finished" toast) **or** the process belongs to a non-active chat session.
- Only `completion` events toast. Watch matches (`watch_match`) stay in-chat — they can legitimately fire many times per process and would spam the notification center.
- `error` mode toasts only non-zero exit codes; `off` disables; `all`/`result` toast every completion.
- Failure toasts surface the exit code in the title: *"Background process failed (exit 2)"*; body is the command line (truncated to 140 chars).

## Known overlap

In the hidden + active-session case the user may get this toast and then the existing "Hermes finished" toast a few seconds later when the chained agent turn (which the poller injects) completes. They carry different information (immediate process result vs. agent's follow-up), so I left both rather than adding suppression heuristics; happy to gate one on the other if maintainers prefer. Related: #43255 adds a settings toggle for the agent-finished toast — this PR is independent of it but composes fine (different store, different event).

## Testing

- `tests/test_tui_gateway_server.py` poller test extended to assert the enriched payload (`event_type`/`command`/`exit_code`) — 4 poller tests pass; the one failing test in that file (`test_browser_manage_connect_default_local_reports_launch_hint`) fails identically on pristine `main`.
- New `process-notifications.test.ts` (10 cases: mode normalization incl. `false`→`off`, error-mode gating, watch-match suppression, body truncation/fallback) — passes.
- Full desktop vitest suite: the 6 failures present are identical on pristine `main` (verified on a clean worktree at the same commit); no new failures.
- `tsc --noEmit` and `eslint` clean on all touched files.
