### PR TITLE
fix(state): catch FK violation in append_message when session deleted…

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4169,9 +4169,10 @@ class SessionDB:
         effect_disposition: Optional[str] = None,
         timestamp: Any = None,
         api_content: Optional[str] = None,
-    ) -> int:
+    ) -> Optional[int]:
         """
-        Append a message to a session. Returns the message row ID.
+        Append a message to a session. Returns the message row ID, or None
+        if the session was deleted concurrently (FK violation).
 
         Also increments the session's message_count (and tool_call_count
         if role is 'tool' or tool_calls is present).
@@ -4224,34 +4225,50 @@ class SessionDB:
             num_tool_calls = len(tool_calls) if isinstance(tool_calls, list) else 1
 
         def _do(conn):
-            cursor = conn.execute(
-                """INSERT INTO messages (session_id, role, content, tool_call_id,
-                   tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
-                   reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items, platform_message_id, observed, active, api_content)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                (
-                    session_id,
-                    role,
-                    stored_content,
-                    tool_call_id,
-                    tool_calls_json,
-                    _scrub_surrogates(tool_name),
-                    effect_disposition,
-                    message_timestamp,
-                    token_count,
-                    finish_reason,
-                    _scrub_surrogates(reasoning),
-                    _scrub_surrogates(reasoning_content),
-                    reasoning_details_json,
-                    codex_items_json,
-                    codex_message_items_json,
-                    platform_message_id,
-                    1 if observed else 0,
-                    1,
-                    _scrub_surrogates(api_content) if isinstance(api_content, str) else None,
-                ),
-            )
+            try:
+                cursor = conn.execute(
+                    """INSERT INTO messages (session_id, role, content, tool_call_id,
+                       tool_calls, tool_name, effect_disposition, timestamp, token_count, finish_reason,
+                       reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
+                       codex_message_items, platform_message_id, observed, active, api_content)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        session_id,
+                        role,
+                        stored_content,
+                        tool_call_id,
+                        tool_calls_json,
+                        _scrub_surrogates(tool_name),
+                        effect_disposition,
+                        message_timestamp,
+                        token_count,
+                        finish_reason,
+                        _scrub_surrogates(reasoning),
+                        _scrub_surrogates(reasoning_content),
+                        reasoning_details_json,
+                        codex_items_json,
+                        codex_message_items_json,
+                        platform_message_id,
+                        1 if observed else 0,
+                        1,
+                        _scrub_surrogates(api_content) if isinstance(api_content, str) else None,
+                    ),
+                )
+            except sqlite3.IntegrityError as exc:
+                # Gate on FK violation only — re-raise other integrity failures
+                # so they surface as real errors rather than silent data loss.
+                if exc.sqlite_errorcode == sqlite3.SQLITE_CONSTRAINT_FOREIGNKEY:
+                    # The session was deleted between the caller's read and this
+                    # write (dashboard bulk-delete, prune, or manual remove
+                    # racing with an in-flight inbound event). Silently drop the
+                    # message — there is no valid session to attach it to.
+                    logger.debug(
+                        "append_message: session %s gone, dropping %s message",
+                        session_id,
+                        role,
+                    )
+                    return None
+                raise
             msg_id = cursor.lastrowid
 
             # Update counters

--- a/tests/test_lazy_session_regressions.py
+++ b/tests/test_lazy_session_regressions.py
@@ -8,10 +8,13 @@ Tests cover:
 5. Prune — finalize_orphaned_compression_sessions catches ghost continuations
 """
 
+import sqlite3
 import threading
 import time
 import types
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 
 
@@ -629,3 +632,87 @@ class TestFinalizeOrphanedCompressionSessions:
 
         session = db.get_session("titled-ghost")
         assert session["end_reason"] == "orphaned_compression"
+
+
+class TestAppendMessageAfterSessionDelete:
+    def test_returns_none_and_leaves_no_rows_after_session_delete(self, tmp_path):
+        db = _make_session_db(tmp_path)
+
+        db.create_session(session_id="victim", source="tui", model="test")
+        db.delete_session("victim")
+
+        result = db.append_message("victim", role="user", content="late message")
+
+        assert result is None
+        assert db.get_messages("victim") == []
+
+    def test_parallel_delete_while_append_both_complete_cleanly(self, tmp_path):
+        db = _make_session_db(tmp_path)
+        db.create_session(session_id="race-session", source="tui", model="test")
+
+        errors = []
+
+        def deleter():
+            try:
+                for _ in range(50):
+                    db.create_session(
+                        session_id="race-session",
+                        source="tui",
+                        model="test",
+                    )
+                    db.delete_session("race-session")
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        def appender():
+            try:
+                for _ in range(50):
+                    db.append_message(
+                        "race-session",
+                        role="user",
+                        content="ping",
+                    )
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        t1 = threading.Thread(target=deleter)
+        t2 = threading.Thread(target=appender)
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        assert errors == [], f"Unexpected errors: {errors}"
+
+# ===========================================================================
+# append_message FK / IntegrityError gating
+# ===========================================================================
+
+class TestAppendMessageIntegrityGating:
+    """append_message() must swallow only FK violations (deleted session)
+    and re-raise every other IntegrityError instead of masking it."""
+
+    def test_append_message_returns_none_when_session_deleted(self, tmp_path):
+        """If the session row is deleted between the caller's read and the
+        INSERT, the FK on messages.session_id fails. That race is benign —
+        the message has no valid session to attach to — so append_message
+        must return None rather than raising."""
+        db = _make_session_db(tmp_path)
+
+        db.create_session(session_id="gone", source="tui", model="test")
+        # Hard-delete the session row (dashboard bulk-delete / prune path).
+        db.delete_session("gone")
+
+        result = db.append_message("gone", role="user", content="orphan")
+        assert result is None
+
+    def test_append_message_reraises_non_fk_integrity_error(self, tmp_path):
+        """A non-FK IntegrityError (e.g. NOT NULL on messages.role) is a real
+        schema/serialization bug and must propagate — the FK-only guard must
+        NOT swallow it as if the session had merely been deleted."""
+        db = _make_session_db(tmp_path)
+
+        db.create_session(session_id="live", source="tui", model="test")
+
+        with pytest.raises(sqlite3.IntegrityError):
+            db.append_message("live", role=None, content="bad")


### PR DESCRIPTION
## Summary

Adds `sqlite3.IntegrityError` handling to `append_message()` in
`hermes_state.py` to prevent a crash when a session is deleted
concurrently with an in-flight message write.

---

## Root cause

`append_message()` executes an `INSERT INTO messages` with a foreign key
constraint on `session_id`. When a session is deleted between the
caller's read and the write (e.g. dashboard bulk-delete, prune, or
manual remove racing with an inbound gateway event), SQLite raises
`sqlite3.IntegrityError` due to the FK violation. This exception was not
caught, causing the gateway to crash with an unhandled error instead of
gracefully dropping the orphaned write.

