### PR TITLE
feat(update): configurable default branch via updates.branch

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2362,6 +2362,14 @@ DEFAULT_CONFIG = {
 
     # ``hermes update`` behaviour.
     "updates": {
+        # Default branch for ``hermes update`` when ``--branch`` is not
+        # passed on the command line. Deployments that run a fork's
+        # integration branch (e.g. a ``team-agent`` branch carrying local
+        # patches on top of upstream main) set this so EVERY update path —
+        # CLI, gateway /update, desktop — tracks that branch consistently.
+        # Empty/unset means "main". Note: updates always pull from the
+        # ``origin`` remote; point origin at your fork if you maintain one.
+        "branch": "",
         # Run a full ``hermes backup``-style zip of HERMES_HOME before every
         # ``hermes update``.  Backups land in ``<HERMES_HOME>/backups/`` and
         # can be restored with ``hermes import <path>``.  Off by default —

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7673,8 +7673,32 @@ def _resolve_update_branch(args) -> str:
     or whitespace-only values as the default" parsing so every consumer of
     ``--branch`` (check path, git-update path, ZIP-fallback path) agrees on
     the same answer.
+
+    Resolution order:
+      1. explicit ``--branch NAME`` on the command line
+      2. ``updates.branch`` in config.yaml — lets deployments that run a
+         fork's integration branch (e.g. ``team-agent``) have EVERY update
+         path (CLI, gateway /update, desktop) track that branch without
+         remembering a flag
+      3. ``"main"``
     """
-    return (getattr(args, "branch", None) or "main").strip() or "main"
+    explicit = (getattr(args, "branch", None) or "").strip()
+    if explicit:
+        return explicit
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        cfg_branch = str(
+            (cfg.get("updates", {}) or {}).get("branch") or ""
+        ).strip()
+        if cfg_branch:
+            return cfg_branch
+    except Exception:
+        # Config trouble must never break updates — the update may be the
+        # fix for the config trouble.
+        pass
+    return "main"
 
 
 def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):

--- a/tests/test_update_branch_config.py
+++ b/tests/test_update_branch_config.py
@@ -1,0 +1,53 @@
+"""Tests for _resolve_update_branch — the ``hermes update`` branch default.
+
+Resolution order: --branch flag > updates.branch in config.yaml > "main".
+"""
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from hermes_cli.main import _resolve_update_branch
+
+
+def args(branch=None):
+    return SimpleNamespace(branch=branch)
+
+
+def with_config(cfg):
+    return patch("hermes_cli.config.load_config", return_value=cfg)
+
+
+class TestResolveUpdateBranch:
+    def test_defaults_to_main(self):
+        with with_config({}):
+            assert _resolve_update_branch(args()) == "main"
+
+    def test_explicit_flag_wins(self):
+        with with_config({"updates": {"branch": "team-agent"}}):
+            assert _resolve_update_branch(args("hotfix")) == "hotfix"
+
+    def test_config_branch_used_when_no_flag(self):
+        with with_config({"updates": {"branch": "team-agent"}}):
+            assert _resolve_update_branch(args()) == "team-agent"
+
+    def test_blank_flag_falls_through_to_config(self):
+        with with_config({"updates": {"branch": "team-agent"}}):
+            assert _resolve_update_branch(args("   ")) == "team-agent"
+
+    def test_blank_config_falls_through_to_main(self):
+        with with_config({"updates": {"branch": "  "}}):
+            assert _resolve_update_branch(args()) == "main"
+
+    def test_missing_updates_section(self):
+        with with_config({"other": True}):
+            assert _resolve_update_branch(args()) == "main"
+
+    def test_config_error_never_breaks_updates(self):
+        with patch(
+            "hermes_cli.config.load_config",
+            side_effect=RuntimeError("corrupt config"),
+        ):
+            assert _resolve_update_branch(args()) == "main"
+
+    def test_none_updates_section(self):
+        with with_config({"updates": None}):
+            assert _resolve_update_branch(args()) == "main"


### PR DESCRIPTION
## Motivation

`hermes update` always defaults `--branch` to `main`. Deployments that run a fork's integration branch (local patches stacked on upstream main — a common operator pattern) have to remember `--branch NAME` on every CLI update, and have **no way at all** to redirect the gateway `/update` command or desktop-app updates, which never pass the flag.

## Change

New optional `updates.branch` config key:

```yaml
updates:
  branch: team-agent
```

Resolution order in `_resolve_update_branch()`:

1. explicit `--branch NAME` on the command line
2. `updates.branch` from config.yaml
3. `"main"` (unchanged default)

Stock behavior is byte-identical when the key is unset. Config read failures fall back to `main` — an update must never be blocked by the config it might be about to fix.

All three consumers of `--branch` (check path, git-update path, ZIP-fallback path) already route through `_resolve_update_branch()`, so every update path picks this up consistently.

## Tests

`tests/test_update_branch_config.py` — 8 tests covering the resolution order, blank/whitespace handling at both levels, missing/None `updates` section, and config-error fallback.