### PR TITLE
fix(desktop): don't hard-fail the updater's rebuild when npm is missing

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5160,7 +5160,17 @@ def cmd_gui(args: argparse.Namespace):
         if not npm:
             print("Desktop GUI requires Node.js/npm, but npm was not found on PATH.")
             print("Install Node.js, then run:  hermes gui")
-            sys.exit(1)
+            # The updater's headless rebuild (`hermes desktop --build-only`,
+            # invoked from apps/bootstrap-installer .../update.rs) runs this
+            # right after a successful code update. A missing Node toolchain is
+            # NOT a failed update — the code already updated and the existing
+            # packaged app keeps running — so degrade to a non-fatal skip
+            # (exit 0), mirroring the web-UI build's behaviour during update
+            # (`_build_web_ui(fatal=False)`). Otherwise the bootstrap turns an
+            # optional, recoverable rebuild into a red "UPDATE DIDN'T FINISH"
+            # for CLI-only / Node-less hosts. An interactive launch still fails:
+            # the user explicitly asked to run the app and it can't be built.
+            sys.exit(0 if getattr(args, "build_only", False) else 1)
     else:
         npm = None
 

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -121,6 +121,23 @@ def test_gui_exits_when_npm_missing(tmp_path, monkeypatch, capsys):
     assert "npm was not found" in capsys.readouterr().out
 
 
+def test_gui_build_only_skips_gracefully_when_npm_missing(tmp_path, monkeypatch, capsys):
+    """The updater's headless `hermes desktop --build-only` rebuild must NOT
+    hard-fail when Node/npm is absent: the code update already succeeded and the
+    existing packaged app still runs, so a missing toolchain is a non-fatal skip
+    (exit 0) — otherwise the bootstrap shows a red "UPDATE DIDN'T FINISH" on
+    CLI-only / Node-less hosts. The actionable guidance is still printed."""
+    root = _make_desktop_tree(tmp_path)
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)
+
+    with patch("hermes_cli.main.shutil.which", return_value=None), \
+         pytest.raises(SystemExit) as exc:
+        cli_main.cmd_gui(_ns(build_only=True))
+
+    assert exc.value.code == 0
+    assert "npm was not found" in capsys.readouterr().out
+
+
 def test_gui_skip_build_requires_existing_packaged_app(tmp_path, monkeypatch, capsys):
     root = _make_desktop_tree(tmp_path)
     monkeypatch.setattr(cli_main, "PROJECT_ROOT", root)


### PR DESCRIPTION
## Summary

A user updating via the desktop app's "Update" button got a red **"UPDATE DIDN'T FINISH"** dialog ("Rebuilding the desktop app failed (exit Some(1))"). The bootstrap log shows the actual cause:

```
update stage stage=update  state=Succeeded     # ✓ code update finished
update stage stage=rebuild state=Running
bootstrap.log: Desktop GUI requires Node.js/npm, but npm was not found on PATH.
update stage stage=rebuild state=Failed error=Some("Rebuilding the desktop app failed (exit Some(1))...")
```

The updater (`apps/bootstrap-installer/.../update.rs`) runs `hermes update` then `hermes desktop --build-only`, and treats any non-zero exit from the rebuild as a hard failure. `cmd_gui` calls `sys.exit(1)` when `npm` isn't on PATH — so a host without Node.js gets the alarming "didn't finish" error **even though the code update succeeded and the existing packaged app keeps running**.

This is inconsistent with the web-UI build, which during `hermes update` skips **non-fatally** when npm is missing (`_build_web_ui(fatal=False)` returns `not fatal`).

## Fix

In `cmd_gui`, when npm is missing **and** `--build-only` is set (the updater's headless rebuild), exit `0` with the same "install Node.js, then run `hermes gui`" guidance instead of `1`. The bootstrap then reports the update as complete with a note, rather than a red failure.

An interactive `hermes gui` / `hermes desktop` launch is unchanged — it still exits non-zero, because the user explicitly asked to run the app and it can't be built without Node.

- Commit 1: the one-line exit-code fix (gated on `build_only`).
- Commit 2: regression test.

## Test plan

- [x] `scripts/run_tests.sh tests/hermes_cli/test_gui_command.py` (28 passed)
- New `test_gui_build_only_skips_gracefully_when_npm_missing` asserts exit 0 + guidance for `--build-only`.
- Existing `test_gui_exits_when_npm_missing` still asserts exit 1 for an interactive launch.