### PR TITLE
test(gateway): tolerate Windows media path aliases

### DIFF
--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -5,6 +5,7 @@ background session) across gateway messenger platforms.
 """
 
 import asyncio
+import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -46,6 +47,42 @@ def _make_runner():
     runner.hooks = HookRegistry()
 
     return runner
+
+
+def _assert_same_file_path(actual: str, expected: str) -> None:
+    try:
+        if os.path.samefile(actual, expected):
+            return
+    except (FileNotFoundError, OSError, ValueError):
+        pass
+
+    assert os.path.normcase(os.path.normpath(actual)) == os.path.normcase(
+        os.path.normpath(expected)
+    )
+
+
+def test_same_file_path_assertion_accepts_windows_shortname_alias(monkeypatch):
+    """Path assertions should accept aliases that resolve to the same file."""
+
+    calls = []
+
+    def fake_samefile(actual: str, expected: str) -> bool:
+        calls.append((actual, expected))
+        return True
+
+    monkeypatch.setattr(os.path, "samefile", fake_samefile)
+
+    _assert_same_file_path(
+        r"C:\Users\IVANPE~1\AppData\Local\Temp\bg_media\clip.ogg",
+        r"C:\Users\Ivan Pervushin\AppData\Local\Temp\bg_media\clip.ogg",
+    )
+
+    assert calls == [
+        (
+            r"C:\Users\IVANPE~1\AppData\Local\Temp\bg_media\clip.ogg",
+            r"C:\Users\Ivan Pervushin\AppData\Local\Temp\bg_media\clip.ogg",
+        )
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -338,13 +375,13 @@ class TestRunBackgroundTask:
             await runner._run_background_task("make stuff", source, "bg_test")
 
             mock_adapter.send_voice.assert_called_once()
-            assert mock_adapter.send_voice.call_args.kwargs["audio_path"] == _ogg
+            _assert_same_file_path(mock_adapter.send_voice.call_args.kwargs["audio_path"], _ogg)
             mock_adapter.send_video.assert_called_once()
-            assert mock_adapter.send_video.call_args.kwargs["video_path"] == _mp4
+            _assert_same_file_path(mock_adapter.send_video.call_args.kwargs["video_path"], _mp4)
             mock_adapter.send_image_file.assert_called_once()
-            assert mock_adapter.send_image_file.call_args.kwargs["image_path"] == _png
+            _assert_same_file_path(mock_adapter.send_image_file.call_args.kwargs["image_path"], _png)
             mock_adapter.send_document.assert_called_once()
-            assert mock_adapter.send_document.call_args.kwargs["file_path"] == _pdf
+            _assert_same_file_path(mock_adapter.send_document.call_args.kwargs["file_path"], _pdf)
         finally:
             import shutil as _shutil
             _shutil.rmtree(_tmpdir, ignore_errors=True)


### PR DESCRIPTION
## What does this PR do?

Fixes a Windows-only test failure in `tests/gateway/test_background_command.py` where media path assertions compared raw path strings. On Windows systems with 8.3 shortname aliases enabled, two spellings such as `IVANPE~1` and `Ivan Pervushin` can refer to the same file while failing a direct string comparison.

The test now compares file identity first, then falls back to normalized path comparison. This keeps the media routing assertions strict while tolerating equivalent Windows path aliases.

## Related Issue

Fixes #44301

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `tests/gateway/test_background_command.py`: add `_assert_same_file_path()` for path assertions that need to tolerate same-file aliases.
- `tests/gateway/test_background_command.py`: add regression coverage for Windows 8.3 shortname aliases.
- `tests/gateway/test_background_command.py`: use the helper for voice, video, image, and document media path assertions.

## How to Test

1. `UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest tests/gateway/test_background_command.py -k "same_file_path_assertion or media_files_routed_by_type"`
2. `UV_CACHE_DIR=/private/tmp/uv-cache uv run pytest tests/gateway/test_background_command.py`
3. `scripts/run_tests.sh tests/gateway/test_background_command.py`
4. `UV_CACHE_DIR=/private/tmp/uv-cache uv run ruff check .`
5. `UV_CACHE_DIR=/private/tmp/uv-cache uv run python scripts/check-windows-footguns.py --all`

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS local Codex environment; Windows 8.3 path alias behavior is covered by a focused regression test.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable; this is a gateway test assertion fix with no UI changes.
