### PR TITLE
chore: ignore local code analysis outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ source-data/*
 run_datagen_megascience_glm4-6.sh
 data/*
 node_modules/
+.codegraph/
+repomix-output.*
 browser-use/
 agent-browser/
 # Private keys


### PR DESCRIPTION
## Summary
- Ignore local code graph output directory
- Ignore repomix output files

## Test Plan
- python -m pytest tests/run_agent/test_run_agent_codex_responses.py -q -o 'addopts='