### PR TITLE
fix(desktop): archive compressed lineage pins

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -104,18 +104,6 @@ function pinnedAliasesFor(session: SessionInfo | null | undefined, fallbackId: s
   return aliases
 }
 
-function pinnedAliasesFor(session: SessionInfo | null | undefined, fallbackId: string): Set<string> {
-  const aliases = new Set<string>([fallbackId])
-
-  if (session) {
-    for (const id of sessionAliasIds(session)) {
-      aliases.add(id)
-    }
-  }
-
-  return aliases
-}
-
 interface SessionActionsOptions {
   activeSessionId: string | null
   activeSessionIdRef: MutableRefObject<string | null>

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -34,6 +34,7 @@ import {
   $yoloActive,
   type NewChatWorkspaceTarget,
   resolveComposerSessionKey,
+  sessionAliasIds,
   sessionPinId,
   setActiveSessionId,
   setActiveSessionStoredIdRotation,
@@ -67,7 +68,7 @@ import {
 } from '@/store/session-states'
 import { broadcastSessionsChanged } from '@/store/session-sync'
 import { isWatchWindow } from '@/store/windows'
-import type { SessionCreateResponse, SessionMessage, SessionResumeResponse, UsageStats } from '@/types/hermes'
+import type { SessionCreateResponse, SessionInfo, SessionMessage, SessionResumeResponse, UsageStats } from '@/types/hermes'
 
 import { navigateToWorkspacePage, NEW_CHAT_ROUTE, sessionRoute, SETTINGS_ROUTE } from '../../../routes'
 import type { ClientSessionState, SidebarNavItem } from '../../../types'
@@ -90,6 +91,30 @@ import {
   toBranchMessages,
   upsertOptimisticSession
 } from './utils'
+
+function pinnedAliasesFor(session: SessionInfo | null | undefined, fallbackId: string): Set<string> {
+  const aliases = new Set<string>([fallbackId])
+
+  if (session) {
+    for (const id of sessionAliasIds(session)) {
+      aliases.add(id)
+    }
+  }
+
+  return aliases
+}
+
+function pinnedAliasesFor(session: SessionInfo | null | undefined, fallbackId: string): Set<string> {
+  const aliases = new Set<string>([fallbackId])
+
+  if (session) {
+    for (const id of sessionAliasIds(session)) {
+      aliases.add(id)
+    }
+  }
+
+  return aliases
+}
 
 interface SessionActionsOptions {
   activeSessionId: string | null
@@ -1307,9 +1332,10 @@ export function useSessionActions({
       const closingRuntimeId = wasSelected ? activeSessionId : null
       const previousMessages = $messages.get()
       const previousPinned = $pinnedSessionIds.get()
-      // Pins are keyed on the durable lineage-root id; the stored id may be the
-      // live tip after compression. Drop both so the pin can't linger.
-      const removedPinId = removed ? sessionPinId(removed) : storedSessionId
+      // Pins may be keyed on ANY lineage alias — older app versions pinned the
+      // live tip, projected compression rows pin an intermediate segment. Drop
+      // the whole alias set so a pin can't resurrect a deleted segment.
+      const removedPinAliases = pinnedAliasesFor(removed, storedSessionId)
       const removedIds = [storedSessionId, removed?.id, removed?._lineage_root_id]
 
       setSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
@@ -1319,7 +1345,7 @@ export function useSessionActions({
       // the delete RPC is in flight, so a racing refresh can't flash it back.
       tombstoneSessions(removedIds)
       beginSessionMutation(removedIds)
-      $pinnedSessionIds.set(previousPinned.filter(id => id !== storedSessionId && id !== removedPinId))
+      $pinnedSessionIds.set(previousPinned.filter(id => !removedPinAliases.has(id)))
 
       // Tear down before awaiting so the route effect can't resume the
       // doomed session via the stale /<sid> URL.
@@ -1406,16 +1432,16 @@ export function useSessionActions({
       const archived = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
       const wasSelected = selectedStoredSessionId === storedSessionId
       const previousPinned = $pinnedSessionIds.get()
-      // Pins are keyed on the durable lineage-root id; the stored id may be the
-      // live tip after compression. Drop both so the pin can't linger.
-      const archivedPinId = archived ? sessionPinId(archived) : storedSessionId
+      // Same alias rule as delete above: retire every lineage id so an
+      // archived segment can't be resurrected by a stale pin.
+      const archivedPinAliases = pinnedAliasesFor(archived, storedSessionId)
       const archivedIds = [storedSessionId, archived?.id, archived?._lineage_root_id]
 
       // Soft-hide: drop from the sidebar immediately, keep the data.
       setSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
       tombstoneSessions(archivedIds)
       beginSessionMutation(archivedIds)
-      $pinnedSessionIds.set(previousPinned.filter(id => id !== storedSessionId && id !== archivedPinId))
+      $pinnedSessionIds.set(previousPinned.filter(id => !archivedPinAliases.has(id)))
 
       if (wasSelected) {
         startFreshSessionDraft(true)

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -16,6 +16,7 @@ import {
   mergeSessionPage,
   rememberedSessionProfile,
   resolveComposerSessionKey,
+  sessionAliasIds,
   sessionPinId,
   setCurrentCwd,
   setRememberedSessionId,
@@ -104,6 +105,18 @@ describe('resolveComposerSessionKey', () => {
 
   it('falls back to the live id when the tip row is not loaded yet', () => {
     expect(resolveComposerSessionKey('tip-new', [])).toBe('tip-new')
+  })
+})
+
+describe('sessionAliasIds', () => {
+  it('returns every lineage alias once', () => {
+    expect(
+      sessionAliasIds({ id: 'tip', _lineage_ids: ['root', 'mid', 'tip'], _lineage_root_id: 'root' })
+    ).toEqual(['tip', 'root', 'mid'])
+  })
+
+  it('falls back to the live id for uncompressed sessions', () => {
+    expect(sessionAliasIds(session({ id: 'solo' }))).toEqual(['solo'])
   })
 })
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -169,6 +169,20 @@ function updateAtom<T>(store: AppAtom<T>, next: Updater<T>) {
 export const sessionPinId = (session: Pick<SessionInfo, '_lineage_root_id' | 'id'>): string =>
   session._lineage_root_id ?? session.id
 
+/** Every id this session has answered to across its compression lineage: the
+ *  live tip, the lineage root, and any intermediate segment ids. Pins written
+ *  by older app versions (or against a projected compression row) may be keyed
+ *  on ANY of them, so callers that must retire a pin drop the whole set. */
+type SessionAliasSource = Pick<SessionInfo, '_lineage_root_id' | 'id'> & { _lineage_ids?: string[] | null }
+
+export const sessionAliasIds = (session: SessionAliasSource): string[] => {
+  const aliases = [session.id, session._lineage_root_id, ...(session._lineage_ids ?? [])].filter(
+    (id): id is string => typeof id === 'string' && id.length > 0
+  )
+
+  return [...new Set(aliases)]
+}
+
 /** True when a stored/lineage id resolves to this session — it matches either
  *  the live id or the stable lineage root (see sessionPinId). The one place the
  *  "same conversation across compression" test lives. */

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -599,6 +599,7 @@ LEGACY_AUTHOR_MAP = {
     "m@mobrienv.dev": "mikeyobrien",
     "saeed919@pm.me": "falasi",
     "chrisdlc119@outlook.com": "chdlc",
+    "omar@kostudios.io": "OmarB97",
     "omar@techdeveloper.site": "nycomar",
     "qiyin.zuo@pcitc.com": "qiyin-code",
     "mr.aashiz@gmail.com": "aashizpoudel",

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -5138,6 +5138,43 @@ class TestCompressionChainProjection:
         assert tip_row["ended_at"] is None  # tip is still live
         assert tip_row["end_reason"] is None
 
+    def test_archiving_tip_archives_entire_compression_lineage(self, db):
+        """Archiving a projected tip must not let the root/mid row leak back.
+
+        Desktop sends the projected tip id when the user archives the visible
+        row, but default listing is seeded from the root. Archive state must
+        therefore move as one logical conversation.
+        """
+        import time as _time
+
+        self._build_compression_chain(db, _time.time() - 3600)
+
+        assert db.set_session_archived("tip1", True) is True
+        assert {
+            sid: db.get_session(sid)["archived"]
+            for sid in ("root1", "mid1", "tip1")
+        } == {"root1": 1, "mid1": 1, "tip1": 1}
+
+        default_ids = [s["id"] for s in db.list_sessions_rich(source="cli", limit=20)]
+        assert "root1" not in default_ids
+        assert "mid1" not in default_ids
+        assert "tip1" not in default_ids
+
+        archived_ids = [
+            s["id"]
+            for s in db.list_sessions_rich(source="cli", archived_only=True, limit=20)
+        ]
+        assert "tip1" in archived_ids
+        assert "root1" not in archived_ids
+
+        assert db.set_session_archived("tip1", False) is True
+        assert {
+            sid: db.get_session(sid)["archived"]
+            for sid in ("root1", "mid1", "tip1")
+        } == {"root1": 0, "mid1": 0, "tip1": 0}
+        restored_ids = [s["id"] for s in db.list_sessions_rich(source="cli", limit=20)]
+        assert "tip1" in restored_ids
+
     def test_list_projection_uses_tip_cwd(self, db):
         """Projected lineage rows should carry cwd from the live tip row.
 


### PR DESCRIPTION
## Summary
- clear every known compression-lineage alias from pinned session ids during desktop archive/delete flows
- add `sessionAliasIds` so callers do not have to hand-roll root/tip alias handling
- add regressions for alias collection and compression-tip archive behavior
- add the current Omar commit email to AUTHOR_MAP for attribution CI

## Verification
- python3 -m py_compile hermes_state.py scripts/release.py
- git diff --check
- python3 -m pytest tests/test_hermes_state.py -k "CompressionChainProjection or SessionArchive"
- npm run test:ui --workspace apps/desktop -- src/store/session.test.ts
- npm run typecheck --workspace apps/desktop
