### PR TITLE
fix(termux): align manual psutil install with supported installer

### DIFF
--- a/tests/test_termux_manual_install_docs.py
+++ b/tests/test_termux_manual_install_docs.py
@@ -1,0 +1,45 @@
+"""Regression coverage for the Termux manual install guide."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TERMUX_DOCS = [
+    REPO_ROOT / "website" / "docs" / "getting-started" / "termux.md",
+    REPO_ROOT
+    / "website"
+    / "i18n"
+    / "zh-Hans"
+    / "docusaurus-plugin-content-docs"
+    / "current"
+    / "getting-started"
+    / "termux.md",
+]
+
+
+def test_manual_termux_install_runs_psutil_shim_before_pip_install() -> None:
+    """The documented manual path must match install.sh's Android psutil prebuild."""
+    for doc in TERMUX_DOCS:
+        text = doc.read_text(encoding="utf-8")
+        manual_start = (
+            text.find("## Option 2: Manual install")
+            if "## Option 2: Manual install" in text
+            else text.index("## 方式二：手动安装")
+        )
+        manual_text = text[manual_start:]
+        shim_idx = manual_text.index("python scripts/install_psutil_android.py")
+        install_idx = manual_text.index("python -m pip install -e '.[termux]'")
+
+        assert shim_idx < install_idx, f"{doc} installs package before psutil shim"
+
+
+def test_termux_docs_cover_32_bit_maturin_target() -> None:
+    """Termux troubleshooting should cover the armv8l/maturin failure from #31415."""
+    for doc in TERMUX_DOCS:
+        text = doc.read_text(encoding="utf-8")
+
+        assert "Unsupported Android architecture: armv8l" in text
+        assert 'CARGO_BUILD_TARGET="armv7-linux-androideabi"' in text
+        assert 'CARGO_BUILD_TARGET="aarch64-linux-android"' in text

--- a/website/docs/getting-started/termux.md
+++ b/website/docs/getting-started/termux.md
@@ -26,11 +26,13 @@ The tested Termux bundle installs:
 - Honcho memory support
 - ACP support
 
-Concretely, it maps to:
+Concretely, after the Android psutil prebuild shown in the manual path below, it maps to:
 
 ```bash
 python -m pip install -e '.[termux]' -c constraints-termux.txt
 ```
+
+On a fresh Android environment, use the one-line installer or follow the full manual sequence below instead of running that pip command by itself.
 
 ## What is not part of the tested path yet?
 
@@ -58,6 +60,7 @@ On Termux, the installer automatically:
 
 - uses `pkg` for system packages
 - creates the venv with `python -m venv`
+- prebuilds the Android psutil compatibility shim before the Python package install
 - attempts the broad `.[termux-all]` extra first and falls back to the smaller `.[termux]` extra (then a base install) — the curl installer matches this order automatically
 - links `hermes` into `$PREFIX/bin` so it stays on your Termux PATH
 - skips the untested browser / WhatsApp bootstrap
@@ -102,7 +105,17 @@ python -m pip install --upgrade pip setuptools wheel
 
 `ANDROID_API_LEVEL` is important for Rust / maturin-based packages such as `jiter`.
 
-### 4. Install the tested Termux bundle
+### 4. Prebuild psutil for Android
+
+```bash
+python scripts/install_psutil_android.py
+```
+
+Python 3.13 on Termux reports `sys.platform == "android"`, and upstream psutil currently rejects that platform during package metadata generation. Hermes ships this temporary compatibility shim so the manual path matches what the one-line installer does automatically.
+
+If the command fails because the build toolchain is missing, re-run the package install from step 1 and retry this step before continuing.
+
+### 5. Install the tested Termux bundle
 
 ```bash
 python -m pip install -e '.[termux]' -c constraints-termux.txt
@@ -114,7 +127,7 @@ If you only want the minimal core agent, this also works:
 python -m pip install -e '.' -c constraints-termux.txt
 ```
 
-### 5. Put `hermes` on your Termux PATH
+### 6. Put `hermes` on your Termux PATH
 
 ```bash
 ln -sf "$PWD/venv/bin/hermes" "$PREFIX/bin/hermes"
@@ -122,14 +135,14 @@ ln -sf "$PWD/venv/bin/hermes" "$PREFIX/bin/hermes"
 
 `$PREFIX/bin` is already on PATH in Termux, so this makes the `hermes` command persist across new shells without re-activating the venv every time.
 
-### 6. Verify the install
+### 7. Verify the install
 
 ```bash
 hermes version
 hermes doctor
 ```
 
-### 7. Start Hermes
+### 8. Start Hermes
 
 ```bash
 hermes
