### PR TITLE
fix(agent): honor HERMES_TLS_MAX_VERSION to cap provider TLS handshakes

### DIFF
--- a/agent/process_bootstrap.py
+++ b/agent/process_bootstrap.py
@@ -16,6 +16,13 @@ Three concerns, all tied to ``AIAgent`` boot-time / runtime IO setup:
    ``HTTPS_PROXY`` / ``HTTP_PROXY`` / ``ALL_PROXY``;
    ``_get_proxy_for_base_url`` respects ``NO_PROXY`` for the given base URL.
 
+4. **TLS version cap** — ``_get_tls_ssl_context`` honors
+   ``network.tls_max_version`` from config.yaml (bridged to the internal
+   ``HERMES_TLS_MAX_VERSION`` env var at startup) and ``_apply_tls_max_version``
+   composes that cap onto the httpx ``verify`` value the client builders already
+   carry, so users behind TLS-1.3-hostile networks or CDN edges can cap provider
+   connections at TLS 1.2 without losing per-provider CA settings.
+
 ``run_agent`` re-exports every name so existing
 ``from run_agent import _get_proxy_from_env`` imports keep working
 unchanged.
@@ -142,6 +149,100 @@ def _get_proxy_for_base_url(base_url: Optional[str]) -> Optional[str]:
     return proxy
 
 
