### PR TITLE
fix(web): guarantee keyless web search/extract registration + don't cache failed plugin discovery

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1069,8 +1069,21 @@ class PluginManager:
             self._plugin_skills.clear()
             self._aux_tasks.clear()
             self._context_engine = None
+        # Set the flag up front as a re-entrancy guard (a plugin's register()
+        # can transitively trigger discovery again), but reset it if the sweep
+        # raises so a failed scan is NOT cached as "discovered with an empty
+        # registry" — callers swallow the exception and would otherwise be
+        # permanently stranded on the early-return above (the "No web provider
+        # configured" class of failures).
         self._discovered = True
+        try:
+            self._discover_and_load_inner()
+        except BaseException:
+            self._discovered = False
+            raise
 
+    def _discover_and_load_inner(self) -> None:
+        """The actual discovery sweep — see :meth:`discover_and_load`."""
         manifests: List[PluginManifest] = []
 
         # 1. Bundled plugins (<repo>/plugins/<name>/)

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -365,6 +365,40 @@ class TestPluginDiscovery:
         }
         assert len(non_bundled) == 1
 
+    def test_failed_discovery_is_not_cached(self, tmp_path, monkeypatch):
+        """A sweep that raises must not cache 'discovered' with no plugins.
+
+        Regression for the stranded-empty-registry class of failures: callers
+        (e.g. tools.web_tools._ensure_web_plugins_loaded) swallow discovery
+        exceptions as warnings, so if a failed sweep flipped ``_discovered``
+        permanently, every later call would early-return against an empty
+        registry ("No web provider configured") for the process lifetime.
+        """
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(plugins_dir, "retry_plugin")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        mgr = PluginManager()
+
+        def _boom(self_inner):
+            raise RuntimeError("sweep failed")
+
+        monkeypatch.setattr(PluginManager, "_discover_and_load_inner", _boom)
+        with pytest.raises(RuntimeError, match="sweep failed"):
+            mgr.discover_and_load()
+        assert mgr._discovered is False, "failed sweep was cached as discovered"
+
+        # A later call (with discovery healthy again) must do the real scan.
+        monkeypatch.undo()
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+        mgr.discover_and_load()
+        assert mgr._discovered is True
+        non_bundled = {
+            n: p for n, p in mgr._plugins.items()
+            if p.manifest.source != "bundled"
+        }
+        assert len(non_bundled) == 1
+
     def test_discover_skips_dir_without_manifest(self, tmp_path, monkeypatch):
         """Directories without plugin.yaml are silently skipped."""
         plugins_dir = tmp_path / "hermes_test" / "plugins"

