### PR TITLE
fix(gateway): attachment context notes guide extraction instead of punting (PDF/DOCX + audio)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1425,6 +1425,33 @@ def _build_media_placeholder(event) -> str:
     return "\n".join(parts)
 
 
+def _build_document_context_note(display_name: str, agent_path: str, mtype: str) -> str:
+    """Context note prepended to a user turn when they attach a document.
+
+    Text documents (``text/*``) have their content inlined upstream by the
+    platform adapter, so the note just confirms that and records the path.
+
+    Binary documents (PDF, DOCX, XLSX, …) cannot be inlined as text. The note
+    must tell the agent to *extract* the text itself before answering — earlier
+    wording ("Ask the user what they'd like you to do with it") steered the
+    model into punting back to the user, which is why attached PDFs/DOCX looked
+    "unreadable" to the agent even though it has the tools to read them.
+    """
+    if mtype.startswith("text/"):
+        return (
+            f"[The user sent a text document: '{display_name}'. "
+            f"Its content has been included below. "
+            f"The file is also saved at: {agent_path}]"
+        )
+    return (
+        f"[The user sent a document: '{display_name}'. It is saved at: {agent_path}. "
+        f"Its text is not inlined here (it's a binary format such as PDF or DOCX). "
+        f"To read it, extract the document's text yourself — for example with the "
+        f"terminal tool or the ocr-and-documents skill — before answering, instead "
+        f"of asking the user to paste the contents.]"
+    )
+
+
 def _format_duration(seconds: float) -> str:
     total = int(round(seconds))
     if total < 0:
@@ -7732,18 +7759,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # cache directories are auto-mounted at /root/.hermes/cache/* by get_cache_directory_mounts().
                 agent_path = to_agent_visible_cache_path(path)
 
-                if mtype.startswith("text/"):
-                    context_note = (
-                        f"[The user sent a text document: '{display_name}'. "
-                        f"Its content has been included below. "
-                        f"The file is also saved at: {agent_path}]"
-                    )
-                else:
-                    context_note = (
-                        f"[The user sent a document: '{display_name}'. "
-                        f"The file is saved at: {agent_path}. "
-                        f"Ask the user what they'd like you to do with it.]"
-                    )
+                context_note = _build_document_context_note(display_name, agent_path, mtype)
                 message_text = f"{context_note}\n\n{message_text}"
 
         if getattr(event, "reply_to_text", None) and event.reply_to_message_id:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7727,7 +7727,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _note = (
                     f"[The user sent an audio file attachment: '{_display}'. "
                     f"It is saved at: {_agent_path}. "
-                    f"Ask the user what they'd like you to do with it, or pass the path to a transcription or media tool.]"
+                    f"Its content is not inlined here. If the user's request involves "
+                    f"what the audio contains, transcribe or process it yourself — for "
+                    f"example by passing the path to a transcription or media tool — "
+                    f"instead of asking the user to describe it. Only ask what to do "
+                    f"with it if their intent is genuinely unclear.]"
                 )
                 message_text = f"{_note}\n\n{message_text}"
 

--- a/tests/gateway/test_document_context_note.py
+++ b/tests/gateway/test_document_context_note.py
@@ -1,0 +1,57 @@
+"""Tests for the document context note prepended to user turns with attachments.
+
+A user who attaches a PDF / DOCX in chat used to see the agent treat it as
+"unreadable" because the context note told the model to "Ask the user what
+they'd like you to do with it" — steering it away from extracting the text it
+is perfectly capable of reading. These tests pin the contract:
+
+- text documents: note confirms the (adapter-)inlined content + records path.
+- binary documents (PDF/DOCX/…): note tells the agent to extract the text
+  itself and never tells it to punt back to the user.
+"""
+
+import importlib
+
+import pytest
+
+gateway_run = importlib.import_module("gateway.run")
+_build_document_context_note = gateway_run._build_document_context_note
+
+
+class TestTextDocumentNote:
+    @pytest.mark.parametrize("mtype", ["text/plain", "text/markdown", "text/csv"])
+    def test_text_note_mentions_included_content_and_path(self, mtype):
+        note = _build_document_context_note("notes.txt", "/cache/doc_notes.txt", mtype)
+        assert "text document" in note
+        assert "notes.txt" in note
+        assert "/cache/doc_notes.txt" in note
+        assert "included below" in note
+
+
+class TestBinaryDocumentNote:
+    @pytest.mark.parametrize(
+        "mtype",
+        [
+            "application/pdf",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "application/octet-stream",
+        ],
+    )
+    def test_binary_note_guides_extraction(self, mtype):
+        note = _build_document_context_note("contract.pdf", "/cache/doc_contract.pdf", mtype)
+        # Records the path so the agent can open it.
+        assert "/cache/doc_contract.pdf" in note
+        # Tells the agent to read it by extracting the text...
+        assert "extract" in note.lower()
+        # ...and does NOT steer it into punting back to the user (the bug).
+        assert "ask the user" not in note.lower()
+        assert "paste" in note.lower()
+
+    def test_binary_note_distinct_from_text_note(self):
+        text_note = _build_document_context_note("a.txt", "/c/a.txt", "text/plain")
+        pdf_note = _build_document_context_note("a.pdf", "/c/a.pdf", "application/pdf")
+        assert text_note != pdf_note
+        # The text path claims content is inlined; the binary path must not.
+        assert "included below" in text_note
+        assert "included below" not in pdf_note

--- a/tests/gateway/test_telegram_audio_vs_voice.py
+++ b/tests/gateway/test_telegram_audio_vs_voice.py
@@ -134,6 +134,10 @@ async def test_audio_attachment_context_note_format():
     assert "audio file attachment" in result.lower()
     # Should NOT contain the voice-message transcription wrapper text
     assert "voice message" not in result.lower()
+    # Guides the agent to transcribe/process the file itself rather than
+    # punting back to the user (same bug class as the PDF/DOCX note).
+    assert "transcri" in result.lower()
+    assert "ask the user what they'd like" not in result.lower()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Salvage of PR #44175 by @xxxigm (cherry-picked, authorship preserved) plus a sibling-site fix: gateway attachment context notes no longer steer the agent into punting back to the user.

Reported (Desktop, Malvict): attaching a DOCX or PDF is "not readable by the agent." Root cause was the binary-document context note in `gateway/run.py` literally telling the agent to "Ask the user what they'd like you to do with it" — so the model punted instead of extracting the text it can already read via terminal / the ocr-and-documents skill.

## Changes

- `gateway/run.py`: binary-document note now instructs the agent to extract the document's text itself before answering; note construction pulled into unit-testable `_build_document_context_note()` (from #44175, @xxxigm)
- `tests/gateway/test_document_context_note.py`: new contract tests — binary notes guide extraction and never say "ask the user" (from #44175, @xxxigm)
- `gateway/run.py`: **sibling site** — the audio file attachment note had the same "Ask the user what they'd like you to do with it" phrasing; rewritten to instruct the agent to transcribe/process the file itself when the request involves its content (follow-up commit)
- `tests/gateway/test_telegram_audio_vs_voice.py`: contract assertion pinning the audio note's no-punt wording

## Validation

| | Result |
|---|---|
| `tests/gateway/test_document_context_note.py` + `test_telegram_audio_vs_voice.py` | 13 passed |
| `test_discord_document_handling.py` + `test_telegram_documents.py` | all passed |

Closes #44175 (salvaged with credit).


## Infographic

![gateway-attachment-notes-extract-dont-punt](https://v3b.fal.media/files/b/0a9de682/0t8rV-rXYHvLoaoPbN5Zn_V9ND3rzr.png)
