### PR TITLE
fix(cli): resolve session ID before delete like GET/PATCH do (#44117)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1467,7 +1467,11 @@ class APIServerAdapter(BasePlatformAdapter):
         if err:
             return err
         db = self._ensure_session_db()
-        deleted = db.delete_session(session_id)
+        # Resolve prefix/alias IDs the same way GET and PATCH do, so
+        # compression-root IDs and short prefixes work for delete too.
+        resolved = db.resolve_session_id(session_id)
+        target = resolved or session_id
+        deleted = db.delete_session(target)
         return web.json_response({"object": "hermes.session.deleted", "id": session_id, "deleted": bool(deleted)})
 
     async def _handle_session_messages(self, request: "web.Request") -> "web.Response":

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6088,7 +6088,11 @@ async def delete_session_endpoint(session_id: str, profile: Optional[str] = None
     # desktop routes their DELETE to the remote backend. Omit for current/default.
     db = _open_session_db_for_profile(profile)
     try:
-        if not db.delete_session(session_id):
+        # Resolve prefix/alias IDs the same way GET and PATCH do, so
+        # compression-root IDs and short prefixes work for delete too.
+        resolved = db.resolve_session_id(session_id)
+        target = resolved or session_id
+        if not db.delete_session(target):
             raise HTTPException(status_code=404, detail="Session not found")
         return {"ok": True}
     finally:


### PR DESCRIPTION
Fixes #44117. The DELETE /api/sessions/{id} endpoint did raw WHERE id=? lookup without resolving the session ID first, unlike the GET and PATCH endpoints which use resolve_session_id() for prefix/alias/compression-root resolution. This caused 'session not found' errors when the frontend held a compression lineage root ID or short prefix that needed resolution.