### PR TITLE
fix: preserve binary files in GitHub skill installs

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -75,6 +75,49 @@ class TestParseFrontmatterQuick:
 
 
 # ---------------------------------------------------------------------------
+# GitHubSource._fetch_file_content
+# ---------------------------------------------------------------------------
+
+
+class TestFetchFileContent:
+    def _source(self):
+        return GitHubSource(auth=MagicMock(spec=GitHubAuth))
+
+    def _response(self, content: bytes, content_type: str, encoding: str = "utf-8"):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.content = content
+        resp.headers = {"content-type": content_type}
+        resp.encoding = encoding
+        return resp
+
+    def test_text_skill_file_decodes_to_string(self):
+        src = self._source()
+        with patch.object(
+            src,
+            "_github_get",
+            return_value=self._response(b"# Skill\n", "text/plain; charset=utf-8"),
+        ):
+            content = src._fetch_file_content("acme/skills", "demo/SKILL.md")
+
+        assert content == "# Skill\n"
+
+    def test_binary_skill_asset_preserves_raw_bytes(self):
+        src = self._source()
+        png_bytes = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\xff"
+        with patch.object(
+            src,
+            "_github_get",
+            return_value=self._response(png_bytes, "image/png"),
+        ):
+            content = src._fetch_file_content("acme/skills", "demo/assets/icon.png")
+
+        assert isinstance(content, bytes)
+        assert content == png_bytes
+        assert content.startswith(b"\x89PNG\r\n\x1a\n")
+
+
+# ---------------------------------------------------------------------------
 # GitHubSource skills.sh.json grouping sidecar (category support)
 # ---------------------------------------------------------------------------
 

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -61,6 +61,61 @@ INDEX_CACHE_TTL = 3600  # 1 hour
 _REDIRECT_STATUS_CODES = {301, 302, 303, 307, 308}
 _MAX_SKILL_FETCH_REDIRECTS = 5
 
+_TEXT_SKILL_FILE_EXTENSIONS = {
+    "",
+    ".adoc",
+    ".cfg",
+    ".conf",
+    ".css",
+    ".csv",
+    ".env",
+    ".gitignore",
+    ".htm",
+    ".html",
+    ".ini",
+    ".jinja",
+    ".jinja2",
+    ".js",
+    ".json",
+    ".jsonl",
+    ".jsx",
+    ".lock",
+    ".lua",
+    ".md",
+    ".mdx",
+    ".py",
+    ".rb",
+    ".rst",
+    ".sh",
+    ".sql",
+    ".svg",
+    ".toml",
+    ".ts",
+    ".tsx",
+    ".txt",
+    ".xml",
+    ".yaml",
+    ".yml",
+}
+
+_TEXT_CONTENT_TYPES = (
+    "text/",
+    "application/json",
+    "application/javascript",
+    "application/x-yaml",
+    "application/xml",
+    "application/yaml",
+)
+
+
+def _is_probably_text_skill_file(path: str, content_type: str = "") -> bool:
+    """Return True for skill files that should be decoded as UTF-8 text."""
+    suffix = Path(path).suffix.lower()
+    if suffix in _TEXT_SKILL_FILE_EXTENSIONS:
+        return True
+    media_type = content_type.split(";", 1)[0].strip().lower()
+    return any(media_type.startswith(prefix) for prefix in _TEXT_CONTENT_TYPES)
+
 
 # ---------------------------------------------------------------------------
 # Data models
@@ -513,7 +568,7 @@ class GitHubSource(SkillSource):
         skill_md_path = f"{skill_path}/SKILL.md"
 
         content = self._fetch_file_content(repo, skill_md_path)
-        if not content:
+        if not content or isinstance(content, bytes):
             return None
 
         fm = self._parse_frontmatter_quick(content)
@@ -729,8 +784,8 @@ class GitHubSource(SkillSource):
         return last_resp
 
 
-    def _download_directory(self, repo: str, path: str) -> Dict[str, str]:
-        """Recursively download all text files from a GitHub directory.
+    def _download_directory(self, repo: str, path: str) -> Dict[str, Union[str, bytes]]:
+        """Recursively download all files from a GitHub directory.
 
         Uses the Git Trees API first (single call for the entire tree) to
         avoid per-directory rate limiting that causes silent subdirectory
