### PR TITLE
[Hermes][Desktop][vision-session-dedupe-upstream][1/n] Fix vision routing and compression lineage dedupe

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -563,6 +563,7 @@ _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = _API_KEY_PROVIDER_AUX_MODELS_FALL
 # differs from their main chat model, map it here.  The vision auto-detect
 # "exotic provider" branch checks this before falling back to the main model.
 _PROVIDER_VISION_MODELS: Dict[str, str] = {
+    "opencode-zen": "gemini-3-flash",
     "xiaomi": "mimo-v2.5",
     "zai": "glm-5v-turbo",
 }

--- a/apps/desktop/src/app/chat/sidebar/session-index.ts
+++ b/apps/desktop/src/app/chat/sidebar/session-index.ts
@@ -24,8 +24,10 @@ export function buildSessionByAnyId(
   for (const session of [...cronSessions, ...messagingSessions, ...visibleSessions]) {
     map.set(session.id, session)
 
-    if (session._lineage_root_id && !map.has(session._lineage_root_id)) {
-      map.set(session._lineage_root_id, session)
+    for (const id of [session._lineage_root_id, ...(session._lineage_ids ?? [])]) {
+      if (id && !map.has(id)) {
+        map.set(id, session)
+      }
     }
   }
 

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -14,8 +14,12 @@ import {
   applyConfiguredDefaultProjectDir,
   getRememberedSessionId,
   mergeSessionPage,
+<<<<<<< HEAD
   rememberedSessionProfile,
   resolveComposerSessionKey,
+=======
+  sessionAliasIds,
+>>>>>>> 6c95fe27d (Refresh on upstream/main: resolve conflicts (no behavior change))
   sessionPinId,
   setCurrentCwd,
   setRememberedSessionId,
@@ -89,6 +93,12 @@ describe('sessionPinId', () => {
     // After auto-compression the entry surfaces under a fresh tip id but keeps
     // the original root — pinning on the root keeps the pin stable.
     expect(sessionPinId(session({ id: 'tip', _lineage_root_id: 'root' }))).toBe('root')
+  })
+
+  it('collects every compression segment as an alias', () => {
+    expect(
+      sessionAliasIds(session({ id: 'tip', _lineage_root_id: 'root', _lineage_ids: ['root', 'mid', 'tip'] }))
+    ).toEqual(['tip', 'root', 'mid'])
   })
 })
 
@@ -209,6 +219,7 @@ describe('mergeSessionPage', () => {
     expect(merged.map(s => s.id)).toEqual(['b', 'a-new'])
   })
 
+<<<<<<< HEAD
   it('never regresses last_active behind an optimistic user-send bump', () => {
     const previous = [session({ id: 'old', last_active: 9_000 })]
     const incoming = [session({ id: 'old', last_active: 100, message_count: 4 })]
@@ -267,6 +278,37 @@ describe('touchSessionActivity', () => {
     touchSessionActivity('missing', { at: 99 })
 
     expect($sessions.get()).toBe(prev)
+=======
+  it('replaces a stale pinned intermediate segment with the live tip', () => {
+    const previous = [session({ id: 'mid', _lineage_root_id: 'root' })]
+    const incoming = [session({ id: 'tip', _lineage_root_id: 'root', _lineage_ids: ['root', 'mid', 'tip'] })]
+
+    const merged = mergeSessionPage(previous, incoming, ['mid'])
+
+    expect(merged.map(s => s.id)).toEqual(['tip'])
+  })
+
+  it('dedupes incoming rows that describe the same lineage', () => {
+    const incoming = [
+      session({ id: 'tip', _lineage_root_id: 'root', _lineage_ids: ['root', 'mid', 'tip'] }),
+      session({ id: 'mid', _lineage_root_id: 'root' })
+    ]
+
+    const merged = mergeSessionPage([], incoming, ['mid'])
+
+    expect(merged.map(s => s.id)).toEqual(['tip'])
+  })
+
+  it('prefers the live lineage row when a stale incoming segment arrives first', () => {
+    const incoming = [
+      session({ id: 'mid', _lineage_root_id: 'root', last_active: 100 }),
+      session({ id: 'tip', _lineage_root_id: 'root', _lineage_ids: ['root', 'mid', 'tip'], last_active: 200 })
+    ]
+
+    const merged = mergeSessionPage([], incoming, ['mid'])
+
+    expect(merged.map(s => s.id)).toEqual(['tip'])
+>>>>>>> 6c95fe27d (Refresh on upstream/main: resolve conflicts (no behavior change))
   })
 })
 

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -14,12 +14,9 @@ import {
   applyConfiguredDefaultProjectDir,
   getRememberedSessionId,
   mergeSessionPage,
-<<<<<<< HEAD
   rememberedSessionProfile,
   resolveComposerSessionKey,
-=======
   sessionAliasIds,
->>>>>>> 6c95fe27d (Refresh on upstream/main: resolve conflicts (no behavior change))
   sessionPinId,
   setCurrentCwd,
   setRememberedSessionId,
@@ -219,7 +216,6 @@ describe('mergeSessionPage', () => {
     expect(merged.map(s => s.id)).toEqual(['b', 'a-new'])
   })
 
-<<<<<<< HEAD
   it('never regresses last_active behind an optimistic user-send bump', () => {
     const previous = [session({ id: 'old', last_active: 9_000 })]
     const incoming = [session({ id: 'old', last_active: 100, message_count: 4 })]
@@ -238,6 +234,36 @@ describe('mergeSessionPage', () => {
 
     expect(merged.map(s => s.id)).toEqual(['tip-5'])
     expect(merged[0]?.last_active).toBe(9_000)
+  })
+  it('replaces a stale pinned intermediate segment with the live tip', () => {
+    const previous = [session({ id: 'mid', _lineage_root_id: 'root' })]
+    const incoming = [session({ id: 'tip', _lineage_root_id: 'root', _lineage_ids: ['root', 'mid', 'tip'] })]
+
+    const merged = mergeSessionPage(previous, incoming, ['mid'])
+
+    expect(merged.map(s => s.id)).toEqual(['tip'])
+  })
+
+  it('dedupes incoming rows that describe the same lineage', () => {
+    const incoming = [
+      session({ id: 'tip', _lineage_root_id: 'root', _lineage_ids: ['root', 'mid', 'tip'] }),
+      session({ id: 'mid', _lineage_root_id: 'root' })
+    ]
+
+    const merged = mergeSessionPage([], incoming, ['mid'])
+
+    expect(merged.map(s => s.id)).toEqual(['tip'])
+  })
+
+  it('prefers the live lineage row when a stale incoming segment arrives first', () => {
+    const incoming = [
+      session({ id: 'mid', _lineage_root_id: 'root', last_active: 100 }),
+      session({ id: 'tip', _lineage_root_id: 'root', _lineage_ids: ['root', 'mid', 'tip'], last_active: 200 })
+    ]
+
+    const merged = mergeSessionPage([], incoming, ['mid'])
+
+    expect(merged.map(s => s.id)).toEqual(['tip'])
   })
 })
 
@@ -278,37 +304,6 @@ describe('touchSessionActivity', () => {
     touchSessionActivity('missing', { at: 99 })
 
     expect($sessions.get()).toBe(prev)
-=======
-  it('replaces a stale pinned intermediate segment with the live tip', () => {
-    const previous = [session({ id: 'mid', _lineage_root_id: 'root' })]
-    const incoming = [session({ id: 'tip', _lineage_root_id: 'root', _lineage_ids: ['root', 'mid', 'tip'] })]
-
-    const merged = mergeSessionPage(previous, incoming, ['mid'])
-
-    expect(merged.map(s => s.id)).toEqual(['tip'])
-  })
-
-  it('dedupes incoming rows that describe the same lineage', () => {
-    const incoming = [
-      session({ id: 'tip', _lineage_root_id: 'root', _lineage_ids: ['root', 'mid', 'tip'] }),
-      session({ id: 'mid', _lineage_root_id: 'root' })
-    ]
-
-    const merged = mergeSessionPage([], incoming, ['mid'])
-
-    expect(merged.map(s => s.id)).toEqual(['tip'])
-  })
-
-  it('prefers the live lineage row when a stale incoming segment arrives first', () => {
-    const incoming = [
-      session({ id: 'mid', _lineage_root_id: 'root', last_active: 100 }),
-      session({ id: 'tip', _lineage_root_id: 'root', _lineage_ids: ['root', 'mid', 'tip'], last_active: 200 })
-    ]
-
-    const merged = mergeSessionPage([], incoming, ['mid'])
-
-    expect(merged.map(s => s.id)).toEqual(['tip'])
->>>>>>> 6c95fe27d (Refresh on upstream/main: resolve conflicts (no behavior change))
   })
 })
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -169,7 +169,6 @@ function updateAtom<T>(store: AppAtom<T>, next: Updater<T>) {
 export const sessionPinId = (session: Pick<SessionInfo, '_lineage_root_id' | 'id'>): string =>
   session._lineage_root_id ?? session.id
 
-<<<<<<< HEAD
 /** True when a stored/lineage id resolves to this session — it matches either
  *  the live id or the stable lineage root (see sessionPinId). The one place the
  *  "same conversation across compression" test lives. */
@@ -197,7 +196,8 @@ export function resolveComposerSessionKey(
   const row = sessions.find(session => sessionMatchesStoredId(session, selectedSessionId))
 
   return row ? sessionPinId(row) : selectedSessionId
-=======
+}
+
 export const sessionAliasIds = (session: Pick<SessionInfo, '_lineage_ids' | '_lineage_root_id' | 'id'>): string[] => {
   const aliases = [session.id, session._lineage_root_id, ...(session._lineage_ids ?? [])].filter(
     (id): id is string => typeof id === 'string' && id.length > 0
@@ -235,7 +235,6 @@ function dedupeSessionsByAlias(sessions: SessionInfo[]): SessionInfo[] {
   }
 
   return deduped.length === sessions.length ? sessions : deduped
->>>>>>> 6c95fe27d (Refresh on upstream/main: resolve conflicts (no behavior change))
 }
 
 /** Merge a fresh server session page into the in-memory list, keeping any

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -169,6 +169,7 @@ function updateAtom<T>(store: AppAtom<T>, next: Updater<T>) {
 export const sessionPinId = (session: Pick<SessionInfo, '_lineage_root_id' | 'id'>): string =>
   session._lineage_root_id ?? session.id
 
+<<<<<<< HEAD
 /** True when a stored/lineage id resolves to this session — it matches either
  *  the live id or the stable lineage root (see sessionPinId). The one place the
  *  "same conversation across compression" test lives. */
@@ -196,6 +197,45 @@ export function resolveComposerSessionKey(
   const row = sessions.find(session => sessionMatchesStoredId(session, selectedSessionId))
 
   return row ? sessionPinId(row) : selectedSessionId
+=======
+export const sessionAliasIds = (session: Pick<SessionInfo, '_lineage_ids' | '_lineage_root_id' | 'id'>): string[] => {
+  const aliases = [session.id, session._lineage_root_id, ...(session._lineage_ids ?? [])].filter(
+    (id): id is string => typeof id === 'string' && id.length > 0
+  )
+
+  return [...new Set(aliases)]
+}
+
+function dedupeSessionsByAlias(sessions: SessionInfo[]): SessionInfo[] {
+  const aliasIndex = new Map<string, number>()
+  const deduped: SessionInfo[] = []
+
+  for (const session of sessions) {
+    const aliases = sessionAliasIds(session)
+    const existingIndex = aliases.map(id => aliasIndex.get(id)).find(index => index !== undefined)
+
+    if (existingIndex !== undefined) {
+      const current = deduped[existingIndex]
+      if (
+        aliases.length > sessionAliasIds(current).length ||
+        (aliases.length === sessionAliasIds(current).length && session.last_active > current.last_active)
+      ) {
+        deduped[existingIndex] = session
+      }
+      for (const id of aliases) {
+        aliasIndex.set(id, existingIndex)
+      }
+      continue
+    }
+
+    for (const id of aliases) {
+      aliasIndex.set(id, deduped.length)
+    }
+    deduped.push(session)
+  }
+
+  return deduped.length === sessions.length ? sessions : deduped
+>>>>>>> 6c95fe27d (Refresh on upstream/main: resolve conflicts (no behavior change))
 }
 
 /** Merge a fresh server session page into the in-memory list, keeping any
@@ -218,7 +258,8 @@ export function resolveComposerSessionKey(
  *  `keepIds` carries both the working set and the pinned set. Pins are stored
  *  on the durable lineage-root id (see {@link sessionPinId}), while the loaded
  *  row surfaces under its live compression tip, so we match a survivor by
- *  either its live `id` or its `_lineage_root_id`. Optimistic deletes/archives
+ *  its live `id`, `_lineage_root_id`, or any historical `_lineage_ids` alias.
+ *  Optimistic deletes/archives
  *  drop the row from `previous` (and unpin it), so a removed session can't be
  *  resurrected here. */
 export function mergeSessionPage(
@@ -252,22 +293,21 @@ export function mergeSessionPage(
     return merged
   }
 
-  const incomingIds = new Set(merged.map(session => session.id))
-
   // Deduplicate by compression lineage: when auto-compression rotates the tip
   // id (old #4 → new #5), the incoming page carries the new tip but the
   // previous list still holds the old one.  Without lineage-level dedup both
-  // rows survive as separate sidebar entries (fixes #43483).
-  const incomingLineageKeys = new Set(merged.map(session => session._lineage_root_id ?? session.id))
+  // rows survive as separate sidebar entries (fixes #43483). Dedupe the
+  // title-carried `merged` rows (not raw `incoming`) so carried titles survive.
+  const dedupedIncoming = dedupeSessionsByAlias(merged)
+  const incomingAliases = new Set(dedupedIncoming.flatMap(sessionAliasIds))
 
   const survivors = previous.filter(
     session =>
-      !incomingIds.has(session.id) &&
-      !incomingLineageKeys.has(session._lineage_root_id ?? session.id) &&
-      (keep.has(session.id) || (session._lineage_root_id != null && keep.has(session._lineage_root_id)))
+      !sessionAliasIds(session).some(id => incomingAliases.has(id)) &&
+      sessionAliasIds(session).some(id => keep.has(id))
   )
 
-  return survivors.length ? [...survivors, ...merged] : merged
+  return survivors.length ? [...survivors, ...dedupedIncoming] : dedupedIncoming
 }
 
 /** Raise a session in recents on user send (before stream / turn resolve). */

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -464,6 +464,9 @@ export interface SessionInfo {
    *  continuation tip. Stable across compressions — used as the durable id for
    *  pins so a pinned conversation survives auto-compression. */
   _lineage_root_id?: null | string
+  /** Every persisted session id in the compression chain, root through live tip.
+   *  Lets old pinned/search/selection ids resolve to the same displayed row. */
+  _lineage_ids?: string[]
   input_tokens: number
   is_active: boolean
   last_active: number

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4702,17 +4702,52 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         root_ids = list(dict.fromkeys(root_ids))
         placeholders = ",".join("?" * len(root_ids))
+        # ``best_child`` mirrors the single-child selection in
+        # ``get_compression_tip``: for each compression-ended parent, pick the
+        # one continuation child (skipping branch/delegate/tool rows) preferring
+        # a further compression continuation, then a still-live child, then a
+        # stale closed sibling such as ``ws_orphan_reap``. The old
+        # ``child.started_at >= parent.ended_at`` discriminator was too brittle —
+        # a gateway/compression race can insert the real continuation before the
+        # parent's ``ended_at`` is written, so the walk would follow the stale
+        # websocket sibling and drop the live tip. Walking one best child per
+        # step keeps this batch walk consistent with ``get_compression_tip``.
         query = f"""
-            WITH RECURSIVE chain(root_id, cur_id, depth, path) AS (
+            WITH RECURSIVE best_child AS (
+                SELECT parent_id, child_id FROM (
+                    SELECT
+                        parent.id AS parent_id,
+                        child.id AS child_id,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY parent.id
+                            ORDER BY
+                                CASE
+                                    WHEN child.end_reason = 'compression' THEN 0
+                                    WHEN child.ended_at IS NULL THEN 1
+                                    ELSE 2
+                                END,
+                                COALESCE(
+                                    (SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = child.id),
+                                    child.started_at
+                                ) DESC,
+                                child.started_at DESC,
+                                child.id DESC
+                        ) AS rn
+                    FROM sessions parent
+                    JOIN sessions child ON child.parent_session_id = parent.id
+                    WHERE parent.end_reason = 'compression'
+                      AND json_extract(COALESCE(child.model_config, '{{}}'), '$._branched_from') IS NULL
+                      AND json_extract(COALESCE(child.model_config, '{{}}'), '$._delegate_from') IS NULL
+                      AND COALESCE(child.source, '') != 'tool'
+                ) WHERE rn = 1
+            ),
+            chain(root_id, cur_id, depth, path) AS (
                 SELECT id, id, 0, ',' || id || ',' FROM sessions WHERE id IN ({placeholders})
                 UNION ALL
-                SELECT c.root_id, child.id, c.depth + 1, c.path || child.id || ','
+                SELECT c.root_id, bc.child_id, c.depth + 1, c.path || bc.child_id || ','
                 FROM chain c
-                JOIN sessions parent ON parent.id = c.cur_id
-                JOIN sessions child ON child.parent_session_id = c.cur_id
-                WHERE parent.end_reason = 'compression'
-                  AND child.started_at >= parent.ended_at
-                  AND instr(c.path, ',' || child.id || ',') = 0
+                JOIN best_child bc ON bc.parent_id = c.cur_id
+                WHERE instr(c.path, ',' || bc.child_id || ',') = 0
             )
             SELECT root_id, cur_id, depth
             FROM chain

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4677,6 +4677,84 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     _SESSION_COMPACT_EXCLUDED = frozenset({"system_prompt"})
     _session_compact_cols_sql: Optional[str] = None
 
+    @staticmethod
+    def _surfaced_session_clause(alias: str = "s") -> str:
+        """SQL predicate for rows shown by list_sessions_rich by default."""
+        return (
+            f"({alias}.parent_session_id IS NULL"
+            f" OR json_extract({alias}.model_config, '$._branched_from') IS NOT NULL"
+            " OR EXISTS (SELECT 1 FROM sessions p"
+            f"            WHERE p.id = {alias}.parent_session_id"
+            "            AND p.end_reason = 'branched'"
+            f"            AND {alias}.started_at >= p.ended_at))"
+        )
+
+    def _batch_compression_lineages(self, root_ids: List[str]) -> Dict[str, Dict[str, Any]]:
+        """Walk compression-continuation chains for multiple roots in one query.
+
+        Returns a dict mapping root_id -> {"tip_id": tip_id, "ids": [root..tip]}
+        for each requested root. Replaces the N+1 ``get_compression_tip()``
+        calls in ``list_sessions_rich`` and gives desktop enough aliases to
+        collapse stale pinned intermediate segments into the live row.
+        """
+        if not root_ids:
+            return {}
+
+        root_ids = list(dict.fromkeys(root_ids))
+        placeholders = ",".join("?" * len(root_ids))
+        query = f"""
+            WITH RECURSIVE chain(root_id, cur_id, depth, path) AS (
+                SELECT id, id, 0, ',' || id || ',' FROM sessions WHERE id IN ({placeholders})
+                UNION ALL
+                SELECT c.root_id, child.id, c.depth + 1, c.path || child.id || ','
+                FROM chain c
+                JOIN sessions parent ON parent.id = c.cur_id
+                JOIN sessions child ON child.parent_session_id = c.cur_id
+                WHERE parent.end_reason = 'compression'
+                  AND child.started_at >= parent.ended_at
+                  AND instr(c.path, ',' || child.id || ',') = 0
+            )
+            SELECT root_id, cur_id, depth
+            FROM chain
+            ORDER BY root_id, depth
+        """
+        with self._lock:
+            cursor = self._conn.execute(query, root_ids)
+            rows = cursor.fetchall()
+
+        lineages: Dict[str, Dict[str, Any]] = {
+            rid: {"tip_id": rid, "ids": [rid], "_depth": 0} for rid in root_ids
+        }
+        for row in rows:
+            rid = row["root_id"]
+            cid = row["cur_id"]
+            depth = int(row["depth"] or 0)
+            entry = lineages.setdefault(rid, {"tip_id": rid, "ids": [rid], "_depth": 0})
+            if cid not in entry["ids"]:
+                entry["ids"].append(cid)
+            if depth >= int(entry.get("_depth") or 0):
+                entry["tip_id"] = cid
+                entry["_depth"] = depth
+
+        for entry in lineages.values():
+            entry.pop("_depth", None)
+        return lineages
+
+    def _batch_compression_tips(self, root_ids: List[str]) -> Dict[str, str]:
+        """Walk compression-continuation chains for multiple roots in one query.
+
+        Returns a dict mapping root_id -> tip_id for each root that has a
+        continuation chain. Roots with no continuation are omitted.
+        Replaces the N+1 ``get_compression_tip()`` calls in ``list_sessions_rich``.
+        """
+        lineages = self._batch_compression_lineages(root_ids)
+        tips = {}
+        for rid, lineage in lineages.items():
+            tid = lineage.get("tip_id")
+            if tid and tid != rid:
+                tips[rid] = tid
+        return tips
+
     def list_sessions_rich(
         self,
         source: str = None,
@@ -4991,12 +5069,23 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # as the live conversation. Keep the root's started_at to preserve
         # chronological ordering by original conversation start.
         if project_compression_tips and not include_children:
+            # Batch project: collect compression roots, walk all chains in
+            # a single SQL query, then fetch tip rows individually.
+            compression_roots = [
+                s["id"] for s in sessions if s.get("end_reason") == "compression"
+            ]
+            if compression_roots:
+                lineages = self._batch_compression_lineages(compression_roots)
+            else:
+                lineages = {}
+
             projected = []
             for s in sessions:
                 if s.get("end_reason") != "compression":
                     projected.append(s)
                     continue
-                tip_id = self.get_compression_tip(s["id"])
+                lineage = lineages.get(s["id"]) or {"tip_id": s["id"], "ids": [s["id"]]}
+                tip_id = lineage.get("tip_id", s["id"])
                 if tip_id == s["id"]:
                     projected.append(s)
                     continue
@@ -5015,6 +5104,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     if key in tip_row:
                         merged[key] = tip_row[key]
                 merged["_lineage_root_id"] = s["id"]
+                merged["_lineage_ids"] = lineage.get("ids") or [s["id"], tip_id]
                 projected.append(merged)
             sessions = projected
 

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -1740,6 +1740,7 @@ class SessionSearchMixin:
 
         def score(row: Dict[str, Any]) -> int:
             ids = [str(row.get("id") or ""), str(row.get("_lineage_root_id") or "")]
+            ids.extend(str(value or "") for value in row.get("_lineage_ids") or [])
             normalized = [value.lower() for value in ids if value]
             if any(value == needle for value in normalized):
                 return 0

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -5245,6 +5245,35 @@ class TestVisionAutoSkipsKimiCoding:
         assert client is fake_or_client
         assert model == "google/gemini-3-flash-preview"
 
+    def test_opencode_zen_uses_aux_vision_model_not_text_model(self, monkeypatch):
+        """OpenCode Zen text models should use the provider's vision aux model."""
+        fake_client = MagicMock(name="opencode_zen_client")
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._read_main_provider", lambda: "opencode-zen",
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._read_main_model", lambda: "deepseek-v4-flash-free",
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._main_model_supports_vision",
+            lambda provider, model: provider == "opencode-zen" and model == "gemini-3-flash",
+        )
+        rpc_mock = MagicMock(return_value=(fake_client, "gemini-3-flash"))
+        monkeypatch.setattr(
+            "agent.auxiliary_client.resolve_provider_client", rpc_mock,
+        )
+
+        provider, client, model = resolve_vision_provider_client()
+
+        assert provider == "opencode-zen"
+        assert client is fake_client
+        assert model == "gemini-3-flash"
+        rpc_mock.assert_called_once()
+        args, kwargs = rpc_mock.call_args
+        assert args[:2] == ("opencode-zen", "gemini-3-flash")
+        assert kwargs.get("is_vision") is True
+
     def test_kimi_coding_cn_skipped_too(self, monkeypatch):
         """Same skip applies to the CN variant."""
         fake_or_client = MagicMock(name="openrouter_client")

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2550,6 +2550,7 @@ class TestWebServerEndpoints:
         # ...carrying the durable lineage root so the desktop can match pins.
         tip = next(r for r in rows if r["id"] == "tip-new")
         assert tip.get("_lineage_root_id") == "root-old"
+        assert tip.get("_lineage_ids") == ["root-old", "tip-new"]
 
     def test_search_dedupes_compression_lineage_to_tip(self):
         """A conversation that auto-compresses leaves the matched term in both

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -4812,6 +4812,7 @@ class TestListSessionsRich:
         # Projection surfaces the tip's id in the root's slot.
         assert top[0]["id"] == "tip1"
         assert top[0]["_lineage_root_id"] == "root1"
+        assert top[0]["_lineage_ids"] == ["root1", "tip1"]
 
     def test_rich_list_includes_title(self, db):
         db.create_session("s1", "cli")
@@ -5109,6 +5110,30 @@ class TestCompressionChainProjection:
         # root1's tip must be tip1 (via mid1), not delegate1.
         assert db.get_compression_tip("root1") == "tip1"
 
+    def test_batch_compression_tips_single_root(self, db):
+        """Regression: the batched query has exactly one IN clause, so the
+        binding list must match len(root_ids) — passing root_ids * 2 raised
+        sqlite3.ProgrammingError for every list_sessions_rich call.
+        """
+        import time as _time
+        self._build_compression_chain(db, _time.time() - 3600)
+        assert db._batch_compression_tips(["root1"]) == {"root1": "tip1"}
+        assert db._batch_compression_lineages(["root1"]) == {
+            "root1": {"tip_id": "tip1", "ids": ["root1", "mid1", "tip1"]},
+        }
+
+    def test_batch_compression_tips_multiple_roots(self, db):
+        import time as _time
+        self._build_compression_chain(db, _time.time() - 3600)
+        db.create_session("solo", "cli")
+        tips = db._batch_compression_tips(["root1", "solo"])
+        # solo has no continuation chain, so it is omitted (maps to itself)
+        assert tips == {"root1": "tip1"}
+        assert db._batch_compression_lineages(["root1", "solo"]) == {
+            "root1": {"tip_id": "tip1", "ids": ["root1", "mid1", "tip1"]},
+            "solo": {"tip_id": "solo", "ids": ["solo"]},
+        }
+
     def test_list_surfaces_tip_for_compressed_root(self, db):
         """The list must show the tip's id/message_count/preview in place of
         the root row, so users can see and resume the live conversation.
@@ -5134,6 +5159,7 @@ class TestCompressionChainProjection:
         # The row surfaces the tip's identity but preserves the root's start
         # timestamp for stable ordering and lineage tracking.
         assert tip_row["_lineage_root_id"] == "root1"
+        assert tip_row["_lineage_ids"] == ["root1", "mid1", "tip1"]
         assert tip_row["preview"].startswith("latest message")
         assert tip_row["ended_at"] is None  # tip is still live
         assert tip_row["end_reason"] is None
@@ -7215,6 +7241,23 @@ class TestSessionIdSearch:
         assert automation == {"20260603_090200_cron", "20260603_090200_tool"}
         assert chats == {"20260603_090200_cli"}
 
+    def test_search_sessions_by_id_matches_projected_intermediate_lineage_id(self, db):
+        root = "20260602_235959_root99"
+        mid = "20260603_003000_mid99"
+        tip = "20260603_010000_tip01"
+        db.create_session(session_id=root, source="cli")
+        db.append_message(root, role="user", content="root conversation")
+        db.end_session(root, "compression")
+        db.create_session(session_id=mid, source="cli", parent_session_id=root)
+        db.append_message(mid, role="user", content="middle conversation")
+        db.end_session(mid, "compression")
+        db.create_session(session_id=tip, source="cli", parent_session_id=mid)
+        db.append_message(tip, role="user", content="continued conversation")
+
+        matches = db.search_sessions_by_id("mid99")
+
+        assert [s["id"] for s in matches] == [tip]
+        assert matches[0]["_lineage_ids"] == [root, mid, tip]
 
 class TestListCronJobRuns:
     """``list_cron_job_runs`` powers the desktop cron run-history endpoint.

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -543,6 +543,23 @@ def test_prompt_submit_golden_transcript_matches_flag_off_and_on(monkeypatch):
             server._sessions.pop("sid", None)
 
     assert run_flag_on() == run_flag_off()
+def test_enrich_with_attached_images_preserves_failure_analysis(monkeypatch, tmp_path):
+    image = tmp_path / "screenshot.png"
+    image.write_bytes(b"not-a-real-png-but-the-tool-is-mocked")
+
+    async def fake_vision_analyze_tool(*, image_url: str, user_prompt: str):
+        return json.dumps({
+            "success": False,
+            "analysis": "could not find suitable inference handler for deepseek-v4-flash-free",
+        })
+
+    monkeypatch.setattr("tools.vision_tools.vision_analyze_tool", fake_vision_analyze_tool)
+
+    enriched = server._enrich_with_attached_images("please inspect this", [str(image)])
+
+    assert "could not find suitable inference handler for deepseek-v4-flash-free" in enriched
+    assert "analysis failed" not in enriched
+    assert "please inspect this" in enriched
 
 
 def test_session_context_explicit_cwd_for_ephemeral_task(monkeypatch, tmp_path):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6200,14 +6200,18 @@ def _enrich_with_attached_images(user_text: str, image_paths: list[str]) -> str:
             r = _json.loads(
                 asyncio.run(vision_analyze_tool(image_url=str(p), user_prompt=prompt))
             )
-            desc = r.get("analysis", "") if r.get("success") else None
+            desc = str(r.get("analysis") or "").strip()
+            if not desc and not r.get("success"):
+                desc = str(r.get("error") or "").strip()
             parts.append(
                 f"[The user attached an image:\n{desc}]\n{hint}"
                 if desc
-                else f"[The user attached an image but analysis failed.]\n{hint}"
+                else f"[The user attached an image, but automatic analysis did not return a description.]\n{hint}"
             )
-        except Exception:
-            parts.append(f"[The user attached an image but analysis failed.]\n{hint}")
+        except Exception as exc:
+            parts.append(
+                f"[The user attached an image, but automatic analysis failed before returning a description: {exc}]\n{hint}"
+            )
 
     text = user_text or ""
     prefix = "\n\n".join(parts)


### PR DESCRIPTION
## Why

Hermes desktop can show stale compressed continuation rows beside the live continuation tip when a pinned or previously selected intermediate session id remains in renderer state. The same report also exposed screenshot-analysis failures for OpenCode Zen / DeepSeek sessions because auxiliary vision auto-routing reused the text model instead of a vision-capable model.

## What changed

- Routes OpenCode Zen auxiliary vision analysis through `gemini-3-flash` instead of the active text model.
- Preserves provider failure details from `vision_analyze` when attached-image enrichment fails.
- Projects compression chains with `_lineage_ids`, not only `_lineage_root_id`, so root, intermediate, and tip ids all resolve to the surfaced live row.
- Updates the remaining upstream desktop session store to dedupe incoming and retained rows by every lineage alias, preferring the richer or fresher live row.
- Adds the `omar@kostudios.io` contributor mapping required by upstream release attribution checks.
- Adds focused backend and desktop store regressions for the image-analysis and lineage-alias cases.

## How to review

Start with `agent/auxiliary_client.py` and `tui_gateway/server.py` for the vision-routing and failure-surfacing fix. Then review `hermes_state.py` for `_lineage_ids` projection, followed by `apps/desktop/src/store/session.ts` for alias-aware renderer dedupe. `scripts/release.py` only adds the contributor email mapping required by `check-attribution`.

## Evidence

- Clean upstream port is two commits on top of `upstream/main` at `ee1a744ace`.
- Current `upstream/main` no longer contains the fork-only `remote-sessions` and `sidebar-selection` renderer stores, so those deleted-store changes were intentionally not carried forward.
- The surviving upstream surface is backend lineage projection plus `apps/desktop/src/store/session.ts`.
- A read-only SQLite probe of the live Hermes DB during task `hermes-desktop-vision-session-dedupe-20260611` observed `Job Status Summary and Updates #5 -> #6 -> #7` as one compression chain, matching the duplicate-sidebar repro.

## Verification

- `python3 -m pytest -q tests/agent/test_auxiliary_client.py::TestVisionAutoSkipsKimiCoding::test_opencode_zen_uses_aux_vision_model_not_text_model tests/test_tui_gateway_server.py::test_enrich_with_attached_images_preserves_failure_analysis tests/test_hermes_state.py::TestCompressionChainProjection::test_batch_compression_tips_single_root tests/test_hermes_state.py::TestCompressionChainProjection::test_batch_compression_tips_multiple_roots tests/test_hermes_state.py::TestCompressionChainProjection::test_list_surfaces_tip_for_compressed_root tests/test_hermes_state.py::TestSessionIdSearch::test_search_sessions_by_id_matches_projected_intermediate_lineage_id tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_get_sessions_order_recent_surfaces_compression_tip tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_search_dedupes_compression_lineage_to_tip` -> 8 passed, 1 existing `audioop` deprecation warning.
- `npm --prefix apps/desktop run test:ui -- src/store/session.test.ts` -> 23 passed.
- `npm --prefix apps/desktop run typecheck` -> passed.
- `python3 -m py_compile scripts/release.py` -> passed.
- `git diff --check upstream/main...HEAD` -> passed.

<!-- pr-quality:no-visual-required: this is routing/session-identity behavior; focused backend/store regressions cover the visible duplicate-row failure without requiring a screenshot artifact. -->

## Risks / gaps

- Accepted scope: existing pin storage is not rewritten in place because `_lineage_ids` intentionally lets already-stored intermediate ids resolve to the live row after the next sidebar refresh.
- task: hermes-desktop-vision-session-dedupe-20260611 tracks the remaining release/install follow-through after upstream review.

## Collaborators

- Omar Baradei, ko-mac operator, reported the Hermes desktop screenshot-analysis failure and duplicate compressed sessions on June 11, 2026.
- Codex, ko-mac local coding agent, adapted and verified the upstream port for task `hermes-desktop-vision-session-dedupe-20260611`.