### PR TITLE
fix(agent): steer GPT/Codex family to V4A for single-file edits too

### DIFF
--- a/agent/coding_context.py
+++ b/agent/coding_context.py
@@ -106,13 +106,19 @@ _GIT_TIMEOUT = 2.5
 # multi-file) and mode="replace" (find-and-swap). We nudge each family toward
 # its native format. Unknown families get nothing (the brief's neutral wording
 # stands). Substrings match the model id; aligned with TOOL_USE_ENFORCEMENT_MODELS.
+#
+# GPT/Codex get V4A for ALL edits, single-file included: in codex-rs,
+# apply_patch (V4A — apply_patch.lark) is the ONLY file editor, no
+# str_replace-style tool exists, and the shipped model prompts say to use
+# apply_patch even "for single file edits" — so a replace-mode nudge would
+# steer those models toward a format their first-party harness never taught
+# them.
 _EDIT_FORMAT_GUIDANCE: dict[str, tuple[tuple[str, ...], str]] = {
     "patch": (
         ("gpt", "codex"),
         "- Edit format: author new files with `write_file`; for edits to "
-        "existing code prefer `patch` with `mode='patch'` (V4A multi-file diff) "
-        "for structured or multi-file changes — it's the diff format you handle "
-        "most reliably. Use `mode='replace'` for a single small swap.",
+        "existing code use `patch` with `mode='patch'` (V4A diff) — including "
+        "single-file edits. It's the edit format you handle most reliably.",
     ),
     "replace": (
         ("claude", "sonnet", "opus", "haiku",

--- a/tests/agent/test_coding_context.py
+++ b/tests/agent/test_coding_context.py
@@ -312,6 +312,10 @@ class TestEditFormatSteering:
         assert "mode='patch'" in brief
         assert "V4A" in brief
         assert "write_file" in brief  # new files authored, not patched
+        # Codex-family harnesses ship apply_patch (V4A) as the ONLY editor and
+        # instruct it even for single-file edits — never nudge replace mode.
+        assert "single-file" in brief
+        assert "mode='replace'" not in brief
 
     def test_anthropic_family_gets_replace_nudge(self, tmp_path):
         _git_init(tmp_path)


### PR DESCRIPTION
## Problem

The coding-posture brief told GPT/Codex-family models to prefer `patch` `mode='patch'` (V4A) for structured/multi-file changes, but ended with "Use `mode='replace'` for a single small swap." That nudges those models toward an edit format their first-party harness never exposes to them.

## Verification (primary sources, not secondhand)

Checked against `openai/codex` current `main`:

- **`apply_patch` is the only file editor in codex-rs.** Zero occurrences of `str_replace` or `old_string` anywhere in the repo.
- **The grammar is exactly our V4A dialect.** `core/src/tools/handlers/apply_patch.lark` — `*** Begin Patch` / `*** Update File:` / `@@` context hunks / `*** Move to:` — same format `tools/patch_parser.py` implements.
- **The shipped model prompts instruct V4A for single-file edits.** `gpt_5_codex_prompt.md`, `gpt-5.2-codex_prompt.md`, `gpt-5.1-codex-max_prompt.md` (+ instruction templates) all contain "apply_patch for single file edits"; `gpt_5_1_prompt.md` / `gpt_5_2_prompt.md` say "Use the `apply_patch` tool to edit files (NEVER try `applypatch` or `apply-patch`)".
- **OpenAI ships this per-model as metadata** — `ModelInfo.apply_patch_tool_type` gates the handler in `core/src/tools/spec_plan.rs` and the `codex-api` models endpoint.

The replace-family line (Claude + open-weight) is untouched: Claude Code's `FileEdit` is `old_string`/`new_string`/`replace_all` exact string replacement and is the **only** file editor in its tool union (confirmed from Anthropic's shipped `sdk-tools.d.ts`, v2.1.168) — which is exactly our `mode='replace'`.

## Change

One guidance line: the GPT/Codex-family edit-format nudge now steers to `mode='patch'` (V4A) for **all** edits, single-file included, and no longer mentions replace mode. Comment above `_EDIT_FORMAT_GUIDANCE` documents the evidence.

## Tests

`test_openai_family_gets_v4a_nudge` extended: GPT brief must mention single-file V4A and must NOT contain `mode='replace'`. `tests/agent/test_coding_context.py`: 46 passed.