### PR TITLE
fix(hindsight): declare packaging as a plugin dependency

### DIFF
--- a/plugins/memory/hindsight/plugin.yaml
+++ b/plugins/memory/hindsight/plugin.yaml
@@ -3,6 +3,7 @@ version: 1.0.0
 description: "Hindsight — long-term memory with knowledge graph, entity resolution, and multi-strategy retrieval."
 pip_dependencies:
   - "hindsight-client>=0.4.22"
+  - "packaging>=20.0"
 requires_env: []
 hooks:
   - on_session_end


### PR DESCRIPTION
## Summary

The hindsight memory plugin imports `packaging.version.Version` but never declares `packaging` in `pip_dependencies` (only `hindsight-client` is listed). On stripped/minimal venvs where `packaging` isn't pulled in transitively, the import fails — and both call sites swallow the `ModuleNotFoundError` in a bare `except`, so the failure is silent and misattributed.

## Root cause

`packaging` is used in two places in `plugins/memory/hindsight/__init__.py`:

1. `_meets_minimum_version()` (~L118) — `from packaging.version import Version`
2. The client auto-upgrade check in `initialize()` (~L1085)

Both are wrapped in `try: ... except Exception: return False / pass`. When `packaging` is missing:

- `_meets_minimum_version()` returns `False` for **any** input
- `_check_api_supports_update_mode_append()` then treats a perfectly healthy server as too old and logs:

  > Hindsight API at http://… reports version '0.7.2', older than 0.5.0. Falling back to per-process document_id …

- The plugin falls back to a per-process `document_id`, disabling `update_mode='append'` dedup. A 0.7.x server (well above the 0.5.0 minimum) is wrongly downgraded.

## Reproduction

On a venv without `packaging` installed (e.g. the stripped install venv), point the plugin at any Hindsight server ≥ 0.5.0. Retain works, but logs show the spurious "older than 0.5.0" warning and session-scoped append dedup never activates.

```
ModuleNotFoundError: No module named 'packaging'
```

## Fix

Declare `packaging` in `pip_dependencies` so `hermes memory setup` installs it alongside `hindsight-client` (the setup wizard reads `pip_dependencies` and installs any missing entries via `__import__` detection). This is the smallest, manifest-level fix; the swallowed-import call sites are left as-is since they're a reasonable defensive fallback once the dependency is actually present.

```yaml
pip_dependencies:
  - "hindsight-client>=0.4.22"
  - "packaging>=20.0"
```

## Test plan

- [x] Confirmed `packaging` is imported but undeclared on current `main`
- [x] Verified `hermes_cli/memory_setup.py` installs missing `pip_dependencies` entries
- [x] After installing `packaging` into the venv, `Version("0.7.2") >= Version("0.5.0")` returns `True` and the misleading warning disappears (verified on a live 0.7.2 server)