--- a/tests/tools/test_web_keyless_default_fallback.py
+++ b/tests/tools/test_web_keyless_default_fallback.py
@@ -1,0 +1,100 @@
+"""Regression: the keyless Parallel web default must survive a failed sweep.
+
+``web_search`` / ``web_extract`` are documented to work out of the box with
+zero setup via the bundled keyless Parallel free-MCP backend. That guarantee
+only holds if the bundled ``plugins/web/*`` providers are registered in
+``agent.web_search_registry``. The dispatch triggers the general plugin sweep
+(:func:`hermes_cli.plugins._ensure_plugins_discovered`) to do that — but the
+sweep can finish without registering them (its exception swallowed as a
+warning, a packaged layout where it ran before the bundled tree was
+importable, or a stale empty-discovery cache). When that happened, *both*
+tools dead-ended on "No web {search,extract} provider configured" even though
+no setup should be needed.
+
+These tests pin the invariant that :func:`tools.web_tools._ensure_web_plugins_loaded`
+guarantees the keyless default is registered regardless of the sweep's outcome,
+and that the direct-registration fallback honors an explicit ``plugins.disabled``
+entry. Real imports from the bundled plugin modules — no provider mocking.
+"""
+from __future__ import annotations
+
+import pytest
+
+import agent.web_search_registry as reg
+import hermes_cli.plugins as plugins
+from tools import web_tools
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    reg._reset_for_tests()
+    yield
+    reg._reset_for_tests()
+
+
+def _boom(*_a, **_k):
+    raise RuntimeError("discovery boom")
+
+
+def test_keyless_default_registered_when_discovery_raises(monkeypatch):
+    """A swallowed discovery failure must not strand the keyless default."""
+    monkeypatch.setattr(plugins, "_ensure_plugins_discovered", _boom)
+    assert reg.get_provider("parallel") is None
+
+    web_tools._ensure_web_plugins_loaded()
+
+    parallel = reg.get_provider("parallel")
+    assert parallel is not None, "keyless Parallel default not restored"
+    # It is the universal keyless default precisely because it does both.
+    assert parallel.supports_search()
+    assert parallel.supports_extract()
+
+
+def test_fallback_registers_full_bundled_set(monkeypatch):
+    """The fix covers the whole bundled provider class, not just parallel."""
+    monkeypatch.setattr(plugins, "_ensure_plugins_discovered", _boom)
+
+    web_tools._ensure_web_plugins_loaded()
+
+    names = {p.name for p in reg.list_providers()}
+    # Every bundled backend a user might have configured should be reachable
+    # again, so an explicit ``web.extract_backend: firecrawl`` etc. resolves.
+    for expected in ("parallel", "firecrawl", "tavily", "exa"):
+        assert expected in names, f"{expected} missing after fallback"
+
+
+def test_fallback_honors_explicit_disable(monkeypatch):
+    """A backend the user turned off via plugins.disabled stays off."""
+    monkeypatch.setattr(plugins, "_get_disabled_plugins", lambda: {"web-parallel"})
+
+    web_tools._register_bundled_web_providers_directly()
+
+    names = {p.name for p in reg.list_providers()}
+    assert "parallel" not in names, "explicit disable was ignored"
+    # Other bundled backends are unaffected by the parallel disable.
+    assert "tavily" in names
+
+
+def test_fallback_is_noop_when_discovery_already_registered(monkeypatch):
+    """Healthy path: don't pay for the direct sweep when parallel is present."""
+    # Pretend the general sweep already registered the keyless default.
+    import importlib
+
+    class _Ctx:
+        def register_web_search_provider(self, provider):
+            reg.register_provider(provider)
+
+    importlib.import_module("plugins.web.parallel").register(_Ctx())
+    monkeypatch.setattr(plugins, "_ensure_plugins_discovered", lambda *a, **k: None)
+
+    calls = {"n": 0}
+    real = web_tools._register_bundled_web_providers_directly
+
+    def _spy():
+        calls["n"] += 1
+        real()
+
+    monkeypatch.setattr(web_tools, "_register_bundled_web_providers_directly", _spy)
+    web_tools._ensure_web_plugins_loaded()
+
+    assert calls["n"] == 0, "direct-registration ran on the healthy path"

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -810,6 +810,17 @@ def _ensure_web_plugins_loaded() -> None:
     Mirrors :func:`tools.browser_tool._ensure_browser_plugins_loaded` exactly:
     the underlying discovery call is idempotent and cheap on subsequent
     invocations.
