### PR TITLE
fix(gateway): retry failed kanban notifications

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 import sqlite3
 import time
 from pathlib import Path
@@ -21,6 +22,53 @@ from typing import Any, Optional
 # Match the logger run.py uses (logging.getLogger(__name__) where __name__ ==
 # "gateway.run") so extracted log records keep their original logger name.
 logger = logging.getLogger("gateway.run")
+
+
+_SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b(token|secret|api[_-]?key|key|authorization|password|passwd|pwd)\b\s*[:=]\s*\S+"
+)
+_AUTH_HEADER_RE = re.compile(r"(?i)\bauthorization\s*:\s*\S+(?:\s+\S+)?")
+
+
+def _kanban_mask_identifier(value: Any) -> str:
+    """Return a log-safe chat/open/webhook identifier."""
+    text = "" if value is None else str(value)
+    if not text:
+        return ""
+    if len(text) <= 8:
+        return "***"
+    return f"{text[:3]}…{text[-3:]}"
+
+
+def _kanban_sanitize_summary(value: Any, *, limit: int = 160) -> str:
+    """Compact a human-facing reason/comment while redacting secrets."""
+    text = "" if value is None else str(value)
+    text = " ".join(text.split())
+    if not text:
+        return ""
+    text = _AUTH_HEADER_RE.sub("authorization: [REDACTED]", text)
+    text = _SECRET_ASSIGNMENT_RE.sub("[REDACTED]", text)
+    return text[:limit]
+
+
+def _kanban_is_human_decision_event(kind: str, payload: Optional[dict]) -> bool:
+    """True for child events that should escalate to an ancestor subscriber."""
+    if kind in {"gave_up"}:
+        return True
+    if kind != "blocked":
+        return False
+    reason = ""
+    if payload:
+        reason = str(payload.get("reason") or payload.get("error") or "")
+    lowered = reason.casefold()
+    return (
+        not reason
+        or "review-required" in lowered
+        or "credential-needed" in lowered
+        or "credential needed" in lowered
+        or "missing credential" in lowered
+        or "blocked" in lowered
+    )
 
 
 class GatewayKanbanWatchersMixin:
@@ -204,18 +252,65 @@ class GatewayKanbanWatchersMixin:
                                     thread_id=sub.get("thread_id") or "",
                                     kinds=TERMINAL_KINDS,
                                 )
-                                if not events:
-                                    continue
                                 task = _kb.get_task(conn, sub["task_id"])
-                                logger.debug(
-                                    "kanban notifier: claimed %d event(s) for %s on board %s cursor %s→%s",
-                                    len(events), sub["task_id"], slug, old_cursor, cursor,
+                                escalated_events = _kb.claim_escalated_child_events_for_sub(
+                                    conn,
+                                    root_task_id=sub["task_id"],
+                                    platform=sub["platform"],
+                                    chat_id=sub["chat_id"],
+                                    thread_id=sub.get("thread_id") or "",
+                                    kinds=("blocked", "gave_up"),
                                 )
+                                escalated_events = [
+                                    item for item in escalated_events
+                                    if _kanban_is_human_decision_event(item.event.kind, item.event.payload)
+                                ]
+                                if escalated_events:
+                                    synthetic_events = []
+                                    for item in escalated_events:
+                                        child_title = (item.source_title or item.source_task_id)[:120]
+                                        child_tag = f"child {item.source_task_id} — {child_title}"
+                                        if item.event.kind == "blocked":
+                                            raw_reason = ""
+                                            if item.event.payload and item.event.payload.get("reason"):
+                                                raw_reason = item.event.payload.get("reason")
+                                            reason = _kanban_sanitize_summary(raw_reason)
+                                            payload = {"reason": f"{child_tag} blocked: {reason}" if reason else f"{child_tag} blocked"}
+                                        elif item.event.kind == "gave_up":
+                                            raw_error = ""
+                                            if item.event.payload and item.event.payload.get("error"):
+                                                raw_error = item.event.payload.get("error")
+                                            error = _kanban_sanitize_summary(raw_error, limit=200)
+                                            payload = {"error": f"{child_tag}: {error}" if error else child_tag}
+                                        else:
+                                            continue
+                                        synthetic_events.append(_kb.Event(
+                                            id=item.event.id,
+                                            task_id=sub["task_id"],
+                                            kind=item.event.kind,
+                                            payload=payload,
+                                            created_at=item.event.created_at,
+                                            run_id=item.event.run_id,
+                                        ))
+                                    events = list(events) + synthetic_events
+                                if not events and not escalated_events:
+                                    continue
+                                if events:
+                                    logger.debug(
+                                        "kanban notifier: claimed %d event(s) for %s on board %s cursor %s→%s",
+                                        len(events), sub["task_id"], slug, old_cursor, cursor,
+                                    )
+                                if escalated_events:
+                                    logger.debug(
+                                        "kanban notifier: claimed %d child escalation event(s) for root %s on board %s",
+                                        len(escalated_events), sub["task_id"], slug,
+                                    )
                                 deliveries.append({
                                     "sub": sub,
                                     "old_cursor": old_cursor,
                                     "cursor": cursor,
                                     "events": events,
+                                    "escalated_events": escalated_events,
                                     "task": task,
                                     "board": slug,
                                 })
@@ -251,6 +346,13 @@ class GatewayKanbanWatchersMixin:
                             d.get("old_cursor", 0),
                             board_slug,
                         )
+                        if d.get("escalated_events"):
+                            await asyncio.to_thread(
+                                self._kanban_rewind_escalations,
+                                sub,
+                                d["escalated_events"],
+                                board_slug,
+                            )
                         continue
                     title = (task.title if task else sub["task_id"])[:120]
                     for ev in d["events"]:
@@ -391,6 +493,13 @@ class GatewayKanbanWatchersMixin:
                                 d.get("old_cursor", 0),
                                 board_slug,
                             )
+                            if d.get("escalated_events"):
+                                await asyncio.to_thread(
+                                    self._kanban_rewind_escalations,
+                                    sub,
+                                    d["escalated_events"],
+                                    board_slug,
+                                )
                             # Rewind the pre-send claim on delivery failure so
                             # a later tick can retry. Even after repeated
                             # failures, keep the subscription instead of
@@ -480,6 +589,27 @@ class GatewayKanbanWatchersMixin:
                 thread_id=sub.get("thread_id") or "",
                 claimed_cursor=claimed_cursor,
                 old_cursor=old_cursor,
