### PR TITLE
fix(desktop): route /compress via session.compress and stop masking slash.exec errors behind "not a quick/plugin/skill command"

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -356,6 +356,190 @@ describe('usePromptActions slash.exec dispatch payloads', () => {
   })
 })
 
+// Rendered slash output lands in the session state as system messages — pull
+// the text parts back out of the captured updateSessionState seeds.
+function renderedSeedTexts(seeds: Record<string, unknown>[]): string[] {
+  return seeds.flatMap(state => {
+    const messages = Array.isArray(state.messages)
+      ? (state.messages as Array<{ parts?: Array<{ text?: string }> }>)
+      : []
+
+    return messages.flatMap(message => (message.parts ?? []).map(part => part.text ?? ''))
+  })
+}
+
+describe('usePromptActions /compress', () => {
+  beforeEach(() => {
+    setSessions(() => [sessionInfo()])
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('routes through session.compress (not the slash worker) and renders the summary', async () => {
+    const seeds: Record<string, unknown>[] = []
+
+    const requestGateway = vi.fn(async (method: string) =>
+      (method === 'session.compress'
+        ? {
+            removed: 8,
+            summary: {
+              headline: 'Compressed: 234 → 226 messages',
+              noop: false,
+              token_line: 'Approx request size: ~285,727 → ~198,104 tokens'
+            }
+          }
+        : {}) as never
+    )
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => seeds.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/compress')
+
+    // The dedicated RPC is the TUI's path and has no slash-worker pipe
+    // timeout — and the call carries an LLM-sized client timeout instead of
+    // the 30s WS default, so a large session's compression can finish.
+    expect(requestGateway).toHaveBeenCalledWith('session.compress', { session_id: RUNTIME_SESSION_ID }, 120_000)
+    expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
+    expect(requestGateway).not.toHaveBeenCalledWith('command.dispatch', expect.anything())
+
+    const texts = renderedSeedTexts(seeds)
+    expect(texts.some(text => text.includes('Compressed: 234 → 226 messages'))).toBe(true)
+  })
+
+  it('passes a focus topic through as focus_topic', async () => {
+    const requestGateway = vi.fn(async () => ({ removed: 0 }) as never)
+
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />)
+
+    await handle!.submitText('/compress the auth refactor')
+
+    expect(requestGateway).toHaveBeenCalledWith(
+      'session.compress',
+      {
+        focus_topic: 'the auth refactor',
+        session_id: RUNTIME_SESSION_ID
+      },
+      120_000
+    )
+  })
+
+  it('surfaces the RPC error verbatim (e.g. the busy guard) instead of a routing error', async () => {
+    const seeds: Record<string, unknown>[] = []
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.compress') {
+        throw new Error('session busy — /interrupt the current turn before /compress')
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => seeds.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/compress')
+
+    const texts = renderedSeedTexts(seeds)
+    expect(texts.some(text => text.includes('session busy'))).toBe(true)
+    expect(texts.some(text => text.includes('not a quick/plugin/skill command'))).toBe(false)
+  })
+})
+
+describe('usePromptActions exec fallback error reporting', () => {
+  beforeEach(() => {
+    setSessions(() => [sessionInfo()])
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('surfaces the slash.exec failure when command.dispatch only adds "not a quick/plugin/skill command"', async () => {
+    const seeds: Record<string, unknown>[] = []
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'slash.exec') {
+        throw new Error('slash worker timed out')
+      }
+
+      if (method === 'command.dispatch') {
+        throw new Error('not a quick/plugin/skill command: status')
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => seeds.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/status')
+
+    // The dispatch fallback knowing nothing about /status is routing noise;
+    // the worker timeout is what actually went wrong (#44456).
+    const texts = renderedSeedTexts(seeds)
+    expect(texts.some(text => text.includes('slash worker timed out'))).toBe(true)
+    expect(texts.some(text => text.includes('not a quick/plugin/skill command'))).toBe(false)
+  })
+
+  it('still reports a real command.dispatch failure for skill/quick commands', async () => {
+    const seeds: Record<string, unknown>[] = []
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'slash.exec') {
+        throw new Error('skill command: use command.dispatch for /my-skill')
+      }
+
+      if (method === 'command.dispatch') {
+        throw new Error('quick command failed with exit code 1')
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => seeds.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/my-skill')
+
+    const texts = renderedSeedTexts(seeds)
+    expect(texts.some(text => text.includes('quick command failed with exit code 1'))).toBe(true)
+  })
+})
+
 describe('usePromptActions desktop slash pickers', () => {
   beforeEach(() => {
     setSessions(() => [sessionInfo({ id: '20260610_120000_abcdef', title: 'Loaded session' })])

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -29,9 +29,19 @@ import {
   setYoloActive
 } from '@/store/session'
 
-import type { BrowserManageResponse, SessionTitleResponse, SlashExecResponse } from '../../../types'
+import type {
+  BrowserManageResponse,
+  SessionCompressResponse,
+  SessionTitleResponse,
+  SlashExecResponse
+} from '../../../types'
 
 import { type GatewayRequest, isSessionIdCandidate, renderCommandsCatalog, slashStatusText } from './utils'
+
+// Manual compression is LLM-bound and routinely outlives the desktop's 30s
+// default WS request timeout on large sessions — give it the TUI client's
+// 120s RPC budget (HERMES_TUI_RPC_TIMEOUT_MS default) instead.
+const SESSION_COMPRESS_TIMEOUT_MS = 120_000
 
 /** Everything a slash handler needs about the invocation it's serving. */
 interface SlashActionCtx {
@@ -128,6 +138,8 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           return
         }
 
+        let slashExecError: unknown = null
+
         const handleDispatch = async (
           dispatch: NonNullable<ReturnType<typeof parseCommandDispatch>>
         ): Promise<void> => {
@@ -203,8 +215,11 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           renderSlashOutput(output?.warning ? `warning: ${output.warning}\n${body}` : body)
 
           return
-        } catch {
-          // Fall back to command.dispatch for skill/send/alias directives.
+        } catch (error) {
+          // Fall back to command.dispatch for skill/send/alias directives. Keep
+          // the original error: a slash.exec worker timeout/crash is the real
+          // failure, not the "not a quick/plugin/skill command" routing noise.
+          slashExecError = error
         }
 
         try {
@@ -220,7 +235,19 @@ export function useSlashCommand(deps: SlashCommandDeps) {
 
           await handleDispatch(dispatch)
         } catch (err) {
-          renderSlashOutput(`error: ${err instanceof Error ? err.message : String(err)}`)
+          // "not a quick/plugin/skill command" just means the fallback had
+          // nothing to add — the slash.exec failure (worker timeout, crash) is
+          // the real error, so don't bury it under the routing noise.
+          const dispatchMessage = err instanceof Error ? err.message : String(err)
+
+          const original =
+            slashExecError && dispatchMessage.includes('not a quick/plugin/skill command')
+              ? slashExecError instanceof Error
+                ? slashExecError.message
+                : String(slashExecError)
+              : ''
+
+          renderSlashOutput(`error: ${original ? `/${name} failed: ${original}` : dispatchMessage}`)
         }
       }
 
@@ -233,6 +260,50 @@ export function useSlashCommand(deps: SlashCommandDeps) {
         },
         branch: async () => {
           await branchCurrentSession()
+        },
+        // /compress runs the gateway's dedicated session.compress RPC — the
+        // same path the TUI uses (ui-tui slash/commands/session.ts). It must
+        // NOT go through runExec: compressing a large session outlives the
+        // slash worker's pipe timeout, and the resulting slash.exec error used
+        // to cascade into command.dispatch's misleading "not a
+        // quick/plugin/skill command: compress" (#44456).
+        compress: async ctx => {
+          const resolved = await withSlashOutput(ctx)
+
+          if (!resolved) {
+            return
+          }
+
+          const { render: renderSlashOutput, sessionId } = resolved
+          const focusTopic = ctx.arg.trim()
+
+          try {
+            const result = await requestGateway<SessionCompressResponse>(
+              'session.compress',
+              {
+                session_id: sessionId,
+                ...(focusTopic ? { focus_topic: focusTopic } : {})
+              },
+              SESSION_COMPRESS_TIMEOUT_MS
+            )
+
+            const summary = result?.summary
+
+            if (summary?.headline) {
+              renderSlashOutput(
+                [summary.noop ? summary.headline : `✓ ${summary.headline}`, summary.token_line, summary.note]
+                  .filter(Boolean)
+                  .join('\n')
+              )
+
+              return
+            }
+
+            const removed = result?.removed ?? 0
+            renderSlashOutput(removed > 0 ? `compressed ${removed} messages` : 'nothing to compress')
+          } catch (err) {
+            renderSlashOutput(`error: ${err instanceof Error ? err.message : String(err)}`)
+          }
         },
         // /yolo maps to the status-bar YOLO control — a per-session approval
         // bypass, same scope as the TUI's Shift+Tab. With no session yet we arm

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -52,6 +52,16 @@ export interface BrowserManageResponse {
   messages?: string[]
 }
 
+export interface SessionCompressResponse {
+  removed?: number
+  summary?: {
+    headline?: string
+    noop?: boolean
+    note?: null | string
+    token_line?: string
+  }
+}
+
 export interface SessionSteerResponse {
   // 'queued' == accepted into the live turn's steer slot (injected at the next
   // tool-result boundary); 'rejected' == no live tool window, caller queues.

--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -206,6 +206,9 @@ describe('desktop slash command curation', () => {
     expect(resolveDesktopCommand('/reset')?.surface).toEqual({ kind: 'action', action: 'new' })
     expect(resolveDesktopCommand('/resume')?.surface).toEqual({ kind: 'picker', picker: 'session' })
     expect(resolveDesktopCommand('/usage')?.surface).toEqual({ kind: 'exec' })
+    // /compress must stay an action (session.compress RPC): the exec path's
+    // slash worker times out on large sessions (#44456).
+    expect(resolveDesktopCommand('/compress')?.surface).toEqual({ kind: 'action', action: 'compress' })
     expect(resolveDesktopCommand('/clear')?.surface).toEqual({ kind: 'unavailable', reason: 'terminal' })
     // Skill / quick commands aren't in the registry.
     expect(resolveDesktopCommand('/gif-search')).toBeNull()

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -31,6 +31,7 @@ export interface DesktopThemeCommandOption {
 export type DesktopActionId =
   | 'branch'
   | 'browser'
+  | 'compress'
   | 'handoff'
   | 'hatch'
   | 'help'
@@ -129,6 +130,11 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
     aliases: ['/learning', '/memory-graph'],
     surface: action('journey')
   },
+  // /compress is an action, not exec: it must use the session.compress RPC
+  // (the TUI's path). The slash worker route times out on large sessions,
+  // and the dispatcher's command.dispatch fallback then reports a bogus
+  // "not a quick/plugin/skill command: compress" (#44456).
+  { name: '/compress', description: 'Compress this conversation context', surface: action('compress') },
 
   // Overlay pickers
   { name: '/model', description: 'Switch the model for this session', surface: picker('model'), hidden: true },
@@ -148,7 +154,6 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
     surface: exec()
   },
   { name: '/background', description: 'Run a prompt in the background', aliases: ['/bg', '/btw'], surface: exec() },
-  { name: '/compress', description: 'Compress this conversation context', surface: exec() },
   { name: '/debug', description: 'Create a debug report', surface: exec() },
   { name: '/goal', description: 'Manage the standing goal for this session', surface: exec() },
   { name: '/personality', description: 'Switch personality for this session', surface: exec(), args: true },


### PR DESCRIPTION
## Summary

Fixes #44456

Desktop `/compress` failed with `not a quick/plugin/skill command: compress` after ~1 minute on large sessions, leaving the conversation uncompressed. The reported error is a red herring produced by error masking in the desktop's slash dispatcher — the real failure is a timeout on the slash-worker path.

## What actually happens

The desktop does **not** route `/compress` to `command.dispatch` first (the issue's suggested root cause). The chain is:

1. `runExec` calls `slash.exec` first (`apps/desktop/src/app/session/hooks/use-prompt-actions.ts`).
2. `slash.exec` runs built-ins in the `_SlashWorker` subprocess. Compressing a large session takes longer than every timeout on this path: the desktop WS client caps each RPC at **30s** (`DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS`, `apps/desktop/src/hermes.ts`), and the worker's pipe read at **45s** (`HERMES_TUI_SLASH_TIMEOUT_S`, `tui_gateway/server.py`). The reporter's own `agent.log` shows the ~285k-token compression LLM call alone taking 35s+ — server-side compression even *completes* after the client has already given up.
3. The client's 30s timeout fires first → `slash.exec` rejects.
4. `runExec`'s blanket `catch {}` swallowed that error and fell back to `command.dispatch`, which legitimately knows nothing about built-ins and returned the misleading 4018.

The CLI works because it compresses in-process; the TUI works because it never sends `/compress` through `slash.exec` — it has a local handler calling the dedicated `session.compress` RPC (`ui-tui/src/app/slash/commands/session.ts`) with the TUI client's 120s RPC budget, served on the gateway's long-handler pool with no pipe timeout.

The 3-patch redirect pattern proposed in the issue (from #37254) would not help here: `slash.exec` already owns `/compress` and is already called first — redirecting `command.dispatch` back to it would just bounce into the same timeout.

## Changes

- **`/compress` becomes a desktop `action`** (`desktop-slash-commands.ts`) with a handler that calls `session.compress` — the TUI's path. Server-side busy guard surfaces verbatim, the manual-compression summary (`Compressed: N → M messages` + token line) renders inline, and `/compress <topic>` passes the focus topic through.
- **`requestGateway` accepts an optional per-call `timeoutMs`** (threaded to the underlying client, which already supports it); `session.compress` uses **120s**, matching the TUI client's `HERMES_TUI_RPC_TIMEOUT_MS` default — without this the reroute would still die at the 30s WS default on exactly the sessions that need compressing most.
- **Stop masking `slash.exec` failures** for the remaining exec commands: `runExec` now keeps the original `slash.exec` error, and when the `command.dispatch` fallback fails with `not a quick/plugin/skill command`, it reports the original error (e.g. `/status failed: slash worker timed out`) instead of the routing noise. Real fallback errors (skill/quick command failures) are reported unchanged.

This also removes a hidden double-compression: the old path compressed the worker's copy of the session *and* then the live session again via `_mirror_slash_side_effects`.

## Testing

- 5 new vitest cases: `/compress` routes via `session.compress` with the 120s timeout (never `slash.exec`/`command.dispatch`) and renders the summary; focus topic passthrough; busy-guard error surfaces verbatim; worker-timeout error surfaces instead of the 4018 noise; genuine `command.dispatch` failures still surface.
- Registry assertion that `/compress` resolves to the `compress` action surface.
- `apps/desktop`: full vitest suite — same 7 pre-existing failures as clean `main`, zero new; `tsc --noEmit` clean; eslint 0 errors, warning count unchanged from baseline.
