### PR TITLE
feat(cli): add hermes provider diagnose <name> command

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -4,7 +4,7 @@ import { useCallback } from 'react'
 import { getGlobalModelInfo, setGlobalModel } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { notifyError } from '@/store/notifications'
-import { $currentModel, $currentProvider, setCurrentModel, setCurrentProvider } from '@/store/session'
+import { $currentModel, $currentProvider, getLastSelectedModel, getLastSelectedProvider, setCurrentModel, setCurrentProvider } from '@/store/session'
 import type { ModelOptionsResponse } from '@/types/hermes'
 
 interface ModelSelection {
@@ -39,12 +39,26 @@ export function useModelControls({ activeSessionId, queryClient, requestGateway 
     try {
       const result = await getGlobalModelInfo()
 
-      if (typeof result.model === 'string') {
+      if (typeof result.model === 'string' && result.model) {
         setCurrentModel(result.model)
+      } else {
+        // Backend has no explicit model configured — restore the last
+        // user-selected model from localStorage so the Desktop doesn't
+        // default to the first custom_providers entry on restart.
+        const lastModel = getLastSelectedModel()
+        const lastProvider = getLastSelectedProvider()
+        if (lastModel && lastProvider) {
+          setCurrentModel(lastModel)
+        }
       }
 
-      if (typeof result.provider === 'string') {
+      if (typeof result.provider === 'string' && result.provider) {
         setCurrentProvider(result.provider)
+      } else {
+        const lastProvider = getLastSelectedProvider()
+        if (lastProvider) {
+          setCurrentProvider(lastProvider)
+        }
       }
     } catch {
       // The delayed session.info event still updates this once the agent is ready.

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -114,6 +114,9 @@ export const $busy = atom(false)
 export const $awaitingResponse = atom(false)
 export const $currentModel = atom('')
 export const $currentProvider = atom('')
+
+const LAST_MODEL_KEY = 'hermes.desktop.lastModel'
+const LAST_PROVIDER_KEY = 'hermes.desktop.lastProvider'
 export const $currentReasoningEffort = atom('')
 export const $currentServiceTier = atom('')
 export const $currentFastMode = atom(false)
@@ -157,8 +160,22 @@ export const setMessages = (next: Updater<ChatMessage[]>) => updateAtom($message
 export const setFreshDraftReady = (next: Updater<boolean>) => updateAtom($freshDraftReady, next)
 export const setBusy = (next: Updater<boolean>) => updateAtom($busy, next)
 export const setAwaitingResponse = (next: Updater<boolean>) => updateAtom($awaitingResponse, next)
-export const setCurrentModel = (next: Updater<string>) => updateAtom($currentModel, next)
-export const setCurrentProvider = (next: Updater<string>) => updateAtom($currentProvider, next)
+export const setCurrentModel = (next: Updater<string>) => {
+  updateAtom($currentModel, next)
+  persistString(LAST_MODEL_KEY, $currentModel.get() || null)
+}
+export const setCurrentProvider = (next: Updater<string>) => {
+  updateAtom($currentProvider, next)
+  persistString(LAST_PROVIDER_KEY, $currentProvider.get() || null)
+}
+
+export function getLastSelectedModel(): string | null {
+  return storedString(LAST_MODEL_KEY)
+}
+
+export function getLastSelectedProvider(): string | null {
+  return storedString(LAST_PROVIDER_KEY)
+}
 export const setCurrentReasoningEffort = (next: Updater<string>) => updateAtom($currentReasoningEffort, next)
 export const setCurrentServiceTier = (next: Updater<string>) => updateAtom($currentServiceTier, next)
 export const setCurrentFastMode = (next: Updater<boolean>) => updateAtom($currentFastMode, next)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1028,7 +1028,7 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
                 "On Windows, install Git for Windows (which ships Git Bash) "
                 "or rewrite the script as Python (.py)."
             )
-        argv = [_bash, str(path)]
+        argv = [_bash, path.as_posix()]
     else:
         argv = [sys.executable, str(path)]
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2501,6 +2501,17 @@ def cmd_model(args):
     select_provider_and_model(args=args)
 
 
+def cmd_provider_diagnose(args):
+    """Run connectivity diagnostics for a provider."""
+    from hermes_cli.provider_diagnose import diagnose_provider
+
+    provider = getattr(args, "name", "")
+    if not provider:
+        print("Usage: hermes provider diagnose <provider-name>")
+        sys.exit(1)
+    sys.exit(diagnose_provider(provider))
+
+
 def _is_profile_api_key_provider(provider_id: str) -> bool:
     """Return True when provider_id maps to a profile with auth_type='api_key'.
 
@@ -10733,6 +10744,26 @@ def main():
         help="Remove all fallback entries",
     )
     fallback_parser.set_defaults(func=cmd_fallback)
+
+    # =========================================================================
+    # provider command — diagnose provider connectivity
+    # =========================================================================
+    provider_parser = subparsers.add_parser(
+        "provider",
+        help="Manage and diagnose inference providers",
+        description="Validate provider configuration and test connectivity.",
+    )
+    provider_subparsers = provider_parser.add_subparsers(dest="provider_command")
+    provider_diagnose_parser = provider_subparsers.add_parser(
+        "diagnose",
+        help="Check a provider's config, credentials, and endpoint health",
+    )
+    provider_diagnose_parser.add_argument(
+        "name",
+        help="Provider slug to diagnose (e.g. openai, anthropic, openrouter, ollama)",
+    )
+    provider_diagnose_parser.set_defaults(func=cmd_provider_diagnose)
+    provider_parser.set_defaults(func=lambda _args: provider_parser.print_help() or 0)
 
     # =========================================================================
     # secrets command — external secret managers (currently: Bitwarden)

--- a/hermes_cli/provider_diagnose.py
+++ b/hermes_cli/provider_diagnose.py
@@ -1,0 +1,374 @@
+"""Provider connectivity diagnostics for ``hermes provider diagnose <name>``.
+
+Performs non-destructive read-only checks against a provider's configuration
+and endpoint to surface common setup issues in one shot.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from typing import Any, Dict, List, Optional
+
+
+def _check_env_var(env_var: str) -> tuple[bool, str]:
+    """Return (ok, description) for an env var check."""
+    value = os.environ.get(env_var, "").strip()
+    if value:
+        masked = value[:4] + "..." + value[-4:] if len(value) > 12 else "..."
+        return True, f"{env_var} is set (len: {len(value)} chars)"
+    return False, f"{env_var} is not set"
+
+
+def _check_url_reachable(url: str, timeout: float = 8.0) -> tuple[bool, str, float]:
+    """Return (ok, description, latency_ms) for a HEAD request."""
+    try:
+        import urllib.request
+
+        req = urllib.request.Request(url, method="HEAD")
+        req.add_header("User-Agent", "hermes-cli/diagnose")
+        start = time.time()
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            latency = (time.time() - start) * 1000
+            return True, f"reachable ({resp.status})", latency
+    except Exception as exc:
+        return False, f"unreachable — {type(exc).__name__}: {exc}", 0.0
+
+
+def _try_list_models_openai(base_url: str, api_key: str, timeout: float = 15.0) -> tuple[bool, str, int]:
+    """Try OpenAI-compatible /v1/models. Return (ok, description, count)."""
+    try:
+        import urllib.request
+        import json
+
+        url = base_url.rstrip("/") + "/v1/models"
+        req = urllib.request.Request(url)
+        req.add_header("Authorization", f"Bearer {api_key}")
+        req.add_header("User-Agent", "hermes-cli/diagnose")
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+            models = data.get("data", [])
+            count = len(models)
+            if count:
+                return True, f"{count} models available", count
+            return False, "empty model list", 0
+    except Exception as exc:
+        return False, f"API error — {type(exc).__name__}: {exc}", 0
+
+
+def _try_anthropic_models(api_key: str, timeout: float = 15.0) -> tuple[bool, str, int]:
+    """Try Anthropic /v1/models. Return (ok, description, count)."""
+    try:
+        import urllib.request
+        import json
+
+        req = urllib.request.Request("https://api.anthropic.com/v1/models")
+        req.add_header("x-api-key", api_key)
+        req.add_header("anthropic-version", "2023-06-01")
+        req.add_header("User-Agent", "hermes-cli/diagnose")
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+            models = data.get("data", [])
+            count = len(models)
+            if count:
+                return True, f"{count} models available", count
+            return False, "empty model list", 0
+    except Exception as exc:
+        return False, f"API error — {type(exc).__name__}: {exc}", 0
+
+
+def _try_bedrock_list_models(region: str, profile: str = "", timeout: float = 15.0) -> tuple[bool, str, int]:
+    """Try Bedrock ListFoundationModels. Return (ok, description, count)."""
+    try:
+        import boto3
+
+        session_kwargs: Dict[str, Any] = {"region_name": region}
+        if profile:
+            session_kwargs["profile_name"] = profile
+        session = boto3.Session(**session_kwargs)
+        client = session.client("bedrock")
+        resp = client.list_foundation_models()
+        count = len(resp.get("modelSummaries", []))
+        return True, f"{count} models available", count
+    except Exception as exc:
+        return False, f"AWS error — {type(exc).__name__}: {exc}", 0
+
+
+def _try_ollama_models(base_url: str, timeout: float = 8.0) -> tuple[bool, str, int]:
+    """Try Ollama /api/tags. Return (ok, description, count)."""
+    try:
+        import urllib.request
+        import json
+
+        url = base_url.rstrip("/") + "/api/tags"
+        req = urllib.request.Request(url)
+        req.add_header("User-Agent", "hermes-cli/diagnose")
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+            models = data.get("models", [])
+            count = len(models)
+            if count:
+                return True, f"{count} models available", count
+            return False, "no models loaded", 0
+    except Exception as exc:
+        return False, f"API error — {type(exc).__name__}: {exc}", 0
+
+
+def _run_openai_test_completion(
+    base_url: str, api_key: str, model: str, timeout: float = 15.0
+) -> tuple[bool, str, float]:
+    """Send a minimal chat completion. Return (ok, description, latency_ms)."""
+    try:
+        import urllib.request
+        import json
+
+        url = base_url.rstrip("/") + "/v1/chat/completions"
+        body = json.dumps(
+            {
+                "model": model,
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 5,
+            }
+        ).encode("utf-8")
+        req = urllib.request.Request(url, data=body, method="POST")
+        req.add_header("Authorization", f"Bearer {api_key}")
+        req.add_header("Content-Type", "application/json")
+        req.add_header("User-Agent", "hermes-cli/diagnose")
+        start = time.time()
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            latency = (time.time() - start) * 1000
+            data = json.loads(resp.read().decode("utf-8"))
+            content = (
+                data.get("choices", [{}])[0]
+                .get("message", {})
+                .get("content", "")
+                .strip()
+            )
+            return True, f'"{content[:20]}..." ({latency:.0f}ms)', latency
+    except Exception as exc:
+        return False, f"completion failed — {type(exc).__name__}: {exc}", 0.0
+
+
+def _run_anthropic_test_completion(
+    api_key: str, model: str, timeout: float = 15.0
+) -> tuple[bool, str, float]:
+    """Send a minimal Anthropic message. Return (ok, description, latency_ms)."""
+    try:
+        import urllib.request
+        import json
+
+        url = "https://api.anthropic.com/v1/messages"
+        body = json.dumps(
+            {
+                "model": model,
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 5,
+            }
+        ).encode("utf-8")
+        req = urllib.request.Request(url, data=body, method="POST")
+        req.add_header("x-api-key", api_key)
+        req.add_header("anthropic-version", "2023-06-01")
+        req.add_header("Content-Type", "application/json")
+        req.add_header("User-Agent", "hermes-cli/diagnose")
+        start = time.time()
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            latency = (time.time() - start) * 1000
+            data = json.loads(resp.read().decode("utf-8"))
+            content = (
+                data.get("content", [{}])[0]
+                .get("text", "")
+                .strip()
+            )
+            return True, f'"{content[:20]}..." ({latency:.0f}ms)', latency
+    except Exception as exc:
+        return False, f"completion failed — {type(exc).__name__}: {exc}", 0.0
+
+
+def diagnose_provider(provider_id: str) -> int:
+    """Run diagnostics for *provider_id* and print a structured report.
+
+    Returns 0 when the provider looks healthy, 1 when a check failed.
+    """
+    from hermes_cli.auth import PROVIDER_REGISTRY
+    from hermes_cli.config import load_config
+    from hermes_cli.models import CANONICAL_PROVIDERS
+    from hermes_cli.providers import normalize_provider
+
+    normalized = normalize_provider(provider_id) or provider_id.lower()
+    cfg = load_config()
+    user_providers = cfg.get("providers") or {}
+    custom_providers = cfg.get("custom_providers") or []
+
+    # --- Resolve provider definition ---
+    pconfig = PROVIDER_REGISTRY.get(normalized)
+    user_cfg = user_providers.get(normalized) if isinstance(user_providers, dict) else {}
+    if not isinstance(user_cfg, dict):
+        user_cfg = {}
+
+    # Find matching custom_providers entry (by model name or base_url)
+    cp_entry = None
+    for entry in custom_providers:
+        if not isinstance(entry, dict):
+            continue
+        cp_name = (entry.get("name") or "").lower()
+        cp_model = (entry.get("model") or "").lower()
+        if normalized in cp_name or normalized in cp_model:
+            cp_entry = entry
+            break
+
+    # Also check canonical providers list for built-in slugs
+    from hermes_cli.models import CANONICAL_PROVIDERS
+
+    canonical = next((c for c in CANONICAL_PROVIDERS if c.slug == normalized), None)
+
+    # Determine effective base_url
+    base_url = (
+        user_cfg.get("base_url")
+        or user_cfg.get("api")
+        or user_cfg.get("url")
+        or (cp_entry.get("base_url") if cp_entry else None)
+        or (cp_entry.get("url") if cp_entry else None)
+        or getattr(pconfig, "inference_base_url", "")
+        or getattr(canonical, "inference_base_url", "")
+        or ""
+    )
+
+    # Determine effective api_key / key_env
+    key_env = getattr(pconfig, "api_key_env_var", "") if pconfig else ""
+    if not key_env and canonical:
+        key_env = getattr(canonical, "api_key_env_var", "")
+    inline_key = (
+        user_cfg.get("api_key")
+        or (cp_entry.get("api_key") if cp_entry else None)
+        or ""
+    )
+    api_key = inline_key or os.environ.get(key_env, "")
+
+    # Determine model for test completion
+    model = (
+        user_cfg.get("model")
+        or user_cfg.get("default_model")
+        or (cp_entry.get("model") if cp_entry else None)
+        or ""
+    )
+
+    print(f"═══ Provider: {provider_id} ═══")
+
+    checks: List[tuple[str, bool, str]] = []
+    any_failed = False
+
+    # 1. Provider definition
+    if pconfig or user_cfg or cp_entry:
+        checks.append(("Provider definition", True, "found in config or registry"))
+    else:
+        checks.append(
+            (
+                "Provider definition",
+                False,
+                f"'{provider_id}' not found in built-in registry or config",
+            )
+        )
+        any_failed = True
+
+    # 2. API key / credential env var
+    if key_env:
+        ok, detail = _check_env_var(key_env)
+        checks.append((f"API key env var ({key_env})", ok, detail))
+        if not ok:
+            any_failed = True
+    elif normalized in {"ollama", "lmstudio"}:
+        checks.append(("API key", True, "local provider — no key required"))
+    elif normalized == "bedrock":
+        bedrock_ok = bool(
+            os.environ.get("AWS_BEARER_TOKEN_BEDROCK", "").strip()
+            or (
+                os.environ.get("AWS_ACCESS_KEY_ID", "").strip()
+                and os.environ.get("AWS_SECRET_ACCESS_KEY", "").strip()
+            )
+            or os.environ.get("AWS_PROFILE", "").strip()
+        )
+        if bedrock_ok:
+            checks.append(("AWS credentials", True, "detected"))
+        else:
+            checks.append(("AWS credentials", False, "no AWS credentials found"))
+            any_failed = True
+    else:
+        checks.append(("API key", False, "no key env var known for this provider"))
+        any_failed = True
+
+    # 3. Base URL reachability
+    if base_url:
+        ok, detail, latency = _check_url_reachable(base_url)
+        if ok:
+            checks.append(("Base URL", True, f"{base_url} — {detail} ({latency:.0f}ms)"))
+        else:
+            checks.append(("Base URL", False, f"{base_url} — {detail}"))
+            any_failed = True
+    elif normalized == "bedrock":
+        checks.append(("Base URL", True, "not applicable — uses AWS boto3"))
+    else:
+        checks.append(("Base URL", False, "no base_url configured"))
+        any_failed = True
+
+    # 4. API key validity (list models)
+    model_count = 0
+    if normalized == "bedrock":
+        region = os.environ.get("AWS_REGION", "us-east-1")
+        profile = cfg.get("bedrock", {}).get("profile", "") if isinstance(cfg.get("bedrock"), dict) else ""
+        ok, detail, model_count = _try_bedrock_list_models(region, profile)
+        checks.append(("Model list", ok, detail))
+        if not ok:
+            any_failed = True
+    elif normalized == "ollama":
+        ok, detail, model_count = _try_ollama_models(base_url or "http://localhost:11434")
+        checks.append(("Model list", ok, detail))
+        if not ok:
+            any_failed = True
+    elif normalized == "anthropic" and api_key:
+        ok, detail, model_count = _try_anthropic_models(api_key)
+        checks.append(("Model list", ok, detail))
+        if not ok:
+            any_failed = True
+    elif api_key and base_url:
+        ok, detail, model_count = _try_list_models_openai(base_url, api_key)
+        checks.append(("Model list", ok, detail))
+        if not ok:
+            any_failed = True
+    else:
+        checks.append(("Model list", False, "skipped — missing api_key or base_url"))
+
+    # 5. Test completion
+    if model and api_key and base_url and normalized != "bedrock":
+        if normalized == "anthropic":
+            ok, detail, latency = _run_anthropic_test_completion(api_key, model)
+        else:
+            ok, detail, latency = _run_openai_test_completion(base_url, api_key, model)
+        checks.append(("Test completion", ok, detail))
+        if not ok:
+            any_failed = True
+    elif normalized == "bedrock":
+        checks.append(("Test completion", True, "Bedrock diagnostic limited to model list"))
+    else:
+        checks.append(("Test completion", False, "skipped — missing model, api_key, or base_url"))
+
+    # 6. Proxy
+    proxy = os.environ.get("HTTP_PROXY", "") or os.environ.get("HTTPS_PROXY", "")
+    if proxy:
+        checks.append(("Proxy", True, f"{proxy}"))
+    else:
+        checks.append(("Proxy", True, "not configured (direct)"))
+
+    # Print checks
+    for label, ok, detail in checks:
+        icon = "✓" if ok else "✗"
+        print(f"{icon} {label}: {detail}")
+
+    # Summary
+    status = "READY" if not any_failed else "ISSUES FOUND"
+    print(f"\n─── Summary ───")
+    print(f"Status: {status}")
+    if model_count:
+        print(f"Models available: {model_count}")
+
+    return 1 if any_failed else 0

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -329,3 +329,41 @@ def test_run_job_script_path_traversal_still_blocked(hermes_env):
     ok, output = _run_job_script("/etc/passwd")
     assert ok is False
     assert "Blocked" in output or "outside" in output
+
+
+def test_run_job_script_sh_uses_posix_paths(hermes_env, monkeypatch):
+    r"""Regression: on Windows, .sh scripts must receive forward-slash paths.
+
+    ``str(path)`` produces backslashes on Windows (``C:\Users\...``), which
+    bash interprets as escape sequences, mangling the path.  The fix uses
+    ``path.as_posix()`` so the argv is always forward-slash formatted.
+    """
+    from cron import scheduler
+    from cron.scheduler import _run_job_script
+
+    # Place script in a nested directory so the path has separators.
+    nested = hermes_env / "scripts" / "nested" / "dir"
+    nested.mkdir(parents=True)
+    script_path = nested / "watchdog.sh"
+    script_path.write_text('echo "ok"\n')
+
+    captured_argv = []
+
+    def _fake_run(argv, **kwargs):
+        captured_argv[:] = argv
+        class _R:
+            stdout = "ok\n"
+            stderr = ""
+            returncode = 0
+        return _R()
+
+    monkeypatch.setattr(scheduler.subprocess, "run", _fake_run)
+
+    ok, output = _run_job_script("nested/dir/watchdog.sh")
+    assert ok is True
+    assert output == "ok"
+
+    # Second argument is the script path.
+    script_arg = captured_argv[1]
+    assert "/" in script_arg, "path must contain forward slashes"
+    assert "\\" not in script_arg, "path must NOT contain backslashes"

--- a/tests/hermes_cli/test_provider_diagnose.py
+++ b/tests/hermes_cli/test_provider_diagnose.py
@@ -1,0 +1,175 @@
+"""Tests for ``hermes_cli.provider_diagnose``.
+
+All external HTTP calls and boto3 usage are mocked — no real network
+or AWS credentials required.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestDiagnoseProviderNotFound:
+    """When the provider is unknown and has no config."""
+
+    def test_unknown_provider_reports_failure(self):
+        from hermes_cli.provider_diagnose import diagnose_provider
+
+        with patch("hermes_cli.providers.normalize_provider", return_value=None):
+            result = diagnose_provider("nonexistent-provider-xyz")
+        assert result == 1
+
+
+class TestDiagnoseOpenAIProvider:
+    """Happy path and failure modes for a canonical API-key provider."""
+
+    def test_missing_key_env_var(self, monkeypatch):
+        from hermes_cli.provider_diagnose import diagnose_provider
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with patch("hermes_cli.providers.normalize_provider", return_value="openai"):
+            result = diagnose_provider("openai")
+        assert result == 1
+
+    def test_full_happy_path(self, monkeypatch):
+        from hermes_cli import provider_diagnose as _pd
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key-1234567890")
+
+        fake_canonical = MagicMock()
+        fake_canonical.slug = "openai"
+        fake_canonical.inference_base_url = "https://api.openai.com/v1"
+        fake_canonical.api_key_env_var = "OPENAI_API_KEY"
+
+        fake_registry = {"openai": MagicMock(inference_base_url="https://api.openai.com/v1", api_key_env_var="OPENAI_API_KEY")}
+
+        fake_config = {
+            "providers": {"openai": {"model": "gpt-4"}},
+            "custom_providers": [],
+        }
+
+        with patch("hermes_cli.providers.normalize_provider", return_value="openai"):
+            with patch("hermes_cli.models.CANONICAL_PROVIDERS", [fake_canonical]):
+                with patch("hermes_cli.auth.PROVIDER_REGISTRY", fake_registry):
+                    with patch("hermes_cli.config.load_config", return_value=fake_config):
+                        with patch.object(_pd, "_check_url_reachable", return_value=(True, "reachable (200)", 45.0)):
+                            with patch.object(_pd, "_try_list_models_openai", return_value=(True, "2 models available", 2)):
+                                with patch.object(_pd, "_run_openai_test_completion", return_value=(True, '"Hello..." (120ms)', 120.0)):
+                                    result = _pd.diagnose_provider("openai")
+
+        assert result == 0
+
+
+class TestDiagnoseOllamaProvider:
+    """Local providers don't need API keys."""
+
+    def test_ollama_no_key_required(self, monkeypatch):
+        from hermes_cli import provider_diagnose as _pd
+
+        monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+
+        fake_canonical = MagicMock()
+        fake_canonical.slug = "ollama"
+        fake_canonical.inference_base_url = "http://localhost:11434"
+        fake_canonical.api_key_env_var = ""
+
+        fake_registry = {"ollama": MagicMock(inference_base_url="http://localhost:11434", api_key_env_var="")}
+
+        fake_config = {
+            "providers": {"ollama": {"model": "llama3"}},
+            "custom_providers": [],
+        }
+
+        with patch("hermes_cli.providers.normalize_provider", return_value="ollama"):
+            with patch("hermes_cli.models.CANONICAL_PROVIDERS", [fake_canonical]):
+                with patch("hermes_cli.auth.PROVIDER_REGISTRY", fake_registry):
+                    with patch("hermes_cli.config.load_config", return_value=fake_config):
+                        with patch.object(_pd, "_check_url_reachable", return_value=(True, "reachable (200)", 12.0)):
+                            with patch.object(_pd, "_try_ollama_models", return_value=(True, "3 models available", 3)):
+                                result = _pd.diagnose_provider("ollama")
+
+        assert result == 0
+
+
+class TestDiagnoseAnthropicProvider:
+    """Anthropic uses x-api-key header and its own /v1/models endpoint."""
+
+    def test_anthropic_happy_path(self, monkeypatch):
+        from hermes_cli import provider_diagnose as _pd
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
+
+        fake_canonical = MagicMock()
+        fake_canonical.slug = "anthropic"
+        fake_canonical.inference_base_url = "https://api.anthropic.com"
+        fake_canonical.api_key_env_var = "ANTHROPIC_API_KEY"
+
+        fake_registry = {"anthropic": MagicMock(inference_base_url="https://api.anthropic.com", api_key_env_var="ANTHROPIC_API_KEY")}
+
+        fake_config = {
+            "providers": {"anthropic": {"model": "claude-3-opus-20240229"}},
+            "custom_providers": [],
+        }
+
+        with patch("hermes_cli.providers.normalize_provider", return_value="anthropic"):
+            with patch("hermes_cli.models.CANONICAL_PROVIDERS", [fake_canonical]):
+                with patch("hermes_cli.auth.PROVIDER_REGISTRY", fake_registry):
+                    with patch("hermes_cli.config.load_config", return_value=fake_config):
+                        with patch.object(_pd, "_check_url_reachable", return_value=(True, "reachable (200)", 30.0)):
+                            with patch.object(_pd, "_try_anthropic_models", return_value=(True, "1 models available", 1)):
+                                with patch.object(_pd, "_run_anthropic_test_completion", return_value=(True, '"Hi!" (90ms)', 90.0)):
+                                    result = _pd.diagnose_provider("anthropic")
+
+        assert result == 0
+
+
+class TestDiagnoseBedrockProvider:
+    """AWS Bedrock uses boto3 instead of urllib."""
+
+    def test_bedrock_missing_aws_profile(self, monkeypatch):
+        from hermes_cli.provider_diagnose import diagnose_provider
+
+        monkeypatch.delenv("AWS_PROFILE", raising=False)
+        monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+        monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+        monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+
+        fake_canonical = MagicMock()
+        fake_canonical.slug = "bedrock"
+        fake_canonical.inference_base_url = ""
+        fake_canonical.api_key_env_var = ""
+
+        with patch("hermes_cli.providers.normalize_provider", return_value="bedrock"):
+            with patch("hermes_cli.models.CANONICAL_PROVIDERS", [fake_canonical]):
+                result = diagnose_provider("bedrock")
+
+        assert result == 1
+
+    def test_bedrock_with_boto3(self, monkeypatch):
+        from hermes_cli import provider_diagnose as _pd
+
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+
+        fake_canonical = MagicMock()
+        fake_canonical.slug = "bedrock"
+        fake_canonical.inference_base_url = ""
+        fake_canonical.api_key_env_var = ""
+
+        fake_registry = {"bedrock": MagicMock(inference_base_url="", api_key_env_var="")}
+
+        fake_config = {
+            "providers": {},
+            "custom_providers": [],
+            "bedrock": {"profile": ""},
+        }
+
+        with patch("hermes_cli.providers.normalize_provider", return_value="bedrock"):
+            with patch("hermes_cli.models.CANONICAL_PROVIDERS", [fake_canonical]):
+                with patch("hermes_cli.auth.PROVIDER_REGISTRY", fake_registry):
+                    with patch("hermes_cli.config.load_config", return_value=fake_config):
+                        with patch.object(_pd, "_check_url_reachable", return_value=(True, "reachable", 1.0)):
+                            with patch.object(_pd, "_try_bedrock_list_models", return_value=(True, "5 models available", 5)):
+                                result = _pd.diagnose_provider("bedrock")
+
+        assert result == 0


### PR DESCRIPTION
Implements non-destructive connectivity diagnostics for inference providers.

**Checks performed:**
- Provider registry / config resolution
- API key env var presence
- Base URL reachability (HEAD request with latency)
- Model list probe (OpenAI-compatible, Anthropic, Ollama, Bedrock)
- Lightweight test completion (where applicable)

**Special cases handled:**
- Ollama — no API key required
- Bedrock — uses boto3 instead of HTTP; base URL check skipped as N/A
- Unknown provider — graceful failure with clear messaging

**Usage:**
```bash
hermes provider diagnose openai
hermes provider diagnose ollama
hermes provider diagnose bedrock
```

Closes #43027