### PR TITLE
fix: define --ifm-background-color in :root for light mode

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -21,6 +21,7 @@
   --ifm-font-family-base: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   --ifm-font-family-monospace: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
 
+  --ifm-background-color: #ffffff;
   --ifm-code-font-size: 90%;
   --ifm-heading-font-weight: 600;
 


### PR DESCRIPTION
The --ifm-background-color CSS variable was only defined under [data-theme="dark"] (as #07070d) in custom.css. In light mode the variable resolved to transparent black (Infimas default), making any text that used it for color invisible against dark backgrounds.

## What does this PR do?

Add --ifm-background-color: #ffffff to the :root block as an explicit light-mode value. The .filterActive class on the User Stories page uses this variable for text color on dark active-state buttons — this fix makes "All" and "All sources" filter buttons visible in light mode. Dark mode is unaffected.

Note: #ffffff is an explicit light-mode override, not the Infima default (which is transparent). The bundled Infima light stylesheet defines --ifm-background-color: transparent at default.css:134 — the override is needed because the variable was only being set under [data-theme="dark"].

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #91491

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- website/src/css/custom.css: added --ifm-background-color: #ffffff to the :root block

## How to Test

1. Open https://hermes-agent.nousresearch.com/docs/user-stories in light mode
2. Click on "All" or "All sources" filter options 
3. Text should now be visible (white on dark background)

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] Ive read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isnt a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] Ive run `pytest tests/ -q` and all tests pass
- [ ] Ive added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] Ive tested on my platform: macOS

### Documentation & Housekeeping

<!-- Check all that apply. Its OK to check "N/A" if a category doesnt apply to your change. -->

- [ ] Ive updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] Ive updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] Ive updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] Ive considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] Ive updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if youre adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that arent already available (prefer stdlib, curl, existing Hermes tools)
- [ ] Ive tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->
BEFORE:
<img width="159" height="186" alt="Screenshot 2026-06-11 at 13 37 21" src="https://github.com/user-attachments/assets/2fd298d7-ae91-47ef-a21b-33116cb56fac" />

AFTER:
<img width="154" height="177" alt="Screenshot 2026-06-11 at 13 36 46" src="https://github.com/user-attachments/assets/24ab3690-fe55-4610-9602-7f5c89050a04" />