### PR TITLE
docs: add self-hosted web backend setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ All documentation lives at **[hermes-agent.nousresearch.com/docs](https://hermes
 | [Messaging Gateway](https://hermes-agent.nousresearch.com/docs/user-guide/messaging)                | Telegram, Discord, Slack, WhatsApp, Signal, Home Assistant |
 | [Security](https://hermes-agent.nousresearch.com/docs/user-guide/security)                          | Command approval, DM pairing, container isolation          |
 | [Tools & Toolsets](https://hermes-agent.nousresearch.com/docs/user-guide/features/tools)            | 40+ tools, toolset system, terminal backends               |
+| [Self-hosted Web Backends](docs/self-hosted-web-backends.md)                                       | Configure SearXNG and Firecrawl for local web search/extract |
 | [Skills System](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills)              | Procedural memory, Skills Hub, creating skills             |
 | [Memory](https://hermes-agent.nousresearch.com/docs/user-guide/features/memory)                     | Persistent memory, user profiles, best practices           |
 | [MCP Integration](https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp)               | Connect any MCP server for extended capabilities           |

--- a/docs/self-hosted-web-backends.md
+++ b/docs/self-hosted-web-backends.md
@@ -1,0 +1,90 @@
+# Self-Hosted Web Backends
+
+Hermes can route web search and URL extraction through local services instead
+of the Nous Tool Gateway or hosted vendor APIs. This page covers the supported
+configuration for SearXNG and Firecrawl.
+
+## Backend Roles
+
+SearXNG is search-only. Use it for `web_search`.
+
+Firecrawl supports both search and extraction. It is the usual self-hosted
+choice for `web_extract`.
+
+If you run both, configure them per capability:
+
+```yaml
+web:
+  search_backend: searxng
+  extract_backend: firecrawl
+```
+
+The shared fallback form also works when one backend should handle both tools:
+
+```yaml
+web:
+  backend: firecrawl
+```
+
+## SearXNG
+
+Hermes reads the SearXNG instance URL from `SEARXNG_URL`.
+
+Add this to `~/.hermes/.env`:
+
+```bash
+SEARXNG_URL=http://localhost:8080
+```
+
+Then select SearXNG for search:
+
+```bash
+hermes config set web.search_backend searxng
+```
+
+Use `SEARXNG_URL`, not `SEARXNG_BASE_URL` or
+`SEARXNG_INSTANCE_URL`. The bundled SearXNG provider and setup checks both
+look for `SEARXNG_URL`.
+
+## Firecrawl
+
+Hermes reads self-hosted Firecrawl from `FIRECRAWL_API_URL`.
+
+Add this to `~/.hermes/.env`:
+
+```bash
+FIRECRAWL_API_URL=http://localhost:3002
+```
+
+Then select Firecrawl for extraction:
+
+```bash
+hermes config set web.extract_backend firecrawl
+```
+
+If your Firecrawl server enforces an API key, set the same key in Hermes:
+
+```bash
+FIRECRAWL_API_KEY=local-firecrawl-key
+```
+
+For Firecrawl cloud, set `FIRECRAWL_API_KEY` without
+`FIRECRAWL_API_URL`.
+
+## Plugin Availability
+
+The bundled backend plugins are `web-searxng` and `web-firecrawl`. They are
+discovered automatically as backend plugins. If you have customized plugin
+loading, make sure those two plugins are not disabled.
+
+## Troubleshooting
+
+If Hermes falls back to another provider, check these first:
+
+1. `~/.hermes/.env` contains `SEARXNG_URL` for SearXNG and
+   `FIRECRAWL_API_URL` for self-hosted Firecrawl.
+2. `web.search_backend` and `web.extract_backend` are set when you want
+   different providers for search and extraction.
+3. The selected backend plugin is enabled and visible in `hermes tools`.
+4. Restart the gateway after changing `.env` or backend config so the running
+   process sees the new values.


### PR DESCRIPTION
## Summary
- add a self-hosted web backend setup guide for SearXNG and Firecrawl
- document the supported env vars: `SEARXNG_URL`, `FIRECRAWL_API_URL`, and optional `FIRECRAWL_API_KEY`
- link the new guide from the README documentation table

## Why
Users configuring local SearXNG and Firecrawl instances can otherwise end up with ambiguous env var names or backend selection, causing Hermes to fall back to another provider.

Fixes #44194.

## Validation
- `git diff --check`