### PR TITLE
fix: prevent codex credential rotation loops

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1133,6 +1133,15 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
         if fb_provider == "openai-codex":
             fb_api_mode = "codex_responses"
+        elif (
+            fb_provider in {"kimi-coding", "kimi-coding-cn"}
+            or (base_url_host_matches(fb_base_url, "api.kimi.com") and "/coding" in fb_base_url.lower())
+        ):
+            # Kimi Coding Plan speaks Anthropic Messages on the /coding route.
+            # resolve_provider_client wraps it in an OpenAI-compatible shim, but
+            # the main loop still needs the Anthropic transport mode so fallback
+            # requests don't hit /chat/completions and 404.
+            fb_api_mode = "anthropic_messages"
         elif fb_provider == "anthropic" or fb_base_url.rstrip("/").lower().endswith("/anthropic"):
             fb_api_mode = "anthropic_messages"
         elif _fb_is_azure:

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1622,6 +1622,94 @@ def _normalize_pool_priorities(provider: str, entries: List[PooledCredential]) -
     return changed
 
 
+def _credential_health_rank(entry: PooledCredential) -> int:
+    """Sort key component for duplicate cleanup: usable > exhausted > dead."""
+    if entry.last_status == STATUS_DEAD:
+        return 2
+    if entry.last_status == STATUS_EXHAUSTED:
+        return 1
+    return 0
+
+
+def _credential_freshness(entry: PooledCredential) -> float:
+    """Best-effort timestamp used to keep the freshest duplicate credential."""
+    for value in (
+        entry.last_refresh,
+        entry.last_status_at,
+        entry.expires_at,
+        entry.expires_at_ms,
+    ):
+        parsed = _parse_absolute_timestamp(value)
+        if parsed is not None:
+            return parsed
+    return 0.0
+
+
+def _deduplicate_pool_entries(provider: str, entries: List[PooledCredential]) -> bool:
+    """Remove unsafe duplicate seeded entries and ensure every entry has a unique id.
+
+    Runtime rotation uses credential ids for ``current()``, ``_replace_entry()``,
+    lease tracking, and persisted status updates. If two entries share an id,
+    a 401 on one credential can mark/select the other and spin forever. This was
+    observed with OpenAI Codex shared-auth pools where a DEAD singleton and a
+    fresh singleton both had ``id=b279b4``.
+
+    Auto-seeded singleton/env sources should only have one active entry per
+    source, so collapse duplicates and prefer the healthiest/freshest one.
+    Manual entries are user-managed independent credentials, so preserve them
+    and only rewrite colliding ids.
+    """
+    changed = False
+
+    best_by_source: Dict[str, Tuple[int, PooledCredential]] = {}
+    duplicate_indexes: Set[int] = set()
+    for idx, entry in enumerate(entries):
+        if _is_manual_source(entry.source):
+            continue
+        source = (entry.source or "").strip()
+        if not source:
+            continue
+        existing = best_by_source.get(source)
+        if existing is None:
+            best_by_source[source] = (idx, entry)
+            continue
+        existing_idx, existing_entry = existing
+        candidate_key = (
+            _credential_health_rank(entry),
+            -_credential_freshness(entry),
+            entry.priority,
+        )
+        existing_key = (
+            _credential_health_rank(existing_entry),
+            -_credential_freshness(existing_entry),
+            existing_entry.priority,
+        )
+        if candidate_key < existing_key:
+            duplicate_indexes.add(existing_idx)
+            best_by_source[source] = (idx, entry)
+        else:
+            duplicate_indexes.add(idx)
+
+    if duplicate_indexes:
+        entries[:] = [entry for idx, entry in enumerate(entries) if idx not in duplicate_indexes]
+        changed = True
+
+    seen_ids: Set[str] = set()
+    for idx, entry in enumerate(entries):
+        entry_id = str(entry.id or "").strip()
+        if entry_id and entry_id not in seen_ids:
+            seen_ids.add(entry_id)
+            continue
+        new_id = uuid.uuid4().hex[:6]
+        while new_id in seen_ids:
+            new_id = uuid.uuid4().hex[:6]
+        entries[idx] = replace(entry, id=new_id)
+        seen_ids.add(new_id)
+        changed = True
+
+    return changed
+
+
 def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tuple[bool, Set[str]]:
     changed = False
     active_sources: Set[str] = set()
