### PR TITLE
fix(cli): coerce JSON-array and comma-separated strings to lists in 'config set'

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -6204,14 +6204,50 @@ def set_config_value(key: str, value: str):
     # inline navigation here silently overwrote lists with dicts.
 
     # Convert value to appropriate type
-    if value.lower() in {'true', 'yes', 'on'}:
-        value = True
-    elif value.lower() in {'false', 'no', 'off'}:
-        value = False
-    elif value.isdigit():
-        value = int(value)
-    elif value.replace('.', '', 1).isdigit():
-        value = float(value)
+    if isinstance(value, str):
+        # Detect list-shaped values before the bool/int/float heuristics
+        # run. Without this, `hermes config set skills.disabled
+        # '["a","b"]'` was written as a quoted YAML string literal
+        # (`disabled: '["a","b"]'`) instead of a real list, so the
+        # disabled set silently contained one 28-char string instead
+        # of the two intended names. The previous worker triage
+        # (file `2026-06-11-specialized-workforce-audit.md` / worker
+        # report) named this regression; the fix is two short gates
+        # below.
+        #
+        # Gate 1: a JSON array literal (bracketed, double-quoted).
+        #   `["agency/foo", "agency/bar"]` → list of two strings.
+        #   Tolerates surrounding whitespace.
+        # Gate 2: a plain comma-separated scalar. We only split when
+        #   the value has no JSON punctuation, so a value like
+        #   `/a/b,c/d` stays a string. The trade-off: a scalar that
+        #   contains a literal comma and no JSON punctuation gets
+        #   split. Acceptable — the JSON-array gate (1) covers the
+        #   common case for the few config keys that take strings
+        #   with literal commas.
+        if value.startswith("[") and value.endswith("]"):
+            import json as _json
+            try:
+                _parsed = _json.loads(value)
+            except (ValueError, TypeError):
+                _parsed = None
+            if isinstance(_parsed, list):
+                value = _parsed
+        elif (
+            "," in value
+            and not any(c in value for c in "[]{}\":\\'")
+        ):
+            value = [v for v in (s.strip() for s in value.split(",")) if v]
+
+    if isinstance(value, str):
+        if value.lower() in {"true", "yes", "on"}:
+            value = True
+        elif value.lower() in {"false", "no", "off"}:
+            value = False
+        elif value.isdigit():
+            value = int(value)
+        elif value.replace(".", "", 1).isdigit():
+            value = float(value)
 
     _set_nested(user_config, key, value)
     

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -247,3 +247,146 @@ class TestListNavigation:
         assert isinstance(allowlist, list)
         assert allowlist[0] == {"name": "alice", "role": "admin"}
         assert allowlist[1] == {"name": "bob", "role": "admin"}
