### PR TITLE
feat(profile): add link command for git-backed profile directories

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10121,6 +10121,55 @@ def cmd_profile(args):
         print()
 
 
+    elif action == "link":
+        from hermes_cli.profiles import link_profile, check_profile_links, unlink_profile
+
+        do_check = getattr(args, "check", False)
+        do_unlink = getattr(args, "unlink", False)
+        move_existing = getattr(args, "move", False)
+
+        if do_check:
+            name = args.profile_name
+            if not name:
+                print("Error: profile name required for --check")
+                sys.exit(1)
+            try:
+                for line in check_profile_links(name):
+                    print(line)
+            except (FileNotFoundError, ValueError) as e:
+                print(f"Error: {e}")
+                sys.exit(1)
+            return
+
+        if do_unlink:
+            name = args.profile_name
+            if not name:
+                print("Error: profile name required for --unlink")
+                sys.exit(1)
+            try:
+                for line in unlink_profile(name):
+                    print(line)
+            except (FileNotFoundError, ValueError) as e:
+                print(f"Error: {e}")
+                sys.exit(1)
+            return
+
+        # Default: create link
+        name = args.profile_name
+        path = args.path
+        if not name or not path:
+            print("Usage: hermes profile link <name> <path>")
+            print("       hermes profile link --check <name>")
+            print("       hermes profile link --unlink <name>")
+            sys.exit(1)
+        try:
+            for line in link_profile(name, Path(path), move_existing=move_existing):
+                print(line)
+        except (FileNotFoundError, ValueError) as e:
+            print(f"Error: {e}")
+            sys.exit(1)
+
+
 def _render_distribution_plan(plan) -> None:
     """Print a human-readable summary of a pending distribution install."""
     from hermes_cli.profile_distribution import MANIFEST_FILENAME

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -646,6 +646,214 @@ def write_profile_meta(
 
 
 # ---------------------------------------------------------------------------
+# Profile linking (git-backed profiles, issue #44179)
+# ---------------------------------------------------------------------------
+
+# Files/dirs that are portable and safe to symlink to an external git repo.
+_LINKABLE_ITEMS: list[str] = [
+    "SOUL.md",
+    "config.yaml",
+    "mcp.json",
+    "skills",
+    "cron",
+    "plugins",
+]
+
+# Metadata file written by link_profile to record the link target.
+_LINK_META_FILE = ".profile-link.json"
+
+
+def link_profile(
+    profile_name: str,
+    external_path: Path,
+    *,
+    move_existing: bool = False,
+) -> list[str]:
+    """Symlink portable profile files from *external_path* into the profile dir.
+
+    The external directory becomes the source of truth — ``git pull`` there
+    instantly updates what Hermes reads.  Returns a list of human-readable
+    status lines describing what was linked / skipped.
+
+    Raises ``ValueError`` or ``FileNotFoundError`` on invalid input.
+    """
+    validate_profile_name(profile_name)
+    canon = normalize_profile_name(profile_name)
+    profile_dir = get_profile_dir(canon)
+
+    if not profile_dir.is_dir():
+        raise FileNotFoundError(
+            f"Profile '{canon}' does not exist. Create it first with "
+            f"`hermes profile create {canon}`."
+        )
+    if not external_path.is_absolute():
+        external_path = Path.cwd() / external_path
+    external_path = external_path.resolve()
+    if not external_path.is_dir():
+        raise FileNotFoundError(f"External path does not exist: {external_path}")
+    # Check it's a git repo (or inside one)
+    git_dir = external_path / ".git"
+    if not git_dir.exists():
+        # Walk up to check parent dirs
+        found = False
+        for parent in external_path.parents:
+            if (parent / ".git").exists():
+                found = True
+                break
+        if not found:
+            raise ValueError(
+                f"External path is not a git repository: {external_path}\n"
+                f"Initialize with `git init` or point to an existing repo."
+            )
+
+    results: list[str] = []
+    link_meta: dict[str, str] = {}
+
+    for item_name in _LINKABLE_ITEMS:
+        src = external_path / item_name
+        dst = profile_dir / item_name
+
+        if not src.exists():
+            results.append(f"  SKIP  {item_name} — not found in external repo")
+            continue
+
+        if dst.is_symlink():
+            # Already a symlink — update target if different
+            current_target = dst.resolve()
+            if current_target == src.resolve():
+                results.append(f"  OK    {item_name} — already linked")
+                link_meta[item_name] = str(src)
+                continue
+            else:
+                dst.unlink()
+        elif dst.exists():
+            if move_existing:
+                # Move existing profile content into external repo
+                if dst.is_dir():
+                    if src.is_dir():
+                        # Merge: copy files from dst into src
+                        for child in dst.iterdir():
+                            target = src / child.name
+                            if not target.exists():
+                                shutil.move(str(child), str(src))
+                        shutil.rmtree(dst)
+                    else:
+                        shutil.rmtree(dst)
+                else:
+                    # dst is a file, src is also a file — back up dst
+                    backup = dst.with_suffix(dst.suffix + ".bak")
+                    shutil.move(str(dst), str(backup))
+                    results.append(f"  BACKUP {item_name} → {backup.name}")
+            else:
+                results.append(
+                    f"  SKIP  {item_name} — exists in profile (use --move to migrate)"
+                )
+                continue
+
+        # Create symlink: dst (profile) → src (external)
+        dst.symlink_to(src)
+        link_meta[item_name] = str(src)
+        results.append(f"  LINK  {item_name} → {src}")
+
+    # Write link metadata
+    meta_path = profile_dir / _LINK_META_FILE
+    meta_path.write_text(
+        json.dumps(
+            {"external_path": str(external_path), "linked_items": link_meta},
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    results.append(f"\n  Link metadata saved to {meta_path}")
+    results.append(
+        f"  External repo: {external_path}"
+    )
+    return results
+
+
+def check_profile_links(profile_name: str) -> list[str]:
+    """Verify that symlinks from a linked profile are intact.
+
+    Returns a list of status lines.  Raises if the profile has no link metadata.
+    """
+    validate_profile_name(profile_name)
+    canon = normalize_profile_name(profile_name)
+    profile_dir = get_profile_dir(canon)
+
+    meta_path = profile_dir / _LINK_META_FILE
+    if not meta_path.exists():
+        raise FileNotFoundError(
+            f"Profile '{canon}' is not linked. "
+            f"Use `hermes profile link {canon} <path>` first."
+        )
+
+    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    external = Path(meta["external_path"])
+    results: list[str] = [f"Link target: {external}"]
+
+    for item_name, expected_src in meta.get("linked_items", {}).items():
+        dst = profile_dir / item_name
+        src = Path(expected_src)
+
+        if not dst.is_symlink():
+            results.append(f"  BROKEN {item_name} — not a symlink")
+        elif not dst.exists():
+            results.append(f"  BROKEN {item_name} — target missing: {src}")
+        elif dst.resolve() != src.resolve():
+            results.append(
+                f"  CHANGED {item_name} — points to {dst.resolve()}, expected {src}"
+            )
+        else:
+            results.append(f"  OK     {item_name}")
+
+    return results
+
+
+def unlink_profile(profile_name: str) -> list[str]:
+    """Remove symlinks and restore regular files for a linked profile.
+
+    Copies the external files back into the profile directory so it's
+    self-contained again.  Returns a list of status lines.
+    """
+    validate_profile_name(profile_name)
+    canon = normalize_profile_name(profile_name)
+    profile_dir = get_profile_dir(canon)
+
+    meta_path = profile_dir / _LINK_META_FILE
+    if not meta_path.exists():
+        raise FileNotFoundError(
+            f"Profile '{canon}' is not linked. Nothing to unlink."
+        )
+
+    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    results: list[str] = []
+
+    for item_name in meta.get("linked_items", {}):
+        dst = profile_dir / item_name
+
+        if not dst.is_symlink():
+            results.append(f"  SKIP  {item_name} — not a symlink")
+            continue
+
+        src = dst.resolve()
+        dst.unlink()
+
+        if src.exists():
+            if src.is_dir():
+                shutil.copytree(str(src), str(dst))
+            else:
+                shutil.copy2(str(src), str(dst))
+            results.append(f"  RESTORE {item_name} — copied from {src}")
+        else:
+            results.append(f"  REMOVE  {item_name} — target was missing")
+
+    # Remove link metadata
+    meta_path.unlink()
+    results.append(f"\n  Link metadata removed. Profile is now self-contained.")
+    return results
+
+
+# ---------------------------------------------------------------------------
 # CRUD operations
 # ---------------------------------------------------------------------------
 

--- a/hermes_cli/subcommands/profile.py
+++ b/hermes_cli/subcommands/profile.py
@@ -200,4 +200,42 @@ def build_profile_parser(subparsers, *, cmd_profile: Callable) -> None:
     )
     profile_info.add_argument("profile_name", help="Profile to inspect")
 
+    # ---------- Link subcommand (issue #44179) ----------
+    profile_link = profile_subparsers.add_parser(
+        "link",
+        help="Link a profile to an external git repo via symlinks",
+        description=(
+            "Create symlinks from the profile directory to an external "
+            "git-managed folder.  After linking, the external repo is the "
+            "source of truth — git pull instantly updates Hermes."
+        ),
+    )
+    profile_link.add_argument(
+        "profile_name",
+        nargs="?",
+        default=None,
+        help="Profile to link",
+    )
+    profile_link.add_argument(
+        "path",
+        nargs="?",
+        default=None,
+        help="Path to external git repository",
+    )
+    profile_link.add_argument(
+        "--move",
+        action="store_true",
+        help="Move existing profile files into the external repo before linking",
+    )
+    profile_link.add_argument(
+        "--check",
+        action="store_true",
+        help="Verify symlinks are intact (no profile_name/path required)",
+    )
+    profile_link.add_argument(
+        "--unlink",
+        action="store_true",
+        help="Remove symlinks and restore regular files",
+    )
+
     profile_parser.set_defaults(func=cmd_profile)

--- a/tests/hermes_cli/test_profile_link.py
+++ b/tests/hermes_cli/test_profile_link.py
@@ -1,0 +1,280 @@
+"""Tests for ``hermes profile link`` — git-backed profile symlinks (issue #44179)."""
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def profile_env(tmp_path, monkeypatch):
+    """Create a minimal profile environment for testing.
+
+    Returns (hermes_home, profile_dir, external_repo).
+    """
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    profiles_root = hermes_home / "profiles"
+    profiles_root.mkdir()
+
+    # Create a test profile
+    profile_dir = profiles_root / "testprofile"
+    profile_dir.mkdir()
+    (profile_dir / "config.yaml").write_text("model: test\n")
+    (profile_dir / "SOUL.md").write_text("# Test SOUL\n")
+    (profile_dir / "skills").mkdir()
+    (profile_dir / "skills" / "example.skill").write_text("example")
+
+    # Create an external git repo
+    external = tmp_path / "my-dotfiles"
+    external.mkdir()
+    subprocess.run(["git", "init"], cwd=str(external), capture_output=True)
+    (external / "SOUL.md").write_text("# External SOUL\n")
+    (external / "config.yaml").write_text("model: external\n")
+    (external / "skills").mkdir()
+    (external / "skills" / "remote.skill").write_text("remote skill")
+    (external / ".gitignore").write_text("*.pyc\n")
+    subprocess.run(["git", "add", "."], cwd=str(external), capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "init"],
+        cwd=str(external), capture_output=True,
+        env={**os.environ, "GIT_AUTHOR_NAME": "Test", "GIT_AUTHOR_EMAIL": "t@t.com",
+             "GIT_COMMITTER_NAME": "Test", "GIT_COMMITTER_EMAIL": "t@t.com"},
+    )
+
+    # Patch hermes home
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    # Patch get_profile_dir and related functions
+    import hermes_cli.profiles as prof
+    monkeypatch.setattr(prof, "_get_profiles_root", lambda: profiles_root)
+    monkeypatch.setattr(prof, "_get_default_hermes_home", lambda: hermes_home)
+
+    return hermes_home, profile_dir, external
+
+
+class TestLinkProfile:
+    """Tests for link_profile()."""
+
+    def test_link_creates_symlinks(self, profile_env):
+        hermes_home, profile_dir, external = profile_env
+        from hermes_cli.profiles import link_profile
+
+        results = link_profile("testprofile", external, move_existing=True)
+
+        # config.yaml and SOUL.md should be symlinks
+        assert (profile_dir / "config.yaml").is_symlink()
+        assert (profile_dir / "SOUL.md").is_symlink()
+        assert (profile_dir / "skills").is_symlink()
+
+        # Symlinks should point to external repo
+        assert (profile_dir / "config.yaml").resolve() == (external / "config.yaml").resolve()
+        assert (profile_dir / "SOUL.md").resolve() == (external / "SOUL.md").resolve()
+
+        # Metadata file should exist
+        meta_path = profile_dir / ".profile-link.json"
+        assert meta_path.exists()
+        meta = json.loads(meta_path.read_text())
+        assert meta["external_path"] == str(external.resolve())
+        assert "config.yaml" in meta["linked_items"]
+        assert "SOUL.md" in meta["linked_items"]
+
+        # Results should mention LINK
+        assert any("LINK" in line for line in results)
+
+    def test_link_skips_missing_items(self, profile_env):
+        hermes_home, profile_dir, external = profile_env
+        from hermes_cli.profiles import link_profile
+
+        # mcp.json doesn't exist in external repo
+        results = link_profile("testprofile", external)
+
+        assert any("SKIP" in line and "mcp.json" in line for line in results)
+
+    def test_link_rejects_non_git_repo(self, profile_env):
+        hermes_home, profile_dir, external = profile_env
+        from hermes_cli.profiles import link_profile
+
+        non_repo = external.parent / "not-a-repo"
+        non_repo.mkdir()
+
+        with pytest.raises(ValueError, match="not a git repository"):
+            link_profile("testprofile", non_repo)
+
+    def test_link_rejects_missing_profile(self, profile_env):
+        hermes_home, profile_dir, external = profile_env
+        from hermes_cli.profiles import link_profile
+
+        with pytest.raises(FileNotFoundError, match="does not exist"):
+            link_profile("nonexistent", external)
+
+    def test_link_rejects_missing_external_path(self, profile_env):
+        hermes_home, profile_dir, external = profile_env
+        from hermes_cli.profiles import link_profile
+
+        with pytest.raises(FileNotFoundError, match="does not exist"):
+            link_profile("testprofile", Path("/tmp/nonexistent_path_xyz"))
+
+    def test_link_idempotent(self, profile_env):
+        """Running link twice should be safe (OK status for existing links)."""
+        hermes_home, profile_dir, external = profile_env
+        from hermes_cli.profiles import link_profile
+
+        link_profile("testprofile", external, move_existing=True)
+        results = link_profile("testprofile", external)
+
+        assert any("OK" in line for line in results)
+
+    def test_link_skips_existing_non_symlink(self, profile_env):
+        """Without --move, existing regular files should be skipped."""
+        hermes_home, profile_dir, external = profile_env
+        from hermes_cli.profiles import link_profile
+
+        results = link_profile("testprofile", external)
+
+        # config.yaml existed as a regular file, should be skipped
+        assert any("SKIP" in line and "config.yaml" in line for line in results)
+
+    def test_link_with_move(self, profile_env):
+        """With --move, existing files should be backed up and replaced."""
+        hermes_home, profile_dir, external = profile_env
+        from hermes_cli.profiles import link_profile
+
+        results = link_profile("testprofile", external, move_existing=True)
+
+        # config.yaml should now be a symlink
+        assert (profile_dir / "config.yaml").is_symlink()
+        assert (profile_dir / "config.yaml").resolve() == (external / "config.yaml").resolve()
+
+        # Original should be backed up
+        assert (profile_dir / "config.yaml.bak").exists()
+
+    def test_link_reads_external_content(self, profile_env):
+        """After linking, reading the profile file should show external content."""
+        hermes_home, profile_dir, external = profile_env
+        from hermes_cli.profiles import link_profile
+
+        link_profile("testprofile", external, move_existing=True)
+
+        # Read through the symlink
+        content = (profile_dir / "config.yaml").read_text()
+        assert content == "model: external\n"
+
+
+class TestCheckProfileLinks:
+    """Tests for check_profile_links()."""
+
+    def test_check_ok(self, profile_env):
+        hermes_home, profile_dir, external = profile_env
+        from hermes_cli.profiles import link_profile, check_profile_links
+
+        link_profile("testprofile", external, move_existing=True)
+        results = check_profile_links("testprofile")
+
+        assert any("OK" in line for line in results)
+        assert any(str(external.resolve()) in line for line in results)
+
+    def test_check_detects_broken(self, profile_env):
+        hermes_home, profile_dir, external = profile_env
+        from hermes_cli.profiles import link_profile, check_profile_links
+
+        link_profile("testprofile", external, move_existing=True)
+
+        # Remove the external file to break the symlink
+        (external / "config.yaml").unlink()
+
+        results = check_profile_links("testprofile")
+        assert any("BROKEN" in line and "config.yaml" in line for line in results)
+
+    def test_check_rejects_unlinked_profile(self, profile_env):
+        hermes_home, profile_dir, external = profile_env
+        from hermes_cli.profiles import check_profile_links
+
+        with pytest.raises(FileNotFoundError, match="not linked"):
+            check_profile_links("testprofile")
+
+
+class TestUnlinkProfile:
+    """Tests for unlink_profile()."""
+
+    def test_unlink_restores_files(self, profile_env):
+        hermes_home, profile_dir, external = profile_env
+        from hermes_cli.profiles import link_profile, unlink_profile
+
+        link_profile("testprofile", external, move_existing=True)
+        results = unlink_profile("testprofile")
+
+        # Should no longer be symlinks
+        assert not (profile_dir / "config.yaml").is_symlink()
+        assert not (profile_dir / "SOUL.md").is_symlink()
+
+        # Files should contain external content (copied back)
+        assert (profile_dir / "config.yaml").read_text() == "model: external\n"
+
+        # Metadata should be removed
+        assert not (profile_dir / ".profile-link.json").exists()
+
+        assert any("RESTORE" in line for line in results)
+
+    def test_unlink_rejects_unlinked_profile(self, profile_env):
+        hermes_home, profile_dir, external = profile_env
+        from hermes_cli.profiles import unlink_profile
+
+        with pytest.raises(FileNotFoundError, match="not linked"):
+            unlink_profile("testprofile")
+
+
+class TestParserIntegration:
+    """Test the CLI parser accepts link subcommand."""
+
+    def test_parser_accepts_link(self):
+        """Verify the link subcommand is registered."""
+        import argparse
+        from hermes_cli.subcommands.profile import build_profile_parser
+
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers()
+        build_profile_parser(subparsers, cmd_profile=lambda x: None)
+
+        # Should parse without error
+        args = parser.parse_args(["profile", "link", "myprofile", "/tmp/repo"])
+        assert args.profile_action == "link"
+        assert args.profile_name == "myprofile"
+        assert args.path == "/tmp/repo"
+
+    def test_parser_accepts_link_check(self):
+        import argparse
+        from hermes_cli.subcommands.profile import build_profile_parser
+
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers()
+        build_profile_parser(subparsers, cmd_profile=lambda x: None)
+
+        args = parser.parse_args(["profile", "link", "--check", "myprofile"])
+        assert args.check is True
+        assert args.profile_name == "myprofile"
+
+    def test_parser_accepts_link_unlink(self):
+        import argparse
+        from hermes_cli.subcommands.profile import build_profile_parser
+
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers()
+        build_profile_parser(subparsers, cmd_profile=lambda x: None)
+
+        args = parser.parse_args(["profile", "link", "--unlink", "myprofile"])
+        assert args.unlink is True
+        assert args.profile_name == "myprofile"
+
+    def test_parser_accepts_link_move(self):
+        import argparse
+        from hermes_cli.subcommands.profile import build_profile_parser
+
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers()
+        build_profile_parser(subparsers, cmd_profile=lambda x: None)
+
+        args = parser.parse_args(["profile", "link", "--move", "myprofile", "/tmp/repo"])
+        assert args.move is True


### PR DESCRIPTION
## Problem

Users want to keep their Hermes profile (SOUL.md, config.yaml, skills/, cron/) version-controlled in a git repo, but the distribution system (`hermes profile install`) strips `.git/` after cloning — the installed profile is no longer a live git checkout.

A third-party tool ([agentlink](https://github.com/codingforentrepreneurs/agentlink)) exists specifically to fill this gap, confirming unmet demand.

## Solution

Add `hermes profile link <name> <path>` that symlinks portable profile files from an external git repository into the profile directory.

**Commands:**
- `hermes profile link <name> <path>` — create symlinks to external git repo
- `hermes profile link --check <name>` — verify symlinks are intact
- `hermes profile link --unlink <name>` — remove symlinks, restore regular files
- `hermes profile link --move <name> <path>` — migrate existing profile files into external repo before linking

**Linked items:** SOUL.md, config.yaml, mcp.json, skills/, cron/, plugins/
**Excluded (runtime-only):** .env, auth.json, memories/, sessions/, state.db, logs/

After linking, the external git repo is the source of truth. `git pull` in the repo instantly updates what Hermes reads. No reinstall needed.

## Implementation

- `hermes_cli/profiles.py` — `link_profile()`, `check_profile_links()`, `unlink_profile()` (208 lines)
- `hermes_cli/subcommands/profile.py` — parser for `link` subcommand (38 lines)
- `hermes_cli/main.py` — dispatch in `cmd_profile()` (49 lines)
- `tests/hermes_cli/test_profile_link.py` — 18 tests covering all paths

## Testing

```
18 passed in 1.19s
```

Closes #44179