@@ -2163,16 +2251,17 @@ def load_pool(provider: str) -> CredentialPool:
         for payload in raw_entries
     )
     entries = [PooledCredential.from_dict(provider, payload) for payload in raw_entries]
+    dedupe_changed = _deduplicate_pool_entries(provider, entries)
 
     if provider.startswith(CUSTOM_POOL_PREFIX):
         # Custom endpoint pool — seed from custom_providers config and model config
         custom_changed, custom_sources = _seed_custom_pool(provider, entries)
-        changed = raw_needs_sanitization or custom_changed
+        changed = raw_needs_sanitization or dedupe_changed or custom_changed
         changed |= _prune_stale_seeded_entries(entries, custom_sources)
     else:
         singleton_changed, singleton_sources = _seed_from_singletons(provider, entries)
         env_changed, env_sources = _seed_from_env(provider, entries)
-        changed = raw_needs_sanitization or singleton_changed or env_changed
+        changed = raw_needs_sanitization or dedupe_changed or singleton_changed or env_changed
         changed |= _prune_stale_seeded_entries(entries, singleton_sources | env_sources)
         changed |= _normalize_pool_priorities(provider, entries)
 

--- a/funciones.txt
+++ b/funciones.txt
@@ -15,3 +15,8 @@
 - Estado: implementado
 - Descripción: los perfiles que no tengan `providers.openai-codex` local pueden usar el auth Codex del root/global como credencial compartida; si el token necesita refresh, se actualiza el auth global bajo un lock del propio fichero en vez de clonar tokens rotados al `auth.json` aislado del perfil.
 - Notas: `HERMES_CODEX_SHARED_AUTH=0` fuerza auth Codex estrictamente por perfil. `get_codex_auth_status()` expone `auth_scope/auth_store` para diagnosticar si se usa perfil o shared.
+
+## Credential pool duplicate-id and Kimi fallback hardening
+- Estado: implementado
+- Descripción: el cargador de pools de credenciales sanea entradas auto-sembradas duplicadas por `source`, conserva la credencial más sana/fresca y garantiza IDs únicos para evitar bucles de rotación 401 con credenciales OAuth inválidas. El fallback a `kimi-coding` usa modo Anthropic Messages para endpoints `/coding`, evitando 404 al caer desde Codex.
+- Notas: aplicado para desbloquear perfiles ZKTeco con una sola credencial Codex y fallback `kimi-coding/kimi-k2-0905`.

--- a/funciones.txt
+++ b/funciones.txt
@@ -1,0 +1,17 @@
+# funciones.txt — Hermes Agent
+
+## OpenViking memory cost controls
+- Estado: implementado
+- Descripción: controles para reducir coste Gemini/OpenViking manteniendo búsqueda explícita (`viking_search`, `viking_read`, `viking_browse`) y permitiendo desactivar captura automática de turnos, prefetch automático y commits automáticos por perfil mediante variables de entorno.
+- Variables: `OPENVIKING_AUTO_SYNC`, `OPENVIKING_AUTO_PREFETCH`, `OPENVIKING_AUTO_COMMIT`, `OPENVIKING_MIN_COMMIT_TURNS`, `OPENVIKING_PREFETCH_TOP_K`, `OPENVIKING_SYNC_USER_CHAR_LIMIT`, `OPENVIKING_SYNC_ASSISTANT_CHAR_LIMIT`.
+- Notas: aplicado en `ancora-web` y `ancora-2-web` con auto-sync/prefetch/commit desactivados para mantener búsqueda manual y recortar gasto automático.
+
+## Telegram attachment delivery for generated .md files
+- Estado: implementado
+- Descripción: cuando un perfil opere por Telegram y genere un fichero `.md`, se le indica que lo envíe como `MEDIA:/absolute/path/to/file.md` para que el gateway lo entregue como documento descargable en lugar de dejar solo la ruta en el chat.
+- Notas: la mejora aplica a todos los perfiles que usen el hint de plataforma Telegram.
+
+## Shared Codex auth for profile-isolated Hermes
+- Estado: implementado
+- Descripción: los perfiles que no tengan `providers.openai-codex` local pueden usar el auth Codex del root/global como credencial compartida; si el token necesita refresh, se actualiza el auth global bajo un lock del propio fichero en vez de clonar tokens rotados al `auth.json` aislado del perfil.
+- Notas: `HERMES_CODEX_SHARED_AUTH=0` fuerza auth Codex estrictamente por perfil. `get_codex_auth_status()` expone `auth_scope/auth_store` para diagnosticar si se usa perfil o shared.

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -946,6 +946,7 @@ def _auth_lock_path() -> Path:
 
 
 _auth_lock_holder = threading.local()
