### PR TITLE
fix(config): update @types/node lockfile entry to 24.13.2 (#44121)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8418,9 +8418,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.13.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.1.tgz",
-      "integrity": "sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==",
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Fixes #44121. The package-lock.json pinned @types/node to 24.13.1 but npm 11 resolves ^24.12.0 to 24.13.2 (the latest), causing 'npm ci' to fail with a version mismatch. Updated the lockfile entry to 24.13.2 with its correct integrity hash so npm ci passes cleanly on npm 11.