### PR TITLE
docs(plugins): how to resolve the working directory in a plugin

### DIFF
--- a/website/docs/guides/build-a-hermes-plugin.md
+++ b/website/docs/guides/build-a-hermes-plugin.md
@@ -225,6 +225,46 @@ def unit_convert(args: dict, **kwargs) -> str:
 3. **Never raise:** Catch all exceptions, return error JSON instead.
 4. **Accept `**kwargs`:** Hermes may pass additional context in the future.
 
+### Resolving the working directory
+
+If your tool receives a filename from the model, resolve it the same way every
+built-in tool does — against the configured working directory, not the process
+CWD. The working directory is `terminal.cwd` in `config.yaml`, which the gateway
+bridges to the `TERMINAL_CWD` environment variable. Hermes sets that env var; it
+does **not** `chdir`, so a plain `os.getcwd()` in the gateway returns the
+container's launch directory (often `/`), not your workspace.
+
+```python
+import os
+from pathlib import Path
+
+
+def _workspace() -> Path:
+    # Same resolution the built-in tools use (see agent/tool_executor.py).
+    return Path(os.environ.get("TERMINAL_CWD") or os.getcwd())
+
+
+def _resolve(p: str) -> str:
+    path = Path(p)
+    return str(path if path.is_absolute() else (_workspace() / path).resolve())
+```
+
+Set `terminal.cwd: /workspace` (or wherever your files live) in `config.yaml` so
+`TERMINAL_CWD` points at the right place — don't hardcode `/workspace` in the
+plugin. There is no `hermes.utils.config` module; if you need config or the
+Hermes home directory, import `from hermes_cli.config import load_config` and
+`from hermes_constants import get_hermes_home`.
+
+:::tip Plugin edits not taking effect?
+Plugins are re-discovered on every start, so there's no stale on-disk cache to
+clear. If an edit doesn't show up after a restart, the running copy is coming
+from somewhere other than the file you edited: confirm the plugin lives under
+`$HERMES_HOME/plugins/<name>/` (in Docker, that's inside your mounted
+`HERMES_HOME`, e.g. `/opt/data/plugins/...`) and isn't baked into the image at
+build time — a `COPY`'d plugin needs a `docker compose build`, not just a
+container restart.
+:::
+
 ## Step 5: Write the registration
 
 Create `__init__.py` — this wires schemas to handlers:


### PR DESCRIPTION
## Summary

Plugin authors trying to turn a model-supplied filename into a real path keep hitting "the file isn't found unless Hermes passes an absolute path." The cause is a documentation gap, not a code bug:

- The working directory is `terminal.cwd` in `config.yaml`, which the gateway bridges to the `TERMINAL_CWD` env var. The gateway **sets the env var but does not `chdir`**, so a plain `os.getcwd()` inside a gateway plugin returns the container's launch directory (often `/`), not the workspace.
- Authors guess at imports like `from hermes.utils.config import get_hermes_home, get_config` — that module doesn't exist, the import throws, and the swallowed exception silently falls back to `os.getcwd()`.

This adds a short **"Resolving the working directory"** subsection to the plugin guide that:

- shows the exact `TERMINAL_CWD`-then-`getcwd()` resolution every built-in tool already uses (`agent/tool_executor.py`),
- points at the real imports (`from hermes_cli.config import load_config`, `from hermes_constants import get_hermes_home`) and notes there is no `hermes.utils.config`,
- adds a tip explaining why plugin edits can look stale (plugins are re-discovered every start — there's no on-disk cache; a stale copy means wrong location or a plugin baked into the Docker image, which needs a rebuild, not just a restart).

Docs-only change.

## Test plan

- [ ] `cd website && npm run build` renders the guide (the new `:::tip` admonition included) without MDX errors.