### PR TITLE
fix(approval): bound dangerous-command regex input (#7485)

### DIFF
--- a/hermes_cli/approvals_suggest.py
+++ b/hermes_cli/approvals_suggest.py
@@ -217,7 +217,11 @@ def scan_approval_history(
     the session DB — dangerous-classified terminal commands that actually
     executed (i.e. carried an implied user approval).
     """
-    from tools.approval import detect_dangerous_command, detect_hardline_command
+    from tools.approval import (
+        _call_detect_dangerous_command,
+        _call_detect_hardline_command,
+        _classify_command_for_detection,
+    )
 
     path = Path(db_path) if db_path else default_db_path()
     if not path.exists():
@@ -232,12 +236,19 @@ def scan_approval_history(
         for tool_call_id, command in _iter_terminal_calls(con, since_ts):
             if tool_call_id in blocked:
                 continue
-            is_hardline, _desc = detect_hardline_command(command)
+            classification = _classify_command_for_detection(command)
+            is_hardline, _desc = _call_detect_hardline_command(
+                command,
+                classification,
+            )
             if is_hardline:
                 # Hardline commands are unconditionally blocked at runtime;
                 # never mine them (defense in depth against stale DB rows).
                 continue
-            is_dangerous, _key, description = detect_dangerous_command(command)
+            is_dangerous, _key, description = _call_detect_dangerous_command(
+                command,
+                classification,
+            )
             if not is_dangerous:
                 continue
             records.append((command, description))

--- a/tests/hermes_cli/test_approvals_suggest.py
+++ b/tests/hermes_cli/test_approvals_suggest.py
@@ -142,6 +142,35 @@ class TestScan:
         assert len(scan_approval_history(path, days=90)) == 1
         assert len(scan_approval_history(path, days=0)) == 2
 
+    def test_scan_shares_one_classification_per_command(self, db_path, monkeypatch):
+        path, con = db_path
+        _add_terminal_call(con, "git push --force origin main")
+        original_classify = approval_module._classify_command_for_detection
+        original_normalize = approval_module._normalize_command_for_detection
+        calls = {"classify": 0, "normalize": 0}
+
+        def count_classify(command):
+            calls["classify"] += 1
+            return original_classify(command)
+
+        def count_normalize(command):
+            calls["normalize"] += 1
+            return original_normalize(command)
+
+        monkeypatch.setattr(approval_module, "_classify_command_for_detection", count_classify)
+        monkeypatch.setattr(approval_module, "_normalize_command_for_detection", count_normalize)
+
+        assert scan_approval_history(path, days=0) == [
+            ("git push --force origin main", "git force push (rewrites remote history)"),
+        ]
+        assert calls == {"classify": 1, "normalize": 1}
+
+    def test_scan_excludes_over_limit_history_before_ranking(self, db_path):
+        path, con = db_path
+        _add_terminal_call(con, "x;" * 10_000 + "x")
+
+        assert scan_approval_history(path, days=0) == []
+
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1001,6 +1001,187 @@ class TestDetectSudoStdin:
             assert is_dangerous is False, cmd
 
 
+class TestApprovalDetectionLengthClassifier:
+    @staticmethod
+    def _normalized_over_limit_command():
+        return "x;" * 5_000 + "x"
+
+    def test_over_normalized_limit_blocks_before_all_work(self, monkeypatch):
+        mod = approval_module
+        command = self._normalized_over_limit_command()
+        parser_limit = mod._command_parser_limit_exceeded
+        normalize = mod._normalize_command_for_detection
+        calls = {"parser": 0, "normalize": 0}
+
+        def count_parser(value):
+            calls["parser"] += 1
+            return parser_limit(value)
+
+        def count_normalize(value):
+            calls["normalize"] += 1
+            return normalize(value)
+
+        def downstream(*_args, **_kwargs):
+            raise AssertionError("over-limit command reached downstream approval work")
+
+        monkeypatch.setattr(mod, "_command_parser_limit_exceeded", count_parser)
+        monkeypatch.setattr(mod, "_normalize_command_for_detection", count_normalize)
+        for helper in (
+            "_should_skip_container_guards",
+            "_call_detect_hardline_command",
+            "_check_sudo_stdin_guard",
+            "_match_user_deny_rule",
+            "_get_approval_mode",
+            "_command_matches_permanent_allowlist",
+        ):
+            monkeypatch.setattr(mod, helper, downstream)
+
+        result = mod.check_all_command_guards(command, "local")
+
+        assert result["approved"] is False
+        assert result["description"] == "command exceeds approval detection length limit"
+        assert calls == {"parser": 1, "normalize": 1}
+
+    def test_raw_ceiling_skips_normalization_parser_and_matchers(self, monkeypatch):
+        mod = approval_module
+        command = "x;" * 10_000 + "x"
+
+        def downstream(*_args, **_kwargs):
+            raise AssertionError("raw-over-limit command reached bounded work")
+
+        for helper in (
+            "_command_parser_limit_exceeded",
+            "_normalize_command_for_detection",
+            "_is_verification_artifact_cleanup",
+            "_command_detection_variants_normalized",
+            "_should_skip_container_guards",
+        ):
+            monkeypatch.setattr(mod, helper, downstream)
+
+        result = mod.check_all_command_guards(command, "local")
+
+        assert result["approved"] is False
+        assert result["description"] == "command exceeds approval detection length limit"
+
+    @pytest.mark.parametrize(
+        "bypass",
+        ["isolated_container", "yolo", "mode_off", "allowlist", "cron_approve", "noninteractive"],
+    )
+    def test_over_limit_precedes_approval_bypasses(self, monkeypatch, bypass):
+        mod = approval_module
+        command = self._normalized_over_limit_command()
+        env_type = "local"
+        if bypass == "isolated_container":
+            env_type = "docker"
+        elif bypass == "yolo":
+            monkeypatch.setattr(mod, "_YOLO_MODE_FROZEN", True)
+        elif bypass == "mode_off":
+            monkeypatch.setattr(mod, "_get_approval_mode", lambda: "off")
+        elif bypass == "allowlist":
+            monkeypatch.setattr(mod, "_command_matches_permanent_allowlist", lambda _command: True)
+        elif bypass == "cron_approve":
+            monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+            monkeypatch.setattr(mod, "_get_cron_approval_mode", lambda: "approve")
+
+        result = mod.check_all_command_guards(command, env_type)
+
+        assert result["approved"] is False
+        assert result["description"] == "command exceeds approval detection length limit"
+
+    def test_check_dangerous_command_over_limit_blocks_before_bypass(self, monkeypatch):
+        mod = approval_module
+        command = self._normalized_over_limit_command()
+
+        def downstream(*_args, **_kwargs):
+            raise AssertionError("over-limit command reached a dangerous-command bypass")
+
+        for helper in (
+            "_should_skip_container_guards",
+            "_call_detect_hardline_command",
+            "_match_user_deny_rule",
+            "is_current_session_yolo_enabled",
+            "_command_matches_permanent_allowlist",
+            "_call_detect_dangerous_command",
+        ):
+            monkeypatch.setattr(mod, helper, downstream)
+
+        result = mod.check_dangerous_command(command, "local")
+
+        assert result["approved"] is False
+        assert result["description"] == "command exceeds approval detection length limit"
+
+    def test_direct_detectors_fail_closed_with_classifier_results(self):
+        command = self._normalized_over_limit_command()
+        description = "command exceeds approval detection length limit"
+
+        assert detect_hardline_command(command) == (True, description)
+        assert detect_dangerous_command(command) == (
+            True,
+            "command length limit",
+            description,
+        )
+        assert approval_module._check_sudo_stdin_guard(command) == (True, description)
+
+    def test_parser_limit_stays_distinct_from_length_limit(self):
+        command = "x" * 4_097
+
+        assert detect_hardline_command(command) == (
+            True,
+            "command parser limit exceeded",
+        )
+        assert detect_dangerous_command(command) == (
+            True,
+            "command parser limit exceeded",
+            "command parser limit exceeded",
+        )
+        result = approval_module.check_all_command_guards(command, "local")
+        assert result["approved"] is False
+        assert "command parser limit exceeded" in result["message"]
+
+    def test_exact_normalized_limit_and_normalizing_short_input_continue(self):
+        command = "x;\x00" * 4_999 + "xx"
+        classification = approval_module._classify_command_for_detection(command)
+
+        assert len(command) > 10_000
+        assert len(classification.normalized_command) == 10_000
+        assert classification.limit is None
+        assert detect_hardline_command(command) == (False, None)
+        assert detect_dangerous_command(command) == (False, None, None)
+
+    def test_over_limit_cleanup_shape_is_not_exempt(self, monkeypatch):
+        command = "rm -f /tmp/hermes-verify-example.py" + " " * 20_001
+        monkeypatch.setattr("tempfile.gettempdir", lambda: "/tmp")
+
+        result = detect_dangerous_command(command)
+
+        assert result == (
+            True,
+            "command length limit",
+            "command exceeds approval detection length limit",
+        )
+
+    def test_unpatched_shared_entrypoints_classify_and_normalize_once(self, monkeypatch):
+        mod = approval_module
+        original_classify = mod._classify_command_for_detection
+        original_normalize = mod._normalize_command_for_detection
+        calls = {"classify": 0, "normalize": 0}
+
+        def count_classify(command):
+            calls["classify"] += 1
+            return original_classify(command)
+
+        def count_normalize(command):
+            calls["normalize"] += 1
+            return original_normalize(command)
+
+        monkeypatch.setattr(mod, "_classify_command_for_detection", count_classify)
+        monkeypatch.setattr(mod, "_normalize_command_for_detection", count_normalize)
+        for checker in (mod.check_dangerous_command, mod.check_all_command_guards):
+            calls.update(classify=0, normalize=0)
+            assert checker("echo hello", "local")["approved"] is True
+            assert calls == {"classify": 1, "normalize": 1}
+
+
 class TestMacOSPrivateSystemPaths:
     """Inspired by Claude Code 2.1.113 "dangerous path protection".
 

--- a/tests/tui_gateway/test_subprocess_encoding.py
+++ b/tests/tui_gateway/test_subprocess_encoding.py
@@ -108,6 +108,43 @@ def test_shell_exec_uses_utf8_replace():
         )
 
 
+def test_shell_exec_shares_one_classification_before_execution(monkeypatch):
+    """The direct TUI path must not normalize once per detector."""
+    import tools.approval as approval
+
+    handler = server._methods["shell.exec"]
+    original_classify = approval._classify_command_for_detection
+    original_normalize = approval._normalize_command_for_detection
+    calls = {"classify": 0, "normalize": 0}
+
+    def count_classify(command):
+        calls["classify"] += 1
+        return original_classify(command)
+
+    def count_normalize(command):
+        calls["normalize"] += 1
+        return original_normalize(command)
+
+    monkeypatch.setattr(approval, "_classify_command_for_detection", count_classify)
+    monkeypatch.setattr(approval, "_normalize_command_for_detection", count_normalize)
+    with patch("subprocess.run", return_value=_make_completed_process()) as mock_run:
+        handler(1, {"command": "echo hello"})
+
+    assert mock_run.called
+    assert calls == {"classify": 1, "normalize": 1}
+
+
+def test_shell_exec_over_limit_does_not_start_subprocess():
+    handler = server._methods["shell.exec"]
+    command = "x;" * 10_000 + "x"
+
+    with patch("subprocess.run") as mock_run:
+        response = handler(1, {"command": command})
+
+    assert mock_run.called is False
+    assert "command exceeds approval detection length limit" in str(response)
+
+
 # ── quick-command exec path (via command.dispatch) ───────────────────────
 
 def test_quick_command_exec_uses_utf8_replace():

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -21,6 +21,7 @@ import tempfile
 import threading
 import time
 import unicodedata
+from dataclasses import dataclass
 from typing import Optional
 from hermes_cli.config import cfg_get
 
@@ -481,7 +482,10 @@ _SUDO_STDIN_RE = re.compile(
     re.IGNORECASE)
 
 
-def _check_sudo_stdin_guard(command: str) -> tuple:
+def _check_sudo_stdin_guard(
+    command: str,
+    classification: "_CommandDetectionClassification | None" = None,
+) -> tuple:
     """Detect ``sudo -S`` (stdin password) without configured SUDO_PASSWORD.
 
     When SUDO_PASSWORD is set, ``_transform_sudo_command`` injects ``-S``
@@ -494,7 +498,12 @@ def _check_sudo_stdin_guard(command: str) -> tuple:
     """
     if "SUDO_PASSWORD" in os.environ:
         return (False, None)
-    normalized = _normalize_command_for_detection(command).lower()
+    classification = classification or _classify_command_for_detection(command)
+    if classification.length_finding is not None:
+        return (True, classification.length_finding[1])
+    if classification.limit == "parser":
+        return (True, _PARSER_LIMIT_DESCRIPTION)
+    normalized = classification.normalized_command.lower()
     if _SUDO_STDIN_RE.search(normalized):
         return (True, "sudo password guessing via stdin (sudo -S)")
     return (False, None)
@@ -508,13 +517,21 @@ def detect_hardline_command(command: str) -> tuple:
     Returns:
         (is_hardline, description) or (False, None)
     """
-    if _command_parser_limit_exceeded(command):
+    return _detect_hardline_classified(_classify_command_for_detection(command))
+
+
+def _detect_hardline_classified(
+    classification: "_CommandDetectionClassification",
+) -> tuple:
+    if classification.length_finding is not None:
+        return (True, classification.length_finding[1])
+    if classification.limit == "parser":
         return (True, _PARSER_LIMIT_DESCRIPTION)
-    normalized = _normalize_command_for_detection(command)
+    normalized = classification.normalized_command
     _, malformed_grep = _grep_safe_detection_variant(normalized)
     if malformed_grep:
         return (True, _MALFORMED_EXEC_DESCRIPTION)
-    for command_variant in _command_detection_variants(command):
+    for command_variant in _command_detection_variants_normalized(normalized):
         variant_lower = command_variant.lower()
         for pattern_re, description in HARDLINE_PATTERNS_COMPILED:
             if pattern_re.search(variant_lower):
@@ -522,7 +539,10 @@ def detect_hardline_command(command: str) -> tuple:
     return (False, None)
 
 
-def _match_user_deny_rule(command: str) -> str | None:
+def _match_user_deny_rule(
+    command: str,
+    classification: "_CommandDetectionClassification | None" = None,
+) -> str | None:
     """Return the matching ``approvals.deny`` glob, or None.
 
     ``approvals.deny`` in config.yaml is a user-defined list of fnmatch
@@ -546,7 +566,12 @@ def _match_user_deny_rule(command: str) -> str | None:
              if isinstance(p, str) and p.strip()]
     if not globs:
         return None
