### PR TITLE
fix(hindsight): make tool-call retain async to match auto-retain behavior

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1551,12 +1551,13 @@ class HindsightMemoryProvider(MemoryProvider):
                     content,
                     context=context,
                     tags=args.get("tags"),
+                    retain_async=self._retain_async,
                 )
-                logger.debug("Tool hindsight_retain: bank=%s, content_len=%d, context=%s",
-                             self._bank_id, len(content), context)
+                logger.debug("Tool hindsight_retain: bank=%s, content_len=%d, context=%s, async=%s",
+                             self._bank_id, len(content), context, self._retain_async)
                 self._run_hindsight_operation(lambda client: client.aretain(**retain_kwargs))
-                logger.debug("Tool hindsight_retain: success")
-                return json.dumps({"result": "Memory stored successfully."})
+                logger.debug("Tool hindsight_retain: queued for async processing")
+                return json.dumps({"result": "Memory queued for storage (async)."})
             except Exception as e:
                 logger.warning("hindsight_retain failed: %s", e, exc_info=True)
                 return tool_error(f"Failed to store memory: {e}")


### PR DESCRIPTION
## Problem

Calling `hindsight_retain(content="...")` blocks the agent for up to **30 seconds** because the tool handler passes `retain_async=False` (the default) to the Hindsight API. The server processes synchronously: LLM fact extraction → embeddings → vector indexing → observation consolidation — all before responding.

Meanwhile, the **auto-retain** path (`sync_turn`) already uses `retain_async=True` and returns immediately.

## Fix

One-line change: pass `retain_async=self._retain_async` (defaults to `True`) to `_build_retain_kwargs` in the tool handler, matching the auto-retain semantics.

### Before
```
hindsight_retain("fact") → blocks for ~27s while server processes
```

### After  
```
hindsight_retain("fact") → returns in <1s, server processes in background
```

## Why this is safe

- The auto-retain path (`sync_turn`) has used `retain_async=True` since the Hindsight plugin was introduced — this just aligns the tool path with existing behavior
- No data loss risk: the Hindsight server queues async retains and processes them reliably
- The success message is updated from "stored successfully" to "queued for storage (async)" for honesty

## Testing

- Syntax check passes
- Tested against Hindsight 0.8.1: async retain returns in <1s vs 27s for sync