### PR TITLE
fix(desktop): resync active chat after gateway reconnect

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -885,6 +885,7 @@ export function DesktopController() {
     onGatewayReady: g => {
       gatewayRef.current = g
     },
+    refreshActiveSession: () => hydrateFromStoredSession(3),
     refreshHermesConfig,
     refreshSessions
   })

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -105,11 +105,12 @@ function fakeDesktop() {
   }
 }
 
-function Harness() {
+function Harness({ refreshActiveSession }: { refreshActiveSession?: () => Promise<void> } = {}) {
   useGatewayBoot({
     handleGatewayEvent: () => undefined,
     onConnectionReady: () => undefined,
     onGatewayReady: () => undefined,
+    refreshActiveSession,
     refreshHermesConfig: async () => undefined,
     refreshSessions: async () => undefined
   })
@@ -266,5 +267,26 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
 
     expect($gatewayState.get()).toBe('open')
     expect($desktopBoot.get().error).toBeNull()
+  })
+
+  it('resyncs the active transcript after reconnect so missed gateway events do not require an app restart', async () => {
+    const refreshActiveSession = vi.fn(async () => undefined)
+
+    render(<Harness refreshActiveSession={refreshActiveSession} />)
+    await flushAsync()
+    expect(refreshActiveSession).not.toHaveBeenCalled()
+
+    FakeWebSocket.mode = 'fail'
+    act(() => FakeWebSocket.instances[0].drop())
+    await flushAsync()
+    await advanceBackoff()
+
+    expect(refreshActiveSession).not.toHaveBeenCalled()
+
+    FakeWebSocket.mode = 'open'
+    await advanceBackoff()
+
+    expect($gatewayState.get()).toBe('open')
+    expect(refreshActiveSession).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -54,6 +54,9 @@ interface GatewayBootOptions {
     connection: Awaited<ReturnType<NonNullable<typeof window.hermesDesktop>['getConnection']>> | null
   ) => void
   onGatewayReady: (gateway: HermesGateway | null) => void
+  /** Rehydrate the active transcript after a successful reconnect so deltas
+   *  emitted while the WebSocket was down don't require an app restart. */
+  refreshActiveSession?: () => Promise<void>
   refreshHermesConfig: () => Promise<void>
   refreshSessions: () => Promise<void>
 }
@@ -62,6 +65,7 @@ export function useGatewayBoot({
   handleGatewayEvent,
   onConnectionReady,
   onGatewayReady,
+  refreshActiveSession,
   refreshHermesConfig,
   refreshSessions
 }: GatewayBootOptions) {
@@ -69,6 +73,7 @@ export function useGatewayBoot({
     handleGatewayEvent,
     onConnectionReady,
     onGatewayReady,
+    refreshActiveSession,
     refreshHermesConfig,
     refreshSessions
   })
@@ -77,6 +82,7 @@ export function useGatewayBoot({
     handleGatewayEvent,
     onConnectionReady,
     onGatewayReady,
+    refreshActiveSession,
     refreshHermesConfig,
     refreshSessions
   }
@@ -168,8 +174,12 @@ export function useGatewayBoot({
 
         reconnectAttempt = 0
         // Resync state that may have moved on the backend while we were asleep.
+        // In addition to the sidebar/config, rehydrate the active transcript:
+        // any deltas/completion events emitted while the WebSocket was down are
+        // otherwise missing from the renderer until a full app restart.
         await callbacksRef.current.refreshHermesConfig().catch(() => undefined)
         await callbacksRef.current.refreshSessions().catch(() => undefined)
+        await callbacksRef.current.refreshActiveSession?.().catch(() => undefined)
       } catch (err) {
         // OAuth session expired mid-reconnect: surface the actionable "sign in
         // again" message once instead of silently looping the backoff against a


### PR DESCRIPTION
## Summary
- rehydrate the active Desktop transcript after a successful gateway reconnect so missed WebSocket events are pulled from the persisted session instead of requiring an app restart
- keep the existing sidebar/config refresh path and add the active transcript as a small optional reconnect callback
- surface a recoverable boot error after prolonged reconnect failures so the UI exposes recovery controls while retries continue

## Test Plan
- npm run test:ui -- src/app/gateway/hooks/use-gateway-boot.test.tsx
- npm run typecheck
- npx eslint src/app/gateway/hooks/use-gateway-boot.ts src/app/gateway/hooks/use-gateway-boot.test.tsx src/app/desktop-controller.tsx