### PR TITLE
feat(kanban): non-blocking 'tracking' link kind for organizational epics

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -495,6 +495,13 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_link = sub.add_parser("link", help="Add a parent->child dependency")
     p_link.add_argument("parent_id")
     p_link.add_argument("child_id")
+    p_link.add_argument(
+        "--kind", choices=("blocking", "tracking"), default="blocking",
+        help="'blocking' (default) gates the child until the parent is done; "
+             "'tracking' is organizational only (tracking epics) and never "
+             "gates. On an EXISTING edge, --kind converts it in place and "
+             "re-evaluates the child's readiness. (t_a3bebeea)",
+    )
     p_unlink = sub.add_parser("unlink", help="Remove a parent->child dependency")
     p_unlink.add_argument("parent_id")
     p_unlink.add_argument("child_id")
@@ -1797,9 +1804,27 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
 
 
 def _cmd_link(args: argparse.Namespace) -> int:
+    kind = getattr(args, "kind", "blocking")
     with kb.connect_closing() as conn:
-        kb.link_tasks(conn, args.parent_id, args.child_id)
-    print(f"Linked {args.parent_id} -> {args.child_id}")
+        existing = conn.execute(
+            "SELECT link_kind FROM task_links "
+            "WHERE parent_id = ? AND child_id = ?",
+            (args.parent_id, args.child_id),
+        ).fetchone()
+        if existing is not None:
+            # Edge already exists: --kind converts it in place (INSERT OR
+            # IGNORE in link_tasks would silently keep the old kind).
+            if existing["link_kind"] == kind:
+                print(f"Already linked {args.parent_id} -> {args.child_id} ({kind})")
+                return 0
+            kb.set_link_kind(conn, args.parent_id, args.child_id, kind)
+            print(
+                f"Converted link {args.parent_id} -> {args.child_id} "
+                f"to {kind} (child readiness re-evaluated)"
+            )
+            return 0
+        kb.link_tasks(conn, args.parent_id, args.child_id, kind=kind)
+    print(f"Linked {args.parent_id} -> {args.child_id} ({kind})")
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1043,6 +1043,10 @@ CREATE TABLE IF NOT EXISTS tasks (
 CREATE TABLE IF NOT EXISTS task_links (
     parent_id  TEXT NOT NULL,
     child_id   TEXT NOT NULL,
+    -- 'blocking' (default): parent must be done/archived before the child can
+    -- be claimed (the classic dependency edge). 'tracking': organizational
+    -- membership only (e.g. a tracking epic) — never gates the child.
+    link_kind  TEXT NOT NULL DEFAULT 'blocking',
     PRIMARY KEY (parent_id, child_id)
 );
 
@@ -1578,6 +1582,23 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
 
     Called by ``init_db`` so opening an old DB is always safe.
     """
+    # task_links.link_kind ('blocking' | 'tracking') — added 2026-06-09
+    # (t_a3bebeea). NOT NULL DEFAULT backfills every legacy row as 'blocking',
+    # so existing links keep their gating semantics unchanged. Skip when the
+    # table itself doesn't exist yet (pre-task_links legacy DBs): the schema
+    # CREATE TABLE that follows creates it with the column already in place.
+    if conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='task_links'"
+    ).fetchone():
+        link_cols = {
+            row["name"] for row in conn.execute("PRAGMA table_info(task_links)")
+        }
+        if "link_kind" not in link_cols:
+            _add_column_if_missing(
+                conn, "task_links", "link_kind",
+                "link_kind TEXT NOT NULL DEFAULT 'blocking'",
+            )
+
     cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
     if "tenant" not in cols:
         _add_column_if_missing(conn, "tasks", "tenant", "tenant TEXT")
@@ -2410,9 +2431,17 @@ def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) 
 # Links
 # ---------------------------------------------------------------------------
 
-def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
+LINK_KINDS = ("blocking", "tracking")
+
+
+def link_tasks(
+    conn: sqlite3.Connection, parent_id: str, child_id: str,
+    kind: str = "blocking",
+) -> None:
     if parent_id == child_id:
         raise ValueError("a task cannot depend on itself")
+    if kind not in LINK_KINDS:
+        raise ValueError(f"unknown link kind {kind!r} (expected one of {LINK_KINDS})")
     with write_txn(conn):
         missing = _find_missing_parents(conn, [parent_id, child_id])
         if missing:
@@ -2422,22 +2451,54 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
                 f"linking {parent_id} -> {child_id} would create a cycle"
             )
         conn.execute(
-            "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
-            (parent_id, child_id),
+            "INSERT OR IGNORE INTO task_links (parent_id, child_id, link_kind) "
+            "VALUES (?, ?, ?)",
+            (parent_id, child_id, kind),
         )
         # If child was ready but parent is not yet done, demote child to todo.
-        parent_status = conn.execute(
-            "SELECT status FROM tasks WHERE id = ?", (parent_id,)
-        ).fetchone()["status"]
-        if parent_status != "done":
-            conn.execute(
-                "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'ready'",
-                (child_id,),
-            )
+        # Tracking links are organizational only — they never demote.
+        if kind == "blocking":
+            parent_status = conn.execute(
+                "SELECT status FROM tasks WHERE id = ?", (parent_id,)
+            ).fetchone()["status"]
+            if parent_status != "done":
+                conn.execute(
+                    "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'ready'",
+                    (child_id,),
+                )
         _append_event(
             conn, child_id, "linked",
-            {"parent": parent_id, "child": child_id},
+            {"parent": parent_id, "child": child_id, "kind": kind},
         )
+
+
+def set_link_kind(
+    conn: sqlite3.Connection, parent_id: str, child_id: str, kind: str,
+) -> bool:
+    """Convert an existing parent->child edge between 'blocking' and 'tracking'.
+
+    The operator affordance for a wedged tracking epic: flip the edge to
+    'tracking' and the child stops being gated. Runs ``recompute_ready`` so a
+    todo child whose only gate was this edge promotes immediately. Returns
+    ``False`` when the edge does not exist. (t_a3bebeea)
+    """
+    if kind not in LINK_KINDS:
+        raise ValueError(f"unknown link kind {kind!r} (expected one of {LINK_KINDS})")
+    with write_txn(conn):
+        cur = conn.execute(
+            "UPDATE task_links SET link_kind = ? "
+            "WHERE parent_id = ? AND child_id = ?",
+            (kind, parent_id, child_id),
+        )
+        if cur.rowcount != 1:
+            return False
+        _append_event(
+            conn, child_id, "link_kind_changed",
+            {"parent": parent_id, "child": child_id, "kind": kind},
+        )
+    # Outside the write txn: re-evaluate gating now that the edge changed.
+    recompute_ready(conn)
+    return True
 
 
 def _would_cycle(conn: sqlite3.Connection, parent_id: str, child_id: str) -> bool:
@@ -2929,7 +2990,7 @@ def recompute_ready(
             parents = conn.execute(
                 "SELECT t.status FROM tasks t "
                 "JOIN task_links l ON l.parent_id = t.id "
-                "WHERE l.child_id = ?",
+                "WHERE l.child_id = ? AND l.link_kind = 'blocking'",
                 (task_id,),
             ).fetchall()
             if all(p["status"] in ("done", "archived") for p in parents):
@@ -2996,7 +3057,8 @@ def claim_task(
         undone = conn.execute(
             "SELECT 1 FROM task_links l "
             "JOIN tasks p ON p.id = l.parent_id "
-            "WHERE l.child_id = ? AND p.status NOT IN ('done', 'archived') LIMIT 1",
+            "WHERE l.child_id = ? AND l.link_kind = 'blocking' "
+            "AND p.status NOT IN ('done', 'archived') LIMIT 1",
             (task_id,),
         ).fetchone()
         if undone:
@@ -4201,7 +4263,7 @@ def promote_task(
         parents = conn.execute(
             "SELECT t.id, t.status FROM tasks t "
             "JOIN task_links l ON l.parent_id = t.id "
-            "WHERE l.child_id = ?",
+            "WHERE l.child_id = ? AND l.link_kind = 'blocking'",
             (task_id,),
         ).fetchall()
         unsatisfied = [
@@ -4272,7 +4334,8 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
         undone_parents = conn.execute(
             "SELECT 1 FROM task_links l "
             "JOIN tasks p ON p.id = l.parent_id "
-            "WHERE l.child_id = ? AND p.status != 'done' LIMIT 1",
+            "WHERE l.child_id = ? AND l.link_kind = 'blocking' "
+            "AND p.status != 'done' LIMIT 1",
             (task_id,),
         ).fetchone()
         new_status = "todo" if undone_parents else "ready"

--- a/tests/hermes_cli/test_kanban_tracking_link.py
+++ b/tests/hermes_cli/test_kanban_tracking_link.py
@@ -1,0 +1,188 @@
+"""Regression tests for t_a3bebeea — non-blocking 'tracking' link kind.
+
+The wedge: a *tracking epic* (organizational parent, e.g. the Loopy AI epic
+t_6875775d) linked over its work items made the kernel's ``parents_not_done``
+invariant gate every child until the epic itself was done — but the epic
+can't be done until its children are: a structural standoff that previously
+forced the operator into the unlink + force-promote dance
+(``reference_kanban_force_promoted_child_wedge``).
+
+The fix: ``task_links.link_kind`` ('blocking' default | 'tracking').
+Only 'blocking' edges gate a child, at all five enforcement sites
+(claim_task, recompute_ready, promote_task, unblock_task, link_tasks's
+ready->todo demotion). 'tracking' edges are membership only.
+
+These tests pin down:
+
+* A child whose only parent edge is 'tracking' claims + completes while the
+  parent is open — the wedge scenario, eliminated.
+* The default 'blocking' edge still gates exactly as before (no behavior
+  change for existing graphs; the migration backfills legacy rows as
+  'blocking').
+* ``recompute_ready`` promotes a todo child whose only parent is tracking.
+* ``set_link_kind`` blocking->tracking is the operator affordance: the child
+  un-gates immediately via ``recompute_ready``.
+* The additive migration is idempotent on a legacy DB lacking ``link_kind``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Isolated HERMES_HOME with an empty kanban DB."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+# ---------------------------------------------------------------------------
+# (a) The wedge scenario: tracking parent never gates the child
+# ---------------------------------------------------------------------------
+
+
+def test_tracking_parent_does_not_block_child_claim(kanban_home: Path) -> None:
+    """A child tracking-linked under an OPEN epic must claim and complete
+    while the epic is still open — previously claim_task demoted it to todo
+    with ``claim_rejected (parents_not_done)`` every attempt."""
+    with kb.connect() as conn:
+        epic = kb.create_task(conn, title="tracking epic (stays open)")
+        child = kb.create_task(conn, title="work item")
+        kb.link_tasks(conn, epic, child, kind="tracking")
+
+        # Tracking link must not demote the ready child.
+        assert kb.get_task(conn, child).status == "ready"
+
+        claimed = kb.claim_task(conn, child)
+        assert claimed is not None, "tracking parent must not gate the claim"
+        kb.complete_task(conn, child, result="done while epic open")
+
+        assert kb.get_task(conn, child).status == "done"
+        assert kb.get_task(conn, epic).status != "done", "epic untouched"
+
+
+# ---------------------------------------------------------------------------
+# (b) Default 'blocking' semantics are unchanged
+# ---------------------------------------------------------------------------
+
+
+def test_blocking_parent_still_gates_child(kanban_home: Path) -> None:
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="blocking parent")
+        child = kb.create_task(conn, title="dependent child")
+        kb.link_tasks(conn, parent, child)  # default kind='blocking'
+
+        # link_tasks demotes a ready child under an undone blocking parent.
+        assert kb.get_task(conn, child).status == "todo"
+        assert kb.claim_task(conn, child) is None
+
+        # Parent completion releases the child (recompute_ready runs inside).
+        kb.claim_task(conn, parent)
+        kb.complete_task(conn, parent, result="ok")
+        assert kb.get_task(conn, child).status == "ready"
+        assert kb.claim_task(conn, child) is not None
+
+
+# ---------------------------------------------------------------------------
+# (c) recompute_ready promotes a todo child whose only parent is tracking
+# ---------------------------------------------------------------------------
+
+
+def test_recompute_ready_promotes_child_with_only_tracking_parent(
+    kanban_home: Path,
+) -> None:
+    with kb.connect() as conn:
+        epic = kb.create_task(conn, title="tracking epic")
+        child = kb.create_task(conn, title="work item")
+        kb.link_tasks(conn, epic, child, kind="tracking")
+
+        # Force the child into todo (simulating any racy writer / legacy
+        # state); the dispatcher's recompute must promote it back.
+        conn.execute(
+            "UPDATE tasks SET status = 'todo' WHERE id = ?", (child,)
+        )
+        conn.commit()
+
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, child).status == "ready"
+
+
+# ---------------------------------------------------------------------------
+# (d) Operator affordance: convert a wedged blocking edge in place
+# ---------------------------------------------------------------------------
+
+
+def test_set_link_kind_unwedges_blocked_child(kanban_home: Path) -> None:
+    with kb.connect() as conn:
+        epic = kb.create_task(conn, title="accidental blocking epic")
+        child = kb.create_task(conn, title="wedged work item")
+        kb.link_tasks(conn, epic, child)  # blocking -> child demoted to todo
+        assert kb.get_task(conn, child).status == "todo"
+
+        assert kb.set_link_kind(conn, epic, child, "tracking") is True
+        # set_link_kind runs recompute_ready: the child un-gates immediately.
+        assert kb.get_task(conn, child).status == "ready"
+        assert kb.claim_task(conn, child) is not None
+
+        # Converting a non-existent edge reports failure, mutates nothing.
+        ghost = kb.create_task(conn, title="unlinked")
+        assert kb.set_link_kind(conn, epic, ghost, "tracking") is False
+
+
+def test_link_kind_rejects_unknown_kind(kanban_home: Path) -> None:
+    with kb.connect() as conn:
+        a = kb.create_task(conn, title="a")
+        b = kb.create_task(conn, title="b")
+        with pytest.raises(ValueError):
+            kb.link_tasks(conn, a, b, kind="organizational")
+        with pytest.raises(ValueError):
+            kb.set_link_kind(conn, a, b, "soft")
+
+
+# ---------------------------------------------------------------------------
+# (e) Additive migration: legacy DB without link_kind
+# ---------------------------------------------------------------------------
+
+
+def test_migration_backfills_legacy_links_as_blocking(kanban_home: Path) -> None:
+    """A pre-migration task_links row (no link_kind column) must come out of
+    the migration as 'blocking' — zero behavior change for existing graphs —
+    and re-running the migration must be a no-op."""
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="legacy parent")
+        child = kb.create_task(conn, title="legacy child", parents=[parent])
+
+        # Rewind the schema to its legacy shape (SQLite >= 3.35 DROP COLUMN);
+        # the existing edge survives, now without a kind.
+        conn.execute("ALTER TABLE task_links DROP COLUMN link_kind")
+        conn.commit()
+        cols = {r["name"] for r in conn.execute("PRAGMA table_info(task_links)")}
+        assert "link_kind" not in cols
+
+        # Migration is additive + idempotent.
+        kb._migrate_add_optional_columns(conn)
+        kb._migrate_add_optional_columns(conn)
+        conn.commit()
+
+        row = conn.execute(
+            "SELECT link_kind FROM task_links "
+            "WHERE parent_id = ? AND child_id = ?",
+            (parent, child),
+        ).fetchone()
+        assert row["link_kind"] == "blocking"
+
+        # And the backfilled edge still gates: the child stays gated until
+        # the parent completes.
+        assert kb.claim_task(conn, child) is None
+        kb.claim_task(conn, parent)
+        kb.complete_task(conn, parent, result="ok")
+        assert kb.get_task(conn, child).status == "ready"


