### PR TITLE
fix(agent): don't clobber multimodal user content with persist_user_message override

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1466,6 +1466,13 @@ class AIAgent:
         history. When an override is configured for the active turn, mutate the
         in-memory messages list in place so both persistence and returned
         history stay clean.
+
+        Multimodal turns (OpenAI-style content-part lists) are left untouched:
+        the turn-start crash-resilience persist runs before the first API call
+        on the same list the request is built from, so replacing the list with
+        the text-only override would strip image parts before they ever reach
+        the model (#44242). Image redaction for the session DB happens in
+        ``_flush_messages_to_session_db`` instead.
         """
         idx = getattr(self, "_persist_user_message_idx", None)
         override = getattr(self, "_persist_user_message_override", None)
@@ -1474,6 +1481,8 @@ class AIAgent:
         if 0 <= idx < len(messages):
             msg = messages[idx]
             if isinstance(msg, dict) and msg.get("role") == "user":
+                if isinstance(msg.get("content"), list):
+                    return
                 msg["content"] = override
 
     def _persist_session(self, messages: List[Dict], conversation_history: List[Dict] = None):

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -6179,6 +6179,36 @@ class TestPersistUserMessageOverride:
         first_db_write = agent._session_db.append_message.call_args_list[0].kwargs
         assert first_db_write["content"] == "Hello there"
 
+    def test_override_leaves_multimodal_content_intact(self, agent):
+        """Multimodal user turns must keep their image parts (#44242).
+
+        The turn-start crash-resilience persist runs before the first API
+        call on the same list the request is built from — clobbering the
+        content-part list with the text-only override would drop the image
+        end-to-end.
+        """
+        agent._session_db = MagicMock()
+        agent.session_id = "session-123"
+        agent._last_flushed_db_idx = 0
+        agent._persist_user_message_idx = 0
+        agent._persist_user_message_override = "What color is this?"
+        multimodal_content = [
+            {"type": "text", "text": "What color is this?"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/png;base64,AAAA"},
+            },
+        ]
+        messages = [{"role": "user", "content": multimodal_content}]
+
+        agent._persist_session(messages, [])
+
+        # API-bound message keeps the image part.
+        assert messages[0]["content"] == multimodal_content
+        # DB persistence still redacts the image to a text placeholder.
+        first_db_write = agent._session_db.append_message.call_args_list[0].kwargs
+        assert first_db_write["content"] == "What color is this?\n[screenshot]"
+
 
 class TestReasoningReplayForStrictProviders:
     """Assistant replay must preserve provider-native reasoning fields."""


### PR DESCRIPTION
## Summary

Image content blocks sent through the ACP adapter never reached the model: `build_turn_context` runs a crash-resilience persist of the inbound user turn **before the first API call**, and `_persist_session` → `_apply_persist_user_message_override` mutates the **same** `messages` list the request is later built from. The ACP adapter passes a text-only `persist_user_message` for multimodal prompts (`acp_adapter/server.py`), so the `[{type:"text"}, {type:"image_url"}]` content list was replaced with a plain string before any provider call — the image was dropped end-to-end, on every provider, regardless of vision support.

## Fix

`_apply_persist_user_message_override` now leaves content-part lists untouched. The synthetic-prefix cleanup the override exists for (voice prefix in `cli.py`, ACP steering text) only ever applies to string-content turns, and image redaction for the session DB already happens downstream in `_flush_messages_to_session_db` (images → `[screenshot]` placeholder), so DB bloat is not a concern.

## Verification

- Traced the full path on `main`: ACP `_content_blocks_to_openai_user_content` produces the multimodal list → `turn_context.py` early `_persist_session` (crash-resilience persist) → override clobbers `msg["content"]` before the request is assembled.
- New regression test: multimodal user turn keeps its `image_url` part through `_persist_session`, while the DB write still gets the redacted text form.
- Existing `TestPersistUserMessageOverride` text-turn test unchanged and passing — voice-prefix/steering cleanup behavior is preserved.
- `tests/run_agent/` + `tests/agent/test_turn_context.py`: 1627 passed, 2 failed — the two `test_provider_parity.py::TestAuxiliaryClientProviderPriority` failures are pre-existing test-ordering pollution (they fail identically on pristine `origin/main` in a full-suite run and pass in isolation both with and without this change).

Fixes #44242

🤖 Generated with [Claude Code](https://claude.com/claude-code)