### PR TITLE
fix(update): preserve local commits during update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4528,6 +4528,46 @@ def _capture_head_sha(git_cmd, cwd) -> str | None:
         return None
 
 
+def _count_local_commits_ahead_of_remote(git_cmd, cwd, branch: str) -> int:
+    """Return count of local-only commits relative to origin/{branch}.
+
+    A diverged ``hermes update`` used to hard-reset to origin/{branch}. That is
+    acceptable for pure upstream rewrites, but destructive when users carry a
+    local patch commit (for example a site-specific hotfix). This helper lets
+    the update path distinguish those cases before choosing reset vs rebase.
+    """
+    try:
+        result = subprocess.run(
+            git_cmd + ["rev-list", f"origin/{branch}..HEAD", "--count"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return int((result.stdout or "0").strip() or "0")
+    except (ValueError, subprocess.CalledProcessError, OSError):
+        return 0
+
+
+def _create_local_update_backup_branch(git_cmd, cwd, branch: str) -> str | None:
+    """Create a best-effort backup branch before rebasing local update commits."""
+    safe_branch = "".join(ch if ch.isalnum() or ch in "._-" else "-" for ch in branch)
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    backup_branch = f"hermes-local-backup/{safe_branch}-{stamp}"
+    try:
+        result = subprocess.run(
+            git_cmd + ["branch", backup_branch, "HEAD"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            return backup_branch
+    except OSError:
+        pass
+    return None
+
+
 def _validate_critical_files_syntax(root) -> tuple[bool, str | None, str | None]:
     """Compile each file in ``_UPDATE_CRITICAL_FILES`` to catch SyntaxErrors.
 
@@ -9898,26 +9938,73 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 text=True,
             )
             if pull_result.returncode != 0:
-                # ff-only failed — local and remote have diverged (e.g. upstream
-                # force-pushed or rebase).  Since local changes are already
-                # stashed, reset to match the remote exactly.
-                print(
-                    "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
+                # ff-only failed.  If the user carries local-only commits, do
+                # NOT discard them with reset --hard; preserve a backup branch
+                # and rebase those local patches onto the fetched upstream.
+                # Only fall back to reset when there are no local commits to
+                # save (e.g. remote history changed but local HEAD has nothing
+                # unique).
+                local_commit_count = _count_local_commits_ahead_of_remote(
+                    git_cmd, PROJECT_ROOT, branch
                 )
-                reset_result = subprocess.run(
-                    git_cmd + ["reset", "--hard", f"origin/{branch}"],
-                    cwd=PROJECT_ROOT,
-                    capture_output=True,
-                    text=True,
-                )
-                if reset_result.returncode != 0:
-                    print(f"✗ Failed to reset to origin/{branch}.")
-                    if reset_result.stderr.strip():
-                        print(f"  {reset_result.stderr.strip()}")
+                if local_commit_count > 0:
                     print(
-                        f"  Try manually: git fetch origin && git reset --hard origin/{branch}"
+                        "  ⚠ Fast-forward not possible; "
+                        f"preserving {local_commit_count} local commit(s)."
                     )
-                    sys.exit(1)
+                    backup_branch = _create_local_update_backup_branch(
+                        git_cmd, PROJECT_ROOT, branch
+                    )
+                    if backup_branch:
+                        print(f"  ✓ Local commits backed up on {backup_branch}")
+                    else:
+                        print("  ⚠ Could not create a local backup branch; continuing carefully.")
+                    print("  → rebasing local commits onto origin/%s..." % branch)
+                    rebase_result = subprocess.run(
+                        git_cmd + ["rebase", f"origin/{branch}"],
+                        cwd=PROJECT_ROOT,
+                        capture_output=True,
+                        text=True,
+                    )
+                    if rebase_result.returncode != 0:
+                        subprocess.run(
+                            git_cmd + ["rebase", "--abort"],
+                            cwd=PROJECT_ROOT,
+                            capture_output=True,
+                            text=True,
+                        )
+                        print("✗ Could not rebase local commits onto the updated upstream.")
+                        if rebase_result.stderr.strip():
+                            print(f"  {rebase_result.stderr.strip().splitlines()[0]}")
+                        if backup_branch:
+                            print(
+                                f"  Your local commits are preserved on: {backup_branch}"
+                            )
+                        print(
+                            "  Resolve manually, or run from a clean upstream checkout after saving local patches."
+                        )
+                        sys.exit(1)
+                else:
+                    # ff-only failed and no local commits exist — local and
+                    # remote state diverged without local work to preserve, so
+                    # reset to match the remote exactly.
+                    print(
+                        "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
+                    )
+                    reset_result = subprocess.run(
+                        git_cmd + ["reset", "--hard", f"origin/{branch}"],
+                        cwd=PROJECT_ROOT,
+                        capture_output=True,
+                        text=True,
+                    )
+                    if reset_result.returncode != 0:
+                        print(f"✗ Failed to reset to origin/{branch}.")
+                        if reset_result.stderr.strip():
+                            print(f"  {reset_result.stderr.strip()}")
+                        print(
+                            f"  Try manually: git fetch origin && git reset --hard origin/{branch}"
+                        )
+                        sys.exit(1)
 
             # Post-pull syntax guard: validate critical-path files actually
             # parse before declaring the update successful. If a bad commit

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4528,13 +4528,16 @@ def _capture_head_sha(git_cmd, cwd) -> str | None:
         return None
 
 
-def _count_local_commits_ahead_of_remote(git_cmd, cwd, branch: str) -> int:
-    """Return count of local-only commits relative to origin/{branch}.
+def _count_local_commits_ahead_of_remote(git_cmd, cwd, branch: str) -> int | None:
+    """Return count of local-only commits relative to origin/{branch}, or None if unknown.
 
     A diverged ``hermes update`` used to hard-reset to origin/{branch}. That is
     acceptable for pure upstream rewrites, but destructive when users carry a
     local patch commit (for example a site-specific hotfix). This helper lets
     the update path distinguish those cases before choosing reset vs rebase.
+
+    Returns None when the count cannot be determined (git command failure, parse
+    error) — the caller must fail closed rather than guess.
     """
     try:
         result = subprocess.run(
@@ -4546,7 +4549,7 @@ def _count_local_commits_ahead_of_remote(git_cmd, cwd, branch: str) -> int:
         )
         return int((result.stdout or "0").strip() or "0")
     except (ValueError, subprocess.CalledProcessError, OSError):
-        return 0
+        return None
 
 
 def _create_local_update_backup_branch(git_cmd, cwd, branch: str) -> str | None:
@@ -9947,7 +9950,16 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 local_commit_count = _count_local_commits_ahead_of_remote(
                     git_cmd, PROJECT_ROOT, branch
                 )
-                if local_commit_count > 0:
+                if local_commit_count is None:
+                    # Cannot determine local commit count — fail closed rather
+                    # than risk discarding user work with reset --hard.
+                    print("✗ Fast-forward failed and local commit status is unknown.")
+                    print("  Cannot safely proceed — check your local state:")
+                    print(f"    git status")
+                    print(f"    git log --oneline origin/{branch}..HEAD")
+                    print("  Then retry: hermes update")
+                    sys.exit(1)
+                elif local_commit_count > 0:
                     print(
                         "  ⚠ Fast-forward not possible; "
                         f"preserving {local_commit_count} local commit(s)."
@@ -9967,7 +9979,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         text=True,
                     )
                     if rebase_result.returncode != 0:
-                        subprocess.run(
+                        abort_result = subprocess.run(
                             git_cmd + ["rebase", "--abort"],
                             cwd=PROJECT_ROOT,
                             capture_output=True,
@@ -9976,6 +9988,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         print("✗ Could not rebase local commits onto the updated upstream.")
                         if rebase_result.stderr.strip():
                             print(f"  {rebase_result.stderr.strip().splitlines()[0]}")
+                        if abort_result.returncode != 0:
+                            print("  ⚠ Rebase --abort also failed; your working tree may be in a partial rebase state.")
+                            print("     Run: git rebase --abort")
+                            print("     Then check: git status")
                         if backup_branch:
                             print(
                                 f"  Your local commits are preserved on: {backup_branch}"

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -455,6 +455,7 @@ class TestCmdUpdateBranchFallback:
         import subprocess as _subprocess
         build_ok = _subprocess.CompletedProcess([], 0, stdout="", stderr="")
         with patch.object(hm, "_is_termux_env", return_value=False), \
+             patch.object(hm, "_web_ui_build_needed", return_value=True), \
              patch.object(hm, "_run_with_idle_timeout", return_value=build_ok) as mock_idle:
             cmd_update(mock_args)
 

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -534,6 +534,7 @@ def _make_update_side_effect(
     ff_only_fails=False,
     reset_fails=False,
     rebase_fails=False,
+    rebase_abort_fails=False,
     fetch_fails=False,
     fetch_stderr="",
 ):
@@ -564,6 +565,8 @@ def _make_update_side_effect(
                 )
             return SimpleNamespace(stdout="Updating abc..def\n", stderr="", returncode=0)
         if "rebase" in joined and "--abort" in joined:
+            if rebase_abort_fails:
+                return SimpleNamespace(stdout="", stderr="fatal: cannot abort\n", returncode=1)
             return SimpleNamespace(stdout="", stderr="", returncode=0)
         if "rebase" in joined and f"origin/{current_branch}" in joined:
             if rebase_fails:
@@ -674,17 +677,82 @@ def test_cmd_update_rebase_failure_preserves_local_commits_without_reset(
     reset_calls = [c for c in recorded if "reset" in c and "--hard" in c]
     assert reset_calls == []
 
-    # Assert a backup branch was created
+    # Assert a backup branch was created with correct naming format
     backup_branch_calls = [
         c for c in recorded if c[:2] == ["git", "branch"] and "hermes-local-backup" in " ".join(c)
     ]
     assert len(backup_branch_calls) == 1
+    # Verify branch name starts with correct prefix (hermes-local-backup/main- for main branch)
+    assert backup_branch_calls[0][2].startswith("hermes-local-backup/main-")
 
     # Verify user-facing output mentions backup branch preservation
     out = capsys.readouterr().out
     assert "Could not rebase local commits" in out
     assert "hermes-local-backup" in out
     assert "local commits are preserved" in out
+
+
+def test_cmd_update_fails_closed_when_local_commit_count_unknown(
+    monkeypatch, tmp_path, capsys
+):
+    """When ff-only fails but local commit count cannot be determined, fail safely
+    without running reset --hard that might discard unknown local work."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+
+    # Mock _count_local_commits_ahead_of_remote to return None (unknown)
+    monkeypatch.setattr(
+        hermes_main, "_count_local_commits_ahead_of_remote",
+        lambda *args, **kwargs: None,
+    )
+
+    side_effect, recorded = _make_update_side_effect(ff_only_fails=True)
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    with pytest.raises(SystemExit, match="1"):
+        hermes_main.cmd_update(SimpleNamespace())
+
+    # Assert no reset --hard was executed (fail closed)
+    reset_calls = [c for c in recorded if "reset" in c and "--hard" in c]
+    assert reset_calls == []
+
+    # Assert no rebase was attempted
+    rebase_calls = [c for c in recorded if "rebase" in c]
+    assert rebase_calls == []
+
+    # Verify user-facing output explains the situation
+    out = capsys.readouterr().out
+    assert "local commit status is unknown" in out
+    assert "git status" in out
+
+
+def test_cmd_update_reports_abort_failure_explicitly(
+    monkeypatch, tmp_path, capsys
+):
+    """When rebase fails AND rebase --abort also fails, provide explicit recovery guidance."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+
+    side_effect, recorded = _make_update_side_effect(
+        ff_only_fails=True,
+        local_ahead_count="1",
+        rebase_fails=True,
+        rebase_abort_fails=True,
+    )
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    with pytest.raises(SystemExit, match="1"):
+        hermes_main.cmd_update(SimpleNamespace())
+
+    # Assert rebase --abort was attempted
+    rebase_abort_calls = [c for c in recorded if "rebase" in c and "--abort" in c]
+    assert len(rebase_abort_calls) == 1
+
+    # Verify output mentions abort failure and provides manual recovery steps
+    out = capsys.readouterr().out
+    assert "Rebase --abort also failed" in out
+    assert "partial rebase state" in out
+    assert "git rebase --abort" in out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -530,8 +530,10 @@ def test_install_heartbeat_prints_when_dependency_install_is_silent(monkeypatch,
 def _make_update_side_effect(
     current_branch="main",
     commit_count="3",
+    local_ahead_count="0",
     ff_only_fails=False,
     reset_fails=False,
+    rebase_fails=False,
     fetch_fails=False,
     fetch_stderr="",
 ):
@@ -549,6 +551,8 @@ def _make_update_side_effect(
             return SimpleNamespace(stdout=f"{current_branch}\n", stderr="", returncode=0)
         if "checkout" in joined and "main" in joined:
             return SimpleNamespace(stdout="", stderr="", returncode=0)
+        if "rev-list" in joined and f"origin/{current_branch}..HEAD" in joined:
+            return SimpleNamespace(stdout=f"{local_ahead_count}\n", stderr="", returncode=0)
         if "rev-list" in joined:
             return SimpleNamespace(stdout=f"{commit_count}\n", stderr="", returncode=0)
         if "--ff-only" in joined:
@@ -559,6 +563,10 @@ def _make_update_side_effect(
                     returncode=128,
                 )
             return SimpleNamespace(stdout="Updating abc..def\n", stderr="", returncode=0)
+        if "rebase" in joined and f"origin/{current_branch}" in joined:
+            if rebase_fails:
+                return SimpleNamespace(stdout="", stderr="CONFLICT\n", returncode=1)
+            return SimpleNamespace(stdout="Successfully rebased\n", stderr="", returncode=0)
         if "reset" in joined and "--hard" in joined:
             if reset_fails:
                 return SimpleNamespace(stdout="", stderr="error: unable to write\n", returncode=1)
@@ -568,12 +576,14 @@ def _make_update_side_effect(
     return side_effect, recorded
 
 
-def test_cmd_update_falls_back_to_reset_when_ff_only_fails(monkeypatch, tmp_path, capsys):
-    """When --ff-only fails (diverged history), update resets to origin/{branch}."""
+def test_cmd_update_falls_back_to_reset_when_ff_only_fails_without_local_commits(
+    monkeypatch, tmp_path, capsys
+):
+    """When only upstream history changed, update may reset to origin/{branch}."""
     _setup_update_mocks(monkeypatch, tmp_path)
     monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
 
-    side_effect, recorded = _make_update_side_effect(ff_only_fails=True)
+    side_effect, recorded = _make_update_side_effect(ff_only_fails=True, local_ahead_count="0")
     monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
 
     hermes_main.cmd_update(SimpleNamespace())
@@ -584,6 +594,36 @@ def test_cmd_update_falls_back_to_reset_when_ff_only_fails(monkeypatch, tmp_path
 
     out = capsys.readouterr().out
     assert "Fast-forward not possible" in out
+
+
+def test_cmd_update_rebases_instead_of_resetting_when_local_commits_exist(
+    monkeypatch, tmp_path, capsys
+):
+    """Local-only commits must not be discarded by a diverged update."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+
+    side_effect, recorded = _make_update_side_effect(
+        ff_only_fails=True,
+        local_ahead_count="1",
+    )
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    hermes_main.cmd_update(SimpleNamespace())
+
+    reset_calls = [c for c in recorded if "reset" in c and "--hard" in c]
+    rebase_calls = [c for c in recorded if "rebase" in c and "origin/main" in c]
+    backup_branch_calls = [
+        c for c in recorded if c[:2] == ["git", "branch"] and "hermes-local-backup" in " ".join(c)
+    ]
+
+    assert reset_calls == []
+    assert rebase_calls == [["git", "rebase", "origin/main"]]
+    assert len(backup_branch_calls) == 1
+
+    out = capsys.readouterr().out
+    assert "local commit" in out
+    assert "rebasing local commits" in out
 
 
 def test_cmd_update_no_reset_when_ff_only_succeeds(monkeypatch, tmp_path):

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -563,6 +563,8 @@ def _make_update_side_effect(
                     returncode=128,
                 )
             return SimpleNamespace(stdout="Updating abc..def\n", stderr="", returncode=0)
+        if "rebase" in joined and "--abort" in joined:
+            return SimpleNamespace(stdout="", stderr="", returncode=0)
         if "rebase" in joined and f"origin/{current_branch}" in joined:
             if rebase_fails:
                 return SimpleNamespace(stdout="", stderr="CONFLICT\n", returncode=1)
@@ -638,6 +640,51 @@ def test_cmd_update_no_reset_when_ff_only_succeeds(monkeypatch, tmp_path):
 
     reset_calls = [c for c in recorded if "reset" in c and "--hard" in c]
     assert len(reset_calls) == 0
+
+
+def test_cmd_update_rebase_failure_preserves_local_commits_without_reset(
+    monkeypatch, tmp_path, capsys
+):
+    """When rebase fails with local commits, abort the rebase, preserve the backup
+    branch, never execute reset --hard, and exit with recoverable state.
+
+    Regression test for #44380: ensure the safe update recovery feature correctly
+    handles rebase conflicts by aborting gracefully and leaving local commits
+    accessible via the backup branch, rather than discarding them.
+    """
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+
+    side_effect, recorded = _make_update_side_effect(
+        ff_only_fails=True,
+        local_ahead_count="2",
+        rebase_fails=True,
+    )
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    with pytest.raises(SystemExit, match="1"):
+        hermes_main.cmd_update(SimpleNamespace())
+
+    # Assert rebase --abort was executed
+    rebase_abort_calls = [c for c in recorded if "rebase" in c and "--abort" in c]
+    assert len(rebase_abort_calls) == 1
+    assert rebase_abort_calls[0] == ["git", "rebase", "--abort"]
+
+    # Assert no reset --hard was executed (local commits must not be discarded)
+    reset_calls = [c for c in recorded if "reset" in c and "--hard" in c]
+    assert reset_calls == []
+
+    # Assert a backup branch was created
+    backup_branch_calls = [
+        c for c in recorded if c[:2] == ["git", "branch"] and "hermes-local-backup" in " ".join(c)
+    ]
+    assert len(backup_branch_calls) == 1
+
+    # Verify user-facing output mentions backup branch preservation
+    out = capsys.readouterr().out
+    assert "Could not rebase local commits" in out
+    assert "hermes-local-backup" in out
+    assert "local commits are preserved" in out
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Preserve local-only commits during `hermes update` when fast-forward pull fails.
- Create a backup branch and rebase local commits onto `origin/<branch>` instead of resetting them away.
- Stabilize update-related tests and sync the root package lock with current dependency resolution.

## Test plan
- `python -m py_compile hermes_cli/main.py`
- `python -m pytest -q -o 'addopts=' tests/hermes_cli/test_update_autostash.py tests/hermes_cli/test_cmd_update.py`
- `python -m json.tool package-lock.json`
- `npm ci --ignore-scripts --no-audit --no-fund --dry-run`

## Notes
This is intended to make `hermes update` safer for users carrying local hotfixes or site-specific patches.