### PR TITLE
fix(docs): target installer venv in voice extra install command

### DIFF
--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -270,7 +270,7 @@ hermes config set terminal.backend ssh       # Remote server
 # From the Hermes install directory (the curl installer placed it at
 # ~/.hermes/hermes-agent on Linux/macOS or %LOCALAPPDATA%\hermes\hermes-agent on Windows):
 cd ~/.hermes/hermes-agent
-uv pip install -e ".[voice]"
+uv pip install --python ./venv/bin/python -e ".[voice]"
 # Includes faster-whisper for free local speech-to-text
 ```
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/quickstart.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/quickstart.md
@@ -259,7 +259,7 @@ hermes config set terminal.backend ssh       # 远程服务器
 # 在 Hermes 安装目录下运行（curl 安装器在 Linux/macOS 上将其放置于
 # ~/.hermes/hermes-agent，在 Windows 上为 %LOCALAPPDATA%\hermes\hermes-agent）：
 cd ~/.hermes/hermes-agent
-uv pip install -e ".[voice]"
+uv pip install --python ./venv/bin/python -e ".[voice]"
 # 包含 faster-whisper，用于免费的本地语音转文字
 ```
 


### PR DESCRIPTION
## What does this PR do?

Fixes the voice-mode extra install command in the quickstart docs to target the installer-created virtual environment explicitly, preventing failures on fresh curl-installed setups where no venv is active.

## Related Issue

Fixes #44364

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- `website/docs/getting-started/quickstart.md`: Changed `uv pip install -e ".[voice]"` to `uv pip install --python ./venv/bin/python -e ".[voice]"` so it targets the installer-created venv without requiring manual activation.
- `website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/quickstart.md`: Same fix for the Chinese localization.

## How to Test

1. On a fresh system (or simulate by deactivating any venv), `cd ~/.hermes/hermes-agent`
2. Run `uv pip install --python ./venv/bin/python -e ".[voice]"` — it should install successfully
3. Verify `faster-whisper`, `sounddevice`, and `numpy` are installed in the venv: `./venv/bin/python -c "import faster_whisper; print('OK')"`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (N/A — documentation only)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (docs-only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Code Intelligence

- Analyzed: `website/docs/getting-started/quickstart.md` (voice-mode section, line 267-275)
- Blast radius: LOW — documentation-only change, no code behavior affected
- Related patterns: The same `uv pip install` without `--python` pattern exists in MCP and ACP sections of the same file, but those are out of scope for this issue
