### PR TITLE
fix(gateway): set launchd file descriptor limits

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3961,6 +3961,18 @@ def generate_launchd_plist() -> str:
     
     <key>KeepAlive</key>
     <true/>
+
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>4096</integer>
+    </dict>
+
+    <key>HardResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>8192</integer>
+    </dict>
     
     <key>StandardOutPath</key>
     <string>{log_dir}/gateway.log</string>

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -641,6 +641,15 @@ class TestLaunchdServiceRecovery:
             == DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
         )
 
+    def test_launchd_plist_sets_file_descriptor_limits(self):
+        plist = gateway_cli.generate_launchd_plist()
+
+        assert "<key>SoftResourceLimits</key>" in plist
+        assert "<key>HardResourceLimits</key>" in plist
+        assert "<key>NumberOfFiles</key>" in plist
+        assert "<integer>4096</integer>" in plist
+        assert "<integer>8192</integer>" in plist
+
     def test_launchd_install_repairs_outdated_plist_without_force(self, tmp_path, monkeypatch):
         plist_path = tmp_path / "ai.hermes.gateway.plist"
         plist_path.write_text("<plist>old content</plist>", encoding="utf-8")


### PR DESCRIPTION
## Summary
- add launchd SoftResourceLimits/HardResourceLimits for gateway file descriptors
- cover the generated plist with a focused regression test

## Verification
- `uv sync --extra dev`
- `uv run --extra dev python -m pytest -o 'addopts=' tests/hermes_cli/test_gateway_service.py::TestLaunchdServiceRecovery::test_launchd_plist_sets_file_descriptor_limits tests/hermes_cli/test_gateway_service.py::TestServiceWorkingDirIsStable::test_launchd_plist_keepalive_unconditional -q`\n\nSplit out of #39350 per review feedback.