### PR TITLE
fix(qqbot): extract reply_to from gateway metadata before discarding

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -2439,7 +2439,11 @@ class QQAdapter(BasePlatformAdapter):
         Applies format_message(), splits long messages via truncate_message(),
         and retries transient failures with exponential backoff.
         """
-        del metadata
+        # Extract reply_to from metadata when not passed as a separate kwarg.
+        # The gateway sometimes carries reply_to_message_id inside metadata
+        # (e.g. thread-aware delivery paths) instead of the reply_to parameter.
+        if not reply_to and metadata:
+            reply_to = metadata.get("reply_to_message_id")
 
         if not self.is_connected:
             if not await self._wait_for_reconnection():

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -630,6 +630,103 @@ class TestWaitForReconnection:
 
 
 # ---------------------------------------------------------------------------
+# send() metadata reply_to extraction
+# ---------------------------------------------------------------------------
+
+class TestSendMetadataReplyTo:
+    """Test that send() extracts reply_to from metadata when not explicitly provided."""
+
+    def _make_adapter(self, **extra):
+        from gateway.platforms.qqbot import QQAdapter
+        adapter = QQAdapter(_make_config(**extra))
+        adapter._running = True
+        adapter._ws = SimpleNamespace(closed=False)
+        adapter._http_client = mock.MagicMock()
+        return adapter
+
+    @pytest.mark.asyncio
+    async def test_extracts_reply_to_from_metadata(self):
+        """When reply_to is None, send() should extract it from metadata."""
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        sent_with = {}
+        original_send_chunk = adapter._send_chunk
+
+        async def capture_send_chunk(chat_id, content, reply_to=None):
+            sent_with["reply_to"] = reply_to
+            from gateway.platforms.base import SendResult
+            return SendResult(success=True, message_id="msg_1")
+
+        adapter._send_chunk = capture_send_chunk
+
+        result = await adapter.send(
+            "test_openid",
+            "Hello!",
+            reply_to=None,
+            metadata={"reply_to_message_id": "inbound_msg_42"},
+        )
+        assert result.success
+        assert sent_with["reply_to"] == "inbound_msg_42"
+
+    @pytest.mark.asyncio
+    async def test_explicit_reply_to_takes_precedence(self):
+        """When reply_to is already set, metadata should not override it."""
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        sent_with = {}
+
+        async def capture_send_chunk(chat_id, content, reply_to=None):
+            sent_with["reply_to"] = reply_to
+            from gateway.platforms.base import SendResult
+            return SendResult(success=True, message_id="msg_1")
+
+        adapter._send_chunk = capture_send_chunk
+
+        result = await adapter.send(
+            "test_openid",
+            "Hello!",
+            reply_to="explicit_reply",
+            metadata={"reply_to_message_id": "metadata_reply"},
+        )
+        assert result.success
+        assert sent_with["reply_to"] == "explicit_reply"
+
+    @pytest.mark.asyncio
+    async def test_no_reply_to_when_both_absent(self):
+        """When both reply_to and metadata are absent, send() works normally."""
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        sent_with = {}
+
+        async def capture_send_chunk(chat_id, content, reply_to=None):
+            sent_with["reply_to"] = reply_to
+            from gateway.platforms.base import SendResult
+            return SendResult(success=True, message_id="msg_1")
+
+        adapter._send_chunk = capture_send_chunk
+
+        result = await adapter.send("test_openid", "Hello!")
+        assert result.success
+        assert sent_with["reply_to"] is None
+
+    @pytest.mark.asyncio
+    async def test_empty_metadata_does_not_crash(self):
+        """Empty metadata dict should not cause issues."""
+        adapter = self._make_adapter(app_id="a", client_secret="b")
+        sent_with = {}
+
+        async def capture_send_chunk(chat_id, content, reply_to=None):
+            sent_with["reply_to"] = reply_to
+            from gateway.platforms.base import SendResult
+            return SendResult(success=True, message_id="msg_1")
+
+        adapter._send_chunk = capture_send_chunk
+
+        result = await adapter.send(
+            "test_openid", "Hello!", reply_to=None, metadata={}
+        )
+        assert result.success
+        assert sent_with["reply_to"] is None
+
+
+# ---------------------------------------------------------------------------
 # ChunkedUploader
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What does this PR do?

Fixes the QQBot adapter's `send()` method to extract `reply_to_message_id` from gateway metadata before discarding it. Previously, `del metadata` threw away the reply context, causing QQ group messages to fail with "主动消息失败, 无权限" (proactive message failed, no permission) when the gateway delivered responses without an explicit `reply_to` kwarg (e.g. background task results, goal status notices, shutdown notifications).

## Related Issue

Fixes #44294

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/qqbot/adapter.py`: Replaced `del metadata` with a conditional extraction of `reply_to_message_id` from metadata when `reply_to` is not explicitly provided as a kwarg. The extraction follows the same pattern used by other adapters (Telegram's `_metadata_reply_to_message_id`).
- `tests/gateway/test_qqbot.py`: Added `TestSendMetadataReplyTo` class with 4 tests covering: metadata extraction, explicit reply_to precedence, both absent, and empty metadata.

## How to Test

1. Run the new tests: `pytest tests/gateway/test_qqbot.py::TestSendMetadataReplyTo -v`
2. Run the full QQBot test suite: `pytest tests/gateway/test_qqbot.py -v`
3. Integration: configure a QQ Bot in a group, send a message, observe that responses are delivered via reply (no "主动消息失败" retries).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `QQAdapter.send()` (callers: gateway delivery paths via `base._send_with_retry`, direct `adapter.send()` calls in `gateway/run.py`)
- Blast radius: LOW — single adapter, only affects QQBot reply behavior
- Related patterns: Telegram's `_metadata_reply_to_message_id` uses the same extraction pattern; Feishu sets `reply_to_message_id` in metadata at line 17816 of `gateway/run.py`
