### PR TITLE
fix(cli): bind alt voice record keys with escape sequences

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11608,22 +11608,26 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
         # Voice push-to-talk key: configurable via config.yaml (voice.record_key)
         # Default: Ctrl+B (avoids conflict with Ctrl+R readline reverse-search).
-        # Config spellings (ctrl/control/alt/option/opt) are normalized to
-        # prompt_toolkit's c-x / a-x format via ``normalize_voice_record_key_for_prompt_toolkit``
-        # so the same config value binds identically in the TUI and CLI
-        # (Copilot round-9 review on #19835). ``super``/``win``/``windows``
+        # Config spellings (ctrl/control/alt/option/opt) are normalized to a
+        # shared internal form, then translated to prompt_toolkit's real
+        # binding syntax at the final ``@kb.add`` call. Alt/Option chords must
+        # bind as ``("escape", key)`` rather than ``"a-key"``, or startup
+        # crashes while the keymap is registered. ``super``/``win``/``windows``
         # configs silently fall back to the default here since prompt_toolkit
         # has no super modifier — log a warning so users notice the
         # TUI/CLI split instead of a silent mismatch (round-11).
         _raw_key: object = "ctrl+b"
+        _voice_binding = ("c-b",)
         try:
             from hermes_cli.config import load_config
             from hermes_cli.voice import (
                 normalize_voice_record_key_for_prompt_toolkit,
+                voice_record_key_binding_for_prompt_toolkit,
                 voice_record_key_from_config,
             )
             _raw_key = voice_record_key_from_config(load_config())
             _voice_key = normalize_voice_record_key_for_prompt_toolkit(_raw_key)
+            _voice_binding = voice_record_key_binding_for_prompt_toolkit(_raw_key)
             if (
                 isinstance(_raw_key, str)
                 and _raw_key.strip().lower().split("+", 1)[0].strip() in {"super", "win", "windows"}
@@ -11637,6 +11641,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 )
         except Exception:
             _voice_key = "c-b"
+            _voice_binding = ("c-b",)
 
         # Cache the UI label here — same ``_raw_key`` that drives the
         # prompt_toolkit binding below. Every status / placeholder /
@@ -11645,7 +11650,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # voice.record_key mid-session (Copilot round-13 on #19835).
         self.set_voice_record_key_cache(_raw_key)
 
