### PR TITLE
fix(gateway): preserve profile flag in 'service not installed' hint

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3228,12 +3228,25 @@ def systemd_uninstall(system: bool = False):
     print(f"✓ {_service_scope_label(system).capitalize()} service uninstalled")
 
 
+def _gateway_install_hint(system: bool = False) -> str:
+    """Suggested install command, preserving the active profile and scope.
+
+    Each profile gets its own service unit (``hermes-gateway-<profile>``),
+    so a user running ``hermes -p stock gateway start`` must install with
+    the same profile flag — plain ``hermes gateway install`` would install
+    the *default* profile's service instead (#44421).
+    """
+    scope_flag = " --system" if system else ""
+    profile_arg = _profile_arg()
+    profile_flag = f" {profile_arg}" if profile_arg else ""
+    return f"{'sudo ' if system else ''}hermes{profile_flag} gateway install{scope_flag}"
+
+
 def _require_service_installed(action: str, system: bool = False) -> None:
     unit_path = get_systemd_unit_path(system=system)
     if not unit_path.exists():
-        scope_flag = " --system" if system else ""
-        print("✗ Gateway service is not installed")
-        print(f"  Run: {'sudo ' if system else ''}hermes gateway install{scope_flag}")
+        print(f"✗ Gateway service is not installed")
+        print(f"  Run: {_gateway_install_hint(system)}")
         sys.exit(1)
 
 
@@ -3393,7 +3406,7 @@ def systemd_status(deep: bool = False, system: bool = False, full: bool = False)
 
     if not unit_path.exists():
         print("✗ Gateway service is not installed")
-        print(f"  Run: {'sudo ' if system else ''}hermes gateway install{scope_flag}")
+        print(f"  Run: {_gateway_install_hint(system)}")
         return
 
     if has_conflicting_systemd_units():

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -417,6 +417,21 @@ class TestRequireServiceInstalled:
 
         gateway_cli._require_service_installed("start")
 
+    def test_install_hint_preserves_profile_flag(self, tmp_path, monkeypatch, capsys):
+        # `hermes -p stock gateway start` without a per-profile unit must
+        # suggest installing *that profile's* service — a bare
+        # `hermes gateway install` would install the default profile's
+        # unit instead (#44421).
+        unit_path = tmp_path / "hermes-gateway-stock.service"
+        monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
+        monkeypatch.setattr(gateway_cli, "_profile_arg", lambda hermes_home=None: "--profile stock")
+
+        with pytest.raises(SystemExit):
+            gateway_cli._require_service_installed("start")
+
+        out = capsys.readouterr().out
+        assert "hermes --profile stock gateway install" in out
+
 
 class TestGeneratedSystemdUnits:
     def _expected_timeout_stop_sec(self) -> str:


### PR DESCRIPTION
## Summary

Per-profile gateway instances already exist: each profile gets its own service unit — `get_service_name()` returns `hermes-gateway-<profile>` for `HERMES_HOME=~/.hermes/profiles/<profile>`, the generated unit pins `HERMES_HOME` and runs `... --profile <name> gateway run`, and the launchd label/plist are suffixed the same way. So the supported workflow is:

```bash
hermes -p stock gateway install   # one-time: installs hermes-gateway-stock
hermes -p stock gateway start
hermes -p stock gateway status
```

The trap (root cause of #44421): when a user runs `hermes -p stock gateway start` before installing that profile's service, the error hint says

```
✗ Gateway service is not installed
  Run: hermes gateway install
```

— dropping the profile flag. Following the hint installs the **default** profile's unit, the profile gateway still won't start, and the user reasonably concludes per-profile gateways aren't supported.

## Fix

Add `_gateway_install_hint()` which preserves the active profile flag (via the existing `_profile_arg()`) and the `--system` scope, and use it at both hint sites (`_require_service_installed`, `systemd_status`):

```
✗ Gateway service is not installed
  Run: hermes --profile stock gateway install
```

For the default profile (and hash-suffixed custom `HERMES_HOME` paths, where `_profile_arg()` returns "") the hint is unchanged.

## Testing

- New test `test_install_hint_preserves_profile_flag` in `TestRequireServiceInstalled`.
- `tests/hermes_cli/test_gateway_service.py`: 154 passed; the 6 failures in `TestGatewaySystemServiceRouting` are pre-existing on `origin/main` (verified by running the same file with the change stashed: same 6 fail, 153 pass).

Fixes #44421
