### PR TITLE
fix(lazy-deps): use _is_satisfied in active_features() to prevent false-positive activation on transitive installs (#44404)

### DIFF
--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -301,13 +301,14 @@ class TestIsSatisfiedVersionAware:
 
 class TestActiveFeatures:
     def test_no_packages_installed_returns_empty(self, monkeypatch):
-        monkeypatch.setattr(ld, "_is_present", lambda spec: False)
+        monkeypatch.setattr(ld, "_is_satisfied", lambda spec: False)
         assert ld.active_features() == []
 
     def test_finds_features_with_at_least_one_package_installed(self, monkeypatch):
-        # Pretend only honcho-ai is installed; nothing else.
+        # Pretend only honcho-ai is installed at the pinned version;
+        # nothing else.
         monkeypatch.setattr(
-            ld, "_is_present",
+            ld, "_is_satisfied",
             lambda spec: ld._pkg_name_from_spec(spec) == "honcho-ai",
         )
         active = ld.active_features()
@@ -321,7 +322,7 @@ class TestActiveFeatures:
         # for the feature to count as active (user activated it before,
         # one transitive may have been uninstalled separately).
         monkeypatch.setattr(
-            ld, "_is_present",
+            ld, "_is_satisfied",
             lambda spec: ld._pkg_name_from_spec(spec) == "slack-bolt",
         )
         assert "platform.slack" in ld.active_features()
@@ -404,3 +405,66 @@ class TestRefreshActiveFeatures:
         result = ld.refresh_active_features()
         assert result["a.ok"] == "current"
         assert result["b.fail"].startswith("failed:")
+
+
+# ---------------------------------------------------------------------------
+# active_features() must not false-positive on transitive installs at the
+# wrong version. Regression test for #44404.
+#
+# The reported bug: platform.slack pins aiohttp==3.13.4. If some other
+# backend drags aiohttp 3.14.1 in transitively, _is_present("aiohttp==3.13.4")
+# returns True (matches on package name), so active_features() reports
+# platform.slack as "active" even though the user never installed it.
+# refresh_active_features() then triggers `pip install aiohttp==3.13.4` —
+# a downgrade — and on Windows the .pyd file can be locked by the gateway,
+# failing the refresh outright.
+#
+# Behavior contract being asserted:
+#   A feature is "active" only if at least one of its declared packages
+#   is installed at the pinned version. A transitive install at a
+#   different version must not activate the feature.
+#
+# This test deliberately does NOT mock _is_present / _is_satisfied — it
+# exercises the real importlib.metadata path so a regression on either
+# helper would also be caught. `packaging` is a transitive of pip and is
+# always present in any pip-based venv, which makes the impossible
+# version pin a deterministic stand-in for the aiohttp 3.14.1 case in
+# the issue.
+# ---------------------------------------------------------------------------
+
+
+class TestActiveFeaturesVersionAware:
+    def test_present_at_wrong_version_is_not_active(self, monkeypatch):
+        # Inject a feature pinned to a real-but-mismatched version of
+        # `packaging`. `packaging` is always present in any pip-based
+        # venv (transitive of pip itself) at version 24.x today; pinning
+        # the test feature to an older but-parsable version makes:
+        #   _is_present("packaging==20.0")  -> True
+        #   _is_satisfied("packaging==20.0") -> False
+        # (the version parses cleanly but does not match the installed
+        # version). Note: an impossible version like
+        # ``packaging==0.0.0-impossible`` would NOT work here, because
+        # :func:`_is_satisfied` has an ``InvalidVersion`` fallback that
+        # returns True ("don't churn"). The bug in #44404 is specifically
+        # about a real-but-different version, not malformed strings.
+        monkeypatch.setitem(
+            ld.LAZY_DEPS,
+            "test.buggy-feature",
+            ("packaging==20.0",),
+        )
+        try:
+            active = ld.active_features()
+        finally:
+            # Clean up even if the assertion fails — the buggy feature
+            # must not bleed into other tests in the same session.
+            monkeypatch.delitem(ld.LAZY_DEPS, "test.buggy-feature")
+        # The user never activated test.buggy-feature. A transitive
+        # install of `packaging` at a non-pinned version must NOT mark
+        # the feature as active. The pre-fix code (which used
+        # _is_present, presence-only) failed this assertion; the fix
+        # switches active_features() to _is_satisfied.
+        assert "test.buggy-feature" not in active, (
+            f"active_features() false-positive: {active!r} includes a "
+            f"feature pinned to a real-but-mismatched version, "
+            f"indicating presence-only detection (regression of #44404)"
+        )

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -543,7 +543,11 @@ def active_features() -> list[str]:
     """Return the list of features the user has ever lazy-installed.
 
     A feature counts as "active" if at least one of its declared packages
-    is currently installed in the venv (presence check, ignoring version).
+    is currently installed in the venv *at the pinned version* (see
+    :func:`_is_satisfied`). A presence-only check would false-positive on
+    transitive installs — e.g. aiohttp 3.14.1 dragged in by another
+    backend would mark ``platform.slack`` (pinned to aiohttp==3.13.4) as
+    "active" and trigger an unnecessary downgrade on ``hermes update``.
     Features the user has never enabled stay quiet.
 
     Used by ``hermes update`` to figure out which lazy backends need a
@@ -551,7 +555,7 @@ def active_features() -> list[str]:
     """
     active = []
     for feature, specs in LAZY_DEPS.items():
-        if any(_is_present(s) for s in specs):
+        if any(_is_satisfied(s) for s in specs):
             active.append(feature)
     return active
 


### PR DESCRIPTION
## Summary

`active_features()` in `tools/lazy_deps.py` was using `_is_present` (package name installed at ANY version) to decide which lazy backends the user had activated. This false-positives on transitive installs:

- `platform.slack` pins `aiohttp==3.13.4`
- If some other backend drags `aiohttp 3.14.1` in transitively, `_is_present("aiohttp==3.13.4")` returns `True` (matches on package name only)
- `active_features()` then reports `platform.slack` as active even though the user never installed it
- `refresh_active_features()` runs `pip install aiohttp==3.13.4` — a downgrade
- On Windows the `.pyd` file is often locked by the running gateway, failing the refresh outright

## Fix

One-line change in `tools/lazy_deps.py:558`:

```python
# before
if any(_is_present(s) for s in specs):
# after
if any(_is_satisfied(s) for s in specs):
```

`_is_satisfied` is the existing presence + version check at line 285, with the same "don't churn" fallbacks for `InvalidVersion` / `InvalidSpecifier` / `packaging` unavailable that already protect `refresh_active_features()` from spurious upgrades.

Plus a docstring update on `active_features()` to reflect the new semantic: a feature is "active" iff at least one declared package is installed *at the pinned version*.

## Test-first proof

A regression test was added in `tests/tools/test_lazy_deps.py` (`TestActiveFeaturesVersionAware::test_present_at_wrong_version_is_not_active`) that:

- Does **not** mock `_is_present` or `_is_satisfied` — exercises the real `importlib.metadata` path so a regression on either helper would also be caught
- Injects a feature pinned to a real-but-mismatched version of `packaging` (always present in any pip-based venv as a transitive of pip; pinned to `20.0` while venv has `26.0` today)
- Asserts the feature is NOT in the active set

Before the fix: test FAILS — `test.buggy-feature` is in the active list, confirming the bug.
After the fix: test PASSES — `test.buggy-feature` is correctly excluded.

Three existing tests in `TestActiveFeatures` were updated to monkeypatch `_is_satisfied` instead of `_is_present` (the implementation hook changed; the contract they assert is unchanged).

## Test plan

- [x] New regression test reproduces the bug pre-fix
- [x] New regression test passes post-fix
- [x] All 62 tests in `tests/tools/test_lazy_deps.py` pass
- [x] Per-file isolation runner (`scripts/run_tests.sh tests/tools/test_lazy_deps.py`) passes
- [x] No other test file references `_is_present` or `active_features` (verified via grep)
- [ ] Full `scripts/run_tests.sh` suite (can be checked by CI; left out of local run to keep iteration tight)

## Reproduction (issue #44404)

In any venv where `packaging` is installed transitively at version `26.0`:

```python
import tools.lazy_deps as ld
ld.LAZY_DEPS["test.buggy-feature"] = ("packaging==20.0",)
print("test.buggy-feature" in ld.active_features())  # True pre-fix, False post-fix
```

## Related

- Fixes #44404
- Sibling issue #44403 (ensure() should verify real import after install) is in the same module but is a separate concern — left for a separate PR per the "fix the whole bug class but one focused PR per defect" contribution norm.

## Notes for reviewers

The semantic shift from "presence at any version" to "presence at pinned version" is intentional and matches the issue's Option A. If a user previously installed a lazy feature then manually upgraded a transitive dep past the pin, that feature will no longer be reported as active — which is correct: the user's manual install supersedes the pin, and `hermes update` shouldn't try to roll it back.
