### PR TITLE
feat(providers): add CoreWeave Serverless Inference provider plugin

### DIFF
--- a/plugins/model-providers/coreweave/__init__.py
+++ b/plugins/model-providers/coreweave/__init__.py
@@ -1,0 +1,44 @@
+"""CoreWeave Serverless Inference provider profile.
+
+CoreWeave Serverless Inference (formerly W&B Inference) is a standard
+OpenAI-compatible endpoint serving leading open models on CoreWeave. API-key
+auth via ``COREWEAVE_API_KEY``; the ``/v1/models`` catalog is live so the picker
+fetches models automatically.
+
+The endpoint also accepts an optional ``openai-project`` header (``team/project``)
+for usage attribution. It is only required for accounts whose default project
+lacks Inference access. Because the value is per-user we do not ship a static
+``default_headers`` for it; users that need it supply it via
+``model.default_headers`` in ``config.yaml`` (see the provider docs), which
+``_apply_user_default_headers`` merges onto both the main and auxiliary clients.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+coreweave = ProviderProfile(
+    name="coreweave",
+    aliases=("coreweave-inference", "coreweave-serverless"),
+    display_name="CoreWeave Serverless Inference",
+    description="CoreWeave Serverless Inference — open models on CoreWeave",
+    signup_url="https://wandb.ai/settings",  # where Inference API keys are issued
+    # env_vars: 1st = API key, 2nd = optional base-url override
+    env_vars=("COREWEAVE_API_KEY", "COREWEAVE_BASE_URL"),
+    base_url="https://api.inference.wandb.ai/v1",
+    auth_type="api_key",
+    default_aux_model="google/gemma-4-31B-it",  # cheap model for background tasks
+    fallback_models=(
+        # Safety net only — the picker fetches the live /v1/models catalog.
+        # Only tool-calling / agentic models belong here.
+        "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B",
+        "meta-llama/Llama-3.3-70B-Instruct",
+        "deepseek-ai/DeepSeek-V4-Pro",
+        "google/gemma-4-31B-it",
+        "Qwen/Qwen3.6-27B",
+        "moonshotai/Kimi-K2.6",
+        "MiniMaxAI/MiniMax-M2.5",
+        "zai-org/GLM-5.2",
+    ),
+)
+
+register_provider(coreweave)

--- a/plugins/model-providers/coreweave/plugin.yaml
+++ b/plugins/model-providers/coreweave/plugin.yaml
@@ -1,0 +1,5 @@
+name: coreweave-provider
+kind: model-provider
+version: 1.0.0
+description: CoreWeave Serverless Inference (open models on CoreWeave)
+author: Juan-Lee Pang (juan-lee), CoreWeave

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1755,6 +1755,7 @@ AUTHOR_MAP = {
     "steveonjava@gmail.com": "steveonjava",  # PR #29669 (redact secrets in kanban tool payloads)
     "afnlegion01@gmail.com": "Afnath-max",  # PR #49129 salvage (opencode-zen catalog refresh + uncapped/live-first picker)
     "sharma.priyanshu96@gmail.com": "ipriyaaanshu",  # PR #51488 salvage (clear stale base_url on gateway model switches; #25107)
+    "jpang@coreweave.com": "juan-lee",  # CoreWeave Serverless Inference provider plugin
 }
 
 

--- a/tests/providers/test_profile_wiring.py
+++ b/tests/providers/test_profile_wiring.py
@@ -294,3 +294,13 @@ class TestRequestOverridesParity:
             request_overrides={"top_p": 0.9},
         )
         assert kw["top_p"] == 0.9
+
+
+def test_coreweave_profile_resolves():
+    """CoreWeave Serverless Inference fast-path plugin resolves by id and aliases."""
+    p = get_provider_profile("coreweave")
+    assert p is not None
+    assert p.base_url == "https://api.inference.wandb.ai/v1"
+    assert "COREWEAVE_API_KEY" in p.env_vars
+    for alias in ("coreweave-inference", "coreweave-serverless"):
+        assert get_provider_profile(alias) is p

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -26,6 +26,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **Kimi / Moonshot (China)** | `KIMI_CN_API_KEY` in `~/.hermes/.env` (provider: `kimi-coding-cn`; aliases: `kimi-cn`, `moonshot-cn`) |
 | **Arcee AI** | `ARCEEAI_API_KEY` in `~/.hermes/.env` (provider: `arcee`; aliases: `arcee-ai`, `arceeai`) |
 | **GMI Cloud** | `GMI_API_KEY` in `~/.hermes/.env` (provider: `gmi`; aliases: `gmi-cloud`, `gmicloud`) |
+| **CoreWeave Serverless Inference** | `COREWEAVE_API_KEY` in `~/.hermes/.env` (provider: `coreweave`; aliases: `coreweave-inference`, `coreweave-serverless`) |
 | **MiniMax** | `MINIMAX_API_KEY` in `~/.hermes/.env` (provider: `minimax`) |
 | **MiniMax China** | `MINIMAX_CN_API_KEY` in `~/.hermes/.env` (provider: `minimax-cn`) |
 | **xAI (Grok) — Responses API** | `XAI_API_KEY` in `~/.hermes/.env` (provider: `xai`) |
@@ -257,6 +258,10 @@ hermes chat --provider arcee --model trinity-large-thinking
 # Use the exact model ID returned by GMI's /v1/models endpoint.
 hermes chat --provider gmi --model zai-org/GLM-5.1-FP8
 # Requires: GMI_API_KEY in ~/.hermes/.env
+
+# CoreWeave Serverless Inference
+hermes chat --provider coreweave --model meta-llama/Llama-3.3-70B-Instruct
+# Requires: COREWEAVE_API_KEY in ~/.hermes/.env
 ```
 
 Or set the provider permanently in `config.yaml`:
@@ -266,7 +271,7 @@ model:
   default: "zai-org/GLM-5.1-FP8"
 ```
 
-Base URLs can be overridden with `NOVITA_BASE_URL`, `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, `DASHSCOPE_BASE_URL`, `XIAOMI_BASE_URL`, `GMI_BASE_URL`, or `TOKENHUB_BASE_URL` environment variables.
+Base URLs can be overridden with `NOVITA_BASE_URL`, `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, `DASHSCOPE_BASE_URL`, `XIAOMI_BASE_URL`, `GMI_BASE_URL`, `COREWEAVE_BASE_URL`, or `TOKENHUB_BASE_URL` environment variables.
 
 :::note Z.AI Endpoint Auto-Detection
 When using the Z.AI / GLM provider, Hermes automatically probes multiple endpoints (global, China, coding variants) to find one that accepts your API key. You don't need to set `GLM_BASE_URL` manually — the working endpoint is detected and cached automatically.
@@ -486,6 +491,36 @@ model:
 ```
 
 The base URL can be overridden with `GMI_BASE_URL` (default: `https://api.gmi-serving.com/v1`).
+
+### CoreWeave Serverless Inference
+
+Open models served via [CoreWeave Serverless Inference](https://www.coreweave.com/solutions/ai-inference) (formerly W&B Inference) — OpenAI-compatible API, API key authentication. The model catalog is fetched live from `/v1/models`.
+
+```bash
+# CoreWeave Serverless Inference
+hermes chat --provider coreweave --model meta-llama/Llama-3.3-70B-Instruct
+# Requires: COREWEAVE_API_KEY in ~/.hermes/.env
+```
+
+Or set it permanently in `config.yaml`:
+```yaml
+model:
+  provider: "coreweave"
+  default: "meta-llama/Llama-3.3-70B-Instruct"
+```
+
+Get your API key at [wandb.ai/settings](https://wandb.ai/settings) (CoreWeave Inference keys are still issued there). The base URL can be overridden with `COREWEAVE_BASE_URL` (default: `https://api.inference.wandb.ai/v1`).
+
+:::note Project attribution header
+Most accounts work as-is. Accounts whose default project lacks Inference access must supply the `openai-project` header (`team/project`) — add it under `model.default_headers` in `config.yaml`:
+
+```yaml
+model:
+  provider: "coreweave"
+  default_headers:
+    openai-project: "your-team/your-project"
+```
+:::
 
 ### StepFun
 


### PR DESCRIPTION
CoreWeave Serverless Inference (formerly W&B Inference) is a standard OpenAI-compatible endpoint serving open models on CoreWeave. Adds it via the fast-path plugin pattern (zero core edits): a ProviderProfile under plugins/model-providers/coreweave/ with COREWEAVE_API_KEY auth, base URL https://api.inference.wandb.ai/v1, and live /v1/models catalog.

The optional openai-project header (only needed for accounts whose default project lacks Inference access) is handled via the existing model.default_headers config escape hatch, documented in the provider docs.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

Adds **CoreWeave Serverless Inference** (formerly W&B Inference) as a first-class
model provider via the documented fast-path plugin pattern — a declarative
`ProviderProfile` under `plugins/model-providers/coreweave/` with **zero core
edits**. It's a standard OpenAI-compatible endpoint, so it auto-wires into
credential resolution, the `--provider` flag, the `/model` picker, `provider:model`
alias syntax, and `hermes setup`. The `/v1/models` catalog is fetched live;
`fallback_models` is only a safety net. First-class treatment (vs. the generic
`custom` path) is justified by the picker entry, alias syntax, and live catalog,
matching how Novita/GMI are integrated.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #43964

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `plugins/model-providers/coreweave/__init__.py` — new `ProviderProfile`
  (id `coreweave`; aliases `coreweave-inference`, `coreweave-serverless`;
  `COREWEAVE_API_KEY` auth; base URL `https://api.inference.wandb.ai/v1`)
- `plugins/model-providers/coreweave/plugin.yaml` — manifest
- `website/docs/integrations/providers.md` — table row, section, `COREWEAVE_BASE_URL`
  override note, and project-attribution-header guidance (set via
  `model.default_headers` in `config.yaml` — not a new env var)
- `tests/providers/test_profile_wiring.py` — resolution + alias invariant test

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Resolution/aliases (no key): `python -c "from providers import get_provider_profile as g; p=g('coreweave'); assert g('coreweave-inference') is p; print(p.base_url)"`
2. `scripts/run_tests.sh tests/providers/` → 107 passed
3. Live (needs `COREWEAVE_API_KEY` in `~/.hermes/.env`): `hermes model` shows
   "CoreWeave Serverless Inference"; `hermes chat --provider coreweave --model meta-llama/Llama-3.3-70B-Instruct`

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->
<img width="805" height="627" alt="image" src="https://github.com/user-attachments/assets/4c7b8e54-ef3f-42cc-b3df-2578467e85dc" />
<img width="1132" height="526" alt="image" src="https://github.com/user-attachments/assets/2881683b-882c-4024-94d5-6f8ebcda92aa" />
<img width="717" height="566" alt="image" src="https://github.com/user-attachments/assets/a229f33f-d37e-4576-80ff-c0199ba4af0a" />
<img width="1527" height="978" alt="image" src="https://github.com/user-attachments/assets/b7cc0178-2346-4c38-86ce-7a85fa96929f" />

