### PR TITLE
fix(photon): use im.space.create() instead of im.space() for DM resolution

### DIFF
--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -390,7 +390,7 @@ async function resolveSpace(spaceId) {
     try {
       const im = imessage(app);
       const user = await im.user(phoneTarget);
-      const space = await im.space(user);
+      const space = await im.space.create(user);
       rememberKnownSpace(spaceId, space);
       rememberKnownSpace(phoneTarget, space);
       rememberKnownSpace(space?.id, space);


### PR DESCRIPTION
## Summary

Fixes outbound iMessage delivery via Photon when initiating to a phone number that hasn't previously messaged the agent.

## Root Cause

`resolveSpace()` in `plugins/platforms/photon/sidecar/index.mjs` calls `im.space(user)` to create a DM conversation space. However, the Spectrum SDK's `createPlatformInstance()` exposes `space.create()` and `space.get()`, **not** `space()` directly — `im.space` does not exist on the platform instance.

## Fix

One-line change: `im.space(user)` → `im.space.create(user)`

This matches the actual API surface returned by `createPlatformInstance()` in `chunk-LX437ZTY.js`:
- `im.user(id)` — resolve a user
- `im.space.create(users, params?)` — create a DM space
- `im.space.get(id, params?)` — get existing space by ID

## Symptom

`POST /send {"spaceId": "+886..."}` on the sidecar fails with:
```
TypeError: im.space is not a function
```

After fix, the phone number is resolved to a DM space and the message is delivered successfully.

## Testing
- Before: `im.space(user)` → `TypeError`
- After: `im.space.create(user)` → space created → message sent