### PR TITLE
fix(feishu): use interactive operator auth for approval card actions

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2772,8 +2772,7 @@ class FeishuAdapter(BasePlatformAdapter):
 
         operator = getattr(event, "operator", None)
         open_id = str(getattr(operator, "open_id", "") or "")
-        sender_id = SimpleNamespace(open_id=open_id, user_id=str(getattr(operator, "user_id", "") or ""))
-        if not self._allow_group_message(sender_id, state.get("chat_id", ""), is_bot=False):
+        if not self._is_interactive_operator_authorized(open_id):
             logger.warning("[Feishu] Unauthorized approval click by %s", open_id or "<unknown>")
             return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
 

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -401,6 +401,63 @@ class TestCardActionCallbackResponse:
         assert response.card is None
         mock_submit.assert_not_called()
 
+    def test_update_prompt_empty_allowlists_fail_closed(self, _patch_callback_card_types):
+        """When no allowlists are configured, update-prompt card actions are rejected.
+
+        This matches ``_allow_group_message`` which defaults to ``allowlist``
+        policy — with no allowed users configured, everyone is rejected by
+        default (fail-closed), preserving the security boundary for update
+        prompts.
+        """
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._update_prompt_state[7] = {
+            "session_key": "sess-up-7",
+            "message_id": "msg_up_007",
+            "chat_id": "oc_12345",
+        }
+        data = _make_card_action_data(
+            {"hermes_update_prompt_action": "y", "update_prompt_id": 7},
+            open_id="ou_intruder",
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_submit:
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is None
+        assert 7 in adapter._update_prompt_state
+        mock_submit.assert_not_called()
+
+    def test_approval_empty_allowlists_open_by_default(self, _patch_callback_card_types):
+        """When no allowlists are configured, any card-action operator is authorized for approvals.
+
+        This matches ``_is_interactive_operator_authorized`` which returns True
+        when both ``_admins`` and ``_allowed_group_users`` are empty — there is
+        no restriction configured, so there is no restriction applied. Approval
+        cards are workflow-level, not system-level, so they default open.
+        """
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._approval_state[9] = {
+            "session_key": "sess-ap-9",
+            "message_id": "msg_ap_009",
+            "chat_id": "oc_12345",
+        }
+        data = _make_card_action_data(
+            {"hermes_action": "approve_once", "approval_id": 9},
+            open_id="ou_intruder",
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        # Authorized — card is returned and resolution is scheduled.
+        assert response.card is not None
+        assert response.card.type == "raw"
 
     def test_update_prompt_chat_mismatch_returns_no_card(self, _patch_callback_card_types):
         adapter = _make_adapter()


### PR DESCRIPTION
Approval card-action buttons (approve/deny) now use `_is_interactive_operator_authorized`, which allows clicks when no admins/allowlists are configured — fixing button clicks being silently rejected in default setups.

Update-prompt card actions intentionally keep the fail-closed `_allow_group_message` check (3fa15b33d): they write state, so they stay locked down when no allowlist is configured.

Rebased on latest main. Tests: `scripts/run_tests.sh tests/gateway/test_feishu_approval_buttons.py` — 15 passed.