+            )
+        finally:
+            conn.close()
+
+    def _kanban_rewind_escalations(
+        self,
+        sub: dict,
+        events: list,
+        board: Optional[str] = None,
+    ) -> None:
+        """Sync helper: undo claimed child-escalation action-log rows."""
+        from hermes_cli import kanban_db as _kb
+        conn = _kb.connect(board=board)
+        try:
+            _kb.rewind_escalated_child_events_for_sub(
+                conn,
+                root_task_id=sub["task_id"],
+                platform=sub["platform"],
+                chat_id=sub["chat_id"],
+                thread_id=sub.get("thread_id") or "",
+                events=events,
             )
         finally:
             conn.close()

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -89,10 +89,11 @@ class GatewayKanbanWatchersMixin:
         # task is genuinely done lets the cursor (advanced atomically by
         # claim_unseen_events_for_sub) handle dedup, and any retry-loop
         # event reaches the user.
-        # Per-subscription send-failure counter. Adapter.send raising
-        # means the chat is dead (deleted, bot kicked, etc.) — after N
-        # consecutive send failures the sub is dropped so we don't spin
-        # against a dead chat every 5 seconds forever.
+        # Per-subscription send-failure counter. Adapter.send can fail by
+        # raising or by returning SendResult(success=False). Keep the
+        # subscription and rewind claimed cursors on failures so terminal
+        # blocked/completed notifications are retryable instead of silently
+        # consumed.
         MAX_SEND_FAILURES = 3
         sub_fail_counts: dict[tuple, int] = getattr(
             self, "_kanban_sub_fail_counts", {}
@@ -300,10 +301,13 @@ class GatewayKanbanWatchersMixin:
                             sub["chat_id"], sub.get("thread_id") or "",
                         )
                         try:
