### PR TITLE
fix(discord): cancel _bot_task on connect() timeout to prevent zombie client

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -910,6 +910,17 @@ class DiscordAdapter(BasePlatformAdapter):
 
         except asyncio.TimeoutError:
             logger.error("[%s] Timeout waiting for connection to Discord", self.name, exc_info=True)
+            # Cancel the background bot task so it cannot fire on_message after
+            # this adapter is discarded.  Without this, the task keeps running and
+            # a later successful reconnect leaves two active Discord clients that
+            # each process every message, producing duplicate threads/responses.
+            if self._bot_task and not self._bot_task.done():
+                self._bot_task.cancel()
+                try:
+                    await self._bot_task
+                except (asyncio.CancelledError, Exception):
+                    pass
+                self._bot_task = None
             self._release_platform_lock()
             return False
         except Exception as e:  # pragma: no cover - defensive logging
@@ -919,6 +930,20 @@ class DiscordAdapter(BasePlatformAdapter):
 
     async def disconnect(self) -> None:
         """Disconnect from Discord."""
+        # Cancel the bot task before closing the client.  If connect() timed out
+        # and returned False, the background client.start() task may still be
+        # running; calling client.close() alone is not enough to stop it because
+        # discord.py's reconnect loop can ignore the closed flag while a
+        # WebSocket handshake is in flight.  Explicitly cancelling the task here
+        # ensures the zombie client cannot receive or dispatch any further events.
+        if self._bot_task and not self._bot_task.done():
+            self._bot_task.cancel()
+            try:
+                await self._bot_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        self._bot_task = None
+
         # Clean up all active voice connections before closing the client
         for guild_id in list(self._voice_clients.keys()):
             try:

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -280,6 +280,88 @@ async def test_connect_releases_token_lock_on_timeout(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_connect_timeout_cancels_bot_task(monkeypatch):
+    """Regression: connect() timeout must cancel _bot_task so the zombie
+    Discord client cannot fire on_message after the adapter is discarded.
+
+    Without this fix, the orphaned task eventually completes its WebSocket
+    handshake and a subsequent successful reconnect leaves two live clients
+    that each process every message, producing duplicate threads.
+    """
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    monkeypatch.setattr("gateway.status.acquire_scoped_lock", lambda scope, identity, metadata=None: (True, None))
+    monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: None)
+
+    intents = SimpleNamespace(
+        message_content=False, dm_messages=False, guild_messages=False,
+        members=False, voice_states=False,
+    )
+    monkeypatch.setattr(discord_platform.Intents, "default", lambda: intents)
+
+    class NeverReadyBot(FakeBot):
+        """Bot whose start() never fires on_ready — simulates a slow gateway handshake."""
+        async def start(self, token):
+            await asyncio.Event().wait()  # hang forever
+
+    monkeypatch.setattr(
+        discord_platform.commands,
+        "Bot",
+        lambda **kwargs: NeverReadyBot(
+            intents=kwargs["intents"],
+            proxy=kwargs.get("proxy"),
+            allowed_mentions=kwargs.get("allowed_mentions"),
+        ),
+    )
+
+    async def fake_wait_for(awaitable, timeout):
+        awaitable.close()
+        raise asyncio.TimeoutError()
+
+    monkeypatch.setattr(discord_platform.asyncio, "wait_for", fake_wait_for)
+
+    ok = await adapter.connect()
+
+    assert ok is False
+    assert adapter._bot_task is None, (
+        "_bot_task must be cancelled and cleared on connect() timeout; "
+        "leaving it alive creates a zombie Discord client that produces duplicate threads"
+    )
+
+
+@pytest.mark.asyncio
+async def test_disconnect_cancels_running_bot_task(monkeypatch):
+    """Regression: disconnect() must cancel _bot_task even when connect() timed out.
+
+    _dispose_unused_adapter calls disconnect() on adapters whose connect() returned
+    False.  If _bot_task was still running (zombie), disconnect() must cancel it.
+    """
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    monkeypatch.setattr("gateway.status.acquire_scoped_lock", lambda scope, identity, metadata=None: (True, None))
+    monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: None)
+
+    # Simulate a zombie bot_task that never finishes (as if discord.py is mid-handshake)
+    async def _forever():
+        await asyncio.Event().wait()  # hang forever
+
+    zombie_task = asyncio.create_task(_forever())
+    adapter._bot_task = zombie_task
+    adapter._client = AsyncMock()
+    adapter._post_connect_task = None
+    adapter._voice_clients = {}
+    adapter._running = True
+    adapter._ready_event = asyncio.Event()
+
+    await adapter.disconnect()
+
+    # The task must have been cancelled (done + cancelled) and cleared from the adapter.
+    assert adapter._bot_task is None, "disconnect() must clear _bot_task"
+    assert zombie_task.done(), "disconnect() must have awaited the bot task to completion"
+    assert zombie_task.cancelled(), "disconnect() must cancel the zombie bot task"
+
+
+@pytest.mark.asyncio
 async def test_connect_does_not_wait_for_slash_sync(monkeypatch):
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
 


