### PR TITLE
fix(delegate): stop subagent tool completion lines leaking into parent CLI display

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -417,7 +417,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
 
     # ── Logging / callbacks ──────────────────────────────────────────
     tool_names_str = ", ".join(name for _, name, _, _, _, _ in parsed_calls)
-    if not agent.quiet_mode:
+    if not agent.quiet_mode and getattr(agent, "tool_progress_mode", "all") != "off":
         print(f"  ⚡ Concurrent: {num_tools} tool calls — {tool_names_str}")
         for i, (tc, name, args, middleware_trace, block_result, blocked_by_guardrail) in enumerate(parsed_calls, 1):
             args_str = json.dumps(args, ensure_ascii=False)
@@ -702,7 +702,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         if agent._should_emit_quiet_tool_messages():
             cute_msg = _get_cute_tool_message_impl(name, args, tool_duration, result=function_result)
             agent._safe_print(f"  {cute_msg}")
-        elif getattr(agent, "tool_progress_mode", "all") != "off":
+        elif not agent.quiet_mode and getattr(agent, "tool_progress_mode", "all") != "off":
             _preview_str = _multimodal_text_summary(function_result)
             if agent.verbose_logging:
                 print(f"  ✅ Tool {i+1} completed in {tool_duration:.2f}s")
@@ -866,7 +866,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         elif function_name == "skill_manage":
             agent._iters_since_skill = 0
 
-        if not agent.quiet_mode:
+        if not agent.quiet_mode and getattr(agent, "tool_progress_mode", "all") != "off":
             args_str = json.dumps(function_args, ensure_ascii=False)
             if agent.verbose_logging:
                 print(f"  📞 Tool {i}: {function_name}({list(function_args.keys())})")
@@ -1384,7 +1384,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # entire batch.  The model sees it on the next API iteration.
         agent._apply_pending_steer_to_tool_results(messages, 1)
 
-        if not agent.quiet_mode:
+        if not agent.quiet_mode and getattr(agent, "tool_progress_mode", "all") != "off":
             if agent.verbose_logging:
                 print(f"  ✅ Tool {i} completed in {tool_duration:.2f}s")
                 print(agent._wrap_verbose("Result: ", function_result))


### PR DESCRIPTION
## Summary
Subagent tool-completion lines no longer leak raw `✅ Tool N completed in Xs - {json...}` spam into the parent CLI display during `delegate_task`.

Root cause: commit 550b72dd8 (#33860 fix) changed the concurrent-path result-rendering gate from `not agent.quiet_mode` to `tool_progress_mode != "off"`. Subagents are built with `quiet_mode=True` but inherit the default `tool_progress_mode="all"`, so every child tool call bypassed the curated tree-view relay (`_build_child_progress_callback`) and printed full result previews up the ladder.

## Changes
- `agent/tool_executor.py`: all 4 direct-print sites (concurrent header/args, concurrent completion, sequential args, sequential completion) now gate on BOTH `not agent.quiet_mode` AND `tool_progress_mode != "off"`.

## Validation
| Scenario | Before | After |
|---|---|---|
| delegate_task subagent (quiet=True, mode=all) | prints every child tool result | silent (tree-view relay only) |
| CLI verbose, tool-progress all | prints | prints |
| CLI verbose, tool-progress off (#33860) | suppressed | suppressed |

Targeted tests: `tests/cli/test_tool_progress_scrollback.py`, `tests/run_agent/test_concurrent_interrupt.py`, `tests/run_agent/test_tool_executor_contextvar_propagation.py`, `tests/agent/test_tool_dispatch_helpers.py`, `tests/agent/test_display_tool_failure.py` — 73 passed, 0 failed.

## Infographic
![Subagent Tool Noise Leak — Fixed](https://v3b.fal.media/files/b/0a9ddbe1/KJXe1fdl97cElT42T99Y-_cAGvDImw.png)