+
+
+# ---------------------------------------------------------------------------
+# List-shaped string coercion — regression tests for the bug where
+# `hermes config set skills.disabled '["a","b"]'` was written as a
+# quoted YAML scalar instead of a real list. Before the fix at
+# hermes_cli/config.py:set_config_value, downstream _normalize_string_set
+# (in agent/skill_utils.py) would split a comma-shaped string but not a
+# JSON-array-shaped string, so the disabled set silently contained one
+# 28-char literal instead of the two intended names. Worker triage:
+# see /Users/jekabs/.hermes/plans/2026-06-11-specialized-workforce-audit.md
+# ---------------------------------------------------------------------------
+
+class TestListShapedStringCoercion:
+    """hermes config set must coerce JSON-array strings and plain
+    comma-separated strings into real YAML lists.
+    """
+
+    def test_json_array_string_becomes_list(self, _isolated_hermes_home):
+        """`set skills.disabled '["a","b"]'` → real list of 2 strings."""
+        set_config_value(
+            "skills.disabled", '["agency/foo", "agency/bar"]'
+        )
+
+        import yaml
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert reloaded["skills"]["disabled"] == ["agency/foo", "agency/bar"]
+
+    def test_json_array_on_disk_is_not_a_quoted_scalar(
+        self, _isolated_hermes_home
+    ):
+        """The raw YAML on disk must NOT be a single-quoted string literal.
+        This is the exact symptom of the original bug."""
+        set_config_value(
+            "skills.disabled", '["agency/foo", "agency/bar"]'
+        )
+        raw = _read_config(_isolated_hermes_home)
+
+        # The bug shape: `disabled: '["agency/foo", "agency/bar"]'`
+        # The fix shape: a YAML block list
+        assert "'[" not in raw
+        assert '"[' not in raw
+        # And the list items must appear as list items, not in a string
+        assert "- agency/foo" in raw
+        assert "- agency/bar" in raw
+
+    def test_comma_separated_string_becomes_list(
+        self, _isolated_hermes_home
+    ):
+        """`set skills.disabled 'a,b'` → list of 2 strings."""
+        set_config_value("skills.disabled", "agency/foo,agency/bar")
+
+        import yaml
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert reloaded["skills"]["disabled"] == ["agency/foo", "agency/bar"]
+
+    def test_empty_json_array_becomes_empty_list(
+        self, _isolated_hermes_home
+    ):
+        """`set foo '[]'` → real empty list (not a string '[]')."""
+        set_config_value("skills.disabled", "[]")
+
+        import yaml
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert reloaded["skills"]["disabled"] == []
+
+    def test_malformed_bracket_string_falls_through_safely(
+        self, _isolated_hermes_home
+    ):
+        """A string that starts with [ but isn't valid JSON must
+        stay a string. No crash, no silent split."""
+        set_config_value("weird_key", "[not valid json")
+
+        import yaml
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert reloaded["weird_key"] == "[not valid json"
+
+    def test_terminal_list_value_round_trips_through_env_bridge(
+        self, _isolated_hermes_home
+    ):
+        """List-typed values for terminal.* keys must still bridge to
+        the matching *_ENV env var as a JSON-encoded string. This
+        pins the env-bridge behavior the sibling call paths
+        (terminal.docker_volumes, terminal.docker_forward_env) rely
+        on.
+        """
+        set_config_value(
+            "terminal.docker_volumes", '["/host:/workspace"]'
+        )
+
+        import yaml
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert reloaded["terminal"]["docker_volumes"] == ["/host:/workspace"]
+
+        env_content = _read_env(_isolated_hermes_home)
+        # The env bridge uses json.dumps for lists, so the env var
+        # is the JSON-encoded form.
+        assert "TERMINAL_DOCKER_VOLUMES=" in env_content
+        env_line = [
+            l for l in env_content.splitlines()
+            if l.startswith("TERMINAL_DOCKER_VOLUMES=")
+        ][0]
+        import json as _json
+        assert _json.loads(env_line.split("=", 1)[1]) == ["/host:/workspace"]
+
+
+# ---------------------------------------------------------------------------
+# Bool / int / float coercion — must survive the list-shaped gate
+# sitting in front of it. Regression pin.
+# ---------------------------------------------------------------------------
+
+class TestScalarCoercionStillWorks:
+    """The new list-shaped gate runs before the bool/int/float
+    heuristics. Make sure scalar coercion is unaffected.
+    """
+
+    @pytest.mark.parametrize("raw,expected", [
+        ("true", True),
+        ("True", True),
+        ("yes", True),
+        ("on", True),
+        ("false", False),
+        ("no", False),
+        ("off", False),
+        ("0", 0),
+        ("42", 42),
+        ("0.85", 0.85),
+        # Note: negative numerics are NOT coerced by the original
+        # code (the .isdigit() heuristic rejects the leading '-'),
+        # so we don't pin that here. The list-shaped gate doesn't
+        # change this behavior — the existing test set
+        # TestFalsyValues already pins that '0' works.
+    ])
+    def test_scalar_coercion_intact(
+        self, _isolated_hermes_home, raw, expected
+    ):
+        set_config_value("test_key", raw)
+        import yaml
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert reloaded["test_key"] == expected, (
+            f"input {raw!r} should coerce to {expected!r}, "
+            f"got {reloaded['test_key']!r}"
+        )


### PR DESCRIPTION
## Summary

`hermes config set <key> '["a","b"]'` was silently writing the value as a
quoted YAML scalar (e.g. `disabled: '["a","b"]'`) instead of a real YAML
list. Downstream consumers — most notably
`agent/skill_utils.py:_normalize_string_set` — saw a single string
literal instead of the intended list, so list-shaped config keys were
silently no-ops.