### PR DESCRIPTION
## What does this PR do?

Fixes a race condition where a timed-out Discord `connect()` attempt leaves its background `asyncio.Task` running, eventually producing two simultaneous live Discord clients in the same process causing every @mention to create two threads.

When `connect()` waits for the ready event and times out, the `asyncio.Task` running `client.start()` is left alive. `discord.py`'s internal reconnect loop can ignore `client.close()` while a WebSocket handshake is in flight, so the orphaned task continues, completes the handshake, and fires `on_ready`. When the reconnect watcher then successfully connects a new adapter, both clients remain active - each with its own `on_message` handler and independent `MessageDeduplicator` instance. Because deduplication is per-adapter, cross-client duplicates are invisible to it, and every incoming message is processed twice, each time creating its own auto-thread.

The fix explicitly cancels and awaits `_bot_task` in two places:
1. The `asyncio.TimeoutError` handler inside `connect()` - catches the case where the adapter's own inner `wait_for` fires before the gateway's outer timeout wrapper.
2. At the start of `disconnect()` - the load-bearing path, always reached via `_dispose_unused_adapter` for failed adapters, regardless of which timeout fired first.

## Related Issue

No existing issue - discovered from production logs showing two identical inbound message events in two separate thread IDs 357ms apart, traced back to a zombie client that had been running for 41+ hours.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `plugins/platforms/discord/adapter.py`: in the `TimeoutError` handler of `connect()`, cancel and await `_bot_task` before releasing the platform lock and returning `False`; in `disconnect()`, cancel and await `_bot_task` at the top of the method before any other cleanup, ensuring zombie tasks from failed connect attempts are always terminated
- `tests/gateway/test_discord_connect.py`: two regression tests - `test_connect_timeout_cancels_bot_task` (simulates a connect timeout via a never-ready bot, asserts `_bot_task` is `None` on return) and `test_disconnect_cancels_running_bot_task` (injects a live zombie task directly, calls `disconnect()`, asserts `task.cancelled()`)

## How to Test

**Unit tests (no live Discord required):**
```
pytest tests/gateway/test_discord_connect.py -q
```
All 18 tests pass, including the two new regression tests. Verified on both local env (Python 3.14, mocked discord) and VPS runtime (Python 3.11, real discord.py).

**Root cause evidence from production logs:**
```
# Network outage caused three consecutive connect() timeouts
20:16:58  ✗ discord error: discord connect timed out after 30s
20:17:48  Reconnecting discord (attempt 2)...
20:18:18  Reconnect discord error: discord connect timed out after 30s
20:19:18  Reconnecting discord (attempt 3)...
20:19:48  Reconnect discord error: discord connect timed out after 30s

# Attempt 1's orphaned bot_task eventually completed - no preceding watcher line
20:20:28  [Discord] Connected as Caelum-Agent#9932   ← zombie from attempt 1

# Reconnect watcher's real attempt 4 also connected
20:21:54  [Discord] Connected as Caelum-Agent#9932   ← real reconnect
          ✓ discord reconnected successfully

# 41 hours later - same message, two threads, 357ms apart
14:01:01.937  inbound: chat=1514630532162650296  msg='...'
14:01:02.294  inbound: chat=1514630537946333426  msg='...'  ← duplicate
```

Process uptime at the time of the duplicate (`uptime=236700s`) traces the running process back to the original startup at 20:17, confirming both clients ran continuously for 41+ hours.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(discord): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (Oracle VPS, Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - or N/A (`asyncio` task cancellation is cross-platform)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A

## Screenshots / Logs

Gateway logs showing the zombie connect followed by duplicate inbound message events are included in the **How to Test** section above.