### PR TITLE
feat(gateway): add protected sensitive input capture

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2511,6 +2511,49 @@ class BasePlatformAdapter(ABC):
             metadata=metadata,
         )
 
+    async def send_secret_capture(
+        self,
+        chat_id: str,
+        prompt: str,
+        env_var: str,
+        secret_id: str,
+        session_key: str,
+        metadata: Optional[Dict[str, Any]] = None,
+        timeout_seconds: Optional[int] = None,
+    ) -> SendResult:
+        """Send a protected sensitive-input prompt.
+
+        Rich adapters may override this with inline cancel buttons.  The
+        default text fallback is intentionally explicit that anything typed
+        next is treated as the sensitive payload and that cancellation is only
+        available where the platform provides a dedicated control.
+        """
+        timeout_note = f" This request expires in {timeout_seconds} seconds." if timeout_seconds else ""
+        text = (
+            f"🔐 Protected sensitive input requested for `{env_var}`.\n\n"
+            f"{prompt}\n\n"
+            "Send the value in your next message. While this request is pending, "
+            "anything you type — including slash commands — is treated as the secret value. "
+            "The agent model will not receive that message as chat text; Hermes stores it locally."
+            f"{timeout_note}"
+        )
+        return await self.send(chat_id=chat_id, content=text, metadata=metadata)
+
+    async def finalize_secret_capture(
+        self,
+        chat_id: str,
+        secret_id: str,
+        status: str,
+        env_var: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Update/acknowledge a sensitive-input prompt after resolve/cancel/timeout.
+
+        Default adapters do nothing to avoid extra messages on platforms where
+        editing the original prompt is unavailable or noisy.
+        """
+        return SendResult(success=True)
+
     async def send_private_notice(
         self,
         chat_id: str,
@@ -3870,6 +3913,49 @@ class BasePlatformAdapter(ABC):
 
         # Check if there's already an active handler for this session
         if session_key in self._active_sessions:
+            # Protected sensitive-input replies must reach the gateway runner
+            # even while the original agent turn is active and blocked inside
+            # request_sensitive_input().  Otherwise the reply is queued as a
+            # follow-up turn and the tool times out while the raw secret sits
+            # in pending-message state.  This applies to slash-prefixed values
+            # too: while a secret prompt is pending, typed text is payload, not
+            # a command.
+            try:
+                from tools import secret_capture_gateway as _secret_mod
+                _pending_secret = _secret_mod.get_pending_for_session(session_key, source=event.source)
+            except Exception:
+                _pending_secret = None
+            if _pending_secret is not None:
+                logger.debug(
+                    "[%s] Routing message to sensitive-input intercept for %s",
+                    self.name, session_key,
+                )
+                try:
+                    _thread_meta = _thread_metadata_for_source(
+                        event.source, _reply_anchor_for_event(event)
+                    )
+                    response = await self._message_handler(event)
+                    _text, _eph_ttl = self._unwrap_ephemeral(response)
+                    if _text:
+                        _r = await self._send_with_retry(
+                            chat_id=event.source.chat_id,
+                            content=_text,
+                            reply_to=_reply_anchor_for_event(event),
+                            metadata=_thread_meta,
+                        )
+                        if _eph_ttl > 0 and _r.success and _r.message_id:
+                            self._schedule_ephemeral_delete(
+                                chat_id=event.source.chat_id,
+                                message_id=_r.message_id,
+                                ttl_seconds=_eph_ttl,
+                            )
+                except Exception as e:
+                    logger.error(
+                        "[%s] Sensitive-input intercept dispatch failed: %s",
+                        self.name, e, exc_info=True,
+                    )
+                return
+
             # Certain commands must bypass the active-session guard and be
             # dispatched directly to the gateway runner.  Without this, they
             # are queued as pending messages and either:

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -481,6 +481,8 @@ class TelegramAdapter(BasePlatformAdapter):
         # Clarify button state: clarify_id → session_key (for the clarify tool's
         # multiple-choice prompts; see GatewayRunner clarify_callback wiring).
         self._clarify_state: Dict[str, str] = {}
+        self._secret_capture_state: Dict[str, Dict[str, Any]] = {}
+        self._secret_capture_prompt_messages: Dict[str, int] = {}
         # Notification mode for message sends.
         # "important" — only final responses, approvals, and slash confirmations
         #               trigger notifications; tool progress, streaming, status
@@ -2896,6 +2898,90 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.warning("[%s] send_clarify failed: %s", self.name, e)
             return SendResult(success=False, error=str(e))
 
+    async def send_secret_capture(
+        self,
+        chat_id: str,
+        prompt: str,
+        env_var: str,
+        secret_id: str,
+        session_key: str,
+        metadata: Optional[Dict[str, Any]] = None,
+        timeout_seconds: Optional[int] = None,
+    ) -> SendResult:
+        """Send protected sensitive-input prompt with an inline cancel button."""
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+        try:
+            thread_id = self._metadata_thread_id(metadata)
+            timeout_line = f"\n\n<i>Expires in {int(timeout_seconds)} seconds.</i>" if timeout_seconds else ""
+            text = (
+                f"🔐 <b>Protected sensitive input</b> for <code>{_html.escape(env_var)}</code>\n\n"
+                f"{_html.escape(prompt)}\n\n"
+                "Send the value in your next message. While this request is pending, "
+                "anything you type — including slash commands — is treated as the secret value. "
+                "Use the Cancel button to cancel. The agent model will not receive that message "
+                "as chat text; Hermes stores it locally."
+                f"{timeout_line}"
+            )
+            keyboard = InlineKeyboardMarkup([[
+                InlineKeyboardButton("❌ Cancel", callback_data=f"sgc:cancel:{secret_id}"),
+            ]])
+            reply_to_id = self._reply_to_message_id_for_send(None, metadata, reply_to_mode=self._reply_to_mode)
+            kwargs: Dict[str, Any] = {
+                "chat_id": int(chat_id),
+                "text": text,
+                "parse_mode": ParseMode.HTML,
+                "reply_markup": keyboard,
+                "reply_to_message_id": reply_to_id,
+                **self._link_preview_kwargs(),
+            }
+            kwargs.update(self._thread_kwargs_for_send(chat_id, thread_id, metadata, reply_to_message_id=reply_to_id))
+            msg = await self._send_message_with_thread_fallback(**kwargs)
+            self._secret_capture_state[secret_id] = {
+                "session_key": session_key,
+                "env_var": env_var,
+                "chat_id": str(chat_id),
+            }
+            self._secret_capture_prompt_messages[secret_id] = int(msg.message_id)
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as e:
+            logger.warning("[%s] send_secret_capture failed: %s", self.name, e)
+            return SendResult(success=False, error=str(e))
+
+    async def finalize_secret_capture(
+        self,
+        chat_id: str,
+        secret_id: str,
+        status: str,
+        env_var: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Edit the original secret prompt to a terminal state and clear buttons."""
+        message_id = self._secret_capture_prompt_messages.pop(secret_id, None)
+        self._secret_capture_state.pop(secret_id, None)
+        if not self._bot or not message_id:
+            return SendResult(success=True)
+        labels = {
+            "received": "✅ Sensitive input received. Continuing…",
+            "stored": "✅ Sensitive input stored.",
+            "timeout": "⌛ Sensitive input request expired. Start a new request before sending the value.",
+            "button_cancelled": "❌ Sensitive input request cancelled.",
+            "session_cleared": "❌ Sensitive input request cancelled.",
+        }
+        text = labels.get(status, "Sensitive input request resolved.")
+        try:
+            await self._bot.edit_message_text(
+                chat_id=int(chat_id),
+                message_id=int(message_id),
+                text=f"{text}\n\n<code>{_html.escape(env_var)}</code>",
+                parse_mode=ParseMode.HTML,
+                reply_markup=None,
+            )
+            return SendResult(success=True, message_id=str(message_id))
+        except Exception as e:
+            logger.debug("[%s] finalize_secret_capture failed: %s", self.name, e)
+            return SendResult(success=False, error=str(e))
+
     async def send_model_picker(
         self,
         chat_id: str,
@@ -3563,6 +3649,59 @@ class TelegramAdapter(BasePlatformAdapter):
                         await self._send_message_with_thread_fallback(**send_kwargs)
                 except Exception as exc:
                     logger.error("[%s] slash-confirm callback failed: %s", self.name, exc, exc_info=True)
+            return
+
+        # --- Sensitive-input callbacks (sgc:cancel:secret_id) ---
+        if data.startswith("sgc:"):
+            parts = data.split(":", 2)
+            if len(parts) == 3 and parts[1] == "cancel":
+                secret_id = parts[2]
+                caller_id = str(getattr(query.from_user, "id", ""))
+                if not self._is_callback_user_authorized(
+                    caller_id,
+                    chat_id=query_chat_id,
+                    chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                    thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                    user_name=query_user_name,
+                ):
+                    await query.answer(text="⛔ You are not authorized to cancel this prompt.")
+                    return
+                state = self._secret_capture_state.get(secret_id)
+                if not state:
+                    await query.answer(text="This sensitive-input request has already been resolved.")
+                    return
+                try:
+                    from gateway.session import SessionSource
+                    from tools.secret_capture_gateway import cancel_gateway_secret
+                    _callback_source = SessionSource(
+                        platform=Platform.TELEGRAM,
+                        chat_id=str(query_chat_id) if query_chat_id is not None else "",
+                        chat_type="dm" if str(query_chat_type) == "private" else str(query_chat_type or "group"),
+                        user_id=caller_id,
+                        user_name=query_user_name,
+                        thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                    )
+                    resolved = cancel_gateway_secret(secret_id, reason="button_cancelled", source=_callback_source)
+                except Exception as exc:
+                    logger.error("[%s] cancel_gateway_secret failed: %s", self.name, exc)
+                    resolved = False
+                if state.get("user_id") and str(state.get("user_id")) != caller_id:
+                    await query.answer(text="⛔ This prompt belongs to another user.")
+                    return
+                if resolved:
+                    await query.answer(text="Cancelled.")
+                    try:
+                        await query.edit_message_text(
+                            text=f"❌ Sensitive input request cancelled.\n\n<code>{_html.escape(str(state.get('env_var') or ''))}</code>",
+                            parse_mode=ParseMode.HTML,
+                            reply_markup=None,
+                        )
+                    except Exception:
+                        pass
+                    self._secret_capture_state.pop(secret_id, None)
+                    self._secret_capture_prompt_messages.pop(secret_id, None)
+                else:
+                    await query.answer(text="This sensitive-input request has already been resolved.")
             return
 
         # --- Clarify callbacks (cl:clarify_id:idx | cl:clarify_id:other) ---
@@ -5338,6 +5477,21 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         return getattr(update, "effective_message", None) or getattr(update, "message", None)
 
+    def _message_has_pending_secret_capture(self, event: MessageEvent) -> bool:
+        """Return True when this Telegram event should bypass pre-filters for secret capture."""
+        try:
+            from gateway.session import build_session_key
+            from tools import secret_capture_gateway as scg
+            self._apply_topic_recovery(event)
+            key = build_session_key(
+                event.source,
+                group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
+                thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
+            )
+            return scg.get_pending_for_session(key, source=event.source) is not None
+        except Exception:
+            return False
+
     async def _handle_text_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming text messages.
 
@@ -5348,13 +5502,21 @@ class TelegramAdapter(BasePlatformAdapter):
         msg = self._effective_update_message(update)
         if not msg or not msg.text:
             return
+
+        event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
+        if self._message_has_pending_secret_capture(event):
+            # Secret replies must bypass mention filters, trigger-text cleaning,
+            # observed-message attribution/logging, and text batching. The
+            # gateway runner captures this raw text before plugin hooks or
+            # normal dispatch.
+            await self.handle_message(event)
+            return
+
         if not self._should_process_message(msg):
             if self._should_observe_unmentioned_group_message(msg):
                 self._observe_unmentioned_group_message(msg, MessageType.TEXT, update_id=update.update_id)
             return
         await self._ensure_forum_commands(update.message)
-
-        event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
         event.text = self._clean_bot_trigger_text(event.text)
         event = self._apply_telegram_group_observe_attribution(event)
         self._enqueue_text_event(event)
@@ -5364,11 +5526,14 @@ class TelegramAdapter(BasePlatformAdapter):
         msg = self._effective_update_message(update)
         if not msg or not msg.text:
             return
+        event = self._build_message_event(msg, MessageType.COMMAND, update_id=update.update_id)
+        if self._message_has_pending_secret_capture(event):
+            await self.handle_message(event)
+            return
         if not self._should_process_message(msg, is_command=True):
             return
         await self._ensure_forum_commands(msg)
 
-        event = self._build_message_event(msg, MessageType.COMMAND, update_id=update.update_id)
         event.text = self._clean_bot_trigger_text(event.text)
         event = self._apply_telegram_group_observe_attribution(event)
         await self.handle_message(event)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6364,6 +6364,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # are system-generated and must skip user authorization.
         is_internal = bool(getattr(event, "internal", False))
 
+        _quick_key = self._session_key_for_source(source)
+
+        # Protected sensitive-input replies must preempt plugin hooks and every
+        # other text consumer so raw secrets cannot be logged, rewritten, or
+        # routed as ordinary chat.  Entries are bound to the original
+        # platform/chat/thread/user before the prompt is sent, so this early
+        # check still fails closed for unrelated users/sessions.
+        if not is_internal:
+            _secret_mod = None
+            try:
+                from tools import secret_capture_gateway as _secret_mod
+                _pending_secret = _secret_mod.get_pending_for_session(_quick_key, source=source)
+            except Exception:
+                _pending_secret = None
+            if _pending_secret is not None and _secret_mod is not None:
+                _raw_secret_reply = event.text or ""
+                if _raw_secret_reply != "":
+                    _resolved = _secret_mod.resolve_gateway_secret(
+                        _pending_secret.secret_id, _raw_secret_reply, source=source,
+                    )
+                    if _resolved:
+                        logger.info(
+                            "Gateway intercepted protected secret payload for env=%s",
+                            _pending_secret.env_var,
+                        )
+                        return ""
+
         # Fire pre_gateway_dispatch plugin hook for user-originated messages.
         # Plugins receive the MessageEvent and may return a dict influencing flow:
         #   {"action": "skip",    "reason": ...}    -> drop (no reply, plugin handled)
@@ -6460,7 +6487,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # IMPORTANT: recognized slash commands must bypass this interception.
         # Otherwise control/session commands like /new or /help get silently
         # consumed as update answers instead of being dispatched normally.
-        _quick_key = self._session_key_for_source(source)
         _update_prompts = getattr(self, "_update_prompt_pending", {})
         if _update_prompts.get(_quick_key):
             raw = (event.text or "").strip()
@@ -14270,6 +14296,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 set_current_session_key,
                 unregister_gateway_notify,
             )
+            from tools import secret_capture_gateway as _secret_capture_mod
 
             def _approval_notify_sync(approval_data: dict) -> None:
                 """Send the approval request to the user from the agent thread.
@@ -14350,6 +14377,51 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         _approval_send_fut.result(timeout=15)
                 except Exception as _e:
                     logger.error("Failed to send approval request: %s", _e)
+
+            def _secret_capture_notify_sync(entry) -> None:
+                """Send protected sensitive-input prompt from the agent thread."""
+                entry.bind_source(source)
+                timeout_seconds = _secret_capture_mod.get_secret_capture_timeout()
+                if getattr(type(_status_adapter), "send_secret_capture", None) is not None:
+                    _secret_fut = safe_schedule_threadsafe(
+                        _status_adapter.send_secret_capture(
+                            chat_id=_status_chat_id,
+                            prompt=entry.prompt,
+                            env_var=entry.env_var,
+                            secret_id=entry.secret_id,
+                            session_key=entry.session_key,
+                            metadata=_status_thread_metadata,
+                            timeout_seconds=timeout_seconds,
+                        ),
+                        _loop_for_step,
+                        logger=logger,
+                        log_message="send_secret_capture scheduling error",
+                    )
+                    if _secret_fut is None:
+                        raise RuntimeError("send_secret_capture: loop unavailable")
+                    _secret_result = _secret_fut.result()
+                    if not getattr(_secret_result, "success", False):
+                        raise RuntimeError(getattr(_secret_result, "error", "send_secret_capture failed"))
+
+            def _secret_capture_finalize_sync(entry, status: str) -> None:
+                if getattr(type(_status_adapter), "finalize_secret_capture", None) is None:
+                    return
+                _secret_final_fut = safe_schedule_threadsafe(
+                    _status_adapter.finalize_secret_capture(
+                        chat_id=_status_chat_id,
+                        secret_id=entry.secret_id,
+                        status=status,
+                        env_var=entry.env_var,
+                        metadata=_status_thread_metadata,
+                    ),
+                    _loop_for_step,
+                    logger=logger,
+                    log_message="finalize_secret_capture scheduling error",
+                )
+                # Do not block here. Finalization may be triggered from the
+                # gateway event loop while resolving a user message/callback;
+                # waiting on a coroutine scheduled to the same loop would stall
+                # the gateway until timeout.  The prompt update is best-effort.
 
             # Prepend pending model switch note so the model knows about the switch
             _pending_notes = getattr(self, '_pending_model_notes', {})
@@ -14443,6 +14515,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _approval_session_key = session_key or ""
             _approval_session_token = set_current_session_key(_approval_session_key)
             register_gateway_notify(_approval_session_key, _approval_notify_sync)
+            _secret_capture_mod.register_notify(_approval_session_key, _secret_capture_notify_sync)
+            _secret_capture_mod.register_finalize(_approval_session_key, _secret_capture_finalize_sync)
             try:
                 # If _prepare_inbound_message_text buffered image paths for native
                 # attachment, wrap the user turn as an OpenAI-style multimodal
@@ -14488,6 +14562,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 result = agent.run_conversation(_api_run_message, **_conversation_kwargs)
             finally:
                 unregister_gateway_notify(_approval_session_key)
+                _secret_capture_mod.unregister_notify(_approval_session_key)
                 # Cancel any pending clarify entries so blocked agent
                 # threads don't hang past the end of the run (interrupt,
                 # completion, gateway shutdown).  Idempotent.

--- a/tests/gateway/test_pre_gateway_dispatch.py
+++ b/tests/gateway/test_pre_gateway_dispatch.py
@@ -61,6 +61,35 @@ def _make_runner(platform: Platform):
 
 
 @pytest.mark.asyncio
+async def test_pending_secret_preempts_pre_gateway_dispatch(monkeypatch):
+    """Sensitive replies are captured before plugin hooks can see raw text."""
+    from tools import secret_capture_gateway
+
+    event = _make_event("super-secret-value")
+    runner, adapter = _make_runner(Platform.WHATSAPP)
+    session_key = runner._session_key_for_source(event.source)  # noqa: SLF001
+    entry = secret_capture_gateway.register("sid-prehook", session_key, "MY_SECRET", "Send it")
+    entry.bind_source(event.source)
+
+    called = {"value": False}
+
+    def _fake_hook(name, **kwargs):
+        called["value"] = True
+        raise AssertionError("pre_gateway_dispatch saw a secret payload")
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+    try:
+        result = await runner._handle_message(event)
+    finally:
+        secret_capture_gateway.clear_session(session_key)
+
+    assert result == ""
+    assert called["value"] is False
+    assert entry.value == "super-secret-value"
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_hook_skip_short_circuits_dispatch(monkeypatch):
     """A plugin returning {'action': 'skip'} drops the message before auth."""
     _clear_auth_env(monkeypatch)

--- a/tests/gateway/test_sensitive_input_active_session.py
+++ b/tests/gateway/test_sensitive_input_active_session.py
@@ -1,0 +1,56 @@
+"""Active-session bypass tests for protected sensitive input."""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.session import SessionSource, build_session_key
+
+
+class _Adapter(BasePlatformAdapter):
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id: str, content: str, reply_to=None, metadata=None) -> SendResult:
+        return SendResult(success=True, message_id="sent")
+
+    async def get_chat_info(self, chat_id: str):
+        return {}
+
+
+@pytest.mark.asyncio
+async def test_pending_secret_bypasses_active_session_queue(monkeypatch):
+    from tools import secret_capture_gateway
+
+    adapter = _Adapter(PlatformConfig(enabled=True, extra={}), Platform.TELEGRAM)
+    adapter._message_handler = AsyncMock(return_value="")
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="42",
+        user_name="Tester",
+    )
+    event = MessageEvent(
+        text="/looks-like-command-but-is-secret",
+        message_type=MessageType.COMMAND,
+        source=source,
+    )
+    session_key = build_session_key(source, group_sessions_per_user=True, thread_sessions_per_user=False)
+    adapter._active_sessions[session_key] = asyncio.Event()
+    entry = secret_capture_gateway.register("sid-active", session_key, "MY_SECRET", "Send it")
+    entry.bind_source(source)
+    try:
+        await adapter.handle_message(event)
+    finally:
+        secret_capture_gateway.clear_session(session_key)
+
+    adapter._message_handler.assert_awaited_once_with(event)
+    assert session_key not in adapter._pending_messages
+    assert entry.value is None  # Base adapter only routes; GatewayRunner resolves.

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -191,6 +191,44 @@ def test_unmentioned_group_messages_can_be_observed_without_dispatching():
     asyncio.run(_run())
 
 
+def test_pending_secret_bypasses_group_mention_filter_and_observe():
+    async def _run():
+        from gateway.session import build_session_key
+        from tools import secret_capture_gateway
+
+        adapter = _make_adapter(
+            require_mention=True,
+            allowed_chats=["-100"],
+            group_allowed_chats=["-100"],
+            observe_unmentioned_group_messages=True,
+        )
+        store = _FakeSessionStore()
+        adapter._session_store = store
+        adapter.handle_message = AsyncMock()
+        msg = _group_message("super-secret-value")
+        event = adapter._build_message_event(msg, MessageType.TEXT, update_id=1002)
+        session_key = build_session_key(
+            event.source,
+            group_sessions_per_user=adapter.config.extra.get("group_sessions_per_user", True),
+            thread_sessions_per_user=adapter.config.extra.get("thread_sessions_per_user", False),
+        )
+        entry = secret_capture_gateway.register("sid-group", session_key, "MY_SECRET", "Send it")
+        entry.bind_source(event.source)
+        try:
+            update = SimpleNamespace(update_id=1002, message=msg, effective_message=None)
+            await adapter._handle_text_message(update, SimpleNamespace())
+        finally:
+            secret_capture_gateway.clear_session(session_key)
+
+        adapter.handle_message.assert_awaited_once()
+        dispatched = adapter.handle_message.await_args.args[0]
+        assert dispatched.text == "super-secret-value"
+        assert dispatched.source.user_id == "111"
+        assert store.messages == []
+
+    asyncio.run(_run())
+
+
 def test_observed_group_context_uses_shared_source_and_prompt_for_later_mentions():
     async def _run():
         adapter = _make_adapter(

--- a/tests/gateway/test_telegram_sensitive_input.py
+++ b/tests/gateway/test_telegram_sensitive_input.py
@@ -1,0 +1,136 @@
+"""Tests for Telegram protected sensitive-input prompts."""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN = "Markdown"
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.constants.ChatType.PRIVATE = "private"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+_ensure_telegram_mock()
+
+from gateway.config import PlatformConfig
+from gateway.platforms.telegram import TelegramAdapter
+
+
+def _make_adapter(extra=None):
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token", extra=extra or {}))
+    adapter._bot = AsyncMock()
+    adapter._app = MagicMock()
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_send_secret_capture_renders_precise_prompt_and_cancel_button():
+    adapter = _make_adapter()
+    mock_msg = MagicMock()
+    mock_msg.message_id = 321
+    assert adapter._bot is not None
+    adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+    result = await adapter.send_secret_capture(
+        chat_id="12345",
+        prompt="Send <token>",
+        env_var="MY_SECRET",
+        secret_id="sid1",
+        session_key="session1",
+        metadata={"thread_id": "777", "reply_to_message_id": "555"},
+        timeout_seconds=600,
+    )
+
+    assert result.success is True
+    assert result.message_id == "321"
+    kwargs = adapter._bot.send_message.call_args.kwargs
+    assert kwargs["chat_id"] == 12345
+    assert "Protected sensitive input" in kwargs["text"]
+    assert "Send &lt;token&gt;" in kwargs["text"]
+    assert "including slash commands" in kwargs["text"]
+    assert "Use the Cancel button" in kwargs["text"]
+    assert "agent model will not receive" in kwargs["text"]
+    assert kwargs["reply_markup"] is not None
+    assert adapter._secret_capture_state["sid1"]["session_key"] == "session1"
+    assert adapter._secret_capture_prompt_messages["sid1"] == 321
+
+
+@pytest.mark.asyncio
+async def test_finalize_secret_capture_edits_prompt_and_clears_state():
+    adapter = _make_adapter()
+    assert adapter._bot is not None
+    adapter._bot.edit_message_text = AsyncMock()
+    adapter._secret_capture_state["sid2"] = {"session_key": "session2", "env_var": "MY_SECRET", "chat_id": "12345"}
+    adapter._secret_capture_prompt_messages["sid2"] = 654
+
+    result = await adapter.finalize_secret_capture(
+        chat_id="12345",
+        secret_id="sid2",
+        status="timeout",
+        env_var="MY_SECRET",
+    )
+
+    assert result.success is True
+    assert "sid2" not in adapter._secret_capture_state
+    assert "sid2" not in adapter._secret_capture_prompt_messages
+    kwargs = adapter._bot.edit_message_text.call_args.kwargs
+    assert kwargs["message_id"] == 654
+    assert "expired" in kwargs["text"]
+    assert kwargs["reply_markup"] is None
+
+
+@pytest.mark.asyncio
+async def test_secret_capture_cancel_callback_resolves_and_edits(monkeypatch):
+    from tools import secret_capture_gateway
+
+    adapter = _make_adapter()
+    adapter._secret_capture_state["sid3"] = {"session_key": "session3", "env_var": "MY_SECRET", "chat_id": "12345"}
+    adapter._secret_capture_prompt_messages["sid3"] = 111
+
+    entry = secret_capture_gateway.register("sid3", "session3", "MY_SECRET", "Send it")
+    from gateway.session import SessionSource
+    from gateway.config import Platform
+    entry.bind_source(SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm", user_id="42"))
+    try:
+        query = MagicMock()
+        query.data = "sgc:cancel:sid3"
+        query.message.chat_id = 12345
+        query.message.chat.type = "private"
+        query.message.message_thread_id = None
+        query.from_user.id = "42"
+        query.from_user.first_name = "Tester"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+        update = MagicMock()
+        update.callback_query = query
+        monkeypatch.setattr(adapter, "_is_callback_user_authorized", lambda *a, **kw: True)
+
+        await adapter._handle_callback_query(update, MagicMock())
+
+        assert entry.cancelled is True
+        assert entry.reason == "button_cancelled"
+        assert "sid3" not in adapter._secret_capture_state
+        query.edit_message_text.assert_awaited()
+    finally:
+        secret_capture_gateway.clear_session("session3")

--- a/tests/tools/test_sensitive_input_tool.py
+++ b/tests/tools/test_sensitive_input_tool.py
@@ -1,0 +1,140 @@
+import json
+import threading
+import time
+
+
+class _Source:
+    platform = type("P", (), {"value": "telegram"})()
+    chat_id = "chat1"
+    thread_id = "topic1"
+    user_id = "user1"
+    message_id = "m1"
+
+
+class _OtherSource:
+    platform = type("P", (), {"value": "telegram"})()
+    chat_id = "chat1"
+    thread_id = "topic1"
+    user_id = "user2"
+    message_id = "m2"
+
+
+def test_request_sensitive_input_unavailable_does_not_leak(monkeypatch):
+    from tools import sensitive_input_tool
+    from tools import secret_capture_gateway
+
+    monkeypatch.setattr(secret_capture_gateway, "get_notify", lambda session_key: None)
+    result = json.loads(sensitive_input_tool.request_sensitive_input("MY_SECRET", "Send it"))
+    assert result["success"] is False
+    assert result["secret_capture_status"] == "unavailable"
+    assert "super-secret-value" not in json.dumps(result)
+
+
+def test_request_sensitive_input_uses_cli_secret_callback_when_available(monkeypatch):
+    from tools import sensitive_input_tool
+    from tools import secret_capture_gateway
+    from tools import skills_tool
+
+    monkeypatch.setattr("tools.approval.get_current_session_key", lambda default="": "s-cli")
+    monkeypatch.setattr(secret_capture_gateway, "get_notify", lambda session_key: None)
+    skills_tool.set_secret_capture_callback(
+        lambda env_var, prompt: {
+            "success": True,
+            "stored_as": env_var,
+            "validated": False,
+            "skipped": False,
+            "value": "super-secret-value",
+        }
+    )
+    try:
+        result = json.loads(sensitive_input_tool.request_sensitive_input("MY_SECRET", "Send it"))
+    finally:
+        skills_tool.set_secret_capture_callback(None)
+
+    assert result["success"] is True
+    assert result["stored_as"] == "MY_SECRET"
+    assert result["secret_capture_status"] == "stored"
+    assert "super-secret-value" not in json.dumps(result)
+
+
+def test_request_sensitive_input_stores_safe_receipt(monkeypatch):
+    from tools import sensitive_input_tool
+    from tools import secret_capture_gateway
+
+    saved = {}
+    monkeypatch.setattr("tools.approval.get_current_session_key", lambda default="": "s1")
+
+    def fake_save(key, value):
+        saved["key"] = key
+        saved["value"] = value
+        return {"success": True, "stored_as": key, "value": value, "secret": value}
+
+    monkeypatch.setattr("hermes_cli.config.save_env_value_secure", fake_save)
+
+    def notify(entry):
+        def resolve():
+            time.sleep(0.05)
+            secret_capture_gateway.resolve_gateway_secret(entry.secret_id, "super-secret-value")
+        threading.Thread(target=resolve, daemon=True).start()
+
+    secret_capture_gateway.register_notify("s1", notify)
+    try:
+        result = json.loads(sensitive_input_tool.request_sensitive_input("MY_SECRET", "Send it", timeout_seconds=2))
+    finally:
+        secret_capture_gateway.unregister_notify("s1")
+
+    assert saved == {"key": "MY_SECRET", "value": "super-secret-value"}
+    assert result["success"] is True
+    assert result["stored_as"] == "MY_SECRET"
+    assert result["secret_capture_status"] == "stored"
+    assert "super-secret-value" not in json.dumps(result)
+
+
+def test_secret_capture_resolve_is_single_use_and_source_bound():
+    from tools import secret_capture_gateway
+
+    entry = secret_capture_gateway.register("sid-atomic", "session-atomic", "MY_SECRET", "Send it")
+    entry.bind_source(_Source())
+    try:
+        assert secret_capture_gateway.resolve_gateway_secret("sid-atomic", "wrong", source=_OtherSource()) is False
+        assert secret_capture_gateway.resolve_gateway_secret("sid-atomic", "first", source=_Source()) is True
+        assert secret_capture_gateway.resolve_gateway_secret("sid-atomic", "second", source=_Source()) is False
+        assert secret_capture_gateway.cancel_gateway_secret("sid-atomic", "button_cancelled", source=_Source()) is False
+        assert entry.value == "first"
+        assert entry.cancelled is False
+    finally:
+        secret_capture_gateway.clear_session("session-atomic")
+
+
+def test_secret_capture_timeout_marks_reason_and_finalize_callback():
+    from tools import secret_capture_gateway
+
+    statuses = []
+    entry = secret_capture_gateway.register("sid-timeout", "session-timeout", "MY_SECRET", "Send it")
+    secret_capture_gateway.register_finalize("session-timeout", lambda e, status: statuses.append((e.secret_id, status)))
+    try:
+        resolved = secret_capture_gateway.wait_for_response("sid-timeout", timeout=0)
+        assert resolved is entry
+        assert resolved is not None
+        assert resolved.cancelled is True
+        assert resolved.reason == "timeout"
+        assert statuses == [("sid-timeout", "timeout")]
+        assert secret_capture_gateway.resolve_gateway_secret("sid-timeout", "late") is False
+    finally:
+        secret_capture_gateway.unregister_notify("session-timeout")
+
+
+def test_request_sensitive_input_timeout_reports_timeout(monkeypatch):
+    from tools import sensitive_input_tool
+    from tools import secret_capture_gateway
+
+    monkeypatch.setattr("tools.approval.get_current_session_key", lambda default="": "s-timeout")
+    secret_capture_gateway.register_notify("s-timeout", lambda entry: None)
+    try:
+        result = json.loads(sensitive_input_tool.request_sensitive_input("MY_SECRET", "Send it", timeout_seconds=0))
+    finally:
+        secret_capture_gateway.unregister_notify("s-timeout")
+
+    assert result["success"] is False
+    assert result["secret_capture_status"] == "timeout"
+    assert result["skipped"] is True

--- a/tools/secret_capture_gateway.py
+++ b/tools/secret_capture_gateway.py
@@ -1,0 +1,250 @@
+"""Gateway-side protected secret/sensitive-input capture.
+
+A tool call registers a pending request, the gateway sends a user-facing prompt,
+and the next typed message from the same user/session is captured as sensitive
+payload instead of being appended to normal chat history.  Only safe metadata is
+returned to the LLM/tool result; the raw value is written locally by the tool
+callback.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+FinalizeCallback = Callable[["_SecretCaptureEntry", str], None]
+NotifyCallback = Callable[["_SecretCaptureEntry"], None]
+
+
+@dataclass
+class _SecretCaptureEntry:
+    secret_id: str
+    session_key: str
+    env_var: str
+    prompt: str
+    event: threading.Event = field(default_factory=threading.Event)
+    value: Optional[str] = None
+    cancelled: bool = False
+    reason: str = ""
+    resolved: bool = False
+    # Bound by the gateway notification callback before the prompt is sent.
+    platform: str = ""
+    chat_id: str = ""
+    thread_id: str = ""
+    user_id: str = ""
+    message_id: str = ""
+
+    def signature(self) -> Dict[str, str]:
+        return {
+            "secret_id": self.secret_id,
+            "session_key": self.session_key,
+            "env_var": self.env_var,
+            "prompt": self.prompt,
+        }
+
+    def bind_source(self, source: Any) -> None:
+        """Attach routing/user identity metadata from a gateway SessionSource."""
+        self.platform = str(getattr(getattr(source, "platform", None), "value", "") or "")
+        self.chat_id = str(getattr(source, "chat_id", "") or "")
+        self.thread_id = str(getattr(source, "thread_id", "") or "")
+        self.user_id = str(getattr(source, "user_id", "") or "")
+        self.message_id = str(getattr(source, "message_id", "") or "")
+
+    def matches_source(self, source: Any) -> bool:
+        """Return True if a reply/callback is allowed to resolve this entry."""
+        if not self.platform and not self.chat_id and not self.user_id:
+            # Backward-compatible for unit tests and non-gateway callers that do
+            # not bind a source. Gateway-bound entries are always bound before
+            # the prompt is sent.
+            return True
+        platform = str(getattr(getattr(source, "platform", None), "value", "") or "")
+        chat_id = str(getattr(source, "chat_id", "") or "")
+        thread_id = str(getattr(source, "thread_id", "") or "")
+        user_id = str(getattr(source, "user_id", "") or "")
+        if self.platform and platform != self.platform:
+            return False
+        if self.chat_id and chat_id != self.chat_id:
+            return False
+        if self.thread_id and thread_id != self.thread_id:
+            return False
+        if self.user_id and user_id != self.user_id:
+            return False
+        return True
+
+
+_lock = threading.RLock()
+_entries: Dict[str, _SecretCaptureEntry] = {}
+_session_index: Dict[str, list[str]] = {}
+_notify_cbs: Dict[str, NotifyCallback] = {}
+_finalize_cbs: Dict[str, FinalizeCallback] = {}
+
+
+def _remove_entry_locked(entry: _SecretCaptureEntry) -> None:
+    _entries.pop(entry.secret_id, None)
+    ids = _session_index.get(entry.session_key)
+    if ids and entry.secret_id in ids:
+        ids.remove(entry.secret_id)
+        if not ids:
+            _session_index.pop(entry.session_key, None)
+
+
+def _finalize(entry: _SecretCaptureEntry, status: str) -> None:
+    cb = None
+    with _lock:
+        cb = _finalize_cbs.get(entry.session_key)
+    if cb is None:
+        return
+    try:
+        cb(entry, status)
+    except Exception:
+        logger.debug("secret-capture finalize callback failed", exc_info=True)
+
+
+def register(secret_id: str, session_key: str, env_var: str, prompt: str) -> _SecretCaptureEntry:
+    entry = _SecretCaptureEntry(
+        secret_id=secret_id,
+        session_key=session_key or "",
+        env_var=env_var,
+        prompt=prompt,
+    )
+    with _lock:
+        _entries[secret_id] = entry
+        _session_index.setdefault(entry.session_key, []).append(secret_id)
+    return entry
+
+
+def wait_for_response(secret_id: str, timeout: float) -> Optional[_SecretCaptureEntry]:
+    with _lock:
+        entry = _entries.get(secret_id)
+    if entry is None:
+        return None
+
+    try:
+        from tools.environments.base import touch_activity_if_due
+    except Exception:  # pragma: no cover
+        touch_activity_if_due = None
+
+    deadline = time.monotonic() + max(timeout, 0.0)
+    activity_state = {"last_touch": time.monotonic(), "start": time.monotonic()}
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        if entry.event.wait(timeout=min(1.0, remaining)):
+            break
+        if touch_activity_if_due is not None:
+            touch_activity_if_due(activity_state, "waiting for user secret input")
+
+    timed_out = False
+    with _lock:
+        current = _entries.get(secret_id)
+        if current is entry:
+            # No resolver/canceller won the race before timeout.
+            entry.cancelled = True
+            entry.reason = entry.reason or "timeout"
+            timed_out = True
+            _remove_entry_locked(entry)
+    if timed_out:
+        entry.event.set()
+        _finalize(entry, "timeout")
+    return entry
+
+
+def resolve_gateway_secret(secret_id: str, value: str, source: Any = None) -> bool:
+    with _lock:
+        entry = _entries.get(secret_id)
+        if entry is None or entry.resolved or entry.cancelled:
+            return False
+        if source is not None and not entry.matches_source(source):
+            return False
+        entry.value = str(value) if value is not None else ""
+        entry.cancelled = False
+        entry.resolved = True
+        _remove_entry_locked(entry)
+        entry.event.set()
+    _finalize(entry, "received")
+    return True
+
+
+def cancel_gateway_secret(secret_id: str, reason: str = "cancelled", source: Any = None) -> bool:
+    with _lock:
+        entry = _entries.get(secret_id)
+        if entry is None or entry.resolved or entry.cancelled:
+            return False
+        if source is not None and not entry.matches_source(source):
+            return False
+        entry.value = None
+        entry.cancelled = True
+        entry.reason = reason or "cancelled"
+        _remove_entry_locked(entry)
+        entry.event.set()
+    _finalize(entry, entry.reason or "cancelled")
+    return True
+
+
+def get_pending_for_session(session_key: str, source: Any = None) -> Optional[_SecretCaptureEntry]:
+    with _lock:
+        ids = list(_session_index.get(session_key or "") or [])
+        for sid in ids:
+            entry = _entries.get(sid)
+            if entry is not None and (source is None or entry.matches_source(source)):
+                return entry
+    return None
+
+
+def has_pending(session_key: str) -> bool:
+    return get_pending_for_session(session_key) is not None
+
+
+def clear_session(session_key: str) -> int:
+    with _lock:
+        ids = list(_session_index.pop(session_key or "", []) or [])
+        entries = [_entries.pop(sid, None) for sid in ids]
+    cancelled = 0
+    for entry in entries:
+        if entry is None:
+            continue
+        entry.cancelled = True
+        entry.reason = "session_cleared"
+        entry.event.set()
+        cancelled += 1
+        _finalize(entry, "session_cleared")
+    return cancelled
+
+
+def register_notify(session_key: str, cb: NotifyCallback) -> None:
+    with _lock:
+        _notify_cbs[session_key or ""] = cb
+
+
+def register_finalize(session_key: str, cb: FinalizeCallback) -> None:
+    with _lock:
+        _finalize_cbs[session_key or ""] = cb
+
+
+def unregister_notify(session_key: str) -> None:
+    # Clear pending entries while the finalize callback is still registered so
+    # platform prompts can be edited/expired during agent interruption/cleanup.
+    clear_session(session_key or "")
+    with _lock:
+        _notify_cbs.pop(session_key or "", None)
+        _finalize_cbs.pop(session_key or "", None)
+
+
+def get_notify(session_key: str) -> Optional[NotifyCallback]:
+    with _lock:
+        return _notify_cbs.get(session_key or "")
+
+
+def get_secret_capture_timeout() -> int:
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config() or {}
+        agent_cfg = cfg.get("agent", {}) or {}
+        return int(agent_cfg.get("secret_capture_timeout", agent_cfg.get("clarify_timeout", 600)))
+    except Exception:
+        return 600

--- a/tools/sensitive_input_tool.py
+++ b/tools/sensitive_input_tool.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Protected sensitive-input tool.
+
+The agent can request one secret value from the current user/session without the
+raw value entering LLM-visible tool results.  In gateway mode the next typed
+message from the same user/session is intercepted by
+``tools.secret_capture_gateway``; in contexts without a gateway callback the
+tool fails closed and tells the agent not to ask for the secret in normal chat.
+"""
+from __future__ import annotations
+
+import json
+import re
+import uuid
+
+from tools.registry import registry, tool_error
+
+_ENV_VAR_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _safe_error(code: str, env_var: str, message: str | None = None) -> str:
+    payload = {
+        "success": False,
+        "stored_as": env_var,
+        "secret_capture_status": code,
+        "error": code,
+    }
+    if message:
+        payload["message"] = message
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def request_sensitive_input(env_var: str, prompt: str, timeout_seconds: int | None = None) -> str:
+    env_var = (env_var or "").strip()
+    prompt = (prompt or "").strip()
+    if not env_var or not _ENV_VAR_RE.match(env_var):
+        return tool_error("env_var must be a valid environment variable name.")
+    if not prompt:
+        return tool_error("prompt is required.")
+
+    try:
+        from tools.approval import get_current_session_key
+        from tools import secret_capture_gateway as scg
+    except Exception:
+        return _safe_error(
+            "unavailable",
+            env_var,
+            "Protected sensitive input is not available in this session. Do not ask the user to paste the secret in normal chat.",
+        )
+
+    session_key = get_current_session_key("")
+    notify = scg.get_notify(session_key)
+    if notify is None:
+        # Local CLI already has a masked secret-entry bridge for skill setup.
+        # Reuse it when present so the tool is not advertised in CLI only to
+        # fail at runtime.  The callback returns a safe receipt and never
+        # exposes the raw value to the model.
+        try:
+            from tools import skills_tool as _skills_tool
+            callback = getattr(_skills_tool, "_secret_capture_callback", None)
+            if callback is not None:
+                receipt = callback(env_var, prompt) or {}
+                if receipt.get("success") and not receipt.get("skipped"):
+                    receipt = dict(receipt)
+                    receipt["secret_capture_status"] = "stored"
+                    receipt.pop("value", None)
+                    receipt.pop("secret", None)
+                    return json.dumps(receipt, ensure_ascii=False)
+        except Exception:
+            pass
+        return _safe_error(
+            "unavailable",
+            env_var,
+            "Protected sensitive input is not available in this session. Do not ask the user to paste the secret in normal chat.",
+        )
+
+    secret_id = uuid.uuid4().hex[:12]
+    entry = scg.register(secret_id, session_key, env_var, prompt)
+    try:
+        notify(entry)
+    except Exception:
+        scg.clear_session(session_key)
+        return _safe_error("send_failed", env_var)
+
+    try:
+        timeout = int(timeout_seconds) if timeout_seconds is not None else int(scg.get_secret_capture_timeout())
+    except Exception:
+        timeout = scg.get_secret_capture_timeout()
+    resolved = scg.wait_for_response(secret_id, timeout=float(timeout))
+    if resolved is None:
+        return _safe_error("missing_state", env_var)
+    if resolved.cancelled:
+        status = resolved.reason or "cancelled"
+        return json.dumps({
+            "success": False,
+            "stored_as": env_var,
+            "secret_capture_status": status,
+            "skipped": True,
+        }, ensure_ascii=False)
+    if not resolved.value:
+        return json.dumps({
+            "success": False,
+            "stored_as": env_var,
+            "secret_capture_status": "empty",
+            "skipped": True,
+        }, ensure_ascii=False)
+
+    try:
+        from hermes_cli.config import save_env_value_secure
+        receipt = save_env_value_secure(env_var, resolved.value)
+    except Exception:
+        # Do not echo exception details after a secret has been captured; some
+        # lower layers may include values or file snippets in error strings.
+        return _safe_error("store_failed", env_var)
+    receipt.update({
+        "secret_capture_status": "stored",
+        "message": f"Stored {env_var} via protected sensitive-input capture.",
+    })
+    # Defense-in-depth: never include the raw value in LLM-visible output.
+    receipt.pop("value", None)
+    receipt.pop("secret", None)
+    return json.dumps(receipt, ensure_ascii=False)
+
+
+def check_sensitive_input_requirements() -> bool:
+    return True
+
+
+REQUEST_SENSITIVE_INPUT_SCHEMA = {
+    "name": "request_sensitive_input",
+    "description": (
+        "Request a password, OTP, API key, token, or other secret from the user "
+        "via protected local/gateway capture. The next typed payload is stored "
+        "locally under env_var and is never returned to the model. Use this instead "
+        "of asking for secrets in normal chat."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "env_var": {
+                "type": "string",
+                "description": "Environment variable / local alias to store, e.g. TDLIB_TEST_PASSWORD.",
+            },
+            "prompt": {
+                "type": "string",
+                "description": "User-facing prompt explaining exactly what secret to send.",
+            },
+            "timeout_seconds": {
+                "type": "integer",
+                "description": "Optional wait timeout in seconds. Defaults to agent.secret_capture_timeout or clarify_timeout.",
+            },
+        },
+        "required": ["env_var", "prompt"],
+    },
+}
+
+
+registry.register(
+    name="request_sensitive_input",
+    toolset="sensitive_input",
+    schema=REQUEST_SENSITIVE_INPUT_SCHEMA,
+    handler=lambda args, **kw: request_sensitive_input(
+        env_var=args.get("env_var", ""),
+        prompt=args.get("prompt", ""),
+        timeout_seconds=args.get("timeout_seconds"),
+    ),
+    check_fn=check_sensitive_input_requirements,
+    emoji="🔐",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -53,8 +53,8 @@ _HERMES_CORE_TOOLS = [
     "todo", "memory",
     # Session history search
     "session_search",
-    # Clarifying questions
-    "clarify",
+    # Clarifying questions and protected secret input
+    "clarify", "request_sensitive_input",
     # Code execution + delegation
     "execute_code", "delegate_task",
     # Cronjob management
@@ -334,6 +334,13 @@ TOOLSETS = {
         "includes": ["web", "file"]  # For searching error messages and solutions, and file operations
     },
     
+
+    "sensitive_input": {
+        "description": "Protected password/API-key/OTP capture without exposing the raw value to the model",
+        "tools": ["request_sensitive_input"],
+        "includes": []
+    },
+
     "safe": {
         "description": "Safe toolkit without terminal access",
         "tools": [],

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -20,6 +20,26 @@ The security model has seven layers:
 6. **Cross-session isolation** — sessions cannot access each other's data or state; cron job storage paths are hardened against path traversal attacks
 7. **Input sanitization** — working directory parameters in terminal tool backends are validated against an allowlist to prevent shell injection
 
+## Protected sensitive input
+
+When Hermes needs a password, OTP, API key, token, or similar secret during an agent task, it should use the `request_sensitive_input` tool instead of asking the user to paste the value into normal chat.
+
+What happens:
+
+1. The agent calls `request_sensitive_input(env_var, prompt)`.
+2. Hermes sends a platform-native protected prompt. On Telegram this includes a **Cancel** button.
+3. The next typed message from the same user/session is intercepted before plugin hooks, update prompts, slash commands, clarify prompts, and normal agent dispatch.
+4. That message is stored locally under the requested env var and is not appended to chat history or returned in the tool result.
+5. The prompt is finalized as received, cancelled, or expired so stale prompts do not keep inviting users to send secrets.
+
+Important limitations:
+
+- The value is still delivered to the local Hermes process and stored locally (normally in `.env`); it is not a remote vault.
+- Platform providers may retain the original user message in their own chat history.
+- If a prompt expires or the gateway restarts, start a new protected request before sending the value.
+- While a protected prompt is pending, anything typed — including slash commands — is treated as the secret payload. Use the platform cancel control to cancel.
+
+
 ## Dangerous Command Approval
 
 Before executing any command, Hermes checks it against a curated list of dangerous patterns. If a match is found, the user must explicitly approve it.


### PR DESCRIPTION
## Summary

Adds a protected `request_sensitive_input` tool for passwords, OTPs, API keys, and similar secrets in gateway sessions.

The tool asks the user through a platform-native prompt and captures the next reply from the same user/session before it can enter normal chat history, plugin hooks, update prompts, slash commands, clarify prompts, text batching, or active-session follow-up queues. The raw value is stored locally via `save_env_value_secure`; tool results only contain safe receipt metadata.

Telegram gets a dedicated prompt with a Cancel button and terminal prompt states for received/cancelled/expired.

## Security/UX notes

- Secret replies are source-bound to the original platform/chat/thread/user.
- Slash-prefixed values are captured as payload while a secret prompt is pending.
- Telegram group mention filters and observed-unmentioned logging are bypassed for pending secret replies so raw secrets are not stored as group context.
- Active-session queueing is bypassed so a waiting `request_sensitive_input` tool can resolve immediately.
- Timeout/cancel/session cleanup finalizes prompt state where supported.
- CLI uses the existing masked secret-capture callback when available; otherwise the tool fails closed.

## Tests

- `python -m py_compile tools/sensitive_input_tool.py tools/secret_capture_gateway.py gateway/run.py gateway/platforms/base.py gateway/platforms/telegram.py toolsets.py`
- `python -m pytest tests/tools/test_sensitive_input_tool.py tests/gateway/test_sensitive_input_active_session.py tests/gateway/test_pre_gateway_dispatch.py tests/gateway/test_telegram_sensitive_input.py tests/gateway/test_telegram_group_gating.py tests/cli/test_cli_secret_capture.py tests/gateway/test_telegram_clarify_buttons.py tests/gateway/test_platform_base.py -q`
- `git diff --cached --check`

Local result: `228 passed in 4.29s`.