+_codex_shared_auth_lock_holder = threading.local()
 
 
 @contextmanager
@@ -1039,6 +1040,61 @@ def _auth_store_lock(timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS):
         yield
 
 
+def _codex_shared_auth_enabled() -> bool:
+    """Whether profile processes may use the global-root Codex auth as shared auth.
+
+    Profile reads already had a read-only global auth fallback.  This toggle
+    extends that same behaviour to Codex refresh writes so a profile does not
+    clone a global OAuth token pair into its isolated auth.json and race future
+    refreshes.  Set ``HERMES_CODEX_SHARED_AUTH=0`` to force strict per-profile
+    Codex auth.
+    """
+    raw = os.getenv("HERMES_CODEX_SHARED_AUTH", "").strip().lower()
+    if raw in {"0", "false", "no", "off"}:
+        return False
+    return True
+
+
+def _codex_shared_auth_file_path() -> Optional[Path]:
+    if not _codex_shared_auth_enabled():
+        return None
+    return _global_auth_file_path()
+
+
+def _codex_auth_lock_path_for(auth_file: Path) -> Path:
+    return auth_file.with_suffix(".lock")
+
+
+@contextmanager
+def _codex_auth_store_lock_for(
+    auth_file: Path,
+    timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS,
+):
+    """Lock the auth store that owns Codex tokens.
+
+    Local profile auth uses the normal profile lock.  Shared/global Codex auth
+    uses a separate holder so refreshes across profile processes serialize on
+    the global ``auth.lock`` instead of racing through each profile's isolated
+    lock file.
+    """
+    local_path = _auth_file_path()
+    try:
+        is_local = auth_file.resolve(strict=False) == local_path.resolve(strict=False)
+    except Exception:
+        is_local = auth_file == local_path
+    if is_local:
+        with _auth_store_lock(timeout_seconds=timeout_seconds):
+            yield
+        return
+    with _file_lock(
+        _codex_auth_lock_path_for(auth_file),
+        _codex_shared_auth_lock_holder,
+        timeout_seconds,
+        "Timed out waiting for shared Codex auth store lock",
+    ):
+        yield
+
+
 def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
     auth_file = auth_file or _auth_file_path()
     if not auth_file.exists():
@@ -1079,8 +1135,8 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
     return {"version": AUTH_STORE_VERSION, "providers": {}}
 
 
-def _save_auth_store(auth_store: Dict[str, Any]) -> Path:
-    auth_file = _auth_file_path()
+def _save_auth_store(auth_store: Dict[str, Any], auth_file: Optional[Path] = None) -> Path:
+    auth_file = auth_file or _auth_file_path()
     auth_file.parent.mkdir(parents=True, exist_ok=True)
     # Tighten parent dir to 0o700 so siblings can't traverse to creds.
     # No-op on Windows (POSIX mode bits not enforced); ignore failures.
@@ -3320,53 +3376,100 @@ def _print_loopback_ssh_hint(redirect_uri: str, *, docs_url: str | None = None) 
 # where one app's refresh invalidates the other's session.
 # =============================================================================
 