@@ -175,6 +188,7 @@ Treat browser / WhatsApp tooling on Android as experimental until documented oth
 Use the tested Termux bundle instead:
 
 ```bash
+python scripts/install_psutil_android.py
 python -m pip install -e '.[termux]' -c constraints-termux.txt
 ```
 
@@ -193,6 +207,7 @@ python -m venv venv
 source venv/bin/activate
 export ANDROID_API_LEVEL="$(getprop ro.build.version.sdk)"
 python -m pip install --upgrade pip setuptools wheel
+python scripts/install_psutil_android.py
 python -m pip install -e '.[termux]' -c constraints-termux.txt
 ```
 
@@ -203,6 +218,22 @@ Set the API level explicitly before installing:
 ```bash
 export ANDROID_API_LEVEL="$(getprop ro.build.version.sdk)"
 python -m pip install -e '.[termux]' -c constraints-termux.txt
+```
+
+### `jiter` / `maturin` reports `Unsupported Android architecture: armv8l`
+
+Some 32-bit Termux devices report `armv8l`, which maturin does not accept as a build target. Set an explicit Rust target before installing:
+
+```bash
+export ANDROID_API_LEVEL="$(getprop ro.build.version.sdk)"
+export CARGO_BUILD_TARGET="armv7-linux-androideabi"
+python -m pip install -e '.[termux]' -c constraints-termux.txt
+```
+
+On a 64-bit Termux runtime, use `aarch64-linux-android` instead:
+
+```bash
+export CARGO_BUILD_TARGET="aarch64-linux-android"
 ```
 
 ### `hermes doctor` says ripgrep or Node is missing
@@ -224,6 +255,7 @@ pkg install clang rust make pkg-config libffi openssl
 Then retry:
 
 ```bash
+python scripts/install_psutil_android.py
 python -m pip install -e '.[termux]' -c constraints-termux.txt
 ```
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/termux.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/getting-started/termux.md
@@ -21,11 +21,13 @@ description: "通过 Termux 在 Android 手机上直接运行 Hermes Agent"
 - Honcho 记忆支持
 - ACP 支持
 
-具体对应以下命令：
+具体来说，在下方手动路径中的 Android psutil 预构建步骤完成后，它对应以下命令：
 
 ```bash
 python -m pip install -e '.[termux]' -c constraints-termux.txt
 ```
+
+在全新的 Android 环境中，请使用一行安装程序，或按下面完整手动流程执行；不要单独直接运行这条 pip 命令。
 
 ## 哪些功能尚未纳入已验证路径？
 
@@ -52,6 +54,7 @@ curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
 在 Termux 上，安装程序会自动：
 - 使用 `pkg` 安装系统包
 - 使用 `python -m venv` 创建虚拟环境
+- 在 Python 包安装前预构建 Android psutil 兼容 shim
 - 优先尝试较大的 `.[termux-all]` 扩展，失败后回退到较小的 `.[termux]` 扩展（再次失败则进行基础安装）——curl 安装程序自动按此顺序执行
 - 将 `hermes` 链接到 `$PREFIX/bin`，使其保留在 Termux PATH 中
 - 跳过未经验证的浏览器 / WhatsApp 引导
@@ -95,7 +98,17 @@ python -m pip install --upgrade pip setuptools wheel
 
 `ANDROID_API_LEVEL` 对于基于 Rust / maturin 的包（如 `jiter`）非常重要。
 
-### 4. 安装已验证的 Termux 包
+### 4. 为 Android 预构建 psutil
+
+```bash
+python scripts/install_psutil_android.py
+```
+
+Termux 上的 Python 3.13 会报告 `sys.platform == "android"`，而上游 psutil 当前会在生成包元数据时拒绝该平台。Hermes 随仓库提供这个临时兼容 shim，使手动安装路径与一行安装程序自动执行的流程保持一致。
+
+如果该命令因为缺少构建工具链而失败，请重新执行第 1 步的包安装，然后先重试本步骤再继续。
+
+### 5. 安装已验证的 Termux 包
 
 ```bash
 python -m pip install -e '.[termux]' -c constraints-termux.txt
@@ -107,7 +120,7 @@ python -m pip install -e '.[termux]' -c constraints-termux.txt
 python -m pip install -e '.' -c constraints-termux.txt
 ```
 
-### 5. 将 `hermes` 添加到 Termux PATH
+### 6. 将 `hermes` 添加到 Termux PATH
 
 ```bash
 ln -sf "$PWD/venv/bin/hermes" "$PREFIX/bin/hermes"
