### PR TITLE
[hermes-desktop-active-prompt-sender-attribution][1/n] Label active prompts with sender device

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -43,6 +43,7 @@ import {
   $currentCwd,
   $currentModel,
   $currentProvider,
+  $localDeviceName,
   sessionMatchesStoredId,
   setCurrentBranch,
   setCurrentCwd,
@@ -51,6 +52,7 @@ import {
   setCurrentReasoningEffort,
   setCurrentServiceTier,
   setCurrentUsage,
+  setLocalDeviceName,
   setSessions,
   setTurnStartedAt,
   setYoloActive
@@ -285,6 +287,17 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         // Backends with the change watcher broadcast pet/cron/sessions change
         // events; consumers demote their legacy polls to slow backstops.
         setChangeEventsAvailable(Boolean((payload as { change_events?: boolean } | undefined)?.change_events))
+
+        {
+          // The gateway names the host it runs on; seed it once so locally
+          // submitted prompts can be attributed to this device.
+          const rawDeviceName = (payload as { device_name?: unknown } | undefined)?.device_name
+          const deviceName = typeof rawDeviceName === 'string' ? rawDeviceName.trim() : ''
+
+          if (deviceName && !$localDeviceName.get()) {
+            setLocalDeviceName(deviceName)
+          }
+        }
 
         return
       } else if (event.type === 'skin.changed') {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -14,6 +14,7 @@ import {
   $connection,
   $currentCwd,
   $currentUsage,
+  $localDeviceName,
   $messages,
   $sessions,
   $turnStartedAt,
@@ -1516,7 +1517,38 @@ describe('usePromptActions desktop slash pickers', () => {
 describe('usePromptActions submit / queue drain semantics', () => {
   afterEach(() => {
     cleanup()
+    $localDeviceName.set('')
     vi.restoreAllMocks()
+  })
+
+  it('stamps the optimistic user message with the local device name immediately', async () => {
+    $localDeviceName.set(' Omar MacBook Pro ')
+    const seeds: Record<string, unknown>[] = []
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => seeds.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('continue')
+
+    const firstSeededMessage = (seeds[0]?.messages as Array<{ senderDevice?: string }> | undefined)?.[0]
+
+    expect(firstSeededMessage?.senderDevice).toBe('Omar MacBook Pro')
+    expect(requestGateway).toHaveBeenCalledWith(
+      'prompt.submit',
+      {
+        session_id: RUNTIME_SESSION_ID,
+        text: 'continue'
+      },
+      1_800_000
+    )
   })
 
   it('clears a leftover interrupted flag on a fresh submit (so the new turn streams)', async () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -21,6 +21,7 @@ import {
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
 import { requestDesktopOnboarding } from '@/store/onboarding'
 import {
+  $localDeviceName,
   $sessions,
   resolveComposerSessionKey,
   setAwaitingResponse,
@@ -46,6 +47,12 @@ import {
   type SubmitTextOptions,
   withSessionBusyRetry
 } from './utils'
+
+function localSenderDevice(): string | undefined {
+  const deviceName = $localDeviceName.get().trim()
+
+  return deviceName || undefined
+}
 
 interface SubmitPromptDeps {
   activeSessionIdRef: MutableRefObject<string | null>
@@ -308,6 +315,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       }
 
       const optimisticId = `user-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+      const optimisticSenderDevice = localSenderDevice()
 
       // What the bubble shows. A `/skill` send carries the whole expanded
       // skill body as its text — model-facing scaffolding — so the dispatcher
@@ -319,7 +327,8 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         id: optimisticId,
         role: 'user',
         parts: [textPart(bubbleText || (attachmentRefs.length ? '' : attachments.map(a => a.label).join(', ')))],
-        attachmentRefs
+        attachmentRefs,
+        ...(optimisticSenderDevice ? { senderDevice: optimisticSenderDevice } : {})
       })
 
       const releaseBusy = () => {

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -394,6 +394,9 @@ export const $currentFastMode = atom(storedBoolean(COMPOSER_FAST_KEY, false))
 // Persistence lives in the backend config (approvals.mode), so this is a plain
 // reflection of the truth the gateway reports rather than its own store.
 export const $yoloActive = atom(false)
+// This device's resolved gateway name. The active prompt card uses it before
+// the persisted gateway echo catches up.
+export const $localDeviceName = atom('')
 export const $currentCwd = atom(getRememberedWorkspaceCwd())
 export const $newChatWorkspaceTarget = atom<NewChatWorkspaceTarget>(undefined)
 export const $newChatWorkspaceTargetGeneration = atom(0)
@@ -510,6 +513,7 @@ export const setCurrentFastMode = (next: Updater<boolean>) => {
 }
 
 export const setYoloActive = (next: Updater<boolean>) => updateAtom($yoloActive, next)
+export const setLocalDeviceName = (next: Updater<string>) => updateAtom($localDeviceName, next)
 
 export const setCurrentCwd = (next: Updater<string>) => {
   updateAtom($currentCwd, next)


### PR DESCRIPTION
## Why

The active prompt card can render before the persisted gateway echo arrives. Without an optimistic `senderDevice`, the prompt briefly appears unattributed even though the local gateway already advertised the sending device name.

## What changed

- Capture this device's resolved gateway name from the first `gateway.ready` event.
- Store that value in a small renderer atom.
- Attach the local device name to the optimistic user message seeded for active prompts.
- Keep the gateway `prompt.submit` payload unchanged so this upstream PR stays independent of remote sender attribution work.

## How to review

- Review `use-message-stream.ts` for the one-time `gateway.ready` device-name capture.
- Review `use-prompt-actions.ts` and its test to confirm only the optimistic renderer message gets `senderDevice`.
- Confirm the `prompt.submit` assertion still proves the gateway payload is unchanged.

## Evidence

- Focused active-prompt UI test passed locally: 1 file, 27 tests passed.
- Desktop typecheck passed locally with `tsc -p . --noEmit`.
- `git diff --check upstream/main...HEAD` passed with no whitespace errors.

No visual evidence required: this is a renderer state/test change for a transient optimistic prompt label, and the packaged app path has already been deployed from the paired fork PR for local verification.
<!-- pr-quality:no-visual-required: renderer state/test change for a transient optimistic prompt label; paired fork build already installed locally for live app verification -->

## Verification

- `npm --prefix apps/desktop run test:ui -- src/app/session/hooks/use-prompt-actions.test.tsx`
- `npm --prefix apps/desktop run typecheck`
- `git diff --check upstream/main...HEAD`

## Risks / gaps

- I did not add remote sender attribution here; that belongs to the separate `hermes-mesh-session-continuity-substrate` / `hermes-remote-attach-foundations-20260609` lane and keeping it out avoids pulling unrelated upstream dependencies into this PR.
- This upstream branch has not been visually re-tested in Electron because the change is covered by renderer state tests and the paired fork build was already installed locally for live app verification.

## Collaborators

- Omar Baradei: operator/product feedback, Hermes desktop active-prompt UX context, 2026-06-11.
- ko-mac.codex#9a70c65ef5: Codex desktop worker on ko-mac, upstream PR preparation and verification for `hermes-desktop-active-prompt-sender-attribution-20260611`, 2026-06-11.
