### PR TITLE
fix(web): throttle Brave free-tier searches

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1017,6 +1017,9 @@ DEFAULT_CONFIG = {
         "backend": "",           # shared fallback — applies to both search and extract
         "search_backend": "",    # per-capability override for web_search (e.g. "searxng")
         "extract_backend": "",   # per-capability override for web_extract (e.g. "native")
+        "brave_free": {
+            "min_request_interval_seconds": 1.5,
+        },
     },
 
     "browser": {

--- a/plugins/web/brave_free/provider.py
+++ b/plugins/web/brave_free/provider.py
@@ -39,11 +39,11 @@ _last_request_monotonic: float | None = None
 
 
 def _load_brave_free_config() -> Dict[str, Any]:
-    """Read ``web.brave_free`` from config.yaml."""
+    """Read ``web.brave_free`` from config.yaml without deepcopying it."""
     try:
-        from hermes_cli.config import load_config
+        from hermes_cli.config import load_config_readonly
 
-        cfg = load_config()
+        cfg = load_config_readonly()
         web_section = cfg.get("web") if isinstance(cfg, dict) else None
         brave_section = web_section.get("brave_free") if isinstance(web_section, dict) else None
         return brave_section if isinstance(brave_section, dict) else {}

--- a/plugins/web/brave_free/provider.py
+++ b/plugins/web/brave_free/provider.py
@@ -11,6 +11,8 @@ Config keys this provider responds to::
     web:
       search_backend: "brave-free"     # explicit per-capability
       backend: "brave-free"            # shared fallback
+      brave_free:
+        min_request_interval_seconds: 1.5
 
 Auth env var::
 
@@ -20,7 +22,10 @@ Auth env var::
 from __future__ import annotations
 
 import logging
+import math
 import os
+import threading
+import time
 from typing import Any, Dict
 
 from agent.web_search_provider import WebSearchProvider
@@ -28,6 +33,61 @@ from agent.web_search_provider import WebSearchProvider
 logger = logging.getLogger(__name__)
 
 _BRAVE_ENDPOINT = "https://api.search.brave.com/res/v1/web/search"
+_DEFAULT_MIN_REQUEST_INTERVAL_SECONDS = 1.5
+_THROTTLE_LOCK = threading.Lock()
+_last_request_monotonic: float | None = None
+
+
+def _load_brave_free_config() -> Dict[str, Any]:
+    """Read ``web.brave_free`` from config.yaml."""
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        web_section = cfg.get("web") if isinstance(cfg, dict) else None
+        brave_section = web_section.get("brave_free") if isinstance(web_section, dict) else None
+        return brave_section if isinstance(brave_section, dict) else {}
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Could not load web.brave_free config: %s", exc)
+        return {}
+
+
+def _min_request_interval_seconds() -> float:
+    value = _load_brave_free_config().get(
+        "min_request_interval_seconds",
+        _DEFAULT_MIN_REQUEST_INTERVAL_SECONDS,
+    )
+    try:
+        interval = float(value)
+    except (TypeError, ValueError):
+        return _DEFAULT_MIN_REQUEST_INTERVAL_SECONDS
+    if not math.isfinite(interval):
+        return _DEFAULT_MIN_REQUEST_INTERVAL_SECONDS
+    return max(0.0, interval)
+
+
+def _throttle_brave_request() -> None:
+    """Serialize Brave API requests and enforce the configured process-local gap."""
+    global _last_request_monotonic
+
+    interval = _min_request_interval_seconds()
+    if interval <= 0:
+        return
+
+    with _THROTTLE_LOCK:
+        now = time.monotonic()
+        if _last_request_monotonic is not None:
+            wait_seconds = interval - (now - _last_request_monotonic)
+            if wait_seconds > 0:
+                time.sleep(wait_seconds)
+                now = time.monotonic()
+        _last_request_monotonic = now
+
+
+def _reset_throttle_for_tests() -> None:
+    global _last_request_monotonic
+    with _THROTTLE_LOCK:
+        _last_request_monotonic = None
 
 
 class BraveFreeWebSearchProvider(WebSearchProvider):
@@ -73,6 +133,7 @@ class BraveFreeWebSearchProvider(WebSearchProvider):
         count = max(1, min(int(limit), 20))
 
         try:
+            _throttle_brave_request()
             resp = httpx.get(
                 _BRAVE_ENDPOINT,
                 params={"q": query, "count": count},

--- a/tests/tools/test_web_providers_brave_free.py
+++ b/tests/tools/test_web_providers_brave_free.py
@@ -194,6 +194,23 @@ class TestBraveFreeProviderSearch:
         assert result["success"] is False
         assert "BRAVE_SEARCH_API_KEY" in result["error"]
 
+    def test_config_loader_uses_readonly_fast_path(self, monkeypatch):
+        from hermes_cli import config
+        from plugins.web.brave_free import provider
+
+        monkeypatch.setattr(
+            config,
+            "load_config_readonly",
+            lambda: {"web": {"brave_free": {"min_request_interval_seconds": 0.25}}},
+        )
+        monkeypatch.setattr(
+            config,
+            "load_config",
+            lambda: pytest.fail("Brave free hot path should not deepcopy config"),
+        )
+
+        assert provider._load_brave_free_config() == {"min_request_interval_seconds": 0.25}
+
     def test_default_throttles_consecutive_calls_to_1_5_second_gap(self, monkeypatch):
         monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "BSAkey123")
         from plugins.web.brave_free import provider

--- a/tests/tools/test_web_providers_brave_free.py
+++ b/tests/tools/test_web_providers_brave_free.py
@@ -20,6 +20,15 @@ import pytest
 from tests.tools.conftest import register_all_web_providers
 
 
+@pytest.fixture(autouse=True)
+def _reset_brave_free_throttle():
+    from plugins.web.brave_free import provider
+
+    provider._reset_throttle_for_tests()
+    yield
+    provider._reset_throttle_for_tests()
+
+
 # ---------------------------------------------------------------------------
 # BraveFreeWebSearchProvider unit tests
 # ---------------------------------------------------------------------------
@@ -184,6 +193,86 @@ class TestBraveFreeProviderSearch:
         result = BraveFreeWebSearchProvider().search("q", limit=5)
         assert result["success"] is False
         assert "BRAVE_SEARCH_API_KEY" in result["error"]
+
+    def test_default_throttles_consecutive_calls_to_1_5_second_gap(self, monkeypatch):
+        monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "BSAkey123")
+        from plugins.web.brave_free import provider
+
+        monkeypatch.setattr(provider, "_load_brave_free_config", lambda: {})
+
+        with (
+            patch("httpx.get", return_value=self._mock_resp({"web": {"results": []}})),
+            patch.object(provider.time, "monotonic", side_effect=[100.0, 100.1, 101.5]),
+            patch.object(provider.time, "sleep") as sleep_mock,
+        ):
+            search_provider = provider.BraveFreeWebSearchProvider()
+            search_provider.search("first", limit=5)
+            search_provider.search("second", limit=5)
+
+        sleep_mock.assert_called_once_with(pytest.approx(1.4))
+
+    def test_custom_config_interval_is_respected(self, monkeypatch):
+        monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "BSAkey123")
+        from plugins.web.brave_free import provider
+
+        monkeypatch.setattr(
+            provider,
+            "_load_brave_free_config",
+            lambda: {"min_request_interval_seconds": 2.25},
+        )
+
+        with (
+            patch("httpx.get", return_value=self._mock_resp({"web": {"results": []}})),
+            patch.object(provider.time, "monotonic", side_effect=[10.0, 10.75, 12.25]),
+            patch.object(provider.time, "sleep") as sleep_mock,
+        ):
+            search_provider = provider.BraveFreeWebSearchProvider()
+            search_provider.search("first", limit=5)
+            search_provider.search("second", limit=5)
+
+        sleep_mock.assert_called_once_with(pytest.approx(1.5))
+
+    def test_zero_config_interval_disables_sleep(self, monkeypatch):
+        monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "BSAkey123")
+        from plugins.web.brave_free import provider
+
+        monkeypatch.setattr(
+            provider,
+            "_load_brave_free_config",
+            lambda: {"min_request_interval_seconds": 0},
+        )
+
+        with (
+            patch("httpx.get", return_value=self._mock_resp({"web": {"results": []}})),
+            patch.object(provider.time, "sleep") as sleep_mock,
+        ):
+            search_provider = provider.BraveFreeWebSearchProvider()
+            search_provider.search("first", limit=5)
+            search_provider.search("second", limit=5)
+
+        sleep_mock.assert_not_called()
+
+    @pytest.mark.parametrize("bad_value", ["not-a-number", float("inf"), None])
+    def test_invalid_config_interval_falls_back_to_default(self, monkeypatch, bad_value):
+        monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "BSAkey123")
+        from plugins.web.brave_free import provider
+
+        monkeypatch.setattr(
+            provider,
+            "_load_brave_free_config",
+            lambda: {"min_request_interval_seconds": bad_value},
+        )
+
+        with (
+            patch("httpx.get", return_value=self._mock_resp({"web": {"results": []}})),
+            patch.object(provider.time, "monotonic", side_effect=[20.0, 20.25, 21.5]),
+            patch.object(provider.time, "sleep") as sleep_mock,
+        ):
+            search_provider = provider.BraveFreeWebSearchProvider()
+            search_provider.search("first", limit=5)
+            search_provider.search("second", limit=5)
+
+        sleep_mock.assert_called_once_with(pytest.approx(1.25))
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1564,26 +1564,33 @@ Environment scrubbing (strips `*_API_KEY`, `*_TOKEN`, `*_SECRET`, `*_PASSWORD`, 
 
 ## Web Search Backends
 
-The `web_search` and `web_extract` tools support five backend providers. Configure the backend in `config.yaml` or via `hermes tools`:
+The `web_search` and `web_extract` tools support eight backend providers. Configure the backend in `config.yaml` or via `hermes tools`:
 
 ```yaml
 web:
-  backend: firecrawl    # firecrawl | searxng | parallel | tavily | exa
+  backend: firecrawl    # firecrawl | searxng | brave-free | ddgs | parallel | tavily | exa | xai
 
   # Or use per-capability keys to mix providers (e.g. free search + paid extract):
-  search_backend: "searxng"
+  search_backend: "brave-free"
   extract_backend: "firecrawl"
+
+  # Brave free-tier requests are process-throttled by default for its 1 QPS limit.
+  brave_free:
+    min_request_interval_seconds: 1.5   # Set 0 to disable
 ```
 
 | Backend | Env Var | Search | Extract |
 |---------|---------|--------|---------|
 | **Firecrawl** (default) | `FIRECRAWL_API_KEY` | ✔ | ✔ |
 | **SearXNG** | `SEARXNG_URL` | ✔ | — |
+| **Brave** (free tier) | `BRAVE_SEARCH_API_KEY` | ✔ | — |
+| **DuckDuckGo** (ddgs) | _(none)_ | ✔ | — |
 | **Parallel** | `PARALLEL_API_KEY` | ✔ | ✔ |
 | **Tavily** | `TAVILY_API_KEY` | ✔ | ✔ |
 | **Exa** | `EXA_API_KEY` | ✔ | ✔ |
+| **xAI** | `XAI_API_KEY` | ✔ | — |
 
-**Backend selection:** If `web.backend` is not set, the backend is auto-detected from available API keys. If only `SEARXNG_URL` is set, SearXNG is used. If only `EXA_API_KEY` is set, Exa is used. If only `TAVILY_API_KEY` is set, Tavily is used. If only `PARALLEL_API_KEY` is set, Parallel is used. Otherwise Firecrawl is the default.
+**Backend selection:** If `web.backend` is not set, the backend is auto-detected from available API keys and local packages. Use `web.search_backend` / `web.extract_backend` when you want an explicit provider or a search-only provider (SearXNG, Brave, DuckDuckGo, xAI) paired with a separate extraction backend.
 
 **SearXNG** is a free, self-hosted, privacy-respecting metasearch engine that queries 70+ search engines. No API key needed — just set `SEARXNG_URL` to your instance (e.g., `http://localhost:8080`). SearXNG is search-only; `web_extract` requires a separate extract provider (set `web.extract_backend`). See the [Web Search setup guide](/user-guide/features/web-search) for Docker setup instructions.
 


### PR DESCRIPTION
## Summary
- add configurable process-local throttling for the bundled Brave Search free-tier provider
- default `web.brave_free.min_request_interval_seconds` to 1.5s, with 0 disabling the sleep
- document the Brave throttle option and add regression coverage for default, custom, disabled, and invalid config values

## Why
Brave Search API rate limits are enforced with a 1-second sliding window per subscription. Hermes can issue `web_search` calls back-to-back, which can trip free-tier 429s. A small configurable client-side gap avoids that without requiring a separate Brave MCP server.

## Test Plan
- [x] `UV_CACHE_DIR=/tmp/uv-cache uv run --with pytest --with httpx python -m pytest tests/tools/test_web_providers_brave_free.py -q -o 'addopts='`
- [x] `git diff --check`
