### PR TITLE
feat(skill): add community safety review report generation

### DIFF
--- a/skills/safety/community-safety-review/SKILL.md
+++ b/skills/safety/community-safety-review/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: community-safety-review
+description: Helps human moderators review suspicious claims, unsafe links, impersonation signs, unclear ownership, and misleading messages in a Hermes Agent community. Produces neutral safety notes only. Never accuses anyone and never enforces. Human review is always required.
+---
+
+# Community Safety Review Skill for Hermes
+
+## Overview
+
+This skill helps a Hermes Agent assist **human moderators** and community
+managers when they need to review a potentially suspicious message, project
+claim, or link inside a community space.
+
+The skill does **not** make decisions. It produces a structured, neutral
+**safety note** that a human can read, verify, and act on. Every output ends
+with a reminder that human review is required.
+
+The goal is to make community safety review more organized, calmer, and
+evidence-based — not faster accusations.
+
+## Problem statement
+
+Communities receive many messages every day. Some of them include:
+
+- fake official claims
+- misleading project names
+- unsafe or suspicious links
+- impersonation signs
+- unclear ownership
+- pressure-style wording
+- missing verification sources
+- mismatched usernames, domains, or branding
+- claims that cannot be verified from public sources
+
+Moderators have limited time and often review these messages in a hurry. A
+hurried review can either miss a real problem or, worse, label an innocent
+person unfairly. Both outcomes hurt the community.
+
+This skill gives moderators a consistent, neutral structure so they can review
+suspicious messages carefully and keep a written record of *why* something
+looked unclear — without jumping to conclusions.
+
+## When to use this skill
+
+Use this skill when a human moderator wants help to:
+
+- review a message that claims to be from an official source
+- check whether a link or domain looks suspicious or mismatched
+- look for impersonation signs (copied names, avatars, or branding)
+- organize notes about a project whose ownership is unclear
+- summarize why a message feels misleading, using observable evidence
+- prepare a neutral handoff note for other moderators
+
+## When not to use this skill
+
+Do **not** use this skill to:
+
+- automatically ban, mute, kick, or punish anyone
+- make a final decision about whether a person is malicious
+- declare someone a "scammer" or any other accusation
+- replace human judgment or community rules
+- review private personal data that the moderator is not authorized to handle
+- act as legal, security, or identity-verification authority
+
+This skill is an assistant for human review. It is **not** an enforcement tool.
+
+## Expected inputs
+
+A moderator may provide some or all of the following:
+
+- the message text being reviewed (or a neutral description of it)
+- the claimed identity or role (for example, "claims to be an admin")
+- any links, domains, or handles included in the message
+- any public verification sources the moderator already checked
+- context about where and when the message appeared
+
+Inputs may be incomplete. Missing information is expected and should be recorded
+as missing, not guessed.
+
+## Expected outputs
+
+A single, neutral **safety note** based on the template in
+`templates/safety-review.md`. The note contains:
+
+- what is being reviewed
+- the claimed identity
+- the links provided
+- the verification sources checked
+- any suspicious signals observed (with the evidence for each)
+- missing information
+- a risk level: LOW / MEDIUM / HIGH / UNKNOWN
+- a suggested moderator action (a review suggestion, never an enforcement order)
+- a short neutral summary
+- a human review disclaimer
+
+The output is meant to be pasted into a moderator note, not posted publicly as
+an accusation.
+
+## Review workflow
+
+1. **Collect** the available inputs from the moderator. Record what is present
+   and what is missing.
+2. **Restate** the claimed identity and the message neutrally, without judgment.
+3. **List the links** exactly as provided. Note any mismatched domains,
+   look-alike spellings, or branding that does not match the claimed source.
+4. **Check verification sources.** Record which public sources were checked and
+   what they showed. If none were checked, say so.
+5. **Scan for suspicious signals** using the checklist below. For each signal
+   found, write the specific observable evidence next to it.
+6. **Record missing information** that a human would need to reach a conclusion.
+7. **Assign a risk level** using the framework below, based only on observable
+   evidence.
+8. **Suggest a moderator action** framed as a review step, never as a
+   punishment.
+9. **Write a neutral summary** and attach the human review disclaimer.
+
+## Suspicious signal checklist
+
+Look for, and record evidence for, any of the following:
+
+- **Fake official claims** — claims to be staff, admin, or an official source
+  without a verifiable basis.
+- **Misleading project names** — a name that imitates a known, trusted project.
+- **Unsafe or suspicious links** — shortened, obfuscated, or look-alike URLs.
+- **Impersonation signs** — copied display names, avatars, or branding.
+- **Unclear ownership** — no public, verifiable owner or maintainer.
+- **Pressure-style wording** — urgency, secrecy, or "act now" framing.
+- **Missing verification sources** — no public evidence supports the claim.
+- **Mismatched usernames, domains, or branding** — the handle, domain, and
+  stated identity do not line up.
+- **Unverifiable claims** — statements that cannot be confirmed from public
+  sources.
+
+A signal should only be recorded when there is observable evidence for it.
+Do not record a signal based on a feeling alone.
+
+## Risk level framework
+
+- **LOW** — No obvious suspicious signal was found, but human review is still
+  recommended.
+- **MEDIUM** — Some information is unclear or missing. Manual verification is
+  needed before any conclusion.
+- **HIGH** — Strong suspicious signals exist, such as impersonation signs,
+  unsafe links, fake official claims, or pressure-style wording. Human review is
+  strongly recommended before any action.
+- **UNKNOWN** — There is not enough information to make a useful safety note.
+
+A risk level describes *how much careful review is recommended*. It is never a
+verdict about a person.
+
+## Moderator handoff notes
+
+The safety note is designed to be handed to another human. When writing the
+handoff:
+
+- keep the tone calm and factual
+- separate observed evidence from interpretation
+- always list what is still missing
+- suggest a next review step, not a punishment
+- make it easy for the next moderator to disagree and re-check
+
+## Safety notes
+
+- This skill never accuses anyone. It describes observable signals only.
+- It never recommends an automatic ban or enforcement action.
+- It always states that human review is required.
+- When evidence is absent, it records UNKNOWN instead of guessing.
+- It does not invent verification sources or links that were not provided.
+- It treats the reviewed person as innocent until a human, using community
+  rules, decides otherwise.
+
+## Output style rules
+
+- Stay neutral. Never call anyone a "scammer" or any similar label.
+- Prefer soft, evidence-based phrasing such as "suspicious signal detected"
+  or "this claim could not be verified from public sources."
+- Always include "human review required."
+- If there is no evidence, do not speculate.
+- If information is missing, write UNKNOWN rather than filling the gap.
+- Describe the message and the claim; do not pass judgment on the person.
+
+## Examples of safe output
+
+Safe, neutral phrasing:
+
+- "Suspicious signal detected: the link domain does not match the claimed
+  official source. Human review required."
+- "Claimed identity could not be verified from public sources. Risk level:
+  MEDIUM. Manual verification is recommended."
+- "No obvious suspicious signal was found, but human review is still
+  recommended. Risk level: LOW."
+- "Not enough information was provided to write a useful safety note. Risk
+  level: UNKNOWN."
+
+Phrasing to avoid:
+
+- "This person is a scammer." (accusation)
+- "Ban this user." (enforcement)
+- "This is definitely fake." (conclusion without human review)
+
+## Future automation ideas
+
+These are ideas only. Phase 1 includes no code, scripts, or UI.
+
+- An optional helper that highlights look-alike domains for a moderator to
+  inspect.
+- An optional checklist prompt that walks a moderator through the signals.
+- An optional log format so a community can keep a neutral history of past
+  safety notes for transparency.
+
+Any future automation must keep the same principles: neutral output, no
+accusations, no enforcement, and human review always required.