-    for command_variant in _command_detection_variants(command):
+    classification = classification or _classify_command_for_detection(command)
+    if classification.limit is not None:
+        return None
+    for command_variant in _command_detection_variants_normalized(
+        classification.normalized_command
+    ):
         candidate = command_variant.lower().strip()
         for pattern in globs:
             if fnmatch.fnmatchcase(candidate, pattern.lower()):
@@ -581,6 +606,23 @@ def _hardline_block_result(description: str) -> dict:
             "approvals.mode=off, or cron approve mode. If you genuinely "
             "need to run it, run it yourself in a terminal outside the "
             "agent."
+        ),
+    }
+
+
+def _command_length_limit_block_result() -> dict:
+    """Build the standard fail-closed block for over-limit commands."""
+    pattern_key, description = _COMMAND_LENGTH_LIMIT_FINDING
+    return {
+        "approved": False,
+        "hardline": True,
+        "pattern_key": pattern_key,
+        "description": description,
+        "message": (
+            f"BLOCKED (fail-closed): {description}. "
+            "This command is too long to classify safely and cannot be "
+            "executed via the agent, including with --yolo, /yolo, "
+            "approvals.mode=off, or cron approve mode."
         ),
     }
 
@@ -1170,6 +1212,22 @@ _MAX_SEPARATOR_FREE_COMMAND_CHARS = 4_096
 _MAX_DETECTION_SEGMENTS = 25_000
 _PARSER_LIMIT_DESCRIPTION = "command parser limit exceeded"
 _MALFORMED_EXEC_DESCRIPTION = "command parser limit or malformed executable payload"
