### PR TITLE
fix(profile): preserve user-added skills and cron jobs on install --force / update

### DIFF
--- a/hermes_cli/profile_distribution.py
+++ b/hermes_cli/profile_distribution.py
@@ -51,7 +51,11 @@ Manifest format (``distribution.yaml`` at the profile root)::
 Update semantics:
 
 * Distribution-owned paths (SOUL.md, mcp.json, skills/, cron/,
-  distribution.yaml) are replaced from the new source.
+  distribution.yaml) are replaced from the new source.  Directories are
+  merged, not mirrored: content shipped by the distribution is replaced
+  (skill directories wholesale), while entries the user added inside them —
+  skills installed via ``hermes skills install``, user cron jobs — are
+  preserved.
 * ``config.yaml`` is distribution-owned but preserved on update unless
   ``--force-config`` is passed (user overrides typically live here).
 * User-owned paths (memories/, sessions/, state.db, auth.json, .env,
@@ -545,6 +549,45 @@ def plan_install(
     )
 
 
+def _replace_dir_merging_user_entries(src: Path, dest: Path) -> None:
+    """Copy directory *src* into *dest* without destroying user additions.
+
+    A plain rmtree+copytree of each distribution directory would delete
+    anything the user added inside it — skills installed into the profile via
+    ``hermes skills install``, cron jobs created after install.  Both
+    ``install --force`` and ``update`` promise "user data preserved", so:
+
+    * a shipped directory that is a skill root (contains SKILL.md) replaces
+      its counterpart wholesale, so files the new version dropped or renamed
+      don't linger inside distribution-owned skills;
+    * any other shipped directory is merged recursively (covers category
+      folders like ``skills/coding/`` shared by distribution and user);
+    * shipped files overwrite their counterparts;
+    * entries under *dest* that the distribution does not ship are left
+      untouched.
+    """
+    if dest.is_symlink() or dest.is_file():
+        dest.unlink()
+    dest.mkdir(parents=True, exist_ok=True)
+    for child in src.iterdir():
+        node = dest / child.name
+        if child.is_dir():
+            if node.is_symlink() or node.is_file():
+                node.unlink()
+            elif node.is_dir() and (child / "SKILL.md").is_file():
+                shutil.rmtree(node)
+            if node.is_dir():
+                _replace_dir_merging_user_entries(child, node)
+            else:
+                shutil.copytree(child, node)
+        else:
+            if node.is_symlink():
+                node.unlink()
+            elif node.is_dir():
+                shutil.rmtree(node)
+            shutil.copy2(child, node)
+
+
 def _copy_dist_payload(
     staged: Path,
     target: Path,
@@ -556,7 +599,9 @@ def _copy_dist_payload(
     User-owned paths are never touched.  ``config.yaml`` is replaced only when
     ``preserve_config`` is False (fresh install or ``--force-config`` update).
     ``.env.template`` is renamed to ``.env.EXAMPLE`` in the target to avoid
-    shadowing a real ``.env``.
+    shadowing a real ``.env``.  Directories are merged so user-added entries
+    inside them (e.g. extra skills) survive — see
+    :func:`_replace_dir_merging_user_entries`.
     """
     target.mkdir(parents=True, exist_ok=True)
 
@@ -574,18 +619,7 @@ def _copy_dist_payload(
 
         dest = target / name
         if entry.is_dir():
-            if dest.exists():
-                shutil.rmtree(dest)
-            staged_resolved = staged.resolve()
-            shutil.copytree(
-                entry,
-                dest,
-                ignore=lambda d, names: (
-                    [n for n in names if n in USER_OWNED_EXCLUDE]
-                    if Path(d).resolve() == staged_resolved
-                    else []
-                ),
-            )
+            _replace_dir_merging_user_entries(entry, dest)
         else:
             shutil.copy2(entry, dest)
 

--- a/hermes_cli/subcommands/profile.py
+++ b/hermes_cli/subcommands/profile.py
@@ -176,12 +176,14 @@ def build_profile_parser(subparsers, *, cmd_profile: Callable) -> None:
 
     profile_update = profile_subparsers.add_parser(
         "update",
-        help="Re-pull a distribution and apply updates (user data preserved)",
+        help="Re-pull a distribution and apply updates (user additions preserved)",
         description=(
-            "Fetch the distribution from its recorded source and overwrite "
-            "distribution-owned files (SOUL.md, skills/, cron/, mcp.json). "
-            "User data (memories, sessions, auth, .env) is never touched. "
-            "config.yaml is preserved unless --force-config is passed."
+            "Fetch the distribution from its recorded source, update "
+            "distribution-owned files (SOUL.md, mcp.json, distribution.yaml), "
+            "and merge distribution-owned directories (skills/, cron/) so "
+            "skills or cron jobs you added locally remain in place. User data "
+            "(memories, sessions, auth, .env) is never touched. config.yaml "
+            "is preserved unless --force-config is passed."
         ),
     )
     profile_update.add_argument("profile_name", help="Profile to update")

--- a/tests/hermes_cli/test_profile_distribution.py
+++ b/tests/hermes_cli/test_profile_distribution.py
@@ -675,3 +675,125 @@ class TestErrorSurfaces:
         staged = _make_staging_dir(profile_env, "bad", manifest=mf)
         with pytest.raises((ValueError, DistributionError)):
             plan_install(str(staged), tmp_path / "work")
+
+
+# ===========================================================================
+# User-added entries inside dist-owned dirs survive force install / update
+# ===========================================================================
+
+
+def _plant_user_skill(profile_dir: Path, rel: str) -> Path:
+    """Simulate `hermes skills install` adding a skill to an installed profile."""
+    skill = profile_dir / "skills" / rel
+    skill.mkdir(parents=True, exist_ok=True)
+    (skill / "SKILL.md").write_text(
+        f"---\nname: {Path(rel).name}\ndescription: user-added\n---\n# User skill\n"
+    )
+    return skill
+
+
+class TestUserAdditionsSurviveReinstall:
+    """``install --force`` and ``update`` both advertise "user data preserved".
+
+    Entries the user added under skills/ and cron/ — e.g. via
+    ``hermes skills install`` or ``hermes cron add`` — must survive, while
+    distribution-shipped content is still replaced from the new source.
+    """
+
+    def test_force_install_preserves_user_added_skill(self, profile_env):
+        staged = _make_staging_dir(profile_env, "src")
+        plan = install_distribution(str(staged), name="keepskills")
+        _plant_user_skill(plan.target_dir, "user-extra")
+
+        install_distribution(str(staged), name="keepskills", force=True)
+
+        assert (plan.target_dir / "skills" / "user-extra" / "SKILL.md").exists(), (
+            "user-added skill was deleted by install --force"
+        )
+        assert (plan.target_dir / "skills" / "demo" / "SKILL.md").exists()
+
+    def test_update_preserves_user_added_skill(self, profile_env):
+        staged = _make_staging_dir(profile_env, "src")
+        plan = install_distribution(str(staged), name="keepskills2")
+        _plant_user_skill(plan.target_dir, "user-extra")
+
+        # Distribution ships a new version of its own skill
+        (staged / "skills" / "demo" / "SKILL.md").write_text(
+            "---\nname: demo\ndescription: v2\n---\n# Demo skill v2\n"
+        )
+        update_distribution("keepskills2")
+
+        assert (plan.target_dir / "skills" / "user-extra" / "SKILL.md").exists(), (
+            "user-added skill was deleted by profile update"
+        )
+        assert "v2" in (plan.target_dir / "skills" / "demo" / "SKILL.md").read_text()
+
+    def test_update_preserves_user_skill_in_shared_category_dir(self, profile_env):
+        """``hermes skills install --category coding`` nests skills under a
+        category folder the distribution may also ship."""
+        staged = _make_staging_dir(profile_env, "src")
+        (staged / "skills" / "coding" / "dist-skill").mkdir(parents=True)
+        (staged / "skills" / "coding" / "dist-skill" / "SKILL.md").write_text(
+            "---\nname: dist-skill\ndescription: shipped\n---\n# Shipped\n"
+        )
+        plan = install_distribution(str(staged), name="catkeep")
+        _plant_user_skill(plan.target_dir, "coding/mine")
+
+        update_distribution("catkeep")
+
+        assert (plan.target_dir / "skills" / "coding" / "mine" / "SKILL.md").exists(), (
+            "user skill inside a shared category folder was deleted"
+        )
+        assert (
+            plan.target_dir / "skills" / "coding" / "dist-skill" / "SKILL.md"
+        ).exists()
+
+    def test_update_preserves_user_added_cron_job(self, profile_env):
+        staged = _make_staging_dir(profile_env, "src")
+        plan = install_distribution(str(staged), name="cronkeep")
+        (plan.target_dir / "cron" / "mine.json").write_text('{"schedule": "0 0 * * *"}')
+
+        update_distribution("cronkeep")
+
+        assert (plan.target_dir / "cron" / "mine.json").exists(), (
+            "user-added cron job was deleted by profile update"
+        )
+        assert (plan.target_dir / "cron" / "daily.json").exists()
+
+    def test_update_replaces_nested_dist_file_symlink_without_following_target(
+        self,
+        profile_env,
+        tmp_path,
+    ):
+        staged = _make_staging_dir(profile_env, "src")
+        (staged / "cron" / "daily.json").write_text('{"schedule": "0 9 * * *"}')
+        plan = install_distribution(str(staged), name="cronlink")
+
+        external_target = tmp_path / "outside-daily.json"
+        external_target.write_text("outside user content")
+        profile_cron = plan.target_dir / "cron" / "daily.json"
+        profile_cron.unlink()
+        _symlink_file_or_skip(profile_cron, external_target)
+
+        (staged / "cron" / "daily.json").write_text('{"schedule": "0 10 * * *"}')
+        update_distribution("cronlink")
+
+        assert not profile_cron.is_symlink()
+        assert profile_cron.read_text() == '{"schedule": "0 10 * * *"}'
+        assert external_target.read_text() == "outside user content"
+
+    def test_update_still_mirrors_dist_shipped_skill_dir(self, profile_env):
+        """Files the distribution drops from one of ITS OWN skills must not
+        linger after update — a dist-shipped skill dir is replaced wholesale."""
+        staged = _make_staging_dir(profile_env, "src")
+        (staged / "skills" / "demo" / "old_helper.py").write_text("# stale\n")
+        plan = install_distribution(str(staged), name="mirrorsk")
+        assert (plan.target_dir / "skills" / "demo" / "old_helper.py").exists()
+
+        (staged / "skills" / "demo" / "old_helper.py").unlink()
+        update_distribution("mirrorsk")
+
+        assert not (plan.target_dir / "skills" / "demo" / "old_helper.py").exists(), (
+            "stale file inside a dist-shipped skill survived update"
+        )
+        assert (plan.target_dir / "skills" / "demo" / "SKILL.md").exists()

--- a/website/docs/user-guide/profile-distributions.md
+++ b/website/docs/user-guide/profile-distributions.md
@@ -240,11 +240,12 @@ research-bot/
 
 ### Distribution-owned vs user-owned
 
-When an installer updates to a new version, some things get replaced (author's domain) and some things stay put (installer's domain). Defaults:
+When an installer updates to a new version, some things are updated from the distribution (author's domain) and some things stay put (installer's domain). Distribution-owned directories are merged so installer-added entries under `skills/` and `cron/` survive, while distribution-shipped files are refreshed.
 
 | Category | Paths | On update |
 |---|---|---|
-| **Distribution-owned** | `SOUL.md`, `config.yaml`, `mcp.json`, `skills/`, `cron/`, `distribution.yaml` | Replaced from the new clone |
+| **Distribution-owned files** | `SOUL.md`, `mcp.json`, `distribution.yaml`, and distribution-shipped files under `skills/` and `cron/` | Updated from the new clone |
+| **Merged distribution-owned directories** | `skills/`, `cron/` | Merged recursively: distribution-shipped entries are updated, but installer-added skills and cron jobs are preserved. A distribution-shipped skill root that contains `SKILL.md` is replaced as that distribution's skill. |
 | **Config override** | `config.yaml` | Actually preserved by default — the installer may have tuned model or provider. Pass `--force-config` on update to reset. |
 | **User-owned** | `memories/`, `sessions/`, `state.db*`, `auth.json`, `.env`, `logs/`, `workspace/`, `plans/`, `home/`, `*_cache/`, `local/` | Never touched |
 
@@ -382,7 +383,7 @@ hermes profile update research-bot
 What happens:
 
 1. Re-clones the repo from the recorded source URL.
-2. Replaces distribution-owned files (SOUL, skills, cron, mcp.json).
+2. Updates distribution-owned files (`SOUL.md`, `mcp.json`, `distribution.yaml`) and merges distribution-owned directories (`skills/`, `cron/`): shipped entries are refreshed while skills or cron jobs you added locally remain in place.
 3. **Preserves** your `config.yaml` — you may have tuned the model, temperature, or other settings. Pass `--force-config` to overwrite.
 4. **Never touches** user data: memories, sessions, auth, `.env`, logs, state.
 


### PR DESCRIPTION
Fixes #25120

## What

`hermes profile install --force` and `hermes profile update` both advertise "user data preserved" in their help text, but `_copy_dist_payload()` rmtree'd + recopied every directory the distribution ships. Anything the user added inside `skills/` after install was silently deleted — including skills installed with `hermes skills install`, which writes into the same tree. User-added `cron/` jobs were deleted the same way.

This is the destructive replacement reported in #25120, implemented along the lines of its "Option B — additive merge", with one refinement for distribution-owned skills (below).

## How

A new `_replace_dir_merging_user_entries()` replaces the wholesale `rmtree` + `copytree` in `_copy_dist_payload()`:

- a shipped directory that is a **skill root** (contains `SKILL.md`) still replaces its counterpart wholesale, so files dropped or renamed by the new version don't linger inside distribution-owned skills;
- any **other shipped directory merges recursively** — this covers category folders like `skills/devops/` shared by the distribution and `hermes skills install --category devops` (the exact layout in #25120's repro);
- shipped **files overwrite** their counterparts;
- entries the distribution doesn't ship are **left untouched**.

One semantics change to be aware of: a skill the distribution *removes* in a new version now lingers in the profile instead of being deleted as a side effect of the mirror. If cleanup of dist-removed skills matters, the follow-up would be payload bookkeeping in the installed manifest (record shipped entries at install; delete previously-shipped-now-absent ones on update). Happy to iterate in that direction if you prefer.

Also removed: the `ignore=` lambda previously passed to `copytree`, which was dead code — it only filtered names when the visited directory equaled the staged *root*, but that `copytree` started one level below the root, so the predicate never fired. Top-level filtering already happens via the `name in USER_OWNED_EXCLUDE` guard at the top of the loop; `TestNestedUserOwnedExcludeNotFiltered` passes unchanged.

The module docstring's "Update semantics" section and the `profile update` parser description are updated to state the merge behavior, which makes the existing "(user data preserved)" help text on `--force` and `update` accurate.

## How to test

New tests in `tests/hermes_cli/test_profile_distribution.py::TestUserAdditionsSurviveReinstall` — written first, red on `main`, green with this change:

- `test_force_install_preserves_user_added_skill`
- `test_update_preserves_user_added_skill` — dist's own skill still receives its new content
- `test_update_preserves_user_skill_in_shared_category_dir` — #25120's `skills/<category>/<custom-skill>` case
- `test_update_preserves_user_added_cron_job`
- `test_update_still_mirrors_dist_shipped_skill_dir` — guard: stale files inside a dist-shipped skill must NOT linger (passes before and after)

```
pytest tests/hermes_cli/test_profile_distribution.py    # 74 passed
```

End-to-end repro (fails on stock `main` at e71d7468, fixed with this branch):

<details><summary>repro script</summary>

```bash
#!/usr/bin/env bash
set -euo pipefail
HERMES_CMD="${HERMES_CMD:-hermes}"
TMP=$(mktemp -d)
trap 'rm -rf "$TMP"' EXIT
export HERMES_HOME="$TMP/hermes-home"
mkdir -p "$HERMES_HOME"

DIST="$TMP/demo-dist"
mkdir -p "$DIST/skills/dist-skill"
cat > "$DIST/distribution.yaml" <<'EOF'
name: demodist
version: 0.1.0
description: minimal repro distribution
EOF
printf -- '---\nname: dist-skill\ndescription: shipped by the distribution\n---\n# dist skill\n' \
  > "$DIST/skills/dist-skill/SKILL.md"
printf 'soul\n' > "$DIST/SOUL.md"

$HERMES_CMD profile install "$DIST" --yes >/dev/null

PROFILE="$HERMES_HOME/profiles/demodist"
mkdir -p "$PROFILE/skills/my-skill"
printf -- '---\nname: my-skill\ndescription: added by the user\n---\n# my skill\n' \
  > "$PROFILE/skills/my-skill/SKILL.md"
echo "skills before reinstall: $(ls "$PROFILE/skills" | tr '\n' ' ')"

$HERMES_CMD profile install "$DIST" --yes --force >/dev/null

echo "skills after reinstall:  $(ls "$PROFILE/skills" | tr '\n' ' ')"
if [ -d "$PROFILE/skills/my-skill" ]; then
  echo "OK: user-added skill preserved"
else
  echo "BUG: user-added skill was DELETED"
fi
```
</details>

Before this change: `BUG: user-added skill was DELETED`. After: `OK: user-added skill preserved`.

## Platforms

macOS (Darwin 25.2.0), Python 3.11.15. Full `scripts/run_tests.sh tests/hermes_cli/` run: the only failures (11 tests across 4 gateway/service test files, plus 2 provider files with collection errors) are identical on a pristine `main` worktree in this environment — pre-existing and unrelated to this change. The code path touched here is platform-independent (`pathlib`/`shutil` only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
