### PR TITLE
fix(kanban): kanban_complete is idempotent for already-terminal tasks

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -1812,3 +1812,38 @@ def test_board_param_in_all_schemas():
         assert "board" not in schema["parameters"].get("required", []), (
             f"{schema['name']} marks board as required; must be optional"
         )
+
+
+def test_complete_is_idempotent_for_already_done_task(worker_env):
+    """A worker calling kanban_complete on an ALREADY-done task with no summary
+    must get success (not 'provide at least one of: summary'), so it exits cleanly.
+
+    Regression: the parameter validation ran BEFORE the already-terminal check, so
+    a worker that re-called complete on a done task (with nothing to add) hit the
+    'provide a summary' error, retried forever, and became a zombie that held an
+    inference slot. complete must be idempotent for terminal tasks.
+    """
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    tid = worker_env  # already created + claimed (status running)
+
+    # Drive the task to a terminal (done) state, as the dispatcher would after a
+    # successful first completion.
+    conn = kb.connect()
+    try:
+        assert kb.complete_task(conn, tid, summary="first completion") is True
+    finally:
+        conn.close()
+
+    # Now the worker calls complete again with NO summary (it has nothing to add —
+    # the task is already done). This is the exact call that used to loop forever.
+    out = kt._handle_complete({"task_id": tid})
+    d = json.loads(out)
+
+    assert d.get("ok") is True, (
+        f"completing an already-done task must succeed, got: {out}"
+    )
+    assert "provide at least one of" not in out, (
+        "must NOT demand a summary for an already-terminal task"
+    )

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -483,6 +483,26 @@ def _handle_complete(args: dict, **kw) -> str:
     ownership_err = _enforce_worker_task_ownership(tid)
     if ownership_err:
         return ownership_err
+    # Idempotent early-out for an already-terminal task. If the task is already
+    # done/archived the work is finished, so return success and let the worker exit
+    # cleanly — WITHOUT requiring a summary. Otherwise a worker that re-calls
+    # kanban_complete on a done task with no summary hits the "provide at least one
+    # of: summary" validation below, retries the identical call (it has nothing to
+    # add — the task is done), and loops forever, becoming a zombie that never exits
+    # and holds an inference slot. The parameter validation must not gate a task that
+    # is already complete.
+    try:
+        kb_chk, conn_chk = _connect(board=args.get("board"))
+        try:
+            _existing = kb_chk.get_task(conn_chk, tid)
+        finally:
+            conn_chk.close()
+        if _existing is not None and getattr(_existing, "status", None) in ("done", "archived"):
+            return _ok(task_id=tid, already_complete=True)
+    except Exception:
+        # A failure in the status probe must never block a legitimate completion;
+        # fall through to the normal path.
+        pass
     summary = args.get("summary")
     metadata = args.get("metadata")
     result = args.get("result")


### PR DESCRIPTION
A worker calling kanban_complete on an already-done task with no summary hit the
"provide at least one of: summary" validation, which runs BEFORE the
already-terminal check. The worker then retried the identical call (it has nothing
to add — the task is done) and looped forever, becoming a zombie process that never
exits and holds an inference/worker slot. Under a per-profile in-progress cap this
also stalls the dispatcher, which sees the slot occupied and stops spawning.

Add an idempotent early-out: if the task is already done/archived, return success so
the worker exits cleanly, without demanding a summary. The status probe is wrapped so
a probe failure never blocks a legitimate completion.

Adds a regression test that drives a task to done then re-completes it with no
summary, asserting success instead of the summary-required error.