@@ -115,14 +128,14 @@ ln -sf "$PWD/venv/bin/hermes" "$PREFIX/bin/hermes"
 
 `$PREFIX/bin` 在 Termux 中已默认在 PATH 中，因此这样做可以让 `hermes` 命令在新 shell 中持续可用，无需每次重新激活虚拟环境。
 
-### 6. 验证安装
+### 7. 验证安装
 
 ```bash
 hermes version
 hermes doctor
 ```
 
-### 7. 启动 Hermes
+### 8. 启动 Hermes
 
 ```bash
 hermes
@@ -168,6 +181,7 @@ npm install
 改用已验证的 Termux 包：
 
 ```bash
+python scripts/install_psutil_android.py
 python -m pip install -e '.[termux]' -c constraints-termux.txt
 ```
 
@@ -185,6 +199,7 @@ python -m venv venv
 source venv/bin/activate
 export ANDROID_API_LEVEL="$(getprop ro.build.version.sdk)"
 python -m pip install --upgrade pip setuptools wheel
+python scripts/install_psutil_android.py
 python -m pip install -e '.[termux]' -c constraints-termux.txt
 ```
 
@@ -195,6 +210,22 @@ python -m pip install -e '.[termux]' -c constraints-termux.txt
 ```bash
 export ANDROID_API_LEVEL="$(getprop ro.build.version.sdk)"
 python -m pip install -e '.[termux]' -c constraints-termux.txt
+```
+
+### `jiter` / `maturin` 报错 `Unsupported Android architecture: armv8l`
+
+部分 32 位 Termux 设备会报告 `armv8l`，但 maturin 不接受它作为构建目标。安装前显式设置 Rust 目标：
+
+```bash
+export ANDROID_API_LEVEL="$(getprop ro.build.version.sdk)"
+export CARGO_BUILD_TARGET="armv7-linux-androideabi"
+python -m pip install -e '.[termux]' -c constraints-termux.txt
+```
+
+如果你的 Termux 运行时是 64 位，请改用 `aarch64-linux-android`：
+
+```bash
+export CARGO_BUILD_TARGET="aarch64-linux-android"
 ```
 
 ### `hermes doctor` 提示缺少 ripgrep 或 Node
@@ -216,6 +247,7 @@ pkg install clang rust make pkg-config libffi openssl
 然后重试：
 
 ```bash
+python scripts/install_psutil_android.py
 python -m pip install -e '.[termux]' -c constraints-termux.txt
 ```
 


### PR DESCRIPTION
## Problem

The supported Termux installer prebuilds Hermes' Android psutil compatibility shim before installing the Python package, but the documented manual-install path previously went directly to `pip install -e '.[termux]'`.

On a fresh Android environment, that difference causes the manual path to fail when upstream psutil rejects `sys.platform == "android"`. This PR closes that Termux compatibility gap by aligning the documented manual workflow with the behavior already implemented by the supported installer; it is not only a documentation clarification.

## What Changed

- updates the Termux manual-install guide so fresh Android installs run `python scripts/install_psutil_android.py` before `pip install -e '.[termux]'`
- mirrors the change in the zh-Hans Termux guide
- adds troubleshooting for `jiter` / `maturin` on 32-bit `armv8l` Termux devices using `CARGO_BUILD_TARGET`
- adds regression coverage so both manual guides keep the psutil shim before package installation and retain the 32-bit Rust target guidance

## Reproduction

On current `main`, I reproduced the psutil failure path by extracting psutil 7.2.2 from the pinned sdist and running its metadata step with `sys.platform` forced to `android`. The unpatched sdist exits with:

```text
platform android is not supported
```

Applying Hermes' existing `prepare_patched_psutil_sdist()` shim moves past that original rejection point. This confirms that the missing shim step in the manual workflow is the broken path reported in #31415.

## Validation

```bash
scripts/run_tests.sh tests/test_termux_manual_install_docs.py tests/hermes_cli/test_psutil_android_extract.py tests/test_install_sh_termux_network_prereqs.py -- -q
venv/bin/ruff check tests/test_termux_manual_install_docs.py
git diff --check
```

After rebasing onto the latest `main`, the focused documentation regression tests pass (`2 passed`), and the complete PR patch passes `git apply --check` cleanly against a fresh `main` worktree.

Fixes #31415