-def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
-    """Read Codex OAuth tokens from Hermes auth store (~/.hermes/auth.json).
-    
-    Returns dict with 'tokens' (access_token, refresh_token) and 'last_refresh'.
-    Raises AuthError if no Codex tokens are stored.
+def _provider_state_from_store(auth_store: Dict[str, Any], provider_id: str) -> Optional[Dict[str, Any]]:
+    providers = auth_store.get("providers")
+    if isinstance(providers, dict):
+        state = providers.get(provider_id)
+        if isinstance(state, dict):
+            return dict(state)
+    return None
+
+
+def _read_codex_tokens(
+    *,
+    _lock: bool = True,
+    auth_file: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Read Codex OAuth tokens from the owning Hermes auth store.
+
+    Returns dict with ``tokens`` (access_token, refresh_token), ``last_refresh``,
+    ``auth_file`` and ``auth_scope``.  In profile mode, when the profile has no
+    local ``providers.openai-codex`` block, this reads the global-root auth.json
+    as shared Codex auth.  Runtime refresh then writes back to that same file
+    under that file's lock, avoiding per-profile token clones and refresh races.
     """
-    if _lock:
-        with _auth_store_lock():
-            auth_store = _load_auth_store()
+    candidates: list[tuple[Path, str]] = []
+    if auth_file is not None:
+        candidates.append((Path(auth_file), "explicit"))
     else:
-        auth_store = _load_auth_store()
-    state = _load_provider_state(auth_store, "openai-codex")
-    if not state:
-        raise AuthError(
-            "No Codex credentials stored. Run `hermes auth` to authenticate.",
-            provider="openai-codex",
-            code="codex_auth_missing",
-            relogin_required=True,
-        )
-    tokens = state.get("tokens")
-    if not isinstance(tokens, dict):
-        raise AuthError(
-            "Codex auth state is missing tokens. Run `hermes auth` to re-authenticate.",
-            provider="openai-codex",
-            code="codex_auth_invalid_shape",
-            relogin_required=True,
-        )
-    access_token = tokens.get("access_token")
-    refresh_token = tokens.get("refresh_token")
-    if not isinstance(access_token, str) or not access_token.strip():
-        raise AuthError(
-            "Codex auth is missing access_token. Run `hermes auth` to re-authenticate.",
-            provider="openai-codex",
-            code="codex_auth_missing_access_token",
-            relogin_required=True,
-        )
-    if not isinstance(refresh_token, str) or not refresh_token.strip():
-        raise AuthError(
-            "Codex auth is missing refresh_token. Run `hermes auth` to re-authenticate.",
-            provider="openai-codex",
-            code="codex_auth_missing_refresh_token",
-            relogin_required=True,
-        )
-    return {
-        "tokens": tokens,
-        "last_refresh": state.get("last_refresh"),
-    }
+        candidates.append((_auth_file_path(), "profile"))
+        shared_path = _codex_shared_auth_file_path()
+        if shared_path is not None:
+            try:
+                same_as_local = shared_path.resolve(strict=False) == _auth_file_path().resolve(strict=False)
+            except Exception:
+                same_as_local = shared_path == _auth_file_path()
+            if not same_as_local:
+                candidates.append((shared_path, "shared"))
+
+    missing_error: Optional[AuthError] = None
+    for candidate_path, scope in candidates:
+        def _load_candidate() -> Dict[str, Any]:
+            return _load_auth_store(candidate_path)
+
+        if _lock:
+            with _codex_auth_store_lock_for(candidate_path):
+                auth_store = _load_candidate()
+        else:
+            auth_store = _load_candidate()
+        state = _provider_state_from_store(auth_store, "openai-codex")
+        if not state:
+            missing_error = AuthError(
+                "No Codex credentials stored. Run `hermes auth` to authenticate.",
+                provider="openai-codex",
+                code="codex_auth_missing",
+                relogin_required=True,
+            )
+            continue
+        tokens = state.get("tokens")
+        if not isinstance(tokens, dict):
+            raise AuthError(
+                "Codex auth state is missing tokens. Run `hermes auth` to re-authenticate.",
+                provider="openai-codex",
+                code="codex_auth_invalid_shape",
+                relogin_required=True,
+            )
+        access_token = tokens.get("access_token")
+        refresh_token = tokens.get("refresh_token")
+        if not isinstance(access_token, str) or not access_token.strip():
+            raise AuthError(
+                "Codex auth is missing access_token. Run `hermes auth` to re-authenticate.",
+                provider="openai-codex",
+                code="codex_auth_missing_access_token",
+                relogin_required=True,
+            )
+        if not isinstance(refresh_token, str) or not refresh_token.strip():
+            raise AuthError(
+                "Codex auth is missing refresh_token. Run `hermes auth` to re-authenticate.",
+                provider="openai-codex",
+                code="codex_auth_missing_refresh_token",
+                relogin_required=True,
+            )
+        return {
+            "tokens": tokens,
+            "last_refresh": state.get("last_refresh"),
+            "auth_file": candidate_path,
+            "auth_scope": scope,
+        }
+
+    if missing_error is not None:
+        raise missing_error
+    raise AuthError(
+        "No Codex credentials stored. Run `hermes auth` to authenticate.",
+        provider="openai-codex",
+        code="codex_auth_missing",
+        relogin_required=True,
+    )
 
 
 def _sync_codex_pool_entries(
@@ -3470,13 +3573,28 @@ def _sync_codex_pool_entries(
         entry["last_error_reset_at"] = None
 
 
-def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: str = None) -> None:
-    """Save Codex OAuth tokens to Hermes auth store (~/.hermes/auth.json)."""
+def _save_codex_tokens(
+    tokens: Dict[str, str],
+    last_refresh: str = None,
+    label: str = None,
+    *,
+    auth_file: Optional[Path] = None,
+    _lock: bool = True,
+) -> None:
+    """Save Codex OAuth tokens to a Hermes auth store.
+
+    ``auth_file`` is normally the profile auth.json.  When runtime credentials
+    were borrowed from shared/global Codex auth, callers pass that global path
+    so refresh updates the broker token pair instead of creating a stale copy
+    inside the profile.
+    """
     if last_refresh is None:
         last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-    with _auth_store_lock():
-        auth_store = _load_auth_store()
-        state = _load_provider_state(auth_store, "openai-codex") or {}
+    target_auth_file = Path(auth_file) if auth_file is not None else _auth_file_path()
+
+    def _write() -> None:
+        auth_store = _load_auth_store(target_auth_file)
+        state = _provider_state_from_store(auth_store, "openai-codex") or {}
         # Capture the previous singleton tokens BEFORE overwriting them.  The
         # pool-sync step uses this to distinguish legacy singleton-aliases
         # (which should be refreshed) from independent accounts that
@@ -3495,7 +3613,13 @@ def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: 
             last_refresh,
             previous_singleton_tokens=previous_singleton_tokens,
         )
