### PR TITLE
fix(tui): escape surrogates in StdioTransport to prevent UnicodeEncodeError

### DIFF
--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -100,20 +100,37 @@ def test_write_json_closed_stream_returns_false(server):
     assert server.write_json({"x": 1}) is False
 
 
-def test_write_json_unicode_encode_error_re_raises(server):
-    """A non-UTF-8 stdout encoding raises UnicodeEncodeError (a ValueError
-    subclass).  It must NOT be swallowed as 'peer gone' — that would let
-    `entry.py` exit cleanly via the False path and hide the real config
-    bug.  We re-raise so the existing crash-log infrastructure records it."""
+def test_write_json_ascii_stream_handles_non_ascii_payload(server):
+    """With ``ensure_ascii=True``, non-ASCII characters (e.g. CJK, accented
+    Latin) are escaped to ``\\uXXXX`` in the JSON output, so an ASCII-only
+    stream never raises ``UnicodeEncodeError``.
+
+    Regression test for https://github.com/NousResearch/hermes-agent/issues/44287
+    """
 
     class _AsciiOnly:
         def write(self, line):
-            line.encode("ascii")  # raises UnicodeEncodeError on non-ascii
+            line.encode("ascii")  # would raise on non-ASCII bytes
         def flush(self): pass
 
     server._real_stdout = _AsciiOnly()
-    with pytest.raises(UnicodeEncodeError):
-        server.write_json({"msg": "héllo"})
+    # Should succeed — payload is escaped to pure ASCII by ensure_ascii=True.
+    assert server.write_json({"msg": "héllo"}) is True
+
+
+def test_write_json_surrogates_do_not_crash(server, capture):
+    """Unpaired UTF-16 surrogates (\\ud800-\\udfff) in the payload must be
+    safely escaped by ``ensure_ascii=True`` instead of causing
+    ``UnicodeEncodeError: surrogates not allowed``.
+
+    Regression test for https://github.com/NousResearch/hermes-agent/issues/44287
+    """
+    s, buf = capture
+    # ``json.dumps(ensure_ascii=True)`` escapes surrogates to ``\\ud8xx``.
+    surrogate_str = "before\ud800after"
+    assert s.write_json({"msg": surrogate_str}) is True
+    output = json.loads(buf.getvalue())
+    assert output["msg"] == surrogate_str
 
 
 def test_write_json_unrelated_value_error_re_raises(server):

--- a/tui_gateway/transport.py
+++ b/tui_gateway/transport.py
@@ -134,7 +134,14 @@ class StdioTransport:
         # block other threads emitting their own frames.  A non-JSON-safe
         # payload is a programming error: re-raise so the crash log
         # captures it instead of silently exiting via the False path.
-        line = json.dumps(obj, ensure_ascii=False) + "\n"
+        #
+        # ``ensure_ascii=True`` escapes every non-ASCII character (including
+        # unpaired UTF-16 surrogates from CESU-8 / WSL paths) to ``\uXXXX``.
+        # The resulting JSON is pure ASCII, so ``stream.write()`` can never
+        # raise ``UnicodeEncodeError`` regardless of the stream's encoding.
+        # The TUI frontend (``JSON.parse``) decodes the escapes transparently.
+        # See: https://github.com/NousResearch/hermes-agent/issues/44287
+        line = json.dumps(obj, ensure_ascii=True) + "\n"
 
         with self._lock:
             stream = self._stream_getter()


### PR DESCRIPTION
## What does this PR do?

Fixes `UnicodeEncodeError: surrogates not allowed` crash in `StdioTransport.write()` when the LLM API returns assistant messages containing unpaired UTF-16 surrogates (non-BMP characters like emoji or rare CJK ideographs encoded via CESU-8). Previously, the TUI child process would enter an infinite spawn-crash loop.

## Related Issue

Fixes #44287

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/transport.py`: Changed `json.dumps(obj, ensure_ascii=False)` to `json.dumps(obj, ensure_ascii=True)` in `StdioTransport.write()`. This escapes all non-ASCII characters (including unpaired surrogates) to `\uXXXX`, producing pure-ASCII JSON that is safe for any stream encoding.
- `tests/tui_gateway/test_protocol.py`: Updated `test_write_json_unicode_encode_error_re_raises` → `test_write_json_ascii_stream_handles_non_ascii_payload` to verify that non-ASCII payloads are now safely escaped. Added `test_write_json_surrogates_do_not_crash` regression test for unpaired surrogates in the payload.

## How to Test

1. `cd hermes-agent && python -m pytest tests/tui_gateway/test_protocol.py -v -x`
2. Verify `test_write_json_ascii_stream_handles_non_ascii_payload` passes (non-ASCII CJK/accented chars are escaped)
3. Verify `test_write_json_surrogates_do_not_crash` passes (unpaired `\ud800` is safely escaped)
4. All 60 tests in the file should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/tui_gateway/test_protocol.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `StdioTransport.write` (callers: 3 via `write_json` routing, flows through stdio pipe to TUI frontend)
- Blast radius: LOW — single-line behavioral change in serialization; TUI frontend's `JSON.parse` handles `\uXXXX` escapes transparently
- Related patterns: `ws.py` and `event_publisher.py` also use `ensure_ascii=False` but write to WebSocket/queue (not raw stdout encoding), so they are not affected by the same surrogate encoding issue