-        @kb.add(_voice_key)
+        @kb.add(*_voice_binding)
         def handle_voice_record(event):
             """Toggle voice recording when voice mode is active.
 

--- a/hermes_cli/voice.py
+++ b/hermes_cli/voice.py
@@ -106,7 +106,14 @@ def voice_record_key_from_config(cfg: Any) -> Any:
 
 
 def normalize_voice_record_key_for_prompt_toolkit(raw: Any) -> str:
-    """Coerce ``voice.record_key`` into prompt_toolkit's ``c-x`` / ``a-x`` format.
+    """Coerce ``voice.record_key`` into Hermes' normalized modifier form.
+
+    The return value is an internal normalized token (``c-x`` / ``a-x``),
+    not the exact argument list that prompt_toolkit's ``@kb.add`` expects
+    for every modifier. Alt/Option bindings still normalize to ``a-...`` so
+    the CLI status label logic and the TUI parser share one canonical form.
+    Use :func:`voice_record_key_binding_for_prompt_toolkit` at the actual
+    prompt_toolkit binding site.
 
     Mirrors the TUI parser contract (``ui-tui/src/lib/platform.ts``)
     so one config value binds the same shortcut in both runtimes:
@@ -180,6 +187,26 @@ def normalize_voice_record_key_for_prompt_toolkit(raw: Any) -> str:
         return _DEFAULT_PT_KEY
 
     return f"{normalized_mod}{named}"
+
+
+def voice_record_key_binding_for_prompt_toolkit(raw: Any) -> tuple[str, ...]:
+    """Return the real ``@kb.add`` argument sequence for ``voice.record_key``.
+
+    prompt_toolkit accepts Ctrl chords as a single token (``"c-b"``), but
+    Alt/Option chords must be registered as an Escape-prefixed key sequence
+    rather than ``"a-b"`` / ``"a-space"``. Keeping this translation in one
+    helper lets CLI startup share the same config/status normalization while
+    binding the portable prompt_toolkit representation that actually works.
+    """
+    normalized = normalize_voice_record_key_for_prompt_toolkit(raw)
+
+    if normalized.startswith("a-"):
+        key = normalized[2:]
+        if key:
+            return ("escape", key)
+        return (_DEFAULT_PT_KEY,)
+
+    return (normalized,)
 
 
 def format_voice_record_key_for_status(raw: Any) -> str:

--- a/tests/hermes_cli/test_voice_wrapper.py
+++ b/tests/hermes_cli/test_voice_wrapper.py
@@ -13,6 +13,7 @@ import os
 import sys
 
 import pytest
+from prompt_toolkit.key_binding import KeyBindings
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -169,6 +170,43 @@ class TestNormalizeVoiceRecordKeyForPromptToolkit:
         assert normalize_voice_record_key_for_prompt_toolkit("alt+c") == "a-c"
         assert normalize_voice_record_key_for_prompt_toolkit("alt+d") == "a-d"
         assert normalize_voice_record_key_for_prompt_toolkit("alt+l") == "a-l"
+
+
+class TestVoiceRecordKeyBindingForPromptToolkit:
+    def test_ctrl_binding_stays_single_prompt_toolkit_token(self):
+        from hermes_cli.voice import voice_record_key_binding_for_prompt_toolkit
+
+        assert voice_record_key_binding_for_prompt_toolkit("ctrl+b") == ("c-b",)
+        assert voice_record_key_binding_for_prompt_toolkit("control+o") == ("c-o",)
+
+    def test_alt_bindings_become_escape_sequences(self):
+        from hermes_cli.voice import voice_record_key_binding_for_prompt_toolkit
+
+        assert voice_record_key_binding_for_prompt_toolkit("alt+r") == ("escape", "r")
+        assert voice_record_key_binding_for_prompt_toolkit("option+space") == ("escape", "space")
+        assert voice_record_key_binding_for_prompt_toolkit("opt+enter") == ("escape", "enter")
+
+    @pytest.mark.parametrize(
+        ("raw_key", "expected"),
+        [
+            ("ctrl+b", ("c-b",)),
+            ("alt+r", ("escape", "r")),
+            ("alt+space", ("escape", "space")),
+            ("alt+enter", ("escape", "enter")),
+            ("ctrl+spcae", ("c-b",)),
+        ],
+    )
+    def test_binding_sequences_register_with_prompt_toolkit(self, raw_key, expected):
+        from hermes_cli.voice import voice_record_key_binding_for_prompt_toolkit
+
+        binding = voice_record_key_binding_for_prompt_toolkit(raw_key)
+        assert binding == expected
+
+        kb = KeyBindings()
+
+        @kb.add(*binding)
+        def _handler(event):
+            return None
 
 
 class TestVoiceRecordKeyFromConfig:


### PR DESCRIPTION
## What does this PR do?

Fixes the classic CLI startup crash behind `voice.record_key: alt+<key>` configs. The root cause is that prompt_toolkit rejects `a-...` tokens at `@kb.add()` time, so this change keeps Hermes' shared voice-key normalization but translates Alt/Option bindings into prompt_toolkit's actual Escape-prefixed sequence form when registering the CLI keybinding.

## Related Issue

Fixes #11387

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/voice.py`: added `voice_record_key_binding_for_prompt_toolkit()` so Alt/Option keys normalize once but bind as `("escape", key)` for prompt_toolkit.
- `cli.py`: switched the voice push-to-talk binding site to use the real prompt_toolkit binding tuple instead of passing `a-...` tokens directly into `@kb.add()`.
- `tests/hermes_cli/test_voice_wrapper.py`: added regression tests that assert Alt bindings become Escape sequences and can be registered by real `prompt_toolkit.key_binding.KeyBindings` objects without raising.

## Addressing maintainer feedback

- `#11397` (closed prior PR): that approach prevented the crash by rejecting `alt+...` and falling back to `Ctrl+B`. This PR does not revive the fallback-only behavior.
- `#11440` (closed prior PR): that PR picked the correct support direction for Alt bindings. This PR keeps that direction, but narrows the implementation to prompt_toolkit's actual `("escape", key)` API and adds direct registration coverage.
- `#11526` (closed prior PR): that bot PR also used fallback behavior. This PR avoids silently changing the user's configured shortcut when Alt is otherwise supportable.

## How to Test

1. Set `voice.record_key: alt+space` or `voice.record_key: alt+r` in `~/.hermes/config.yaml`.
2. Launch `hermes` and confirm startup reaches the prompt instead of failing with `ValueError: Invalid key: a-space` / `a-r`.
3. Run `/opt/homebrew/bin/timeout -k 30 480 $VIRTUAL_ENV/bin/pytest tests/hermes_cli/test_voice_wrapper.py tests/cli/test_cli_status_bar.py tests/cli/test_cli_init.py -q`.
4. Optionally verify the bound shortcut manually in the classic CLI voice mode.

## What platforms tested on

- macOS on darwin-arm64 (local)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS darwin-arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Local broad-suite note: `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh` stopped during collection on an unrelated environment issue, `tests/hermes_cli/test_dashboard_auth_401_reauth.py` failing with `ModuleNotFoundError: No module named 'fastapi'` before the suite could reach all downstream tests. Covering subset run was green: `tests/hermes_cli/test_voice_wrapper.py`, `tests/cli/test_cli_status_bar.py`, and `tests/cli/test_cli_init.py` (`129 passed`).

<!-- autocontrib:worker-id=issue-new-6e0d7fe6 kind=pr-open -->