### PR TITLE
fix(desktop): confirm copy actions

### DIFF
--- a/apps/desktop/src/app/updates-overlay.tsx
+++ b/apps/desktop/src/app/updates-overlay.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react'
 
 import { BrandMark } from '@/components/brand-mark'
 import { Button } from '@/components/ui/button'
-import { writeClipboardText } from '@/components/ui/copy-button'
+import { copyTextWithFeedback } from '@/components/ui/copy-button'
 import {
   Dialog,
   DialogContent,
@@ -279,10 +279,14 @@ function ManualView({ command, message, onDone }: { command: string | null; mess
       return
     }
 
-    void writeClipboardText(command).then(() => {
-      setCopied(true)
-      window.setTimeout(() => setCopied(false), 1800)
-    })
+    void copyTextWithFeedback(command, { successMessage: u.copied, successTitle: u.copy })
+      .then(copied => {
+        if (copied) {
+          setCopied(true)
+          window.setTimeout(() => setCopied(false), 1800)
+        }
+      })
+      .catch(() => undefined)
   }
 
   // No command (e.g. the Linux sandbox-blocked relaunch): render the explanatory

--- a/apps/desktop/src/components/desktop-install-overlay.tsx
+++ b/apps/desktop/src/components/desktop-install-overlay.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { BrandMark } from '@/components/brand-mark'
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
+import { copyTextWithFeedback } from '@/components/ui/copy-button'
 import { ErrorIcon } from '@/components/ui/error-state'
 import { Loader } from '@/components/ui/loader'
 import { LogView } from '@/components/ui/log-view'
@@ -491,7 +492,11 @@ export function DesktopInstallOverlay({ enabled = true }: DesktopInstallOverlayP
             <div className="mt-2 flex items-center gap-2">
               <Button
                 onClick={() => {
-                  void navigator.clipboard?.writeText(ups.installCommand).catch(() => {})
+                  void copyTextWithFeedback(ups.installCommand, {
+                    errorMessage: copy.copyCommand,
+                    successMessage: t.common.copied,
+                    successTitle: copy.copyCommand
+                  }).catch(() => undefined)
                 }}
                 size="sm"
                 variant="secondary"
@@ -682,11 +687,15 @@ export function DesktopInstallOverlay({ enabled = true }: DesktopInstallOverlayP
                     const fullText = state.error ? `Error: ${state.error}\n\n${text}` : text
 
                     try {
-                      await navigator.clipboard.writeText(fullText)
+                      await copyTextWithFeedback(fullText, {
+                        errorMessage: copy.copyOutput,
+                        successMessage: copy.copiedOutput,
+                        successTitle: copy.copyOutput
+                      })
                       setCopied(true)
                       window.setTimeout(() => setCopied(false), 1500)
                     } catch {
-                      // ignore -- some environments forbid clipboard writes
+                      // copyTextWithFeedback already posts the failure toast.
                     }
                   }}
                   size="sm"

--- a/apps/desktop/src/components/ui/copy-button.test.tsx
+++ b/apps/desktop/src/components/ui/copy-button.test.tsx
@@ -2,12 +2,14 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { I18nProvider } from '@/i18n'
+import { $notifications, clearNotifications } from '@/store/notifications'
 
-import { CopyButton } from './copy-button'
+import { CopyButton, copyTextWithFeedback } from './copy-button'
 
 describe('CopyButton i18n', () => {
   afterEach(() => {
     cleanup()
+    clearNotifications()
     vi.restoreAllMocks()
   })
 
@@ -32,5 +34,26 @@ describe('CopyButton i18n', () => {
     await waitFor(() => expect(writeText).toHaveBeenCalledWith('hello'))
     await waitFor(() => expect(screen.getByRole('button', { name: '已复制' })).toBeTruthy())
     expect(screen.getByRole('button', { name: '已复制' }).textContent).toContain('已复制')
+  })
+
+  it('posts a success notification after a clipboard write resolves', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText }
+    })
+
+    await copyTextWithFeedback('hello', {
+      haptic: false,
+      successMessage: 'Copied session ID',
+      successTitle: 'Copy ID'
+    })
+
+    expect(writeText).toHaveBeenCalledWith('hello')
+    expect($notifications.get()[0]).toMatchObject({
+      kind: 'success',
+      message: 'Copied session ID',
+      title: 'Copy ID'
+    })
   })
 })

--- a/apps/desktop/src/components/ui/copy-button.tsx
+++ b/apps/desktop/src/components/ui/copy-button.tsx
@@ -4,10 +4,11 @@ import { Button } from '@/components/ui/button'
 import { ContextMenuItem } from '@/components/ui/context-menu'
 import { DropdownMenuItem } from '@/components/ui/dropdown-menu'
 import { Tip } from '@/components/ui/tooltip'