--- a/skills/safety/community-safety-review/SKILL.md
+++ b/skills/safety/community-safety-review/SKILL.md
@@ -198,13 +198,75 @@ Phrasing to avoid:
 - "Ban this user." (enforcement)
 - "This is definitely fake." (conclusion without human review)
 
+## Project safety review helper (optional script)
+
+In addition to the message-review workflow above, the skill ships a small
+optional helper for reviewing a **Web3/GameFi project** from its public
+information. It is a lightweight, dependency-free Python script that reads a
+JSON description of a project and produces the same kind of neutral safety
+note — automatically detecting public risk signals and trust signals.
+
+The helper keeps every principle of this skill: public signals only, no private
+data, no network calls, no accusations, no enforcement, and a manual-verification
+reminder on every report. The review level it assigns describes *how much
+careful human review is recommended* — it is never a verdict and never claims a
+project is a scam.
+
+### Files
+
+- `scripts/safety_review.py` — the analyzer (Python 3.8+, standard library only).
+- `scripts/sample-project.json` — a sample input.
+- `templates/project-safety-review.md` — a blank note to fill in by hand.
+- `reports/sample-report.md` — a committed example of generated output.
+
+### How to run
+
+```bash
+cd scripts
+python safety_review.py sample-project.json            # print the note
+python safety_review.py sample-project.json --report   # also save to ../reports/
+cat project.json | python safety_review.py -           # read from stdin
+```
+
+### Input
+
+A single JSON object. All fields are optional — provide what is public and
+known. Free-text fields (`description`, `marketing_text`, `documentation`,
+`roadmap`) are scanned for risky language; structured fields record presence or
+clarity. The `reviewer_flags` list lets a human record signals that text
+scanning cannot see (`broken_links`, `copied_content`, `fake_social_proof`,
+`fake_partnership`, `impersonation`). See the header of `safety_review.py` for
+the full field list.
+
+### Risk signals it checks
+
+Anonymous/unclear team, no public documentation, no working product/demo,
+unrealistic reward claims, guaranteed-profit language, aggressive referral
+focus, unverified partnership claims, suspicious token-sale wording, unclear
+tokenomics, no/inactive GitHub, copied content (reviewer flag), broken links
+(reviewer flag), no audit/security information, pressure tactics, and possible
+fabricated social proof.
+
+### Trust signals it checks
+
+Documentation available, working demo/product, public team or named
+contributors, GitHub provided/active, community activity described, transparent
+tokenomics, audit/security notes, roadmap provided, and absence of
+guaranteed-profit language.
+
+### Review levels
+
+- **LOW** — few/no risk signals; human review still recommended.
+- **MEDIUM** — some signals or gaps; manual verification needed.
+- **HIGH** — multiple notable signals; careful human review strongly recommended.
+- **HUMAN REVIEW REQUIRED** — not enough public information to assess.
+
 ## Future automation ideas
 
