### PR TITLE
fix(agent): skip persist_user_message override when content is a multimodal list

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1474,6 +1474,8 @@ class AIAgent:
         if 0 <= idx < len(messages):
             msg = messages[idx]
             if isinstance(msg, dict) and msg.get("role") == "user":
+                if isinstance(msg.get("content"), list):
+                    return
                 msg["content"] = override
 
     def _persist_session(self, messages: List[Dict], conversation_history: List[Dict] = None):

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -6179,6 +6179,28 @@ class TestPersistUserMessageOverride:
         first_db_write = agent._session_db.append_message.call_args_list[0].kwargs
         assert first_db_write["content"] == "Hello there"
 
+    def test_persist_session_preserves_multimodal_content(self, agent):
+        """Multimodal content lists (images, audio) must not be clobbered."""
+        agent._session_db = MagicMock()
+        agent.session_id = "session-123"
+        agent._last_flushed_db_idx = 0
+        agent._persist_user_message_idx = 0
+        agent._persist_user_message_override = "[Image attachment]"
+        multimodal_content = [
+            {"type": "text", "text": "Describe this image."},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc123"}},
+        ]
+        messages = [
+            {"role": "user", "content": multimodal_content},
+            {"role": "assistant", "content": "A cat."},
+        ]
+
+        agent._apply_persist_user_message_override(messages)
+
+        assert messages[0]["content"] is multimodal_content
+        assert isinstance(messages[0]["content"], list)
+        assert messages[0]["content"][1]["type"] == "image_url"
+
 
 class TestReasoningReplayForStrictProviders:
     """Assistant replay must preserve provider-native reasoning fields."""


### PR DESCRIPTION
## What does this PR do?

Fixes `_apply_persist_user_message_override()` clobbering multimodal user message content (image blocks, audio blocks) with a plain text string, causing vision models to never receive attached images sent via the ACP adapter.

## Related Issue

Fixes #44242

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `run_agent.py`: Added `isinstance(msg.get("content"), list)` guard in `_apply_persist_user_message_override()` — when the user message content is a list (multimodal: text + image_url, etc.), skip the override entirely. Text-only string content is still overridden as before.
- `tests/run_agent/test_run_agent.py`: Added `test_persist_session_preserves_multimodal_content` to verify multimodal content lists are preserved and not clobbered by the persist override.

## How to Test

1. Configure a vision-capable model (e.g. `openrouter/google/gemini-2.5-flash-lite`)
2. Send an image via ACP `session/prompt` with a multimodal content block
3. Before fix: model replies "IMAGE_NOT_RECEIVED" — image was dropped
4. After fix: model correctly identifies the image content
5. Run `pytest tests/run_agent/test_run_agent.py::TestPersistUserMessageOverride -v` — both tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `run_agent.py::_apply_persist_user_message_override` (callers: 2 in `_persist_session` and `run_conversation`)
- Blast radius: LOW — guard only adds an early-return for list content; text-only paths unchanged
- Related patterns: ACP adapter passes `persist_user_message` as plain string; `_persist_session` and `run_conversation` both call the override
