### PR TITLE
fix(dashboard): pass --yes to skills install spawned from web UI

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7639,7 +7639,7 @@ async def install_skill_hub(body: SkillInstallRequest, profile: Optional[str] = 
         raise HTTPException(status_code=400, detail="identifier is required")
     try:
         proc = _spawn_hermes_action(
-            _profile_cli_args(body.profile or profile) + ["skills", "install", identifier],
+            _profile_cli_args(body.profile or profile) + ["skills", "install", identifier, "--yes"],
             "skills-install",
         )
     except HTTPException:
@@ -8377,7 +8377,7 @@ async def create_profile_endpoint(body: ProfileCreate):
             continue
         try:
             proc = _spawn_hermes_action(
-                ["-p", body.name, "skills", "install", ident],
+                ["-p", body.name, "skills", "install", ident, "--yes"],
                 "skills-install",
             )
             hub_installs.append({"identifier": ident, "pid": proc.pid})


### PR DESCRIPTION
## Summary
- The dashboard's "Browse Hub" skill install (`/api/skills/hub/install`) and the new-profile hub-skill installer both spawn `hermes skills install <id>` with stdin closed, but the CLI prompts for confirmation and that prompt hits EOF, auto-cancelling the install.
- Add `--yes` to both spawn sites, matching the existing `/api/skills/hub/uninstall` endpoint which already passes `--yes`.

Fixes #43829

## Test plan
- [ ] Confirm `hermes skills install <id> --yes` installs without prompting
- [ ] Confirm Browse Hub install in the dashboard now completes instead of cancelling