### PR TITLE
fix(lazy-deps): add import smoke test in ensure() after metadata verification

### DIFF
--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -178,7 +178,34 @@ class TestEnsure:
             ld, "_venv_pip_install",
             lambda specs, **kw: ld._InstallResult(True, "ok", ""),
         )
+        # find_spec smoke test: pretend the package is importable.
+        import importlib.util
+        monkeypatch.setattr(importlib.util, "find_spec", lambda name: True)
         ld.ensure("test.install", prompt=False)
+
+    def test_install_success_metadata_ok_but_import_broken(self, monkeypatch):
+        """Regression: pip succeeds + metadata is correct, but actual files
+        are missing (e.g. partial install, .pyd overwritten).  ensure() must
+        raise FeatureUnavailable instead of silently succeeding."""
+        monkeypatch.setitem(ld.LAZY_DEPS, "test.broken", ("chardet>=7",))
+        call_count = {"n": 0}
+
+        def fake_satisfied(spec):
+            call_count["n"] += 1
+            return call_count["n"] > 1  # missing first, installed after
+
+        monkeypatch.setattr(ld, "_is_satisfied", fake_satisfied)
+        monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
+        monkeypatch.setattr(
+            ld, "_venv_pip_install",
+            lambda specs, **kw: ld._InstallResult(True, "ok", ""),
+        )
+        # find_spec returns None — package metadata is present but files
+        # are broken / missing.
+        import importlib.util
+        monkeypatch.setattr(importlib.util, "find_spec", lambda name: None)
+        with pytest.raises(ld.FeatureUnavailable, match="import check failed"):
+            ld.ensure("test.broken", prompt=False)
 
     def test_install_failure_surfaces_pip_stderr(self, monkeypatch):
         monkeypatch.setitem(ld.LAZY_DEPS, "test.fail", ("zzzfake>=1",))

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -521,6 +521,27 @@ def ensure(feature: str, *, prompt: bool = True) -> None:
             "(may require Python restart)"
         )
 
+    # Smoke-test: metadata may report success even when actual files are
+    # broken (e.g. .pyd overwritten on Windows, partial install with
+    # missing submodules).  Verify each installed package is actually
+    # importable via importlib.util.find_spec().
+    import importlib.util
+    _broken = []
+    for spec in missing:
+        pkg = _pkg_name_from_spec(spec)
+        # pip normalises hyphens to underscores in the wheel, but the
+        # Python import name uses underscores too — try both.
+        mod_name = pkg.replace("-", "_")
+        if importlib.util.find_spec(mod_name) is None and importlib.util.find_spec(pkg) is None:
+            _broken.append(pkg)
+    if _broken:
+        raise FeatureUnavailable(
+            feature, tuple(missing),
+            "install reported success and metadata is correct, but "
+            f"import check failed for: {', '.join(_broken)} "
+            "(files may be missing or corrupted — try restarting Python)"
+        )
+
     logger.info("Lazy install complete for feature %r", feature)
 
 


### PR DESCRIPTION
## What does this PR do?

Adds an `importlib.util.find_spec()` smoke test in `ensure()` after the metadata version check passes. This catches cases where pip reports success and metadata is correct, but actual package files are broken or missing (partial install, `.pyd` overwritten on Windows, RECORD lists missing files).

## Related Issue

Fixes #44403

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/lazy_deps.py`: After `feature_missing()` returns empty (metadata OK), iterate over just-installed specs and verify each package is importable via `importlib.util.find_spec()`. If any package fails the import check, raise `FeatureUnavailable` with a descriptive message.
- `tests/tools/test_lazy_deps.py`: Added `test_install_success_metadata_ok_but_import_broken` regression test. Updated `test_install_success_path` to mock `find_spec` for the fake package.

## How to Test

1. Run `pytest tests/tools/test_lazy_deps.py -v` — all 62 tests should pass
2. Verify the new test: `pytest tests/tools/test_lazy_deps.py::TestEnsure::test_install_success_metadata_ok_but_import_broken -v`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `ensure()`, `feature_missing()`, `_is_satisfied()`, `_pkg_name_from_spec()` in `tools/lazy_deps.py`
- Blast radius: LOW — new verification step only runs after successful pip install + metadata check. Existing `test_install_succeeds_but_still_missing_raises` still catches the metadata-level failure case.
- Related patterns: Hyphens in pip package names are normalized to underscores for Python imports (`slack-bolt` → `slack_bolt`). The check tries both forms to handle edge cases.
