### PR TITLE
fix(tui): keep reasoning-only assistant turns visible on session resume

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -847,6 +847,41 @@ def test_history_to_messages_preserves_tool_calls_for_resume_display():
     ]
 
 
+def test_history_to_messages_keeps_reasoning_only_assistant_turn():
+    # A thinking-only assistant turn (reasoning present, no visible text) is
+    # persisted and recallable, but was dropped from the resumed session view
+    # as "empty" -- so it vanished while the agent could still recall it from
+    # the transcript. Keep it (with reasoning) so the desktop "Thinking…"
+    # disclosure renders. (#44022)
+    history = [
+        {"role": "user", "content": "think about this"},
+        {"role": "assistant", "content": "", "reasoning": "step-by-step thoughts"},
+        {"role": "assistant", "content": "here is the answer"},
+    ]
+
+    assert server._history_to_messages(history) == [
+        {"role": "user", "text": "think about this"},
+        {"role": "assistant", "text": "", "reasoning": "step-by-step thoughts"},
+        {"role": "assistant", "text": "here is the answer"},
+    ]
+
+
+def test_history_to_messages_still_drops_empty_assistant_without_reasoning():
+    # A genuinely empty assistant turn (no text, no reasoning, no tool calls)
+    # remains filtered out -- the fix only spares reasoning-bearing turns.
+    history = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "", "reasoning": ""},
+        {"role": "assistant", "content": "   "},
+        {"role": "assistant", "content": "real reply"},
+    ]
+
+    assert server._history_to_messages(history) == [
+        {"role": "user", "text": "hi"},
+        {"role": "assistant", "text": "real reply"},
+    ]
+
+
 def test_history_to_messages_renders_multimodal_content():
     # bb/gui preserves image URLs in the resume payload so the desktop
     # renderer's extractEmbeddedImages can pull them back out and display

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3458,16 +3458,27 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
                 {"role": "tool", "name": name, "context": _tool_ctx(name, args)}
             )
             continue
-        if not content_text.strip():
+        # An assistant turn may carry only reasoning/thinking content with no
+        # visible text (extended-thinking turns, thinking-only recovery
+        # responses). Such a turn is persisted with its reasoning fields and is
+        # recallable from the transcript, but dropping it here as "empty" makes
+        # it vanish from the resumed/reloaded session view while the desktop's
+        # reasoning disclosure has nothing to render. Keep it when it carries
+        # reasoning so the "Thinking…" block still shows. (#44022)
+        reasoning_keys = (
+            "reasoning",
+            "reasoning_content",
+            "reasoning_details",
+            "codex_reasoning_items",
+        )
+        has_reasoning = role == "assistant" and any(
+            m.get(key) for key in reasoning_keys
+        )
+        if not content_text.strip() and not has_reasoning:
             continue
         msg = {"role": role, "text": content_text}
         if role == "assistant":
-            for key in (
-                "reasoning",
-                "reasoning_content",
-                "reasoning_details",
-                "codex_reasoning_items",
-            ):
+            for key in reasoning_keys:
                 if key in m and m.get(key) is not None:
                     msg[key] = m.get(key)
         messages.append(msg)


### PR DESCRIPTION
## Problem

On the desktop/TUI app, an assistant turn that produced **only a thinking/reasoning block** (extended-thinking turns, thinking-only recovery responses) **disappears from the session view** on resume/reload — while the turn is still in the transcript DB, so a *new* session can recall "what was said." This is the second symptom reported on #44022 ([scorpio-dot's comment](https://github.com/NousResearch/hermes-agent/issues/44022#issuecomment-4682933915)):

> after 2 or 3 messages, mainly when the LLM starts to use its "thinking" block, the message disappears entirely. I tested by opening a new session and getting the agent to recall what was said in that session and it can see the messages but they are still invisible in the session.

## Root cause

`tui_gateway/server.py::_history_to_messages` drops any message whose coerced text is empty **before** the assistant `reasoning` fields are attached:

```python
if not content_text.strip():
    continue
msg = {"role": role, "text": content_text}
if role == "assistant":
    for key in ("reasoning", "reasoning_content", "reasoning_details", "codex_reasoning_items"):
        if key in m and m.get(key) is not None:
            msg[key] = m.get(key)   # <- never reached for a reasoning-only turn
```

A reasoning-only assistant turn has empty `content` but non-empty reasoning, so it is filtered out of the resume payload entirely. The turn is still persisted (`gateway/session.py` stores the reasoning fields), which is why recall from a fresh session works — the asymmetry is display-only, on the history→messages serialization path used by desktop/TUI resume and reload.

## Fix

Keep an assistant turn when it carries any reasoning content, even with empty visible text, so the desktop's reasoning ("Thinking…") disclosure has something to render. Genuinely empty turns (no text, no reasoning, no tool calls) are still filtered out, and tool-call-only turns are unaffected.

## Tests

- `test_history_to_messages_keeps_reasoning_only_assistant_turn` — a reasoning-only turn survives with its `reasoning` field intact.
- `test_history_to_messages_still_drops_empty_assistant_without_reasoning` — empty/whitespace turns with no reasoning are still dropped.

Both pass; full `tests/test_tui_gateway_server.py` shows no new failures (one pre-existing unrelated `browser_manage` failure present on `main` as well).

## Scope

This is the **display/serialization** half of #44022's reports. The separate "resume fails with *No LLM provider configured*" provider-restore bug is addressed by #44062 (the complete restore-side fix) / #44151, and the persist-side by #44109. Using `Refs #44022` rather than `Fixes` so the provider bug isn't auto-closed.

Refs #44022

🤖 Generated with [Claude Code](https://claude.com/claude-code)