### PR TITLE
fix(agent): resolve custom: prefix in vision provider before normalisation

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4142,6 +4142,7 @@ def resolve_vision_provider_client(
     requested, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
         "vision", provider, model, base_url, api_key
     )
+    raw_requested = requested
     requested = _normalize_vision_provider(requested)
 
     def _finalize(resolved_provider: str, sync_client: Any, default_model: Optional[str]):
@@ -4152,6 +4153,27 @@ def resolve_vision_provider_client(
             async_client, async_model = _to_async_client(sync_client, final_model, is_vision=True)
             return resolved_provider, async_client, async_model
         return resolved_provider, sync_client, final_model
+
+    # When the user specifies ``custom:<name>`` (e.g. ``custom:minimax``),
+    # _normalize_aux_provider strips the ``custom:`` prefix, collapsing it to
+    # the bare built-in provider name.  Try the named custom provider lookup
+    # with the raw name *before* falling through to the general dispatch so
+    # the user's custom_providers entry is honoured (#44349).
+    if raw_requested and raw_requested.startswith("custom:"):
+        try:
+            from hermes_cli.runtime_provider import _get_named_custom_provider
+            custom_entry = _get_named_custom_provider(raw_requested)
+        except Exception:
+            custom_entry = None
+        if custom_entry is not None:
+            client, final_model = resolve_provider_client(
+                raw_requested,
+                model=resolved_model or custom_entry.get("model"),
+                async_mode=async_mode,
+                api_mode=resolved_api_mode,
+            )
+            if client is not None:
+                return _finalize(raw_requested, client, final_model)
 
     if resolved_base_url:
         provider_for_base_override = (

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -491,3 +491,53 @@ class TestCustomProviderAliasCollision:
         assert isinstance(client, OpenAI)
         assert "override.example.com" in str(client.base_url)
         assert client.api_key == "override-key"
+
+
+class TestResolveVisionProviderClientCustomPrefix:
+    """resolve_vision_provider_client should honour custom:<name> even when
+    <name> matches a built-in provider (#44349)."""
+
+    def test_custom_prefix_resolves_to_named_custom_provider(self, tmp_path):
+        """custom:minimax should use the user's custom_providers entry, not the
+        built-in minimax provider."""
+        _write_config(tmp_path, {
+            "model": {"default": "test-model"},
+            "custom_providers": [
+                {"name": "minimax", "base_url": "http://custom-minimax.local/v1", "api_key": "custom-key"},
+            ],
+        })
+        from agent.auxiliary_client import resolve_vision_provider_client
+        provider, client, model = resolve_vision_provider_client("custom:minimax")
+        assert client is not None
+        assert "custom-minimax.local" in str(client.base_url)
+
+    def test_custom_prefix_unknown_provider_returns_none(self, tmp_path):
+        """custom:nonexistent should return None when no custom_providers entry matches."""
+        _write_config(tmp_path, {
+            "model": {"default": "test-model"},
+            "custom_providers": [
+                {"name": "beans", "base_url": "http://beans.local/v1", "api_key": "k"},
+            ],
+        })
+        from agent.auxiliary_client import resolve_vision_provider_client
+        provider, client, model = resolve_vision_provider_client("custom:nonexistent")
+        assert client is None
+
+    def test_custom_prefix_with_providers_dict_format(self, tmp_path):
+        """custom:<name> should also match providers: dict entries."""
+        _write_config(tmp_path, {
+            "model": {"default": "test-model"},
+            "providers": {
+                "minimax": {
+                    "provider": "openai",
+                    "base_url": "http://providers-dict-minimax.local/v1",
+                    "api_key_env": "MINIMAX_CN_API_KEY",
+                },
+            },
+        })
+        import os
+        os.environ["MINIMAX_CN_API_KEY"] = "cn-key"
+        from agent.auxiliary_client import resolve_vision_provider_client
+        provider, client, model = resolve_vision_provider_client("custom:minimax")
+        assert client is not None
+        assert "providers-dict-minimax.local" in str(client.base_url)


### PR DESCRIPTION
## What does this PR do?

Fixes `auxiliary.vision.provider: custom:<name>` collapsing to the bare built-in provider when `<name>` matches a built-in (e.g. `custom:minimax` → `minimax`). The user's `custom_providers` entry was never consulted, causing 401 on the wrong endpoint.

## Related Issue

Fixes #44349

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py`: In `resolve_vision_provider_client`, save the raw provider before `_normalize_vision_provider` strips the `custom:` prefix. When the raw name starts with `custom:`, try `_get_named_custom_provider(raw)` before falling through to general dispatch. This ensures the user's custom_providers entry is found.
- `tests/agent/test_auxiliary_named_custom_providers.py`: 3 new tests — custom prefix resolves to named provider, unknown custom prefix returns None, custom prefix matches providers: dict format.

## How to Test

1. Set `custom_providers: [{name: minimax, base_url: http://custom.local/v1, api_key: k}]` in config.yaml
2. Set `auxiliary.vision.provider: custom:minimax`
3. Call `resolve_vision_provider_client("custom:minimax")` — should use the custom endpoint, not built-in minimax
4. Run `pytest tests/agent/test_auxiliary_named_custom_providers.py -xvs` — all 32 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

⚠️ GitNexus unavailable — grep-based fallback used.
- Checked: `agent/auxiliary_client.py` (`_normalize_aux_provider`, `resolve_vision_provider_client`, `_get_named_custom_provider`)
- Blast radius: LOW — affects only `custom:<name>` vision provider resolution path
- Related patterns: same bug family as #16290, #16727, PR #39732
