### PR TITLE
fix(desktop): preserve the packaged app when an Electron rebuild fails

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5421,6 +5421,83 @@ def _stop_desktop_processes_locking_build(desktop_dir: Path) -> list[int]:
     return stopped
 
 
+_DESKTOP_REBUILD_BACKUP_DIRNAME = ".rebuild-backup"
+
+
+def _backup_desktop_unpacked_app(desktop_dir: Path) -> Optional[tuple[Path, Path]]:
+    """Move the current unpacked desktop app aside before a repack.
+
+    before-pack.cjs wipes ``appOutDir`` (e.g. ``release/win-unpacked`` holding
+    the live ``Hermes.exe``) so the pack always stages into a clean tree — but
+    the Electron download/extract runs *after* that wipe, so a pack that fails
+    (corrupt cached zip, blocked download, proxy timeout) destroys the only
+    executable the user has and turns their desktop shortcut into a dead link
+    (#44225). Renaming the directory aside keeps a same-volume copy we can
+    restore if the pack ultimately fails, while the hook still finds a clean
+    tree at the original path.
+
+    The backup lives under ``release/.rebuild-backup/`` — NOT a sibling rename
+    — because ``_purge_electron_build_cache`` rmtree's ``release/*-unpacked``
+    between retries and ``_desktop_packaged_executable`` globs ``mac*``; a
+    sibling name would match one of those and either get purged mid-retry or
+    masquerade as the freshly-built app.
+
+    Returns ``(original, backup)``, or ``None`` when there is nothing to back
+    up or the rename failed — in which case the build proceeds exactly as it
+    did before this guard existed. Best-effort: never raises.
+    """
+    exe = _desktop_packaged_executable(desktop_dir)
+    if exe is None:
+        return None
+    try:
+        release_dir = (desktop_dir / "release").resolve()
+        unpacked = exe.resolve()
+    except OSError:
+        return None
+    # Walk up from the executable to the directory directly under release/
+    # (win-unpacked, mac-arm64, linux-unpacked, …) — that is electron-builder's
+    # appOutDir, the unit the before-pack hook deletes.
+    while unpacked.parent != release_dir:
+        if unpacked.parent == unpacked:  # hit filesystem root: exe not under release/
+            return None
+        unpacked = unpacked.parent
+    backup = release_dir / _DESKTOP_REBUILD_BACKUP_DIRNAME / unpacked.name
+    try:
+        if backup.exists():
+            shutil.rmtree(backup)
+        backup.parent.mkdir(parents=True, exist_ok=True)
+        unpacked.rename(backup)
+    except OSError:
+        return None
+    return unpacked, backup
+
+
+def _restore_desktop_unpacked_app(original: Path, backup: Path) -> bool:
+    """Put the pre-rebuild unpacked app back after a failed pack.
+
+    A failed pack may have left a partial tree at ``original``; that tree is a
+    pure build artifact the next pack wipes anyway, so it is safe to discard in
+    favor of the known-good backup. Best-effort: never raises.
+    """
+    try:
+        if original.exists():
+            shutil.rmtree(original)
+        backup.rename(original)
+    except OSError:
+        return False
+    _discard_desktop_unpacked_backup(backup)  # remove the now-empty holder dir
+    return True
+
+
+def _discard_desktop_unpacked_backup(backup: Path) -> None:
+    """Drop the pre-rebuild backup once the new pack has succeeded."""
+    try:
+        shutil.rmtree(backup, ignore_errors=True)
+        backup.parent.rmdir()  # only succeeds when no other backup remains
+    except OSError:
+        pass
+
+
 def _desktop_macos_relaunchable_fixup(desktop_dir: Path) -> None:
     """Make a locally-built (unsigned) macOS desktop app survive in-place self-update.
 
@@ -5708,6 +5785,7 @@ def cmd_gui(args: argparse.Namespace):
             if _force_adhoc_macos_signing(env, source_mode=source_mode):
                 print("  → No Developer ID configured; ad-hoc signing this local rebuild "
                       "(CSC_IDENTITY_AUTO_DISCOVERY=false)")
+            backup_entry = None
             if not source_mode:
                 # A running desktop instance launched from release/win-unpacked
                 # holds Hermes.exe locked on Windows, so the pack can't replace
@@ -5717,6 +5795,10 @@ def cmd_gui(args: argparse.Namespace):
                 stopped = _stop_desktop_processes_locking_build(desktop_dir)
                 if stopped:
                     print(f"  ⚠ Stopped running desktop app to free the build output (pid {', '.join(map(str, stopped))})")
+                # Park the current unpacked app outside the pack's blast radius
+                # so a failed rebuild can't leave the user with no executable
+                # at all (#44225); restored below if every retry fails.
+                backup_entry = _backup_desktop_unpacked_app(desktop_dir)
             build_result = subprocess.run([npm, "run", build_script], cwd=desktop_dir, env=env, check=False)
             if (
                 build_result.returncode != 0
@@ -5762,6 +5844,9 @@ def cmd_gui(args: argparse.Namespace):
                 _stop_desktop_processes_locking_build(desktop_dir)
                 build_result = subprocess.run([npm, "run", build_script], cwd=desktop_dir, env=mirror_env, check=False)
             if build_result.returncode != 0:
+                if backup_entry is not None and _restore_desktop_unpacked_app(*backup_entry):
+                    print("  ↩ Restored the previous desktop app build — the existing")
+                    print("    install (and its shortcuts) keep working until a rebuild succeeds.")
                 print("✗ Desktop GUI build failed")
                 print(f"  Run manually:  cd apps/desktop && npm run {build_script}")
                 if sys.platform == "win32":
@@ -5770,6 +5855,14 @@ def cmd_gui(args: argparse.Namespace):
                 print("  If the log shows Electron download retries, rebuild via a mirror:")
                 print("    ELECTRON_MIRROR=<mirror-base-url> hermes desktop --force-build")
                 sys.exit(build_result.returncode or 1)
+            if backup_entry is not None:
+                if _desktop_packaged_executable(desktop_dir) is None:
+                    # Pack reported success but left no launchable app (seen
+                    # with misconfigured targets): the old build is still the
+                    # only working one, so put it back instead of dropping it.
+                    _restore_desktop_unpacked_app(*backup_entry)
+                else:
+                    _discard_desktop_unpacked_backup(backup_entry[1])
             packaged_executable = _desktop_packaged_executable(desktop_dir)
             if not source_mode:
                 # Locally-built apps are ad-hoc signed; make them relaunchable after

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -716,18 +716,29 @@ def test_gui_does_not_retry_after_packaged_executable_exists(tmp_path, monkeypat
     root = _make_desktop_tree(tmp_path)
     monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
     # Executable EXISTS at failure time → late failure, not a corrupt download.
-    _make_packaged_executable(root, monkeypatch, platform="darwin")
+    exe = _make_packaged_executable(root, monkeypatch, platform="darwin")
     monkeypatch.delenv("ELECTRON_MIRROR", raising=False)
 
     install_ok = subprocess.CompletedProcess(["npm", "ci"], 0)
-    pack_fail = subprocess.CompletedProcess(["npm", "run", "pack"], 1)
+
+    # The #44225 backup guard parks the pre-existing app under
+    # release/.rebuild-backup before the pack, and before-pack.cjs then wipes
+    # appOutDir. A real late failure (e.g. macOS code signing) still leaves the
+    # freshly-assembled Hermes.app at appOutDir, which is the executable-present
+    # signal #40187's fast-fail keys on — so the pack mock must re-materialize
+    # it, exactly as before-pack + assembly do on disk, or the discriminator
+    # would misread this as the empty appOutDir of a corrupt download.
+    def _pack_leaves_app(cmd, **kwargs):
+        exe.parent.mkdir(parents=True, exist_ok=True)
+        exe.write_text("", encoding="utf-8")
+        return subprocess.CompletedProcess(cmd, 1)
 
     with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
          patch("hermes_cli.main._run_npm_install_deterministic", return_value=install_ok), \
          patch("hermes_cli.main._desktop_macos_relaunchable_fixup"), \
          patch("hermes_cli.main._purge_electron_build_cache", return_value=[Path("/c/electron.zip")]) as mock_purge, \
          patch("hermes_cli.main._redownload_electron_dist", return_value=True) as mock_dl, \
-         patch("hermes_cli.main.subprocess.run", return_value=pack_fail) as mock_run, \
+         patch("hermes_cli.main.subprocess.run", side_effect=_pack_leaves_app) as mock_run, \
          pytest.raises(SystemExit) as exc:
         cli_main.cmd_gui(_ns())
 
@@ -1056,3 +1067,168 @@ def test_desktop_launch_options_survives_config_error():
         flags, gpu = cli_main._desktop_launch_options()
     assert flags == []
     assert gpu == "auto"
+
+
+# ---------------------------------------------------------------------------
+# #44225: a failed pack must not destroy the only working desktop app.
+# before-pack.cjs wipes appOutDir before the Electron download/extract, so
+# without the backup/restore guard a failed rebuild (corrupt cache, blocked
+# download) leaves the user's shortcut pointing at a deleted Hermes.exe.
+# ---------------------------------------------------------------------------
+
+
+def test_backup_desktop_unpacked_app_moves_dir_into_holder(tmp_path, monkeypatch):
+    root = _make_desktop_tree(tmp_path)
+    exe = _make_packaged_executable(root, monkeypatch, platform="win32")
+    desktop_dir = root / "apps" / "desktop"
+
+    entry = cli_main._backup_desktop_unpacked_app(desktop_dir)
+
+    assert entry is not None
+    original, backup = entry
+    assert original == (desktop_dir / "release" / "win-unpacked").resolve()
+    assert backup == original.parent / ".rebuild-backup" / "win-unpacked"
+    assert not original.exists()
+    assert (backup / "Hermes.exe").exists()
+    assert not exe.exists()
+
+
+def test_backup_desktop_unpacked_app_none_without_packaged_app(tmp_path, monkeypatch):
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main.sys, "platform", "win32")
+    assert cli_main._backup_desktop_unpacked_app(root / "apps" / "desktop") is None
+
+
+def test_backup_resolves_mac_app_bundle_to_appoutdir(tmp_path, monkeypatch):
+    """On macOS the exe is nested in Hermes.app; the unit moved aside must be
+    the directory directly under release/ (electron-builder's appOutDir)."""
+    root = _make_desktop_tree(tmp_path)
+    _make_packaged_executable(root, monkeypatch, platform="darwin")
+    desktop_dir = root / "apps" / "desktop"
+
+    entry = cli_main._backup_desktop_unpacked_app(desktop_dir)
+
+    assert entry is not None
+    original, backup = entry
+    assert original == (desktop_dir / "release" / "mac-arm64").resolve()
+    assert (backup / "Hermes.app" / "Contents" / "MacOS" / "Hermes").exists()
+
+
+def test_backup_survives_electron_cache_purge(tmp_path, monkeypatch):
+    """_purge_electron_build_cache rmtree's release/*-unpacked between retries;
+    the parked copy must sit outside that glob or a retry destroys it too."""
+    root = _make_desktop_tree(tmp_path)
+    _make_packaged_executable(root, monkeypatch, platform="win32")
+    desktop_dir = root / "apps" / "desktop"
+
+    entry = cli_main._backup_desktop_unpacked_app(desktop_dir)
+    assert entry is not None
+    _, backup = entry
+
+    with patch("hermes_cli.main._electron_download_cache_dirs", return_value=[]):
+        cli_main._purge_electron_build_cache(desktop_dir)
+
+    assert (backup / "Hermes.exe").exists()
+
+
+def test_backup_not_mistaken_for_packaged_executable(tmp_path, monkeypatch):
+    """The parked mac bundle must not match the mac* detection glob, or a
+    failed --build-only would report the dead backup as a launchable app."""
+    root = _make_desktop_tree(tmp_path)
+    _make_packaged_executable(root, monkeypatch, platform="darwin")
+    desktop_dir = root / "apps" / "desktop"
+
+    assert cli_main._backup_desktop_unpacked_app(desktop_dir) is not None
+    assert cli_main._desktop_packaged_executable(desktop_dir) is None
+
+
+def test_restore_desktop_unpacked_app_replaces_partial_tree(tmp_path, monkeypatch):
+    root = _make_desktop_tree(tmp_path)
+    exe = _make_packaged_executable(root, monkeypatch, platform="win32")
+    exe.write_text("good build", encoding="utf-8")
+    desktop_dir = root / "apps" / "desktop"
+
+    original, backup = cli_main._backup_desktop_unpacked_app(desktop_dir)
+    # Simulate a pack that died mid-stage: partial tree, no executable.
+    original.mkdir(parents=True)
+    (original / "resources").mkdir()
+
+    assert cli_main._restore_desktop_unpacked_app(original, backup) is True
+    assert exe.read_text(encoding="utf-8") == "good build"
+    assert not (original / "resources").exists()
+    assert not backup.parent.exists()  # empty .rebuild-backup holder removed
+
+
+def test_gui_pack_failure_restores_previous_packaged_app(tmp_path, monkeypatch, capsys):
+    """End-to-end: every pack attempt fails → old app is back where the
+    desktop shortcut points, and the backup holder is gone."""
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch, platform="win32")
+    packaged_exe.write_text("good build", encoding="utf-8")
+    monkeypatch.setenv("ELECTRON_MIRROR", "https://example.test/electron/")
+
+    install_ok = subprocess.CompletedProcess(["npm", "ci"], 0)
+    pack_fail = subprocess.CompletedProcess(["npm", "run", "pack"], 1)
+
+    with patch("hermes_cli.main.shutil.which", return_value="C:\\npm"), \
+         patch("hermes_cli.main._run_npm_install_deterministic", return_value=install_ok), \
+         patch("hermes_cli.main._purge_electron_build_cache", return_value=[]), \
+         patch("hermes_cli.main._stop_desktop_processes_locking_build", return_value=[]), \
+         patch("hermes_cli.main.subprocess.run", return_value=pack_fail), \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns(build_only=True))
+
+    assert exc.value.code == 1
+    assert packaged_exe.read_text(encoding="utf-8") == "good build"
+    assert not (root / "apps" / "desktop" / "release" / ".rebuild-backup").exists()
+    out = capsys.readouterr().out
+    assert "Restored the previous desktop app build" in out
+
+
+def test_gui_pack_success_discards_backup_and_uses_new_build(tmp_path, monkeypatch):
+    """A pack that produces a fresh app drops the parked copy."""
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch, platform="win32")
+    packaged_exe.write_text("old build", encoding="utf-8")
+    desktop_dir = root / "apps" / "desktop"
+
+    install_ok = subprocess.CompletedProcess(["npm", "ci"], 0)
+
+    def _pack(cmd, **kwargs):
+        # Real pack re-creates the unpacked tree from scratch.
+        packaged_exe.parent.mkdir(parents=True, exist_ok=True)
+        packaged_exe.write_text("new build", encoding="utf-8")
+        return subprocess.CompletedProcess(cmd, 0)
+
+    with patch("hermes_cli.main.shutil.which", return_value="C:\\npm"), \
+         patch("hermes_cli.main._run_npm_install_deterministic", return_value=install_ok), \
+         patch("hermes_cli.main._stop_desktop_processes_locking_build", return_value=[]), \
+         patch("hermes_cli.main._write_desktop_build_stamp"), \
+         patch("hermes_cli.main.subprocess.run", side_effect=_pack):
+        cli_main.cmd_gui(_ns(build_only=True))
+
+    assert packaged_exe.read_text(encoding="utf-8") == "new build"
+    assert not (desktop_dir / "release" / ".rebuild-backup").exists()
+
+
+def test_gui_pack_success_without_artifact_restores_backup(tmp_path, monkeypatch):
+    """Zero exit but no launchable app (misconfigured targets): keep the old
+    build rather than deleting the only working one."""
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+    packaged_exe = _make_packaged_executable(root, monkeypatch, platform="win32")
+    packaged_exe.write_text("good build", encoding="utf-8")
+
+    install_ok = subprocess.CompletedProcess(["npm", "ci"], 0)
+    pack_ok = subprocess.CompletedProcess(["npm", "run", "pack"], 0)
+
+    with patch("hermes_cli.main.shutil.which", return_value="C:\\npm"), \
+         patch("hermes_cli.main._run_npm_install_deterministic", return_value=install_ok), \
+         patch("hermes_cli.main._stop_desktop_processes_locking_build", return_value=[]), \
+         patch("hermes_cli.main._write_desktop_build_stamp"), \
+         patch("hermes_cli.main.subprocess.run", return_value=pack_ok):
+        cli_main.cmd_gui(_ns(build_only=True))
+
+    assert packaged_exe.read_text(encoding="utf-8") == "good build"


