### PR TITLE
feat(cli): add remote control for human intervention prompts

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11620,6 +11620,63 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             outcome = outcome[:119] + "…"
         _cprint(f"\n{_DIM}{icon} {label}: {detail} → {outcome}{_RST}")
 
+    def _setup_remote_intervention(self, *, kind, preview, timeout, command="", description="", risk_level=""):
+        """Create a pending record (when remote control enabled) and return
+        (remote_code, remote_actions, risk_explanation). Never raises.
+
+        Shared by the sudo + clarify callbacks so the deny/extend wiring stays
+        in one place. Mirrors the inline logic in _approval_callback (Task 4),
+        which is intentionally left untouched.
+        """
+        rc = self._remote_intervention_settings()
+        risk_expl = self._explain_command_risk_for_notify(command, description, risk_level, rc)
+        remote_code, remote_actions = "", None
+        if bool(rc.get("enabled")):
+            allowed = []
+            if rc.get("allow_deny", True):
+                allowed.append("deny")
+            if rc.get("allow_extend", True):
+                allowed.append("extend")
+            try:
+                rec = self._rc_create_pending(
+                    kind=kind, title=kind, preview=preview,
+                    session_key=getattr(self, "session_id", ""), timeout_seconds=timeout,
+                    max_total_wait_minutes=int(rc.get("max_total_wait_minutes", 15)),
+                    allowed_actions=allowed or None)
+                remote_code = rec.code
+                remote_actions = (allowed + ["status"]) if allowed else ["status"]
+            except Exception:
+                remote_code, remote_actions = "", None
+        return remote_code, remote_actions, risk_expl
+
+    def _poll_remote_intervention(self, remote_code, current_deadline):
+        """Consume one remote decision. Returns (signal, source, deadline) where
+        signal is 'deny' | 'extend' | None and deadline is the (possibly bumped,
+        monotonic) deadline. Never raises.
+
+        The store only ever yields deny/extend (it has no password/answer
+        field), so this can never inject a sudo password or pick a clarify
+        option — it can only cancel (deny) or push the deadline out (extend).
+        """
+        import time as _t
+        if not remote_code:
+            return (None, "", current_deadline)
+        try:
+            snap = self._rc_consume(remote_code)
+        except Exception:
+            return (None, "", current_deadline)
+        if snap is None:
+            return (None, "", current_deadline)
+        if getattr(snap, "decision", None) == "deny":
+            return ("deny", getattr(snap, "decision_source", "") or "mobile", current_deadline)
+        if getattr(snap, "decision", None) == "extend":
+            delta = max(0.0, getattr(snap, "deadline_ts", 0.0) - _t.time())
+            new_deadline = _t.monotonic() + delta
+            if new_deadline > current_deadline:
+                current_deadline = new_deadline
+            return ("extend", getattr(snap, "decision_source", "") or "mobile", current_deadline)
+        return (None, "", current_deadline)
+
     def _clarify_callback(self, question, choices):
         """
         Platform callback for the clarify tool. Called from the agent thread.
@@ -11649,37 +11706,89 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # thread. Modal prompts must paint at once and must not be gated by the
         # _invalidate throttle / resize guard — see _paint_now / _invalidate (#41098).
         self._paint_now()
-
-        # Poll for the user's response. The countdown in the hint line updates
-        # on each repaint; refresh it once a second so the timer stays visible
-        # while we wait. Selection changes (↑/↓) trigger instant repaints via
-        # the key bindings.
-        _last_countdown_refresh = _time.monotonic()
-        while True:
-            try:
-                result = response_queue.get(timeout=1)
-                self._clarify_deadline = 0
-                self._persist_prompt_summary("?", "Clarify", question, str(result))
-                return result
-            except queue.Empty:
-                remaining = self._clarify_deadline - _time.monotonic()
-                if remaining <= 0:
-                    break
-                now = _time.monotonic()
-                if now - _last_countdown_refresh >= 1.0:
-                    _last_countdown_refresh = now
-                    self._paint_now()
-
-        # Timed out — tear down the UI and let the agent decide
-        self._clarify_state = None
-        self._clarify_freetext = False
-        self._clarify_deadline = 0
-        self._paint_now()
-        _cprint(f"\n{_DIM}(clarify timed out after {timeout}s — agent will decide){_RST}")
-        return (
-            "The user did not provide a response within the time limit. "
-            "Use your best judgement to make the choice and proceed."
+        # --- remote control wiring (mobile deny/extend; answering is local) ---
+        # Remote deny == cancel (timeout-equivalent: the agent decides); there
+        # is NO remote path that selects an option. risk_level/explanation are
+        # N/A for clarify, so _risk comes back "".
+        remote_code, remote_actions, _risk = self._setup_remote_intervention(
+            kind="clarify", preview=str(question)[:200], timeout=timeout,
         )
+
+        try:
+            from hermes_cli.human_intervention_notifications import notify_human_intervention
+            notify_human_intervention(
+                "clarify",
+                "Hermes needs your input",
+                f"Question: {question}",
+                session_key=getattr(self, "session_id", ""),
+                dedupe_key=f"clarify:{question}",
+                timeout_seconds=timeout,
+                remote_code=remote_code,
+                remote_actions=remote_actions,
+            )
+        except Exception:
+            pass
+
+        try:
+            # Poll for the user's response. The countdown in the hint line updates
+            # on each repaint; refresh it once a second so the timer stays visible
+            # while we wait. Selection changes (↑/↓) trigger instant repaints via
+            # the key bindings. Local answers are checked FIRST every iteration,
+            # so a local choice always wins over a remote decision.
+            _last_countdown_refresh = _time.monotonic()
+            while True:
+                try:
+                    result = response_queue.get(timeout=1)
+                    self._clarify_deadline = 0
+                    self._persist_prompt_summary("?", "Clarify", question, str(result))
+                    return result
+                except queue.Empty:
+                    remaining = self._clarify_deadline - _time.monotonic()
+                    if remaining <= 0:
+                        break
+                    if remote_code:
+                        signal, source, self._clarify_deadline =                             self._poll_remote_intervention(remote_code, self._clarify_deadline)
+                        if signal == "deny":
+                            # Remote deny == cancel/timeout-equivalent: tear the
+                            # UI down and let the agent decide. It must NOT pick
+                            # an option for the user.
+                            self._clarify_state = None
+                            self._clarify_freetext = False
+                            self._clarify_deadline = 0
+                            self._paint_now()
+                            _cprint(f"\n{_DIM}(clarify denied remotely ({source}) — agent will decide){_RST}")
+                            self._persist_prompt_summary("?", "Clarify", question, "denied remotely")
+                            return (
+                                "The user did not provide a response within the time limit. "
+                                "Use your best judgement to make the choice and proceed."
+                            )
+                        # extend just bumped the deadline above; keep waiting.
+                    now = _time.monotonic()
+                    if now - _last_countdown_refresh >= 1.0:
+                        _last_countdown_refresh = now
+                        self._paint_now()
+
+            # Timed out — tear down the UI and let the agent decide
+            self._clarify_state = None
+            self._clarify_freetext = False
+            self._clarify_deadline = 0
+            self._paint_now()
+            _cprint(f"\n{_DIM}(clarify timed out after {timeout}s — agent will decide){_RST}")
+            self._persist_prompt_summary("?", "Clarify", question, "timed out")
+            return (
+                "The user did not provide a response within the time limit. "
+                "Use your best judgement to make the choice and proceed."
+            )
+        finally:
+            # Clear any pending record on every exit path. Consuming an
+            # already-resolved decision returns None, which is harmless.
+            # NOTE: never `return` inside this finally.
+            if remote_code:
+                try:
+                    self._rc_consume(remote_code)
+                    self._rc_cleanup()
+                except Exception:
+                    pass
 
     def _sudo_password_callback(self) -> str:
         """
@@ -11703,35 +11812,215 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # Modal prompt — paint immediately, bypassing the throttle/resize guard
         # so the prompt can't be dropped and time out unseen (#41098).
         self._paint_now()
+        # --- remote control wiring (mobile cancel/extend; NEVER a password) ---
+        # Remote deny == cancel: it returns "" (continue without sudo), exactly
+        # like the timeout path. A password can ONLY be supplied locally; the
+        # store has no password field, so remote password injection is
+        # structurally impossible.
+        remote_code, remote_actions, _risk = self._setup_remote_intervention(
+            kind="sudo", preview="sudo password request", timeout=timeout,
+        )
 
-        while True:
-            try:
-                result = response_queue.get(timeout=1)
-                self._sudo_state = None
-                self._sudo_deadline = 0
-                self._restore_modal_input_snapshot()
-                self._paint_now()
-                if result:
-                    _cprint(f"\n{_DIM}  ✓ Password received (cached for session){_RST}")
+        try:
+            from hermes_cli.human_intervention_notifications import notify_human_intervention
+            notify_human_intervention(
+                "sudo",
+                "Hermes needs your sudo password",
+                "A command is waiting for sudo password input in the CLI.",
+                session_key=getattr(self, "session_id", ""),
+                dedupe_key="sudo-password",
+                timeout_seconds=timeout,
+                remote_code=remote_code,
+                remote_actions=remote_actions,
+            )
+        except Exception:
+            pass
+
+        try:
+            while True:
+                try:
+                    # Local answer is checked FIRST every iteration, so a local
+                    # password always wins over a remote decision.
+                    result = response_queue.get(timeout=1)
+                    self._sudo_state = None
+                    self._sudo_deadline = 0
+                    self._restore_modal_input_snapshot()
+                    self._paint_now()
+                    if result:
+                        _cprint(f"\n{_DIM}  ✓ Password received (cached for session){_RST}")
+                    else:
+                        _cprint(f"\n{_DIM}  ⏭ Skipped{_RST}")
+                    return result
+                except queue.Empty:
+                    remaining = self._sudo_deadline - _time.monotonic()
+                    if remaining <= 0:
+                        break
+                    if remote_code:
+                        signal, source, self._sudo_deadline = \
+                            self._poll_remote_intervention(remote_code, self._sudo_deadline)
+                        if signal == "deny":
+                            # Remote cancel == continue without sudo. NEVER a
+                            # password. Tear down exactly like the timeout path.
+                            self._sudo_state = None
+                            self._sudo_deadline = 0
+                            self._restore_modal_input_snapshot()
+                            self._paint_now()
+                            _cprint(f"\n{_DIM}  (sudo cancelled remotely ({source}) — continuing without sudo){_RST}")
+                            return ""
+                        # extend just bumped the deadline above; keep waiting.
+                    self._paint_now()
+
+            self._sudo_state = None
+            self._sudo_deadline = 0
+            self._restore_modal_input_snapshot()
+            self._paint_now()
+            _cprint(f"\n{_DIM}  ⏱ Timeout — continuing without sudo{_RST}")
+            return ""
+        finally:
+            # Clear any pending record on every exit path. Consuming an
+            # already-resolved decision returns None, which is harmless.
+            # NOTE: never `return` inside this finally.
+            if remote_code:
+                try:
+                    self._rc_consume(remote_code)
+                    self._rc_cleanup()
+                except Exception:
+                    pass
+
+    def _remote_intervention_settings(self) -> dict:
+        """Return the notifications.human_intervention.remote_control config.
+
+        Reads ``notifications.human_intervention.remote_control`` from the live
+        config and merges it over safe defaults so callers can rely on every
+        key being present and well-typed. Any missing/oddly-typed key falls
+        back to its default; any error returns the all-default dict.
+
+        Keeping this a real method (not a closure) makes it trivially patchable
+        from tests and keeps Task 7 (config defaults) a one-line change.
+        """
+        defaults = {
+            "enabled": False,
+            "allow_deny": True,
+            "allow_extend": True,
+            "allow_approve": False,
+            "approve_medium": True,
+            "approve_high_typed_confirm": True,
+            "approve_token_len": 4,
+            "never_approve_levels": ["critical"],
+            "code_ttl_seconds": 90,
+            "max_extend_minutes": 15,
+            "max_total_wait_minutes": 15,
+            "allowed_targets": [],
+            "risk_explanation": {
+                "enabled": True,
+                "only_for_risk_levels": ["high", "critical"],
+                "max_chars": 280,
+                "timeout_seconds": 3,
+                "fallback_to_static": True,
+                "use_llm": False,
+            },
+        }
+        try:
+            from hermes_cli.config import load_config
+            cfg = load_config() or {}
+            notifications = cfg.get("notifications") if isinstance(cfg, dict) else None
+            human = notifications.get("human_intervention") if isinstance(notifications, dict) else None
+            rc = human.get("remote_control") if isinstance(human, dict) else None
+            if not isinstance(rc, dict):
+                return defaults
+            merged = dict(defaults)
+            for key, value in rc.items():
+                if key == "risk_explanation":
+                    if isinstance(value, dict):
+                        re_merged = dict(defaults["risk_explanation"])
+                        re_merged.update(value)
+                        merged["risk_explanation"] = re_merged
                 else:
-                    _cprint(f"\n{_DIM}  ⏭ Skipped{_RST}")
-                return result
-            except queue.Empty:
-                remaining = self._sudo_deadline - _time.monotonic()
-                if remaining <= 0:
-                    break
-                self._paint_now()
+                    merged[key] = value
+            return merged
+        except Exception:
+            return defaults
 
-        self._sudo_state = None
-        self._sudo_deadline = 0
-        self._restore_modal_input_snapshot()
-        self._paint_now()
-        _cprint(f"\n{_DIM}  ⏱ Timeout — continuing without sudo{_RST}")
-        return ""
+    def _explain_command_risk_for_notify(self, command, description, risk_level, rc_settings) -> str:
+        """Return an advisory risk explanation for the notification body.
+
+        Gated to the configured risk levels (high/critical by default) and only
+        when explanation is enabled. Advisory only: it must never block or break
+        approval, so it is wrapped in try/except and returns "" on any issue.
+        """
+        try:
+            re_cfg = rc_settings.get("risk_explanation", {}) if isinstance(rc_settings, dict) else {}
+            if not isinstance(re_cfg, dict):
+                return ""
+            if not re_cfg.get("enabled", False):
+                return ""
+            only_for = re_cfg.get("only_for_risk_levels", ["high", "critical"])
+            if not isinstance(only_for, (list, tuple, set)):
+                only_for = ["high", "critical"]
+            normalized = str(risk_level or "").strip().lower()
+            if normalized not in {str(x).strip().lower() for x in only_for}:
+                return ""
+            # Lazy import keeps this cheap and lets tests patch the explainer.
+            # When use_llm is configured, pass the bounded auxiliary-model
+            # explainer; otherwise llm_fn=None yields an instant static
+            # explanation that never blocks the prompt.
+            from hermes_cli import human_intervention_risk_explainer as _expl
+            max_chars = int(re_cfg.get("max_chars", 280) or 280)
+            timeout_seconds = int(re_cfg.get("timeout_seconds", 3) or 3)
+            use_llm = bool(re_cfg.get("use_llm", False))
+            llm_fn = _expl.default_llm_fn if use_llm else None
+            return _expl.explain_command_risk(
+                command=command,
+                description=description,
+                risk_level=risk_level,
+                llm_fn=llm_fn,
+                max_chars=max_chars,
+                timeout_seconds=timeout_seconds,
+            )
+        except Exception:
+            return ""
+
+    def _rc_create_pending(self, **kw):
+        """Thin patchable wrapper around the pending-intervention store."""
+        from hermes_cli.human_intervention_remote_control import create_pending_intervention
+        return create_pending_intervention(**kw)
+
+    def _rc_consume(self, code):
+        """Thin patchable wrapper to consume a remote deny/extend decision."""
+        from hermes_cli.human_intervention_remote_control import consume_remote_decision
+        return consume_remote_decision(code)
+
+    def _rc_cleanup(self):
+        """Thin patchable wrapper to reap expired pending interventions."""
+        from hermes_cli.human_intervention_remote_control import cleanup_expired
+        return cleanup_expired()
+
+    def _compute_approve_tier(self, risk_level, rc):
+        """Return (approve_tier, never_levels). tier in 'none'|'one_tap'|'typed_confirm'.
+
+        Decides whether (and how) a dangerous-command prompt may be approved
+        remotely. critical/hardline levels — and any level in
+        ``never_approve_levels`` — are NEVER remotely approvable, and approval
+        is disabled entirely unless ``allow_approve`` is set. medium maps to a
+        one-tap approve, high to a typed-confirm approve (token required).
+        """
+        never = rc.get("never_approve_levels") or ["critical"]
+        never = [str(x).strip().lower() for x in never]
+        lvl = str(risk_level or "").strip().lower()
+        if not bool(rc.get("allow_approve")):
+            return ("none", never)
+        if lvl in never:
+            return ("none", never)
+        if lvl == "medium" and bool(rc.get("approve_medium", True)):
+            return ("one_tap", never)
+        if lvl == "high" and bool(rc.get("approve_high_typed_confirm", True)):
+            return ("typed_confirm", never)
+        return ("none", never)
 
     def _approval_callback(self, command: str, description: str,
                            *, allow_permanent: bool = True,
-                           smart_denied: bool = False) -> str:
+                           smart_denied: bool = False,
+                           risk_level: str = "") -> str:
         """
         Prompt for dangerous command approval through the prompt_toolkit UI.
 
@@ -11745,6 +12034,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         Uses _approval_lock to serialize concurrent requests (e.g. from
         parallel delegation subtasks) so each prompt gets its own turn
         and the shared _approval_state / _approval_deadline aren't clobbered.
+
+        Remote control: when enabled, a pending-intervention record is created
+        so a mobile gateway command can DENY or EXTEND this prompt. Approval
+        itself stays local-only — there is no remote approve path. A local
+        answer always wins because response_queue.get() is checked first each
+        poll iteration, before any remote decision is consulted.
         """
         import time as _time
 
@@ -11771,39 +12066,157 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # the command is denied on timeout without the user ever seeing it
             # (#41098). The countdown refreshes below paint the same way.
             self._paint_now()
-
-            _last_countdown_refresh = _time.monotonic()
-            while True:
+            # --- remote control wiring (mobile deny/extend/approve) ---
+            rc = self._remote_intervention_settings()
+            remote_enabled = bool(rc.get("enabled"))
+            # Decide whether this prompt may be remotely approved and how.
+            # critical/never levels (and allow_approve=False) yield "none" so
+            # no approve line/token is ever advertised or accepted.
+            approve_tier, _never = self._compute_approve_tier(risk_level, rc)
+            approve_token = ""
+            remote_code = ""
+            remote_actions = None
+            if remote_enabled:
+                allowed = []
+                if rc.get("allow_deny", True):
+                    allowed.append("deny")
+                if rc.get("allow_extend", True):
+                    allowed.append("extend")
                 try:
-                    result = response_queue.get(timeout=1)
-                    self._approval_state = None
-                    self._approval_deadline = 0
-                    self._paint_now()
-                    _outcome_labels = {
-                        "once": "allowed once",
-                        "session": "allowed for session",
-                        "always": "added to allowlist",
-                        "deny": "denied",
-                    }
-                    self._persist_prompt_summary(
-                        "⚠", "Approval", command,
-                        _outcome_labels.get(result, str(result)),
+                    # Always create the pending record when remote control is
+                    # enabled: even with no deny/extend actions, the approve
+                    # tier (handled separately) may still allow a remote approve.
+                    rec = self._rc_create_pending(
+                        kind=intervention_kind,
+                        title="approval",
+                        preview=command,
+                        session_key=getattr(self, "session_id", ""),
+                        timeout_seconds=timeout,
+                        max_total_wait_minutes=int(rc.get("max_total_wait_minutes", 15)),
+                        allowed_actions=allowed or None,
+                        risk_level=risk_level,
+                        approve_tier=approve_tier,
                     )
-                    return result
-                except queue.Empty:
-                    remaining = self._approval_deadline - _time.monotonic()
-                    if remaining <= 0:
-                        break
-                    now = _time.monotonic()
-                    if now - _last_countdown_refresh >= 1.0:
-                        _last_countdown_refresh = now
-                        self._paint_now()
+                    remote_code = rec.code
+                    # The store generates the typed-confirm token (if any).
+                    approve_token = getattr(rec, "approve_token", "") or ""
+                    remote_actions = (allowed + ["status"]) if allowed else ["status"]
+                    # Expose for tests + UI.
+                    self._approval_state["remote_code"] = remote_code
+                except Exception:
+                    remote_code = ""
+                    remote_actions = None
+                    approve_token = ""
 
-            self._approval_state = None
-            self._approval_deadline = 0
-            self._paint_now()
-            _cprint(f"\n{_DIM}  ⏱ Timeout — denying command{_RST}")
-            return "deny"
+            # Compute the (possibly LLM-backed, ~seconds) danger explanation
+            # AFTER the local panel has been painted, so a slow auxiliary call
+            # never delays the local approval prompt. The explanation only
+            # enriches the mobile notification below.
+            risk_expl = self._explain_command_risk_for_notify(command, description, risk_level, rc)
+            try:
+                from hermes_cli.human_intervention_notifications import notify_human_intervention
+                notify_human_intervention(
+                    intervention_kind,
+                    "Hermes needs command approval" if intervention_kind == "approval" else "Hermes needs computer-use approval",
+                    f"{description}\nCommand: {command}",
+                    session_key=getattr(self, "session_id", ""),
+                    dedupe_key=f"{intervention_kind}:{command}",
+                    timeout_seconds=timeout,
+                    remote_code=remote_code,
+                    remote_actions=remote_actions,
+                    risk_level=risk_level,
+                    risk_explanation=risk_expl,
+                    approve_tier=approve_tier,
+                    approve_token=approve_token,
+                )
+            except Exception:
+                pass
+
+            try:
+                _last_countdown_refresh = _time.monotonic()
+                _outcome_labels = {
+                    "once": "allowed once",
+                    "session": "allowed for session",
+                    "always": "added to allowlist",
+                    "deny": "denied",
+                }
+                while True:
+                    try:
+                        # Local answer is checked FIRST every iteration, so a
+                        # local choice always wins over a remote decision.
+                        result = response_queue.get(timeout=1)
+                        self._approval_state = None
+                        self._approval_deadline = 0
+                        self._paint_now()
+                        self._persist_prompt_summary(
+                            "⚠", "Approval", command,
+                            _outcome_labels.get(result, str(result)),
+                        )
+                        return result
+                    except queue.Empty:
+                        remaining = self._approval_deadline - _time.monotonic()
+                        if remaining <= 0:
+                            break
+                        if remote_code:
+                            snap = self._rc_consume(remote_code)
+                            if snap is not None and snap.decision == "deny":
+                                # Remote deny → behave like a local deny.
+                                self._approval_state = None
+                                self._approval_deadline = 0
+                                self._paint_now()
+                                _cprint(
+                                    f"\n{_DIM}  ⏹ Denied remotely "
+                                    f"({snap.decision_source or 'mobile'}){_RST}"
+                                )
+                                self._persist_prompt_summary(
+                                    "⚠", "Approval", command, "denied remotely"
+                                )
+                                return "deny"
+                            if snap is not None and getattr(snap, "decision", None) == "approve":
+                                # Remote approve → behave like a local "once".
+                                # Only reachable when the store accepted an
+                                # approve (tier != none); critical/never levels
+                                # never produce an approve snapshot.
+                                self._approval_state = None
+                                self._approval_deadline = 0
+                                self._invalidate()
+                                _cprint(
+                                    f"\n{_DIM}  ✅ Approved remotely "
+                                    f"({snap.decision_source or 'mobile'}){_RST}"
+                                )
+                                return "once"
+                            if snap is not None and snap.decision == "extend":
+                                # Translate the store's wall-clock deadline into
+                                # the CLI's monotonic clock; only ever increase.
+                                import time as _t
+                                delta = max(0.0, snap.deadline_ts - _t.time())
+                                new_deadline = _time.monotonic() + delta
+                                if new_deadline > self._approval_deadline:
+                                    self._approval_deadline = new_deadline
+                                self._paint_now()
+                                # keep waiting
+                        now = _time.monotonic()
+                        if now - _last_countdown_refresh >= 1.0:
+                            _last_countdown_refresh = now
+                            self._paint_now()
+
+                self._approval_state = None
+                self._approval_deadline = 0
+                self._paint_now()
+                _cprint(f"\n{_DIM}  ⏱ Timeout — denying command{_RST}")
+                self._persist_prompt_summary("⚠", "Approval", command, "timed out / denied")
+                return "deny"
+            finally:
+                # Clear any pending record on every exit path. Consuming an
+                # already-resolved deny returns None, which is harmless.
+                # NOTE: never `return` inside this finally (avoids the
+                # SyntaxWarning that would otherwise swallow the verdict).
+                if remote_code:
+                    try:
+                        self._rc_consume(remote_code)
+                        self._rc_cleanup()
+                    except Exception:
+                        pass
 
     def _approval_choices(self, command: str, *, allow_permanent: bool = True,
                           smart_denied: bool = False) -> list[str]:
@@ -11829,6 +12242,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         verdict = self._approval_callback(
             command=f"computer_use: {summary}",
             description=f"Allow computer_use to perform `{action}`?",
+            intervention_kind="computer_use",
         )
         return {
             "once": "approve_once",

--- a/cli.py
+++ b/cli.py
@@ -11643,7 +11643,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     kind=kind, title=kind, preview=preview,
                     session_key=getattr(self, "session_id", ""), timeout_seconds=timeout,
                     max_total_wait_minutes=int(rc.get("max_total_wait_minutes", 15)),
-                    allowed_actions=allowed or None)
+                    allowed_actions=allowed if allowed else [],
+                    approve_token_len=int(rc.get("approve_token_len", 4)))
                 remote_code = rec.code
                 remote_actions = (allowed + ["status"]) if allowed else ["status"]
             except Exception:
