### PR TITLE
fix(cli): skip dashboard re-exec on Windows to avoid execvpe segfault

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10304,6 +10304,10 @@ def cmd_dashboard(args):
                 f"Running a dedicated dashboard for profile '{_launch_profile}' "
                 "(machine-dashboard re-exec is not supported on Windows)."
             )
+            # Mark the launch isolated so any downstream profile-routing checks
+            # treat this exactly like an explicit --isolated invocation rather
+            # than relying on incidental fall-through.
+            args.isolated = True
         else:
             print(
                 f"Routing to the machine dashboard (profile '{_launch_profile}' "

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10291,28 +10291,42 @@ def cmd_dashboard(args):
                     pass
             sys.exit(0)
 
-        print(
-            f"Routing to the machine dashboard (profile '{_launch_profile}' "
-            f"preselected). Use --isolated for a dedicated per-profile server."
-        )
-        reexec_argv = [
-            sys.executable, "-m", "hermes_cli.main",
-            "-p", "default",
-            "dashboard",
-            "--port", str(args.port),
-            "--host", args.host,
-            "--open-profile", _launch_profile,
-        ]
-        if args.no_open:
-            reexec_argv.append("--no-open")
-        if getattr(args, "insecure", False):
-            reexec_argv.append("--insecure")
-        if getattr(args, "skip_build", False):
-            reexec_argv.append("--skip-build")
-        env = os.environ.copy()
-        # Drop the profile HERMES_HOME so the child binds the machine root.
-        env.pop("HERMES_HOME", None)
-        os.execvpe(sys.executable, reexec_argv, env)
+        # os.execvpe atomically replaces the process on POSIX, but on Windows
+        # CPython implements it as CreateProcess() + Py_Exit(0); interpreter
+        # finalization segfaults in a native-extension teardown, crashing the
+        # backend with exit code 3221225477 (STATUS_ACCESS_VIOLATION) and
+        # crash-looping zombie dashboards on escalating ports (#44282). On
+        # Windows, skip the re-exec and run the dashboard in place for this
+        # profile (same as --isolated) — crash-free and keeps Electron's
+        # per-profile process tracking intact.
+        if sys.platform == "win32":
+            print(
+                f"Running a dedicated dashboard for profile '{_launch_profile}' "
+                "(machine-dashboard re-exec is not supported on Windows)."
+            )
+        else:
+            print(
+                f"Routing to the machine dashboard (profile '{_launch_profile}' "
+                f"preselected). Use --isolated for a dedicated per-profile server."
+            )
+            reexec_argv = [
+                sys.executable, "-m", "hermes_cli.main",
+                "-p", "default",
+                "dashboard",
+                "--port", str(args.port),
+                "--host", args.host,
+                "--open-profile", _launch_profile,
+            ]
+            if args.no_open:
+                reexec_argv.append("--no-open")
+            if getattr(args, "insecure", False):
+                reexec_argv.append("--insecure")
+            if getattr(args, "skip_build", False):
+                reexec_argv.append("--skip-build")
+            env = os.environ.copy()
+            # Drop the profile HERMES_HOME so the child binds the machine root.
+            env.pop("HERMES_HOME", None)
+            os.execvpe(sys.executable, reexec_argv, env)
 
     # Attach gui.log early so dashboard startup/build failures are captured in
     # the same logs directory as every other Hermes surface.

--- a/tests/hermes_cli/test_dashboard_unified_launch.py
+++ b/tests/hermes_cli/test_dashboard_unified_launch.py
@@ -94,11 +94,15 @@ class TestUnifiedDashboardRouting:
         monkeypatch.setattr(main_mod.sys, "platform", "win32")
         execs = []
         monkeypatch.setattr(main_mod.os, "execvpe", lambda *a, **k: execs.append(a))
-        # Stop before actually starting a server: make the first post-routing
-        # dependency check bail.
+        # Stop before actually starting a server: force the post-routing web-UI
+        # dependency check to bail. Setting the sys.modules entry to None makes
+        # `import fastapi` raise ImportError, which cmd_dashboard converts to a
+        # clean SystemExit(1). Asserting on SystemExit specifically (not a broad
+        # tuple) keeps an unrelated AttributeError/TypeError regression failing
+        # loudly instead of being silently swallowed.
         monkeypatch.setitem(sys.modules, "fastapi", None)
 
-        with pytest.raises((SystemExit, AttributeError, ImportError, TypeError)):
+        with pytest.raises(SystemExit):
             main_mod.cmd_dashboard(_args())
 
         assert execs == []  # Windows must NOT re-exec (would segfault)

--- a/tests/hermes_cli/test_dashboard_unified_launch.py
+++ b/tests/hermes_cli/test_dashboard_unified_launch.py
@@ -82,6 +82,43 @@ class TestUnifiedDashboardRouting:
         # Profile HERMES_HOME dropped so the child binds the machine root.
         assert "HERMES_HOME" not in env
 
+    def test_windows_profile_launch_does_not_reexec(self, main_mod, monkeypatch):
+        """On Windows os.execvpe segfaults during interpreter finalization
+        (#44282 STATUS_ACCESS_VIOLATION). The re-exec must be skipped and the
+        command must fall through to in-place dashboard startup, never calling
+        os.execvpe."""
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name", lambda: "worker_x"
+        )
+        monkeypatch.setattr(main_mod, "_dashboard_listening", lambda host, port: False)
+        monkeypatch.setattr(main_mod.sys, "platform", "win32")
+        execs = []
+        monkeypatch.setattr(main_mod.os, "execvpe", lambda *a, **k: execs.append(a))
+        # Stop before actually starting a server: make the first post-routing
+        # dependency check bail.
+        monkeypatch.setitem(sys.modules, "fastapi", None)
+
+        with pytest.raises((SystemExit, AttributeError, ImportError, TypeError)):
+            main_mod.cmd_dashboard(_args())
+
+        assert execs == []  # Windows must NOT re-exec (would segfault)
+
+    def test_windows_profile_launch_still_attaches_when_running(self, main_mod, monkeypatch):
+        """The attach path (machine dashboard already listening) is exec-free
+        and must still work on Windows."""
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name", lambda: "worker_x"
+        )
+        monkeypatch.setattr(main_mod, "_dashboard_listening", lambda host, port: True)
+        monkeypatch.setattr(main_mod.sys, "platform", "win32")
+        execs = []
+        monkeypatch.setattr(main_mod.os, "execvpe", lambda *a, **k: execs.append(a))
+
+        with pytest.raises(SystemExit) as exc:
+            main_mod.cmd_dashboard(_args())
+        assert exc.value.code == 0
+        assert execs == []
+
     def test_isolated_flag_skips_routing(self, main_mod, monkeypatch):
         monkeypatch.setattr(
             "hermes_cli.profiles.get_active_profile_name", lambda: "worker_x"


### PR DESCRIPTION
## What does this PR do?

Named-profile dashboards crash-loop on Windows. `cmd_dashboard()` re-execs the named-profile dashboard as the machine dashboard via `os.execvpe()`. On POSIX that atomically replaces the process; on Windows CPython implements `os.execvpe` as `CreateProcess()` + `Py_Exit(0)`, and interpreter finalization segfaults in a native-extension teardown — the backend exits with `3221225477` (`STATUS_ACCESS_VIOLATION`) and spawns zombie dashboards on escalating ports (9121, 9122, …). Every non-default profile is affected; the default profile never enters the re-exec path. Introduced by #44007 (`875aa8f16`).

This guards the re-exec spawn behind `sys.platform != "win32"`. On Windows we skip the re-exec and run the dashboard in place for the launching profile (the same behavior `--isolated` already provides) — crash-free, with Electron's per-profile process tracking intact. The exec-free attach path (machine dashboard already listening → open browser at `?profile=<name>`) is unchanged and still works on Windows.

> Audited siblings: `os.execvpe` is used only at this dashboard re-exec call site in `hermes_cli/main.py` (`git grep os.execvpe` returns one hit). No widening needed.

## Related Issue

Fixes #44282

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py`: in `cmd_dashboard()`, guard the named-profile → machine-dashboard re-exec (`os.execvpe`) behind `sys.platform != "win32"`; on Windows fall through to in-place per-profile dashboard startup with an informational message. The attach path is untouched.
- `tests/hermes_cli/test_dashboard_unified_launch.py`: add regression tests asserting Windows never calls `os.execvpe` (falls through) and the attach path still exits 0 on Windows.

## How to Test

1. `uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest tests/hermes_cli/test_dashboard_unified_launch.py -v`
2. On Windows (Python 3.14): switch to a non-default profile and launch the dashboard; the backend now starts in place instead of exiting with `3221225477`.
3. On macOS/Linux: named-profile dashboard still re-execs to the unified machine dashboard (unchanged).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the dashboard launch tests and they pass
- [x] I've added tests for my changes
- [ ] I've tested on my platform: macOS (logic verified headlessly; Windows runtime crash per reporter)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] I've considered cross-platform impact (Windows, macOS)
- [x] I've updated tool descriptions/schemas — N/A