### PR TITLE
fix: preserve custom: prefix in _normalize_aux_provider for named custom providers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -168,7 +168,14 @@ def _normalize_aux_provider(provider: Optional[str]) -> str:
         suffix = normalized.split(":", 1)[1].strip()
         if not suffix:
             return "custom"
-        normalized = suffix
+        # Preserve the full ``custom:<name>`` form so that downstream
+        # resolution (resolve_provider_client, _get_named_custom_provider)
+        # can correctly distinguish a user-declared custom_providers entry
+        # from a built-in provider that happens to share the same name
+        # (e.g. ``custom:minimax`` vs the built-in ``minimax`` provider).
+        # Stripping the prefix here causes the named-custom lookup to be
+        # short-circuited by the built-in provider branch (#44349).
+        return normalized
     if normalized == "codex":
         return "openai-codex"
     if normalized == "main":

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -156,6 +156,19 @@ class TestNormalizeAuxProvider:
         assert _normalize_aux_provider("github-copilot-acp") == "copilot-acp"
         assert _normalize_aux_provider("copilot-acp-agent") == "copilot-acp"
 
+    def test_preserves_custom_prefix(self):
+        """``custom:<name>`` must stay as-is so named-custom resolution
+        can distinguish a user-declared custom_providers entry from a
+        built-in provider with the same name (#44349)."""
+        assert _normalize_aux_provider("custom:minimax") == "custom:minimax"
+        assert _normalize_aux_provider("custom:localchat") == "custom:localchat"
+        assert _normalize_aux_provider("custom:kimi") == "custom:kimi"
+
+    def test_bare_custom_prefix_empty_suffix_returns_custom(self):
+        """``custom:`` with empty suffix resolves to bare ``custom``."""
+        assert _normalize_aux_provider("custom:") == "custom"
+        assert _normalize_aux_provider("custom:  ") == "custom"
+
 
 class TestReadCodexAccessToken:
     def test_valid_auth_store(self, tmp_path, monkeypatch):

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -59,7 +59,10 @@ class TestNormalizeVisionProvider:
 
     def test_custom_colon_named_provider_preserved(self):
         from agent.auxiliary_client import _normalize_vision_provider
-        assert _normalize_vision_provider("custom:beans") == "beans"
+        # ``custom:`` prefix is now preserved so named-custom resolution
+        # can distinguish user-declared custom_providers entries from
+        # built-in providers (#44349).
+        assert _normalize_vision_provider("custom:beans") == "custom:beans"
 
     def test_codex_alias_still_works(self):
         from agent.auxiliary_client import _normalize_vision_provider
@@ -491,3 +494,38 @@ class TestCustomProviderAliasCollision:
         assert isinstance(client, OpenAI)
         assert "override.example.com" in str(client.base_url)
         assert client.api_key == "override-key"
+
+    def test_custom_prefix_preserves_name_through_resolution(self, tmp_path):
+        """``custom:minimax`` with a custom_providers entry named ``minimax``
+        must resolve to the user's custom endpoint, not the built-in minimax
+        provider (#44349).
+
+        This tests the full resolution chain: _normalize_aux_provider must
+        preserve the ``custom:`` prefix so _get_named_custom_provider can
+        skip the built-in guard and match the user's custom entry.
+        """
+        _write_config(tmp_path, {
+            "model": {"provider": "openrouter", "default": "anthropic/claude-sonnet-4.6"},
+            "custom_providers": [
+                {
+                    "name": "minimax",
+                    "base_url": "https://my-custom-minimax.example.com/v1",
+                    "api_key": "my-custom-minimax-key",
+                    "api_mode": "chat_completions",
+                },
+            ],
+        })
+        from agent.auxiliary_client import resolve_provider_client
+        from openai import OpenAI
+        # Passing ``custom:minimax`` — this should route to the user's
+        # custom entry, not the built-in minimax provider.
+        client, _ = resolve_provider_client("custom:minimax", raw_codex=True)
+        assert client is not None, (
+            "resolve_provider_client('custom:minimax') returned None — "
+            "custom prefix was likely stripped before named-custom lookup"
+        )
+        assert isinstance(client, OpenAI)
+        assert "my-custom-minimax.example.com" in str(client.base_url), (
+            f"Expected custom base_url, got {client.base_url}"
+        )
+        assert client.api_key == "my-custom-minimax-key"


### PR DESCRIPTION
## Summary

Fixes #44349: When `auxiliary.vision.provider` is set to `custom:<name>` where `<name>` matches a built-in provider (e.g. `custom:minimax`), `_normalize_aux_provider()` stripped the `custom:` prefix and returned just `<name>`. This caused resolution to use the built-in provider instead of the user's `custom_providers` entry, producing 401 errors.

## Root Cause

In `agent/auxiliary_client.py:_normalize_aux_provider()`, line 171:

```python
normalized = suffix  # BUG: strips custom: prefix
```

When input is `custom:minimax`, the function returned `minimax`, which routes to the built-in minimax provider.

## Fix

Changed `_normalize_aux_provider()` to preserve the full `custom:<name>` form. This preserves the prefix through the resolution chain so `resolve_provider_client` reaches the named-custom lookup in `_get_named_custom_provider()`, which already handles `custom:` prefix correctly.

## Changes

| File | Change |
|------|--------|
| `agent/auxiliary_client.py` | 1-line fix + comment |
| `tests/agent/test_auxiliary_client.py` | 2 new unit tests |
| `tests/agent/test_auxiliary_named_custom_providers.py` | 1 new integration test + 1 updated test |

## Test Plan

- [x] `test_auxiliary_client.py` — 209/209 passed
- [x] `test_auxiliary_named_custom_providers.py` — 30/30 passed

Closes #44349