### PR TITLE
fix(agent): persist plugin-transformed responses so resume replays what the user saw

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -42,6 +42,41 @@ def _is_pure_tool_call_tail(msg: dict) -> bool:
     return not flatten_message_text(msg.get("content")).strip()
 
 
+def _sync_final_response_to_last_assistant(messages, final_response) -> bool:
+    """Write the hook-transformed ``final_response`` back into the turn's last
+    assistant text message so persisted history matches what the user was
+    shown (#44239).
+
+    Walks backwards only within the current turn (stops at the user message
+    that started it, mirroring the reasoning extraction in
+    :func:`finalize_turn`). Only a plain-text assistant row is updated — a
+    tool-call row or multimodal (list) content is never rewritten, because
+    reconciling a transformed string against those structures is ambiguous.
+
+    The row may already have been flushed to SQLite by the incremental
+    tool-call persist, which stamps ``_DB_PERSISTED_MARKER`` so later flushes
+    skip it (``run_agent._persist_session``). Editing content in place without
+    clearing that marker would leave the transform invisible in the durable
+    store — the same resume-replays-raw-text bug this fix exists to close, just
+    relocated. Pop the marker so the next ``_persist_session`` re-writes the
+    row, exactly as the #43849/#44100 tail-fill block does.
+
+    Returns True if a message was updated.
+    """
+    for msg in reversed(messages):
+        if not isinstance(msg, dict):
+            continue
+        if msg.get("role") == "user":
+            break  # turn boundary — never rewrite a prior turn
+        if msg.get("role") == "assistant":
+            if msg.get("tool_calls") or not isinstance(msg.get("content"), str):
+                break
+            msg["content"] = final_response
+            msg.pop("_db_persisted", None)
+            return True
+    return False
+
+
 # Verification continuation scaffolding flags: verify-on-stop / pre_verify
 # inject a synthetic user nudge to keep the agent going one more turn.
 # These nudges must be stripped from returned/live history to avoid
