### PR TITLE
fix: resolve tool search context with provider config

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -552,7 +552,14 @@ def _resolve_active_context_length() -> int:
         if not model_id:
             return 0
         from agent.model_metadata import get_model_context_length
-        return int(get_model_context_length(model_id) or 0)
+        return int(get_model_context_length(
+            model_id,
+            base_url=str(model_cfg.get("base_url") or ""),
+            api_key=str(model_cfg.get("api_key") or ""),
+            config_context_length=model_cfg.get("context_length"),
+            provider=str(model_cfg.get("provider") or ""),
+            custom_providers=cfg.get("custom_providers") if isinstance(cfg.get("custom_providers"), list) else None,
+        ) or 0)
     except Exception as e:
         logger.debug("Could not resolve active context length: %s", e)
         return 0


### PR DESCRIPTION
## Summary
- Pass the active provider, base URL, API key marker, custom providers, and explicit context override into Tool Search's context-length resolver.
- Keeps provider-specific context caps intact, e.g. GPT-5.5 through OpenAI Codex OAuth resolving to 272k instead of the direct-OpenAI 1.05M fallback.

## Why
Tool Search activation is thresholded against a percentage of the active model context window. The old resolver called `get_model_context_length(model_id)` with only the model ID, so provider-aware branches could be skipped and the threshold could be too high.

## Verification
- `python -m pytest tests -q -o 'addopts=' --tb=short -k 'tool_search or context_length'`
