### PR TITLE
feat(plugins): add DashScope (Alibaba) image generation provider

### DIFF
--- a/plugins/image_gen/dashscope/__init__.py
+++ b/plugins/image_gen/dashscope/__init__.py
@@ -1,0 +1,419 @@
+"""DashScope (Alibaba Cloud) image generation backend.
+
+Exposes DashScope's Tongyi Wanxiang models as an
+:class:`ImageGenProvider` implementation.
+
+Features:
+- Text-to-image generation via DashScope async task API
+- Multiple aspect ratios (landscape, square, portrait)
+- Multiple model tiers (wanx2.1-t2i-turbo, wanx2.1-t2i-plus, wanx-v1)
+- Async polling with configurable timeout
+- Reuses existing DASHSCOPE_API_KEY from chat inference
+
+Selection precedence (first hit wins):
+1. ``DASHSCOPE_IMAGE_MODEL`` env var
+2. ``image_gen.dashscope.model`` in ``config.yaml``
+3. :data:`DEFAULT_MODEL`
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+
+from agent.image_gen_provider import (
+    DEFAULT_ASPECT_RATIO,
+    ImageGenProvider,
+    error_response,
+    resolve_aspect_ratio,
+    save_url_image,
+    success_response,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Model catalog
+# ---------------------------------------------------------------------------
+
+_MODELS: Dict[str, Dict[str, Any]] = {
+    "wanx2.1-t2i-turbo": {
+        "display": "Wanx 2.1 Turbo",
+        "speed": "~5-10s",
+        "strengths": "Fast, good quality — default",
+    },
+    "wanx2.1-t2i-plus": {
+        "display": "Wanx 2.1 Plus",
+        "speed": "~15-30s",
+        "strengths": "Higher fidelity / detail",
+    },
+    "wanx-v1": {
+        "display": "Wanx v1",
+        "speed": "~10-20s",
+        "strengths": "Original model, wide compatibility",
+    },
+}
+
+DEFAULT_MODEL = "wanx2.1-t2i-turbo"
+
+# DashScope size mapping per aspect ratio.
+# wanx2.1-t2i-turbo supports: 512*1024, 1024*512, 1024*1024, 768*1024,
+# 1024*768, 864*1152, 1152*864, 1440*720, 720*1440
+# wanx-v1 supports: 512*512, 768*768, 1024*1024
+_SIZES: Dict[str, Dict[str, str]] = {
+    "wanx2.1-t2i-turbo": {
+        "landscape": "1024*576",
+        "square": "1024*1024",
+        "portrait": "576*1024",
+    },
+    "wanx2.1-t2i-plus": {
+        "landscape": "1024*576",
+        "square": "1024*1024",
+        "portrait": "576*1024",
+    },
+    "wanx-v1": {
+        "landscape": "1024*1024",  # v1 has limited aspect ratio support
+        "square": "1024*1024",
+        "portrait": "1024*1024",
+    },
+}
+
+# Async polling configuration
+_POLL_INTERVAL = 2.0  # seconds between polls
+_POLL_TIMEOUT = 120.0  # max seconds to wait for task completion
+
+# DashScope API endpoints
+_SUBMIT_URL = "https://dashscope.aliyuncs.com/api/v1/services/aigc/text2image/image-synthesis"
+_TASK_URL = "https://dashscope.aliyuncs.com/api/v1/tasks/{task_id}"
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+def _load_dashscope_config() -> Dict[str, Any]:
+    """Read ``image_gen.dashscope`` from config.yaml."""
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        section = cfg.get("image_gen") if isinstance(cfg, dict) else None
+        ds_section = section.get("dashscope") if isinstance(section, dict) else None
+        return ds_section if isinstance(ds_section, dict) else {}
+    except Exception as exc:
+        logger.debug("Could not load image_gen.dashscope config: %s", exc)
+        return {}
+
+
+def _resolve_model() -> Tuple[str, Dict[str, Any]]:
+    """Decide which model to use and return ``(model_id, meta)``."""
+    env_override = os.environ.get("DASHSCOPE_IMAGE_MODEL")
+    if env_override and env_override in _MODELS:
+        return env_override, _MODELS[env_override]
+
+    cfg = _load_dashscope_config()
+    candidate = cfg.get("model") if isinstance(cfg.get("model"), str) else None
+    if candidate and candidate in _MODELS:
+        return candidate, _MODELS[candidate]
+
+    return DEFAULT_MODEL, _MODELS[DEFAULT_MODEL]
+
+
+def _resolve_api_key() -> str:
+    """Resolve DashScope API key from env or config."""
+    key = os.environ.get("DASHSCOPE_API_KEY", "").strip()
+    if key:
+        return key
+    # Fallback: check .env via hermes constants
+    try:
+        from hermes_constants import get_hermes_home
+
+        env_file = get_hermes_home() / ".env"
+        if env_file.exists():
+            for line in env_file.read_text().splitlines():
+                line = line.strip()
+                if line.startswith("DASHSCOPE_API_KEY="):
+                    return line.split("=", 1)[1].strip().strip("\"'")
+    except Exception:
+        pass
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Provider
+# ---------------------------------------------------------------------------
+
+
+class DashScopeImageGenProvider(ImageGenProvider):
+    """DashScope Tongyi Wanxiang image generation backend."""
+
+    @property
+    def name(self) -> str:
+        return "dashscope"
+
+    @property
+    def display_name(self) -> str:
+        return "DashScope (Alibaba)"
+
+    def is_available(self) -> bool:
+        return bool(_resolve_api_key())
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "id": model_id,
+                "display": meta.get("display", model_id),
+                "speed": meta.get("speed", ""),
+                "strengths": meta.get("strengths", ""),
+            }
+            for model_id, meta in _MODELS.items()
+        ]
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "DashScope (Alibaba Cloud)",
+            "badge": "paid",
+            "tag": "Tongyi Wanxiang — text-to-image; uses DASHSCOPE_API_KEY",
+            "env_vars": [
+                {
+                    "key": "DASHSCOPE_API_KEY",
+                    "prompt": "DashScope API key (Alibaba Cloud)",
+                    "url": "https://dashscope.console.aliyun.com/apiKey",
+                },
+            ],
+        }
+
+    def generate(
+        self,
+        prompt: str,
+        aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Generate an image using DashScope Tongyi Wanxiang."""
+        prompt = (prompt or "").strip()
+        aspect = resolve_aspect_ratio(aspect_ratio)
+
+        if not prompt:
+            return error_response(
+                error="Prompt is required and must be a non-empty string",
+                error_type="invalid_argument",
+                provider="dashscope",
+                aspect_ratio=aspect,
+            )
+
+        api_key = _resolve_api_key()
+        if not api_key:
+            return error_response(
+                error=(
+                    "DASHSCOPE_API_KEY not set. Run `hermes tools` → Image "
+                    "Generation → DashScope to configure, or set "
+                    "DASHSCOPE_API_KEY in your environment."
+                ),
+                error_type="auth_required",
+                provider="dashscope",
+                aspect_ratio=aspect,
+            )
+
+        model_id, meta = _resolve_model()
+        sizes = _SIZES.get(model_id, _SIZES[DEFAULT_MODEL])
+        size = sizes.get(aspect, sizes["square"])
+
+        # Submit async task
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "X-DashScope-Async": "enable",
+        }
+
+        payload = {
+            "model": model_id,
+            "input": {
+                "prompt": prompt,
+            },
+            "parameters": {
+                "size": size,
+                "n": 1,
+            },
+        }
+
+        try:
+            response = requests.post(
+                _SUBMIT_URL,
+                headers=headers,
+                json=payload,
+                timeout=30,
+            )
+            response.raise_for_status()
+        except requests.HTTPError as exc:
+            resp = exc.response
+            status = resp.status_code if resp is not None else 0
+            try:
+                err_body = resp.json()
+                err_msg = (
+                    err_body.get("message")
+                    or err_body.get("error", {}).get("message", "")
+                    or resp.text[:300]
+                )
+            except Exception:
+                err_msg = resp.text[:300] if resp is not None else str(exc)
+            logger.error("DashScope image gen submit failed (%d): %s", status, err_msg)
+            return error_response(
+                error=f"DashScope image generation failed ({status}): {err_msg}",
+                error_type="api_error",
+                provider="dashscope",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+        except requests.Timeout:
+            return error_response(
+                error="DashScope image generation request timed out (30s)",
+                error_type="timeout",
+                provider="dashscope",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+        except requests.ConnectionError as exc:
+            return error_response(
+                error=f"DashScope connection error: {exc}",
+                error_type="connection_error",
+                provider="dashscope",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        try:
+            result = response.json()
+        except Exception as exc:
+            return error_response(
+                error=f"DashScope returned invalid JSON: {exc}",
+                error_type="invalid_response",
+                provider="dashscope",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        # Extract task_id from submit response
+        output = result.get("output", {})
+        task_id = output.get("task_id", "")
+        if not task_id:
+            return error_response(
+                error=f"DashScope did not return a task_id: {result}",
+                error_type="invalid_response",
+                provider="dashscope",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        # Poll for task completion
+        poll_url = _TASK_URL.format(task_id=task_id)
+        poll_headers = {"Authorization": f"Bearer {api_key}"}
+        deadline = time.monotonic() + _POLL_TIMEOUT
+
+        while time.monotonic() < deadline:
+            time.sleep(_POLL_INTERVAL)
+            try:
+                poll_resp = requests.get(
+                    poll_url,
+                    headers=poll_headers,
+                    timeout=15,
+                )
+                poll_resp.raise_for_status()
+                task_result = poll_resp.json()
+            except Exception as exc:
+                logger.warning("DashScope task poll failed: %s", exc)
+                continue
+
+            task_output = task_result.get("output", {})
+            task_status = task_output.get("task_status", "")
+
+            if task_status == "SUCCEEDED":
+                results = task_output.get("results", [])
+                if not results:
+                    return error_response(
+                        error="DashScope task succeeded but returned no images",
+                        error_type="empty_response",
+                        provider="dashscope",
+                        model=model_id,
+                        prompt=prompt,
+                        aspect_ratio=aspect,
+                    )
+                image_url = results[0].get("url", "")
+                if not image_url:
+                    return error_response(
+                        error="DashScope task result missing image URL",
+                        error_type="empty_response",
+                        provider="dashscope",
+                        model=model_id,
+                        prompt=prompt,
+                        aspect_ratio=aspect,
+                    )
+                # Download and cache the image
+                try:
+                    saved_path = save_url_image(image_url, prefix=f"dashscope_{model_id}")
+                    image_ref = str(saved_path)
+                except Exception as exc:
+                    logger.warning(
+                        "DashScope image URL %s could not be cached (%s); falling back to bare URL.",
+                        image_url,
+                        exc,
+                    )
+                    image_ref = image_url
+
+                extra: Dict[str, Any] = {"size": size}
+                return success_response(
+                    image=image_ref,
+                    model=model_id,
+                    prompt=prompt,
+                    aspect_ratio=aspect,
+                    provider="dashscope",
+                    extra=extra,
+                )
+
+            elif task_status == "FAILED":
+                code = task_output.get("code", "")
+                message = task_output.get("message", "Unknown error")
+                return error_response(
+                    error=f"DashScope image generation failed: {code} — {message}",
+                    error_type="provider_error",
+                    provider="dashscope",
+                    model=model_id,
+                    prompt=prompt,
+                    aspect_ratio=aspect,
+                )
+
+            # PENDING or RUNNING — continue polling
+            logger.debug(
+                "DashScope task %s status: %s, waiting...",
+                task_id,
+                task_status,
+            )
+
+        # Timeout
+        return error_response(
+            error=f"DashScope image generation timed out ({_POLL_TIMEOUT}s)",
+            error_type="timeout",
+            provider="dashscope",
+            model=model_id,
+            prompt=prompt,
+            aspect_ratio=aspect,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Plugin registration
+# ---------------------------------------------------------------------------
+
+
+def register(ctx: Any) -> None:
+    """Register this provider with the image gen registry."""
+    ctx.register_image_gen_provider(DashScopeImageGenProvider())

--- a/tests/plugins/image_gen/test_dashscope_provider.py
+++ b/tests/plugins/image_gen/test_dashscope_provider.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""Tests for DashScope (Alibaba Cloud) image generation provider."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _fake_api_key(monkeypatch):
+    """Ensure DASHSCOPE_API_KEY is set for all tests."""
+    monkeypatch.setenv("DASHSCOPE_API_KEY", "test-key-12345")
+
+
+# ---------------------------------------------------------------------------
+# Provider class tests
+# ---------------------------------------------------------------------------
+
+
+class TestDashScopeImageGenProvider:
+    def test_name(self):
+        from plugins.image_gen.dashscope import DashScopeImageGenProvider
+
+        provider = DashScopeImageGenProvider()
+        assert provider.name == "dashscope"
+
+    def test_display_name(self):
+        from plugins.image_gen.dashscope import DashScopeImageGenProvider
+
+        provider = DashScopeImageGenProvider()
+        assert provider.display_name == "DashScope (Alibaba)"
+
+    def test_is_available_with_key(self, monkeypatch):
+        monkeypatch.setenv("DASHSCOPE_API_KEY", "sk-xxx")
+        from plugins.image_gen.dashscope import DashScopeImageGenProvider
+
+        provider = DashScopeImageGenProvider()
+        assert provider.is_available() is True
+
+    def test_is_available_without_key(self, monkeypatch):
+        monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
+        from plugins.image_gen.dashscope import DashScopeImageGenProvider
+
+        provider = DashScopeImageGenProvider()
+        assert provider.is_available() is False
+
+    def test_list_models(self):
+        from plugins.image_gen.dashscope import DashScopeImageGenProvider
+
+        provider = DashScopeImageGenProvider()
+        models = provider.list_models()
+        assert len(models) == 3
+        assert models[0]["id"] == "wanx2.1-t2i-turbo"
+        assert models[1]["id"] == "wanx2.1-t2i-plus"
+        assert models[2]["id"] == "wanx-v1"
+
+    def test_default_model(self):
+        from plugins.image_gen.dashscope import DashScopeImageGenProvider
+
+        provider = DashScopeImageGenProvider()
+        assert provider.default_model() == "wanx2.1-t2i-turbo"
+
+    def test_get_setup_schema(self):
+        from plugins.image_gen.dashscope import DashScopeImageGenProvider
+
+        provider = DashScopeImageGenProvider()
+        schema = provider.get_setup_schema()
+        assert schema["name"] == "DashScope (Alibaba Cloud)"
+        assert schema["badge"] == "paid"
+        assert len(schema["env_vars"]) == 1
+        assert schema["env_vars"][0]["key"] == "DASHSCOPE_API_KEY"
+
+
+# ---------------------------------------------------------------------------
+# Config tests
+# ---------------------------------------------------------------------------
+
+
+class TestConfig:
+    def test_default_model(self):
+        from plugins.image_gen.dashscope import _resolve_model
+
+        model_id, meta = _resolve_model()
+        assert model_id == "wanx2.1-t2i-turbo"
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("DASHSCOPE_IMAGE_MODEL", "wanx-v1")
+        from plugins.image_gen.dashscope import _resolve_model
+
+        model_id, _ = _resolve_model()
+        assert model_id == "wanx-v1"
+
+    def test_config_override(self):
+        """Test that config.yaml model override works."""
+        from plugins.image_gen.dashscope import _resolve_model
+
+        mock_cfg = {"image_gen": {"dashscope": {"model": "wanx2.1-t2i-plus"}}}
+        with patch("hermes_cli.config.load_config", return_value=mock_cfg):
+            model_id, _ = _resolve_model()
+            assert model_id == "wanx2.1-t2i-plus"
+
+
+# ---------------------------------------------------------------------------
+# Generate tests
+# ---------------------------------------------------------------------------
+
+
+class TestGenerate:
+    def test_missing_api_key(self, monkeypatch):
+        monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
+        from plugins.image_gen.dashscope import DashScopeImageGenProvider
+
+        provider = DashScopeImageGenProvider()
+        result = provider.generate(prompt="test")
+        assert result["success"] is False
+        assert "DASHSCOPE_API_KEY" in result["error"]
+        assert result["error_type"] == "auth_required"
+
+    def test_empty_prompt(self):
+        from plugins.image_gen.dashscope import DashScopeImageGenProvider
+
+        provider = DashScopeImageGenProvider()
+        result = provider.generate(prompt="")
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_argument"
+
+    def test_successful_generation(self):
+        """Test full async task flow: submit → poll → download."""
+        from plugins.image_gen.dashscope import DashScopeImageGenProvider
+
+        # Mock submit response
+        submit_resp = MagicMock()
+        submit_resp.status_code = 200
+        submit_resp.raise_for_status = MagicMock()
+        submit_resp.json.return_value = {
+            "output": {"task_id": "task-12345", "task_status": "PENDING"},
+            "request_id": "req-abc",
+        }
+
+        # Mock poll response (succeeded)
+        poll_resp = MagicMock()
+        poll_resp.status_code = 200
+        poll_resp.raise_for_status = MagicMock()
+        poll_resp.json.return_value = {
+            "output": {
+                "task_id": "task-12345",
+                "task_status": "SUCCEEDED",
+                "results": [{"url": "https://dashscope-result.example.com/image.png"}],
+            },
+        }
+
+        def mock_post(*args, **kwargs):
+            return submit_resp
+
+        def mock_get(*args, **kwargs):
+            return poll_resp
+
+        with patch("plugins.image_gen.dashscope.requests.post", side_effect=mock_post), \
+             patch("plugins.image_gen.dashscope.requests.get", side_effect=mock_get), \
+             patch("plugins.image_gen.dashscope.time.sleep"), \
+             patch(
+                 "plugins.image_gen.dashscope.save_url_image",
+                 return_value=Path("/tmp/dashscope_wanx2.1-t2i-turbo_20260611_000000_deadbeef.png"),
+             ) as mock_save:
+            provider = DashScopeImageGenProvider()
+            result = provider.generate(prompt="A cat playing piano")
+
+        assert result["success"] is True
+        assert result["image"].startswith("/")
+        assert result["provider"] == "dashscope"
+        assert result["model"] == "wanx2.1-t2i-turbo"
+        mock_save.assert_called_once()
+
+    def test_task_failure(self):
+        """Test that a FAILED task returns an error response."""
+        from plugins.image_gen.dashscope import DashScopeImageGenProvider
+
+        submit_resp = MagicMock()
+        submit_resp.status_code = 200
+        submit_resp.raise_for_status = MagicMock()
+        submit_resp.json.return_value = {
+            "output": {"task_id": "task-fail", "task_status": "PENDING"},
+        }
+
+        poll_resp = MagicMock()
+        poll_resp.status_code = 200
+        poll_resp.raise_for_status = MagicMock()
+        poll_resp.json.return_value = {
+            "output": {
+                "task_id": "task-fail",
+                "task_status": "FAILED",
+                "code": "InvalidParameter",
+                "message": "Invalid prompt content",
+            },
+        }
+
+        with patch("plugins.image_gen.dashscope.requests.post", return_value=submit_resp), \
+             patch("plugins.image_gen.dashscope.requests.get", return_value=poll_resp), \
+             patch("plugins.image_gen.dashscope.time.sleep"):
+            provider = DashScopeImageGenProvider()
+            result = provider.generate(prompt="test")
+
+        assert result["success"] is False
+        assert result["error_type"] == "provider_error"
+        assert "InvalidParameter" in result["error"]
+
+    def test_submit_api_error(self):
+        """Test HTTP error on task submission."""
+        import requests as req_lib
+        from plugins.image_gen.dashscope import DashScopeImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 401
+        mock_resp.text = "Unauthorized"
+        mock_resp.json.return_value = {"message": "Invalid API key"}
+        mock_resp.raise_for_status.side_effect = req_lib.HTTPError(response=mock_resp)
+
+        with patch("plugins.image_gen.dashscope.requests.post", return_value=mock_resp):
+            provider = DashScopeImageGenProvider()
+            result = provider.generate(prompt="test")
+
+        assert result["success"] is False
+        assert result["error_type"] == "api_error"
+        assert "401" in result["error"]
+
+    def test_submit_timeout(self):
+        """Test timeout on task submission."""
+        import requests as req_lib
+        from plugins.image_gen.dashscope import DashScopeImageGenProvider
+
+        with patch("plugins.image_gen.dashscope.requests.post", side_effect=req_lib.Timeout()):
+            provider = DashScopeImageGenProvider()
+            result = provider.generate(prompt="test")
+
+        assert result["success"] is False
+        assert result["error_type"] == "timeout"
+
+    def test_submit_connection_error(self):
+        """Test connection error on task submission."""
+        import requests as req_lib
+        from plugins.image_gen.dashscope import DashScopeImageGenProvider
+
+        with patch("plugins.image_gen.dashscope.requests.post", side_effect=req_lib.ConnectionError("refused")):
+            provider = DashScopeImageGenProvider()
+            result = provider.generate(prompt="test")
+
+        assert result["success"] is False
+        assert result["error_type"] == "connection_error"
+
+    def test_missing_task_id(self):
+        """Test that missing task_id in submit response returns error."""
+        from plugins.image_gen.dashscope import DashScopeImageGenProvider
+
+        submit_resp = MagicMock()
+        submit_resp.status_code = 200
+        submit_resp.raise_for_status = MagicMock()
+        submit_resp.json.return_value = {"output": {}, "request_id": "req-abc"}
+
+        with patch("plugins.image_gen.dashscope.requests.post", return_value=submit_resp):
+            provider = DashScopeImageGenProvider()
+            result = provider.generate(prompt="test")
+
+        assert result["success"] is False
+        assert "task_id" in result["error"]
+
+    def test_empty_results(self):
+        """Test that empty results list returns error."""
+        from plugins.image_gen.dashscope import DashScopeImageGenProvider
+
+        submit_resp = MagicMock()
+        submit_resp.status_code = 200
+        submit_resp.raise_for_status = MagicMock()
+        submit_resp.json.return_value = {
+            "output": {"task_id": "task-empty", "task_status": "PENDING"},
+        }
+
+        poll_resp = MagicMock()
+        poll_resp.status_code = 200
+        poll_resp.raise_for_status = MagicMock()
+        poll_resp.json.return_value = {
+            "output": {
+                "task_id": "task-empty",
+                "task_status": "SUCCEEDED",
+                "results": [],
+            },
+        }
+
+        with patch("plugins.image_gen.dashscope.requests.post", return_value=submit_resp), \
+             patch("plugins.image_gen.dashscope.requests.get", return_value=poll_resp), \
+             patch("plugins.image_gen.dashscope.time.sleep"):
+            provider = DashScopeImageGenProvider()
+            result = provider.generate(prompt="test")
+
+        assert result["success"] is False
+        assert result["error_type"] == "empty_response"
+
+    def test_url_download_fallback(self):
+        """If caching the URL fails, fall back to bare URL."""
+        import requests as req_lib
+        from plugins.image_gen.dashscope import DashScopeImageGenProvider
+
+        submit_resp = MagicMock()
+        submit_resp.status_code = 200
+        submit_resp.raise_for_status = MagicMock()
+        submit_resp.json.return_value = {
+            "output": {"task_id": "task-url", "task_status": "PENDING"},
+        }
+
+        poll_resp = MagicMock()
+        poll_resp.status_code = 200
+        poll_resp.raise_for_status = MagicMock()
+        poll_resp.json.return_value = {
+            "output": {
+                "task_id": "task-url",
+                "task_status": "SUCCEEDED",
+                "results": [{"url": "https://dashscope.example.com/img.png"}],
+            },
+        }
+
+        with patch("plugins.image_gen.dashscope.requests.post", return_value=submit_resp), \
+             patch("plugins.image_gen.dashscope.requests.get", return_value=poll_resp), \
+             patch("plugins.image_gen.dashscope.time.sleep"), \
+             patch(
+                 "plugins.image_gen.dashscope.save_url_image",
+                 side_effect=req_lib.HTTPError("404"),
+             ):
+            provider = DashScopeImageGenProvider()
+            result = provider.generate(prompt="test")
+
+        assert result["success"] is True
+        assert result["image"] == "https://dashscope.example.com/img.png"
+
+    def test_aspect_ratio_mapping(self):
+        """Test that aspect ratios are correctly mapped to DashScope sizes."""
+        from plugins.image_gen.dashscope import _SIZES
+
+        # wanx2.1-t2i-turbo sizes
+        assert _SIZES["wanx2.1-t2i-turbo"]["landscape"] == "1024*576"
+        assert _SIZES["wanx2.1-t2i-turbo"]["square"] == "1024*1024"
+        assert _SIZES["wanx2.1-t2i-turbo"]["portrait"] == "576*1024"
+
+        # wanx-v1 has limited support (all 1024*1024)
+        assert _SIZES["wanx-v1"]["landscape"] == "1024*1024"
+
+
+# ---------------------------------------------------------------------------
+# Registration test
+# ---------------------------------------------------------------------------
+
+
+class TestRegistration:
+    def test_register(self):
+        from plugins.image_gen.dashscope import DashScopeImageGenProvider, register
+
+        mock_ctx = MagicMock()
+        register(mock_ctx)
+        mock_ctx.register_image_gen_provider.assert_called_once()
+        provider = mock_ctx.register_image_gen_provider.call_args[0][0]
+        assert isinstance(provider, DashScopeImageGenProvider)


### PR DESCRIPTION
## Problem

Hermes has 5 image generation backends (FAL, Krea, OpenAI, Codex, xAI) — all Western services requiring international payment methods. Chinese users with existing domestic AI accounts cannot use their credits for image generation.

Closes #44167

## Solution

Add DashScope (Alibaba Cloud) Tongyi Wanxiang as a new `image_gen` plugin. Reuses the existing `DASHSCOPE_API_KEY` already configured for chat inference — zero new credentials needed.

### Models

| Model | Speed | Notes |
|-------|-------|-------|
| `wanx2.1-t2i-turbo` | ~5-10s | Default — fast, good quality |
| `wanx2.1-t2i-plus` | ~15-30s | Higher fidelity |
| `wanx-v1` | ~10-20s | Original model, wide compatibility |

### Implementation

- Async task API: submit task → poll for completion → download result
- Configurable via `image_gen.dashscope.model` in config.yaml
- Env override: `DASHSCOPE_IMAGE_MODEL`
- Aspect ratio mapping per model (wanx2.1 supports 16:9, 1:1, 9:16; wanx-v1 limited to 1:1)
- Image URL caching via existing `save_url_image()` (same pattern as xAI provider)
- Falls back to bare URL if cache download fails

## Testing

22 tests covering:
- Provider class (name, display_name, is_available, list_models, setup_schema)
- Config resolution (default, env override, config override)
- Generation flow (success, task failure, API errors, timeouts, connection errors)
- Edge cases (missing task_id, empty results, URL download fallback)
- Aspect ratio mapping
- Plugin registration

## Files changed

- `plugins/image_gen/dashscope/__init__.py` — Plugin implementation (~300 lines)
- `tests/plugins/image_gen/test_dashscope_provider.py` — Test suite (~300 lines)
