### PR TITLE
hindsight: send configured bank missions via acreate_bank and close stale client before retry replacement

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import asyncio
 import atexit
 import importlib
+import inspect
 import json
 import logging
 import os
@@ -598,7 +599,10 @@ class HindsightMemoryProvider(MemoryProvider):
         # Bank
         self._bank_mission = ""
         self._bank_retain_mission: str | None = None
+        self._bank_reflect_mission: str | None = None
+        self._bank_observations_mission: str | None = None
         self._bank_id_template = ""
+        self._configured_bank_cache: set[tuple[str, str | None, str | None, str | None, str | None]] = set()
 
     @property
     def name(self) -> str:
@@ -954,6 +958,61 @@ class HindsightMemoryProvider(MemoryProvider):
             )
         )
 
+    def _bank_config_cache_key(self) -> tuple[str, str | None, str | None, str | None, str | None]:
+        return (
+            self._bank_id,
+            self._bank_mission or None,
+            self._bank_retain_mission,
+            self._bank_reflect_mission,
+            self._bank_observations_mission,
+        )
+
+    def _ensure_bank_config(self, client) -> None:
+        """Apply configured Hindsight bank missions once per bank/config."""
+        if not (
+            self._bank_mission
+            or self._bank_retain_mission
+            or self._bank_reflect_mission
+            or self._bank_observations_mission
+        ):
+            return
+        cache_key = self._bank_config_cache_key()
+        if cache_key in self._configured_bank_cache:
+            return
+        acreate_bank = getattr(client, "acreate_bank", None)
+        if not callable(acreate_bank):
+            logger.warning(
+                "Hindsight client does not expose acreate_bank; configured bank missions were not applied"
+            )
+            self._configured_bank_cache.add(cache_key)
+            return
+        kwargs: dict[str, Any] = {"bank_id": self._bank_id}
+        if self._bank_mission:
+            kwargs["mission"] = self._bank_mission
+        if self._bank_retain_mission:
+            kwargs["retain_mission"] = self._bank_retain_mission
+        if self._bank_reflect_mission:
+            kwargs["reflect_mission"] = self._bank_reflect_mission
+        if self._bank_observations_mission:
+            kwargs["observations_mission"] = self._bank_observations_mission
+        logger.debug("Applying Hindsight bank config: bank=%s", self._bank_id)
+        self._run_sync(acreate_bank(**kwargs))
+        self._configured_bank_cache.add(cache_key)
+
+    def _close_client_for_retry(self, client) -> None:
+        """Best-effort client close before replacing a stale embedded client."""
+        close = getattr(client, "aclose", None)
+        if not callable(close):
+            close = getattr(client, "close", None)
+        if not callable(close):
+            return
+        try:
+            result = close()
+            if inspect.isawaitable(result):
+                self._run_sync(result)
+        except Exception as exc:
+            logger.debug("Hindsight stale client close failed before retry: %s", exc)
+
     def _ensure_writer(self) -> None:
         """Lazy-start the single retain-writer thread.
 
@@ -1025,6 +1084,7 @@ class HindsightMemoryProvider(MemoryProvider):
         """Run an async Hindsight client operation, retrying once after idle shutdown."""
         client = self._get_client()
         try:
+            self._ensure_bank_config(client)
             return self._run_sync(operation(client))
         except Exception as exc:
             if not self._is_retriable_embedded_connection_error(exc):
@@ -1033,9 +1093,11 @@ class HindsightMemoryProvider(MemoryProvider):
                 "Hindsight embedded daemon appears unreachable; recreating client and retrying once: %s",
                 exc,
             )
+            self._close_client_for_retry(client)
             self._client = None
             client = self._get_client()
             self._client = client
+            self._ensure_bank_config(client)
             return self._run_sync(operation(client))
 
     def _probe_url(self) -> str:
@@ -1177,6 +1239,8 @@ class HindsightMemoryProvider(MemoryProvider):
         # Bank options
         self._bank_mission = self._config.get("bank_mission", "")
         self._bank_retain_mission = self._config.get("bank_retain_mission") or None
+        self._bank_reflect_mission = self._config.get("bank_reflect_mission") or None
+        self._bank_observations_mission = self._config.get("bank_observations_mission") or None
 
         # Tags
         self._retain_tags = _normalize_retain_tags(

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -10,6 +10,7 @@ import os
 import re
 import stat
 import sys
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -76,6 +77,7 @@ def _make_mock_client():
         return_value=SimpleNamespace(text="Synthesized answer")
     )
     client.aretain_batch = AsyncMock()
+    client.acreate_bank = AsyncMock()
     client.aclose = AsyncMock()
     return client
 
@@ -592,6 +594,79 @@ class TestToolHandlers:
         assert provider._client is second_client
         first_client.arecall.assert_called_once()
         second_client.arecall.assert_called_once()
+
+    def test_configured_bank_missions_applied_once_before_first_operation(self, provider_with_config):
+        p = provider_with_config(
+            bank_mission="Answer as Hermes, not generic Hindsight.",
+            bank_retain_mission="Extract durable Hermes-specific facts.",
+        )
+        events = []
+
+        async def _acreate_bank(**kwargs):
+            events.append(("config", kwargs))
+            return SimpleNamespace(ok=True)
+
+        async def _aretain(**kwargs):
+            events.append(("retain", kwargs))
+            return SimpleNamespace(ok=True)
+
+        async def _arecall(**kwargs):
+            events.append(("recall", kwargs))
+            return SimpleNamespace(results=[])
+
+        p._client.acreate_bank = AsyncMock(side_effect=_acreate_bank)
+        p._client.aretain = AsyncMock(side_effect=_aretain)
+        p._client.arecall = AsyncMock(side_effect=_arecall)
+        p._run_sync = lambda coro: asyncio.run(coro)
+
+        p.handle_tool_call("hindsight_retain", {"content": "user prefers concise replies"})
+        p.handle_tool_call("hindsight_recall", {"query": "reply style"})
+
+        p._client.acreate_bank.assert_awaited_once()
+        config_kwargs = p._client.acreate_bank.await_args.kwargs
+        assert config_kwargs["bank_id"] == "test-bank"
+        assert config_kwargs["mission"] == "Answer as Hermes, not generic Hindsight."
+        assert config_kwargs["retain_mission"] == "Extract durable Hermes-specific facts."
+        assert [event[0] for event in events] == ["config", "retain", "recall"]
+
+    def test_local_embedded_retry_closes_stale_client_before_replacement(self, provider, monkeypatch):
+        events = []
+        first_client = _make_mock_client()
+        second_client = _make_mock_client()
+
+        async def _failing_recall(**kwargs):
+            raise RuntimeError("Cannot connect to host 127.0.0.1:8888")
+
+        async def _close():
+            events.append("close")
+
+        async def _recovered_recall(**kwargs):
+            events.append("second-call")
+            return SimpleNamespace(results=[SimpleNamespace(text="Recovered memory")])
+
+        first_client.arecall = AsyncMock(side_effect=_failing_recall)
+        first_client.aclose = AsyncMock(side_effect=_close)
+        second_client.arecall = AsyncMock(side_effect=_recovered_recall)
+        clients = iter([first_client, second_client])
+
+        def _get_client():
+            client = next(clients)
+            if client is second_client:
+                events.append("replace")
+            return client
+
+        provider._mode = "local_embedded"
+        provider._client = first_client
+        provider._run_sync = lambda coro: asyncio.run(coro)
+        monkeypatch.setattr(provider, "_get_client", _get_client)
+
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_recall", {"query": "test"}
+        ))
+
+        assert result["result"] == "1. Recovered memory"
+        first_client.aclose.assert_awaited_once()
+        assert events[:2] == ["close", "replace"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two related fixes in the Hindsight memory provider, both with regression tests:

**1. Configured bank missions are parsed but never sent to Hindsight.** The provider reads `bank_mission` / `bank_retain_mission` from config but never transmits them, so banks run on package-default missions. Practical effect we observed: memory content drifting in language/style away from the configured (English-only) missions, because the configured constraint never reached the engine. Fix: `_ensure_bank_config()` sends the configured missions via `acreate_bank(...)` before the first retain/recall/reflect operation, cached per bank/config so it is applied once, with a graceful warning path when the client lacks `acreate_bank`. Also adds optional `bank_reflect_mission` / `bank_observations_mission` config passthrough.

**2. Stale embedded client replaced without close.** In `_run_hindsight_operation()`'s retriable-error path, `self._client` is set to `None` and a new client created without closing the old one, leaking aiohttp sessions/connectors. Over time the embedded daemon degrades ("Daemon for profile X is no longer responsive, restarting…" — we logged 140 such events over ~12 days on one install). Fix: best-effort `_close_client_for_retry()` (handles `aclose`/`close`, sync or awaitable, exceptions swallowed so a close failure never masks the retry), called before replacement.

## Tests

Both tests fail against the unpatched provider and pass with the fixes (mock-client level, no daemon/network):
- `test_configured_bank_missions_applied_once_before_first_operation`
- `test_local_embedded_retry_closes_stale_client_before_replacement`

Verified on two production installs (Linux + macOS, Python 3.11): full provider suite green (105/104 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
