### PR TITLE
fix(desktop): handle the 'prefill' command.dispatch response — /undo works again

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
@@ -3,6 +3,7 @@ import type { MutableRefObject } from 'react'
 import { useEffect, useRef } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { onComposerInsertRequest } from '@/app/chat/composer/focus'
 import { $composerAttachments, type ComposerAttachment } from '@/store/composer'
 import { $connection, $sessions, setSessions } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
@@ -259,6 +260,79 @@ describe('usePromptActions desktop slash pickers', () => {
         session_id: RUNTIME_SESSION_ID
       }
     })
+  })
+})
+
+describe('usePromptActions /undo prefill dispatch', () => {
+  beforeEach(() => {
+    setSessions(() => [sessionInfo()])
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('renders the undo notice and prefills the composer instead of erroring or auto-submitting', async () => {
+    // Gateway /undo path: slash.exec rejects (command.dispatch owns /undo) and
+    // command.dispatch answers {type:"prefill"} — the shape that used to fall
+    // out of parseCommandDispatch as "invalid response: command.dispatch".
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'slash.exec') {
+        throw new Error('handled via command.dispatch')
+      }
+
+      if (method === 'command.dispatch') {
+        return {
+          type: 'prefill',
+          message: 'make the tests pass',
+          notice: '↶ Undid 1 turn (2 message(s)).'
+        } as never
+      }
+
+      return {} as never
+    })
+
+    const inserts: { target: string; text: string }[] = []
+    const offInsert = onComposerInsertRequest(({ target, text }) => inserts.push({ target, text }))
+
+    let lastState: Record<string, unknown> = {}
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={state => (lastState = state)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    try {
+      await handle!.submitText('/undo')
+
+      expect(requestGateway).toHaveBeenCalledWith('command.dispatch', {
+        session_id: RUNTIME_SESSION_ID,
+        name: 'undo',
+        arg: ''
+      })
+
+      const systemText = ((lastState.messages ?? []) as { parts: { text?: string }[] }[])
+        .map(message => message.parts.map(part => part.text ?? '').join(''))
+        .join('\n')
+
+      // The rewind notice renders as a system line — not the old parse failure.
+      expect(systemText).toContain('↶ Undid 1 turn (2 message(s)).')
+      expect(systemText).not.toContain('invalid response')
+
+      // The undone text lands in the main composer (the insert bus defers a
+      // macrotask)…
+      await waitFor(() => expect(inserts).toEqual([{ target: 'main', text: 'make the tests pass' }]))
+
+      // …for edit-and-resubmit; it is NOT auto-submitted like a 'send' dispatch.
+      expect(requestGateway).not.toHaveBeenCalledWith('prompt.submit', expect.anything())
+    } finally {
+      offInsert()
+    }
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -2,6 +2,7 @@ import type { AppendMessage, ThreadMessage } from '@assistant-ui/react'
 import { useStore } from '@nanostores/react'
 import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 
+import { requestComposerInsert } from '@/app/chat/composer/focus'
 import { getProfiles, transcribeAudio } from '@/hermes'
 import { translateNow, type Translations, useI18n } from '@/i18n'
 import { stripAnsi } from '@/lib/ansi'
@@ -897,6 +898,20 @@ export function usePromptActions({
 
           if (dispatch.type === 'alias') {
             await runSlash(`/${dispatch.target}${arg ? ` ${arg}` : ''}`, sessionId, false)
+
+            return
+          }
+
+          if (dispatch.type === 'prefill') {
+            // /undo: the gateway already rewound the history — render its
+            // notice, then drop the undone message text into the composer so
+            // the user can edit and resubmit (matching the TUI), instead of
+            // auto-submitting it like 'send'.
+            if (dispatch.notice?.trim()) {
+              renderSlashOutput(dispatch.notice)
+            }
+
+            requestComposerInsert(dispatch.message, { target: 'main' })
 
             return
           }

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -102,11 +102,18 @@ export interface SendCommandDispatchResponse {
   message: string
 }
 
+export interface PrefillCommandDispatchResponse {
+  type: 'prefill'
+  message: string
+  notice?: string
+}
+
 export type CommandDispatchResponse =
   | ExecCommandDispatchResponse
   | AliasCommandDispatchResponse
   | SkillCommandDispatchResponse
   | SendCommandDispatchResponse
+  | PrefillCommandDispatchResponse
 
 export type SidebarNavId = 'artifacts' | 'command-center' | 'messaging' | 'new-session' | 'settings' | 'skills'
 

--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { ComposerAttachment } from '@/store/composer'
 
-import { coerceThinkingText, optimisticAttachmentRef } from './chat-runtime'
+import { coerceThinkingText, optimisticAttachmentRef, parseCommandDispatch } from './chat-runtime'
 
 const DATA_URL = 'data:image/png;base64,iVBORw0KGgoAAAANS'
 
@@ -35,6 +35,34 @@ describe('optimisticAttachmentRef', () => {
     expect(optimisticAttachmentRef(attachment({ kind: 'file', refText: '@file:src/a.ts', previewUrl: DATA_URL }))).toBe(
       '@file:src/a.ts'
     )
+  })
+})
+
+describe('parseCommandDispatch', () => {
+  it('parses the prefill dispatch /undo returns (message + notice)', () => {
+    // Gateway shape: {"type": "prefill", "message": target_text, "notice": notice}
+    expect(
+      parseCommandDispatch({ type: 'prefill', message: 'edit me', notice: '↶ Undid 1 turn (2 message(s)).' })
+    ).toEqual({ type: 'prefill', message: 'edit me', notice: '↶ Undid 1 turn (2 message(s)).' })
+  })
+
+  it('parses a prefill without a notice', () => {
+    expect(parseCommandDispatch({ type: 'prefill', message: 'edit me' })).toEqual({
+      type: 'prefill',
+      message: 'edit me',
+      notice: undefined
+    })
+  })
+
+  it('rejects a prefill whose message is missing or not a string', () => {
+    expect(parseCommandDispatch({ type: 'prefill' })).toBeNull()
+    expect(parseCommandDispatch({ type: 'prefill', message: 42, notice: 'n' })).toBeNull()
+  })
+
+  it('still rejects unknown dispatch types and non-objects', () => {
+    expect(parseCommandDispatch({ type: 'confetti' })).toBeNull()
+    expect(parseCommandDispatch(null)).toBeNull()
+    expect(parseCommandDispatch('prefill')).toBeNull()
   })
 })
 

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -239,6 +239,13 @@ export function parseCommandDispatch(raw: unknown): CommandDispatchResponse | nu
     case 'send':
       return typeof row.message === 'string' ? { type: 'send', message: row.message } : null
 
+    case 'prefill':
+      // /undo backs up N turns and hands back the undone user message so the
+      // client can drop it into the composer for edit-and-resubmit.
+      return typeof row.message === 'string'
+        ? { type: 'prefill', message: row.message, notice: str(row.notice) }
+        : null
+
     default:
       return null
   }


### PR DESCRIPTION
## Problem

Fixes #43560.

> In Hermes Desktop, running `/undo` shows `error: invalid response: command.dispatch` instead of performing the undo action. The same command works correctly in TUI mode.

## Root cause

The gateway's `command.dispatch` handler for `/undo` replies with `{"type": "prefill", "message": <undone user text>, "notice": "↶ Undid N turn(s)..."}` (`tui_gateway/server.py:7866`). The desktop's `parseCommandDispatch()` (`apps/desktop/src/lib/chat-runtime.ts:219`) had no `prefill` case, so the switch fell through to `default: return null`, and the caller in `apps/desktop/src/app/session/hooks/use-prompt-actions.ts:887` rendered `error: invalid response: command.dispatch`. (The undo itself succeeds on the backend — only the response handling failed.)

## Fix

TUI-parity behavior (the TUI renders the notice as a sys line and drops the undone text into the input box via `ctx.composer.setInput`):

- `parseCommandDispatch` now accepts `{type: 'prefill', message: string, notice?: string}`, mirroring the TUI's `asCommandDispatch` (`ui-tui/src/lib/rpc.ts:37`).
- Added `PrefillCommandDispatchResponse` to the `CommandDispatchResponse` union in `apps/desktop/src/app/types.ts`.
- The `runExec` dispatch handler renders the notice as a system line, then prefills the main composer through the existing external-insert bus (`requestComposerInsert(message, { target: 'main' })`), which sets the text, places the caret at the end, and focuses the input — and returns without auto-submitting (unlike `send`).

## Tests

- `chat-runtime.test.ts`: new `parseCommandDispatch` suite — prefill with/without notice, rejection of missing/non-string `message`, unknown types still return null.
- `use-prompt-actions.test.tsx`: behavior test driving `/undo` through `submitText` with `slash.exec` rejecting and `command.dispatch` returning the real gateway shape; asserts the notice system line, no `invalid response` error, the undone text arriving on the composer insert bus targeted at `main`, and that no `prompt.submit` fires.

`cd apps/desktop && npx vitest run --environment jsdom src/lib/chat-runtime.test.ts src/app/session/hooks/use-prompt-actions.test.tsx` → 37/37 passed; `npx tsc --noEmit` clean; eslint on touched files: no new warnings vs baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)