@@ -11914,7 +11915,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             "approve_high_typed_confirm": True,
             "approve_token_len": 4,
             "never_approve_levels": ["critical"],
-            "code_ttl_seconds": 90,
             "max_extend_minutes": 15,
             "max_total_wait_minutes": 15,
             "allowed_targets": [],
@@ -12100,9 +12100,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         session_key=getattr(self, "session_id", ""),
                         timeout_seconds=timeout,
                         max_total_wait_minutes=int(rc.get("max_total_wait_minutes", 15)),
-                        allowed_actions=allowed or None,
+                        allowed_actions=allowed if allowed else [],
                         risk_level=risk_level,
                         approve_tier=approve_tier,
+                        approve_token_len=int(rc.get("approve_token_len", 4)),
                     )
                     remote_code = rec.code
                     # The store generates the typed-confirm token (if any).

--- a/cli.py
+++ b/cli.py
@@ -24,6 +24,7 @@ except ModuleNotFoundError:
     pass
 
 import logging
+import math
 import os
 import shutil
 import sys
@@ -11670,7 +11671,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         if getattr(snap, "decision", None) == "deny":
             return ("deny", getattr(snap, "decision_source", "") or "mobile", current_deadline)
         if getattr(snap, "decision", None) == "extend":
-            delta = max(0.0, getattr(snap, "deadline_ts", 0.0) - _t.time())
+            try:
+                deadline_ts = float(getattr(snap, "deadline_ts", 0.0))
+                if not math.isfinite(deadline_ts):
+                    return (None, "", current_deadline)
+                delta = max(0.0, deadline_ts - _t.time())
+            except (TypeError, ValueError):
+                return (None, "", current_deadline)
             new_deadline = _t.monotonic() + delta
             if new_deadline > current_deadline:
                 current_deadline = new_deadline
@@ -12158,7 +12165,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         if remaining <= 0:
                             break
                         if remote_code:
-                            snap = self._rc_consume(remote_code)
+                            try:
+                                snap = self._rc_consume(remote_code)
+                            except Exception:
+                                snap = None
                             if snap is not None and snap.decision == "deny":
                                 # Remote deny → behave like a local deny.
                                 self._approval_state = None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14615,6 +14615,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "expired": "该等待项已超时。",
                 "already_resolved": "该等待项已处理。",
                 "action_not_allowed": "该操作不被允许。",
+                "invalid_minutes": "延长分钟必须是正整数。",
             }.get(reason, f"操作失败：{reason}。")
 
         try:
@@ -14657,7 +14658,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 try:
                     minutes = int(tokens[2])
                 except (TypeError, ValueError):
-                    minutes = 15
+                    return "延长分钟必须是正整数。"
+                if minutes <= 0:
+                    return "延长分钟必须是正整数。"
             ok, reason, _rec = set_remote_decision(
                 code, "extend", minutes=minutes, source=platform_name or "mobile"
             )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9487,6 +9487,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     return await self._handle_approve_command(event)
                 return await self._handle_deny_command(event)
 
+            # /intervention (/iv) controls a human-intervention prompt in a
+            # DIFFERENT CLI process (not this gateway agent), so a busy gateway
+            # agent must never block it — bypass the running-agent guard.
+            if _cmd_def_inner and _cmd_def_inner.name == "intervention":
+                return await self._handle_intervention_command(event)
+
             # /agents (/tasks alias) should be query-only and never interrupt.
             if _cmd_def_inner and _cmd_def_inner.name == "agents":
                 return await self._handle_agents_command(event)
@@ -10002,6 +10008,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         if canonical == "deny":
             return await self._handle_deny_command(event)
+
+        if canonical == "intervention":
+            return await self._handle_intervention_command(event)
 
         if canonical == "update":
             return await self._handle_update_command(event)
@@ -14545,6 +14554,122 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     _APPROVAL_TIMEOUT_SECONDS = 300  # 5 minutes
 
 
+
+    async def _handle_intervention_command(self, event: MessageEvent) -> str:
+        """Handle /intervention (/iv) — approve/deny/extend/status a REMOTE CLI prompt.
+
+        This controls a pending human-intervention prompt living in a *different*
+        CLI process (tracked in the shared human-interventions store), keyed by a
+        short code. It is intentionally separate from the gateway's own /approve,
+        /deny, /status commands (which act on in-process approvals).
+
+        Remote ``approve`` is tiered: one-tap for low/medium-risk waits and a
+        typed confirm token for higher-risk ones, while the store still refuses
+        critical/disabled tiers (``approve_not_allowed``). The handler is gated by
+        the ``notifications.human_intervention.remote_control`` config block
+        (``enabled`` + ``allowed_targets``) and never raises.
+        """
+        import time as _time
+
+        source = event.source
+        usage = "用法: /iv <approve|deny|extend|status> <审批码> [分钟/令牌]"
+
+        args = (event.get_command_args() or "").strip()
+        tokens = args.split()
+        if not tokens:
+            return usage
+
+        subcommand = tokens[0].lower()
+        if subcommand not in {"deny", "extend", "status", "approve"}:
+            return usage
+
+        code = tokens[1] if len(tokens) > 1 else ""
+        if not code:
+            return usage
+
+        # Authorization: read the remote_control config defensively.
+        try:
+            from hermes_cli.config import load_config
+            cfg = (load_config() or {})
+            rc = (((cfg.get("notifications") or {}).get("human_intervention") or {}).get("remote_control") or {})
+        except Exception:
+            rc = {}
+
+        if not rc.get("enabled", False):
+            return "远程介入控制未启用。"
+
+        allowed_targets = rc.get("allowed_targets") or []
+        platform_name = (
+            source.platform.value
+            if getattr(source, "platform", None) and getattr(source.platform, "value", None)
+            else str(getattr(source, "platform", "") or "")
+        )
+        # If allowed_targets is empty, allow any platform (keeps gating opt-in
+        # and tests simple). A non-empty list is an allowlist.
+        if allowed_targets and platform_name and platform_name not in allowed_targets:
+            return "此平台无权执行远程介入控制。"
+
+        def _map_error(reason: str) -> str:
+            return {
+                "not_found": "未找到该等待项。",
+                "expired": "该等待项已超时。",
+                "already_resolved": "该等待项已处理。",
+                "action_not_allowed": "该操作不被允许。",
+            }.get(reason, f"操作失败：{reason}。")
+
+        try:
+            from hermes_cli.human_intervention_remote_control import (
+                set_remote_decision, get_pending_intervention,
+            )
+
+            if subcommand == "approve":
+                # tokens[2] (if present) is the typed-confirm token, NOT minutes.
+                token = tokens[2] if len(tokens) > 2 else None
+                ok, reason, _rec = set_remote_decision(
+                    code, "approve", token=token, source=platform_name or "mobile"
+                )
+                if ok:
+                    return f"已批准 CLI 等待项 {code}。"
+                if reason == "approve_not_allowed":
+                    return "该命令不支持远程批准（高危/critical），请回到 CLI。"
+                if reason == "bad_token":
+                    return "确认令牌不正确或缺失：高风险命令需 /iv approve <审批码> <令牌>。"
+                return _map_error(reason)
+
+            if subcommand == "status":
+                rec = get_pending_intervention(code)
+                if rec is None:
+                    return f"{code}: 未找到或已过期。"
+                remaining = max(0, rec.deadline_ts - _time.time())
+                return f"{code}: {rec.state}, 类型 {rec.kind}, 剩余约 {int(remaining)}s。"
+
+            if subcommand == "deny":
+                ok, reason, _rec = set_remote_decision(
+                    code, "deny", source=platform_name or "mobile"
+                )
+                if ok:
+                    return f"已拒绝 CLI 等待项 {code}。"
+                return _map_error(reason)
+
+            # subcommand == "extend"
+            minutes = 15
+            if len(tokens) > 2:
+                try:
+                    minutes = int(tokens[2])
+                except (TypeError, ValueError):
+                    minutes = 15
+            ok, reason, _rec = set_remote_decision(
+                code, "extend", minutes=minutes, source=platform_name or "mobile"
+            )
+            if ok:
+                msg = f"已延长 CLI 等待项 {code}：{minutes} 分钟。"
+                if reason == "clamped":
+                    msg += "（已达最大等待上限）"
+                return msg
+            return _map_error(reason)
+        except Exception as exc:  # never raise out of a command handler
+            logger.warning("/iv command failed: %s", exc)
+            return "远程介入控制操作失败。"
 
     # Built-in messaging platforms where the ``/update`` command is allowed.
     # ACP, API server, and webhooks are programmatic interfaces that should

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14616,6 +14616,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "already_resolved": "该等待项已处理。",
                 "action_not_allowed": "该操作不被允许。",
                 "invalid_minutes": "延长分钟必须是正整数。",
+                "exceeds_max_extend": f"延长分钟超过最大限制 ({rc.get('max_extend_minutes', 15)} 分钟)。",
             }.get(reason, f"操作失败：{reason}。")
 
         try:
@@ -14661,8 +14662,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     return "延长分钟必须是正整数。"
                 if minutes <= 0:
                     return "延长分钟必须是正整数。"
+
+            max_extend_minutes = rc.get("max_extend_minutes")
+            if max_extend_minutes is not None:
+                max_extend_minutes = int(max_extend_minutes)
+
             ok, reason, _rec = set_remote_decision(
-                code, "extend", minutes=minutes, source=platform_name or "mobile"
+                code, "extend", minutes=minutes, source=platform_name or "mobile",
+                max_extend_minutes=max_extend_minutes
             )
             if ok:
                 msg = f"已延长 CLI 等待项 {code}：{minutes} 分钟。"

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -99,6 +99,10 @@ COMMAND_REGISTRY: list[CommandDef] = [
                gateway_only=True, args_hint="[session|always]"),
     CommandDef("deny", "Deny a pending dangerous command (optionally with a reason)", "Session",
                gateway_only=True, args_hint="[all] [reason]"),