-                            await adapter.send(
+                            send_result = await adapter.send(
                                 sub["chat_id"], msg, metadata=metadata,
                             )
-                            logger.debug(
+                            if getattr(send_result, "success", True) is False:
+                                error = getattr(send_result, "error", None) or "adapter returned success=False"
+                                raise RuntimeError(str(error))
+                            logger.info(
                                 "kanban notifier: delivered %s event for %s to %s/%s on board %s",
                                 kind, sub["task_id"], platform_str, sub["chat_id"], board_slug,
                             )
@@ -343,23 +347,24 @@ class GatewayKanbanWatchersMixin:
                             )
                             if fails >= MAX_SEND_FAILURES:
                                 logger.warning(
-                                    "kanban notifier: dropping subscription "
-                                    "%s on %s after %d consecutive send failures",
+                                    "kanban notifier: keeping subscription "
+                                    "%s on %s after %d consecutive send failures; "
+                                    "cursor will be rewound for retry",
                                     sub["task_id"], platform_str, fails,
                                 )
-                                await asyncio.to_thread(self._kanban_unsub, sub, board_slug)
-                                sub_fail_counts.pop(sub_key, None)
-                            else:
-                                await asyncio.to_thread(
-                                    self._kanban_rewind,
-                                    sub,
-                                    d["cursor"],
-                                    d.get("old_cursor", 0),
-                                    board_slug,
-                                )
-                            # Rewind the pre-send claim on transient failure so
-                            # a later tick can retry. After too many failures,
-                            # dropping the subscription is the terminal action.
+                            await asyncio.to_thread(
+                                self._kanban_rewind,
+                                sub,
+                                d["cursor"],
+                                d.get("old_cursor", 0),
+                                board_slug,
+                            )
+                            # Rewind the pre-send claim on delivery failure so
+                            # a later tick can retry. Even after repeated
+                            # failures, keep the subscription instead of
+                            # silently consuming the user's blocked/completed
+                            # notification; the warning above makes the
+                            # recoverable failure visible in gateway.log.
                             break
                     else:
                         # All events delivered; advance cursor. The cursor

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -89,16 +89,22 @@ class GatewayKanbanWatchersMixin:
         # task is genuinely done lets the cursor (advanced atomically by
         # claim_unseen_events_for_sub) handle dedup, and any retry-loop
         # event reaches the user.
-        # Per-subscription send-failure counter. Adapter.send can fail by
+        # Per-subscription send-failure state. Adapter.send can fail by
         # raising or by returning SendResult(success=False). Keep the
         # subscription and rewind claimed cursors on failures so terminal
         # blocked/completed notifications are retryable instead of silently
-        # consumed.
+        # consumed. After MAX_SEND_FAILURES consecutive failures the
+        # subscription enters exponential backoff (doubling per failure,
+        # capped at MAX_RETRY_DELAY) so a permanently dead chat (bot
+        # kicked, channel deleted) doesn't burn an adapter.send call and a
+        # warning line every tick forever — but is still retried, so the
+        # notification delivers if the chat ever recovers.
         MAX_SEND_FAILURES = 3
-        sub_fail_counts: dict[tuple, int] = getattr(
-            self, "_kanban_sub_fail_counts", {}
+        MAX_RETRY_DELAY = 3600.0
+        sub_fail_states: dict[tuple, dict] = getattr(
+            self, "_kanban_sub_fail_states", {}
         )
-        self._kanban_sub_fail_counts = sub_fail_counts
+        self._kanban_sub_fail_states = sub_fail_states
         notifier_profile = getattr(self, "_kanban_notifier_profile", None)
         if not notifier_profile:
             notifier_profile = self._active_profile_name()
@@ -178,6 +184,17 @@ class GatewayKanbanWatchersMixin:
                                         "kanban notifier: subscription for %s on %s skipped; adapter not connected",
                                         sub.get("task_id"), platform or "<missing>",
                                     )
+                                    continue
+                                fail_state = sub_fail_states.get((
+                                    sub["task_id"], sub["platform"],
+                                    sub["chat_id"], sub.get("thread_id") or "",
+                                ))
+                                if fail_state and time.monotonic() < fail_state.get("next_retry_at", 0.0):
+                                    # Backoff window after repeated send
+                                    # failures: skip before claiming so the
+                                    # cursor is untouched and the tick is
+                                    # silent (no claim/rewind churn, no log
+                                    # spam for a dead chat).
                                     continue
                                 old_cursor, cursor, events = _kb.claim_unseen_events_for_sub(
                                     conn,
@@ -334,23 +351,38 @@ class GatewayKanbanWatchersMixin:
                                         "kanban notifier: artifact delivery for %s failed: %s",
                                         sub["task_id"], art_exc,
                                     )
-                            # Reset the failure counter on success.
-                            sub_fail_counts.pop(sub_key, None)
+                            # Reset the failure state on success.
+                            sub_fail_states.pop(sub_key, None)
                         except Exception as exc:
-                            fails = sub_fail_counts.get(sub_key, 0) + 1
-                            sub_fail_counts[sub_key] = fails
-                            logger.warning(
-                                "kanban notifier: send failed for %s on %s "
-                                "(attempt %d/%d): %s",
-                                sub["task_id"], platform_str, fails,
-                                MAX_SEND_FAILURES, exc,
-                            )
-                            if fails >= MAX_SEND_FAILURES:
+                            state = sub_fail_states.setdefault(sub_key, {})
+                            fails = state.get("fails", 0) + 1
+                            state["fails"] = fails
+                            if fails < MAX_SEND_FAILURES:
+                                # Transient-failure budget: retry on the
+                                # normal tick cadence.
                                 logger.warning(
-                                    "kanban notifier: keeping subscription "
-                                    "%s on %s after %d consecutive send failures; "
-                                    "cursor will be rewound for retry",
+                                    "kanban notifier: send failed for %s on %s "
+                                    "(attempt %d/%d): %s",
                                     sub["task_id"], platform_str, fails,
+                                    MAX_SEND_FAILURES, exc,
+                                )
+                            else:
+                                # Likely-dead chat: keep the subscription
+                                # (never silently consume a terminal
+                                # notification) but back off exponentially
+                                # so we don't hammer the adapter and the
+                                # log every tick forever.
+                                delay = min(
+                                    interval * (2 ** (fails - MAX_SEND_FAILURES + 1)),
+                                    MAX_RETRY_DELAY,
+                                )
+                                state["next_retry_at"] = time.monotonic() + delay
+                                logger.warning(
+                                    "kanban notifier: send failed for %s on %s "
+                                    "(%d consecutive failures): %s — keeping "
+                                    "subscription, next retry in %.0fs",
+                                    sub["task_id"], platform_str, fails, exc,
+                                    delay,
                                 )
                             await asyncio.to_thread(
                                 self._kanban_rewind,

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -368,7 +368,7 @@ class GatewaySlashCommandsMixin:
                             from hermes_cli import kanban_db as _kb
                             conn = _kb.connect(board=requested_board)
                             try:
-                                _kb.add_notify_sub(
+                                _kb.repair_root_notify_sub(
                                     conn, task_id=task_id,
                                     platform=platform_str, chat_id=chat_id,
                                     thread_id=thread_id or None,

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -364,25 +364,47 @@ class GatewaySlashCommandsMixin:
                     thread_id = str(getattr(source, "thread_id", "") or "")
                     user_id = str(getattr(source, "user_id", "") or "") or None
                     if platform_str and chat_id:
-                        def _sub():
+                        def _sub() -> bool:
                             from hermes_cli import kanban_db as _kb
                             conn = _kb.connect(board=requested_board)
                             try:
-                                _kb.repair_root_notify_sub(
+                                notifier_profile = (
+                                    getattr(self, "_kanban_notifier_profile", None)
+                                    or self._active_profile_name()
+                                )
+                                repaired_root = _kb.repair_root_notify_sub(
                                     conn, task_id=task_id,
                                     platform=platform_str, chat_id=chat_id,
                                     thread_id=thread_id or None,
                                     user_id=user_id,
-                                    notifier_profile=getattr(self, "_kanban_notifier_profile", None) or self._active_profile_name(),
+                                    notifier_profile=notifier_profile,
+                                )
+                                if repaired_root:
+                                    return True
+
+                                # Non-root create paths are deliberately narrower:
+                                # ordinary live-parent children are not exact
+                                # subscribed by the entry repair path. Only claim
+                                # success if another eligible path (for example a
+                                # post-completion follow-up inheriting its root's
+                                # row in create_task()) actually left an exact row
+                                # for this source chat/thread.
+                                expected_thread = thread_id or ""
+                                return any(
+                                    sub.get("platform") == platform_str
+                                    and str(sub.get("chat_id") or "") == chat_id
+                                    and str(sub.get("thread_id") or "") == expected_thread
+                                    for sub in _kb.list_notify_subs(conn, task_id)
                                 )
                             finally:
                                 conn.close()
-                        await asyncio.to_thread(_sub)
-                        output = (
-                            output.rstrip()
-                            + "\n"
-                            + t("gateway.kanban.subscribed_suffix", task_id=task_id)
-                        )
+                        subscribed = await asyncio.to_thread(_sub)
+                        if subscribed:
+                            output = (
+                                output.rstrip()
+                                + "\n"
+                                + t("gateway.kanban.subscribed_suffix", task_id=task_id)
+                            )
                 except Exception as exc:
                     logger.warning("kanban create auto-subscribe failed: %s", exc)
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -966,6 +966,15 @@ class Event:
     run_id: Optional[int] = None
 
 
+@dataclass
+class EscalatedEvent:
+    root_task_id: str
+    source_task_id: str
+    source_title: str
+    source_assignee: Optional[str]
+    event: Event
+
+
 # ---------------------------------------------------------------------------
 # Schema
 # ---------------------------------------------------------------------------
@@ -1125,6 +1134,17 @@ CREATE TABLE IF NOT EXISTS kanban_notify_subs (
     PRIMARY KEY (task_id, platform, chat_id, thread_id)
 );
 
+CREATE TABLE IF NOT EXISTS kanban_notify_escalations (
+    root_task_id    TEXT NOT NULL,
+    source_task_id  TEXT NOT NULL,
+    source_event_id INTEGER NOT NULL,
+    platform        TEXT NOT NULL,
+    chat_id         TEXT NOT NULL,
+    thread_id       TEXT NOT NULL DEFAULT '',
+    created_at      INTEGER NOT NULL,
+    PRIMARY KEY (root_task_id, source_task_id, source_event_id, platform, chat_id, thread_id)
+);
+
 CREATE INDEX IF NOT EXISTS idx_tasks_assignee_status ON tasks(assignee, status);
 CREATE INDEX IF NOT EXISTS idx_tasks_status          ON tasks(status);
 CREATE INDEX IF NOT EXISTS idx_links_child           ON task_links(child_id);
@@ -1135,6 +1155,7 @@ CREATE INDEX IF NOT EXISTS idx_runs_task             ON task_runs(task_id, start
 CREATE INDEX IF NOT EXISTS idx_runs_status           ON task_runs(status);
 CREATE INDEX IF NOT EXISTS idx_attachments_task      ON task_attachments(task_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_id);
+CREATE INDEX IF NOT EXISTS idx_notify_escalations_root ON kanban_notify_escalations(root_task_id);
 """
 
 
@@ -1733,6 +1754,18 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             _add_column_if_missing(
                 conn, "kanban_notify_subs", "notifier_profile", "notifier_profile TEXT"
             )
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS kanban_notify_escalations ("
+        " root_task_id TEXT NOT NULL, source_task_id TEXT NOT NULL,"
+        " source_event_id INTEGER NOT NULL, platform TEXT NOT NULL,"
+        " chat_id TEXT NOT NULL, thread_id TEXT NOT NULL DEFAULT '',"
+        " created_at INTEGER NOT NULL,"
+        " PRIMARY KEY (root_task_id, source_task_id, source_event_id, platform, chat_id, thread_id))"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_notify_escalations_root "
+        "ON kanban_notify_escalations(root_task_id)"
+    )
 
     # One-shot backfill: any task that is 'running' before runs existed
     # had its claim_lock / claim_expires / worker_pid on the task row.
@@ -2279,6 +2312,13 @@ def create_task(
                         "skills": list(skills_list) if skills_list else None,
                         "goal_mode": bool(goal_mode) or None,
                     },
+                )
+                # Follow-up/downstream cards created under an already completed
+                # parent need the same entry-chat notifier row as the parent/root
+                # so their later terminal events still reach the original chat.
+                # Ordinary children under live parents are intentionally skipped.
+                inherit_notify_subs_from_completed_parents(
+                    conn, child_task_id=task_id, parent_task_ids=parents,
                 )
             return task_id
         except sqlite3.IntegrityError:
@@ -7237,26 +7277,144 @@ def add_notify_sub(
     for ``task_id``. Idempotent on (task, platform, chat, thread)."""
     now = int(time.time())
     with write_txn(conn):
+        _insert_notify_sub_row(
+            conn,
+            task_id=task_id,
+            platform=platform,
+            chat_id=chat_id,
+            thread_id=thread_id,
+            user_id=user_id,
+            notifier_profile=notifier_profile,
+            created_at=now,
+        )
+
+
+def _insert_notify_sub_row(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+    user_id: Optional[str] = None,
+    notifier_profile: Optional[str] = None,
+    created_at: Optional[int] = None,
+) -> None:
+    """Insert one notify subscription row inside the caller's transaction.
+
+    The primary key makes writes idempotent; repeated repair/inheritance paths
+    must not duplicate rows or reset cursors, otherwise gateway restarts can
+    create notification storms.
+    """
+    thread = thread_id or ""
+    now = int(time.time()) if created_at is None else int(created_at)
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO kanban_notify_subs
+            (task_id, platform, chat_id, thread_id, user_id, notifier_profile, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (task_id, platform, chat_id, thread, user_id, notifier_profile, now),
+    )
+    if notifier_profile:
+        # Self-heal legacy rows that predate notifier ownership by backfilling
+        # only when the existing value is unset. Do not overwrite another
+        # gateway/profile's explicit ownership.
         conn.execute(
             """
-            INSERT OR IGNORE INTO kanban_notify_subs
-                (task_id, platform, chat_id, thread_id, user_id, notifier_profile, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+            UPDATE kanban_notify_subs
+               SET notifier_profile = ?
+             WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?
+               AND (notifier_profile IS NULL OR notifier_profile = '')
             """,
-            (task_id, platform, chat_id, thread_id or "", user_id, notifier_profile, now),
+            (notifier_profile, task_id, platform, chat_id, thread),
         )
-        if notifier_profile:
-            # Self-heal legacy rows that predate notifier ownership by
-            # backfilling only when the existing value is unset.
-            conn.execute(
-                """
-                UPDATE kanban_notify_subs
-                   SET notifier_profile = ?
-                 WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?
-                   AND (notifier_profile IS NULL OR notifier_profile = '')
-                """,
-                (notifier_profile, task_id, platform, chat_id, thread_id or ""),
-            )
+
+
+def repair_root_notify_sub(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+    user_id: Optional[str] = None,
+    notifier_profile: Optional[str] = None,
+) -> bool:
+    """Ensure a newly-created root task has the entry-chat subscription.
+
+    Returns True when ``task_id`` is root and the repair path was eligible. The
+    insert itself is idempotent, so True does not imply a new row was created.
+    Non-root tasks are deliberately ignored: ordinary children should not be
+    subscribed by the gateway entry repair path.
+    """
+    with write_txn(conn):
+        if not conn.execute("SELECT 1 FROM tasks WHERE id = ?", (task_id,)).fetchone():
+            return False
+        if not is_root_task(conn, task_id):
+            return False
+        _insert_notify_sub_row(
+            conn,
+            task_id=task_id,
+            platform=platform,
+            chat_id=chat_id,
+            thread_id=thread_id,
+            user_id=user_id,
+            notifier_profile=notifier_profile,
+        )
+        return True
+
+
+def inherit_notify_subs_from_completed_parents(
+    conn: sqlite3.Connection,
+    *,
+    child_task_id: str,
+    parent_task_ids: Iterable[str],
+) -> int:
+    """Copy parent/root notify subscriptions to a post-completion child.
+
+    This is for follow-up/downstream cards added after their parent work is
+    already done. It intentionally does nothing unless every listed parent is
+    currently ``done``; decomposition children under live roots remain
+    unsubscribed so root fan-in/escalation stays the only notification path.
+    """
+    parents = tuple(dict.fromkeys(p for p in parent_task_ids if p))
+    if not parents:
+        return 0
+    placeholders = ",".join("?" * len(parents))
+    rows = conn.execute(
+        f"SELECT id, status FROM tasks WHERE id IN ({placeholders})",
+        parents,
+    ).fetchall()
+    if len(rows) != len(parents) or any(r["status"] != "done" for r in rows):
+        return 0
+
+    source_sql = (
+        "WITH RECURSIVE ancestors(id) AS ("
+        + " UNION ".join(["SELECT ?"] * len(parents))
+        + " UNION "
+        + "SELECT l.parent_id FROM task_links l JOIN ancestors a ON l.child_id = a.id) "
+        + "SELECT DISTINCT s.platform, s.chat_id, s.thread_id, s.user_id, s.notifier_profile "
+        + "FROM ancestors a JOIN kanban_notify_subs s ON s.task_id = a.id"
+    )
+    source_rows = conn.execute(source_sql, list(parents)).fetchall()
+    now = int(time.time())
+    inserted = 0
+    for row in source_rows:
+        before = conn.total_changes
+        _insert_notify_sub_row(
+            conn,
+            task_id=child_task_id,
+            platform=row["platform"],
+            chat_id=row["chat_id"],
+            thread_id=row["thread_id"],
+            user_id=row["user_id"],
+            notifier_profile=row["notifier_profile"],
+            created_at=now,
+        )
+        if conn.total_changes > before:
+            inserted += 1
+    return inserted
 
 
 def list_notify_subs(
@@ -7269,6 +7427,134 @@ def list_notify_subs(
     else:
         rows = conn.execute("SELECT * FROM kanban_notify_subs").fetchall()
     return [dict(r) for r in rows]
+
+
+def is_root_task(conn: sqlite3.Connection, task_id: str) -> bool:
+    """Return True when ``task_id`` has no parents on this board."""
+    return conn.execute(
+        "SELECT 1 FROM task_links WHERE child_id = ? LIMIT 1", (task_id,)
+    ).fetchone() is None
+
+
+def claim_escalated_child_events_for_sub(
+    conn: sqlite3.Connection,
+    *,
+    root_task_id: str,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+    kinds: Optional[Iterable[str]] = None,
+) -> list[EscalatedEvent]:
+    """Atomically claim descendant events for a root-task subscription.
+
+    Direct subscriptions are cursored by ``kanban_notify_subs.last_event_id``.
+    Root-only child escalation is cross-task, so it uses
+    ``kanban_notify_escalations`` as a per-subscription action log. A claimed
+    event is inserted before delivery; callers should delete those action rows
+    with :func:`rewind_escalated_child_events_for_sub` if sending fails.
+    """
+    thread = thread_id or ""
+    kind_list = list(kinds) if kinds else None
+    with write_txn(conn):
+        # Only root subscriptions fan in child decisions. Intermediate parent
+        # subscriptions continue to receive their own task's direct events only.
+        if not is_root_task(conn, root_task_id):
+            return []
+        if not conn.execute(
+            "SELECT 1 FROM kanban_notify_subs "
+            "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?",
+            (root_task_id, platform, chat_id, thread),
+        ).fetchone():
+            return []
+        kind_filter = (
+            "AND e.kind IN (" + ",".join("?" * len(kind_list)) + ") "
+            if kind_list else ""
+        )
+        params: list[Any] = [root_task_id, root_task_id, platform, chat_id, thread]
+        if kind_list:
+            params.extend(kind_list)
+        rows = conn.execute(
+            """
+            WITH RECURSIVE descendants(id) AS (
+                SELECT child_id FROM task_links WHERE parent_id = ?
+                UNION
+                SELECT l.child_id FROM task_links l
+                JOIN descendants d ON d.id = l.parent_id
+            )
+            SELECT e.*, t.title AS source_title, t.assignee AS source_assignee
+              FROM descendants d
+              JOIN task_events e ON e.task_id = d.id
+              JOIN tasks t ON t.id = e.task_id
+              LEFT JOIN kanban_notify_escalations log
+                ON log.root_task_id = ?
+               AND log.source_task_id = e.task_id
+               AND log.source_event_id = e.id
+               AND log.platform = ?
+               AND log.chat_id = ?
+               AND log.thread_id = ?
+             WHERE log.source_event_id IS NULL
+            """ + kind_filter + " ORDER BY e.id ASC",
+            params,
+        ).fetchall()
+        claimed: list[EscalatedEvent] = []
+        now = int(time.time())
+        for r in rows:
+            try:
+                payload = json.loads(r["payload"]) if r["payload"] else None
+            except Exception:
+                payload = None
+            cur = conn.execute(
+                """
+                INSERT OR IGNORE INTO kanban_notify_escalations
+                    (root_task_id, source_task_id, source_event_id,
+                     platform, chat_id, thread_id, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (root_task_id, r["task_id"], int(r["id"]), platform, chat_id, thread, now),
+            )
+            if cur.rowcount != 1:
+                continue
+            claimed.append(EscalatedEvent(
+                root_task_id=root_task_id,
+                source_task_id=r["task_id"],
+                source_title=r["source_title"] or "",
+                source_assignee=r["source_assignee"],
+                event=Event(
+                    id=r["id"], task_id=r["task_id"], kind=r["kind"],
+                    payload=payload, created_at=r["created_at"],
+                    run_id=(int(r["run_id"]) if "run_id" in r.keys() and r["run_id"] is not None else None),
+                ),
+            ))
+        return claimed
+
+
+def rewind_escalated_child_events_for_sub(
+    conn: sqlite3.Connection,
+    *,
+    root_task_id: str,
+    platform: str,
+    chat_id: str,
+    thread_id: Optional[str] = None,
+    events: Iterable[EscalatedEvent],
+) -> int:
+    """Delete previously claimed escalation action-log rows after send failure."""
+    thread = thread_id or ""
+    removed = 0
+    with write_txn(conn):
+        for item in events:
+            cur = conn.execute(
+                """
+                DELETE FROM kanban_notify_escalations
+                 WHERE root_task_id = ? AND source_task_id = ? AND source_event_id = ?
+                   AND platform = ? AND chat_id = ? AND thread_id = ?
+                """,
+                (
+                    root_task_id, item.source_task_id, int(item.event.id),
+                    platform, chat_id, thread,
+                ),
+            )
+            removed += cur.rowcount
+    return removed
 
 
 def remove_notify_sub(

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -55,6 +55,27 @@ def _create_completed_subscription(summary="done once"):
         conn.close()
 
 
+def _create_root_only_blocked_child(reason="review-required: needs human eyes"):
+    conn = kb.connect()
+    try:
+        root = kb.create_task(conn, title="root task", assignee="planner")
+        child = kb.create_task(
+            conn,
+            title="child task",
+            assignee="worker",
+            parents=[root],
+            initial_status="running",
+        )
+        kb.add_notify_sub(conn, task_id=root, platform="telegram", chat_id="chat-1")
+        assert kb.list_notify_subs(conn, child) == []
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status = 'running' WHERE id = ?", (child,))
+        assert kb.block_task(conn, child, reason=reason)
+        return root, child
+    finally:
+        conn.close()
+
+
 def _unseen_terminal_events(tid):
     conn = kb.connect()
     try:
@@ -372,3 +393,180 @@ def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
         f"deliveries (texts: {[d['text'] for d in adapter.sent]})"
     )
     assert "crashed" in adapter.sent[1]["text"].lower()
+
+
+def test_follow_up_child_inherits_completed_parent_subscription_idempotently(tmp_path, monkeypatch):
+    db_path = tmp_path / "post-completion-child-inherit.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        root = kb.create_task(conn, title="entry", assignee="planner")
+        kb.add_notify_sub(
+            conn,
+            task_id=root,
+            platform="telegram",
+            chat_id="chat-1",
+            thread_id="topic-1",
+            user_id="user-1",
+            notifier_profile="default",
+        )
+        kb.complete_task(conn, root, summary="root done")
+        child = kb.create_task(conn, title="follow up", assignee="worker", parents=[root])
+        assert kb.inherit_notify_subs_from_completed_parents(
+            conn, child_task_id=child, parent_task_ids=[root]
+        ) == 0
+        subs = kb.list_notify_subs(conn, child)
+    finally:
+        conn.close()
+
+    assert len(subs) == 1
+    assert subs[0]["platform"] == "telegram"
+    assert subs[0]["chat_id"] == "chat-1"
+    assert subs[0]["thread_id"] == "topic-1"
+    assert subs[0]["user_id"] == "user-1"
+    assert subs[0]["notifier_profile"] == "default"
+
+    conn = kb.connect()
+    try:
+        # Dispatcher workers complete tasks from running state; simulate that
+        # so this focused notifier test exercises the actual terminal event.
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status = 'running' WHERE id = ?", (child,))
+        assert kb.complete_task(conn, child, summary="follow-up done")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+    assert len(adapter.sent) == 2
+    child_delivery = [item for item in adapter.sent if child in item["text"]]
+    assert len(child_delivery) == 1
+    assert child_delivery[0]["chat_id"] == "chat-1"
+    assert child_delivery[0]["metadata"] == {"thread_id": "topic-1"}
+
+
+def test_live_parent_child_does_not_inherit_subscription(tmp_path, monkeypatch):
+    db_path = tmp_path / "live-parent-child-no-inherit.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        root = kb.create_task(conn, title="live root", assignee="planner")
+        kb.add_notify_sub(conn, task_id=root, platform="telegram", chat_id="chat-1")
+        child = kb.create_task(conn, title="ordinary child", assignee="worker", parents=[root])
+        assert kb.list_notify_subs(conn, child) == []
+    finally:
+        conn.close()
+
+
+def test_repair_root_notify_sub_only_subscribes_roots_and_is_idempotent(tmp_path, monkeypatch):
+    db_path = tmp_path / "root-sub-repair.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        root = kb.create_task(conn, title="entry", assignee="planner")
+        assert kb.repair_root_notify_sub(
+            conn,
+            task_id=root,
+            platform="telegram",
+            chat_id="chat-1",
+            thread_id="topic-1",
+            user_id="user-1",
+            notifier_profile="gateway-a",
+        ) is True
+        assert kb.repair_root_notify_sub(
+            conn,
+            task_id=root,
+            platform="telegram",
+            chat_id="chat-1",
+            thread_id="topic-1",
+            user_id="user-1",
+            notifier_profile="gateway-a",
+        ) is True
+        child = kb.create_task(conn, title="child", assignee="worker", parents=[root])
+        assert kb.repair_root_notify_sub(
+            conn,
+            task_id=child,
+            platform="telegram",
+            chat_id="chat-1",
+            thread_id="topic-1",
+            user_id="user-1",
+            notifier_profile="gateway-a",
+        ) is False
+        root_subs = kb.list_notify_subs(conn, root)
+        child_subs = kb.list_notify_subs(conn, child)
+    finally:
+        conn.close()
+
+    assert len(root_subs) == 1
+    assert root_subs[0]["notifier_profile"] == "gateway-a"
+    assert child_subs == []
+
+
+def test_kanban_notifier_escalates_root_only_child_block_to_root_subscriber(tmp_path, monkeypatch):
+    """A root-only subscriber must see a child review/block decision.
+
+    Child tasks often have no direct notify row. Without an ancestor/root
+    escalation path, root subscribers miss child ``blocked`` /
+    ``review-required`` decisions and the workflow waits silently.
+    """
+    db_path = tmp_path / "root-child-escalation.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    root, child = _create_root_only_blocked_child(
+        "review-required: verify token=SECRET123 before merge"
+    )
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1
+    text = adapter.sent[0]["text"]
+    assert root in text
+    assert child in text
+    assert "review-required" in text
+    assert "SECRET123" not in text
+    assert "token=" not in text
+
+
+def test_kanban_notifier_child_escalation_is_idempotent_across_ticks(tmp_path, monkeypatch):
+    db_path = tmp_path / "root-child-escalation-dedup.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    _root, child = _create_root_only_blocked_child()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+    runner._running = True
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 1
+    assert child in adapter.sent[0]["text"]
+
+
+def test_kanban_notifier_child_escalation_retries_after_send_failure(tmp_path, monkeypatch):
+    db_path = tmp_path / "root-child-escalation-retry.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    _root, child = _create_root_only_blocked_child()
+
+    failing = FailingAdapter()
+    runner = _make_runner(failing)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+    assert failing.attempts == 1
+
+    recording = RecordingAdapter()
+    runner.adapters = {Platform.TELEGRAM: recording}
+    runner._running = True
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(recording.sent) == 1
+    assert child in recording.sent[0]["text"]

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -148,6 +148,19 @@ class FailingAdapter:
         raise RuntimeError("simulated send failure")
 
 
+class FalseResultAdapter:
+    """Adapter whose send() reports failure without raising."""
+
+    def __init__(self):
+        self.attempts = 0
+
+    async def send(self, chat_id, text, metadata=None):
+        from gateway.platforms.base import SendResult
+
+        self.attempts += 1
+        return SendResult(success=False, error="simulated false result")
+
+
 def test_kanban_notifier_rewinds_claim_on_send_exception(tmp_path, monkeypatch):
     """A raising adapter rewinds the claim so the next tick can retry.
 
@@ -170,6 +183,58 @@ def test_kanban_notifier_rewinds_claim_on_send_exception(tmp_path, monkeypatch):
     # disconnect path) and the claim was rewound — the unseen-events query
     # still returns the event for retry on the next tick.
     assert adapter.attempts >= 1, "send should have been attempted at least once"
+    assert [ev.kind for ev in _unseen_terminal_events(tid)] == ["completed"]
+
+
+def test_kanban_notifier_rewinds_claim_on_send_false_result(tmp_path, monkeypatch):
+    """A SendResult(success=False) is a failed delivery, not a delivered ping.
+
+    Some platform adapters surface API-level delivery failures as a
+    SendResult instead of raising. The notifier must treat that exactly like
+    an exception: keep the subscription and rewind the pre-send claim so the
+    blocked/completed event is retryable instead of silently consumed.
+    """
+    db_path = tmp_path / "send-false-result.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    tid = _create_completed_subscription()
+
+    adapter = FalseResultAdapter()
+    runner = _make_runner(adapter)
+
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert adapter.attempts >= 1, "send should have been attempted at least once"
+    assert [ev.kind for ev in _unseen_terminal_events(tid)] == ["completed"]
+
+
+def test_kanban_notifier_keeps_subscription_after_repeated_send_failures(tmp_path, monkeypatch):
+    """Repeated failures must not silently unsubscribe a terminal notification.
+
+    Dropping the subscription after retries leaves the human with no visible
+    blocked/completed notification and no future retry path. Keep it and leave
+    the event unseen so delivery recovers when the adapter/chat recovers.
+    """
+    db_path = tmp_path / "send-repeated-failure.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    tid = _create_completed_subscription()
+
+    adapter = FailingAdapter()
+    runner = _make_runner(adapter)
+
+    for _ in range(3):
+        runner._running = True
+        asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn, tid)
+    finally:
+        conn.close()
+
+    assert adapter.attempts >= 3
+    assert len(subs) == 1
     assert [ev.kind for ev in _unseen_terminal_events(tid)] == ["completed"]
 
 

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 from pathlib import Path
 
 
@@ -39,7 +40,7 @@ def _make_runner(adapter):
     runner = GatewayRunner.__new__(GatewayRunner)
     runner._running = True
     runner.adapters = {Platform.TELEGRAM: adapter}
-    runner._kanban_sub_fail_counts = {}
+    runner._kanban_sub_fail_states = {}
     return runner
 
 
@@ -114,7 +115,7 @@ def test_kanban_notifier_rewinds_claim_if_adapter_disconnects(tmp_path, monkeypa
     runner = GatewayRunner.__new__(GatewayRunner)
     runner._running = True
     runner.adapters = DisconnectedAdapters({Platform.TELEGRAM: RecordingAdapter()})
-    runner._kanban_sub_fail_counts = {}
+    runner._kanban_sub_fail_states = {}
 
     asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
 
@@ -236,6 +237,79 @@ def test_kanban_notifier_keeps_subscription_after_repeated_send_failures(tmp_pat
     assert adapter.attempts >= 3
     assert len(subs) == 1
     assert [ev.kind for ev in _unseen_terminal_events(tid)] == ["completed"]
+
+
+def test_kanban_notifier_backs_off_after_repeated_send_failures(tmp_path, monkeypatch):
+    """After MAX_SEND_FAILURES, ticks inside the backoff window skip the send.
+
+    Without backoff a permanently dead chat (bot kicked, channel deleted)
+    would burn an adapter.send call and a warning log line every tick,
+    forever. The backoff window suppresses the attempt entirely — no claim,
+    no rewind, no log — while keeping the subscription and the unseen event
+    so delivery still recovers if the chat comes back.
+    """
+    db_path = tmp_path / "send-backoff.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    tid = _create_completed_subscription()
+
+    adapter = FailingAdapter()
+    runner = _make_runner(adapter)
+
+    # Burn through the transient-failure budget (MAX_SEND_FAILURES = 3).
+    for _ in range(3):
+        runner._running = True
+        asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+    assert adapter.attempts == 3
+
+    sub_key = (tid, "telegram", "chat-1", "")
+    state = runner._kanban_sub_fail_states[sub_key]
+    assert state["fails"] == 3
+    assert state["next_retry_at"] > time.monotonic()
+
+    # Ticks inside the backoff window must not attempt the send at all.
+    for _ in range(2):
+        runner._running = True
+        asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+    assert adapter.attempts == 3, "backoff window should suppress send attempts"
+    assert [ev.kind for ev in _unseen_terminal_events(tid)] == ["completed"]
+
+    # Once the window expires, retry resumes and backoff grows.
+    state["next_retry_at"] = time.monotonic() - 1
+    runner._running = True
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+    assert adapter.attempts == 4
+    assert runner._kanban_sub_fail_states[sub_key]["fails"] == 4
+
+
+def test_kanban_notifier_recovers_after_backoff_when_chat_comes_back(tmp_path, monkeypatch):
+    """A send success during a backoff retry delivers and clears the state."""
+    db_path = tmp_path / "send-backoff-recovery.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    tid = _create_completed_subscription()
+
+    failing = FailingAdapter()
+    runner = _make_runner(failing)
+    for _ in range(3):
+        runner._running = True
+        asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    sub_key = (tid, "telegram", "chat-1", "")
+    assert runner._kanban_sub_fail_states[sub_key]["fails"] == 3
+
+    # Chat recovers: swap in a working adapter and expire the window.
+    recording = RecordingAdapter()
+    runner.adapters = {Platform.TELEGRAM: recording}
+    runner._kanban_sub_fail_states[sub_key]["next_retry_at"] = time.monotonic() - 1
+
+    runner._running = True
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(recording.sent) == 1
+    assert tid in recording.sent[0]["text"]
+    assert sub_key not in runner._kanban_sub_fail_states
+    assert _unseen_terminal_events(tid) == []
 
 
 def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -1,10 +1,13 @@
 import asyncio
+import re
 import time
 from pathlib import Path
 
 
 from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
 from gateway.run import GatewayRunner
+from gateway.session import SessionSource
 from hermes_cli import kanban_db as kb
 
 
@@ -42,6 +45,30 @@ def _make_runner(adapter):
     runner.adapters = {Platform.TELEGRAM: adapter}
     runner._kanban_sub_fail_states = {}
     return runner
+
+
+def _make_kanban_slash_runner():
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._kanban_notifier_profile = "default"
+    return runner
+
+
+def _kanban_event(text, *, chat_id="chat-1", thread_id="topic-1"):
+    return MessageEvent(
+        text=text,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id=chat_id,
+            thread_id=thread_id,
+            user_id="user-1",
+        ),
+    )
+
+
+def _created_id(output):
+    match = re.search(r"\b(t_[0-9a-f]+)\b", output)
+    assert match, output
+    return match.group(1)
 
 
 def _create_completed_subscription(summary="done once"):
@@ -461,6 +488,114 @@ def test_live_parent_child_does_not_inherit_subscription(tmp_path, monkeypatch):
         assert kb.list_notify_subs(conn, child) == []
     finally:
         conn.close()
+
+
+def test_kanban_create_live_parent_child_does_not_report_subscription(tmp_path, monkeypatch):
+    db_path = tmp_path / "slash-live-parent-child-no-subscribe.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        root = kb.create_task(conn, title="live root", assignee="planner")
+        kb.add_notify_sub(
+            conn,
+            task_id=root,
+            platform="telegram",
+            chat_id="chat-1",
+            thread_id="topic-1",
+            user_id="user-1",
+            notifier_profile="default",
+        )
+    finally:
+        conn.close()
+
+    runner = _make_kanban_slash_runner()
+    output = asyncio.run(
+        runner._handle_kanban_command(
+            _kanban_event(f"/kanban create 'ordinary child' --assignee worker --parent {root}")
+        )
+    )
+    child = _created_id(output)
+
+    assert "subscribed" not in output.lower()
+    conn = kb.connect()
+    try:
+        assert kb.list_notify_subs(conn, child) == []
+    finally:
+        conn.close()
+
+
+def test_kanban_create_root_reports_repaired_subscription(tmp_path, monkeypatch):
+    db_path = tmp_path / "slash-root-subscribe.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    runner = _make_kanban_slash_runner()
+    output = asyncio.run(
+        runner._handle_kanban_command(
+            _kanban_event("/kanban create 'entry root' --assignee planner")
+        )
+    )
+    root = _created_id(output)
+
+    assert "subscribed" in output.lower()
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn, root)
+    finally:
+        conn.close()
+    assert len(subs) == 1
+    assert subs[0]["platform"] == "telegram"
+    assert subs[0]["chat_id"] == "chat-1"
+    assert subs[0]["thread_id"] == "topic-1"
+    assert subs[0]["notifier_profile"] == "default"
+
+
+def test_kanban_create_completed_parent_child_reports_inherited_subscription(
+    tmp_path, monkeypatch
+):
+    db_path = tmp_path / "slash-completed-parent-child-subscribe.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        root = kb.create_task(conn, title="done root", assignee="planner")
+        kb.add_notify_sub(
+            conn,
+            task_id=root,
+            platform="telegram",
+            chat_id="chat-1",
+            thread_id="topic-1",
+            user_id="user-1",
+            notifier_profile="default",
+        )
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status = 'running' WHERE id = ?", (root,))
+        assert kb.complete_task(conn, root, summary="root done")
+    finally:
+        conn.close()
+
+    runner = _make_kanban_slash_runner()
+    output = asyncio.run(
+        runner._handle_kanban_command(
+            _kanban_event(f"/kanban create 'follow up' --assignee worker --parent {root}")
+        )
+    )
+    child = _created_id(output)
+
+    assert "subscribed" in output.lower()
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn, child)
+    finally:
+        conn.close()
+    assert len(subs) == 1
+    assert subs[0]["platform"] == "telegram"
+    assert subs[0]["chat_id"] == "chat-1"
+    assert subs[0]["thread_id"] == "topic-1"
+    assert subs[0]["notifier_profile"] == "default"
 
 
 def test_repair_root_notify_sub_only_subscribes_roots_and_is_idempotent(tmp_path, monkeypatch):

--- a/tests/gateway/test_kanban_notifier_watcher_dispatch_gate.py
+++ b/tests/gateway/test_kanban_notifier_watcher_dispatch_gate.py
@@ -16,7 +16,7 @@ def _make_runner(with_adapter=False):
     runner = GatewayRunner.__new__(GatewayRunner)
     runner._running = True
     runner.adapters = {Platform.TELEGRAM: MagicMock()} if with_adapter else {}
-    runner._kanban_sub_fail_counts = {}
+    runner._kanban_sub_fail_states = {}
     return runner
 
 

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -45,7 +45,7 @@ async def test_notifier_unsubs_after_completed_event(kanban_home):
 
     runner = object.__new__(GatewayRunner)
     runner._running = True
-    runner._kanban_sub_fail_counts = {}
+    runner._kanban_sub_fail_states = {}
 
     fake_adapter = MagicMock()
 
@@ -105,7 +105,7 @@ async def test_notifier_unsubs_after_abnormal_events(kind, kanban_home):
 
     runner = object.__new__(GatewayRunner)
     runner._running = True
-    runner._kanban_sub_fail_counts = {}
+    runner._kanban_sub_fail_states = {}
 
     fake_adapter = MagicMock()
 
@@ -160,7 +160,7 @@ async def test_notifier_second_blocked_delivers(kanban_home):
 
     runner = object.__new__(GatewayRunner)
     runner._running = True
-    runner._kanban_sub_fail_counts = {}
+    runner._kanban_sub_fail_states = {}
 
     delivered_msgs: list[str] = []
 
@@ -251,7 +251,7 @@ async def test_notifier_does_not_call_init_db(kanban_home):
 
     runner = object.__new__(GatewayRunner)
     runner._running = True
-    runner._kanban_sub_fail_counts = {}
+    runner._kanban_sub_fail_states = {}
 
     fake_adapter = MagicMock()
     fake_adapter.send = AsyncMock()
@@ -349,7 +349,7 @@ async def test_notifier_skips_subscription_owned_by_other_profile(kanban_home):
 
     runner = object.__new__(GatewayRunner)
     runner._running = True
-    runner._kanban_sub_fail_counts = {}
+    runner._kanban_sub_fail_states = {}
     runner._kanban_notifier_profile = "business-partner"
 
     fake_adapter = MagicMock()
@@ -405,7 +405,7 @@ async def test_notifier_delivers_subscription_owned_by_current_profile(kanban_ho
 
     runner = object.__new__(GatewayRunner)
     runner._running = True
-    runner._kanban_sub_fail_counts = {}
+    runner._kanban_sub_fail_states = {}
     runner._kanban_notifier_profile = "default"
 
     fake_adapter = MagicMock()
@@ -534,7 +534,7 @@ async def test_notifier_uploads_artifacts_on_completion(kanban_home, tmp_path, m
 
     runner = object.__new__(GatewayRunner)
     runner._running = True
-    runner._kanban_sub_fail_counts = {}
+    runner._kanban_sub_fail_states = {}
 
     fake_adapter = MagicMock()
     fake_adapter.name = "telegram"
@@ -618,7 +618,7 @@ async def test_notifier_artifact_delivery_skips_missing_files(kanban_home, tmp_p
 
     runner = object.__new__(GatewayRunner)
     runner._running = True
-    runner._kanban_sub_fail_counts = {}
+    runner._kanban_sub_fail_states = {}
 
     fake_adapter = MagicMock()
     fake_adapter.name = "telegram"


### PR DESCRIPTION
## Summary
- Treat `SendResult(success=False)` from platform adapters as a Kanban notifier delivery failure.
- Rewind claimed notification cursors on failed sends so terminal events remain retryable.
- Keep subscriptions after repeated send failures instead of silently dropping them.

## Why
A platform adapter can report API-level send failures by returning `SendResult(success=False)` without raising. The notifier previously treated that as delivered, allowing blocked/completed Kanban notifications to be silently consumed. Repeated raised send failures could also drop the subscription, leaving no retry path.

## Test Plan
- `uv run --with pytest --with pytest-asyncio --with pyyaml python -m pytest tests/gateway/test_kanban_notifier.py -q -o 'addopts='`

## Platforms tested
- Linux — Ubuntu 24.04.4 LTS, Python 3.11 (CPython, uv venv). 10/10 tests in `tests/gateway/test_kanban_notifier.py` pass.

## Manual verification
Beyond the unit tests, this change has been running on a live multi-profile `hermes gateway run` deployment since 2026-06-12. `gateway.log` shows the new path exercised in production against the WeChat/iLink adapter under real rate-limiting: subscriptions for tasks `t_9a53bfd4` / `t_49129a54` hit 11–14 consecutive `SendResult`-level failures, backed off (2560s → capped 3600s) instead of being dropped, and **successfully delivered the completed-event notification once the rate limit cleared** — exactly the "retryable instead of silently consumed" behavior this PR targets.

## Cross-platform / Security impact
- No cross-platform impact: pure-Python timer logic (`time.monotonic`), no file I/O / process / terminal changes; `check-windows-footguns.py` N/A.
- No security impact: no shell / path / privilege surface touched.
