### PR TITLE
fix(web): add anysearch to backend whitelist and provider registry

### DIFF
--- a/agent/web_search_registry.py
+++ b/agent/web_search_registry.py
@@ -126,6 +126,7 @@ _LEGACY_PREFERENCE = (
     "exa",
     "searxng",
     "brave-free",
+    "anysearch",
     "ddgs",
 )
 

--- a/plugins/web/anysearch/__init__.py
+++ b/plugins/web/anysearch/__init__.py
@@ -1,0 +1,15 @@
+"""AnySearch web search plugin — bundled, auto-loaded.
+
+Backed by the public AnySearch MCP server (``api.anysearch.com/mcp``).
+No API key required — free tier works reliably in mainland China and
+other regions where DuckDuckGo is blocked or slow.
+"""
+
+from __future__ import annotations
+
+from plugins.web.anysearch.provider import AnySearchWebSearchProvider
+
+
+def register(ctx) -> None:
+    """Register the AnySearch provider with the plugin context."""
+    ctx.register_web_search_provider(AnySearchWebSearchProvider())

--- a/plugins/web/anysearch/provider.py
+++ b/plugins/web/anysearch/provider.py
@@ -1,0 +1,180 @@
+"""AnySearch web search — plugin form.
+
+Subclasses :class:`agent.web_search_provider.WebSearchProvider`. Calls the
+AnySearch MCP server (``api.anysearch.com/mcp``) via Streamable HTTP using
+the MCP ``tools/call`` JSON-RPC method. No API key required — the public
+endpoint is free and works reliably in regions where DuckDuckGo is blocked
+(mainland China, some corporate networks).
+
+Config keys this provider responds to::
+
+    web:
+      search_backend: "anysearch"   # explicit per-capability
+      backend: "anysearch"          # shared fallback
+
+The MCP endpoint URL can be overridden via env var::
+
+    ANYSEARCH_MCP_URL=https://api.anysearch.com/mcp
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Dict, List
+
+from agent.web_search_provider import WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_URL = "https://api.anysearch.com/mcp"
+
+
+def _anysearch_url() -> str:
+    """Return the AnySearch MCP URL from env, falling back to default."""
+    try:
+        from hermes_cli.config import get_env_value
+
+        val = get_env_value("ANYSEARCH_MCP_URL")
+    except Exception:
+        val = None
+    if val is None:
+        val = os.getenv("ANYSEARCH_MCP_URL", "")
+    return (val or "").strip() or _DEFAULT_URL
+
+
+def _call_mcp_tool(
+    tool_name: str, arguments: Dict[str, Any], *, timeout: int = 30
+) -> Dict[str, Any]:
+    """Call a tool on the AnySearch MCP server via Streamable HTTP.
+
+    Sends a JSON-RPC ``tools/call`` request and returns the parsed result.
+    Falls back gracefully on network / protocol errors.
+    """
+    import httpx
+
+    url = _anysearch_url()
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": tool_name, "arguments": arguments},
+    }
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            resp = client.post(url, json=payload, headers=headers)
+            resp.raise_for_status()
+            data = resp.json()
+    except httpx.TimeoutException:
+        return {"success": False, "error": f"AnySearch MCP request timed out ({timeout}s)"}
+    except httpx.HTTPStatusError as exc:
+        return {"success": False, "error": f"AnySearch HTTP {exc.response.status_code}: {exc.response.text[:200]}"}
+    except Exception as exc:  # noqa: BLE001
+        return {"success": False, "error": f"AnySearch MCP call failed: {exc}"}
+
+    # Extract the result from JSON-RPC response
+    if "error" in data:
+        err = data["error"]
+        return {"success": False, "error": f"AnySearch MCP error: {err.get('message', err)}"}
+
+    result = data.get("result", {})
+    content = result.get("content", [])
+
+    # MCP tool results come as a list of content blocks; extract text
+    text_parts = []
+    for block in content:
+        if isinstance(block, dict) and block.get("type") == "text":
+            text_parts.append(block.get("text", ""))
+        elif isinstance(block, str):
+            text_parts.append(block)
+
+    if not text_parts:
+        return {"success": False, "error": "AnySearch returned empty result"}
+
+    combined = "\n".join(text_parts)
+
+    # Try to parse as JSON (structured search results)
+    try:
+        return json.loads(combined)
+    except (json.JSONDecodeError, TypeError):
+        pass
+
+    # Return as plain text content
+    return {"success": True, "data": {"web": [{"title": "Result", "url": "", "description": combined, "position": 1}]}}
+
+
+class AnySearchWebSearchProvider(WebSearchProvider):
+    """Web search via the AnySearch MCP API.
+
+    Free, no API key required. Works reliably in mainland China and other
+    regions where DuckDuckGo is blocked. Supports both search and extract
+    via the MCP tools/call protocol.
+    """
+
+    @property
+    def name(self) -> str:
+        return "anysearch"
+
+    @property
+    def display_name(self) -> str:
+        return "AnySearch (MCP)"
+
+    def is_available(self) -> bool:
+        """Always available — no API key required.
+
+        The public MCP endpoint is free. We check for ``httpx`` importability
+        as the only hard dependency.
+        """
+        try:
+            import httpx  # noqa: F401
+
+            return True
+        except ImportError:
+            return False
+
+    def supports_search(self) -> bool:
+        return True
+
+    def supports_extract(self) -> bool:
+        return True
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        """Execute a web search via AnySearch MCP."""
+        result = _call_mcp_tool("search", {"query": query, "limit": limit})
+
+        # Normalize the response to match the expected shape
+        if result.get("success"):
+            return result
+
+        # If the raw result has a different shape, try to normalize
+        if "data" in result and "web" in result.get("data", {}):
+            return {"success": True, "data": result["data"]}
+
+        return result
+
+    def extract(self, urls: List[str], **kwargs: Any) -> Any:
+        """Extract content from URLs via AnySearch MCP."""
+        result = _call_mcp_tool("extract", {"urls": urls}, timeout=60)
+
+        if result.get("success"):
+            return result.get("data", [])
+
+        # Return error in the expected list shape
+        return [{"url": u, "title": "", "content": "", "error": result.get("error", "Unknown error")} for u in urls]
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "AnySearch (MCP)",
+            "badge": "free · no key · search + extract",
+            "tag": "Free MCP-based search — works in China without VPN. No API key needed.",
+            "env_vars": [
+                {
+                    "key": "ANYSEARCH_MCP_URL",
+                    "prompt": "AnySearch MCP endpoint URL (optional, defaults to api.anysearch.com/mcp)",
+                    "required": False,
+                },
+            ],
+        }

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -149,7 +149,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai"}:
+    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai", "anysearch"}:
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -236,6 +236,13 @@ def _is_backend_available(backend: str) -> bool:
             from tools.xai_http import has_xai_credentials
             return has_xai_credentials()
         except Exception:
+            return False
+    if backend == "anysearch":
+        # AnySearch MCP is always available (free, no key). Only needs httpx.
+        try:
+            import httpx  # noqa: F401
+            return True
+        except ImportError:
             return False
     return False
 


### PR DESCRIPTION
## Summary

- Add **AnySearch MCP** as a bundled web search/extract backend plugin (`plugins/web/anysearch/`)
- Add `"anysearch"` to the `_get_backend()` whitelist in `tools/web_tools.py` so `web.backend: anysearch` is recognized
- Add `"anysearch"` to `_is_backend_available()` — always available (free, no API key; only needs `httpx`)
- Add `"anysearch"` to `_LEGACY_PREFERENCE` in `agent/web_search_registry.py` (positioned before `ddgs` as a free-tier alternative)

## Root Cause

`tools/web_tools.py` line 152 hard-codes the backend whitelist:

```python
if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai"}:
```

`"anysearch"` is missing, so `web.backend: anysearch` silently falls through to the auto-detect chain, landing on `ddgs` — which times out in mainland China and other regions where DuckDuckGo is unreachable.

## Fix

1. **Plugin**: `plugins/web/anysearch/provider.py` — calls the public AnySearch MCP server (`api.anysearch.com/mcp`) via Streamable HTTP `tools/call`. Supports both search and extract.
2. **Whitelist**: Added `"anysearch"` to the set on line 152 of `tools/web_tools.py`.
3. **Availability**: Added `anysearch` case to `_is_backend_available()` — checks `httpx` importability (same pattern as `ddgs` checking its package).
4. **Registry**: Added `"anysearch"` to `_LEGACY_PREFERENCE` tuple in `agent/web_search_registry.py`.

## Duplicate Check

- No open PRs found for `"anysearch"` in `NousResearch/hermes-agent`.
- No open PRs found for `"web.backend" + "whitelist"`.
- No open PRs found touching `plugins/web/anysearch/`.

## Test Plan

```bash
# Syntax check
python3 -c "import py_compile; [py_compile.compile(f, doraise=True) for f in ['plugins/web/anysearch/__init__.py', 'plugins/web/anysearch/provider.py', 'tools/web_tools.py', 'agent/web_search_registry.py']]"

# Existing web tools tests
scripts/run_tests.sh tests/tools/test_web_tools*.py

# Web search registry tests
scripts/run_tests.sh tests/ -k "web_search"

# Skill size + extract tests
scripts/run_tests.sh tests/tools/test_skill_size_limits.py tests/website/test_extract_skills.py
```

Closes #43883