@@ -743,7 +798,7 @@ class GitHubSource(SkillSource):
         logger.debug("Tree API unavailable for %s/%s, falling back to Contents API", repo, path)
         return self._download_directory_recursive(repo, path)
 
-    def _download_directory_via_tree(self, repo: str, path: str) -> Optional[Dict[str, str]]:
+    def _download_directory_via_tree(self, repo: str, path: str) -> Optional[Dict[str, Union[str, bytes]]]:
         """Download an entire directory using the Git Trees API (single request).
 
         Returns:
@@ -770,7 +825,7 @@ class GitHubSource(SkillSource):
             return {}
 
         # Filter to blobs under our target path and fetch content
-        files: Dict[str, str] = {}
+        files: Dict[str, Union[str, bytes]] = {}
         for item in tree_entries:
             if item.get("type") != "blob":
                 continue
@@ -786,7 +841,7 @@ class GitHubSource(SkillSource):
 
         return files if files else None
 
-    def _download_directory_recursive(self, repo: str, path: str) -> Dict[str, str]:
+    def _download_directory_recursive(self, repo: str, path: str) -> Dict[str, Union[str, bytes]]:
         """Recursively download via Contents API (fallback)."""
         url = f"https://api.github.com/repos/{repo}/contents/{path.rstrip('/')}"
         try:
@@ -801,7 +856,7 @@ class GitHubSource(SkillSource):
         if not isinstance(entries, list):
             return {}
 
-        files: Dict[str, str] = {}
+        files: Dict[str, Union[str, bytes]] = {}
         for entry in entries:
             name = entry.get("name", "")
             entry_type = entry.get("type", "")
@@ -846,16 +901,23 @@ class GitHubSource(SkillSource):
 
         return None
 
-    def _fetch_file_content(self, repo: str, path: str) -> Optional[str]:
-        """Fetch a single file's content from GitHub."""
+    def _fetch_file_content(self, repo: str, path: str) -> Optional[Union[str, bytes]]:
+        """Fetch a single file's content from GitHub, preserving binary bytes."""
         url = f"https://api.github.com/repos/{repo}/contents/{path}"
         resp = self._github_get(
             url,
             headers={**self.auth.get_headers(), "Accept": "application/vnd.github.v3.raw"},
         )
-        if resp is not None and resp.status_code == 200:
-            return resp.text
-        return None
+        if resp is None or resp.status_code != 200:
+            return None
+
+        content_type = resp.headers.get("content-type", "")
+        if _is_probably_text_skill_file(path, content_type):
+            try:
+                return resp.content.decode(resp.encoding or "utf-8")
+            except UnicodeDecodeError:
+                return resp.content
+        return resp.content
 
     def _get_skillsh_groupings(self, repo: str) -> Optional[Dict[str, str]]:
         """Fetch and parse the repo-root ``skills.sh.json`` grouping sidecar.
@@ -878,7 +940,11 @@ class GitHubSource(SkillSource):
             return self._skillsh_groupings[repo]
 
         content = self._fetch_file_content(repo, "skills.sh.json")
-        groupings = self._parse_skillsh_groupings(content) if content else None
+        groupings = (
+            self._parse_skillsh_groupings(content)
+            if content and not isinstance(content, bytes)
+            else None
+        )
         self._skillsh_groupings[repo] = groupings
         return groupings
 


### PR DESCRIPTION
## Summary
- Preserve raw bytes for binary files fetched from GitHub-backed skill directories
- Keep text skill files decoded as UTF-8 for metadata/frontmatter and skills.sh parsing
- Add regression coverage for text decoding and byte-for-byte PNG asset preservation

## Test Plan
- `/home/rivuza/hermes-agent/.venv/bin/python -m pytest tests/tools/test_skills_hub.py::TestFetchFileContent -q`
- `/home/rivuza/hermes-agent/.venv/bin/python -m pytest tests/tools/test_skills_hub.py -q`
- `/home/rivuza/hermes-agent/.venv/bin/python -m pytest tests/tools/test_skills_hub.py tests/hermes_cli/test_skills_hub.py -q`

Closes #44046