### PR TITLE
feat(gateway): show crash cause in the back-online notification after an unclean restart

### DIFF
--- a/gateway/crash_diagnostics.py
+++ b/gateway/crash_diagnostics.py
@@ -1,0 +1,510 @@
+"""Best-effort OS crash diagnostics for gateway restart notifications."""
+
+from __future__ import annotations
+
+import json
+import platform
+import re
+import shutil
+import signal
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+_DEFAULT_TIMEOUT_SECONDS = 2.0
+_MAX_BACKTRACE_FRAMES = 4
+
+
+def recent_crashes(
+    name_filter: str = "python",
+    since_hours: int = 24,
+    limit: int = 10,
+) -> list[dict[str, Any]]:
+    """Return newest-first OS crash records.
+
+    This is intentionally best-effort: unsupported platforms, missing tools,
+    parse failures, permission errors, and timeouts all degrade to ``[]``.
+    """
+    try:
+        system = platform.system().lower()
+        if system == "darwin":
+            return _macos_recent_crashes(name_filter, since_hours, limit)
+        if system == "linux":
+            return _linux_recent_crashes(name_filter, since_hours, limit)
+        if system == "windows":
+            return _windows_recent_crashes(name_filter, since_hours, limit)
+    except Exception:
+        return []
+    return []
+
+
+def restart_notice(
+    name_filter: str = "python",
+    since_hours: int = 24,
+) -> str:
+    """Format the newest crash as a restart-notification suffix."""
+    try:
+        crashes = recent_crashes(name_filter=name_filter, since_hours=since_hours, limit=1)
+        if not crashes:
+            return ""
+        return _format_restart_notice(crashes[0])
+    except Exception:
+        return ""
+
+
+def _format_restart_notice(record: dict[str, Any]) -> str:
+    cause = _clean_text(record.get("cause")) or "native crash"
+    signal = _clean_text(record.get("signal"))
+    process = _clean_text(record.get("process"))
+    backtrace = record.get("backtrace")
+    frame = ""
+    if isinstance(backtrace, list) and backtrace:
+        frame = _clean_text(backtrace[0])
+
+    line = f"Crash cause: {cause}"
+    # When cause inference fell through to the bare signal name, don't
+    # repeat it in the parenthetical ("SIGTRAP (Python, SIGTRAP)").
+    details = [item for item in (process, signal) if item and item != cause]
+    if details:
+        line += f" ({', '.join(details)})"
+    if frame:
+        line += f"\nFaulting frame: {frame}"
+    return f"\n\n{line}"
+
+
+def _macos_recent_crashes(
+    name_filter: str,
+    since_hours: int,
+    limit: int,
+) -> list[dict[str, Any]]:
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=max(1, int(since_hours)))
+    reports: list[Path] = []
+    for directory in (
+        Path.home() / "Library" / "Logs" / "DiagnosticReports",
+        Path("/Library/Logs/DiagnosticReports"),
+    ):
+        try:
+            reports.extend(directory.glob("*.ips"))
+        except Exception:
+            continue
+
+    records: list[dict[str, Any]] = []
+    for report in sorted(reports, key=_safe_mtime, reverse=True):
+        if len(records) >= limit:
+            break
+        try:
+            mtime = datetime.fromtimestamp(report.stat().st_mtime, timezone.utc)
+            if mtime < cutoff:
+                continue
+            parsed = _parse_macos_ips(report)
+            if not parsed or not _matches_filter(parsed, name_filter):
+                continue
+            records.append(parsed)
+        except Exception:
+            continue
+    return records
+
+
+def _parse_macos_ips(path: Path) -> dict[str, Any] | None:
+    try:
+        raw = path.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        return None
+
+    header = None
+    try:
+        body = json.loads(raw)
+    except json.JSONDecodeError:
+        try:
+            header_text, payload = raw.split("\n", 1)
+            body = json.loads(payload)
+        except Exception:
+            return None
+        try:
+            header = json.loads(header_text)
+        except json.JSONDecodeError:
+            header = None
+
+    if not isinstance(body, dict):
+        return None
+
+    # DiagnosticReports mixes report kinds in *.ips — hangs (288), jetsam
+    # (298) — and only bug_type 309 is a crash report. Skip the rest; keep
+    # reports whose header is missing or unreadable (best-effort).
+    if isinstance(header, dict):
+        bug_type = str(header.get("bug_type") or "")
+        if bug_type and bug_type != "309":
+            return None
+
+    process = body.get("procName") or body.get("name") or path.stem.split("_")[0]
+    exception = body.get("exception") if isinstance(body.get("exception"), dict) else {}
+    signal = exception.get("signal") or exception.get("type")
+    backtrace = _macos_triggered_backtrace(body)
+    return {
+        "when": body.get("captureTime") or datetime.fromtimestamp(
+            _safe_mtime(path),
+            timezone.utc,
+        ).isoformat(),
+        "process": process,
+        "signal": signal,
+        "cause": _infer_cause(signal, backtrace),
+        "backtrace": backtrace,
+    }
+
+
+def _macos_triggered_backtrace(body: dict[str, Any]) -> list[str]:
+    images = body.get("usedImages") if isinstance(body.get("usedImages"), list) else []
+    threads = body.get("threads") if isinstance(body.get("threads"), list) else []
+    selected = None
+    for thread in threads:
+        if isinstance(thread, dict) and thread.get("triggered"):
+            selected = thread
+            break
+    if selected is None and threads:
+        selected = threads[0] if isinstance(threads[0], dict) else None
+    frames = selected.get("frames") if isinstance(selected, dict) else []
+    if not isinstance(frames, list):
+        return []
+
+    out: list[str] = []
+    for frame in frames[:_MAX_BACKTRACE_FRAMES]:
+        if not isinstance(frame, dict):
+            continue
+        image_name = _macos_image_name(frame, images)
+        symbol = frame.get("symbol") or frame.get("symbolLocation") or frame.get("imageOffset")
+        line = ": ".join(str(part) for part in (image_name, symbol) if part)
+        if line:
+            out.append(line)
+    return out
+
+
+def _macos_image_name(frame: dict[str, Any], images: list[Any]) -> str:
+    image_index = frame.get("imageIndex")
+    try:
+        image = images[int(image_index)]
+    except Exception:
+        image = None
+    if isinstance(image, dict):
+        value = image.get("name") or image.get("path")
+        if value:
+            return Path(str(value)).name
+    value = frame.get("imageName") or frame.get("imagePath")
+    return Path(str(value)).name if value else ""
+
+
+def _linux_recent_crashes(
+    name_filter: str,
+    since_hours: int,
+    limit: int,
+) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    if shutil.which("coredumpctl"):
+        output = _run(
+            [
+                "coredumpctl",
+                "--no-pager",
+                "--json=short",
+                "--reverse",
+                "--since",
+                f"{max(1, int(since_hours))} hours ago",
+            ]
+        )
+        records.extend(_parse_coredumpctl_json(output, name_filter, limit))
+        for record in records[:limit]:
+            pid = record.pop("_pid", None)
+            if not pid or record.get("backtrace"):
+                continue
+            info = _run(["coredumpctl", "--no-pager", "info", str(pid)])
+            backtrace = _parse_coredumpctl_info_backtrace(info)
+            if backtrace:
+                record["backtrace"] = backtrace
+                record["cause"] = _infer_cause(record.get("signal"), backtrace)
+
+    if not records and shutil.which("journalctl"):
+        output = _run(
+            [
+                "journalctl",
+                "-k",  # kernel log only — segfault/oom lines drown in the full journal
+                "--no-pager",
+                "--since",
+                f"{max(1, int(since_hours))} hours ago",
+                "-n",
+                "200",
+                "-o",
+                "short-iso",
+            ]
+        )
+        records.extend(_parse_journal_crashes(output, name_filter, limit))
+
+    return records[:limit]
+
+
+def _parse_coredumpctl_json(
+    text: str,
+    name_filter: str,
+    limit: int,
+) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for row in _coredumpctl_json_rows(text):
+        if len(records) >= limit:
+            break
+        if not isinstance(row, dict):
+            continue
+        # ``coredumpctl --json=short`` emits one compact JSON array with
+        # lowercase keys (time/pid/sig/exe) and the signal as a number; the
+        # journal field spellings are kept as a fallback for other shapes.
+        process = (
+            row.get("exe")
+            or row.get("COREDUMP_COMM")
+            or row.get("COREDUMP_EXE")
+            or row.get("EXE")
+            or row.get("COMM")
+        )
+        signal_value = row.get("sig")
+        if signal_value is None:
+            signal_value = row.get("COREDUMP_SIGNAL_NAME") or row.get("SIGNAL")
+        backtrace = _split_backtrace(row.get("STACKTRACE") or row.get("MESSAGE"))
+        record = {
+            "when": row.get("time") or row.get("__REALTIME_TIMESTAMP") or row.get("TIME"),
+            "process": Path(str(process)).name if process else "",
+            "signal": _signal_display_name(signal_value),
+            "backtrace": backtrace,
+            "_pid": row.get("pid") or row.get("COREDUMP_PID") or row.get("PID"),
+        }
+        if not _matches_filter(record, name_filter):
+            continue
+        record["cause"] = _infer_cause(record.get("signal"), backtrace)
+        records.append(record)
+    return records
+
+
+def _coredumpctl_json_rows(text: str) -> list[Any]:
+    stripped = text.strip()
+    if not stripped:
+        return []
+    try:
+        payload = json.loads(stripped)
+    except json.JSONDecodeError:
+        payload = None
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict):
+        return [payload]
+    rows: list[Any] = []
+    for line in stripped.splitlines():
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(row, list):
+            rows.extend(row)
+        else:
+            rows.append(row)
+    return rows
+
+
+def _signal_display_name(value: Any) -> str:
+    """Map a numeric signal (how ``coredumpctl --json`` reports it) to its name."""
+    try:
+        return signal.Signals(int(value)).name
+    except Exception:
+        return _clean_text(value)
+
+
+def _parse_coredumpctl_info_backtrace(text: str) -> list[str]:
+    frames: list[str] = []
+    in_stack = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            if in_stack and frames:
+                break
+            continue
+        if stripped.lower().startswith("stack trace"):
+            in_stack = True
+            continue
+        if not in_stack:
+            continue
+        if stripped.startswith("#"):
+            frames.append(_clean_text(stripped))
+            if len(frames) >= _MAX_BACKTRACE_FRAMES:
+                break
+            continue
+        if frames:
+            break
+    return frames
+
+
+def _parse_journal_crashes(
+    text: str,
+    name_filter: str,
+    limit: int,
+) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    patterns = ("segfault", "core dumped", "oom-killer", "out of memory", "killed process")
+    for line in reversed(text.splitlines()):
+        if len(records) >= limit:
+            break
+        lower = line.lower()
+        if not any(pattern in lower for pattern in patterns):
+            continue
+        process = _extract_process_name(line)
+        record = {
+            "when": line[:25].strip(),
+            "process": process,
+            "signal": _extract_signal(line),
+            "cause": _infer_cause(_extract_signal(line), [line]),
+            "backtrace": [line.strip()],
+        }
+        if _matches_filter(record, name_filter):
+            records.append(record)
+    return records
+
+
+def _windows_recent_crashes(
+    name_filter: str,
+    since_hours: int,
+    limit: int,
+) -> list[dict[str, Any]]:
+    if sys.platform != "win32":
+        return []
+    shell = shutil.which("powershell.exe") or shutil.which("powershell") or shutil.which("pwsh")
+    if not shell:
+        return []
+
+    hours = max(1, int(since_hours))
+    command = (
+        "$events = Get-WinEvent -FilterHashtable "
+        f"@{{LogName='Application'; Id=1000,1001; StartTime=(Get-Date).AddHours(-{hours})}} "
+        f"-MaxEvents {max(1, int(limit))}; "
+        "$events | Select-Object TimeCreated,ProviderName,Message | ConvertTo-Json -Depth 4 -Compress"
+    )
+    output = _run([shell, "-NoProfile", "-NonInteractive", "-Command", command])
+    if not output:
+        return []
+    try:
+        payload = json.loads(output)
+    except json.JSONDecodeError:
+        return []
+    rows = payload if isinstance(payload, list) else [payload]
+    records: list[dict[str, Any]] = []
+    for row in rows:
+        if len(records) >= limit:
+            break
+        if not isinstance(row, dict):
+            continue
+        message = str(row.get("Message") or "")
+        process = _extract_windows_faulting_app(message)
+        record = {
+            "when": row.get("TimeCreated"),
+            "process": process,
+            "signal": "Windows Error Reporting",
+            "cause": _infer_cause(None, [message]),
+            "backtrace": _split_backtrace(message),
+        }
+        if _matches_filter(record, name_filter):
+            records.append(record)
+    return records
+
+
+def _run(cmd: list[str]) -> str:
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=_DEFAULT_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except Exception:
+        return ""
+    if result.returncode != 0 and not result.stdout:
+        return ""
+    return result.stdout or ""
+
+
+def _matches_filter(record: dict[str, Any], name_filter: str) -> bool:
+    needle = str(name_filter or "").strip().lower()
+    if not needle:
+        return True
+    haystack_parts: list[str] = []
+    for key in ("process", "signal", "cause"):
+        value = record.get(key)
+        if value:
+            haystack_parts.append(str(value))
+    backtrace = record.get("backtrace")
+    if isinstance(backtrace, list):
+        haystack_parts.extend(str(item) for item in backtrace[:_MAX_BACKTRACE_FRAMES])
+    return needle in "\n".join(haystack_parts).lower()
+
+
+def _infer_cause(signal: Any, lines: list[str]) -> str:
+    text = " ".join([str(signal or ""), *[str(line) for line in lines]]).lower()
+    signal_text = str(signal or "").upper()
+
+    if any(token in text for token in ("mlx", "metal", "mps")):
+        return "GPU error (Metal/MLX)"
+    if any(token in text for token in ("cuda", "nvidia", "cublas", "cudnn")):
+        return "GPU error (CUDA/NVIDIA)"
+    if any(token in text for token in ("oom-killer", "out of memory", "memory pressure", "killed process")):
+        return "out of memory"
+    if "SIGSEGV" in signal_text or "segfault" in text:
+        return "segmentation fault"
+    if "SIGABRT" in signal_text or "abort" in text:
+        return "process aborted"
+    if "SIGKILL" in signal_text:
+        return "killed by SIGKILL"
+    if signal_text:
+        return signal_text
+    return "native crash"
+
+
+def _split_backtrace(value: Any) -> list[str]:
+    if not value:
+        return []
+    lines = [line.strip() for line in str(value).splitlines() if line.strip()]
+    return lines[:_MAX_BACKTRACE_FRAMES]
+
+
+def _extract_process_name(line: str) -> str:
+    for pattern in (
+        r"\bcomm=\"([^\"]+)\"",
+        r"\bProcess\s+(\S+)",
+        r"\bpython[0-9.]*\b",
+    ):
+        match = re.search(pattern, line, re.IGNORECASE)
+        if match:
+            return match.group(1) if match.groups() else match.group(0)
+    return ""
+
+
+def _extract_signal(line: str) -> str:
+    match = re.search(r"\bSIG[A-Z0-9]+\b", line)
+    if match:
+        return match.group(0)
+    if "segfault" in line.lower():
+        return "SIGSEGV"
+    return ""
+
+
+def _extract_windows_faulting_app(message: str) -> str:
+    match = re.search(r"Faulting application name:\s*([^,\r\n]+)", message, re.IGNORECASE)
+    if match:
+        return match.group(1).strip()
+    return ""
+
+
+def _clean_text(value: Any) -> str:
+    text = str(value or "").strip()
+    return " ".join(text.split())
+
+
+def _safe_mtime(path: Path) -> float:
+    try:
+        return path.stat().st_mtime
+    except Exception:
+        return 0.0