+def _get_tls_ssl_context() -> Optional["ssl.SSLContext"]:
+    """Build an ``ssl.SSLContext`` capped by ``HERMES_TLS_MAX_VERSION``.
+
+    Some CDN edges and middleboxes accept TLS 1.2 handshakes but kill
+    TLS 1.3 ClientHellos, surfacing as ``[SSL: UNEXPECTED_EOF_WHILE_READING]``
+    roughly 15s into every request while ``curl`` (which uses the OS TLS
+    stack on Windows/macOS) works fine (#44365, DeepSeek's edge).  The
+    user-facing knob is ``network.tls_max_version: "1.2"`` in config.yaml,
+    bridged onto ``HERMES_TLS_MAX_VERSION`` at process startup by
+    ``hermes_constants.apply_tls_max_version`` (this layer has no config
+    access, and spawned agent subprocesses must inherit the cap; an
+    explicitly exported env var wins over config.yaml).
+
+    Accepted values: ``1.2`` / ``1.3``, optionally prefixed ``tls``/``tlsv``
+    (case-insensitive).  Returns ``None`` — meaning "use httpx defaults" —
+    when the variable is unset, empty, or invalid.  The context honors the
+    same CA-bundle overrides as the rest of the CLI: ``HERMES_CA_BUNDLE`` >
+    ``REQUESTS_CA_BUNDLE`` > ``SSL_CERT_FILE``.
+    """
+    raw = os.environ.get("HERMES_TLS_MAX_VERSION", "").strip()
+    if not raw:
+        return None
+
+    import logging
+    import ssl
+
+    logger = logging.getLogger(__name__)
+
+    normalized = raw.lower()
+    for prefix in ("tlsv", "tls"):
+        if normalized.startswith(prefix):
+            normalized = normalized[len(prefix):]
+            break
+    max_version = {
+        "1.2": ssl.TLSVersion.TLSv1_2,
+        "1.3": ssl.TLSVersion.TLSv1_3,
+    }.get(normalized)
+    if max_version is None:
+        logger.warning(
+            "Ignoring HERMES_TLS_MAX_VERSION=%r: expected '1.2' or '1.3'", raw
+        )
+        return None
+
+    cafile = None
+    for env_var in ("HERMES_CA_BUNDLE", "REQUESTS_CA_BUNDLE", "SSL_CERT_FILE"):
+        path = os.environ.get(env_var, "").strip()
+        if path:
+            cafile = path
+            break
+    try:
+        ctx = ssl.create_default_context(cafile=cafile)
+    except OSError as exc:
+        logger.warning(
+            "Ignoring HERMES_TLS_MAX_VERSION=%r: failed to load CA bundle "
+            "%r: %s", raw, cafile, exc
+        )
+        return None
+    ctx.maximum_version = max_version
+    return ctx
+
+
+def _apply_tls_max_version(verify: Any) -> Any:
+    """Compose the ``HERMES_TLS_MAX_VERSION`` cap onto an httpx ``verify``.
+
+    Main resolves per-provider ``ssl_ca_cert`` / ``ssl_verify`` into the httpx
+    ``verify`` argument (``True``, ``False``, or an ``ssl.SSLContext``).  The
+    TLS cap must ride on top of that rather than replace it:
+
+    * an existing ``SSLContext`` (a per-provider CA bundle) → cap it in place
+      so the caller's CA material survives;
+    * ``True`` (certifi default) → swap in a fresh capped default context;
+    * ``False`` (verification disabled, local dev only) → left untouched; a
+      max-version cap needs a context, and a caller who turned verification
+      off has opted out of TLS policy entirely.
+
+    Returns ``verify`` unchanged when the cap is unset or invalid.
+    """
+    capped = _get_tls_ssl_context()
+    if capped is None:
+        return verify
+
+    import ssl
+
+    if isinstance(verify, ssl.SSLContext):
+        try:
+            verify.maximum_version = capped.maximum_version
+        except (ValueError, OSError):
+            pass
+        return verify
+    if verify is True:
+        return capped
+    return verify
+
+
 def build_keepalive_http_client(
     base_url: str = "",
     *,
@@ -173,6 +274,9 @@ def build_keepalive_http_client(
         import httpx
 
         proxy = _get_proxy_for_base_url(base_url)
+        # Cap the TLS handshake if HERMES_TLS_MAX_VERSION is set (#44365),
+        # composing onto any per-provider verify context already resolved.
+        verify = _apply_tls_max_version(verify)
 
         limits = httpx.Limits(
             max_keepalive_connections=20,
@@ -223,5 +327,7 @@ __all__ = [
     "_install_safe_stdio",
     "_get_proxy_from_env",
     "_get_proxy_for_base_url",
+    "_get_tls_ssl_context",
+    "_apply_tls_max_version",
     "build_keepalive_http_client",
 ]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1681,14 +1681,18 @@ if _config_path.exists():
             file=sys.stderr,
         )
 
-# Apply IPv4 preference if configured (before any HTTP clients are created).
+# Apply IPv4 preference and TLS-version cap if configured (before any HTTP
+# clients are created).
 try:
-    from hermes_constants import apply_ipv4_preference
+    from hermes_constants import apply_ipv4_preference, apply_tls_max_version
     _network_cfg = (_cfg if '_cfg' in dir() else {}).get("network", {})
-    if isinstance(_network_cfg, dict) and _network_cfg.get("force_ipv4"):
-        apply_ipv4_preference(force=True)
+    if isinstance(_network_cfg, dict):
+        if _network_cfg.get("force_ipv4"):
+            apply_ipv4_preference(force=True)
+        if _network_cfg.get("tls_max_version"):
+            apply_tls_max_version(_network_cfg.get("tls_max_version"))
 except Exception as _bootstrap_exc:
-    print(f"  Warning: IPv4 preference application failed: {_bootstrap_exc}", file=sys.stderr)
+    print(f"  Warning: network preference application failed: {_bootstrap_exc}", file=sys.stderr)
 
 # Validate config structure early — log warnings so gateway operators see problems
 try:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2838,6 +2838,16 @@ DEFAULT_CONFIG = {
         # Python tries AAAA records first and hangs for the full TCP timeout
         # before falling back to IPv4.  Set to true to skip IPv6 entirely.
         "force_ipv4": False,
+        # Cap the TLS version used for provider connections.  Some CDN edges
+        # and middleboxes accept TLS 1.2 handshakes but kill TLS 1.3
+        # ClientHellos, surfacing as ``[SSL: UNEXPECTED_EOF_WHILE_READING]``
+        # while curl (OS TLS stack) works fine (#44365).  Set to "1.2" to cap
+        # the handshake; "" (default) keeps the OpenSSL default.  "1.0"/"1.1"
+        # are rejected — this knob exists to dodge broken TLS 1.3 paths, not
+        # to enable deprecated protocols.  Bridged to HERMES_TLS_MAX_VERSION
+        # at startup (an explicitly exported env var wins, so one-off shell
+        # overrides keep working).
+        "tls_max_version": "",
     },
 
     # Gateway settings — control how messaging platforms (Telegram, Discord,
@@ -3303,7 +3313,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 33,
+    "_config_version": 34,
 }
 
 # =============================================================================

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -570,8 +570,13 @@ try:
                 if _early_redact is not None:
                     os.environ["HERMES_REDACT_SECRETS"] = str(_early_redact).lower()
         _early_net_cfg = _early_cfg_raw.get("network", {})
-        if isinstance(_early_net_cfg, dict) and _early_net_cfg.get("force_ipv4"):
-            _FORCE_IPV4_EARLY = True
+        if isinstance(_early_net_cfg, dict):
+            if _early_net_cfg.get("force_ipv4"):
+                _FORCE_IPV4_EARLY = True
+            if _early_net_cfg.get("tls_max_version"):
+                from hermes_constants import apply_tls_max_version as _apply_tls
+
+                _apply_tls(_early_net_cfg.get("tls_max_version"))
         del _early_cfg_raw
     del _cfg_path
 except Exception:

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -976,6 +976,25 @@ def apply_ipv4_preference(force: bool = False) -> None:
     socket.getaddrinfo = _ipv4_getaddrinfo  # type: ignore[assignment]
 
 
+def apply_tls_max_version(value) -> None:
+    """Bridge ``network.tls_max_version`` from config.yaml to the env var.
+
+    ``agent.process_bootstrap._get_tls_ssl_context`` reads
+    ``HERMES_TLS_MAX_VERSION`` at HTTP-client build time (the agent runtime
+    has no config access at that layer, and spawned agent subprocesses must
+    inherit the cap).  This bridges the user-facing config.yaml key onto
+    that internal env var at process startup.
+
+    An explicitly exported ``HERMES_TLS_MAX_VERSION`` wins over config.yaml
+    so one-off shell overrides keep working.  Validation (accepting only
+    1.2/1.3) stays in ``_get_tls_ssl_context``; this just forwards the raw
+    value.  Safe to call multiple times.
+    """
+    if not value:
+        return
+    os.environ.setdefault("HERMES_TLS_MAX_VERSION", str(value).strip())
+
+
 # ─── Streaming Response Constants ────────────────────────────────────────────
 
 # Response ID for partial stream stubs used during error recovery

--- a/run_agent.py
+++ b/run_agent.py
@@ -112,6 +112,8 @@ from agent.process_bootstrap import (
     OpenAI,  # noqa: F401  # re-exported for tests that mock.patch("run_agent.OpenAI")
     _SafeWriter,  # noqa: F401  # re-exported for tests that `from run_agent import _SafeWriter`
     _get_proxy_for_base_url,
+    _get_tls_ssl_context,  # noqa: F401  # re-exported for tests that import it via run_agent
+    _apply_tls_max_version,
 )
 from agent.iteration_budget import IterationBudget
 
@@ -3948,6 +3950,13 @@ class AIAgent:
             # Explicitly read proxy settings so requests route through
             # HTTP_PROXY / HTTPS_PROXY / NO_PROXY correctly.
             _proxy = _get_proxy_for_base_url(base_url)
+
+            # HERMES_TLS_MAX_VERSION caps the TLS handshake (#44365: some CDN
+            # edges kill TLS 1.3 ClientHellos mid-handshake).  Compose the cap
+            # onto the per-provider ``verify`` already resolved so any
+            # per-provider CA bundle survives; the capped context then rides
+            # both the client and the plain no-proxy mounts below.
+            verify = _apply_tls_max_version(verify)
 
             # Proactive pool reaping: close idle connections at 20 s,
             # before reverse proxies (30–60 s typical) send FIN and

--- a/tests/run_agent/test_keepalive_tls_max_version.py
+++ b/tests/run_agent/test_keepalive_tls_max_version.py
@@ -1,0 +1,225 @@
+"""HERMES_TLS_MAX_VERSION must cap the TLS handshake on the primary client.
+
+Some CDN edges and middleboxes accept TLS 1.2 handshakes but kill TLS 1.3
+ClientHellos, surfacing as ``[SSL: UNEXPECTED_EOF_WHILE_READING]`` ~15s into
+every request while ``curl`` (OS TLS stack) works fine — #44365 hit this on
+Windows desktop against DeepSeek's edge.  ``network.tls_max_version: "1.2"``
+in config.yaml (bridged to the internal ``HERMES_TLS_MAX_VERSION`` env var by
+``hermes_constants.apply_tls_max_version`` at startup) caps the handshake for
+the keepalive-enabled httpx.Client injected by ``_create_openai_client``.
+
+httpx ignores client-level ``verify`` when an explicit ``transport`` is
+passed, so main mounts a verify-carrying transport per scheme; these tests
+pin that the cap lands on every pool the client can route through — the base
+transport, the plain no-proxy mounts, and (when a proxy env var is set) the
+proxy mount too.  The path #44365's reporter would actually exercise has no
+proxy, but a capped direct transport next to an uncapped proxy mount would
+silently reintroduce the bug for proxied users.
+
+The cap must also *compose* with main's per-provider ``verify`` plumbing
+(``ssl_ca_cert`` / ``ssl_verify`` resolved to an ``ssl.SSLContext``): capping
+must not discard a caller-supplied CA bundle.
+"""
+import ssl
+
+import httpx
+
+from agent.process_bootstrap import _apply_tls_max_version, _get_tls_ssl_context
+from run_agent import AIAgent
+
+_PROXY_KEYS = ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+               "https_proxy", "http_proxy", "all_proxy")
+
+
+def _clear_env(monkeypatch):
+    for key in _PROXY_KEYS + ("HERMES_TLS_MAX_VERSION",):
+        monkeypatch.delenv(key, raising=False)
+
+
+def _pool_ssl_contexts(client: httpx.Client):
+    """Collect the ssl contexts of the base transport and all mounts."""
+    contexts = []
+    transports = [client._transport, *client._mounts.values()]
+    for transport in transports:
+        if transport is None:
+            continue
+        pool = getattr(transport, "_pool", None)
+        ctx = getattr(pool, "_ssl_context", None)
+        if ctx is not None:
+            contexts.append(ctx)
+    return contexts
+
+
+def test_unset_env_returns_none(monkeypatch):
+    _clear_env(monkeypatch)
+    assert _get_tls_ssl_context() is None
+    monkeypatch.setenv("HERMES_TLS_MAX_VERSION", "   ")
+    assert _get_tls_ssl_context() is None
+
+
+def test_caps_maximum_version_at_tls12(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("HERMES_TLS_MAX_VERSION", "1.2")
+    ctx = _get_tls_ssl_context()
+    assert isinstance(ctx, ssl.SSLContext)
+    assert ctx.maximum_version == ssl.TLSVersion.TLSv1_2
+
+
+def test_accepts_tls_prefixes_case_insensitive(monkeypatch):
+    _clear_env(monkeypatch)
+    for raw in ("TLSv1.2", "tls1.2", "TLS1.2"):
+        monkeypatch.setenv("HERMES_TLS_MAX_VERSION", raw)
+        ctx = _get_tls_ssl_context()
+        assert ctx is not None and ctx.maximum_version == ssl.TLSVersion.TLSv1_2, raw
+    monkeypatch.setenv("HERMES_TLS_MAX_VERSION", "1.3")
+    ctx = _get_tls_ssl_context()
+    assert ctx is not None and ctx.maximum_version == ssl.TLSVersion.TLSv1_3
+
+
+def test_invalid_values_are_ignored(monkeypatch):
+    _clear_env(monkeypatch)
+    # 1.0/1.1 are deliberately rejected — the knob exists to dodge broken
+    # TLS 1.3 paths, not to enable deprecated protocol versions.
+    for raw in ("1.1", "1.0", "garbage", "ssl3"):
+        monkeypatch.setenv("HERMES_TLS_MAX_VERSION", raw)
+        assert _get_tls_ssl_context() is None, raw
+
+
+# ─── composition with main's per-provider verify plumbing ───────────────────
+
+
+def test_apply_cap_noop_when_unset(monkeypatch):
+    _clear_env(monkeypatch)
+    assert _apply_tls_max_version(True) is True
+    assert _apply_tls_max_version(False) is False
+    existing = ssl.create_default_context()
+    assert _apply_tls_max_version(existing) is existing
+
+
+def test_apply_cap_swaps_true_for_capped_context(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("HERMES_TLS_MAX_VERSION", "1.2")
+    result = _apply_tls_max_version(True)
+    assert isinstance(result, ssl.SSLContext)
+    assert result.maximum_version == ssl.TLSVersion.TLSv1_2
+
+
+def test_apply_cap_preserves_existing_ca_context(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("HERMES_TLS_MAX_VERSION", "1.2")
+    provided = ssl.create_default_context()
+    result = _apply_tls_max_version(provided)
+    # Same object — per-provider CA material must survive; only the ceiling moves.
+    assert result is provided
+    assert result.maximum_version == ssl.TLSVersion.TLSv1_2
+
+
+def test_apply_cap_leaves_verify_false_untouched(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("HERMES_TLS_MAX_VERSION", "1.2")
+    assert _apply_tls_max_version(False) is False
+
+
+# ─── end-to-end through the keepalive client builder ────────────────────────
+
+
+def test_keepalive_client_transport_gets_capped_context(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("HERMES_TLS_MAX_VERSION", "1.2")
+    client = AIAgent._build_keepalive_http_client("https://api.deepseek.com")
+    assert isinstance(client, httpx.Client)
+    try:
+        contexts = _pool_ssl_contexts(client)
+        assert contexts, "expected the keepalive transport to expose an ssl context"
+        for ctx in contexts:
+            assert ctx.maximum_version == ssl.TLSVersion.TLSv1_2
+    finally:
+        client.close()
+
+
+def test_proxy_mount_inherits_capped_context(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("HERMES_TLS_MAX_VERSION", "1.2")
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7897")
+    client = AIAgent._build_keepalive_http_client("https://api.deepseek.com")
+    assert isinstance(client, httpx.Client)
+    try:
+        pools = [
+            type(mount._pool).__name__
+            for mount in client._mounts.values()
+            if mount is not None and hasattr(mount, "_pool")
+        ]
+        assert "HTTPProxy" in pools, pools
+        contexts = _pool_ssl_contexts(client)
+        assert contexts
+        for ctx in contexts:
+            assert ctx.maximum_version == ssl.TLSVersion.TLSv1_2
+    finally:
+        client.close()
+
+
+def test_unset_env_keeps_default_tls(monkeypatch):
+    _clear_env(monkeypatch)
+    client = AIAgent._build_keepalive_http_client("https://api.deepseek.com")
+    assert isinstance(client, httpx.Client)
+    try:
+        for ctx in _pool_ssl_contexts(client):
+            assert ctx.maximum_version == ssl.TLSVersion.MAXIMUM_SUPPORTED
+    finally:
+        client.close()
+
+
+# ─── config.yaml bridge — hermes_constants.apply_tls_max_version ────────────
+
+
+def test_default_config_ships_tls_max_version_off():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    assert DEFAULT_CONFIG["network"]["tls_max_version"] == ""
+
+
+def test_bridge_sets_env_from_config(monkeypatch):
+    from hermes_constants import apply_tls_max_version
+
+    _clear_env(monkeypatch)
+    apply_tls_max_version("1.2")
+    import os
+
+    assert os.environ["HERMES_TLS_MAX_VERSION"] == "1.2"
+
+
+def test_bridge_does_not_override_explicit_env(monkeypatch):
+    from hermes_constants import apply_tls_max_version
+
+    _clear_env(monkeypatch)
+    monkeypatch.setenv("HERMES_TLS_MAX_VERSION", "1.3")
+    apply_tls_max_version("1.2")
+    import os
+
+    assert os.environ["HERMES_TLS_MAX_VERSION"] == "1.3"
+
+
+def test_bridge_noop_on_empty(monkeypatch):
+    from hermes_constants import apply_tls_max_version
+
+    _clear_env(monkeypatch)
+    for value in ("", None, 0):
+        apply_tls_max_version(value)
+    import os
+
+    assert "HERMES_TLS_MAX_VERSION" not in os.environ
+
+
+def test_bridge_handles_yaml_float_and_whitespace(monkeypatch):
+    """yaml parses an unquoted ``tls_max_version: 1.2`` as a float."""
+    from hermes_constants import apply_tls_max_version
+
+    _clear_env(monkeypatch)
+    apply_tls_max_version(1.2)
+    ctx = _get_tls_ssl_context()
+    assert ctx is not None and ctx.maximum_version == ssl.TLSVersion.TLSv1_2
+
+    _clear_env(monkeypatch)
+    apply_tls_max_version("  1.2  ")
+    ctx = _get_tls_ssl_context()
+    assert ctx is not None and ctx.maximum_version == ssl.TLSVersion.TLSv1_2


### PR DESCRIPTION
## Summary

#44365 reports intermittent DeepSeek connection failures on Windows desktop: the bundled Python/OpenSSL dies with `[SSL: UNEXPECTED_EOF_WHILE_READING]` ~15s into every TLS 1.3 handshake against `api.deepseek.com`, while a TLS 1.2-only handshake succeeds in 0.33s (and `curl`/PowerShell work because they use the OS TLS stack, not OpenSSL). This is a known class of CDN-edge/middlebox behavior — the server (or something in the path) accepts TLS 1.2 ClientHellos but kills TLS 1.3 ones.

This adds the escape hatch the issue asks for, as a config.yaml setting:

```yaml
network:
  tls_max_version: "1.2"
```

## Implementation

- `hermes_cli/config.py`: new `network.tls_max_version` key (default `""` = OpenSSL default), sibling of `network.force_ipv4` in the existing "connectivity workarounds" section. Per the AGENTS.md contribution rubric, the user-facing surface is config.yaml — the env var below is an internal bridge.
- `hermes_constants.py`: `apply_tls_max_version()` bridges the config value onto the internal `HERMES_TLS_MAX_VERSION` env var (same pattern as `gateway.strict` → `HERMES_MEDIA_DELIVERY_STRICT`). The env-var hop is needed because `agent/process_bootstrap.py` has no config access at HTTP-client build time, and spawned agent subprocesses must inherit the cap. An explicitly exported env var wins over config.yaml, so one-off shell overrides keep working.
- Bridged at both entrypoints that already apply `network.force_ipv4`: the `hermes_cli/main.py` early raw-yaml block (covers CLI, desktop dashboard spawns, TUI gateway — no extra config.yaml read) and the `gateway/run.py` bootstrap.
- `agent/process_bootstrap.py`: `_get_tls_ssl_context()` parses the value (accepts `1.2`/`1.3`, optional `tls`/`tlsv` prefix, case-insensitive; yaml floats fine) and builds an `ssl.SSLContext` with `maximum_version` capped. It honors the CLI's existing CA-bundle override convention (`HERMES_CA_BUNDLE` > `REQUESTS_CA_BUNDLE` > `SSL_CERT_FILE`, same precedence as `_resolve_requests_verify` in `agent/model_metadata.py`). Unset/invalid values fall back to httpx defaults with a logged warning; `1.0`/`1.1` are deliberately rejected — the knob exists to dodge broken TLS 1.3 paths, not to enable deprecated protocols.
- `run_agent.py` `_build_keepalive_http_client`: passes the context to **both** the keepalive `HTTPTransport` (httpx ignores client-level `verify` when an explicit `transport` is passed) and the `httpx.Client` (so the proxy mount built internally from `proxy=` inherits the same cap — otherwise proxied users would silently keep the broken default).

## Tests

`tests/run_agent/test_keepalive_tls_max_version.py` (12 tests): parsing (unset/blank, prefixes, invalid + 1.0/1.1 rejection), integration pins that the capped context lands on the transport pool and on the `HTTPProxy` mount when `HTTPS_PROXY` is set, that the default path keeps `MAXIMUM_SUPPORTED`, and the config bridge (sets the env var, never overrides an explicitly exported one, no-op on empty, handles yaml-float `1.2` and whitespace). Adjacent suites (`test_create_openai_client_proxy_env`, `test_openai_client_lifecycle`, `test_ipv4_preference`, `hermes_cli/test_config.py`) all pass.

Fixes #44365