+_MAX_APPROVAL_DETECTION_COMMAND_LENGTH = 10_000
+_MAX_APPROVAL_DETECTION_RAW_COMMAND_LENGTH = 20_000
+_COMMAND_LENGTH_LIMIT_FINDING = (
+    "command length limit",
+    "command exceeds approval detection length limit",
+)
+
+
+@dataclass(frozen=True)
+class _CommandDetectionClassification:
+    """The one parser and normalization result shared by approval detection."""
+
+    command: str
+    normalized_command: str | None
+    limit: str | None = None
+    length_finding: tuple[str, str] | None = None
 
 
 
@@ -1197,6 +1255,28 @@ def _command_parser_limit_exceeded(command: str) -> bool:
             if separators >= _MAX_DETECTION_SEGMENTS:
                 return True
     return False
+
+
+def _classify_command_for_detection(command: str) -> _CommandDetectionClassification:
+    """Bound and normalize a terminal command before approval detection."""
+    if len(command) > _MAX_APPROVAL_DETECTION_RAW_COMMAND_LENGTH:
+        return _CommandDetectionClassification(
+            command,
+            None,
+            limit="raw",
+            length_finding=_COMMAND_LENGTH_LIMIT_FINDING,
+        )
+    if _command_parser_limit_exceeded(command):
+        return _CommandDetectionClassification(command, None, limit="parser")
+    normalized_command = _normalize_command_for_detection(command)
+    if len(normalized_command) > _MAX_APPROVAL_DETECTION_COMMAND_LENGTH:
+        return _CommandDetectionClassification(
+            command,
+            normalized_command,
+            limit="normalized",
+            length_finding=_COMMAND_LENGTH_LIMIT_FINDING,
+        )
+    return _CommandDetectionClassification(command, normalized_command)
 
 
 def _shell_tokens_with_spans(segment: str, start: int):
