### PR TITLE
feat: add context fill warning before compression

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1323,6 +1323,26 @@ def init_agent(
         _compression_cfg.get("abort_on_summary_failure", False)
     ).lower() in {"true", "1", "yes"}
 
+    # Context-fill warning: one-time per-compression-cycle reminder emitted
+    # via _emit_status when usage crosses compression.warning_threshold,
+    # before auto-compression fires at compression.threshold.  The fired
+    # state lives on the agent (_context_fill_warning_cycle) keyed to the
+    # engine's compression_count — see conversation_loop's
+    # _maybe_emit_context_fill_warning.
+    agent._context_warning_enabled = str(
+        _compression_cfg.get("warning_enabled", True)
+    ).lower() in {"true", "1", "yes"}
+    try:
+        agent._context_warning_threshold = float(
+            _compression_cfg.get("warning_threshold", 0.7)
+        )
+    except (TypeError, ValueError):
+        agent._context_warning_threshold = 0.7
+    agent._context_warning_message = str(
+        _compression_cfg.get("warning_message", "") or ""
+    ).strip()
+    agent._context_fill_warning_cycle = None
+
     # Read optional explicit context_length override for the auxiliary
     # compression model. Custom endpoints often cannot report this via
     # /models, so the startup feasibility check needs the config hint.

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -124,6 +124,94 @@ def _ra():
     return run_agent
 
 