@@ -259,10 +294,17 @@ def finalize_turn(
         _cleanup_errors.append(f"cleanup_task_resources: {_cleanup_err}")
         logger.error("finalize_turn: _cleanup_task_resources failed: %s", _cleanup_err, exc_info=True)
 
-    # Persist session to both JSON log and SQLite only after private retry
-    # scaffolding has been removed. Otherwise a later user "continue" turn
-    # can replay assistant("(empty)") / recovery nudges and fall into the
-    # same empty-response loop again.
+    # Prepare the durable transcript before it is read or persisted. Private
+    # retry scaffolding is dropped first: otherwise a later user "continue"
+    # turn can replay assistant("(empty)") / recovery nudges and fall into the
+    # same empty-response loop again. Then close any interrupted tool tail and
+    # enforce the "delivered final_response ⇒ assistant row" invariant.
+    #
+    # The actual ``_persist_session`` call is deferred until AFTER the
+    # transform_llm_output hook below, so a plugin-transformed response is what
+    # lands in the session history (#44239). Everything in this block only
+    # mutates the in-memory transcript, so deferring the write does not change
+    # what any of these steps compute.
     try:
         agent._drop_trailing_empty_response_scaffolding(messages)
 
@@ -349,54 +391,64 @@ def finalize_turn(
         _apply_override = getattr(agent, "_apply_persist_user_message_override", None)
         if callable(_apply_override):
             _apply_override(messages)
-        agent._persist_session(messages, conversation_history)
-    except Exception as _persist_err:
-        _cleanup_errors.append(f"persist_session: {_persist_err}")
-        logger.error("finalize_turn: _persist_session failed: %s", _persist_err, exc_info=True)
+    except Exception as _prep_err:
+        _cleanup_errors.append(f"finalize_prep: {_prep_err}")
+        logger.error("finalize_turn: transcript prep failed: %s", _prep_err, exc_info=True)
 
     # ── Turn-exit diagnostic log ─────────────────────────────────────
     # Always logged at INFO so agent.log captures WHY every turn ended.
     # When the last message is a tool result (agent was mid-work), log
     # at WARNING — this is the "just stops" scenario users report.
-    _last_msg_role = messages[-1].get("role") if messages else None
-    _last_tool_name = None
-    if _last_msg_role == "tool":
-        # Walk back to find the assistant message with the tool call
-        for _m in reversed(messages):
-            if _m.get("role") == "assistant" and _m.get("tool_calls"):
-                _tcs = _m["tool_calls"]
-                if _tcs and isinstance(_tcs[0], dict):
-                    _last_tool_name = _tcs[-1].get("function", {}).get("name")
-                break
+    #
+    # Guarded: this block sits between the transcript prep above and the
+    # deferred _persist_session below (#44239), so an exception raised while
+    # merely BUILDING a log line would skip the session write and lose the
+    # turn — the #8049 failure mode. It walks message dicts without an
+    # isinstance guard on every access (``messages[-1].get`` /
+    # ``_m.get(...)``), which raises on a malformed non-dict entry. Diagnostics
+    # must never gate persistence, so a failure here is logged and dropped.
+    try:
+        _last_msg_role = messages[-1].get("role") if messages else None
+        _last_tool_name = None
+        if _last_msg_role == "tool":
+            # Walk back to find the assistant message with the tool call
+            for _m in reversed(messages):
+                if _m.get("role") == "assistant" and _m.get("tool_calls"):
+                    _tcs = _m["tool_calls"]
+                    if _tcs and isinstance(_tcs[0], dict):
+                        _last_tool_name = _tcs[-1].get("function", {}).get("name")
+                    break
 
-    _turn_tool_count = sum(
-        1 for m in messages
-        if isinstance(m, dict) and m.get("role") == "assistant" and m.get("tool_calls")
-    )
-    _resp_len = len(final_response) if final_response else 0
-    _budget_used = agent.iteration_budget.used if agent.iteration_budget else 0
-    _budget_max = agent.iteration_budget.max_total if agent.iteration_budget else 0
-
-    _diag_msg = (
-        "Turn ended: reason=%s model=%s api_calls=%d/%d budget=%d/%d "
-        "tool_turns=%d last_msg_role=%s response_len=%d session=%s"
-    )
-    _diag_args = (
-        _turn_exit_reason, agent.model, api_call_count, agent.max_iterations,
-        _budget_used, _budget_max,
-        _turn_tool_count, _last_msg_role, _resp_len,
-        agent.session_id or "none",
-    )
-
-    if _last_msg_role == "tool" and not interrupted:
-        # Agent was mid-work — this is the "just stops" case.
-        logger.warning(
-            "Turn ended with pending tool result (agent may appear stuck). "
-            + _diag_msg + " last_tool=%s",
-            *_diag_args, _last_tool_name,
+        _turn_tool_count = sum(
+            1 for m in messages
+            if isinstance(m, dict) and m.get("role") == "assistant" and m.get("tool_calls")
         )
-    else:
-        logger.info(_diag_msg, *_diag_args)
+        _resp_len = len(final_response) if final_response else 0
+        _budget_used = agent.iteration_budget.used if agent.iteration_budget else 0
+        _budget_max = agent.iteration_budget.max_total if agent.iteration_budget else 0
+
+        _diag_msg = (
+            "Turn ended: reason=%s model=%s api_calls=%d/%d budget=%d/%d "
+            "tool_turns=%d last_msg_role=%s response_len=%d session=%s"
+        )
+        _diag_args = (
+            _turn_exit_reason, agent.model, api_call_count, agent.max_iterations,
+            _budget_used, _budget_max,
+            _turn_tool_count, _last_msg_role, _resp_len,
+            agent.session_id or "none",
+        )
+
+        if _last_msg_role == "tool" and not interrupted:
+            # Agent was mid-work — this is the "just stops" case.
+            logger.warning(
+                "Turn ended with pending tool result (agent may appear stuck). "
+                + _diag_msg + " last_tool=%s",
+                *_diag_args, _last_tool_name,
+            )
+        else:
+            logger.info(_diag_msg, *_diag_args)
+    except Exception as _diag_err:
+        logger.warning("finalize_turn: turn-exit diagnostic log failed: %s", _diag_err)
 
     # File-mutation verifier footer.
     # If one or more ``write_file`` / ``patch`` calls failed during this
@@ -503,6 +555,30 @@ def finalize_turn(
                     break  # First non-empty string wins
         except Exception as exc:
             logger.warning("transform_llm_output hook failed: %s", exc)
+
+    # Persist session to both JSON log and SQLite. This runs AFTER the
+    # transform_llm_output hook so a plugin-transformed response is what lands
+    # in the session history (#44239). Without it the user sees the transformed
+    # text this turn, but the raw model output is what gets replayed on the
+    # next turn and after /resume. The transformed text is synced into the
+    # turn's last assistant row first, so result["messages"], the JSON log and
+    # SQLite all agree with final_response.
+    #
+    # Persistence stays BEFORE post_llm_call: that hook is observability-only
+    # per docs/observability/README.md (its return value is discarded — there
+    # is no override path), and its plugins may read the session store
+    # expecting the completed turn to already be present.
+    #
+    # Guarded like the other post-loop cleanup surfaces so an SQLite write
+    # failure surfaces on ``cleanup_errors`` instead of killing the turn
+    # (#8049); the transcript-prep steps above already ran regardless.
+    try:
+        if _response_transformed:
+            _sync_final_response_to_last_assistant(messages, final_response)
+        agent._persist_session(messages, conversation_history)
+    except Exception as _persist_err:
+        _cleanup_errors.append(f"persist_session: {_persist_err}")
+        logger.error("finalize_turn: _persist_session failed: %s", _persist_err, exc_info=True)
 
     # Plugin hook: post_llm_call
     # Fired once per turn after the tool-calling loop completes.

--- a/tests/agent/test_44239_transform_persist_order.py
+++ b/tests/agent/test_44239_transform_persist_order.py
@@ -1,0 +1,752 @@
+"""Regression tests for #44239 — transform_llm_output vs. persistence order.
+
+The ``transform_llm_output`` hook fires in ``finalize_turn``. Before the
+fix, ``_persist_session`` ran *before* the hook and the transformed text
+was never written back into the assistant message, so the user saw the
+transformed response while ``result["messages"]``, the JSON log, and the
+SQLite session DB all kept the raw model output — which was then replayed
+on resume / next turn.
+
+These tests drive ``finalize_turn`` directly with a stub agent and a
+patched ``hermes_cli.plugins.invoke_hook`` and assert INVARIANTS:
+
+* the transformed text is synced into the turn's last assistant message
+  before persistence (delivered text == persisted text);
+* persistence still runs after ``transform_llm_output`` and before
+  ``post_llm_call`` (observability plugins may read the session store
+  expecting the turn to be there);
+* an untransformed response persists the raw model output unchanged;
+* the sync never crosses the turn boundary or rewrites a tool-call /
+  non-text assistant message.
+
+The final test (``test_real_persist_lands_transformed_text_in_sqlite``)
+drives the REAL ``AIAgent._persist_session`` (JSON log + SQLite SessionDB)
+against a temporary ``HERMES_HOME`` to verify that the storage level — not
+just the in-memory snapshot — contains the transformed text.
+"""
+
+import copy
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+import hermes_cli.plugins as plugins_mod
+from agent.turn_finalizer import (
+    _sync_final_response_to_last_assistant,
+    finalize_turn,
+)
+
+
+class _StubAgent:
+    """Bare-minimum agent surface that finalize_turn touches on the happy
+    path (final_response present, not interrupted, budget remaining, no
+    footer/explainer, no skill/memory review)."""
+
+    def __init__(self):
+        self.max_iterations = 100
+        self.iteration_budget = SimpleNamespace(remaining=99, used=1, max_total=100)
+        self.quiet_mode = True
+        self.model = "test-model"
+        self.provider = "test-provider"
+        self.base_url = ""
+        self.platform = "cli"
+        self.session_id = "sess-44239"
+        self.session_input_tokens = 0
+        self.session_output_tokens = 0
+        self.session_cache_read_tokens = 0
+        self.session_cache_write_tokens = 0
+        self.session_reasoning_tokens = 0
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+        self.session_total_tokens = 0
+        self.session_estimated_cost_usd = 0.0
+        self.session_cost_status = "ok"
+        self.session_cost_source = "none"
+        self.context_compressor = SimpleNamespace(last_prompt_tokens=0)
+        self._tool_guardrail_halt_decision = None
+        self._turn_failed_file_mutations = None
+        self._interrupt_message = None
+        self._stream_callback = None
+        self._response_was_previewed = False
+        self._skill_nudge_interval = 0
+        self._iters_since_skill = 0
+        self.valid_tool_names = set()
+        self.events = []          # ordered record of persist + hook firings
+        self.persisted_messages = None  # deep copy taken at persist time
+
+    def _handle_max_iterations(self, messages, api_call_count):
+        raise AssertionError("budget-exhaustion path not expected in these tests")
+
+    def _emit_status(self, *_args, **_kwargs):
+        pass
+
+    def _safe_print(self, *_args, **_kwargs):
+        pass
+
+    def _save_trajectory(self, messages, user_message, completed):
+        pass
+
+    def _cleanup_task_resources(self, task_id):
+        pass
+
+    def _drop_trailing_empty_response_scaffolding(self, messages):
+        pass
+
+    def _persist_session(self, messages, conversation_history):
+        self.events.append("persist")
+        self.persisted_messages = copy.deepcopy(messages)
+
+    def _file_mutation_verifier_enabled(self):
+        return False
+
+    def _turn_completion_explainer_enabled(self):
+        return False
+
+    def _drain_pending_steer(self):
+        return None
+
+    def clear_interrupt(self):
+        pass
+
+    def _sync_external_memory_for_turn(self, **kwargs):
+        pass
+
+
+def _run_finalize(monkeypatch, transform_result, messages):
+    agent = _StubAgent()
+
+    def fake_invoke_hook(hook_name, **kwargs):
+        agent.events.append(hook_name)
+        if hook_name == "transform_llm_output":
+            return [transform_result] if transform_result is not None else []
+        return []
+
+    monkeypatch.setattr(plugins_mod, "invoke_hook", fake_invoke_hook)
+
+    result = finalize_turn(
+        agent,
+        final_response=messages[-1]["content"],
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task-1",
+        turn_id="turn-1",
+        user_message="hi",
+        original_user_message="hi",
+        _should_review_memory=False,
+        _turn_exit_reason="text_response(finish_reason=stop)",
+    )
+    return agent, result
+
+
+def test_transformed_response_is_persisted(monkeypatch):
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "raw model output"},
+    ]
+    agent, result = _run_finalize(
+        monkeypatch, "[RENDERED] raw model output", messages,
+    )
+
+    assert result["final_response"] == "[RENDERED] raw model output"
+    assert result["response_transformed"] is True
+    # In-memory history handed back to the caller matches what was shown.
+    assert result["messages"][-1]["content"] == "[RENDERED] raw model output"
+    # ...and so does what hit the session store.
+    assert agent.persisted_messages[-1]["content"] == "[RENDERED] raw model output"
+
+
+def test_hook_persist_ordering(monkeypatch):
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "raw model output"},
+    ]
+    agent, _ = _run_finalize(monkeypatch, "[RENDERED] x", messages)
+
+    # Transform must precede persist (so the transform is durable);
+    # persist must precede post_llm_call (observability plugins may read
+    # the session store inside that hook).
+    assert agent.events.index("transform_llm_output") < agent.events.index("persist")
+    assert agent.events.index("persist") < agent.events.index("post_llm_call")
+
+
+def test_untransformed_response_persists_raw(monkeypatch):
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "raw model output"},
+    ]
+    agent, result = _run_finalize(monkeypatch, None, messages)
+
+    assert result["response_transformed"] is False
+    assert agent.persisted_messages[-1]["content"] == "raw model output"
+
+
+def test_sync_skips_tool_call_assistant_message():
+    messages = [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"id": "c1", "type": "function",
+                            "function": {"name": "x", "arguments": "{}"}}],
+        },
+    ]
+    assert _sync_final_response_to_last_assistant(messages, "new") is False
+    assert messages[1]["content"] == ""
+
+
+def test_sync_does_not_cross_turn_boundary():
+    messages = [
+        {"role": "assistant", "content": "prior turn answer"},
+        {"role": "user", "content": "this turn"},
+        {"role": "tool", "content": "{}", "tool_call_id": "c1"},
+    ]
+    assert _sync_final_response_to_last_assistant(messages, "new") is False
+    assert messages[0]["content"] == "prior turn answer"
+
+
+def test_sync_skips_non_text_content():
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": [{"type": "text", "text": "multimodal"}]},
+    ]
+    assert _sync_final_response_to_last_assistant(messages, "new") is False
+
+
+def test_sync_updates_last_assistant_text_message():
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "raw"},
+        {"role": "tool", "content": "{}", "tool_call_id": "c1"},
+    ]
+    assert _sync_final_response_to_last_assistant(messages, "new") is True
+    assert messages[1]["content"] == "new"
+
+
+def test_sync_clears_db_persisted_marker():
+    """A row already flushed to SQLite must be re-written after the sync.
+
+    The incremental tool-call persist stamps ``_db_persisted`` on rows it has
+    written, and ``_persist_session`` skips any row carrying that marker. If
+    the sync edits content in place without clearing it, the transformed text
+    never reaches the durable store — the #44239 symptom, just relocated from
+    "persisted too early" to "skipped as already persisted".
+    """
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "raw", "_db_persisted": True},
+    ]
+    assert _sync_final_response_to_last_assistant(messages, "new") is True
+    assert messages[1]["content"] == "new"
+    assert "_db_persisted" not in messages[1]
+
+
+def test_real_persist_lands_transformed_text_in_sqlite(tmp_path, monkeypatch):
+    """Storage-level regression: real AIAgent._persist_session against a
+    temporary HERMES_HOME so the JSON/SQLite resume path is exercised.
+
+    The stub-based tests above verify ordering and the in-memory snapshot.
+    This test drives the REAL AIAgent's _persist_session (which writes to
+    both the JSON session log and the SQLite SessionDB) against a temp
+    HERMES_HOME, then queries the DB to confirm the transformed text —
+    not the raw model output — is what was persisted. If the sync-before-
+    persist ordering regresses, the DB will contain the raw output and
+    the resume path will replay stale text.
+    """
+    from run_agent import AIAgent
+    from hermes_state import SessionDB
+
+    # Isolated HERMES_HOME so we never touch the user's real session store.
+    hermes_home = Path(tempfile.mkdtemp(prefix="hermes-persist-test-"))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    # Real SessionDB with a pre-created session.
+    db_path = hermes_home / "state.db"
+    db = SessionDB(db_path=db_path)
+    session_id = "sess-44239-storage"
+    db.create_session(session_id=session_id, source="test", model="test-model")
+
+    # Build a bare real AIAgent with the real _persist_session,
+    # _drop_trailing_empty_response_scaffolding, _save_session_log,
+    # and _flush_messages_to_session_db — the methods that write to
+    # the durable store. Stub only the methods that either do real
+    # I/O we don't need (cleanup) or throw without a full agent init.
+    agent = object.__new__(AIAgent)
+    agent._session_db = db
+    agent._session_db_created = True
+    agent.session_id = session_id
+
+    # Attributes that finalize_turn reads from the agent.
+    agent.max_iterations = 100
+    agent.iteration_budget = SimpleNamespace(remaining=99, used=1, max_total=100)
+    agent.quiet_mode = True
+    agent.model = "test-model"
+    agent.provider = "test-provider"
+    agent.base_url = ""
+    agent.platform = "cli"
+    agent.session_input_tokens = 0
+    agent.session_output_tokens = 0
+    agent.session_cache_read_tokens = 0
+    agent.session_cache_write_tokens = 0
+    agent.session_reasoning_tokens = 0
+    agent.session_prompt_tokens = 0
+    agent.session_completion_tokens = 0
+    agent.session_total_tokens = 0
+    agent.session_estimated_cost_usd = 0.0
+    agent.session_cost_status = "ok"
+    agent.session_cost_source = "none"
+    agent.context_compressor = SimpleNamespace(last_prompt_tokens=0)
+    agent._tool_guardrail_halt_decision = None
+    agent._turn_failed_file_mutations = None
+    agent._interrupt_message = None
+    agent._stream_callback = None
+    agent._response_was_previewed = False
+    agent._skill_nudge_interval = 0
+    agent._iters_since_skill = 0
+    agent.valid_tool_names = set()
+
+    # Attributes that _persist_session and children need.
+    agent.save_trajectories = False
+    agent._persist_disabled = False
+    agent._session_messages = None
+    agent._session_json_enabled = False
+    agent._session_init_model_config = None
+    agent._parent_session_id = None
+    agent._cached_system_prompt = None
+    agent._flushed_db_message_ids = set()
+    agent._flushed_db_message_session_id = None
+    agent._last_flushed_db_idx = 0
+    # commit_memory_session runs heavy machinery not exercised here.
+    agent.commit_memory_session = lambda *a, **k: None
+
+    # Stub _cleanup_task_resources: the real method tries
+    # _ra().cleanup_vm / _ra().cleanup_browser which aren't available
+    # in a bare agent.
+    agent._cleanup_task_resources = lambda task_id: None
+    # Stub clear_interrupt: the real method references thread/interrupt
+    # machinery (_execution_thread_id, _active_children_lock) not present
+    # on a bare agent.
+    agent.clear_interrupt = lambda: None
+    # Stub _sync_external_memory_for_turn: the real method references
+    # _memory_manager which isn't set on a bare agent.
+    agent._sync_external_memory_for_turn = lambda **kwargs: None
+
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "raw model output"},
+    ]
+
+    events = []
+
+    def fake_invoke_hook(hook_name, **kwargs):
+        events.append(hook_name)
+        if hook_name == "transform_llm_output":
+            return ["[STORED VIA REAL PERSIST] raw model output"]
+        return []
+
+    monkeypatch.setattr(plugins_mod, "invoke_hook", fake_invoke_hook)
+
+    result = finalize_turn(
+        agent,
+        final_response="raw model output",
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task-1",
+        turn_id="turn-1",
+        user_message="hi",
+        original_user_message="hi",
+        _should_review_memory=False,
+        _turn_exit_reason="text_response(finish_reason=stop)",
+    )
+
+    # 1. Hook ordering invariant (same as test_hook_persist_ordering).
+    assert events.index("transform_llm_output") < events.index("post_llm_call"), (
+        f"Expected transform before post_llm_call, got: {events}"
+    )
+
+    # 2. In-memory result carries the transformed text.
+    assert result["final_response"] == "[STORED VIA REAL PERSIST] raw model output"
+    assert result["messages"][-1]["content"] == "[STORED VIA REAL PERSIST] raw model output"
+
+    # 3. SQLite SessionDB has the transformed text — this is the key
+    #    regression assertion that stub-based tests cannot make.
+    saved = db.get_messages_as_conversation(session_id)
+    assistant_contents = [
+        m.get("content", "") for m in saved if m.get("role") == "assistant"
+    ]
+    assert any("[STORED VIA REAL PERSIST]" in (c or "") for c in assistant_contents), (
+        f"Transformed text not found in SQLite DB. "
+        f"Assistant contents: {assistant_contents}"
+    )
+    assert not any(
+        c and "raw model output" in c
+        and "[STORED VIA REAL PERSIST]" not in c
+        for c in assistant_contents
+    ), (
+        f"Raw model output leaked into SQLite DB (untransformed). "
+        f"Assistant contents: {assistant_contents}"
+    )
+
+
+# Disjoint sentinels: the transformed marker does not contain the raw
+# marker, so "transformed is present" and "raw is absent" are independent
+# assertions with no substring overlap to reason around.
+_RAW_MARKER = "RAW_44239_UNTRANSFORMED"
+_XFORM_MARKER = "XFORM_44239_DELIVERED"
+
+
+def test_resume_reads_back_transformed_text_from_disk(tmp_path, monkeypatch):
+    """Storage-level regression for #44239 — what the user saw is what a
+    resume reads back off disk.
+
+    Everything above this test either stubs ``_persist_session`` or reads
+    the DB through the same handle that wrote it. This one closes the loop
+    on the contract the PR exists to protect:
+
+    * an isolated ``HERMES_HOME`` under ``tmp_path`` (``get_hermes_home()``
+      reads the env var at call time, so nothing can touch the real store);
+    * the REAL ``AIAgent._persist_session`` — both durable writers, the
+      SQLite ``SessionDB`` flush *and* the JSON session snapshot
+      (``sessions.write_json_snapshots``), which the earlier storage test
+      leaves disabled;
+    * read back through a FRESH ``SessionDB`` handle via
+      ``get_messages_as_conversation`` — the same call ``/resume`` uses in
+      ``hermes_cli/cli_agent_setup_mixin.py`` — plus the JSON snapshot file.
+
+    Deliberately asserts on DISK ONLY, and before any in-memory check, so a
+    regression in the sync-before-persist ordering fails *here* on the
+    storage contract rather than being masked by an earlier in-memory
+    assertion. Pre-fix, ``_persist_session`` ran before
+    ``transform_llm_output``, so the raw text was flushed and stamped with
+    the dedup marker — the transformed text never reached the store and
+    resume replayed something the user was never shown.
+    """
+    import json
+
+    from hermes_state import SessionDB
+    from run_agent import AIAgent
+
+    hermes_home = tmp_path / "hermes-home"
+    logs_dir = hermes_home / "sessions"
+    logs_dir.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    db_path = hermes_home / "state.db"
+    session_id = "sess-44239-resume"
+    writer_db = SessionDB(db_path=db_path)
+    writer_db.create_session(session_id=session_id, source="test", model="test-model")
+
+    agent = object.__new__(AIAgent)
+    agent._session_db = writer_db
+    agent._session_db_created = True
+    agent.session_id = session_id
+
+    # finalize_turn reads these off the agent.
+    agent.max_iterations = 100
+    agent.iteration_budget = SimpleNamespace(remaining=99, used=1, max_total=100)
+    agent.quiet_mode = True
+    agent.model = "test-model"
+    agent.provider = "test-provider"
+    agent.base_url = ""
+    agent.platform = "cli"
+    agent.session_input_tokens = 0
+    agent.session_output_tokens = 0
+    agent.session_cache_read_tokens = 0
+    agent.session_cache_write_tokens = 0
+    agent.session_reasoning_tokens = 0
+    agent.session_prompt_tokens = 0
+    agent.session_completion_tokens = 0
+    agent.session_total_tokens = 0
+    agent.session_estimated_cost_usd = 0.0
+    agent.session_cost_status = "ok"
+    agent.session_cost_source = "none"
+    agent.context_compressor = SimpleNamespace(last_prompt_tokens=0)
+    agent._tool_guardrail_halt_decision = None
+    agent._turn_failed_file_mutations = None
+    agent._interrupt_message = None
+    agent._stream_callback = None
+    agent._response_was_previewed = False
+    agent._skill_nudge_interval = 0
+    agent._iters_since_skill = 0
+    agent.valid_tool_names = set()
+
+    # _persist_session and its two writers. Both durable paths are ON.
+    agent.save_trajectories = False
+    agent._persist_disabled = False
+    agent._session_messages = None
+    agent._session_json_enabled = True
+    agent.logs_dir = logs_dir
+    agent.session_start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    agent.tools = []
+    agent.verbose_logging = False
+    agent._session_init_model_config = None
+    agent._parent_session_id = None
+    agent._cached_system_prompt = None
+    agent._flushed_db_message_ids = set()
+    agent._flushed_db_message_session_id = None
+    agent._last_flushed_db_idx = 0
+    agent.commit_memory_session = lambda *a, **k: None
+
+    # Stubs for machinery a bare (never-__init__'d) agent cannot provide;
+    # none of them sit on the persistence path under test.
+    agent._cleanup_task_resources = lambda task_id: None
+    agent.clear_interrupt = lambda: None
+    agent._sync_external_memory_for_turn = lambda **kwargs: None
+
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": _RAW_MARKER},
+    ]
+
+    def fake_invoke_hook(hook_name, **kwargs):
+        if hook_name == "transform_llm_output":
+            return [_XFORM_MARKER]
+        return []
+
+    monkeypatch.setattr(plugins_mod, "invoke_hook", fake_invoke_hook)
+
+    result = finalize_turn(
+        agent,
+        final_response=_RAW_MARKER,
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task-1",
+        turn_id="turn-1",
+        user_message="hi",
+        original_user_message="hi",
+        _should_review_memory=False,
+        _turn_exit_reason="text_response(finish_reason=stop)",
+    )
+
+    # ── Disk assertions first — this is the point of the test ───────────
+
+    # 1. SQLite, re-opened as a resuming process would: the transformed
+    #    text is there and the raw text is nowhere in the transcript.
+    restored = SessionDB(db_path=db_path).get_messages_as_conversation(session_id)
+    restored_contents = [
+        m.get("content") or "" for m in restored if m.get("role") == "assistant"
+    ]
+    assert any(_XFORM_MARKER in c for c in restored_contents), (
+        f"Resume read back no transformed text from SQLite. "
+        f"Assistant contents: {restored_contents}"
+    )
+    assert not any(_RAW_MARKER in c for c in restored_contents), (
+        f"Raw pre-transform text survived into SQLite and would be replayed "
+        f"on resume. Assistant contents: {restored_contents}"
+    )
+
+    # 2. JSON session snapshot — the other durable writer _persist_session
+    #    drives, for tooling that reads sessions/*.json directly.
+    snapshot_path = logs_dir / f"session_{session_id}.json"
+    assert snapshot_path.exists(), (
+        f"JSON session snapshot was never written to {snapshot_path}"
+    )
+    snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    snapshot_contents = [
+        m.get("content") or ""
+        for m in snapshot.get("messages", [])
+        if m.get("role") == "assistant"
+    ]
+    assert any(_XFORM_MARKER in c for c in snapshot_contents), (
+        f"Transformed text missing from the JSON session snapshot. "
+        f"Assistant contents: {snapshot_contents}"
+    )
+    assert not any(_RAW_MARKER in c for c in snapshot_contents), (
+        f"Raw pre-transform text survived into the JSON session snapshot. "
+        f"Assistant contents: {snapshot_contents}"
+    )
+
+    # 3. Only now the in-memory sanity check: the store agrees with what
+    #    the caller (and therefore the user) was handed.
+    assert result["final_response"] == _XFORM_MARKER
+
+
+def test_pre_flushed_assistant_row_still_receives_transformed_text(tmp_path, monkeypatch):
+    """Storage-level regression for the already-flushed row (#44239).
+
+    A turn that called tools flushes its assistant row to SQLite mid-turn via
+    the incremental persist, which stamps ``_DB_PERSISTED_MARKER``.
+    ``_persist_session`` skips any row carrying that marker, so moving the
+    persist call after ``transform_llm_output`` is not sufficient on its own:
+    the sync must also clear the marker, or the transformed text is silently
+    dropped at the storage layer while every in-memory assertion still passes.
+
+    This drives the real ``_persist_session`` twice against an isolated
+    ``HERMES_HOME`` — once to flush and stamp the raw row, once through
+    ``finalize_turn`` — and asserts the durable store ends up with the
+    transformed text.
+    """
+    from hermes_state import SessionDB
+    from run_agent import AIAgent
+
+    hermes_home = tmp_path / "hermes-home-preflushed"
+    logs_dir = hermes_home / "sessions"
+    logs_dir.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    db_path = hermes_home / "state.db"
+    session_id = "sess-44239-preflushed"
+    writer_db = SessionDB(db_path=db_path)
+    writer_db.create_session(session_id=session_id, source="test", model="test-model")
+
+    agent = object.__new__(AIAgent)
+    agent._session_db = writer_db
+    agent._session_db_created = True
+    agent.session_id = session_id
+
+    agent.max_iterations = 100
+    agent.iteration_budget = SimpleNamespace(remaining=99, used=1, max_total=100)
+    agent.quiet_mode = True
+    agent.model = "test-model"
+    agent.provider = "test-provider"
+    agent.base_url = ""
+    agent.platform = "cli"
+    agent.session_input_tokens = 0
+    agent.session_output_tokens = 0
+    agent.session_cache_read_tokens = 0
+    agent.session_cache_write_tokens = 0
+    agent.session_reasoning_tokens = 0
+    agent.session_prompt_tokens = 0
+    agent.session_completion_tokens = 0
+    agent.session_total_tokens = 0
+    agent.session_estimated_cost_usd = 0.0
+    agent.session_cost_status = "ok"
+    agent.session_cost_source = "none"
+    agent.context_compressor = SimpleNamespace(last_prompt_tokens=0)
+    agent._tool_guardrail_halt_decision = None
+    agent._turn_failed_file_mutations = None
+    agent._interrupt_message = None
+    agent._stream_callback = None
+    agent._response_was_previewed = False
+    agent._skill_nudge_interval = 0
+    agent._iters_since_skill = 0
+    agent.valid_tool_names = set()
+
+    agent.save_trajectories = False
+    agent._persist_disabled = False
+    agent._session_messages = None
+    agent._session_json_enabled = False
+    agent.logs_dir = logs_dir
+    agent.session_start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    agent.tools = []
+    agent.verbose_logging = False
+    agent._session_init_model_config = None
+    agent._parent_session_id = None
+    agent._cached_system_prompt = None
+    agent._flushed_db_message_ids = set()
+    agent._flushed_db_message_session_id = None
+    agent._last_flushed_db_idx = 0
+    agent.commit_memory_session = lambda *a, **k: None
+
+    agent._cleanup_task_resources = lambda task_id: None
+    agent.clear_interrupt = lambda: None
+    agent._sync_external_memory_for_turn = lambda **kwargs: None
+
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": _RAW_MARKER},
+    ]
+
+    # Mid-turn incremental flush: writes the raw row and stamps the dedup
+    # marker, exactly as the tool-call persist path does.
+    agent._persist_session(messages, [])
+    assert messages[-1].get("_db_persisted") is True, (
+        "precondition failed: the incremental flush did not stamp the dedup "
+        "marker, so this test would not exercise the skip path"
+    )
+
+    def fake_invoke_hook(hook_name, **kwargs):
+        if hook_name == "transform_llm_output":
+            return [_XFORM_MARKER]
+        return []
+
+    monkeypatch.setattr(plugins_mod, "invoke_hook", fake_invoke_hook)
+
+    result = finalize_turn(
+        agent,
+        final_response=_RAW_MARKER,
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task-1",
+        turn_id="turn-1",
+        user_message="hi",
+        original_user_message="hi",
+        _should_review_memory=False,
+        _turn_exit_reason="text_response(finish_reason=stop)",
+    )
+
+    restored = SessionDB(db_path=db_path).get_messages_as_conversation(session_id)
+    restored_contents = [
+        m.get("content") or "" for m in restored if m.get("role") == "assistant"
+    ]
+    assert any(_XFORM_MARKER in c for c in restored_contents), (
+        f"Transformed text never reached SQLite for a pre-flushed assistant "
+        f"row — the dedup marker skipped the re-write. "
+        f"Assistant contents: {restored_contents}"
+    )
+    assert result["final_response"] == _XFORM_MARKER
+
+
+def test_persist_survives_malformed_message_in_diagnostic_log(monkeypatch):
+    """Deferring the persist must not let a diagnostic failure lose the turn.
+
+    Moving ``_persist_session`` below ``transform_llm_output`` puts the
+    turn-exit diagnostic block between the transcript prep and the write. That
+    block indexes message dicts without an isinstance guard on every access, so
+    a malformed non-dict entry raises while merely building a log line. Before
+    this guard the raise propagated out of ``finalize_turn`` with the session
+    never persisted — reintroducing the #8049 "cleanup lost the turn" failure
+    that the surrounding guards exist to prevent.
+
+    Uses an empty ``final_response`` so the prep block does not append a
+    closing assistant row; the tail stays a tool result, which is what sends
+    the diagnostic down its message-walking branch.
+    """
+    agent = _StubAgent()
+    monkeypatch.setattr(plugins_mod, "invoke_hook", lambda hook_name, **kwargs: [])
+
+    messages = [
+        {"role": "user", "content": "hi"},
+        "MALFORMED",  # non-dict entry the diagnostic walk chokes on
+        {"role": "tool", "content": "{}", "tool_call_id": "c1"},
+    ]
+
+    # A malformed entry also trips the reasoning-extraction walk further down,
+    # which is unguarded on clean main too and sits AFTER the persist. That
+    # raise is pre-existing and out of scope here; what must not regress is
+    # that the session is already written by the time it happens.
+    try:
+        finalize_turn(
+            agent,
+            final_response="",
+            api_call_count=1,
+            interrupted=False,
+            failed=False,
+            messages=messages,
+            conversation_history=[],
+            effective_task_id="task-1",
+            turn_id="turn-1",
+            user_message="hi",
+            original_user_message="hi",
+            _should_review_memory=False,
+            _turn_exit_reason="empty_response",
+        )
+    except AttributeError:
+        pass
+
+    assert "persist" in agent.events, (
+        "session was never persisted — a diagnostic-log failure between the "
+        "transcript prep and the deferred persist swallowed the turn (#8049)"
+    )


