### PR TITLE
fix(gateway): reset _last_flushed_db_idx on cached-agent reuse

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12433,6 +12433,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             agent._last_activity_ts = time.time()
             agent._last_activity_desc = "starting new turn (cached)"
         agent._api_call_count = 0
+        # Reset the SessionDB flush cursor so _flush_messages_to_session_db
+        # recomputes flush_from from the new turn's conversation_history
+        # length instead of carrying over a stale offset from the previous
+        # turn.  Without this, a cached agent with _last_flushed_db_idx=N
+        # skips persisting the assistant reply when the new turn's history
+        # length is ≤N, producing consecutive user rows in the transcript
+        # and context-corrupting replay on subsequent turns (#44327).
+        agent._last_flushed_db_idx = 0
 
     def _release_evicted_agent_soft(self, agent: Any) -> None:
         """Soft cleanup for cache-evicted agents — preserves session tool state.

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -1448,6 +1448,54 @@ class TestCachedAgentInactivityReset:
         )
 
 
+    def test_flush_cursor_reset_on_fresh_turn(self):
+        """_last_flushed_db_idx must be reset to 0 on every cached-agent
+        turn so _flush_messages_to_session_db recomputes flush_from from
+        the new turn's conversation_history length (#44327)."""
+        from gateway.run import GatewayRunner
+
+        agent = self._fake_agent()
+        agent._last_flushed_db_idx = 42  # stale from previous turn
+
+        with patch("gateway.run.time") as mock_time:
+            mock_time.time.return_value = _FAKE_NOW
+            GatewayRunner._init_cached_agent_for_turn(agent, interrupt_depth=0)
+
+        assert agent._last_flushed_db_idx == 0, (
+            "_last_flushed_db_idx must be reset on cached-agent reuse; "
+            "stale cursor causes _flush_messages_to_session_db to skip "
+            "assistant replies, producing consecutive-user transcript rows"
+        )
+
+    def test_flush_cursor_reset_on_interrupt_turn(self):
+        """_last_flushed_db_idx must be reset even on interrupt-recursive
+        turns (depth>0) — the flush cursor is turn-scoped, not
+        watchdog-scoped."""
+        from gateway.run import GatewayRunner
+
+        agent = self._fake_agent()
+        agent._last_flushed_db_idx = 30
+
+        GatewayRunner._init_cached_agent_for_turn(agent, interrupt_depth=1)
+
+        assert agent._last_flushed_db_idx == 0, (
+            "_last_flushed_db_idx must reset at any interrupt depth"
+        )
+
+    def test_flush_cursor_reset_when_already_zero(self):
+        """Reset is idempotent — no-op when cursor is already 0."""
+        from gateway.run import GatewayRunner
+
+        agent = self._fake_agent()
+        agent._last_flushed_db_idx = 0
+
+        with patch("gateway.run.time") as mock_time:
+            mock_time.time.return_value = _FAKE_NOW
+            GatewayRunner._init_cached_agent_for_turn(agent, interrupt_depth=0)
+
+        assert agent._last_flushed_db_idx == 0
+
+
 class TestAgentConfigSignatureUserId:
     """Shared-thread cache must not reuse an agent across users.
 


### PR DESCRIPTION
## What does this PR do?

Resets `_last_flushed_db_idx` on cached `AIAgent` reuse so `_flush_messages_to_session_db` recomputes its flush offset from the new turn's `conversation_history` length instead of carrying a stale cursor from the previous turn.  Without this, the assistant reply is silently skipped and the transcript accumulates consecutive `user` rows, corrupting context replay on subsequent turns.

## Related Issue

Fixes #44327

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: Added `agent._last_flushed_db_idx = 0` to `_init_cached_agent_for_turn()` so the SessionDB flush cursor is reset on every cached-agent turn, regardless of interrupt depth.
- `tests/gateway/test_agent_cache.py`: Added 3 tests verifying the flush cursor reset (fresh turn, interrupt-recursive turn, idempotent zero case).

## How to Test

1. Start a gateway session and send multiple messages to build conversation history.
2. Verify that each assistant reply appears in the SQLite `messages` table (`sqlite3 ~/.hermes/state.db "SELECT role, content FROM messages WHERE session_id='<id>'"`).
3. Before this fix, a cached agent could skip persisting the assistant row, producing consecutive `user` rows that corrupt context replay.
4. Run `pytest tests/gateway/test_agent_cache.py -v -k flush_cursor` — all 3 new tests should pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `_init_cached_agent_for_turn` (callers: 3 in gateway/run.py)
- Analyzed: `_flush_messages_to_session_db` (uses `_last_flushed_db_idx` in flush_from computation)
- Blast radius: LOW — single line addition, scoped to cached-agent reuse path
- Related patterns: `_last_flushed_db_idx` is also reset by scaffolding-drop clamps (#31507) and compression-reset paths (#43066); this fix covers the missing gateway cached-agent path
