### PR TITLE
fix(agent): suppress Codex gpt-5.5 autoraise notice when an external context engine is active

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1504,6 +1504,12 @@ def init_agent(
 
     if _selected_engine is not None:
         agent.context_compressor = _selected_engine
+        # External engines own compaction policy: the host compression
+        # threshold (including the Codex gpt-5.5 autoraise above) only
+        # configures the built-in ContextCompressor and never reaches the
+        # plugin, so the autoraise notice would announce a change that does
+        # not apply. Drop it. (#44439)
+        agent._compression_threshold_autoraised = None
         # Resolve context_length for plugin engines — mirrors switch_model() path
         from agent.model_metadata import get_model_context_length
         _plugin_ctx_len = get_model_context_length(
@@ -1678,7 +1684,13 @@ def init_agent(
 
     if not agent.quiet_mode:
         if compression_enabled:
-            print(f"📊 Context limit: {agent.context_compressor.context_length:,} tokens (compress at {int(compression_threshold*100)}% = {agent.context_compressor.threshold_tokens:,})")
+            # Report the active engine's own threshold — for a plugin engine
+            # the host compression_threshold is not in effect, and mixing the
+            # two printed a percent that contradicted the token count. (#44439)
+            _active_threshold_pct = getattr(
+                agent.context_compressor, "threshold_percent", compression_threshold
+            )
+            print(f"📊 Context limit: {agent.context_compressor.context_length:,} tokens (compress at {int(_active_threshold_pct*100)}% = {agent.context_compressor.threshold_tokens:,})")
         else:
             print(f"📊 Context limit: {agent.context_compressor.context_length:,} tokens (auto-compression disabled)")
         # One-time notice when the Codex gpt-5.5 autoraise kicked in, with the

--- a/tests/run_agent/test_plugin_context_engine_init.py
+++ b/tests/run_agent/test_plugin_context_engine_init.py
@@ -139,3 +139,101 @@ def test_plugin_engine_update_model_args():
     assert "model" in kw
     assert "provider" in kw
     assert "api_mode" in kw
+
+
+def _codex_agent_kwargs():
+    return dict(
+        model="gpt-5.5",
+        provider="openai-codex",
+        api_key="test-key-1234567890",
+        base_url="https://chatgpt.com/backend-api/codex",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+
+def test_codex_gpt55_autoraise_suppressed_for_plugin_engine():
+    """Codex gpt-5.5 autoraise must not fire when an external engine is active.
+
+    Regression test for #44439 — the host compression threshold (including
+    the 0.85 autoraise) never reaches a plugin context engine, so the notice
+    announced a change that did not apply.
+    """
+    engine = _StubEngine()
+    cfg = {
+        "context": {"engine": "stub"},
+        "compression": {"enabled": True, "threshold": 0.75},
+        "agent": {},
+    }
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.context_engine.load_context_engine", return_value=engine),
+        patch("agent.model_metadata.get_model_context_length", return_value=272_000),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(**_codex_agent_kwargs())
+
+    assert agent.context_compressor is engine
+    assert agent._compression_threshold_autoraised is None
+    assert agent._compression_warning is None
+    # The engine's own policy is untouched by the host threshold.
+    assert engine.threshold_percent == 0.75
+
+
+def test_codex_gpt55_autoraise_still_applies_to_builtin_compressor():
+    """Stock built-in compressor keeps the 50% → 85% Codex gpt-5.5 autoraise."""
+    cfg = {
+        "compression": {"enabled": True, "threshold": 0.50},
+        "agent": {},
+    }
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("agent.context_compressor.get_model_context_length", return_value=272_000),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(**_codex_agent_kwargs())
+
+    assert agent._compression_threshold_autoraised == {"from": 0.50, "to": 0.85}
+    assert agent.context_compressor.threshold_percent == 0.85
+    # Gateway parity: the notice is stashed for replay on turn 1.
+    assert agent._compression_warning and "85%" in agent._compression_warning
+
+
+def test_codex_gpt55_autoraise_applies_when_plugin_engine_missing():
+    """If the configured engine fails to load, the built-in compressor is
+    active and the autoraise (plus its notice) must still apply."""
+    cfg = {
+        "context": {"engine": "no-such-engine"},
+        "compression": {"enabled": True, "threshold": 0.50},
+        "agent": {},
+    }
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch(
+            "plugins.context_engine.load_context_engine",
+            side_effect=ValueError("not found"),
+        ),
+        patch("hermes_cli.plugins.get_plugin_context_engine", return_value=None),
+        patch("agent.context_compressor.get_model_context_length", return_value=272_000),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(**_codex_agent_kwargs())
+
+    assert agent._compression_threshold_autoraised == {"from": 0.50, "to": 0.85}
+    assert agent.context_compressor.threshold_percent == 0.85


### PR DESCRIPTION
## Summary

Fixes #44439

When `context.engine` selects a plugin context engine (e.g. LCM), the host compression threshold — including the Codex gpt-5.5 50% → 85% autoraise from `_compression_threshold_for_model()` — only configures the built-in `ContextCompressor` and **never reaches the plugin** (`update_model()` passes model/context_length/credentials only). Plugin engines own their compaction policy via their own `threshold_percent`.

Two user-visible problems followed:

1. **Misleading autoraise notice.** `agent._compression_threshold_autoraised` was set before engine selection and gated only on `compression.enabled`, so with `context.engine: lcm` + the Codex gpt-5.5 route the user got *"auto-compaction was raised to 85% (from 75%)"* — both at CLI startup and replayed on gateway turn 1 via `_compression_warning` — even though no host-side threshold change actually applied.
2. **Self-contradicting startup line.** The `📊 Context limit … (compress at X% = N tokens)` line printed the *host* `compression_threshold` percent (85% after autoraise) next to the *engine's* `threshold_tokens` (computed from the engine's own 0.75), so percent and token count disagreed.

## Changes

- `agent/agent_init.py`: when a plugin engine is selected, clear `_compression_threshold_autoraised`, suppressing both the startup notice and the gateway turn-1 replay.
- `agent/agent_init.py`: the startup context-limit line now reports the active engine's own `threshold_percent`, so percent and token count always agree. For the built-in compressor this is identical to the previous output.

## Behavior preserved

- Stock Hermes (built-in compressor) still auto-raises 50% → 85% for `openai-codex` + `gpt-5.5` and shows the notice with the opt-out command.
- If a configured engine fails to load and Hermes falls back to the built-in compressor, the autoraise still applies (gated on the *selected* engine, not the config string).
- `compression.codex_gpt55_autoraise: false` keeps working as the explicit opt-out.

Note on the issue's framing: the external engine's compaction policy was never actually overridden — the raised threshold was computed but unused with a plugin engine active. The real bug was the notice (and startup line) announcing a change that didn't apply, which is exactly what acceptance criterion 2 ("the notice is not shown when no host-side threshold change actually applies") targets; criterion 1 already held.

## Tests

Three new tests in `tests/run_agent/test_plugin_context_engine_init.py`:

- plugin engine + Codex gpt-5.5 route → no autoraise flag, no `_compression_warning`, engine's own `threshold_percent` untouched
- built-in compressor + Codex gpt-5.5 → autoraise 0.50 → 0.85 still applies, notice stashed for gateway replay
- configured engine missing → fallback to built-in → autoraise still applies

`tests/run_agent/` + `tests/agent/test_arcee_trinity_overrides.py` + context-engine suites pass (the two `test_provider_parity.py` failures in a full-directory run reproduce identically on clean `main` — pre-existing test-order pollution, unrelated).
