### PR TITLE
fix(lazy-deps): add explicit av dependency for stt.faster_whisper

### DIFF
--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -94,6 +94,15 @@ class TestAllowlist:
                 assert ld._spec_is_safe(spec), \
                     f"{feature}: spec {spec!r} fails safety check"
 
+    def test_stt_faster_whisper_includes_av(self):
+        """Regression: faster-whisper requires av>=11 transitively —
+        listing it explicitly handles corrupted-venv / interrupted-install
+        scenarios where transitive resolution fails."""
+        specs = ld.LAZY_DEPS["stt.faster_whisper"]
+        av_specs = [s for s in specs if s.startswith("av")]
+        assert len(av_specs) == 1, f"expected exactly one av spec, got {av_specs}"
+        assert av_specs[0].startswith("av>="), f"expected av>=floor pin, got {av_specs[0]}"
+
     def test_feature_install_command_returns_pip_invocation(self):
         cmd = ld.feature_install_command("memory.honcho")
         assert cmd is not None

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -111,6 +111,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         "faster-whisper==1.2.1",
         "sounddevice==0.5.5",
         "numpy==2.4.3",
+        "av>=11,<18",  # faster-whisper transitive dep; explicit for corrupted-venv resilience
     ),
 
     # ─── Image generation backends ─────────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

Adds `av>=11,<18` to the `stt.faster_whisper` dependency spec in `tools/lazy_deps.py`. The `faster-whisper` package requires `av>=11` as a transitive dependency, but when transitive resolution fails (corrupted venv, interrupted install), `import faster_whisper` raises `ModuleNotFoundError: No module named 'av'`. Listing `av` explicitly ensures it is always installed alongside `faster-whisper`.

## Related Issue

Fixes #44399

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/lazy_deps.py`: Added `"av>=11,<18"` to the `stt.faster_whisper` dependency tuple, with a comment explaining the transitive dependency rationale
- `tests/tools/test_lazy_deps.py`: Added regression test `test_stt_faster_whisper_includes_av` that verifies `av` is present in the spec and uses `>=` pinning

## How to Test

1. Run `python3 -c "import tools.lazy_deps as ld; print(ld.LAZY_DEPS['stt.faster_whisper'])"` — output should include `'av>=11,<18'`
2. Run `python3 -c "import tools.lazy_deps as ld; assert ld._spec_is_safe('av>=11,<18')"` — should pass without assertion
3. Run `pytest tests/tools/test_lazy_deps.py -v` — all 63 tests should pass (62 existing + 1 new)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `tools/lazy_deps.py` (callers: ensure, feature_install_command, active_features; flows: STT setup)
- Blast radius: LOW — single-line addition to a data dict, no control-flow changes
- Related patterns: follows the same pattern as `platform.discord` listing `brotlicffi` as an explicit transitive dep