### PR TITLE
fix(desktop): keep active indicator after compression

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -16,6 +16,7 @@ import { triggerHaptic } from '@/lib/haptics'
 import { modelOptionsQueryKey } from '@/lib/model-options'
 import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
 import { invalidateSlashCompletions } from '@/lib/slash-completion-cache'
+import { asText } from '@/lib/text'
 import { type AgentNoticePayload, clearAgentNotice, nativeNoticeInput, showAgentNotice } from '@/store/agent-notices'
 import { reconcileApprovalModeForProfile } from '@/store/approval-mode'
 import { billingCtaLabel, clearBillingBlock, runBillingRecovery, setBillingBlock } from '@/store/billing-block'
@@ -51,6 +52,7 @@ import {
   setCurrentReasoningEffort,
   setCurrentServiceTier,
   setCurrentUsage,
+  setSelectedStoredSessionId,
   setSessions,
   setTurnStartedAt,
   setYoloActive
@@ -354,6 +356,12 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
           reconcileApprovalModeForProfile(event.profile, payload.approval_mode)
         }
 
+        // The live stored session key. After a compression the backend rotates
+        // it to the continuation session (see _sync_session_key_after_compress),
+        // so re-anchoring the sidebar to this value keeps the active-session
+        // indicator on the live row instead of stranding it on the ended parent.
+        const storedSessionKey = asText(payload?.stored_session_id).trim()
+
         if (apply) {
           // Do not call setCurrentModel / setCurrentProvider here. Composer
           // model/provider is sticky UI state (localStorage + manual picks).
@@ -405,6 +413,9 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         }
 
         if (sessionId && hasStatePatch) {
+          // Pass the live key as storedSessionId so the runtime→stored mapping
+          // (and the sidebar working dot) re-anchors to the continuation row
+          // when it rotates. `undefined` when absent = leave the mapping as-is.
           updateSessionState(
             sessionId,
             state => ({
@@ -415,6 +426,16 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
             }),
             payload?.stored_session_id || undefined
           )
+        } else if (sessionId && storedSessionKey) {
+          // No runtime-state patch this tick, but the key may still have rotated
+          // (compression) — re-anchor the mapping without mutating other state.
+          updateSessionState(sessionId, state => state, storedSessionKey)
+        }
+
+        if (isActiveEvent && storedSessionKey) {
+          // Move the sidebar's selection highlight with the focused session's
+          // live key so a mid-turn compression doesn't drop the active indicator.
+          setSelectedStoredSessionId(storedSessionKey)
         }
 
         // The running→busy transition must reach EVERY session, not just the

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8030,6 +8030,7 @@ def _fallback_session_info(session: dict) -> dict:
         "project": _project_info_for_cwd(cwd),
         "lazy": True,
         "model": _resolve_model(),
+        "stored_session_id": _session_lookup_key(session) or "",
         "skills": {},
         "tools": {},
     }


### PR DESCRIPTION
## Summary
- emit the gateway live `session_key` in `session.info` updates so desktop can see the post-compression stored id
- rebind selected/working desktop state when a running session rotates from a parent id to a continuation id
- make sidebar selected/working row checks lineage-aware so the glowing active marker follows the visible row

## Root Cause
After context compression, the gateway session id can rotate to a continuation session while the visible sidebar row still represents the parent/compressed lineage. `session.info` did not expose the live stored `session_key`, and the sidebar compared only the rendered row id against `$workingSessionIds`, so the currently running session could lose the orange active indicator even though `/api/status` still reported an active session.

## Tests
- `cd apps/desktop && eslint src/app/chat/sidebar/index.tsx src/app/session/hooks/use-message-stream.ts src/app/session/hooks/use-message-stream.test.tsx src/app/session/hooks/use-session-state-cache.test.tsx src/lib/chat-messages.ts src/store/session.ts src/store/session.test.ts src/types/hermes.ts`
- `cd apps/desktop && vitest run --environment jsdom src/store/session.test.ts src/app/session/hooks/use-session-state-cache.test.tsx src/app/session/hooks/use-message-stream.test.tsx`
- `cd apps/desktop && npm run typecheck`
- `python3 -m pytest tests/test_tui_gateway_server.py -k "session_info_includes_live_session_key or session_info_includes_mcp_servers"`