### PR TITLE
fix(feishu): ignore thread_id from DM quoted replies to prevent isolated sessions

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -3123,6 +3123,10 @@ class FeishuAdapter(BasePlatformAdapter):
                 text = f"{hint}\n\n{text}" if text else hint
 
         thread_id = getattr(message, "thread_id", None) or getattr(message, "root_id", None) or None
+        # Feishu DMs (p2p) do not support real threads; quoted replies populate
+        # thread_id/root_id but should not create isolated sessions (#44028).
+        if chat_type == "p2p":
+            thread_id = None
         reply_to_message_id = (
             getattr(message, "parent_id", None)
             or getattr(message, "upper_message_id", None)

--- a/tests/gateway/test_feishu_dm_thread_id.py
+++ b/tests/gateway/test_feishu_dm_thread_id.py
@@ -1,0 +1,145 @@
+"""
+Test that Feishu DM (p2p) quoted replies do not create isolated sessions.
+
+Regression test for #44028: quoted replies in DMs populate thread_id/root_id
+from the Lark SDK, but Feishu DMs don't support real threads.  Without the
+guard, these IDs flow into build_source() and produce isolated session keys.
+"""
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import asyncio
+
+
+class TestFeishuDMQuotedReplyNoThread(unittest.TestCase):
+    """Verify p2p quoted replies don't leak thread_id into session keys."""
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_p2p_quoted_reply_ignores_thread_id(self):
+        """In DM (p2p) mode, thread_id from a quoted reply must be cleared."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._dispatch_inbound_event = AsyncMock()
+        adapter.get_chat_info = AsyncMock(
+            return_value={"chat_id": "oc_dm", "name": "DM", "type": "dm"}
+        )
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={"user_id": "ou_sender", "user_name": "Alice", "user_id_alt": None}
+        )
+
+        # Quoted reply in a DM: Lark SDK fills thread_id/root_id
+        message = SimpleNamespace(
+            chat_id="oc_dm",
+            thread_id="om_parent_msg",  # <-- this should be ignored in p2p
+            root_id="om_root_msg",
+            parent_id="om_parent_msg",
+            upper_message_id=None,
+            message_type="text",
+            content='{"text":"reply to you"}',
+            message_id="om_new_msg",
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=SimpleNamespace(event=SimpleNamespace(message=message)),
+                message=message,
+                sender_id=SimpleNamespace(open_id="ou_sender", user_id=None, union_id=None),
+                is_bot=False,
+                chat_type="p2p",
+                message_id="om_new_msg",
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.await_args.args[0]
+        # thread_id must be None for p2p — quoted reply must not isolate the session
+        self.assertIsNone(event.source.thread_id)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_group_quoted_reply_preserves_thread_id(self):
+        """In group mode, thread_id from a quoted reply must be preserved."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._dispatch_inbound_event = AsyncMock()
+        adapter.get_chat_info = AsyncMock(
+            return_value={"chat_id": "oc_group", "name": "Group", "type": "group"}
+        )
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={"user_id": "ou_sender", "user_name": "Alice", "user_id_alt": None}
+        )
+
+        message = SimpleNamespace(
+            chat_id="oc_group",
+            thread_id="omt_thread_123",
+            root_id=None,
+            parent_id="om_parent_msg",
+            upper_message_id=None,
+            message_type="text",
+            content='{"text":"threaded reply"}',
+            message_id="om_thread_msg",
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=SimpleNamespace(event=SimpleNamespace(message=message)),
+                message=message,
+                sender_id=SimpleNamespace(open_id="ou_sender", user_id=None, union_id=None),
+                is_bot=False,
+                chat_type="group",
+                message_id="om_thread_msg",
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.await_args.args[0]
+        # Group threads must preserve thread_id
+        self.assertEqual(event.source.thread_id, "omt_thread_123")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_p2p_no_thread_id_unchanged(self):
+        """Normal DM (no quoted reply) must still work with thread_id=None."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._dispatch_inbound_event = AsyncMock()
+        adapter.get_chat_info = AsyncMock(
+            return_value={"chat_id": "oc_dm", "name": "DM", "type": "dm"}
+        )
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={"user_id": "ou_sender", "user_name": "Bob", "user_id_alt": None}
+        )
+
+        message = SimpleNamespace(
+            chat_id="oc_dm",
+            thread_id=None,
+            root_id=None,
+            parent_id=None,
+            upper_message_id=None,
+            message_type="text",
+            content='{"text":"hello"}',
+            message_id="om_normal",
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=SimpleNamespace(event=SimpleNamespace(message=message)),
+                message=message,
+                sender_id=SimpleNamespace(open_id="ou_sender", user_id=None, union_id=None),
+                is_bot=False,
+                chat_type="p2p",
+                message_id="om_normal",
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.await_args.args[0]
+        self.assertIsNone(event.source.thread_id)
+        self.assertIn("hello", event.text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where Feishu/Lark DM quoted replies (引用回复) create isolated sessions, causing the agent to lose conversation context. In p2p (DM) chat mode, the Lark SDK populates `thread_id`/`root_id` for quoted replies, which flows into `build_source()` and produces a different session key than the normal DM session.

## Related Issue

Fixes #44028

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/feishu.py`: Added a guard after `thread_id` extraction to clear it when `chat_type == "p2p"`, since Feishu DMs don't support real threads — only groups do.
- `tests/gateway/test_feishu_dm_thread_id.py`: Added 3 regression tests — (1) p2p quoted reply clears thread_id, (2) group quoted reply preserves thread_id, (3) normal p2p message with no thread_id unchanged.

## How to Test

1. Run the new tests: `pytest tests/gateway/test_feishu_dm_thread_id.py -v`
2. Verify all 3 tests pass (p2p thread_id cleared, group thread_id preserved, normal p2p unaffected)
3. Optionally: send a quoted reply in a Feishu DM and verify the response uses the existing session

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `_process_inbound_message()` in `gateway/platforms/feishu.py` (thread_id extraction at line 3125)
- Blast radius: LOW — only affects Feishu DM (p2p) message processing; group threads unchanged
- Related patterns: Session key isolation via thread_id is used by other adapters (Telegram, Slack, Matrix) but those platforms don't populate thread_id for DM replies
