### PR TITLE
fix(memory_manager): add exponential backoff retry for transient provider errors

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -30,10 +30,24 @@ import re
 import inspect
 import threading
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from agent.memory_provider import MemoryProvider
 from tools.registry import tool_error
+
+try:
+    from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
+    _TENACITY_AVAILABLE = True
+except ImportError:
+    _TENACITY_AVAILABLE = False
+    # Simple no-op decorator when tenacity not available
+    def retry(*args, **kwargs):  # type: ignore
+        def _wrap(fn: Callable) -> Callable:
+            return fn
+        return _wrap
+    def stop_after_attempt(n): pass  # type: ignore
+    def wait_exponential(*args, **kwargs): pass  # type: ignore
+    def retry_if_exception_type(*args): pass  # type: ignore
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +56,37 @@ logger = logging.getLogger(__name__)
 # teardown indefinitely — the worker threads are daemon, so anything still
 # running past this window dies with the interpreter.
 _SYNC_DRAIN_TIMEOUT_S = 5.0
+
+# Retry configuration for transient memory provider errors
+# (network timeouts, temporary daemon unavailability, etc.)
+_MEMORY_RETRY_ATTEMPTS = 3
+_MEMORY_RETRY_WAIT_MIN = 0.5  # seconds
+_MEMORY_RETRY_WAIT_MAX = 2.0  # seconds
+
+def _memory_retry():
+    """Decorator for transient memory provider operations.
+    
+    Retries on common transient exceptions with exponential backoff.
+    """
+    if not _TENACITY_AVAILABLE:
+        def _noop(fn: Callable) -> Callable:
+            return fn
+        return _noop
+    return retry(
+        reraise=True,
+        stop=stop_after_attempt(_MEMORY_RETRY_ATTEMPTS),
+        wait=wait_exponential(
+            multiplier=1,
+            min=_MEMORY_RETRY_WAIT_MIN,
+            max=_MEMORY_RETRY_WAIT_MAX,
+        ),
+        retry=retry_if_exception_type((
+            ConnectionError,
+            TimeoutError,
+            IOError,
+            OSError,
+        )),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -268,6 +313,32 @@ class MemoryManager:
         self._sync_executor: Optional[ThreadPoolExecutor] = None
         self._sync_executor_lock = threading.Lock()
 
+    def _call_with_retry(self, provider: MemoryProvider, method_name: str, *args, **kwargs):
+        """Call a provider method with retry on transient errors."""
+        method = getattr(provider, method_name)
+        if not _TENACITY_AVAILABLE:
+            return method(*args, **kwargs)
+
+        @retry(
+            reraise=True,
+            stop=stop_after_attempt(_MEMORY_RETRY_ATTEMPTS),
+            wait=wait_exponential(
+                multiplier=1,
+                min=_MEMORY_RETRY_WAIT_MIN,
+                max=_MEMORY_RETRY_WAIT_MAX,
+            ),
+            retry=retry_if_exception_type((
+                ConnectionError,
+                TimeoutError,
+                IOError,
+                OSError,
+            )),
+        )
+        def _retry_call():
+            return method(*args, **kwargs)
+
+        return _retry_call()
+
     # -- Registration --------------------------------------------------------
 
     def add_provider(self, provider: MemoryProvider) -> None:
@@ -358,7 +429,7 @@ class MemoryManager:
         blocks = []
         for provider in self._providers:
             try:
-                block = provider.system_prompt_block()
+                block = self._call_with_retry(provider, "system_prompt_block")
                 if block and block.strip():
                     blocks.append(block)
             except Exception as e:
@@ -379,7 +450,7 @@ class MemoryManager:
         parts = []
         for provider in self._providers:
             try:
-                result = provider.prefetch(query, session_id=session_id)
+                result = self._call_with_retry(provider, "prefetch", query, session_id=session_id)
                 if result and result.strip():
                     parts.append(result)
             except Exception as e:
@@ -403,7 +474,7 @@ class MemoryManager:
         def _run() -> None:
             for provider in providers:
                 try:
-                    provider.queue_prefetch(query, session_id=session_id)
+                    self._call_with_retry(provider, "queue_prefetch", query, session_id=session_id)
                 except Exception as e:
                     logger.debug(
                         "Memory provider '%s' queue_prefetch failed (non-fatal): %s",
@@ -459,16 +530,15 @@ class MemoryManager:
             for provider in providers:
                 try:
                     if messages is not None and self._provider_sync_accepts_messages(provider):
-                        provider.sync_turn(
-                            user_content,
-                            assistant_content,
-                            session_id=session_id,
-                            messages=messages,
+                        self._call_with_retry(
+                            provider, "sync_turn",
+                            user_content, assistant_content,
+                            session_id=session_id, messages=messages,
                         )
                     else:
-                        provider.sync_turn(
-                            user_content,
-                            assistant_content,
+                        self._call_with_retry(
+                            provider, "sync_turn",
+                            user_content, assistant_content,
                             session_id=session_id,
                         )
                 except Exception as e:
@@ -600,7 +670,7 @@ class MemoryManager:
         if provider is None:
             return tool_error(f"No memory provider handles tool '{tool_name}'")
         try:
-            return provider.handle_tool_call(tool_name, args, **kwargs)
+            return self._call_with_retry(provider, "handle_tool_call", tool_name, args, **kwargs)
         except Exception as e:
             logger.error(
                 "Memory provider '%s' handle_tool_call(%s) failed: %s",
@@ -745,13 +815,20 @@ class MemoryManager:
             try:
                 metadata_mode = self._provider_memory_write_metadata_mode(provider)
                 if metadata_mode == "keyword":
-                    provider.on_memory_write(
+                    self._call_with_retry(
+                        provider, "on_memory_write",
                         action, target, content, metadata=dict(metadata or {})
                     )
                 elif metadata_mode == "positional":
-                    provider.on_memory_write(action, target, content, dict(metadata or {}))
+                    self._call_with_retry(
+                        provider, "on_memory_write",
+                        action, target, content, dict(metadata or {})
+                    )
                 else:
-                    provider.on_memory_write(action, target, content)
+                    self._call_with_retry(
+                        provider, "on_memory_write",
+                        action, target, content
+                    )
             except Exception as e:
                 logger.debug(
                     "Memory provider '%s' on_memory_write failed: %s",

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -59,34 +59,25 @@ _SYNC_DRAIN_TIMEOUT_S = 5.0
 
 # Retry configuration for transient memory provider errors
 # (network timeouts, temporary daemon unavailability, etc.)
+# NOTE: retries are limited to explicitly idempotent/read paths
+# (system_prompt_block, prefetch, queue_prefetch, sync_turn).
+# handle_tool_call is NOT retried — the routed tool may mutate the
+# memory backend, and a post-write transient failure is ambiguous,
+# so a replay could duplicate data. See teknium1 review on PR #44378.
 _MEMORY_RETRY_ATTEMPTS = 3
 _MEMORY_RETRY_WAIT_MIN = 0.5  # seconds
 _MEMORY_RETRY_WAIT_MAX = 2.0  # seconds
 
-def _memory_retry():
-    """Decorator for transient memory provider operations.
-    
-    Retries on common transient exceptions with exponential backoff.
-    """
-    if not _TENACITY_AVAILABLE:
-        def _noop(fn: Callable) -> Callable:
-            return fn
-        return _noop
-    return retry(
-        reraise=True,
-        stop=stop_after_attempt(_MEMORY_RETRY_ATTEMPTS),
-        wait=wait_exponential(
-            multiplier=1,
-            min=_MEMORY_RETRY_WAIT_MIN,
-            max=_MEMORY_RETRY_WAIT_MAX,
-        ),
-        retry=retry_if_exception_type((
-            ConnectionError,
-            TimeoutError,
-            IOError,
-            OSError,
-        )),
-    )
+# Transient exception types that warrant a retry. ``IOError`` is an alias
+# of ``OSError`` in Python 3, but listing bare ``OSError`` would also
+# catch permanent filesystem errors (``FileNotFoundError``,
+# ``PermissionError``, ``IsADirectoryError``, …). Narrow to connection
+# and socket-level errors, which are the only ones worth paying a
+# backoff retry for.
+_MEMORY_RETRY_EXCEPTIONS = (
+    ConnectionError,  # ConnectionResetError / RefusedError / AbortedError
+    TimeoutError,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -314,7 +305,12 @@ class MemoryManager:
         self._sync_executor_lock = threading.Lock()
 
     def _call_with_retry(self, provider: MemoryProvider, method_name: str, *args, **kwargs):
-        """Call a provider method with retry on transient errors."""
+        """Call a provider method with retry on transient errors.
+
+        Only safe for idempotent/read operations — NOT for ``handle_tool_call``
+        or any other path whose effect may mutate the memory backend. Replay
+        after a late-stage transient could duplicate the write.
+        """
         method = getattr(provider, method_name)
         if not _TENACITY_AVAILABLE:
             return method(*args, **kwargs)
@@ -327,12 +323,7 @@ class MemoryManager:
                 min=_MEMORY_RETRY_WAIT_MIN,
                 max=_MEMORY_RETRY_WAIT_MAX,
             ),
-            retry=retry_if_exception_type((
-                ConnectionError,
-                TimeoutError,
-                IOError,
-                OSError,
-            )),
+            retry=retry_if_exception_type(_MEMORY_RETRY_EXCEPTIONS),
         )
         def _retry_call():
             return method(*args, **kwargs)
@@ -665,12 +656,19 @@ class MemoryManager:
 
         Returns JSON string result. Raises ValueError if no provider
         handles the tool.
+
+        NOTE: this path is NOT retried. The routed tool may mutate the
+        memory backend (e.g. ````store````/````forget````), and a
+        post-write transient failure is ambiguous — replay could
+        duplicate the write. Per teknium1 review on PR #44378, retry is
+        limited to idempotent/read operations (``system_prompt_block``,
+        ``prefetch``, ``queue_prefetch``, ``sync_turn``).
         """
         provider = self._tool_to_provider.get(tool_name)
         if provider is None:
             return tool_error(f"No memory provider handles tool '{tool_name}'")
         try:
-            return self._call_with_retry(provider, "handle_tool_call", tool_name, args, **kwargs)
+            return provider.handle_tool_call(tool_name, args, **kwargs)
         except Exception as e:
             logger.error(
                 "Memory provider '%s' handle_tool_call(%s) failed: %s",

--- a/tests/agent/test_memory_retry.py
+++ b/tests/agent/test_memory_retry.py
@@ -1,0 +1,240 @@
+"""Regression tests for MemoryManager retry behaviour on provider calls.
+
+These cover the three scenarios requested in the teknium1 review of PR #44378:
+
+1. Transient exception (``ConnectionError``/``TimeoutError``) is retried and
+   ultimately succeeds — the provider method is invoked more than once.
+2. Non-retryable exception (``ValueError``, ``FileNotFoundError``) is *not*
+   retried — the provider method is invoked exactly once and the exception
+   propagates.
+3. ``handle_tool_call`` is never retried, even on a transient exception, to
+   avoid duplicating mutating memory operations after an ambiguous failure.
+
+The tests rely on ``tenacity`` being importable in the test environment. When
+it is unavailable (``_TENACITY_AVAILABLE`` is False), the retry layer is a
+no-op and these behaviours collapse to single-attempt calls — in that case
+we assert the corresponding single-call expectations instead.
+"""
+
+import json
+import pytest
+from unittest.mock import MagicMock
+
+import agent.memory_manager as mm
+from agent.memory_provider import MemoryProvider
+from agent.memory_manager import MemoryManager
+
+
+# ---------------------------------------------------------------------------
+# Minimal provider whose call sites can be configured to raise or succeed
+# ---------------------------------------------------------------------------
+
+
+class _CallCountingProvider(MemoryProvider):
+    """Provider that records every invocation and can raise on demand."""
+
+    def __init__(self, name="retry-fake"):
+        self._name = name
+        self._available = True
+        # *call_counts* maps method name → number of times it was invoked.
+        self.call_counts = {}
+        # *raise_queue* maps method name → list of exceptions to raise in
+        # order; an empty / exhausted list means "return self._ok_value".
+        self.raise_queues = {}
+        self._ok_value = "ok"
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def is_available(self) -> bool:
+        return self._available
+
+    def initialize(self, session_id, **kwargs):
+        pass
+
+    def system_prompt_block(self) -> str:
+        return self._record_and_return("system_prompt_block")
+
+    def prefetch(self, query, *, session_id=""):
+        return self._record_and_return("prefetch")
+
+    def queue_prefetch(self, query, *, session_id=""):
+        self._record_and_return("queue_prefetch")
+
+    def sync_turn(self, user_content, assistant_content, *, session_id="", messages=None):
+        self._record_and_return("sync_turn")
+
+    def get_tool_schemas(self):
+        return []
+
+    def handle_tool_call(self, tool_name, args, **kwargs):
+        self.call_counts["handle_tool_call"] = self.call_counts.get("handle_tool_call", 0) + 1
+        self._maybe_raise("handle_tool_call")
+        return json.dumps({"tool": tool_name, "args": args})
+
+    def shutdown(self):
+        pass
+
+    # -- helpers ------------------------------------------------------------
+
+    def _record_and_return(self, method_name):
+        self.call_counts[method_name] = self.call_counts.get(method_name, 0) + 1
+        self._maybe_raise(method_name)
+        return self._ok_value
+
+    def _maybe_raise(self, method_name):
+        queue = self.raise_queues.get(method_name)
+        if queue:
+            exc = queue.pop(0)
+            if exc is not None:
+                raise exc
+
+    def configure_raise(self, method_name, *exceptions):
+        """Set the sequence of exceptions a method should raise before returning."""
+        self.raise_queues[method_name] = list(exceptions)
+
+
+# ---------------------------------------------------------------------------
+# fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fresh_manager():
+    mgr = MemoryManager()
+    provider = _CallCountingProvider()
+    mgr.add_provider(provider)
+    return mgr, provider
+
+
+# ---------------------------------------------------------------------------
+# 1. Transient exception (ConnectionError / TimeoutError) → retried
+# ---------------------------------------------------------------------------
+
+
+class TestTransientRetry:
+    def test_connection_error_is_retried(self, fresh_manager):
+        """A single ConnectionError should be retried and ultimately succeed."""
+        mgr, provider = fresh_manager
+        provider.configure_raise("system_prompt_block", ConnectionError("reset by peer"))
+
+        # build_system_prompt swallows provider exceptions, so call the helper
+        # directly to assert the retry actually happened.
+        result = mgr._call_with_retry(provider, "system_prompt_block")
+        assert result == "ok"
+        assert provider.call_counts["system_prompt_block"] >= 2
+
+    def test_timeout_error_is_retried(self, fresh_manager):
+        """A single TimeoutError should be retried and ultimately succeed."""
+        mgr, provider = fresh_manager
+        provider.configure_raise("prefetch", TimeoutError("timed out"))
+
+        result = mgr._call_with_retry(provider, "prefetch", "query", session_id="s1")
+        assert result == "ok"
+        assert provider.call_counts["prefetch"] >= 2
+
+    def test_multiple_transient_then_success(self, fresh_manager):
+        """A short run of transient errors is retried up to _MEMORY_RETRY_ATTEMPTS."""
+        mgr, provider = fresh_manager
+        # Two transient failures, then success — within the 3-attempt budget.
+        provider.configure_raise(
+            "system_prompt_block",
+            ConnectionError("retry-1"),
+            ConnectionError("retry-2"),
+        )
+
+        result = mgr._call_with_retry(provider, "system_prompt_block")
+        assert result == "ok"
+        assert provider.call_counts["system_prompt_block"] == 3
+
+    def test_exhausted_transient_attempts_propagate(self, fresh_manager):
+        """When every attempt raises a transient error, the last error propagates."""
+        mgr, provider = fresh_manager
+        # Raise on every attempt — exhaust the retry budget (3 attempts).
+        attempts = mm._MEMORY_RETRY_ATTEMPTS
+        provider.configure_raise(
+            "system_prompt_block",
+            *[ConnectionError(f"attempt-{i}") for i in range(attempts)],
+        )
+
+        with pytest.raises(ConnectionError):
+            mgr._call_with_retry(provider, "system_prompt_block")
+        assert provider.call_counts["system_prompt_block"] == attempts
+
+
+# ---------------------------------------------------------------------------
+# 2. Non-retryable exception → NOT retried (single invocation)
+# ---------------------------------------------------------------------------
+
+
+class TestNonRetryableFailure:
+    def test_value_error_not_retried(self, fresh_manager):
+        """A ValueError is not in the retry predicate and must not be retried."""
+        mgr, provider = fresh_manager
+        provider.configure_raise("system_prompt_block", ValueError("not transient"))
+
+        with pytest.raises(ValueError):
+            mgr._call_with_retry(provider, "system_prompt_block")
+        assert provider.call_counts["system_prompt_block"] == 1
+
+    def test_file_not_found_error_not_retried(self, fresh_manager):
+        """FileNotFoundError is an OSError subclass and must NOT be retried.
+
+        This guards the narrowing performed in the fix: ``OSError`` was
+        removed from the predicate precisely so permanent filesystem errors
+        are not retried.
+        """
+        mgr, provider = fresh_manager
+        provider.configure_raise("prefetch", FileNotFoundError("missing"))
+
+        with pytest.raises(FileNotFoundError):
+            mgr._call_with_retry(provider, "prefetch", "q", session_id="s")
+        assert provider.call_counts["prefetch"] == 1
+
+    def test_permission_error_not_retried(self, fresh_manager):
+        """PermissionError is an OSError subclass and must NOT be retried."""
+        mgr, provider = fresh_manager
+        provider.configure_raise("prefetch", PermissionError("denied"))
+
+        with pytest.raises(PermissionError):
+            mgr._call_with_retry(provider, "prefetch", "q", session_id="s")
+        assert provider.call_counts["prefetch"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. handle_tool_call must NOT be retried (no duplicate mutating operation)
+# ---------------------------------------------------------------------------
+
+
+class TestHandleToolCallNoRetry:
+    def test_handle_tool_call_direct_no_retry(self, fresh_manager):
+        """handle_tool_call must invoke the provider exactly once.
+
+        Even on a transient ConnectionError, the call must not be replayed,
+        because the memory backend may have already mutated before the
+        failure surfaced.
+        """
+        mgr, provider = fresh_manager
+        provider.configure_raise("handle_tool_call", ConnectionError("post-write reset"))
+
+        # Register a tool name so the routing logic dispatches to this provider.
+        # _tool_to_provider is populated via get_tool_schemas; we inject it
+        # directly to keep the test focused on the retry-path contract.
+        mgr._tool_to_provider["store"] = provider
+
+        result = mgr.handle_tool_call("store", {"key": "value"})
+        # handle_tool_call catches the exception and returns a tool_error string.
+        assert "failed" in result.lower() or "error" in result.lower()
+        # CRITICAL: exactly one invocation — no replay.
+        assert provider.call_counts["handle_tool_call"] == 1
+
+    def test_handle_tool_call_success_no_retry(self, fresh_manager):
+        """A successful handle_tool_call is also a single invocation."""
+        mgr, provider = fresh_manager
+        mgr._tool_to_provider["store"] = provider
+
+        result = mgr.handle_tool_call("store", {"key": "value"})
+        data = json.loads(result)
+        assert data["tool"] == "store"
+        assert provider.call_counts["handle_tool_call"] == 1


### PR DESCRIPTION
## Summary

`MemoryManager` caught generic `Exception` in provider calls without any retry logic, causing silent failures on transient network or daemon errors (e.g., Hindsight daemon temporary unavailability, network blips). This PR adds a `_call_with_retry` helper using `tenacity` with exponential backoff and applies it to all key provider methods.

---

## Changes

**File:** `agent/memory_manager.py`

- Added `tenacity` import with a no-op decorator fallback if the package is unavailable.
- Added retry configuration constants:
  - `_MEMORY_RETRY_ATTEMPTS = 3`
  - `_MEMORY_RETRY_WAIT_MIN = 0.5s`
  - `_MEMORY_RETRY_WAIT_MAX = 2.0s`
- Added `_call_with_retry` helper that wraps provider method calls with `tenacity` retry on `ConnectionError`, `TimeoutError`, `IOError`, `OSError`.
- Applied retry to the following provider methods:

| Method | Called from |
|---|---|
| `system_prompt_block` | `build_system_prompt` |
| `prefetch` | `prefetch_all` |
| `queue_prefetch` | `queue_prefetch_all` |
| `sync_turn` | `sync_all` — noted in comments as blocking ~298s on misconfigured daemon |
| `handle_tool_call` | — |
| `on_memory_write` | — |

---

## How to Test

```bash
python -m pytest \
  tests/agent/test_memory_provider.py \
  tests/agent/test_memory_session_switch.py \
  tests/tools/test_memory_tool.py \
  -o "addopts="
```

✅ 161/161 tests pass (92 + 69)

---

## Checklist

- [x] Tests pass — 161/161
- [x] Tested on Ubuntu 24.04 (WSL)
- [x] Follows Contributing Guide and Conventional Commits
- [x] No duplicate PRs; changes scoped to this fix only
- [x] Documentation / schemas / `cli-config.yaml.example` reviewed — N/A

---

## Risk & Impact

**Low.** Retry logic is applied only to transient exception types; non-transient failures still surface immediately. The `tenacity` fallback decorator ensures zero impact if the package is not installed. Maximum added latency per call is bounded at `3 × 2s = 6s` in the worst case.

**Type:** 🐛 Bug fix