### PR TITLE
fix(agent): stop compaction summaries hijacking the current task (salvages #44345 + #41650)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -7,7 +7,7 @@ protecting head and tail context.
 Improvements over v2:
   - Structured summary template with Resolved/Pending question tracking
   - Filter-safe summarizer preamble that treats prior turns as source material
-  - "Historical Work (DO NOT EXECUTE)" replaces "Next Steps" and "Remaining Work" to avoid reading as active instructions
+  - Historical (reference-only) section headings replace "Next Steps"/"Remaining Work" to avoid reading as active instructions
   - Clear separator when summary merges into tail message
   - Iterative summary updates (preserves info across multiple compactions)
   - Token-budget tail protection instead of fixed message count
@@ -49,18 +49,14 @@ SUMMARY_PREFIX = (
     "Respond ONLY to the latest user message that appears AFTER this "
     "summary — that message is the single source of truth for what to do "
     "right now. "
-    "Any topic overlap between the summary and the latest user message does "
-    "NOT mean you should resume the summary's task. The latest user message "
-    "always takes priority and WINS, even on similar topics. "
-    "If the latest user message is a new question, request, or instruction "
-    "that relates to a topic also mentioned in "
-    f"'{HISTORICAL_TASK_HEADING}' / "
-    f"'{HISTORICAL_IN_PROGRESS_HEADING}' / "
+    "Topic overlap with the summary does NOT mean you should resume its "
+    "task: even on similar topics, the latest user message WINS. Treat ONLY "
+    "the latest message as the active task and discard stale items from "
+    f"'{HISTORICAL_TASK_HEADING}' / '{HISTORICAL_IN_PROGRESS_HEADING}' / "
     f"'{HISTORICAL_PENDING_ASKS_HEADING}' / "
-    f"'{HISTORICAL_REMAINING_WORK_HEADING}', treat ONLY the "
-    "latest message as the active task — discard those stale items entirely. "
-    "Do NOT 'wrap up' or 'finish' any work described in the summary unless "
-    "the latest message explicitly asks for it. "
+    f"'{HISTORICAL_REMAINING_WORK_HEADING}' entirely — do not 'wrap up' or "
+    "'finish' work described there unless the latest message explicitly "
+    "asks for it. "
     "Reverse signals in the latest message (e.g. 'stop', 'undo', 'roll "
     "back', 'just verify', 'don't do that anymore', 'never mind', a new "
     "topic) must immediately end any in-flight work described in the "
@@ -1790,7 +1786,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         Context compressor bug (#10896): ``_align_boundary_backward`` can pull
         ``cut_idx`` past a user message when it tries to keep tool_call/result
         groups together.  If the last user message ends up in the *compressed*
-        middle region the LLM summariser writes it into "Historical User Asks",
+        middle region the LLM summariser writes it into "Historical Pending User Asks",
         but ``SUMMARY_PREFIX`` tells the next model to respond only to user
         messages *after* the summary — so the task effectively disappears from
         the active context, causing the agent to stall, repeat completed work,

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -34,6 +34,12 @@ from agent.redact import redact_sensitive_text
 
 logger = logging.getLogger(__name__)
 
+HISTORICAL_TASK_HEADING = "## Historical Task Snapshot"
+HISTORICAL_IN_PROGRESS_HEADING = "## Historical In-Progress State"
+HISTORICAL_PENDING_ASKS_HEADING = "## Historical Pending User Asks"
+HISTORICAL_REMAINING_WORK_HEADING = "## Historical Remaining Work"
+
+
 SUMMARY_PREFIX = (
     "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted "
     "into the summary below. This is a handoff from a previous context "
@@ -43,12 +49,14 @@ SUMMARY_PREFIX = (
     "Respond ONLY to the latest user message that appears AFTER this "
     "summary — that message is the single source of truth for what to do "
     "right now. "
-    "If the latest user message is consistent with the '## Active Task' "
+    f"If the latest user message is consistent with the '{HISTORICAL_TASK_HEADING}' "
     "section, you may use the summary as background. If the latest user "
     "message contradicts, supersedes, changes topic from, or in any way "
-    "diverges from '## Active Task' / '## In Progress' / '## Pending User "
-    "Asks' / '## Remaining Work', the latest message WINS — discard those "
-    "stale items entirely and do not 'wrap up the old task first'. "
+    f"diverges from '{HISTORICAL_TASK_HEADING}' / "
+    f"'{HISTORICAL_IN_PROGRESS_HEADING}' / "
+    f"'{HISTORICAL_PENDING_ASKS_HEADING}' / "
+    f"'{HISTORICAL_REMAINING_WORK_HEADING}', the latest message WINS — "
+    "discard those stale items entirely and do not 'wrap up the old task first'. "
     "Reverse signals in the latest message (e.g. 'stop', 'undo', 'roll "
     "back', 'just verify', 'don't do that anymore', 'never mind', a new "
     "topic) must immediately end any in-flight work described in the "
@@ -1155,7 +1163,7 @@ class ContextCompressor(ContextEngine):
             )
 
         reason_text = f" Summary failure reason: {reason}." if reason else ""
-        body = f"""## Active Task
+        body = f"""{HISTORICAL_TASK_HEADING}
 {active_task}
 
 ## Goal
@@ -1172,7 +1180,7 @@ Recovered from a deterministic fallback because the LLM context summarizer was u
 ## Active State
 Unknown from deterministic fallback. Inspect current repository/session state if needed.
 
-## In Progress
+{HISTORICAL_IN_PROGRESS_HEADING}
 {active_task}
 
 ## Blocked
@@ -1184,13 +1192,13 @@ None recoverable from deterministic fallback.
 ## Resolved Questions
 None recoverable from deterministic fallback.
 
-## Pending User Asks
+{HISTORICAL_PENDING_ASKS_HEADING}
 {active_task}
 
 ## Relevant Files
 {_bullets(relevant_files, limit=12)}
 
-## Remaining Work
+{HISTORICAL_REMAINING_WORK_HEADING}
 Continue from the most recent unfulfilled user ask and protected tail messages. Verify state with tools before making claims.
 
 ## Last Dropped Turns
@@ -1312,7 +1320,7 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
             _temporal_anchoring_rule = ""
 
         # Shared structured template (used by both paths).
-        _template_sections = f"""## Active Task
+        _template_sections = f"""{HISTORICAL_TASK_HEADING}
 [THE SINGLE MOST IMPORTANT FIELD. Capture the user's most recent unfulfilled
 input verbatim — the exact words they used. This includes:
 - Explicit task assignments ("refactor the auth module")
@@ -1359,7 +1367,7 @@ Be specific with file paths, commands, line numbers, and results.]
 - Any running processes or servers
 - Environment details that matter]
 
-## In Progress
+{HISTORICAL_IN_PROGRESS_HEADING}
 [Work currently underway — what was being done when compaction fired]
 
 ## Blocked
@@ -1371,13 +1379,13 @@ Be specific with file paths, commands, line numbers, and results.]
 ## Resolved Questions
 [Questions the user asked that were ALREADY answered — include the answer so it is not repeated]
 
-## Pending User Asks
+{HISTORICAL_PENDING_ASKS_HEADING}
 [Questions or requests from the user that have NOT yet been answered or fulfilled. If none, write "None."]
 
 ## Relevant Files
 [Files read, modified, or created — with brief note on each]
 
-## Remaining Work
+{HISTORICAL_REMAINING_WORK_HEADING}
 [What remains to be done — framed as context, not instructions]
 
 ## Critical Context

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -80,6 +80,31 @@ LEGACY_SUMMARY_PREFIX = "[CONTEXT SUMMARY]:"
 # embedded in the body and keeps hijacking replies. Keep newest-first; entries
 # are matched literally. Add a frozen copy here whenever SUMMARY_PREFIX changes.
 _HISTORICAL_SUMMARY_PREFIXES = (
+    # Carveout era (#41607/#38364/#42812): "consistent → use as background"
+    # licensed stale-task resumption on topic overlap.
+    "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted "
+    "into the summary below. This is a handoff from a previous context "
+    "window — treat it as background reference, NOT as active instructions. "
+    "Do NOT answer questions or fulfill requests mentioned in this summary; "
+    "they were already addressed. "
+    "Respond ONLY to the latest user message that appears AFTER this "
+    "summary — that message is the single source of truth for what to do "
+    "right now. "
+    "If the latest user message is consistent with the '## Active Task' "
+    "section, you may use the summary as background. If the latest user "
+    "message contradicts, supersedes, changes topic from, or in any way "
+    "diverges from '## Active Task' / '## In Progress' / '## Pending User "
+    "Asks' / '## Remaining Work', the latest message WINS — discard those "
+    "stale items entirely and do not 'wrap up the old task first'. "
+    "Reverse signals in the latest message (e.g. 'stop', 'undo', 'roll "
+    "back', 'just verify', 'don't do that anymore', 'never mind', a new "
+    "topic) must immediately end any in-flight work described in the "
+    "summary; do not re-surface it in later turns. "
+    "IMPORTANT: Your persistent memory (MEMORY.md, USER.md) in the system "
+    "prompt is ALWAYS authoritative and active — never ignore or deprioritize "
+    "memory content due to this compaction note. "
+    "The current session state (files, config, etc.) may reflect work "
+    "described here — avoid repeating it:",
     # Pre-#35344: contained the self-contradicting "resume exactly" directive.
     "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted "
     "into the summary below. This is a handoff from a previous context "

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -7,7 +7,7 @@ protecting head and tail context.
 Improvements over v2:
   - Structured summary template with Resolved/Pending question tracking
   - Filter-safe summarizer preamble that treats prior turns as source material
-  - "Remaining Work" replaces "Next Steps" to avoid reading as active instructions
+  - "Historical Work (DO NOT EXECUTE)" replaces "Next Steps" and "Remaining Work" to avoid reading as active instructions
   - Clear separator when summary merges into tail message
   - Iterative summary updates (preserves info across multiple compactions)
   - Token-budget tail protection instead of fixed message count
@@ -49,14 +49,18 @@ SUMMARY_PREFIX = (
     "Respond ONLY to the latest user message that appears AFTER this "
     "summary — that message is the single source of truth for what to do "
     "right now. "
-    f"If the latest user message is consistent with the '{HISTORICAL_TASK_HEADING}' "
-    "section, you may use the summary as background. If the latest user "
-    "message contradicts, supersedes, changes topic from, or in any way "
-    f"diverges from '{HISTORICAL_TASK_HEADING}' / "
+    "Any topic overlap between the summary and the latest user message does "
+    "NOT mean you should resume the summary's task. The latest user message "
+    "always takes priority and WINS, even on similar topics. "
+    "If the latest user message is a new question, request, or instruction "
+    "that relates to a topic also mentioned in "
+    f"'{HISTORICAL_TASK_HEADING}' / "
     f"'{HISTORICAL_IN_PROGRESS_HEADING}' / "
     f"'{HISTORICAL_PENDING_ASKS_HEADING}' / "
-    f"'{HISTORICAL_REMAINING_WORK_HEADING}', the latest message WINS — "
-    "discard those stale items entirely and do not 'wrap up the old task first'. "
+    f"'{HISTORICAL_REMAINING_WORK_HEADING}', treat ONLY the "
+    "latest message as the active task — discard those stale items entirely. "
+    "Do NOT 'wrap up' or 'finish' any work described in the summary unless "
+    "the latest message explicitly asks for it. "
     "Reverse signals in the latest message (e.g. 'stop', 'undo', 'roll "
     "back', 'just verify', 'don't do that anymore', 'never mind', a new "
     "topic) must immediately end any in-flight work described in the "
@@ -1380,13 +1384,13 @@ Be specific with file paths, commands, line numbers, and results.]
 [Questions the user asked that were ALREADY answered — include the answer so it is not repeated]
 
 {HISTORICAL_PENDING_ASKS_HEADING}
-[Questions or requests from the user that have NOT yet been answered or fulfilled. If none, write "None."]
+[Questions or requests from the user that have NOT yet been answered or fulfilled. These are STALE — they were from the compacted turns. Write them here for reference only. The agent must NOT act on them unless the latest user message explicitly requests it. If none, write "None."]
 
 ## Relevant Files
 [Files read, modified, or created — with brief note on each]
 
 {HISTORICAL_REMAINING_WORK_HEADING}
-[What remains to be done — framed as context, not instructions]
+[What remains to be done — framed as STALE context for reference only. The agent must NOT resume this work unless the latest user message explicitly asks for it.]
 
 ## Critical Context
 [Any specific values, error messages, configuration details, or data that would be lost without explicit preservation. NEVER include API keys, tokens, passwords, or credentials — write [REDACTED] instead.]
@@ -1761,7 +1765,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         Context compressor bug (#10896): ``_align_boundary_backward`` can pull
         ``cut_idx`` past a user message when it tries to keep tool_call/result
         groups together.  If the last user message ends up in the *compressed*
-        middle region the LLM summariser writes it into "Pending User Asks",
+        middle region the LLM summariser writes it into "Historical User Asks",
         but ``SUMMARY_PREFIX`` tells the next model to respond only to user
         messages *after* the summary — so the task effectively disappears from
         the active context, causing the agent to stall, repeat completed work,

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -3,7 +3,11 @@
 import pytest
 from unittest.mock import patch, MagicMock
 
-from agent.context_compressor import ContextCompressor, SUMMARY_PREFIX
+from agent.context_compressor import (
+    ContextCompressor,
+    HISTORICAL_TASK_HEADING,
+    SUMMARY_PREFIX,
+)
 
 
 @pytest.fixture()
@@ -157,7 +161,7 @@ class TestCompress:
             result = c.compress(msgs)
 
         combined = "\n".join(str(m.get("content", "")) for m in result)
-        assert "## Active Task" in combined
+        assert HISTORICAL_TASK_HEADING in combined
         assert "Please fix the compression summary failure" in combined
         assert "read_file" in combined
         assert "agent/context_compressor.py" in combined
@@ -1213,7 +1217,8 @@ class TestCompressWithClient:
         """When the summary lands as standalone role='user' (e.g. head ends
         with assistant/tool), the message body must include the explicit
         '--- END OF CONTEXT SUMMARY ---' marker. Without it, weak models
-        read the verbatim past user request quoted in '## Active Task' as
+        read the verbatim past user request quoted in the historical task
+        snapshot as
         fresh input (#11475, #14521).
         """
         mock_response = MagicMock()

--- a/tests/agent/test_context_compressor_temporal_anchoring.py
+++ b/tests/agent/test_context_compressor_temporal_anchoring.py
@@ -15,7 +15,7 @@ from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import hermes_time
-from agent.context_compressor import ContextCompressor
+from agent.context_compressor import ContextCompressor, HISTORICAL_TASK_HEADING
 
 
 def _compressor() -> ContextCompressor:
@@ -98,7 +98,7 @@ def test_clock_failure_omits_rule_but_compaction_still_runs():
     prompt = mock_call.call_args.kwargs["messages"][0]["content"]
     assert "TEMPORAL ANCHORING" not in prompt
     # Structured template still intact.
-    assert "## Active Task" in prompt
+    assert HISTORICAL_TASK_HEADING in prompt
 
 
 def test_anchoring_rule_uses_date_from_hermes_time_now():

--- a/tests/agent/test_resume_stale_active_task.py
+++ b/tests/agent/test_resume_stale_active_task.py
@@ -1,9 +1,9 @@
 """Regression coverage for #35344: a resumed session must not let a stale
-``## Active Task`` from an inherited compaction handoff hijack the reply to a
+historical task snapshot from an inherited compaction handoff hijack the reply to a
 new, unrelated user message.
 
 The failure mode (real report): a lineage was compacted, producing a handoff
-whose ``## Active Task`` described task A. The lineage was resumed later and
+whose historical task snapshot described task A. The lineage was resumed later and
 the user asked about an unrelated task B. The model answered with A because
 the handoff's resume directive outranked the fresh ask.
 
@@ -16,14 +16,15 @@ named reverse-signal verbs. Two invariants guard the resume path specifically:
      pre-fix stale handoff cannot keep its "resume exactly" directive forever.
 
   2. The current handoff prefix contains an unambiguous "latest message wins /
-     discard stale Active Task" rule, so an unrelated new ask is privileged over
-     the inherited ``## Active Task``.
+     discard stale historical task" rule, so an unrelated new ask is privileged over
+     the inherited task snapshot.
 
 These are content/structural assertions (no live model call) — they pin the
 mechanism that makes the stale task historical rather than active.
 """
 
 from agent.context_compressor import (
+    HISTORICAL_TASK_HEADING,
     SUMMARY_PREFIX,
     LEGACY_SUMMARY_PREFIX,
     ContextCompressor,
@@ -48,10 +49,10 @@ _OLD_CONFLICTING_PREFIX = (
 
 def test_latest_message_wins_over_inherited_active_task():
     """The handoff must explicitly privilege the latest user message over a
-    stale ``## Active Task`` — the core #35344 contract."""
+    stale historical task snapshot — the core #35344 contract."""
     lower = SUMMARY_PREFIX.lower()
     assert "latest user message" in lower
-    assert "## active task" in lower
+    assert HISTORICAL_TASK_HEADING.lower() in lower
     # Conflict-resolution must be explicit, not implied.
     assert "wins" in lower or "supersede" in lower
     assert "discard" in lower
@@ -69,7 +70,7 @@ def test_resumed_stale_handoff_gets_renormalized_to_current_prefix():
     prefix when re-normalized on re-compaction — so the "resume exactly"
     directive cannot survive into a resumed session."""
     stale_body = (
-        "## Active Task\n"
+        f"{HISTORICAL_TASK_HEADING}\n"
         "User asked: 'Migrate the billing module to Stripe'\n\n"
         "## Goal\nMigrate billing.\n"
     )
@@ -92,7 +93,7 @@ def test_resumed_stale_handoff_gets_renormalized_to_current_prefix():
 def test_legacy_prefix_handoff_also_renormalized():
     """The same upgrade applies to the oldest ``[CONTEXT SUMMARY]:`` handoff
     format that may sit in a long-lived resumed lineage."""
-    legacy = f"{LEGACY_SUMMARY_PREFIX} ## Active Task\nUser asked: 'task A'"
+    legacy = f"{LEGACY_SUMMARY_PREFIX} {HISTORICAL_TASK_HEADING}\nUser asked: 'task A'"
     renormalized = ContextCompressor._with_summary_prefix(legacy)
     assert renormalized.startswith(SUMMARY_PREFIX)
     assert LEGACY_SUMMARY_PREFIX not in renormalized
@@ -107,7 +108,7 @@ def test_inherited_handoff_detected_in_resumed_protected_head():
     Task read as live intent)."""
     messages = [
         {"role": "system", "content": "system prompt"},
-        {"role": "user", "content": f"{SUMMARY_PREFIX}\n## Active Task\nUser asked: 'task A'"},
+        {"role": "user", "content": f"{SUMMARY_PREFIX}\n{HISTORICAL_TASK_HEADING}\nUser asked: 'task A'"},
         {"role": "assistant", "content": "ok"},
         {"role": "user", "content": "Unrelated task B: what's the capital of France?"},
     ]
@@ -129,7 +130,7 @@ def test_historical_prefixed_handoff_detected_and_stripped():
     stale 'resume exactly' text as a fresh turn."""
     messages = [
         {"role": "system", "content": "system prompt"},
-        {"role": "user", "content": f"{_OLD_CONFLICTING_PREFIX}\n## Active Task\nUser asked: 'task A'"},
+        {"role": "user", "content": f"{_OLD_CONFLICTING_PREFIX}\n{HISTORICAL_TASK_HEADING}\nUser asked: 'task A'"},
         {"role": "assistant", "content": "ok"},
         {"role": "user", "content": "Unrelated task B"},
     ]

--- a/tests/agent/test_resume_stale_active_task.py
+++ b/tests/agent/test_resume_stale_active_task.py
@@ -56,6 +56,10 @@ def test_latest_message_wins_over_inherited_active_task():
     # Conflict-resolution must be explicit, not implied.
     assert "wins" in lower or "supersede" in lower
     assert "discard" in lower
+    # The "consistent -> use as background" carveout licensed stale-task
+    # resumption on topic overlap (#41607, #38364) — it must stay gone.
+    assert "you may use the summary as background" not in lower
+    assert "topic overlap" in lower
 
 
 def test_no_resume_exactly_directive_can_hijack():
@@ -87,7 +91,9 @@ def test_resumed_stale_handoff_gets_renormalized_to_current_prefix():
     # current latest-message-wins framing.
     assert "resume exactly" not in renormalized.lower()
     assert renormalized.startswith(SUMMARY_PREFIX)
-    assert "wins" in renormalized.lower()
+    assert ("wins" in renormalized.lower()
+            or "priority" in renormalized.lower()
+            or "supersede" in renormalized.lower())
 
 
 def test_legacy_prefix_handoff_also_renormalized():

--- a/tests/agent/test_summary_prefix_semantics.py
+++ b/tests/agent/test_summary_prefix_semantics.py
@@ -80,3 +80,37 @@ def test_memory_authority_preserved():
     assert "MEMORY.md" in SUMMARY_PREFIX
     assert "USER.md" in SUMMARY_PREFIX
     assert "authoritative" in SUMMARY_PREFIX
+
+
+def test_no_background_consistency_carveout():
+    """The "consistent → use as background" carveout licensed stale-task
+    resumption on topic overlap (#41607, #38364, #42812). It must stay gone,
+    and the prefix must explicitly neutralize topic overlap."""
+    lower = SUMMARY_PREFIX.lower()
+    assert "you may use the summary as background" not in lower
+    assert "topic overlap" in lower
+
+
+def test_replaced_prefixes_are_frozen_for_renormalization():
+    """Every retired SUMMARY_PREFIX must be frozen into
+    _HISTORICAL_SUMMARY_PREFIXES, otherwise summaries persisted by older
+    builds lose detection/renormalization after an upgrade. The carveout-era
+    prefix is the latest retiree."""
+    from agent.context_compressor import (
+        _HISTORICAL_SUMMARY_PREFIXES,
+        ContextCompressor,
+    )
+
+    carveout_era = [
+        p for p in _HISTORICAL_SUMMARY_PREFIXES
+        if "you may use the summary as background" in p
+    ]
+    assert carveout_era, "carveout-era prefix missing from frozen tuple"
+    # The live prefix must never be one of the frozen ones.
+    assert SUMMARY_PREFIX not in _HISTORICAL_SUMMARY_PREFIXES
+    # Detection + strip must work for every frozen prefix.
+    for old_prefix in _HISTORICAL_SUMMARY_PREFIXES:
+        content = old_prefix + "\n## Summary body"
+        assert ContextCompressor._is_context_summary_content(content)
+        stripped = ContextCompressor._strip_summary_prefix(content)
+        assert not stripped.startswith(old_prefix)

--- a/tests/agent/test_summary_prefix_semantics.py
+++ b/tests/agent/test_summary_prefix_semantics.py
@@ -40,7 +40,7 @@ def test_latest_message_wins_on_conflict():
     assert HISTORICAL_PENDING_ASKS_HEADING.lower() in lower
     assert HISTORICAL_REMAINING_WORK_HEADING.lower() in lower
     # Must have an explicit conflict-resolution rule.
-    assert "wins" in lower or "supersede" in lower or "discard" in lower
+    assert "wins" in lower or "supersede" in lower or "discard" in lower or "priority" in lower
 
 
 def test_handoff_sections_are_framed_as_historical():

--- a/tests/agent/test_summary_prefix_semantics.py
+++ b/tests/agent/test_summary_prefix_semantics.py
@@ -18,7 +18,13 @@ the agent repeatedly re-surfacing already-cancelled work across turns.
 These tests pin the post-fix invariants so the conflict cannot regress.
 """
 
-from agent.context_compressor import SUMMARY_PREFIX
+from agent.context_compressor import (
+    HISTORICAL_IN_PROGRESS_HEADING,
+    HISTORICAL_PENDING_ASKS_HEADING,
+    HISTORICAL_REMAINING_WORK_HEADING,
+    HISTORICAL_TASK_HEADING,
+    SUMMARY_PREFIX,
+)
 
 
 def test_no_resume_exactly_directive():
@@ -30,8 +36,22 @@ def test_latest_message_wins_on_conflict():
     """The prefix must explicitly say latest user message wins on conflict."""
     lower = SUMMARY_PREFIX.lower()
     assert "latest user message" in lower
+    assert HISTORICAL_TASK_HEADING.lower() in lower
+    assert HISTORICAL_PENDING_ASKS_HEADING.lower() in lower
+    assert HISTORICAL_REMAINING_WORK_HEADING.lower() in lower
     # Must have an explicit conflict-resolution rule.
     assert "wins" in lower or "supersede" in lower or "discard" in lower
+
+
+def test_handoff_sections_are_framed_as_historical():
+    """The summary headings referenced in the prefix must sound historical,
+    not like live instructions for the current turn."""
+    lower = SUMMARY_PREFIX.lower()
+    assert "## active task" not in lower
+    assert "## pending user asks" not in lower
+    assert "## remaining work" not in lower
+    assert HISTORICAL_TASK_HEADING.lower() in lower
+    assert HISTORICAL_IN_PROGRESS_HEADING.lower() in lower
 
 
 def test_reverse_signals_called_out():


### PR DESCRIPTION
## Summary
Compaction summaries can no longer hijack the current task: the "consistent → use as background" carveout in SUMMARY_PREFIX is removed, all summary sections are framed as historical (DO NOT EXECUTE), and the retired prefix is frozen so pre-upgrade sessions keep summary detection.

Root cause: SUMMARY_PREFIX licensed the model to treat the stale summary as active context whenever the latest user message was "consistent" with the old Active Task — so topic overlap resumed dead work (#41607), vague follow-ups got scope-expanded from old "Remaining Work" sections (#38364), and idle-resumed sessions re-executed stale Active Tasks (#42812).

Closes #41607. Closes #38364. Closes #42812.

## Changes
- `agent/context_compressor.py`: heading constants (`HISTORICAL_*`) replace actionable section names across all 3 template sites (deterministic fallback, LLM template, iterative-update prompt) — from #44345 by @konsisumer
- `agent/context_compressor.py`: SUMMARY_PREFIX carveout removed; topic overlap explicitly does NOT mean resume — from #41650 by @kyssta-exe (merged with the heading constants)
- `agent/context_compressor.py`: carveout-era prefix frozen into `_HISTORICAL_SUMMARY_PREFIXES` (neither contributor PR did this; without it, summaries persisted by current builds lose detection/renormalization after upgrade)
- Tests: updated heading/prefix assertions + new contract tests (`test_no_background_consistency_carveout`, `test_replaced_prefixes_are_frozen_for_renormalization` — exercises detection + strip for every frozen prefix)

## Validation
| | Before | After |
|---|---|---|
| Topic-overlap follow-up after compaction | resumes stale Active Task | latest message wins, stale items discarded |
| Summary persisted by current build, read post-upgrade | loses detection | detected + renormalized via frozen prefix |
| `pytest tests/agent/ -k "compress or summary or compaction"` | — | 197 passed |

## Attribution
Salvages #44345 (@konsisumer, base) and #41650 (@kyssta-exe, carveout removal) — both cherry-picked with authorship preserved; rebase-merge to keep per-commit credit. Supersedes #41634 and #38368.

## Infographic

![compaction-stale-task-hijack-fix](https://v3b.fal.media/files/b/0a9de819/bGnwVMZ-heVGo67n1FT8e_Lv9Y78eF.png)
