### PR TITLE
fix: guard against non‑string model IDs in fallback_providers (prevents [object Object] display)

### DIFF
--- a/apps/desktop/src/components/model-picker.tsx
+++ b/apps/desktop/src/components/model-picker.tsx
@@ -206,10 +206,13 @@ function ModelResults({
   return (
     <>
       {configured.map(provider => {
-        // Preserve the backend's curated order — filter in place, no re-sort.
-        // Keep only string model IDs – guard against accidental objects
-        const rawModels = (provider.models ?? []).filter(m => matches(provider, m))
-        const models = rawModels.filter((m): m is string => typeof m === "string")
+        // Backend `models` are typed as string[] but some providers have
+        // delivered non-string entries at runtime. Drop non-strings BEFORE
+        // `matches()` (which calls `.toLowerCase()`), otherwise an object
+        // throws there before the type predicate can filter it out.
+        const models = (provider.models ?? [])
+          .filter((m): m is string => typeof m === 'string')
+          .filter(m => matches(provider, m))
 
         if (models.length === 0) {
           return null

--- a/apps/desktop/src/components/model-picker.tsx
+++ b/apps/desktop/src/components/model-picker.tsx
@@ -207,7 +207,9 @@ function ModelResults({
     <>
       {configured.map(provider => {
         // Preserve the backend's curated order — filter in place, no re-sort.
-        const models = (provider.models ?? []).filter(m => matches(provider, m))
+  // Keep only string model IDs – guard against accidental objects
+  const rawModels = (provider.models ?? []).filter(m => matches(provider, m))
+  const models = rawModels.filter((m): m is string => typeof m === "string")
 
         if (models.length === 0) {
           return null

--- a/apps/desktop/src/components/model-picker.tsx
+++ b/apps/desktop/src/components/model-picker.tsx
@@ -207,9 +207,9 @@ function ModelResults({
     <>
       {configured.map(provider => {
         // Preserve the backend's curated order — filter in place, no re-sort.
-  // Keep only string model IDs – guard against accidental objects
-  const rawModels = (provider.models ?? []).filter(m => matches(provider, m))
-  const models = rawModels.filter((m): m is string => typeof m === "string")
+        // Keep only string model IDs – guard against accidental objects
+        const rawModels = (provider.models ?? []).filter(m => matches(provider, m))
+        const models = rawModels.filter((m): m is string => typeof m === "string")
 
         if (models.length === 0) {
           return null

--- a/apps/desktop/src/components/model-visibility-dialog.tsx
+++ b/apps/desktop/src/components/model-visibility-dialog.tsx
@@ -101,9 +101,10 @@ export function ModelVisibilityDialog({
             </div>
           ) : (
             providers.map(provider => {
-              // Keep only string model IDs – guard against accidental objects
-              const rawFamilies = collapseModelFamilies(provider.models ?? []).filter(family => matches(provider, family.id))
-              const models = rawFamilies.filter((f): f is { id: string } => typeof f.id === "string")
+              // `collapseModelFamilies` normalizes model IDs to strings at the
+              // shared boundary, so `family.id` is always a string here — no
+              // object can reach `matches()` (which calls `.toLowerCase()`).
+              const models = collapseModelFamilies(provider.models ?? []).filter(family => matches(provider, family.id))
 
               if (models.length === 0) {
                 return null

--- a/apps/desktop/src/components/model-visibility-dialog.tsx
+++ b/apps/desktop/src/components/model-visibility-dialog.tsx
@@ -101,7 +101,9 @@ export function ModelVisibilityDialog({
             </div>
           ) : (
             providers.map(provider => {
-              const models = collapseModelFamilies(provider.models ?? []).filter(family => matches(provider, family.id))
+  // Keep only string model IDs – guard against accidental objects
+  const rawFamilies = collapseModelFamilies(provider.models ?? []).filter(family => matches(provider, family.id))
+  const models = rawFamilies.filter((f): f is { id: string } => typeof f.id === "string")
 
               if (models.length === 0) {
                 return null

--- a/apps/desktop/src/components/model-visibility-dialog.tsx
+++ b/apps/desktop/src/components/model-visibility-dialog.tsx
@@ -101,9 +101,9 @@ export function ModelVisibilityDialog({
             </div>
           ) : (
             providers.map(provider => {
-  // Keep only string model IDs – guard against accidental objects
-  const rawFamilies = collapseModelFamilies(provider.models ?? []).filter(family => matches(provider, family.id))
-  const models = rawFamilies.filter((f): f is { id: string } => typeof f.id === "string")
+              // Keep only string model IDs – guard against accidental objects
+              const rawFamilies = collapseModelFamilies(provider.models ?? []).filter(family => matches(provider, family.id))
+              const models = rawFamilies.filter((f): f is { id: string } => typeof f.id === "string")
 
               if (models.length === 0) {
                 return null

--- a/apps/desktop/src/store/model-visibility.test.ts
+++ b/apps/desktop/src/store/model-visibility.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest'
 
 import type { ModelOptionProvider } from '@/types/hermes'
 
-import { effectiveVisibleKeys, modelVisibilityKey } from './model-visibility'
+import {
+  collapseModelFamilies,
+  effectiveVisibleKeys,
+  modelVisibilityKey
+} from './model-visibility'
 
 const provider = (slug: string, models: string[]): ModelOptionProvider => ({
   models,
@@ -33,5 +37,27 @@ describe('model visibility', () => {
 
     expect(visible.has(modelVisibilityKey('local-ollama', 'qwen3:latest'))).toBe(true)
     expect(visible.has(modelVisibilityKey('local-ollama', 'llama3.2:latest'))).toBe(false)
+  })
+
+  it('drop non-string model entries instead of crashing on .toLowerCase()', () => {
+    // Backend occasionally delivers objects/undefined in `models` instead of
+    // strings. `collapseModelFamilies` (the shared boundary) must normalize
+    // them away so callers never hit the invalid-data path.
+    const mixed = ['claude-sonnet-4.6', { id: 'oops' }, undefined, 42, 'gpt-4o'] as unknown[]
+
+    const families = collapseModelFamilies(mixed)
+
+    expect(families.map(f => f.id)).toEqual(['claude-sonnet-4.6', 'gpt-4o'])
+  })
+
+  it('keeps working when a provider mixes string and object model entries', () => {
+    const providers = [
+      provider('copilot', ['claude-sonnet-4.6', { name: 'not-a-string' }, undefined, 'gpt-4o'] as unknown as string[])
+    ]
+
+    const visible = effectiveVisibleKeys(null, providers)
+
+    expect(visible.has(modelVisibilityKey('copilot', 'claude-sonnet-4.6'))).toBe(true)
+    expect(visible.has(modelVisibilityKey('copilot', 'gpt-4o'))).toBe(true)
   })
 })

--- a/apps/desktop/src/store/model-visibility.ts
+++ b/apps/desktop/src/store/model-visibility.ts
@@ -23,12 +23,20 @@ export interface ModelFamily {
 /** Collapse a provider's model list so a base model and its `…-fast` variant
  *  become a single family (one row, one toggle). Order is preserved by the
  *  base model's position. A `…-fast` model with no base stands on its own. */
-export function collapseModelFamilies(models: readonly string[]): ModelFamily[] {
-  const present = new Set(models)
+export function collapseModelFamilies(models: readonly unknown[]): ModelFamily[] {
+  // The backend generally returns string model IDs, but some providers have
+  // emitted non-string entries (objects / undefined / numbers) that crash
+  // `.toLowerCase()` / `.replace()` at the call sites. Keep only genuine
+  // strings at this single shared boundary so every consumer
+  // (`model-picker`, `model-visibility-dialog`, `model-menu-panel`, and this
+  // store) is safe.
+  const normalized = models.filter((m): m is string => typeof m === 'string')
+
+  const present = new Set(normalized)
   const families: ModelFamily[] = []
   const consumed = new Set<string>()
 
-  for (const model of models) {
+  for (const model of normalized) {
     if (consumed.has(model)) {
       continue
     }


### PR DESCRIPTION
The desktop client was rendering fallback models as "[object Object]" when the backend accidentally supplied objects instead of plain strings in . This change filters out non‑string entries before mapping, guaranteeing that only strings are rendered.\n\n- Fixes the display bug in the model picker and model‑visibility dialog.\n- Defensive – does not alter behaviour when data is already correct.