### PR TITLE
fix: include plugin platforms in status

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -458,9 +458,15 @@ def show_status(args):
         
         print(f"  {name:<12}  {check_mark(has_token)} {status}")
 
-    # Plugin-registered platforms
+    # Plugin-registered platforms.  Plugin adapters register themselves during
+    # plugin discovery, so status must trigger discovery before reading the
+    # platform registry; otherwise this section only ever sees built-ins that
+    # were imported elsewhere in the process.
     try:
+        from hermes_cli.plugins import discover_plugins
         from gateway.platform_registry import platform_registry
+
+        discover_plugins()
         for entry in platform_registry.plugin_entries():
             configured = entry.check_fn()
             status_str = "configured" if configured else "not configured"

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -133,6 +133,52 @@ def test_show_status_reports_nous_inference_key_without_portal_login(monkeypatch
     assert "Nous inference credentials are configured" in output
 
 
+def test_show_status_includes_plugin_registered_platform(monkeypatch, capsys, tmp_path):
+    from hermes_cli import status as status_mod
+    import hermes_cli.auth as auth_mod
+    import hermes_cli.gateway as gateway_mod
+    import hermes_cli.plugins as plugins_mod
+    from gateway.platform_registry import PlatformEntry, platform_registry
+
+    monkeypatch.setattr(status_mod, "get_env_path", lambda: tmp_path / ".env", raising=False)
+    monkeypatch.setattr(status_mod, "get_hermes_home", lambda: tmp_path, raising=False)
+    monkeypatch.setattr(status_mod, "load_config", lambda: {"model": "gpt-5.4"}, raising=False)
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "openai-codex", raising=False)
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "OpenAI Codex", raising=False)
+    monkeypatch.setattr(auth_mod, "get_nous_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_qwen_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_xai_oauth_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_minimax_oauth_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(gateway_mod, "find_gateway_pids", lambda exclude_pids=None: [], raising=False)
+
+    platform_registry.unregister("testchat")
+
+    def fake_discover_plugins():
+        platform_registry.register(
+            PlatformEntry(
+                name="testchat",
+                label="TestChat",
+                adapter_factory=lambda cfg: object(),
+                check_fn=lambda: True,
+                source="plugin",
+                plugin_name="testchat-plugin",
+            )
+        )
+        return []
+
+    monkeypatch.setattr(plugins_mod, "discover_plugins", fake_discover_plugins)
+    try:
+        status_mod.show_status(SimpleNamespace(all=False, deep=False))
+        output = capsys.readouterr().out
+    finally:
+        platform_registry.unregister("testchat")
+
+    assert "TestChat" in output
+    assert "configured (plugin)" in output
+
+
 # ---------------------------------------------------------------------------
 # Helpers shared by xAI OAuth status tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Trigger plugin discovery before `hermes status` reads plugin-registered platform entries
- Preserve existing built-in platform status output
- Add regression coverage for a plugin-registered messaging platform appearing in the status output

## Test Plan
- `/home/rivuza/hermes-agent/.venv/bin/python -m pytest tests/hermes_cli/test_status.py::test_show_status_includes_plugin_registered_platform -q`
- `/home/rivuza/hermes-agent/.venv/bin/python -m pytest tests/hermes_cli/test_status.py -q`

Closes #44119