+_DEFAULT_CONTEXT_WARNING_MESSAGE = (
+    "Context is getting high. Save important progress before continuing."
+)
+
+
+def _context_usage_snapshot(agent: Any) -> Dict[str, Any]:
+    """Best-known context usage, shaped for the ``pre_llm_call`` hook payload.
+
+    Reads the active context engine's tracked counters — the same signal the
+    CLI status bar renders.  ``last_prompt_tokens`` is parked at the ``-1``
+    sentinel right after a compression (until the next real API response
+    reports usage), so it is clamped to 0 here; consumers never see a
+    negative count.
+
+    Safe on agents without a context engine (all fields zero/None).
+    """
+    engine = getattr(agent, "context_compressor", None)
+    try:
+        tokens = int(getattr(engine, "last_prompt_tokens", 0) or 0)
+        length = int(getattr(engine, "context_length", 0) or 0)
+        compressions = int(getattr(engine, "compression_count", 0) or 0)
+    except (TypeError, ValueError):
+        tokens, length, compressions = 0, 0, 0
+    tokens = max(0, tokens)
+    length = max(0, length)
+    return {
+        "context_tokens": tokens,
+        "context_length": length,
+        "context_percent": (tokens / length * 100.0) if length else 0.0,
+        "compression_count": compressions,
+        "compression_threshold": getattr(engine, "threshold_percent", None),
+        "context_warning_threshold": getattr(
+            agent, "_context_warning_threshold", None
+        ),
+    }
+
+
+def _maybe_emit_context_fill_warning(agent: Any) -> bool:
+    """Surface the one-time context-fill warning when usage crosses
+    ``compression.warning_threshold`` (default 0.7), before auto-compression
+    fires at ``compression.threshold``.
+
+    Fires at most once per compression cycle: the fired state
+    (``agent._context_fill_warning_cycle``) is keyed to the engine's
+    ``compression_count``, so each compaction — which increments the count
+    and parks ``last_prompt_tokens`` at the ``-1`` sentinel — re-arms the
+    warning for the next context buildup.  ``reset_session_state`` clears
+    the state on /new // reset.
+
+    Emitted via ``_emit_status`` so every host surfaces it the same way as
+    other lifecycle notices (CLI print, gateway chat message, TUI/desktop
+    status event).  Nothing is injected into the message list, so prompt
+    caching and persisted history are untouched.
+
+    Returns True when the warning was emitted by this call.
+    """
+    if not getattr(agent, "_context_warning_enabled", False):
+        return False
+    engine = getattr(agent, "context_compressor", None)
+    if engine is None:
+        return False
+    try:
+        threshold = float(getattr(agent, "_context_warning_threshold", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        return False
+    if threshold <= 0:
+        return False
+
+    snapshot = _context_usage_snapshot(agent)
+    if not snapshot["context_length"]:
+        return False
+    cycle = snapshot["compression_count"]
+    if getattr(agent, "_context_fill_warning_cycle", None) == cycle:
+        return False  # already warned during this buildup
+    if snapshot["context_tokens"] / snapshot["context_length"] < threshold:
+        return False
+
+    agent._context_fill_warning_cycle = cycle
+    message = (
+        str(getattr(agent, "_context_warning_message", "") or "").strip()
+        or _DEFAULT_CONTEXT_WARNING_MESSAGE
+    )
+    agent._emit_status(
+        f"⚠️ CONTEXT {snapshot['context_percent']:.0f}% FULL\n\n{message}"
+    )
+    return True
+
+
 def _nous_entitlement_message(capability: str) -> str:
     try:
         from hermes_cli.nous_account import (
@@ -419,6 +507,8 @@ def run_conversation(
         set_session_context=set_session_context,
         set_current_write_origin=set_current_write_origin,
         ra=_ra,
+        context_usage_snapshot=_context_usage_snapshot,
+        maybe_emit_context_fill_warning=_maybe_emit_context_fill_warning,
     )
     user_message = _ctx.user_message
     original_user_message = _ctx.original_user_message

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -77,6 +77,8 @@ def build_turn_context(
     set_session_context,
     set_current_write_origin,
     ra,
+    context_usage_snapshot,
+    maybe_emit_context_fill_warning,
 ) -> TurnContext:
     """Run the once-per-turn setup and return the loop's input context.
 
@@ -313,6 +315,15 @@ def build_turn_context(
                 if not _compressor.should_compress(_preflight_tokens):
                     break
 
+    # ── Context-fill warning ──
+    # One-time reminder that context usage crossed
+    # compression.warning_threshold and auto-compression is approaching.
+    # Runs AFTER preflight so it reads the freshest signal: preflight seeds
+    # compressor.last_prompt_tokens with its estimate when safe, and a
+    # compaction parks the sentinel/-1 + bumps compression_count, which
+    # re-arms the warning for the next buildup cycle.
+    maybe_emit_context_fill_warning(agent)
+
     # Plugin hook: pre_llm_call (context injected into user message, not system prompt).
     plugin_user_context = ""
     try:
@@ -328,6 +339,7 @@ def build_turn_context(
             model=agent.model,
             platform=getattr(agent, "platform", None) or "",
             sender_id=getattr(agent, "_user_id", None) or "",
+            **context_usage_snapshot(agent),
         )
         _ctx_parts: list[str] = []
         for r in _pre_results:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1141,6 +1141,16 @@ DEFAULT_CONFIG = {
     "compression": {
         "enabled": True,
         "threshold": 0.50,            # compress when context usage exceeds this ratio
+        "warning_enabled": True,      # surface a one-time reminder when context usage
+                                      # crosses warning_threshold, before auto-compression
+                                      # fires. Warns once per compression cycle; re-arms
+                                      # after each compaction (and on /new — see
+                                      # reset_session_state).
+        "warning_threshold": 0.7,     # warn when context usage reaches this ratio of the
+                                      # model's context window. Only meaningful when set
+                                      # below compression.threshold — otherwise compression
+                                      # fires first and the warning never appears.
+        "warning_message": "Context is getting high. Save important progress before continuing.",
         "target_ratio": 0.20,         # fraction of threshold to preserve as recent tail
         "protect_last_n": 20,         # minimum recent messages to keep uncompressed
         "hygiene_hard_message_limit": 400,  # gateway session-hygiene force-compress threshold by message count

--- a/run_agent.py
+++ b/run_agent.py
@@ -642,6 +642,13 @@ class AIAgent:
         # Turn counter (added after reset_session_state was first written — #2635)
         self._user_turn_count = 0
 
+        # Re-arm the context-fill warning for the fresh session.  The fired
+        # state is keyed to the engine's compression_count, which the engine
+        # reset below sends back to 0 — without this line a warning fired at
+        # cycle 0 in the old session would suppress the first warning of the
+        # new one.
+        self._context_fill_warning_cycle = None
+
         # Context engine reset/transition (works for built-in compressor and plugins)
         self._transition_context_engine_session(
             old_session_id=old_session_id,

--- a/tests/agent/test_context_fill_warning.py
+++ b/tests/agent/test_context_fill_warning.py
@@ -1,0 +1,322 @@
+"""Context-fill warning (compression.warning_*) + pre_llm_call usage payload.
+
+Covers:
+  - config defaults expose the warning keys under ``compression``
+  - the warning fires at/above the threshold, not below
+  - the warning fires once per compression cycle and re-arms after a
+    compaction (compression_count bump + last_prompt_tokens sentinel)
+  - reset_session_state() re-arms the warning for a fresh session
+  - the enriched pre_llm_call payload stays backward compatible with
+    hooks written before the context-usage fields existed
+"""
+
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+# Ensure repo root is importable
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+# Stub out optional heavy dependencies not installed in the test environment
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+from agent.conversation_loop import (
+    _DEFAULT_CONTEXT_WARNING_MESSAGE,
+    _context_usage_snapshot,
+    _maybe_emit_context_fill_warning,
+)
+
+
+def _make_agent(
+    tokens=0,
+    length=200_000,
+    compressions=0,
+    enabled=True,
+    threshold=0.7,
+    message="",
+    with_engine=True,
+):
+    """Lightweight stand-in for AIAgent with just the attrs the helpers read."""
+    statuses = []
+    engine = None
+    if with_engine:
+        engine = SimpleNamespace(
+            last_prompt_tokens=tokens,
+            context_length=length,
+            compression_count=compressions,
+            threshold_percent=0.8,
+        )
+    agent = SimpleNamespace(
+        context_compressor=engine,
+        _context_warning_enabled=enabled,
+        _context_warning_threshold=threshold,
+        _context_warning_message=message,
+        _context_fill_warning_cycle=None,
+        _emit_status=lambda msg: statuses.append(msg),
+    )
+    agent._statuses = statuses
+    return agent
+
+
+# ---------------------------------------------------------------------------
+# Config defaults
+# ---------------------------------------------------------------------------
+
+class TestConfigDefaults:
+    def test_warning_keys_present_under_compression(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        comp = DEFAULT_CONFIG["compression"]
+        assert comp["warning_enabled"] is True
+        assert comp["warning_threshold"] == 0.7
+        assert (
+            comp["warning_message"]
+            == "Context is getting high. Save important progress before continuing."
+        )
+
+    def test_default_message_constant_matches_config(self):
+        """The in-code fallback and the config default must not drift apart."""
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        assert (
+            _DEFAULT_CONTEXT_WARNING_MESSAGE
+            == DEFAULT_CONFIG["compression"]["warning_message"]
+        )
+
+    def test_compression_trigger_keys_unchanged(self):
+        """Adding warning keys must not disturb the compression trigger keys."""
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        comp = DEFAULT_CONFIG["compression"]
+        assert comp["enabled"] is True
+        assert 0 < comp["threshold"] <= 1
+
+
+# ---------------------------------------------------------------------------
+# _context_usage_snapshot (pre_llm_call payload fields)
+# ---------------------------------------------------------------------------
+
+class TestContextUsageSnapshot:
+    def test_fields_from_engine(self):
+        agent = _make_agent(tokens=50_000, length=200_000, compressions=2)
+        snap = _context_usage_snapshot(agent)
+        assert snap == {
+            "context_tokens": 50_000,
+            "context_length": 200_000,
+            "context_percent": 25.0,
+            "compression_count": 2,
+            "compression_threshold": 0.8,
+            "context_warning_threshold": 0.7,
+        }
+
+    def test_post_compression_sentinel_clamped(self):
+        """last_prompt_tokens is parked at -1 right after a compaction."""
+        agent = _make_agent(tokens=-1, length=200_000)
+        snap = _context_usage_snapshot(agent)
+        assert snap["context_tokens"] == 0
+        assert snap["context_percent"] == 0.0
+
+    def test_no_engine_is_safe(self):
+        agent = _make_agent(with_engine=False)
+        snap = _context_usage_snapshot(agent)
+        assert snap["context_tokens"] == 0
+        assert snap["context_length"] == 0
+        assert snap["context_percent"] == 0.0
+        assert snap["compression_count"] == 0
+        assert snap["compression_threshold"] is None
+
+    def test_zero_context_length_no_division(self):
+        agent = _make_agent(tokens=10_000, length=0)
+        assert _context_usage_snapshot(agent)["context_percent"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# _maybe_emit_context_fill_warning
+# ---------------------------------------------------------------------------
+
+class TestContextFillWarning:
+    def test_fires_at_exact_threshold(self):
+        agent = _make_agent(tokens=140_000, length=200_000)  # exactly 70%
+        assert _maybe_emit_context_fill_warning(agent) is True
+        assert len(agent._statuses) == 1
+        assert agent._statuses[0].startswith("⚠️ CONTEXT 70% FULL\n\n")
+        assert _DEFAULT_CONTEXT_WARNING_MESSAGE in agent._statuses[0]
+
+    def test_fires_above_threshold(self):
+        agent = _make_agent(tokens=180_000, length=200_000)  # 90%
+        assert _maybe_emit_context_fill_warning(agent) is True
+
+    def test_does_not_fire_below_threshold(self):
+        agent = _make_agent(tokens=139_999, length=200_000)  # just under 70%
+        assert _maybe_emit_context_fill_warning(agent) is False
+        assert agent._statuses == []
+        assert agent._context_fill_warning_cycle is None
+
+    def test_fires_once_per_cycle(self):
+        agent = _make_agent(tokens=150_000, length=200_000)
+        assert _maybe_emit_context_fill_warning(agent) is True
+        # Same cycle, even higher usage — must stay quiet.
+        agent.context_compressor.last_prompt_tokens = 158_000
+        assert _maybe_emit_context_fill_warning(agent) is False
+        assert len(agent._statuses) == 1
+
+    def test_rearms_after_compression(self):
+        agent = _make_agent(tokens=150_000, length=200_000, compressions=0)
+        assert _maybe_emit_context_fill_warning(agent) is True
+
+        # Simulate what compress_context() does: bump the cycle counter and
+        # park last_prompt_tokens at the -1 sentinel until real usage arrives.
+        agent.context_compressor.compression_count = 1
+        agent.context_compressor.last_prompt_tokens = -1
+        assert _maybe_emit_context_fill_warning(agent) is False  # 0% — fresh cycle
+
+        # Context builds back up past the threshold in the new cycle.
+        agent.context_compressor.last_prompt_tokens = 150_000
+        assert _maybe_emit_context_fill_warning(agent) is True
+        assert len(agent._statuses) == 2
+
+    def test_disabled_never_fires(self):
+        agent = _make_agent(tokens=190_000, length=200_000, enabled=False)
+        assert _maybe_emit_context_fill_warning(agent) is False
+        assert agent._statuses == []
+
+    def test_no_engine_is_safe(self):
+        agent = _make_agent(tokens=190_000, with_engine=False)
+        assert _maybe_emit_context_fill_warning(agent) is False
+
+    def test_zero_context_length_never_fires(self):
+        agent = _make_agent(tokens=190_000, length=0)
+        assert _maybe_emit_context_fill_warning(agent) is False
+
+    def test_nonpositive_threshold_never_fires(self):
+        agent = _make_agent(tokens=190_000, length=200_000, threshold=0)
+        assert _maybe_emit_context_fill_warning(agent) is False
+
+    def test_custom_message_used(self):
+        agent = _make_agent(
+            tokens=150_000, length=200_000, message="Save your work now."
+        )
+        assert _maybe_emit_context_fill_warning(agent) is True
+        assert "Save your work now." in agent._statuses[0]
+
+    def test_empty_message_falls_back_to_default(self):
+        agent = _make_agent(tokens=150_000, length=200_000, message="   ")
+        assert _maybe_emit_context_fill_warning(agent) is True
+        assert _DEFAULT_CONTEXT_WARNING_MESSAGE in agent._statuses[0]
+
+    def test_works_with_real_compressor_attrs(self):
+        """Guard the attribute coupling against ContextCompressor renames."""
+        from agent.context_compressor import ContextCompressor
+
+        compressor = ContextCompressor(
+            model="test", quiet_mode=True, config_context_length=200_000
+        )
+        compressor.last_prompt_tokens = 150_000  # 75% of 200K
+        agent = _make_agent()
+        agent.context_compressor = compressor
+
+        snap = _context_usage_snapshot(agent)
+        assert snap["context_tokens"] == 150_000
+        assert snap["context_length"] == 200_000
+        assert snap["compression_threshold"] == compressor.threshold_percent
+
+        assert _maybe_emit_context_fill_warning(agent) is True
+        assert len(agent._statuses) == 1
+
+
+# ---------------------------------------------------------------------------
+# reset_session_state re-arms the warning
+# ---------------------------------------------------------------------------
+
+class TestResetSessionStateRearm:
+    def test_reset_clears_fired_cycle(self):
+        from run_agent import AIAgent
+
+        agent = AIAgent.__new__(AIAgent)  # skip __init__ entirely
+        # Seed the attributes reset_session_state() writes
+        agent.session_total_tokens = 0
+        agent.session_input_tokens = 0
+        agent.session_output_tokens = 0
+        agent.session_prompt_tokens = 0
+        agent.session_completion_tokens = 0
+        agent.session_cache_read_tokens = 0
+        agent.session_cache_write_tokens = 0
+        agent.session_reasoning_tokens = 0
+        agent.session_api_calls = 0
+        agent.session_estimated_cost_usd = 0.0
+        agent.session_cost_status = "unknown"
+        agent.session_cost_source = "none"
+        agent._user_turn_count = 3
+        agent.context_compressor = None
+
+        agent._context_fill_warning_cycle = 2
+        agent.reset_session_state()
+        assert agent._context_fill_warning_cycle is None
+
+
+# ---------------------------------------------------------------------------
+# pre_llm_call payload backward compatibility
+# ---------------------------------------------------------------------------
+
+def _enriched_payload(agent):
+    """The exact kwargs shape run_conversation() now sends to pre_llm_call."""
+    return dict(
+        session_id="s1",
+        task_id="t1",
+        turn_id="turn-1",
+        user_message="hi",
+        conversation_history=[],
+        is_first_turn=True,
+        model="test-model",
+        platform="cli",
+        sender_id="",
+        **_context_usage_snapshot(agent),
+    )
+
+
+class TestPreLlmCallPayloadBackCompat:
+    def test_legacy_named_signature_still_works(self):
+        """Hooks written against the documented pre-enrichment signature
+        (named params + **kwargs) must keep working unchanged."""
+        from hermes_cli.plugins import PluginManager
+
+        def legacy_hook(
+            session_id, user_message, conversation_history,
+            is_first_turn, model, platform, **kwargs,
+        ):
+            return {"context": f"recalled for {session_id}"}
+
+        mgr = PluginManager()
+        mgr._hooks.setdefault("pre_llm_call", []).append(legacy_hook)
+
+        agent = _make_agent(tokens=50_000, length=200_000)
+        results = mgr.invoke_hook("pre_llm_call", **_enriched_payload(agent))
+        assert results == [{"context": "recalled for s1"}]
+
+    def test_new_fields_reach_kwargs_only_hooks(self):
+        from hermes_cli.plugins import PluginManager
+
+        seen = {}
+
+        def observer(**kwargs):
+            seen.update(kwargs)
+            return None
+
+        mgr = PluginManager()
+        mgr._hooks.setdefault("pre_llm_call", []).append(observer)
+
+        agent = _make_agent(tokens=150_000, length=200_000, compressions=1)
+        mgr.invoke_hook("pre_llm_call", **_enriched_payload(agent))
+
+        assert seen["context_tokens"] == 150_000
+        assert seen["context_length"] == 200_000
+        assert seen["context_percent"] == 75.0
+        assert seen["compression_count"] == 1
+        assert seen["compression_threshold"] == 0.8
+        assert seen["context_warning_threshold"] == 0.7
+        # Pre-existing fields are untouched
+        assert seen["user_message"] == "hi"
+        assert seen["is_first_turn"] is True

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -524,6 +524,12 @@ def my_callback(session_id: str, user_message: str, conversation_history: list,
 | `is_first_turn` | `bool` | `True` if this is the first turn of a new session, `False` on subsequent turns |
 | `model` | `str` | The model identifier (e.g. `"anthropic/claude-sonnet-4.6"`) |
 | `platform` | `str` | Where the session is running: `"cli"`, `"telegram"`, `"discord"`, etc. |
+| `context_tokens` | `int` | Best-known context usage in tokens (post-preflight; `0` right after a compaction until the next real API response) |
+| `context_length` | `int` | The model's context window in tokens (`0` if unknown) |
+| `context_percent` | `float` | `context_tokens / context_length * 100` (`0.0` when the window is unknown) |
+| `compression_count` | `int` | Number of compactions so far in this session |
+| `compression_threshold` | `float \| None` | Configured compression trigger ratio (`compression.threshold`) |
+| `context_warning_threshold` | `float \| None` | Configured context-fill warning ratio (`compression.warning_threshold`) |
 
 **Fires:** In `run_agent.py`, inside `run_conversation()`, after context compression but before the main `while` loop. Fires once per `run_conversation()` call (i.e. once per user turn), not once per API call within the tool loop.
 


### PR DESCRIPTION
## What does this PR do?

Adds a configurable context-fill warning before automatic compression.

The goal is to warn users before context gets high enough to trigger compression, so they can save important progress or summarize state before continuing.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Adds `compression.warning_enabled`
- Adds `compression.warning_threshold` with default `0.7`
- Adds `compression.warning_message`
- Emits a visible status warning when context usage crosses the warning threshold
- Fires once per compression cycle, not every turn
- Re-arms after compression or session reset
- Enriches the `pre_llm_call` hook payload with context usage fields:
  - `context_tokens`
  - `context_length`
  - `context_percent`
  - `compression_count`
  - `compression_threshold`
  - `context_warning_threshold`

## Behavior

Default visible format:

    ⚠️ CONTEXT 70% FULL

    Context is getting high. Save important progress before continuing.

The warning uses existing context engine/compressor state rather than a separate token estimator. It emits through the existing status mechanism used for lifecycle notices, so it is user-visible without injecting content into the model prompt or persisted message history.

## Safety / Scope

- Does not mutate persisted conversation history
- Does not auto-write files
- Does not add a cron/timer reminder
- Does not add a new model tool
- Additive/backward-compatible hook payload fields only

## Tests

Added `tests/agent/test_context_fill_warning.py`.

Local targeted test result:

    22 passed