-These are ideas only. Phase 1 includes no code, scripts, or UI.
+Further ideas that would keep the same principles:
 
-- An optional helper that highlights look-alike domains for a moderator to
-  inspect.
-- An optional checklist prompt that walks a moderator through the signals.
+- An optional helper that highlights look-alike domains for a reviewer to inspect.
+- An optional checklist prompt that walks a reviewer through the signals.
 - An optional log format so a community can keep a neutral history of past
   safety notes for transparency.
 

--- a/skills/safety/community-safety-review/reports/.gitignore
+++ b/skills/safety/community-safety-review/reports/.gitignore
@@ -1,0 +1,5 @@
+# Generated, timestamped safety notes are local artifacts — keep them out of git.
+safety-review-*.md
+
+# The committed sample report is tracked on purpose.
+!sample-report.md

--- a/skills/safety/community-safety-review/reports/sample-report.md
+++ b/skills/safety/community-safety-review/reports/sample-report.md
@@ -1,0 +1,57 @@
+# Community Safety Review Note
+
+> Neutral safety note based on **public information only**. This is **not** an accusation and **not** an enforcement action. It identifies risk signals for a human to verify. **Human review is required.**
+
+**Project name:** Galactic Yield Quest
+**Generated:** 2026-06-11 12:17 UTC
+**Review level:** HIGH
+
+## Sources reviewed
+
+- https://galactic-yield-quest.example
+- https://x.com/galacticyieldq
+- https://t.me/galacticyieldquest
+
+## Detected risk signals
+
+- **Guaranteed-profit language** — matched: "guaranteed returns"
+- **Unrealistic reward claims** — matched: "1000x"
+- **Aggressive referral / recruitment focus** — matched: "refer a friend", "affiliate bonus"
+- **Unverified partnership / endorsement claims** — matched: "partnered with"
+- **Suspicious token-sale wording** — matched: "presale"
+- **Pressure tactics (urgency / scarcity)** — matched: "limited time only", "limited time", "don't miss out"
+- **Possible fabricated social proof** — matched: "thousands of happy investors"
+- **Broken or dead links reported** — flagged by reviewer
+- **Anonymous or unclear team** — Anonymous core team, no names or profiles listed
+- **No public documentation provided** — documentation field empty
+- **No working product/demo provided** — demo field empty
+- **No GitHub provided** — github field empty
+- **No audit / security information provided** — audit field empty
+- **Unclear tokenomics** — unclear — supply not disclosed
+
+## Positive trust signals
+
+- Roadmap provided
+- Community activity described
+
+## Missing information
+
+- documentation
+- demo
+- github
+- audit
+
+## Explanation
+
+Multiple notable risk signals were detected in the public information. Careful human review is strongly recommended before engaging.
+
+## Review level reference
+
+- **LOW** — few/no risk signals; human review still recommended.
+- **MEDIUM** — some signals or gaps; manual verification needed.
+- **HIGH** — multiple notable signals; careful human review strongly recommended.
+- **HUMAN REVIEW REQUIRED** — not enough public information to assess.
+
+## Final human-review note
+
+This note was prepared from public, reviewer-supplied information to assist human reviewers. It does **not** accuse the project or any person, does **not** claim the project is a scam, and does **not** enforce any action. The detected signals are unverified and may have innocent explanations. A human must verify every signal against original sources and apply the community's own rules before making any decision. **Manual verification required.**

