### PR TITLE
fix(cli): serve profile dashboard in-place on Windows instead of re-exec

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10317,6 +10317,7 @@ def cmd_dashboard(args):
     #     the sticky active_profile file) with the launching profile
     #     preselected in the UI's switcher.
     # `--isolated` opts out and preserves the old per-profile behavior.
+    # Windows skips the re-exec leg and serves in-place (no real execve there).
     try:
         from hermes_cli.profiles import get_active_profile_name
         _launch_profile = get_active_profile_name()
@@ -10340,28 +10341,39 @@ def cmd_dashboard(args):
                     pass
             sys.exit(0)
 
-        print(
-            f"Routing to the machine dashboard (profile '{_launch_profile}' "
-            f"preselected). Use --isolated for a dedicated per-profile server."
-        )
-        reexec_argv = [
-            sys.executable, "-m", "hermes_cli.main",
-            "-p", "default",
-            "dashboard",
-            "--port", str(args.port),
-            "--host", args.host,
-            "--open-profile", _launch_profile,
-        ]
-        if args.no_open:
-            reexec_argv.append("--no-open")
-        if getattr(args, "insecure", False):
-            reexec_argv.append("--insecure")
-        if getattr(args, "skip_build", False):
-            reexec_argv.append("--skip-build")
-        env = os.environ.copy()
-        # Drop the profile HERMES_HOME so the child binds the machine root.
-        env.pop("HERMES_HOME", None)
-        os.execvpe(sys.executable, reexec_argv, env)
+        if os.name == "nt":
+            # Windows has no real execve: the CRT emulates it as spawn-new +
+            # terminate-current, so whoever spawned this process — notably the
+            # desktop app's backend pool, which tracks this exact PID — sees
+            # an immediate crash and reaps the backend (#44309). Serve the
+            # profile in-place instead (same behavior as --isolated).
+            print(
+                f"Serving a dedicated dashboard for profile '{_launch_profile}' "
+                f"(Windows cannot re-exec into the machine dashboard)."
+            )
+        else:
+            print(
+                f"Routing to the machine dashboard (profile '{_launch_profile}' "
+                f"preselected). Use --isolated for a dedicated per-profile server."
+            )
+            reexec_argv = [
+                sys.executable, "-m", "hermes_cli.main",
+                "-p", "default",
+                "dashboard",
+                "--port", str(args.port),
+                "--host", args.host,
+                "--open-profile", _launch_profile,
+            ]
+            if args.no_open:
+                reexec_argv.append("--no-open")
+            if getattr(args, "insecure", False):
+                reexec_argv.append("--insecure")
+            if getattr(args, "skip_build", False):
+                reexec_argv.append("--skip-build")
+            env = os.environ.copy()
+            # Drop the profile HERMES_HOME so the child binds the machine root.
+            env.pop("HERMES_HOME", None)
+            os.execvpe(sys.executable, reexec_argv, env)
 
     # Attach gui.log early so dashboard startup/build failures are captured in
     # the same logs directory as every other Hermes surface.

--- a/tests/hermes_cli/test_dashboard_unified_launch.py
+++ b/tests/hermes_cli/test_dashboard_unified_launch.py
@@ -115,6 +115,37 @@ class TestUnifiedDashboardRouting:
             main_mod.cmd_dashboard(_args())
         assert listening_calls == []
 
+    def test_windows_profile_launch_serves_in_place(self, main_mod, monkeypatch, capsys):
+        """On Windows the CRT emulates execve as spawn+terminate, which makes
+        the desktop's PID-tracked pool backend look like an instant crash
+        (#44309). The routing must serve the profile in-place instead."""
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name", lambda: "auditor"
+        )
+        monkeypatch.setattr(main_mod, "_dashboard_listening", lambda host, port: False)
+        monkeypatch.setattr(main_mod.os, "name", "nt")
+        execs = []
+        monkeypatch.setattr(main_mod.os, "execvpe", lambda *a, **k: execs.append(a))
+        monkeypatch.setitem(sys.modules, "fastapi", None)
+
+        with pytest.raises((SystemExit, AttributeError, ImportError, TypeError)):
+            main_mod.cmd_dashboard(_args())
+        assert execs == []  # never re-exec'd; fell through to serve in-place
+        assert "dedicated dashboard for profile 'auditor'" in capsys.readouterr().out
+
+    def test_windows_profile_launch_still_attaches(self, main_mod, monkeypatch):
+        """The attach leg involves no exec, so Windows keeps it: a running
+        machine dashboard is reused instead of starting a per-profile one."""
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name", lambda: "auditor"
+        )
+        monkeypatch.setattr(main_mod, "_dashboard_listening", lambda host, port: True)
+        monkeypatch.setattr(main_mod.os, "name", "nt")
+
+        with pytest.raises(SystemExit) as exc:
+            main_mod.cmd_dashboard(_args())
+        assert exc.value.code == 0
+
     def test_reexec_child_does_not_reroute(self, main_mod, monkeypatch):
         """The re-exec'd child carries --open-profile; the guard must treat
         that as 'already routed' and never re-exec again (no exec loop)."""


### PR DESCRIPTION
## Problem

The desktop app spawns per-profile pool backends as `hermes --profile <name> dashboard ...` with `HERMES_DESKTOP=1` (`apps/desktop/electron/main.cjs`, `spawnPoolBackend`). Any named profile launching `dashboard` without `--isolated` hits the unified machine-dashboard routing in `hermes_cli/main.py`, which re-execs via `os.execvpe`.

On POSIX that is a true process replacement — same PID, the Electron parent keeps tracking it. On Windows there is no real `execve`: the CRT emulates it as spawn-new + terminate-current. The PID the desktop is watching dies immediately (reported as `3221225477` / `0xC0000005`), the pool reaps the backend, and the desktop shows the gateway as failed. When a named profile is set as the *active* profile, the primary backend hits the same path and the desktop crash-loops from boot.

## Fix

- Keep the no-exec **attach** leg (machine dashboard already listening → open `?profile=<name>` and exit) on all platforms.
- On Windows, skip the **re-exec** leg and serve the profile dashboard in-place, with the same semantics as `--isolated`. This also keeps the desktop's PID tracking intact: the process it spawned is the process that serves.

POSIX behavior is unchanged.

## Tests

- `test_windows_profile_launch_serves_in_place` — Windows + named profile + no dashboard listening → no `execvpe`, falls through to serve in-place.
- `test_windows_profile_launch_still_attaches` — Windows + dashboard already listening → attach leg still exits 0.
- All existing routing tests pass unchanged (`tests/hermes_cli/test_dashboard_unified_launch.py`: 8 passed; `test_gui_command.py`: 27 passed).

Fixes #44309

🤖 Generated with [Claude Code](https://claude.com/claude-code)