### PR TITLE
fix(desktop): preserve resilient streaming voice playback

### DIFF
--- a/apps/desktop/src/lib/voice-playback.ts
+++ b/apps/desktop/src/lib/voice-playback.ts
@@ -20,6 +20,12 @@ let currentAudio: HTMLAudioElement | null = null
 let currentStop: (() => void) | null = null
 let sequence = 0
 
+function unloadAudio(audio: HTMLAudioElement) {
+  audio.pause()
+  audio.src = ''
+  audio.load()
+}
+
 function currentState(
   status: VoicePlaybackState['status'],
   options?: VoicePlaybackOptions,
@@ -45,9 +51,7 @@ export function stopVoicePlayback() {
   currentStop = null
 
   if (currentAudio) {
-    currentAudio.pause()
-    currentAudio.src = ''
-    currentAudio.load()
+    unloadAudio(currentAudio)
     currentAudio = null
   }
 
@@ -124,6 +128,7 @@ function openSpeechStream(wsUrl: string, options: VoicePlaybackOptions): SpeechS
   const pendingSends: string[] = []
 
   let settle: (value: 'done' | 'fallback') => void = () => undefined
+  let stop: (() => void) | null = null
 
   const done = new Promise<'done' | 'fallback'>(resolve => {
     settle = value => {
@@ -132,7 +137,10 @@ function openSpeechStream(wsUrl: string, options: VoicePlaybackOptions): SpeechS
       }
 
       settled = true
-      currentStop = null
+
+      if (currentStop === stop) {
+        currentStop = null
+      }
 
       try {
         ws.close()
@@ -158,7 +166,8 @@ function openSpeechStream(wsUrl: string, options: VoicePlaybackOptions): SpeechS
 
   // stopVoicePlayback() → immediate barge-in: kill the socket (the server
   // aborts synthesis on disconnect) and the audio context (cuts sound now).
-  currentStop = () => settle('done')
+  stop = () => settle('done')
+  currentStop = stop
 
   const finishWhenDrained = () => {
     const remainingMs = context ? Math.max(0, nextStartAt - context.currentTime) * 1_000 : 0
@@ -284,9 +293,10 @@ export async function startSpeechStream(options: VoicePlaybackOptions): Promise<
   setVoicePlaybackState(currentState('preparing', options))
 
   const session = openSpeechStream(wsUrl, options)
+  const ownSequence = sequence
 
   void session.done.then(outcome => {
-    if (outcome === 'done') {
+    if (outcome === 'done' && ownSequence === sequence) {
       setVoicePlaybackState(currentState('idle'))
     }
   })
@@ -320,6 +330,7 @@ async function playSpeechDataUrl(
 
   await new Promise<void>((resolve, reject) => {
     let stall: number | null = null
+    let stop: (() => void) | null = null
 
     const cleanup = () => {
       if (stall !== null) {
@@ -330,7 +341,10 @@ async function playSpeechDataUrl(
       audio.removeEventListener('ended', onEnded)
       audio.removeEventListener('error', onError)
       audio.removeEventListener('timeupdate', armStall)
-      currentStop = null
+
+      if (currentStop === stop) {
+        currentStop = null
+      }
     }
 
     const armStall = () => {
@@ -340,6 +354,7 @@ async function playSpeechDataUrl(
 
       stall = window.setTimeout(() => {
         cleanup()
+        unloadAudio(audio)
         reject(new Error('Playback stalled'))
       }, PLAYBACK_STALL_MS)
     }
@@ -351,13 +366,16 @@ async function playSpeechDataUrl(
 
     const onError = () => {
       cleanup()
+      unloadAudio(audio)
       reject(new Error('Playback failed'))
     }
 
-    currentStop = () => {
+    stop = () => {
       cleanup()
       resolve()
     }
+
+    currentStop = stop
 
     audio.addEventListener('ended', onEnded, { once: true })
     audio.addEventListener('error', onError, { once: true })
@@ -370,7 +388,9 @@ async function playSpeechDataUrl(
     return false
   }
 
-  currentAudio = null
+  if (currentAudio === audio) {
+    currentAudio = null
+  }
 
   return true
 }

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2365,17 +2365,18 @@ def text_to_speech_tool(
             )
     else:
         timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        output_stem = f"tts_{timestamp}_{uuid.uuid4().hex}"
         out_dir = Path(DEFAULT_OUTPUT_DIR)
         out_dir.mkdir(parents=True, exist_ok=True)
         if command_provider_config is not None:
             fmt = _get_command_tts_output_format(command_provider_config)
-            file_path = out_dir / f"tts_{timestamp}.{fmt}"
+            file_path = out_dir / f"{output_stem}.{fmt}"
         # Use .ogg for Telegram with providers that support native Opus output,
         # otherwise fall back to .mp3 (Edge TTS will attempt ffmpeg conversion later).
         elif want_opus and provider in {"openai", "elevenlabs", "mistral", "gemini"}:
-            file_path = out_dir / f"tts_{timestamp}.ogg"
+            file_path = out_dir / f"{output_stem}.ogg"
         else:
-            file_path = out_dir / f"tts_{timestamp}.mp3"
+            file_path = out_dir / f"{output_stem}.mp3"
 
     # Ensure parent directory exists
     file_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

Updates this PR for Hermes Desktop's current streaming TTS/barge-in architecture.

- preserves upstream WebSocket/PCM sentence streaming instead of restoring the now-obsolete renderer-side chunk/prefetch implementation;
- prevents stale streaming or fallback playback from clearing a newer playback callback/state;
- fully unloads fallback audio on playback errors or stalls;
- adds a UUID suffix to default TTS output files, preventing same-second filename collisions without changing caller-supplied paths.

## Motivation

The original client-side chunk/prefetch implementation conflicts with newer upstream streaming TTS. Replaying it would duplicate and regress the current server-driven sentence pipeline. This revision retains only the resilience fixes that remain applicable.

## Testing

- `git diff --check origin/main..HEAD`
- `npx eslint src/lib/voice-playback.ts src/hermes.ts`
- `npm run typecheck`
- `npx vitest run --environment jsdom src/hermes.test.ts` — 19 passed
- `uv run --with pytest python -m pytest tests/tools/test_tts_opus_routing.py -q -o 'addopts='` — 2 passed

## Notes

This is intentionally a small compatibility update over current upstream streaming behavior, not a reintroduction of the former renderer-side queue/prefetch design.
