### PR TITLE
fix(simplex): use structured /_send for DM text messages to prevent silent drops

### DIFF
--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -825,15 +825,17 @@ class SimplexAdapter(BasePlatformAdapter):
 
         if content:
             corr_id = self._make_corr_id()
+            # Structured form: addresses by ID, and json.dumps escapes
+            # newlines + special chars correctly.  The bare @id text
+            # syntax is unreliable for DMs — the daemon silently drops
+            # messages when it cannot resolve the display name.
+            composed = json.dumps(
+                [{"msgContent": {"type": "text", "text": content}}]
+            )
             if chat_id.startswith("group:"):
-                # Structured form: addresses by numeric ID, and json.dumps
-                # escapes newlines + special chars correctly.
-                composed = json.dumps(
-                    [{"msgContent": {"type": "text", "text": content}}]
-                )
                 cmd_str = f"/_send #{chat_id[6:]} json {composed}"
             else:
-                cmd_str = f"@{chat_id} {content}"
+                cmd_str = f"/_send @{chat_id} json {composed}"
 
             await self._send_ws({"corrId": corr_id, "cmd": cmd_str})
 

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -205,12 +205,13 @@ def test_corr_id_pending_set_self_trims():
 
 @pytest.mark.asyncio
 async def test_send_dm():
-    """DMs use the bare ``@<id> text`` chat-command form.
+    """DMs use the structured ``/_send @<id> json [...]`` form.
 
-    The bracketed form ``@[<id>] text`` is what the daemon's man page
-    documents, but in practice both addressing styles route through
-    the same chat-command parser; bare ``@<id>`` matches what every
-    Hermes deployment has been using in production for months.
+    The bare ``@<id> text`` chat-command form is unreliable — the
+    daemon silently drops messages when it cannot resolve the display
+    name.  The structured ``/_send`` form addresses by ID and
+    survives newlines/quoting through ``json.dumps``, matching what
+    ``send_image`` and ``send_document`` already do.
     """
     from gateway.config import PlatformConfig
     cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
@@ -222,7 +223,11 @@ async def test_send_dm():
     result = await adapter.send("contact-42", "Hello, SimpleX!")
     mock_ws.send.assert_called_once()
     payload = json.loads(mock_ws.send.call_args[0][0])
-    assert payload["cmd"] == "@contact-42 Hello, SimpleX!"
+    assert payload["cmd"].startswith("/_send @contact-42 json ")
+    msg_content = json.loads(payload["cmd"].split(" json ", 1)[1])[0][
+        "msgContent"
+    ]
+    assert msg_content == {"type": "text", "text": "Hello, SimpleX!"}
     assert payload["corrId"].startswith(_CORR_PREFIX)
     assert result.success is True
 


### PR DESCRIPTION
## What does this PR do?

Fixes the SimpleX adapter's `send()` method to use the structured `/_send @<id> json [...]` format for DM text messages, instead of the unreliable bare `@<id> text` format. This aligns DM text sends with how `send_image` and `send_document` already work, preventing silent message drops when the daemon cannot resolve display names.

## Related Issue

Fixes #44400

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/simplex/adapter.py`: Changed the DM branch in `send()` from bare `@{chat_id} {content}` to structured `/_send @{chat_id} json {composed}` format, matching the group branch and the existing `send_image`/`send_document` methods.
- `tests/gateway/test_simplex_plugin.py`: Updated `test_send_dm` to assert the new structured format, mirroring the existing `test_send_group` assertions.

## How to Test

1. Run the SimpleX adapter test suite: `pytest tests/gateway/test_simplex_plugin.py -v`
2. Verify all 28 tests pass, specifically `test_send_dm` and `test_send_group`
3. The DM test now asserts `/_send @contact-42 json [...]` instead of `@contact-42 text`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_simplex_plugin.py -v` and all 28 tests pass
- [x] I've added tests for my changes (updated existing test to match new behavior)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `SimplexAdapter.send()` (1 caller via gateway dispatch, consistent with `send_image`/`send_document` pattern)
- Blast radius: LOW — single method in plugin adapter, no core changes
- Related patterns: `send_image()` and `send_document()` already use `/_send @{chat_id} json {composed}` for DMs; this fix brings `send()` in line
