### PR TITLE
fix: resolve pinned Telegram sessions into sidebar Pinned section

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -412,13 +412,15 @@ export function ChatSidebar({
 
   // Index sessions by both their live id and their lineage-root id so a pin
   // stored as the pre-compression root resolves to the live continuation tip.
+  // Include messaging sessions (Telegram, etc.) so pinned gateway chats also
+  // resolve into the Pinned section.
   const sessionByAnyId = useMemo(() => {
     const map = new Map<string, SessionInfo>()
 
     // Cron sessions are listed separately but can still be pinned, so index
     // them too — otherwise a pinned cron job can't resolve into the Pinned
     // section. Recents take precedence on id collisions (set last).
-    for (const s of [...cronSessions, ...visibleSessions]) {
+    for (const s of [...cronSessions, ...messagingSessions, ...visibleSessions]) {
       map.set(s.id, s)
 
       if (s._lineage_root_id && !map.has(s._lineage_root_id)) {


### PR DESCRIPTION
The sessionByAnyId map only indexed cronSessions and visibleSessions
(local CLI chats), so a pinned gateway session (Telegram, etc.) stored
its pinId in localStorage but could never be resolved back to a
SessionInfo object — the Pinned section rendered empty for those.

Include messagingSessions in the lookup so pinned gateway chats appear
correctly at the top of the sidebar.
