### PR TITLE
fix(mcp): pass safe_env directly to StdioServerParameters to prevent …

### DIFF
--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -592,3 +592,48 @@ class TestBuildSafeEnvPassthrough:
             "empty dict must not be coerced to None; "
             "None would make the child inherit the full parent env"
         )
+
+    def test_run_stdio_passes_empty_env_not_none(self, monkeypatch):
+        """MCPServerTask._run_stdio forwards {} to StdioServerParameters.
+
+        Regression guard: exercises the real production call site at
+        lines 1386-1390. If line 1389 is reverted to
+        env=safe_env if safe_env else None, this test fails because
+        StdioServerParameters receives None instead of {}.
+        """
+        import tools.mcp_tool as mcp_mod
+        import asyncio
+
+        monkeypatch.setattr(os, "environ", {})
+
+        captured = {}
+
+        class _Stop(Exception):
+            pass
+
+        class FakeStdioServerParameters:
+            def __init__(self, *args, **kwargs):
+                captured["env"] = kwargs.get("env")
+                raise _Stop()
+
+        monkeypatch.setattr(
+            mcp_mod, "StdioServerParameters", FakeStdioServerParameters
+        )
+
+        server = mcp_mod.MCPServerTask("test-empty-env")
+        server._sampling = None
+
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(
+                server._run_stdio({"command": "mcp-fake", "args": []})
+            )
+        except _Stop:
+            pass
+        finally:
+            loop.close()
+
+        assert captured.get("env") == {}, (
+            f"expected env={{}}, got {captured.get('env')!r}; "
+            "old ternary safe_env if safe_env else None would yield None"
+        )

--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -542,3 +542,53 @@ class TestMCPInitialConnectionRetry:
                 await task
 
         asyncio.get_event_loop().run_until_complete(_run())
+
+
+# ---------------------------------------------------------------------------
+# Fix 2c: _build_safe_env empty-dict passthrough (env leak regression)
+# ---------------------------------------------------------------------------
+
+class TestBuildSafeEnvPassthrough:
+    """Empty dict from _build_safe_env must survive to StdioServerParameters.
+
+    The bug: when _build_safe_env returned {}, the old ternary
+    ``safe_env if safe_env else None`` collapsed it to None in
+    StdioServerParameters, causing the child process to inherit the
+    full parent env. The fix passes safe_env directly so {} is
+    preserved and only _SAFE_ENV_KEYS (and user_env) reach the MCP
+    server subprocess.
+    """
+
+    def test_returns_empty_dict_with_no_safe_keys(self, monkeypatch):
+        """When os.environ has no safe keys and user_env is None, return {}."""
+        monkeypatch.setattr(os, "environ", {})
+        from tools.mcp_tool import _build_safe_env
+
+        result = _build_safe_env(None)
+        assert result == {}
+        assert isinstance(result, dict)
+
+    def test_empty_dict_passed_to_stdio_params_not_none(self, monkeypatch):
+        """StdioServerParameters must receive {} (not None) when safe_env is empty."""
+        monkeypatch.setattr(os, "environ", {})
+        from tools.mcp_tool import _build_safe_env
+        from mcp import StdioServerParameters
+
+        safe_env = _build_safe_env(None)
+        assert safe_env == {}
+
+        # Demonstrate the old bug: falsy-check collapses {} to None.
+        assert (safe_env if safe_env else None) is None, (
+            "regression guard: empty dict is falsy — old ternary would pass None"
+        )
+
+        # The fix passes safe_env directly — {} survives.
+        params = StdioServerParameters(
+            command="test-command",
+            args=[],
+            env=safe_env,
+        )
+        assert params.env == {}, (
+            "empty dict must not be coerced to None; "
+            "None would make the child inherit the full parent env"
+        )

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1386,7 +1386,7 @@ class MCPServerTask:
         server_params = StdioServerParameters(
             command=command,
             args=args,
-            env=safe_env if safe_env else None,
+            env=safe_env,
         )
 
         sampling_kwargs = self._sampling.session_kwargs() if self._sampling else {}


### PR DESCRIPTION
## Summary

Fixes a credential leak in the stdio MCP transport where an empty
`safe_env` dict was silently coerced to `None` in
`StdioServerParameters`, causing the child MCP process to inherit the
full parent environment including all secret variables.

---

## Root cause

`_build_safe_env()` in `tools/mcp_tool.py` filters `os.environ` to a
safe allowlist (`_SAFE_ENV_KEYS`) and returns a dict. When the host
environment contains none of the allowed keys (e.g. systemd unit,
minimal Docker container, CI with a stripped env, or macOS launchd
without PATH/HOME), the function returns `{}`.

The call site used a falsy check:

    env=safe_env if safe_env else None

An empty dict is falsy in Python, so `{}` was passed as `None` to
`StdioServerParameters`. The MCP SDK treats `env=None` as "inherit
parent environment", so all variables present in the Hermes process
(`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GITHUB_TOKEN`, etc.) were
forwarded to the stdio MCP subprocess, bypassing the intended filter.

---

## Behavioral change

Before: when `_build_safe_env` returned `{}`, the child MCP subprocess
inherited the full parent environment.

After: `safe_env` is passed directly to `StdioServerParameters`. An
empty dict is forwarded as-is, so the child subprocess receives an
empty environment as intended. The filter now works correctly in all
deployment scenarios.

---

## What changed

**`tools/mcp_tool.py`**
- Replaced `env=safe_env if safe_env else None` with `env=safe_env`
  in `_run_stdio()`

**`tests/tools/test_mcp_stability.py`**
- Added `TestBuildSafeEnvPassthrough` with three tests:
  `test_returns_empty_dict_with_no_safe_keys` verifies that
  `_build_safe_env` returns `{}` when `os.environ` contains no safe
  keys; `test_empty_dict_passed_to_stdio_params_not_none` verifies
  that `StdioServerParameters` accepts an empty dict as `env`;
  `test_run_stdio_passes_empty_env_not_none` is a regression guard
  that exercises the real production call site in `_run_stdio` and
  fails if line 1389 is reverted to `env=safe_env if safe_env else None`

---

## What is NOT changed

- `_build_safe_env` logic unchanged
- `_SAFE_ENV_KEYS` allowlist unchanged
- HTTP and SSE transports unchanged
- Existing MCP stability tests pass