### PR TITLE
 fix(tui): pick up config model changes in open chats and on the Models page

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1051,6 +1051,94 @@ def test_resolve_model_strips_config_model(monkeypatch):
     assert server._resolve_model() == "nous/hermes-test"
 
 
+def _sync_test_session(**extra):
+    session = {
+        "agent": types.SimpleNamespace(model="old/model"),
+        "session_key": "session-key",
+    }
+    session.update(extra)
+    return session
+
+
+def _patch_config_model(monkeypatch, model, provider=""):
+    monkeypatch.delenv("HERMES_MODEL", raising=False)
+    monkeypatch.delenv("HERMES_INFERENCE_MODEL", raising=False)
+    cfg_model = {"default": model}
+    if provider:
+        cfg_model["provider"] = provider
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"model": cfg_model})
+
+
+def test_config_sync_switches_unpinned_session(monkeypatch):
+    _patch_config_model(monkeypatch, "new/model", provider="nous")
+    session = _sync_test_session(config_model_seen=("old/model", "nous"))
+    calls = []
+    monkeypatch.setattr(
+        server,
+        "_apply_model_switch",
+        lambda sid, sess, raw, **kw: calls.append((sid, raw, kw)),
+    )
+
+    server._sync_agent_model_with_config("sid", session)
+
+    assert calls == [
+        (
+            "sid",
+            "new/model --provider nous",
+            {"confirm_expensive_model": True, "pin_session_override": False},
+        )
+    ]
+    assert session["config_model_seen"] == ("new/model", "nous")
+
+
+def test_config_sync_skips_session_pinned_by_model_command(monkeypatch):
+    _patch_config_model(monkeypatch, "new/model")
+    session = _sync_test_session(
+        config_model_seen=("old/model", ""),
+        model_override={"model": "pinned/model"},
+    )
+    monkeypatch.setattr(
+        server,
+        "_apply_model_switch",
+        lambda *a, **k: pytest.fail("pinned session must not be switched"),
+    )
+
+    server._sync_agent_model_with_config("sid", session)
+
+
+def test_config_sync_noop_when_config_unchanged(monkeypatch):
+    _patch_config_model(monkeypatch, "old/model")
+    session = _sync_test_session(config_model_seen=("old/model", ""))
+    monkeypatch.setattr(
+        server,
+        "_apply_model_switch",
+        lambda *a, **k: pytest.fail("unchanged config must not switch"),
+    )
+
+    server._sync_agent_model_with_config("sid", session)
+
+
+def test_config_sync_failure_emits_error_once_per_edit(monkeypatch):
+    _patch_config_model(monkeypatch, "broken/model")
+    session = _sync_test_session(config_model_seen=("old/model", ""))
+
+    def boom(*a, **k):
+        raise ValueError("no such model")
+
+    monkeypatch.setattr(server, "_apply_model_switch", boom)
+    emits = []
+    monkeypatch.setattr(
+        server, "_emit", lambda ev, sid, payload: emits.append((ev, payload))
+    )
+
+    server._sync_agent_model_with_config("sid", session)
+    server._sync_agent_model_with_config("sid", session)
+
+    assert len(emits) == 1
+    assert emits[0][0] == "error"
+    assert "broken/model" in emits[0][1]["message"]
+
+
 def test_startup_runtime_uses_tui_provider_env(monkeypatch):
     monkeypatch.setenv("HERMES_MODEL", "nous/hermes-test")
     monkeypatch.setenv("HERMES_TUI_PROVIDER", "nous")

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1091,6 +1091,21 @@ def test_config_sync_switches_unpinned_session(monkeypatch):
     assert session["config_model_seen"] == ("new/model", "nous")
 
 
