### PR TITLE
fix(image-routing): check native vision support before aux override

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -337,12 +337,16 @@ def decide_image_input_mode(
         return "text"
 
     # auto
-    if _explicit_aux_vision_override(cfg):
-        return "text"
-
+    # Check native vision support first — if the main model can see images,
+    # use native mode directly rather than routing through an auxiliary vision
+    # LLM (which adds latency and may fail for providers that reject
+    # multimodal tool_result messages, e.g. Xiaomi MiMo).
     supports = _lookup_supports_vision(provider, model, cfg)
     if supports is True:
         return "native"
+
+    if _explicit_aux_vision_override(cfg):
+        return "text"
     return "text"
 
 

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -97,11 +97,17 @@ class TestDecideImageInputMode:
         with patch("agent.image_routing._lookup_supports_vision", return_value=None):
             assert decide_image_input_mode("openrouter", "brand-new-slug", {}) == "text"
 
-    def test_auto_respects_aux_vision_override_even_for_vision_model(self):
-        """If the user configured a dedicated vision backend, don't bypass it."""
+    def test_auto_native_vision_takes_priority_over_aux_override(self):
+        """When the main model supports vision natively, use it directly."""
         cfg = {"auxiliary": {"vision": {"provider": "openrouter", "model": "google/gemini-2.5-flash"}}}
         with patch("agent.image_routing._lookup_supports_vision", return_value=True):
-            assert decide_image_input_mode("anthropic", "claude-sonnet-4", cfg) == "text"
+            assert decide_image_input_mode("anthropic", "claude-sonnet-4", cfg) == "native"
+
+    def test_auto_aux_vision_override_used_when_main_model_lacks_vision(self):
+        """Aux vision override is used when the main model does NOT support vision."""
+        cfg = {"auxiliary": {"vision": {"provider": "openrouter", "model": "google/gemini-2.5-flash"}}}
+        with patch("agent.image_routing._lookup_supports_vision", return_value=False):
+            assert decide_image_input_mode("anthropic", "claude-2", cfg) == "text"
 
     def test_none_config_is_auto(self):
         with patch("agent.image_routing._lookup_supports_vision", return_value=True):
@@ -279,15 +285,15 @@ class TestAutoModeRespectsOverride:
         with patch("agent.models_dev.get_model_capabilities", return_value=None):
             assert decide_image_input_mode("custom", "unknown", {}) == "text"
 
-    def test_explicit_aux_vision_override_still_wins(self):
-        # If the user has configured a dedicated vision aux backend, respect
-        # it even when supports_vision: true is also set.
+    def test_native_vision_wins_over_aux_override_with_config_supports_vision(self):
+        # Native vision takes priority: if supports_vision: true is in config,
+        # use native even when aux backend is also configured.
         cfg = {
             "model": {"supports_vision": True},
             "auxiliary": {"vision": {"provider": "openrouter", "model": "gemini-2.5-pro"}},
         }
         with patch("agent.models_dev.get_model_capabilities", return_value=None):
-            assert decide_image_input_mode("custom", "qwen3.6-35b", cfg) == "text"
+            assert decide_image_input_mode("custom", "qwen3.6-35b", cfg) == "native"
 
 
 # ─── build_native_content_parts ──────────────────────────────────────────────


### PR DESCRIPTION
## Problem

When `auxiliary.vision` is explicitly configured in `config.yaml`, `_explicit_aux_vision_override()` forces **all** images through the auxiliary vision LLM text pipeline — even when the **main model itself supports vision natively** (e.g. `mimo-v2.5` with `supports_vision=True`).

This causes two issues:
1. **Unnecessary latency** — images are sent to an auxiliary vision model instead of being handled directly by the main model
2. **Provider failures** — providers like Xiaomi MiMo that accept images in user messages but reject them in `tool_result` messages get HTTP 400 errors when images are routed through the auxiliary pipeline

## Root Cause

In `agent/image_routing.py`, `decide_image_input_mode()` checks `_explicit_aux_vision_override()` **before** checking native vision support:

```python
# Before (buggy)
if _explicit_aux_vision_override(cfg):
    return "text"  # Always, regardless of main model capabilities

supports = _lookup_supports_vision(provider, model, cfg)
if supports is True:
    return "native"  # Never reached when aux is configured
```

## Fix

Swap the check order: verify native vision support first, then fall through to aux override only when the main model does NOT support vision:

```python
# After (fixed)
supports = _lookup_supports_vision(provider, model, cfg)
if supports is True:
    return "native"  # Main model can see images → use it

if _explicit_aux_vision_override(cfg):
    return "text"  # Main model can't see → use aux if configured
```

## Changes

- `agent/image_routing.py` — Swap check order in `decide_image_input_mode()`
- `tests/agent/test_image_routing.py` — Update 2 tests to reflect new priority (native wins over aux), add 1 test for aux fallback when main model lacks vision

## Testing

```
77 passed in 0.35s (test_image_routing.py)
30 passed in 0.23s (test_computer_use_vision_routing.py)
```

Closes #44299
