### PR TITLE
fix(api-server): accept archived field in PATCH /api/sessions/{id} endpoint

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1308,8 +1308,12 @@ class APIServerAdapter(BasePlatformAdapter):
             "reasoning_tokens", "estimated_cost_usd", "actual_cost_usd",
             "api_call_count", "parent_session_id", "last_active", "preview",
             "_lineage_root_id",
+            "archived",
         )
         payload = {key: session.get(key) for key in safe_keys if key in session}
+        # SQLite stores booleans as integers; convert for the API contract.
+        if "archived" in payload:
+            payload["archived"] = bool(payload["archived"])
         # Avoid exposing full system prompts/model_config through the client API;
         # callers only need to know whether those snapshots exist.
         payload["has_system_prompt"] = bool(session.get("system_prompt"))
@@ -1441,7 +1445,7 @@ class APIServerAdapter(BasePlatformAdapter):
         body, err = await self._read_json_body(request)
         if err:
             return err
-        allowed = {"title", "end_reason"}
+        allowed = {"title", "end_reason", "archived"}
         unknown = sorted(set(body) - allowed)
         if unknown:
             return web.json_response(_openai_error(f"Unsupported session fields: {', '.join(unknown)}", code="unsupported_session_field"), status=400)
@@ -1454,6 +1458,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response(_openai_error(str(exc), code="invalid_title"), status=400)
         if body.get("end_reason"):
             db.end_session(session_id, str(body["end_reason"]))
+        if "archived" in body:
+            db.set_session_archived(session_id, bool(body["archived"]))
         session = db.get_session(session_id) or session
         return web.json_response({"object": "hermes.session", "session": self._session_response(session)})
 

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -434,3 +434,79 @@ async def test_session_header_rejected_without_api_key(adapter, session_db):
         assert resp.status == 403
         data = await resp.json()
         assert "X-Hermes-Session-Key requires API key" in data["error"]["message"]
+
+
+# ---------------------------------------------------------------------------
+# PATCH /api/sessions/{id} — archived field
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_patch_session_archive(adapter, session_db):
+    """PATCH with {archived: true} archives the session via SessionDB."""
+    session_id = session_db.create_session("to-archive", "api_server")
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.patch(
+            f"/api/sessions/{session_id}",
+            json={"archived": True},
+        )
+        assert resp.status == 200
+        data = await resp.json()
+        assert data["session"]["archived"] is True
+
+    # Verify in DB
+    row = session_db.get_session(session_id)
+    assert row is not None
+    assert row["archived"] == 1
+
+
+@pytest.mark.asyncio
+async def test_patch_session_unarchive(adapter, session_db):
+    """PATCH with {archived: false} un-archives a previously archived session."""
+    session_id = session_db.create_session("to-unarchive", "api_server")
+    session_db.set_session_archived(session_id, True)
+
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.patch(
+            f"/api/sessions/{session_id}",
+            json={"archived": False},
+        )
+        assert resp.status == 200
+        data = await resp.json()
+        assert data["session"]["archived"] is False
+
+    row = session_db.get_session(session_id)
+    assert row["archived"] == 0
+
+
+@pytest.mark.asyncio
+async def test_patch_session_rejects_unknown_fields(adapter, session_db):
+    """PATCH still rejects fields not in the allowed set."""
+    session_id = session_db.create_session("reject-test", "api_server")
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.patch(
+            f"/api/sessions/{session_id}",
+            json={"bogus_field": "nope"},
+        )
+        assert resp.status == 400
+        data = await resp.json()
+        assert "bogus_field" in data["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_patch_session_title_and_archived_together(adapter, session_db):
+    """PATCH can update title and archived in a single request."""
+    session_id = session_db.create_session("combo", "api_server")
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.patch(
+            f"/api/sessions/{session_id}",
+            json={"title": "My Session", "archived": True},
+        )
+        assert resp.status == 200
+        data = await resp.json()
+        assert data["session"]["title"] == "My Session"
+        assert data["session"]["archived"] is True


### PR DESCRIPTION
## What does this PR do?

Fixes the PATCH `/api/sessions/{session_id}` endpoint to accept the `archived` field, allowing the Desktop client to archive/unarchive sessions. Previously, the endpoint only allowed `title` and `end_reason`, causing HTTP 400 "Unsupported session fields: archived" when the Desktop sent `{ archived: true }`.

## Related Issue

Fixes #44449

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/api_server.py`: Added `"archived"` to the PATCH handler's allowed set and added a handler block calling `db.set_session_archived()`. Also exposed `"archived"` in `_session_response()` safe_keys with boolean conversion (SQLite stores as 0/1 integer).
- `tests/gateway/test_session_api.py`: Added 4 tests — archive, unarchive, reject unknown fields, archive+title combined.

## How to Test

1. Start an API server: `hermes dashboard --api-server`
2. Create a session via the API or Desktop
3. Send `PATCH /api/sessions/{id}` with body `{"archived": true}` — should return 200
4. Verify the session is archived: `hermes sessions list` (archived sessions hidden by default)
5. Send `PATCH /api/sessions/{id}` with body `{"archived": false}` — should return 200

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `_handle_patch_session`, `_session_response` (callers: Desktop setSessionArchived, session settings page)
- Blast radius: LOW — only affects PATCH session endpoint, existing title/end_reason handlers unchanged
- Related patterns: SessionDB.set_session_archived() already handles compression chain propagation (recursive ancestors/descendants)
