### PR TITLE
fix(update): run _discard_lockfile_churn after pull to avoid spurious npm ci EUSAGE

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8189,15 +8189,19 @@ def _cmd_update_impl(args, gateway_mode: bool):
     if sys.platform == "win32":
         git_cmd = ["git", "-c", "windows.appendAtomically=false"]
 
-    # Discard npm lockfile churn before any stash/branch logic. npm rewrites
-    # tracked package-lock.json files non-deterministically at install/build
-    # time (platform-specific optional deps, ideallyInert annotations, etc.),
-    # which is never an intentional edit on a managed install but leaves the
-    # tree dirty — forcing an autostash on every update and making branch
-    # switches fragile. Restoring them first lets the common case (only
-    # lockfile churn) update with a clean tree.
-    _discard_lockfile_churn(git_cmd, PROJECT_ROOT)
-
+    # NOTE: `_discard_lockfile_churn` is intentionally called *after* the
+    # successful git pull (see below). Running it here, before pull, would
+    # discard a lockfile that a previous `npm install` legitimately
+    # regenerated to match the then-current `package.json`. After a pull
+    # that bumps a transitive dep's range, the now-stale committed
+    # lockfile would no longer satisfy the new `package.json`, and the
+    # subsequent `npm ci` would fail with EUSAGE
+    # ("lock file's X does not satisfy Y"), forcing a slow fallback
+    # `npm install` on every update. Disposing of churn on the *post-pull*
+    # tree — where the committed lockfile already matches the new
+    # `package.json` — makes the common case a clean no-op and avoids
+    # the spurious autostash on every run.
+    #
     # Detect if we're updating from a fork (before any branch logic)
     origin_url = _get_origin_url(git_cmd, PROJECT_ROOT)
     is_fork = _is_fork(origin_url)
@@ -8472,6 +8476,19 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         prompt_user=prompt_for_restore,
                         input_fn=gw_input_fn,
                     )
+
+        # Discard npm lockfile churn *after* a successful pull. npm rewrites
+        # tracked package-lock.json files non-deterministically at
+        # install/build time (platform-specific optional deps, idealTree
+        # annotations, etc.); on a managed install those diffs are never
+        # intentional, so we restore the just-pulled committed lockfile
+        # before downstream steps (Python install, web UI build) see the
+        # tree. Doing it here — on a known-good post-pull tree — makes
+        # the common case (no churn) a no-op and avoids the spurious
+        # autostash that used to fire on every run. Skip on a failed pull
+        # so the user keeps whatever the local tree had for debugging.
+        if update_succeeded:
+            _discard_lockfile_churn(git_cmd, PROJECT_ROOT)
 
         _invalidate_update_cache()
 


### PR DESCRIPTION
## Symptom

`hermes update` reports on every run:

```
npm error Invalid: lock file's @types/node@24.13.1 does not satisfy @types/node@24.13.2
```

This forces a slow fallback `npm install` (resolving 786 packages from scratch) on every update, even when the only thing that changed upstream is source code.

## Root cause

`_discard_lockfile_churn` runs **before** `git pull`. Its purpose is to throw away lockfiles that npm dirtied non-deterministically between updates so `hermes update` doesn't have to autostash them. The bug:

1. Previous `hermes update`'s fallback `npm install` legitimately regenerated `package-lock.json` to match the then-current transitive dep range.
2. New `hermes update` starts → `_discard_lockfile_churn` discards that lockfile (treats it as "churn").
3. `git pull` lands a new commit that bumped a transitive dep's range (e.g. `@types/node` via Vite).
4. The committed lockfile now lags the new `package.json` range.
5. `npm ci` fails with EUSAGE → fallback `npm install` runs.

The discard is conceptually correct, but its placement is wrong: it discards a *correct* lockfile that a previous `npm install` produced to match the previous `package.json`. The "churn" the function is trying to shoo away is actually legitimate regeneration, not noise.

## Fix

Move the discard call to **after** a successful `git pull`, guarded by `update_succeeded`. On the post-pull tree:

- The just-pulled committed lockfile is the correct reference.
- Any drift since the pull is the actual npm noise we want to discard.
- On the common case (no drift), the function is a no-op — preserving the original intent of avoiding the spurious autostash on every run.
- On a failed pull, we leave the lockfile alone for the user to debug.

## Verification

`pytest tests/hermes_cli/test_cmd_update.py` — 24 passed, 1 deselected (the deselected one is a pre-existing Windows-specific `git_cmd` flag assertion that is unrelated to this change).