### PR TITLE
fix(cli): dashboard status/stop/update miss running dashboards when --profile precedes the subcommand

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5314,6 +5314,52 @@ def cmd_gui(args: argparse.Namespace):
     sys.exit(launch_result.returncode)
 
 
+def _is_hermes_dashboard_cmdline(command: str) -> bool:
+    """True when *command* is a ``hermes dashboard`` invocation.
+
+    Anchored token matching instead of fixed substrings, so the global
+    ``--profile``/``-p`` flag may sit between the hermes entrypoint and the
+    ``dashboard`` subcommand (#44035):
+
+        hermes --profile work dashboard --port 9119
+        python -m hermes_cli.main --profile work dashboard
+        python hermes_cli/main.py --profile=work dashboard
+
+    The match is anchored on a hermes entrypoint token (the ``hermes``
+    console script, ``-m hermes_cli.main``, or a ``hermes_cli/main.py``
+    path); the first argument after it — skipping only the global profile
+    flag — must be the literal ``dashboard`` subcommand.  Unrelated
+    processes whose cmdline merely mentions "dashboard" (chat sessions,
+    grafana, ...) still don't match.
+    """
+    tokens = command.split()
+    for i, raw in enumerate(tokens):
+        token = raw.strip("\"'")  # wmic CommandLine may quote the executable
+        path = token.replace("\\", "/")
+        is_entry = (
+            path.rsplit("/", 1)[-1] in ("hermes", "hermes.exe")
+            or (token == "hermes_cli.main" and i > 0 and tokens[i - 1] == "-m")
+            or path.endswith("hermes_cli/main.py")
+        )
+        if not is_entry:
+            continue
+        j = i + 1
+        while j < len(tokens):
+            arg = tokens[j]
+            if arg in ("--profile", "-p"):
+                j += 2  # skip the flag and its value
+                continue
+            if arg.startswith("--profile="):
+                j += 1
+                continue
+            if arg == "dashboard":
+                return True
+            break  # first real argument is a different subcommand
+        # Keep scanning: a wrapper (e.g. ``sh -c``) may hold the real
+        # entrypoint in a later token.
+    return False
+
+
 def _find_stale_dashboard_pids(
     *,
     exclude_pids: set[int] | None = None,
@@ -5343,11 +5389,6 @@ def _find_stale_dashboard_pids(
 
     Returns an empty list on any scan error (missing ps/wmic, timeout, etc.).
     """
-    patterns = [
-        "hermes dashboard",
-        "hermes_cli.main dashboard",
-        "hermes_cli/main.py dashboard",
-    ]
     self_pid = os.getpid()
     dashboard_pids: list[int] = []
 
@@ -5378,7 +5419,7 @@ def _find_stale_dashboard_pids(
                 elif line.startswith("ProcessId="):
                     pid_str = line[len("ProcessId=") :]
                     if (
-                        any(p in current_cmd for p in patterns)
+                        _is_hermes_dashboard_cmdline(current_cmd)
                         and int(pid_str) != self_pid
                     ):
                         try:
@@ -5386,8 +5427,8 @@ def _find_stale_dashboard_pids(
                         except ValueError:
                             pass
         else:
-            # Linux / macOS: scan the process table via ps and match against
-            # the same explicit patterns list used on Windows.  Using ps
+            # Linux / macOS: scan the process table via ps and match with
+            # the same anchored matcher used on Windows.  Using ps
             # (rather than `pgrep -f "hermes.*dashboard"`) keeps us consistent
             # with `hermes_cli.gateway._scan_gateway_pids` and avoids the
             # greedy regex matching unrelated cmdlines that merely contain
@@ -5411,7 +5452,7 @@ def _find_stale_dashboard_pids(
                     except ValueError:
                         continue
                     command = parts[1]
-                    if any(p in command for p in patterns) and pid != self_pid:
+                    if _is_hermes_dashboard_cmdline(command) and pid != self_pid:
                         dashboard_pids.append(pid)
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
         return []

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -140,6 +140,49 @@ class TestFindStaleDashboardPids:
         with patch("subprocess.run", side_effect=sp.TimeoutExpired("ps", 10)):
             assert _find_stale_dashboard_pids() == []
 
+    def test_profile_flag_before_subcommand_matched(self):
+        """The global --profile/-p flag may sit between the hermes
+        entrypoint and the ``dashboard`` subcommand; such processes must
+        still be detected (#44035).
+        """
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="\n".join([
+                    _ps_line(12345, "/x/venv/bin/python -m hermes_cli.main --profile work dashboard --host 0.0.0.0 --port 9119 --no-open"),
+                    _ps_line(12346, "hermes -p work dashboard --no-open"),
+                    _ps_line(12347, "python /home/x/hermes_cli/main.py --profile=work dashboard"),
+                ]) + "\n",
+                stderr="",
+            )
+            assert sorted(_find_stale_dashboard_pids()) == [12345, 12346, 12347]
+
+    def test_profile_flag_after_subcommand_matched(self):
+        """The other argv order — profile flag after the subcommand —
+        keeps working too."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=_ps_line(12345, "hermes dashboard --profile work --port 9119") + "\n",
+                stderr="",
+            )
+            assert _find_stale_dashboard_pids() == [12345]
+
+    def test_profile_qualified_non_dashboard_not_matched(self):
+        """Anchored matching: a profile-qualified hermes process running a
+        *different* subcommand must not be picked up, even when its cmdline
+        mentions the word 'dashboard' elsewhere."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="\n".join([
+                    _ps_line(22222, "python3 -m hermes_cli.main --profile work gateway"),
+                    _ps_line(22223, "hermes --profile work chat -q 'open the dashboard'"),
+                ]) + "\n",
+                stderr="",
+            )
+            assert _find_stale_dashboard_pids() == []
+
     def test_unrelated_process_containing_word_dashboard_not_matched(self):
         """Guards against greedy pgrep-style matching catching chat sessions
         or unrelated processes whose cmdline happens to contain 'dashboard'.


### PR DESCRIPTION
## Problem

`hermes dashboard --status`, `hermes dashboard --stop`, and the stale-dashboard cleanup in `hermes update` miss a running dashboard when the global `--profile` flag appears **before** the `dashboard` subcommand, e.g.:

```
python -m hermes_cli.main --profile work dashboard --host 0.0.0.0 --port 9119 --no-open
```

`--status` reports "No hermes dashboard processes running" while the server is listening, and `hermes update` leaves the old backend running against a freshly rebuilt JS bundle.

## Root cause

`_find_stale_dashboard_pids()` (`hermes_cli/main.py:5346` on main) matches fixed substrings against the process cmdline:

```python
patterns = [
    "hermes dashboard",
    "hermes_cli.main dashboard",
    "hermes_cli/main.py dashboard",
]
```

When `--profile $PROFILE` (or `-p $PROFILE` / `--profile=$PROFILE`) sits between the entrypoint and the subcommand, none of these substrings appear in the cmdline, so the process is never detected.

## Fix

Replace the substring patterns with an anchored token matcher, `_is_hermes_dashboard_cmdline()`, used by both the POSIX `ps` branch and the Windows `wmic` branch:

- anchors on a hermes entrypoint token: the `hermes`/`hermes.exe` console script, `-m hermes_cli.main`, or a `hermes_cli/main.py` path;
- the first argument after the entrypoint must be the literal `dashboard` subcommand, skipping **only** the global profile flag in either form (`--profile X`, `-p X`, `--profile=X`) — so the flag can sit before or after the subcommand;
- any other first argument breaks the match, so unrelated processes whose cmdline merely mentions "dashboard" (chat sessions, grafana, ...) still don't match.

All existing guards are preserved: grep-line skip, self-PID exclusion, `exclude_pids` (desktop-managed backend, #37532), and empty-list returns on scan errors.

## Tests

Added to `tests/hermes_cli/test_update_stale_dashboard.py::TestFindStaleDashboardPids`:

- `test_profile_flag_before_subcommand_matched` — flag-before order across all three entrypoint shapes and all three flag forms;
- `test_profile_flag_after_subcommand_matched` — existing flag-after order keeps working;
- `test_profile_qualified_non_dashboard_not_matched` — profile-qualified `gateway`/`chat` processes (one mentioning "dashboard" in its args) are not matched.

```
pytest tests/hermes_cli/test_update_stale_dashboard.py tests/hermes_cli/test_dashboard_lifecycle_flags.py
35 passed
```

Fixes #44035

🤖 Generated with [Claude Code](https://claude.com/claude-code)