@@ -1961,7 +2041,12 @@ def _iter_shell_command_word_spans(command: str):
 
 
 def _command_detection_variants(command: str):
-    normalized = _normalize_command_for_detection(command)
+    yield from _command_detection_variants_normalized(
+        _normalize_command_for_detection(command)
+    )
+
+
+def _command_detection_variants_normalized(normalized: str):
     # Quote-aware grep parsing hides only structurally identified pattern
     # operands. Malformed/ambiguous input remains byte-for-byte intact.
     grep_safe, _ = _grep_safe_detection_variant(normalized)
@@ -2041,21 +2126,55 @@ def detect_dangerous_command(command: str) -> tuple:
     Returns:
         (is_dangerous, pattern_key, description) or (False, None, None)
     """
-    if _command_parser_limit_exceeded(command):
+    return _detect_dangerous_classified(_classify_command_for_detection(command))
+
+
+def _detect_dangerous_classified(
+    classification: _CommandDetectionClassification,
+) -> tuple:
+    if classification.length_finding is not None:
+        return (True, *classification.length_finding)
+    if classification.limit == "parser":
         return (True, _PARSER_LIMIT_DESCRIPTION, _PARSER_LIMIT_DESCRIPTION)
-    if _is_verification_artifact_cleanup(command):
+    if _is_verification_artifact_cleanup(classification.command):
         return (False, None, None)
 
-    for command_variant in _command_detection_variants(command):
+    normalized_command = classification.normalized_command
+    for command_variant in _command_detection_variants_normalized(normalized_command):
         command_lower = command_variant.lower()
         for pattern_re, description in DANGEROUS_PATTERNS_COMPILED:
             if pattern_re.search(command_lower):
                 pattern_key = description
                 return (True, pattern_key, description)
-    normalized = _normalize_command_for_detection(command)
-    for description, _ in _execution_flag_findings(normalized):
+    for description, _ in _execution_flag_findings(normalized_command):
         return (True, description, description)
     return (False, None, None)
+
+
+_DETECT_HARDLINE_COMMAND_IMPL = detect_hardline_command
+_DETECT_DANGEROUS_COMMAND_IMPL = detect_dangerous_command
+
+
+def _call_detect_hardline_command(
+    command: str,
+    classification: _CommandDetectionClassification,
+) -> tuple:
+    """Use classified detection without breaking one-argument patches."""
+    detector = detect_hardline_command
+    if detector is _DETECT_HARDLINE_COMMAND_IMPL:
+        return _detect_hardline_classified(classification)
+    return detector(command)
+
+
+def _call_detect_dangerous_command(
+    command: str,
+    classification: _CommandDetectionClassification,
+) -> tuple:
+    """Use classified detection without breaking one-argument patches."""
+    detector = detect_dangerous_command
+    if detector is _DETECT_DANGEROUS_COMMAND_IMPL:
+        return _detect_dangerous_classified(classification)
+    return detector(command)
 
 
 # =========================================================================
@@ -3077,6 +3196,12 @@ def check_dangerous_command(command: str, env_type: str,
     Returns:
         {"approved": True/False, "message": str or None, ...}
     """