Practical scenario: a user deletes a session from the dashboard while
the gateway is processing an inbound message for that session. The
appender thread hits the FK violation and propagates the exception up
through the call stack.

---

## Behavioral change

Before: `append_message()` raised `sqlite3.IntegrityError` when the
target session no longer existed, crashing the caller.

After: the `INSERT` is wrapped in a `try/except sqlite3.IntegrityError`
block. On FK violation, the method logs a `DEBUG` message and returns
`None`. The `UPDATE sessions` counter block is not reached, so no
stale counters are written. The caller receives `None` and continues
normally.

---

## What changed

**`hermes_state.py`**
- Wrapped the `INSERT INTO messages` statement in `append_message._do()`
  with `try/except sqlite3.IntegrityError`
- On violation: `logger.debug` logs session id and role, then returns
  `None` before the counter UPDATE
- The fix is scoped to `append_message` only, not to `_execute_write`,
  to avoid masking real integrity errors in other write paths

**`tests/test_lazy_session_regressions.py`**
- Added `TestAppendMessageAfterSessionDelete` with two tests:
  `test_returns_none_and_leaves_no_rows_after_session_delete` verifies
  that `append_message` returns `None` and leaves no rows after the
  session is deleted; `test_parallel_delete_while_append_both_complete_cleanly`
  runs concurrent delete and append loops (50 iterations each) and
  asserts no exceptions are raised from either thread

---

## What is NOT changed

- `_execute_write` retry logic unchanged
- `delete_session` unchanged
- No schema changes
- Existing state tests pass; new tests cover the FK-violation path