### PR TITLE
fix(agent): show "continuing..." instead of "(empty)" on post-tool recovery path

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3943,7 +3943,7 @@ def run_conversation(
                         # Without this, we'd have tool → user which most
                         # APIs reject as an invalid sequence.
                         _nudge_msg = agent._build_assistant_message(assistant_message, finish_reason)
-                        _nudge_msg["content"] = "(empty)"
+                        _nudge_msg["content"] = "continuing..."
                         _nudge_msg["_empty_recovery_synthetic"] = True
                         messages.append(_nudge_msg)
                         messages.append({

--- a/cli.py
+++ b/cli.py
@@ -5779,6 +5779,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 hidden_tool_messages += 1
                 continue
 
+            if msg.get("_empty_recovery_synthetic"):
+                continue
+
             if role not in {"user", "assistant"}:
                 continue
 


### PR DESCRIPTION
When the model returns empty content after tool calls, Hermes already has a recovery mechanism in `conversation_loop.py` that injects a continuation nudge. However, the placeholder assistant message displayed `"(empty)"` to the user — which is confusing.

**Changes:**

1. **`agent/conversation_loop.py`** — Changed the placeholder from `"(empty)"` to `"continuing..."` so users can see recovery is active.
2. **`cli.py`** — Added `_empty_recovery_synthetic` filter in `show_history()` so recovery scaffolding doesn't clutter `/history`.

**Result:** Instead of seeing `(empty)` in the terminal, users see `continuing...` followed by the real response. The recovery is no longer silent or confusing.

Ref: #42503