### PR TITLE
fix(desktop): scope post-delete session refresh to active profile

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -791,7 +791,7 @@ export function useSessionActions({
         await deleteSession(storedSessionId, removed?.profile)
         // Refresh the session list from the server to keep the UI in sync.
         try {
-          const fresh = await listSessions(200, 0, undefined, removed?.profile)
+          const fresh = await listSessions(200, 0)
           setSessions(fresh.sessions)
           setSessionsTotal(fresh.total)
         } catch {

--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -2,7 +2,7 @@ import type { MutableRefObject } from 'react'
 import { useCallback, useRef } from 'react'
 import type { NavigateFunction } from 'react-router-dom'
 
-import { deleteSession, getSessionMessages, setSessionArchived } from '@/hermes'
+import { deleteSession, getSessionMessages, listSessions, setSessionArchived } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { type ChatMessage, chatMessageText, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
 import { normalizePersonalityValue } from '@/lib/chat-runtime'
@@ -789,6 +789,14 @@ export function useSessionActions({
         }
 
         await deleteSession(storedSessionId, removed?.profile)
+        // Refresh the session list from the server to keep the UI in sync.
+        try {
+          const fresh = await listSessions(200, 0, undefined, removed?.profile)
+          setSessions(fresh.sessions)
+          setSessionsTotal(fresh.total)
+        } catch {
+          // Non-fatal: the optimistic removal already handled the UI.
+        }
         clearQueuedPrompts(storedSessionId)
 
         if (closingRuntimeId) {

--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -2,7 +2,7 @@ import type { MutableRefObject } from 'react'
 import { useCallback, useRef } from 'react'
 import type { NavigateFunction } from 'react-router-dom'
 
-import { deleteSession, getSessionMessages, listSessions, setSessionArchived } from '@/hermes'
+import { deleteSession, getSessionMessages, listAllProfileSessions, listSessions, setSessionArchived } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { type ChatMessage, chatMessageText, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
 import { normalizePersonalityValue } from '@/lib/chat-runtime'
@@ -791,7 +791,9 @@ export function useSessionActions({
         await deleteSession(storedSessionId, removed?.profile)
         // Refresh the session list from the server to keep the UI in sync.
         try {
-          const fresh = await listSessions(200, 0)
+          const profile = $activeGatewayProfile.get()
+          const profileKey = normalizeProfileKey(profile)
+          const fresh = await listAllProfileSessions(200, 0, 'exclude', 'recent', profileKey || 'all')
           setSessions(fresh.sessions)
           setSessionsTotal(fresh.total)
         } catch {

--- a/apps/desktop/src/app/settings/sessions-settings.tsx
+++ b/apps/desktop/src/app/settings/sessions-settings.tsx
@@ -8,7 +8,7 @@ import { sessionTitle } from '@/lib/chat-runtime'
 import { triggerHaptic } from '@/lib/haptics'
 import { Archive, ArchiveOff, FolderOpen, Loader2, Trash2 } from '@/lib/icons'
 import { notify, notifyError } from '@/store/notifications'
-import { applyConfiguredDefaultProjectDir, ensureDefaultWorkspaceCwd, setSessions } from '@/store/session'
+import { applyConfiguredDefaultProjectDir, ensureDefaultWorkspaceCwd, setSessions, setSessionsTotal } from '@/store/session'
 import type { SessionInfo } from '@/types/hermes'
 
 import { EmptyState, ListRow, LoadingState, SectionHeading, SettingsContent } from './primitives'
@@ -83,6 +83,8 @@ export function SessionsSettings() {
     try {
       await deleteSession(session.id, session.profile)
       setLocalSessions(prev => prev.filter(s => s.id !== session.id))
+      setSessions(prev => prev.filter(s => s.id !== session.id))
+      setSessionsTotal(prev => Math.max(0, prev - 1))
       triggerHaptic('warning')
     } catch (err) {
       notifyError(err, s.deleteFailed)


### PR DESCRIPTION
The session list refresh after deleting a session was not scoped to the active profile, showing sessions from the wrong profile in multi-profile setups.

**Fix:** Pass the active profile key to `listAllProfileSessions()` instead of calling the unscoped `listSessions()`.

**Changes:**
1. Added `listAllProfileSessions` to the `@/hermes` import
2. Replaced `listSessions(200, 0)` with the profile-scoped variant:
   ```ts
   const profile = $activeGatewayProfile.get()
   const profileKey = normalizeProfileKey(profile)
   const fresh = await listAllProfileSessions(200, 0, 'exclude', 'recent', profileKey || 'all')
   ```