### PR TITLE
fix(desktop): keep assistant prose contiguous around thinking

### DIFF
--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import type { ChatMessage, ChatMessagePart } from './chat-messages'
 import {
   appendAssistantTextPart,
+  appendReasoningPart,
   chatMessageText,
   preserveLocalAssistantErrors,
   renderMediaTags,
@@ -11,6 +12,27 @@ import {
 } from './chat-messages'
 
 describe('toChatMessages', () => {
+  it('keeps adjacent assistant prose contiguous across reasoning-only rows', () => {
+    const messages = toChatMessages([
+      { role: 'assistant', content: 'Got', reasoning: 'Checking the result.', timestamp: 1 },
+      { role: 'assistant', content: ' it. Let me find good poster candidates.', reasoning: 'Next step.', timestamp: 2 }
+    ])
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0].parts.map(p => p.type)).toEqual(['reasoning', 'text', 'reasoning'])
+    expect(chatMessageText(messages[0])).toBe('Got it. Let me find good poster candidates.')
+  })
+
+  it('keeps plain adjacent assistant rows as separate messages', () => {
+    const messages = toChatMessages([
+      { role: 'assistant', content: 'First complete reply.', timestamp: 1 },
+      { role: 'assistant', content: 'Second complete reply.', timestamp: 2 }
+    ])
+
+    expect(messages).toHaveLength(2)
+    expect(messages.map(chatMessageText)).toEqual(['First complete reply.', 'Second complete reply.'])
+  })
+
   it('keeps a turn with interleaved tool-only rows in a single bubble', () => {
     const messages = toChatMessages([
       { role: 'assistant', content: 'Planning.', timestamp: 1 },
@@ -121,6 +143,35 @@ describe('toChatMessages', () => {
     ])
 
     expect(chatMessageText(message)).toBe('@file:foo.ts\n\nlook')
+  })
+})
+
+describe('appendAssistantTextPart', () => {
+  it('continues assistant text through trailing reasoning without splitting the prose', () => {
+    const parts = appendAssistantTextPart(
+      appendReasoningPart(appendAssistantTextPart([], 'Tar killed, backup state cleared, Plex started. Let me'), 'Checking.'),
+      ' monitor:'
+    )
+
+    const textParts = parts.filter((part): part is Extract<ChatMessagePart, { type: 'text' }> => part.type === 'text')
+
+    expect(parts.map(part => part.type)).toEqual(['text', 'reasoning'])
+    expect(textParts.map(part => part.text)).toEqual([
+      'Tar killed, backup state cleared, Plex started. Let me monitor:'
+    ])
+  })
+
+  it('does not move assistant text backward across tool rows', () => {
+    const withTool = upsertToolPart(appendAssistantTextPart([], 'Plex is up and serving.'), {
+      name: 'terminal',
+      tool_id: 'tool-1'
+    }, 'running')
+
+    const parts = appendAssistantTextPart(appendReasoningPart(withTool, 'Reading poster metadata.'), 'Now applying posters.')
+    const textParts = parts.filter((part): part is Extract<ChatMessagePart, { type: 'text' }> => part.type === 'text')
+
+    expect(parts.map(part => part.type)).toEqual(['text', 'tool-call', 'reasoning', 'text'])
+    expect(textParts.map(part => part.text)).toEqual(['Plex is up and serving.', 'Now applying posters.'])
   })
 })
 

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -189,8 +189,45 @@ export function appendTextPart(parts: ChatMessagePart[], delta: string): ChatMes
 }
 
 export function appendAssistantTextPart(parts: ChatMessagePart[], delta: string): ChatMessagePart[] {
-  const next = appendTextPart(parts, delta)
-  const last = next.at(-1)
+  const next = [...parts]
+  let textIndex = next.length - 1
+
+  if (next[textIndex]?.type !== 'text') {
+    textIndex = -1
+
+    // Reasoning rows are chrome around the model voice; tool rows are
+    // chronology. Continue prose through trailing reasoning, but never move it
+    // backward across a tool call.
+    for (let index = next.length - 1; index >= 0; index -= 1) {
+      const part = next[index]
+
+      if (part.type === 'text') {
+        textIndex = index
+
+        break
+      }
+
+      if (part.type !== 'reasoning') {
+        break
+      }
+    }
+  }
+
+  if (textIndex === -1) {
+    next.push(textPart(delta))
+    textIndex = next.length - 1
+  } else {
+    const part = next[textIndex]
+
+    if (part?.type === 'text') {
+      next[textIndex] = { ...part, text: `${part.text}${delta}` }
+    } else {
+      next.push(textPart(delta))
+      textIndex = next.length - 1
+    }
+  }
+
+  const last = next[textIndex]
 
   if (last?.type === 'text') {
     const current = last.text
@@ -200,10 +237,28 @@ export function appendAssistantTextPart(parts: ChatMessagePart[], delta: string)
 
     const needsMediaPass = deltaMayContainMedia || current.includes('MEDIA:')
     const nextText = needsMediaPass ? renderMediaTags(current) : current
-    next[next.length - 1] = nextText === current ? last : { ...last, text: nextText }
+    next[textIndex] = nextText === current ? last : { ...last, text: nextText }
   }
 
   return next
+}
+
+function appendAssistantParts(parts: ChatMessagePart[], appended: ChatMessagePart[]): ChatMessagePart[] {
+  return appended.reduce<ChatMessagePart[]>((next, part) => {
+    if (part.type === 'text') {
+      return appendAssistantTextPart(next, part.text)
+    }
+
+    return [...next, part]
+  }, parts)
+}
+
+function assistantTurnContinuationParts(parts: ChatMessagePart[]): boolean {
+  return parts.some(part => part.type === 'reasoning' || part.type === 'tool-call')
+}
+
+function shouldAppendToActiveAssistant(active: ChatMessage, nextParts: ChatMessagePart[]): boolean {
+  return assistantTurnContinuationParts(active.parts) || assistantTurnContinuationParts(nextParts)
 }
 
 export function appendReasoningPart(parts: ChatMessagePart[], delta: string): ChatMessagePart[] {
@@ -685,7 +740,7 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
       return false
     }
 
