### PR TITLE
fix: persist finalized LLM hook responses

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -27,6 +27,28 @@ import os
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 
 
+def _sync_final_response_to_last_assistant(messages, final_response):
+    """Make the durable assistant turn match the finalized response text."""
+    if final_response is None:
+        return
+    for msg in reversed(messages):
+        if isinstance(msg, dict) and msg.get("role") == "assistant":
+            msg["content"] = final_response
+            return
+
+
+def _extract_post_llm_response_override(hook_result):
+    """Return a post_llm_call response override, if the hook supplied one."""
+    if isinstance(hook_result, str):
+        return hook_result if hook_result else None
+    if isinstance(hook_result, dict):
+        for key in ("response", "override_response", "assistant_response"):
+            value = hook_result.get(key)
+            if isinstance(value, str) and value:
+                return value
+    return None
+
+
 def finalize_turn(
     agent,
     *,
@@ -135,12 +157,10 @@ def finalize_turn(
     # Clean up VM and browser for this task after conversation completes
     agent._cleanup_task_resources(effective_task_id)
 
-    # Persist session to both JSON log and SQLite only after private retry
-    # scaffolding has been removed. Otherwise a later user "continue" turn
-    # can replay assistant("(empty)") / recovery nudges and fall into the
-    # same empty-response loop again.
+    # Remove private retry scaffolding before any durable snapshot is written.
+    # Otherwise a later user "continue" turn can replay assistant("(empty)") /
+    # recovery nudges and fall into the same empty-response loop again.
     agent._drop_trailing_empty_response_scaffolding(messages)
-    agent._persist_session(messages, conversation_history)
 
     # ── Turn-exit diagnostic log ─────────────────────────────────────
     # Always logged at INFO so agent.log captures WHY every turn ended.
@@ -284,6 +304,12 @@ def finalize_turn(
         except Exception as exc:
             logger.warning("transform_llm_output hook failed: %s", exc)
 
+    # Keep post_llm_call observers aligned with any transform_llm_output result.
+    # Some plugins use the hook for external persistence and inspect the
+    # conversation_history snapshot, so update the in-memory assistant turn
+    # before handing it to the hook.
+    _sync_final_response_to_last_assistant(messages, final_response)
+
     # Plugin hook: post_llm_call
     # Fired once per turn after the tool-calling loop completes.
     # Plugins can use this to persist conversation data (e.g. sync
@@ -291,7 +317,7 @@ def finalize_turn(
     if final_response and not interrupted:
         try:
             from hermes_cli.plugins import invoke_hook as _invoke_hook
-            _invoke_hook(
+            _post_results = _invoke_hook(
                 "post_llm_call",
                 session_id=agent.session_id,
                 task_id=effective_task_id,
@@ -302,8 +328,21 @@ def finalize_turn(
                 model=agent.model,
                 platform=getattr(agent, "platform", None) or "",
             )
+            for _hook_result in _post_results:
+                _override = _extract_post_llm_response_override(_hook_result)
+                if _override:
+                    final_response = _override
+                    _response_transformed = True
+                    break
         except Exception as exc:
             logger.warning("post_llm_call hook failed: %s", exc)
+
+    # Persist the finalized assistant text, not the raw model output.  Hooks
+    # such as transform_llm_output/post_llm_call may render or override the
+    # user-visible response after the tool loop; the session log, SQLite DB,
+    # external memory sync, and next-turn replay must all see that same text.
+    _sync_final_response_to_last_assistant(messages, final_response)
+    agent._persist_session(messages, conversation_history)
 
     # Extract reasoning from the CURRENT turn only.  Walk backwards
     # but stop at the user message that started this turn — anything

--- a/tests/agent/test_turn_finalizer.py
+++ b/tests/agent/test_turn_finalizer.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from types import SimpleNamespace
+
+from agent.turn_finalizer import finalize_turn
+
+
+class DummyAgent:
+    def __init__(self):
+        self.max_iterations = 10
+        self.iteration_budget = SimpleNamespace(remaining=9, used=1, max_total=10)
+        self.quiet_mode = True
+        self.model = "test-model"
+        self.provider = "test-provider"
+        self.base_url = ""
+        self.platform = "test"
+        self.session_id = "session-1"
+        self.valid_tool_names = set()
+        self._skill_nudge_interval = 0
+        self._iters_since_skill = 0
+        self._tool_guardrail_halt_decision = None
+        self._response_was_previewed = False
+        self._interrupt_message = None
+        self._stream_callback = object()
+        self.context_compressor = SimpleNamespace(last_prompt_tokens=0)
+
+        self.session_input_tokens = 0
+        self.session_output_tokens = 0
+        self.session_cache_read_tokens = 0
+        self.session_cache_write_tokens = 0
+        self.session_reasoning_tokens = 0
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+        self.session_total_tokens = 0
+        self.session_estimated_cost_usd = 0.0
+        self.session_cost_status = "ok"
+        self.session_cost_source = "test"
+
+        self.persisted_messages = None
+        self.memory_sync_messages = None
+        self.memory_sync_response = None
+
+    def _emit_status(self, *_args, **_kwargs):
+        pass
+
+    def _safe_print(self, *_args, **_kwargs):
+        pass
+
+    def _handle_max_iterations(self, messages, api_call_count):  # pragma: no cover
+        raise AssertionError("unexpected max-iteration summary")
+
+    def _save_trajectory(self, *_args, **_kwargs):
+        pass
+
+    def _cleanup_task_resources(self, *_args, **_kwargs):
+        pass
+
+    def _drop_trailing_empty_response_scaffolding(self, messages):
+        self.scaffolding_dropped = True
+
+    def _persist_session(self, messages, conversation_history):
+        self.persisted_messages = deepcopy(messages)
+        self.persisted_history = deepcopy(conversation_history)
+
+    def _file_mutation_verifier_enabled(self):
+        return False
+
+    def _turn_completion_explainer_enabled(self):
+        return False
+
+    def _drain_pending_steer(self):
+        return None
+
+    def _sync_external_memory_for_turn(self, *, original_user_message, final_response, interrupted, messages):
+        self.memory_sync_response = final_response
+        self.memory_sync_messages = deepcopy(messages)
+
+    def _spawn_background_review(self, *_args, **_kwargs):
+        pass
+
+    def clear_interrupt(self):
+        self.cleared_interrupt = True
+
+
+def _run_finalizer(agent, messages, *, final_response="raw answer"):
+    return finalize_turn(
+        agent,
+        final_response=final_response,
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=messages,
+        effective_task_id="task-1",
+        turn_id="turn-1",
+        user_message="hello",
+        original_user_message="hello",
+        _should_review_memory=False,
+        _turn_exit_reason="text_response(stop)",
+    )
+
+
+def test_transform_llm_output_persists_final_assistant_message(monkeypatch):
+    def fake_invoke_hook(name, **kwargs):
+        if name == "transform_llm_output":
+            assert kwargs["response_text"] == "raw answer"
+            return ["[rendered] raw answer"]
+        if name == "post_llm_call":
+            assert kwargs["assistant_response"] == "[rendered] raw answer"
+            assert kwargs["conversation_history"][-1]["content"] == "[rendered] raw answer"
+            return []
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", fake_invoke_hook)
+    agent = DummyAgent()
+    messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "raw answer"},
+    ]
+
+    result = _run_finalizer(agent, messages)
+
+    assert result["final_response"] == "[rendered] raw answer"
+    assert result["messages"][-1]["content"] == "[rendered] raw answer"
+    assert agent.persisted_messages is not None
+    assert agent.memory_sync_messages is not None
+    assert agent.persisted_messages[-1]["content"] == "[rendered] raw answer"
+    assert agent.memory_sync_messages[-1]["content"] == "[rendered] raw answer"
+    assert agent.memory_sync_response == "[rendered] raw answer"
+
+
+def test_post_llm_call_response_override_persists_final_assistant_message(monkeypatch):
+    def fake_invoke_hook(name, **kwargs):
+        if name == "transform_llm_output":
+            return []
+        if name == "post_llm_call":
+            assert kwargs["assistant_response"] == "raw answer"
+            return [{"response": "patched response"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", fake_invoke_hook)
+    agent = DummyAgent()
+    messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "raw answer"},
+    ]
+
+    result = _run_finalizer(agent, messages)
+
+    assert result["final_response"] == "patched response"
+    assert result["messages"][-1]["content"] == "patched response"
+    assert agent.persisted_messages is not None
+    assert agent.memory_sync_messages is not None
+    assert agent.persisted_messages[-1]["content"] == "patched response"
+    assert agent.memory_sync_messages[-1]["content"] == "patched response"
+    assert agent.memory_sync_response == "patched response"


### PR DESCRIPTION
## Summary
- Delay turn persistence until after `transform_llm_output` and `post_llm_call` finalization
- Sync the finalized assistant text back into the last assistant message before JSON/SQLite persistence, external memory sync, and result return
- Honor `post_llm_call` response override return values such as `{"response": "..."}`
- Add regression coverage for transform and post-hook persistence invariants

## Test Plan
- `/home/rivuza/hermes-agent/.venv/bin/python -m pytest tests/agent/test_turn_finalizer.py -q`
- `/home/rivuza/hermes-agent/.venv/bin/python -m pytest tests/agent/test_turn_finalizer.py tests/agent/test_shell_hooks.py tests/agent/test_plugin_llm.py -q`

Closes #44239
Closes #14894