### PR TITLE
fix(desktop): carve sidebar nav rows out of the titlebar drag region

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -797,7 +797,14 @@ export function ChatSidebar({
                     <SidebarMenuButton
                       aria-disabled={!isInteractive}
                       className={cn(
-                        'flex h-7 w-full justify-start gap-2 rounded-md border border-transparent px-2 text-left text-[0.8125rem] font-medium text-(--ui-text-secondary) transition-colors duration-100 ease-out hover:bg-(--ui-control-hover-background) hover:text-foreground hover:transition-none',
+                        // no-drag: these rows sit directly under the titlebar's
+                        // [-webkit-app-region:drag] strips (app-shell.tsx), with only
+                        // 6px of clearance. Drag regions win hit-testing over DOM
+                        // (pointer-events can't override), and on Linux/WSLg the
+                        // resolved region has been observed to swallow clicks on the
+                        // top rows. Same carve-out as USER_BUBBLE_BASE_CLASS in
+                        // thread.tsx.
+                        'flex h-7 w-full justify-start gap-2 rounded-md border border-transparent px-2 text-left text-[0.8125rem] font-medium text-(--ui-text-secondary) transition-colors duration-100 ease-out [-webkit-app-region:no-drag] hover:bg-(--ui-control-hover-background) hover:text-foreground hover:transition-none',
                         active &&
                           'border-(--ui-stroke-tertiary) bg-(--ui-control-active-background) text-foreground shadow-none hover:border-(--ui-stroke-tertiary)!',
                         !isInteractive &&


### PR DESCRIPTION
## Summary

Top nav rows in the left sidebar (New session / Skills / Messaging / Artifacts) can be unclickable while the rest of the UI works. This is an `-webkit-app-region: drag` hit-test issue, not GPU/compositing:

- The shell paints invisible titlebar drag strips across the top 34px (`app-shell.tsx`).
- The sidebar nav group clears them by only **6px** (`pt-[calc(var(--titlebar-height)+0.375rem)]`).
- Drag regions win hit-testing over DOM elements regardless of `pointer-events`, so a row whose top edge falls within the band stops receiving clicks. Linux WCO (enabled since Electron 32; this app ships 40) is the newest overlay implementation and has known region quirks (electron/electron#43030).

Fix: apply the same `[-webkit-app-region:no-drag]` carve-out the codebase already uses for sticky user bubbles (`USER_BUBBLE_BASE_CLASS` in `thread.tsx`, identical Electron-level failure mode) to the sidebar nav buttons. One class string plus a comment; harmless on every platform since these rows were never draggable surface.

## Test plan

- [ ] `npm run typecheck` / `npm run lint` in `apps/desktop` (CI)
- [ ] macOS + Linux: sidebar nav rows render and click as before; window still draggable from the titlebar band outside the rows
- [ ] Regression check on the top rows specifically — clickable across the full button height, not just below the 34px band