### PR TITLE
chore: harden Hermes gateway and web quota guards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8418,9 +8418,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.13.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.1.tgz",
-      "integrity": "sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==",
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -14559,9 +14559,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "18.1.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-18.1.2.tgz",
-      "integrity": "sha512-rF5MAmps5esSlhCA+N1b6IYHDw9j/btzGaqfgie522jS02Ju/HXBxamlXVlKEHAxoMKQL77HWI8jlqWsFuekZA==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.1.tgz",
+      "integrity": "sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -19659,7 +19659,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19676,7 +19675,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19693,7 +19691,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19710,7 +19707,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19727,7 +19723,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19744,7 +19739,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19761,7 +19755,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19778,7 +19771,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19795,7 +19787,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19812,7 +19803,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19829,7 +19819,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19846,7 +19835,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19863,7 +19851,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19880,7 +19867,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19897,7 +19883,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19914,7 +19899,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19931,7 +19915,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19948,7 +19931,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19965,7 +19947,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19982,7 +19963,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19999,7 +19979,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20016,7 +19995,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20033,7 +20011,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20050,7 +20027,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20067,7 +20043,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20084,7 +20059,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }

--- a/scripts/whatsapp-bridge/package-lock.json
+++ b/scripts/whatsapp-bridge/package-lock.json
@@ -623,19 +623,18 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
@@ -645,9 +644,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
-      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -727,7 +726,7 @@
       "name": "baileys",
       "version": "7.0.0-rc.9",
       "resolved": "git+ssh://git@github.com/WhiskeySockets/Baileys.git#01047debd81beb20da7b7779b08edcb06aa03770",