--- a/gateway/crash_diagnostics.py
+++ b/gateway/crash_diagnostics.py
@@ -247,6 +247,8 @@ def _linux_recent_crashes(
                 "--reverse",
                 "--since",
                 since_arg,
+                "-n",
+                str(max(_MAX_CANDIDATE_RECORDS, int(limit))),
             ]
         )
         records.extend(

--- a/gateway/crash_diagnostics.py
+++ b/gateway/crash_diagnostics.py
@@ -9,17 +9,20 @@ import shutil
 import signal
 import subprocess
 import sys
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 _DEFAULT_TIMEOUT_SECONDS = 2.0
 _MAX_BACKTRACE_FRAMES = 4
+_MAX_CANDIDATE_RECORDS = 100
 
 
 def recent_crashes(
     name_filter: str = "python",
-    since_hours: int = 24,
+    *,
+    expected_pid: int | None = None,
+    since: datetime | None = None,
     limit: int = 10,
 ) -> list[dict[str, Any]]:
     """Return newest-first OS crash records.
@@ -28,13 +31,31 @@ def recent_crashes(
     parse failures, permission errors, and timeouts all degrade to ``[]``.
     """
     try:
+        pid = _coerce_pid(expected_pid)
+        if pid is None or not isinstance(since, datetime) or since.tzinfo is None:
+            return []
         system = platform.system().lower()
         if system == "darwin":
-            return _macos_recent_crashes(name_filter, since_hours, limit)
+            return _macos_recent_crashes(
+                name_filter,
+                expected_pid=pid,
+                since=since,
+                limit=limit,
+            )
         if system == "linux":
-            return _linux_recent_crashes(name_filter, since_hours, limit)
+            return _linux_recent_crashes(
+                name_filter,
+                expected_pid=pid,
+                since=since,
+                limit=limit,
+            )
         if system == "windows":
-            return _windows_recent_crashes(name_filter, since_hours, limit)
+            return _windows_recent_crashes(
+                name_filter,
+                expected_pid=pid,
+                since=since,
+                limit=limit,
+            )
     except Exception:
         return []
     return []
@@ -42,11 +63,21 @@ def recent_crashes(
 
 def restart_notice(
     name_filter: str = "python",
-    since_hours: int = 24,
+    *,
+    expected_pid: int | None = None,
+    since: datetime | None = None,
 ) -> str:
     """Format the newest crash as a restart-notification suffix."""
     try:
-        crashes = recent_crashes(name_filter=name_filter, since_hours=since_hours, limit=1)
+        pid = _coerce_pid(expected_pid)
+        if pid is None or not isinstance(since, datetime) or since.tzinfo is None:
+            return ""
+        crashes = recent_crashes(
+            name_filter=name_filter,
+            expected_pid=pid,
+            since=since,
+            limit=1,
+        )
         if not crashes:
             return ""
         return _format_restart_notice(crashes[0])
@@ -76,10 +107,12 @@ def _format_restart_notice(record: dict[str, Any]) -> str:
 
 def _macos_recent_crashes(
     name_filter: str,
-    since_hours: int,
+    *,
+    expected_pid: int,
+    since: datetime,
     limit: int,
 ) -> list[dict[str, Any]]:
-    cutoff = datetime.now(timezone.utc) - timedelta(hours=max(1, int(since_hours)))
+    cutoff = _as_utc(since)
     reports: list[Path] = []
     for directory in (
         Path.home() / "Library" / "Logs" / "DiagnosticReports",
@@ -100,6 +133,8 @@ def _macos_recent_crashes(
                 continue
             parsed = _parse_macos_ips(report)
             if not parsed or not _matches_filter(parsed, name_filter):
+                continue
+            if not _matches_identity(parsed, expected_pid, cutoff):
                 continue
             records.append(parsed)
         except Exception:
@@ -147,6 +182,7 @@ def _parse_macos_ips(path: Path) -> dict[str, Any] | None:
             _safe_mtime(path),
             timezone.utc,
         ).isoformat(),
+        "_pid": body.get("pid"),
         "process": process,
         "signal": signal,
         "cause": _infer_cause(signal, backtrace),
@@ -155,8 +191,10 @@ def _parse_macos_ips(path: Path) -> dict[str, Any] | None:
 
 
 def _macos_triggered_backtrace(body: dict[str, Any]) -> list[str]:
-    images = body.get("usedImages") if isinstance(body.get("usedImages"), list) else []
-    threads = body.get("threads") if isinstance(body.get("threads"), list) else []
+    raw_images = body.get("usedImages")
+    images: list[Any] = raw_images if isinstance(raw_images, list) else []
+    raw_threads = body.get("threads")
+    threads: list[Any] = raw_threads if isinstance(raw_threads, list) else []
     selected = None
     for thread in threads:
         if isinstance(thread, dict) and thread.get("triggered"):
@@ -183,7 +221,7 @@ def _macos_triggered_backtrace(body: dict[str, Any]) -> list[str]:
 def _macos_image_name(frame: dict[str, Any], images: list[Any]) -> str:
     image_index = frame.get("imageIndex")
     try:
-        image = images[int(image_index)]
+        image = images[int(str(image_index))]
     except Exception:
         image = None
     if isinstance(image, dict):
@@ -196,10 +234,13 @@ def _macos_image_name(frame: dict[str, Any], images: list[Any]) -> str:
 
 def _linux_recent_crashes(
     name_filter: str,
-    since_hours: int,
+    *,
+    expected_pid: int,
+    since: datetime,
     limit: int,
 ) -> list[dict[str, Any]]:
     records: list[dict[str, Any]] = []
+    since_arg = _as_utc(since).isoformat()
     if shutil.which("coredumpctl"):
         output = _run(
             [
@@ -208,12 +249,20 @@ def _linux_recent_crashes(
                 "--json=short",
                 "--reverse",
                 "--since",
-                f"{max(1, int(since_hours))} hours ago",
+                since_arg,
             ]
         )
-        records.extend(_parse_coredumpctl_json(output, name_filter, limit))
+        records.extend(
+            _parse_coredumpctl_json(
+                output,
+                name_filter,
+                limit,
+                expected_pid=expected_pid,
+                since=since,
+            )
+        )
         for record in records[:limit]:
-            pid = record.pop("_pid", None)
+            pid = record.get("_pid")
             if not pid or record.get("backtrace"):
                 continue
             info = _run(["coredumpctl", "--no-pager", "info", str(pid)])
@@ -229,14 +278,22 @@ def _linux_recent_crashes(
                 "-k",  # kernel log only — segfault/oom lines drown in the full journal
                 "--no-pager",
                 "--since",
-                f"{max(1, int(since_hours))} hours ago",
+                since_arg,
                 "-n",
                 "200",
                 "-o",
                 "short-iso",
             ]
         )
-        records.extend(_parse_journal_crashes(output, name_filter, limit))
+        records.extend(
+            _parse_journal_crashes(
+                output,
+                name_filter,
+                limit,
+                expected_pid=expected_pid,
+                since=since,
+            )
+        )
 
     return records[:limit]
 
@@ -245,6 +302,9 @@ def _parse_coredumpctl_json(
     text: str,
     name_filter: str,
     limit: int,
+    *,
+    expected_pid: int | None = None,
+    since: datetime | None = None,
 ) -> list[dict[str, Any]]:
     records: list[dict[str, Any]] = []
     for row in _coredumpctl_json_rows(text):
@@ -275,6 +335,9 @@ def _parse_coredumpctl_json(
         }
         if not _matches_filter(record, name_filter):
             continue
+        if expected_pid is not None and since is not None:
+            if not _matches_identity(record, expected_pid, since):
+                continue
         record["cause"] = _infer_cause(record.get("signal"), backtrace)
         records.append(record)
     return records
@@ -341,6 +404,9 @@ def _parse_journal_crashes(
     text: str,
     name_filter: str,
     limit: int,
+    *,
+    expected_pid: int | None = None,
+    since: datetime | None = None,
 ) -> list[dict[str, Any]]:
     records: list[dict[str, Any]] = []
     patterns = ("segfault", "core dumped", "oom-killer", "out of memory", "killed process")
@@ -352,20 +418,27 @@ def _parse_journal_crashes(
             continue
         process = _extract_process_name(line)
         record = {
-            "when": line[:25].strip(),
+            "when": line.split(maxsplit=1)[0] if line.strip() else "",
             "process": process,
             "signal": _extract_signal(line),
             "cause": _infer_cause(_extract_signal(line), [line]),
             "backtrace": [line.strip()],
+            "_pid": _extract_pid(line),
         }
-        if _matches_filter(record, name_filter):
-            records.append(record)
+        if not _matches_filter(record, name_filter):
+            continue
+        if expected_pid is not None and since is not None:
+            if not _matches_identity(record, expected_pid, since):
+                continue
+        records.append(record)
     return records
 
 
 def _windows_recent_crashes(
     name_filter: str,
-    since_hours: int,
+    *,
+    expected_pid: int,
+    since: datetime,
     limit: int,
 ) -> list[dict[str, Any]]:
     if sys.platform != "win32":
@@ -374,11 +447,12 @@ def _windows_recent_crashes(
     if not shell:
         return []
 
-    hours = max(1, int(since_hours))
+    since_arg = _as_utc(since).isoformat()
     command = (
+        f"$start = [DateTimeOffset]::Parse('{since_arg}').UtcDateTime; "
         "$events = Get-WinEvent -FilterHashtable "
-        f"@{{LogName='Application'; Id=1000,1001; StartTime=(Get-Date).AddHours(-{hours})}} "
-        f"-MaxEvents {max(1, int(limit))}; "
+        "@{LogName='Application'; Id=1000,1001; StartTime=$start} "
+        f"-MaxEvents {max(_MAX_CANDIDATE_RECORDS, int(limit))}; "
         "$events | Select-Object TimeCreated,ProviderName,Message | ConvertTo-Json -Depth 4 -Compress"
     )
     output = _run([shell, "-NoProfile", "-NonInteractive", "-Command", command])
@@ -403,9 +477,13 @@ def _windows_recent_crashes(
             "signal": "Windows Error Reporting",
             "cause": _infer_cause(None, [message]),
             "backtrace": _split_backtrace(message),
+            "_pid": _extract_windows_faulting_pid(message),
         }
-        if _matches_filter(record, name_filter):
-            records.append(record)
+        if not _matches_filter(record, name_filter):
+            continue
+        if not _matches_identity(record, expected_pid, since):
+            continue
+        records.append(record)
     return records
 
 
@@ -440,6 +518,75 @@ def _matches_filter(record: dict[str, Any], name_filter: str) -> bool:
     if isinstance(backtrace, list):
         haystack_parts.extend(str(item) for item in backtrace[:_MAX_BACKTRACE_FRAMES])
     return needle in "\n".join(haystack_parts).lower()
+
+
+def _matches_identity(
+    record: dict[str, Any],
+    expected_pid: int,
+    since: datetime,
+) -> bool:
+    pid = _coerce_pid(record.get("_pid") or record.get("pid"))
+    occurred_at = _parse_record_time(record.get("when"))
+    if pid != expected_pid or occurred_at is None:
+        return False
+    return occurred_at >= _as_utc(since)
+
+
+def _coerce_pid(value: Any) -> int | None:
+    try:
+        pid = int(str(value).strip(), 0)
+    except (TypeError, ValueError):
+        return None
+    return pid if pid > 0 else None
+
+
+def _parse_record_time(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        parsed = value
+    else:
+        text = str(value or "").strip()
+        if not text:
+            return None
+        try:
+            timestamp = int(text)
+        except (TypeError, ValueError):
+            timestamp = None
+        if timestamp is not None:
+            if abs(timestamp) >= 100_000_000_000_000:
+                seconds = timestamp / 1_000_000
+            elif abs(timestamp) >= 100_000_000_000:
+                seconds = timestamp / 1_000
+            else:
+                seconds = timestamp
+            try:
+                parsed = datetime.fromtimestamp(seconds, timezone.utc)
+            except (OverflowError, OSError, ValueError):
+                return None
+        else:
+            windows_date = re.fullmatch(r"/Date\(([-+]?\d+)(?:[-+]\d{4})?\)/", text)
+            if windows_date:
+                try:
+                    parsed = datetime.fromtimestamp(
+                        int(windows_date.group(1)) / 1_000,
+                        timezone.utc,
+                    )
+                except (OverflowError, OSError, ValueError):
+                    return None
+            else:
+                text = re.sub(r"\s+(Z|[-+]\d{2}:?\d{2})$", r"\1", text)
+                try:
+                    parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+                except ValueError:
+                    return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed.astimezone(timezone.utc)
+
+
+def _as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        raise ValueError("timestamp must include a timezone")
+    return value.astimezone(timezone.utc)
 
 
 def _infer_cause(signal: Any, lines: list[str]) -> str:
@@ -482,6 +629,17 @@ def _extract_process_name(line: str) -> str:
     return ""
 
 
+def _extract_pid(line: str) -> int | None:
+    for pattern in (
+        r"\b[A-Za-z0-9_.-]+\[(\d+)\]",
+        r"\b(?:killed process|process|pid)[\s:=]+(\d+)\b",
+    ):
+        match = re.search(pattern, line, re.IGNORECASE)
+        if match:
+            return _coerce_pid(match.group(1))
+    return None
+
+
 def _extract_signal(line: str) -> str:
     match = re.search(r"\bSIG[A-Z0-9]+\b", line)
     if match:
@@ -496,6 +654,15 @@ def _extract_windows_faulting_app(message: str) -> str:
     if match:
         return match.group(1).strip()
     return ""
+
+
+def _extract_windows_faulting_pid(message: str) -> int | None:
+    match = re.search(
+        r"Faulting application process id:\s*(0x[0-9a-f]+|\d+)",
+        message,
+        re.IGNORECASE,
+    )
+    return _coerce_pid(match.group(1)) if match else None
 
 
 def _clean_text(value: Any) -> str:

--- a/gateway/crash_diagnostics.py
+++ b/gateway/crash_diagnostics.py
@@ -178,10 +178,7 @@ def _parse_macos_ips(path: Path) -> dict[str, Any] | None:
     signal = exception.get("signal") or exception.get("type")
     backtrace = _macos_triggered_backtrace(body)
     return {
-        "when": body.get("captureTime") or datetime.fromtimestamp(
-            _safe_mtime(path),
-            timezone.utc,
-        ).isoformat(),
+        "when": body.get("captureTime"),
         "_pid": body.get("pid"),
         "process": process,
         "signal": signal,
@@ -282,7 +279,7 @@ def _linux_recent_crashes(
                 "-n",
                 "200",
                 "-o",
-                "short-iso",
+                "short-iso-precise",
             ]
         )
         records.extend(
@@ -620,6 +617,7 @@ def _split_backtrace(value: Any) -> list[str]:
 def _extract_process_name(line: str) -> str:
     for pattern in (
         r"\bcomm=\"([^\"]+)\"",
+        r"\bKilled process\s+\d+\s+\(([^)]+)\)",
         r"\bProcess\s+(\S+)",
         r"\bpython[0-9.]*\b",
     ):
@@ -658,7 +656,7 @@ def _extract_windows_faulting_app(message: str) -> str:
 
 def _extract_windows_faulting_pid(message: str) -> int | None:
     match = re.search(
-        r"Faulting application process id:\s*(0x[0-9a-f]+|\d+)",
+        r"Faulting (?:application )?process id:\s*(0x[0-9a-f]+|\d+)",
         message,
         re.IGNORECASE,
     )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1331,27 +1331,24 @@ def _runtime_status_indicates_previous_gateway(status: Optional[dict[str, Any]])
     return state in _PREVIOUS_GATEWAY_ACTIVE_STATES
 
 
-def _crash_scan_window_hours(status: Optional[dict[str, Any]]) -> int:
-    """Bound the crash-record scan to the previous gateway's lifetime.
-
-    The crash that killed the previous gateway must postdate its last runtime
-    status write, so older OS crash records (e.g. an unrelated Python crash
-    yesterday) cannot be the cause. Falls back to 24h when the timestamp is
-    missing or unparsable.
-    """
-    fallback_hours = 24
+def _previous_gateway_crash_identity(
+    status: Optional[dict[str, Any]],
+) -> Optional[tuple[int, datetime]]:
+    """Return the prior gateway PID and exact last status timestamp."""
+    if not isinstance(status, dict):
+        return None
     try:
-        raw = str((status or {}).get("updated_at") or "").strip()
-        if not raw:
-            return fallback_hours
+        pid = int(str(status.get("pid")))
+        raw = str(status.get("updated_at") or "").strip()
         updated_at = datetime.fromisoformat(raw.replace("Z", "+00:00"))
-        if updated_at.tzinfo is None:
-            updated_at = updated_at.replace(tzinfo=timezone.utc)
-        elapsed = datetime.now(timezone.utc) - updated_at
-        hours = int(elapsed.total_seconds() // 3600) + 1
-        return max(1, min(fallback_hours, hours))
-    except Exception:
-        return fallback_hours
+    except (TypeError, ValueError):
+        return None
+    if pid <= 0 or updated_at.tzinfo is None:
+        return None
+    try:
+        return pid, updated_at.astimezone(timezone.utc)
+    except (OverflowError, ValueError):
+        return None
 
 
 # Mark this process as a gateway so cli.py's module-level load_cli_config()
@@ -15216,6 +15213,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     async def _restart_crash_notice(
         self, previous_status: Optional[dict[str, Any]] = None
     ) -> str:
+        identity = _previous_gateway_crash_identity(previous_status)
+        if identity is None:
+            return ""
+        expected_pid, since = identity
         try:
             from gateway.crash_diagnostics import restart_notice
         except Exception:
@@ -15224,7 +15225,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             notice = await asyncio.to_thread(
                 restart_notice,
                 name_filter="python",
-                since_hours=_crash_scan_window_hours(previous_status),
+                expected_pid=expected_pid,
+                since=since,
             )
         except Exception:
             return ""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7443,12 +7443,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # of a restart cycle (see _is_stale_restart_redelivery).
         if _restart_notification_pending() or planned_restart_notification_pending:
             self._booted_from_restart = True
-        await self._send_restart_notification()
+        restart_notification_target = await self._send_restart_notification()
+        skip_home_startup_targets = (
+            {restart_notification_target} if restart_notification_target is not None else None
+        )
 
         # Broadcast a lightweight "gateway is back" message to configured home
-        # channels only for non-chat planned restarts (terminal/SIGUSR1/service
-        # paths). Chat-originated /restart already has a precise reply target
-        # in .restart_notify.json, so keep that lifecycle in the originating
+        # channels after non-chat planned restarts and unclean recoveries.
+        # Chat-originated /restart already has a precise reply target in
+        # .restart_notify.json, so keep that lifecycle in the originating
         # chat/topic instead of also leaking it to the configured home channel.
         should_notify_home_startup = planned_restart_notification_pending or _previous_gateway_unclean
         if should_notify_home_startup:
@@ -7456,12 +7459,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if (
                 _previous_gateway_unclean
                 and not planned_restart_notification_pending
-                and self._home_channel_startup_notification_targets(skip_targets=None)
+                and self._home_channel_startup_notification_targets(
+                    skip_targets=skip_home_startup_targets
+                )
             ):
                 crash_notice = await self._restart_crash_notice(_previous_runtime_status)
             try:
                 await self._send_home_channel_startup_notifications(
-                    skip_targets=None,
+                    skip_targets=skip_home_startup_targets,
                     extra_notice=crash_notice,
                 )
             finally:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -43,7 +43,7 @@ import sqlite3
 from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Callable, Dict, Optional, Any, List, Union
 
 # account_usage imports the OpenAI SDK chain (~230 ms). Only needed by
@@ -1315,6 +1315,43 @@ def _planned_restart_notification_pending() -> bool:
 
 def _clear_planned_restart_notification() -> None:
     _planned_restart_notification_path().unlink(missing_ok=True)
+
+
+_PREVIOUS_GATEWAY_ACTIVE_STATES = frozenset({"starting", "running", "draining", "degraded"})
+
+
+def _runtime_status_indicates_previous_gateway(status: Optional[dict[str, Any]]) -> bool:
+    """Return True when the persisted status looks like a prior live gateway."""
+    if not isinstance(status, dict):
+        return False
+    kind = status.get("kind")
+    if kind not in (None, "hermes-gateway"):
+        return False
+    state = str(status.get("gateway_state") or "").strip().lower()
+    return state in _PREVIOUS_GATEWAY_ACTIVE_STATES
+
+
+def _crash_scan_window_hours(status: Optional[dict[str, Any]]) -> int:
+    """Bound the crash-record scan to the previous gateway's lifetime.
+
+    The crash that killed the previous gateway must postdate its last runtime
+    status write, so older OS crash records (e.g. an unrelated Python crash
+    yesterday) cannot be the cause. Falls back to 24h when the timestamp is
+    missing or unparsable.
+    """
+    fallback_hours = 24
+    try:
+        raw = str((status or {}).get("updated_at") or "").strip()
+        if not raw:
+            return fallback_hours
+        updated_at = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        if updated_at.tzinfo is None:
+            updated_at = updated_at.replace(tzinfo=timezone.utc)
+        elapsed = datetime.now(timezone.utc) - updated_at
+        hours = int(elapsed.total_seconds() // 3600) + 1
+        return max(1, min(fallback_hours, hours))
+    except Exception:
+        return fallback_hours
 
 
 # Mark this process as a gateway so cli.py's module-level load_cli_config()
@@ -6888,6 +6925,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.info("Active profile: %s", _profile)
         except Exception:
             pass
+        _previous_runtime_status = None
+        try:
+            from gateway.status import read_runtime_status
+            _previous_runtime_status = read_runtime_status()
+        except Exception:
+            pass
         try:
             from gateway.status import write_runtime_status
             write_runtime_status(gateway_state="starting", exit_reason=None)
@@ -7098,7 +7141,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # This prevents unwanted auto-resets after `hermes update`,
         # `hermes gateway restart`, or `/restart`.
         _clean_marker = _hermes_home / ".clean_shutdown"
-        if _clean_marker.exists():
+        _previous_clean_shutdown = _clean_marker.exists()
+        _previous_gateway_unclean = (
+            not _previous_clean_shutdown
+            and _runtime_status_indicates_previous_gateway(_previous_runtime_status)
+        )
+        if _previous_clean_shutdown:
             logger.info("Previous gateway exited cleanly — skipping session suspension")
             try:
                 _clean_marker.unlink()
@@ -7405,13 +7453,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # paths). Chat-originated /restart already has a precise reply target
         # in .restart_notify.json, so keep that lifecycle in the originating
         # chat/topic instead of also leaking it to the configured home channel.
-        if planned_restart_notification_pending:
+        should_notify_home_startup = planned_restart_notification_pending or _previous_gateway_unclean
+        if should_notify_home_startup:
+            crash_notice = ""
+            if (
+                _previous_gateway_unclean
+                and not planned_restart_notification_pending
+                and self._home_channel_startup_notification_targets(skip_targets=None)
+            ):
+                crash_notice = await self._restart_crash_notice(_previous_runtime_status)
             try:
                 await self._send_home_channel_startup_notifications(
                     skip_targets=None,
+                    extra_notice=crash_notice,
                 )
             finally:
-                _clear_planned_restart_notification()
+                if planned_restart_notification_pending:
+                    _clear_planned_restart_notification()
 
         # Automatically continue fresh sessions that were interrupted by the
         # previous gateway restart/shutdown.  The resume_pending flag is cleared
@@ -15056,6 +15114,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self,
         *,
         skip_targets: Optional[set[tuple[str, str, Optional[str]]]] = None,
+        extra_notice: str = "",
     ) -> set[tuple[str, str, Optional[str]]]:
         """Notify configured home channels that the gateway is back online.
 
@@ -15064,24 +15123,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         when a more specific restart notification is queued for the same chat.
         """
         delivered: set[tuple[str, str, Optional[str]]] = set()
-        skipped = skip_targets or set()
-        message = "♻️ Gateway online — Hermes is back and ready."
+        message = "♻️ Gateway online — Hermes is back and ready." + (extra_notice or "")
 
-        for platform, adapter in self.adapters.items():
-            home = self.config.get_home_channel(platform)
-            if not home or not home.chat_id:
-                continue
-
-            platform_cfg = self.config.platforms.get(platform)
-            if platform_cfg is not None and not platform_cfg.gateway_restart_notification:
-                logger.info(
-                    "Home-channel startup notification suppressed: %s has gateway_restart_notification=false",
-                    platform.value,
-                )
-                continue
-
-            target = (platform.value, str(home.chat_id), str(home.thread_id) if home.thread_id else None)
-            if target in skipped or target in delivered:
+        for platform, adapter, home, target in self._home_channel_startup_notification_targets(
+            skip_targets=skip_targets,
+        ):
+            if target in delivered:
                 continue
 
             try:
@@ -15131,6 +15178,57 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
 
         return delivered
+
+    def _home_channel_startup_notification_targets(
+        self,
+        *,
+        skip_targets: Optional[set[tuple[str, str, Optional[str]]]] = None,
+    ) -> list[
+        tuple[Platform, BasePlatformAdapter, HomeChannel, tuple[str, str, Optional[str]]]
+    ]:
+        targets: list[
+            tuple[Platform, BasePlatformAdapter, HomeChannel, tuple[str, str, Optional[str]]]
+        ] = []
+        skipped = skip_targets or set()
+        for platform, adapter in self.adapters.items():
+            home = self.config.get_home_channel(platform)
+            if not home or not home.chat_id:
+                continue
+
+            platform_cfg = self.config.platforms.get(platform)
+            if platform_cfg is not None and not platform_cfg.gateway_restart_notification:
+                logger.info(
+                    "Home-channel startup notification suppressed: %s has gateway_restart_notification=false",
+                    platform.value,
+                )
+                continue
+
+            target = (
+                platform.value,
+                str(home.chat_id),
+                str(home.thread_id) if home.thread_id else None,
+            )
+            if target in skipped:
+                continue
+            targets.append((platform, adapter, home, target))
+        return targets
+
+    async def _restart_crash_notice(
+        self, previous_status: Optional[dict[str, Any]] = None
+    ) -> str:
+        try:
+            from gateway.crash_diagnostics import restart_notice
+        except Exception:
+            return ""
+        try:
+            notice = await asyncio.to_thread(
+                restart_notice,
+                name_filter="python",
+                since_hours=_crash_scan_window_hours(previous_status),
+            )
+        except Exception:
+            return ""
+        return notice if isinstance(notice, str) else ""
 
     def _set_session_env(self, context: SessionContext) -> list:
         """Set session context variables for the current async task.

--- a/tests/gateway/restart_test_helpers.py
+++ b/tests/gateway/restart_test_helpers.py
@@ -103,6 +103,12 @@ def make_restart_runner(
     runner._send_home_channel_startup_notifications = (
         GatewayRunner._send_home_channel_startup_notifications.__get__(runner, GatewayRunner)
     )
+    runner._home_channel_startup_notification_targets = (
+        GatewayRunner._home_channel_startup_notification_targets.__get__(runner, GatewayRunner)
+    )
+    runner._restart_crash_notice = GatewayRunner._restart_crash_notice.__get__(
+        runner, GatewayRunner
+    )
     runner._status_action_label = GatewayRunner._status_action_label.__get__(
         runner, GatewayRunner
     )

--- a/tests/gateway/test_crash_diagnostics.py
+++ b/tests/gateway/test_crash_diagnostics.py
@@ -1,0 +1,233 @@
+import json
+
+import gateway.crash_diagnostics as cd
+
+
+def test_restart_notice_formats_crash_cause_and_faulting_frame(monkeypatch):
+    monkeypatch.setattr(
+        cd,
+        "recent_crashes",
+        lambda **_kwargs: [
+            {
+                "process": "Python",
+                "signal": "SIGABRT",
+                "cause": "GPU error (Metal/MLX)",
+                "backtrace": ["libmlx.dylib: mlx_abort"],
+            }
+        ],
+    )
+
+    assert cd.restart_notice() == (
+        "\n\nCrash cause: GPU error (Metal/MLX) (Python, SIGABRT)"
+        "\nFaulting frame: libmlx.dylib: mlx_abort"
+    )
+
+
+def test_recent_crashes_swallows_reader_failure(monkeypatch):
+    monkeypatch.setattr(cd.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(
+        cd,
+        "_macos_recent_crashes",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    assert cd.recent_crashes() == []
+
+
+def test_parse_macos_ips_extracts_triggered_thread(tmp_path):
+    report = tmp_path / "Python-2026-06-05.ips"
+    report.write_text(
+        "header\n"
+        + json.dumps(
+            {
+                "procName": "Python",
+                "captureTime": "2026-06-05 09:08:00.000 +0800",
+                "exception": {"signal": "SIGABRT"},
+                "usedImages": [{"name": "libsystem_kernel.dylib"}, {"name": "libmlx.dylib"}],
+                "threads": [
+                    {"frames": [{"imageIndex": 0, "symbol": "idle"}]},
+                    {
+                        "triggered": True,
+                        "frames": [
+                            {"imageIndex": 1, "symbol": "mlx_abort"},
+                            {"imageIndex": 0, "symbol": "__pthread_kill"},
+                        ],
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    parsed = cd._parse_macos_ips(report)
+
+    assert parsed is not None
+    assert parsed["process"] == "Python"
+    assert parsed["signal"] == "SIGABRT"
+    assert parsed["cause"] == "GPU error (Metal/MLX)"
+    assert parsed["backtrace"][:2] == [
+        "libmlx.dylib: mlx_abort",
+        "libsystem_kernel.dylib: __pthread_kill",
+    ]
+
+
+def test_linux_journal_parser_filters_to_python_crashes():
+    text = "\n".join(
+        [
+            "2026-06-05T09:00:00Z host kernel: unrelated segfault in node",
+            "2026-06-05T09:08:00Z host kernel: python[123]: segfault at 0 ip 0 sp 0 error 4",
+        ]
+    )
+
+    records = cd._parse_journal_crashes(text, "python", 5)
+
+    assert len(records) == 1
+    assert records[0]["process"] == "python"
+    assert records[0]["signal"] == "SIGSEGV"
+    assert records[0]["cause"] == "segmentation fault"
+
+
+def test_parse_coredumpctl_info_backtrace_extracts_stack_frames():
+    text = """
+           PID: 1234 (python)
+        Signal: 11 (SEGV)
+   Stack trace of thread 1234:
+            #0  0x000000 libnative.so crash_here
+            #1  0x000001 python PyEval_EvalFrame
+
+    Metadata after stack
+    """
+
+    assert cd._parse_coredumpctl_info_backtrace(text) == [
+        "#0 0x000000 libnative.so crash_here",
+        "#1 0x000001 python PyEval_EvalFrame",
+    ]
+
+
+def test_run_returns_empty_string_on_timeout(monkeypatch):
+    def _raise_timeout(*_args, **_kwargs):
+        raise TimeoutError("slow")
+
+    monkeypatch.setattr(cd.subprocess, "run", _raise_timeout)
+
+    assert cd._run(["fake"]) == ""
+
+
+def test_parse_coredumpctl_json_array_with_lowercase_fields():
+    # Real ``coredumpctl --json=short`` shape: one compact JSON array with
+    # lowercase keys and the signal as a number (systemd format-table output).
+    text = json.dumps(
+        [
+            {
+                "time": 1765432100000000,
+                "pid": 4242,
+                "uid": 1000,
+                "gid": 1000,
+                "sig": 11,
+                "corefile": "present",
+                "exe": "/usr/bin/python3.12",
+                "size": 123456,
+            },
+            {
+                "time": 1765432000000000,
+                "pid": 4100,
+                "sig": 6,
+                "corefile": "present",
+                "exe": "/usr/bin/node",
+                "size": 2222,
+            },
+        ]
+    )
+
+    records = cd._parse_coredumpctl_json(text, "python", 5)
+
+    assert len(records) == 1
+    assert records[0]["process"] == "python3.12"
+    assert records[0]["signal"] == "SIGSEGV"
+    assert records[0]["cause"] == "segmentation fault"
+    assert records[0]["_pid"] == 4242
+
+
+def test_parse_coredumpctl_json_keeps_journal_field_fallback():
+    text = "\n".join(
+        [
+            json.dumps(
+                {
+                    "COREDUMP_COMM": "python3",
+                    "COREDUMP_SIGNAL_NAME": "SIGABRT",
+                    "COREDUMP_PID": "77",
+                }
+            ),
+            "not json",
+        ]
+    )
+
+    records = cd._parse_coredumpctl_json(text, "python", 5)
+
+    assert len(records) == 1
+    assert records[0]["process"] == "python3"
+    assert records[0]["signal"] == "SIGABRT"
+
+
+def test_parse_coredumpctl_json_garbage_returns_empty():
+    assert cd._parse_coredumpctl_json("No coredumps found.", "python", 5) == []
+    assert cd._parse_coredumpctl_json("", "python", 5) == []
+
+
+def test_signal_display_name_maps_numbers():
+    assert cd._signal_display_name(11) == "SIGSEGV"
+    assert cd._signal_display_name("6") == "SIGABRT"
+    assert cd._signal_display_name("SIGKILL") == "SIGKILL"
+    assert cd._signal_display_name(None) == ""
+
+
+def test_linux_journalctl_fallback_scans_kernel_log(monkeypatch):
+    commands = []
+
+    def _fake_run(cmd):
+        commands.append(cmd)
+        return "2026-06-05T09:08:00Z host kernel: python[123]: segfault at 0 ip 0 sp 0 error 4"
+
+    monkeypatch.setattr(
+        cd.shutil,
+        "which",
+        lambda name: None if name == "coredumpctl" else f"/usr/bin/{name}",
+    )
+    monkeypatch.setattr(cd, "_run", _fake_run)
+
+    records = cd._linux_recent_crashes("python", 24, 5)
+
+    assert len(records) == 1
+    assert records[0]["signal"] == "SIGSEGV"
+    assert commands and commands[0][0] == "journalctl"
+    assert "-k" in commands[0]
+
+
+def test_parse_macos_ips_filters_on_header_bug_type(tmp_path):
+    body = json.dumps(
+        {"procName": "Python", "exception": {"signal": "SIGABRT"}, "threads": []}
+    )
+
+    # Hang report (bug_type 288) — same .ips extension, not a crash.
+    hang = tmp_path / "Python-hang.ips"
+    hang.write_text(json.dumps({"bug_type": "288"}) + "\n" + body, encoding="utf-8")
+    assert cd._parse_macos_ips(hang) is None
+
+    # Crash report (bug_type 309) parses normally.
+    crash = tmp_path / "Python-crash.ips"
+    crash.write_text(json.dumps({"bug_type": "309"}) + "\n" + body, encoding="utf-8")
+    parsed = cd._parse_macos_ips(crash)
+    assert parsed is not None
+    assert parsed["signal"] == "SIGABRT"
+
+
+def test_restart_notice_does_not_repeat_signal_as_cause(monkeypatch):
+    monkeypatch.setattr(
+        cd,
+        "recent_crashes",
+        lambda **_kwargs: [
+            {"process": "Python", "signal": "SIGTRAP", "cause": "SIGTRAP", "backtrace": []}
+        ],
+    )
+
+    assert cd.restart_notice() == "\n\nCrash cause: SIGTRAP (Python)"

--- a/tests/gateway/test_crash_diagnostics.py
+++ b/tests/gateway/test_crash_diagnostics.py
@@ -453,6 +453,45 @@ def test_linux_journalctl_fallback_scans_kernel_log(monkeypatch):
     assert commands[0][format_index] == "short-iso-precise"
 
 
+def test_linux_coredumpctl_bounds_candidate_records(monkeypatch):
+    commands = []
+    since = datetime(2026, 6, 5, 9, 8, tzinfo=timezone.utc)
+
+    def _fake_run(cmd):
+        commands.append(cmd)
+        if "info" in cmd:
+            return ""
+        return json.dumps(
+            [
+                {
+                    "time": int((since + timedelta(seconds=1)).timestamp() * 1_000_000),
+                    "pid": 123,
+                    "sig": 11,
+                    "exe": "/usr/bin/python3.12",
+                }
+            ]
+        )
+
+    monkeypatch.setattr(
+        cd.shutil,
+        "which",
+        lambda name: "/usr/bin/coredumpctl" if name == "coredumpctl" else None,
+    )
+    monkeypatch.setattr(cd, "_run", _fake_run)
+
+    records = cd._linux_recent_crashes(
+        "python",
+        expected_pid=123,
+        since=since,
+        limit=1,
+    )
+
+    assert len(records) == 1
+    assert commands[0][0] == "coredumpctl"
+    limit_index = commands[0].index("-n") + 1
+    assert commands[0][limit_index] == str(cd._MAX_CANDIDATE_RECORDS)
+
+
 def test_windows_reader_requires_matching_pid_after_exact_status_time(monkeypatch):
     since = datetime(2026, 7, 15, 10, 30, 30, tzinfo=timezone.utc)
     commands = []

--- a/tests/gateway/test_crash_diagnostics.py
+++ b/tests/gateway/test_crash_diagnostics.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime, timedelta, timezone
 
 import gateway.crash_diagnostics as cd
 
@@ -17,21 +18,88 @@ def test_restart_notice_formats_crash_cause_and_faulting_frame(monkeypatch):
         ],
     )
 
-    assert cd.restart_notice() == (
+    assert cd.restart_notice(
+        expected_pid=4242,
+        since=datetime(2026, 7, 15, tzinfo=timezone.utc),
+    ) == (
         "\n\nCrash cause: GPU error (Metal/MLX) (Python, SIGABRT)"
         "\nFaulting frame: libmlx.dylib: mlx_abort"
     )
 
 
+def test_restart_notice_forwards_exact_crash_identity(monkeypatch):
+    since = datetime(2026, 7, 15, 10, 30, 30, tzinfo=timezone.utc)
+    captured = {}
+
+    def _fake_recent_crashes(**kwargs):
+        captured.update(kwargs)
+        return [
+            {
+                "process": "python3.12",
+                "signal": "SIGSEGV",
+                "cause": "segmentation fault",
+                "backtrace": [],
+            }
+        ]
+
+    monkeypatch.setattr(cd, "recent_crashes", _fake_recent_crashes)
+
+    notice = cd.restart_notice(expected_pid=4242, since=since)
+
+    assert "Crash cause: segmentation fault" in notice
+    assert captured == {
+        "name_filter": "python",
+        "expected_pid": 4242,
+        "since": since,
+        "limit": 1,
+    }
+
+
+def test_restart_notice_skips_lookup_without_complete_identity(monkeypatch):
+    lookups = []
+
+    def _unexpected_lookup(**kwargs):
+        lookups.append(kwargs)
+        return []
+
+    monkeypatch.setattr(cd, "recent_crashes", _unexpected_lookup)
+
+    assert cd.restart_notice() == ""
+    assert cd.restart_notice(expected_pid=4242) == ""
+    assert cd.restart_notice(since=datetime.now(timezone.utc)) == ""
+    assert cd.restart_notice(expected_pid=4242, since=datetime(2026, 7, 15)) == ""
+    assert lookups == []
+
+
 def test_recent_crashes_swallows_reader_failure(monkeypatch):
+    since = datetime(2026, 7, 15, tzinfo=timezone.utc)
     monkeypatch.setattr(cd.platform, "system", lambda: "Darwin")
     monkeypatch.setattr(
         cd,
         "_macos_recent_crashes",
-        lambda *_args: (_ for _ in ()).throw(RuntimeError("boom")),
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
     )
 
-    assert cd.recent_crashes() == []
+    assert cd.recent_crashes(expected_pid=4242, since=since) == []
+
+
+def test_recent_crashes_passes_exact_identity_to_platform_reader(monkeypatch):
+    since = datetime(2026, 7, 15, 10, 30, 30, tzinfo=timezone.utc)
+    captured = {}
+
+    def _fake_linux_reader(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return []
+
+    monkeypatch.setattr(cd.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(cd, "_linux_recent_crashes", _fake_linux_reader)
+
+    assert cd.recent_crashes(expected_pid=4242, since=since, limit=3) == []
+    assert captured == {
+        "args": ("python",),
+        "kwargs": {"expected_pid": 4242, "since": since, "limit": 3},
+    }
 
 
 def test_parse_macos_ips_extracts_triggered_thread(tmp_path):
@@ -40,6 +108,7 @@ def test_parse_macos_ips_extracts_triggered_thread(tmp_path):
         "header\n"
         + json.dumps(
             {
+                "pid": 4242,
                 "procName": "Python",
                 "captureTime": "2026-06-05 09:08:00.000 +0800",
                 "exception": {"signal": "SIGABRT"},
@@ -62,6 +131,7 @@ def test_parse_macos_ips_extracts_triggered_thread(tmp_path):
     parsed = cd._parse_macos_ips(report)
 
     assert parsed is not None
+    assert parsed["_pid"] == 4242
     assert parsed["process"] == "Python"
     assert parsed["signal"] == "SIGABRT"
     assert parsed["cause"] == "GPU error (Metal/MLX)"
@@ -69,6 +139,57 @@ def test_parse_macos_ips_extracts_triggered_thread(tmp_path):
         "libmlx.dylib: mlx_abort",
         "libsystem_kernel.dylib: __pthread_kill",
     ]
+
+
+def test_macos_reader_requires_matching_pid_after_exact_status_time(tmp_path, monkeypatch):
+    since = datetime(2026, 7, 15, 10, 30, 30, tzinfo=timezone.utc)
+    reports = tmp_path / "Library" / "Logs" / "DiagnosticReports"
+    reports.mkdir(parents=True)
+
+    def _write_report(name, *, pid, capture_time, signal):
+        (reports / name).write_text(
+            json.dumps(
+                {
+                    "pid": pid,
+                    "procName": "Python",
+                    "captureTime": capture_time,
+                    "exception": {"signal": signal},
+                    "threads": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    _write_report(
+        "Python-unrelated.ips",
+        pid=9002,
+        capture_time="2026-07-15 18:45:00.000 +0800",
+        signal="SIGABRT",
+    )
+    _write_report(
+        "Python-too-early.ips",
+        pid=4242,
+        capture_time="2026-07-15 18:30:29.000 +0800",
+        signal="SIGABRT",
+    )
+    _write_report(
+        "Python-matching.ips",
+        pid=4242,
+        capture_time="2026-07-15 18:31:00.000 +0800",
+        signal="SIGSEGV",
+    )
+    monkeypatch.setattr(cd.Path, "home", classmethod(lambda _cls: tmp_path))
+
+    records = cd._macos_recent_crashes(
+        "python",
+        expected_pid=4242,
+        since=since,
+        limit=5,
+    )
+
+    assert len(records) == 1
+    assert records[0]["_pid"] == 4242
+    assert records[0]["signal"] == "SIGSEGV"
 
 
 def test_linux_journal_parser_filters_to_python_crashes():
@@ -148,6 +269,53 @@ def test_parse_coredumpctl_json_array_with_lowercase_fields():
     assert records[0]["_pid"] == 4242
 
 
+def test_coredump_rows_require_matching_pid_after_exact_status_time():
+    since = datetime(2026, 7, 15, 10, 30, 30, tzinfo=timezone.utc)
+
+    def _micros(value):
+        return int(value.timestamp() * 1_000_000)
+
+    text = json.dumps(
+        [
+            {
+                "time": _micros(since + timedelta(minutes=20)),
+                "pid": 9002,
+                "sig": 6,
+                "exe": "/usr/bin/python3.12",
+            },
+            {
+                "time": _micros(since - timedelta(microseconds=1)),
+                "pid": 4242,
+                "sig": 6,
+                "exe": "/usr/bin/python3.12",
+            },
+            {
+                "time": _micros(since + timedelta(minutes=10)),
+                "sig": 6,
+                "exe": "/usr/bin/python3.12",
+            },
+            {
+                "time": _micros(since + timedelta(minutes=1)),
+                "pid": 4242,
+                "sig": 11,
+                "exe": "/usr/bin/python3.12",
+            },
+        ]
+    )
+
+    records = cd._parse_coredumpctl_json(
+        text,
+        "python",
+        5,
+        expected_pid=4242,
+        since=since,
+    )
+
+    assert len(records) == 1
+    assert records[0]["_pid"] == 4242
+    assert records[0]["signal"] == "SIGSEGV"
+
+
 def test_parse_coredumpctl_json_keeps_journal_field_fallback():
     text = "\n".join(
         [
@@ -183,10 +351,16 @@ def test_signal_display_name_maps_numbers():
 
 def test_linux_journalctl_fallback_scans_kernel_log(monkeypatch):
     commands = []
+    since = datetime(2026, 6, 5, 9, 7, tzinfo=timezone.utc)
 
     def _fake_run(cmd):
         commands.append(cmd)
-        return "2026-06-05T09:08:00Z host kernel: python[123]: segfault at 0 ip 0 sp 0 error 4"
+        return "\n".join(
+            [
+                "2026-06-05T09:09:00Z host kernel: python[999]: segfault at 0 ip 0 sp 0 error 4",
+                "2026-06-05T09:08:00Z host kernel: python[123]: segfault at 0 ip 0 sp 0 error 4",
+            ]
+        )
 
     monkeypatch.setattr(
         cd.shutil,
@@ -195,12 +369,64 @@ def test_linux_journalctl_fallback_scans_kernel_log(monkeypatch):
     )
     monkeypatch.setattr(cd, "_run", _fake_run)
 
-    records = cd._linux_recent_crashes("python", 24, 5)
+    records = cd._linux_recent_crashes(
+        "python",
+        expected_pid=123,
+        since=since,
+        limit=5,
+    )
 
     assert len(records) == 1
+    assert records[0]["_pid"] == 123
     assert records[0]["signal"] == "SIGSEGV"
     assert commands and commands[0][0] == "journalctl"
     assert "-k" in commands[0]
+    since_index = commands[0].index("--since") + 1
+    assert commands[0][since_index] == "2026-06-05T09:07:00+00:00"
+
+
+def test_windows_reader_requires_matching_pid_after_exact_status_time(monkeypatch):
+    since = datetime(2026, 7, 15, 10, 30, 30, tzinfo=timezone.utc)
+    commands = []
+
+    def _event(pid, when, exception_code):
+        return {
+            "TimeCreated": when,
+            "ProviderName": "Application Error",
+            "Message": (
+                "Faulting application name: python.exe, version: 3.12.0\n"
+                f"Faulting application process id: 0x{pid:x}\n"
+                f"Exception code: {exception_code}"
+            ),
+        }
+
+    rows = [
+        _event(9002, "2026-07-15T10:45:00Z", "0x80000003"),
+        _event(4242, "2026-07-15T10:30:29Z", "0x80000003"),
+        _event(4242, "2026-07-15T10:31:00Z", "0xc0000005"),
+    ]
+
+    monkeypatch.setattr(cd.sys, "platform", "win32")
+    monkeypatch.setattr(cd.shutil, "which", lambda _name: "C:/Windows/powershell.exe")
+
+    def _fake_run(cmd):
+        commands.append(cmd)
+        return json.dumps(rows)
+
+    monkeypatch.setattr(cd, "_run", _fake_run)
+
+    records = cd._windows_recent_crashes(
+        "python",
+        expected_pid=4242,
+        since=since,
+        limit=5,
+    )
+
+    assert len(records) == 1
+    assert records[0]["_pid"] == 4242
+    assert records[0]["when"] == "2026-07-15T10:31:00Z"
+    assert "2026-07-15T10:30:30+00:00" in commands[0][-1]
+    assert "-MaxEvents 100" in commands[0][-1]
 
 
 def test_parse_macos_ips_filters_on_header_bug_type(tmp_path):
@@ -230,4 +456,7 @@ def test_restart_notice_does_not_repeat_signal_as_cause(monkeypatch):
         ],
     )
 
-    assert cd.restart_notice() == "\n\nCrash cause: SIGTRAP (Python)"
+    assert cd.restart_notice(
+        expected_pid=4242,
+        since=datetime(2026, 7, 15, tzinfo=timezone.utc),
+    ) == "\n\nCrash cause: SIGTRAP (Python)"

--- a/tests/gateway/test_crash_diagnostics.py
+++ b/tests/gateway/test_crash_diagnostics.py
@@ -1,6 +1,8 @@
 import json
 from datetime import datetime, timedelta, timezone
 
+import pytest
+
 import gateway.crash_diagnostics as cd
 
 
@@ -179,6 +181,14 @@ def test_macos_reader_requires_matching_pid_after_exact_status_time(tmp_path, mo
         signal="SIGSEGV",
     )
     monkeypatch.setattr(cd.Path, "home", classmethod(lambda _cls: tmp_path))
+    original_glob = cd.Path.glob
+    monkeypatch.setattr(
+        cd.Path,
+        "glob",
+        lambda directory, pattern: original_glob(directory, pattern)
+        if directory == reports
+        else [],
+    )
 
     records = cd._macos_recent_crashes(
         "python",
@@ -190,6 +200,40 @@ def test_macos_reader_requires_matching_pid_after_exact_status_time(tmp_path, mo
     assert len(records) == 1
     assert records[0]["_pid"] == 4242
     assert records[0]["signal"] == "SIGSEGV"
+
+
+def test_macos_reader_ignores_reports_without_capture_time(tmp_path, monkeypatch):
+    reports = tmp_path / "Library" / "Logs" / "DiagnosticReports"
+    reports.mkdir(parents=True)
+    (reports / "Python-missing-time.ips").write_text(
+        json.dumps(
+            {
+                "pid": 4242,
+                "procName": "Python",
+                "exception": {"signal": "SIGSEGV"},
+                "threads": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(cd.Path, "home", classmethod(lambda _cls: tmp_path))
+    original_glob = cd.Path.glob
+    monkeypatch.setattr(
+        cd.Path,
+        "glob",
+        lambda directory, pattern: original_glob(directory, pattern)
+        if directory == reports
+        else [],
+    )
+
+    records = cd._macos_recent_crashes(
+        "python",
+        expected_pid=4242,
+        since=datetime.now(timezone.utc) - timedelta(minutes=1),
+        limit=5,
+    )
+
+    assert records == []
 
 
 def test_linux_journal_parser_filters_to_python_crashes():
@@ -206,6 +250,27 @@ def test_linux_journal_parser_filters_to_python_crashes():
     assert records[0]["process"] == "python"
     assert records[0]["signal"] == "SIGSEGV"
     assert records[0]["cause"] == "segmentation fault"
+
+
+def test_linux_journal_parser_keeps_oom_process_name():
+    since = datetime(2026, 6, 5, 9, 7, tzinfo=timezone.utc)
+    text = (
+        "2026-06-05T09:08:00.000000+0000 host kernel: "
+        "Out of memory: Killed process 4242 (python3.12) total-vm:1234kB"
+    )
+
+    records = cd._parse_journal_crashes(
+        text,
+        "python",
+        5,
+        expected_pid=4242,
+        since=since,
+    )
+
+    assert len(records) == 1
+    assert records[0]["_pid"] == 4242
+    assert records[0]["process"] == "python3.12"
+    assert records[0]["cause"] == "out of memory"
 
 
 def test_parse_coredumpctl_info_backtrace_extracts_stack_frames():
@@ -351,14 +416,15 @@ def test_signal_display_name_maps_numbers():
 
 def test_linux_journalctl_fallback_scans_kernel_log(monkeypatch):
     commands = []
-    since = datetime(2026, 6, 5, 9, 7, tzinfo=timezone.utc)
+    since = datetime(2026, 6, 5, 9, 8, 0, 500_000, tzinfo=timezone.utc)
 
     def _fake_run(cmd):
         commands.append(cmd)
         return "\n".join(
             [
-                "2026-06-05T09:09:00Z host kernel: python[999]: segfault at 0 ip 0 sp 0 error 4",
-                "2026-06-05T09:08:00Z host kernel: python[123]: segfault at 0 ip 0 sp 0 error 4",
+                "2026-06-05T09:08:00.750000+0000 host kernel: python[999]: segfault at 0 ip 0 sp 0 error 4",
+                "2026-06-05T09:08:00.499999+0000 host kernel: python[123]: segfault at 0 ip 0 sp 0 error 4",
+                "2026-06-05T09:08:00.750000+0000 host kernel: python[123]: segfault at 0 ip 0 sp 0 error 4",
             ]
         )
 
@@ -382,7 +448,9 @@ def test_linux_journalctl_fallback_scans_kernel_log(monkeypatch):
     assert commands and commands[0][0] == "journalctl"
     assert "-k" in commands[0]
     since_index = commands[0].index("--since") + 1
-    assert commands[0][since_index] == "2026-06-05T09:07:00+00:00"
+    assert commands[0][since_index] == "2026-06-05T09:08:00.500000+00:00"
+    format_index = commands[0].index("-o") + 1
+    assert commands[0][format_index] == "short-iso-precise"
 
 
 def test_windows_reader_requires_matching_pid_after_exact_status_time(monkeypatch):
@@ -395,7 +463,7 @@ def test_windows_reader_requires_matching_pid_after_exact_status_time(monkeypatc
             "ProviderName": "Application Error",
             "Message": (
                 "Faulting application name: python.exe, version: 3.12.0\n"
-                f"Faulting application process id: 0x{pid:x}\n"
+                f"Faulting process id: 0x{pid:x}\n"
                 f"Exception code: {exception_code}"
             ),
         }
@@ -403,7 +471,11 @@ def test_windows_reader_requires_matching_pid_after_exact_status_time(monkeypatc
     rows = [
         _event(9002, "2026-07-15T10:45:00Z", "0x80000003"),
         _event(4242, "2026-07-15T10:30:29Z", "0x80000003"),
-        _event(4242, "2026-07-15T10:31:00Z", "0xc0000005"),
+        _event(
+            4242,
+            f"/Date({int(datetime(2026, 7, 15, 10, 31, tzinfo=timezone.utc).timestamp() * 1_000)})/",
+            "0xc0000005",
+        ),
     ]
 
     monkeypatch.setattr(cd.sys, "platform", "win32")
@@ -424,9 +496,17 @@ def test_windows_reader_requires_matching_pid_after_exact_status_time(monkeypatc
 
     assert len(records) == 1
     assert records[0]["_pid"] == 4242
-    assert records[0]["when"] == "2026-07-15T10:31:00Z"
+    assert records[0]["when"].startswith("/Date(")
     assert "2026-07-15T10:30:30+00:00" in commands[0][-1]
     assert "-MaxEvents 100" in commands[0][-1]
+
+
+@pytest.mark.parametrize(
+    "label",
+    ["Faulting process id", "Faulting application process id"],
+)
+def test_extract_windows_faulting_pid_accepts_common_event_wording(label):
+    assert cd._extract_windows_faulting_pid(f"{label}: 0x1092") == 4242
 
 
 def test_parse_macos_ips_filters_on_header_bug_type(tmp_path):

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -1,6 +1,7 @@
 """Tests for /restart notification — the gateway notifies the requester on comeback."""
 
 import json
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -43,6 +44,47 @@ def test_planned_restart_notification_pending_roundtrip(tmp_path, monkeypatch):
     gateway_run._clear_planned_restart_notification()
 
     assert gateway_run._planned_restart_notification_pending() is False
+
+
+def test_runtime_status_indicates_previous_gateway_only_for_active_states():
+    assert gateway_run._runtime_status_indicates_previous_gateway(None) is False
+    assert gateway_run._runtime_status_indicates_previous_gateway({}) is False
+    assert (
+        gateway_run._runtime_status_indicates_previous_gateway(
+            {"kind": "hermes-gateway", "gateway_state": "running"}
+        )
+        is True
+    )
+    assert (
+        gateway_run._runtime_status_indicates_previous_gateway(
+            {"kind": "hermes-gateway", "gateway_state": "starting"}
+        )
+        is True
+    )
+    assert (
+        gateway_run._runtime_status_indicates_previous_gateway(
+            {"kind": "hermes-gateway", "gateway_state": "stopped"}
+        )
+        is False
+    )
+    assert (
+        gateway_run._runtime_status_indicates_previous_gateway(
+            {"kind": "other", "gateway_state": "running"}
+        )
+        is False
+    )
+
+
+def test_crash_scan_window_hours_bounds_to_previous_status():
+    fresh = datetime.now(timezone.utc).isoformat()
+    assert gateway_run._crash_scan_window_hours({"updated_at": fresh}) == 1
+
+    stale = (datetime.now(timezone.utc) - timedelta(hours=200)).isoformat()
+    assert gateway_run._crash_scan_window_hours({"updated_at": stale}) == 24
+
+    assert gateway_run._crash_scan_window_hours(None) == 24
+    assert gateway_run._crash_scan_window_hours({}) == 24
+    assert gateway_run._crash_scan_window_hours({"updated_at": "garbage"}) == 24
 
 
 # ── _handle_restart_command writes .restart_notify.json ──────────────────
@@ -265,6 +307,103 @@ async def test_send_home_channel_startup_notification_to_configured_home(tmp_pat
         "home-42",
         "♻️ Gateway online — Hermes is back and ready.",
     )
+
+
+@pytest.mark.asyncio
+async def test_send_home_channel_startup_notification_appends_crash_notice(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="home"))
+
+    delivered = await runner._send_home_channel_startup_notifications(
+        extra_notice="\n\nCrash cause: segmentation fault (Python, SIGSEGV)"
+    )
+
+    assert delivered == {("telegram", "home-42", None)}
+    assert adapter.send.call_args[0][1] == (
+        "♻️ Gateway online — Hermes is back and ready."
+        "\n\nCrash cause: segmentation fault (Python, SIGSEGV)"
+    )
+
+
+def test_home_channel_startup_targets_skip_disabled_without_sending(tmp_path, monkeypatch):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, _adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification = False
+
+    assert runner._home_channel_startup_notification_targets() == []
+
+
+@pytest.mark.asyncio
+async def test_restart_crash_notice_swallows_import_failures(monkeypatch):
+    runner, _adapter = make_restart_runner()
+
+    original_import = __import__
+
+    def _boom(name, *args, **kwargs):
+        if name == "gateway.crash_diagnostics":
+            raise RuntimeError("import exploded")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", _boom)
+
+    assert await runner._restart_crash_notice() == ""
+
+
+@pytest.mark.asyncio
+async def test_restart_crash_notice_uses_thread_for_best_effort_lookup(monkeypatch):
+    runner, _adapter = make_restart_runner()
+    calls = []
+
+    async def _fake_to_thread(func, *args, **kwargs):
+        calls.append((func, args, kwargs))
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(gateway_run.asyncio, "to_thread", _fake_to_thread)
+    monkeypatch.setattr(
+        "gateway.crash_diagnostics.restart_notice",
+        lambda **_kwargs: "\n\nCrash cause: process aborted (Python, SIGABRT)",
+    )
+
+    assert (
+        await runner._restart_crash_notice()
+        == "\n\nCrash cause: process aborted (Python, SIGABRT)"
+    )
+    assert calls
+    assert calls[0][2] == {"name_filter": "python", "since_hours": 24}
+
+
+@pytest.mark.asyncio
+async def test_restart_crash_notice_narrows_window_to_previous_status(monkeypatch):
+    # A crash record older than the previous gateway's last status write
+    # cannot be its cause — the scan window shrinks accordingly.
+    runner, _adapter = make_restart_runner()
+    captured = {}
+
+    async def _fake_to_thread(func, *args, **kwargs):
+        captured.update(kwargs)
+        return ""
+
+    monkeypatch.setattr(gateway_run.asyncio, "to_thread", _fake_to_thread)
+
+    status = {"updated_at": datetime.now(timezone.utc).isoformat()}
+    await runner._restart_crash_notice(status)
+
+    assert captured["since_hours"] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -1,7 +1,7 @@
 """Tests for /restart notification — the gateway notifies the requester on comeback."""
 
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -75,16 +75,40 @@ def test_runtime_status_indicates_previous_gateway_only_for_active_states():
     )
 
 
-def test_crash_scan_window_hours_bounds_to_previous_status():
-    fresh = datetime.now(timezone.utc).isoformat()
-    assert gateway_run._crash_scan_window_hours({"updated_at": fresh}) == 1
+def test_previous_gateway_crash_identity_requires_pid_and_exact_timestamp():
+    expected_since = datetime(2026, 7, 15, 10, 30, 30, tzinfo=timezone.utc)
+    status = {
+        "pid": "4242",
+        "updated_at": "2026-07-15T18:30:30+08:00",
+    }
 
-    stale = (datetime.now(timezone.utc) - timedelta(hours=200)).isoformat()
-    assert gateway_run._crash_scan_window_hours({"updated_at": stale}) == 24
+    assert gateway_run._previous_gateway_crash_identity(status) == (
+        4242,
+        expected_since,
+    )
+    assert gateway_run._previous_gateway_crash_identity(None) is None
+    assert gateway_run._previous_gateway_crash_identity({}) is None
+    assert (
+        gateway_run._previous_gateway_crash_identity(
+            {"pid": 4242, "updated_at": "garbage"}
+        )
+        is None
+    )
+    assert (
+        gateway_run._previous_gateway_crash_identity(
+            {"pid": 0, "updated_at": expected_since.isoformat()}
+        )
+        is None
+    )
 
-    assert gateway_run._crash_scan_window_hours(None) == 24
-    assert gateway_run._crash_scan_window_hours({}) == 24
-    assert gateway_run._crash_scan_window_hours({"updated_at": "garbage"}) == 24
+
+def test_previous_gateway_crash_identity_rejects_unrepresentable_utc_time():
+    status = {
+        "pid": 4242,
+        "updated_at": "0001-01-01T00:00:00+14:00",
+    }
+
+    assert gateway_run._previous_gateway_crash_identity(status) is None
 
 
 # ── _handle_restart_command writes .restart_notify.json ──────────────────
@@ -368,6 +392,7 @@ async def test_restart_crash_notice_swallows_import_failures(monkeypatch):
 async def test_restart_crash_notice_uses_thread_for_best_effort_lookup(monkeypatch):
     runner, _adapter = make_restart_runner()
     calls = []
+    since = datetime(2026, 7, 15, 10, 30, 30, tzinfo=timezone.utc)
 
     async def _fake_to_thread(func, *args, **kwargs):
         calls.append((func, args, kwargs))
@@ -380,30 +405,46 @@ async def test_restart_crash_notice_uses_thread_for_best_effort_lookup(monkeypat
     )
 
     assert (
-        await runner._restart_crash_notice()
+        await runner._restart_crash_notice(
+            {"pid": 4242, "updated_at": since.isoformat()}
+        )
         == "\n\nCrash cause: process aborted (Python, SIGABRT)"
     )
     assert calls
-    assert calls[0][2] == {"name_filter": "python", "since_hours": 24}
+    assert calls[0][2] == {
+        "name_filter": "python",
+        "expected_pid": 4242,
+        "since": since,
+    }
 
 
 @pytest.mark.asyncio
-async def test_restart_crash_notice_narrows_window_to_previous_status(monkeypatch):
-    # A crash record older than the previous gateway's last status write
-    # cannot be its cause — the scan window shrinks accordingly.
+async def test_restart_crash_notice_skips_lookup_without_complete_identity(monkeypatch):
     runner, _adapter = make_restart_runner()
-    captured = {}
+    calls = []
 
     async def _fake_to_thread(func, *args, **kwargs):
-        captured.update(kwargs)
+        calls.append((func, args, kwargs))
         return ""
 
     monkeypatch.setattr(gateway_run.asyncio, "to_thread", _fake_to_thread)
 
-    status = {"updated_at": datetime.now(timezone.utc).isoformat()}
-    await runner._restart_crash_notice(status)
+    assert await runner._restart_crash_notice(None) == ""
+    assert await runner._restart_crash_notice({}) == ""
+    assert (
+        await runner._restart_crash_notice(
+            {"pid": 4242, "updated_at": "garbage"}
+        )
+        == ""
+    )
+    assert (
+        await runner._restart_crash_notice(
+            {"updated_at": datetime.now(timezone.utc).isoformat()}
+        )
+        == ""
+    )
 
-    assert captured["since_hours"] == 1
+    assert calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -385,7 +385,12 @@ async def test_restart_crash_notice_swallows_import_failures(monkeypatch):
 
     monkeypatch.setattr("builtins.__import__", _boom)
 
-    assert await runner._restart_crash_notice() == ""
+    assert (
+        await runner._restart_crash_notice(
+            {"pid": 4242, "updated_at": datetime.now(timezone.utc).isoformat()}
+        )
+        == ""
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -145,9 +145,21 @@ async def test_runner_records_connected_platform_state_on_success(monkeypatch, t
 
 
 @pytest.mark.asyncio
-async def test_runner_appends_crash_notice_after_unclean_previous_gateway(
+@pytest.mark.parametrize(
+    ("crash_notice", "expected_suffix"),
+    [
+        (
+            "\n\nCrash cause: segmentation fault (Python, SIGSEGV)",
+            "\n\nCrash cause: segmentation fault (Python, SIGSEGV)",
+        ),
+        ("", ""),
+    ],
+)
+async def test_runner_notifies_after_unclean_previous_gateway(
     monkeypatch,
     tmp_path,
+    crash_notice,
+    expected_suffix,
 ):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     write_runtime_status(gateway_state="running", exit_reason=None)
@@ -171,9 +183,7 @@ async def test_runner_appends_crash_notice_after_unclean_previous_gateway(
     monkeypatch.setattr(runner, "_create_adapter", lambda _platform, _config: adapter)
     monkeypatch.setattr(runner.hooks, "discover_and_load", lambda: None)
     monkeypatch.setattr(runner.hooks, "emit", AsyncMock())
-    runner._restart_crash_notice = AsyncMock(
-        return_value="\n\nCrash cause: segmentation fault (Python, SIGSEGV)"
-    )
+    runner._restart_crash_notice = AsyncMock(return_value=crash_notice)
 
     ok = await runner.start()
 
@@ -184,9 +194,8 @@ async def test_runner_appends_crash_notice_after_unclean_previous_gateway(
     assert adapter.sent == [
         (
             "ops-home",
-            "♻️ Gateway online — Hermes is back and ready."
-            "\n\nCrash cause: segmentation fault (Python, SIGSEGV)",
-            None,
+            "♻️ Gateway online — Hermes is back and ready." + expected_suffix,
+            {"non_conversational": True},
         )
     ]
 
@@ -223,6 +232,87 @@ async def test_runner_does_not_report_crash_notice_on_first_start(monkeypatch, t
     assert ok is True
     runner._restart_crash_notice.assert_not_awaited()
     assert adapter.sent == []
+
+
+@pytest.mark.asyncio
+async def test_runner_does_not_notify_after_clean_previous_gateway(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+    write_runtime_status(gateway_state="running", exit_reason=None)
+    (tmp_path / ".clean_shutdown").touch()
+    config = GatewayConfig(
+        platforms={
+            Platform.DISCORD: PlatformConfig(
+                enabled=True,
+                token="***",
+                home_channel=HomeChannel(
+                    platform=Platform.DISCORD,
+                    chat_id="ops-home",
+                    name="Ops Home",
+                ),
+            )
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+    adapter = _SuccessfulAdapter()
+
+    monkeypatch.setattr(runner, "_create_adapter", lambda _platform, _config: adapter)
+    monkeypatch.setattr(runner.hooks, "discover_and_load", lambda: None)
+    monkeypatch.setattr(runner.hooks, "emit", AsyncMock())
+    runner._restart_crash_notice = AsyncMock(return_value="unexpected")
+
+    ok = await runner.start()
+
+    assert ok is True
+    runner._restart_crash_notice.assert_not_awaited()
+    assert adapter.sent == []
+
+
+@pytest.mark.asyncio
+async def test_runner_preserves_planned_restart_notice_without_crash_scan(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+    write_runtime_status(gateway_state="running", exit_reason=None)
+    (tmp_path / ".clean_shutdown").touch()
+    (tmp_path / ".restart_pending.json").write_text("{}", encoding="utf-8")
+    config = GatewayConfig(
+        platforms={
+            Platform.DISCORD: PlatformConfig(
+                enabled=True,
+                token="***",
+                home_channel=HomeChannel(
+                    platform=Platform.DISCORD,
+                    chat_id="ops-home",
+                    name="Ops Home",
+                ),
+            )
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+    adapter = _SuccessfulAdapter()
+
+    monkeypatch.setattr(runner, "_create_adapter", lambda _platform, _config: adapter)
+    monkeypatch.setattr(runner.hooks, "discover_and_load", lambda: None)
+    monkeypatch.setattr(runner.hooks, "emit", AsyncMock())
+    runner._restart_crash_notice = AsyncMock(return_value="unexpected")
+
+    ok = await runner.start()
+
+    assert ok is True
+    runner._restart_crash_notice.assert_not_awaited()
+    assert adapter.sent == [
+        (
+            "ops-home",
+            "♻️ Gateway online — Hermes is back and ready.",
+            {"non_conversational": True},
+        )
+    ]
+    assert not (tmp_path / ".restart_pending.json").exists()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -1,11 +1,11 @@
 import pytest
 from unittest.mock import AsyncMock
 
-from gateway.config import GatewayConfig, Platform, PlatformConfig
-from gateway.platforms.base import BasePlatformAdapter
+from gateway.config import GatewayConfig, HomeChannel, Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
 from gateway.restart import GATEWAY_FATAL_CONFIG_EXIT_CODE
 from gateway.run import GatewayRunner
-from gateway.status import read_runtime_status
+from gateway.status import read_runtime_status, write_runtime_status
 
 
 class _RetryableFailureAdapter(BasePlatformAdapter):
@@ -50,6 +50,7 @@ class _DisabledAdapter(BasePlatformAdapter):
 class _SuccessfulAdapter(BasePlatformAdapter):
     def __init__(self):
         super().__init__(PlatformConfig(enabled=True, token="***"), Platform.DISCORD)
+        self.sent = []
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         return True
@@ -58,7 +59,8 @@ class _SuccessfulAdapter(BasePlatformAdapter):
         self._mark_disconnected()
 
     async def send(self, chat_id, content, reply_to=None, metadata=None):
-        raise NotImplementedError
+        self.sent.append((chat_id, content, metadata))
+        return SendResult(success=True, message_id="startup")
 
     async def get_chat_info(self, chat_id):
         return {"id": chat_id}
@@ -140,6 +142,126 @@ async def test_runner_records_connected_platform_state_on_success(monkeypatch, t
     assert state["platforms"]["discord"]["state"] == "connected"
     assert state["platforms"]["discord"]["error_code"] is None
     assert state["platforms"]["discord"]["error_message"] is None
+
+
+@pytest.mark.asyncio
+async def test_runner_appends_crash_notice_after_unclean_previous_gateway(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    write_runtime_status(gateway_state="running", exit_reason=None)
+    config = GatewayConfig(
+        platforms={
+            Platform.DISCORD: PlatformConfig(
+                enabled=True,
+                token="***",
+                home_channel=HomeChannel(
+                    platform=Platform.DISCORD,
+                    chat_id="ops-home",
+                    name="Ops Home",
+                ),
+            )
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+    adapter = _SuccessfulAdapter()
+
+    monkeypatch.setattr(runner, "_create_adapter", lambda _platform, _config: adapter)
+    monkeypatch.setattr(runner.hooks, "discover_and_load", lambda: None)
+    monkeypatch.setattr(runner.hooks, "emit", AsyncMock())
+    runner._restart_crash_notice = AsyncMock(
+        return_value="\n\nCrash cause: segmentation fault (Python, SIGSEGV)"
+    )
+
+    ok = await runner.start()
+
+    assert ok is True
+    runner._restart_crash_notice.assert_awaited_once()
+    (previous_status,) = runner._restart_crash_notice.await_args.args
+    assert previous_status["gateway_state"] == "running"
+    assert adapter.sent == [
+        (
+            "ops-home",
+            "♻️ Gateway online — Hermes is back and ready."
+            "\n\nCrash cause: segmentation fault (Python, SIGSEGV)",
+            None,
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_runner_does_not_report_crash_notice_on_first_start(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config = GatewayConfig(
+        platforms={
+            Platform.DISCORD: PlatformConfig(
+                enabled=True,
+                token="***",
+                home_channel=HomeChannel(
+                    platform=Platform.DISCORD,
+                    chat_id="ops-home",
+                    name="Ops Home",
+                ),
+            )
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+    adapter = _SuccessfulAdapter()
+
+    monkeypatch.setattr(runner, "_create_adapter", lambda _platform, _config: adapter)
+    monkeypatch.setattr(runner.hooks, "discover_and_load", lambda: None)
+    monkeypatch.setattr(runner.hooks, "emit", AsyncMock())
+    runner._restart_crash_notice = AsyncMock(
+        return_value="\n\nCrash cause: segmentation fault (Python, SIGSEGV)"
+    )
+
+    ok = await runner.start()
+
+    assert ok is True
+    runner._restart_crash_notice.assert_not_awaited()
+    assert adapter.sent == []
+
+
+@pytest.mark.asyncio
+async def test_runner_does_not_scan_crashes_when_restart_notifications_disabled(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    write_runtime_status(gateway_state="running", exit_reason=None)
+    config = GatewayConfig(
+        platforms={
+            Platform.DISCORD: PlatformConfig(
+                enabled=True,
+                token="***",
+                home_channel=HomeChannel(
+                    platform=Platform.DISCORD,
+                    chat_id="ops-home",
+                    name="Ops Home",
+                ),
+                gateway_restart_notification=False,
+            )
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+    adapter = _SuccessfulAdapter()
+
+    monkeypatch.setattr(runner, "_create_adapter", lambda _platform, _config: adapter)
+    monkeypatch.setattr(runner.hooks, "discover_and_load", lambda: None)
+    monkeypatch.setattr(runner.hooks, "emit", AsyncMock())
+    runner._restart_crash_notice = AsyncMock(
+        return_value="\n\nCrash cause: segmentation fault (Python, SIGSEGV)"
+    )
+
+    ok = await runner.start()
+
+    assert ok is True
+    runner._restart_crash_notice.assert_not_awaited()
+    assert adapter.sent == []
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -1,6 +1,9 @@
+import json
+
 import pytest
 from unittest.mock import AsyncMock
 
+import gateway.run as gateway_run
 from gateway.config import GatewayConfig, HomeChannel, Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter, SendResult
 from gateway.restart import GATEWAY_FATAL_CONFIG_EXIT_CODE
@@ -162,6 +165,7 @@ async def test_runner_notifies_after_unclean_previous_gateway(
     expected_suffix,
 ):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     write_runtime_status(gateway_state="running", exit_reason=None)
     config = GatewayConfig(
         platforms={
@@ -201,8 +205,114 @@ async def test_runner_notifies_after_unclean_previous_gateway(
 
 
 @pytest.mark.asyncio
+async def test_runner_does_not_duplicate_restart_notice_in_home_channel(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    write_runtime_status(gateway_state="running", exit_reason=None)
+    (tmp_path / ".restart_notify.json").write_text(
+        json.dumps({"platform": "discord", "chat_id": "ops-home"}),
+        encoding="utf-8",
+    )
+    config = GatewayConfig(
+        platforms={
+            Platform.DISCORD: PlatformConfig(
+                enabled=True,
+                token="***",
+                home_channel=HomeChannel(
+                    platform=Platform.DISCORD,
+                    chat_id="ops-home",
+                    name="Ops Home",
+                ),
+            )
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+    adapter = _SuccessfulAdapter()
+
+    monkeypatch.setattr(runner, "_create_adapter", lambda _platform, _config: adapter)
+    monkeypatch.setattr(runner.hooks, "discover_and_load", lambda: None)
+    monkeypatch.setattr(runner.hooks, "emit", AsyncMock())
+    runner._restart_crash_notice = AsyncMock(
+        return_value="\n\nCrash cause: segmentation fault (Python, SIGSEGV)"
+    )
+
+    ok = await runner.start()
+
+    assert ok is True
+    runner._restart_crash_notice.assert_not_awaited()
+    assert adapter.sent == [
+        (
+            "ops-home",
+            "♻ Gateway restarted successfully. Your session continues.",
+            {"non_conversational": True},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_runner_notifies_without_cause_when_previous_status_lacks_identity(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    (tmp_path / "gateway_state.json").write_text(
+        json.dumps(
+            {
+                "kind": "hermes-gateway",
+                "gateway_state": "running",
+                "updated_at": "2026-07-15T10:30:30+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+    config = GatewayConfig(
+        platforms={
+            Platform.DISCORD: PlatformConfig(
+                enabled=True,
+                token="***",
+                home_channel=HomeChannel(
+                    platform=Platform.DISCORD,
+                    chat_id="ops-home",
+                    name="Ops Home",
+                ),
+            )
+        },
+        sessions_dir=tmp_path / "sessions",
+    )
+    runner = GatewayRunner(config)
+    adapter = _SuccessfulAdapter()
+    crash_reader_calls = []
+
+    monkeypatch.setattr(runner, "_create_adapter", lambda _platform, _config: adapter)
+    monkeypatch.setattr(runner.hooks, "discover_and_load", lambda: None)
+    monkeypatch.setattr(runner.hooks, "emit", AsyncMock())
+    monkeypatch.setattr(
+        "gateway.crash_diagnostics.restart_notice",
+        lambda **_kwargs: crash_reader_calls.append(True),
+    )
+
+    ok = await runner.start()
+
+    assert ok is True
+    assert crash_reader_calls == []
+    assert adapter.sent == [
+        (
+            "ops-home",
+            "♻️ Gateway online — Hermes is back and ready.",
+            {"non_conversational": True},
+        )
+    ]
+
+
+@pytest.mark.asyncio
 async def test_runner_does_not_report_crash_notice_on_first_start(monkeypatch, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     config = GatewayConfig(
         platforms={
             Platform.DISCORD: PlatformConfig(
@@ -321,6 +431,7 @@ async def test_runner_does_not_scan_crashes_when_restart_notifications_disabled(
     tmp_path,
 ):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     write_runtime_status(gateway_state="running", exit_reason=None)
     config = GatewayConfig(
         platforms={


### PR DESCRIPTION
## What does this PR do?

When the gateway dies from a native crash — a GPU/Metal OOM, a segfault in a C extension, the OOM-killer — there is no Python traceback and no record of *why* it died. This PR makes the existing home-channel back-online notification carry a short, best-effort cause read from the OS's own crash record:

> ♻️ Gateway online — Hermes is back and ready.
>
> Crash cause: segmentation fault (python3.12, SIGSEGV)
> Faulting frame: #0 0x00007fd727aeca7a clock_nanosleep (libc.so.6 + 0xeca7a)

(real output — see Verification below)

It follows the three review notes in #41763:

1. **Wired into the existing notification, not a standalone module.** The cause is an optional suffix on the same message sent by `_send_home_channel_startup_notifications()` in `gateway/run.py` — no new notification path, no new config key. The module lives in `gateway/crash_diagnostics.py`, next to `shutdown_forensics.py` and its only caller. (Forensics captures context when a signal handler gets to run; this covers the crashes where none does — SIGKILL, SIGSEGV in native code.)

2. **Unexpected restarts only.** "Unclean" is detected from Hermes' own signals: the `.clean_shutdown` marker is absent **and** the persisted runtime status still shows an active gateway state. First start, clean stop, and planned restarts (`/restart`, `hermes gateway restart`, service restarts) never scan and never notify. The OS crash record only supplies the *why*, never the *whether* — an unrelated Python crash on the box can't fake an "unexpected restart" message, and the scan window is clamped to the previous process's last status write so a stale record can't be misattributed.

3. **Best-effort, silent, gated, stdlib-only.** The per-platform `gateway_restart_notification` setting and home-channel config are checked *before* any scan — disabled notifications mean no subprocess is ever spawned. Readers are stdlib-only (`subprocess`, `json`, `pathlib`, `signal`), wrapped at the import, call, and subprocess layers with 2s timeouts, degrade to an empty suffix on any failure, and run via `asyncio.to_thread`, so the startup event loop is never blocked. `Get-WinEvent` only runs on `win32`; `scripts/check-windows-footguns.py` passes.

**Behavior note (please review):** today nothing is sent after a crash recovery — the home-channel "back online" message only fires for planned non-chat restarts. This PR extends it to unclean restarts (same message, same per-platform gate), which is exactly where the cause is useful. If you'd prefer that behind its own setting, happy to adjust.

**Related:** #42528 by the issue author wires the cause via the planned-restart path; this PR triggers off the gateway's own clean-shutdown/runtime-status markers instead, so it fires specifically on crashes. Credit to @WestWaters for the issue and the groundwork on OS crash sources. A "recent crashes" section in `hermes doctor` would be a natural follow-up, kept out of this PR for reviewability.

## Related Issue

Fixes #41763

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/crash_diagnostics.py` (new): per-OS crash-record readers — macOS `.ips` DiagnosticReports (crash reports only, `bug_type` 309; triggered thread's frames), Linux `coredumpctl list --json=short` + `coredumpctl info` (compact-array / lowercase-key / numeric-signal shape per systemd's `coredumpctl.c` and `format-table.c`) with a `journalctl -k` fallback, Windows Application event log (IDs 1000/1001) via `Get-WinEvent`. GPU-aware cause inference (Metal/MLX, CUDA/NVIDIA).
- `gateway/run.py`: detect unclean previous exit (clean-shutdown marker + persisted runtime status), append the cause to the existing home-channel startup notification via `asyncio.to_thread`, clamp the scan window to the previous process's last status write.
- `tests/gateway/test_crash_diagnostics.py` (new), plus integration tests in `tests/gateway/test_restart_notification.py` and `tests/gateway/test_runner_startup_failures.py`.

## How to Test

1. `pytest tests/gateway/test_crash_diagnostics.py tests/gateway/test_restart_notification.py tests/gateway/test_runner_startup_failures.py -q` — covers the parsers and the integration invariants through `Gateway.start()`: unclean restart appends the cause; first start and `gateway_restart_notification: false` neither scan nor send; planned restarts are unchanged.
2. Manual (any platform): start the gateway with a home channel configured, `kill -9` the gateway process, start it again — the back-online message arrives; if the OS recorded a crash for the previous process, the cause line is appended.
3. Real end-to-end on Linux: induced a genuine `SIGSEGV` of a python process on `ubuntu-latest` with systemd-coredump and ran this module against it — raw `coredumpctl` JSON, parsed record, and final notice all verified: https://github.com/sdyckjq-lab/hermes-agent/actions/runs/27344610529

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (see the note on #42528 above)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the full suite via `scripts/run_tests.sh` — no regressions: every failure on my machine is a pre-existing macOS-environment failure that reproduces identically on a clean `main` checkout (verified with a side-by-side baseline run); the 79 tests covering this change all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3 (real `.ips` crash reports) + Ubuntu via CI (real systemd-coredump segfault)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (module docstrings) — no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (reuses the existing `gateway_restart_notification` gate, no new keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `Get-WinEvent` is guarded, no POSIX-only assumptions on the Windows path, `scripts/check-windows-footguns.py` passes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Real end-to-end run on `ubuntu-latest` (genuine segfault → systemd-coredump → this module):

```text
RAW JSON: [{"time":1781178557710206,"pid":7191,"uid":1001,"gid":1001,"sig":11,
           "corefile":"present","exe":"/usr/bin/python3.12","size":832026}]
PARSED:   process=python3.12  signal=SIGSEGV  cause=segmentation fault
NOTICE:   "\n\nCrash cause: segmentation fault (python3.12, SIGSEGV)
           \nFaulting frame: #0 0x00007fd727aeca7a clock_nanosleep (libc.so.6 + 0xeca7a)"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


