### PR TITLE
fix(lazy-deps): verify real import names after install, not just metadata

### DIFF
--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -206,6 +206,74 @@ class TestEnsure:
         with pytest.raises(ld.FeatureUnavailable, match="still not importable"):
             ld.ensure("test.cache", prompt=False)
 
+    @staticmethod
+    def _successful_install(monkeypatch, feature, spec):
+        # Shared setup: pip succeeds and the metadata version check passes
+        # (missing on first probe, satisfied after "install").
+        monkeypatch.setitem(ld.LAZY_DEPS, feature, (spec,))
+        call_count = {"n": 0}
+
+        def fake_satisfied(_spec):
+            call_count["n"] += 1
+            return call_count["n"] > 1
+
+        monkeypatch.setattr(ld, "_is_satisfied", fake_satisfied)
+        monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
+        monkeypatch.setattr(
+            ld, "_venv_pip_install",
+            lambda specs, **kw: ld._InstallResult(True, "ok", ""),
+        )
+
+    def test_install_metadata_ok_but_import_broken_raises(self, monkeypatch):
+        # Regression for the gap behind #44403: pip succeeds and the
+        # metadata version check passes, but the dist's files are broken —
+        # none of its declared top-level modules can be found.
+        import importlib.metadata
+        import importlib.util
+
+        self._successful_install(monkeypatch, "test.broken", "zzzfake>=1")
+        monkeypatch.setattr(
+            importlib.metadata, "packages_distributions",
+            lambda: {"zzzfake_mod": ["zzzfake"]},
+        )
+        monkeypatch.setattr(importlib.util, "find_spec", lambda name: None)
+        with pytest.raises(ld.FeatureUnavailable, match="import check failed"):
+            ld.ensure("test.broken", prompt=False)
+
+    def test_import_smoke_test_uses_real_import_names(self, monkeypatch):
+        # Dist name and import name routinely differ (Pillow → PIL,
+        # discord.py → discord, google-api-python-client →
+        # googleapiclient). The smoke test must resolve names from the
+        # dist's own metadata, never from the dist name.
+        import importlib.metadata
+        import importlib.util
+
+        self._successful_install(monkeypatch, "test.renamed", "zzzfake-py>=1")
+        monkeypatch.setattr(
+            importlib.metadata, "packages_distributions",
+            lambda: {"zzzfake": ["zzzfake-py"]},
+        )
+        monkeypatch.setattr(
+            importlib.util, "find_spec",
+            lambda name: object() if name == "zzzfake" else None,
+        )
+        ld.ensure("test.renamed", prompt=False)  # no exception
+
+    def test_import_smoke_test_skips_dists_without_metadata(self, monkeypatch):
+        # A dist that declares no importable top-level modules (or path-like
+        # junk only) can't be verified — skip it rather than guess and
+        # fail a working install.
+        import importlib.metadata
+        import importlib.util
+
+        self._successful_install(monkeypatch, "test.opaque", "zzzfake>=1")
+        monkeypatch.setattr(
+            importlib.metadata, "packages_distributions",
+            lambda: {"zzzfake/subdir": ["zzzfake"]},
+        )
+        monkeypatch.setattr(importlib.util, "find_spec", lambda name: None)
+        ld.ensure("test.opaque", prompt=False)  # no exception
+
 
 # ---------------------------------------------------------------------------
 # is_available

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -259,6 +259,31 @@ class TestEnsure:
         )
         ld.ensure("test.renamed", prompt=False)  # no exception
 
+    def test_import_smoke_test_accepts_already_loaded_module(self, monkeypatch):
+        # Tool tests routinely inject spec-less stub modules straight into
+        # sys.modules (types.ModuleType("fal_client")); find_spec reads
+        # module.__spec__ on those and raises. A module that's already
+        # loaded is importable by definition — never flag it broken.
+        import importlib.metadata
+        import importlib.util
+        import sys
+        import types
+
+        self._successful_install(monkeypatch, "test.stubbed", "zzzfake>=1")
+        monkeypatch.setattr(
+            importlib.metadata, "packages_distributions",
+            lambda: {"zzzfake_mod": ["zzzfake"]},
+        )
+        monkeypatch.setitem(
+            sys.modules, "zzzfake_mod", types.ModuleType("zzzfake_mod")
+        )
+
+        def specless(name):
+            raise ValueError(f"{name}.__spec__ is None")
+
+        monkeypatch.setattr(importlib.util, "find_spec", specless)
+        ld.ensure("test.stubbed", prompt=False)  # no exception
+
     def test_import_smoke_test_skips_dists_without_metadata(self, monkeypatch):
         # A dist that declares no importable top-level modules (or path-like
         # junk only) can't be verified — skip it rather than guess and

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -670,6 +670,11 @@ def _broken_imports(specs: tuple[str, ...]) -> list[str]:
         if not modules:
             continue
         for module in modules:
+            # Already loaded means importable — and find_spec on a
+            # sys.modules entry reads module.__spec__, which raises on
+            # stub modules (tests inject spec-less fakes via sys.modules).
+            if module in sys.modules:
+                break
             try:
                 if importlib.util.find_spec(module) is not None:
                     break

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -618,6 +618,68 @@ def _core_constraints_file() -> Optional[Path]:
         return None
 
 
