### PR TITLE
fix(bitwarden): honor zero TTL for disk cache

### DIFF
--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -498,7 +498,7 @@ def fetch_bitwarden_secrets(
     secrets, warnings = _run_bws_list(bws, access_token, project_id, server_url)
     entry = _CachedFetch(secrets=secrets, fetched_at=time.time())
     _CACHE[cache_key] = entry
-    if use_cache:
+    if use_cache and cache_ttl_seconds > 0:
         _write_disk_cache(cache_key, entry, home_path)
     return secrets, warnings
 

--- a/tests/test_bitwarden_secrets.py
+++ b/tests/test_bitwarden_secrets.py
@@ -666,6 +666,31 @@ def test_env_loader_calls_bsm_when_enabled(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+def test_disk_cache_not_written_when_ttl_zero(monkeypatch, tmp_path):
+    """cache_ttl_seconds=0 disables both disk reads and disk writes."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    fake_binary = tmp_path / "bws"
+    fake_binary.write_text("")
+    payload = _fake_bws_payload([{"key": "K1", "value": "v1"}])
+
+    call_count = {"n": 0}
+    def fake_run(*a, **kw):
+        call_count["n"] += 1
+        return mock.Mock(returncode=0, stdout=payload, stderr="")
+    monkeypatch.setattr(bw.subprocess, "run", fake_run)
+    bw._reset_cache_for_tests(home)
+
+    secrets, _ = bw.fetch_bitwarden_secrets(
+        access_token="0.t", project_id="proj-1", binary=fake_binary,
+        cache_ttl_seconds=0, home_path=home,
+    )
+
+    assert secrets == {"K1": "v1"}
+    assert call_count["n"] == 1
+    assert not bw._disk_cache_path(home).exists()
+
+
 def test_disk_cache_written_after_first_fetch(monkeypatch, tmp_path):
     """First fetch hits bws AND writes a 0600 file under hermes_home/cache/."""
     home = tmp_path / ".hermes"


### PR DESCRIPTION
## Summary
- Treat `secrets.bitwarden.cache_ttl_seconds: 0` as disabling both reads and writes for the Bitwarden Secrets Manager disk cache.
- Avoid writing `~/.hermes/cache/bws_cache.json` when the configured TTL is zero.
- Add a regression test covering the zero-TTL disk-cache write path.

## Why
`_read_disk_cache()` and `_CachedFetch.is_fresh()` already treat `ttl_seconds <= 0` as disabled. However, after a fresh BWS fetch, `fetch_bitwarden_secrets()` still wrote the disk cache whenever `use_cache=True`, even with `cache_ttl_seconds=0`.

That makes the documented/config-comment meaning of `0 disables` surprising, and can persist BSM-sourced secret values on disk despite a user setting TTL to zero.

## Test Plan
RED, with the new test present but `agent/secret_sources/bitwarden.py` temporarily restored to `origin/main`:

```bash
PYTHONPATH="$PWD" ~/.hermes/hermes-agent/venv/bin/python -m pytest \
  tests/test_bitwarden_secrets.py::test_disk_cache_not_written_when_ttl_zero \
  -q -o 'addopts=' --tb=short
```

Observed failure:

```text
E   AssertionError: assert not True
E    +  where True = PosixPath('.../.hermes/cache/bws_cache.json').exists
```

GREEN / targeted verification on this branch:

```bash
PYTHONPATH="$PWD" ~/.hermes/hermes-agent/venv/bin/python -m pytest \
  tests/test_bitwarden_secrets.py::test_disk_cache_not_written_when_ttl_zero \
  -q -o 'addopts=' --tb=short
# 1 passed

PYTHONPATH="$PWD" ~/.hermes/hermes-agent/venv/bin/python -m pytest \
  tests/test_bitwarden_secrets.py \
  -q -o 'addopts=' --tb=short
# 43 passed
```