### PR TITLE
Add AlphaHunt research YAML contract

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -88,6 +88,14 @@ class _OpenAIProxy:
     __slots__ = ()
 
     def __call__(self, *args, **kwargs):
+        if "http_client" not in kwargs:
+            try:
+                import httpx
+
+                kwargs = dict(kwargs)
+                kwargs["http_client"] = httpx.Client(trust_env=True)
+            except Exception:
+                pass
         return _load_openai_cls()(*args, **kwargs)
 
     def __instancecheck__(self, obj):
@@ -3092,6 +3100,13 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
                 _ph_async = _gpf_async(_inferred)
                 if _ph_async and _ph_async.default_headers:
                     async_kwargs["default_headers"] = dict(_ph_async.default_headers)
+        except Exception:
+            pass
+    if "http_client" not in async_kwargs:
+        try:
+            import httpx
+
+            async_kwargs["http_client"] = httpx.AsyncClient(trust_env=True)
         except Exception:
             pass
     return AsyncOpenAI(**async_kwargs), model

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -57,9 +57,18 @@ def run_codex_app_server_turn(
             approval_callback = _get_approval_callback()
         except Exception:
             approval_callback = None
+
+        def _on_codex_app_server_event(event: dict) -> None:
+            method = event.get("method") if isinstance(event, dict) else None
+            if method:
+                agent._touch_activity(f"codex app-server event: {method}")
+            else:
+                agent._touch_activity("codex app-server event")
+
         agent._codex_session = CodexAppServerSession(
             cwd=cwd,
             approval_callback=approval_callback,
+            on_event=_on_codex_app_server_event,
         )
 
     # NOTE: the user message is ALREADY appended to messages by the
@@ -75,6 +84,7 @@ def run_codex_app_server_turn(
             # Codex app-server needs a finite deadline for interrupt/retire
             # hygiene even when the outer gateway timeout is unlimited.
             turn_timeout = 86400.0
+        agent._touch_activity("running codex app-server turn")
         turn = agent._codex_session.run_turn(
             user_input=user_message,
             turn_timeout=turn_timeout,

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -66,7 +66,18 @@ def run_codex_app_server_turn(
     # return reaches us. Do NOT append again — that would duplicate.
 
     try:
-        turn = agent._codex_session.run_turn(user_input=user_message)
+        try:
+            turn_timeout = float(os.environ.get("HERMES_AGENT_TIMEOUT", "1800"))
+        except (TypeError, ValueError):
+            turn_timeout = 1800.0
+        if turn_timeout <= 0:
+            # Codex app-server needs a finite deadline for interrupt/retire
+            # hygiene even when the outer gateway timeout is unlimited.
+            turn_timeout = 86400.0
+        turn = agent._codex_session.run_turn(
+            user_input=user_message,
+            turn_timeout=turn_timeout,
+        )
     except Exception as exc:
         logger.exception("codex app-server turn failed")
         # Crash → unconditionally drop the session so the next turn
@@ -161,8 +172,18 @@ def run_codex_app_server_turn(
         except Exception:
             logger.debug("background review spawn raised", exc_info=True)
 
+    if turn.interrupted or turn.error is not None:
+        final_response = turn.error or "Codex app-server turn interrupted."
+        if turn.final_text:
+            final_response = (
+                f"{final_response}\n\nPartial response before failure:\n"
+                f"{turn.final_text}"
+            )
+    else:
+        final_response = turn.final_text
+
     return {
-        "final_response": turn.final_text,
+        "final_response": final_response,
         "messages": messages,
         "api_calls": 1,  # one app-server "turn" maps to one logical API call
         "completed": not turn.interrupted and turn.error is None,

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -32,6 +32,7 @@ def run_codex_app_server_turn(
     original_user_message: Any,
     messages: List[Dict[str, Any]],
     effective_task_id: str,
+    conversation_history: List[Dict[str, Any]] | None = None,
     should_review_memory: bool = False,
 ) -> Dict[str, Any]:
     """Codex app-server runtime path. Hands the entire turn to a `codex
@@ -87,6 +88,10 @@ def run_codex_app_server_turn(
         except Exception:
             pass
         agent._codex_session = None
+        try:
+            agent._persist_session(messages, conversation_history)
+        except Exception:
+            logger.warning("codex app-server failed-turn persistence raised", exc_info=True)
         return {
             "final_response": (
                 f"Codex app-server turn failed: {exc}. "
@@ -96,6 +101,7 @@ def run_codex_app_server_turn(
             "api_calls": 0,
             "completed": False,
             "partial": True,
+            "failed": True,
             "error": str(exc),
         }
 
@@ -181,6 +187,14 @@ def run_codex_app_server_turn(
             )
     else:
         final_response = turn.final_text
+
+    # The codex_app_server path returns before the standard chat-completions
+    # loop reaches its final persistence block. Persist here so gateway
+    # continuations can reload the just-completed turn from SessionDB.
+    try:
+        agent._persist_session(messages, conversation_history)
+    except Exception:
+        logger.warning("codex app-server turn persistence raised", exc_info=True)
 
     return {
         "final_response": final_response,

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1319,7 +1319,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             self._summary_failure_cooldown_until = time.monotonic() + _SUMMARY_FAILURE_COOLDOWN_SECONDS
             self._last_summary_error = "no auxiliary LLM provider configured"
             logger.warning("Context compression: no provider available for "
-                            "summary. Middle turns will be dropped without summary "
+                            "summary. Middle turns will use deterministic fallback "
                             "for %d seconds.",
                             _SUMMARY_FAILURE_COOLDOWN_SECONDS)
             return None

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -429,7 +429,7 @@ def compress_context(
             agent._last_compression_summary_warning = summary_error
             agent._emit_warning(
                 f"⚠ Compression summary failed: {summary_error}. "
-                "Inserted a fallback context marker."
+                "Inserted a local structured fallback summary."
             )
     else:
         # No hard failure — but did the configured aux model error out

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -382,6 +382,8 @@ def run_conversation(
     # Installed once, transparent when streams are healthy, prevents crash on write.
     _install_safe_stdio()
 
+    agent._touch_activity("starting conversation turn")
+
     agent._ensure_db_session()
 
     # Tell auxiliary_client what the live main provider/model are for
@@ -579,6 +581,7 @@ def run_conversation(
     # producing a different system prompt and breaking the Anthropic
     # prefix cache.
     if agent._cached_system_prompt is None:
+        agent._touch_activity("building system prompt")
         _restore_or_build_system_prompt(agent, system_message, conversation_history)
 
     active_system_prompt = agent._cached_system_prompt

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -757,6 +757,7 @@ def run_conversation(
             original_user_message=original_user_message,
             messages=messages,
             effective_task_id=effective_task_id,
+            conversation_history=conversation_history,
             should_review_memory=_should_review_memory,
         )
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2533,6 +2533,15 @@ def run_conversation(
                     agent._client_log_context(),
                     _error_summary,
                 )
+                if (
+                    error_type == "TypeError"
+                    and "'NoneType' object is not iterable" in str(api_error)
+                    and getattr(agent, "provider", "") == "openai-codex"
+                ):
+                    logger.exception(
+                        "OpenAI Codex NoneType iterable traceback for diagnostics. %s",
+                        agent._client_log_context(),
+                    )
 
                 _provider = getattr(agent, "provider", "unknown")
                 _base = getattr(agent, "base_url", "unknown")

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -55,9 +55,9 @@ _STDERR_TAIL_LINES = 12
 _HERMES_TO_CODEX_PERMISSION_PROFILE = {
     "auto": "workspace-write",
     "approval-required": "read-only-with-approval",
-    "unrestricted": "full-access",
+    "unrestricted": "danger-full-access",
     # Backstop alias used by some skills/tests.
-    "yolo": "full-access",
+    "yolo": "danger-full-access",
 }
 
 
@@ -247,24 +247,36 @@ class CodexAppServerSession:
             client_name="hermes",
             client_title="Hermes Agent",
             client_version=_get_hermes_version(),
+            capabilities={"experimentalApi": True},
+            timeout=30.0,
         )
-        # Permission selection is intentionally NOT sent on thread/start.
-        # Two reasons (live-tested against codex 0.130.0):
-        #   1. `thread/start.permissions` is gated behind the experimentalApi
-        #      capability on this codex version — we'd have to opt in during
-        #      initialize and accept the unstable surface.
-        #   2. Even with experimentalApi declared and the correct shape
-        #      (`{"type": "profile", "id": "..."}`, not `{"profileId": ...}`),
-        #      codex requires a matching `[permissions]` table in
-        #      ~/.codex/config.toml or it fails the request with
-        #      'default_permissions requires a [permissions] table'.
-        # Letting codex pick its default (`:read-only` unless the user has
-        # configured otherwise in their codex config.toml) is the standard
-        # codex CLI workflow and avoids fighting codex's own validation.
-        # Users who want a write-capable profile configure it in their
-        # ~/.codex/config.toml the same way they would for any codex usage.
-        params: dict[str, Any] = {"cwd": self._cwd}
-        result = self._client.request("thread/start", params, timeout=15)
+        params: dict[str, Any] = {
+            "cwd": self._cwd,
+            "permissionProfile": {"type": "profile", "id": self._permission_profile},
+        }
+        try:
+            result = self._client.request("thread/start", params, timeout=15)
+        except CodexAppServerError as exc:
+            # Older/stricter Codex app-server builds rejected the
+            # thread/start permissions field even though they advertised the
+            # related request/approval protocol. Keep those installs usable by
+            # retrying with Codex's config-file default, but only for schema /
+            # permissions validation failures. Other startup failures still
+            # surface normally so auth/provider errors are not masked.
+            err_text = f"{exc.message} {exc.data or ''}".lower()
+            if (
+                "permissions" not in err_text
+                and "permission" not in err_text
+                and "unknown field" not in err_text
+                and "invalid params" not in err_text
+            ):
+                raise
+            logger.warning(
+                "codex rejected thread/start permission profile %r; "
+                "retrying with codex config default",
+                self._permission_profile,
+            )
+            result = self._client.request("thread/start", {"cwd": self._cwd}, timeout=15)
         # Cross-fill thread.id/sessionId — different codex versions have
         # serialized this under either key. Mirrors openclaw beta.8's
         # tolerance fix so future codex drops/renames don't KeyError us
@@ -365,7 +377,7 @@ class CodexAppServerSession:
         *,
         turn_timeout: float = 600.0,
         notification_poll_timeout: float = 0.25,
-        post_tool_quiet_timeout: float = 90.0,
+        post_tool_quiet_timeout: float = 900.0,
     ) -> TurnResult:
         """Send a user message and block until turn/completed, while
         forwarding server-initiated approval requests and projecting items
@@ -375,7 +387,9 @@ class CodexAppServerSession:
         goes quiet for this many seconds without emitting another item or
         `turn/completed`, fast-fail and mark the session for retirement.
         Mirrors openclaw beta.8's post-tool completion watchdog (#81697)
-        so a wedged codex doesn't burn the full turn deadline.
+        so a wedged codex doesn't burn the full turn deadline. Keep this long
+        enough for real local code/test tasks, where Codex may spend several
+        minutes reasoning after a tool result before emitting the final answer.
         """
         # Pre-create the result so startup failures (codex subprocess can't
         # spawn, initialize handshake rejects, thread/start blows up) surface

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -651,11 +651,12 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         task_name = job.get("name", job["id"])
         job_id = job.get("id", "")
         delivery_content = (
-            f"Cronjob Response: {task_name}\n"
+            f"Cron job run completed: {task_name}\n"
             f"(job_id: {job_id})\n"
             f"-------------\n\n"
             f"{content}\n\n"
-            f"To stop or manage this job, send me a new message (e.g. \"stop reminder {task_name}\")."
+            f"Manage this scheduled job by sending a new message, for example: "
+            f"\"stop reminder {task_name}\"."
         )
     else:
         delivery_content = content
@@ -1395,6 +1396,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
     logger.info("Prompt: %s", prompt[:100])
 
     agent = None
+    _cron_worker_still_running = False
 
     # Mark this as a cron session so the approval system can apply cron_mode.
     # This env var is process-wide and persists for the lifetime of the
@@ -1682,6 +1684,8 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # env passthrough registrations) when the cron run hops into the worker
         # thread used for inactivity timeout monitoring.
         _cron_context = contextvars.copy_context()
+        if hasattr(agent, "_touch_activity"):
+            agent._touch_activity("submitting cron conversation")
         _cron_future = _cron_pool.submit(_cron_context.run, agent.run_conversation, prompt)
         _inactivity_timeout = False
         try:
@@ -1707,6 +1711,22 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                             pass
                     if _idle_secs >= _cron_inactivity_limit:
                         _inactivity_timeout = True
+                        if hasattr(agent, "interrupt"):
+                            agent.interrupt("Cron job timed out (inactivity)")
+                        try:
+                            _cron_future.result(timeout=15)
+                        except concurrent.futures.TimeoutError:
+                            # ``concurrent.futures.TimeoutError`` is an alias
+                            # of the built-in TimeoutError, so a worker that
+                            # exits by raising TimeoutError can land here too.
+                            # Only treat it as still running when the future
+                            # itself has not completed.
+                            if not _cron_future.done():
+                                _cron_worker_still_running = True
+                        except Exception:
+                            # Preserve the timeout diagnostic below; the worker
+                            # did exit, so normal resource cleanup is safe.
+                            pass
                         break
         except Exception:
             _cron_pool.shutdown(wait=False, cancel_futures=True)
@@ -1735,8 +1755,6 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 _last_desc, _iter_n, _iter_max,
                 _cur_tool or "none",
             )
-            if hasattr(agent, "interrupt"):
-                agent.interrupt("Cron job timed out (inactivity)")
             raise TimeoutError(
                 f"Cron job '{job_name}' idle for "
                 f"{int(_secs_ago)}s (limit {int(_cron_inactivity_limit)}s) "
@@ -1825,7 +1843,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         clear_session_vars(_ctx_tokens)
         for _var_name in _cron_delivery_vars:
             _VAR_MAP[_var_name].set("")
-        if _session_db:
+        if _session_db and not _cron_worker_still_running:
             try:
                 _session_db.end_session(_cron_session_id, "cron_complete")
             except (Exception, KeyboardInterrupt) as e:
@@ -1834,24 +1852,39 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 _session_db.close()
             except (Exception, KeyboardInterrupt) as e:
                 logger.debug("Job '%s': failed to close SQLite session store: %s", job_id, e)
+        elif _session_db and _cron_worker_still_running:
+            logger.warning(
+                "Job '%s': cron worker still running after inactivity timeout; "
+                "deferring SQLite session cleanup to avoid closing resources "
+                "under the worker thread",
+                job_id,
+            )
         # Release subprocesses, terminal sandboxes, browser daemons, and the
         # main OpenAI/httpx client held by this ephemeral cron agent. Without
         # this, a gateway that ticks cron every N minutes leaks fds per job
         # until it hits EMFILE (#10200 / "too many open files").
         try:
-            if agent is not None:
+            if agent is not None and not _cron_worker_still_running:
                 agent.close()
+            elif agent is not None and _cron_worker_still_running:
+                logger.warning(
+                    "Job '%s': cron worker still running after inactivity timeout; "
+                    "deferring agent.close() to avoid closing resources under "
+                    "the worker thread",
+                    job_id,
+                )
         except (Exception, KeyboardInterrupt) as e:
             logger.debug("Job '%s': failed to close agent resources: %s", job_id, e)
         # Each cron run spins up a short-lived worker thread whose event loop
         # dies as soon as the ``ThreadPoolExecutor`` shuts down. Any async
         # httpx clients cached under that loop are now unusable — reap them
         # so their transports don't accumulate in the process-global cache.
-        try:
-            from agent.auxiliary_client import cleanup_stale_async_clients
-            cleanup_stale_async_clients()
-        except Exception as e:
-            logger.debug("Job '%s': failed to reap stale auxiliary clients: %s", job_id, e)
+        if not _cron_worker_still_running:
+            try:
+                from agent.auxiliary_client import cleanup_stale_async_clients
+                cleanup_stale_async_clients()
+            except Exception as e:
+                logger.debug("Job '%s': failed to reap stale auxiliary clients: %s", job_id, e)
 
 
 def tick(verbose: bool = True, adapters=None, loop=None) -> int:

--- a/docs/alphahunt/HERMES_RESEARCH_RUNBOOK.md
+++ b/docs/alphahunt/HERMES_RESEARCH_RUNBOOK.md
@@ -1,0 +1,48 @@
+# Hermes AlphaHunt Research Runbook
+
+Use this runbook when Hermes performs research that should also create an
+AlphaHunt project research artifact.
+
+## System Prompt
+
+```plain
+你是 AlphaHunt 的调研代理。每次调研任务完成时，必须同时产出：
+1. markdown 调研正文
+2. AlphaHunt project research YAML
+YAML 必须通过 gateway.alphahunt.research_yaml 的校验。
+如果无法满足必填字段，不要编造，明确输出 validation_error 和缺失项。
+AlphaHunt 和 Hermes 都不执行交易、不下注、不下单、不签名、不管理资金。
+market / odds / prediction 输出永远 reference-only，只能给 observe / research / manual_review / no_participation。
+```
+
+## Operator Flow
+
+1. Produce the markdown research body.
+2. Convert the same conclusions into the YAML envelope from
+   `docs/alphahunt/RESEARCH_OUTPUT_CONTRACT.md`.
+3. Validate the YAML:
+
+```bash
+python -m gateway.alphahunt.research_yaml --validate <research.yaml>
+```
+
+4. If validation fails, report `validation_error` and the missing or invalid
+   fields. Do not invent facts to make the envelope pass.
+5. For AlphaHunt dry-run import, follow
+   `docs/alphahunt/INTEGRATION_DRYRUN.md`.
+
+## Boundaries
+
+Hermes research output is reference-only. It must not call live AlphaHunt APIs,
+write AlphaHunt production databases, connect cron, send notifications, execute
+trades, place wagers, place orders, sign transactions, or manage funds.
+
+For `market`, `odds`, or prediction-style research, allowed actions are only:
+
+- `observe`
+- `research`
+- `manual_review`
+- `no_participation`
+
+Use `ignore` when the safest operator recommendation is to drop the item from
+the research queue.

--- a/docs/alphahunt/HERMES_RESEARCH_RUNBOOK.md
+++ b/docs/alphahunt/HERMES_RESEARCH_RUNBOOK.md
@@ -20,6 +20,10 @@ market / odds / prediction 输出永远 reference-only，只能给 observe / res
 1. Produce the markdown research body.
 2. Convert the same conclusions into the YAML envelope from
    `docs/alphahunt/RESEARCH_OUTPUT_CONTRACT.md`.
+   `asset_class` must be an AlphaHunt authorized production enum. If it is an
+   unauthorized new category, use `DRAFT:<name>`. DRAFT values only go into the
+   research note / raw_json and must not be written into the
+   `projects.asset_class` production enum column.
 3. Validate the YAML:
 
 ```bash

--- a/docs/alphahunt/INTEGRATION_DRYRUN.md
+++ b/docs/alphahunt/INTEGRATION_DRYRUN.md
@@ -1,0 +1,30 @@
+# AlphaHunt Research Dry Run
+
+Hermes can produce AlphaHunt project research YAML without using AlphaHunt API
+keys or live endpoints.
+
+Validate a Hermes sample first:
+
+```bash
+python -m gateway.alphahunt.research_yaml --validate docs/alphahunt/samples/protocol_ethena.yaml
+```
+
+Then feed the YAML to the AlphaHunt P08 dry-run/import script:
+
+```bash
+python3 /home/ubuntu/alphahunt/scripts/create_project_from_research.py docs/alphahunt/samples/protocol_ethena.yaml
+python3 /home/ubuntu/alphahunt/scripts/create_project_from_research.py docs/alphahunt/samples/stock_example.yaml
+python3 /home/ubuntu/alphahunt/scripts/create_project_from_research.py docs/alphahunt/samples/commodity_copper.yaml
+python3 /home/ubuntu/alphahunt/scripts/create_project_from_research.py docs/alphahunt/samples/macro_fomc.yaml
+python3 /home/ubuntu/alphahunt/scripts/create_project_from_research.py docs/alphahunt/samples/market_worldcup.yaml
+```
+
+This integration is dry-run only from the Hermes side:
+
+- No AlphaHunt API key is required.
+- Hermes does not write AlphaHunt production DBs.
+- Hermes does not call live AlphaHunt endpoints.
+- Hermes does not connect cron or notifications.
+- Hermes does not execute trades, place wagers, sign transactions, or manage funds.
+
+Any live handoff requires separate user authorization and a separate H7 design.

--- a/docs/alphahunt/PIPELINE_VS_RESEARCH.md
+++ b/docs/alphahunt/PIPELINE_VS_RESEARCH.md
@@ -1,0 +1,26 @@
+# AlphaHunt Pipeline vs Hermes Research
+
+Hermes currently has an AlphaHunt event decision pipeline in
+`gateway/platforms/alphahunt_stage.py`. That file is a per-event analysis stage
+handler for cleaner, screener, sentinel, packager, and fast-triage decisions.
+
+The new `gateway.alphahunt.research_yaml` module is different. It is a generic
+Hermes research output generator and validator for proactive project research.
+
+Do not mix the two surfaces:
+
+- `alphahunt_stage.py` handles event decision objects.
+- `gateway.alphahunt.research_yaml` handles project research notes.
+- An event decision object is not a project research note.
+- A project research YAML envelope is not a per-event decision packet.
+
+The research YAML is intended for AlphaHunt P08:
+
+```bash
+python3 /home/ubuntu/alphahunt/scripts/create_project_from_research.py docs/alphahunt/samples/protocol_ethena.yaml
+```
+
+This handoff remains dry-run/operator-controlled unless a user separately
+authorizes a live workflow. Hermes must not write AlphaHunt production DBs,
+call AlphaHunt live APIs, place trades, place wagers, sign transactions, manage
+funds, or send notifications as part of this research output path.

--- a/docs/alphahunt/RESEARCH_OUTPUT_CONTRACT.md
+++ b/docs/alphahunt/RESEARCH_OUTPUT_CONTRACT.md
@@ -16,7 +16,7 @@ place orders, sign transactions, place wagers, or manage funds.
 ```yaml
 subject: "<human-readable name and idempotency anchor>"
 kind: <stock|etf|protocol|commodity_theme|macro_event|industry_theme|market>
-asset_class: "<known class or DRAFT:new_class>"
+asset_class: "<authorized production enum or DRAFT:new_class>"
 tickers: ["..."]
 chain: "<chain>"
 contract_addresses: ["0x..."]
@@ -67,6 +67,11 @@ Validation must fail when any of these are missing or empty:
 
 `note.next_check_at` must be parseable ISO8601.
 
+`asset_class` must be an AlphaHunt authorized production enum. If it is an
+unauthorized new category, use `DRAFT:<name>`. DRAFT values only go into the
+research note / raw_json and must not be written into the
+`projects.asset_class` production enum column.
+
 `source_references` belongs under `note.source_references`. Top-level
 `source_references` must fail validation so the envelope stays aligned with the
 AlphaHunt `project_research_note` contract.
@@ -87,8 +92,8 @@ Unknown kinds must fail validation.
 
 ## Asset Class
 
-`asset_class` must be one of the known Hermes/AlphaHunt classes accepted by
-`gateway.alphahunt.research_yaml`, or it must use the draft form:
+`asset_class` must be one of the AlphaHunt authorized production enums accepted
+by `gateway.alphahunt.research_yaml`, or it must use the draft form:
 
 ```yaml
 asset_class: "DRAFT:new_class_name"

--- a/docs/alphahunt/RESEARCH_OUTPUT_CONTRACT.md
+++ b/docs/alphahunt/RESEARCH_OUTPUT_CONTRACT.md
@@ -1,0 +1,126 @@
+# Hermes AlphaHunt Research Output Contract
+
+This contract defines the standard Hermes research envelope that can be handed
+to AlphaHunt P08 `create_project_from_research.py`.
+
+Hermes research output must contain two synchronized artifacts:
+
+1. A human-readable markdown research body.
+2. A machine-readable AlphaHunt project research YAML envelope.
+
+The YAML envelope is reference-only. Hermes and AlphaHunt do not execute trades,
+place orders, sign transactions, place wagers, or manage funds.
+
+## Envelope
+
+```yaml
+subject: "<human-readable name and idempotency anchor>"
+kind: <stock|etf|protocol|commodity_theme|macro_event|industry_theme|market>
+asset_class: "<known class or DRAFT:new_class>"
+tickers: ["..."]
+chain: "<chain>"
+contract_addresses: ["0x..."]
+aliases: ["...", "..."]
+market_meta:
+  rules: "<settlement rule text>"
+  settlement: "<settlement condition>"
+  deadline: "<ISO8601>"
+research_markdown: |
+  <Hermes markdown research body>
+note:
+  thesis: "<one-sentence core thesis>"
+  key_assumptions: ["...", "..."]
+  risk_triggers: ["...", "..."]
+  invalidation_conditions: ["...", "..."]
+  observables:
+    - name: "<metric>"
+      source: "<source>"
+      threshold: "<threshold>"
+      direction: "up|down"
+  next_check_at: "2026-06-18T00:00:00+00:00"
+  bull_case: ["..."]
+  bear_case: ["..."]
+  confidence: 0.6
+  action_suggestion: "<reference-only suggestion>"
+  source_references: ["https://..."]
+```
+
+## Required Fields
+
+Validation must fail when any of these are missing or empty:
+
+- `subject`
+- `kind`
+- `asset_class`
+- `research_markdown`
+- `note.thesis`
+- `note.key_assumptions`
+- `note.risk_triggers`
+- `note.invalidation_conditions`
+- `note.observables`
+- `note.next_check_at`
+- `note.source_references`
+
+`note.observables` must contain at least one item. Each item must include
+`name`, `source`, `threshold`, and `direction`; `direction` must be `up` or
+`down`.
+
+`note.next_check_at` must be parseable ISO8601.
+
+`source_references` belongs under `note.source_references`. Top-level
+`source_references` must fail validation so the envelope stays aligned with the
+AlphaHunt `project_research_note` contract.
+
+## Kind
+
+`kind` is a closed enum:
+
+- `stock`
+- `etf`
+- `protocol`
+- `commodity_theme`
+- `macro_event`
+- `industry_theme`
+- `market`
+
+Unknown kinds must fail validation.
+
+## Asset Class
+
+`asset_class` must be one of the known Hermes/AlphaHunt classes accepted by
+`gateway.alphahunt.research_yaml`, or it must use the draft form:
+
+```yaml
+asset_class: "DRAFT:new_class_name"
+```
+
+New asset classes without the `DRAFT:` prefix must fail validation.
+
+## Market Boundary
+
+`market` research is only research. It is not a betting, trading, execution, or
+funds-management instruction.
+
+Additional `market` requirements:
+
+- `market_meta.rules`, `market_meta.settlement`, and `market_meta.deadline` are required.
+- `market_meta.deadline` must be parseable ISO8601.
+- `note.action_suggestion` must be one of `ignore`, `observe`, `research`,
+  `manual_review`, or `no_participation`.
+- The output must state `reference-only`, `no_participation`, and `no_execution`.
+- The output must not contain English execution or wagering trigger words such
+  as `bet`, `wager`, `execute`, `stake`, or `kelly`.
+
+Chinese operator-facing language may additionally state: 不自动下注, 不自动交易,
+不保证收益.
+
+## Validator
+
+Use the pure Hermes-side validator:
+
+```bash
+python -m gateway.alphahunt.research_yaml --validate docs/alphahunt/samples/protocol_ethena.yaml
+```
+
+The validator does not read secrets, call AlphaHunt APIs, write databases, call
+live endpoints, or access external data sources.

--- a/docs/alphahunt/samples/commodity_copper.yaml
+++ b/docs/alphahunt/samples/commodity_copper.yaml
@@ -1,0 +1,37 @@
+subject: Copper electrification demand research
+kind: commodity_theme
+asset_class: commodity_theme
+aliases:
+- copper
+- electrification
+- grid demand
+research_markdown: |
+  # Copper Theme Research
+
+  Copper demand is tied to grid investment, electric equipment, construction activity, and mine supply disruptions.
+note:
+  thesis: Copper deserves monitoring while electrification demand offsets cyclical
+    construction softness.
+  key_assumptions:
+  - Grid capex remains elevated.
+  - Mine supply disruptions persist.
+  risk_triggers:
+  - China construction demand weakens further.
+  - Inventories rebuild quickly.
+  invalidation_conditions:
+  - Visible inventories rise for four consecutive weeks.
+  - Treatment charges normalize sharply.
+  observables:
+  - name: Exchange copper inventory
+    source: LME/COMEX public inventory data
+    threshold: four-week trend
+    direction: up
+  next_check_at: '2026-06-18T00:00:00+00:00'
+  bull_case:
+  - Key assumptions continue to hold.
+  bear_case:
+  - Risk triggers become observable.
+  confidence: 0.6
+  action_suggestion: research
+  source_references:
+  - https://www.lme.com/

--- a/docs/alphahunt/samples/commodity_copper.yaml
+++ b/docs/alphahunt/samples/commodity_copper.yaml
@@ -1,6 +1,6 @@
 subject: Copper electrification demand research
 kind: commodity_theme
-asset_class: commodity_theme
+asset_class: commodity
 aliases:
 - copper
 - electrification

--- a/docs/alphahunt/samples/macro_fomc.yaml
+++ b/docs/alphahunt/samples/macro_fomc.yaml
@@ -1,0 +1,37 @@
+subject: FOMC policy path research
+kind: macro_event
+asset_class: macro_event
+aliases:
+- FOMC
+- Federal Reserve
+- policy rates
+research_markdown: |
+  # FOMC Macro Research
+
+  The macro event hinges on inflation progress, labor-market cooling, and communication around the expected policy path.
+note:
+  thesis: Policy-path expectations should be reassessed after the next inflation and
+    labor releases.
+  key_assumptions:
+  - Inflation continues to moderate.
+  - Labor conditions cool without a sharp break.
+  risk_triggers:
+  - Inflation re-accelerates.
+  - Unemployment rises abruptly.
+  invalidation_conditions:
+  - Core inflation surprises higher twice.
+  - FOMC guidance shifts hawkish.
+  observables:
+  - name: Core PCE inflation
+    source: BEA release
+    threshold: monthly change
+    direction: down
+  next_check_at: '2026-06-18T00:00:00+00:00'
+  bull_case:
+  - Key assumptions continue to hold.
+  bear_case:
+  - Risk triggers become observable.
+  confidence: 0.6
+  action_suggestion: research
+  source_references:
+  - https://www.federalreserve.gov/monetarypolicy/fomccalendars.htm

--- a/docs/alphahunt/samples/macro_fomc.yaml
+++ b/docs/alphahunt/samples/macro_fomc.yaml
@@ -1,6 +1,6 @@
 subject: FOMC policy path research
 kind: macro_event
-asset_class: macro_event
+asset_class: macro_theme
 aliases:
 - FOMC
 - Federal Reserve

--- a/docs/alphahunt/samples/market_worldcup.yaml
+++ b/docs/alphahunt/samples/market_worldcup.yaml
@@ -1,6 +1,6 @@
 subject: World Cup champion prediction market research
 kind: market
-asset_class: prediction_market
+asset_class: DRAFT:prediction_market
 aliases:
 - World Cup champion
 - prediction market

--- a/docs/alphahunt/samples/market_worldcup.yaml
+++ b/docs/alphahunt/samples/market_worldcup.yaml
@@ -1,0 +1,42 @@
+subject: World Cup champion prediction market research
+kind: market
+asset_class: prediction_market
+aliases:
+- World Cup champion
+- prediction market
+market_meta:
+  rules: Market resolves according to the venue's published champion settlement rules.
+  settlement: Winning national team after the final is officially completed.
+  deadline: '2026-07-19T23:59:00+00:00'
+research_markdown: |
+  # World Cup Market Research
+
+  This output is reference-only. It is for observation and manual review, not automated participation.
+
+  Boundary: no_participation, no_execution, 不自动下注, 不自动交易, 不保证收益.
+note:
+  thesis: The market is suitable only for observation because sports outcomes are
+    high-variance.
+  key_assumptions:
+  - Venue rules remain stable.
+  - Team availability data is current.
+  risk_triggers:
+  - Rule ambiguity.
+  - Major injury or roster uncertainty.
+  invalidation_conditions:
+  - Settlement wording changes.
+  - Liquidity becomes too thin for reliable interpretation.
+  observables:
+  - name: Market-implied probability
+    source: Public market page
+    threshold: large move after official news
+    direction: up
+  next_check_at: '2026-06-18T00:00:00+00:00'
+  bull_case:
+  - Key assumptions continue to hold.
+  bear_case:
+  - Risk triggers become observable.
+  confidence: 0.6
+  action_suggestion: no_participation
+  source_references:
+  - https://www.fifa.com/

--- a/docs/alphahunt/samples/protocol_ethena.yaml
+++ b/docs/alphahunt/samples/protocol_ethena.yaml
@@ -1,0 +1,40 @@
+subject: Ethena protocol basis-yield research
+kind: protocol
+asset_class: DRAFT:crypto_protocol
+chain: ethereum
+contract_addresses:
+- '0x0000000000000000000000000000000000000000'
+aliases:
+- Ethena
+- USDe
+- sUSDe
+research_markdown: |
+  # Ethena Protocol Research
+
+  Ethena's opportunity depends on durable demand for dollar-denominated crypto yield, exchange liquidity, and transparent collateral/risk disclosures.
+note:
+  thesis: Ethena is worth continued research if collateral transparency and exchange
+    liquidity remain intact.
+  key_assumptions:
+  - USDe supply remains liquid across major venues.
+  - Funding-rate income remains observable.
+  risk_triggers:
+  - Sustained depeg pressure.
+  - Material decline in disclosed backing quality.
+  invalidation_conditions:
+  - USDe trades below 0.98 for a full day.
+  - Collateral reporting becomes stale.
+  observables:
+  - name: USDe secondary-market peg
+    source: Public exchange market data
+    threshold: '0.98'
+    direction: down
+  next_check_at: '2026-06-18T00:00:00+00:00'
+  bull_case:
+  - Key assumptions continue to hold.
+  bear_case:
+  - Risk triggers become observable.
+  confidence: 0.6
+  action_suggestion: research
+  source_references:
+  - https://docs.ethena.fi/

--- a/docs/alphahunt/samples/stock_example.yaml
+++ b/docs/alphahunt/samples/stock_example.yaml
@@ -1,6 +1,6 @@
 subject: Example Semiconductor Inc research
 kind: stock
-asset_class: stock
+asset_class: DRAFT:us_stock
 tickers:
 - EXSM
 aliases:

--- a/docs/alphahunt/samples/stock_example.yaml
+++ b/docs/alphahunt/samples/stock_example.yaml
@@ -1,0 +1,37 @@
+subject: Example Semiconductor Inc research
+kind: stock
+asset_class: stock
+tickers:
+- EXSM
+aliases:
+- Example Semiconductor
+research_markdown: |
+  # Example Semiconductor Research
+
+  The company is a placeholder equity research sample for validating the Hermes AlphaHunt research envelope.
+note:
+  thesis: The equity case depends on revenue growth translating into durable margin
+    expansion.
+  key_assumptions:
+  - Demand remains resilient.
+  - Inventory normalizes over the next two quarters.
+  risk_triggers:
+  - Guidance cut.
+  - Gross margin compression.
+  invalidation_conditions:
+  - Revenue growth turns negative.
+  - Management withdraws margin targets.
+  observables:
+  - name: Quarterly revenue growth
+    source: Company filings
+    threshold: positive year over year
+    direction: up
+  next_check_at: '2026-06-18T00:00:00+00:00'
+  bull_case:
+  - Key assumptions continue to hold.
+  bear_case:
+  - Risk triggers become observable.
+  confidence: 0.6
+  action_suggestion: research
+  source_references:
+  - https://www.sec.gov/edgar

--- a/gateway/alphahunt/__init__.py
+++ b/gateway/alphahunt/__init__.py
@@ -1,0 +1,1 @@
+"""AlphaHunt integration helpers."""

--- a/gateway/alphahunt/research_yaml.py
+++ b/gateway/alphahunt/research_yaml.py
@@ -30,18 +30,14 @@ KINDS = frozenset(
 
 KNOWN_ASSET_CLASSES = frozenset(
     {
-        "stock",
         "equity",
         "etf",
         "crypto",
         "commodity",
-        "commodity_theme",
-        "macro",
-        "macro_event",
+        "macro_theme",
         "industry",
         "industry_theme",
         "market",
-        "prediction_market",
     }
 )
 
@@ -222,7 +218,7 @@ def sample_research_envelope(kind: str) -> dict[str, Any]:
         "stock": {
             "subject": "Example Semiconductor Inc research",
             "kind": "stock",
-            "asset_class": "stock",
+            "asset_class": "DRAFT:us_stock",
             "tickers": ["EXSM"],
             "aliases": ["Example Semiconductor"],
             "research_markdown": (
@@ -267,7 +263,7 @@ def sample_research_envelope(kind: str) -> dict[str, Any]:
         "commodity_theme": {
             "subject": "Copper electrification demand research",
             "kind": "commodity_theme",
-            "asset_class": "commodity_theme",
+            "asset_class": "commodity",
             "aliases": ["copper", "electrification", "grid demand"],
             "research_markdown": (
                 "# Copper Theme Research\n\n"
@@ -289,7 +285,7 @@ def sample_research_envelope(kind: str) -> dict[str, Any]:
         "macro_event": {
             "subject": "FOMC policy path research",
             "kind": "macro_event",
-            "asset_class": "macro_event",
+            "asset_class": "macro_theme",
             "aliases": ["FOMC", "Federal Reserve", "policy rates"],
             "research_markdown": (
                 "# FOMC Macro Research\n\n"
@@ -311,7 +307,7 @@ def sample_research_envelope(kind: str) -> dict[str, Any]:
         "market": {
             "subject": "World Cup champion prediction market research",
             "kind": "market",
-            "asset_class": "prediction_market",
+            "asset_class": "DRAFT:prediction_market",
             "aliases": ["World Cup champion", "prediction market"],
             "market_meta": {
                 "rules": "Market resolves according to the venue's published champion settlement rules.",

--- a/gateway/alphahunt/research_yaml.py
+++ b/gateway/alphahunt/research_yaml.py
@@ -1,0 +1,525 @@
+"""AlphaHunt project research YAML envelope helpers.
+
+This module is intentionally pure: it validates and renders research payloads
+without network access, secrets, API calls, or database writes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+KINDS = frozenset(
+    {
+        "stock",
+        "etf",
+        "protocol",
+        "commodity_theme",
+        "macro_event",
+        "industry_theme",
+        "market",
+    }
+)
+
+KNOWN_ASSET_CLASSES = frozenset(
+    {
+        "stock",
+        "equity",
+        "etf",
+        "crypto",
+        "commodity",
+        "commodity_theme",
+        "macro",
+        "macro_event",
+        "industry",
+        "industry_theme",
+        "market",
+        "prediction_market",
+    }
+)
+
+REQUIRED_NOTE_FIELDS = (
+    "thesis",
+    "key_assumptions",
+    "risk_triggers",
+    "invalidation_conditions",
+    "observables",
+    "next_check_at",
+    "source_references",
+)
+
+MARKET_ACTIONS = frozenset(
+    {
+        "ignore",
+        "observe",
+        "research",
+        "manual_review",
+        "no_participation",
+    }
+)
+
+MARKET_FORBIDDEN_TERMS = (
+    "bet",
+    "wager",
+    "execute",
+    "stake",
+    "kelly",
+)
+
+
+class _LiteralString(str):
+    pass
+
+
+class _ResearchDumper(yaml.SafeDumper):
+    pass
+
+
+def _literal_representer(dumper: yaml.SafeDumper, data: _LiteralString) -> yaml.nodes.ScalarNode:
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+
+
+_ResearchDumper.add_representer(_LiteralString, _literal_representer)
+
+
+def build_research_envelope(data: dict[str, Any]) -> dict[str, Any]:
+    """Return a normalized copy of a Hermes research payload."""
+
+    if not isinstance(data, dict):
+        raise TypeError("research data must be a dict")
+
+    envelope = copy.deepcopy(data)
+    for list_key in ("tickers", "contract_addresses", "aliases"):
+        if list_key in envelope and envelope[list_key] is None:
+            envelope[list_key] = []
+    if "note" in envelope and isinstance(envelope["note"], dict):
+        note = envelope["note"]
+        for list_key in (
+            "key_assumptions",
+            "risk_triggers",
+            "invalidation_conditions",
+            "observables",
+            "bull_case",
+            "bear_case",
+            "source_references",
+        ):
+            if list_key in note and note[list_key] is None:
+                note[list_key] = []
+    return envelope
+
+
+def validate_research_envelope(envelope: dict[str, Any]) -> list[str]:
+    """Validate an AlphaHunt project research envelope.
+
+    Returns a list of human-readable errors. An empty list means the envelope is
+    valid for the Hermes-side contract.
+    """
+
+    errors: list[str] = []
+    if not isinstance(envelope, dict):
+        return ["envelope must be a mapping"]
+
+    _require_nonempty_string(envelope, "subject", errors)
+
+    kind = envelope.get("kind")
+    if not isinstance(kind, str) or not kind.strip():
+        errors.append("kind is required")
+    elif kind not in KINDS:
+        errors.append(f"kind must be one of {sorted(KINDS)}")
+
+    _validate_asset_class(envelope.get("asset_class"), errors)
+    _require_nonempty_string(envelope, "research_markdown", errors)
+    if "source_references" in envelope:
+        errors.append("source_references must be nested under note.source_references")
+
+    note = envelope.get("note")
+    if not isinstance(note, dict):
+        errors.append("note is required")
+        note = {}
+
+    for field in REQUIRED_NOTE_FIELDS:
+        if field not in note:
+            errors.append(f"note.{field} is required")
+
+    _require_nonempty_string(note, "thesis", errors, prefix="note.")
+    _require_nonempty_list(note, "key_assumptions", errors, prefix="note.")
+    _require_nonempty_list(note, "risk_triggers", errors, prefix="note.")
+    _require_nonempty_list(note, "invalidation_conditions", errors, prefix="note.")
+    _validate_observables(note.get("observables"), errors)
+    _validate_next_check_at(note.get("next_check_at"), errors)
+    _validate_confidence(note.get("confidence"), errors)
+    _require_nonempty_list(note, "source_references", errors, prefix="note.")
+
+    if kind in {"stock", "etf"}:
+        _require_nonempty_list(envelope, "tickers", errors)
+    if kind == "protocol":
+        _require_nonempty_string(envelope, "chain", errors)
+    if kind == "market":
+        _validate_market_boundary(envelope, note, errors)
+
+    return errors
+
+
+def dump_research_yaml(envelope: dict[str, Any]) -> str:
+    """Render a research envelope as stable YAML."""
+
+    rendered = _prepare_literals(copy.deepcopy(envelope))
+    return yaml.dump(
+        rendered,
+        Dumper=_ResearchDumper,
+        allow_unicode=True,
+        sort_keys=False,
+        default_flow_style=False,
+    )
+
+
+def load_research_yaml(text: str) -> dict[str, Any]:
+    """Load a research envelope from YAML text."""
+
+    loaded = yaml.safe_load(text)
+    if loaded is None:
+        return {}
+    if not isinstance(loaded, dict):
+        raise ValueError("research YAML must contain a mapping")
+    return loaded
+
+
+def sample_research_envelope(kind: str) -> dict[str, Any]:
+    """Return a built-in sample envelope for docs and smoke tests."""
+
+    samples = {
+        "protocol": {
+            "subject": "Ethena protocol basis-yield research",
+            "kind": "protocol",
+            "asset_class": "DRAFT:crypto_protocol",
+            "chain": "ethereum",
+            "contract_addresses": ["0x0000000000000000000000000000000000000000"],
+            "aliases": ["Ethena", "USDe", "sUSDe"],
+            "research_markdown": (
+                "# Ethena Protocol Research\n\n"
+                "Ethena's opportunity depends on durable demand for dollar-denominated crypto yield, "
+                "exchange liquidity, and transparent collateral/risk disclosures.\n"
+            ),
+            "note": _base_note(
+                "Ethena is worth continued research if collateral transparency and exchange liquidity remain intact.",
+                ["USDe supply remains liquid across major venues.", "Funding-rate income remains observable."],
+                ["Sustained depeg pressure.", "Material decline in disclosed backing quality."],
+                ["USDe trades below 0.98 for a full day.", "Collateral reporting becomes stale."],
+                "USDe secondary-market peg",
+                "Public exchange market data",
+                "0.98",
+                "down",
+                source_references=["https://docs.ethena.fi/"],
+            ),
+        },
+        "stock": {
+            "subject": "Example Semiconductor Inc research",
+            "kind": "stock",
+            "asset_class": "stock",
+            "tickers": ["EXSM"],
+            "aliases": ["Example Semiconductor"],
+            "research_markdown": (
+                "# Example Semiconductor Research\n\n"
+                "The company is a placeholder equity research sample for validating the Hermes "
+                "AlphaHunt research envelope.\n"
+            ),
+            "note": _base_note(
+                "The equity case depends on revenue growth translating into durable margin expansion.",
+                ["Demand remains resilient.", "Inventory normalizes over the next two quarters."],
+                ["Guidance cut.", "Gross margin compression."],
+                ["Revenue growth turns negative.", "Management withdraws margin targets."],
+                "Quarterly revenue growth",
+                "Company filings",
+                "positive year over year",
+                "up",
+                source_references=["https://www.sec.gov/edgar"],
+            ),
+        },
+        "etf": {
+            "subject": "Example broad market ETF research",
+            "kind": "etf",
+            "asset_class": "etf",
+            "tickers": ["EXETF"],
+            "aliases": ["Example Broad Market ETF"],
+            "research_markdown": (
+                "# Example ETF Research\n\n"
+                "This ETF sample focuses on exposure, liquidity, tracking quality, and macro sensitivity.\n"
+            ),
+            "note": _base_note(
+                "The ETF remains useful as a liquid proxy if spreads and tracking error stay contained.",
+                ["Underlying basket remains liquid.", "Tracking error remains low."],
+                ["Creation/redemption stress.", "Unexpected index methodology change."],
+                ["Bid/ask spreads widen materially.", "Tracking error breaches historical range."],
+                "Bid/ask spread",
+                "Fund sponsor and exchange data",
+                "near recent median",
+                "down",
+                source_references=["https://www.sec.gov/edgar"],
+            ),
+        },
+        "commodity_theme": {
+            "subject": "Copper electrification demand research",
+            "kind": "commodity_theme",
+            "asset_class": "commodity_theme",
+            "aliases": ["copper", "electrification", "grid demand"],
+            "research_markdown": (
+                "# Copper Theme Research\n\n"
+                "Copper demand is tied to grid investment, electric equipment, construction activity, "
+                "and mine supply disruptions.\n"
+            ),
+            "note": _base_note(
+                "Copper deserves monitoring while electrification demand offsets cyclical construction softness.",
+                ["Grid capex remains elevated.", "Mine supply disruptions persist."],
+                ["China construction demand weakens further.", "Inventories rebuild quickly."],
+                ["Visible inventories rise for four consecutive weeks.", "Treatment charges normalize sharply."],
+                "Exchange copper inventory",
+                "LME/COMEX public inventory data",
+                "four-week trend",
+                "up",
+                source_references=["https://www.lme.com/"],
+            ),
+        },
+        "macro_event": {
+            "subject": "FOMC policy path research",
+            "kind": "macro_event",
+            "asset_class": "macro_event",
+            "aliases": ["FOMC", "Federal Reserve", "policy rates"],
+            "research_markdown": (
+                "# FOMC Macro Research\n\n"
+                "The macro event hinges on inflation progress, labor-market cooling, and communication "
+                "around the expected policy path.\n"
+            ),
+            "note": _base_note(
+                "Policy-path expectations should be reassessed after the next inflation and labor releases.",
+                ["Inflation continues to moderate.", "Labor conditions cool without a sharp break."],
+                ["Inflation re-accelerates.", "Unemployment rises abruptly."],
+                ["Core inflation surprises higher twice.", "FOMC guidance shifts hawkish."],
+                "Core PCE inflation",
+                "BEA release",
+                "monthly change",
+                "down",
+                source_references=["https://www.federalreserve.gov/monetarypolicy/fomccalendars.htm"],
+            ),
+        },
+        "market": {
+            "subject": "World Cup champion prediction market research",
+            "kind": "market",
+            "asset_class": "prediction_market",
+            "aliases": ["World Cup champion", "prediction market"],
+            "market_meta": {
+                "rules": "Market resolves according to the venue's published champion settlement rules.",
+                "settlement": "Winning national team after the final is officially completed.",
+                "deadline": "2026-07-19T23:59:00+00:00",
+            },
+            "research_markdown": (
+                "# World Cup Market Research\n\n"
+                "This output is reference-only. It is for observation and manual review, not automated "
+                "participation.\n\n"
+                "Boundary: no_participation, no_execution, 不自动下注, 不自动交易, 不保证收益.\n"
+            ),
+            "note": _base_note(
+                "The market is suitable only for observation because sports outcomes are high-variance.",
+                ["Venue rules remain stable.", "Team availability data is current."],
+                ["Rule ambiguity.", "Major injury or roster uncertainty."],
+                ["Settlement wording changes.", "Liquidity becomes too thin for reliable interpretation."],
+                "Market-implied probability",
+                "Public market page",
+                "large move after official news",
+                "up",
+                action_suggestion="no_participation",
+                source_references=["https://www.fifa.com/"],
+            ),
+        },
+    }
+    if kind not in samples:
+        raise ValueError(f"unknown sample kind: {kind}")
+    return build_research_envelope(samples[kind])
+
+
+def _base_note(
+    thesis: str,
+    assumptions: list[str],
+    risks: list[str],
+    invalidations: list[str],
+    observable_name: str,
+    observable_source: str,
+    observable_threshold: str,
+    observable_direction: str,
+    *,
+    action_suggestion: str = "research",
+    source_references: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "thesis": thesis,
+        "key_assumptions": assumptions,
+        "risk_triggers": risks,
+        "invalidation_conditions": invalidations,
+        "observables": [
+            {
+                "name": observable_name,
+                "source": observable_source,
+                "threshold": observable_threshold,
+                "direction": observable_direction,
+            }
+        ],
+        "next_check_at": "2026-06-18T00:00:00+00:00",
+        "bull_case": ["Key assumptions continue to hold."],
+        "bear_case": ["Risk triggers become observable."],
+        "confidence": 0.6,
+        "action_suggestion": action_suggestion,
+        "source_references": source_references or ["https://example.com/research-source"],
+    }
+
+
+def _require_nonempty_string(mapping: dict[str, Any], key: str, errors: list[str], *, prefix: str = "") -> None:
+    value = mapping.get(key)
+    if not isinstance(value, str) or not value.strip():
+        errors.append(f"{prefix}{key} is required")
+
+
+def _require_nonempty_list(mapping: dict[str, Any], key: str, errors: list[str], *, prefix: str = "") -> None:
+    value = mapping.get(key)
+    if not isinstance(value, list) or not value:
+        errors.append(f"{prefix}{key} must contain at least one item")
+
+
+def _validate_asset_class(value: Any, errors: list[str]) -> None:
+    if not isinstance(value, str) or not value.strip():
+        errors.append("asset_class is required")
+        return
+    if value in KNOWN_ASSET_CLASSES or value.startswith("DRAFT:"):
+        return
+    errors.append("asset_class must be a known class or use DRAFT:<name>")
+
+
+def _validate_observables(value: Any, errors: list[str]) -> None:
+    if not isinstance(value, list) or not value:
+        errors.append("note.observables must contain at least one item")
+        return
+    for index, item in enumerate(value):
+        if not isinstance(item, dict):
+            errors.append(f"note.observables[{index}] must be a mapping")
+            continue
+        for field in ("name", "source", "threshold", "direction"):
+            if not isinstance(item.get(field), str) or not item[field].strip():
+                errors.append(f"note.observables[{index}].{field} is required")
+        direction = item.get("direction")
+        if isinstance(direction, str) and direction not in {"up", "down"}:
+            errors.append(f"note.observables[{index}].direction must be up or down")
+
+
+def _validate_next_check_at(value: Any, errors: list[str]) -> None:
+    if not isinstance(value, str) or not value.strip():
+        errors.append("note.next_check_at is required")
+        return
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        errors.append("note.next_check_at must be parseable ISO8601")
+
+
+def _validate_confidence(value: Any, errors: list[str]) -> None:
+    if value is None:
+        return
+    if not isinstance(value, (int, float)) or isinstance(value, bool) or not 0 <= value <= 1:
+        errors.append("note.confidence must be a number between 0 and 1")
+
+
+def _validate_market_boundary(envelope: dict[str, Any], note: dict[str, Any], errors: list[str]) -> None:
+    market_meta = envelope.get("market_meta")
+    if not isinstance(market_meta, dict):
+        errors.append("market_meta is required for market research")
+    else:
+        for field in ("rules", "settlement", "deadline"):
+            if not isinstance(market_meta.get(field), str) or not market_meta[field].strip():
+                errors.append(f"market_meta.{field} is required for market research")
+        deadline = market_meta.get("deadline")
+        if isinstance(deadline, str) and deadline.strip():
+            try:
+                datetime.fromisoformat(deadline.replace("Z", "+00:00"))
+            except ValueError:
+                errors.append("market_meta.deadline must be parseable ISO8601")
+
+    action = note.get("action_suggestion")
+    if action not in MARKET_ACTIONS:
+        errors.append(f"market note.action_suggestion must be one of {sorted(MARKET_ACTIONS)}")
+
+    haystack = "\n".join(_iter_strings(envelope)).lower()
+    for term in MARKET_FORBIDDEN_TERMS:
+        if re.search(rf"\b{re.escape(term)}\b", haystack):
+            errors.append(f"market research must not contain forbidden term: {term}")
+
+    if "reference-only" not in haystack:
+        errors.append("market research must state reference-only")
+    if "no_participation" not in haystack:
+        errors.append("market research must state no_participation")
+    if "no_execution" not in haystack:
+        errors.append("market research must state no_execution")
+
+
+def _iter_strings(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, dict):
+        strings: list[str] = []
+        for item in value.values():
+            strings.extend(_iter_strings(item))
+        return strings
+    if isinstance(value, list):
+        strings = []
+        for item in value:
+            strings.extend(_iter_strings(item))
+        return strings
+    return []
+
+
+def _prepare_literals(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _prepare_literals(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_prepare_literals(item) for item in value]
+    if isinstance(value, str) and "\n" in value:
+        return _LiteralString(value)
+    return value
+
+
+def _validate_file(path: Path) -> int:
+    envelope = load_research_yaml(path.read_text(encoding="utf-8"))
+    errors = validate_research_envelope(envelope)
+    if errors:
+        for error in errors:
+            print(f"validation_error: {error}", file=sys.stderr)
+        return 1
+    print(f"valid: {path}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate or render AlphaHunt project research YAML.")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--validate", type=Path, metavar="FILE", help="validate a research YAML file")
+    group.add_argument("--render-sample", choices=sorted(["protocol", "stock", "etf", "commodity_theme", "macro_event", "market"]))
+    args = parser.parse_args(argv)
+
+    if args.validate:
+        return _validate_file(args.validate)
+
+    envelope = sample_research_envelope(args.render_sample)
+    errors = validate_research_envelope(envelope)
+    if errors:
+        for error in errors:
+            print(f"validation_error: {error}", file=sys.stderr)
+        return 1
+    print(dump_research_yaml(envelope), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gateway/platforms/alphahunt_stage.py
+++ b/gateway/platforms/alphahunt_stage.py
@@ -8,7 +8,10 @@ import json
 import logging
 import os
 import re
+import subprocess
+import tempfile
 import time
+from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 import requests
@@ -19,6 +22,10 @@ STAGE_MODES = frozenset({"cleaner", "screener", "sentinel", "packager"})
 QWEN_MODES = STAGE_MODES | frozenset({"fast_triage"})
 QWEN_ANALYZER = "qwen_7b_local"
 QWEN_MODEL = "qwen2.5:7b"
+CODEX_ANALYZER = "codex_spark"
+CODEX_MODEL = os.environ.get("HERMES_CODEX_SPARK_MODEL", "gpt-5.3-codex-spark").strip() or "gpt-5.3-codex-spark"
+DEFAULT_CODEX_BIN = "/home/leo/.hermes/node/bin/codex"
+DEFAULT_CODEX_TIMEOUT_SEC = 180
 DEFAULT_OLLAMA_URL = "http://127.0.0.1:11434/api/generate"
 DEFAULT_QWEN_TIMEOUT_SEC = 90
 DEFAULT_QWEN_NUM_PREDICT = 1024
@@ -217,7 +224,7 @@ def _env_int(name: str, default: int) -> int:
         return default
 
 
-def is_qwen_analysis_payload(payload: Dict[str, Any]) -> bool:
+def is_alphahunt_stage_payload(payload: Dict[str, Any]) -> bool:
     mode = str(payload.get("analysis_mode") or "").strip().lower()
     if mode == "fast_triage":
         return True
@@ -226,12 +233,32 @@ def is_qwen_analysis_payload(payload: Dict[str, Any]) -> bool:
     ctx = payload.get("context") if isinstance(payload.get("context"), dict) else {}
     routing = ctx.get("routing_policy") if isinstance(ctx.get("routing_policy"), dict) else {}
     engine = str(routing.get("preferred_engine") or "").strip().lower()
-    return not engine or engine in {"qwen_local", "qwen_7b_local"} or engine.startswith("qwen")
+    return (
+        not engine
+        or engine in {"qwen_local", "qwen_7b_local", CODEX_ANALYZER, "codex", "codex_local"}
+        or engine.startswith("qwen")
+        or engine.startswith("codex")
+    )
+
+
+def is_qwen_analysis_payload(payload: Dict[str, Any]) -> bool:
+    """Backward-compatible alias for the AlphaHunt analysis dispatcher."""
+    return is_alphahunt_stage_payload(payload)
+
+
+def _analyzer_for_mode(mode: str) -> str:
+    return CODEX_ANALYZER if mode in STAGE_MODES else QWEN_ANALYZER
+
+
+def _model_for_mode(mode: str) -> str:
+    return CODEX_MODEL if mode in STAGE_MODES else QWEN_MODEL
 
 
 def build_prompt(payload: Dict[str, Any], *, validation_error: str = "") -> str:
     mode = str(payload.get("analysis_mode") or "").strip().lower()
     example = expected_output_shape(mode)
+    analyzer = _analyzer_for_mode(mode)
+    model = _model_for_mode(mode)
     repair = ""
     if validation_error:
         repair = f"\n上一次输出未通过 schema 校验：{validation_error}\n只返回修复后的严格 JSON。"
@@ -239,7 +266,7 @@ def build_prompt(payload: Dict[str, Any], *, validation_error: str = "") -> str:
         f"{PROMPTS[mode]}\n"
         "硬性要求：只输出一个 JSON object，不要 Markdown，不要解释文字，不要代码块。\n"
         "顶层必须包含 output；output 必须包含 stage、stage_schema_version、analyzer、model、stage_output。\n"
-        f"stage 必须是 {mode}；analyzer 必须是 {QWEN_ANALYZER}；model 必须是 {QWEN_MODEL}。\n"
+        f"stage 必须是 {mode}；analyzer 必须是 {analyzer}；model 必须是 {model}。\n"
         f"stage_schema_version 必须是 {SCHEMA_VERSION_BY_MODE[mode]}。\n"
         f"期望形状示例：{json.dumps(example, ensure_ascii=False, separators=(',', ':'))}\n"
         f"{repair}\n"
@@ -312,8 +339,8 @@ def expected_output_shape(mode: str) -> Dict[str, Any]:
         "output": {
             "stage": mode,
             "stage_schema_version": SCHEMA_VERSION_BY_MODE[mode],
-            "analyzer": QWEN_ANALYZER,
-            "model": QWEN_MODEL,
+            "analyzer": _analyzer_for_mode(mode),
+            "model": _model_for_mode(mode),
             "stage_output": examples[mode],
         }
     }
@@ -340,6 +367,57 @@ def call_ollama(prompt: str, *, timeout: int = DEFAULT_QWEN_TIMEOUT_SEC) -> str:
     return str(data.get("response") or "")
 
 
+def call_codex_spark(prompt: str, *, timeout: int = DEFAULT_CODEX_TIMEOUT_SEC) -> str:
+    codex_bin = os.environ.get("HERMES_CODEX_BIN", DEFAULT_CODEX_BIN).strip() or DEFAULT_CODEX_BIN
+    workdir = os.environ.get("HERMES_CODEX_WORKDIR", os.getcwd()).strip() or os.getcwd()
+    request_timeout = max(10, min(timeout, _env_int("HERMES_CODEX_TIMEOUT_SEC", DEFAULT_CODEX_TIMEOUT_SEC)))
+    with tempfile.NamedTemporaryFile("w+", encoding="utf-8", suffix=".txt", delete=False) as out_file:
+        output_path = out_file.name
+    cmd = [
+        codex_bin,
+        "exec",
+        "-m",
+        CODEX_MODEL,
+        "--ephemeral",
+        "--skip-git-repo-check",
+        "--sandbox",
+        "read-only",
+        "-C",
+        workdir,
+        "--output-last-message",
+        output_path,
+        "-",
+    ]
+    try:
+        completed = subprocess.run(
+            cmd,
+            input=prompt,
+            cwd=workdir,
+            text=True,
+            capture_output=True,
+            timeout=request_timeout,
+            check=False,
+        )
+        try:
+            output_text = Path(output_path).read_text(encoding="utf-8").strip()
+        except Exception:
+            output_text = ""
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"codex_spark_timeout:{request_timeout}s") from exc
+    finally:
+        try:
+            Path(output_path).unlink(missing_ok=True)
+        except Exception:
+            pass
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout or "Codex Spark analysis failed").strip()
+        raise RuntimeError(detail[-2000:])
+    text = output_text or (completed.stdout or "").strip()
+    if not text:
+        raise RuntimeError("codex_spark_empty_output")
+    return text
+
+
 def parse_json_object(text: str) -> Dict[str, Any]:
     text = (text or "").strip()
     if text.startswith("```"):
@@ -364,8 +442,8 @@ def validate_output(mode: str, callback: Dict[str, Any]) -> Tuple[bool, str]:
     expected = {
         "stage": mode,
         "stage_schema_version": SCHEMA_VERSION_BY_MODE[mode],
-        "analyzer": QWEN_ANALYZER,
-        "model": QWEN_MODEL,
+        "analyzer": _analyzer_for_mode(mode),
+        "model": _model_for_mode(mode),
     }
     for key, value in expected.items():
         if output.get(key) != value:
@@ -414,9 +492,19 @@ def _validate_stage_output_minimal(mode: str, stage_output: Dict[str, Any]) -> T
 def normalize_callback(payload: Dict[str, Any], model_obj: Dict[str, Any]) -> Dict[str, Any]:
     mode = str(payload.get("analysis_mode") or "").strip().lower()
     analysis_id = str(payload.get("analysis_id") or payload.get("request_id") or "").strip()
+    output = model_obj.get("output") if isinstance(model_obj.get("output"), dict) else None
+    if output is None:
+        output = {"stage_output": model_obj}
+    output = dict(output)
+    output["stage"] = mode
+    output["stage_schema_version"] = SCHEMA_VERSION_BY_MODE[mode]
+    output["analyzer"] = _analyzer_for_mode(mode)
+    output["model"] = _model_for_mode(mode)
+    if not isinstance(output.get("stage_output"), dict):
+        output["stage_output"] = {"status": "error", "reason": "missing_stage_output"}
     result = {
         "analysis_id": analysis_id,
-        "output": model_obj["output"],
+        "output": output,
     }
     event_id = str(payload.get("event_id") or "").strip()
     if event_id:
@@ -431,8 +519,8 @@ def error_callback(payload: Dict[str, Any], mode: str, reason: str) -> Dict[str,
         "output": {
             "stage": mode,
             "stage_schema_version": SCHEMA_VERSION_BY_MODE[mode],
-            "analyzer": QWEN_ANALYZER,
-            "model": QWEN_MODEL,
+            "analyzer": _analyzer_for_mode(mode),
+            "model": _model_for_mode(mode),
             "stage_output": {"status": "error", "reason": reason},
         },
     }
@@ -442,15 +530,20 @@ def error_callback(payload: Dict[str, Any], mode: str, reason: str) -> Dict[str,
     return result
 
 
-def run_qwen_stage(payload: Dict[str, Any]) -> Dict[str, Any]:
+def run_alphahunt_stage(payload: Dict[str, Any]) -> Dict[str, Any]:
     mode = str(payload.get("analysis_mode") or "").strip().lower()
     if mode not in QWEN_MODES:
-        raise ValueError(f"unsupported qwen analysis_mode: {mode}")
-    timeout = _env_int("HERMES_QWEN_TIMEOUT_SEC", DEFAULT_QWEN_TIMEOUT_SEC)
+        raise ValueError(f"unsupported alphahunt analysis_mode: {mode}")
+    timeout = (
+        _env_int("HERMES_CODEX_TIMEOUT_SEC", DEFAULT_CODEX_TIMEOUT_SEC)
+        if mode in STAGE_MODES
+        else _env_int("HERMES_QWEN_TIMEOUT_SEC", DEFAULT_QWEN_TIMEOUT_SEC)
+    )
     validation_error = ""
     for attempt in range(2):
         try:
-            raw = call_ollama(build_prompt(payload, validation_error=validation_error), timeout=timeout)
+            prompt = build_prompt(payload, validation_error=validation_error)
+            raw = call_codex_spark(prompt, timeout=timeout) if mode in STAGE_MODES else call_ollama(prompt, timeout=timeout)
             model_obj = parse_json_object(raw)
             callback = normalize_callback(payload, model_obj)
         except requests.Timeout:
@@ -465,6 +558,11 @@ def run_qwen_stage(payload: Dict[str, Any]) -> Dict[str, Any]:
             return callback
         validation_error = err
     return error_callback(payload, mode, f"schema_invalid:{validation_error}")
+
+
+def run_qwen_stage(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Backward-compatible entrypoint; stage modes now route to Codex Spark."""
+    return run_alphahunt_stage(payload)
 
 
 def callback_headers(body: bytes, callback_auth: str = "") -> Dict[str, str]:

--- a/gateway/platforms/alphahunt_stage.py
+++ b/gateway/platforms/alphahunt_stage.py
@@ -206,6 +206,17 @@ OUTPUT_SCHEMAS: Dict[str, Dict[str, Any]] = {
 }
 
 
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or str(raw).strip() == "":
+        return default
+    try:
+        return int(str(raw).strip())
+    except (TypeError, ValueError):
+        logger.warning("Invalid %s=%r; using default %s", name, raw, default)
+        return default
+
+
 def is_qwen_analysis_payload(payload: Dict[str, Any]) -> bool:
     mode = str(payload.get("analysis_mode") or "").strip().lower()
     if mode == "fast_triage":
@@ -311,8 +322,8 @@ def expected_output_shape(mode: str) -> Dict[str, Any]:
 def call_ollama(prompt: str, *, timeout: int = DEFAULT_QWEN_TIMEOUT_SEC) -> str:
     url = os.environ.get("HERMES_QWEN_OLLAMA_URL", DEFAULT_OLLAMA_URL).strip() or DEFAULT_OLLAMA_URL
     model = os.environ.get("HERMES_QWEN_MODEL", QWEN_MODEL).strip() or QWEN_MODEL
-    num_predict = int(os.environ.get("HERMES_QWEN_NUM_PREDICT", str(DEFAULT_QWEN_NUM_PREDICT)) or DEFAULT_QWEN_NUM_PREDICT)
-    num_ctx = int(os.environ.get("HERMES_QWEN_NUM_CTX", str(DEFAULT_QWEN_NUM_CTX)) or DEFAULT_QWEN_NUM_CTX)
+    num_predict = _env_int("HERMES_QWEN_NUM_PREDICT", DEFAULT_QWEN_NUM_PREDICT)
+    num_ctx = _env_int("HERMES_QWEN_NUM_CTX", DEFAULT_QWEN_NUM_CTX)
     resp = requests.post(
         url,
         json={
@@ -435,7 +446,7 @@ def run_qwen_stage(payload: Dict[str, Any]) -> Dict[str, Any]:
     mode = str(payload.get("analysis_mode") or "").strip().lower()
     if mode not in QWEN_MODES:
         raise ValueError(f"unsupported qwen analysis_mode: {mode}")
-    timeout = int(os.environ.get("HERMES_QWEN_TIMEOUT_SEC", str(DEFAULT_QWEN_TIMEOUT_SEC)) or DEFAULT_QWEN_TIMEOUT_SEC)
+    timeout = _env_int("HERMES_QWEN_TIMEOUT_SEC", DEFAULT_QWEN_TIMEOUT_SEC)
     validation_error = ""
     for attempt in range(2):
         try:

--- a/gateway/platforms/alphahunt_stage.py
+++ b/gateway/platforms/alphahunt_stage.py
@@ -1,0 +1,486 @@
+"""AlphaHunt local-Qwen analysis stage handler."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+import re
+import time
+from typing import Any, Dict, Optional, Tuple
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+STAGE_MODES = frozenset({"cleaner", "screener", "sentinel", "packager"})
+QWEN_MODES = STAGE_MODES | frozenset({"fast_triage"})
+QWEN_ANALYZER = "qwen_7b_local"
+QWEN_MODEL = "qwen2.5:7b"
+DEFAULT_OLLAMA_URL = "http://127.0.0.1:11434/api/generate"
+DEFAULT_QWEN_TIMEOUT_SEC = 90
+DEFAULT_QWEN_NUM_PREDICT = 1024
+DEFAULT_QWEN_NUM_CTX = 4096
+
+PROMPTS: Dict[str, str] = {
+    "cleaner": (
+        "你只负责把 raw_snapshot 清洗成 normalized_event。保留 source、asset_class、"
+        "identity_key、action_window、关键字段与显式 data gap。禁止给投资结论，禁止补脑补字段。"
+    ),
+    "screener": (
+        "你只负责把 normalized_event 转成 opportunity_candidate。必须拆成 base_fields、"
+        "asset_specific_fields、decision_fields，不得越权输出 green/act_now。"
+    ),
+    "sentinel": (
+        "你只负责阻断。检查 Web3、A股/ETF、港股打新、美债、黄金的 blocking rules。"
+        "risk_veto.active=true 时必须阻断 green/act_now。"
+    ),
+    "packager": (
+        "你是 Agent 4 打包员。输入是前三段产出（cleaner_output_v1、screener_output_v1、"
+        "sentinel_output_v1）。你只做拼装：把三段事实层结论合成 hermes_decision_object_v2 "
+        "解释层需要的 context_packet（normalized_event + opportunity_candidate? + risk_review）。"
+        "禁止新增事实、禁止给 action_color/recommended_action、禁止覆盖 sentinel 的 blocking risk。"
+        "输出必须严格符合 packager_output_v1。"
+    ),
+    "fast_triage": (
+        "你是一过筛 (fast_triage) 员。输入是 raw_snapshot 或 normalized_event。你只判断该事件"
+        "是否有进入 4-stage agent chain 的价值。输出严格 JSON。"
+    ),
+}
+
+SCHEMA_VERSION_BY_MODE = {
+    "cleaner": "cleaner_output_v1",
+    "screener": "screener_output_v1",
+    "sentinel": "sentinel_output_v1",
+    "packager": "packager_output_v1",
+    "fast_triage": "fast_triage_v1",
+}
+
+OUTPUT_SCHEMAS: Dict[str, Dict[str, Any]] = {
+    "cleaner": {
+        "type": "object",
+        "required": ["status"],
+        "properties": {
+            "status": {"enum": ["ok", "rejected", "error"]},
+            "reason": {"type": "string"},
+            "normalized_event": {
+                "type": "object",
+                "required": ["event_id", "asset_class", "event_type", "source", "normalized_fields"],
+                "properties": {
+                    "event_id": {"type": "string", "minLength": 1},
+                    "asset_class": {"type": "string", "minLength": 1},
+                    "event_type": {"type": "string", "minLength": 1},
+                    "source": {"type": "string", "minLength": 1},
+                    "normalized_fields": {"type": "object", "minProperties": 1},
+                },
+            },
+            "data_gaps": {"type": "array"},
+        },
+        "allOf": [
+            {
+                "if": {"properties": {"status": {"const": "ok"}}},
+                "then": {"required": ["normalized_event", "data_gaps"]},
+            }
+        ],
+    },
+    "screener": {
+        "type": "object",
+        "required": ["status"],
+        "properties": {
+            "status": {"enum": ["ok", "rejected", "error"]},
+            "reason": {"type": "string"},
+            "opportunity_candidate": {
+                "type": "object",
+                "required": ["opportunity_id", "asset_class", "base_fields", "asset_specific_fields", "decision_fields"],
+                "properties": {
+                    "opportunity_id": {"type": "string", "minLength": 1},
+                    "asset_class": {"type": "string", "minLength": 1},
+                    "base_fields": {"type": "object", "minProperties": 1},
+                    "asset_specific_fields": {"type": "object", "minProperties": 1},
+                    "decision_fields": {"type": "object", "minProperties": 1},
+                },
+            },
+        },
+        "allOf": [
+            {
+                "if": {"properties": {"status": {"const": "ok"}}},
+                "then": {"required": ["opportunity_candidate"]},
+            }
+        ],
+    },
+    "sentinel": {
+        "type": "object",
+        "required": ["status"],
+        "properties": {
+            "status": {"enum": ["ok", "rejected", "error"]},
+            "reason": {"type": "string"},
+            "risks": {"type": "array"},
+            "risk_veto": {
+                "type": "object",
+                "required": ["active"],
+                "properties": {"active": {"type": "boolean"}, "reason": {"type": "string"}},
+            },
+            "blocking_rules": {"type": "array"},
+        },
+        "allOf": [
+            {
+                "if": {"properties": {"status": {"const": "ok"}}},
+                "then": {"required": ["risks", "risk_veto"]},
+            }
+        ],
+    },
+    "packager": {
+        "type": "object",
+        "required": ["status"],
+        "properties": {
+            "status": {"enum": ["ok", "rejected", "error"]},
+            "reason": {"type": "string"},
+            "context_packet": {
+                "type": "object",
+                "required": ["normalized_event", "risk_review"],
+                "properties": {
+                    "normalized_event": {
+                        "type": "object",
+                        "required": ["event_id", "asset_class", "event_type", "source", "normalized_fields"],
+                        "properties": {
+                            "event_id": {"type": "string", "minLength": 1},
+                            "asset_class": {"type": "string", "minLength": 1},
+                            "event_type": {"type": "string", "minLength": 1},
+                            "source": {"type": "string", "minLength": 1},
+                            "normalized_fields": {"type": "object", "minProperties": 1},
+                        },
+                    },
+                    "opportunity_candidate": {
+                        "type": "object",
+                        "required": [
+                            "opportunity_id",
+                            "asset_class",
+                            "base_fields",
+                            "asset_specific_fields",
+                            "decision_fields",
+                        ],
+                        "properties": {
+                            "opportunity_id": {"type": "string", "minLength": 1},
+                            "asset_class": {"type": "string", "minLength": 1},
+                            "base_fields": {"type": "object", "minProperties": 1},
+                            "asset_specific_fields": {"type": "object", "minProperties": 1},
+                            "decision_fields": {"type": "object", "minProperties": 1},
+                        },
+                    },
+                    "risk_review": {
+                        "type": "object",
+                        "required": ["risks", "risk_veto"],
+                        "properties": {
+                            "risks": {"type": "array"},
+                            "risk_veto": {
+                                "type": "object",
+                                "required": ["active"],
+                                "properties": {"active": {"type": "boolean"}, "reason": {"type": "string"}},
+                            },
+                            "blocking_rules": {"type": "array"},
+                        },
+                    },
+                },
+            },
+        },
+        "allOf": [
+            {
+                "if": {"properties": {"status": {"const": "ok"}}},
+                "then": {"required": ["context_packet"]},
+            }
+        ],
+    },
+    "fast_triage": {
+        "type": "object",
+        "required": ["status", "triage_decision", "reason", "matched_signals", "data_gap"],
+        "properties": {
+            "status": {"const": "ok"},
+            "triage_decision": {"enum": ["advance", "reject", "needs_human"]},
+            "reason": {"type": "string"},
+            "matched_signals": {"type": "array", "items": {"type": "string"}},
+            "data_gap": {"type": "array"},
+        },
+    },
+}
+
+
+def is_qwen_analysis_payload(payload: Dict[str, Any]) -> bool:
+    mode = str(payload.get("analysis_mode") or "").strip().lower()
+    if mode == "fast_triage":
+        return True
+    if mode not in STAGE_MODES:
+        return False
+    ctx = payload.get("context") if isinstance(payload.get("context"), dict) else {}
+    routing = ctx.get("routing_policy") if isinstance(ctx.get("routing_policy"), dict) else {}
+    engine = str(routing.get("preferred_engine") or "").strip().lower()
+    return not engine or engine in {"qwen_local", "qwen_7b_local"} or engine.startswith("qwen")
+
+
+def build_prompt(payload: Dict[str, Any], *, validation_error: str = "") -> str:
+    mode = str(payload.get("analysis_mode") or "").strip().lower()
+    example = expected_output_shape(mode)
+    repair = ""
+    if validation_error:
+        repair = f"\n上一次输出未通过 schema 校验：{validation_error}\n只返回修复后的严格 JSON。"
+    return (
+        f"{PROMPTS[mode]}\n"
+        "硬性要求：只输出一个 JSON object，不要 Markdown，不要解释文字，不要代码块。\n"
+        "顶层必须包含 output；output 必须包含 stage、stage_schema_version、analyzer、model、stage_output。\n"
+        f"stage 必须是 {mode}；analyzer 必须是 {QWEN_ANALYZER}；model 必须是 {QWEN_MODEL}。\n"
+        f"stage_schema_version 必须是 {SCHEMA_VERSION_BY_MODE[mode]}。\n"
+        f"期望形状示例：{json.dumps(example, ensure_ascii=False, separators=(',', ':'))}\n"
+        f"{repair}\n"
+        f"输入 payload：{json.dumps(payload, ensure_ascii=False, sort_keys=True)}"
+    )
+
+
+def expected_output_shape(mode: str) -> Dict[str, Any]:
+    examples = {
+        "cleaner": {
+            "status": "ok",
+            "normalized_event": {
+                "event_id": "<event id>",
+                "asset_class": "<asset class>",
+                "event_type": "<event type>",
+                "source": "<source>",
+                "normalized_fields": {"identity_key": "<identity key>"},
+            },
+            "data_gaps": [],
+        },
+        "screener": {
+            "status": "ok",
+            "opportunity_candidate": {
+                "opportunity_id": "<opportunity id>",
+                "asset_class": "<asset class>",
+                "base_fields": {"source_event_id": "<event id>"},
+                "asset_specific_fields": {"instrument": "<instrument>"},
+                "decision_fields": {"screening_decision": "<candidate|reject|needs_human>"},
+            },
+        },
+        "sentinel": {
+            "status": "ok",
+            "risks": [],
+            "risk_veto": {"active": False, "reason": "none"},
+            "blocking_rules": [],
+        },
+        "packager": {
+            "status": "ok",
+            "context_packet": {
+                "normalized_event": {
+                    "event_id": "<event id>",
+                    "asset_class": "<asset class>",
+                    "event_type": "<event type>",
+                    "source": "<source>",
+                    "normalized_fields": {"identity_key": "<identity key>"},
+                },
+                "opportunity_candidate": {
+                    "opportunity_id": "<opportunity id>",
+                    "asset_class": "<asset class>",
+                    "base_fields": {"source_event_id": "<event id>"},
+                    "asset_specific_fields": {"instrument": "<instrument>"},
+                    "decision_fields": {"screening_decision": "<candidate|reject|needs_human>"},
+                },
+                "risk_review": {
+                    "risks": [],
+                    "risk_veto": {"active": False, "reason": "none"},
+                    "blocking_rules": [],
+                },
+            },
+        },
+        "fast_triage": {
+            "status": "ok",
+            "triage_decision": "advance",
+            "reason": "<one sentence>",
+            "matched_signals": [],
+            "data_gap": [],
+        },
+    }
+    return {
+        "output": {
+            "stage": mode,
+            "stage_schema_version": SCHEMA_VERSION_BY_MODE[mode],
+            "analyzer": QWEN_ANALYZER,
+            "model": QWEN_MODEL,
+            "stage_output": examples[mode],
+        }
+    }
+
+
+def call_ollama(prompt: str, *, timeout: int = DEFAULT_QWEN_TIMEOUT_SEC) -> str:
+    url = os.environ.get("HERMES_QWEN_OLLAMA_URL", DEFAULT_OLLAMA_URL).strip() or DEFAULT_OLLAMA_URL
+    model = os.environ.get("HERMES_QWEN_MODEL", QWEN_MODEL).strip() or QWEN_MODEL
+    num_predict = int(os.environ.get("HERMES_QWEN_NUM_PREDICT", str(DEFAULT_QWEN_NUM_PREDICT)) or DEFAULT_QWEN_NUM_PREDICT)
+    num_ctx = int(os.environ.get("HERMES_QWEN_NUM_CTX", str(DEFAULT_QWEN_NUM_CTX)) or DEFAULT_QWEN_NUM_CTX)
+    resp = requests.post(
+        url,
+        json={
+            "model": model,
+            "prompt": prompt,
+            "stream": False,
+            "format": "json",
+            "options": {"num_predict": num_predict, "num_ctx": num_ctx},
+        },
+        timeout=timeout,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    return str(data.get("response") or "")
+
+
+def parse_json_object(text: str) -> Dict[str, Any]:
+    text = (text or "").strip()
+    if text.startswith("```"):
+        text = re.sub(r"^```(?:json)?\s*", "", text)
+        text = re.sub(r"\s*```$", "", text)
+    try:
+        obj = json.loads(text)
+    except json.JSONDecodeError:
+        match = re.search(r"\{.*\}", text, flags=re.DOTALL)
+        if not match:
+            raise
+        obj = json.loads(match.group(0))
+    if not isinstance(obj, dict):
+        raise ValueError("model output must be a JSON object")
+    return obj
+
+
+def validate_output(mode: str, callback: Dict[str, Any]) -> Tuple[bool, str]:
+    output = callback.get("output") if isinstance(callback.get("output"), dict) else None
+    if output is None:
+        return False, "missing output object"
+    expected = {
+        "stage": mode,
+        "stage_schema_version": SCHEMA_VERSION_BY_MODE[mode],
+        "analyzer": QWEN_ANALYZER,
+        "model": QWEN_MODEL,
+    }
+    for key, value in expected.items():
+        if output.get(key) != value:
+            return False, f"output.{key} expected {value!r}"
+    stage_output = output.get("stage_output")
+    if not isinstance(stage_output, dict):
+        return False, "output.stage_output must be object"
+    try:
+        from jsonschema import Draft202012Validator
+
+        errors = sorted(Draft202012Validator(OUTPUT_SCHEMAS[mode]).iter_errors(stage_output), key=lambda e: e.path)
+        if errors:
+            return False, errors[0].message
+    except ImportError:
+        return _validate_stage_output_minimal(mode, stage_output)
+    return True, ""
+
+
+def _validate_stage_output_minimal(mode: str, stage_output: Dict[str, Any]) -> Tuple[bool, str]:
+    status = stage_output.get("status")
+    if mode == "fast_triage":
+        if status != "ok":
+            return False, "status must be ok"
+        if stage_output.get("triage_decision") not in {"advance", "reject", "needs_human"}:
+            return False, "invalid triage_decision"
+        for key in ("reason", "matched_signals", "data_gap"):
+            if key not in stage_output:
+                return False, f"{key} is required"
+        return True, ""
+    if status not in {"ok", "rejected", "error"}:
+        return False, "invalid status"
+    if status != "ok":
+        return True, ""
+    required_by_mode = {
+        "cleaner": ("normalized_event", "data_gaps"),
+        "screener": ("opportunity_candidate",),
+        "sentinel": ("risks", "risk_veto"),
+        "packager": ("context_packet",),
+    }
+    for key in required_by_mode[mode]:
+        if key not in stage_output:
+            return False, f"{key} is required"
+    return True, ""
+
+
+def normalize_callback(payload: Dict[str, Any], model_obj: Dict[str, Any]) -> Dict[str, Any]:
+    mode = str(payload.get("analysis_mode") or "").strip().lower()
+    analysis_id = str(payload.get("analysis_id") or payload.get("request_id") or "").strip()
+    result = {
+        "analysis_id": analysis_id,
+        "output": model_obj["output"],
+    }
+    event_id = str(payload.get("event_id") or "").strip()
+    if event_id:
+        result["event_id"] = event_id
+    return result
+
+
+def error_callback(payload: Dict[str, Any], mode: str, reason: str) -> Dict[str, Any]:
+    analysis_id = str(payload.get("analysis_id") or payload.get("request_id") or "").strip()
+    result: Dict[str, Any] = {
+        "analysis_id": analysis_id,
+        "output": {
+            "stage": mode,
+            "stage_schema_version": SCHEMA_VERSION_BY_MODE[mode],
+            "analyzer": QWEN_ANALYZER,
+            "model": QWEN_MODEL,
+            "stage_output": {"status": "error", "reason": reason},
+        },
+    }
+    event_id = str(payload.get("event_id") or "").strip()
+    if event_id:
+        result["event_id"] = event_id
+    return result
+
+
+def run_qwen_stage(payload: Dict[str, Any]) -> Dict[str, Any]:
+    mode = str(payload.get("analysis_mode") or "").strip().lower()
+    if mode not in QWEN_MODES:
+        raise ValueError(f"unsupported qwen analysis_mode: {mode}")
+    timeout = int(os.environ.get("HERMES_QWEN_TIMEOUT_SEC", str(DEFAULT_QWEN_TIMEOUT_SEC)) or DEFAULT_QWEN_TIMEOUT_SEC)
+    validation_error = ""
+    for attempt in range(2):
+        try:
+            raw = call_ollama(build_prompt(payload, validation_error=validation_error), timeout=timeout)
+            model_obj = parse_json_object(raw)
+            callback = normalize_callback(payload, model_obj)
+        except requests.Timeout:
+            return error_callback(payload, mode, "qwen_timeout")
+        except Exception as exc:
+            validation_error = f"invalid_json:{exc}"
+            if attempt == 0:
+                continue
+            return error_callback(payload, mode, f"schema_invalid:{validation_error}")
+        ok, err = validate_output(mode, callback)
+        if ok:
+            return callback
+        validation_error = err
+    return error_callback(payload, mode, f"schema_invalid:{validation_error}")
+
+
+def callback_headers(body: bytes, callback_auth: str = "") -> Dict[str, str]:
+    headers = {"Content-Type": "application/json"}
+    api_key = os.environ.get("CENTRAL_CALLBACK_API_KEY", "").strip() or callback_auth.strip()
+    if api_key:
+        headers["X-API-Key"] = api_key
+        headers["Authorization"] = f"Bearer {api_key}"
+    secret = (
+        os.environ.get("CENTRAL_CALLBACK_SECRET", "").strip()
+        or os.environ.get("HERMES_CALLBACK_SECRET", "").strip()
+        or os.environ.get("HERMES_DISPATCH_SECRET", "").strip()
+    )
+    if secret:
+        ts = str(int(time.time()))
+        msg = f"{ts}.".encode("utf-8") + body
+        sig = hmac.new(secret.encode("utf-8"), msg, hashlib.sha256).hexdigest()
+        headers["X-Hermes-Timestamp"] = ts
+        headers["X-Hermes-Signature"] = f"sha256={sig}"
+    return headers
+
+
+def post_callback(payload: Dict[str, Any], callback: Dict[str, Any], *, callback_url: str = "", callback_auth: str = "") -> None:
+    url = (callback_url or payload.get("callback_url") or os.environ.get("CENTRAL_CALLBACK_URL") or "").strip()
+    if not url:
+        return
+    auth = callback_auth or str(payload.get("callback_auth") or "")
+    body = json.dumps(callback, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    resp = requests.post(url, data=body, headers=callback_headers(body, auth), timeout=15)
+    resp.raise_for_status()

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -59,9 +59,9 @@ from gateway.platforms.base import (
     is_network_accessible,
 )
 from gateway.platforms.alphahunt_stage import (
-    is_qwen_analysis_payload,
+    is_alphahunt_stage_payload,
     post_callback as _post_alphahunt_stage_callback,
-    run_qwen_stage,
+    run_alphahunt_stage,
 )
 
 logger = logging.getLogger(__name__)
@@ -1811,7 +1811,7 @@ class APIServerAdapter(BasePlatformAdapter):
         except (json.JSONDecodeError, Exception):
             return web.json_response(_openai_error("Invalid JSON in request body"), status=400)
 
-        if isinstance(body, dict) and is_qwen_analysis_payload(body):
+        if isinstance(body, dict) and is_alphahunt_stage_payload(body):
             return await self._handle_alphahunt_qwen_analysis(request, body)
 
         messages = body.get("messages")
@@ -2883,12 +2883,12 @@ class APIServerAdapter(BasePlatformAdapter):
             body = await request.json()
         except (json.JSONDecodeError, Exception):
             return web.json_response(_openai_error("Invalid JSON in request body"), status=400)
-        if not isinstance(body, dict) or not is_qwen_analysis_payload(body):
+        if not isinstance(body, dict) or not is_alphahunt_stage_payload(body):
             return web.json_response(_openai_error("Unsupported analysis payload"), status=400)
         return await self._handle_alphahunt_qwen_analysis(request, body)
 
     async def _handle_alphahunt_qwen_analysis(self, request: "web.Request", body: Dict[str, Any]) -> "web.Response":
-        """Run AlphaHunt stage/fast_triage requests through local Qwen and callback Central."""
+        """Run AlphaHunt stage/fast_triage requests and callback Central."""
         loop = asyncio.get_running_loop()
         callback_url = (
             str(body.get("callback_url") or "").strip()
@@ -2899,7 +2899,7 @@ class APIServerAdapter(BasePlatformAdapter):
             or request.headers.get("X-AlphaHunt-Callback-Auth", "").strip()
         )
         try:
-            callback = await loop.run_in_executor(None, run_qwen_stage, body)
+            callback = await loop.run_in_executor(None, run_alphahunt_stage, body)
             await loop.run_in_executor(
                 None,
                 lambda: _post_alphahunt_stage_callback(
@@ -2910,7 +2910,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 ),
             )
         except Exception as exc:
-            logger.error("AlphaHunt Qwen analysis failed: %s", exc, exc_info=True)
+            logger.error("AlphaHunt analysis failed: %s", exc, exc_info=True)
             return web.json_response(
                 {
                     "accepted": False,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -678,6 +678,7 @@ class _HermesAnalysisResponseCache:
     def __init__(self, max_items: int = 1000):
         from collections import OrderedDict
         self._store = OrderedDict()
+        self._inflight: Dict[str, "asyncio.Task[Any]"] = {}
         self._max = max_items
 
     def _purge(self) -> None:
@@ -706,25 +707,59 @@ class _HermesAnalysisResponseCache:
         self._store[key] = {"resp": response, "expires_at": time.time() + ttl}
         self._purge()
 
+    async def get_or_set(self, key: str, ttl: int, compute_coro):
+        cached = self.get(key)
+        if cached is not None:
+            logger.info("Hermes analysis response cache hit: %s", key)
+            return cached
+
+        task = self._inflight.get(key)
+        if task is None:
+            async def _compute_and_store():
+                response = await compute_coro()
+                if _is_cacheable_analysis_response(response):
+                    response = _analysis_cache_store_value(response)
+                    self.set(key, response, ttl)
+                return response
+
+            task = asyncio.create_task(_compute_and_store())
+            self._inflight[key] = task
+
+            def _clear_inflight(done_task: "asyncio.Task[Any]") -> None:
+                if self._inflight.get(key) is done_task:
+                    self._inflight.pop(key, None)
+
+            task.add_done_callback(_clear_inflight)
+
+        return await asyncio.shield(task)
+
 
 _analysis_response_cache = _HermesAnalysisResponseCache()
+
+
+def _is_cacheable_analysis_response(response) -> bool:
+    result = response[0] if isinstance(response, tuple) and response else None
+    return isinstance(result, dict) and not result.get("failed")
+
+
+def _analysis_cache_store_value(response):
+    """Store only reusable response fields, not request/session-bound metadata."""
+    if not (isinstance(response, tuple) and response and isinstance(response[0], dict)):
+        return response
+    result = dict(response[0])
+    result.pop("session_id", None)
+    return (result, *response[1:])
 
 
 async def _maybe_cached_analysis_response(payload: Dict[str, Any], compute_coro):
     cache_key = _hermes_cache_key(payload)
     if cache_key is None:
         return await compute_coro()
-
-    cached = _analysis_response_cache.get(cache_key)
-    if cached is not None:
-        logger.info("Hermes analysis response cache hit: %s", cache_key)
-        return cached
-
-    response = await compute_coro()
-    result = response[0] if isinstance(response, tuple) and response else None
-    if not (isinstance(result, dict) and result.get("failed")):
-        _analysis_response_cache.set(cache_key, response, _hermes_cache_ttl(payload))
-    return response
+    return await _analysis_response_cache.get_or_set(
+        cache_key,
+        _hermes_cache_ttl(payload),
+        compute_coro,
+    )
 
 
 def _make_request_fingerprint(body: Dict[str, Any], keys: List[str]) -> str:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -58,6 +58,11 @@ from gateway.platforms.base import (
     SendResult,
     is_network_accessible,
 )
+from gateway.platforms.alphahunt_stage import (
+    is_qwen_analysis_payload,
+    post_callback as _post_alphahunt_stage_callback,
+    run_qwen_stage,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -627,6 +632,99 @@ class _IdempotencyCache:
 
 
 _idem_cache = _IdempotencyCache()
+
+
+def _hermes_cache_key(payload: dict) -> str | None:
+    """
+    Read the pre-computed stable key from Central's routing_policy.
+    Returns None if key is missing (caller should skip caching).
+    """
+    ctx = payload.get("context") or {}
+    if not isinstance(ctx, dict):
+        return None
+    rp = ctx.get("routing_policy") or {}
+    if not isinstance(rp, dict):
+        return None
+    cache_cfg = rp.get("cache") or {}
+    if not isinstance(cache_cfg, dict):
+        return None
+    stable_key = str(cache_cfg.get("key") or "").strip()
+    if not stable_key:
+        return None
+    mode = str(payload.get("analysis_mode") or "unknown")
+    return f"{stable_key}:{mode}"
+
+
+def _hermes_cache_ttl(payload: dict) -> int:
+    """TTL from routing_policy.cache.ttl_sec, default 900."""
+    ctx = payload.get("context") or {}
+    if not isinstance(ctx, dict):
+        return 900
+    rp = ctx.get("routing_policy") or {}
+    if not isinstance(rp, dict):
+        return 900
+    cache_cfg = rp.get("cache") or {}
+    if not isinstance(cache_cfg, dict):
+        return 900
+    try:
+        return int(cache_cfg.get("ttl_sec") or 900)
+    except (TypeError, ValueError):
+        return 900
+
+
+class _HermesAnalysisResponseCache:
+    """In-memory cache for Central analysis responses keyed by routing_policy."""
+
+    def __init__(self, max_items: int = 1000):
+        from collections import OrderedDict
+        self._store = OrderedDict()
+        self._max = max_items
+
+    def _purge(self) -> None:
+        now = time.time()
+        expired = [key for key, item in self._store.items() if item["expires_at"] <= now]
+        for key in expired:
+            self._store.pop(key, None)
+        while len(self._store) > self._max:
+            self._store.popitem(last=False)
+
+    def get(self, key: str):
+        self._purge()
+        item = self._store.get(key)
+        if item is None:
+            return None
+        self._store.move_to_end(key)
+        return item["resp"]
+
+    def set(self, key: str, response, ttl: int) -> None:
+        try:
+            ttl = int(ttl)
+        except (TypeError, ValueError):
+            ttl = 900
+        if ttl <= 0:
+            return
+        self._store[key] = {"resp": response, "expires_at": time.time() + ttl}
+        self._purge()
+
+
+_analysis_response_cache = _HermesAnalysisResponseCache()
+
+
+async def _maybe_cached_analysis_response(payload: Dict[str, Any], compute_coro):
+    cache_key = _hermes_cache_key(payload)
+    if cache_key is None:
+        return await compute_coro()
+
+    cached = _analysis_response_cache.get(cache_key)
+    if cached is not None:
+        logger.info("Hermes analysis response cache hit: %s", cache_key)
+        return cached
+
+    response = await compute_coro()
+    result = response[0] if isinstance(response, tuple) and response else None
+    if not (isinstance(result, dict) and result.get("failed")):
+        _analysis_response_cache.set(cache_key, response, _hermes_cache_ttl(payload))
+    return response
 
 
 def _make_request_fingerprint(body: Dict[str, Any], keys: List[str]) -> str:
@@ -1678,6 +1776,9 @@ class APIServerAdapter(BasePlatformAdapter):
         except (json.JSONDecodeError, Exception):
             return web.json_response(_openai_error("Invalid JSON in request body"), status=400)
 
+        if isinstance(body, dict) and is_qwen_analysis_payload(body):
+            return await self._handle_alphahunt_qwen_analysis(request, body)
+
         messages = body.get("messages")
         if not messages or not isinstance(messages, list):
             return web.json_response(
@@ -1887,11 +1988,14 @@ class APIServerAdapter(BasePlatformAdapter):
                 gateway_session_key=gateway_session_key,
             )
 
+        async def _compute_completion_cached():
+            return await _maybe_cached_analysis_response(body, _compute_completion)
+
         idempotency_key = request.headers.get("Idempotency-Key")
         if idempotency_key:
             fp = _make_request_fingerprint(body, keys=["model", "messages", "tools", "tool_choice", "stream"])
             try:
-                result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_completion)
+                result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_completion_cached)
             except Exception as e:
                 logger.error("Error running agent for chat completions: %s", e, exc_info=True)
                 return web.json_response(
@@ -1900,7 +2004,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 )
         else:
             try:
-                result, usage = await _compute_completion()
+                result, usage = await _compute_completion_cached()
             except Exception as e:
                 logger.error("Error running agent for chat completions: %s", e, exc_info=True)
                 return web.json_response(
@@ -2735,6 +2839,60 @@ class APIServerAdapter(BasePlatformAdapter):
 
         return response
 
+    async def _handle_alphahunt_analysis(self, request: "web.Request") -> "web.Response":
+        """POST /v1/analysis — AlphaHunt AnalysisRequest dispatch format."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        try:
+            body = await request.json()
+        except (json.JSONDecodeError, Exception):
+            return web.json_response(_openai_error("Invalid JSON in request body"), status=400)
+        if not isinstance(body, dict) or not is_qwen_analysis_payload(body):
+            return web.json_response(_openai_error("Unsupported analysis payload"), status=400)
+        return await self._handle_alphahunt_qwen_analysis(request, body)
+
+    async def _handle_alphahunt_qwen_analysis(self, request: "web.Request", body: Dict[str, Any]) -> "web.Response":
+        """Run AlphaHunt stage/fast_triage requests through local Qwen and callback Central."""
+        loop = asyncio.get_running_loop()
+        callback_url = (
+            str(body.get("callback_url") or "").strip()
+            or request.headers.get("X-AlphaHunt-Callback-URL", "").strip()
+        )
+        callback_auth = (
+            str(body.get("callback_auth") or "").strip()
+            or request.headers.get("X-AlphaHunt-Callback-Auth", "").strip()
+        )
+        try:
+            callback = await loop.run_in_executor(None, run_qwen_stage, body)
+            await loop.run_in_executor(
+                None,
+                lambda: _post_alphahunt_stage_callback(
+                    body,
+                    callback,
+                    callback_url=callback_url,
+                    callback_auth=callback_auth,
+                ),
+            )
+        except Exception as exc:
+            logger.error("AlphaHunt Qwen analysis failed: %s", exc, exc_info=True)
+            return web.json_response(
+                {
+                    "accepted": False,
+                    "failed": True,
+                    "error": str(exc),
+                    "analysis_id": body.get("analysis_id") or body.get("request_id"),
+                },
+                status=500,
+            )
+        return web.json_response(
+            {
+                "accepted": True,
+                "analysis_id": callback.get("analysis_id"),
+                "output": callback.get("output"),
+            }
+        )
+
     async def _handle_responses(self, request: "web.Request") -> "web.Response":
         """POST /v1/responses — OpenAI Responses API format."""
         auth_err = self._check_auth(request)
@@ -2933,6 +3091,9 @@ class APIServerAdapter(BasePlatformAdapter):
                 gateway_session_key=gateway_session_key,
             )
 
+        async def _compute_response_cached():
+            return await _maybe_cached_analysis_response(body, _compute_response)
+
         idempotency_key = request.headers.get("Idempotency-Key")
         if idempotency_key:
             fp = _make_request_fingerprint(
@@ -2940,7 +3101,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 keys=["input", "instructions", "previous_response_id", "conversation", "model", "tools"],
             )
             try:
-                result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_response)
+                result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_response_cached)
             except Exception as e:
                 logger.error("Error running agent for responses: %s", e, exc_info=True)
                 return web.json_response(
@@ -2949,7 +3110,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 )
         else:
             try:
-                result, usage = await _compute_response()
+                result, usage = await _compute_response_cached()
             except Exception as e:
                 logger.error("Error running agent for responses: %s", e, exc_info=True)
                 return web.json_response(
@@ -4067,6 +4228,8 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_post("/api/sessions/{session_id}/chat", self._handle_session_chat)
             self._app.router.add_post("/api/sessions/{session_id}/chat/stream", self._handle_session_chat_stream)
             self._app.router.add_post("/v1/chat/completions", self._handle_chat_completions)
+            self._app.router.add_post("/v1/analysis", self._handle_alphahunt_analysis)
+            self._app.router.add_post("/analysis", self._handle_alphahunt_analysis)
             self._app.router.add_post("/v1/responses", self._handle_responses)
             self._app.router.add_get("/v1/responses/{response_id}", self._handle_get_response)
             self._app.router.add_delete("/v1/responses/{response_id}", self._handle_delete_response)

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -4378,13 +4378,21 @@ class MessageSender:
     @staticmethod
     def strip_cron_wrapper(content: str) -> str:
         """Strip scheduler cron header/footer wrapper for cleaner Yuanbao output."""
-        if not content.startswith("Cronjob Response: "):
+        cron_prefixes = ("Cron job run completed: ", "Cronjob Response: ")
+        if not content.startswith(cron_prefixes):
             return content
 
         divider = "\n-------------\n\n"
-        footer_prefix = '\n\nTo stop or manage this job, send me a new message (e.g. "stop reminder '
+        footer_prefixes = (
+            '\n\nManage this scheduled job by sending a new message, for example: "stop reminder ',
+            '\n\nTo stop or manage this job, send me a new message (e.g. "stop reminder ',
+        )
         divider_pos = content.find(divider)
-        footer_pos = content.rfind(footer_prefix)
+        footer_pos = -1
+        for footer_prefix in footer_prefixes:
+            footer_pos = content.rfind(footer_prefix)
+            if footer_pos >= 0:
+                break
         if divider_pos < 0 or footer_pos < 0 or footer_pos <= divider_pos:
             return content
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1660,6 +1660,41 @@ def _preserve_queued_followup_history_offset(
     return merged
 
 
+def _conversation_message_count(messages: list[dict]) -> int:
+    """Count transcript rows that should rehydrate into conversation context."""
+    count = 0
+    for msg in messages or []:
+        role = msg.get("role")
+        if not role or role in {"session_meta", "system"}:
+            continue
+        count += 1
+    return count
+
+
+def _agent_already_persisted_turn(
+    session_db,
+    session_id: str,
+    history: list[dict],
+    *,
+    session_was_split: bool = False,
+) -> bool:
+    """Return True when the agent already wrote this turn to SQLite.
+
+    Gateway normally skips its SQLite write because the agent writes the same
+    messages directly. Some gateway runtimes can return messages without that
+    DB write completing; if we skip blindly, the next Feishu turn sees only
+    session_meta and loses the visible chat context.
+    """
+    if session_db is None or not session_id:
+        return False
+    try:
+        persisted = session_db.get_messages(session_id)
+    except Exception:
+        return False
+    prior_count = 0 if session_was_split else _conversation_message_count(history)
+    return _conversation_message_count(persisted) > prior_count
+
+
 class GatewayRunner:
     """
     Main gateway controller.
@@ -9142,11 +9177,22 @@ class GatewayRunner:
                             {"role": "assistant", "content": response, "timestamp": ts}
                         )
                 else:
-                    # The agent already persisted these messages to SQLite via
-                    # _flush_messages_to_session_db(), so skip the DB write here
-                    # to prevent the duplicate-write bug (#860).  We still write
-                    # to JSONL for backward compatibility and as a backup.
-                    agent_persisted = self._session_db is not None
+                    # The agent usually persists these messages to SQLite via
+                    # _flush_messages_to_session_db(), so the gateway skips DB
+                    # writes to prevent duplicate rows (#860). Verify that the
+                    # write actually happened first: some gateway runtimes can
+                    # return a successful result while SQLite still contains
+                    # only session_meta, which makes the next Feishu turn lose
+                    # all visible chat context.
+                    agent_persisted = _agent_already_persisted_turn(
+                        self._session_db,
+                        session_entry.session_id,
+                        history,
+                        session_was_split=bool(
+                            agent_result.get("session_id")
+                            and agent_result["session_id"] != session_entry.session_id
+                        ),
+                    )
                     # Attach the inbound platform message_id to the first user
                     # entry written this turn so platform-level quote-resolution
                     # (e.g. Yuanbao QuoteContextMiddleware's transcript fallback)

--- a/run_agent.py
+++ b/run_agent.py
@@ -4358,11 +4358,12 @@ class AIAgent:
         original_user_message: Any,
         messages: List[Dict[str, Any]],
         effective_task_id: str,
+        conversation_history: Optional[List[Dict[str, Any]]] = None,
         should_review_memory: bool = False,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.codex_runtime.run_codex_app_server_turn``."""
         from agent.codex_runtime import run_codex_app_server_turn
-        return run_codex_app_server_turn(self, user_message=user_message, original_user_message=original_user_message, messages=messages, effective_task_id=effective_task_id, should_review_memory=should_review_memory)
+        return run_codex_app_server_turn(self, user_message=user_message, original_user_message=original_user_message, messages=messages, effective_task_id=effective_task_id, conversation_history=conversation_history, should_review_memory=should_review_memory)
 
 def main(
     query: str = None,

--- a/tests/agent/transports/test_codex_app_server_session.py
+++ b/tests/agent/transports/test_codex_app_server_session.py
@@ -149,17 +149,54 @@ class TestLifecycle:
         method_calls = [m for (m, _) in client.requests if m == "thread/start"]
         assert len(method_calls) == 1
 
-    def test_thread_start_passes_cwd_only(self):
-        """thread/start carries cwd. We intentionally do NOT pass `permissions`
-        on this codex version (experimentalApi-gated + requires matching
-        config.toml [permissions] table). Letting codex use its default
-        (read-only unless user configures otherwise) is the documented path."""
+    def test_thread_start_passes_permissions_profile(self):
+        """thread/start carries Hermes' mapped permission profile so codex
+        does not silently fall back to read-only after Hermes approved writes."""
         client = FakeClient()
         s = make_session(client, permission_profile="workspace-write")
         s.ensure_started()
         method, params = next(r for r in client.requests if r[0] == "thread/start")
         assert params["cwd"] == "/tmp"
-        assert "permissions" not in params  # see session.ensure_started() comment
+        assert params["permissionProfile"] == {"type": "profile", "id": "workspace-write"}
+
+    def test_initialize_enables_experimental_api_for_permissions(self):
+        class CapturingClient(FakeClient):
+            def __init__(self):
+                super().__init__()
+                self.initialize_kwargs = None
+
+            def initialize(self, **kwargs):
+                self.initialize_kwargs = kwargs
+                return super().initialize(**kwargs)
+
+        client = CapturingClient()
+        s = make_session(client, permission_profile="workspace-write")
+        s.ensure_started()
+        assert client.initialize_kwargs["capabilities"] == {"experimentalApi": True}
+
+    def test_thread_start_retries_without_permissions_if_codex_rejects_field(self):
+        from agent.transports.codex_app_server import CodexAppServerError
+
+        client = FakeClient()
+        seen = {"count": 0}
+
+        def reject_permissions_once(method, params):
+            if method == "thread/start":
+                seen["count"] += 1
+                if "permissionProfile" in params:
+                    raise CodexAppServerError(
+                        code=-32602,
+                        message="invalid params: unknown field permissionProfile",
+                    )
+                return {"thread": {"id": "thread-fallback"}}
+            return {}
+
+        client._request_handler = reject_permissions_once
+        s = make_session(client, permission_profile="workspace-write")
+        assert s.ensure_started() == "thread-fallback"
+        assert seen["count"] == 2
+        assert client.requests[0][1]["permissionProfile"] == {"type": "profile", "id": "workspace-write"}
+        assert client.requests[1] == ("thread/start", {"cwd": "/tmp"})
 
     def test_close_idempotent(self):
         client = FakeClient()

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -522,11 +522,11 @@ class TestDeliverResultWrapping:
 
         send_mock.assert_called_once()
         sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
-        assert "Cronjob Response: daily-report" in sent_content
+        assert "Cron job run completed: daily-report" in sent_content
         assert "(job_id: test-job)" in sent_content
         assert "-------------" in sent_content
         assert "Here is today's summary." in sent_content
-        assert "To stop or manage this job" in sent_content
+        assert "Manage this scheduled job" in sent_content
 
     def test_delivery_uses_job_id_when_no_name(self):
         """When a job has no name, the wrapper should fall back to job id."""
@@ -547,7 +547,7 @@ class TestDeliverResultWrapping:
             _deliver_result(job, "Output.")
 
         sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
-        assert "Cronjob Response: abc-123" in sent_content
+        assert "Cron job run completed: abc-123" in sent_content
 
     def test_delivery_skips_wrapping_when_config_disabled(self):
         """When cron.wrap_response is false, deliver raw content without header/footer."""
@@ -572,7 +572,7 @@ class TestDeliverResultWrapping:
         send_mock.assert_called_once()
         sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
         assert sent_content == "Clean output only."
-        assert "Cronjob Response" not in sent_content
+        assert "Cron job run completed" not in sent_content
         assert "The agent cannot see" not in sent_content
 
     def test_delivery_extracts_media_tags_before_send(self, tmp_path, monkeypatch):

--- a/tests/gateway/test_alphahunt_stage.py
+++ b/tests/gateway/test_alphahunt_stage.py
@@ -92,8 +92,12 @@ def _model_json(mode: str) -> str:
             "output": {
                 "stage": mode,
                 "stage_schema_version": alphahunt_stage.SCHEMA_VERSION_BY_MODE[mode],
-                "analyzer": alphahunt_stage.QWEN_ANALYZER,
-                "model": alphahunt_stage.QWEN_MODEL,
+                "analyzer": (
+                    alphahunt_stage.CODEX_ANALYZER
+                    if mode in alphahunt_stage.STAGE_MODES
+                    else alphahunt_stage.QWEN_ANALYZER
+                ),
+                "model": alphahunt_stage.CODEX_MODEL if mode in alphahunt_stage.STAGE_MODES else alphahunt_stage.QWEN_MODEL,
                 "stage_output": _stage_output(mode),
             }
         }
@@ -101,16 +105,25 @@ def _model_json(mode: str) -> str:
 
 
 @pytest.mark.parametrize("mode", ["cleaner", "screener", "sentinel", "packager", "fast_triage"])
-def test_qwen_stage_returns_strict_json_callback(monkeypatch, mode):
-    monkeypatch.setattr(alphahunt_stage, "call_ollama", lambda *args, **kwargs: _model_json(mode))
+def test_alphahunt_stage_returns_strict_json_callback(monkeypatch, mode):
+    if mode in alphahunt_stage.STAGE_MODES:
+        monkeypatch.setattr(alphahunt_stage, "call_codex_spark", lambda *args, **kwargs: _model_json(mode))
+    else:
+        monkeypatch.setattr(alphahunt_stage, "call_ollama", lambda *args, **kwargs: _model_json(mode))
 
-    result = alphahunt_stage.run_qwen_stage(_payload(mode))
+    result = alphahunt_stage.run_alphahunt_stage(_payload(mode))
 
     encoded = json.dumps(result, ensure_ascii=False, separators=(",", ":"))
     decoded = json.loads(encoded)
     assert decoded == result
     assert result["analysis_id"] == f"req-{mode}"
     assert result["output"]["stage"] == mode
+    assert result["output"]["analyzer"] == (
+        alphahunt_stage.CODEX_ANALYZER if mode in alphahunt_stage.STAGE_MODES else alphahunt_stage.QWEN_ANALYZER
+    )
+    assert result["output"]["model"] == (
+        alphahunt_stage.CODEX_MODEL if mode in alphahunt_stage.STAGE_MODES else alphahunt_stage.QWEN_MODEL
+    )
     assert result["output"]["stage_output"]["status"] == "ok"
     ok, err = alphahunt_stage.validate_output(mode, result)
     assert ok, err
@@ -213,11 +226,17 @@ def test_fast_triage_decisions_validate(monkeypatch, decision):
     assert ok, err
 
 
-def test_is_qwen_analysis_payload_matches_stage_and_fast_triage():
-    assert alphahunt_stage.is_qwen_analysis_payload(_payload("cleaner")) is True
-    assert alphahunt_stage.is_qwen_analysis_payload(_payload("fast_triage")) is True
-    assert alphahunt_stage.is_qwen_analysis_payload({"analysis_mode": "rejudge"}) is False
-    assert alphahunt_stage.is_qwen_analysis_payload(
+def test_is_alphahunt_stage_payload_matches_stage_and_fast_triage():
+    assert alphahunt_stage.is_alphahunt_stage_payload(_payload("cleaner")) is True
+    assert alphahunt_stage.is_alphahunt_stage_payload(_payload("fast_triage")) is True
+    assert alphahunt_stage.is_alphahunt_stage_payload({"analysis_mode": "rejudge"}) is False
+    assert alphahunt_stage.is_alphahunt_stage_payload(
+        {
+            "analysis_mode": "cleaner",
+            "context": {"routing_policy": {"preferred_engine": "codex_spark"}},
+        }
+    ) is True
+    assert alphahunt_stage.is_alphahunt_stage_payload(
         {
             "analysis_mode": "cleaner",
             "context": {"routing_policy": {"preferred_engine": "central"}},
@@ -226,7 +245,7 @@ def test_is_qwen_analysis_payload_matches_stage_and_fast_triage():
 
 
 @pytest.mark.asyncio
-async def test_analysis_endpoint_dispatches_qwen_and_callback(monkeypatch):
+async def test_analysis_endpoint_dispatches_alphahunt_stage_and_callback(monkeypatch):
     captured = {}
 
     def fake_run(payload):
@@ -249,7 +268,7 @@ async def test_analysis_endpoint_dispatches_qwen_and_callback(monkeypatch):
 
     from gateway.platforms import api_server as api_server_mod
 
-    monkeypatch.setattr(api_server_mod, "run_qwen_stage", fake_run)
+    monkeypatch.setattr(api_server_mod, "run_alphahunt_stage", fake_run)
     monkeypatch.setattr(api_server_mod, "_post_alphahunt_stage_callback", fake_post)
 
     adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={"key": "sk-test"}))
@@ -271,3 +290,51 @@ async def test_analysis_endpoint_dispatches_qwen_and_callback(monkeypatch):
     assert body["output"]["stage"] == "fast_triage"
     assert captured["callback"]["output"]["stage_output"]["triage_decision"] == "advance"
     assert captured["callback_url"] == "http://central/callback"
+
+
+@pytest.mark.asyncio
+async def test_analysis_endpoint_accepts_codex_spark_stage_payload(monkeypatch):
+    captured = {}
+
+    def fake_run(payload):
+        return {
+            "analysis_id": payload["request_id"],
+            "output": {
+                "stage": "cleaner",
+                "stage_schema_version": "cleaner_output_v1",
+                "analyzer": alphahunt_stage.CODEX_ANALYZER,
+                "model": alphahunt_stage.CODEX_MODEL,
+                "stage_output": _stage_output("cleaner"),
+            },
+        }
+
+    def fake_post(payload, callback, *, callback_url="", callback_auth=""):
+        captured["payload"] = payload
+        captured["callback"] = callback
+
+    from gateway.platforms import api_server as api_server_mod
+
+    monkeypatch.setattr(api_server_mod, "run_alphahunt_stage", fake_run)
+    monkeypatch.setattr(api_server_mod, "_post_alphahunt_stage_callback", fake_post)
+
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={"key": "sk-test"}))
+    adapter._run_agent = AsyncMock()
+    app = _create_app(adapter)
+    app.router.add_post("/v1/analysis", adapter._handle_alphahunt_analysis)
+
+    payload = _payload("cleaner")
+    payload["context"]["routing_policy"]["preferred_engine"] = "codex_spark"
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post(
+            "/v1/analysis",
+            headers={"Authorization": "Bearer sk-test"},
+            json=payload,
+        )
+        body = await resp.json()
+
+    assert resp.status == 200
+    assert body["accepted"] is True
+    assert body["output"]["stage"] == "cleaner"
+    assert body["output"]["analyzer"] == alphahunt_stage.CODEX_ANALYZER
+    assert captured["payload"]["context"]["routing_policy"]["preferred_engine"] == "codex_spark"
+    assert captured["callback"]["output"]["stage_output"]["status"] == "ok"

--- a/tests/gateway/test_alphahunt_stage.py
+++ b/tests/gateway/test_alphahunt_stage.py
@@ -1,0 +1,231 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms import alphahunt_stage
+from gateway.platforms.api_server import APIServerAdapter
+from tests.gateway.test_api_server import _create_app
+
+
+def _payload(mode: str) -> dict:
+    payload = {
+        "request_id": f"req-{mode}",
+        "analysis_mode": mode,
+        "context": {"routing_policy": {"preferred_engine": "qwen_local"}},
+    }
+    if mode == "fast_triage":
+        payload["context"] = {}
+    return payload
+
+
+def _stage_output(mode: str) -> dict:
+    outputs = {
+        "cleaner": {
+            "status": "ok",
+            "normalized_event": {
+                "event_id": "evt-1",
+                "asset_class": "bond",
+                "event_type": "auction",
+                "source": "dry_run",
+                "normalized_fields": {"identity_key": "UST-10Y"},
+            },
+            "data_gaps": [],
+        },
+        "screener": {
+            "status": "ok",
+            "opportunity_candidate": {
+                "opportunity_id": "opp-1",
+                "asset_class": "bond",
+                "base_fields": {"source_event_id": "evt-1"},
+                "asset_specific_fields": {"instrument": "UST-10Y"},
+                "decision_fields": {"screening_decision": "candidate"},
+            },
+        },
+        "sentinel": {
+            "status": "ok",
+            "risks": [],
+            "risk_veto": {"active": False, "reason": "none"},
+            "blocking_rules": [],
+        },
+        "packager": {
+            "status": "ok",
+            "context_packet": {
+                "normalized_event": {
+                    "event_id": "evt-1",
+                    "asset_class": "bond",
+                    "event_type": "auction",
+                    "source": "dry_run",
+                    "normalized_fields": {"identity_key": "UST-10Y"},
+                },
+                "opportunity_candidate": {
+                    "opportunity_id": "opp-1",
+                    "asset_class": "bond",
+                    "base_fields": {"source_event_id": "evt-1"},
+                    "asset_specific_fields": {"instrument": "UST-10Y"},
+                    "decision_fields": {"screening_decision": "candidate"},
+                },
+                "risk_review": {
+                    "risks": [],
+                    "risk_veto": {"active": False, "reason": "none"},
+                    "blocking_rules": [],
+                },
+            },
+        },
+        "fast_triage": {
+            "status": "ok",
+            "triage_decision": "advance",
+            "reason": "dry run",
+            "matched_signals": [],
+            "data_gap": [],
+        },
+    }
+    return outputs[mode]
+
+
+def _model_json(mode: str) -> str:
+    return json.dumps(
+        {
+            "output": {
+                "stage": mode,
+                "stage_schema_version": alphahunt_stage.SCHEMA_VERSION_BY_MODE[mode],
+                "analyzer": alphahunt_stage.QWEN_ANALYZER,
+                "model": alphahunt_stage.QWEN_MODEL,
+                "stage_output": _stage_output(mode),
+            }
+        }
+    )
+
+
+@pytest.mark.parametrize("mode", ["cleaner", "screener", "sentinel", "packager", "fast_triage"])
+def test_qwen_stage_returns_strict_json_callback(monkeypatch, mode):
+    monkeypatch.setattr(alphahunt_stage, "call_ollama", lambda *args, **kwargs: _model_json(mode))
+
+    result = alphahunt_stage.run_qwen_stage(_payload(mode))
+
+    encoded = json.dumps(result, ensure_ascii=False, separators=(",", ":"))
+    decoded = json.loads(encoded)
+    assert decoded == result
+    assert result["analysis_id"] == f"req-{mode}"
+    assert result["output"]["stage"] == mode
+    assert result["output"]["stage_output"]["status"] == "ok"
+    ok, err = alphahunt_stage.validate_output(mode, result)
+    assert ok, err
+
+
+def test_stage_prompt_examples_do_not_use_empty_objects():
+    for mode in ["cleaner", "screener", "sentinel", "packager"]:
+        example = alphahunt_stage.expected_output_shape(mode)
+        encoded = json.dumps(example, ensure_ascii=False, separators=(",", ":"))
+        assert "{}" not in encoded
+        ok, err = alphahunt_stage.validate_output(
+            mode,
+            {"analysis_id": f"req-{mode}", "output": example["output"]},
+        )
+        assert ok, err
+
+
+def test_call_ollama_sends_larger_generation_options(monkeypatch):
+    captured = {}
+
+    class DummyResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"response": '{"output":{}}'}
+
+    def fake_post(url, json, timeout):
+        captured["url"] = url
+        captured["json"] = json
+        captured["timeout"] = timeout
+        return DummyResponse()
+
+    monkeypatch.setattr(alphahunt_stage.requests, "post", fake_post)
+
+    result = alphahunt_stage.call_ollama("prompt", timeout=12)
+
+    assert result == '{"output":{}}'
+    assert captured["json"]["options"] == {"num_predict": 1024, "num_ctx": 4096}
+    assert captured["timeout"] == 12
+
+
+@pytest.mark.parametrize("decision", ["advance", "reject", "needs_human"])
+def test_fast_triage_decisions_validate(monkeypatch, decision):
+    def model_json(*args, **kwargs):
+        body = json.loads(_model_json("fast_triage"))
+        body["output"]["stage_output"]["triage_decision"] = decision
+        body["output"]["stage_output"]["reason"] = f"{decision} path"
+        return json.dumps(body)
+
+    monkeypatch.setattr(alphahunt_stage, "call_ollama", model_json)
+
+    result = alphahunt_stage.run_qwen_stage(_payload("fast_triage"))
+
+    assert result["output"]["stage_output"]["status"] == "ok"
+    assert result["output"]["stage_output"]["triage_decision"] == decision
+    ok, err = alphahunt_stage.validate_output("fast_triage", result)
+    assert ok, err
+
+
+def test_is_qwen_analysis_payload_matches_stage_and_fast_triage():
+    assert alphahunt_stage.is_qwen_analysis_payload(_payload("cleaner")) is True
+    assert alphahunt_stage.is_qwen_analysis_payload(_payload("fast_triage")) is True
+    assert alphahunt_stage.is_qwen_analysis_payload({"analysis_mode": "rejudge"}) is False
+    assert alphahunt_stage.is_qwen_analysis_payload(
+        {
+            "analysis_mode": "cleaner",
+            "context": {"routing_policy": {"preferred_engine": "central"}},
+        }
+    ) is False
+
+
+@pytest.mark.asyncio
+async def test_analysis_endpoint_dispatches_qwen_and_callback(monkeypatch):
+    captured = {}
+
+    def fake_run(payload):
+        return {
+            "analysis_id": payload["request_id"],
+            "output": {
+                "stage": "fast_triage",
+                "stage_schema_version": "fast_triage_v1",
+                "analyzer": "qwen_7b_local",
+                "model": "qwen2.5:7b",
+                "stage_output": _stage_output("fast_triage"),
+            },
+        }
+
+    def fake_post(payload, callback, *, callback_url="", callback_auth=""):
+        captured["payload"] = payload
+        captured["callback"] = callback
+        captured["callback_url"] = callback_url
+        captured["callback_auth"] = callback_auth
+
+    from gateway.platforms import api_server as api_server_mod
+
+    monkeypatch.setattr(api_server_mod, "run_qwen_stage", fake_run)
+    monkeypatch.setattr(api_server_mod, "_post_alphahunt_stage_callback", fake_post)
+
+    adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={"key": "sk-test"}))
+    adapter._run_agent = AsyncMock()
+    app = _create_app(adapter)
+    app.router.add_post("/v1/analysis", adapter._handle_alphahunt_analysis)
+
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post(
+            "/v1/analysis",
+            headers={"Authorization": "Bearer sk-test", "X-AlphaHunt-Callback-URL": "http://central/callback"},
+            json=_payload("fast_triage"),
+        )
+        body = await resp.json()
+
+    assert resp.status == 200
+    assert body["accepted"] is True
+    assert body["analysis_id"] == "req-fast_triage"
+    assert body["output"]["stage"] == "fast_triage"
+    assert captured["callback"]["output"]["stage_output"]["triage_decision"] == "advance"
+    assert captured["callback_url"] == "http://central/callback"

--- a/tests/gateway/test_alphahunt_stage.py
+++ b/tests/gateway/test_alphahunt_stage.py
@@ -153,6 +153,48 @@ def test_call_ollama_sends_larger_generation_options(monkeypatch):
     assert captured["timeout"] == 12
 
 
+def test_call_ollama_ignores_invalid_numeric_env(monkeypatch):
+    captured = {}
+
+    class DummyResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"response": '{"output":{}}'}
+
+    def fake_post(url, json, timeout):
+        captured["json"] = json
+        captured["timeout"] = timeout
+        return DummyResponse()
+
+    monkeypatch.setenv("HERMES_QWEN_NUM_PREDICT", "bad")
+    monkeypatch.setenv("HERMES_QWEN_NUM_CTX", "also-bad")
+    monkeypatch.setattr(alphahunt_stage.requests, "post", fake_post)
+
+    result = alphahunt_stage.call_ollama("prompt", timeout=12)
+
+    assert result == '{"output":{}}'
+    assert captured["json"]["options"] == {"num_predict": 1024, "num_ctx": 4096}
+    assert captured["timeout"] == 12
+
+
+def test_run_qwen_stage_ignores_invalid_timeout_env(monkeypatch):
+    captured = {}
+
+    def fake_call(prompt, *, timeout):
+        captured["timeout"] = timeout
+        return _model_json("fast_triage")
+
+    monkeypatch.setenv("HERMES_QWEN_TIMEOUT_SEC", "bad")
+    monkeypatch.setattr(alphahunt_stage, "call_ollama", fake_call)
+
+    result = alphahunt_stage.run_qwen_stage(_payload("fast_triage"))
+
+    assert result["output"]["stage_output"]["status"] == "ok"
+    assert captured["timeout"] == 90
+
+
 @pytest.mark.parametrize("decision", ["advance", "reject", "needs_human"])
 def test_fast_triage_decisions_validate(monkeypatch, decision):
     def model_json(*args, **kwargs):

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -348,6 +348,64 @@ class TestHermesAnalysisResponseCache:
         assert (await _maybe_cached_analysis_response(payload, compute))[0]["final_response"] == "answer-2"
         assert calls == 2
 
+    @pytest.mark.asyncio
+    async def test_concurrent_analysis_payloads_share_inflight_compute(self, monkeypatch):
+        monkeypatch.setattr(api_server_mod, "_analysis_response_cache", _HermesAnalysisResponseCache())
+        calls = 0
+        gate = asyncio.Event()
+        entered = asyncio.Event()
+
+        async def compute():
+            nonlocal calls
+            calls += 1
+            entered.set()
+            await gate.wait()
+            return ({"final_response": "answer"}, {"total_tokens": 1})
+
+        payload = {
+            "analysis_mode": "data_gap_request_result",
+            "context": {
+                "routing_policy": {
+                    "cache": {"key": "data_gap_request_result:event:evt-123", "ttl_sec": 900}
+                }
+            },
+        }
+
+        first = asyncio.create_task(_maybe_cached_analysis_response(payload, compute))
+        second = asyncio.create_task(_maybe_cached_analysis_response(dict(payload, request_id="retry"), compute))
+        await asyncio.wait_for(entered.wait(), timeout=1)
+        assert calls == 1
+
+        gate.set()
+        assert await first == ({"final_response": "answer"}, {"total_tokens": 1})
+        assert await second == ({"final_response": "answer"}, {"total_tokens": 1})
+        assert calls == 1
+
+    @pytest.mark.asyncio
+    async def test_cached_analysis_response_drops_session_bound_metadata(self, monkeypatch):
+        monkeypatch.setattr(api_server_mod, "_analysis_response_cache", _HermesAnalysisResponseCache())
+
+        async def compute():
+            return (
+                {"final_response": "answer", "session_id": "first-session"},
+                {"total_tokens": 1},
+            )
+
+        payload = {
+            "analysis_mode": "data_gap_request_result",
+            "context": {
+                "routing_policy": {
+                    "cache": {"key": "data_gap_request_result:event:evt-123", "ttl_sec": 900}
+                }
+            },
+        }
+
+        first, _ = await _maybe_cached_analysis_response(payload, compute)
+        second, _ = await _maybe_cached_analysis_response(dict(payload, request_id="retry"), compute)
+
+        assert "session_id" not in first
+        assert "session_id" not in second
+
 
 # ---------------------------------------------------------------------------
 # Adapter initialization

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -24,12 +24,17 @@ import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
+from gateway.platforms import api_server as api_server_mod
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.api_server import (
     APIServerAdapter,
     ResponseStore,
+    _HermesAnalysisResponseCache,
     _IdempotencyCache,
     _derive_chat_session_id,
+    _hermes_cache_key,
+    _hermes_cache_ttl,
+    _maybe_cached_analysis_response,
     check_api_server_requirements,
     cors_middleware,
     security_headers_middleware,
@@ -248,6 +253,100 @@ class TestIdempotencyCache:
 
         gate.set()
         assert await second == "response"
+
+
+class TestHermesAnalysisResponseCache:
+    def test_cache_key_uses_routing_policy_key_and_analysis_mode(self):
+        payload = {
+            "request_id": "req-1",
+            "created_at": "2026-05-27T00:00:00Z",
+            "analysis_mode": "rejudge",
+            "context": {
+                "routing_policy": {
+                    "cache": {"key": "data_gap_request_result:event:evt-123"}
+                },
+                "outcome_review": {"recent_failures": ["volatile"]},
+                "recent_peer_signals": [{"id": "peer-1"}],
+                "active_sector_alerts": [{"id": "alert-1"}],
+            },
+        }
+
+        changed = json.loads(json.dumps(payload))
+        changed["request_id"] = "req-2"
+        changed["created_at"] = "2026-05-27T00:01:00Z"
+        changed["deadline_sec"] = 20
+        changed["context"]["outcome_review"]["recent_failures"] = ["changed"]
+        changed["context"]["recent_peer_signals"] = [{"id": "peer-2"}]
+        changed["context"]["active_sector_alerts"] = [{"id": "alert-2"}]
+
+        assert _hermes_cache_key(payload) == "data_gap_request_result:event:evt-123:rejudge"
+        assert _hermes_cache_key(changed) == _hermes_cache_key(payload)
+
+    def test_missing_routing_policy_key_skips_cache(self):
+        assert _hermes_cache_key({"analysis_mode": "rejudge", "context": {}}) is None
+
+    def test_cache_ttl_uses_routing_policy_default_and_invalid_fallback(self):
+        assert _hermes_cache_ttl({"context": {"routing_policy": {"cache": {"ttl_sec": 120}}}}) == 120
+        assert _hermes_cache_ttl({"context": {"routing_policy": {"cache": {}}}}) == 900
+        assert _hermes_cache_ttl({"context": {"routing_policy": {"cache": {"ttl_sec": "bad"}}}}) == 900
+
+    def test_cache_entry_expires_after_ttl(self, monkeypatch):
+        now = 1000.0
+        monkeypatch.setattr(api_server_mod.time, "time", lambda: now)
+        cache = _HermesAnalysisResponseCache()
+
+        cache.set("stable:event:evt-123:rejudge", "cached", ttl=10)
+        assert cache.get("stable:event:evt-123:rejudge") == "cached"
+
+        now = 1011.0
+        assert cache.get("stable:event:evt-123:rejudge") is None
+
+    @pytest.mark.asyncio
+    async def test_repeated_analysis_payload_hits_cache_despite_volatile_fields(self, monkeypatch):
+        monkeypatch.setattr(api_server_mod, "_analysis_response_cache", _HermesAnalysisResponseCache())
+        calls = 0
+
+        async def compute():
+            nonlocal calls
+            calls += 1
+            return ({"final_response": f"answer-{calls}"}, {"total_tokens": 1})
+
+        base = {
+            "analysis_mode": "data_gap_request_result",
+            "context": {
+                "routing_policy": {
+                    "cache": {"key": "data_gap_request_result:event:evt-123", "ttl_sec": 900}
+                }
+            },
+        }
+        first = dict(base, request_id="req-1", created_at="now")
+        second = dict(base, request_id="req-2", created_at="later", deadline_sec=45)
+
+        assert await _maybe_cached_analysis_response(first, compute) == (
+            {"final_response": "answer-1"},
+            {"total_tokens": 1},
+        )
+        assert await _maybe_cached_analysis_response(second, compute) == (
+            {"final_response": "answer-1"},
+            {"total_tokens": 1},
+        )
+        assert calls == 1
+
+    @pytest.mark.asyncio
+    async def test_missing_key_runs_compute_each_time(self, monkeypatch):
+        monkeypatch.setattr(api_server_mod, "_analysis_response_cache", _HermesAnalysisResponseCache())
+        calls = 0
+
+        async def compute():
+            nonlocal calls
+            calls += 1
+            return ({"final_response": f"answer-{calls}"}, {})
+
+        payload = {"analysis_mode": "data_gap_request_result", "context": {}}
+
+        assert (await _maybe_cached_analysis_response(payload, compute))[0]["final_response"] == "answer-1"
+        assert (await _maybe_cached_analysis_response(payload, compute))[0]["final_response"] == "answer-2"
+        assert calls == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_research_yaml.py
+++ b/tests/gateway/test_research_yaml.py
@@ -23,20 +23,31 @@ def test_protocol_sample_passes():
 
 
 def test_stock_and_etf_samples_pass():
-    assert _errors(sample_research_envelope("stock")) == []
+    stock = sample_research_envelope("stock")
+    assert stock["asset_class"] == "DRAFT:us_stock"
+    assert _errors(stock) == []
     assert _errors(sample_research_envelope("etf")) == []
 
 
 def test_commodity_theme_sample_passes():
-    assert _errors(sample_research_envelope("commodity_theme")) == []
+    envelope = sample_research_envelope("commodity_theme")
+    assert envelope["kind"] == "commodity_theme"
+    assert envelope["asset_class"] == "commodity"
+    assert _errors(envelope) == []
 
 
 def test_macro_event_sample_passes():
-    assert _errors(sample_research_envelope("macro_event")) == []
+    envelope = sample_research_envelope("macro_event")
+    assert envelope["kind"] == "macro_event"
+    assert envelope["asset_class"] == "macro_theme"
+    assert _errors(envelope) == []
 
 
 def test_market_sample_passes():
-    assert _errors(sample_research_envelope("market")) == []
+    envelope = sample_research_envelope("market")
+    assert envelope["kind"] == "market"
+    assert envelope["asset_class"] == "DRAFT:prediction_market"
+    assert _errors(envelope) == []
 
 
 def test_dump_and_load_round_trip():
@@ -121,6 +132,14 @@ def test_unknown_asset_class_without_draft_prefix_fails():
     envelope["asset_class"] = "new_vertical"
 
     assert any("DRAFT:<name>" in error for error in _errors(envelope))
+
+
+def test_kind_values_are_not_implicitly_authorized_asset_classes():
+    for asset_class in ["stock", "commodity_theme", "macro_event", "prediction_market"]:
+        envelope = sample_research_envelope("protocol")
+        envelope["asset_class"] = asset_class
+
+        assert any("DRAFT:<name>" in error for error in _errors(envelope))
 
 
 def test_draft_asset_class_passes():

--- a/tests/gateway/test_research_yaml.py
+++ b/tests/gateway/test_research_yaml.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from gateway.alphahunt.research_yaml import (
+    dump_research_yaml,
+    load_research_yaml,
+    sample_research_envelope,
+    validate_research_envelope,
+)
+
+
+def _errors(envelope: dict) -> list[str]:
+    return validate_research_envelope(envelope)
+
+
+def test_protocol_sample_passes():
+    envelope = sample_research_envelope("protocol")
+    assert envelope["asset_class"] == "DRAFT:crypto_protocol"
+    assert "source_references" in envelope["note"]
+    assert "source_references" not in envelope
+    assert _errors(envelope) == []
+
+
+def test_stock_and_etf_samples_pass():
+    assert _errors(sample_research_envelope("stock")) == []
+    assert _errors(sample_research_envelope("etf")) == []
+
+
+def test_commodity_theme_sample_passes():
+    assert _errors(sample_research_envelope("commodity_theme")) == []
+
+
+def test_macro_event_sample_passes():
+    assert _errors(sample_research_envelope("macro_event")) == []
+
+
+def test_market_sample_passes():
+    assert _errors(sample_research_envelope("market")) == []
+
+
+def test_dump_and_load_round_trip():
+    envelope = sample_research_envelope("protocol")
+    loaded = load_research_yaml(dump_research_yaml(envelope))
+    assert loaded == envelope
+
+
+def test_samples_on_disk_validate():
+    sample_dir = Path("docs/alphahunt/samples")
+    for name in [
+        "protocol_ethena.yaml",
+        "stock_example.yaml",
+        "commodity_copper.yaml",
+        "macro_fomc.yaml",
+        "market_worldcup.yaml",
+    ]:
+        envelope = load_research_yaml((sample_dir / name).read_text(encoding="utf-8"))
+        assert _errors(envelope) == []
+
+
+def test_missing_thesis_fails():
+    envelope = sample_research_envelope("protocol")
+    del envelope["note"]["thesis"]
+
+    assert any("note.thesis" in error for error in _errors(envelope))
+
+
+def test_missing_invalidation_conditions_fails():
+    envelope = sample_research_envelope("protocol")
+    del envelope["note"]["invalidation_conditions"]
+
+    assert any("note.invalidation_conditions" in error for error in _errors(envelope))
+
+
+def test_missing_next_check_at_fails():
+    envelope = sample_research_envelope("protocol")
+    del envelope["note"]["next_check_at"]
+
+    assert any("note.next_check_at" in error for error in _errors(envelope))
+
+
+def test_missing_note_source_references_fails():
+    envelope = sample_research_envelope("protocol")
+    del envelope["note"]["source_references"]
+
+    assert any("note.source_references" in error for error in _errors(envelope))
+
+
+def test_top_level_source_references_fails():
+    envelope = sample_research_envelope("protocol")
+    envelope["source_references"] = envelope["note"].pop("source_references")
+
+    errors = _errors(envelope)
+    assert any("note.source_references" in error for error in errors)
+    assert any("source_references must be nested" in error for error in errors)
+
+
+def test_non_iso_next_check_at_fails():
+    envelope = sample_research_envelope("protocol")
+    envelope["note"]["next_check_at"] = "next Thursday"
+
+    assert any("ISO8601" in error for error in _errors(envelope))
+
+
+def test_empty_observables_fails():
+    envelope = sample_research_envelope("protocol")
+    envelope["note"]["observables"] = []
+
+    assert any("note.observables" in error for error in _errors(envelope))
+
+
+def test_unknown_kind_fails():
+    envelope = sample_research_envelope("protocol")
+    envelope["kind"] = "bond"
+
+    assert any("kind must be one of" in error for error in _errors(envelope))
+
+
+def test_unknown_asset_class_without_draft_prefix_fails():
+    envelope = sample_research_envelope("protocol")
+    envelope["asset_class"] = "new_vertical"
+
+    assert any("DRAFT:<name>" in error for error in _errors(envelope))
+
+
+def test_draft_asset_class_passes():
+    envelope = sample_research_envelope("protocol")
+    envelope["asset_class"] = "DRAFT:new_vertical"
+
+    assert _errors(envelope) == []
+
+
+def test_market_output_forbidden_terms_fail():
+    for term in ["bet", "wager", "execute", "stake", "kelly"]:
+        envelope = sample_research_envelope("market")
+        envelope["research_markdown"] += f"\nDo not use this term: {term}."
+
+        assert any(term in error for error in _errors(envelope))
+
+
+def test_market_action_must_be_whitelisted():
+    envelope = sample_research_envelope("market")
+    envelope["note"]["action_suggestion"] = "participate"
+
+    assert any("market note.action_suggestion" in error for error in _errors(envelope))
+
+
+def test_market_actions_allowed():
+    for action in ["ignore", "observe", "research", "manual_review", "no_participation"]:
+        envelope = sample_research_envelope("market")
+        envelope["note"]["action_suggestion"] = action
+
+        assert _errors(envelope) == []

--- a/tests/gateway/test_transcript_offset.py
+++ b/tests/gateway/test_transcript_offset.py
@@ -13,7 +13,10 @@ to ``_run_agent``'s return dict and uses it for the slice.
 """
 
 
-from gateway.run import _preserve_queued_followup_history_offset
+from gateway.run import (
+    _agent_already_persisted_turn,
+    _preserve_queued_followup_history_offset,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -119,6 +122,65 @@ class TestTranscriptHistoryOffset:
 
         assert old_new == fixed_new
         assert len(fixed_new) == 2
+
+
+class _FakeSessionDB:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def get_messages(self, session_id):
+        return list(self.rows)
+
+
+class TestAgentPersistenceDetection:
+    def test_detects_missing_agent_db_write_when_only_session_meta_exists(self):
+        history = []
+        db = _FakeSessionDB([
+            {"role": "session_meta", "tools": []},
+        ])
+
+        assert not _agent_already_persisted_turn(db, "sid", history)
+
+    def test_detects_agent_db_write_when_conversation_count_increased(self):
+        history = [
+            {"role": "session_meta", "tools": []},
+            {"role": "user", "content": "old"},
+            {"role": "assistant", "content": "answer"},
+        ]
+        db = _FakeSessionDB(history + [
+            {"role": "user", "content": "new"},
+            {"role": "assistant", "content": "new answer"},
+        ])
+
+        assert _agent_already_persisted_turn(db, "sid", history)
+
+    def test_session_split_counts_from_zero(self):
+        old_history = [{"role": "user", "content": f"old {i}"} for i in range(20)]
+        compressed_db = _FakeSessionDB([
+            {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+            {"role": "assistant", "content": "continuing"},
+        ])
+
+        assert _agent_already_persisted_turn(
+            compressed_db,
+            "compressed-sid",
+            old_history,
+            session_was_split=True,
+        )
+
+    def test_missing_session_id_is_not_treated_as_split(self):
+        history = [{"role": "user", "content": "old"}]
+        db = _FakeSessionDB([
+            {"role": "session_meta", "tools": []},
+            {"role": "user", "content": "old"},
+        ])
+
+        assert not _agent_already_persisted_turn(
+            db,
+            "sid",
+            history,
+            session_was_split=False,
+        )
 
     def test_multiple_session_meta_larger_drift(self):
         """Two session_meta entries double the offset error.

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -130,6 +130,30 @@ class TestRunConversationCodexPath:
         )
         assert user_count == 1, f"user message appeared {user_count}× in {result['messages']}"
 
+    def test_codex_path_persists_completed_turn_with_history(self, fake_session):
+        """The app-server path returns before the standard loop's final
+        persistence block, so it must flush its own turn and pass the loaded
+        history offset through to avoid duplicating replayed messages."""
+        agent = _make_codex_agent()
+        calls = []
+
+        def capture_persist(messages, conversation_history=None):
+            calls.append((list(messages), conversation_history))
+
+        history = [{"role": "user", "content": "prior"}]
+        with (
+            patch.object(agent, "_spawn_background_review", return_value=None),
+            patch.object(agent, "_persist_session", side_effect=capture_persist),
+        ):
+            result = agent.run_conversation("next", conversation_history=history)
+
+        assert result["completed"] is True
+        assert len(calls) == 1
+        persisted_messages, persisted_history = calls[0]
+        assert persisted_history is history
+        assert persisted_messages[:1] == history
+        assert any(m.get("role") == "user" and m.get("content") == "next" for m in persisted_messages)
+
     def test_background_review_NOT_invoked_below_threshold(self, fake_session):
         """A single turn shouldn't trigger background review — counters
         haven't reached the nudge interval (default 10)."""
@@ -318,8 +342,29 @@ class TestErrorHandling:
             result = agent.run_conversation("hi")
         assert result["completed"] is False
         assert result["partial"] is True
+        assert result["failed"] is True
         assert "subprocess died" in result["error"]
         assert "codex-runtime auto" in result["final_response"]
+
+    def test_session_exception_persists_user_turn(self, monkeypatch):
+        def boom_run_turn(self, user_input, **kwargs):
+            raise RuntimeError("subprocess died")
+
+        monkeypatch.setattr(CodexAppServerSession, "ensure_started",
+                            lambda self: "t1")
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", boom_run_turn)
+
+        agent = _make_codex_agent()
+        calls = []
+        with (
+            patch.object(agent, "_spawn_background_review", return_value=None),
+            patch.object(agent, "_persist_session", side_effect=lambda messages, conversation_history=None: calls.append((list(messages), conversation_history))),
+        ):
+            result = agent.run_conversation("hi")
+
+        assert result["failed"] is True
+        assert len(calls) == 1
+        assert any(m.get("role") == "user" and m.get("content") == "hi" for m in calls[0][0])
 
     def test_interrupted_turn_marked_partial(self, monkeypatch):
         def interrupted_turn(self, user_input, **kwargs):

--- a/tests/test_yuanbao_pipeline.py
+++ b/tests/test_yuanbao_pipeline.py
@@ -40,6 +40,7 @@ from gateway.platforms.yuanbao import (
     GroupAtGuardMiddleware,
     DispatchMiddleware,
     InboundPipelineBuilder,
+    MessageSender,
     YuanbaoAdapter,
 )
 from gateway.config import PlatformConfig
@@ -104,6 +105,29 @@ def make_json_push(
         push["CallbackCommand"] = "Group.CallbackAfterSendMsg"
         push["GroupId"] = group_code
     return json.dumps(push).encode("utf-8")
+
+
+def test_message_sender_strips_new_and_legacy_cron_wrappers():
+    body = "已执行今日审计；本轮未触发主清单安全回填。"
+    new_wrapped = (
+        "Cron job run completed: Leo公众号来源晋级审计与主清单回填\n"
+        "(job_id: 8ae9f132e293)\n"
+        "-------------\n\n"
+        f"{body}\n\n"
+        'Manage this scheduled job by sending a new message, for example: '
+        '"stop reminder Leo公众号来源晋级审计与主清单回填".'
+    )
+    legacy_wrapped = (
+        "Cronjob Response: Leo公众号来源晋级审计与主清单回填\n"
+        "(job_id: 8ae9f132e293)\n"
+        "-------------\n\n"
+        f"{body}\n\n"
+        'To stop or manage this job, send me a new message (e.g. '
+        '"stop reminder Leo公众号来源晋级审计与主清单回填").'
+    )
+
+    assert MessageSender.strip_cron_wrapper(new_wrapped) == body
+    assert MessageSender.strip_cron_wrapper(legacy_wrapped) == body
 
 
 # ============================================================


### PR DESCRIPTION
## Summary
- add Hermes AlphaHunt P08 project research YAML contract docs and runbook
- add pure `gateway.alphahunt.research_yaml` renderer/validator
- add five complete sample YAML envelopes for protocol, stock, commodity, macro, and market research
- add focused tests for required note fields, draft asset classes, market boundaries, and on-disk samples

## Compatibility Notes
- `protocol_ethena.yaml` uses `asset_class: DRAFT:crypto_protocol` because `crypto_protocol` is not treated as an authorized AlphaHunt enum on the Hermes side.
- `source_references` is nested under `note.source_references`; top-level `source_references` now fails validation.
- Every sample note includes `thesis`, `key_assumptions`, `risk_triggers`, `invalidation_conditions`, `observables`, `next_check_at`, and `source_references`.

## Validation
PASS:
```bash
python -m gateway.alphahunt.research_yaml --validate docs/alphahunt/samples/protocol_ethena.yaml
python -m gateway.alphahunt.research_yaml --validate docs/alphahunt/samples/stock_example.yaml
python -m gateway.alphahunt.research_yaml --validate docs/alphahunt/samples/commodity_copper.yaml
python -m gateway.alphahunt.research_yaml --validate docs/alphahunt/samples/macro_fomc.yaml
python -m gateway.alphahunt.research_yaml --validate docs/alphahunt/samples/market_worldcup.yaml
pytest tests/gateway/test_research_yaml.py -q
pytest tests/gateway/test_alphahunt_stage.py -q
```

## AlphaHunt P08 Dry Run
Not completed in this environment. `/home/ubuntu/alphahunt/scripts/create_project_from_research.py` is not present locally, and SSH to `win-hermes` closes during key exchange before commands can run.

No `--live` command was run from Hermes. The Hermes validator is pure and does not read secrets, call live APIs, or write databases.

## H7 Live Handoff
Still requires explicit authorization for AlphaHunt host access, approved asset-class enum handling for protocol/web3 research, production DB write policy, live API credentials policy, cron/notification scope, rollback procedure, and operator signoff.
