### PR TITLE
[Hermes][Desktop][hermes-desktop-crash-survivable-turn-progress][2/n] fix(desktop): recover in-flight turn progress after restart

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -4,7 +4,9 @@ import { useEffect } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { getSessionMessages, type SessionInfo } from '@/hermes'
+import { type ChatMessage, chatMessageText } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
+import { persistInFlightTurnState } from '@/lib/inflight-turn-journal'
 import { $activeGatewayProfile, $newChatProfile } from '@/store/profile'
 import {
   $activeSessionId,
@@ -511,5 +513,178 @@ describe('resumeSession warm-cache mapping integrity', () => {
     const methods = requestGateway.mock.calls.map(([method]) => method)
     expect(methods).not.toContain('session.resume')
     expect(runtimeIdByStoredSessionIdRef.current.get('stored-A')).toBe('rt-A')
+  })
+})
+
+// ── In-flight turn recovery (crash-survivable turn progress) ──────────────────
+// After an app/renderer crash mid-turn, the backend's stored transcript lacks
+// the streaming assistant. On resume, the persisted in-flight journal must fold
+// that tail back onto the restored messages and re-arm the live streaming state
+// (busy, streamId, turn clock) instead of showing a bare, idle transcript.
+function inFlightMessage(role: ChatMessage['role'], text: string, id: string, pending = false): ChatMessage {
+  return { id, parts: [{ text, type: 'text' }], pending, role }
+}
+
+function RecoveryHarness({
+  onReady,
+  onState,
+  requestGateway
+}: {
+  onReady: (resume: (storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) => void
+  onState: (state: ClientSessionState) => void
+  requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+}) {
+  const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value })
+
+  const actions = useSessionActions({
+    activeSessionId: null,
+    activeSessionIdRef: ref<string | null>(null),
+    busyRef: ref(false),
+    creatingSessionRef: ref(false),
+    ensureSessionState: () => ({}) as ClientSessionState,
+    getRouteToken: () => 'token',
+    navigate: vi.fn() as never,
+    requestGateway,
+    runtimeIdByStoredSessionIdRef: ref(new Map<string, string>()),
+    selectedStoredSessionId: null,
+    selectedStoredSessionIdRef: ref<string | null>(null),
+    sessionStateByRuntimeIdRef: ref(new Map<string, ClientSessionState>()),
+    syncSessionStateToView: vi.fn(),
+    updateSessionState: (_sessionId, updater, storedSessionId) => {
+      const next = updater(createClientSessionState(storedSessionId ?? null))
+      onState(next)
+
+      return next
+    }
+  })
+
+  useEffect(() => {
+    onReady(actions.resumeSession)
+  }, [actions.resumeSession, onReady])
+
+  return null
+}
+
+describe('resumeSession in-flight recovery', () => {
+  afterEach(() => {
+    cleanup()
+    setActiveSessionId(null)
+    setResumeFailedSessionId(null)
+    setMessages([])
+    setSessions([])
+    window.localStorage.clear()
+    vi.restoreAllMocks()
+  })
+
+  it('folds a persisted in-flight turn back onto the resumed transcript and re-arms streaming state', async () => {
+    setSessions([storedSession({ message_count: 2 })])
+
+    // The renderer journaled an optimistic user + streaming assistant before the crash.
+    persistInFlightTurnState('rt-old', {
+      awaitingResponse: false,
+      busy: true,
+      messages: [
+        inFlightMessage('user', 'fix crash', 'optimistic-user'),
+        inFlightMessage('assistant', 'partial answer', 'assistant-stream-1', true)
+      ],
+      storedSessionId: 'stored-1',
+      streamId: 'assistant-stream-1',
+      turnStartedAt: 4242
+    })
+
+    // Restarted backend: stored transcript has only the user prompt; turn still running.
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.resume') {
+        return {
+          info: {},
+          messages: [{ content: 'fix crash', role: 'user', timestamp: 1 }],
+          resumed: params?.session_id,
+          running: true,
+          session_id: 'runtime-1'
+        } as never
+      }
+
+      return {} as never
+    })
+
+    vi.mocked(getSessionMessages).mockResolvedValue({
+      messages: [{ content: 'fix crash', role: 'user', timestamp: 1 }],
+      session_id: 'stored-1'
+    } as never)
+
+    let captured: ClientSessionState | undefined
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+    render(<RecoveryHarness onReady={r => (resume = r)} onState={s => (captured = s)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(resume).not.toBeNull())
+    await resume!('stored-1', true)
+
+    expect(captured).toBeDefined()
+    // The streaming assistant tail is grafted back after the stored user prompt.
+    expect(captured?.messages).toHaveLength(2)
+    expect(captured?.messages[0].role).toBe('user')
+    expect(captured?.messages[1].id).toBe('assistant-stream-1')
+    expect(chatMessageText(captured!.messages[1])).toBe('partial answer')
+    expect(captured?.messages[1].pending).toBe(true)
+    // Running state is re-armed as an in-progress stream, not "awaiting first token".
+    expect(captured?.busy).toBe(true)
+    expect(captured?.awaitingResponse).toBe(false)
+    expect(captured?.streamId).toBe('assistant-stream-1')
+    expect(captured?.sawAssistantPayload).toBe(true)
+    expect(captured?.turnStartedAt).toBe(4242)
+  })
+
+  it('does not resurrect a journal turn once the resumed transcript already has the answer', async () => {
+    setSessions([storedSession({ message_count: 3 })])
+
+    persistInFlightTurnState('rt-old', {
+      awaitingResponse: false,
+      busy: true,
+      messages: [
+        inFlightMessage('user', 'fix crash', 'optimistic-user'),
+        inFlightMessage('assistant', 'partial answer', 'assistant-stream-1', true)
+      ],
+      storedSessionId: 'stored-1',
+      streamId: 'assistant-stream-1',
+      turnStartedAt: 4242
+    })
+
+    // The backend completed the turn: stored history now has the final assistant reply.
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.resume') {
+        return {
+          info: {},
+          messages: [
+            { content: 'fix crash', role: 'user', timestamp: 1 },
+            { content: 'final answer', role: 'assistant', timestamp: 2 }
+          ],
+          resumed: params?.session_id,
+          running: false,
+          session_id: 'runtime-1'
+        } as never
+      }
+
+      return {} as never
+    })
+
+    vi.mocked(getSessionMessages).mockResolvedValue({
+      messages: [
+        { content: 'fix crash', role: 'user', timestamp: 1 },
+        { content: 'final answer', role: 'assistant', timestamp: 2 }
+      ],
+      session_id: 'stored-1'
+    } as never)
+
+    let captured: ClientSessionState | undefined
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+    render(<RecoveryHarness onReady={r => (resume = r)} onState={s => (captured = s)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(resume).not.toBeNull())
+    await resume!('stored-1', true)
+
+    expect(captured).toBeDefined()
+    // No stale tail grafted on; the completed turn stands and the journal is cleared.
+    expect(captured?.messages.map(message => chatMessageText(message))).toEqual(['fix crash', 'final answer'])
+    expect(captured?.busy).toBe(false)
+    expect(captured?.streamId).toBeNull()
+    expect(window.localStorage.getItem('hermes.desktop.inflightTurnJournal.v1')).toBeNull()
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -4,7 +4,13 @@ import type { NavigateFunction } from 'react-router-dom'
 
 import { deleteSession, getSessionMessages, setSessionArchived } from '@/hermes'
 import { useI18n } from '@/i18n'
-import { preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
+import { type ChatMessage, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
+import {
+  type BackendInFlightTurn,
+  type InFlightRecoveryResult,
+  mergeBackendInFlightTurn,
+  recoverInFlightTurnJournal
+} from '@/lib/inflight-turn-journal'
 import { setSessionYolo } from '@/lib/yolo-session'
 import { clearQueuedPrompts } from '@/store/composer-queue'
 import { $pinnedSessionIds } from '@/store/layout'
@@ -62,6 +68,40 @@ import {
   toBranchMessages,
   upsertOptimisticSession
 } from './utils'
+
+function noInFlightRecovery(messages: ChatMessage[]): InFlightRecoveryResult {
+  return {
+    applied: false,
+    caughtUp: false,
+    messages,
+    streamId: null,
+    turnStartedAt: null
+  }
+}
+
+// Fold a crashed/mid-flight turn back onto the restored transcript. The renderer
+// journal (survives an app/renderer crash) wins over the backend's `inflight`
+// payload (only present when the backend is still alive mid-turn); a no-op
+// returns `baseMessages` by reference so callers can keep the fast-path ref.
+function recoverResumeInFlight(
+  storedSessionId: null | string,
+  baseMessages: ChatMessage[],
+  backendInFlight: BackendInFlightTurn | null | undefined,
+  keepPending: boolean
+): InFlightRecoveryResult {
+  const backend = mergeBackendInFlightTurn(baseMessages, backendInFlight, { keepPending })
+  const local = recoverInFlightTurnJournal(storedSessionId, backend.messages, { keepPending })
+
+  if (local.applied) {
+    return local
+  }
+
+  if (backend.applied) {
+    return backend
+  }
+
+  return local.caughtUp ? local : noInFlightRecovery(baseMessages)
+}
 
 interface SessionActionsOptions {
   activeSessionId: string | null
@@ -444,7 +484,8 @@ export function useSessionActions({
         }))
       }
 
-      let resumedRunning = false
+      let resumedTurnStillRunning = false
+      let resumedTurnAwaitingResponse = false
 
       try {
         const watchWindow = isWatchWindow()
@@ -514,30 +555,55 @@ export function useSessionActions({
                 return chatMessageArraysEquivalent(currentMessages, resumedMessages) ? currentMessages : resumedMessages
               })()
 
-        // Prefetch-hit fast path: `preferredMessages` IS the live `$messages`
-        // array (already error-merged when `localSnapshot` was built), so reuse
-        // the ref instead of rebuilding a throwaway transcript+Map every switch.
-        const messagesForView =
-          preferredMessages === currentMessages
-            ? currentMessages
-            : preserveLocalAssistantErrors(preferredMessages, currentMessages)
-
-        if (sessionShouldHaveTranscript(stored) && messagesForView.length === 0) {
+        // A genuinely empty transcript for a session that should have one is a
+        // failed resume — fail-latch it. Checked on the pre-recovery messages so
+        // an orphan in-flight journal entry can't mask a lost transcript (a retry
+        // that reloads the real history is safer than surfacing the turn alone).
+        // Recovery below only ever APPENDS the in-flight tail, so this equals the
+        // final transcript's emptiness.
+        if (sessionShouldHaveTranscript(stored) && preferredMessages.length === 0) {
           setActiveSessionId(null)
           activeSessionIdRef.current = null
           setResumeFailedSessionId(storedSessionId)
-          resumedRunning = false
 
           return
         }
+
+        // Crash-survivable turn progress: if the renderer persisted an in-flight
+        // turn (local journal, survives an app/renderer crash) or the backend is
+        // still mid-turn (`resumed.inflight`), fold that tail back onto the
+        // restored transcript. Runs AFTER `preferredMessages` resolves so it
+        // coexists with the prefetch-hit fast path above — a no-op (same ref)
+        // whenever there's nothing to recover, so the common resume pays only a
+        // small bounded localStorage read, never a second transcript reconcile.
+        const resumedRunning = Boolean(resumed.running || resumed.info?.running)
+        const inFlightRecovery = recoverResumeInFlight(
+          storedSessionId,
+          preferredMessages,
+          resumed.inflight,
+          resumedRunning
+        )
+
+        // Prefetch-hit fast path: when recovery is a no-op and `preferredMessages`
+        // IS the live `$messages` array (already error-merged when `localSnapshot`
+        // was built), reuse the ref instead of rebuilding a throwaway
+        // transcript+Map every switch.
+        const messagesForView =
+          !inFlightRecovery.applied && preferredMessages === currentMessages
+            ? currentMessages
+            : preserveLocalAssistantErrors(inFlightRecovery.messages, currentMessages)
+
+        resumedTurnStillRunning = resumedRunning
+        // A recovered assistant tail means the turn already emitted output, so the
+        // composer shows the live "streaming" state rather than the
+        // "awaiting first token" spinner.
+        resumedTurnAwaitingResponse = resumedRunning && !inFlightRecovery.applied
 
         setActiveSessionId(resumed.session_id)
         activeSessionIdRef.current = resumed.session_id
         const runtimeInfo = applyRuntimeInfo(resumed.info)
 
         patchSessionWorkspace(storedSessionId, runtimeInfo?.cwd)
-
-        resumedRunning = Boolean((resumed as { running?: boolean }).running)
 
         updateSessionState(
           resumed.session_id,
@@ -546,7 +612,15 @@ export function useSessionActions({
             ...(runtimeInfo ?? {}),
             messages: messagesForView,
             busy: resumedRunning,
-            awaitingResponse: resumedRunning
+            awaitingResponse: resumedTurnAwaitingResponse,
+            sawAssistantPayload: inFlightRecovery.applied ? true : state.sawAssistantPayload,
+            streamId: resumedRunning && inFlightRecovery.applied ? inFlightRecovery.streamId : null,
+            turnStartedAt:
+              resumedRunning && inFlightRecovery.applied
+                ? (inFlightRecovery.turnStartedAt ?? Date.now())
+                : resumedRunning
+                  ? (state.turnStartedAt ?? Date.now())
+                  : null
           }),
           storedSessionId
         )
@@ -572,7 +646,8 @@ export function useSessionActions({
             return
           }
 
-          setMessages(preserveLocalAssistantErrors(toChatMessages(fallback.messages), $messages.get()))
+          const recovered = recoverInFlightTurnJournal(storedSessionId, toChatMessages(fallback.messages))
+          setMessages(preserveLocalAssistantErrors(recovered.messages, $messages.get()))
         } catch (e) {
           // Fallback also failed: nothing to paint. Leave whatever messages are
           // already shown and fall through to arm the resume-failure latch so
@@ -612,9 +687,9 @@ export function useSessionActions({
         notifyError(err, copy.resumeFailed)
       } finally {
         if (isCurrentResume()) {
-          busyRef.current = resumedRunning
-          setBusy(resumedRunning)
-          setAwaitingResponse(resumedRunning)
+          busyRef.current = resumedTurnStillRunning
+          setBusy(resumedTurnStillRunning)
+          setAwaitingResponse(resumedTurnAwaitingResponse)
         }
       }
     },

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -4,6 +4,7 @@ import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 import type { ChatMessage } from '@/lib/chat-messages'
 import { preserveLocalAssistantErrors } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
+import { clearInFlightTurnJournal, persistInFlightTurnState } from '@/lib/inflight-turn-journal'
 import { setMutableRef } from '@/lib/mutable-ref'
 import {
   $busy,
@@ -256,10 +257,15 @@ export function useSessionStateCache({
         setSessionWorking(previous.storedSessionId, false)
       }
 
+      if (previous.storedSessionId && previous.storedSessionId !== next.storedSessionId) {
+        clearInFlightTurnJournal(previous.storedSessionId)
+      }
+
       if (previous.storedSessionId !== next.storedSessionId || !next.needsInput) {
         setSessionAttention(previous.storedSessionId, false)
       }
 
+      persistInFlightTurnState(sessionId, next)
       setSessionWorking(next.storedSessionId, next.busy)
       setSessionAttention(next.storedSessionId, next.needsInput)
 

--- a/apps/desktop/src/lib/inflight-turn-journal.test.ts
+++ b/apps/desktop/src/lib/inflight-turn-journal.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import type { ChatMessage, ChatMessagePart } from './chat-messages'
+import { chatMessageText } from './chat-messages'
+import {
+  backendInFlightMessages,
+  mergeBackendInFlightTurn,
+  persistInFlightTurnState,
+  readInFlightTurnJournal,
+  recoverInFlightTurnJournal
+} from './inflight-turn-journal'
+
+const textMessage = (role: ChatMessage['role'], text: string, id = `${role}-${text}`): ChatMessage => ({
+  id,
+  parts: [{ text, type: 'text' }],
+  role
+})
+
+const toolPart = (id = 'tool-1'): ChatMessagePart =>
+  ({
+    args: { command: 'echo hi' },
+    argsText: '{"command":"echo hi"}',
+    toolCallId: id,
+    toolName: 'terminal',
+    type: 'tool-call'
+  }) as ChatMessagePart
+
+describe('in-flight turn journal', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('persists only the active user plus assistant/tool tail and restores it after the stored prompt', () => {
+    const earlier = [textMessage('user', 'older prompt'), textMessage('assistant', 'older answer')]
+    const user = textMessage('user', 'fix the desktop crash', 'optimistic-user')
+
+    const assistant: ChatMessage = {
+      id: 'assistant-stream-1',
+      parts: [{ text: 'I found the stream path. ', type: 'text' }, toolPart()],
+      pending: true,
+      role: 'assistant'
+    }
+
+    persistInFlightTurnState('runtime-1', {
+      awaitingResponse: false,
+      busy: true,
+      messages: [...earlier, user, assistant],
+      storedSessionId: 'stored-1',
+      streamId: assistant.id,
+      turnStartedAt: 123
+    })
+
+    const snapshot = readInFlightTurnJournal('stored-1')
+    expect(snapshot?.messages.map(message => message.id)).toEqual(['optimistic-user', 'assistant-stream-1'])
+
+    const storedMessages = [...earlier, textMessage('user', 'fix the desktop crash', 'stored-user')]
+    const recovered = recoverInFlightTurnJournal('stored-1', storedMessages)
+
+    expect(recovered.applied).toBe(true)
+    expect(recovered.turnStartedAt).toBe(123)
+    expect(recovered.messages.map(message => message.id)).toEqual([
+      'user-older prompt',
+      'assistant-older answer',
+      'stored-user',
+      'assistant-stream-1'
+    ])
+    expect(recovered.messages.at(-1)?.pending).toBe(false)
+    expect(recovered.messages.at(-1)?.parts.some(part => part.type === 'tool-call')).toBe(true)
+  })
+
+  it('does not resurrect the journal once stored history already has an assistant response', () => {
+    persistInFlightTurnState('runtime-1', {
+      awaitingResponse: false,
+      busy: true,
+      messages: [
+        textMessage('user', 'continue', 'optimistic-user'),
+        { id: 'assistant-stream-1', parts: [{ text: 'partial', type: 'text' }], pending: true, role: 'assistant' }
+      ],
+      storedSessionId: 'stored-1',
+      streamId: 'assistant-stream-1',
+      turnStartedAt: 123
+    })
+
+    const recovered = recoverInFlightTurnJournal('stored-1', [
+      textMessage('user', 'continue', 'stored-user'),
+      textMessage('assistant', 'final answer', 'stored-assistant')
+    ])
+
+    expect(recovered.applied).toBe(false)
+    expect(recovered.caughtUp).toBe(true)
+    expect(readInFlightTurnJournal('stored-1')).toBeNull()
+  })
+
+  it('clears stale journal state when a turn settles', () => {
+    persistInFlightTurnState('runtime-1', {
+      awaitingResponse: true,
+      busy: true,
+      messages: [
+        textMessage('user', 'continue', 'optimistic-user'),
+        { id: 'assistant-stream-1', parts: [{ text: 'partial', type: 'text' }], pending: true, role: 'assistant' }
+      ],
+      storedSessionId: 'stored-1',
+      streamId: 'assistant-stream-1',
+      turnStartedAt: 123
+    })
+
+    expect(readInFlightTurnJournal('stored-1')).not.toBeNull()
+
+    persistInFlightTurnState('runtime-1', {
+      awaitingResponse: false,
+      busy: false,
+      messages: [],
+      storedSessionId: 'stored-1',
+      streamId: null,
+      turnStartedAt: null
+    })
+
+    expect(readInFlightTurnJournal('stored-1')).toBeNull()
+  })
+})
+
+describe('backend inflight payloads', () => {
+  it('turns a live backend inflight payload into recoverable chat messages', () => {
+    const messages = backendInFlightMessages({
+      assistant: 'partial answer',
+      streaming: true,
+      user: 'write a long answer'
+    })
+
+    expect(messages).toHaveLength(2)
+    expect(messages[0].role).toBe('user')
+    expect(chatMessageText(messages[0])).toBe('write a long answer')
+    expect(messages[1].role).toBe('assistant')
+    expect(messages[1].pending).toBe(true)
+    expect(chatMessageText(messages[1])).toBe('partial answer')
+  })
+
+  it('merges backend inflight output after the matching stored user prompt', () => {
+    const recovered = mergeBackendInFlightTurn(
+      [textMessage('user', 'write a long answer', 'stored-user')],
+      {
+        assistant: 'partial answer',
+        streaming: true,
+        user: 'write a long answer'
+      },
+      { keepPending: true }
+    )
+
+    expect(recovered.applied).toBe(true)
+    expect(recovered.messages.map(message => message.role)).toEqual(['user', 'assistant'])
+    expect(recovered.messages[1].pending).toBe(true)
+    expect(chatMessageText(recovered.messages[1])).toBe('partial answer')
+    expect(recovered.streamId).toBe(recovered.messages[1].id)
+  })
+})

--- a/apps/desktop/src/lib/inflight-turn-journal.ts
+++ b/apps/desktop/src/lib/inflight-turn-journal.ts
@@ -1,0 +1,448 @@
+import {
+  assistantTextPart,
+  type ChatMessage,
+  type ChatMessagePart,
+  chatMessageText,
+  textPart
+} from '@/lib/chat-messages'
+
+const STORAGE_KEY = 'hermes.desktop.inflightTurnJournal.v1'
+const STORE_VERSION = 1
+const MAX_ENTRIES = 24
+const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
+
+export interface BackendInFlightTurn {
+  assistant?: string
+  streaming?: boolean
+  user?: string
+}
+
+export interface InFlightTurnSnapshot {
+  awaitingResponse: boolean
+  busy: boolean
+  messages: ChatMessage[]
+  runtimeSessionId: string
+  storedSessionId: string
+  streamId: null | string
+  turnStartedAt: null | number
+  updatedAt: number
+  version: typeof STORE_VERSION
+}
+
+export interface JournalableSessionState {
+  awaitingResponse: boolean
+  busy: boolean
+  messages: ChatMessage[]
+  storedSessionId: null | string
+  streamId: null | string
+  turnStartedAt: null | number
+}
+
+interface JournalStore {
+  entries: Record<string, InFlightTurnSnapshot>
+  version: typeof STORE_VERSION
+}
+
+export interface InFlightRecoveryResult {
+  applied: boolean
+  caughtUp: boolean
+  messages: ChatMessage[]
+  streamId: null | string
+  turnStartedAt: null | number
+}
+
+function storage(): Storage | null {
+  try {
+    return typeof window === 'undefined' ? null : window.localStorage
+  } catch {
+    return null
+  }
+}
+
+function emptyStore(): JournalStore {
+  return { entries: {}, version: STORE_VERSION }
+}
+
+function loadStore(): JournalStore {
+  const store = storage()
+
+  if (!store) {
+    return emptyStore()
+  }
+
+  try {
+    const raw = store.getItem(STORAGE_KEY)
+
+    if (!raw) {
+      return emptyStore()
+    }
+
+    const parsed = JSON.parse(raw)
+
+    if (!parsed || parsed.version !== STORE_VERSION || typeof parsed.entries !== 'object' || Array.isArray(parsed.entries)) {
+      return emptyStore()
+    }
+
+    return {
+      entries: parsed.entries as Record<string, InFlightTurnSnapshot>,
+      version: STORE_VERSION
+    }
+  } catch {
+    return emptyStore()
+  }
+}
+
+function saveStore(journal: JournalStore): void {
+  const store = storage()
+
+  if (!store) {
+    return
+  }
+
+  try {
+    const entries = Object.fromEntries(
+      Object.entries(journal.entries)
+        .filter(([, entry]) => !isExpired(entry))
+        .sort((a, b) => b[1].updatedAt - a[1].updatedAt)
+        .slice(0, MAX_ENTRIES)
+    )
+
+    if (Object.keys(entries).length === 0) {
+      store.removeItem(STORAGE_KEY)
+
+      return
+    }
+
+    store.setItem(STORAGE_KEY, JSON.stringify({ entries, version: STORE_VERSION }))
+  } catch {
+    // The journal is a best-effort crash-recovery aid. Storage quota/private
+    // mode failures must never break chat streaming.
+  }
+}
+
+function isExpired(entry: InFlightTurnSnapshot, now = Date.now()): boolean {
+  return now - entry.updatedAt > MAX_AGE_MS
+}
+
+function cloneMessages(messages: ChatMessage[]): ChatMessage[] {
+  try {
+    return JSON.parse(JSON.stringify(messages)) as ChatMessage[]
+  } catch {
+    return []
+  }
+}
+
+function normalizedText(value: string): string {
+  return value.replace(/\s+/g, ' ').trim()
+}
+
+function attachmentSignature(message: ChatMessage): string {
+  return (message.attachmentRefs ?? []).join('\n')
+}
+
+function userMessagesMatch(left: ChatMessage, right: ChatMessage): boolean {
+  return (
+    left.role === 'user' &&
+    right.role === 'user' &&
+    normalizedText(chatMessageText(left)) === normalizedText(chatMessageText(right)) &&
+    attachmentSignature(left) === attachmentSignature(right)
+  )
+}
+
+function partHasRecoverableContent(part: ChatMessagePart): boolean {
+  if (part.type === 'text' || part.type === 'reasoning') {
+    return typeof part.text === 'string' && part.text.trim().length > 0
+  }
+
+  return part.type === 'tool-call'
+}
+
+function assistantHasRecoverableContent(message: ChatMessage): boolean {
+  return (
+    message.role === 'assistant' &&
+    (Boolean(message.error) || message.parts.some(partHasRecoverableContent))
+  )
+}
+
+function recoverableTail(messages: ChatMessage[], streamId: null | string): ChatMessage[] {
+  const visible = messages.filter(message => !message.hidden)
+  let assistantIndex = -1
+
+  if (streamId) {
+    assistantIndex = visible.findIndex(message => message.id === streamId && assistantHasRecoverableContent(message))
+  }
+
+  if (assistantIndex < 0) {
+    for (let index = visible.length - 1; index >= 0; index -= 1) {
+      if (assistantHasRecoverableContent(visible[index])) {
+        assistantIndex = index
+
+        break
+      }
+    }
+  }
+
+  if (assistantIndex < 0) {
+    return []
+  }
+
+  let start = assistantIndex
+
+  for (let index = assistantIndex - 1; index >= 0; index -= 1) {
+    if (visible[index].role === 'user') {
+      start = index
+
+      break
+    }
+  }
+
+  return cloneMessages(visible.slice(start))
+}
+
+function normalizeRecoveredTail(tail: ChatMessage[], keepPending: boolean): ChatMessage[] {
+  return cloneMessages(tail).map(message =>
+    message.role === 'assistant'
+      ? {
+          ...message,
+          pending: keepPending ? (message.pending ?? true) : false
+        }
+      : { ...message, pending: false }
+  )
+}
+
+function findMatchingTailUserIndex(messages: ChatMessage[], tailUser: ChatMessage): number {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (userMessagesMatch(messages[index], tailUser)) {
+      return index
+    }
+  }
+
+  return -1
+}
+
+function appendedStreamId(tail: ChatMessage[]): null | string {
+  return tail.find(message => message.role === 'assistant' && assistantHasRecoverableContent(message))?.id ?? null
+}
+
+export function mergeInFlightMessages(
+  baseMessages: ChatMessage[],
+  tailMessages: ChatMessage[],
+  options: { keepPending?: boolean } = {}
+): InFlightRecoveryResult {
+  const tail = normalizeRecoveredTail(tailMessages, Boolean(options.keepPending))
+
+  if (!tail.some(assistantHasRecoverableContent)) {
+    return {
+      applied: false,
+      caughtUp: false,
+      messages: baseMessages,
+      streamId: null,
+      turnStartedAt: null
+    }
+  }
+
+  const tailUserIndex = tail.findIndex(message => message.role === 'user')
+  const tailUser = tailUserIndex >= 0 ? tail[tailUserIndex] : null
+  const streamId = appendedStreamId(tail)
+
+  if (!tailUser) {
+    return {
+      applied: true,
+      caughtUp: false,
+      messages: [...baseMessages, ...tail],
+      streamId,
+      turnStartedAt: null
+    }
+  }
+
+  const matchingUserIndex = findMatchingTailUserIndex(baseMessages, tailUser)
+
+  if (matchingUserIndex < 0) {
+    return {
+      applied: true,
+      caughtUp: false,
+      messages: [...baseMessages, ...tail],
+      streamId,
+      turnStartedAt: null
+    }
+  }
+
+  const assistantAfterUser = baseMessages.slice(matchingUserIndex + 1).some(assistantHasRecoverableContent)
+
+  if (assistantAfterUser) {
+    return {
+      applied: false,
+      caughtUp: true,
+      messages: baseMessages,
+      streamId: null,
+      turnStartedAt: null
+    }
+  }
+
+  const append = tail.slice(tailUserIndex + 1)
+
+  if (append.length === 0) {
+    return {
+      applied: false,
+      caughtUp: false,
+      messages: baseMessages,
+      streamId: null,
+      turnStartedAt: null
+    }
+  }
+
+  return {
+    applied: true,
+    caughtUp: false,
+    messages: [...baseMessages, ...append],
+    streamId,
+    turnStartedAt: null
+  }
+}
+
+function hashText(value: string): string {
+  let hash = 0
+
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) | 0
+  }
+
+  return Math.abs(hash).toString(36)
+}
+
+export function backendInFlightMessages(inflight: BackendInFlightTurn | null | undefined): ChatMessage[] {
+  const user = inflight?.user?.trim() ?? ''
+  const assistant = inflight?.assistant ?? ''
+
+  if (!user && !assistant.trim()) {
+    return []
+  }
+
+  const suffix = hashText(`${user}\0${assistant}`)
+  const messages: ChatMessage[] = []
+
+  if (user) {
+    messages.push({
+      id: `inflight-user-${suffix}`,
+      parts: [textPart(user)],
+      role: 'user'
+    })
+  }
+
+  if (assistant.trim()) {
+    messages.push({
+      id: `inflight-assistant-${suffix}`,
+      parts: [assistantTextPart(assistant)],
+      pending: Boolean(inflight?.streaming),
+      role: 'assistant'
+    })
+  }
+
+  return messages
+}
+
+export function mergeBackendInFlightTurn(
+  baseMessages: ChatMessage[],
+  inflight: BackendInFlightTurn | null | undefined,
+  options: { keepPending?: boolean } = {}
+): InFlightRecoveryResult {
+  return mergeInFlightMessages(baseMessages, backendInFlightMessages(inflight), options)
+}
+
+export function persistInFlightTurnState(runtimeSessionId: string, state: JournalableSessionState): void {
+  const storedSessionId = state.storedSessionId
+
+  if (!storedSessionId) {
+    return
+  }
+
+  const active = state.busy || state.awaitingResponse || Boolean(state.streamId)
+  const tail = active ? recoverableTail(state.messages, state.streamId) : []
+
+  if (!active || tail.length === 0) {
+    clearInFlightTurnJournal(storedSessionId)
+
+    return
+  }
+
+  const journal = loadStore()
+  journal.entries[storedSessionId] = {
+    awaitingResponse: state.awaitingResponse,
+    busy: state.busy,
+    messages: tail,
+    runtimeSessionId,
+    storedSessionId,
+    streamId: state.streamId,
+    turnStartedAt: state.turnStartedAt,
+    updatedAt: Date.now(),
+    version: STORE_VERSION
+  }
+  saveStore(journal)
+}
+
+export function readInFlightTurnJournal(storedSessionId: null | string): InFlightTurnSnapshot | null {
+  if (!storedSessionId) {
+    return null
+  }
+
+  const journal = loadStore()
+  const entry = journal.entries[storedSessionId]
+
+  if (!entry) {
+    return null
+  }
+
+  if (isExpired(entry)) {
+    delete journal.entries[storedSessionId]
+    saveStore(journal)
+
+    return null
+  }
+
+  return entry
+}
+
+export function recoverInFlightTurnJournal(
+  storedSessionId: null | string,
+  baseMessages: ChatMessage[],
+  options: { keepPending?: boolean } = {}
+): InFlightRecoveryResult {
+  const snapshot = readInFlightTurnJournal(storedSessionId)
+
+  if (!snapshot) {
+    return {
+      applied: false,
+      caughtUp: false,
+      messages: baseMessages,
+      streamId: null,
+      turnStartedAt: null
+    }
+  }
+
+  const recovered = mergeInFlightMessages(baseMessages, snapshot.messages, options)
+
+  if (recovered.caughtUp) {
+    clearInFlightTurnJournal(storedSessionId)
+  }
+
+  return {
+    ...recovered,
+    streamId: recovered.applied ? (snapshot.streamId || recovered.streamId) : null,
+    turnStartedAt: recovered.applied ? snapshot.turnStartedAt : null
+  }
+}
+
+export function clearInFlightTurnJournal(storedSessionId: null | string): void {
+  if (!storedSessionId) {
+    return
+  }
+
+  const journal = loadStore()
+
+  if (!(storedSessionId in journal.entries)) {
+    return
+  }
+
+  delete journal.entries[storedSessionId]
+  saveStore(journal)
+}

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -385,11 +385,19 @@ export interface SessionMessagesResponse {
 }
 
 export interface SessionResumeResponse {
+  inflight?: null | SessionInFlightTurn
   info?: SessionRuntimeInfo
   message_count: number
   messages: SessionMessage[]
   resumed: string
+  running?: boolean
   session_id: string
+}
+
+export interface SessionInFlightTurn {
+  assistant?: string
+  streaming?: boolean
+  user?: string
 }
 
 export interface SessionRuntimeInfo {


### PR DESCRIPTION
## Why

Hermes Desktop can lose visible in-flight turn progress if the app process dies mid-turn. On restart, the persisted session transcript may only contain the initiating user prompt, which makes streamed assistant text and tool progress appear lost even when the turn was actively producing useful output before the crash.

## What Changed

- Added a bounded desktop-only in-flight turn journal in localStorage.
- Persisted the current visible user/assistant/tool tail while a session is busy, and clear it once the stored transcript catches up or the turn settles.
- Recovered the journal during session resume, and merged backend `inflight` resume payloads when present.
- Extended desktop resume response typing for optional running/in-flight state.

## How To Review

Start with `apps/desktop/src/lib/inflight-turn-journal.ts`, then check the resume integration in `apps/desktop/src/app/session/hooks/use-session-actions.ts` and the central persistence hook in `apps/desktop/src/app/session/hooks/use-session-state-cache.ts`.

## Evidence

- `git diff --check upstream/main...HEAD` exited rc=0.
- Upstream-visible diff is limited to five files: the journal, journal tests, resume integration, cache persistence, and resume typings.
- Fork-local delivery PR OmarB97/hermes-agent#196 merged with 24/24 checks passing; this branch is the clean upstream carry-forward.

<!-- pr-quality:no-visual-required: state-recovery plumbing only; no visual output change to capture -->

## Verification

- `npm run test:ui -- src/lib/inflight-turn-journal.test.ts src/app/session/hooks/use-session-state-cache.test.tsx src/app/session/hooks/use-message-stream.test.tsx` exited rc=0: 2 files, 10 tests passed.
- `npx eslint src/lib/inflight-turn-journal.ts src/lib/inflight-turn-journal.test.ts src/app/session/hooks/use-session-state-cache.ts src/app/session/hooks/use-session-actions.ts src/types/hermes.ts` exited rc=0.
- `npm run typecheck` exited rc=0.
- `git diff --check upstream/main...HEAD` exited rc=0.

## Risks / Gaps

Accepted no-follow-up rationale: the journal is intentionally local to the desktop renderer and tail-limited, restoring the visible transcript after renderer/app death without mutating model conversation history. Installed-app swap/relaunch verification stays on MeshBoard task `hermes-desktop-crash-survivable-turn-progress-20260611` because it requires a safe restart window for active sessions.

## Collaborators

- Omar Baradei: operator on ko-mac, reported the crash-restart UX failure and requested upstream follow-through on 2026-06-11.
- Codex: ko-mac.codex#765db69c69, local coding lane, iteration 2/n for MeshBoard task `hermes-desktop-crash-survivable-turn-progress-20260611`, implemented and verified the upstream branch on 2026-06-11.
