### PR TITLE
fix: dedupe Kimi provider row in /model picker

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1213,7 +1213,8 @@ def list_authenticated_providers(
     from hermes_cli.models import (
         OPENROUTER_MODELS, _PROVIDER_MODELS,
         _MODELS_DEV_PREFERRED, _merge_with_models_dev, cached_provider_model_ids,
-        get_curated_nous_model_ids,
+        get_curated_nous_model_ids, normalize_provider as _normalize_provider,
+        provider_label as _provider_label,
     )
 
     results: List[dict] = []
@@ -1362,10 +1363,15 @@ def list_authenticated_providers(
         if not isinstance(pdata, dict):
             continue
 
+        slug = _normalize_provider(hermes_id)
+        if slug.lower() in seen_slugs:
+            seen_mdev_ids.add(mdev_id)
+            continue
+
         # Prefer auth.py PROVIDER_REGISTRY for env var names — it's our
         # source of truth.  models.dev can have wrong mappings (e.g.
         # minimax-cn → MINIMAX_API_KEY instead of MINIMAX_CN_API_KEY).
-        pconfig = PROVIDER_REGISTRY.get(hermes_id)
+        pconfig = PROVIDER_REGISTRY.get(slug) or PROVIDER_REGISTRY.get(hermes_id)
         # Skip non-API-key auth providers here — they are handled in
         # section 2 (HERMES_OVERLAYS) with proper auth store checking.
         if pconfig and pconfig.auth_type != "api_key":
@@ -1383,7 +1389,8 @@ def list_authenticated_providers(
             try:
                 from hermes_cli.auth import _load_auth_store
                 store = _load_auth_store()
-                if store and store.get("credential_pool", {}).get(hermes_id):
+                pool = store.get("credential_pool", {}) if store else {}
+                if pool.get(slug) or pool.get(hermes_id):
                     has_creds = True
             except Exception:
                 pass
@@ -1394,17 +1401,16 @@ def list_authenticated_providers(
         # /model picker sees the SAME list `hermes model` would build, with
         # disk caching to keep the picker open snappy. Falls back to the
         # curated static list when the live fetcher returns nothing.
-        model_ids = cached_provider_model_ids(hermes_id)
+        model_ids = cached_provider_model_ids(slug)
         if not model_ids:
-            model_ids = curated.get(hermes_id, [])
-            if hermes_id in _MODELS_DEV_PREFERRED:
-                model_ids = _merge_with_models_dev(hermes_id, model_ids)
+            model_ids = curated.get(slug, [])
+            if slug in _MODELS_DEV_PREFERRED:
+                model_ids = _merge_with_models_dev(slug, model_ids)
         total = len(model_ids)
         top = model_ids[:max_models]
 
-        slug = hermes_id
         pinfo = _mdev_pinfo(mdev_id)
-        display_name = pinfo.name if pinfo else mdev_id
+        display_name = _provider_label(slug) if slug != hermes_id else (pinfo.name if pinfo else mdev_id)
 
         results.append({
             "slug": slug,

--- a/tests/hermes_cli/test_overlay_slug_resolution.py
+++ b/tests/hermes_cli/test_overlay_slug_resolution.py
@@ -68,6 +68,15 @@ def test_kimi_for_coding_overlay_uses_hermes_slug():
     assert kimi_mdev is None, "kimi-for-coding slug should not appear (resolved to kimi-coding)"
 
 
+@patch.dict(os.environ, {"KIMI_API_KEY": "fake-key"}, clear=False)
+def test_kimi_alias_does_not_duplicate_canonical_provider():
+    """Kimi should appear once as the canonical kimi-coding row, not again as bare kimi."""
+    providers = list_authenticated_providers(current_provider="kimi-coding")
+
+    kimi_slugs = [p["slug"] for p in providers if p["slug"] in {"kimi", "kimi-coding"}]
+    assert kimi_slugs == ["kimi-coding"]
+
+
 @patch.dict(os.environ, {"KILOCODE_API_KEY": "fake-key"}, clear=False)
 def test_kilo_overlay_uses_hermes_slug():
     """kilo overlay should resolve to slug='kilocode'."""


### PR DESCRIPTION
## Summary
- normalize models.dev alias rows to Hermes canonical provider slugs before adding them to the picker
- make Kimi aliases render once as `kimi-coding` instead of adding an extra bare `kimi` row
- add a regression test covering the duplicate Kimi provider case

## Test Plan
- pytest tests/hermes_cli/test_overlay_slug_resolution.py -q
- pytest tests/hermes_cli/test_overlay_slug_resolution.py tests/hermes_cli/test_list_picker_providers.py -q
- verified `list_authenticated_providers()` returns only `kimi-coding` on a real configured host