-import { useI18n } from '@/i18n'
+import { translateNow, useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { Check, Copy, X } from '@/lib/icons'
 import { cn } from '@/lib/utils'
+import { notify, notifyError } from '@/store/notifications'
 
 type CopyPayload = string | (() => Promise<string> | string)
 type CopyButtonAppearance = 'button' | 'icon' | 'inline' | 'menu-item' | 'context-menu-item' | 'tool-row'
@@ -34,6 +35,50 @@ export async function writeClipboardText(text: string) {
   throw new Error('Clipboard API is unavailable')
 }
 
+export interface CopyTextFeedbackOptions {
+  errorMessage?: string
+  haptic?: boolean
+  notifyFailure?: boolean
+  notifySuccess?: boolean
+  successMessage?: string
+  successTitle?: string
+}
+
+export async function copyTextWithFeedback(text: string, options: CopyTextFeedbackOptions = {}): Promise<boolean> {
+  if (!text) {
+    return false
+  }
+
+  const {
+    errorMessage = translateNow('common.copyFailed'),
+    haptic = true,
+    notifyFailure = true,
+    notifySuccess = true,
+    successMessage = translateNow('common.copied'),
+    successTitle
+  } = options
+
+  try {
+    await writeClipboardText(text)
+
+    if (haptic) {
+      triggerHaptic('selection')
+    }
+
+    if (notifySuccess) {
+      notify({ kind: 'success', message: successMessage, title: successTitle })
+    }
+
+    return true
+  } catch (error) {
+    if (notifyFailure) {
+      notifyError(error, errorMessage)
+    }
+
+    throw error
+  }
+}
+
 export interface CopyButtonProps {
   appearance?: CopyButtonAppearance
   buttonSize?: React.ComponentProps<typeof Button>['size']
@@ -45,6 +90,7 @@ export interface CopyButtonProps {
   haptic?: boolean
   iconClassName?: string
   label?: string
+  notifySuccess?: boolean
   onCopied?: () => void
   onCopyError?: (error: unknown) => void
   preventDefault?: boolean
@@ -66,6 +112,7 @@ export function CopyButton({
   haptic = true,
   iconClassName,
   label,
+  notifySuccess = true,
   onCopied,
   onCopyError,
   preventDefault = false,
@@ -106,11 +153,13 @@ export function CopyButton({
           return
         }
 
-        await writeClipboardText(value)
-
-        if (haptic) {
-          triggerHaptic('selection')
-        }
+        await copyTextWithFeedback(value, {
+          errorMessage: resolvedErrorMessage,
+          haptic,
+          notifySuccess,
+          successMessage: t.common.copied,
+          successTitle: resolvedLabel
+        })
 
         if (resetRef.current !== null) {
           window.clearTimeout(resetRef.current)
@@ -136,7 +185,18 @@ export function CopyButton({
         }, COPIED_RESET_MS)
       }
     },
-    [haptic, onCopied, onCopyError, preventDefault, stopPropagation, text]
+    [
+      haptic,
+      notifySuccess,
+      onCopied,
+      onCopyError,
+      preventDefault,
+      resolvedErrorMessage,
+      resolvedLabel,
+      stopPropagation,
+      t.common.copied,
+      text
+    ]
   )
 
   const Icon = status === 'copied' ? Check : status === 'error' ? X : Copy

--- a/apps/desktop/src/store/onboarding.ts
+++ b/apps/desktop/src/store/onboarding.ts
@@ -1,5 +1,6 @@
 import { atom } from 'nanostores'
 
+import { copyTextWithFeedback } from '@/components/ui/copy-button'
 import {
   cancelOAuthSession,
   getGlobalModelOptions,
@@ -682,7 +683,7 @@ export function cancelOnboardingFlow() {
 
 async function copyAndFlash(text: string, predicate: (flow: OnboardingFlow) => boolean) {
   try {
-    await navigator.clipboard.writeText(text)
+    await copyTextWithFeedback(text)
   } catch {
     return
   }


### PR DESCRIPTION
## Summary
- add a shared desktop copy helper that shows success/failure feedback and haptic confirmation
- route user-facing desktop copy actions through the helper
- let the session Copy ID menu action dismiss naturally after copying

## Verification
- ../../node_modules/.bin/eslint src/components/ui/copy-button.tsx src/components/ui/copy-button.test.tsx src/app/chat/sidebar/session-actions-menu.tsx src/app/updates-overlay.tsx src/app/profiles/index.tsx src/store/onboarding.ts src/components/desktop-install-overlay.tsx
- npm --workspace apps/desktop run typecheck
- npm --workspace apps/desktop run test:ui -- src/components/ui/copy-button.test.tsx
- rg -n "navigator\.clipboard|clipboard\.writeText|writeText\(|writeClipboardText\(" apps/desktop/src -g "*.{ts,tsx}"