+
+    Triggering discovery is necessary but not *sufficient*: the sweep can
+    finish without registering the bundled web providers (its exception
+    swallowed below as a warning, a packaged layout where discovery ran before
+    the bundled tree was importable, or a stale empty-discovery cache). When
+    that happens the registry is empty and *both* web_search and web_extract
+    dead-end on "No web {search,extract} provider configured" — even though the
+    keyless Parallel default is supposed to work with zero setup. So after
+    discovery we verify the keyless default landed and, if not, register the
+    bundled providers directly (see
+    :func:`_register_bundled_web_providers_directly`).
     """
     try:
         from hermes_cli.plugins import _ensure_plugins_discovered
@@ -821,6 +832,87 @@ def _ensure_web_plugins_loaded() -> None:
         # configured" error this helper is meant to eliminate, with no
         # clue in normal logs about the real cause.
         logger.warning("Web plugin discovery failed (non-fatal): %s", exc)
+
+    # Belt-and-suspenders: guarantee the keyless Parallel default (the
+    # documented zero-setup backend for both web_search and web_extract) is
+    # actually registered. The lookup is a cheap dict hit on the healthy path
+    # (discovery already registered it → no-op); only an empty registry pays
+    # for the direct-registration sweep.
+    try:
+        from agent.web_search_registry import get_provider
+
+        if get_provider("parallel") is None:
+            _register_bundled_web_providers_directly()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Bundled web provider fallback check failed: %s", exc)
+
+
+def _register_bundled_web_providers_directly() -> None:
+    """Register the repo's bundled web providers without the plugin manager.
+
+    The normal path is the general plugin sweep
+    (:func:`hermes_cli.plugins._ensure_plugins_discovered`), which auto-loads
+    every ``plugins/web/<name>`` backend (they are ``kind: backend``). This
+    fallback exists for the runtimes where that sweep does not leave the web
+    registry populated — so the keyless Parallel default (and any bundled
+    backend the user explicitly configured) keeps working instead of
+    surfacing a misleading "No web provider configured" error.
+
+    Imports each bundled ``plugins/web/<name>`` package and calls its
+    ``register()`` directly against :mod:`agent.web_search_registry`. Idempotent
+    (re-register overwrites) and honors an explicit ``plugins.disabled`` entry
+    so a backend the user turned off stays off.
+    """
+    try:
+        from hermes_cli.plugins import (
+            _get_disabled_plugins,
+            get_bundled_plugins_dir,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Bundled web provider fallback unavailable: %s", exc)
+        return
+
+    web_dir = get_bundled_plugins_dir() / "web"
+    if not web_dir.is_dir():
+        return
+
+    disabled = _get_disabled_plugins()
+
+    from agent.web_search_provider import WebSearchProvider
+    from agent.web_search_registry import register_provider
+
+    class _DirectRegistrationCtx:
+        """Minimal plugin ctx exposing only web-provider registration."""
+
+        def register_web_search_provider(self, provider) -> None:
+            if isinstance(provider, WebSearchProvider):
+                register_provider(provider)
+
+    ctx = _DirectRegistrationCtx()
+    import importlib
+
+    for child in sorted(web_dir.iterdir()):
+        if not child.is_dir():
+            continue
+        if not (child / "plugin.yaml").exists() and not (child / "plugin.yml").exists():
+            continue
+        # Respect an explicit disable — match discover_and_load's key/name
+        # check (key ``web/<dir>``; manifest name ``web-<dir-with-dashes>``).
+        if (
+            f"web/{child.name}" in disabled
+            or f"web-{child.name.replace('_', '-')}" in disabled
+        ):
+            continue
+        try:
+            module = importlib.import_module(f"plugins.web.{child.name}")
+            register_fn = getattr(module, "register", None)
+            if callable(register_fn):
+                register_fn(ctx)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "Direct registration of bundled web provider '%s' failed: %s",
+                child.name, exc,
+            )
 
 
 def web_search_tool(query: str, limit: int = 5) -> str:


### PR DESCRIPTION
## Summary
Keyless web search/extract (the documented zero-setup Parallel default) now survives a plugin discovery sweep that fails or comes back empty — and a failed sweep is no longer cached, so discovery retries on the next call.

Salvages PR #44182 by @xxxigm (cherry-picked, authorship preserved) + a root-cause follow-up.

## Changes
- `tools/web_tools.py` (#44182, @xxxigm): after discovery, verify the keyless Parallel provider landed in `agent.web_search_registry`; if not, register the bundled `plugins/web/*` providers directly (honors `plugins.disabled`).
- `tests/tools/test_web_keyless_default_fallback.py` (#44182, @xxxigm): regression tests, real imports, no provider mocking.
- `hermes_cli/plugins.py` (follow-up): `discover_and_load()` set `_discovered = True` before scanning, so a sweep that raised partway was cached as "discovered" with an empty registry for the process lifetime — the root cause behind "No web {search,extract} provider configured". The flag is now a re-entrancy guard only and resets on failure so the next call retries.
- `tests/hermes_cli/test_plugins.py`: regression test for failed-sweep-not-cached.

## Validation
| | Before | After |
|---|---|---|
| Sweep raises partway | `_discovered=True` cached, registry empty forever → both tools error | flag reset, next call rescans; tools work |
| Sweep "succeeds" but registers nothing | "No web search provider configured" | direct fallback registers all 8 bundled providers |
| Explicit `plugins.disabled: web-parallel` | n/a | parallel stays off, others register |

E2E (real imports, temp HERMES_HOME, blanked credentials): reproduced the stranded-registry failure on the pre-fix path, confirmed `web_search_tool` resolves the keyless parallel provider after both fixes. Targeted tests: 21/21 pass.

Fixes the failure reported on Discord (dashboard logs: both `web_search` and `web_extract` returning "No provider configured" with no config changes).

## Infographic

![keyless-web-revival](https://v3b.fal.media/files/b/0a9de6ce/lUGDBJZgpuo7aXykNgdfn_JNRM2B5e.png)