--- a/skills/safety/community-safety-review/scripts/safety_review.py
+++ b/skills/safety/community-safety-review/scripts/safety_review.py
@@ -1,0 +1,514 @@
+#!/usr/bin/env python3
+"""safety_review.py — lightweight community safety review for Web3/GameFi projects.
+
+Reads public project information from a JSON file (or stdin) and produces a
+neutral, structured **safety review note** in Markdown. It detects public
+*risk signals* and *trust signals*, lists what information is missing, and
+assigns a review level: LOW / MEDIUM / HIGH / HUMAN REVIEW REQUIRED.
+
+Positioning (important):
+  - This tool NEVER claims a project is a scam.
+  - It identifies public risk signals only and produces a human-review note.
+  - It uses public, reviewer-supplied information only — no private data,
+    no scraping, no network calls, no automated enforcement.
+  - Every report ends with a manual-verification reminder.
+
+The "review level" describes how much careful human review is recommended.
+It is not a verdict about a project or any person.
+
+Usage:
+    python safety_review.py sample-project.json
+    python safety_review.py sample-project.json --report
+    cat project.json | python safety_review.py -
+
+Input JSON (all fields optional; provide what you have):
+    {
+      "project_name": "Example Project",
+      "sources": ["https://example.com", "https://x.com/example"],
+      "team": "Anonymous team, no names listed",
+      "team_public": false,
+      "documentation": "https://docs.example.com",
+      "demo": "https://example.com/play",
+      "github": "https://github.com/example/example",
+      "github_active": true,
+      "audit": "",
+      "roadmap": "Q3: launch",
+      "tokenomics": "unclear",
+      "community": "Active Discord with real discussion",
+      "description": "Free text describing the project ...",
+      "marketing_text": "Promotional copy to scan for risky language ...",
+      "reviewer_flags": ["broken_links"]
+    }
+
+`reviewer_flags` lets a human record signals that cannot be detected from text
+alone (e.g. "broken_links", "copied_content", "fake_social_proof"). See
+REVIEWER_FLAG_LABELS below for the recognised values.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# --- Language-based risk signals -------------------------------------------
+# Each entry: key -> (human label, weight, [trigger phrases]).
+# Phrases are matched case-insensitively with word boundaries, so short words
+# do not match inside unrelated words (e.g. "ico" will not match "unicorn").
+# A "strong" signal has weight 2; a softer/structural one has weight 1.
+
+LANGUAGE_SIGNALS: dict[str, tuple[str, int, tuple[str, ...]]] = {
+    "guaranteed_profit": (
+        "Guaranteed-profit language",
+        2,
+        (
+            "guaranteed profit", "guaranteed return", "guaranteed returns",
+            "guaranteed apy", "risk-free", "risk free", "no risk", "can't lose",
+            "cannot lose", "assured returns", "guaranteed gains",
+        ),
+    ),
+    "unrealistic_rewards": (
+        "Unrealistic reward claims",
+        2,
+        (
+            "100x", "1000x", "10000%", "1000% apy", "get rich", "double your",
+            "triple your", "to the moon", "moonshot", "life-changing money",
+            "passive income for life", "huge gains",
+        ),
+    ),
+    "referral_focus": (
+        "Aggressive referral / recruitment focus",
+        1,
+        (
+            "refer a friend", "referral bonus", "referral reward", "invite and earn",
+            "affiliate bonus", "downline", "recruit", "mlm", "multi-level",
+            "earn for every friend",
+        ),
+    ),
+    "fake_partnership": (
+        "Unverified partnership / endorsement claims",
+        1,
+        (
+            "official partner", "backed by", "partnered with", "in partnership with",
+            "endorsed by", "as featured on", "as seen on",
+        ),
+    ),
+    "suspicious_token_sale": (
+        "Suspicious token-sale wording",
+        2,
+        (
+            "presale", "pre-sale", "private sale", "buy now before", "fair launch guaranteed",
+            "token sale ends", "ico", "ido", "guaranteed allocation", "buy before it's too late",
+        ),
+    ),
+    "pressure_tactics": (
+        "Pressure tactics (urgency / scarcity)",
+        2,
+        (
+            "limited time only", "limited time", "act now", "hurry", "only today",
+            "last chance", "spots filling fast", "don't miss out", "dont miss out",
+            "ends soon", "24 hours only", "before it's gone",
+        ),
+    ),
+    "fake_social_proof": (
+        "Possible fabricated social proof",
+        2,
+        (
+            "thousands of happy investors", "trusted by millions", "join millions",
+            "everyone is buying", "viral sensation", "fastest growing in history",
+        ),
+    ),
+}
+
+LANGUAGE_PATTERNS: dict[str, list[tuple[str, re.Pattern]]] = {
+    key: [(p, re.compile(r"\b" + re.escape(p) + r"\b", re.IGNORECASE)) for p in phrases]
+    for key, (_, _, phrases) in LANGUAGE_SIGNALS.items()
+}
+
+# Manual flags a human reviewer can supply for things text scanning cannot see.
+REVIEWER_FLAG_LABELS: dict[str, tuple[str, int]] = {
+    "broken_links": ("Broken or dead links reported", 1),
+    "copied_content": ("Copied website / documentation language reported", 2),
+    "fake_social_proof": ("Fabricated social proof reported", 2),
+    "fake_partnership": ("Fake partnership claim reported", 2),
+    "impersonation": ("Impersonation of a known project reported", 2),
+}
+
+# Words that mark a "team" field as anonymous / unclear.
+ANON_MARKERS = ("anon", "anonymous", "unknown", "no team", "not listed", "hidden", "n/a")
+
+# Words that mark tokenomics as unclear.
+UNCLEAR_MARKERS = ("unclear", "unknown", "tbd", "n/a", "not disclosed", "none", "hidden")
+
+# Key information categories used to decide whether there is enough public
+# information to form any view at all.
+INFO_FIELDS = (
+    "sources", "team", "documentation", "demo", "github",
+    "audit", "tokenomics", "roadmap", "community",
+)
+
+
+def _text(value) -> str:
+    """Coerce a JSON value to a single lowercase-able string for scanning."""
+    if value is None:
+        return ""
+    if isinstance(value, (list, tuple)):
+        return " ".join(_text(v) for v in value)
+    return str(value)
+
+
+def _has(value) -> bool:
+    """True if a field carries usable, non-empty content."""
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (list, tuple, dict)):
+        return len(value) > 0
+    return bool(value)
+
+
+def _looks_anonymous(team_value, team_public) -> bool:
+    if team_public is True:
+        return False
+    if team_public is False:
+        return True
+    text = _text(team_value).lower()
+    if not text.strip():
+        return False  # absence is handled as "missing", not as a signal
+    return any(marker in text for marker in ANON_MARKERS)
+
+
+def _looks_unclear(value) -> bool:
+    text = _text(value).lower()
+    if not text.strip():
+        return False
+    return any(marker in text for marker in UNCLEAR_MARKERS)
+
+
+def analyze(project: dict) -> dict:
+    """Detect risk signals, trust signals, and missing information.
+
+    Returns a dict with: risk_signals, trust_signals, missing, level, and a
+    short explanation. Each signal is {"label", "evidence", "weight"}.
+    """
+    risk_signals: list[dict] = []
+    trust_signals: list[str] = []
+
+    # Combined free text used for language scanning.
+    scan_blob = " ".join(
+        _text(project.get(f))
+        for f in ("description", "marketing_text", "documentation", "roadmap")
+    )
+
+    # 1) Language-based signals.
+    for key, (label, weight, _phrases) in LANGUAGE_SIGNALS.items():
+        hits = [phrase for phrase, pat in LANGUAGE_PATTERNS[key] if pat.search(scan_blob)]
+        if hits:
+            risk_signals.append({
+                "label": label,
+                "evidence": "matched: " + ", ".join(f'"{h}"' for h in hits[:4]),
+                "weight": weight,
+            })
+
+    # 2) Reviewer-supplied manual flags.
+    for raw in project.get("reviewer_flags") or []:
+        flag = str(raw).strip().lower()
+        if flag in REVIEWER_FLAG_LABELS:
+            label, weight = REVIEWER_FLAG_LABELS[flag]
+            risk_signals.append({
+                "label": label,
+                "evidence": "flagged by reviewer",
+                "weight": weight,
+            })
+
+    # 3) Structural signals (presence / clarity of public information).
+    team_public = project.get("team_public")
+    if _looks_anonymous(project.get("team"), team_public):
+        risk_signals.append({
+            "label": "Anonymous or unclear team",
+            "evidence": _text(project.get("team")) or "team marked non-public",
+            "weight": 1,
+        })
+    elif team_public is True or (_has(project.get("team")) and not _looks_anonymous(project.get("team"), team_public)):
+        trust_signals.append("Public team or named contributors")
+
+    if not _has(project.get("documentation")):
+        risk_signals.append({
+            "label": "No public documentation provided",
+            "evidence": "documentation field empty",
+            "weight": 1,
+        })
+    else:
+        trust_signals.append("Documentation available")
+
+    if not _has(project.get("demo")):
+        risk_signals.append({
+            "label": "No working product/demo provided",
+            "evidence": "demo field empty",
+            "weight": 1,
+        })
+    else:
+        trust_signals.append("Working demo / product link provided")
+
+    github = project.get("github")
+    github_active = project.get("github_active")
+    if not _has(github):
+        risk_signals.append({
+            "label": "No GitHub provided",
+            "evidence": "github field empty",
+            "weight": 1,
+        })
+    elif github_active is False:
+        risk_signals.append({
+            "label": "Inactive GitHub reported",
+            "evidence": f"{_text(github)} (marked inactive)",
+            "weight": 1,
+        })
+    else:
+        trust_signals.append("GitHub repository provided")
+        if github_active is True:
+            trust_signals.append("GitHub reported as active")
+
+    if not _has(project.get("audit")):
+        risk_signals.append({
+            "label": "No audit / security information provided",
+            "evidence": "audit field empty",
+            "weight": 1,
+        })
+    else:
+        trust_signals.append("Audit / security notes provided")
+
+    if _looks_unclear(project.get("tokenomics")):
+        risk_signals.append({
+            "label": "Unclear tokenomics",
+            "evidence": _text(project.get("tokenomics")),
+            "weight": 1,
+        })
+    elif _has(project.get("tokenomics")):
+        trust_signals.append("Transparent tokenomics described")
+
+    if _has(project.get("roadmap")):
+        trust_signals.append("Roadmap provided")
+    if _has(project.get("community")):
+        trust_signals.append("Community activity described")
+    # Absence of guaranteed-profit language is itself a mild trust signal.
+    if not any(s["label"].startswith("Guaranteed-profit") for s in risk_signals):
+        trust_signals.append("No guaranteed-profit language detected")
+
+    # 4) Missing information.
+    missing = [f for f in INFO_FIELDS if not _has(project.get(f))]
+
+    # 5) Review level.
+    weight_total = sum(s["weight"] for s in risk_signals)
+    strong_count = sum(1 for s in risk_signals if s["weight"] >= 2)
+    info_present = len(INFO_FIELDS) - len(missing)
+
+    if info_present < 3 and strong_count == 0:
+        level = "HUMAN REVIEW REQUIRED"
+        explanation = (
+            "Not enough public information was provided to form any view. A human "
+            "should gather more sources before assessing."
+        )
+    elif strong_count >= 2 or weight_total >= 6:
+        level = "HIGH"
+        explanation = (
+            "Multiple notable risk signals were detected in the public information. "
+            "Careful human review is strongly recommended before engaging."
+        )
+    elif weight_total >= 2:
+        level = "MEDIUM"
+        explanation = (
+            "Some risk signals or gaps were detected. Manual verification is needed "
+            "before reaching any conclusion."
+        )
+    else:
+        level = "LOW"
+        explanation = (
+            "Few or no risk signals were detected in the public information, but "
+            "human review is still recommended."
+        )
+
+    return {
+        "risk_signals": risk_signals,
+        "trust_signals": trust_signals,
+        "missing": missing,
+        "level": level,
+        "explanation": explanation,
+        "weight_total": weight_total,
+        "strong_count": strong_count,
+    }
+
+
+def build_markdown(project: dict, result: dict, generated: str) -> str:
+    """Render a neutral Markdown safety review note."""
+    name = _text(project.get("project_name")).strip() or "Unnamed project"
+    sources = project.get("sources") or []
+    if isinstance(sources, str):
+        sources = [sources]
+
+    lines: list[str] = []
+    lines.append("# Community Safety Review Note")
+    lines.append("")
+    lines.append(
+        "> Neutral safety note based on **public information only**. This is "
+        "**not** an accusation and **not** an enforcement action. It identifies "
+        "risk signals for a human to verify. **Human review is required.**"
+    )
+    lines.append("")
+    lines.append(f"**Project name:** {name}")
+    lines.append(f"**Generated:** {generated}")
+    lines.append(f"**Review level:** {result['level']}")
+    lines.append("")
+
+    lines.append("## Sources reviewed")
+    lines.append("")
+    if sources:
+        for src in sources:
+            lines.append(f"- {_text(src)}")
+    else:
+        lines.append("- none provided")
+    lines.append("")
+
+    lines.append("## Detected risk signals")
+    lines.append("")
+    if result["risk_signals"]:
+        for sig in result["risk_signals"]:
+            lines.append(f"- **{sig['label']}** — {sig['evidence']}")
+    else:
+        lines.append("- none detected in the provided public information")
+    lines.append("")
+
+    lines.append("## Positive trust signals")
+    lines.append("")
+    if result["trust_signals"]:
+        for sig in result["trust_signals"]:
+            lines.append(f"- {sig}")
+    else:
+        lines.append("- none detected in the provided public information")
+    lines.append("")
+
+    lines.append("## Missing information")
+    lines.append("")
+    if result["missing"]:
+        for field in result["missing"]:
+            lines.append(f"- {field.replace('_', ' ')}")
+    else:
+        lines.append("- none — all reviewed categories had some information")
+    lines.append("")
+
+    lines.append("## Explanation")
+    lines.append("")
+    lines.append(result["explanation"])
+    lines.append("")
+
+    lines.append("## Review level reference")
+    lines.append("")
+    lines.append("- **LOW** — few/no risk signals; human review still recommended.")
+    lines.append("- **MEDIUM** — some signals or gaps; manual verification needed.")
+    lines.append("- **HIGH** — multiple notable signals; careful human review strongly recommended.")
+    lines.append("- **HUMAN REVIEW REQUIRED** — not enough public information to assess.")
+    lines.append("")
+
+    lines.append("## Final human-review note")
+    lines.append("")
+    lines.append(
+        "This note was prepared from public, reviewer-supplied information to "
+        "assist human reviewers. It does **not** accuse the project or any person, "
+        "does **not** claim the project is a scam, and does **not** enforce any "
+        "action. The detected signals are unverified and may have innocent "
+        "explanations. A human must verify every signal against original sources "
+        "and apply the community's own rules before making any decision. "
+        "**Manual verification required.**"
+    )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def slugify(name: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+    return slug or "project"
+
+
+def load_project(path: str) -> dict:
+    """Load the project JSON from a file path or '-' for stdin."""
+    if path == "-":
+        raw = sys.stdin.read()
+    else:
+        raw = Path(path).read_text(encoding="utf-8")
+    data = json.loads(raw)
+    if not isinstance(data, dict):
+        raise ValueError("input JSON must be an object (a single project)")
+    return data
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate a neutral community safety review note for a Web3/GameFi "
+            "project from public information. Identifies risk signals only; never "
+            "claims a project is a scam. Human review always required."
+        )
+    )
+    parser.add_argument(
+        "input",
+        help="Path to the project JSON file, or '-' to read from stdin.",
+    )
+    parser.add_argument(
+        "--report",
+        action="store_true",
+        help="Also write the Markdown note to the reports/ folder.",
+    )
+    parser.add_argument(
+        "--report-dir",
+        default=None,
+        help="Directory for the report (default: ../reports next to this script).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    # Ensure UTF-8 output even on consoles that default to a legacy codepage
+    # (e.g. Windows cp1252), so redirected/piped Markdown stays valid UTF-8.
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+    except (AttributeError, ValueError):
+        pass
+
+    try:
+        project = load_project(args.input)
+    except FileNotFoundError:
+        print(f"error: input file not found: {args.input}", file=sys.stderr)
+        return 2
+    except (json.JSONDecodeError, ValueError) as exc:
+        print(f"error: could not read project JSON: {exc}", file=sys.stderr)
+        return 2
+
+    result = analyze(project)
+    generated = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    markdown = build_markdown(project, result, generated)
+
+    print(markdown)
+
+    if args.report:
+        script_dir = Path(__file__).resolve().parent
+        reports_dir = (
+            Path(args.report_dir) if args.report_dir else script_dir.parent / "reports"
+        )
+        reports_dir.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+        slug = slugify(_text(project.get("project_name")))
+        path = reports_dir / f"safety-review-{slug}-{stamp}.md"
+        path.write_text(markdown, encoding="utf-8")
+        print(f"\nReport written to {path}", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/safety/community-safety-review/scripts/sample-project.json
+++ b/skills/safety/community-safety-review/scripts/sample-project.json
@@ -1,0 +1,22 @@
+{
+  "project_name": "Galactic Yield Quest",
+  "sources": [
+    "https://galactic-yield-quest.example",
+    "https://x.com/galacticyieldq",
+    "https://t.me/galacticyieldquest"
+  ],
+  "team": "Anonymous core team, no names or profiles listed",
+  "team_public": false,
+  "documentation": "",
+  "demo": "",
+  "github": "",
+  "audit": "",
+  "roadmap": "Phase 1: presale. Phase 2: launch. Phase 3: more details soon.",
+  "tokenomics": "unclear — supply not disclosed",
+  "community": "Telegram group with mostly giveaway and price chatter",
+  "description": "A play-to-earn galaxy adventure where every player earns rewards.",
+  "marketing_text": "Join thousands of happy investors! Guaranteed returns up to 1000x. Limited time only presale — don't miss out. Refer a friend and earn an affiliate bonus. Officially partnered with major studios.",
+  "reviewer_flags": [
+    "broken_links"
+  ]
+}

--- a/skills/safety/community-safety-review/templates/project-safety-review.md
+++ b/skills/safety/community-safety-review/templates/project-safety-review.md
@@ -1,0 +1,61 @@
+# Community Safety Review Note
+
+> Neutral safety note based on **public information only**. This is **not** an
+> accusation and **not** an enforcement action. It identifies risk signals for a
+> human to verify. **Human review is required.**
+
+**Project name:** <!-- name of the project under review -->
+**Generated:** <!-- date/time -->
+**Review level:** <!-- LOW / MEDIUM / HIGH / HUMAN REVIEW REQUIRED -->
+
+## Sources reviewed
+
+<!-- List every public link reviewed. Write "none provided" if none. -->
+
+-
+
+## Detected risk signals
+
+<!-- Record only signals with observable evidence from public information.
+     Possible signals: anonymous/unclear team, no public docs, no working
+     demo, unrealistic reward claims, guaranteed-profit language, aggressive
+     referral focus, unverified partnership claims, suspicious token-sale
+     wording, unclear tokenomics, no/inactive GitHub, copied content, broken
+     links, no audit/security info, pressure tactics, fabricated social proof.
+     Write "none detected" if none. -->
+
+- **Signal:** — Evidence:
+
+## Positive trust signals
+
+<!-- e.g. clear docs, working demo, public team, active GitHub, real community
+     activity, transparent tokenomics, audit notes, clear roadmap, no
+     guaranteed-profit language. Write "none detected" if none. -->
+
+-
+
+## Missing information
+
+<!-- List the public information categories a human would still need. -->
+
+-
+
+## Explanation
+
+<!-- A short, calm, evidence-based summary. Avoid labels like "scam". -->
+
+## Review level reference
+
+- **LOW** — few/no risk signals; human review still recommended.
+- **MEDIUM** — some signals or gaps; manual verification needed.
+- **HIGH** — multiple notable signals; careful human review strongly recommended.
+- **HUMAN REVIEW REQUIRED** — not enough public information to assess.
+
+## Final human-review note
+
+This note was prepared from public information to assist human reviewers. It does
+**not** accuse the project or any person, does **not** claim the project is a
+scam, and does **not** enforce any action. The detected signals are unverified
+and may have innocent explanations. A human must verify every signal against
+original sources and apply the community's own rules before making any decision.
+**Manual verification required.**

--- a/skills/safety/community-safety-review/templates/safety-review.md
+++ b/skills/safety/community-safety-review/templates/safety-review.md
@@ -1,0 +1,86 @@
+# Community Safety Review Note
+
+> Neutral safety note for human moderators. This is **not** an accusation and
+> **not** an enforcement action. Human review is required before any decision.
+
+---
+
+## Message / project being reviewed
+
+<!-- Restate the message or project neutrally. Describe what is being reviewed,
+     not who the person "is". Keep it factual. -->
+
+
+
+## Claimed identity
+
+<!-- What does the message claim about its source or author?
+     For example: "claims to be an official admin." Write UNKNOWN if unclear. -->
+
+
+
+## Links provided
+
+<!-- List every link, domain, or handle exactly as provided.
+     Note any mismatched, shortened, or look-alike URLs. Write "none" if none. -->
+
+
+
+## Verification sources checked
+
+<!-- Which public sources were checked, and what did they show?
+     If no sources were checked, write "none checked." Do not invent sources. -->
+
+
+
+## Suspicious signals
+
+<!-- Record only signals with observable evidence. For each, write the evidence.
+     Possible signals: fake official claims, misleading project names, unsafe or
+     suspicious links, impersonation signs, unclear ownership, pressure-style
+     wording, missing verification sources, mismatched usernames/domains/branding,
+     unverifiable claims. Write "none observed" if none. -->
+
+- Signal:
+  - Evidence:
+
+
+
+## Missing information
+
+<!-- List what a human would still need in order to reach a conclusion. -->
+
+
+
+## Risk level
+
+<!-- Choose one. This describes how much careful review is recommended,
+     not a verdict about a person. -->
+
+- [ ] LOW — No obvious suspicious signal, but human review is still recommended.
+- [ ] MEDIUM — Some information is unclear or missing. Manual verification needed.
+- [ ] HIGH — Strong suspicious signals exist. Human review strongly recommended.
+- [ ] UNKNOWN — Not enough information to make a useful safety note.
+
+
+
+## Suggested moderator action
+
+<!-- A review suggestion only — never an enforcement order.
+     Example: "Recommend a moderator verify the domain before responding." -->
+
+
+
+## Neutral summary
+
+<!-- A short, calm summary in evidence-based language. Avoid labels like
+     "scammer". Prefer phrasing such as "suspicious signal detected" or
+     "this claim could not be verified from public sources." -->
+
+
+
+## Human review disclaimer
+
+This note was prepared to assist human moderators. It does not accuse anyone and
+does not enforce any action. A human moderator must review the evidence and apply
+the community's own rules before making any decision. **Human review required.**


### PR DESCRIPTION
## What does this PR do?

Adds Phase 2 for the Community Safety Review Skill.

This skill generates a neutral Markdown safety review report from public, reviewer-supplied project information.

It helps reviewers surface public risk signals, positive trust signals, and missing information without making final accusations or replacing human judgment.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🌟 New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)

## What it includes

- Risk signal checklist
- Positive trust signal checklist
- Missing information checklist
- Review levels: LOW / MEDIUM / HIGH / HUMAN REVIEW REQUIRED
- Evidence-based risk notes
- Sample Markdown report
- Manual verification reminder

## Safety positioning

This tool does not claim that a project is a scam.

It only highlights public, unverified risk signals and missing information so a human reviewer can make a better decision.

## Important notes

- Public signals only
- No private data usage
- No automated enforcement
- No accusation language
- Manual verification required