### PR TITLE
fix(tui-gateway): route /compress through command.dispatch for Desktop/TUI

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3496,6 +3496,102 @@ def test_snapshot_restore_is_blocked_from_tui_worker():
     )
 
 
+def test_command_dispatch_compress_calls_helper(monkeypatch):
+    """command.dispatch routes /compress to _compress_session_history."""
+    seen = {"compress": False, "sync": False, "emit": False}
+
+    def _fake_compress(session, focus_topic=None, **_kw):
+        seen["compress"] = True
+        return 5, {}
+
+    def _fake_sync(sid, session):
+        seen["sync"] = True
+
+    def _fake_emit(event, sid, payload=None):
+        seen["emit"] = True
+
+    agent = types.SimpleNamespace()
+    agent.model = "test-model"
+    server._sessions["sid"] = _session(agent=agent, history=[{"role": "user", "content": "x"}] * 6)
+    monkeypatch.setattr(server, "_compress_session_history", _fake_compress)
+    monkeypatch.setattr(server, "_sync_session_key_after_compress", _fake_sync)
+    monkeypatch.setattr(server, "_emit", _fake_emit)
+    monkeypatch.setattr(server, "_session_info", lambda a, s: {})
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "command.dispatch",
+                "params": {"name": "compress", "session_id": "sid"},
+            }
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert seen["compress"]
+    assert seen["sync"]
+    assert seen["emit"]
+    assert resp["result"]["type"] == "exec"
+    assert "removed 5 messages" in resp["result"]["output"]
+
+
+def test_command_dispatch_compress_noop(monkeypatch):
+    """command.dispatch /compress reports no-op when nothing was removed."""
+    monkeypatch.setattr(
+        server, "_compress_session_history", lambda s, f=None, **kw: (0, {})
+    )
+    monkeypatch.setattr(
+        server, "_sync_session_key_after_compress", lambda sid, s: None
+    )
+    monkeypatch.setattr(server, "_emit", lambda *a, **kw: None)
+    monkeypatch.setattr(server, "_session_info", lambda a, s: {})
+    agent = types.SimpleNamespace()
+    server._sessions["sid"] = _session(agent=agent)
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "command.dispatch",
+                "params": {"name": "compress", "session_id": "sid"},
+            }
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert resp["result"]["type"] == "exec"
+    assert "No compression needed" in resp["result"]["output"]
+
+
+def test_command_dispatch_compress_rejects_while_running():
+    """command.dispatch /compress rejects when session is busy."""
+    server._sessions["sid"] = _session(running=True)
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "command.dispatch",
+                "params": {"name": "compress", "session_id": "sid"},
+            }
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert resp["error"]["code"] == 4009
+    assert "session busy" in resp["error"]["message"]
+
+
+def test_command_dispatch_compress_no_session():
+    """command.dispatch /compress rejects when session_id is missing."""
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "command.dispatch",
+            "params": {"name": "compress", "session_id": "nonexistent"},
+        }
+    )
+    assert resp["error"]["code"] == 4001
+
+
 def test_command_dispatch_exec_nonzero_surfaces_error(monkeypatch):
     monkeypatch.setattr(
         server,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7881,6 +7881,45 @@ def _(rid, params: dict) -> dict:
                 },
             )
 
+    # /compress — handled here (not via the slash worker) because
+    # compression needs direct access to the live session's agent and
+    # history, which the worker subprocess doesn't share.  Mirrors the
+    # compress branch in _mirror_slash_side_effects.
+    if name == "compress":
+        if not session:
+            return _err(rid, 4001, "no active session to compress")
+        if session.get("running"):
+            return _err(
+                rid,
+                4009,
+                "session busy — /interrupt the current turn before /compress",
+            )
+        agent = session.get("agent")
+        if not agent:
+            return _err(rid, 4001, "no agent in session")
+        try:
+            removed, _usage = _compress_session_history(session, arg or None)
+            sid = params.get("session_id", "")
+            _sync_session_key_after_compress(sid, session)
+            _emit("session.info", sid, _session_info(agent, session))
+            if removed:
+                return _ok(
+                    rid,
+                    {
+                        "type": "exec",
+                        "output": f"🗜️ Compressed: removed {removed} messages.",
+                    },
+                )
+            return _ok(
+                rid,
+                {
+                    "type": "exec",
+                    "output": "🗜️ No compression needed — context is already compact.",
+                },
+            )
+        except Exception as exc:
+            return _err(rid, 5005, f"compress failed: {exc}")
+
     return _err(rid, 4018, f"not a quick/plugin/skill command: {name}")
 
 


### PR DESCRIPTION
## What does this PR do?

Routes `/compress` through `command.dispatch` in the TUI gateway so it works in Desktop and TUI clients. Previously, `/compress` returned "not a quick/plugin/skill command: compress" because `command.dispatch` only handled `retry`, `undo`, `goal`, `steer`, and `snapshot` — not `compress`.

## Related Issue

Fixes #44456

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py`: Added `compress` branch in `command.dispatch` that delegates to `_compress_session_history` + `_sync_session_key_after_compress` (same path `_mirror_slash_side_effects` uses), with session-busy guard and `session.info` emission.
- `tests/test_tui_gateway_server.py`: Added 4 tests — compress calls helper, no-op, rejects while running, rejects without session.

## How to Test

1. Launch Hermes Desktop (Electron app)
2. Open a session with some conversation history (4+ messages)
3. Type `/compress` in the chat composer and press Enter
4. Verify the compression runs and reports the result (e.g. "🗜️ Compressed: removed N messages.")
5. Verify `/compress` during an active turn returns "session busy" error
6. Run `pytest tests/test_tui_gateway_server.py -k "command_dispatch_compress" -v` — all 4 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `command.dispatch` in `tui_gateway/server.py` (callers: Desktop `use-prompt-actions.ts`, TUI `createSlashHandler.ts`, web `slashExec.ts`)
- Blast radius: LOW — adds a new branch to an existing dispatcher; no changes to existing branches
- Related patterns: mirrors `_mirror_slash_side_effects` compress branch (line 8596); same helpers (`_compress_session_history`, `_sync_session_key_after_compress`, `_emit`)