### PR DESCRIPTION
## Summary

Fixes #44239

The `transform_llm_output` hook fires in `finalize_turn` **after** `_persist_session`, and its result is never written back into the assistant message. The user sees the transformed text for the current turn, but `result["messages"]`, the JSON session log, and the SQLite session DB all keep the raw model output — which is then replayed as context on the next turn or after a session resume. The whole `response_transformed` delivery chain (gateway message edit, ACP final-response delivery) ensures the transformed text is what the user *sees*, so the raw text resurfacing on resume is clearly unintended.

## Changes — `agent/turn_finalizer.py`

- Split the persistence block in two. The transcript-prep steps (scaffolding drop, verification-nudge drop, interrupted tool-tail close, the #43849/#44100 "delivered `final_response` ⇒ assistant row" invariant, user-message override) stay where they were; the `_persist_session` call moves below the `transform_llm_output` hook.
- Before persisting, a transformed response is synced back into the turn's last assistant text message via `_sync_final_response_to_last_assistant`. The sync walks backwards only within the current turn (stops at the user-message boundary, mirroring the reasoning extraction) and never rewrites a tool-call or multimodal assistant message.
- The sync clears `_DB_PERSISTED_MARKER` on the row it edits. A turn that called tools has already flushed its assistant row via the incremental persist, which stamps that marker, and `_persist_session` skips any row carrying it — so reordering alone leaves the transformed text out of the durable store on exactly the tool-calling turns, while every in-memory assertion still passes. This mirrors the existing marker pop in the #43849/#44100 tail-fill block.
- The turn-exit diagnostic log is now guarded. Deferring the write places it between the prep and the persist, and it indexes message dicts without an isinstance check on every access (`messages[-1].get`, `_m.get(...)`); unguarded, a malformed non-dict entry raises while merely building a log line and the session write is skipped — the #8049 "cleanup lost the turn" failure mode. Diagnostics must never gate persistence.
- Persistence intentionally stays **before** `post_llm_call`: that hook is observability-only per `docs/observability/README.md` (its return value is ignored in code — there is no override path, contrary to what #44239 and #14894 assume), and its plugins may read the session store expecting the completed turn to be present. This means this PR takes a deliberately different approach from #14913, which moves persistence below `post_llm_call`.

## Scope notes

While verifying #44239 I found parts of it don't match the code:

- The `post_llm_call` "override_response path" it describes does not exist — `_invoke_hook("post_llm_call", ...)`'s return value is discarded. So there is nothing to persist for that hook; this PR fixes the half of the issue that is real (`transform_llm_output`).
- The "reference implementation" link in the issue (M1p0/Project-Rin patch) returns 404.
- The reasoning-extraction walk further down has the same non-dict fragility as the diagnostic block, but it sits *after* the persist and behaves identically on clean `main`, so it is left alone rather than widened into this PR.

## Tests

`tests/agent/test_44239_transform_persist_order.py` (12 tests):

- **In-memory / ordering** — transformed text lands in `result["messages"][-1]`; ordering is `transform_llm_output` → persist → `post_llm_call`; untransformed turns persist the raw text unchanged; the sync helper skips tool-call messages and multimodal content, never crosses the turn boundary, and clears the dedup marker.
- **Storage-level** — four tests drive the real `AIAgent._persist_session` against an isolated `HERMES_HOME`, reading back through a **fresh** `SessionDB` handle via `get_messages_as_conversation` (the call `/resume` uses in `hermes_cli/cli_agent_setup_mixin.py`) plus the JSON snapshot, covering the plain case, the pre-flushed (marker-stamped) row, and the malformed-message persistence guarantee. Disk assertions run before any in-memory check so an ordering regression fails on the storage contract rather than being masked.

Each mechanism was verified by reverting it individually: without the reordering, SQLite reads back the raw pre-transform text; without the marker pop, likewise on tool-calling turns; without the diagnostic guard, nothing is persisted at all.

`tests/agent` + `tests/run_agent` at CI parity (`uv sync --locked --extra all --extra dev`, per-file isolation via `scripts/run_tests_parallel.py`): 477 files, 9645 passed, 18 failed. The 18 are 4 files (`test_anthropic_adapter.py`, `test_credential_pool_routing.py`, `test_credential_pool_oat_authtype.py`, `test_verification_evidence.py`) that fail identically on clean `main` in this environment (OAuth credential-file access) — baseline, not from this change.

## Related

- #14894 / #14913 — same ordering concern for `post_llm_call`; see scope note above.