+def test_config_sync_treats_auto_provider_as_unset(monkeypatch):
+    _patch_config_model(monkeypatch, "new/model", provider="auto")
+    session = _sync_test_session(config_model_seen=("old/model", ""))
+    calls = []
+    monkeypatch.setattr(
+        server,
+        "_apply_model_switch",
+        lambda sid, sess, raw, **kw: calls.append(raw),
+    )
+
+    server._sync_agent_model_with_config("sid", session)
+
+    assert calls == ["new/model"]
+
+
 def test_config_sync_skips_session_pinned_by_model_command(monkeypatch):
     _patch_config_model(monkeypatch, "new/model")
     session = _sync_test_session(

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1133,6 +1133,37 @@ def test_config_sync_noop_when_config_unchanged(monkeypatch):
     server._sync_agent_model_with_config("sid", session)
 
 
+def test_config_sync_adopts_baseline_when_agent_already_on_target(monkeypatch):
+    # Branched/resumed sessions reach their first sync with no snapshot but
+    # an agent already built from config; that must not trigger a switch.
+    _patch_config_model(monkeypatch, "old/model")
+    session = _sync_test_session()
+    monkeypatch.setattr(
+        server,
+        "_apply_model_switch",
+        lambda *a, **k: pytest.fail("agent already on target must not switch"),
+    )
+
+    server._sync_agent_model_with_config("sid", session)
+
+    assert session["config_model_seen"] == ("old/model", "")
+
+
+def test_config_sync_switches_when_only_provider_differs(monkeypatch):
+    _patch_config_model(monkeypatch, "old/model", provider="nous")
+    session = _sync_test_session(config_model_seen=("old/model", ""))
+    calls = []
+    monkeypatch.setattr(
+        server,
+        "_apply_model_switch",
+        lambda sid, sess, raw, **kw: calls.append(raw),
+    )
+
+    server._sync_agent_model_with_config("sid", session)
+
+    assert calls == ["old/model --provider nous"]
+
+
 def test_config_sync_failure_emits_error_once_per_edit(monkeypatch):
     _patch_config_model(monkeypatch, "broken/model")
     session = _sync_test_session(config_model_seen=("old/model", ""))

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -937,6 +937,9 @@ def _start_agent_build(sid: str, session: dict) -> None:
             # Session DB row deferred to first run_conversation() call.
             # pending_title applied post-first-message (see cli.exec handler).
             current["agent"] = agent
+            # Baseline for the per-turn config sync; the profile home
+            # override is still active here.
+            current["config_model_seen"] = _config_model_target()
 
             try:
                 worker = _SlashWorker(key, getattr(agent, "model", _resolve_model()))
@@ -1401,6 +1404,16 @@ def _resolve_model() -> str:
     if isinstance(m, str) and m:
         return m.strip()
     return "anthropic/claude-sonnet-4"
+
+
+def _config_model_target() -> tuple[str, str]:
+    """(model, provider) currently selected by env/config."""
+    model = _resolve_model()
+    cfg_model = _load_cfg().get("model")
+    provider = ""
+    if isinstance(cfg_model, dict):
+        provider = str(cfg_model.get("provider") or "").strip()
+    return model, provider
 
 
 def _resolve_startup_runtime() -> tuple[str, str | None]:
@@ -1872,6 +1885,7 @@ def _apply_model_switch(
     raw_input: str,
     *,
     confirm_expensive_model: bool = False,
+    pin_session_override: bool = True,
 ) -> dict:
     from hermes_cli.model_switch import parse_model_flags, switch_model
     from hermes_cli.runtime_provider import resolve_runtime_provider
@@ -1975,7 +1989,7 @@ def _apply_model_switch(
     # contamination bug). agent.switch_model() above already mutated the right
     # agent in place; the override dict makes that choice survive a rebuild
     # without touching shared process state.
-    if isinstance(session, dict):
+    if pin_session_override and isinstance(session, dict):
         session["model_override"] = {
             "model": result.new_model,
             "provider": result.target_provider,
@@ -1990,6 +2004,42 @@ def _apply_model_switch(
         "warning": result.warning_message or "",
         "confirm_required": False,
     }
+
+
+def _sync_agent_model_with_config(sid: str, session: dict) -> None:
+    """Adopt a config.yaml model change at turn start, like gateways do per
+    message. Sessions pinned with /model keep their choice; a failed switch
+    keeps the current model and never blocks the turn.
+    """
+    agent = session.get("agent")
+    if agent is None or session.get("model_override"):
+        return
+    target = _config_model_target()
+    if not target[0]:
+        return
+    seen = session.get("config_model_seen")
+    # Record first so a broken config gets one attempt per edit, not per turn.
+    session["config_model_seen"] = target
+    if target == seen:
+        return
+    if seen is None and target[0] == (getattr(agent, "model", "") or ""):
+        return
+    model, provider = target
+    raw = f"{model} --provider {provider}" if provider else model
+    try:
+        _apply_model_switch(
+            sid,
+            session,
+            raw,
+            confirm_expensive_model=True,
+            pin_session_override=False,
+        )
+    except Exception as e:
+        _emit(
+            "error",
+            sid,
+            {"message": f"Could not switch to configured model {model}: {e}"},
+        )
 
 
 def _compress_session_history(
@@ -3042,6 +3092,7 @@ def _reset_session_agent(sid: str, session: dict) -> dict:
     finally:
         _clear_session_context(tokens)
     session["agent"] = new_agent
+    session["config_model_seen"] = _config_model_target()
     session["attached_images"] = []
     session["edit_snapshots"] = {}
     session["image_counter"] = 0
@@ -5315,6 +5366,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             # the sudo.request overlay. (secret capture is a module global, so
             # re-running is a harmless no-op.)
             _wire_callbacks(sid)
+            _sync_agent_model_with_config(sid, session)
             cwd = _session_cwd(session)
             _register_session_cwd(session)
             cols = session.get("cols", 80)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1413,6 +1413,8 @@ def _config_model_target() -> tuple[str, str]:
     provider = ""
     if isinstance(cfg_model, dict):
         provider = str(cfg_model.get("provider") or "").strip()
+        if provider.lower() == "auto":
+            provider = ""
     return model, provider
 
 
@@ -2021,8 +2023,6 @@ def _sync_agent_model_with_config(sid: str, session: dict) -> None:
     # Record first so a broken config gets one attempt per edit, not per turn.
     session["config_model_seen"] = target
     if target == seen:
-        return
-    if seen is None and target[0] == (getattr(agent, "model", "") or ""):
         return
     model, provider = target
     raw = f"{model} --provider {provider}" if provider else model

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2025,6 +2025,13 @@ def _sync_agent_model_with_config(sid: str, session: dict) -> None:
     if target == seen:
         return
     model, provider = target
+    # Already running the configured model (branched/resumed session before
+    # its first sync, or a config revert after a failed switch): adopt the
+    # baseline without a redundant switch.
+    if model == getattr(agent, "model", "") and (
+        not provider or provider == getattr(agent, "provider", "")
+    ):
+        return
     raw = f"{model} --provider {provider}" if provider else model
     try:
         _apply_model_switch(

--- a/web/src/pages/ModelsPage.tsx
+++ b/web/src/pages/ModelsPage.tsx
@@ -855,38 +855,33 @@ export default function ModelsPage() {
       });
   }, []);
 
-  const load = useCallback(
-    (opts?: { silent?: boolean }) => {
-      if (!opts?.silent) {
-        setLoading(true);
-        setError(null);
-      }
-      Promise.all([
-        api.getModelsAnalytics(days),
-        api.getAuxiliaryModels().catch(() => null),
-      ])
-        .then(([models, auxData]) => {
-          setData(models);
-          setAux(auxData);
-        })
-        .catch((err) => {
-          if (!opts?.silent) setError(String(err));
-        })
-        .finally(() => {
-          if (!opts?.silent) setLoading(false);
-        });
-    },
-    [days],
-  );
+  const load = useCallback(() => {
+    setLoading(true);
+    setError(null);
+    Promise.all([
+      api.getModelsAnalytics(days),
+      api.getAuxiliaryModels().catch(() => null),
+    ])
+      .then(([models, auxData]) => {
+        setData(models);
+        setAux(auxData);
+      })
+      .catch((err) => setError(String(err)))
+      .finally(() => setLoading(false));
+  }, [days]);
 
-  const onAssigned = useCallback(() => {
-    // Reload aux state after any assignment change.
+  const refreshAux = useCallback(() => {
     api
       .getAuxiliaryModels()
       .then(setAux)
       .catch(() => {});
-    setSaveKey((k) => k + 1);
   }, []);
+
+  const onAssigned = useCallback(() => {
+    // Reload aux state after any assignment change.
+    refreshAux();
+    setSaveKey((k) => k + 1);
+  }, [refreshAux]);
 
   useLayoutEffect(() => {
     // Period selector + refresh both live in afterTitle so the controls
@@ -912,7 +907,7 @@ export default function ModelsPage() {
           ghost
           size="icon"
           className="text-muted-foreground hover:text-foreground"
-          onClick={() => load()}
+          onClick={load}
           disabled={loading}
           aria-label={t.common.refresh}
         >
@@ -932,18 +927,22 @@ export default function ModelsPage() {
   }, [load]);
 
   // Model assignments can change outside this page (config editor, chat
-  // /model --global, CLI) — refetch silently when the page regains focus.
+  // /model --global, CLI), so refetch them when the page regains focus.
   useEffect(() => {
-    const refetch = () => {
-      if (document.visibilityState === "visible") load({ silent: true });
+    let last = 0;
+    const onFocus = () => {
+      if (document.visibilityState !== "visible") return;
+      if (Date.now() - last < 1000) return;
+      last = Date.now();
+      refreshAux();
     };
-    window.addEventListener("focus", refetch);
-    document.addEventListener("visibilitychange", refetch);
+    window.addEventListener("focus", onFocus);
+    document.addEventListener("visibilitychange", onFocus);
     return () => {
-      window.removeEventListener("focus", refetch);
-      document.removeEventListener("visibilitychange", refetch);
+      window.removeEventListener("focus", onFocus);
+      document.removeEventListener("visibilitychange", onFocus);
     };
-  }, [load]);
+  }, [refreshAux]);
 
   return (
     <div className="flex min-w-0 max-w-full flex-col gap-6">

--- a/web/src/pages/ModelsPage.tsx
+++ b/web/src/pages/ModelsPage.tsx
@@ -855,20 +855,29 @@ export default function ModelsPage() {
       });
   }, []);
 
-  const load = useCallback(() => {
-    setLoading(true);
-    setError(null);
-    Promise.all([
-      api.getModelsAnalytics(days),
-      api.getAuxiliaryModels().catch(() => null),
-    ])
-      .then(([models, auxData]) => {
-        setData(models);
-        setAux(auxData);
-      })
-      .catch((err) => setError(String(err)))
-      .finally(() => setLoading(false));
-  }, [days]);
+  const load = useCallback(
+    (opts?: { silent?: boolean }) => {
+      if (!opts?.silent) {
+        setLoading(true);
+        setError(null);
+      }
+      Promise.all([
+        api.getModelsAnalytics(days),
+        api.getAuxiliaryModels().catch(() => null),
+      ])
+        .then(([models, auxData]) => {
+          setData(models);
+          setAux(auxData);
+        })
+        .catch((err) => {
+          if (!opts?.silent) setError(String(err));
+        })
+        .finally(() => {
+          if (!opts?.silent) setLoading(false);
+        });
+    },
+    [days],
+  );
 
   const onAssigned = useCallback(() => {
     // Reload aux state after any assignment change.
@@ -903,7 +912,7 @@ export default function ModelsPage() {
           ghost
           size="icon"
           className="text-muted-foreground hover:text-foreground"
-          onClick={load}
+          onClick={() => load()}
           disabled={loading}
           aria-label={t.common.refresh}
         >
@@ -920,6 +929,20 @@ export default function ModelsPage() {
 
   useEffect(() => {
     load();
+  }, [load]);
+
+  // Model assignments can change outside this page (config editor, chat
+  // /model --global, CLI) — refetch silently when the page regains focus.
+  useEffect(() => {
+    const refetch = () => {
+      if (document.visibilityState === "visible") load({ silent: true });
+    };
+    window.addEventListener("focus", refetch);
+    document.addEventListener("visibilitychange", refetch);
+    return () => {
+      window.removeEventListener("focus", refetch);
+      document.removeEventListener("visibilitychange", refetch);
+    };
   }, [load]);
 
   return (


### PR DESCRIPTION
## What does this PR do?

Changing the model in the dashboard config is picked up by the gateways (Telegram, etc.) but not by chats that are already open. The gateways read the model from config.yaml on every message, while the TUI/dashboard chat resolves the model once when the agent is built and never reads the config again. The only way to update a live chat was to run /model manually.

This PR makes the TUI gateway re-resolve the model from config at the start of each turn. If it changed, the live agent is switched in place using the same mechanism as /model, so the provider and credentials are re-resolved, the slash worker is restarted and the conversation history is kept. Sessions pinned with /model keep their model, the same way per-session overrides work in the gateways. If the configured model is invalid, the switch is attempted once per config edit, one error is shown, and the turn continues on the previous model.

It also fixes a similar problem on the Models page of the dashboard: the main/auxiliary assignments were only fetched when the page mounted, so a config change made while the page was open never showed up. The page now refetches the assignments (only that, not the analytics) when it regains focus.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/server.py`
  - New `_sync_agent_model_with_config()`, called from `_run_prompt_submit`. It re-resolves the model and provider from config, skips sessions pinned via `session["model_override"]`, and applies changes through `_apply_model_switch`.
  - New `_config_model_target()` helper that returns the model and provider currently selected by env/config. A `provider: auto` value is treated as unset so provider detection runs instead of failing on a literal "auto".
  - `_apply_model_switch()` takes a new `pin_session_override` kwarg so the config sync path does not pin the session. /model keeps pinning as before.
  - Sessions store a `config_model_seen` snapshot at agent build/rebuild, used as the baseline for the sync.
- `web/src/pages/ModelsPage.tsx`: new `refreshAux()` callback (also reused by the assignment save path) and a mount-once focus/visibilitychange listener that refetches the assignments, with a short guard against the duplicate focus+visibility firing on tab switches.
- `tests/test_tui_gateway_server.py`: five tests for the sync. A config change switches an unpinned session (including the provider flag), `provider: auto` is treated as unset, a pinned session is left alone, an unchanged config is a no-op, and a failing switch emits one error per edit without retrying every turn.

## How to Test

1. Run `hermes dashboard`, open the chat and send a message. The sidebar badge shows the configured model.
2. Without closing the chat, change the main model from the Models page, the Config page or `hermes model` in a terminal.
3. Send another message in the same chat. It runs on the new model without /model or a new session. Telegram behavior is unchanged.
4. Pin the chat with `/model <model>`, change the config model again and send a message. The chat keeps the pinned model.
5. Leave the Models page open, change the model from somewhere else, switch browser tabs and come back. The "Main model" row updates without a manual refresh.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
