### PR TITLE
fix(feishu): ignore thread_id in DM quoted replies to prevent isolated sessions

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -3123,6 +3123,10 @@ class FeishuAdapter(BasePlatformAdapter):
                 text = f"{hint}\n\n{text}" if text else hint
 
         thread_id = getattr(message, "thread_id", None) or getattr(message, "root_id", None) or None
+        # Feishu DMs do not support real threads; quoted replies populate
+        # thread_id/root_id but should not create isolated sessions.
+        if chat_type == "p2p":
+            thread_id = None
         reply_to_message_id = (
             getattr(message, "parent_id", None)
             or getattr(message, "upper_message_id", None)

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -4596,6 +4596,57 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
         )
         adapter._dispatch_inbound_event.assert_not_called()
 
+    def test_dm_quoted_reply_does_not_create_thread_session(self):
+        """Quoted replies in Feishu DMs populate thread_id/root_id but must not
+        create isolated sessions.  Regression guard for #44028."""
+        adapter = self._build_adapter()
+        message = SimpleNamespace(
+            content=json.dumps({"text": "yes, that one"}),
+            message_type="text",
+            message_id="m_dm_quoted",
+            mentions=[],
+            chat_id="oc_dm_chat",
+            parent_id="om_parent",
+            upper_message_id=None,
+            thread_id="om_thread_root",
+            root_id="om_thread_root",
+        )
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message, message=message, sender_id=None,
+                chat_type="p2p", message_id="m_dm_quoted",
+            )
+        )
+        # build_source must be called with thread_id=None despite the
+        # message having thread_id/root_id set.
+        call_kwargs = adapter.build_source.call_args[1]
+        self.assertIsNone(call_kwargs.get("thread_id"),
+                          "DM quoted reply must not pass thread_id to build_source")
+
+    def test_group_quoted_reply_preserves_thread_id(self):
+        """Group threads should still use thread_id — only DMs are stripped."""
+        adapter = self._build_adapter()
+        message = SimpleNamespace(
+            content=json.dumps({"text": "reply in thread"}),
+            message_type="text",
+            message_id="m_grp_thread",
+            mentions=[],
+            chat_id="oc_group_chat",
+            parent_id="om_parent",
+            upper_message_id=None,
+            thread_id="om_thread_root",
+            root_id=None,
+        )
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message, message=message, sender_id=None,
+                chat_type="group", message_id="m_grp_thread",
+            )
+        )
+        call_kwargs = adapter.build_source.call_args[1]
+        self.assertEqual(call_kwargs.get("thread_id"), "om_thread_root",
+                         "Group thread must preserve thread_id")
+
 
 class TestFeishuFetchMessageText(unittest.TestCase):
     def _build_adapter(self):


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where quoted replies (引用回复) in Feishu DMs create isolated sessions, causing the agent to lose all conversation context. The Lark SDK populates `thread_id` for DM quoted replies, but Feishu DMs don't support real threads — the field is erroneously used to build a different session key.

## Related Issue

Fixes #44028

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/feishu.py`: Clear `thread_id` when `chat_type == "p2p"` so DM quoted replies stay in the normal DM session. Group thread behavior is preserved.
- `tests/gateway/test_feishu.py`: Added two regression tests — DM quoted reply strips thread_id, group reply preserves it.

## How to Test

1. Configure a Feishu bot with DM access
2. Start a conversation with the bot (normal messages work fine)
3. Send a quoted reply to one of the bot's messages
4. Before fix: agent loses context (new empty session created)
5. After fix: agent continues in the same session with full context

```bash
pytest tests/gateway/test_feishu.py::TestFeishuProcessInboundMessage::test_dm_quoted_reply_does_not_create_thread_session tests/gateway/test_feishu.py::TestFeishuProcessInboundMessage::test_group_quoted_reply_preserves_thread_id -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `FeishuAdapter._process_inbound_message()` (callers: Lark SDK event handler, flows: 1)
- Blast radius: LOW — only affects Feishu DM inbound message processing
- Related patterns: Session key builder uses `thread_id` for group threads; DMs should not use it