-      "integrity": "sha512-letWyB96JHD6NdqpAiseOfaUBi13u8AhiRcKSRqcVjc5Vw5xoPTZGvVnw8K/NvGBFAvyLJkwim9Mjvwzhx/SlA==",
+      "integrity": "sha512-Pd8QNy2sGdYskMzgdFomzjSv3ZUI7+fGAw3pIfeip8VCHWWOJS+drSUdhosUNbb6jMtg0LdMLQNyjeaF7OaF1g==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -823,21 +822,6 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/body-parser/node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/bytes": {
@@ -1052,14 +1036,14 @@
       "license": "MIT"
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -1078,7 +1062,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -1620,24 +1604,24 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
-      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.3.tgz",
+      "integrity": "sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
         "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -1683,9 +1667,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -2117,9 +2101,9 @@
       "license": "MIT"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -778,7 +778,28 @@ class TestGatewayProtection:
         cmd = "systemctl --user restart hermes-gateway"
         dangerous, key, desc = detect_dangerous_command(cmd)
         assert dangerous is True
-        assert "stop/restart" in desc
+        assert "service" in desc or "hermes gateway" in desc
+
+    def test_hermes_gateway_start_flagged(self):
+        """hermes gateway start can reload/kick the service and should require approval."""
+        cmd = "hermes gateway start"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "hermes gateway" in desc
+
+    def test_launchctl_kickstart_gateway_flagged(self):
+        """Direct launchd kickstart bypass should require approval too."""
+        cmd = "launchctl kickstart -k gui/501/ai.hermes.gateway"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "launchd" in desc
+
+    def test_launchctl_bootout_gateway_flagged(self):
+        """Direct launchd unload bypass should require approval too."""
+        cmd = "launchctl bootout gui/501/ai.hermes.gateway"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "launchd" in desc
 
     def test_pkill_hermes_detected(self):
         """pkill targeting hermes/gateway processes must be caught."""

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -415,9 +415,12 @@ DANGEROUS_PATTERNS = [
     (r'\bfind\b.*-exec(?:dir)?\s+(/\S*/)?rm\b', "find -exec/-execdir rm"),
     (r'\bfind\b.*-delete\b', "find -delete"),
     # Gateway lifecycle protection: prevent the agent from killing its own
-    # gateway process.  These commands trigger a gateway restart/stop that
-    # terminates all running agents mid-work.
-    (r'\bhermes\s+gateway\s+(stop|restart)\b', "stop/restart hermes gateway (kills running agents)"),
+    # gateway process.  These commands trigger a gateway start/restart/stop that
+    # terminates all running agents mid-work.  Cover both the Hermes CLI path
+    # and direct service-manager bypasses such as launchctl/systemctl.
+    (r'\bhermes\s+gateway\s+(start|stop|restart)\b', "manage hermes gateway via cli (kills running agents)"),
+    (r'\blaunchctl\s+[^\n;&|]*\b(?:kickstart|bootout|bootstrap|stop|kill)\b[^\n;&|]*\bai\.hermes\.gateway\b', "manage hermes gateway launchd service (kills running agents)"),
+    (r'\bsystemctl\s+[^\n;&|]*\b(?:start|stop|restart|disable|mask)\b[^\n;&|]*\bhermes-gateway\b', "manage hermes gateway systemd service (kills running agents)"),
     (r'\bhermes\s+update\b', "hermes update (restarts gateway, kills running agents)"),
     # Docker container lifecycle — any user with docker.sock mounted (a common
     # Docker Compose pattern) gives the agent the ability to restart/stop/kill

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -41,6 +41,8 @@ import logging
 import os
 import re
 import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import List, Dict, Any, Optional, TYPE_CHECKING
 import httpx  # noqa: F401 — kept at module top so tests can patch tools.web_tools.httpx
 # After the web-provider plugin migration (PR #25182), the Firecrawl SDK
@@ -132,6 +134,135 @@ def _env_value(name: str) -> str:
 
 def _has_env(name: str) -> bool:
     return bool(_env_value(name))
+
+
+_FREE_TIER_DEFAULT_LIMITS = {
+    "exa": 1000,
+    "tavily": 1000,
+    "firecrawl": 1000,
+    "brave-free": 1000,
+}
+
+
+def _free_tier_guard_config() -> dict:
+    cfg = _load_web_config().get("free_tier_guard", {})
+    return cfg if isinstance(cfg, dict) else {}
+
+
+def _free_tier_guard_enabled() -> bool:
+    return bool(_free_tier_guard_config().get("enabled", False))
+
+
+def _free_tier_month() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m")
+
+
+def _free_tier_usage_path() -> Path:
+    try:
+        from hermes_constants import get_hermes_home
+        home = Path(get_hermes_home())
+    except Exception:
+        home = Path.home() / ".hermes"
+    return home / "usage" / "web_free_tier_usage.json"
+
+
+def _free_tier_limits() -> dict:
+    cfg = _free_tier_guard_config()
+    limits = dict(_FREE_TIER_DEFAULT_LIMITS)
+    configured = cfg.get("limits", {})
+    if isinstance(configured, dict):
+        for provider, value in configured.items():
+            try:
+                limits[str(provider).lower().strip()] = int(value)
+            except (TypeError, ValueError):
+                continue
+    return limits
+
+
+def _load_free_tier_usage() -> dict:
+    path = _free_tier_usage_path()
+    try:
+        if path.exists():
+            data = json.loads(path.read_text())
+            return data if isinstance(data, dict) else {}
+    except Exception:
+        logger.warning("Could not read web free-tier usage file", exc_info=True)
+    return {}
+
+
+def _save_free_tier_usage(data: dict) -> None:
+    path = _free_tier_usage_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(json.dumps(data, indent=2, sort_keys=True))
+        tmp.replace(path)
+    except Exception:
+        logger.warning("Could not write web free-tier usage file", exc_info=True)
+
+
+def _free_tier_status(provider_name: str, units: int) -> dict:
+    provider = (provider_name or "").lower().strip()
+    limit = _free_tier_limits().get(provider)
+    if not _free_tier_guard_enabled() or not limit:
+        return {"enabled": False, "provider": provider}
+    cfg = _free_tier_guard_config()
+    warn_fraction = float(cfg.get("warn_fraction", 0.70))
+    stop_fraction = float(cfg.get("stop_fraction", 0.95))
+    units = max(1, int(units or 1))
+    month = _free_tier_month()
+    usage = _load_free_tier_usage()
+    current = int(((usage.get(month) or {}).get(provider) or 0))
+    projected = current + units
+    return {
+        "enabled": True,
+        "provider": provider,
+        "month": month,
+        "used": current,
+        "limit": limit,
+        "remaining": max(limit - current, 0),
+        "units": units,
+        "projected": projected,
+        "warn": projected >= (limit * warn_fraction),
+        "block": projected >= (limit * stop_fraction),
+        "message": f"Free-tier guard: {provider} has used {current}/{limit} units this month; this call needs {units}.",
+    }
+
+
+def _free_tier_block_message(status: dict) -> str:
+    stop_pct = int(float(_free_tier_guard_config().get("stop_fraction", 0.95)) * 100)
+    return (
+        f"{status.get('message')} Stopping before the configured {stop_pct}% "
+        "free-tier ceiling so provider calls do not fail silently or spill into paid usage. "
+        "Use a fallback provider or explicitly raise the free-tier guard limit after checking the provider dashboard."
+    )
+
+
+def _record_free_tier_usage(provider_name: str, units: int) -> dict:
+    status = _free_tier_status(provider_name, units)
+    if not status.get("enabled"):
+        return status
+    usage = _load_free_tier_usage()
+    month = status["month"]
+    provider = status["provider"]
+    usage.setdefault(month, {})
+    usage[month][provider] = int(usage[month].get(provider, 0)) + int(status["units"])
+    _save_free_tier_usage(usage)
+    return _free_tier_status(provider, 0)
+
+
+def _attach_free_tier_warning(response_data: dict, status: dict) -> dict:
+    if not status.get("enabled") or not status.get("warn"):
+        return response_data
+    warning = (
+        f"Free-tier warning: {status['provider']} projected usage is "
+        f"{status['projected']}/{status['limit']} units for {status['month']}. "
+        "Hermes will stop before the configured free-tier ceiling instead of failing silently."
+    )
+    if isinstance(response_data, dict):
+        response_data.setdefault("warnings", []).append(warning)
+    return response_data
+
 
 def _load_web_config() -> dict:
     """Load the ``web:`` section from ~/.hermes/config.yaml."""
@@ -906,11 +1037,22 @@ def web_search_tool(query: str, limit: int = 5) -> str:
                 ),
             }
         else:
-            logger.info(
-                "Web search via %s: '%s' (limit: %d)",
-                provider.name, query, limit,
-            )
-            response_data = provider.search(query, limit)
+            provider_name = getattr(provider, "name", backend)
+            quota_status = _free_tier_status(provider_name, 1)
+            if quota_status.get("block"):
+                response_data = {
+                    "success": False,
+                    "error": _free_tier_block_message(quota_status),
+                    "quota_guard": quota_status,
+                }
+            else:
+                logger.info(
+                    "Web search via %s: '%s' (limit: %d)",
+                    provider.name, query, limit,
+                )
+                response_data = provider.search(query, limit)
+                post_quota_status = _record_free_tier_usage(provider_name, 1)
+                response_data = _attach_free_tier_warning(response_data, post_quota_status)
 
         debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
         result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
@@ -1015,6 +1157,7 @@ async def web_extract_tool(
         # hosted Search MCP) so we can credit Parallel in the output/UI. Bound
         # here so empty/all-blocked inputs (which skip dispatch) stay defined.
         _free_parallel_extract = False
+        post_quota_status = None
 
         # Dispatch only safe URLs to the configured backend
         if not safe_urls:
@@ -1073,6 +1216,18 @@ async def web_extract_tool(
                         ensure_ascii=False,
                     )
 
+            provider_name = getattr(provider, "name", backend)
+            quota_status = _free_tier_status(provider_name, len(safe_urls))
+            if quota_status.get("block"):
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": _free_tier_block_message(quota_status),
+                        "quota_guard": quota_status,
+                    },
+                    ensure_ascii=False,
+                )
+
             logger.info(
                 "Web extract via %s: %d URL(s)", provider.name, len(safe_urls)
             )
@@ -1088,6 +1243,7 @@ async def web_extract_tool(
                 results = await asyncio.to_thread(
                     provider.extract, safe_urls, format=format
                 )
+            post_quota_status = _record_free_tier_usage(provider_name, len(safe_urls))
 
         # Merge any SSRF-blocked results back in
         if ssrf_blocked:
@@ -1205,6 +1361,8 @@ async def web_extract_tool(
                 "Extraction powered by the free Parallel Web Search MCP "
                 "(https://parallel.ai)."
             )
+        if post_quota_status:
+            trimmed_response = _attach_free_tier_warning(trimmed_response, post_quota_status)
 
         if trimmed_response.get("results") == []:
             result_json = tool_error("Content was inaccessible or not found")


### PR DESCRIPTION
## Summary
- require approval for Hermes gateway lifecycle commands, including `hermes gateway start`, launchd service controls, and systemd service controls
- add a configurable web free-tier usage guard that warns/blocks before configured provider quota ceilings
- update npm lockfiles after audit repair so `npm audit` is clean

## Why
This was prompted by real operator maintenance on a live Hermes install:
- gateway lifecycle commands can interrupt running agents and need explicit approval gates
- web provider free-tier usage should not fail silently or spill into paid/blocked usage without warning
- the local install had lockfile/audit drift after update repair

## Verification
- `python -m py_compile tools/approval.py tools/web_tools.py tests/tools/test_approval.py`
- `/opt/homebrew/bin/pytest tests/tools/test_approval.py::TestGatewayProtection -q -o 'addopts='`
- `npm audit`

Observed locally:
- `py_compile=PASS`
- `13 passed`
- `found 0 vulnerabilities`