+    CommandDef("intervention", "Deny/extend/status a remote CLI prompt by code", "Session",
+               gateway_only=True, aliases=("iv",),
+               args_hint="<deny|extend|status> <code> [minutes]",
+               subcommands=("deny", "extend", "status"))
     CommandDef("background", "Run a prompt in the background", "Session",
                aliases=("bg", "btw"), args_hint="<prompt>"),
     CommandDef("agents", "Show active agents and running tasks", "Session",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2608,9 +2608,8 @@ DEFAULT_CONFIG = {
                 "approve_high_typed_confirm": True,  # high needs a confirm token
                 "approve_token_len": 4,            # typed-confirm token length
                 "never_approve_levels": ["critical"],  # never remotely approvable
-                "code_ttl_seconds": 90,
-                "max_extend_minutes": 15,
-                "max_total_wait_minutes": 15,
+                "max_extend_minutes": 15,          # cap on single /iv extend request
+                "max_total_wait_minutes": 15,      # absolute wait ceiling
                 "allowed_targets": ["telegram", "weixin"],
                 "risk_explanation": {
                     "enabled": True,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2576,6 +2576,65 @@ DEFAULT_CONFIG = {
 
     # Permanently allowed dangerous command patterns (added via "always" approval)
     "command_allowlist": [],
+
+    # Best-effort notifications when the CLI is blocked waiting for the user
+    # to approve a command, answer clarify(), or enter a sudo password. Disabled
+    # by default; if enabled, delivery failures never affect prompt semantics.
+    "notifications": {
+        "human_intervention": {
+            "enabled": False,
+            "channels": ["bell", "log"],
+            "gateway_targets": [],
+            "cooldown_seconds": 20,
+            "repeat_before_timeout_seconds": 15,
+            "include_command_preview": True,
+            "command_preview_chars": 120,
+            # Mobile remote control of a pending CLI human-intervention prompt.
+            # Phase 1: remote DENY (cancel) and EXTEND. Phase 2: tiered remote
+            # APPROVE — medium risk one-tap (/iv approve <code>), high risk
+            # typed-confirm (/iv approve <code> <token>). critical/hardline is
+            # NEVER remotely approvable; remote sudo password / clarify answer
+            # are never allowed. Disabled by default; delivery/parse failures
+            # never change local prompt semantics. Drives /iv deny|extend|
+            # status|approve.
+            "remote_control": {
+                "enabled": False,
+                "allow_deny": True,
+                "allow_extend": True,
+                # Master gate for ANY remote approve. Off by default.
+                "allow_approve": False,
+                # Tier rules (only consulted when allow_approve is True):
+                "approve_medium": True,            # one-tap approve for medium
+                "approve_high_typed_confirm": True,  # high needs a confirm token
+                "approve_token_len": 4,            # typed-confirm token length
+                "never_approve_levels": ["critical"],  # never remotely approvable
+                "code_ttl_seconds": 90,
+                "max_extend_minutes": 15,
+                "max_total_wait_minutes": 15,
+                "allowed_targets": ["telegram", "weixin"],
+                "risk_explanation": {
+                    "enabled": True,
+                    "only_for_risk_levels": ["high", "critical"],
+                    "max_chars": 280,
+                    # Wall-clock budget for the danger explanation. The real
+                    # default_llm_fn → call_llm path measures ~4s on a fast aux
+                    # model (higher than a bare HTTP probe due to client/config
+                    # setup), so 8s leaves jitter margin. Safe to keep generous:
+                    # cli.py computes the explanation AFTER painting the local
+                    # approval panel, so this only delays the mobile
+                    # notification, never the local prompt.
+                    "timeout_seconds": 8,
+                    "fallback_to_static": True,
+                    # Phase 2: use a bounded auxiliary-model call for the danger
+                    # explanation (static fallback on timeout/failure). Off by
+                    # default — only enable with a FAST model at
+                    # auxiliary.approval (a slow reasoning model times out → static).
+                    "use_llm": False,
+                },
+            },
+        },
+    },
+
     # User-defined quick commands that bypass the agent loop (type: exec only)
     "quick_commands": {},
 

--- a/hermes_cli/human_intervention_notifications.py
+++ b/hermes_cli/human_intervention_notifications.py
@@ -1,0 +1,275 @@
+"""Best-effort CLI human-intervention notifications.
+
+This module is intentionally dependency-light and fail-closed: notification
+failures must never change approval, sudo, clarify, or computer_use semantics.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+import threading
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+from hermes_cli.config import load_config
+
+_LAST_NOTIFIED: dict[tuple[str, str], float] = {}
+
+_SECRET_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"(?i)(authorization\s*:\s*bearer\s+)([^\s'\"]+)"), r"\1***"),
+    (re.compile(r"(?i)(authorization\s*:\s*basic\s+)([^\s'\"]+)"), r"\1***"),
+    (re.compile(r"(?i)\b(api[_-]?key|token|secret|password|passwd|pwd)\s*=\s*([^\s'\"&;]+)"), r"\1=***"),
+    (re.compile(r"(?i)\b(api[_-]?key|token|secret|password|passwd|pwd)\s*:\s*([^\s'\"&;]+)"), r"\1:***"),
+    (re.compile(r"(?i)([?&](?:api[_-]?key|token|secret|password|passwd|pwd)=)([^\s'\"&;]+)"), r"\1***"),
+)
+
+
+def _human_cfg() -> dict[str, Any]:
+    cfg = load_config() or {}
+    notifications = cfg.get("notifications") if isinstance(cfg, dict) else None
+    human = notifications.get("human_intervention") if isinstance(notifications, dict) else None
+    if not isinstance(human, dict):
+        return {}
+    return human
+
+
+def _as_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, (list, tuple, set)):
+        return [str(item) for item in value if str(item).strip()]
+    return []
+
+
+def _redact_and_truncate(text: str, max_chars: int = 120) -> str:
+    """Return a redacted, single-line preview no longer than max_chars + ellipsis."""
+    value = str(text or "").replace("\n", " ").replace("\r", " ")
+    value = re.sub(r"\s+", " ", value).strip()
+    for pattern, replacement in _SECRET_PATTERNS:
+        value = pattern.sub(replacement, value)
+    if max_chars <= 0:
+        return ""
+    if len(value) > max_chars:
+        return value[: max(0, max_chars - 1)].rstrip() + "…"
+    return value
+
+
+_REMOTE_ACTION_TEMPLATES: dict[str, str] = {
+    "deny": "/iv deny {code}",
+    "extend": "/iv extend {code} 15",
+    "status": "/iv status {code}",
+}
+
+
+def _compose_message(
+    kind: str,
+    title: str,
+    message: str,
+    *,
+    session_key: str = "",
+    timeout_seconds: int | None = None,
+    remote_code: str = "",
+    remote_actions: list[str] | None = None,
+    risk_level: str = "",
+    risk_explanation: str = "",
+    approve_tier: str = "",
+    approve_token: str = "",
+) -> str:
+    lines = [f"{title}", "请回到 CLI 处理；此通知不会远程批准本地命令。"]
+    if kind:
+        lines.append(f"类型: {kind}")
+    if risk_level:
+        lines.append(f"风险: {risk_level}")
+    if timeout_seconds is not None:
+        lines.append(f"超时: {timeout_seconds}s")
+    if session_key:
+        lines.append(f"会话: {session_key}")
+    if risk_explanation:
+        lines.append("危险解释:")
+        lines.append(risk_explanation)
+    if remote_code and remote_actions:
+        action_lines = [
+            _REMOTE_ACTION_TEMPLATES[action].format(code=remote_code)
+            for action in remote_actions
+            if action in _REMOTE_ACTION_TEMPLATES
+        ]
+        remote_approve_allowed = approve_tier in ("one_tap", "typed_confirm")
+        approve_line = ""
+        if approve_tier == "one_tap":
+            approve_line = f"/iv approve {remote_code}"
+        elif approve_tier == "typed_confirm":
+            approve_line = f"/iv approve {remote_code} {approve_token}"
+        # Approve is the primary action when allowed: list it first.
+        command_lines = ([approve_line] if approve_line else []) + action_lines
+        if command_lines:
+            lines.append("可远程操作:")
+            lines.extend(command_lines)
+            if remote_approve_allowed:
+                if approve_tier == "typed_confirm":
+                    lines.append("注意：高风险命令需输入确认令牌。")
+                else:
+                    lines.append("注意：远程批准等价于本地“仅此一次”。")
+            else:
+                lines.append("注意：当前阶段不支持远程批准。批准请回到 CLI。")
+    preview = str(message or "").strip()
+    if preview:
+        lines.append(preview)
+    return "\n".join(lines)
+
+
+def _write_log(kind: str, title: str, message: str, *, severity: str, session_key: str, timeout_seconds: int | None) -> None:
+    log_dir = get_hermes_home() / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    event = {
+        "ts": datetime.now().isoformat(timespec="seconds"),
+        "kind": kind,
+        "severity": severity,
+        "title": title,
+        "message": message,
+        "session_key": session_key,
+        "timeout_seconds": timeout_seconds,
+    }
+    with (log_dir / "human-intervention.log").open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(event, ensure_ascii=False, sort_keys=True) + "\n")
+
+
+def _send_bell() -> None:
+    sys.stderr.write("\a")
+    sys.stderr.flush()
+
+
+def _send_desktop(title: str, message: str) -> None:
+    notify_send = shutil.which("notify-send")
+    if notify_send:
+        subprocess.run(
+            [notify_send, title, message],
+            timeout=3,
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+
+def _send_gateway_message(args: dict[str, Any]) -> str:
+    try:
+        from hermes_cli.send_cmd import _load_hermes_env
+        _load_hermes_env()
+    except Exception:
+        pass
+
+    from tools.send_message_tool import send_message_tool
+
+    return send_message_tool(args)
+
+
+def _send_gateway_targets(targets: list[str], body: str) -> None:
+    def worker() -> None:
+        for target in targets:
+            try:
+                _send_gateway_message({"action": "send", "target": target, "message": body})
+            except Exception:
+                pass
+
+    thread = threading.Thread(
+        target=worker,
+        name="hermes-human-intervention-gateway-notify",
+        daemon=True,
+    )
+    thread.start()
+
+
+def notify_human_intervention(
+    kind: str,
+    title: str,
+    message: str,
+    *,
+    session_key: str = "",
+    severity: str = "warning",
+    dedupe_key: str = "",
+    timeout_seconds: int | None = None,
+    remote_code: str = "",
+    remote_actions: list[str] | None = None,
+    risk_level: str = "",
+    risk_explanation: str = "",
+    approve_tier: str = "",
+    approve_token: str = "",
+) -> None:
+    """Emit a best-effort human-intervention notification and never raise."""
+    try:
+        cfg = _human_cfg()
+        if not cfg.get("enabled", False):
+            return
+
+        channels = _as_list(cfg.get("channels"))
+        if "log" not in channels:
+            channels.append("log")
+        targets = _as_list(cfg.get("gateway_targets"))
+        if targets and "gateway" not in channels:
+            channels.append("gateway")
+        if not channels:
+            channels = ["log"]
+
+        cooldown = float(cfg.get("cooldown_seconds", 20) or 0)
+        key = (str(kind or "unknown"), str(dedupe_key or message or title or "default"))
+        now = time.monotonic()
+        previous = _LAST_NOTIFIED.get(key)
+        if previous is not None and cooldown > 0 and now - previous < cooldown:
+            return
+        _LAST_NOTIFIED[key] = now
+
+        preview_chars = int(cfg.get("command_preview_chars", 120) or 120)
+        include_preview = bool(cfg.get("include_command_preview", True))
+        preview = _redact_and_truncate(message, preview_chars) if include_preview else ""
+        safe_title = _redact_and_truncate(title, 100)
+        body = _compose_message(
+            str(kind or "unknown"),
+            safe_title,
+            preview,
+            session_key=session_key,
+            timeout_seconds=timeout_seconds,
+            remote_code=remote_code,
+            remote_actions=remote_actions,
+            risk_level=risk_level,
+            risk_explanation=risk_explanation,
+            approve_tier=approve_tier,
+            approve_token=approve_token,
+        )
+
+        if "bell" in channels:
+            try:
+                _send_bell()
+            except Exception:
+                pass
+        if "desktop" in channels:
+            try:
+                _send_desktop(safe_title, preview)
+            except Exception:
+                pass
+        if "gateway" in channels and targets:
+            try:
+                _send_gateway_targets(targets, body)
+            except Exception:
+                pass
+        if "log" in channels:
+            try:
+                _write_log(
+                    str(kind or "unknown"),
+                    safe_title,
+                    preview,
+                    severity=str(severity or "warning"),
+                    session_key=str(session_key or ""),
+                    timeout_seconds=timeout_seconds,
+                )
+            except Exception:
+                pass
+    except Exception:
+        return

--- a/hermes_cli/human_intervention_remote_control.py
+++ b/hermes_cli/human_intervention_remote_control.py
@@ -1,0 +1,418 @@
+"""Local pending human-intervention store for CLI remote control.
+
+Tracks pending CLI human-intervention prompts (approval / sudo / clarify) in a
+small JSON file so a mobile gateway command can later deny or extend them.
+
+THIS MODULE IS PURE LOGIC — no CLI or gateway wiring lives here.
+
+Store layout
+------------
+``$HERMES_HOME/runtime/human-interventions.json`` shaped as::
+
+    {"records": {code: {...record...}}}
+
+Concurrency
+-----------
+A module-level :class:`threading.Lock` guards every read-modify-write so the
+store is consistent *within* a process. Cross-process safety relies on the
+atomicity of :func:`os.replace` (write temp file, then rename over the final
+path) — good enough for this phase where a single CLI process owns its
+pending interventions and the gateway only flips decision flags.
+
+Time
+----
+All time reads go through the module-level :func:`_now` indirection so tests
+can monkeypatch it for deterministic expiry / cleanup behaviour.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import threading
+import time
+from dataclasses import asdict, dataclass, field
+
+from hermes_constants import get_hermes_home
+
+# Expiry slack applied to deadlines before a token is considered too late to
+# act on (covers clock skew + in-flight gateway round-trips).
+GRACE_SECONDS = 30
+
+# Resolved records linger this long before cleanup reaps them.
+RESOLVED_TTL_SECONDS = 5 * 60
+
+# Default extension applied when a caller asks to extend without a duration.
+DEFAULT_EXTEND_MINUTES = 15
+
+# Length (digits) of an auto-generated typed-confirm approval token.
+DEFAULT_APPROVE_TOKEN_LEN = 4
+
+# "deny"/"extend" are the always-available remote actions. "approve" is gated
+# on the per-record approve_tier rather than this tuple (it was never a member
+# of _REMOTE_ACTIONS and stays opt-in per intervention).
+_REMOTE_ACTIONS = ("deny", "extend")
+
+_STORE_LOCK = threading.Lock()
+
+
+def _now() -> float:
+    """Return the current wall-clock time.
+
+    Indirection point so tests can monkeypatch time deterministically.
+    """
+    return time.time()
+
+
+@dataclass
+class PendingIntervention:
+    code: str
+    kind: str            # "approval" | "sudo" | "clarify"
+    title: str
+    preview: str
+    session_key: str
+    state: str           # "pending" | "denied" | "extended" | "approved" | "expired" | "resolved"
+    created_ts: float
+    deadline_ts: float
+    max_deadline_ts: float
+    decision: str | None = None        # "deny" | "extend" | "approve" | None
+    decision_ts: float | None = None
+    decision_source: str = ""
+    # None => both deny and extend allowed. Otherwise only listed actions are.
+    allowed_actions: list[str] | None = None
+    # Tiered remote approval. risk_level is advisory metadata; approve_tier
+    # gates whether approve can be driven remotely and how.
+    risk_level: str = ""
+    approve_tier: str = "none"          # "none" | "one_tap" | "typed_confirm"
+    approve_token: str = ""             # set only for the typed_confirm tier
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "PendingIntervention":
+        # Tolerate extra/legacy keys by filtering to known fields.
+        known = cls.__dataclass_fields__  # type: ignore[attr-defined]
+        return cls(**{k: v for k, v in data.items() if k in known})
+
+
+# ---------------------------------------------------------------------------
+# Persistence helpers
+# ---------------------------------------------------------------------------
+
+
+def _store_path():
+    runtime_dir = get_hermes_home() / "runtime"
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    return runtime_dir / "human-interventions.json"
+
+
+def _load_records() -> dict:
+    """Return the raw ``{code: record_dict}`` mapping.
+
+    A missing or corrupt file is treated as an empty store.
+    """
+    path = _store_path()
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (FileNotFoundError, json.JSONDecodeError, OSError, ValueError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    records = data.get("records")
+    if not isinstance(records, dict):
+        return {}
+    return records
+
+
+def _save_records(records: dict) -> None:
+    """Atomically persist ``records`` via write-temp-then-replace."""
+    path = _store_path()
+    tmp = path.with_name(path.name + f".tmp.{os.getpid()}.{random.randint(0, 1_000_000)}")
+    payload = {"records": records}
+    with open(tmp, "w", encoding="utf-8") as fh:
+        json.dump(payload, fh)
+        fh.flush()
+        os.fsync(fh.fileno())
+    os.replace(tmp, path)
+
+
+def _generate_code(existing: dict) -> str:
+    """Return a 4-digit code not colliding with existing pending records."""
+    for _ in range(10_000):
+        code = f"{random.randint(0, 9999):04d}"
+        if code not in existing:
+            return code
+    # Astronomically unlikely; fall back to a unique-ish value.
+    return f"{random.randint(0, 9999):04d}"
+
+
+def _generate_token(n: int = DEFAULT_APPROVE_TOKEN_LEN, *, avoid: str = "") -> str:
+    """Return a zero-padded numeric token of ``n`` digits.
+
+    Distinct from ``avoid`` (typically the record's code) so a single number
+    can't satisfy both the addressing code and the typed-confirm gate.
+    """
+    n = max(1, int(n))
+    high = 10**n - 1
+    for _ in range(10_000):
+        token = f"{random.randint(0, high):0{n}d}"
+        if token != avoid:
+            return token
+    # Astronomically unlikely; return whatever we have.
+    return f"{random.randint(0, high):0{n}d}"
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def create_pending_intervention(
+    *,
+    kind: str,
+    title: str,
+    preview: str,
+    session_key: str,
+    timeout_seconds: int,
+    max_total_wait_minutes: int = 15,
+    code: str | None = None,
+    allowed_actions: list[str] | None = None,
+    risk_level: str = "",
+    approve_tier: str = "none",
+    approve_token: str | None = None,
+) -> PendingIntervention:
+    """Create and persist a new pending intervention, returning the record.
+
+    Tiered remote approval is opt-in per record via ``approve_tier``:
+      * ``"none"``         — approve cannot be driven remotely (default).
+      * ``"one_tap"``      — a remote approve needs no token.
+      * ``"typed_confirm"``— a remote approve must echo ``approve_token``.
+                             When no token is supplied one is generated
+                             (``DEFAULT_APPROVE_TOKEN_LEN`` digits, distinct
+                             from the addressing ``code``).
+    """
+    with _STORE_LOCK:
+        records = _load_records()
+        if code is None:
+            code = _generate_code(records)
+        elif code in records:
+            # Explicit code collision: overwrite is the caller's intent in
+            # tests, but regenerate uniqueness only applies to auto codes.
+            pass
+
+        # Resolve the approve token according to the tier.
+        if approve_tier == "typed_confirm":
+            token = approve_token if approve_token is not None else _generate_token(
+                DEFAULT_APPROVE_TOKEN_LEN, avoid=code
+            )
+        else:
+            token = ""
+
+        now = _now()
+        rec = PendingIntervention(
+            code=code,
+            kind=kind,
+            title=title,
+            preview=preview,
+            session_key=session_key,
+            state="pending",
+            created_ts=now,
+            deadline_ts=now + timeout_seconds,
+            max_deadline_ts=now + max_total_wait_minutes * 60,
+            decision=None,
+            decision_ts=None,
+            decision_source="",
+            allowed_actions=list(allowed_actions) if allowed_actions is not None else None,
+            risk_level=risk_level,
+            approve_tier=approve_tier,
+            approve_token=token,
+        )
+        records[code] = rec.to_dict()
+        _save_records(records)
+        return rec
+
+
+def get_pending_intervention(code: str) -> PendingIntervention | None:
+    """Return the record for ``code`` or ``None``. Does not mutate state."""
+    with _STORE_LOCK:
+        records = _load_records()
+        raw = records.get(code)
+        if raw is None:
+            return None
+        return PendingIntervention.from_dict(raw)
+
+
+def _action_allowed(rec: PendingIntervention, action: str) -> bool:
+    if action == "approve":
+        return False
+    if action not in _REMOTE_ACTIONS:
+        return False
+    if rec.allowed_actions is None:
+        return True
+    return action in rec.allowed_actions
+
+
+def set_remote_decision(
+    code: str,
+    action: str,
+    *,
+    minutes: int | None = None,
+    token: str | None = None,
+    source: str = "",
+) -> tuple[bool, str, PendingIntervention | None]:
+    """Apply a remote ``deny``/``extend``/``approve`` decision.
+
+    Returns ``(ok, reason, record_or_None)``. On failure ``reason`` is one of
+    ``not_found`` / ``expired`` / ``action_not_allowed`` / ``already_resolved``
+    / ``approve_not_allowed`` / ``bad_token``.
+
+    ``deny`` and ``extend`` keep the phase-1 ``_action_allowed`` gate.
+    ``approve`` is gated separately on the record's ``approve_tier`` (it is
+    never a member of ``_REMOTE_ACTIONS``): the ``one_tap`` tier needs no
+    token, while ``typed_confirm`` requires ``token`` to match the stored
+    ``approve_token``.
+    """
+    with _STORE_LOCK:
+        records = _load_records()
+        raw = records.get(code)
+        if raw is None:
+            return (False, "not_found", None)
+
+        rec = PendingIntervention.from_dict(raw)
+
+        if action == "approve":
+            # Tier gate — approve is opt-in per record, not via _action_allowed.
+            tier = getattr(rec, "approve_tier", "none") or "none"
+            if tier == "none":
+                return (False, "approve_not_allowed", rec)
+
+            if rec.state == "resolved":
+                return (False, "already_resolved", rec)
+
+            now = _now()
+            if now > rec.deadline_ts + GRACE_SECONDS:
+                return (False, "expired", rec)
+
+            if tier == "typed_confirm":
+                expected = rec.approve_token or ""
+                if not token or token != expected:
+                    return (False, "bad_token", rec)
+
+            rec.state = "approved"
+            rec.decision = "approve"
+            rec.decision_ts = now
+            rec.decision_source = source
+            records[code] = rec.to_dict()
+            _save_records(records)
+            return (True, "ok", rec)
+
+        if not _action_allowed(rec, action):
+            return (False, "action_not_allowed", rec)
+
+        if rec.state == "resolved":
+            return (False, "already_resolved", rec)
+
+        now = _now()
+        if now > rec.deadline_ts + GRACE_SECONDS:
+            return (False, "expired", rec)
+
+        reason = "ok"
+        if action == "deny":
+            rec.state = "denied"
+            rec.decision = "deny"
+            rec.decision_ts = now
+            rec.decision_source = source
+        elif action == "extend":
+            mins = DEFAULT_EXTEND_MINUTES if minutes is None else minutes
+            new_deadline = rec.deadline_ts + mins * 60
+            if new_deadline >= rec.max_deadline_ts:
+                new_deadline = rec.max_deadline_ts
+                reason = "clamped"
+            rec.deadline_ts = new_deadline
+            rec.state = "extended"
+            rec.decision = "extend"
+            rec.decision_ts = now
+            rec.decision_source = source
+        else:  # pragma: no cover - guarded by _action_allowed
+            return (False, "action_not_allowed", rec)
+
+        records[code] = rec.to_dict()
+        _save_records(records)
+        return (True, reason, rec)
+
+
+def consume_remote_decision(code: str) -> PendingIntervention | None:
+    """Consume a pending decision once, for the CLI poll loop.
+
+    Returns a snapshot reflecting the decision that was just consumed, or
+    ``None`` when there is nothing actionable (no record, or still pending).
+
+    Consumption semantics:
+      * ``denied``   -> snapshot returned, stored record becomes ``resolved``
+                        (a deny is terminal; further consumes return ``None``).
+      * ``approved`` -> snapshot returned (decision ``approve``), stored record
+                        becomes ``resolved`` (approve is one-shot/terminal;
+                        further consumes return ``None``).
+      * ``extended`` -> snapshot returned (with the already-extended deadline),
+                        stored record reset to ``pending`` with ``decision``
+                        cleared so the CLI can apply the new deadline and keep
+                        waiting. Repeated extends are therefore each consumed
+                        exactly once.
+    """
+    with _STORE_LOCK:
+        records = _load_records()
+        raw = records.get(code)
+        if raw is None:
+            return None
+
+        rec = PendingIntervention.from_dict(raw)
+
+        if rec.state in ("denied", "approved"):
+            snapshot = PendingIntervention.from_dict(rec.to_dict())
+            rec.state = "resolved"
+            records[code] = rec.to_dict()
+            _save_records(records)
+            return snapshot
+
+        if rec.state == "extended":
+            snapshot = PendingIntervention.from_dict(rec.to_dict())
+            rec.state = "pending"
+            rec.decision = None
+            rec.decision_ts = None
+            # decision_source retained for audit; deadline already extended.
+            records[code] = rec.to_dict()
+            _save_records(records)
+            return snapshot
+
+        # pending / resolved / expired => nothing to hand back.
+        return None
+
+
+def cleanup_expired() -> int:
+    """Drop records past their max deadline (plus grace) or stale-resolved.
+
+    Returns the number of records removed.
+    """
+    with _STORE_LOCK:
+        records = _load_records()
+        now = _now()
+        to_remove = []
+        for code, raw in records.items():
+            try:
+                rec = PendingIntervention.from_dict(raw)
+            except (TypeError, ValueError):
+                to_remove.append(code)
+                continue
+            if now > rec.max_deadline_ts + GRACE_SECONDS:
+                to_remove.append(code)
+            elif rec.state == "resolved" and rec.decision_ts is not None \
+                    and now > rec.decision_ts + RESOLVED_TTL_SECONDS:
+                to_remove.append(code)
+        for code in to_remove:
+            records.pop(code, None)
+        if to_remove:
+            _save_records(records)
+        return len(to_remove)

--- a/hermes_cli/human_intervention_remote_control.py
+++ b/hermes_cli/human_intervention_remote_control.py
@@ -13,11 +13,11 @@ Store layout
 
 Concurrency
 -----------
-A module-level :class:`threading.Lock` guards every read-modify-write so the
-store is consistent *within* a process. Cross-process safety relies on the
-atomicity of :func:`os.replace` (write temp file, then rename over the final
-path) — good enough for this phase where a single CLI process owns its
-pending interventions and the gateway only flips decision flags.
+Cross-process safety is enforced via exclusive file locking (fcntl.flock on
+POSIX, msvcrt.locking on Windows) on a dedicated .lock file. Every
+read-modify-write acquires the lock, loads, mutates, and saves atomically.
+This handles concurrent CLI processes and gateway commands racing to update
+the same intervention record.
 
 Time
 ----
@@ -27,11 +27,13 @@ can monkeypatch it for deterministic expiry / cleanup behaviour.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import math
 import os
+import platform
 import random
-import threading
+import sys
 import time
 from dataclasses import asdict, dataclass, field
 
@@ -55,7 +57,42 @@ DEFAULT_APPROVE_TOKEN_LEN = 4
 # of _REMOTE_ACTIONS and stays opt-in per intervention).
 _REMOTE_ACTIONS = ("deny", "extend")
 
-_STORE_LOCK = threading.Lock()
+
+# Cross-process locking via a dedicated .lock file
+@contextlib.contextmanager
+def _store_lock():
+    """Acquire exclusive cross-process lock on the intervention store.
+
+    Uses fcntl.flock on POSIX and msvcrt.locking on Windows. Blocks until
+    the lock is acquired. Ensures atomic read-modify-write across concurrent
+    CLI and gateway processes.
+    """
+    lock_path = _store_path().with_suffix(".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Open lock file in append mode so it's created if missing
+    lock_fd = os.open(str(lock_path), os.O_CREAT | os.O_APPEND | os.O_RDWR, 0o600)
+    try:
+        if platform.system() == "Windows":
+            import msvcrt
+            # Lock first byte of the file
+            msvcrt.locking(lock_fd, msvcrt.LK_LOCK, 1)
+        else:
+            import fcntl
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+
+        yield
+
+    finally:
+        # Release lock (closing the fd releases flock automatically on POSIX,
+        # but explicitly unlock on Windows)
+        if platform.system() == "Windows":
+            try:
+                import msvcrt
+                msvcrt.locking(lock_fd, msvcrt.LK_UNLCK, 1)
+            except Exception:
+                pass
+        os.close(lock_fd)
 
 
 def _now() -> float:
@@ -271,6 +308,7 @@ def create_pending_intervention(
     risk_level: str = "",
     approve_tier: str = "none",
     approve_token: str | None = None,
+    approve_token_len: int = DEFAULT_APPROVE_TOKEN_LEN,
 ) -> PendingIntervention:
     """Create and persist a new pending intervention, returning the record.
 
@@ -279,10 +317,15 @@ def create_pending_intervention(
       * ``"one_tap"``      — a remote approve needs no token.
       * ``"typed_confirm"``— a remote approve must echo ``approve_token``.
                              When no token is supplied one is generated
-                             (``DEFAULT_APPROVE_TOKEN_LEN`` digits, distinct
-                             from the addressing ``code``).
+                             (``approve_token_len`` digits, distinct from the
+                             addressing ``code``).
+
+    Args:
+        approve_token_len: Number of digits for auto-generated typed-confirm
+            tokens (default: DEFAULT_APPROVE_TOKEN_LEN). Wire from config's
+            remote_control.approve_token_len.
     """
-    with _STORE_LOCK:
+    with _store_lock():
         records = _load_records()
         if code is None:
             code = _generate_code(records)
@@ -294,7 +337,7 @@ def create_pending_intervention(
         # Resolve the approve token according to the tier.
         if approve_tier == "typed_confirm":
             token = approve_token if approve_token is not None else _generate_token(
-                DEFAULT_APPROVE_TOKEN_LEN, avoid=code
+                approve_token_len, avoid=code
             )
         else:
             token = ""
@@ -329,7 +372,7 @@ def create_pending_intervention(
 
 def get_pending_intervention(code: str) -> PendingIntervention | None:
     """Return the record for ``code`` or ``None``. Does not mutate state."""
-    with _STORE_LOCK:
+    with _store_lock():
         records = _load_records()
         raw = records.get(code)
         if raw is None:
@@ -354,20 +397,27 @@ def set_remote_decision(
     minutes: int | None = None,
     token: str | None = None,
     source: str = "",
+    max_extend_minutes: int | None = None,
 ) -> tuple[bool, str, PendingIntervention | None]:
     """Apply a remote ``deny``/``extend``/``approve`` decision.
 
     Returns ``(ok, reason, record_or_None)``. On failure ``reason`` is one of
     ``not_found`` / ``expired`` / ``action_not_allowed`` / ``already_resolved``
-    / ``approve_not_allowed`` / ``bad_token`` / ``invalid_minutes``.
+    / ``approve_not_allowed`` / ``bad_token`` / ``invalid_minutes`` /
+    / ``exceeds_max_extend``.
 
     ``deny`` and ``extend`` keep the phase-1 ``_action_allowed`` gate.
     ``approve`` is gated separately on the record's ``approve_tier`` (it is
     never a member of ``_REMOTE_ACTIONS``): the ``one_tap`` tier needs no
     token, while ``typed_confirm`` requires ``token`` to match the stored
     ``approve_token``.
+
+    Args:
+        max_extend_minutes: Maximum allowed extension in minutes. Wire from
+            config's remote_control.max_extend_minutes. When None, no cap is
+            enforced beyond the record's max_deadline_ts.
     """
-    with _STORE_LOCK:
+    with _store_lock():
         records = _load_records()
         raw = records.get(code)
         if raw is None:
@@ -429,6 +479,9 @@ def set_remote_decision(
                 return (False, "invalid_minutes", rec)
             if mins <= 0:
                 return (False, "invalid_minutes", rec)
+            # Enforce max_extend_minutes cap if provided (wired from config)
+            if max_extend_minutes is not None and mins > max_extend_minutes:
+                return (False, "exceeds_max_extend", rec)
             new_deadline = rec.deadline_ts + mins * 60
             if new_deadline >= rec.max_deadline_ts:
                 new_deadline = rec.max_deadline_ts
@@ -464,7 +517,7 @@ def consume_remote_decision(code: str) -> PendingIntervention | None:
                         waiting. Repeated extends are therefore each consumed
                         exactly once.
     """
-    with _STORE_LOCK:
+    with _store_lock():
         records = _load_records()
         raw = records.get(code)
         if raw is None:
@@ -513,7 +566,7 @@ def cleanup_expired() -> int:
 
     Returns the number of records removed.
     """
-    with _STORE_LOCK:
+    with _store_lock():
         records = _load_records()
         now = _now()
         to_remove = []

--- a/hermes_cli/human_intervention_remote_control.py
+++ b/hermes_cli/human_intervention_remote_control.py
@@ -28,6 +28,7 @@ can monkeypatch it for deterministic expiry / cleanup behaviour.
 from __future__ import annotations
 
 import json
+import math
 import os
 import random
 import threading
@@ -165,6 +166,93 @@ def _generate_token(n: int = DEFAULT_APPROVE_TOKEN_LEN, *, avoid: str = "") -> s
     return f"{random.randint(0, high):0{n}d}"
 
 
+def _finite_number(value) -> float | None:
+    """Return ``value`` as a finite float, rejecting bools/strings/NaN/inf."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    value = float(value)
+    if not math.isfinite(value):
+        return None
+    return value
+
+
+def _record_from_raw(raw: dict) -> PendingIntervention | None:
+    """Deserialize and validate one record defensively.
+
+    Gateway commands and CLI poll loops must never crash just because the JSON
+    store was truncated, hand-edited, or written by an older schema. Treat a
+    malformed per-code record as absent; cleanup will later reap it if it is
+    still present.
+    """
+    try:
+        if not isinstance(raw, dict):
+            return None
+
+        required = {
+            "code", "kind", "title", "preview", "session_key", "state",
+            "created_ts", "deadline_ts", "max_deadline_ts",
+        }
+        if not required.issubset(raw):
+            return None
+
+        normalized = dict(raw)
+        for key in ("created_ts", "deadline_ts", "max_deadline_ts"):
+            value = _finite_number(normalized.get(key))
+            if value is None:
+                return None
+            normalized[key] = value
+
+        if normalized.get("decision_ts") is not None:
+            decision_ts = _finite_number(normalized.get("decision_ts"))
+            if decision_ts is None:
+                return None
+            normalized["decision_ts"] = decision_ts
+
+        for key in ("code", "kind", "title", "preview", "session_key", "state"):
+            if not isinstance(normalized.get(key), str):
+                return None
+
+        if normalized["state"] not in {
+            "pending", "denied", "extended", "approved", "expired", "resolved",
+        }:
+            return None
+
+        decision = normalized.get("decision")
+        if decision is not None and decision not in {"deny", "extend", "approve"}:
+            return None
+
+        allowed_actions = normalized.get("allowed_actions")
+        if allowed_actions is not None:
+            if not isinstance(allowed_actions, list) or not all(
+                isinstance(item, str) for item in allowed_actions
+            ):
+                return None
+
+        for key in ("decision_source", "risk_level", "approve_tier", "approve_token"):
+            if key in normalized and not isinstance(normalized.get(key), str):
+                return None
+        if normalized.get("approve_tier", "none") not in {"", "none", "one_tap", "typed_confirm"}:
+            return None
+
+        return PendingIntervention.from_dict(normalized)
+    except (AttributeError, TypeError, ValueError):
+        return None
+
+
+def _is_past_action_deadline(rec: PendingIntervention, now: float) -> bool:
+    """Return True when no remote action may be applied anymore.
+
+    Both deadlines are enforced at the store boundary: the current prompt
+    deadline and the absolute max-total-wait guard. This keeps the cap
+    server-side even if a stale/tampered record carries an overlong
+    ``deadline_ts``.
+    """
+    return (
+        now > rec.deadline_ts + GRACE_SECONDS
+        or now > rec.max_deadline_ts + GRACE_SECONDS
+    )
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -212,6 +300,10 @@ def create_pending_intervention(
             token = ""
 
         now = _now()
+        timeout_seconds = max(0, int(timeout_seconds))
+        max_wait_seconds = max(0, int(max_total_wait_minutes) * 60)
+        max_deadline_ts = now + max_wait_seconds
+        deadline_ts = now + min(timeout_seconds, max_wait_seconds)
         rec = PendingIntervention(
             code=code,
             kind=kind,
@@ -220,8 +312,8 @@ def create_pending_intervention(
             session_key=session_key,
             state="pending",
             created_ts=now,
-            deadline_ts=now + timeout_seconds,
-            max_deadline_ts=now + max_total_wait_minutes * 60,
+            deadline_ts=deadline_ts,
+            max_deadline_ts=max_deadline_ts,
             decision=None,
             decision_ts=None,
             decision_source="",
@@ -242,7 +334,7 @@ def get_pending_intervention(code: str) -> PendingIntervention | None:
         raw = records.get(code)
         if raw is None:
             return None
-        return PendingIntervention.from_dict(raw)
+        return _record_from_raw(raw)
 
 
 def _action_allowed(rec: PendingIntervention, action: str) -> bool:
@@ -267,7 +359,7 @@ def set_remote_decision(
 
     Returns ``(ok, reason, record_or_None)``. On failure ``reason`` is one of
     ``not_found`` / ``expired`` / ``action_not_allowed`` / ``already_resolved``
-    / ``approve_not_allowed`` / ``bad_token``.
+    / ``approve_not_allowed`` / ``bad_token`` / ``invalid_minutes``.
 
     ``deny`` and ``extend`` keep the phase-1 ``_action_allowed`` gate.
     ``approve`` is gated separately on the record's ``approve_tier`` (it is
@@ -281,7 +373,11 @@ def set_remote_decision(
         if raw is None:
             return (False, "not_found", None)
 
-        rec = PendingIntervention.from_dict(raw)
+        rec = _record_from_raw(raw)
+        if rec is None:
+            records.pop(code, None)
+            _save_records(records)
+            return (False, "not_found", None)
 
         if action == "approve":
             # Tier gate — approve is opt-in per record, not via _action_allowed.
@@ -293,7 +389,7 @@ def set_remote_decision(
                 return (False, "already_resolved", rec)
 
             now = _now()
-            if now > rec.deadline_ts + GRACE_SECONDS:
+            if _is_past_action_deadline(rec, now):
                 return (False, "expired", rec)
 
             if tier == "typed_confirm":
@@ -316,7 +412,7 @@ def set_remote_decision(
             return (False, "already_resolved", rec)
 
         now = _now()
-        if now > rec.deadline_ts + GRACE_SECONDS:
+        if _is_past_action_deadline(rec, now):
             return (False, "expired", rec)
 
         reason = "ok"
@@ -327,6 +423,12 @@ def set_remote_decision(
             rec.decision_source = source
         elif action == "extend":
             mins = DEFAULT_EXTEND_MINUTES if minutes is None else minutes
+            try:
+                mins = int(mins)
+            except (TypeError, ValueError):
+                return (False, "invalid_minutes", rec)
+            if mins <= 0:
+                return (False, "invalid_minutes", rec)
             new_deadline = rec.deadline_ts + mins * 60
             if new_deadline >= rec.max_deadline_ts:
                 new_deadline = rec.max_deadline_ts
@@ -368,7 +470,17 @@ def consume_remote_decision(code: str) -> PendingIntervention | None:
         if raw is None:
             return None
 
-        rec = PendingIntervention.from_dict(raw)
+        rec = _record_from_raw(raw)
+        if rec is None:
+            records.pop(code, None)
+            _save_records(records)
+            return None
+
+        if _is_past_action_deadline(rec, _now()):
+            rec.state = "expired"
+            records[code] = rec.to_dict()
+            _save_records(records)
+            return None
 
         if rec.state in ("denied", "approved"):
             snapshot = PendingIntervention.from_dict(rec.to_dict())
@@ -378,6 +490,11 @@ def consume_remote_decision(code: str) -> PendingIntervention | None:
             return snapshot
 
         if rec.state == "extended":
+            # Treat the absolute max deadline as a store-side invariant even
+            # for stale/tampered records. The CLI consumes this wall-clock
+            # value directly, so never hand back an overlong deadline.
+            if rec.deadline_ts > rec.max_deadline_ts:
+                rec.deadline_ts = rec.max_deadline_ts
             snapshot = PendingIntervention.from_dict(rec.to_dict())
             rec.state = "pending"
             rec.decision = None
@@ -401,9 +518,8 @@ def cleanup_expired() -> int:
         now = _now()
         to_remove = []
         for code, raw in records.items():
-            try:
-                rec = PendingIntervention.from_dict(raw)
-            except (TypeError, ValueError):
+            rec = _record_from_raw(raw)
+            if rec is None:
                 to_remove.append(code)
                 continue
             if now > rec.max_deadline_ts + GRACE_SECONDS:

--- a/hermes_cli/human_intervention_risk_explainer.py
+++ b/hermes_cli/human_intervention_risk_explainer.py
@@ -1,0 +1,217 @@
+"""Advisory risk explainer for high-risk CLI human-intervention prompts.
+
+When a high/critical-risk command needs approval, this module produces a short
+Chinese explanation of WHY it is dangerous. It uses an LLM when one is provided
+and a deterministic static fallback otherwise.
+
+This explanation is ADVISORY ONLY. It must never affect risk classification or
+approval semantics, and it must never raise: every failure path degrades to a
+static string (or empty string), so callers can use the result unconditionally.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Callable
+
+from hermes_cli.human_intervention_notifications import _redact_and_truncate
+
+# Risk levels that justify spending an LLM call on an explanation.
+_LLM_RISK_LEVELS = frozenset({"high", "critical"})
+
+# Map known pattern keys to concise Chinese danger phrases. Keys mirror the
+# pattern identifiers produced by the command risk classifier.
+_PATTERN_DANGER_PHRASES: dict[str, str] = {
+    "destructive_delete": "递归删除文件/目录，可能不可逆",
+    "rm_rf": "递归删除文件/目录，可能不可逆",
+    "git_reset": "会丢弃未提交或未跟踪的改动",
+    "git_clean": "会丢弃未提交或未跟踪的改动",
+    "chmod": "修改权限/属主，可能影响访问控制",
+    "chown": "修改权限/属主，可能影响访问控制",
+    "network_pipe_shell": "从网络下载内容直接执行，存在供应链风险",
+    "credential_edit": "修改凭据/密钥文件，可能影响认证",
+    "force_push": "强制推送会覆盖远端历史",
+    "db_drop": "删除数据库/表，数据不可恢复",
+}
+
+_GENERIC_HIGH_RISK = "此命令风险较高，可能造成不可逆或影响系统的后果，请谨慎确认。"
+
+
+def _cap(text: str, max_chars: int) -> str:
+    """Cap text to max_chars characters, using an ellipsis when truncated."""
+    value = str(text or "").strip()
+    if max_chars <= 0:
+        return ""
+    if len(value) <= max_chars:
+        return value
+    return value[: max(0, max_chars - 1)].rstrip() + "…"
+
+
+def _static_explanation(
+    *,
+    risk_level: str,
+    description: str,
+    pattern_keys: list[str] | None,
+) -> str:
+    """Build a deterministic Chinese explanation from keys + description."""
+    phrases: list[str] = []
+    seen: set[str] = set()
+    for key in pattern_keys or []:
+        phrase = _PATTERN_DANGER_PHRASES.get(str(key).strip())
+        if phrase and phrase not in seen:
+            seen.add(phrase)
+            phrases.append(phrase)
+
+    desc = str(description or "").strip()
+    normalized_level = str(risk_level or "").strip().lower()
+    is_high = normalized_level in _LLM_RISK_LEVELS
+
+    if phrases:
+        body = "；".join(phrases)
+        if desc:
+            return f"{body}（{desc}）。"
+        return f"{body}。"
+
+    if desc and is_high:
+        return f"此命令风险较高：{desc}。"
+
+    if is_high:
+        return _GENERIC_HIGH_RISK
+
+    if desc:
+        return desc
+
+    return ""
+
+
+def _build_prompt(*, redacted_command: str, description: str, risk_level: str, max_chars: int) -> str:
+    """Build a concise Chinese instruction prompt for the LLM."""
+    desc = str(description or "").strip()
+    level = str(risk_level or "").strip()
+    lines = [
+        "你是命令风险审查助手。下面是一条需要用户批准的高风险命令。",
+        f"风险级别：{level}" if level else "风险级别：高",
+    ]
+    if desc:
+        lines.append(f"命令说明：{desc}")
+    lines.append(f"命令：{redacted_command}")
+    lines.append(
+        "请用简洁中文，只说明这条命令为什么危险、可能造成什么不可逆后果。"
+        "不要建议是否批准，不要输出任何思考过程，"
+        f"不超过 {max_chars} 字。"
+    )
+    return "\n".join(lines)
+
+
+def explain_command_risk(
+    *,
+    command: str,
+    description: str = "",
+    risk_level: str = "",
+    pattern_keys: list[str] | None = None,
+    llm_fn: Callable[[str, int], str] | None = None,
+    max_chars: int = 280,
+    timeout_seconds: int = 3,
+) -> str:
+    """Return a short Chinese explanation of why a command is risky.
+
+    Advisory only — never raises and never affects approval semantics. For
+    low/medium/empty risk levels the LLM is never invoked.
+    """
+    try:
+        normalized_level = str(risk_level or "").strip().lower()
+        static = _static_explanation(
+            risk_level=risk_level,
+            description=description,
+            pattern_keys=pattern_keys,
+        )
+
+        # Only spend an LLM call for high/critical risk.
+        if llm_fn is not None and normalized_level in _LLM_RISK_LEVELS:
+            redacted_command = _redact_and_truncate(command, max_chars=max_chars)
+            prompt = _build_prompt(
+                redacted_command=redacted_command,
+                description=description,
+                risk_level=risk_level,
+                max_chars=max_chars,
+            )
+            try:
+                llm_result = llm_fn(prompt, timeout_seconds)
+            except Exception:
+                llm_result = ""
+            if isinstance(llm_result, str) and llm_result.strip():
+                return _cap(llm_result, max_chars)
+
+        return _cap(static, max_chars)
+    except Exception:
+        # Defensive: explainer must never raise.
+        return ""
+
+
+def _aux_explain(prompt: str, timeout_seconds: int) -> str:
+    """Single auxiliary-model completion for risk explanation.
+
+    Reuses the SAME aux-LLM path Hermes already uses for smart approvals:
+    tools/approval.py::_smart_approve calls ``agent.auxiliary_client.call_llm``
+    (task="approval"); we mirror that here. This function is the patch seam in
+    tests — it performs the real (network/model) call and returns the raw
+    content string. It may raise or block; default_llm_fn bounds and guards it.
+    """
+    # Imported lazily so the explainer module stays import-cheap and so the
+    # heavy openai SDK tree is only pulled when an LLM explanation is requested.
+    from agent.auxiliary_client import call_llm
+
+    response = call_llm(
+        task="approval",
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0,
+        # Explanations are short; keep the call cheap. Pass the caller's bound
+        # as the request timeout too, though we do not rely on the provider
+        # honoring it (default_llm_fn enforces a hard wall-clock bound).
+        max_tokens=256,
+        timeout=float(timeout_seconds) if timeout_seconds else None,
+    )
+    return (response.choices[0].message.content or "").strip()
+
+
+def default_llm_fn(prompt: str, timeout_seconds: int) -> str:
+    """Bounded auxiliary-model completion for risk explanation.
+
+    Returns '' on ANY failure/timeout so the caller falls back to static.
+    Hard-bounds wall time to timeout_seconds (the aux call may not honor it).
+
+    The prompt is used verbatim — explain_command_risk has already redacted
+    secrets and capped length before passing it here, so this function MUST NOT
+    add any command content of its own.
+    """
+    # Run the (possibly slow / network-bound) aux call in a worker thread and
+    # join for at most timeout_seconds. If the worker has not finished by then,
+    # we abandon it (daemon thread) and return '' so the caller never blocks
+    # longer than the bound. call_llm itself has no cancellation hook, so a
+    # hard process-side cancel is not possible; abandoning the daemon thread is
+    # the safe, bounded behavior.
+    result: dict[str, str] = {}
+
+    def _worker() -> None:
+        try:
+            text = _aux_explain(prompt, timeout_seconds)
+            if isinstance(text, str):
+                result["value"] = text
+        except Exception:
+            # Swallow ALL failures -> caller falls back to static.
+            pass
+
+    try:
+        bound = timeout_seconds if timeout_seconds and timeout_seconds > 0 else 0
+        worker = threading.Thread(
+            target=_worker, name="risk-explainer-aux", daemon=True
+        )
+        worker.start()
+        worker.join(timeout=bound if bound > 0 else None)
+        if worker.is_alive():
+            # Timed out: do not wait any longer; abandon the daemon thread.
+            return ""
+        return result.get("value", "") or ""
+    except Exception:
+        # Never raise: thread creation or join failure degrades to static.
+        return ""

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -1050,6 +1050,109 @@ class TestApprovalRemoteControl:
         assert result["value"] == "once"
         cli._rc_create_pending.assert_not_called()
 
+    def test_approval_poll_errors_do_not_abort_local_prompt(self):
+        cli = _make_cli_stub()
+        cli._remote_intervention_settings = lambda: {
+            "enabled": True,
+            "allow_deny": True,
+            "allow_extend": True,
+            "max_total_wait_minutes": 15,
+            "risk_explanation": {
+                "enabled": False,
+                "only_for_risk_levels": ["high", "critical"],
+            },
+        }
+        cli._rc_create_pending = MagicMock(
+            return_value=SimpleNamespace(code="3131")
+        )
+        cli._rc_cleanup = MagicMock(return_value=0)
+        calls = {"n": 0}
+
+        def _flaky_consume(_code):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise OSError("store temporarily unavailable")
+            return None
+
+        cli._rc_consume = MagicMock(side_effect=_flaky_consume)
+
+        result = {}
+
+        def _run_callback():
+            result["value"] = cli._approval_callback("rm -rf /tmp/x", "wipe")
+
+        with patch.object(cli_module, "_cprint"), \
+             patch.object(cli_module, "notify_human_intervention", create=True):
+            thread = threading.Thread(target=_run_callback, daemon=True)
+            thread.start()
+            self._wait_for_state(cli)
+            deadline = time.time() + 4
+            while calls["n"] < 1 and time.time() < deadline:
+                time.sleep(0.02)
+            cli._approval_state["response_queue"].put("once")
+            thread.join(timeout=3)
+
+        assert calls["n"] >= 1
+        assert not thread.is_alive()
+        assert result["value"] == "once"
+
+    def test_poll_remote_intervention_handles_store_errors(self):
+        cli = _make_cli_stub()
+        cli._rc_consume = MagicMock(side_effect=OSError("store unavailable"))
+        current_deadline = time.monotonic() + 30
+
+        signal, source, deadline = cli._poll_remote_intervention("3131", current_deadline)
+
+        assert signal is None
+        assert source == ""
+        assert deadline == current_deadline
+
+    def test_poll_remote_intervention_denies_and_extends_safely(self):
+        cli = _make_cli_stub()
+        current_deadline = time.monotonic() + 30
+        later_wall_deadline = time.time() + 120
+        cli._rc_consume = MagicMock(return_value=SimpleNamespace(
+            decision="extend",
+            decision_source="telegram",
+            deadline_ts=later_wall_deadline,
+        ))
+
+        signal, source, deadline = cli._poll_remote_intervention("3131", current_deadline)
+
+        assert signal == "extend"
+        assert source == "telegram"
+        assert deadline > current_deadline
+
+        cli._rc_consume = MagicMock(return_value=SimpleNamespace(
+            decision="deny",
+            decision_source="telegram",
+        ))
+        signal, source, deadline2 = cli._poll_remote_intervention("3131", deadline)
+        assert signal == "deny"
+        assert source == "telegram"
+        assert deadline2 == deadline
+
+    def test_poll_remote_intervention_rejects_bad_or_non_extend_decisions(self):
+        cli = _make_cli_stub()
+        current_deadline = time.monotonic() + 30
+
+        cli._rc_consume = MagicMock(return_value=SimpleNamespace(
+            decision="extend",
+            deadline_ts="not-a-number",
+        ))
+        assert cli._poll_remote_intervention("3131", current_deadline) == (
+            None, "", current_deadline
+        )
+
+        cli._rc_consume = MagicMock(return_value=SimpleNamespace(
+            decision="approve",
+            deadline_ts=time.time() + 120,
+        ))
+        assert cli._poll_remote_intervention("3131", current_deadline) == (
+            None, "", current_deadline
+        )
+
+
 
 def _make_sudo_clarify_stub():
     """CLI stub wired for sudo + clarify remote-control tests.

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -769,3 +769,871 @@ class TestClearOverlaysForInterrupt:
         assert not t.is_alive(), "worker thread never unblocked"
         assert result["value"] == "deny"
 
+
+class TestApprovalRemoteControl:
+    """Mobile deny/extend wiring for the dangerous-command approval prompt.
+
+    Approval itself stays local-only: the store only ever drives deny/extend,
+    never a remote approve.
+    """
+
+    def _wait_for_state(self, cli, timeout=3.0):
+        deadline = time.time() + timeout
+        while cli._approval_state is None and time.time() < deadline:
+            time.sleep(0.01)
+        assert cli._approval_state is not None
+
+    def test_approval_callback_accepts_remote_deny(self):
+        cli = _make_cli_stub()
+        cli._remote_intervention_settings = lambda: {
+            "enabled": True,
+            "allow_deny": True,
+            "allow_extend": True,
+            "max_total_wait_minutes": 15,
+            "risk_explanation": {
+                "enabled": False,
+                "only_for_risk_levels": ["high", "critical"],
+            },
+        }
+        cli._rc_create_pending = MagicMock(
+            return_value=SimpleNamespace(code="4242")
+        )
+        cli._rc_cleanup = MagicMock(return_value=0)
+
+        calls = {"n": 0}
+
+        def _consume(code):
+            calls["n"] += 1
+            assert code == "4242"
+            if calls["n"] < 2:
+                return None
+            return SimpleNamespace(
+                decision="deny",
+                decision_source="telegram",
+                deadline_ts=time.time() + 60,
+            )
+
+        cli._rc_consume = MagicMock(side_effect=_consume)
+
+        result = {}
+
+        def _run_callback():
+            result["value"] = cli._approval_callback("rm -rf /tmp/x", "wipe")
+
+        with patch.object(cli_module, "_cprint"), \
+             patch.object(cli_module, "notify_human_intervention", create=True):
+            thread = threading.Thread(target=_run_callback, daemon=True)
+            thread.start()
+            thread.join(timeout=4)
+
+        assert not thread.is_alive()
+        assert result["value"] == "deny"
+        cli._rc_create_pending.assert_called_once()
+
+    def test_approval_callback_remote_extend_bumps_deadline(self):
+        cli = _make_cli_stub()
+        cli._remote_intervention_settings = lambda: {
+            "enabled": True,
+            "allow_deny": True,
+            "allow_extend": True,
+            "max_total_wait_minutes": 15,
+            "risk_explanation": {
+                "enabled": False,
+                "only_for_risk_levels": ["high", "critical"],
+            },
+        }
+        cli._rc_create_pending = MagicMock(
+            return_value=SimpleNamespace(code="7777")
+        )
+        cli._rc_cleanup = MagicMock(return_value=0)
+
+        calls = {"n": 0}
+
+        def _consume(code):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return SimpleNamespace(
+                    decision="extend",
+                    decision_source="telegram",
+                    deadline_ts=time.time() + 600,
+                )
+            return None
+
+        cli._rc_consume = MagicMock(side_effect=_consume)
+
+        result = {}
+        response_queue_holder = {}
+
+        def _run_callback():
+            result["value"] = cli._approval_callback("rm -rf /tmp/x", "wipe")
+
+        with patch.object(cli_module, "_cprint"), \
+             patch.object(cli_module, "notify_human_intervention", create=True):
+            thread = threading.Thread(target=_run_callback, daemon=True)
+            thread.start()
+
+            self._wait_for_state(cli)
+            initial_deadline = cli._approval_deadline
+            response_queue_holder["q"] = cli._approval_state["response_queue"]
+
+            # Wait until the extend is consumed and the deadline bumps.
+            deadline = time.time() + 4
+            while (cli._approval_deadline <= initial_deadline + 1
+                   and time.time() < deadline):
+                time.sleep(0.02)
+
+            assert cli._approval_deadline > initial_deadline + 1, \
+                "extend should have increased the monotonic deadline"
+            # Still waiting (not returned) after the extend.
+            assert thread.is_alive()
+            assert "value" not in result
+
+            response_queue_holder["q"].put("once")
+            thread.join(timeout=3)
+
+        assert not thread.is_alive()
+        assert result["value"] == "once"
+
+    def test_local_answer_wins_over_remote(self):
+        cli = _make_cli_stub()
+        cli._remote_intervention_settings = lambda: {
+            "enabled": True,
+            "allow_deny": True,
+            "allow_extend": True,
+            "max_total_wait_minutes": 15,
+            "risk_explanation": {
+                "enabled": False,
+                "only_for_risk_levels": ["high", "critical"],
+            },
+        }
+        cli._rc_create_pending = MagicMock(
+            return_value=SimpleNamespace(code="5555")
+        )
+        cli._rc_cleanup = MagicMock(return_value=0)
+        cli._rc_consume = MagicMock(
+            return_value=SimpleNamespace(
+                decision="deny",
+                decision_source="telegram",
+                deadline_ts=time.time() + 60,
+            )
+        )
+
+        # Put the local answer on the queue BEFORE creating the prompt so the
+        # very first response_queue.get() succeeds — local must win.
+        pre_queue = queue.Queue()
+        pre_queue.put("session")
+
+        result = {}
+
+        def _run_callback():
+            result["value"] = cli._approval_callback("rm -rf /tmp/x", "wipe")
+
+        # Inject our pre-filled queue by patching queue.Queue used in the
+        # callback to hand back our prepared queue exactly once.
+        orig_queue_cls = queue.Queue
+        made = {"n": 0}
+
+        def _queue_factory(*a, **kw):
+            made["n"] += 1
+            if made["n"] == 1:
+                return pre_queue
+            return orig_queue_cls(*a, **kw)
+
+        with patch.object(cli_module, "_cprint"), \
+             patch.object(cli_module, "notify_human_intervention", create=True), \
+             patch.object(cli_module.queue, "Queue", side_effect=_queue_factory):
+            thread = threading.Thread(target=_run_callback, daemon=True)
+            thread.start()
+            thread.join(timeout=3)
+
+        assert not thread.is_alive()
+        assert result["value"] == "session"
+
+    def test_remote_approve_is_ignored(self):
+        cli = _make_cli_stub()
+        cli._remote_intervention_settings = lambda: {
+            "enabled": True,
+            "allow_deny": True,
+            "allow_extend": True,
+            "max_total_wait_minutes": 15,
+            "risk_explanation": {
+                "enabled": False,
+                "only_for_risk_levels": ["high", "critical"],
+            },
+        }
+        cli._rc_create_pending = MagicMock(
+            return_value=SimpleNamespace(code="9090")
+        )
+        cli._rc_cleanup = MagicMock(return_value=0)
+        cli._rc_consume = MagicMock(return_value=None)
+
+        captured = {}
+
+        def _capture_notify(*args, **kwargs):
+            captured.update(kwargs)
+
+        result = {}
+
+        def _run_callback():
+            result["value"] = cli._approval_callback("rm -rf /tmp/x", "wipe")
+
+        # The callback imports notify_human_intervention from its source
+        # module, so patch it there (not on cli_module).
+        import hermes_cli.human_intervention_notifications as notif_mod
+        with patch.object(cli_module, "_cprint"), \
+             patch.object(notif_mod, "notify_human_intervention",
+                          side_effect=_capture_notify):
+            thread = threading.Thread(target=_run_callback, daemon=True)
+            thread.start()
+            self._wait_for_state(cli)
+            cli._approval_state["response_queue"].put("deny")
+            thread.join(timeout=3)
+
+        assert not thread.is_alive()
+        assert result["value"] == "deny"
+        actions = captured.get("remote_actions")
+        assert actions is not None
+        assert "approve" not in actions
+        assert "deny" in actions
+
+    def test_high_risk_calls_explainer_low_risk_does_not(self):
+        cli = _make_cli_stub()
+        rc = {
+            "risk_explanation": {
+                "enabled": True,
+                "only_for_risk_levels": ["high", "critical"],
+                "max_chars": 280,
+                "timeout_seconds": 3,
+            }
+        }
+        high = cli._explain_command_risk_for_notify(
+            "rm -rf /x", "d", "high", rc
+        )
+        assert isinstance(high, str)
+        assert high != ""
+
+        low = cli._explain_command_risk_for_notify(
+            "ls -la", "d", "low", rc
+        )
+        assert low == ""
+
+    def test_remote_disabled_creates_no_pending(self):
+        cli = _make_cli_stub()
+        cli._remote_intervention_settings = lambda: {
+            "enabled": False,
+            "allow_deny": True,
+            "allow_extend": True,
+            "max_total_wait_minutes": 15,
+            "risk_explanation": {
+                "enabled": False,
+                "only_for_risk_levels": ["high", "critical"],
+            },
+        }
+        cli._rc_create_pending = MagicMock()
+        cli._rc_cleanup = MagicMock(return_value=0)
+        cli._rc_consume = MagicMock(return_value=None)
+
+        result = {}
+
+        def _run_callback():
+            result["value"] = cli._approval_callback("rm -rf /tmp/x", "wipe")
+
+        with patch.object(cli_module, "_cprint"), \
+             patch.object(cli_module, "notify_human_intervention", create=True):
+            thread = threading.Thread(target=_run_callback, daemon=True)
+            thread.start()
+            self._wait_for_state(cli)
+            cli._approval_state["response_queue"].put("once")
+            thread.join(timeout=3)
+
+        assert not thread.is_alive()
+        assert result["value"] == "once"
+        cli._rc_create_pending.assert_not_called()
+
+
+def _make_sudo_clarify_stub():
+    """CLI stub wired for sudo + clarify remote-control tests.
+
+    Adds the clarify state slots the callbacks expect and swaps the modal
+    snapshot helpers for mocks so no real prompt_toolkit app is touched.
+    """
+    cli = _make_cli_stub()
+    cli._clarify_state = None
+    cli._clarify_deadline = 0
+    cli._clarify_freetext = False
+    cli._capture_modal_input_snapshot = MagicMock()
+    cli._restore_modal_input_snapshot = MagicMock()
+    return cli
+
+
+_DENY_EXTEND_RC = {
+    "enabled": True,
+    "allow_deny": True,
+    "allow_extend": True,
+    "max_total_wait_minutes": 15,
+    "risk_explanation": {
+        "enabled": False,
+        "only_for_risk_levels": ["high", "critical"],
+    },
+}
+
+
+class TestSudoClarifyRemoteControl:
+    """Mobile deny/extend wiring for the sudo-password and clarify prompts.
+
+    HARD SAFETY: sudo must NEVER accept a password remotely (deny == cancel,
+    returns ""), and clarify must NEVER have an option chosen remotely (deny ==
+    timeout-equivalent best-judgement string). Remote can only deny or extend.
+    """
+
+    def _wait_for_sudo_state(self, cli, timeout=3.0):
+        deadline = time.time() + timeout
+        while cli._sudo_state is None and time.time() < deadline:
+            time.sleep(0.01)
+        assert cli._sudo_state is not None
+
+    def _wait_for_clarify_state(self, cli, timeout=3.0):
+        deadline = time.time() + timeout
+        while cli._clarify_state is None and time.time() < deadline:
+            time.sleep(0.01)
+        assert cli._clarify_state is not None
+
+    def test_sudo_remote_cancel_returns_empty_never_password(self):
+        cli = _make_sudo_clarify_stub()
+        cli._remote_intervention_settings = lambda: dict(_DENY_EXTEND_RC)
+        cli._rc_create_pending = MagicMock(
+            return_value=SimpleNamespace(code="5555")
+        )
+        cli._rc_cleanup = MagicMock(return_value=0)
+
+        calls = {"n": 0}
+
+        def _consume(code):
+            calls["n"] += 1
+            assert code == "5555"
+            if calls["n"] < 2:
+                return None
+            return SimpleNamespace(
+                decision="deny",
+                decision_source="telegram",
+                deadline_ts=time.time() + 45,
+            )
+
+        cli._rc_consume = MagicMock(side_effect=_consume)
+
+        result = {}
+
+        def _run_callback():
+            result["value"] = cli._sudo_password_callback()
+
+        import hermes_cli.human_intervention_notifications as notif_mod
+        with patch.object(cli_module, "_cprint"), \
+             patch.object(notif_mod, "notify_human_intervention",
+                          create=True):
+            thread = threading.Thread(target=_run_callback, daemon=True)
+            thread.start()
+            # Remote deny lands on ~2nd poll (~2s) — far before the 45s timeout.
+            thread.join(timeout=4)
+
+        assert not thread.is_alive()
+        # The cardinal guarantee: a remote cancel NEVER yields a password.
+        assert result["value"] == ""
+        cli._rc_create_pending.assert_called_once()
+        cli._restore_modal_input_snapshot.assert_called()
+
+    def test_sudo_remote_extend_bumps_deadline(self):
+        cli = _make_sudo_clarify_stub()
+        cli._remote_intervention_settings = lambda: dict(_DENY_EXTEND_RC)
+        cli._rc_create_pending = MagicMock(
+            return_value=SimpleNamespace(code="6666")
+        )
+        cli._rc_cleanup = MagicMock(return_value=0)
+
+        calls = {"n": 0}
+
+        def _consume(code):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return SimpleNamespace(
+                    decision="extend",
+                    decision_source="telegram",
+                    deadline_ts=time.time() + 600,
+                )
+            return None
+
+        cli._rc_consume = MagicMock(side_effect=_consume)
+
+        result = {}
+
+        def _run_callback():
+            result["value"] = cli._sudo_password_callback()
+
+        import hermes_cli.human_intervention_notifications as notif_mod
+        with patch.object(cli_module, "_cprint"), \
+             patch.object(notif_mod, "notify_human_intervention",
+                          create=True):
+            thread = threading.Thread(target=_run_callback, daemon=True)
+            thread.start()
+
+            self._wait_for_sudo_state(cli)
+            initial_deadline = cli._sudo_deadline
+
+            deadline = time.time() + 4
+            while (cli._sudo_deadline <= initial_deadline + 1
+                   and time.time() < deadline):
+                time.sleep(0.02)
+
+            assert cli._sudo_deadline > initial_deadline + 1, \
+                "extend should have increased the monotonic deadline"
+            assert thread.is_alive()
+            assert "value" not in result
+
+            # Finish locally with a real password — local always wins.
+            cli._sudo_state["response_queue"].put("hunter2")
+            thread.join(timeout=3)
+
+        assert not thread.is_alive()
+        assert result["value"] == "hunter2"
+
+    def test_clarify_remote_deny_returns_best_judgement(self):
+        cli = _make_sudo_clarify_stub()
+        cli._remote_intervention_settings = lambda: dict(_DENY_EXTEND_RC)
+        cli._rc_create_pending = MagicMock(
+            return_value=SimpleNamespace(code="7070")
+        )
+        cli._rc_cleanup = MagicMock(return_value=0)
+
+        calls = {"n": 0}
+
+        def _consume(code):
+            calls["n"] += 1
+            assert code == "7070"
+            if calls["n"] < 2:
+                return None
+            return SimpleNamespace(
+                decision="deny",
+                decision_source="telegram",
+                deadline_ts=time.time() + 120,
+            )
+
+        cli._rc_consume = MagicMock(side_effect=_consume)
+
+        result = {}
+
+        def _run_callback():
+            result["value"] = cli._clarify_callback("pick one", ["a", "b"])
+
+        import hermes_cli.human_intervention_notifications as notif_mod
+        with patch.object(cli_module, "_cprint"), \
+             patch.object(notif_mod, "notify_human_intervention",
+                          create=True):
+            thread = threading.Thread(target=_run_callback, daemon=True)
+            thread.start()
+            thread.join(timeout=4)
+
+        assert not thread.is_alive()
+        # Remote deny == timeout-equivalent: agent decides, NO option selected.
+        assert "best judgement" in result["value"]
+        assert result["value"] not in ("a", "b")
+        cli._rc_create_pending.assert_called_once()
+
+    def test_clarify_remote_extend_bumps_deadline(self):
+        cli = _make_sudo_clarify_stub()
+        cli._remote_intervention_settings = lambda: dict(_DENY_EXTEND_RC)
+        cli._rc_create_pending = MagicMock(
+            return_value=SimpleNamespace(code="8080")
+        )
+        cli._rc_cleanup = MagicMock(return_value=0)
+
+        calls = {"n": 0}
+
+        def _consume(code):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return SimpleNamespace(
+                    decision="extend",
+                    decision_source="telegram",
+                    deadline_ts=time.time() + 600,
+                )
+            return None
+
+        cli._rc_consume = MagicMock(side_effect=_consume)
+
+        result = {}
+
+        def _run_callback():
+            result["value"] = cli._clarify_callback("pick one", ["a", "b"])
+
+        import hermes_cli.human_intervention_notifications as notif_mod
+        with patch.object(cli_module, "_cprint"), \
+             patch.object(notif_mod, "notify_human_intervention",
+                          create=True):
+            thread = threading.Thread(target=_run_callback, daemon=True)
+            thread.start()
+
+            self._wait_for_clarify_state(cli)
+            initial_deadline = cli._clarify_deadline
+
+            deadline = time.time() + 4
+            while (cli._clarify_deadline <= initial_deadline + 1
+                   and time.time() < deadline):
+                time.sleep(0.02)
+
+            assert cli._clarify_deadline > initial_deadline + 1, \
+                "extend should have increased the monotonic deadline"
+            assert thread.is_alive()
+            assert "value" not in result
+
+            cli._clarify_state["response_queue"].put("a")
+            thread.join(timeout=3)
+
+        assert not thread.is_alive()
+        assert result["value"] == "a"
+
+    def test_sudo_remote_disabled_no_pending(self):
+        cli = _make_sudo_clarify_stub()
+        cli._remote_intervention_settings = lambda: {
+            "enabled": False,
+            "allow_deny": True,
+            "allow_extend": True,
+            "max_total_wait_minutes": 15,
+            "risk_explanation": {
+                "enabled": False,
+                "only_for_risk_levels": ["high", "critical"],
+            },
+        }
+        cli._rc_create_pending = MagicMock()
+        cli._rc_cleanup = MagicMock(return_value=0)
+        cli._rc_consume = MagicMock(return_value=None)
+
+        result = {}
+
+        def _run_callback():
+            result["value"] = cli._sudo_password_callback()
+
+        import hermes_cli.human_intervention_notifications as notif_mod
+        with patch.object(cli_module, "_cprint"), \
+             patch.object(notif_mod, "notify_human_intervention",
+                          create=True):
+            thread = threading.Thread(target=_run_callback, daemon=True)
+            thread.start()
+            self._wait_for_sudo_state(cli)
+            cli._sudo_state["response_queue"].put("pw")
+            thread.join(timeout=3)
+
+        assert not thread.is_alive()
+        assert result["value"] == "pw"
+        cli._rc_create_pending.assert_not_called()
+
+
+_APPROVE_RC = {
+    "enabled": True,
+    "allow_approve": True,
+    "approve_medium": True,
+    "approve_high_typed_confirm": True,
+    "approve_token_len": 4,
+    "allow_deny": True,
+    "allow_extend": True,
+    "max_total_wait_minutes": 15,
+    "never_approve_levels": ["critical"],
+    "risk_explanation": {
+        "enabled": False,
+        "use_llm": False,
+        "only_for_risk_levels": ["high", "critical"],
+    },
+}
+
+
+class TestApprovalRemoteApprove:
+    """Phase-2 mobile APPROVE wiring for the dangerous-command prompt.
+
+    medium → one-tap, high → typed-confirm, critical → never approvable.
+    Local answer still wins; deny/extend behaviour is unchanged.
+    """
+
+    def _wait_for_state(self, cli, timeout=3.0):
+        deadline = time.time() + timeout
+        while cli._approval_state is None and time.time() < deadline:
+            time.sleep(0.01)
+        assert cli._approval_state is not None
+
+    def test_approval_medium_remote_one_tap_returns_once(self):
+        cli = _make_cli_stub()
+        cli._remote_intervention_settings = lambda: dict(_APPROVE_RC)
+        cli._rc_create_pending = MagicMock(
+            return_value=SimpleNamespace(code="4242", approve_token="")
+        )
+        cli._rc_cleanup = MagicMock(return_value=0)
+
+        calls = {"n": 0}
+
+        def _consume(code):
+            calls["n"] += 1
+            assert code == "4242"
+            if calls["n"] < 2:
+                return None
+            return SimpleNamespace(
+                decision="approve",
+                decision_source="telegram",
+                deadline_ts=time.time() + 60,
+                approve_token="",
+            )
+
+        cli._rc_consume = MagicMock(side_effect=_consume)
+
+        result = {}
+
+        def _run_callback():
+            result["value"] = cli._approval_callback(
+                "ls", "desc", risk_level="medium"
+            )
+
+        with patch.object(cli_module, "_cprint"), \
+             patch.object(cli_module, "notify_human_intervention", create=True):
+            thread = threading.Thread(target=_run_callback, daemon=True)
+            thread.start()
+            thread.join(timeout=4)
+
+        assert not thread.is_alive()
+        assert result["value"] == "once"
+        cli._rc_create_pending.assert_called_once()
+        kwargs = cli._rc_create_pending.call_args.kwargs
+        assert kwargs.get("approve_tier") == "one_tap"
+        assert kwargs.get("risk_level") == "medium"
+
+    def test_approval_high_remote_typed_confirm_returns_once(self):
+        cli = _make_cli_stub()
+        cli._remote_intervention_settings = lambda: dict(_APPROVE_RC)
+        cli._rc_create_pending = MagicMock(
+            return_value=SimpleNamespace(code="4242", approve_token="4815")
+        )
+        cli._rc_cleanup = MagicMock(return_value=0)
+
+        calls = {"n": 0}
+
+        def _consume(code):
+            calls["n"] += 1
+            assert code == "4242"
+            if calls["n"] < 2:
+                return None
+            return SimpleNamespace(
+                decision="approve",
+                decision_source="telegram",
+                deadline_ts=time.time() + 60,
+                approve_token="4815",
+            )
+
+        cli._rc_consume = MagicMock(side_effect=_consume)
+
+        captured = {}
+
+        def _capture_notify(*args, **kwargs):
+            captured.update(kwargs)
+
+        result = {}
+
+        def _run_callback():
+            result["value"] = cli._approval_callback(
+                "rm -rf /tmp/x", "wipe", risk_level="high"
+            )
+
+        import hermes_cli.human_intervention_notifications as notif_mod
+        with patch.object(cli_module, "_cprint"), \
+             patch.object(notif_mod, "notify_human_intervention",
+                          side_effect=_capture_notify):
+            thread = threading.Thread(target=_run_callback, daemon=True)
+            thread.start()
+            thread.join(timeout=4)
+
+        assert not thread.is_alive()
+        assert result["value"] == "once"
+        cli._rc_create_pending.assert_called_once()
+        kwargs = cli._rc_create_pending.call_args.kwargs
+        assert kwargs.get("approve_tier") == "typed_confirm"
+        # The generated token flows into the notification.
+        assert captured.get("approve_tier") == "typed_confirm"
+        assert captured.get("approve_token") == "4815"
+
+    def test_compute_approve_tier_levels(self):
+        cli = _make_cli_stub()
+        rc = dict(_APPROVE_RC)
+
+        tier, never = cli._compute_approve_tier("medium", rc)
+        assert tier == "one_tap"
+        assert "critical" in never
+
+        tier, _ = cli._compute_approve_tier("high", rc)
+        assert tier == "typed_confirm"
+
+        tier, _ = cli._compute_approve_tier("critical", rc)
+        assert tier == "none"
+
+        tier, _ = cli._compute_approve_tier("low", rc)
+        assert tier == "none"
+
+        # allow_approve disabled → never approvable, regardless of level.
+        rc_off = dict(_APPROVE_RC)
+        rc_off["allow_approve"] = False
+        assert cli._compute_approve_tier("medium", rc_off)[0] == "none"
+        assert cli._compute_approve_tier("high", rc_off)[0] == "none"
+
+    def test_approval_critical_no_remote_approve(self):
+        cli = _make_cli_stub()
+        cli._remote_intervention_settings = lambda: dict(_APPROVE_RC)
+        cli._rc_create_pending = MagicMock(
+            return_value=SimpleNamespace(code="4242", approve_token="")
+        )
+        cli._rc_cleanup = MagicMock(return_value=0)
+        cli._rc_consume = MagicMock(return_value=None)
+
+        result = {}
+
+        def _run_callback():
+            result["value"] = cli._approval_callback(
+                "rm -rf /", "wipe root", risk_level="critical"
+            )
+
+        with patch.object(cli_module, "_cprint"), \
+             patch.object(cli_module, "notify_human_intervention", create=True):
+            thread = threading.Thread(target=_run_callback, daemon=True)
+            thread.start()
+            self._wait_for_state(cli)
+            cli._approval_state["response_queue"].put("deny")
+            thread.join(timeout=3)
+
+        assert not thread.is_alive()
+        assert result["value"] == "deny"
+        cli._rc_create_pending.assert_called_once()
+        kwargs = cli._rc_create_pending.call_args.kwargs
+        assert kwargs.get("approve_tier") == "none"
+
+    def test_approval_remote_deny_still_returns_deny(self):
+        cli = _make_cli_stub()
+        cli._remote_intervention_settings = lambda: dict(_APPROVE_RC)
+        cli._rc_create_pending = MagicMock(
+            return_value=SimpleNamespace(code="4242", approve_token="")
+        )
+        cli._rc_cleanup = MagicMock(return_value=0)
+
+        calls = {"n": 0}
+
+        def _consume(code):
+            calls["n"] += 1
+            if calls["n"] < 2:
+                return None
+            return SimpleNamespace(
+                decision="deny",
+                decision_source="telegram",
+                deadline_ts=time.time() + 60,
+                approve_token="",
+            )
+
+        cli._rc_consume = MagicMock(side_effect=_consume)
+
+        result = {}
+
+        def _run_callback():
+            result["value"] = cli._approval_callback(
+                "rm -rf /tmp/x", "wipe", risk_level="medium"
+            )
+
+        with patch.object(cli_module, "_cprint"), \
+             patch.object(cli_module, "notify_human_intervention", create=True):
+            thread = threading.Thread(target=_run_callback, daemon=True)
+            thread.start()
+            thread.join(timeout=4)
+
+        assert not thread.is_alive()
+        assert result["value"] == "deny"
+
+    def test_local_answer_wins_over_remote_approve(self):
+        cli = _make_cli_stub()
+        cli._remote_intervention_settings = lambda: dict(_APPROVE_RC)
+        cli._rc_create_pending = MagicMock(
+            return_value=SimpleNamespace(code="5555", approve_token="")
+        )
+        cli._rc_cleanup = MagicMock(return_value=0)
+        cli._rc_consume = MagicMock(
+            return_value=SimpleNamespace(
+                decision="approve",
+                decision_source="telegram",
+                deadline_ts=time.time() + 60,
+                approve_token="",
+            )
+        )
+
+        # Local answer queued BEFORE the prompt → first get() wins.
+        pre_queue = queue.Queue()
+        pre_queue.put("session")
+
+        result = {}
+
+        def _run_callback():
+            result["value"] = cli._approval_callback(
+                "rm -rf /tmp/x", "wipe", risk_level="medium"
+            )
+
+        orig_queue_cls = queue.Queue
+        made = {"n": 0}
+
+        def _queue_factory(*a, **kw):
+            made["n"] += 1
+            if made["n"] == 1:
+                return pre_queue
+            return orig_queue_cls(*a, **kw)
+
+        with patch.object(cli_module, "_cprint"), \
+             patch.object(cli_module, "notify_human_intervention", create=True), \
+             patch.object(cli_module.queue, "Queue", side_effect=_queue_factory):
+            thread = threading.Thread(target=_run_callback, daemon=True)
+            thread.start()
+            thread.join(timeout=3)
+
+        assert not thread.is_alive()
+        assert result["value"] == "session"
+
+    def test_explain_uses_llm_when_configured(self):
+        cli = _make_cli_stub()
+        import hermes_cli.human_intervention_risk_explainer as expl_mod
+
+        sentinel = object()
+        captured = {}
+
+        def _capture_explain(**kwargs):
+            captured.update(kwargs)
+            return "explained"
+
+        rc_on = {
+            "risk_explanation": {
+                "enabled": True,
+                "use_llm": True,
+                "only_for_risk_levels": ["high", "critical"],
+                "max_chars": 280,
+                "timeout_seconds": 3,
+            }
+        }
+        with patch.object(expl_mod, "default_llm_fn", sentinel, create=True), \
+             patch.object(expl_mod, "explain_command_risk",
+                          side_effect=_capture_explain):
+            out = cli._explain_command_risk_for_notify(
+                "rm -rf /x", "d", "high", rc_on
+            )
+        assert out == "explained"
+        assert captured.get("llm_fn") is sentinel
+
+        # use_llm False → llm_fn stays None.
+        captured.clear()
+        rc_off = {
+            "risk_explanation": {
+                "enabled": True,
+                "use_llm": False,
+                "only_for_risk_levels": ["high", "critical"],
+                "max_chars": 280,
+                "timeout_seconds": 3,
+            }
+        }
+        with patch.object(expl_mod, "default_llm_fn", sentinel, create=True), \
+             patch.object(expl_mod, "explain_command_risk",
+                          side_effect=_capture_explain):
+            cli._explain_command_risk_for_notify("rm -rf /x", "d", "high", rc_off)
+        assert captured.get("llm_fn") is None

--- a/tests/gateway/test_human_intervention_remote_control.py
+++ b/tests/gateway/test_human_intervention_remote_control.py
@@ -108,6 +108,63 @@ async def test_iv_extend_defaults_to_15():
 
 
 @pytest.mark.asyncio
+async def test_iv_extend_rejects_non_positive_minutes_before_store():
+    runner = _make_runner()
+    with patch("hermes_cli.config.load_config", return_value=_enabled_config()), \
+         patch(
+             "hermes_cli.human_intervention_remote_control.set_remote_decision",
+         ) as mock_set:
+        result = await runner._handle_intervention_command(_make_event("extend 7392 -5"))
+
+    assert mock_set.call_count == 0
+    assert "分钟" in result
+    assert "正整数" in result
+
+
+@pytest.mark.asyncio
+async def test_iv_extend_reports_max_wait_clamp():
+    runner = _make_runner()
+    with patch("hermes_cli.config.load_config", return_value=_enabled_config()), \
+         patch(
+             "hermes_cli.human_intervention_remote_control.set_remote_decision",
+             return_value=(True, "clamped", None),
+         ):
+        result = await runner._handle_intervention_command(_make_event("extend 7392 120"))
+
+    assert "已延长" in result
+    assert "最大等待上限" in result
+
+
+@pytest.mark.asyncio
+async def test_iv_extend_real_store_clamps_to_max_wait(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    import importlib
+    import hermes_cli.human_intervention_remote_control as hic
+
+    hic = importlib.reload(hic)
+    runner = _make_runner()
+    rec = hic.create_pending_intervention(
+        kind="approval",
+        title="t",
+        preview="p",
+        session_key="s",
+        timeout_seconds=60,
+        max_total_wait_minutes=2,
+        code="7392",
+    )
+
+    with patch("hermes_cli.config.load_config", return_value=_enabled_config()):
+        result = await runner._handle_intervention_command(_make_event("extend 7392 120"))
+
+    stored = hic.get_pending_intervention("7392")
+    assert "已延长" in result
+    assert "最大等待上限" in result
+    assert stored is not None
+    assert stored.deadline_ts == pytest.approx(rec.max_deadline_ts)
+    assert stored.deadline_ts <= rec.created_ts + 2 * 60
+
+
+@pytest.mark.asyncio
 async def test_iv_status_reports_state():
     runner = _make_runner()
     rec = SimpleNamespace(

--- a/tests/gateway/test_human_intervention_remote_control.py
+++ b/tests/gateway/test_human_intervention_remote_control.py
@@ -1,0 +1,268 @@
+"""Tests for the gateway /intervention (/iv) mobile commands.
+
+These commands control a REMOTE CLI human-intervention prompt by code via the
+``hermes_cli.human_intervention_remote_control`` store. They use a dedicated
+namespace to avoid colliding with the gateway's own /approve, /deny, /status
+commands (which act on in-process approvals / session state).
+
+The handler must:
+  * dispatch deny/extend/status to ``set_remote_decision`` /
+    ``get_pending_intervention``;
+  * dispatch ``approve`` (one-tap + typed-confirm) to ``set_remote_decision``,
+    while the store refuses critical/disabled tiers with a clear message;
+  * be gated by ``remote_control.enabled`` and ``allowed_targets`` config.
+"""
+
+import time
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+def _make_runner():
+    """Build a minimal GatewayRunner without running __init__.
+
+    ``_handle_intervention_command`` only reads ``event.get_command_args()``
+    and ``event.source.platform`` — no other runner state is touched.
+    """
+    from gateway.run import GatewayRunner
+
+    return object.__new__(GatewayRunner)
+
+
+def _make_event(args: str, platform_value: str = "telegram"):
+    return SimpleNamespace(
+        get_command_args=lambda: args,
+        source=SimpleNamespace(
+            platform=SimpleNamespace(value=platform_value),
+            chat_id="c",
+            user_id="u",
+        ),
+    )
+
+
+def _enabled_config(allowed_targets=None):
+    return {
+        "notifications": {
+            "human_intervention": {
+                "remote_control": {
+                    "enabled": True,
+                    "allowed_targets": allowed_targets or [],
+                }
+            }
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_iv_deny_calls_set_remote_decision_deny():
+    runner = _make_runner()
+    with patch("hermes_cli.config.load_config", return_value=_enabled_config()), \
+         patch(
+             "hermes_cli.human_intervention_remote_control.set_remote_decision",
+             return_value=(True, "ok", None),
+         ) as mock_set:
+        result = await runner._handle_intervention_command(_make_event("deny 7392"))
+
+    assert mock_set.call_count == 1
+    args, kwargs = mock_set.call_args
+    assert args[0] == "7392"
+    assert args[1] == "deny"
+    assert "source" in kwargs
+    assert "已拒绝" in result
+    assert "7392" in result
+
+
+@pytest.mark.asyncio
+async def test_iv_extend_with_minutes():
+    runner = _make_runner()
+    with patch("hermes_cli.config.load_config", return_value=_enabled_config()), \
+         patch(
+             "hermes_cli.human_intervention_remote_control.set_remote_decision",
+             return_value=(True, "ok", None),
+         ) as mock_set:
+        result = await runner._handle_intervention_command(_make_event("extend 7392 15"))
+
+    assert mock_set.call_count == 1
+    args, kwargs = mock_set.call_args
+    assert args[0] == "7392"
+    assert args[1] == "extend"
+    assert kwargs.get("minutes") == 15
+    assert "已延长" in result
+    assert "15" in result
+
+
+@pytest.mark.asyncio
+async def test_iv_extend_defaults_to_15():
+    runner = _make_runner()
+    with patch("hermes_cli.config.load_config", return_value=_enabled_config()), \
+         patch(
+             "hermes_cli.human_intervention_remote_control.set_remote_decision",
+             return_value=(True, "ok", None),
+         ) as mock_set:
+        await runner._handle_intervention_command(_make_event("extend 7392"))
+
+    args, kwargs = mock_set.call_args
+    assert kwargs.get("minutes") == 15
+
+
+@pytest.mark.asyncio
+async def test_iv_status_reports_state():
+    runner = _make_runner()
+    rec = SimpleNamespace(
+        code="7392",
+        kind="approval",
+        state="pending",
+        deadline_ts=time.time() + 45,
+    )
+    with patch("hermes_cli.config.load_config", return_value=_enabled_config()), \
+         patch(
+             "hermes_cli.human_intervention_remote_control.get_pending_intervention",
+             return_value=rec,
+         ):
+        result = await runner._handle_intervention_command(_make_event("status 7392"))
+
+    assert "7392" in result
+    assert "pending" in result
+
+
+@pytest.mark.asyncio
+async def test_iv_approve_one_tap_ok():
+    runner = _make_runner()
+    with patch("hermes_cli.config.load_config", return_value=_enabled_config()), \
+         patch(
+             "hermes_cli.human_intervention_remote_control.set_remote_decision",
+             return_value=(True, "ok", object()),
+         ) as mock_set:
+        result = await runner._handle_intervention_command(_make_event("approve 7392"))
+
+    assert mock_set.call_count == 1
+    args, kwargs = mock_set.call_args
+    assert args[0] == "7392"
+    assert args[1] == "approve"
+    assert kwargs.get("token") is None
+    assert "已批准" in result
+    assert "7392" in result
+
+
+@pytest.mark.asyncio
+async def test_iv_approve_typed_confirm_ok():
+    runner = _make_runner()
+    with patch("hermes_cli.config.load_config", return_value=_enabled_config()), \
+         patch(
+             "hermes_cli.human_intervention_remote_control.set_remote_decision",
+             return_value=(True, "ok", object()),
+         ) as mock_set:
+        result = await runner._handle_intervention_command(
+            _make_event("approve 7392 4815")
+        )
+
+    assert mock_set.call_count == 1
+    args, kwargs = mock_set.call_args
+    assert args[0] == "7392"
+    assert args[1] == "approve"
+    assert kwargs.get("token") == "4815"
+    assert "已批准" in result
+
+
+@pytest.mark.asyncio
+async def test_iv_approve_bad_token():
+    runner = _make_runner()
+    with patch("hermes_cli.config.load_config", return_value=_enabled_config()), \
+         patch(
+             "hermes_cli.human_intervention_remote_control.set_remote_decision",
+             return_value=(False, "bad_token", object()),
+         ):
+        result = await runner._handle_intervention_command(
+            _make_event("approve 7392 0000")
+        )
+
+    assert "令牌" in result
+
+
+@pytest.mark.asyncio
+async def test_iv_approve_not_allowed_critical():
+    runner = _make_runner()
+    with patch("hermes_cli.config.load_config", return_value=_enabled_config()), \
+         patch(
+             "hermes_cli.human_intervention_remote_control.set_remote_decision",
+             return_value=(False, "approve_not_allowed", object()),
+         ):
+        result = await runner._handle_intervention_command(_make_event("approve 7392"))
+
+    assert "不支持远程批准" in result
+
+
+@pytest.mark.asyncio
+async def test_iv_approve_auth_unchanged():
+    runner = _make_runner()
+    with patch(
+        "hermes_cli.config.load_config",
+        return_value=_enabled_config(allowed_targets=["telegram"]),
+    ), patch(
+        "hermes_cli.human_intervention_remote_control.set_remote_decision",
+    ) as mock_set:
+        result = await runner._handle_intervention_command(
+            _make_event("approve 7392", platform_value="discord")
+        )
+
+    assert mock_set.call_count == 0
+    assert "无权" in result
+
+
+@pytest.mark.asyncio
+async def test_iv_invalid_code_returns_error():
+    runner = _make_runner()
+    with patch("hermes_cli.config.load_config", return_value=_enabled_config()), \
+         patch(
+             "hermes_cli.human_intervention_remote_control.set_remote_decision",
+             return_value=(False, "not_found", None),
+         ):
+        result = await runner._handle_intervention_command(_make_event("deny 0000"))
+
+    assert "未找到" in result
+
+
+@pytest.mark.asyncio
+async def test_iv_disabled_returns_notice():
+    runner = _make_runner()
+    disabled = {
+        "notifications": {
+            "human_intervention": {"remote_control": {"enabled": False}}
+        }
+    }
+    with patch("hermes_cli.config.load_config", return_value=disabled), \
+         patch(
+             "hermes_cli.human_intervention_remote_control.set_remote_decision",
+         ) as mock_set:
+        result = await runner._handle_intervention_command(_make_event("deny 7392"))
+
+    assert mock_set.call_count == 0
+    assert "未启用" in result
+
+
+@pytest.mark.asyncio
+async def test_iv_unauthorized_platform():
+    runner = _make_runner()
+    with patch(
+        "hermes_cli.config.load_config",
+        return_value=_enabled_config(allowed_targets=["telegram"]),
+    ), patch(
+        "hermes_cli.human_intervention_remote_control.set_remote_decision",
+    ) as mock_set:
+        result = await runner._handle_intervention_command(
+            _make_event("deny 7392", platform_value="discord")
+        )
+
+    assert mock_set.call_count == 0
+    assert "无权" in result
+
+
+@pytest.mark.asyncio
+async def test_iv_usage_when_missing_args():
+    runner = _make_runner()
+    with patch("hermes_cli.config.load_config", return_value=_enabled_config()):
+        result = await runner._handle_intervention_command(_make_event(""))
+
+    assert "用法" in result

--- a/tests/hermes_cli/test_human_intervention_notifications.py
+++ b/tests/hermes_cli/test_human_intervention_notifications.py
@@ -1,0 +1,403 @@
+import json
+import threading
+import time
+
+
+def test_default_config_includes_disabled_human_intervention_notifications():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    cfg = DEFAULT_CONFIG["notifications"]["human_intervention"]
+
+    assert cfg["enabled"] is False
+    assert "log" in cfg["channels"]
+    assert cfg["gateway_targets"] == []
+    assert cfg["cooldown_seconds"] >= 0
+    assert cfg["command_preview_chars"] > 0
+
+
+def test_default_config_includes_remote_control_disabled():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    cfg = DEFAULT_CONFIG["notifications"]["human_intervention"]["remote_control"]
+
+    # Remote control is OFF by default and remote approval is never allowed.
+    assert cfg["enabled"] is False
+    assert cfg["allow_deny"] is True
+    assert cfg["allow_extend"] is True
+    assert cfg["allow_approve"] is False
+    assert cfg["max_total_wait_minutes"] == 15
+    assert cfg["max_extend_minutes"] == 15
+    assert isinstance(cfg["allowed_targets"], list)
+    # Phase-2 tiered-approve defaults: approve gated off, critical never approvable.
+    assert cfg["approve_medium"] is True
+    assert cfg["approve_high_typed_confirm"] is True
+    assert cfg["approve_token_len"] >= 4
+    assert "critical" in cfg["never_approve_levels"]
+    # Advisory risk explanation defaults.
+    re_cfg = cfg["risk_explanation"]
+    assert re_cfg["enabled"] is True
+    assert "high" in re_cfg["only_for_risk_levels"]
+    assert re_cfg["max_chars"] > 0
+    # LLM danger explanation defaults off (opt-in); generous wall-clock budget
+    # so a fast aux model fits without delaying the (already-painted) local panel.
+    assert re_cfg["use_llm"] is False
+    assert re_cfg["timeout_seconds"] >= 8
+
+
+def test_redact_and_truncate_masks_secret_like_command_preview():
+    from hermes_cli.human_intervention_notifications import _redact_and_truncate
+
+    text = "curl -H 'Authorization: Bearer sk-live-secret' https://example.test?api_key=abc123456789"
+
+    preview = _redact_and_truncate(text, 80)
+
+    assert "sk-live-secret" not in preview
+    assert "abc123456789" not in preview
+    assert "Bearer ***" in preview
+    assert "api_key=***" in preview
+    assert len(preview) <= 81
+
+
+def test_bell_and_log_channels_are_best_effort(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from hermes_cli import human_intervention_notifications as mod
+
+    monkeypatch.setattr(mod, "load_config", lambda: {
+        "notifications": {
+            "human_intervention": {
+                "enabled": True,
+                "channels": ["bell", "log"],
+                "gateway_targets": [],
+                "cooldown_seconds": 0,
+                "include_command_preview": True,
+                "command_preview_chars": 120,
+            }
+        }
+    })
+
+    class Stderr:
+        def __init__(self):
+            self.writes = []
+            self.flushed = False
+        def write(self, value):
+            self.writes.append(value)
+        def flush(self):
+            self.flushed = True
+
+    stderr = Stderr()
+    monkeypatch.setattr(mod.sys, "stderr", stderr)
+
+    mod.notify_human_intervention(
+        "approval",
+        "Approval needed",
+        "command: TOKEN=supersecret rm -rf /tmp/example",
+        dedupe_key="one",
+        timeout_seconds=60,
+    )
+
+    assert "\a" in stderr.writes
+    assert stderr.flushed is True
+    log_path = tmp_path / "logs" / "human-intervention.log"
+    assert log_path.exists()
+    line = log_path.read_text(encoding="utf-8").strip()
+    assert "approval" in line
+    assert "TOKEN=***" in line
+    assert "supersecret" not in line
+
+
+def test_gateway_targets_call_send_message_tool_without_blocking_on_slow_target(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from hermes_cli import human_intervention_notifications as mod
+
+    sent = []
+    monkeypatch.setattr(mod, "load_config", lambda: {
+        "notifications": {
+            "human_intervention": {
+                "enabled": True,
+                "channels": ["gateway", "log"],
+                "gateway_targets": ["telegram", "weixin"],
+                "cooldown_seconds": 0,
+                "include_command_preview": True,
+                "command_preview_chars": 120,
+            }
+        }
+    })
+
+    def fake_send_message_tool(args):
+        sent.append(args)
+        if args["target"] == "weixin":
+            time.sleep(0.2)
+        return json.dumps({"success": True})
+
+    monkeypatch.setattr(mod, "_send_gateway_message", fake_send_message_tool)
+
+    start = time.monotonic()
+    mod.notify_human_intervention(
+        "clarify",
+        "Hermes needs input",
+        "Question: deploy now?",
+        session_key="sess-1",
+        dedupe_key="clarify-1",
+        timeout_seconds=120,
+    )
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 0.15
+
+    deadline = time.monotonic() + 1
+    while len(sent) < 2 and time.monotonic() < deadline:
+        time.sleep(0.01)
+
+    assert [call["target"] for call in sent] == ["telegram", "weixin"]
+    assert all(call["action"] == "send" for call in sent)
+    assert all("请回到 CLI" in call["message"] for call in sent)
+
+
+def test_cooldown_suppresses_duplicate_notifications(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from hermes_cli import human_intervention_notifications as mod
+
+    monkeypatch.setattr(mod, "load_config", lambda: {
+        "notifications": {
+            "human_intervention": {
+                "enabled": True,
+                "channels": ["log"],
+                "gateway_targets": [],
+                "cooldown_seconds": 999,
+                "include_command_preview": True,
+                "command_preview_chars": 120,
+            }
+        }
+    })
+    mod._LAST_NOTIFIED.clear()
+
+    mod.notify_human_intervention("approval", "Title", "message", dedupe_key="same")
+    mod.notify_human_intervention("approval", "Title", "message", dedupe_key="same")
+
+    lines = (tmp_path / "logs" / "human-intervention.log").read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+
+
+class _ImmediateQueue:
+    def __init__(self, result):
+        self.result = result
+        self.calls = 0
+    def get(self, timeout=None):
+        self.calls += 1
+        return self.result
+
+
+class _QueueFactory:
+    def __init__(self, result):
+        self.queues = []
+        self.result = result
+    def __call__(self):
+        q = _ImmediateQueue(self.result)
+        self.queues.append(q)
+        return q
+
+
+def _make_cli_stub(cli_mod):
+    cli = cli_mod.HermesCLI.__new__(cli_mod.HermesCLI)
+    cli._approval_lock = threading.Lock()
+    cli._approval_state = None
+    cli._approval_deadline = 0
+    cli._sudo_state = None
+    cli._sudo_deadline = 0
+    cli._clarify_state = None
+    cli._clarify_deadline = 0
+    cli._clarify_freetext = False
+    cli._invalidate = lambda: None
+    cli._capture_modal_input_snapshot = lambda: None
+    cli._restore_modal_input_snapshot = lambda: None
+    return cli
+
+
+def test_approval_callback_notifies_once_without_changing_result(monkeypatch):
+    import cli as cli_mod
+
+    cli = _make_cli_stub(cli_mod)
+    notifications = []
+    queue_factory = _QueueFactory("once")
+
+    monkeypatch.setattr(cli_mod.queue, "Queue", queue_factory)
+    monkeypatch.setattr(cli_mod, "CLI_CONFIG", {"approvals": {"timeout": 60}})
+    monkeypatch.setattr(
+        "hermes_cli.human_intervention_notifications.notify_human_intervention",
+        lambda *args, **kwargs: notifications.append((args, kwargs)),
+    )
+
+    result = cli_mod.HermesCLI._approval_callback(cli, "rm -rf /tmp/example", "Dangerous command")
+
+    assert result == "once"
+    assert len(notifications) == 1
+    args, kwargs = notifications[0]
+    assert args[0] == "approval"
+    assert "Dangerous command" in args[2]
+    assert kwargs["timeout_seconds"] == 60
+
+
+def test_sudo_password_callback_notifies_once_without_changing_result(monkeypatch):
+    import cli as cli_mod
+
+    cli = _make_cli_stub(cli_mod)
+    notifications = []
+    queue_factory = _QueueFactory("secret-password")
+
+    monkeypatch.setattr(cli_mod.queue, "Queue", queue_factory)
+    monkeypatch.setattr(
+        "hermes_cli.human_intervention_notifications.notify_human_intervention",
+        lambda *args, **kwargs: notifications.append((args, kwargs)),
+    )
+
+    result = cli_mod.HermesCLI._sudo_password_callback(cli)
+
+    assert result == "secret-password"
+    assert len(notifications) == 1
+    args, kwargs = notifications[0]
+    assert args[0] == "sudo"
+    assert "sudo" in args[1].lower()
+    assert kwargs["timeout_seconds"] == 45
+
+
+def test_clarify_callback_notifies_once_without_changing_result(monkeypatch):
+    import cli as cli_mod
+
+    cli = _make_cli_stub(cli_mod)
+    notifications = []
+    queue_factory = _QueueFactory("Choice A")
+
+    monkeypatch.setattr(cli_mod.queue, "Queue", queue_factory)
+    monkeypatch.setattr(cli_mod, "CLI_CONFIG", {"clarify": {"timeout": 120}})
+    monkeypatch.setattr(
+        "hermes_cli.human_intervention_notifications.notify_human_intervention",
+        lambda *args, **kwargs: notifications.append((args, kwargs)),
+    )
+
+    result = cli_mod.HermesCLI._clarify_callback(cli, "Deploy now?", ["Choice A", "Choice B"])
+
+    assert result == "Choice A"
+    assert len(notifications) == 1
+    args, kwargs = notifications[0]
+    assert args[0] == "clarify"
+    assert "Deploy now?" in args[2]
+    assert kwargs["timeout_seconds"] == 120
+
+
+def test_notification_includes_remote_deny_extend_but_not_approve():
+    from hermes_cli.human_intervention_notifications import _compose_message
+
+    body = _compose_message(
+        "approval",
+        "Approval needed",
+        "rm -rf /tmp/example",
+        session_key="sess-1",
+        timeout_seconds=60,
+        remote_code="7392",
+        remote_actions=["deny", "extend", "status"],
+        risk_level="high",
+        risk_explanation="会递归删除目标目录，删除通常不可逆。",
+    )
+
+    assert "/iv deny 7392" in body
+    assert "/iv extend 7392 15" in body
+    assert "/iv status 7392" in body
+    assert "风险: high" in body
+    assert "危险解释:" in body and "递归删除" in body
+    assert "/approve" not in body
+    assert "会话: sess-1" in body
+
+
+def test_compose_message_without_new_params_is_unchanged():
+    from hermes_cli.human_intervention_notifications import _compose_message
+
+    body = _compose_message("approval", "t", "m")
+
+    assert "可远程操作:" not in body
+    assert "风险:" not in body
+    assert "危险解释:" not in body
+    assert "/deny" not in body
+    assert "/extend" not in body
+    assert "/approve" not in body
+
+
+def test_notification_medium_one_tap_approve():
+    from hermes_cli.human_intervention_notifications import _compose_message
+
+    body = _compose_message(
+        "approval",
+        "t",
+        "cmd",
+        remote_code="7392",
+        remote_actions=["deny", "extend", "status"],
+        risk_level="medium",
+        approve_tier="one_tap",
+    )
+
+    assert "/iv approve 7392" in body
+    # The approve line must be exactly '/iv approve 7392' with no trailing token.
+    approve_lines = [ln for ln in body.splitlines() if ln.startswith("/iv approve")]
+    assert approve_lines == ["/iv approve 7392"]
+    assert "/iv deny 7392" in body
+    # one_tap clarifying line present.
+    assert "仅此一次" in body
+    # The 'no remote approval' safety line must NOT be present.
+    assert "不支持远程批准" not in body
+
+
+def test_notification_high_typed_confirm_approve():
+    from hermes_cli.human_intervention_notifications import _compose_message
+
+    body = _compose_message(
+        "approval",
+        "t",
+        "cmd",
+        remote_code="7392",
+        remote_actions=["deny", "extend", "status"],
+        risk_level="high",
+        approve_tier="typed_confirm",
+        approve_token="4815",
+    )
+
+    assert "/iv approve 7392 4815" in body
+    assert "4815" in body
+    assert "/iv deny 7392" in body
+    assert "/iv extend 7392 15" in body
+    assert "/iv status 7392" in body
+    assert "不支持远程批准" not in body
+    # typed_confirm clarifying line mentions the confirmation token.
+    assert "确认令牌" in body
+
+
+def test_notification_critical_none_keeps_safety_line():
+    from hermes_cli.human_intervention_notifications import _compose_message
+
+    body = _compose_message(
+        "approval",
+        "t",
+        "cmd",
+        remote_code="7392",
+        remote_actions=["deny", "extend", "status"],
+        risk_level="critical",
+        approve_tier="none",
+    )
+
+    assert "/iv approve" not in body
+    assert "不支持远程批准" in body
+    assert "/iv deny 7392" in body
+    assert "/iv status 7392" in body
+
+
+def test_notification_no_tier_unchanged():
+    from hermes_cli.human_intervention_notifications import _compose_message
+
+    body = _compose_message(
+        "approval",
+        "t",
+        "cmd",
+        remote_code="7392",
+        remote_actions=["deny", "extend", "status"],
+    )
+
+    assert "/iv approve" not in body
+    assert "不支持远程批准" in body

--- a/tests/hermes_cli/test_human_intervention_remote_control.py
+++ b/tests/hermes_cli/test_human_intervention_remote_control.py
@@ -1,0 +1,465 @@
+"""Tests for the local pending human-intervention JSON store.
+
+These exercise hermes_cli.human_intervention_remote_control — a process-local
+store that tracks pending CLI human-intervention prompts so a mobile gateway
+command can later deny/extend them.
+
+Time is monkeypatched via the module-level ``_now`` indirection so expiry and
+cleanup behaviour is deterministic.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def hic():
+    """Import (fresh) the module under test."""
+    import hermes_cli.human_intervention_remote_control as mod
+
+    return importlib.reload(mod)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(monkeypatch, tmp_path):
+    """Point HERMES_HOME at a temp dir for every test."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+
+def test_create_pending_intervention_writes_record(hic):
+    rec = hic.create_pending_intervention(
+        kind="approval",
+        title="Run rm -rf?",
+        preview="rm -rf /tmp/foo",
+        session_key="sess-1",
+        timeout_seconds=120,
+        max_total_wait_minutes=15,
+        code="1234",
+    )
+    assert rec.code == "1234"
+    assert rec.kind == "approval"
+    assert rec.state == "pending"
+    assert rec.session_key == "sess-1"
+    assert rec.deadline_ts > rec.created_ts
+    assert rec.max_deadline_ts >= rec.deadline_ts
+
+    fetched = hic.get_pending_intervention("1234")
+    assert fetched is not None
+    assert fetched.code == "1234"
+    assert fetched.kind == "approval"
+    assert fetched.state == "pending"
+    assert fetched.session_key == "sess-1"
+    assert fetched.deadline_ts > fetched.created_ts
+    assert fetched.max_deadline_ts >= fetched.deadline_ts
+
+
+def test_create_generates_unique_4digit_code(hic):
+    rec = hic.create_pending_intervention(
+        kind="sudo",
+        title="sudo password",
+        preview="sudo apt update",
+        session_key="sess-2",
+        timeout_seconds=60,
+    )
+    assert rec.code.isdigit()
+    assert len(rec.code) == 4
+    # Round-trips through the store.
+    assert hic.get_pending_intervention(rec.code) is not None
+
+
+def test_get_missing_returns_none(hic):
+    assert hic.get_pending_intervention("9999") is None
+
+
+def test_set_remote_decision_deny_marks_denied(hic):
+    hic.create_pending_intervention(
+        kind="approval",
+        title="t",
+        preview="p",
+        session_key="s",
+        timeout_seconds=120,
+        code="2222",
+    )
+    ok, reason, rec = hic.set_remote_decision("2222", "deny", source="mobile")
+    assert ok is True
+    assert reason == "ok"
+    assert rec is not None
+    assert rec.state == "denied"
+    assert rec.decision == "deny"
+    assert rec.decision_ts is not None
+    assert rec.decision_source == "mobile"
+
+    stored = hic.get_pending_intervention("2222")
+    assert stored.state == "denied"
+
+
+def test_set_remote_decision_not_found(hic):
+    ok, reason, rec = hic.set_remote_decision("0000", "deny")
+    assert ok is False
+    assert reason == "not_found"
+    assert rec is None
+
+
+def test_set_remote_decision_extend_bounded(hic):
+    rec = hic.create_pending_intervention(
+        kind="approval",
+        title="t",
+        preview="p",
+        session_key="s",
+        timeout_seconds=60,
+        max_total_wait_minutes=15,
+        code="3333",
+    )
+    created = rec.created_ts
+    base_deadline = rec.deadline_ts
+    max_deadline = rec.max_deadline_ts
+
+    # Extend by 5 minutes — stays under max.
+    ok, reason, r1 = hic.set_remote_decision("3333", "extend", minutes=5)
+    assert ok is True
+    assert reason in ("ok", "clamped")
+    assert r1.state == "extended"
+    assert r1.decision == "extend"
+    assert r1.deadline_ts == pytest.approx(base_deadline + 5 * 60)
+    assert r1.deadline_ts <= max_deadline
+
+    # Extend by a huge amount — must clamp to max_deadline_ts.
+    ok, reason, r2 = hic.set_remote_decision("3333", "extend", minutes=120)
+    assert ok is True
+    assert r2.deadline_ts == pytest.approx(max_deadline)
+    assert r2.deadline_ts <= max_deadline
+    # Sanity: max is created + 15 minutes.
+    assert max_deadline == pytest.approx(created + 15 * 60)
+
+
+def test_expired_token_cannot_be_denied(hic, monkeypatch):
+    hic.create_pending_intervention(
+        kind="approval",
+        title="t",
+        preview="p",
+        session_key="s",
+        timeout_seconds=60,
+        code="4444",
+    )
+    # Jump far into the future so the deadline + grace is well past.
+    base = hic._now()
+    monkeypatch.setattr(hic, "_now", lambda: base + 10_000)
+
+    ok, reason, rec = hic.set_remote_decision("4444", "deny")
+    assert ok is False
+    assert reason == "expired"
+    assert rec is not None  # record still returned for context
+
+
+def test_approve_action_rejected(hic):
+    hic.create_pending_intervention(
+        kind="approval",
+        title="t",
+        preview="p",
+        session_key="s",
+        timeout_seconds=120,
+        code="5555",
+    )
+    ok, reason, rec = hic.set_remote_decision("5555", "approve")
+    assert ok is False
+    # Phase-2: with no approve tier configured, approve is rejected.
+    assert reason in ("action_not_allowed", "approve_disabled", "approve_not_allowed")
+
+
+def test_action_not_allowed_when_restricted(hic):
+    hic.create_pending_intervention(
+        kind="approval",
+        title="t",
+        preview="p",
+        session_key="s",
+        timeout_seconds=120,
+        code="6666",
+        allowed_actions=["extend"],
+    )
+    ok, reason, rec = hic.set_remote_decision("6666", "deny")
+    assert ok is False
+    assert reason == "action_not_allowed"
+
+    ok2, reason2, rec2 = hic.set_remote_decision("6666", "extend", minutes=3)
+    assert ok2 is True
+    assert rec2.state == "extended"
+
+
+def test_consume_remote_decision_deny_then_resolved(hic):
+    hic.create_pending_intervention(
+        kind="approval",
+        title="t",
+        preview="p",
+        session_key="s",
+        timeout_seconds=120,
+        code="7777",
+    )
+    hic.set_remote_decision("7777", "deny", source="mobile")
+
+    consumed = hic.consume_remote_decision("7777")
+    assert consumed is not None
+    assert consumed.decision == "deny"
+
+    stored = hic.get_pending_intervention("7777")
+    assert stored.state == "resolved"
+
+    # Second consume yields no actionable decision.
+    again = hic.consume_remote_decision("7777")
+    assert again is None or again.state == "resolved"
+
+
+def test_consume_remote_decision_extend_resets_to_pending(hic):
+    rec = hic.create_pending_intervention(
+        kind="approval",
+        title="t",
+        preview="p",
+        session_key="s",
+        timeout_seconds=60,
+        max_total_wait_minutes=15,
+        code="8888",
+    )
+    base_deadline = rec.deadline_ts
+    hic.set_remote_decision("8888", "extend", minutes=5)
+
+    consumed = hic.consume_remote_decision("8888")
+    assert consumed is not None
+    assert consumed.decision == "extend"
+    assert consumed.deadline_ts == pytest.approx(base_deadline + 5 * 60)
+
+    stored = hic.get_pending_intervention("8888")
+    assert stored.state == "pending"
+    assert stored.decision is None
+    # The extended deadline is preserved after reset.
+    assert stored.deadline_ts == pytest.approx(base_deadline + 5 * 60)
+
+
+def test_consume_pending_returns_none(hic):
+    hic.create_pending_intervention(
+        kind="approval",
+        title="t",
+        preview="p",
+        session_key="s",
+        timeout_seconds=120,
+        code="1212",
+    )
+    # No decision yet → nothing to consume.
+    assert hic.consume_remote_decision("1212") is None
+
+
+def test_cleanup_expired_removes_old(hic, monkeypatch):
+    hic.create_pending_intervention(
+        kind="approval",
+        title="t",
+        preview="p",
+        session_key="s",
+        timeout_seconds=60,
+        max_total_wait_minutes=15,
+        code="9090",
+    )
+    base = hic._now()
+    # Jump past max_deadline_ts + grace.
+    monkeypatch.setattr(hic, "_now", lambda: base + 15 * 60 + 1000)
+
+    removed = hic.cleanup_expired()
+    assert removed >= 1
+    assert hic.get_pending_intervention("9090") is None
+
+
+# ---------------------------------------------------------------------------
+# Phase-2: tiered remote approve (one_tap / typed_confirm token)
+# ---------------------------------------------------------------------------
+
+
+def test_create_typed_confirm_generates_token(hic):
+    rec = hic.create_pending_intervention(
+        kind="approval",
+        title="t",
+        preview="p",
+        session_key="s",
+        timeout_seconds=120,
+        code="1001",
+        approve_tier="typed_confirm",
+    )
+    assert rec.approve_tier == "typed_confirm"
+    assert rec.approve_token.isdigit()
+    assert len(rec.approve_token) == hic.DEFAULT_APPROVE_TOKEN_LEN == 4
+    assert rec.approve_token != rec.code
+
+    # Token is persisted and survives a reload through the store.
+    fetched = hic.get_pending_intervention("1001")
+    assert fetched is not None
+    assert fetched.approve_token == rec.approve_token
+    assert fetched.approve_tier == "typed_confirm"
+
+
+def test_create_one_tap_no_token(hic):
+    rec = hic.create_pending_intervention(
+        kind="approval",
+        title="t",
+        preview="p",
+        session_key="s",
+        timeout_seconds=120,
+        code="1002",
+        approve_tier="one_tap",
+    )
+    assert rec.approve_tier == "one_tap"
+    assert rec.approve_token == ""
+
+    fetched = hic.get_pending_intervention("1002")
+    assert fetched.approve_token == ""
+    assert fetched.approve_tier == "one_tap"
+
+
+def test_approve_one_tap_succeeds_without_token(hic):
+    hic.create_pending_intervention(
+        kind="approval",
+        title="t",
+        preview="p",
+        session_key="s",
+        timeout_seconds=120,
+        code="1003",
+        approve_tier="one_tap",
+    )
+    ok, reason, rec = hic.set_remote_decision("1003", "approve", source="mobile")
+    assert ok is True
+    assert reason == "ok"
+    assert rec is not None
+    assert rec.state == "approved"
+    assert rec.decision == "approve"
+    assert rec.decision_ts is not None
+    assert rec.decision_source == "mobile"
+
+    stored = hic.get_pending_intervention("1003")
+    assert stored.state == "approved"
+
+
+def test_approve_typed_confirm_requires_correct_token(hic):
+    rec = hic.create_pending_intervention(
+        kind="approval",
+        title="t",
+        preview="p",
+        session_key="s",
+        timeout_seconds=120,
+        code="1004",
+        approve_tier="typed_confirm",
+    )
+    good_token = rec.approve_token
+
+    # Wrong token is rejected.
+    ok, reason, _ = hic.set_remote_decision("1004", "approve", token="0000"
+                                            if good_token != "0000" else "1111")
+    assert ok is False
+    assert reason == "bad_token"
+
+    # Missing token is rejected.
+    ok, reason, _ = hic.set_remote_decision("1004", "approve")
+    assert ok is False
+    assert reason == "bad_token"
+
+    # Correct token succeeds.
+    ok, reason, r = hic.set_remote_decision("1004", "approve", token=good_token)
+    assert ok is True
+    assert reason == "ok"
+    assert r.state == "approved"
+    assert r.decision == "approve"
+
+
+def test_approve_tier_none_rejected(hic):
+    hic.create_pending_intervention(
+        kind="approval",
+        title="t",
+        preview="p",
+        session_key="s",
+        timeout_seconds=120,
+        code="1005",
+    )
+    ok, reason, rec = hic.set_remote_decision("1005", "approve")
+    assert ok is False
+    assert reason == "approve_not_allowed"
+    assert rec is not None
+
+
+def test_consume_approve_is_terminal(hic):
+    hic.create_pending_intervention(
+        kind="approval",
+        title="t",
+        preview="p",
+        session_key="s",
+        timeout_seconds=120,
+        code="1006",
+        approve_tier="one_tap",
+    )
+    ok, _reason, _rec = hic.set_remote_decision("1006", "approve", source="mobile")
+    assert ok is True
+
+    consumed = hic.consume_remote_decision("1006")
+    assert consumed is not None
+    assert consumed.decision == "approve"
+
+    stored = hic.get_pending_intervention("1006")
+    assert stored.state == "resolved"
+
+    # Second consume yields no actionable decision (approve is one-shot).
+    again = hic.consume_remote_decision("1006")
+    assert again is None or again.state == "resolved"
+
+
+def test_deny_extend_unchanged(hic):
+    # Deny still resolves to denied.
+    hic.create_pending_intervention(
+        kind="approval",
+        title="t",
+        preview="p",
+        session_key="s",
+        timeout_seconds=120,
+        code="1007",
+    )
+    ok, reason, rec = hic.set_remote_decision("1007", "deny", source="mobile")
+    assert ok is True
+    assert reason == "ok"
+    assert rec.state == "denied"
+    assert rec.decision == "deny"
+
+    # Extend still bumps the deadline and the consume resets to pending.
+    rec2 = hic.create_pending_intervention(
+        kind="approval",
+        title="t",
+        preview="p",
+        session_key="s",
+        timeout_seconds=60,
+        max_total_wait_minutes=15,
+        code="1008",
+    )
+    base_deadline = rec2.deadline_ts
+    ok, reason, r1 = hic.set_remote_decision("1008", "extend", minutes=5)
+    assert ok is True
+    assert r1.state == "extended"
+    assert r1.deadline_ts == pytest.approx(base_deadline + 5 * 60)
+
+    consumed = hic.consume_remote_decision("1008")
+    assert consumed.decision == "extend"
+    stored = hic.get_pending_intervention("1008")
+    assert stored.state == "pending"
+    assert stored.decision is None
+
+
+def test_expired_approve_rejected(hic, monkeypatch):
+    hic.create_pending_intervention(
+        kind="approval",
+        title="t",
+        preview="p",
+        session_key="s",
+        timeout_seconds=60,
+        code="1009",
+        approve_tier="one_tap",
+    )
+    base = hic._now()
+    monkeypatch.setattr(hic, "_now", lambda: base + 10_000)
+
+    ok, reason, rec = hic.set_remote_decision("1009", "approve")
+    assert ok is False
+    assert reason == "expired"
+    assert rec is not None

--- a/tests/hermes_cli/test_human_intervention_remote_control.py
+++ b/tests/hermes_cli/test_human_intervention_remote_control.py
@@ -638,3 +638,150 @@ def test_expired_approve_rejected(hic, monkeypatch):
     assert ok is False
     assert reason == "expired"
     assert rec is not None
+
+
+def _worker_extend(args):
+    """Multiprocessing worker that extends an intervention record.
+
+    Must be module-level for pickling in multiprocessing.
+    """
+    code, worker_id, iterations, hermes_home = args
+    import os
+    import time
+    os.environ["HERMES_HOME"] = hermes_home
+    # Fresh import in subprocess
+    from hermes_cli.human_intervention_remote_control import set_remote_decision
+
+    for i in range(iterations):
+        ok, reason, _ = set_remote_decision(
+            code, "extend", minutes=1, source=f"worker-{worker_id}-{i}"
+        )
+        # All extends should succeed (or be clamped, but not lost)
+        assert ok or reason == "clamped", f"worker {worker_id} iter {i} failed: {reason}"
+        time.sleep(0.001)  # Small delay to increase race window
+
+
+def test_multiprocessing_race_no_lost_updates(hic, tmp_path):
+    """Regression: concurrent CLI and gateway processes must not lose updates.
+
+    This test spawns multiple processes that race to update the same
+    intervention record. With proper file locking, all updates are serialized
+    and no writes are lost. Without locking, os.replace() races can silently
+    drop updates (last write wins, clobbering intermediate states).
+    """
+    import multiprocessing
+
+    # Create a shared intervention record
+    rec = hic.create_pending_intervention(
+        kind="approval",
+        title="race test",
+        preview="multiprocess",
+        session_key="test",
+        timeout_seconds=300,
+        code="9999",
+    )
+    assert rec.code == "9999"
+
+    num_workers = 4
+    iterations_per_worker = 5
+    processes = []
+
+    for i in range(num_workers):
+        p = multiprocessing.Process(
+            target=_worker_extend,
+            args=(("9999", i, iterations_per_worker, str(tmp_path)),)
+        )
+        p.start()
+        processes.append(p)
+
+    for p in processes:
+        p.join(timeout=10)
+        assert not p.is_alive(), "worker process hung"
+        assert p.exitcode == 0, f"worker process failed with code {p.exitcode}"
+
+    # Verify the record still exists and has consistent state
+    final = hic.get_pending_intervention("9999")
+    assert final is not None, "record was lost during concurrent updates"
+    assert final.code == "9999"
+    # The deadline should have been extended (exact value depends on race
+    # ordering and clamping, but it should be > original)
+    assert final.deadline_ts > rec.deadline_ts
+
+
+def test_max_extend_minutes_enforced(hic):
+    """Test that max_extend_minutes cap is enforced when provided."""
+    hic.create_pending_intervention(
+        kind="approval",
+        title="t",
+        preview="p",
+        session_key="s",
+        timeout_seconds=120,
+        code="8888",
+    )
+
+    # Attempt to extend by 30 minutes with a 15-minute cap
+    ok, reason, rec = hic.set_remote_decision(
+        "8888", "extend", minutes=30, max_extend_minutes=15
+    )
+    assert ok is False
+    assert reason == "exceeds_max_extend"
+
+    # Extend by exactly the cap should succeed
+    ok, reason, rec = hic.set_remote_decision(
+        "8888", "extend", minutes=15, max_extend_minutes=15
+    )
+    assert ok is True
+
+    # Extend without cap should succeed (clamped by max_deadline_ts only)
+    hic.create_pending_intervention(
+        kind="approval",
+        title="t",
+        preview="p",
+        session_key="s",
+        timeout_seconds=120,
+        code="7777",
+    )
+    ok, reason, rec = hic.set_remote_decision(
+        "7777", "extend", minutes=30, max_extend_minutes=None
+    )
+    assert ok is True  # May be clamped but not rejected
+
+
+def test_approve_token_len_wired(hic):
+    """Test that approve_token_len config is used for typed_confirm tokens."""
+    rec = hic.create_pending_intervention(
+        kind="approval",
+        title="t",
+        preview="p",
+        session_key="s",
+        timeout_seconds=120,
+        code="6666",
+        approve_tier="typed_confirm",
+        approve_token_len=6,
+    )
+    assert rec.approve_tier == "typed_confirm"
+    assert rec.approve_token.isdigit()
+    assert len(rec.approve_token) == 6
+    assert rec.approve_token != rec.code
+
+
+def test_empty_allowed_actions_disables_deny_and_extend(hic):
+    """Test that [] as allowed_actions disables both deny and extend remotely."""
+    hic.create_pending_intervention(
+        kind="approval",
+        title="t",
+        preview="p",
+        session_key="s",
+        timeout_seconds=120,
+        code="5555",
+        allowed_actions=[],  # Explicit empty list
+    )
+
+    # Both deny and extend should be rejected
+    ok, reason, rec = hic.set_remote_decision("5555", "deny")
+    assert ok is False
+    assert reason == "action_not_allowed"
+
+    ok, reason, rec = hic.set_remote_decision("5555", "extend", minutes=5)
+    assert ok is False
+    assert reason == "action_not_allowed"

--- a/tests/hermes_cli/test_human_intervention_remote_control.py
+++ b/tests/hermes_cli/test_human_intervention_remote_control.py
@@ -135,6 +135,181 @@ def test_set_remote_decision_extend_bounded(hic):
     assert max_deadline == pytest.approx(created + 15 * 60)
 
 
+def test_create_clamps_initial_deadline_to_max_total_wait(hic, monkeypatch):
+    base = 1_000_000.0
+    monkeypatch.setattr(hic, "_now", lambda: base)
+
+    rec = hic.create_pending_intervention(
+        kind="approval",
+        title="t",
+        preview="p",
+        session_key="s",
+        timeout_seconds=10 * 60,
+        max_total_wait_minutes=2,
+        code="3334",
+    )
+
+    assert rec.max_deadline_ts == pytest.approx(base + 2 * 60)
+    assert rec.deadline_ts == pytest.approx(rec.max_deadline_ts)
+
+
+def test_extend_rejects_non_positive_minutes(hic):
+    rec = hic.create_pending_intervention(
+        kind="approval",
+        title="t",
+        preview="p",
+        session_key="s",
+        timeout_seconds=60,
+        max_total_wait_minutes=15,
+        code="3335",
+    )
+
+    for minutes in (0, -5):
+        ok, reason, updated = hic.set_remote_decision(
+            "3335", "extend", minutes=minutes
+        )
+        assert ok is False
+        assert reason == "invalid_minutes"
+        assert updated is not None
+        assert updated.deadline_ts == pytest.approx(rec.deadline_ts)
+
+
+def test_remote_actions_rejected_after_max_total_wait_even_if_deadline_tampered(hic, monkeypatch):
+    rec = hic.create_pending_intervention(
+        kind="approval",
+        title="t",
+        preview="p",
+        session_key="s",
+        timeout_seconds=60,
+        max_total_wait_minutes=1,
+        code="3336",
+        approve_tier="one_tap",
+    )
+    records = hic._load_records()
+    records["3336"]["deadline_ts"] = rec.max_deadline_ts + 24 * 60 * 60
+    hic._save_records(records)
+
+    monkeypatch.setattr(
+        hic, "_now", lambda: rec.max_deadline_ts + hic.GRACE_SECONDS + 1
+    )
+
+    ok, reason, _ = hic.set_remote_decision("3336", "deny")
+    assert ok is False
+    assert reason == "expired"
+
+    ok, reason, _ = hic.set_remote_decision("3336", "approve")
+    assert ok is False
+    assert reason == "expired"
+
+
+def test_malformed_record_does_not_crash_decision_or_consume(hic):
+    hic._save_records({"3337": {"code": "3337", "state": "pending"}})
+
+    ok, reason, rec = hic.set_remote_decision("3337", "deny")
+
+    assert ok is False
+    assert reason == "not_found"
+    assert rec is None
+    assert hic.consume_remote_decision("3337") is None
+
+
+def test_bad_typed_record_does_not_crash_decision_consume_or_cleanup(hic):
+    hic._save_records({
+        "3338": {
+            "code": "3338",
+            "kind": "approval",
+            "title": "t",
+            "preview": "p",
+            "session_key": "s",
+            "state": "extended",
+            "created_ts": 1_000_000.0,
+            "deadline_ts": "not-a-number",
+            "max_deadline_ts": 1_000_120.0,
+            "decision": "extend",
+        }
+    })
+
+    ok, reason, rec = hic.set_remote_decision("3338", "deny")
+
+    assert ok is False
+    assert reason == "not_found"
+    assert rec is None
+    assert hic.consume_remote_decision("3338") is None
+
+    hic._save_records({
+        "3338b": {
+            "code": "3338b",
+            "kind": "approval",
+            "title": "t",
+            "preview": "p",
+            "session_key": "s",
+            "state": "extended",
+            "created_ts": 1_000_000.0,
+            "deadline_ts": "not-a-number",
+            "max_deadline_ts": 1_000_120.0,
+            "decision": "extend",
+        }
+    })
+    assert hic.cleanup_expired() == 1
+
+
+def test_consume_clamps_tampered_extended_deadline_to_max(hic, monkeypatch):
+    rec = hic.create_pending_intervention(
+        kind="approval",
+        title="t",
+        preview="p",
+        session_key="s",
+        timeout_seconds=60,
+        max_total_wait_minutes=2,
+        code="3339",
+    )
+    records = hic._load_records()
+    records["3339"].update({
+        "state": "extended",
+        "decision": "extend",
+        "deadline_ts": rec.max_deadline_ts + 24 * 60 * 60,
+    })
+    hic._save_records(records)
+    monkeypatch.setattr(hic, "_now", lambda: rec.created_ts + 30)
+
+    consumed = hic.consume_remote_decision("3339")
+
+    assert consumed is not None
+    assert consumed.decision == "extend"
+    assert consumed.deadline_ts == pytest.approx(rec.max_deadline_ts)
+    stored = hic.get_pending_intervention("3339")
+    assert stored is not None
+    assert stored.state == "pending"
+    assert stored.deadline_ts == pytest.approx(rec.max_deadline_ts)
+
+
+def test_consume_rejects_decision_after_max_total_wait(hic, monkeypatch):
+    rec = hic.create_pending_intervention(
+        kind="approval",
+        title="t",
+        preview="p",
+        session_key="s",
+        timeout_seconds=60,
+        max_total_wait_minutes=1,
+        code="3340",
+    )
+    records = hic._load_records()
+    records["3340"].update({
+        "state": "extended",
+        "decision": "extend",
+        "deadline_ts": rec.max_deadline_ts + 24 * 60 * 60,
+    })
+    hic._save_records(records)
+    monkeypatch.setattr(
+        hic, "_now", lambda: rec.max_deadline_ts + hic.GRACE_SECONDS + 1
+    )
+
+    assert hic.consume_remote_decision("3340") is None
+    stored = hic.get_pending_intervention("3340")
+    assert stored is not None
+    assert stored.state == "expired"
+
+
 def test_expired_token_cannot_be_denied(hic, monkeypatch):
     hic.create_pending_intervention(
         kind="approval",

--- a/tests/hermes_cli/test_human_intervention_risk_explainer.py
+++ b/tests/hermes_cli/test_human_intervention_risk_explainer.py
@@ -1,0 +1,214 @@
+"""Tests for the bounded high-risk command risk explainer.
+
+The explainer is advisory only: it must never affect risk classification or
+approval semantics, and must never raise. It produces a short Chinese
+explanation of WHY a command is dangerous, using an LLM when available and a
+deterministic static fallback otherwise.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+from hermes_cli.human_intervention_risk_explainer import (
+    default_llm_fn,
+    explain_command_risk,
+)
+
+# Module path used as the patch seam for the auxiliary-model call. The real
+# _aux_explain wraps agent.auxiliary_client.call_llm (the same helper that
+# tools/approval.py::_smart_approve uses for smart approvals).
+_AUX_SEAM = "hermes_cli.human_intervention_risk_explainer._aux_explain"
+
+
+def test_high_risk_command_uses_llm_explanation_with_static_fallback():
+    recorded: dict[str, object] = {}
+
+    def fake_llm(prompt: str, timeout_seconds: int) -> str:
+        recorded["prompt"] = prompt
+        recorded["timeout"] = timeout_seconds
+        return "会递归删除目标目录，路径变量错误时可能扩大删除范围；删除通常不可逆。"
+
+    result = explain_command_risk(
+        command="rm -rf /tmp/example TOKEN=supersecret",
+        description="Dangerous command",
+        risk_level="high",
+        llm_fn=fake_llm,
+        max_chars=280,
+    )
+
+    assert "递归删除" in result
+    assert "supersecret" not in recorded["prompt"]
+
+
+def test_low_risk_does_not_call_llm():
+    calls: list[tuple[str, int]] = []
+
+    def fake_llm(prompt: str, timeout_seconds: int) -> str:
+        calls.append((prompt, timeout_seconds))
+        return "should not be used"
+
+    result = explain_command_risk(
+        command="ls -la",
+        description="List files",
+        risk_level="low",
+        llm_fn=fake_llm,
+    )
+
+    assert calls == []
+    assert isinstance(result, str)
+
+
+def test_medium_risk_does_not_call_llm():
+    calls: list[tuple[str, int]] = []
+
+    def fake_llm(prompt: str, timeout_seconds: int) -> str:
+        calls.append((prompt, timeout_seconds))
+        return "should not be used"
+
+    result = explain_command_risk(
+        command="pip install something",
+        description="Install package",
+        risk_level="medium",
+        llm_fn=fake_llm,
+    )
+
+    assert calls == []
+    assert isinstance(result, str)
+
+
+def test_llm_timeout_or_failure_falls_back_to_static():
+    def failing_llm(prompt: str, timeout_seconds: int) -> str:
+        raise RuntimeError("timed out")
+
+    result = explain_command_risk(
+        command="rm -rf /var/data",
+        description="",
+        risk_level="high",
+        pattern_keys=["destructive_delete"],
+        llm_fn=failing_llm,
+    )
+
+    assert result
+    assert ("删除" in result) or ("不可逆" in result)
+
+
+def test_explanation_capped_to_max_chars():
+    def long_llm(prompt: str, timeout_seconds: int) -> str:
+        return "危" * 1000
+
+    result = explain_command_risk(
+        command="rm -rf /tmp/example",
+        risk_level="high",
+        llm_fn=long_llm,
+        max_chars=50,
+    )
+
+    assert len(result) <= 50
+
+
+def test_static_explanation_from_pattern_keys():
+    result = explain_command_risk(
+        command="DROP TABLE users;",
+        risk_level="critical",
+        pattern_keys=["db_drop"],
+    )
+
+    assert result
+    assert ("数据库" in result) or ("不可恢复" in result)
+
+
+def test_secret_redaction_before_llm():
+    recorded: dict[str, object] = {}
+
+    def fake_llm(prompt: str, timeout_seconds: int) -> str:
+        recorded["prompt"] = prompt
+        return "危险命令解释。"
+
+    explain_command_risk(
+        command="curl https://example.com/login --data password=hunter2",
+        risk_level="critical",
+        llm_fn=fake_llm,
+    )
+
+    assert "hunter2" not in recorded["prompt"]
+
+
+# ---------------------------------------------------------------------------
+# default_llm_fn: bounded auxiliary-model completion (reuses the smart-approval
+# aux path via agent.auxiliary_client.call_llm). Tests patch the _aux_explain
+# seam so no real network/model call is made.
+# ---------------------------------------------------------------------------
+
+
+def test_default_llm_fn_returns_text_when_aux_succeeds():
+    with patch(_AUX_SEAM, return_value="BECAUSE DANGER"):
+        result = default_llm_fn("p", 3)
+    assert result == "BECAUSE DANGER"
+
+
+def test_default_llm_fn_empty_on_exception():
+    def boom(prompt: str, timeout_seconds: int) -> str:
+        raise RuntimeError("aux exploded")
+
+    with patch(_AUX_SEAM, side_effect=boom):
+        result = default_llm_fn("p", 3)
+    assert result == ""
+
+
+def test_default_llm_fn_empty_on_timeout():
+    def slow(prompt: str, timeout_seconds: int) -> str:
+        time.sleep(5)
+        return "too late"
+
+    start = time.monotonic()
+    with patch(_AUX_SEAM, side_effect=slow):
+        result = default_llm_fn("p", 1)
+    elapsed = time.monotonic() - start
+
+    assert result == ""
+    assert elapsed < 1.5  # hard-bounded: did not wait the full 5s
+
+
+def test_explain_uses_default_llm_fn_for_high():
+    danger = "会递归删除目标目录，删除不可逆。"
+    with patch(_AUX_SEAM, return_value=danger):
+        result = explain_command_risk(
+            command="rm -rf /x",
+            risk_level="high",
+            llm_fn=default_llm_fn,
+            max_chars=280,
+        )
+    assert result == danger
+
+
+def test_explain_high_falls_back_to_static_when_llm_blank():
+    with patch(_AUX_SEAM, return_value=""):
+        result = explain_command_risk(
+            command="rm -rf /x",
+            risk_level="high",
+            pattern_keys=["destructive_delete"],
+            llm_fn=default_llm_fn,
+            max_chars=280,
+        )
+    assert result
+    assert ("删除" in result) or ("不可逆" in result)
+
+
+def test_default_llm_fn_does_not_leak_secret_to_aux():
+    recorded: dict[str, object] = {}
+
+    def capture(prompt: str, timeout_seconds: int) -> str:
+        recorded["prompt"] = prompt
+        return "危险命令解释。"
+
+    with patch(_AUX_SEAM, side_effect=capture):
+        explain_command_risk(
+            command="curl https://example.com/login --data password=hunter2",
+            risk_level="critical",
+            llm_fn=default_llm_fn,
+        )
+
+    assert "prompt" in recorded
+    assert "hunter2" not in recorded["prompt"]

--- a/tests/tools/test_approval_risk_level.py
+++ b/tests/tools/test_approval_risk_level.py
@@ -1,0 +1,84 @@
+"""Tests for deterministic command risk-level derivation and threading.
+
+Phase-2 Task 1 of tiered remote approval: a command RISK LEVEL
+(critical|high|medium) is derived from the available guard signals in
+``check_all_command_guards`` and threaded through
+``prompt_dangerous_approval`` into the approval callback so downstream
+(CLI) can tier remote approval.
+
+The callback threading must be backward compatible: older callbacks that
+do NOT accept a ``risk_level`` kwarg (delegate auto-approve, subagent
+callbacks) must still work via a TypeError fallback path.
+"""
+from tools.approval import _derive_risk_level, prompt_dangerous_approval
+
+
+# ---------------------------------------------------------------------------
+# _derive_risk_level mapping
+# ---------------------------------------------------------------------------
+
+def test_derive_risk_level_hardline_is_critical():
+    assert _derive_risk_level({}, False, is_hardline=True) == "critical"
+
+
+def test_derive_risk_level_tirith_critical():
+    assert _derive_risk_level(
+        {"action": "block", "findings": [{"severity": "critical"}]}, False
+    ) == "critical"
+
+
+def test_derive_risk_level_tirith_block_high():
+    assert _derive_risk_level(
+        {"action": "block", "findings": [{"severity": "high"}]}, False
+    ) == "high"
+
+
+def test_derive_risk_level_dangerous_pattern_high():
+    assert _derive_risk_level({}, True) == "high"
+
+
+def test_derive_risk_level_warn_medium():
+    assert _derive_risk_level(
+        {"action": "warn", "findings": [{"severity": "medium"}]}, False
+    ) == "medium"
+
+
+def test_derive_risk_level_empty_defaults_medium():
+    assert _derive_risk_level({}, False) == "medium"
+
+
+# ---------------------------------------------------------------------------
+# prompt_dangerous_approval threading
+# ---------------------------------------------------------------------------
+
+def test_prompt_dangerous_approval_passes_risk_level():
+    captured = {}
+
+    def fake(cmd, desc, *, allow_permanent=True, risk_level=""):
+        captured["cmd"] = cmd
+        captured["desc"] = desc
+        captured["allow_permanent"] = allow_permanent
+        captured["risk_level"] = risk_level
+        return "once"
+
+    result = prompt_dangerous_approval(
+        "echo hi", "desc", approval_callback=fake, risk_level="high"
+    )
+    assert result == "once"
+    assert captured["risk_level"] == "high"
+
+
+def test_prompt_dangerous_approval_legacy_callback_without_risk_level():
+    """Older callbacks without a risk_level kwarg still work (TypeError fallback)."""
+    captured = {}
+
+    def fake(cmd, desc, *, allow_permanent=True):
+        captured["cmd"] = cmd
+        captured["allow_permanent"] = allow_permanent
+        return "session"
+
+    result = prompt_dangerous_approval(
+        "echo hi", "desc", approval_callback=fake, risk_level="high"
+    )
+    assert result == "session"
+    assert captured["cmd"] == "echo hi"

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -3076,6 +3076,7 @@ def check_all_command_guards(command: str, env_type: str,
         pattern_keys=list(all_keys),
         session_key=session_key,
         surface="cli",
+    )
     risk_level = _derive_risk_level(tirith_result, is_dangerous, is_hardline)
     choice = prompt_dangerous_approval(
         command,

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1736,7 +1736,8 @@ def prompt_dangerous_approval(command: str, description: str,
                               timeout_seconds: int | None = None,
                               allow_permanent: bool = True,
                               approval_callback=None,
-                              *, smart_denied: bool = False) -> str:
+                              *, smart_denied: bool = False,
+                              risk_level: str = "") -> str:
     """Prompt the user to approve a dangerous command (CLI only).
 
     Args:
@@ -1745,11 +1746,14 @@ def prompt_dangerous_approval(command: str, description: str,
             is inappropriate for content-level security findings).
         smart_denied: When True, this is an owner override of a Smart DENY.
             Offer only one-operation approval or denial.
+        risk_level: Deterministic command risk ('critical'|'high'|'medium')
+            derived by the orchestration. Threaded through to the callback
+            so downstream (CLI) can tier remote approval. May be empty.
         approval_callback: Optional callback registered by the CLI for
             prompt_toolkit integration. Signature:
             (command, description, *, allow_permanent=True,
-            smart_denied=False) -> str. Legacy callback signatures remain
-            supported when ``smart_denied`` is false.
+            smart_denied=False, risk_level="") -> str. Legacy callback
+            signatures remain supported via TypeError fallback.
 
     Returns: 'once', 'session', 'always', or 'deny'
     """
@@ -1769,9 +1773,17 @@ def prompt_dangerous_approval(command: str, description: str,
             callback_kwargs = {"allow_permanent": allow_permanent}
             if smart_denied:
                 callback_kwargs["smart_denied"] = True
-            return approval_callback(
-                display_command, display_description, **callback_kwargs
-            )
+            if risk_level:
+                callback_kwargs["risk_level"] = risk_level
+            try:
+                return approval_callback(
+                    display_command, display_description, **callback_kwargs
+                )
+            except TypeError:
+                # Older callbacks without smart_denied or risk_level kwargs
+                # (e.g. delegate auto-approve, subagent callbacks).
+                return approval_callback(command, description,
+                                         allow_permanent=allow_permanent)
         except Exception as e:
             logger.error("Approval callback failed: %s", e, exc_info=True)
             return "deny"
@@ -2632,6 +2644,49 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     return {"resolved": resolved, "choice": choice, "reason": entry.reason}
 
 
+def _derive_risk_level(tirith_result: dict, is_dangerous: bool,
+                       is_hardline: bool = False) -> str:
+    """Map available guard signals to critical|high|medium.
+
+    Deterministic mapping (a prompt is showing, so the floor is 'medium'):
+      - is_hardline                                  -> 'critical'
+      - any tirith finding severity == 'critical'    -> 'critical'
+      - tirith action == 'block' (non-critical)
+        OR any finding severity == 'high'            -> 'high'
+      - is_dangerous (pattern match), no escalation   -> 'high' (conservative)
+      - tirith 'warn' with only medium/low findings   -> 'medium'
+      - otherwise                                     -> 'medium'
+
+    Defensive: ``tirith_result`` may be ``{}`` or lack ``findings``; treat
+    missing signals as no tirith signal. Severities are read
+    case-insensitively.
+    """
+    if is_hardline:
+        return "critical"
+
+    tirith_result = tirith_result or {}
+    action = str(tirith_result.get("action", "") or "").lower()
+    findings = tirith_result.get("findings") or []
+    severities = {
+        str(f.get("severity", "") or "").lower()
+        for f in findings
+        if isinstance(f, dict)
+    }
+
+    if "critical" in severities:
+        return "critical"
+
+    if action == "block" or "high" in severities:
+        return "high"
+
+    if is_dangerous:
+        return "high"
+
+    # tirith 'warn' with only medium/low findings, or no signal at all:
+    # a prompt is showing, so at least medium.
+    return "medium"
+
+
 def check_all_command_guards(command: str, env_type: str,
                              approval_callback=None,
                              has_host_access: bool = False) -> dict:
@@ -3021,12 +3076,13 @@ def check_all_command_guards(command: str, env_type: str,
         pattern_keys=list(all_keys),
         session_key=session_key,
         surface="cli",
-    )
+    risk_level = _derive_risk_level(tirith_result, is_dangerous, is_hardline)
     choice = prompt_dangerous_approval(
         command,
         combined_desc,
         allow_permanent=not has_tirith and not smart_denied_for_owner,
         smart_denied=smart_denied_for_owner,
+        risk_level=risk_level,
         approval_callback=approval_callback,
     )
     _fire_approval_hook(


### PR DESCRIPTION
## Summary
- Add opt-in gateway notifications for CLI human-intervention waits.
- Add `/iv` remote-control commands for pending CLI intervention records: deny, extend, status, and tiered approve.
- Thread command risk level into approval callbacks.
- Allow medium-risk approvals remotely, require typed confirmation for high-risk approvals, and keep critical prompts non-remotely approvable by default.
- Add bounded risk explanation support with static fallback.

## Safety notes
- Remote approve is gated behind config defaults and risk levels.
- Critical prompts remain non-remotely approvable by default.
- Sudo password and clarify-answer entry are not remotely answered by this change.
- Local operator action remains authoritative.

## Test plan
- `python -m py_compile cli.py gateway/run.py hermes_cli/commands.py hermes_cli/config.py hermes_cli/human_intervention_notifications.py hermes_cli/human_intervention_remote_control.py hermes_cli/human_intervention_risk_explainer.py tools/approval.py`
- `python -m pytest -q -o 'addopts=' tests/hermes_cli/test_human_intervention_notifications.py tests/hermes_cli/test_human_intervention_remote_control.py tests/hermes_cli/test_human_intervention_risk_explainer.py tests/gateway/test_human_intervention_remote_control.py tests/tools/test_approval_risk_level.py tests/cli/test_cli_approval_ui.py`

## Notes
This is a larger product/security-sensitive change, so it is opened as a draft for maintainer review.