### PR TITLE
fix: audit sensitive credential file permissions in doctor

### DIFF
--- a/docs/doctor-sensitive-file-permissions-spec.md
+++ b/docs/doctor-sensitive-file-permissions-spec.md
@@ -1,0 +1,24 @@
+# Doctor Sensitive File Permissions Spec
+
+## Problem
+
+Hermes stores credentials in local files such as `$HERMES_HOME/.env`, `$HERMES_HOME/auth.json`, and GitHub CLI's `hosts.yml`. `hermes doctor` already checks whether some of these files exist, but it does not consistently flag when credential-bearing files are readable by group/other users on POSIX systems.
+
+## Goal
+
+Add a small, non-destructive doctor audit that warns when known sensitive credential files are broader than owner-only access.
+
+## Non-goals
+
+- Do not print secrets or file contents.
+- Do not delete, rotate, or rewrite credential files.
+- Do not fail Windows users where POSIX permission bits are not the security model.
+- Do not add a new core model tool.
+
+## Acceptance criteria
+
+- `hermes_cli.doctor` exposes a helper that classifies missing, secure, and too-broad sensitive files.
+- On POSIX, any existing sensitive file with group/other permission bits set is reported as a warning and adds a concrete remediation to the doctor action list.
+- Existing owner-only files report OK.
+- Missing optional files are skipped rather than reported as broken.
+- Tests cover secure, insecure, missing, and Windows-skip behavior.

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -8,6 +8,7 @@ import os
 import sys
 import subprocess
 import shutil
+from dataclasses import dataclass
 from pathlib import Path
 
 from hermes_cli.config import get_project_root, get_hermes_home, get_env_path
@@ -100,6 +101,101 @@ def _termux_install_all_fallback_notes() -> list[str]:
 def _has_provider_env_config(content: str) -> bool:
     """Return True when ~/.hermes/.env contains provider auth/base URL settings."""
     return any(key in content for key in _PROVIDER_ENV_HINTS)
+
+
+@dataclass(frozen=True)
+class SensitiveFilePermissionResult:
+    """Doctor result for a credential-bearing local file permission check."""
+
+    status: str
+    path: Path
+    label: str
+    message: str
+    mode: str | None = None
+    fix: str = ""
+
+
+def _audit_sensitive_file_permission(path: Path, label: str) -> SensitiveFilePermissionResult:
+    """Classify whether a sensitive file is owner-only readable on POSIX.
+
+    Missing files are optional and therefore skipped by callers. Windows uses a
+    different ACL model, so POSIX mode bits are intentionally not assessed there.
+    The check never reads file contents; it only inspects metadata.
+    """
+    path = Path(path)
+    if not path.exists():
+        return SensitiveFilePermissionResult(
+            status="missing",
+            path=path,
+            label=label,
+            message=f"{label} not present",
+        )
+
+    if sys.platform.startswith("win"):
+        return SensitiveFilePermissionResult(
+            status="skip",
+            path=path,
+            label=label,
+            message=f"{label} permission check skipped on Windows",
+        )
+
+    try:
+        mode_int = path.stat().st_mode & 0o777
+    except OSError as exc:
+        return SensitiveFilePermissionResult(
+            status="warn",
+            path=path,
+            label=label,
+            message=f"Could not inspect {label} permissions: {exc}",
+            fix=f"Inspect permissions manually: {path}",
+        )
+
+    mode = f"{mode_int:04o}"
+    if mode_int & 0o077:
+        return SensitiveFilePermissionResult(
+            status="warn",
+            path=path,
+            label=label,
+            message=f"{label} is readable or writable by group/other users",
+            mode=mode,
+            fix=f"Restrict {label} to the current user: chmod 600 {path}",
+        )
+
+    return SensitiveFilePermissionResult(
+        status="ok",
+        path=path,
+        label=label,
+        message=f"{label} is owner-only",
+        mode=mode,
+    )
+
+
+def _check_sensitive_file_permissions(issues: list[str]) -> None:
+    """Report permissions for credential-bearing files without reading them."""
+    _section("Sensitive File Permissions")
+    checks = [
+        (HERMES_HOME / ".env", f"{_DHH}/.env"),
+        (HERMES_HOME / "auth.json", f"{_DHH}/auth.json"),
+        (Path.home() / ".config" / "gh" / "hosts.yml", "GitHub CLI hosts.yml"),
+    ]
+    any_present = False
+    for path, label in checks:
+        result = _audit_sensitive_file_permission(path, label)
+        if result.status == "missing":
+            continue
+        any_present = True
+        detail = f"({result.mode})" if result.mode else ""
+        if result.status == "ok":
+            check_ok(result.message, detail)
+        elif result.status == "skip":
+            check_info(result.message)
+        else:
+            check_warn(result.message, detail)
+            if result.fix:
+                issues.append(result.fix)
+
+    if not any_present:
+        check_info("No known local credential files found to inspect")
 
 
 def _honcho_is_configured_for_doctor() -> bool:
