### PR TITLE
fix(bedrock): enable Claude 1M context metadata

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -312,8 +312,8 @@ def _supports_fast_mode(model: str) -> bool:
 # calls like title generation/session summarization.
 #
 # ``context-1m-2025-08-07`` is still required to unlock the 1M context window
-# on Claude Opus 4.6/4.7 and Sonnet 4.6 when served via AWS Bedrock or Azure
-# AI Foundry. Add it only for those endpoint-specific paths below.
+# on Claude Opus 4.6/4.7/4.8 and Sonnet 4.6 when served via AWS Bedrock or
+# Azure AI Foundry. Add it only for those endpoint-specific paths below.
 _COMMON_BETAS = [
     "interleaved-thinking-2025-05-14",
     "fine-grained-tool-streaming-2025-05-14",
@@ -827,9 +827,9 @@ def build_anthropic_bedrock_client(region: str):
     Attaches the common Anthropic beta headers as client-level defaults so
     that Bedrock-hosted Claude models get the same enhanced features as
     native Anthropic. The ``context-1m-2025-08-07`` beta in particular
-    unlocks the 1M context window for Opus 4.6/4.7 on Bedrock — without
-    it, Bedrock caps these models at 200K even though the Anthropic API
-    serves them with 1M natively.
+    unlocks the 1M context window for Opus 4.6/4.7/4.8 and Sonnet 4.6 on
+    Bedrock — without it, some Bedrock routes cap these models at 200K
+    even though the Anthropic API serves them with 1M natively.
 
     Auth uses the boto3 default credential chain (IAM roles, SSO, env vars).
     """

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -36,6 +36,8 @@ from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
+_BEDROCK_CONTEXT_1M_BETA = "context-1m-2025-08-07"
+
 # ---------------------------------------------------------------------------
 # Ensure boto3/botocore are installed before any code in this module runs.
 # Upstream removed boto3 from [all] extras (PRs #24220, #24515); lazy_deps
@@ -428,10 +430,11 @@ def is_anthropic_bedrock_model(model_id: str) -> bool:
       - ``us.anthropic.claude-*`` (US inference profiles)
       - ``global.anthropic.claude-*`` (global inference profiles)
       - ``eu.anthropic.claude-*`` (EU inference profiles)
+      - ``au.anthropic.claude-*`` (Australia inference profiles)
     """
     model_lower = model_id.lower()
     # Strip regional prefix if present
-    for prefix in ("us.", "global.", "eu.", "ap.", "jp."):
+    for prefix in ("us.", "global.", "eu.", "ap.", "jp.", "au."):
         if model_lower.startswith(prefix):
             model_lower = model_lower[len(prefix):]
             break
@@ -960,6 +963,12 @@ def build_converse_kwargs(
                     "The agent will operate in text-only mode.", model
                 )
 
+    if _requires_context_1m_beta(model):
+        fields = kwargs.setdefault("additionalModelRequestFields", {})
+        betas = fields.setdefault("anthropic_beta", [])
+        if _BEDROCK_CONTEXT_1M_BETA not in betas:
+            betas.append(_BEDROCK_CONTEXT_1M_BETA)
+
     if guardrail_config:
         kwargs["guardrailConfig"] = guardrail_config
 
@@ -1277,8 +1286,10 @@ def classify_bedrock_error(error_message: str) -> str:
 
 BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
     # Anthropic Claude models on Bedrock
-    "anthropic.claude-opus-4-6":     200_000,
-    "anthropic.claude-sonnet-4-6":   200_000,
+    "anthropic.claude-opus-4-8":     1_000_000,
+    "anthropic.claude-opus-4-7":     1_000_000,
+    "anthropic.claude-opus-4-6":     1_000_000,
+    "anthropic.claude-sonnet-4-6":   1_000_000,
     "anthropic.claude-sonnet-4-5":   200_000,
     "anthropic.claude-haiku-4-5":    200_000,
     "anthropic.claude-opus-4":       200_000,
@@ -1304,6 +1315,17 @@ BEDROCK_CONTEXT_LENGTHS: Dict[str, int] = {
 
 # Default for unknown Bedrock models
 BEDROCK_DEFAULT_CONTEXT_LENGTH = 128_000
+
+
+def _requires_context_1m_beta(model_id: str) -> bool:
+    """Return True when Bedrock Converse needs the Claude 1M-context beta.
+
+    Bedrock Converse uses ``additionalModelRequestFields`` instead of the
+    Anthropic ``anthropic-beta`` header. Keep this keyed off the same metadata
+    used for context-window budgeting so advertising 1M context and enabling
+    the request path stay in sync.
+    """
+    return is_anthropic_bedrock_model(model_id) and get_bedrock_context_length(model_id) > 200_000
 
 
 def get_bedrock_context_length(model_id: str) -> int:

--- a/tests/agent/test_bedrock_1m_context.py
+++ b/tests/agent/test_bedrock_1m_context.py
@@ -1,9 +1,9 @@
 """Tests for the 1M-context beta header on AWS Bedrock Claude models.
 
-Claude Opus 4.6/4.7 and Sonnet 4.6 support a 1M context window, but on AWS
-Bedrock (and Microsoft Foundry) that window is still gated behind the
-``context-1m-2025-08-07`` beta header as of 2026-04. Without it, Bedrock
-caps these models at 200K even though ``model_metadata.py`` advertises 1M.
+Claude Opus 4.6/4.7/4.8 and Sonnet 4.6 support a 1M context window, but on AWS
+Bedrock (and Microsoft Foundry) that window has been gated behind the
+``context-1m-2025-08-07`` beta header on some routes. Without it, Bedrock
+can cap these models at 200K even though ``model_metadata.py`` advertises 1M.
 
 These tests guard the invariant that the header is always emitted on the
 Bedrock client path, and that it survives the MiniMax bearer-auth strip.
@@ -55,9 +55,33 @@ class TestBedrockContext1MBeta:
         default_headers = call_kwargs.get("default_headers") or {}
         beta_header = default_headers.get("anthropic-beta", "")
         assert "context-1m-2025-08-07" in beta_header, (
-            "Bedrock client must send context-1m-2025-08-07 or Opus 4.6/4.7 "
+            "Bedrock client must send context-1m-2025-08-07 or Opus 4.6/4.7/4.8 "
             "silently caps at 200K context"
         )
         # Other common betas still present — no regression.
         assert "interleaved-thinking-2025-05-14" in beta_header
         assert "fine-grained-tool-streaming-2025-05-14" in beta_header
+
+    def test_build_converse_kwargs_sends_1m_beta_for_long_context_claude(self):
+        """Bedrock Converse needs anthropic_beta in additionalModelRequestFields."""
+        from agent.bedrock_adapter import build_converse_kwargs
+
+        kwargs = build_converse_kwargs(
+            model="au.anthropic.claude-opus-4-8",
+            messages=[{"role": "user", "content": "hello"}],
+        )
+
+        assert kwargs["additionalModelRequestFields"]["anthropic_beta"] == [
+            "context-1m-2025-08-07"
+        ]
+
+    def test_build_converse_kwargs_skips_1m_beta_for_standard_context_claude(self):
+        """Do not send the 1M beta for Claude IDs still capped at 200K."""
+        from agent.bedrock_adapter import build_converse_kwargs
+
+        kwargs = build_converse_kwargs(
+            model="us.anthropic.claude-sonnet-4-5",
+            messages=[{"role": "user", "content": "hello"}],
+        )
+
+        assert "additionalModelRequestFields" not in kwargs

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1097,13 +1097,17 @@ class TestBedrockErrorClassification:
 class TestBedrockContextLength:
     """Test Bedrock model context length lookup."""
 
+    def test_claude_opus_4_8(self):
+        from agent.bedrock_adapter import get_bedrock_context_length
+        assert get_bedrock_context_length("us.anthropic.claude-opus-4-8") == 1_000_000
+
     def test_claude_opus_4_6(self):
         from agent.bedrock_adapter import get_bedrock_context_length
-        assert get_bedrock_context_length("anthropic.claude-opus-4-6-20250514-v1:0") == 200_000
+        assert get_bedrock_context_length("anthropic.claude-opus-4-6-20250514-v1:0") == 1_000_000
 
     def test_claude_sonnet_versioned(self):
         from agent.bedrock_adapter import get_bedrock_context_length
-        assert get_bedrock_context_length("anthropic.claude-sonnet-4-6-20250514-v1:0") == 200_000
+        assert get_bedrock_context_length("anthropic.claude-sonnet-4-6-20250514-v1:0") == 1_000_000
 
     def test_nova_pro(self):
         from agent.bedrock_adapter import get_bedrock_context_length
@@ -1120,7 +1124,7 @@ class TestBedrockContextLength:
     def test_inference_profile_resolves(self):
         from agent.bedrock_adapter import get_bedrock_context_length
         # Cross-region inference profiles contain the base model ID
-        assert get_bedrock_context_length("us.anthropic.claude-sonnet-4-6") == 200_000
+        assert get_bedrock_context_length("us.anthropic.claude-sonnet-4-6") == 1_000_000
 
     def test_longest_prefix_wins(self):
         from agent.bedrock_adapter import get_bedrock_context_length
@@ -1234,6 +1238,10 @@ class TestIsAnthropicBedrockModel:
     def test_eu_claude(self):
         from agent.bedrock_adapter import is_anthropic_bedrock_model
         assert is_anthropic_bedrock_model("eu.anthropic.claude-sonnet-4-6") is True
+
+    def test_au_claude(self):
+        from agent.bedrock_adapter import is_anthropic_bedrock_model
+        assert is_anthropic_bedrock_model("au.anthropic.claude-opus-4-7") is True
 
 
 class TestEmptyTextBlockFix:


### PR DESCRIPTION
## Summary

- update Bedrock Claude context metadata for 1M-capable Opus/Sonnet models
- align `get_bedrock_context_length()` with versioned and inference-profile Claude IDs
- send `additionalModelRequestFields.anthropic_beta=["context-1m-2025-08-07"]` on the Bedrock Converse path when the selected Claude model advertises >200K context
- keep standard 200K Claude models from receiving the 1M beta

## Why

Some Bedrock Claude routes require the 1M context beta field in the Converse request. Without it, Hermes can budget for a 1M context window but Bedrock still rejects prompts over 200K tokens.

This keeps metadata and request construction in sync.

## Tests

- `python -m pytest tests/agent/test_bedrock_1m_context.py tests/agent/test_bedrock_adapter.py -q`

Result: `130 passed`

## Review

- Independent review flagged the missing Converse `additionalModelRequestFields` path; this PR now includes that fix and regression coverage.
- AU inference-profile IDs are covered so 1M metadata and beta injection work for regional profile prefixes, not just `us/global/eu`.