### PR TITLE
fix: harden Discord self-repair loop

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -685,14 +685,29 @@ class DiscordAdapter(BasePlatformAdapter):
                 }
 
             # Set up intents.
-            # Message Content is required for normal text replies.
+            # Message Content is required for normal text replies, but it is a
+            # privileged intent in Discord's Developer Portal. Requesting it when
+            # it has not been enabled prevents the bot from coming online at all.
+            # Allow a local fallback so slash-command-only operation can still
+            # connect while the portal setting is fixed.
+            message_content_env = os.getenv("DISCORD_MESSAGE_CONTENT_INTENT", "true").strip().lower()
+            request_message_content = message_content_env not in {"0", "false", "no", "off"}
             # Server Members is only needed when the allowlist contains usernames
             # that must be resolved to numeric IDs. Requesting privileged intents
             # that aren't enabled in the Discord Developer Portal can prevent the
             # bot from coming online at all, so avoid requesting members intent
             # unless it is actually necessary.
             intents = Intents.default()
-            intents.message_content = True
+            intents.message_content = request_message_content
+            if not request_message_content:
+                logger.warning(
+                    "[%s] DISCORD_MESSAGE_CONTENT_INTENT=false: Discord will connect "
+                    "without Message Content intent; normal text-message replies may "
+                    "not work, but slash commands such as /ask can still be used. "
+                    "Enable Message Content Intent in the Discord Developer Portal "
+                    "and remove this env override for full functionality.",
+                    self.name,
+                )
             intents.dm_messages = True
             intents.guild_messages = True
             intents.members = (
@@ -782,14 +797,31 @@ class DiscordAdapter(BasePlatformAdapter):
                 # permitted by DISCORD_ALLOW_BOTS are not rejected for
                 # not being in DISCORD_ALLOWED_USERS (fixes #4466).
                 if getattr(message.author, "bot", False):
-                    allow_bots = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
-                    if allow_bots == "none":
-                        return
-                    elif allow_bots == "mentions":
-                        if not self._client.user or self._client.user not in message.mentions:
+                    # Bot authors are allowed if explicitly listed in
+                    # DISCORD_ALLOWED_USERS. This matters for multi-agent
+                    # Discord workflows where another Hermes bot (e.g. a
+                    # handoff/intake agent) @mentions this bot.  The older
+                    # logic checked DISCORD_ALLOW_BOTS before the allowlist,
+                    # so an explicitly trusted bot was silently dropped when
+                    # DISCORD_ALLOW_BOTS kept its safe default of "none".
+                    author_id = str(getattr(message.author, "id", ""))
+                    explicitly_allowed_bot = bool(author_id and author_id in self._allowed_user_ids)
+                    if not explicitly_allowed_bot:
+                        allow_bots = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
+                        if allow_bots == "none":
+                            logger.debug(
+                                "[%s] Ignoring bot message from non-allowlisted bot %s",
+                                self.name,
+                                author_id or getattr(message.author, "name", "unknown"),
+                            )
                             return
-                    # "all" falls through; bot is permitted — skip the
-                    # human-user allowlist below (bots aren't in it).
+                        elif allow_bots == "mentions":
+                            client_user = self._client.user if self._client else None
+                            if not client_user or client_user not in message.mentions:
+                                return
+                    # "all" falls through; explicitly allowlisted bots also
+                    # fall through. Skip the human-user role gate below because
+                    # bots do not have the same member/role shape everywhere.
                 else:
                     # Non-bot: enforce the configured user/role allowlists.
                     # Pass guild + is_dm so role checks are scoped to the

--- a/tests/gateway/test_discord_bot_filter.py
+++ b/tests/gateway/test_discord_bot_filter.py
@@ -2,7 +2,7 @@
 
 import os
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 
 def _make_author(*, bot: bool = False, is_self: bool = False):
@@ -40,20 +40,24 @@ def _make_message(*, author=None, content="hello", mentions=None, is_dm=False):
 class TestDiscordBotFilter(unittest.TestCase):
     """Test the DISCORD_ALLOW_BOTS filtering logic."""
 
-    def _run_filter(self, message, allow_bots="none", client_user=None):
+    def _run_filter(self, message, allow_bots="none", client_user=None, allowed_user_ids=None):
         """Simulate the on_message filter logic and return whether message was accepted."""
         # Replicate the exact filter logic from discord.py on_message
         if message.author == client_user:
             return False  # own messages always ignored
 
+        allowed_user_ids = allowed_user_ids or set()
         if getattr(message.author, "bot", False):
-            allow = allow_bots.lower().strip()
-            if allow == "none":
-                return False
-            elif allow == "mentions":
-                if not client_user or client_user not in message.mentions:
+            author_id = str(getattr(message.author, "id", ""))
+            explicitly_allowed_bot = bool(author_id and author_id in allowed_user_ids)
+            if not explicitly_allowed_bot:
+                allow = allow_bots.lower().strip()
+                if allow == "none":
                     return False
-            # "all" falls through
+                elif allow == "mentions":
+                    if not client_user or client_user not in message.mentions:
+                        return False
+            # "all" falls through; explicit allowlist falls through
         
         return True  # message accepted
 
@@ -72,10 +76,24 @@ class TestDiscordBotFilter(unittest.TestCase):
         self.assertTrue(self._run_filter(msg, "all"))
 
     def test_allow_bots_none_rejects_bots(self):
-        """With allow_bots=none, all other bot messages are rejected."""
+        """With allow_bots=none, non-allowlisted bot messages are rejected."""
         bot = _make_author(bot=True)
         msg = _make_message(author=bot)
         self.assertFalse(self._run_filter(msg, "none"))
+
+    def test_allow_bots_none_accepts_explicitly_allowlisted_bot(self):
+        """DISCORD_ALLOWED_USERS can explicitly trust another bot/agent."""
+        our_user = _make_author(is_self=True)
+        bot = _make_author(bot=True)
+        msg = _make_message(author=bot, mentions=[our_user])
+        self.assertTrue(
+            self._run_filter(
+                msg,
+                "none",
+                our_user,
+                allowed_user_ids={str(bot.id)},
+            )
+        )
 
     def test_allow_bots_all_accepts_bots(self):
         """With allow_bots=all, all bot messages are accepted."""
@@ -99,7 +117,8 @@ class TestDiscordBotFilter(unittest.TestCase):
 
     def test_default_is_none(self):
         """Default behavior (no env var) should be 'none'."""
-        default = os.getenv("DISCORD_ALLOW_BOTS", "none")
+        with patch.dict(os.environ, {}, clear=True):
+            default = os.getenv("DISCORD_ALLOW_BOTS", "none")
         self.assertEqual(default, "none")
 
     def test_case_insensitive(self):


### PR DESCRIPTION
## Summary
- allow Discord to connect in slash-command-only mode when Message Content intent is locally disabled
- accept explicitly allowlisted bot authors even when DISCORD_ALLOW_BOTS keeps the safe default of none
- update bot-filter tests and isolate the default-env assertion

## Tests
- python -m pytest tests/gateway/test_discord_bot_filter.py tests/gateway/test_discord_connect.py -q -o 'addopts='