### PR TITLE
feat: add Discord collaborator policy context

### DIFF
--- a/gateway/discord_identity.py
+++ b/gateway/discord_identity.py
@@ -1,0 +1,203 @@
+"""Discord collaborative-workspace identity, visibility & permission policy.
+
+This module implements the config-driven half of the Discord collaborative
+workspace policy: a mapping of Discord user IDs to display names and roles
+(owner / collaborator / custom), plus helpers that surface
+
+  * **speaker attribution** — a per-message prefix so a shared session shows
+    who is speaking, with their role, id and channel visibility, and
+  * **a permission policy** — prompt guidance that lets collaborators request
+    low-risk work (research, drafts, tasks) but routes sensitive actions
+    (external/paid/destructive/security/prod/customer/legal-finance/config/
+    memory-policy) through owner approval.
+
+Everything degrades to prior behavior when no Discord identity config is
+present: :func:`resolve_discord_identity` returns ``None``,
+:func:`discord_speaker_prefix` returns ``None`` (callers fall back to the
+existing ``[name]`` multi-user prefix), and :func:`build_collab_policy_block`
+returns ``""``.  So unconfigured / single-user deployments are unchanged.
+
+Config lives under the Discord platform's ``extra`` block in ``config.yaml``::
+
+    platforms:
+      discord:
+        enabled: true
+        extra:
+          identities:
+            - id: "111111111111111111"   # Discord user ID (snowflake)
+              name: Jayden
+              role: owner
+            - id: "222222222222222222"
+              name: Peter
+              role: collaborator
+
+``id`` (alias ``user_id``), ``name`` (alias ``display_name``) and ``role``
+are the recognised keys.  ``role`` defaults to ``collaborator`` and is
+normalised to lowercase (stripped of surrounding whitespace).  Only ``owner``
+gets owner privileges; any other value — including custom roles — is kept (in
+lowercase form) and rendered verbatim for attribution, but treated as a
+non-owner.
+
+Roster + visibility are derived from config and channel type.  Callers should
+only render the roster for trusted/configured senders; in shared channels with
+unknown participants the policy block may be deliberately omitted to avoid
+exposing configured collaborator details.  The variable, per-turn part (who is
+speaking *this* message) rides on the user-message prefix, which lives in the
+message tier and never changes the system-prompt block by itself.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+OWNER_ROLE = "owner"
+COLLABORATOR_ROLE = "collaborator"
+
+
+@dataclass(frozen=True)
+class DiscordIdentity:
+    """A configured Discord participant."""
+
+    user_id: str
+    display_name: str
+    role: str = COLLABORATOR_ROLE
+
+    @property
+    def is_owner(self) -> bool:
+        return self.role == OWNER_ROLE
+
+
+def _identity_entries(config: Any) -> List[Dict[str, Any]]:
+    """Pull the raw identity list from ``platforms.discord.extra``.
+
+    Returns an empty list (feature off) for any shape we don't recognise so a
+    malformed config can never raise into prompt construction.
+    """
+    try:
+        # Import locally to avoid a hard import cycle (config <-> session).
+        from .config import Platform
+
+        platforms = getattr(config, "platforms", None) or {}
+        plat = platforms.get(Platform.DISCORD)
+        if plat is None:
+            return []
+        extra = getattr(plat, "extra", None) or {}
+        raw = extra.get("identities")
+        if isinstance(raw, list):
+            return [e for e in raw if isinstance(e, dict)]
+    except Exception:
+        pass
+    return []
+
+
+def load_discord_identities(config: Any) -> Dict[str, DiscordIdentity]:
+    """Build a ``{user_id: DiscordIdentity}`` map from config.
+
+    Owners sort first in :func:`identities_roster`; this map is keyed by id for
+    O(1) resolution.  Entries without a usable id are skipped.
+    """
+    out: Dict[str, DiscordIdentity] = {}
+    for entry in _identity_entries(config):
+        uid = entry.get("id", entry.get("user_id"))
+        if uid is None or str(uid).strip() == "":
+            continue
+        uid = str(uid)
+        name = entry.get("name", entry.get("display_name")) or uid
+        role = str(entry.get("role", COLLABORATOR_ROLE) or COLLABORATOR_ROLE).strip().lower()
+        out[uid] = DiscordIdentity(user_id=uid, display_name=str(name), role=role)
+    return out
+
+
+def identities_roster(config: Any) -> List[DiscordIdentity]:
+    """Configured identities, owners first then by display name — stable order.
+
+    Deterministic ordering keeps the rendered roster identical across turns so
+    it stays cache-stable in the system prompt.
+    """
+    identities = list(load_discord_identities(config).values())
+    identities.sort(key=lambda i: (not i.is_owner, i.display_name.lower(), i.user_id))
+    return identities
+
+
+def resolve_discord_identity(config: Any, user_id: Optional[str]) -> Optional[DiscordIdentity]:
+    """Resolve a Discord user id to its configured identity, or ``None``."""
+    if not user_id:
+        return None
+    return load_discord_identities(config).get(str(user_id))
+
+
+def visibility_label(source: Any) -> str:
+    """Channel visibility for a source: ``"dm"`` (private) or ``"shared_channel"``.
+
+    Anything that isn't a one-on-one DM is treated as shared, since other
+    configured collaborators may read it.
+    """
+    return "dm" if getattr(source, "chat_type", None) == "dm" else "shared_channel"
+
+
+def discord_speaker_prefix(source: Any, config: Any) -> Optional[str]:
+    """Per-message speaker-attribution prefix for a Discord message.
+
+    Returns ``[name · role · id:<id> · <visibility>]`` when the sender resolves
+    to a configured identity, else ``None`` so the caller keeps its existing
+    behavior (plain ``[name]`` prefix in shared sessions, nothing in DMs).
+    """
+    identity = resolve_discord_identity(config, getattr(source, "user_id", None))
+    if identity is None:
+        return None
+    vis = visibility_label(source)
+    return f"[{identity.display_name} · {identity.role} · id:{identity.user_id} · {vis}]"
+
+
+def build_collab_policy_block(identities: List[DiscordIdentity], visibility: str) -> str:
+    """Render the system-prompt guidance block for the shared workspace.
+
+    Covers the participant roster, DM-vs-shared visibility isolation, speaker
+    attribution, and the owner-approval permission policy.  Returns ``""`` when
+    no identities are configured so callers can append unconditionally.
+    """
+    if not identities:
+        return ""
+
+    owners = [i for i in identities if i.is_owner]
+    owner_names = ", ".join(i.display_name for i in owners) or "the owner"
+
+    lines: List[str] = ["", "**Discord collaborative workspace:**"]
+    for ident in identities:
+        lines.append(
+            f"  - {ident.display_name} — {ident.role} (id `{ident.user_id}`)"
+        )
+
+    lines.append(
+        "Each user message is prefixed with "
+        "`[name · role · id:<id> · visibility]` so you always know who is "
+        "speaking and whether the message is private or shared."
+    )
+
+    if visibility == "dm":
+        lines.append(
+            "**Visibility — DM (private):** This conversation is a private DM "
+            "and is NOT visible to other collaborators. Do not reveal another "
+            "person's DM content here, and do not assume shared-channel context "
+            "carries into this private thread."
+        )
+    else:
+        lines.append(
+            "**Visibility — shared channel:** Every configured collaborator can "
+            "read this channel. Anything you say is visible to all of them, so "
+            "do not surface content that was shared with you privately in a DM."
+        )
+
+    lines.append(
+        f"**Permission policy:** Collaborators may directly request low-risk "
+        f"work — research, drafts, summaries, and routine task tracking. "
+        f"Actions that are external/outbound, paid, destructive, "
+        f"security-sensitive, production-affecting, customer-facing, "
+        f"legal/financial, or that change configuration or memory/policy "
+        f"require {owner_names}'s (owner) explicit approval. When a "
+        f"collaborator requests such an action, prepare it and ask for owner "
+        f"approval before executing rather than refusing outright."
+    )
+
+    return "\n".join(lines)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7550,7 +7550,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             group_sessions_per_user=_group_sessions_per_user,
             thread_sessions_per_user=_thread_sessions_per_user,
         )
-        if _is_shared_multi_user and source.user_name:
+        # Discord collaborative workspace: when the sender resolves to a
+        # configured identity, attribute the message with name/role/id and
+        # channel visibility so shared sessions (and DMs from collaborators)
+        # carry speaker + permission context.  Falls back to the plain
+        # multi-user prefix when no Discord identity is configured, preserving
+        # prior behavior.
+        _speaker_prefix = None
+        if source.platform == Platform.DISCORD:
+            from gateway.discord_identity import discord_speaker_prefix
+            _speaker_prefix = discord_speaker_prefix(source, self.config)
+        if _speaker_prefix:
+            message_text = f"{_speaker_prefix} {message_text}"
+        elif _is_shared_multi_user and source.user_name:
             message_text = f"[{source.user_name}] {message_text}"
 
         # Prepend channel context from history backfill (if any).  This

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -16,7 +16,7 @@ import threading
 import uuid
 from pathlib import Path
 from datetime import datetime, timedelta
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Any
 
 logger = logging.getLogger(__name__)
@@ -171,7 +171,13 @@ class SessionContext:
     connected_platforms: List[Platform]
     home_channels: Dict[Platform, HomeChannel]
     shared_multi_user_session: bool = False
-    
+
+    # Configured Discord collaborators (owner/collaborator roster) for this
+    # source's platform. Empty unless the source is Discord and the current
+    # sender resolves to a configured identity; unknown senders do not receive
+    # the roster/policy block.
+    discord_identities: List[Any] = field(default_factory=list)
+
     # Session metadata
     session_key: str = ""
     session_id: str = ""
@@ -186,6 +192,10 @@ class SessionContext:
                 p.value: hc.to_dict() for p, hc in self.home_channels.items()
             },
             "shared_multi_user_session": self.shared_multi_user_session,
+            "discord_identities": [
+                {"user_id": i.user_id, "display_name": i.display_name, "role": i.role}
+                for i in self.discord_identities
+            ],
             "session_key": self.session_key,
             "session_id": self.session_id,
             "created_at": self.created_at.isoformat() if self.created_at else None,
@@ -370,6 +380,17 @@ def build_session_context_prompt(
                 "Do not promise to perform these actions. If the user asks, explain "
                 "that you can only read messages sent directly to you and respond."
             )
+
+        # Collaborative-workspace roster + visibility + permission policy.
+        # Empty string (and thus skipped) unless Discord identities are
+        # configured, so unconfigured deployments are unchanged.
+        if context.discord_identities:
+            from .discord_identity import build_collab_policy_block, visibility_label
+            _policy = build_collab_policy_block(
+                context.discord_identities, visibility_label(context.source)
+            )
+            if _policy:
+                lines.append(_policy)
     elif context.source.platform == Platform.BLUEBUBBLES:
         lines.append("")
         lines.append(
@@ -1424,6 +1445,20 @@ def build_session_context(
         if home:
             home_channels[platform] = home
     
+    # Discord collaborator roster (owner/collaborator), config-driven and empty
+    # unless this is a Discord source whose *sender* resolves to a configured
+    # identity.  Gating on the sender (not just the platform) keeps the roster
+    # and permission policy out of the system prompt for unknown/unconfigured
+    # senders, who must not learn the collaborator list.  In mixed shared
+    # channels this can intentionally omit the policy block on unknown-sender
+    # turns; the per-message speaker prefix is resolved independently per turn,
+    # so its fallback behavior is unaffected by this gate.
+    discord_identities: List[Any] = []
+    if source.platform == Platform.DISCORD:
+        from .discord_identity import identities_roster, resolve_discord_identity
+        if resolve_discord_identity(config, source.user_id) is not None:
+            discord_identities = identities_roster(config)
+
     context = SessionContext(
         source=source,
         connected_platforms=connected,
@@ -1433,6 +1468,7 @@ def build_session_context(
             group_sessions_per_user=getattr(config, "group_sessions_per_user", True),
             thread_sessions_per_user=getattr(config, "thread_sessions_per_user", False),
         ),
+        discord_identities=discord_identities,
     )
     
     if session_entry:

--- a/tests/gateway/test_discord_collab_policy.py
+++ b/tests/gateway/test_discord_collab_policy.py
@@ -1,0 +1,275 @@
+"""Tests for the Discord collaborative-workspace identity & permission policy.
+
+Covers identity resolution, the per-message speaker prefix, the system-prompt
+policy/visibility block, and the wiring through build_session_context /
+build_session_context_prompt — including that unconfigured deployments are
+unchanged.
+"""
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.discord_identity import (
+    COLLABORATOR_ROLE,
+    OWNER_ROLE,
+    DiscordIdentity,
+    build_collab_policy_block,
+    discord_speaker_prefix,
+    identities_roster,
+    load_discord_identities,
+    resolve_discord_identity,
+    visibility_label,
+)
+from gateway.session import (
+    SessionSource,
+    build_session_context,
+    build_session_context_prompt,
+)
+
+
+OWNER_ID = "111111111111111111"
+COLLAB_ID = "222222222222222222"
+
+
+def _collab_config() -> GatewayConfig:
+    """A gateway config with Jayden (owner) + Peter (collaborator) on Discord."""
+    return GatewayConfig(
+        platforms={
+            Platform.DISCORD: PlatformConfig(
+                enabled=True,
+                extra={
+                    "identities": [
+                        {"id": COLLAB_ID, "name": "Peter", "role": "collaborator"},
+                        {"id": OWNER_ID, "name": "Jayden", "role": "owner"},
+                    ]
+                },
+            )
+        }
+    )
+
+
+def _discord_source(user_id=OWNER_ID, user_name="Jayden", chat_type="channel"):
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="900",
+        chat_name="workspace",
+        chat_type=chat_type,
+        user_id=user_id,
+        user_name=user_name,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Identity resolution
+# --------------------------------------------------------------------------- #
+
+class TestIdentityResolution:
+    def test_load_maps_by_id(self):
+        ids = load_discord_identities(_collab_config())
+        assert set(ids) == {OWNER_ID, COLLAB_ID}
+        assert ids[OWNER_ID] == DiscordIdentity(OWNER_ID, "Jayden", OWNER_ROLE)
+        assert ids[COLLAB_ID].role == COLLABORATOR_ROLE
+
+    def test_resolve_known_and_unknown(self):
+        cfg = _collab_config()
+        assert resolve_discord_identity(cfg, OWNER_ID).is_owner is True
+        assert resolve_discord_identity(cfg, COLLAB_ID).display_name == "Peter"
+        assert resolve_discord_identity(cfg, "999") is None
+        assert resolve_discord_identity(cfg, None) is None
+
+    def test_roster_orders_owner_first(self):
+        roster = identities_roster(_collab_config())
+        assert [i.display_name for i in roster] == ["Jayden", "Peter"]
+
+    def test_custom_role_normalized_lowercase(self):
+        # Roles are normalised to lowercase (stripped); a custom role is kept
+        # in that lowercase form and treated as a non-owner.
+        cfg = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    extra={"identities": [{"id": "8", "name": "Rae", "role": "  Reviewer "}]}
+                )
+            }
+        )
+        ident = resolve_discord_identity(cfg, "8")
+        assert ident.role == "reviewer"
+        assert ident.is_owner is False
+
+    def test_user_id_and_display_name_aliases(self):
+        cfg = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    extra={"identities": [{"user_id": "5", "display_name": "Sam"}]}
+                )
+            }
+        )
+        ident = resolve_discord_identity(cfg, "5")
+        assert ident.display_name == "Sam"
+        assert ident.role == COLLABORATOR_ROLE  # default
+
+    def test_absent_config_resolves_to_empty(self):
+        cfg = GatewayConfig()
+        assert load_discord_identities(cfg) == {}
+        assert resolve_discord_identity(cfg, OWNER_ID) is None
+
+    def test_malformed_entries_are_skipped(self):
+        cfg = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    extra={"identities": ["nope", {"name": "no-id"}, {"id": "7", "name": "Ok"}]}
+                )
+            }
+        )
+        ids = load_discord_identities(cfg)
+        assert set(ids) == {"7"}
+
+
+# --------------------------------------------------------------------------- #
+# Speaker prefix + visibility
+# --------------------------------------------------------------------------- #
+
+class TestSpeakerPrefix:
+    def test_visibility_label(self):
+        assert visibility_label(_discord_source(chat_type="dm")) == "dm"
+        assert visibility_label(_discord_source(chat_type="channel")) == "shared_channel"
+        assert visibility_label(_discord_source(chat_type="thread")) == "shared_channel"
+
+    def test_prefix_shared_channel(self):
+        cfg = _collab_config()
+        prefix = discord_speaker_prefix(_discord_source(COLLAB_ID, "Peter"), cfg)
+        assert prefix == f"[Peter · collaborator · id:{COLLAB_ID} · shared_channel]"
+
+    def test_prefix_dm(self):
+        cfg = _collab_config()
+        src = _discord_source(OWNER_ID, "Jayden", chat_type="dm")
+        prefix = discord_speaker_prefix(src, cfg)
+        assert prefix == f"[Jayden · owner · id:{OWNER_ID} · dm]"
+
+    def test_prefix_none_when_unconfigured(self):
+        # No identities configured → None so callers keep prior behavior.
+        assert discord_speaker_prefix(_discord_source(), GatewayConfig()) is None
+
+    def test_prefix_none_for_unknown_user(self):
+        assert discord_speaker_prefix(_discord_source("999", "Stranger"), _collab_config()) is None
+
+
+def _apply_inbound_prefix(message_text, source, config, *, is_shared_multi_user):
+    """Mirror of the inbound prefix selection in ``GatewayRunner`` (run.py).
+
+    Kept in lockstep with that block: a configured Discord sender gets the rich
+    speaker prefix; otherwise we fall back to the plain ``[name]`` multi-user
+    prefix.  Testing the selection here avoids standing up the full runner.
+    """
+    _speaker_prefix = None
+    if source.platform == Platform.DISCORD:
+        _speaker_prefix = discord_speaker_prefix(source, config)
+    if _speaker_prefix:
+        return f"{_speaker_prefix} {message_text}"
+    elif is_shared_multi_user and source.user_name:
+        return f"[{source.user_name}] {message_text}"
+    return message_text
+
+
+class TestInboundPrefixWiring:
+    def test_known_sender_gets_rich_prefix(self):
+        out = _apply_inbound_prefix(
+            "hi", _discord_source(COLLAB_ID, "Peter"), _collab_config(),
+            is_shared_multi_user=True,
+        )
+        assert out == f"[Peter · collaborator · id:{COLLAB_ID} · shared_channel] hi"
+
+    def test_unknown_sender_falls_back_to_plain_prefix(self):
+        out = _apply_inbound_prefix(
+            "hi", _discord_source("999", "Stranger"), _collab_config(),
+            is_shared_multi_user=True,
+        )
+        assert out == "[Stranger] hi"
+
+    def test_unconfigured_discord_falls_back_to_plain_prefix(self):
+        out = _apply_inbound_prefix(
+            "hi", _discord_source(OWNER_ID, "Jayden"), GatewayConfig(),
+            is_shared_multi_user=True,
+        )
+        assert out == "[Jayden] hi"
+
+
+# --------------------------------------------------------------------------- #
+# Policy block rendering
+# --------------------------------------------------------------------------- #
+
+class TestPolicyBlock:
+    def test_empty_without_identities(self):
+        assert build_collab_policy_block([], "shared_channel") == ""
+
+    def test_roster_and_owner_named(self):
+        block = build_collab_policy_block(identities_roster(_collab_config()), "shared_channel")
+        assert "Jayden — owner" in block
+        assert "Peter — collaborator" in block
+        assert "Jayden" in block  # owner named in the permission policy line
+
+    def test_shared_vs_dm_visibility_text(self):
+        roster = identities_roster(_collab_config())
+        shared = build_collab_policy_block(roster, "shared_channel")
+        dm = build_collab_policy_block(roster, "dm")
+        assert "shared channel" in shared.lower()
+        assert "every configured collaborator can" in shared.lower()
+        assert "private dm" in dm.lower()
+        assert "not visible to other collaborators" in dm.lower()
+
+    def test_permission_policy_lists_sensitive_categories(self):
+        block = build_collab_policy_block(identities_roster(_collab_config()), "shared_channel")
+        low = block.lower()
+        assert "require" in low and "approval" in low
+        for cat in ("paid", "destructive", "security", "production", "customer", "memory"):
+            assert cat in low, cat
+
+
+# --------------------------------------------------------------------------- #
+# Wiring through session context
+# --------------------------------------------------------------------------- #
+
+class TestSessionContextWiring:
+    def test_context_populates_roster_for_discord(self):
+        ctx = build_session_context(_discord_source(), _collab_config())
+        assert [i.display_name for i in ctx.discord_identities] == ["Jayden", "Peter"]
+        # Serialization round-trips the roster.
+        assert ctx.to_dict()["discord_identities"][0]["role"] == "owner"
+
+    def test_context_empty_for_non_discord(self):
+        src = SessionSource(platform=Platform.LOCAL, chat_id="local")
+        ctx = build_session_context(src, _collab_config())
+        assert ctx.discord_identities == []
+
+    def test_context_empty_for_unknown_discord_sender(self):
+        # Configured identities exist, but the sender is not one of them.
+        # The roster/policy must NOT leak to an unknown/unconfigured sender.
+        ctx = build_session_context(
+            _discord_source(user_id="999", user_name="Stranger"), _collab_config()
+        )
+        assert ctx.discord_identities == []
+
+    def test_prompt_excludes_policy_for_unknown_discord_sender(self):
+        ctx = build_session_context(
+            _discord_source(user_id="999", user_name="Stranger"), _collab_config()
+        )
+        prompt = build_session_context_prompt(ctx)
+        assert "Discord collaborative workspace" not in prompt
+
+    def test_prompt_includes_policy_for_shared_channel(self):
+        ctx = build_session_context(_discord_source(chat_type="channel"), _collab_config())
+        prompt = build_session_context_prompt(ctx)
+        assert "Discord collaborative workspace" in prompt
+        assert "Jayden — owner" in prompt
+        assert "shared channel" in prompt.lower()
+        assert "require" in prompt.lower() and "approval" in prompt.lower()
+
+    def test_prompt_dm_visibility_text(self):
+        ctx = build_session_context(_discord_source(chat_type="dm"), _collab_config())
+        prompt = build_session_context_prompt(ctx)
+        assert "private DM" in prompt
+        assert "not visible to other collaborators" in prompt.lower()
+
+    def test_prompt_unchanged_when_no_identities(self):
+        # Discord source, but no identities configured → no policy block.
+        cfg = GatewayConfig(platforms={Platform.DISCORD: PlatformConfig(enabled=True)})
+        ctx = build_session_context(_discord_source(), cfg)
+        prompt = build_session_context_prompt(ctx)
+        assert "Discord collaborative workspace" not in prompt


### PR DESCRIPTION
## Summary
- add config-driven Discord identity/role mapping for collaborative channels
- prefix configured Discord senders with name, role, id, and DM/shared visibility
- add prompt guidance for collaborator permissions and owner approval boundaries
- keep behavior unchanged when identities are not configured, and avoid roster injection for unknown senders

## Test Plan
- venv/bin/python -m pytest tests/gateway/test_discord_collab_policy.py tests/gateway/test_session.py tests/gateway/test_config.py tests/gateway/test_discord_channel_prompts.py -q

## Review
- implemented with Claude Code
- independent review flagged unknown-sender roster exposure; fixed by gating policy context on configured senders
- final Claude review found no hard blockers after doc/comment correction