### PR DESCRIPTION
Fixes #44225

## Problem

`hermes update` (including the desktop GUI's **Update Now**) rebuilds the desktop app via `hermes desktop --build-only` after `git pull`. electron-builder's `beforePack` hook (`apps/desktop/scripts/before-pack.cjs`) wipes `appOutDir` — e.g. `release/win-unpacked/` containing the live `Hermes.exe` — before staging, and the Electron download/extract runs **after** that wipe. So any pack failure (corrupt cached Electron zip, blocked/timed-out download) destroys the only executable the user has: the desktop shortcut becomes a dead link and the app is gone until a manual rebuild succeeds.

The CLI's existing retry ladder (cache purge → retry → mirror fallback) reduces how often the pack fails, but restores nothing when all retries fail.

## Fix

In the packaged-build path of `_cmd_desktop` (so it covers `hermes update`, GUI-triggered updates, the installer's headless `--update` rebuild, and manual `hermes desktop --force-build` alike):

- **Before the pack**: move the current unpacked app aside with a cheap same-volume rename into `release/.rebuild-backup/<name>` (`_backup_desktop_unpacked_app`). The `beforePack` hook's stale-dir cleanup semantics are preserved — it simply finds a clean tree.
- **On final failure** (after all existing retries): restore the parked copy over any partial tree, so the existing install and its shortcuts keep working (`_restore_desktop_unpacked_app`), then fail with the same exit code as before.
- **On success**: discard the backup. If a zero-exit pack somehow produced no launchable app, restore instead of discarding.

The holder directory is deliberately *not* a sibling rename: `_purge_electron_build_cache` rmtree's `release/*-unpacked` between retries and `_desktop_packaged_executable` globs `mac*`, so a sibling name would either get purged mid-retry or be mistaken for the freshly-built app. There's a regression test pinning each of those interactions.

All helpers are best-effort and never raise; if the backup rename fails, behavior is exactly what it was before this change.

This is the issue's proposed option A/B, but placed in the CLI pack path rather than `_cmd_update_impl` (option A would miss manual rebuilds) or `before-pack.cjs` (electron-builder has no on-failure hook to drive a restore from).

## Tests

8 new tests in `tests/hermes_cli/test_gui_command.py`: backup/restore unit coverage (including the macOS `Hermes.app` → `appOutDir` resolution), the purge-glob and detection-glob non-interference pins, and end-to-end `cmd_gui` runs for fail-restores / success-discards / zero-exit-without-artifact-restores.

`tests/hermes_cli/test_gui_command.py` (36) and `tests/hermes_cli/test_cmd_update.py` (29) all pass.