-    active.parts = [...active.parts, ...parts]
+    active.parts = appendAssistantParts(active.parts, parts)
     active.timestamp = timestamp ?? active.timestamp
 
     return true
@@ -783,11 +838,8 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
           ? result[activeAssistantIndex]
           : null
 
-      const currentHasToolCall = parts.some(part => part.type === 'tool-call')
-      const activeHasToolCall = Boolean(activeAssistant?.parts.some(part => part.type === 'tool-call'))
-
-      if (activeAssistant && (currentHasToolCall || activeHasToolCall)) {
-        activeAssistant.parts = [...activeAssistant.parts, ...parts]
+      if (activeAssistant && shouldAppendToActiveAssistant(activeAssistant, parts)) {
+        activeAssistant.parts = appendAssistantParts(activeAssistant.parts, parts)
         activeAssistant.timestamp = message.timestamp ?? activeAssistant.timestamp
 
         return


### PR DESCRIPTION
## Summary
- keep streamed assistant prose attached through trailing reasoning/Thinking rows so words do not split across UI blocks
- coalesce stored assistant rows only when reasoning/tool context marks them as the same turn
- add regression tests for the screenshot cases and the plain-adjacent-assistant guardrail

## Verification
- npm --workspace apps/desktop exec eslint src/lib/chat-messages.ts src/lib/chat-messages.test.ts
- npm --workspace apps/desktop exec vitest run src/lib/chat-messages.test.ts -- --environment jsdom
- npm --workspace apps/desktop run typecheck
- npm --workspace apps/desktop run build

Note: the build completed before the branch was pushed, so the build-stamp warning about an unreachable branch was expected for that local build.