### PR DESCRIPTION
## Problem

`task_links` edges always gate: `claim_task` rejects a child with `parents_not_done` until **every** parent is done. That's correct for dependency chains, but linking an organizational/roadmap epic over its work items freezes the whole section of the board until the epic itself closes — the opposite of what a tracking epic is for. Workers (and autonomous drain loops) then re-poke the same unclaimable ready cards, spamming the event log.

## Change

Adds `link_kind` to `task_links` — `'blocking'` (default, existing behavior) or `'tracking'` (organizational only, never gates):

- `hermes kanban link <parent> <child> --kind tracking|blocking` (default `blocking`, so existing scripts are unchanged)
- Re-linking an existing edge with a different `--kind` **converts it in place** and re-evaluates the child's readiness — previously the `INSERT OR IGNORE` made re-linking a silent no-op
- `claim_task` / `promote_task` / `unblock_task` / `recompute_ready` consider only blocking edges
- Migration: `ALTER TABLE ... ADD COLUMN link_kind TEXT NOT NULL DEFAULT 'blocking'` via the existing optional-columns migration path, so live databases keep their semantics on upgrade

## Testing

- New `tests/hermes_cli/test_kanban_tracking_link.py` (6 tests): blocking edges still gate, tracking edges don't, in-place conversion both directions, readiness re-evaluation on convert, default-kind back-compat
- Full kanban suite (`pytest tests/hermes_cli/ -k kanban`): **672 passed** with the patch vs 666 on clean `main`; the same 10 failures occur on clean `main` (pre-existing, unrelated to this change)

Running in production on our deployment since 2026-06-09 — it unwedged a 13-child roadmap epic the same day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)