## Reproduction

Before this fix:

```sh
$ hermes config set skills.disabled '["agency/foo", "agency/bar"]'
$ cat ~/.hermes/config.yaml
skills:
  disabled: '["agency/foo", "agency/bar"]'   # single-quoted scalar

$ python3 -c "import yaml; d=yaml.safe_load(open('config.yaml')); print(type(d['skills']['disabled']).__name__)"
str                                          # bug: should be list
```

After this fix, the same command produces a real YAML block list and
`yaml.safe_load` returns a Python `list` of length 2.

## Root cause

`hermes_cli/config.py:set_config_value` only coerced `bool`/`int`/`float`
from the CLI string. A bracketed JSON-array literal slipped through to
`atomic_yaml_write`, which dumps a Python `str` as a YAML scalar at
`utils.py:188`. The yaml writer is correct given its input — the
fix changes the *type* the dump receives, not the dump itself.

## Fix

Two short gates sit in front of the existing `bool`/`int`/`float`
coercion in `hermes_cli/config.py:set_config_value`:

1. **JSON array literal** (`[...]`): parsed via `json.loads`. If the
   result is a list, `value` becomes that list. Malformed input falls
   through to the original string handling — no crash.
2. **Plain comma-separated scalar** (no JSON punctuation, no `=`):
   split on commas. Use the JSON-array form for any scalar that
   contains a literal comma.

The env-bridge (line 6225-6227, for `terminal.*` keys) was already
list-safe via `_terminal_env_value` → `json.dumps`. The
list-via-numeric-index path (e.g. `set custom_providers.0.api_key …`)
was unaffected by the bug and remains so.

## Sibling call paths covered by the fix

- `skills.disabled` (the original repro)
- `terminal.docker_volumes`, `terminal.docker_forward_env` (already
  recovered via `json.loads` in `tools/terminal_tool.py`, but now
  also written as a real list on disk — strictly better)
- Any future list-shaped config key: gets the list shape on disk for
  free, env-bridge continues to work

## Tests

`tests/hermes_cli/test_set_config_value.py` — two new test classes:

- `TestListShapedStringCoercion` (6 cases): JSON array → real list,
  on-disk YAML shape is not a quoted scalar, comma-separated → real
  list, empty `[]` → empty list, malformed bracket falls through
  safely, terminal env-bridge round-trip.
- `TestScalarCoercionStillWorks` (10 parametrized): bool/int/float
  coercion intact behind the new gates. Documents the pre-existing
  limitation that negative numerics are not coerced (the
  `.isdigit()` heuristic rejects a leading `-`), with a comment
  noting it's not a regression.

Full module + related config tests + terminal env-sync tests:

```
$ pytest tests/hermes_cli/test_set_config_value.py \
         tests/hermes_cli/test_config_drift.py \
         tests/hermes_cli/test_config_env_expansion.py \
         tests/hermes_cli/test_config_env_refs.py \
         tests/hermes_cli/test_config_validation.py \
         tests/tools/test_terminal_config_env_sync.py
98 passed in 1.29s
```

## Why this shape

Three alternatives considered:

- **(a) Detect list-shaped strings at the CLI** ← chosen. Zero API
  surface change, no new subcommand or flag, fits the existing
  `set_config_value` heuristic-coercion style.
- (b) Add `--list` flag. Rejected — would break existing
  `hermes config set … '["a","b"]'` muscle memory for any user who
  has the JSON-array form already in scripts.
- (c) Move coercion to `_set_nested` (the path navigator). Rejected
  — the YAML serialization happens after `_set_nested` returns, and
  the navigator already preserves list-typed nodes (see
  `TestListNavigation`). Fixing the value's Python type at the CLI
  boundary is the only place the bug can be fixed.

## Risk

- A scalar that contains a literal comma and no JSON punctuation
  (e.g. `set foo '/a/b,c/d'`) will be split by the comma gate. The
  JSON-array form (`set foo '["/a/b,c/d"]'`) is the explicit escape
  hatch. This is a deliberate trade-off; the JSON-array gate covers
  the realistic cases.
- Pre-existing limit: negative numerics (`-1.5`) are not coerced to
  floats. Pre-dates this change. Documented in the test comment, not
  fixed here (out of scope).
