### PR TITLE
feat: make SOUL.md truncation limit configurable via agent.soul_max_chars

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1470,7 +1470,13 @@ def load_soul_md() -> Optional[str]:
         if not content:
             return None
         content = _scan_context_content(content, "SOUL.md")
-        content = _truncate_content(content, "SOUL.md")
+        try:
+            from hermes_cli.config import load_config
+            cfg = load_config()
+            max_chars = int(cfg.get("agent", {}).get("soul_max_chars", CONTEXT_FILE_MAX_CHARS))
+        except Exception:
+            max_chars = CONTEXT_FILE_MAX_CHARS
+        content = _truncate_content(content, "SOUL.md", max_chars=max_chars)
         return content
     except Exception as e:
         logger.debug("Could not read SOUL.md from %s: %s", soul_path, e)


### PR DESCRIPTION
## Summary

Makes the 20,000-character SOUL.md truncation limit configurable via agent.soul_max_chars in config.yaml, falling back to CONTEXT_FILE_MAX_CHARS (20,000) when not set.

## Motivation

SOUL.md serves as the agent identity with tone, personality, and operational rules. With larger SOUL files (34k+ chars), the hard 20k truncation drops critical middle sections like delegation rules and code craftsmanship guidelines mid-session. This gives users control without modifying source code.

## Change

In agent/prompt_builder.py load_soul_md(), replace:

    content = _truncate_content(content, "SOUL.md")

with:

    try:
        from hermes_cli.config import load_config
        cfg = load_config()
        max_chars = int(cfg.get("agent", {}).get("soul_max_chars", CONTEXT_FILE_MAX_CHARS))
    except Exception:
        max_chars = CONTEXT_FILE_MAX_CHARS
    content = _truncate_content(content, "SOUL.md", max_chars=max_chars)

The try/except keeps the import lazy - no top-level import needed, and config failures never break load_soul_md().

## Usage

Set in ~/.hermes/config.yaml:

    agent:
      soul_max_chars: 40000

(default: 20000 = CONTEXT_FILE_MAX_CHARS)

## Testing

- If unset: behaves exactly as before (20k limit, no behavior change).
- If set: uses the configured value.
- If config is temporarily unavailable: falls back to 20k default.