### PR TITLE
fix: use Background launchd session over SSH

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3356,6 +3356,19 @@ def generate_launchd_plist() -> str:
         ]
     )
     prog_args_xml = "\n        ".join(prog_args)
+    # LaunchAgents bootstrapped into user/<uid> from SSH/background sessions need
+    # a Background-only session type.  A multi-session Aqua+Background array can
+    # still fail there with `Bootstrap failed: 5: Input/output error`.
+    session_type_xml = (
+        "    <key>LimitLoadToSessionType</key>\n"
+        "    <string>Background</string>\n\n"
+        if _launchd_domain().startswith("user/")
+        else "    <key>LimitLoadToSessionType</key>\n"
+        "    <array>\n"
+        "        <string>Aqua</string>\n"
+        "        <string>Background</string>\n"
+        "    </array>\n\n"
+    )
 
     return f"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -3364,6 +3377,7 @@ def generate_launchd_plist() -> str:
     <key>Label</key>
     <string>{label}</string>
 
+{session_type_xml}
     <key>ProgramArguments</key>
     <array>
         {prog_args_xml}
@@ -3382,12 +3396,6 @@ def generate_launchd_plist() -> str:
         <string>{hermes_home}</string>
     </dict>
 
-    <key>LimitLoadToSessionType</key>
-    <array>
-        <string>Aqua</string>
-        <string>Background</string>
-    </array>
-    
     <key>RunAtLoad</key>
     <true/>
     

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1061,6 +1061,33 @@ class TestLaunchdDomainDetection:
         domain = gateway_cli._launchd_domain()
         assert domain == f"user/501"
 
+    def test_launchd_plist_uses_background_string_for_user_domain(self, monkeypatch):
+        """user/<uid> LaunchAgents need Background-only session type.
+
+        On SSH/background sessions, launchctl can reject a multi-session
+        Aqua+Background array with `Bootstrap failed: 5: Input/output error`.
+        """
+        self._reset_domain_cache()
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "user/501")
+
+        plist = gateway_cli.generate_launchd_plist()
+
+        assert "<key>LimitLoadToSessionType</key>" in plist
+        assert "<string>Background</string>" in plist
+        assert "<string>Aqua</string>" not in plist
+
+    def test_launchd_plist_allows_aqua_and_background_for_gui_domain(self, monkeypatch):
+        """Desktop gui/<uid> LaunchAgents should retain Aqua compatibility."""
+        self._reset_domain_cache()
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+
+        plist = gateway_cli.generate_launchd_plist()
+
+        assert "<key>LimitLoadToSessionType</key>" in plist
+        assert "<array>" in plist
+        assert "<string>Aqua</string>" in plist
+        assert "<string>Background</string>" in plist
+
     def test_caches_result_across_calls(self, monkeypatch):
         """Domain detection should run once and cache the result."""
         self._reset_domain_cache()


### PR DESCRIPTION
## Summary
- Use a Background-only `LimitLoadToSessionType` when the macOS gateway LaunchAgent is generated for the `user/<uid>` launchd domain.
- Keep the existing Aqua+Background array for normal `gui/<uid>` desktop sessions.
- Add regression tests for both plist shapes.

## Why
On SSH/background macOS sessions, `_launchd_domain()` correctly selects `user/<uid>`, but bootstrapping a LaunchAgent with a multi-session `Aqua` + `Background` array can still fail with:

```text
Bootstrap failed: 5: Input/output error
```

Using a plain Background session string fixes `hermes gateway start` over SSH while preserving Aqua compatibility for GUI sessions.

## Test Plan
- `python -m py_compile hermes_cli/gateway.py`
- `uv run --with pytest --with pytest-asyncio --with pytest-timeout python -m pytest tests/hermes_cli/test_gateway_service.py -q -k 'LaunchdDomainDetection or launchd_start_falls_back_to_detached_when_rebootstrap_fails or launchd_install_falls_back_to_detached_on_bootstrap_5 or launchd_restart_falls_back_to_detached_on_error_5' -o 'addopts='`
- Manually verified on macOS SSH/background session:
  - `hermes gateway start`
  - `hermes gateway status`
  - launchd loaded `ai.hermes.gateway` with `LimitLoadToSessionType = Background`