+def _normalize_dist_name(name: str) -> str:
+    """PEP 503 name normalisation: ``Discord.py`` / ``discord_py`` → ``discord-py``."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _broken_imports(specs: tuple[str, ...]) -> list[str]:
+    """Smoke-test that just-installed dists expose importable modules.
+
+    Correct metadata does not guarantee working files: a native extension
+    can be left half-overwritten on Windows while the gateway holds it
+    open, or an interrupted install can leave ``RECORD`` pointing at files
+    that don't exist on disk. Ask the import system whether each dist's
+    declared top-level modules can be found at all.
+
+    Import names come from the installed dist's own metadata
+    (``packages_distributions()``), never from the dist name — the two
+    routinely differ (``Pillow`` → ``PIL``, ``discord.py`` → ``discord``,
+    ``google-api-python-client`` → ``googleapiclient``). A dist counts as
+    broken only when it declares importable modules and *none* of them can
+    be found; a dist with no usable top-level metadata is skipped rather
+    than guessed at. This is a coarse check by design — it catches a fully
+    broken package, not a missing submodule deep inside an importable one.
+
+    Returns the dist names that failed the check.
+    """
+    import importlib
+    import importlib.util
+
+    # Fresh installs aren't visible to already-cached path finders.
+    importlib.invalidate_caches()
+    try:
+        from importlib.metadata import packages_distributions
+        dist_modules: dict[str, list[str]] = {}
+        for module, dists in packages_distributions().items():
+            for dist in dists:
+                dist_modules.setdefault(_normalize_dist_name(dist), []).append(module)
+    except Exception:
+        # No metadata view to verify against — don't guess.
+        return []
+
+    broken: list[str] = []
+    for spec in specs:
+        pkg = _pkg_name_from_spec(spec)
+        # Some build backends leak path-like entries ("pkg/subdir") into
+        # the top-level list; only valid identifiers are importable.
+        modules = [
+            m for m in dist_modules.get(_normalize_dist_name(pkg), [])
+            if m.isidentifier()
+        ]
+        if not modules:
+            continue
+        for module in modules:
+            try:
+                if importlib.util.find_spec(module) is not None:
+                    break
+            except Exception:
+                continue
+        else:
+            broken.append(pkg)
+    return broken
+
+
 def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _InstallResult:
     """Install ``specs`` using the uv → pip → ensurepip ladder.
 
@@ -835,6 +897,19 @@ def ensure(feature: str, *, prompt: bool = True) -> None:
             feature, still_missing,
             "install reported success but packages still not importable "
             "(may require Python restart)"
+        )
+
+    # Metadata being correct doesn't prove the files are: catch installs
+    # where the version check passes but nothing is actually importable
+    # (partial install, native extension clobbered while loaded).
+    broken = _broken_imports(missing)
+    if broken:
+        raise FeatureUnavailable(
+            feature, tuple(missing),
+            "install reported success and metadata checks pass, but "
+            f"import check failed for: {', '.join(broken)} "
+            "(files may be missing or corrupted — try reinstalling, or "
+            "restart and retry)"
         )
 
     logger.info("Lazy install complete for feature %r", feature)


### PR DESCRIPTION
## What does this PR do?

`ensure()`'s post-install verification is metadata-only: pip reports success and the version re-check passes, but nothing proves the installed files actually work (interrupted install leaving `RECORD` entries with no files, a native extension clobbered while the gateway holds it open on Windows). This adds an import smoke test after the metadata check.

The key design point: import names are resolved from **the installed dist's own metadata** (`importlib.metadata.packages_distributions()`), never derived from the dist name. Name-derivation hard-fails working installs for a large chunk of `LAZY_DEPS`, where dist and import names differ:

`Pillow`→`PIL`, `discord.py`→`discord`, `firecrawl-py`→`firecrawl`, `parallel-web`→`parallel`, `google-api-python-client`→`googleapiclient`, `honcho-ai`→`honcho`, `agent-client-protocol`→`acp`, `python-telegram-bot`→`telegram`

(see the review on #44417, which took the name-derivation approach — this PR is the metadata-resolved alternative suggested there).

## Related Issue

Fixes #44403

Note from triage (also commented on the issue): the issue's chardet example can't have gone through `ensure()` — chardet isn't in `LAZY_DEPS` — but the verification gap itself is real and is what this PR closes.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/lazy_deps.py`:
  - New `_normalize_dist_name()` (PEP 503 normalisation) and `_broken_imports()`: calls `importlib.invalidate_caches()` (fresh installs aren't visible to cached path finders), inverts `packages_distributions()` into dist→top-level-modules, and flags a dist only when it declares importable modules and **none** of them can be found via `find_spec()`. Dists with no usable top-level metadata (or path-like junk entries some build backends leak) are skipped rather than guessed at. `find_spec()` is wrapped in try/except — dotted dist names like `discord.py` make a bare call raise `ModuleNotFoundError` instead of returning `None`.
  - `ensure()`: after the existing metadata re-check passes, raise `FeatureUnavailable` listing the broken dists.
- `tests/tools/test_lazy_deps.py`: three new tests — metadata-OK-but-import-broken raises; dist-name≠import-name installs pass (regression guard against name-derivation); dists without top-level metadata are skipped. Existing tests pass unmodified (the smoke test naturally skips the fake `zzzfake` dist since it has no installed metadata).

## How to Test

1. `pytest tests/tools/test_lazy_deps.py -q` — 64 passed
2. False-positive check against a real venv with the tricky packages installed (firecrawl-py, parallel-web, discord.py, google-api-python-client, honcho-ai, agent-client-protocol, Pillow):
   ```python
   import tools.lazy_deps as ld
   ld._broken_imports(("Pillow==12.2.0", "discord.py==2.7.1", ...))  # → []
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — #44417 targets the same issue; this is the alternative implementation suggested in its review, fixing the false-positive and uncaught-exception problems found there
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings added; no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the Windows `.pyd`-clobber case is the main motivating scenario
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (failure mode is a clearer `FeatureUnavailable`, no schema change)
