### PR TITLE
fix(desktop): respect voice.auto_tts setting in voice conversation mode (fixes #44263)

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { playSpeechText, stopVoicePlayback } from '@/lib/voice-playback'
 import { notify, notifyError } from '@/store/notifications'
+import { getHermesConfig } from '@/hermes'
 
 import { useMicRecorder } from './use-mic-recorder'
 
@@ -47,6 +48,7 @@ export function useVoiceConversation({
   const busyRef = useRef(busy)
   const statusRef = useRef<ConversationStatus>('idle')
   const wasEnabledRef = useRef(enabled)
+  const autoTtsRef = useRef<boolean | null>(null)
 
   useEffect(() => {
     enabledRef.current = enabled
@@ -218,6 +220,25 @@ export function useVoiceConversation({
   }, [handle, handleTurn, onFatalError])
 
   const speak = useCallback(async (text: string) => {
+    // Read auto_tts config once and cache it
+    if (autoTtsRef.current === null) {
+      try {
+        const config = await getHermesConfig()
+        autoTtsRef.current = config.voice?.auto_tts !== false
+      } catch {
+        autoTtsRef.current = true
+      }
+    }
+
+    if (!autoTtsRef.current) {
+      // TTS disabled — skip speech, but keep conversation moving
+      if (enabledRef.current) {
+        pendingStartRef.current = true
+      }
+      setStatus('idle')
+      return
+    }
+
     setStatus('speaking')
 
     try {

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { playSpeechText, stopVoicePlayback } from '@/lib/voice-playback'
 import { notify, notifyError } from '@/store/notifications'
-import { getHermesConfig } from '@/hermes'
+import { $autoTts } from '@/store/voice-playback'
 
 import { useMicRecorder } from './use-mic-recorder'
 
@@ -48,7 +48,8 @@ export function useVoiceConversation({
   const busyRef = useRef(busy)
   const statusRef = useRef<ConversationStatus>('idle')
   const wasEnabledRef = useRef(enabled)
-  const autoTtsRef = useRef<boolean | null>(null)
+  // auto_tts read from $autoTts store — refreshed on every config refresh
+
 
   useEffect(() => {
     enabledRef.current = enabled
@@ -220,17 +221,7 @@ export function useVoiceConversation({
   }, [handle, handleTurn, onFatalError])
 
   const speak = useCallback(async (text: string) => {
-    // Read auto_tts config once and cache it
-    if (autoTtsRef.current === null) {
-      try {
-        const config = await getHermesConfig()
-        autoTtsRef.current = config.voice?.auto_tts !== false
-      } catch {
-        autoTtsRef.current = true
-      }
-    }
-
-    if (!autoTtsRef.current) {
+    if (!$autoTts.get()) {
       // TTS disabled — skip speech, but keep conversation moving
       if (enabledRef.current) {
         pendingStartRef.current = true

--- a/apps/desktop/src/app/session/hooks/use-hermes-config.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.ts
@@ -2,6 +2,7 @@ import { type MutableRefObject, useCallback, useState } from 'react'
 
 import { getHermesConfig, getHermesConfigDefaults } from '@/hermes'
 import { BUILTIN_PERSONALITIES, normalizePersonalityValue, personalityNamesFromConfig } from '@/lib/chat-runtime'
+import { setAutoTts } from '@/store/voice-playback'
 import {
   $currentCwd,
   setAvailablePersonalities,
@@ -65,6 +66,7 @@ export function useHermesConfig({ activeSessionIdRef, refreshProjectBranch }: He
 
       setVoiceMaxRecordingSeconds(recordingLimit(config.voice?.max_recording_seconds))
       setSttEnabled(config.stt?.enabled !== false)
+      setAutoTts(config.voice?.auto_tts === true)
     } catch {
       // Config is nice-to-have; chat still works without it.
     }

--- a/apps/desktop/src/store/voice-playback.ts
+++ b/apps/desktop/src/store/voice-playback.ts
@@ -22,3 +22,11 @@ export const $voicePlayback = atom<VoicePlaybackState>({
 export function setVoicePlaybackState(next: VoicePlaybackState) {
   $voicePlayback.set(next)
 }
+
+/** Whether auto-TTS is enabled. Defaults to false (fail-closed). Updated
+ *  when config refreshes so toggling the setting takes effect immediately. */
+export const $autoTts = atom(false)
+
+export function setAutoTts(value: boolean) {
+  $autoTts.set(value)
+}

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -180,6 +180,7 @@ export interface HermesConfig {
     enabled?: boolean
   }
   voice?: {
+    auto_tts?: boolean
     max_recording_seconds?: number
   }
 }


### PR DESCRIPTION
Voice chat was calling playSpeechText without checking voice.auto_tts. Now it reads the config once on first use and skips TTS when disabled. The response still appears as text either way.