### PR TITLE
fix: preserve ACP multimodal content during persistence

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1474,6 +1474,15 @@ class AIAgent:
         if 0 <= idx < len(messages):
             msg = messages[idx]
             if isinstance(msg, dict) and msg.get("role") == "user":
+                # Text-only call paths may pass a synthetic API-facing prompt
+                # and a cleaner transcript string separately. Multimodal
+                # turns, however, keep image/audio blocks in the live
+                # messages list that is still used for the API request after
+                # early crash-resilience persistence. Do not replace those
+                # blocks with the text-only persistence override before the
+                # model call is built.
+                if isinstance(msg.get("content"), list):
+                    return
                 msg["content"] = override
 
     def _persist_session(self, messages: List[Dict], conversation_history: List[Dict] = None):

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -75,6 +75,33 @@ def agent():
         return a
 
 
+def test_persist_user_message_override_rewrites_text_turns(agent):
+    messages = [{"role": "user", "content": "API-only synthetic prefix\nhello"}]
+    agent._persist_user_message_idx = 0
+    agent._persist_user_message_override = "hello"
+
+    agent._apply_persist_user_message_override(messages)
+
+    assert messages == [{"role": "user", "content": "hello"}]
+
+
+def test_persist_user_message_override_preserves_multimodal_turns(agent):
+    multimodal_content = [
+        {"type": "text", "text": "What color is this?"},
+        {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,AAAA"},
+        },
+    ]
+    messages = [{"role": "user", "content": multimodal_content}]
+    agent._persist_user_message_idx = 0
+    agent._persist_user_message_override = "What color is this? [Image attachment]"
+
+    agent._apply_persist_user_message_override(messages)
+
+    assert messages == [{"role": "user", "content": multimodal_content}]
+
+
 @pytest.fixture()
 def agent_with_memory_tool():
     """Agent whose valid_tool_names includes 'memory'."""


### PR DESCRIPTION
## Summary
- Keep text-only `persist_user_message` overrides from replacing multimodal current-turn user content
- Preserve ACP image/image_url blocks through early crash-resilience persistence so they can reach the provider request
- Add regression coverage for text override behavior and multimodal preservation

## Test Plan
- `/home/rivuza/hermes-agent/.venv/bin/python -m pytest tests/run_agent/test_run_agent.py::test_persist_user_message_override_rewrites_text_turns tests/run_agent/test_run_agent.py::test_persist_user_message_override_preserves_multimodal_turns -q`
- `/home/rivuza/hermes-agent/.venv/bin/python -m pytest tests/run_agent/test_run_agent.py -q`

Closes #44242