### PR TITLE
fix(image_routing): check main model vision support before aux override

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -17,12 +17,13 @@ It reads ``agent.image_input_mode`` from config.yaml (``auto`` | ``native``
 | ``text``, default ``auto``) and the active model's capability metadata.
 
 In ``auto`` mode:
-  - If the user has explicitly configured ``auxiliary.vision.provider``
+  - If the active model reports ``supports_vision=True`` in its
+    models.dev metadata (or via the ``supports_vision`` config override),
+    we attach natively — the main model can see the pixels directly.
+  - Otherwise, if the user has explicitly configured ``auxiliary.vision.provider``
     (i.e. not ``auto`` and not empty), we assume they want the text pipeline
-    regardless of the main model — they've opted in to a specific vision
-    backend for a reason (cost, quality, local-only, etc.).
-  - Otherwise, if the active model reports ``supports_vision=True`` in its
-    models.dev metadata, we attach natively.
+    as a fallback (they've opted in to a specific vision backend for a reason:
+    cost, quality, local-only, etc.).
   - Otherwise (non-vision model, no explicit override), we fall back to text.
 
 This keeps ``vision_analyze`` surfaced as a tool in every session — skills
@@ -337,12 +338,13 @@ def decide_image_input_mode(
         return "text"
 
     # auto
-    if _explicit_aux_vision_override(cfg):
-        return "text"
-
     supports = _lookup_supports_vision(provider, model, cfg)
     if supports is True:
-        return "native"
+        return "native"  # main model can see images
+
+    if _explicit_aux_vision_override(cfg):
+        return "text"  # main model can't see -> use aux if configured
+
     return "text"
 
 

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -279,15 +279,26 @@ class TestAutoModeRespectsOverride:
         with patch("agent.models_dev.get_model_capabilities", return_value=None):
             assert decide_image_input_mode("custom", "unknown", {}) == "text"
 
-    def test_explicit_aux_vision_override_still_wins(self):
-        # If the user has configured a dedicated vision aux backend, respect
-        # it even when supports_vision: true is also set.
+    def test_explicit_aux_vision_override_only_applies_when_main_model_not_vision(self):
+        # Aux override is a fallback: when the main model supports vision,
+        # images go native regardless of aux config. The aux override only
+        # applies when the main model is non-vision.
         cfg = {
             "model": {"supports_vision": True},
             "auxiliary": {"vision": {"provider": "openrouter", "model": "gemini-2.5-pro"}},
         }
         with patch("agent.models_dev.get_model_capabilities", return_value=None):
-            assert decide_image_input_mode("custom", "qwen3.6-35b", cfg) == "text"
+            assert decide_image_input_mode("custom", "qwen3.6-35b", cfg) == "native"
+
+    def test_aux_vision_override_wins_when_main_model_not_vision(self):
+        # When the main model does NOT support vision, the explicit aux
+        # override still forces text routing.
+        cfg = {
+            "model": {"supports_vision": False},
+            "auxiliary": {"vision": {"provider": "openrouter", "model": "gemini-2.5-pro"}},
+        }
+        with patch("agent.models_dev.get_model_capabilities", return_value=None):
+            assert decide_image_input_mode("custom", "text-only-model", cfg) == "text"
 
 
 # ─── build_native_content_parts ──────────────────────────────────────────────


### PR DESCRIPTION
## Bug

When `auxiliary.vision` is explicitly configured, images were forced through the text pipeline even when the main model supports vision (e.g. `xiaomi/mimo-v2.5`).

## Root Cause

In `agent/image_routing.py`, `decide_image_input_mode()` checked `_explicit_aux_vision_override()` **before** checking main model vision support, unconditionally blocking the native path.

## Fix

Reorder checks: main model vision support is checked first, aux override becomes a fallback for non-vision models only.

## Changes

- `agent/image_routing.py`: reordered checks in `decide_image_input_mode()`, updated module docstring
- `tests/agent/test_image_routing.py`: split test into two — verifies native when main model supports vision (with aux configured), and text when main model is non-vision (with aux configured)

## Tests

- `tests/agent/test_image_routing.py`: 76 passed
- `tests/agent/test_custom_providers_vision.py`: 13 passed