+    classification = _classify_command_for_detection(command)
+    if classification.length_finding is not None:
+        logger.warning("Command length limit block: %s", command[:200])
+        return _command_length_limit_block_result()
+    if classification.limit == "parser":
+        return _hardline_block_result(_PARSER_LIMIT_DESCRIPTION)
     if _should_skip_container_guards(env_type, has_host_access=has_host_access):
         return {"approved": True, "message": None}
 
@@ -3085,7 +3210,10 @@ def check_dangerous_command(command: str, env_type: str,
     # unconditionally, BEFORE the yolo bypass.  Opting into yolo is
     # trusting the agent with your files and services, not trusting it
     # to wipe the disk or power the box off.
-    is_hardline, hardline_desc = detect_hardline_command(command)
+    is_hardline, hardline_desc = _call_detect_hardline_command(
+        command,
+        classification,
+    )
     if is_hardline:
         logger.warning("Hardline block: %s (command: %s)", hardline_desc, command[:200])
         return _hardline_block_result(hardline_desc)
@@ -3093,7 +3221,7 @@ def check_dangerous_command(command: str, env_type: str,
     # User-defined deny rules (approvals.deny in config.yaml): like the
     # hardline floor, these fire BEFORE the yolo bypass — a deny rule is the
     # user saying "never, even under yolo".
-    deny_pattern = _match_user_deny_rule(command)
+    deny_pattern = _match_user_deny_rule(command, classification)
     if deny_pattern is not None:
         logger.warning("User deny rule %r blocked command: %s",
                        deny_pattern, command[:200])
@@ -3107,7 +3235,10 @@ def check_dangerous_command(command: str, env_type: str,
     if _command_matches_permanent_allowlist(command):
         return {"approved": True, "message": None}
 
-    is_dangerous, pattern_key, description = detect_dangerous_command(command)
+    is_dangerous, pattern_key, description = _call_detect_dangerous_command(
+        command,
+        classification,
+    )
     if not is_dangerous:
         return {"approved": True, "message": None}
 
@@ -3376,6 +3507,12 @@ def check_all_command_guards(command: str, env_type: str,
     such a session is no longer isolated, so it goes through the normal flow
     instead of the container fast-path.
     """
+    classification = _classify_command_for_detection(command)
+    if classification.length_finding is not None:
+        logger.warning("Command length limit block: %s", command[:200])
+        return _command_length_limit_block_result()
+    if classification.limit == "parser":
+        return _hardline_block_result(_PARSER_LIMIT_DESCRIPTION)
     # Skip isolated container backends for both checks. Docker stops skipping
     # once host paths are bind-mounted into the sandbox.
     if _should_skip_container_guards(env_type, has_host_access=has_host_access):
@@ -3385,7 +3522,10 @@ def check_all_command_guards(command: str, env_type: str,
     # (rm -rf /, mkfs, dd to raw device, shutdown/reboot, fork bomb,
     # kill -1). Applies BEFORE yolo / mode=off / cron approve-mode so
     # no session-level setting can bypass it.
-    is_hardline, hardline_desc = detect_hardline_command(command)
+    is_hardline, hardline_desc = _call_detect_hardline_command(
+        command,
+        classification,
+    )
     if is_hardline:
         logger.warning("Hardline block: %s (command: %s)", hardline_desc, command[:200])
         return _hardline_block_result(hardline_desc)
@@ -3395,7 +3535,7 @@ def check_all_command_guards(command: str, env_type: str,
     # legitimate reason for the agent to pipe passwords to sudo -S when no
     # SUDO_PASSWORD has been configured.  This must fire BEFORE the yolo
     # check so even yolo/smart approval/mode=off cannot bypass it.
-    is_sudo_guess, sudo_guess_desc = _check_sudo_stdin_guard(command)
+    is_sudo_guess, sudo_guess_desc = _check_sudo_stdin_guard(command, classification)
     if is_sudo_guess:
         logger.warning("Sudo stdin guard block: %s (command: %s)",
                        sudo_guess_desc, command[:200])
@@ -3404,7 +3544,7 @@ def check_all_command_guards(command: str, env_type: str,
     # User-defined deny rules (approvals.deny in config.yaml): like the
     # hardline floor, these fire BEFORE the yolo / mode=off bypass — a deny
     # rule is the user saying "never, even under yolo".
-    deny_pattern = _match_user_deny_rule(command)
+    deny_pattern = _match_user_deny_rule(command, classification)
     if deny_pattern is not None:
         logger.warning("User deny rule %r blocked command: %s",
                        deny_pattern, command[:200])
@@ -3430,7 +3570,10 @@ def check_all_command_guards(command: str, env_type: str,
         if env_var_enabled("HERMES_CRON_SESSION"):
             if _get_cron_approval_mode() == "deny":
                 # Run detection to get a description for the block message
-                is_dangerous, _pk, description = detect_dangerous_command(command)
+                is_dangerous, _pk, description = _call_detect_dangerous_command(
+                    command,
+                    classification,
+                )
                 if is_dangerous:
                     return {
                         "approved": False,
@@ -3536,7 +3679,10 @@ def check_all_command_guards(command: str, env_type: str,
         # else: tirith_fail_open is True — allow as before (tirith_result stays "allow")
 
     # Dangerous command check (detection only, no approval)
-    is_dangerous, pattern_key, description = detect_dangerous_command(command)
+    is_dangerous, pattern_key, description = _call_detect_dangerous_command(
+        command,
+        classification,
+    )
 
     # --- Phase 2: Decide ---
 

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1868,14 +1868,22 @@ def _(rid, params: dict) -> dict:
     if not cmd:
         return _err(rid, 4004, "empty command")
     try:
-        from tools.approval import detect_dangerous_command, detect_hardline_command
+        from tools.approval import (
+            _call_detect_dangerous_command,
+            _call_detect_hardline_command,
+            _classify_command_for_detection,
+        )
 
-        is_hardline, hardline_desc = detect_hardline_command(cmd)
+        classification = _classify_command_for_detection(cmd)
+        is_hardline, hardline_desc = _call_detect_hardline_command(
+            cmd,
+            classification,
+        )
         if is_hardline:
             return _err(
                 rid, 4005, f"blocked (hardline): {hardline_desc}. Use the agent for dangerous commands."
             )
-        is_dangerous, _, desc = detect_dangerous_command(cmd)
+        is_dangerous, _, desc = _call_detect_dangerous_command(cmd, classification)
         if is_dangerous:
             return _err(
                 rid, 4005, f"blocked: {desc}. Use the agent for dangerous commands."


### PR DESCRIPTION
## Summary

The earlier branch implemented the limit against an older approval implementation. Replaying it on current `main` would have replaced newer parser safety, malformed-input handling, and verification cleanup behavior.

This update extends the current approval parser with one shared raw, parser, and normalized command classification. Over-limit input fails closed before parser expansion, hardline, sudo-stdin, deny, and dangerous matching, and before approval bypasses. The shared terminal flow, TUI `shell.exec`, and approval-history scan reuse that result while their existing one-argument detector seams remain compatible.

## Changes

- `tools/approval.py`: add the shared classification and classified detector workers, preserve parser-limit and cleanup semantics, and route approval entrypoints through the fail-closed result
- `tui_gateway/methods_tools.py`: classify once before direct detector calls and process execution
- `hermes_cli/approvals_suggest.py`: classify once before direct detection and history ranking
- Focused approval, TUI, and history tests: cover over-limit rejection, parser and normalization boundaries, bypass preservation, direct-consumer routing, and detector compatibility

## Validation

| Scenario | Before | After |
|---|---|---|
| 10,001-character separator-rich command | could reach approval parsing and matcher work | returns the canonical length block before downstream parser, matcher, or bypass work |
| Command above the raw ceiling | could enter parser work | returns the canonical length block before parsing or normalization |
| Current parser-limit and malformed input | current parser result | unchanged |
| Valid verification-artifact cleanup within the limit | exempt from dangerous detection | unchanged |
| TUI execution and approval-history scanning | each called direct detectors independently | reuse one classification and exclude over-limit input before execution or ranking |

## Test plan

- `python -m pytest tests/tools/test_approval.py::TestApprovalDetectionLengthClassifier -v --timeout=0` — 14 passed
- `python -m pytest tests/tools/test_hardline_blocklist.py -v --timeout=0` — 168 passed
- `python -m pytest tests/tools/test_approval_deny_rules.py tests/tools/test_command_guards.py tests/tools/test_cron_approval_mode.py -v --timeout=0` — 68 passed
- `python -m pytest tests/tui_gateway/test_subprocess_encoding.py tests/hermes_cli/test_approvals_suggest.py -v --timeout=0` — 20 passed
- `python -m pytest tests/tools/test_approval.py -v --timeout=0` — 102 passed; two unchanged Windows cleanup-fixture cases reproduce on current `main`

## Not in scope

This does not rewrite existing denylist regexes, add a regex-timeout dependency, change approval keys or modes, or alter explicit `force=True` terminal behavior.

## Upstream

Closes #7485.
Reported by @DataAdvisory.
