### PR TITLE
fix(auxiliary): preserve custom: prefix in vision provider resolution

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4142,7 +4142,12 @@ def resolve_vision_provider_client(
     requested, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
         "vision", provider, model, base_url, api_key
     )
-    requested = _normalize_vision_provider(requested)
+    # Preserve the `custom:` prefix so resolve_provider_client can look up
+    # the user's custom_providers entry.  _normalize_aux_provider strips it,
+    # causing ``custom:minimax`` to collapse to bare ``minimax`` (a built-in)
+    # and ignoring the user's custom endpoint/key.  (#44349)
+    if not (requested or '').startswith('custom:'):
+        requested = _normalize_vision_provider(requested)
 
     def _finalize(resolved_provider: str, sync_client: Any, default_model: Optional[str]):
         if sync_client is None:

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -491,3 +491,80 @@ class TestCustomProviderAliasCollision:
         assert isinstance(client, OpenAI)
         assert "override.example.com" in str(client.base_url)
         assert client.api_key == "override-key"
+
+
+
+class TestCustomPrefixPreservedInVision:
+    """Regression test for #44349.
+
+    When auxiliary.vision.provider is set to custom:<name> where <name>
+    matches a built-in provider (e.g. custom:minimax), the custom: prefix
+    must be preserved through resolve_vision_provider_client so
+    resolve_provider_client can look up the user's custom_providers entry
+    instead of collapsing to the built-in.
+    """
+
+    def test_custom_minimax_uses_custom_endpoint(self, tmp_path, monkeypatch):
+        """custom:minimax should resolve to the custom_providers entry, not built-in minimax."""
+        _write_config(tmp_path, {
+            "model": {"default": "test-model", "provider": "openrouter"},
+            "auxiliary": {"vision": {"provider": "custom:minimax", "model": "MiniMax-M3"}},
+            "custom_providers": [{
+                "name": "minimax",
+                "provider": "openai",
+                "base_url": "https://api.minimaxi.com/v1",
+                "api_key_env": "MINIMAX_CN_API_KEY",
+                "api_mode": "chat_completions",
+            }],
+        })
+        monkeypatch.setenv("MINIMAX_CN_API_KEY", "sk-test-cn-key")
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_vision_provider_client
+            provider, client, model = resolve_vision_provider_client()
+
+        assert client is not None
+        # Must use the custom endpoint, not the built-in minimax
+        mock_openai.assert_called_once()
+        _, kwargs = mock_openai.call_args
+        assert "minimaxi.com" in kwargs.get("base_url", ""), (
+            f"Expected custom endpoint minimaxi.com, got {kwargs.get('base_url')!r}"
+        )
+        assert kwargs.get("api_key") == "sk-test-cn-key"
+
+    def test_custom_prefix_not_stripped_for_unknown_provider(self, tmp_path, monkeypatch):
+        """custom:myprovider with a non-builtin name should also work."""
+        _write_config(tmp_path, {
+            "model": {"default": "test-model"},
+            "auxiliary": {"vision": {"provider": "custom:myprovider", "model": "my-vlm"}},
+            "custom_providers": [{
+                "name": "myprovider",
+                "provider": "openai",
+                "base_url": "https://my-vlm.example.com/v1",
+                "api_key_env": "MY_VLM_KEY",
+            }],
+        })
+        monkeypatch.setenv("MY_VLM_KEY", "sk-my-vlm")
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_vision_provider_client
+            provider, client, model = resolve_vision_provider_client()
+
+        assert client is not None
+        mock_openai.assert_called_once()
+        _, kwargs = mock_openai.call_args
+        assert "my-vlm.example.com" in kwargs.get("base_url", "")
+
+    def test_builtin_provider_still_normalizes(self, tmp_path, monkeypatch):
+        """Non-custom providers still go through normalization (alias resolution)."""
+        _write_config(tmp_path, {
+            "model": {"default": "test-model"},
+        })
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+        with patch("agent.auxiliary_client._try_openrouter") as mock_or:
+            mock_or.return_value = (MagicMock(), "google/gemini-2.5-flash")
+            from agent.auxiliary_client import resolve_vision_provider_client
+            provider, client, model = resolve_vision_provider_client(provider="openrouter")
+
+        assert provider == "openrouter"
+        assert client is not None


### PR DESCRIPTION
## What does this PR do?

Fixes `auxiliary.vision.provider` resolution when set to `custom:<name>` where `<name>` matches a built-in provider. The `custom:` prefix was being stripped by `_normalize_vision_provider` before `resolve_provider_client` could use it to look up the user's `custom_providers` entry, causing the request to route to the built-in provider instead — resulting in 401 errors.

## Related Issue

Fixes #44349

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py`: Skip `_normalize_vision_provider` when the provider starts with `custom:` so the prefix is preserved for the named-custom-provider branch in `resolve_provider_client`
- `tests/agent/test_auxiliary_named_custom_providers.py`: Add 3 regression tests verifying `custom:` prefix preservation, non-builtin custom providers, and continued normalization for built-in providers

## How to Test

1. Set `custom_providers` in `config.yaml` with `name: minimax` pointing to a custom endpoint
2. Set `auxiliary.vision.provider: custom:minimax` and `auxiliary.vision.model: MiniMax-M3`
3. Call `vision_analyze` — requests should go to the custom endpoint, not the built-in minimax provider
4. Run `pytest tests/agent/test_auxiliary_named_custom_providers.py -v` — all 32 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/agent/test_auxiliary_named_custom_providers.py -v` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/auxiliary_client.py::resolve_vision_provider_client` (callers: 6+ across vision tools, browser, retry paths)
- Blast radius: LOW — only affects `custom:` prefixed providers in the vision path; built-in provider resolution unchanged
- Related patterns: `_normalize_aux_provider` strips `custom:` prefix; `resolve_provider_client` uses `original_provider` to detect alias-vs-custom divergence at line 3663