-        _save_auth_store(auth_store)
+        _save_auth_store(auth_store, target_auth_file)
+
+    if _lock:
+        with _codex_auth_store_lock_for(target_auth_file):
+            _write()
+    else:
+        _write()
 
 
 def refresh_codex_oauth_pure(
@@ -3629,6 +3753,9 @@ def refresh_codex_oauth_pure(
 def _refresh_codex_auth_tokens(
     tokens: Dict[str, str],
     timeout_seconds: float,
+    *,
+    auth_file: Optional[Path] = None,
+    _lock: bool = True,
 ) -> Dict[str, str]:
     """Refresh Codex access token using the refresh token.
     
@@ -3643,7 +3770,7 @@ def _refresh_codex_auth_tokens(
     updated_tokens["access_token"] = refreshed["access_token"]
     updated_tokens["refresh_token"] = refreshed["refresh_token"]
 
-    _save_codex_tokens(updated_tokens)
+    _save_codex_tokens(updated_tokens, auth_file=auth_file, _lock=_lock)
     return updated_tokens
 
 
@@ -3725,9 +3852,16 @@ def resolve_codex_runtime_credentials(
     if (not should_refresh) and refresh_if_expiring:
         should_refresh = _codex_access_token_is_expiring(access_token, refresh_skew_seconds)
     if should_refresh:
-        # Re-read under lock to avoid racing with other Hermes processes
-        with _auth_store_lock(timeout_seconds=max(float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0)):
-            data = _read_codex_tokens(_lock=False)
+        # Re-read under the lock for the auth store that actually owns the
+        # tokens.  If a profile borrowed global/root Codex auth, refresh the
+        # global file under its global lock instead of cloning stale rotated
+        # tokens into the profile auth.json.
+        auth_file = Path(data.get("auth_file") or _auth_file_path())
+        with _codex_auth_store_lock_for(
+            auth_file,
+            timeout_seconds=max(float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0),
+        ):
+            data = _read_codex_tokens(_lock=False, auth_file=auth_file)
             tokens = dict(data["tokens"])
             access_token = str(tokens.get("access_token", "") or "").strip()
 
@@ -3736,7 +3870,13 @@ def resolve_codex_runtime_credentials(
                 should_refresh = _codex_access_token_is_expiring(access_token, refresh_skew_seconds)
 
             if should_refresh:
-                tokens = _refresh_codex_auth_tokens(tokens, refresh_timeout_seconds)
+                tokens = _refresh_codex_auth_tokens(
+                    tokens,
+                    refresh_timeout_seconds,
+                    auth_file=auth_file,
+                    _lock=False,
+                )
+                data = _read_codex_tokens(_lock=False, auth_file=auth_file)
                 access_token = str(tokens.get("access_token", "") or "").strip()
 
     base_url = (
@@ -3749,6 +3889,8 @@ def resolve_codex_runtime_credentials(
         "base_url": base_url,
         "api_key": access_token,
         "source": "hermes-auth-store",
+        "auth_store": str(data.get("auth_file") or _auth_file_path()),
+        "auth_scope": data.get("auth_scope") or "profile",
         "last_refresh": data.get("last_refresh"),
         "auth_mode": "chatgpt",
     }
@@ -3759,20 +3901,21 @@ def _pool_codex_access_token() -> str:
 
     Used as a fallback by ``resolve_codex_runtime_credentials`` when the
     singleton has no creds.  Reads ``credential_pool.openai-codex`` entries
-    directly from auth.json and picks the first non-empty access_token,
-    preferring entries that are not currently in an exhaustion cooldown.
-    Returns ``""`` when no usable entry is found (caller handles by raising
-    the original AuthError).
+    from the profile auth.json and, in profile mode, from the shared/root
+    auth.json.  Picks the first non-empty access_token, preferring entries
+    that are not currently in an exhaustion cooldown.  Returns ``""`` when no
+    usable entry is found (caller handles by raising the original AuthError).
     """
     try:
-        with _auth_store_lock():
-            auth_store = _load_auth_store()
-        pool = auth_store.get("credential_pool")
-        if not isinstance(pool, dict):
-            return ""
-        entries = pool.get("openai-codex")
-        if not isinstance(entries, list):
-            return ""
+        candidate_paths = [_auth_file_path()]
+        shared_path = _codex_shared_auth_file_path()
+        if shared_path is not None:
+            try:
+                same_as_local = shared_path.resolve(strict=False) == _auth_file_path().resolve(strict=False)
+            except Exception:
+                same_as_local = shared_path == _auth_file_path()
+            if not same_as_local:
+                candidate_paths.append(shared_path)
 
         def _entry_usable(entry: Dict[str, Any]) -> bool:
             if not isinstance(entry, dict):
@@ -3786,9 +3929,18 @@ def _pool_codex_access_token() -> str:
                 return False
             return True
 
-        for entry in entries:
-            if _entry_usable(entry):
-                return str(entry.get("access_token", "")).strip()
+        for auth_file in candidate_paths:
+            with _codex_auth_store_lock_for(auth_file):
+                auth_store = _load_auth_store(auth_file)
+            pool = auth_store.get("credential_pool")
+            if not isinstance(pool, dict):
+                continue
+            entries = pool.get("openai-codex")
+            if not isinstance(entries, list):
+                continue
+            for entry in entries:
+                if _entry_usable(entry):
+                    return str(entry.get("access_token", "")).strip()
     except Exception:
         logger.debug("Codex pool fallback lookup failed", exc_info=True)
     return ""
@@ -5691,12 +5843,13 @@ def get_codex_auth_status() -> Dict[str, Any]:
     except Exception:
         pass
 
-    # Fall back to legacy provider state
+    # Fall back to legacy/shared provider state
     try:
         creds = resolve_codex_runtime_credentials()
         return {
             "logged_in": True,
-            "auth_store": str(_auth_file_path()),
+            "auth_store": creds.get("auth_store") or str(_auth_file_path()),
+            "auth_scope": creds.get("auth_scope"),
             "last_refresh": creds.get("last_refresh"),
             "auth_mode": creds.get("auth_mode"),
             "source": creds.get("source"),

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -444,6 +444,113 @@ def test_token_invalidated_marks_credential_dead(tmp_path, monkeypatch):
     assert persisted["last_error_reason"] == "token_invalidated"
 
 
+def test_load_pool_collapses_duplicate_seeded_source_and_id(tmp_path, monkeypatch):
+    """Duplicate singleton credentials must not trap rotation on one id forever.
+
+    Regression: shared Codex auth could leave two ``device_code`` entries with
+    the same id, one DEAD and one fresh. ``current()`` / ``_replace_entry()``
+    then kept addressing the first id match and the gateway spun on 401
+    token_invalidated without reaching fallback.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "same-id",
+                        "label": "revoked-device-code",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "device_code",
+                        "access_token": "revoked-at",
+                        "refresh_token": "revoked-rt",
+                        "last_status": "dead",
+                        "last_error_code": 401,
+                        "last_error_reason": "token_invalidated",
+                        "last_refresh": "2026-06-10T16:27:09Z",
+                    },
+                    {
+                        "id": "same-id",
+                        "label": "fresh-device-code",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "device_code",
+                        "access_token": "fresh-at",
+                        "refresh_token": "fresh-rt",
+                        "last_status": None,
+                        "last_error_code": None,
+                        "last_error_reason": None,
+                        "last_refresh": "2026-06-10T16:32:08Z",
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    entries = pool.entries()
+
+    assert len(entries) == 1
+    assert entries[0].label == "fresh-device-code"
+    assert entries[0].last_status is None
+    selected = pool.select()
+    assert selected is not None
+    assert selected.access_token == "fresh-at"
+
+    auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    persisted = auth_payload["credential_pool"]["openai-codex"]
+    assert len(persisted) == 1
+    assert persisted[0]["label"] == "fresh-device-code"
+
+
+def test_load_pool_rewrites_duplicate_manual_ids_without_dropping_credentials(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openrouter": [
+                    {
+                        "id": "same-id",
+                        "label": "manual-a",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "key-a",
+                    },
+                    {
+                        "id": "same-id",
+                        "label": "manual-b",
+                        "auth_type": "api_key",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": "key-b",
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openrouter")
+    entries = pool.entries()
+
+    assert len(entries) == 2
+    assert {entry.label for entry in entries} == {"manual-a", "manual-b"}
+    assert len({entry.id for entry in entries}) == 2
+
+    auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    persisted = auth_payload["credential_pool"]["openrouter"]
+    assert len({entry["id"] for entry in persisted}) == 2
+
+
 def test_dead_credential_never_re_enters_rotation_after_ttl(tmp_path, monkeypatch):
     """A DEAD credential must stay excluded regardless of how much time passes.
 

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -483,6 +483,135 @@ def test_auth_add_codex_oauth_keeps_distinct_pool_accounts(tmp_path, monkeypatch
     assert payload["active_provider"] == "openai-codex"
 
 
+def test_codex_profile_reads_shared_root_auth_without_copying(tmp_path, monkeypatch):
+    """Profile Codex auth should borrow the root auth store when local auth is absent."""
+    root = tmp_path / "hermes"
+    profile_home = root / "profiles" / "evacausin"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "shared-access-token",
+                        "refresh_token": "shared-refresh-token",
+                    },
+                    "last_refresh": "2026-06-10T10:00:00Z",
+                    "auth_mode": "chatgpt",
+                }
+            },
+        },
+    )
+
+    from hermes_cli.auth import resolve_codex_runtime_credentials
+
+    creds = resolve_codex_runtime_credentials(refresh_if_expiring=False)
+
+    assert creds["api_key"] == "shared-access-token"
+    assert creds["source"] == "hermes-auth-store"
+    assert not (profile_home / "auth.json").exists()
+
+
+def test_codex_profile_refresh_writes_shared_root_auth(tmp_path, monkeypatch):
+    """Refreshing borrowed Codex auth must update the root store, not clone into the profile."""
+    root = tmp_path / "hermes"
+    profile_home = root / "profiles" / "evacausin"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "old-shared-access-token",
+                        "refresh_token": "old-shared-refresh-token",
+                    },
+                    "last_refresh": "2026-06-10T10:00:00Z",
+                    "auth_mode": "chatgpt",
+                }
+            },
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "device",
+                        "label": "shared",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "device_code",
+                        "access_token": "old-shared-access-token",
+                        "refresh_token": "old-shared-refresh-token",
+                        "last_status": "dead",
+                    }
+                ]
+            },
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth.refresh_codex_oauth_pure",
+        lambda access_token, refresh_token, *, timeout_seconds=20.0: {
+            "access_token": "new-shared-access-token",
+            "refresh_token": "new-shared-refresh-token",
+            "last_refresh": "2026-06-10T10:05:00Z",
+        },
+    )
+
+    from hermes_cli.auth import resolve_codex_runtime_credentials
+
+    creds = resolve_codex_runtime_credentials(force_refresh=True)
+
+    assert creds["api_key"] == "new-shared-access-token"
+    assert not (profile_home / "auth.json").exists()
+    payload = json.loads((root / "auth.json").read_text())
+    state = payload["providers"]["openai-codex"]
+    assert state["tokens"]["access_token"] == "new-shared-access-token"
+    assert state["tokens"]["refresh_token"] == "new-shared-refresh-token"
+    entry = payload["credential_pool"]["openai-codex"][0]
+    assert entry["access_token"] == "new-shared-access-token"
+    assert entry["refresh_token"] == "new-shared-refresh-token"
+    assert entry["last_status"] is None
+
+
+def test_codex_profile_reads_shared_root_pool_without_singleton(tmp_path, monkeypatch):
+    """Profile Codex auth should also borrow root pool-only entries."""
+    root = tmp_path / "hermes"
+    profile_home = root / "profiles" / "evacausin"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {},
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "manual",
+                        "label": "shared-manual",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "manual:device_code",
+                        "access_token": "shared-pool-access-token",
+                        "refresh_token": "shared-pool-refresh-token",
+                    }
+                ]
+            },
+        },
+    )
+
+    from hermes_cli.auth import resolve_codex_runtime_credentials
+
+    creds = resolve_codex_runtime_credentials(refresh_if_expiring=False)
+
+    assert creds["api_key"] == "shared-pool-access-token"
+    assert creds["source"] == "credential_pool"
+    assert not (profile_home / "auth.json").exists()
+
+
 def test_auth_add_xai_oauth_sets_active_provider(tmp_path, monkeypatch):
     """hermes auth add xai-oauth must write providers singleton and set active_provider.
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5492,6 +5492,28 @@ class TestFallbackAnthropicProvider:
         assert agent.api_mode == "chat_completions"
         assert agent.client is mock_client
 
+    def test_fallback_to_kimi_coding_sets_anthropic_api_mode(self, agent):
+        agent._fallback_activated = False
+        agent._fallback_model = {"provider": "kimi-coding", "model": "kimi-k2-0905"}
+        agent._fallback_chain = [agent._fallback_model]
+        agent._fallback_index = 0
+
+        mock_client = MagicMock()
+        mock_client.base_url = "https://api.kimi.com/coding/v1"
+        mock_client.api_key = "sk-kimi-test"
+
+        with (
+            patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)),
+            patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()) as mock_build,
+        ):
+            result = agent._try_activate_fallback()
+
+        assert result is True
+        assert agent.api_mode == "anthropic_messages"
+        assert agent._anthropic_base_url == "https://api.kimi.com/coding/v1"
+        assert agent.client is None
+        mock_build.assert_called_once()
+
 
 def test_aiagent_uses_copilot_acp_client():
     with (


### PR DESCRIPTION
## Summary
- deduplicate auto-seeded credential pool entries and ensure unique credential ids on load
- preserve usable/fresh singleton credentials over DEAD duplicates to avoid infinite 401 rotation loops
- route kimi-coding fallback through Anthropic Messages mode so /coding endpoints do not 404

## Verification
- python -m pytest tests/agent/test_credential_pool.py -q -k 'duplicate or token_invalidated or dead_credential_never'
- python -m pytest tests/run_agent/test_run_agent.py -q -k 'FallbackAnthropicProvider'
- Live smoke: zkteco, zkteco-2, zkteco-3 default CLI prompts returned OK after fallback

## Notes
- ZKTeco profiles were backed up and reduced to one Codex credential plus kimi-coding fallback to unblock live gateways.