@@ -973,6 +1069,8 @@ def run_doctor(args):
                     issues.append(ci.message)
         except Exception:
             pass
+
+    _check_sensitive_file_permissions(issues)
 
     _section("xAI Model Retirement (May 15, 2026)")
 

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -16,6 +16,49 @@ from hermes_cli import doctor as doctor_mod
 from hermes_cli.doctor import _has_provider_env_config
 
 
+class TestSensitiveFilePermissionAudit:
+    def test_secure_existing_file_is_ok(self, tmp_path):
+        secret = tmp_path / "auth.json"
+        secret.write_text("{}", encoding="utf-8")
+        secret.chmod(0o600)
+
+        result = doctor._audit_sensitive_file_permission(secret, "auth store")
+
+        assert result.status == "ok"
+        assert result.mode == "0600"
+        assert "auth store" in result.message
+
+    def test_group_or_other_readable_file_warns(self, tmp_path):
+        secret = tmp_path / ".env"
+        secret.write_text("OPENAI_API_KEY=sk-test\n", encoding="utf-8")
+        secret.chmod(0o644)
+
+        result = doctor._audit_sensitive_file_permission(secret, "env secrets")
+
+        assert result.status == "warn"
+        assert result.mode == "0644"
+        assert "chmod 600" in result.fix
+        assert str(secret) in result.fix
+
+    def test_missing_file_is_skipped(self, tmp_path):
+        result = doctor._audit_sensitive_file_permission(tmp_path / "missing.env", "missing")
+
+        assert result.status == "missing"
+        assert result.mode is None
+        assert result.fix == ""
+
+    def test_windows_skips_posix_mode_assessment(self, monkeypatch, tmp_path):
+        secret = tmp_path / ".env"
+        secret.write_text("OPENAI_API_KEY=sk-test\n", encoding="utf-8")
+        secret.chmod(0o644)
+        monkeypatch.setattr(sys, "platform", "win32")
+
+        result = doctor._audit_sensitive_file_permission(secret, "env secrets")
+
+        assert result.status == "skip"
+        assert result.fix == ""
+
+
 class TestDoctorPlatformHints:
     def test_termux_package_hint(self, monkeypatch):
         monkeypatch.setenv("TERMUX_VERSION", "0.118.3")


### PR DESCRIPTION
## Summary
- add a small spec for auditing sensitive local credential-file permissions
- teach `hermes doctor` to warn when `.env`, `auth.json`, or GitHub CLI `hosts.yml` are group/other accessible on POSIX
- cover secure, insecure, missing, and Windows-skip permission classifications

## Tests
- `python -m pytest tests/hermes_cli/test_doctor.py -k SensitiveFilePermissionAudit -q -o 'addopts='`
- `scripts/run_tests.sh tests/hermes_cli/test_doctor.py`
- `python -m compileall -q hermes_cli/doctor.py`

## Notes
- Non-destructive: the audit only inspects metadata and prints `chmod 600 ...` remediation; it never reads credential file contents.
