### PR TITLE
fix(cron): use path.as_posix() for .sh scripts on Windows

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1028,7 +1028,7 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
                 "On Windows, install Git for Windows (which ships Git Bash) "
                 "or rewrite the script as Python (.py)."
             )
-        argv = [_bash, str(path)]
+        argv = [_bash, path.as_posix()]
     else:
         argv = [sys.executable, str(path)]
 

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -329,3 +329,41 @@ def test_run_job_script_path_traversal_still_blocked(hermes_env):
     ok, output = _run_job_script("/etc/passwd")
     assert ok is False
     assert "Blocked" in output or "outside" in output
+
+
+def test_run_job_script_sh_uses_posix_paths(hermes_env, monkeypatch):
+    r"""Regression: on Windows, .sh scripts must receive forward-slash paths.
+
+    ``str(path)`` produces backslashes on Windows (``C:\Users\...``), which
+    bash interprets as escape sequences, mangling the path.  The fix uses
+    ``path.as_posix()`` so the argv is always forward-slash formatted.
+    """
+    from cron import scheduler
+    from cron.scheduler import _run_job_script
+
+    # Place script in a nested directory so the path has separators.
+    nested = hermes_env / "scripts" / "nested" / "dir"
+    nested.mkdir(parents=True)
+    script_path = nested / "watchdog.sh"
+    script_path.write_text('echo "ok"\n')
+
+    captured_argv = []
+
+    def _fake_run(argv, **kwargs):
+        captured_argv[:] = argv
+        class _R:
+            stdout = "ok\n"
+            stderr = ""
+            returncode = 0
+        return _R()
+
+    monkeypatch.setattr(scheduler.subprocess, "run", _fake_run)
+
+    ok, output = _run_job_script("nested/dir/watchdog.sh")
+    assert ok is True
+    assert output == "ok"
+
+    # Second argument is the script path.
+    script_arg = captured_argv[1]
+    assert "/" in script_arg, "path must contain forward slashes"
+    assert "\\" not in script_arg, "path must NOT contain backslashes"


### PR DESCRIPTION
On Windows, cron `.sh` and `.bash` scripts were passed to bash using `str(path)`, which produced backslash-separated paths. Bash (especially Git Bash / WSL) interprets backslashes as escape characters, so the script path could be mangled and fail to execute.

This change passes `path.as_posix()` for shell scripts so the argument is a forward-slash path regardless of host OS.

- `cron/scheduler.py`: use `path.as_posix()` when invoking `.sh`/`.bash` scripts
- `tests/cron/test_cron_no_agent.py`: add regression test `test_run_job_script_sh_uses_posix_paths`

Closes #43073