### PR TITLE
fix: place runtime context before user request

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -124,6 +124,23 @@ def _ra():
     return run_agent
 
 
+def _format_user_message_with_runtime_context(
+    user_content: str,
+    runtime_context_parts: list[str],
+) -> str:
+    """Return the API-only user message with runtime context before the request.
+
+    The persisted transcript keeps the user's original text.  This formatter is
+    only used for the provider request, where plugin/memory context should read
+    as context framing the request rather than as extra user-authored text after
+    it.
+    """
+    context = "\n\n".join(part for part in runtime_context_parts if part)
+    if not context:
+        return user_content
+    return f"Runtime context:\n{context}\n\n---\nUser request:\n{user_content}"
+
+
 def _nous_entitlement_message(capability: str) -> str:
     try:
         from hermes_cli.nous_account import (
@@ -623,7 +640,10 @@ def run_conversation(
                 if _injections:
                     _base = api_msg.get("content", "")
                     if isinstance(_base, str):
-                        api_msg["content"] = _base + "\n\n" + "\n\n".join(_injections)
+                        api_msg["content"] = _format_user_message_with_runtime_context(
+                            _base,
+                            _injections,
+                        )
 
             # For ALL assistant messages, pass reasoning back to the API
             # This ensures multi-turn reasoning context is preserved

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -18,7 +18,12 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from agent.codex_responses_adapter import _normalize_codex_response
+from agent.codex_responses_adapter import (
+    _chat_messages_to_responses_input,
+    _normalize_codex_response,
+    _preflight_codex_input_items,
+)
+from agent.conversation_loop import _format_user_message_with_runtime_context
 
 import run_agent
 from run_agent import AIAgent
@@ -52,6 +57,31 @@ def test_is_destructive_command_treats_cp_as_mutating():
 
 def test_is_destructive_command_treats_install_as_mutating():
     assert run_agent._is_destructive_command("install template.env .env") is True
+
+
+def test_runtime_context_precedes_user_request_in_api_only_message():
+    formatted = _format_user_message_with_runtime_context(
+        "Please update the docs.",
+        ["Memory context", "Plugin context"],
+    )
+
+    assert formatted == (
+        "Runtime context:\n"
+        "Memory context\n\n"
+        "Plugin context\n\n"
+        "---\n"
+        "User request:\n"
+        "Please update the docs."
+    )
+    assert formatted.index("Memory context") < formatted.index("User request:")
+    assert formatted.index("Plugin context") < formatted.index("Please update")
+
+
+def test_runtime_context_formatter_leaves_user_request_unchanged_without_context():
+    assert (
+        _format_user_message_with_runtime_context("Please update the docs.", [])
+        == "Please update the docs."
+    )
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary

Place API-only runtime context before the real user request, separated by an explicit boundary.

Runtime context from memory prefetch and `pre_llm_call` plugins is currently appended after the user's text. This can make injected context read like additional user-authored content. The new formatter keeps the persisted transcript unchanged, but sends provider requests as:

```text
Runtime context:
...

---
User request:
...
```

## Why

- Keeps plugin/memory context framed as runtime context rather than as a tail appended to the user's words.
- Preserves the single current-turn `role="user"` message, so role alternation and prompt-cache invariants are unchanged.
- Leaves persisted session messages untouched; the formatting is API-call-time only.

## Tests

```bash
python -m pytest \
  tests/run_agent/test_run_agent.py::test_runtime_context_precedes_user_request_in_api_only_message \
  tests/run_agent/test_run_agent.py::test_runtime_context_formatter_leaves_user_request_unchanged_without_context \
  -q -o 'addopts=' --tb=short

python -m py_compile agent/conversation_loop.py tests/run_agent/test_run_agent.py
```

Result: `2 passed, 1 warning`; py_compile ok.