### PR TITLE
fix(web): don't re-run the bundled fallback sweep when web-parallel is explicitly disabled

### DIFF
--- a/plugins/web/parallel/plugin.yaml
+++ b/plugins/web/parallel/plugin.yaml
@@ -1,6 +1,6 @@
 name: web-parallel
 version: 1.0.0
-description: "Parallel.ai web search + content extraction. Search returns objective-tuned results; extract uses the async SDK for parallel page fetches. Requires PARALLEL_API_KEY — sign up at https://parallel.ai."
+description: "Parallel.ai web search + content extraction. Search returns objective-tuned results; extract uses the async SDK for parallel page fetches. Works keyless out of the box via the free hosted Search MCP; set PARALLEL_API_KEY (https://parallel.ai) for the full API."
 author: NousResearch
 kind: backend
 provides_web_providers:

--- a/tests/tools/test_web_keyless_default_fallback.py
+++ b/tests/tools/test_web_keyless_default_fallback.py
@@ -75,6 +75,62 @@ def test_fallback_honors_explicit_disable(monkeypatch):
     assert "tavily" in names
 
 
+def test_no_resweep_when_parallel_explicitly_disabled(monkeypatch):
+    """An explicit web-parallel disable must not re-trigger the sweep per call.
+
+    With ``plugins.disabled: [web-parallel]``, ``get_provider('parallel')``
+    stays ``None`` forever by design. That must read as "intentionally off",
+    not "failed sweep" — otherwise every web_search/web_extract call re-pays
+    the bundled-dir sweep and overwrites live registry entries with fresh
+    bundled instances.
+    """
+    monkeypatch.setattr(plugins, "_get_disabled_plugins", lambda: {"web-parallel"})
+    monkeypatch.setattr(plugins, "_ensure_plugins_discovered", lambda *a, **k: None)
+
+    # Healthy discovery left the registry populated — minus the disabled backend.
+    import importlib
+
+    class _Ctx:
+        def register_web_search_provider(self, provider):
+            reg.register_provider(provider)
+
+    importlib.import_module("plugins.web.tavily").register(_Ctx())
+    before = reg.get_provider("tavily")
+
+    calls = {"n": 0}
+    real = web_tools._register_bundled_web_providers_directly
+
+    def _spy():
+        calls["n"] += 1
+        real()
+
+    monkeypatch.setattr(web_tools, "_register_bundled_web_providers_directly", _spy)
+    web_tools._ensure_web_plugins_loaded()
+    web_tools._ensure_web_plugins_loaded()
+
+    assert calls["n"] == 0, "explicit disable re-triggered the fallback sweep"
+    assert reg.get_provider("parallel") is None
+    # Live registry entries were not replaced by fresh bundled instances.
+    assert reg.get_provider("tavily") is before
+
+
+def test_empty_registry_still_sweeps_when_parallel_disabled(monkeypatch):
+    """A failed sweep registers nothing — emptiness must still trigger recovery.
+
+    Even with web-parallel disabled, an empty registry means the sweep failed,
+    and the other bundled backends must be restored (parallel stays off).
+    """
+    monkeypatch.setattr(plugins, "_get_disabled_plugins", lambda: {"web-parallel"})
+    monkeypatch.setattr(plugins, "_ensure_plugins_discovered", _boom)
+    assert not reg.list_providers()
+
+    web_tools._ensure_web_plugins_loaded()
+
+    names = {p.name for p in reg.list_providers()}
+    assert "parallel" not in names, "explicit disable was ignored"
+    assert "tavily" in names, "failed-sweep recovery skipped with parallel disabled"
+
+
 def test_fallback_is_noop_when_discovery_already_registered(monkeypatch):
     """Healthy path: don't pay for the direct sweep when parallel is present."""
     # Pretend the general sweep already registered the keyless default.

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -836,13 +836,24 @@ def _ensure_web_plugins_loaded() -> None:
     # Belt-and-suspenders: guarantee the keyless Parallel default (the
     # documented zero-setup backend for both web_search and web_extract) is
     # actually registered. The lookup is a cheap dict hit on the healthy path
-    # (discovery already registered it → no-op); only an empty registry pays
-    # for the direct-registration sweep.
+    # (discovery already registered it → no-op). When the user explicitly
+    # disabled web-parallel its absence is intentional, not a failed sweep —
+    # without that check every call would re-pay the direct-registration
+    # sweep and overwrite live registry entries with fresh bundled instances.
+    # An *empty* registry still always triggers the sweep: a failed sweep
+    # registers nothing at all, so emptiness is the failure signal that keeps
+    # the other bundled backends recoverable even with web-parallel disabled.
     try:
-        from agent.web_search_registry import get_provider
+        from agent.web_search_registry import get_provider, list_providers
+        from hermes_cli.plugins import _get_disabled_plugins
 
         if get_provider("parallel") is None:
-            _register_bundled_web_providers_directly()
+            disabled = _get_disabled_plugins()
+            parallel_off = (
+                "web/parallel" in disabled or "web-parallel" in disabled
+            )
+            if not parallel_off or not list_providers():
+                _register_bundled_web_providers_directly()
     except Exception as exc:  # noqa: BLE001
         logger.debug("Bundled web provider fallback check failed: %s", exc)
 


### PR DESCRIPTION
Follow-up to #44433, implementing the non-blocking nit from review (https://github.com/NousResearch/hermes-agent/pull/44433#issuecomment-4684374171) that merged before it could be addressed.

## Problem

`_ensure_web_plugins_loaded` uses `get_provider("parallel") is None` as the failed-sweep sentinel. With `plugins.disabled: [web-parallel]` that lookup stays `None` **by design** — so the full direct-registration fallback (bundled-dir walk, module imports, provider re-instantiation) re-ran on **every** `web_search`/`web_extract` call even when discovery was perfectly healthy, and each pass overwrote other providers' live registry entries with fresh bundled instances (clobbering e.g. a same-name user plugin or per-instance HTTP session state).

## Fix

Treat an explicit `web-parallel` disable as intentional absence, not a failed sweep — with one carve-out: an **empty** registry still always triggers the sweep. A failed sweep registers nothing at all (anything escaping `_discover_and_load_inner` comes from the scan phase, before any plugin registered), so emptiness remains the reliable failure signal that keeps the *other* bundled backends recoverable even when parallel is disabled.

Also touches up the stale `plugins/web/parallel/plugin.yaml` description ("Requires PARALLEL_API_KEY") — the backend works keyless via the free hosted Search MCP, which is the premise of #44433's keyless-default guarantee.

## Tests

- `test_no_resweep_when_parallel_explicitly_disabled` — healthy discovery + explicit disable: the fallback never runs across repeated calls, and live registry entries are not replaced (asserts identity). **Fails on current `main`**, passes with the fix.
- `test_empty_registry_still_sweeps_when_parallel_disabled` — failed sweep + explicit disable: other bundled backends are still restored, parallel stays off (pins the carve-out).

`tests/tools/test_web_keyless_default_fallback.py` + `tests/tools/test_web_providers.py` + `tests/hermes_cli/test_plugins.py`: **107 passed**. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
