### PR TITLE
fix(dashboard): suppress unicode-animations postinstall during npm ci

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4609,13 +4609,18 @@ def _run_npm_install_deterministic(
     the working tree dirty and causes the next ``hermes update`` to stash the
     lockfile — repeatedly.
     """
+    # unicode-animations' postinstall animates to /dev/tty (bypasses
+    # --silent/capture_output). It no-ops when CI is set — same as the TUI
+    # install path and nix/lib.nix npm ci hooks.
+    run_env = {**os.environ, **(env or {}), "CI": "1"}
+
     lockfile = cwd / "package-lock.json"
     if lockfile.exists():
         ci_cmd = [npm, "ci", *extra_args]
         ci_result = subprocess.run(
             ci_cmd,
             cwd=cwd,
-            env=env,
+            env=run_env,
             capture_output=capture_output,
             text=True,
             encoding="utf-8",
@@ -4630,7 +4635,7 @@ def _run_npm_install_deterministic(
     return subprocess.run(
         install_cmd,
         cwd=cwd,
-        env=env,
+        env=run_env,
         capture_output=capture_output,
         text=True,
         encoding="utf-8",

--- a/tests/hermes_cli/test_web_ui_build.py
+++ b/tests/hermes_cli/test_web_ui_build.py
@@ -140,6 +140,22 @@ class TestBuildWebUISkipsWhenFresh:
         assert kwargs["encoding"] == "utf-8"
         assert kwargs["errors"] == "replace"
 
+    def test_npm_install_sets_ci_to_suppress_postinstall_tty_output(self, tmp_path):
+        web_dir, _ = _make_web_dir(tmp_path)
+        (web_dir / "package-lock.json").write_text("{}", encoding="utf-8")
+
+        mock_cp = __import__("subprocess").CompletedProcess([], 0, stdout="", stderr="")
+        with patch("hermes_cli.main.subprocess.run", return_value=mock_cp) as mock_run:
+            _run_npm_install_deterministic(
+                "/usr/bin/npm",
+                web_dir,
+                env={"PYTHON": "/nix/store/python"},
+            )
+
+        _, kwargs = mock_run.call_args
+        assert kwargs["env"]["CI"] == "1"
+        assert kwargs["env"]["PYTHON"] == "/nix/store/python"
+
     def test_npm_install_uses_workspace_web_scope(self, tmp_path):
         web_dir, _ = _make_web_dir(tmp_path)
         # Real workspace checkout: the single lockfile lives at the root, so


### PR DESCRIPTION
## What does this PR do?

When `hermes dashboard` rebuilds the web UI, it runs `npm ci` / `npm install` via `_run_npm_install_deterministic`. The `unicode-animations` dependency has a postinstall script that renders a ~3s braille animation directly to `/dev/tty`, bypassing npm's `--silent` flag and Python's captured stdout/stderr.

This PR sets `CI=1` in the npm subprocess environment inside `_run_npm_install_deterministic`. The package's postinstall already no-ops when `CI` is set — the same approach used by the TUI install path and `nix/lib.nix` npm hooks — so users no longer need to export `CI=1` manually before running `hermes dashboard`.

## Related Issue

N/A (internal UX polish)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py` — merge `CI=1` into the env passed to `npm ci` / `npm install` in `_run_npm_install_deterministic`
- `tests/hermes_cli/test_web_ui_build.py` — assert the npm install subprocess receives `CI=1`

## How to Test

1. Remove or stale the web dist so a rebuild is triggered (e.g. delete `hermes_cli/web_dist/.vite/manifest.json` or touch a source file newer than the dist).
2. Run `hermes dashboard` without setting `CI=1`.
3. Confirm the `unicode-animations` postinstall animation does not appear during the npm install step.
4. Run `pytest tests/hermes_cli/test_web_ui_build.py -q` — all tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: Linux (WSL2)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before: `hermes dashboard` npm install step shows the `unicode-animations` braille demo on `/dev/tty`.

After: install runs quietly; dashboard proceeds directly to the Vite build output.