### PR TITLE
feat: add maintenance action policy validator

### DIFF
--- a/docs/security/maintenance-actions.md
+++ b/docs/security/maintenance-actions.md
@@ -20,6 +20,7 @@ The validator follows a default-deny contract:
 - disabled global policy blocks;
 - malformed global enabled flags block;
 - missing or malformed `actions` blocks;
+- malformed action IDs block;
 - unknown actions block;
 - disabled actions block;
 - malformed action enabled flags block;
@@ -27,8 +28,8 @@ The validator follows a default-deny contract:
 - missing or malformed `exact_argv` blocks;
 - malformed requested argv blocks;
 - exact argv mismatch blocks;
-- shell strings and shell-wrapper forms such as `sh -c`, `bash -lc`, and
-  `/usr/bin/env bash -lc` block;
+- shell strings and shell-wrapper forms such as `sh -c`, `bash -lc`,
+  `/usr/bin/env bash -lc`, and `/usr/bin/env -S ...` block;
 - unattended contexts such as cron, background, scheduler, and unattended runs
   block by default;
 - malformed unattended policy values block;
@@ -37,6 +38,7 @@ The validator follows a default-deny contract:
 - missing postcheck metadata blocks;
 - malformed postcheck metadata blocks;
 - malformed approval-requirement policy values block;
+- malformed current-user approval values block;
 - current-user approval is required by default even after all static gates pass.
 
 The exact-argv rule is intentionally strict. A maintenance action policy names

--- a/docs/security/maintenance-actions.md
+++ b/docs/security/maintenance-actions.md
@@ -1,0 +1,79 @@
+# Maintenance Action Policy Validator
+
+Status: implemented as a non-executing safety primitive.
+
+Hermes includes a small maintenance-action policy validator in
+`tools/maintenance_actions.py`. It is a static classifier, not an actuator. Its
+job is to decide whether a proposed named maintenance action is blocked,
+eligible but waiting for current-user approval, or statically approved by
+policy.
+
+It deliberately does not execute commands, load live `~/.hermes/config.yaml`,
+run preflight probes, run postcheck probes, write audit logs, contact remote
+hosts, or integrate with the terminal tool.
+
+## Safety contract
+
+The validator follows a default-deny contract:
+
+- absent policy blocks;
+- disabled global policy blocks;
+- missing or malformed `actions` blocks;
+- unknown actions block;
+- disabled actions block;
+- malformed action bodies block;
+- missing or malformed `exact_argv` blocks;
+- malformed requested argv blocks;
+- exact argv mismatch blocks;
+- shell strings and shell-wrapper forms such as `sh -c` / `bash -lc` block;
+- unattended contexts such as cron, background, scheduler, and unattended runs
+  block by default;
+- missing preflight metadata blocks;
+- missing postcheck metadata blocks;
+- current-user approval is required by default even after all static gates pass.
+
+The exact-argv rule is intentionally strict. A maintenance action policy names
+one action and one concrete argv list. Aliases, wrapper scripts, shell strings,
+interpolation, or equivalent-looking commands are not considered equivalent.
+
+## Relationship to hardline and Tirith guards
+
+This validator does not replace existing command guards. Hardline shutdown,
+reboot, and similar protections remain authoritative. Tirith and the dangerous
+command approval system remain authoritative.
+
+Future integration must preserve that layering: maintenance-action policy can
+only narrow what is allowed. It must not become a bypass around existing guard
+layers.
+
+## Dry-run classifier
+
+`classify_maintenance_action(...)` wraps `evaluate_maintenance_action(...)` and
+returns a JSON-serializable dict with stable keys:
+
+- `allowed`
+- `eligible`
+- `reason`
+- `action_id`
+- `command_id`
+- `host_label`
+
+This is meant for future UI or tool layers that need a dry-run classification
+surface. It is still inert and does not execute anything.
+
+## Future execution work
+
+Any future execution path must be a separate, reviewed, test-driven slice. At a
+minimum it needs fresh tests for:
+
+1. current-user approval capture;
+2. live read-only preflight verification;
+3. command execution through a non-shell exact argv path;
+4. post-action verification;
+5. audit logging;
+6. interaction with existing hardline/Tirith approval layers;
+7. unattended/cron failure-closed behavior.
+
+Do not combine validator changes with execution integration in the same patch.
+That separation is intentional: first build the interlock, then review whether
+an actuator is justified.

--- a/docs/security/maintenance-actions.md
+++ b/docs/security/maintenance-actions.md
@@ -34,6 +34,7 @@ The validator follows a default-deny contract:
 - malformed preflight metadata blocks;
 - missing postcheck metadata blocks;
 - malformed postcheck metadata blocks;
+- malformed approval-requirement policy values block;
 - current-user approval is required by default even after all static gates pass.
 
 The exact-argv rule is intentionally strict. A maintenance action policy names

--- a/docs/security/maintenance-actions.md
+++ b/docs/security/maintenance-actions.md
@@ -25,11 +25,15 @@ The validator follows a default-deny contract:
 - missing or malformed `exact_argv` blocks;
 - malformed requested argv blocks;
 - exact argv mismatch blocks;
-- shell strings and shell-wrapper forms such as `sh -c` / `bash -lc` block;
+- shell strings and shell-wrapper forms such as `sh -c`, `bash -lc`, and
+  `/usr/bin/env bash -lc` block;
 - unattended contexts such as cron, background, scheduler, and unattended runs
   block by default;
+- malformed unattended policy values block;
 - missing preflight metadata blocks;
+- malformed preflight metadata blocks;
 - missing postcheck metadata blocks;
+- malformed postcheck metadata blocks;
 - current-user approval is required by default even after all static gates pass.
 
 The exact-argv rule is intentionally strict. A maintenance action policy names

--- a/docs/security/maintenance-actions.md
+++ b/docs/security/maintenance-actions.md
@@ -18,9 +18,11 @@ The validator follows a default-deny contract:
 
 - absent policy blocks;
 - disabled global policy blocks;
+- malformed global enabled flags block;
 - missing or malformed `actions` blocks;
 - unknown actions block;
 - disabled actions block;
+- malformed action enabled flags block;
 - malformed action bodies block;
 - missing or malformed `exact_argv` blocks;
 - malformed requested argv blocks;

--- a/tests/tools/test_maintenance_actions.py
+++ b/tests/tools/test_maintenance_actions.py
@@ -137,7 +137,9 @@ class TestMaintenanceActionMalformedPolicy:
             [],
             ["ssh", ""],
             ["bash", "-lc", "ssh host command"],
+            ["bash", "--noprofile", "--norc", "-c", "ssh host command"],
             ["/usr/bin/env", "bash", "-lc", "ssh host command"],
+            ["/usr/bin/env", "FOO=bar", "bash", "-lc", "ssh host command"],
         ],
     )
     def test_missing_or_invalid_exact_argv_blocks(self, exact_argv):
@@ -194,6 +196,34 @@ class TestMaintenanceActionContext:
         assert result.allowed is False
         assert result.reason == "unattended_policy_invalid"
         assert result.eligible is False
+
+    @pytest.mark.parametrize(
+        "require_interactive_user_approval",
+        [None, "", [], {}, 0, "false"],
+    )
+    def test_malformed_approval_requirement_blocks(self, require_interactive_user_approval):
+        result = evaluate_maintenance_action(
+            _policy(require_interactive_user_approval=require_interactive_user_approval),
+            "caspian_inference_restart",
+            SAFE_ARGV,
+            current_user_approved=False,
+        )
+
+        assert result.allowed is False
+        assert result.reason == "invalid_approval_requirement"
+        assert result.eligible is False
+
+    def test_explicit_boolean_false_approval_requirement_allows_static_approval(self):
+        result = evaluate_maintenance_action(
+            _policy(require_interactive_user_approval=False),
+            "caspian_inference_restart",
+            SAFE_ARGV,
+            current_user_approved=False,
+        )
+
+        assert result.allowed is True
+        assert result.reason == "approved"
+        assert result.eligible is True
 
     def test_current_user_approval_allows_when_required_gates_pass(self):
         result = evaluate_maintenance_action(

--- a/tests/tools/test_maintenance_actions.py
+++ b/tests/tools/test_maintenance_actions.py
@@ -88,6 +88,13 @@ class TestMaintenanceActionDefaultDeny:
         assert result.allowed is False
         assert result.reason == "action_disabled"
 
+    @pytest.mark.parametrize("action_id", [None, "", [], {}])
+    def test_malformed_action_id_blocks(self, action_id):
+        result = evaluate_maintenance_action(_policy(), action_id, SAFE_ARGV)
+
+        assert result.allowed is False
+        assert result.reason == "invalid_action_id"
+
     def test_unknown_action_blocks(self):
         result = evaluate_maintenance_action(_policy(), "missing_action", SAFE_ARGV)
 
@@ -167,6 +174,7 @@ class TestMaintenanceActionMalformedPolicy:
             ["bash", "--noprofile", "--norc", "-c", "ssh host command"],
             ["/usr/bin/env", "bash", "-lc", "ssh host command"],
             ["/usr/bin/env", "FOO=bar", "bash", "-lc", "ssh host command"],
+            ["/usr/bin/env", "-S", "bash -lc ssh host command"],
         ],
     )
     def test_missing_or_invalid_exact_argv_blocks(self, exact_argv):
@@ -191,7 +199,7 @@ class TestMaintenanceActionMalformedPolicy:
 class TestMaintenanceActionContext:
     @pytest.mark.parametrize(
         "invocation_context",
-        ["cron", "unattended", "background", "scheduler", "CrOn"],
+        ["cron", "unattended", "background", "scheduler", "CrOn", " cron "],
     )
     @pytest.mark.parametrize("unattended_policy", [None, False, "none", "NONE", "false"])
     def test_unattended_context_blocks_by_default(
@@ -206,6 +214,22 @@ class TestMaintenanceActionContext:
 
         assert result.allowed is False
         assert result.reason == "unattended_forbidden"
+        assert result.eligible is False
+
+    @pytest.mark.parametrize("unattended_policy", [True, "allow", "manual", [], {}])
+    def test_malformed_unattended_policy_blocks_interactive_context(
+        self, unattended_policy
+    ):
+        result = evaluate_maintenance_action(
+            _policy(unattended_policy=unattended_policy),
+            "caspian_inference_restart",
+            SAFE_ARGV,
+            invocation_context="interactive",
+            current_user_approved=True,
+        )
+
+        assert result.allowed is False
+        assert result.reason == "unattended_policy_invalid"
         assert result.eligible is False
 
     @pytest.mark.parametrize("unattended_policy", [True, "allow", "manual", [], {}])
@@ -251,6 +275,19 @@ class TestMaintenanceActionContext:
         assert result.allowed is True
         assert result.reason == "approved"
         assert result.eligible is True
+
+    @pytest.mark.parametrize("current_user_approved", [None, "false", "true", 1, [], {}])
+    def test_malformed_current_user_approved_blocks(self, current_user_approved):
+        result = evaluate_maintenance_action(
+            _policy(),
+            "caspian_inference_restart",
+            SAFE_ARGV,
+            current_user_approved=current_user_approved,
+        )
+
+        assert result.allowed is False
+        assert result.reason == "invalid_current_user_approval"
+        assert result.eligible is False
 
     def test_current_user_approval_allows_when_required_gates_pass(self):
         result = evaluate_maintenance_action(

--- a/tests/tools/test_maintenance_actions.py
+++ b/tests/tools/test_maintenance_actions.py
@@ -1,0 +1,201 @@
+"""Tests for non-executing maintenance-action policy validation."""
+
+import pytest
+
+from tools.approval import detect_hardline_command
+from tools.maintenance_actions import evaluate_maintenance_action
+
+
+SAFE_ARGV = [
+    "ssh",
+    "-o",
+    "BatchMode=yes",
+    "caspian-inference-01",
+    "sudo",
+    "/usr/local/sbin/caspian-power-control",
+    "restart",
+]
+
+
+def _policy(**overrides):
+    policy = {
+        "enabled": True,
+        "require_interactive_user_approval": True,
+        "unattended_policy": "none",
+        "actions": {
+            "caspian_inference_restart": {
+                "enabled": True,
+                "host_label": "caspian-inference-01",
+                "command_id": "caspian_power_control_restart",
+                "exact_argv": list(SAFE_ARGV),
+                "preflight_profile": "caspian_inference_gpu_reset_required_v1",
+                "postcheck_profile": "caspian_inference_qwen_recovery_v1",
+            }
+        },
+    }
+    policy.update(overrides)
+    return policy
+
+
+class TestMaintenanceActionDefaultDeny:
+    def test_absent_policy_blocks(self):
+        result = evaluate_maintenance_action({}, "caspian_inference_restart", SAFE_ARGV)
+
+        assert result.allowed is False
+        assert result.reason == "policy_absent"
+
+    def test_global_disabled_blocks(self):
+        result = evaluate_maintenance_action(
+            _policy(enabled=False), "caspian_inference_restart", SAFE_ARGV
+        )
+
+        assert result.allowed is False
+        assert result.reason == "policy_disabled"
+
+    def test_action_disabled_blocks(self):
+        policy = _policy()
+        policy["actions"]["caspian_inference_restart"]["enabled"] = False
+
+        result = evaluate_maintenance_action(policy, "caspian_inference_restart", SAFE_ARGV)
+
+        assert result.allowed is False
+        assert result.reason == "action_disabled"
+
+    def test_unknown_action_blocks(self):
+        result = evaluate_maintenance_action(_policy(), "missing_action", SAFE_ARGV)
+
+        assert result.allowed is False
+        assert result.reason == "unknown_action"
+
+
+class TestMaintenanceActionExactArgv:
+    def test_exact_argv_match_can_be_eligible(self):
+        result = evaluate_maintenance_action(_policy(), "caspian_inference_restart", SAFE_ARGV)
+
+        assert result.allowed is False
+        assert result.reason == "requires_current_user_approval"
+        assert result.eligible is True
+        assert result.command_id == "caspian_power_control_restart"
+
+    def test_argv_mismatch_blocks(self):
+        changed = list(SAFE_ARGV)
+        changed[-1] = "shutdown"
+
+        result = evaluate_maintenance_action(_policy(), "caspian_inference_restart", changed)
+
+        assert result.allowed is False
+        assert result.reason == "argv_mismatch"
+        assert result.eligible is False
+
+    @pytest.mark.parametrize(
+        "requested_argv",
+        [
+            "ssh caspian-inference-01 sudo /usr/local/sbin/caspian-power-control restart",
+            ["sh", "-c", "ssh caspian-inference-01 sudo /usr/local/sbin/caspian-power-control restart"],
+            ["bash", "-lc", "ssh caspian-inference-01 sudo /usr/local/sbin/caspian-power-control restart"],
+        ],
+    )
+    def test_shell_string_or_interpreter_wrapping_blocks(self, requested_argv):
+        result = evaluate_maintenance_action(
+            _policy(), "caspian_inference_restart", requested_argv
+        )
+
+        assert result.allowed is False
+        assert result.reason in {"argv_must_be_list", "shell_wrapping_forbidden"}
+        assert result.eligible is False
+
+
+class TestMaintenanceActionMalformedPolicy:
+    def test_non_dict_policy_blocks(self):
+        result = evaluate_maintenance_action("not-a-policy", "caspian_inference_restart", SAFE_ARGV)
+
+        assert result.allowed is False
+        assert result.reason == "policy_invalid"
+
+    @pytest.mark.parametrize("actions", [None, [], "not-actions"])
+    def test_missing_or_non_dict_actions_blocks(self, actions):
+        result = evaluate_maintenance_action(
+            _policy(actions=actions), "caspian_inference_restart", SAFE_ARGV
+        )
+
+        assert result.allowed is False
+        assert result.reason == "actions_invalid"
+
+    def test_non_dict_action_body_blocks(self):
+        policy = _policy(actions={"caspian_inference_restart": "not-an-action"})
+
+        result = evaluate_maintenance_action(policy, "caspian_inference_restart", SAFE_ARGV)
+
+        assert result.allowed is False
+        assert result.reason == "action_invalid"
+
+    @pytest.mark.parametrize("exact_argv", [None, "ssh host command", [], ["ssh", ""]])
+    def test_missing_or_invalid_exact_argv_blocks(self, exact_argv):
+        policy = _policy()
+        policy["actions"]["caspian_inference_restart"]["exact_argv"] = exact_argv
+
+        result = evaluate_maintenance_action(policy, "caspian_inference_restart", SAFE_ARGV)
+
+        assert result.allowed is False
+        assert result.reason == "exact_argv_invalid"
+
+    @pytest.mark.parametrize("requested_argv", [[], ["ssh", ""], ["ssh", object()]])
+    def test_empty_or_invalid_requested_argv_blocks(self, requested_argv):
+        result = evaluate_maintenance_action(
+            _policy(), "caspian_inference_restart", requested_argv
+        )
+
+        assert result.allowed is False
+        assert result.reason == "argv_invalid"
+
+
+class TestMaintenanceActionContext:
+    @pytest.mark.parametrize(
+        "invocation_context",
+        ["cron", "unattended", "background", "scheduler", "CrOn"],
+    )
+    def test_unattended_context_blocks_by_default(self, invocation_context):
+        result = evaluate_maintenance_action(
+            _policy(),
+            "caspian_inference_restart",
+            SAFE_ARGV,
+            invocation_context=invocation_context,
+        )
+
+        assert result.allowed is False
+        assert result.reason == "unattended_forbidden"
+        assert result.eligible is False
+
+    def test_current_user_approval_allows_when_required_gates_pass(self):
+        result = evaluate_maintenance_action(
+            _policy(),
+            "caspian_inference_restart",
+            SAFE_ARGV,
+            current_user_approved=True,
+        )
+
+        assert result.allowed is True
+        assert result.reason == "approved"
+        assert result.eligible is True
+
+    def test_missing_preflight_profile_blocks(self):
+        policy = _policy()
+        del policy["actions"]["caspian_inference_restart"]["preflight_profile"]
+
+        result = evaluate_maintenance_action(
+            policy,
+            "caspian_inference_restart",
+            SAFE_ARGV,
+            current_user_approved=True,
+        )
+
+        assert result.allowed is False
+        assert result.reason == "missing_preflight_profile"
+
+
+class TestMaintenanceActionDoesNotWeakenHardline:
+    def test_ordinary_reboot_remains_hardline_blocked(self):
+        is_hardline, description = detect_hardline_command("sudo reboot")
+
+        assert is_hardline is True
+        assert "reboot" in description.lower() or "shutdown" in description.lower()

--- a/tests/tools/test_maintenance_actions.py
+++ b/tests/tools/test_maintenance_actions.py
@@ -129,12 +129,22 @@ class TestMaintenanceActionMalformedPolicy:
         assert result.allowed is False
         assert result.reason == "action_invalid"
 
-    @pytest.mark.parametrize("exact_argv", [None, "ssh host command", [], ["ssh", ""]])
+    @pytest.mark.parametrize(
+        "exact_argv",
+        [
+            None,
+            "ssh host command",
+            [],
+            ["ssh", ""],
+            ["bash", "-lc", "ssh host command"],
+            ["/usr/bin/env", "bash", "-lc", "ssh host command"],
+        ],
+    )
     def test_missing_or_invalid_exact_argv_blocks(self, exact_argv):
         policy = _policy()
         policy["actions"]["caspian_inference_restart"]["exact_argv"] = exact_argv
 
-        result = evaluate_maintenance_action(policy, "caspian_inference_restart", SAFE_ARGV)
+        result = evaluate_maintenance_action(policy, "caspian_inference_restart", exact_argv)
 
         assert result.allowed is False
         assert result.reason == "exact_argv_invalid"
@@ -154,9 +164,12 @@ class TestMaintenanceActionContext:
         "invocation_context",
         ["cron", "unattended", "background", "scheduler", "CrOn"],
     )
-    def test_unattended_context_blocks_by_default(self, invocation_context):
+    @pytest.mark.parametrize("unattended_policy", [None, False, "none", "NONE", "false"])
+    def test_unattended_context_blocks_by_default(
+        self, invocation_context, unattended_policy
+    ):
         result = evaluate_maintenance_action(
-            _policy(),
+            _policy(unattended_policy=unattended_policy),
             "caspian_inference_restart",
             SAFE_ARGV,
             invocation_context=invocation_context,
@@ -164,6 +177,22 @@ class TestMaintenanceActionContext:
 
         assert result.allowed is False
         assert result.reason == "unattended_forbidden"
+        assert result.eligible is False
+
+    @pytest.mark.parametrize("unattended_policy", [True, "allow", "manual", [], {}])
+    def test_malformed_unattended_policy_blocks_unattended_context(
+        self, unattended_policy
+    ):
+        result = evaluate_maintenance_action(
+            _policy(unattended_policy=unattended_policy),
+            "caspian_inference_restart",
+            SAFE_ARGV,
+            invocation_context="cron",
+            current_user_approved=True,
+        )
+
+        assert result.allowed is False
+        assert result.reason == "unattended_policy_invalid"
         assert result.eligible is False
 
     def test_current_user_approval_allows_when_required_gates_pass(self):
@@ -191,6 +220,50 @@ class TestMaintenanceActionContext:
 
         assert result.allowed is False
         assert result.reason == "missing_preflight_profile"
+
+    @pytest.mark.parametrize("preflight_profile", [True, [], {}])
+    def test_malformed_preflight_profile_blocks(self, preflight_profile):
+        policy = _policy()
+        policy["actions"]["caspian_inference_restart"]["preflight_profile"] = preflight_profile
+
+        result = evaluate_maintenance_action(
+            policy,
+            "caspian_inference_restart",
+            SAFE_ARGV,
+            current_user_approved=True,
+        )
+
+        assert result.allowed is False
+        assert result.reason == "invalid_preflight_profile"
+
+    def test_missing_postcheck_profile_blocks(self):
+        policy = _policy()
+        del policy["actions"]["caspian_inference_restart"]["postcheck_profile"]
+
+        result = evaluate_maintenance_action(
+            policy,
+            "caspian_inference_restart",
+            SAFE_ARGV,
+            current_user_approved=True,
+        )
+
+        assert result.allowed is False
+        assert result.reason == "missing_postcheck_profile"
+
+    @pytest.mark.parametrize("postcheck_profile", [True, [], {}])
+    def test_malformed_postcheck_profile_blocks(self, postcheck_profile):
+        policy = _policy()
+        policy["actions"]["caspian_inference_restart"]["postcheck_profile"] = postcheck_profile
+
+        result = evaluate_maintenance_action(
+            policy,
+            "caspian_inference_restart",
+            SAFE_ARGV,
+            current_user_approved=True,
+        )
+
+        assert result.allowed is False
+        assert result.reason == "invalid_postcheck_profile"
 
 
 class TestMaintenanceActionClassifier:

--- a/tests/tools/test_maintenance_actions.py
+++ b/tests/tools/test_maintenance_actions.py
@@ -3,7 +3,7 @@
 import pytest
 
 from tools.approval import detect_hardline_command
-from tools.maintenance_actions import evaluate_maintenance_action
+from tools.maintenance_actions import classify_maintenance_action, evaluate_maintenance_action
 
 
 SAFE_ARGV = [
@@ -191,6 +191,51 @@ class TestMaintenanceActionContext:
 
         assert result.allowed is False
         assert result.reason == "missing_preflight_profile"
+
+
+class TestMaintenanceActionClassifier:
+    def test_classifier_returns_stable_dict_for_blocked_action(self):
+        result = classify_maintenance_action(
+            _policy(), "caspian_inference_restart", ["ssh", "wrong-host"]
+        )
+
+        assert result == {
+            "allowed": False,
+            "eligible": False,
+            "reason": "argv_mismatch",
+            "action_id": "caspian_inference_restart",
+            "command_id": "caspian_power_control_restart",
+            "host_label": "caspian-inference-01",
+        }
+
+    def test_classifier_returns_stable_dict_for_eligible_action(self):
+        result = classify_maintenance_action(_policy(), "caspian_inference_restart", SAFE_ARGV)
+
+        assert result == {
+            "allowed": False,
+            "eligible": True,
+            "reason": "requires_current_user_approval",
+            "action_id": "caspian_inference_restart",
+            "command_id": "caspian_power_control_restart",
+            "host_label": "caspian-inference-01",
+        }
+
+    def test_classifier_returns_stable_dict_for_approved_action(self):
+        result = classify_maintenance_action(
+            _policy(),
+            "caspian_inference_restart",
+            SAFE_ARGV,
+            current_user_approved=True,
+        )
+
+        assert result == {
+            "allowed": True,
+            "eligible": True,
+            "reason": "approved",
+            "action_id": "caspian_inference_restart",
+            "command_id": "caspian_power_control_restart",
+            "host_label": "caspian-inference-01",
+        }
 
 
 class TestMaintenanceActionDoesNotWeakenHardline:

--- a/tests/tools/test_maintenance_actions.py
+++ b/tests/tools/test_maintenance_actions.py
@@ -44,6 +44,18 @@ class TestMaintenanceActionDefaultDeny:
         assert result.allowed is False
         assert result.reason == "policy_absent"
 
+    @pytest.mark.parametrize("enabled", [None, "false", "true", "no", "yes", 1, 0, [], {}])
+    def test_malformed_global_enabled_blocks(self, enabled):
+        result = evaluate_maintenance_action(
+            _policy(enabled=enabled),
+            "caspian_inference_restart",
+            SAFE_ARGV,
+            current_user_approved=True,
+        )
+
+        assert result.allowed is False
+        assert result.reason == "policy_enabled_invalid"
+
     def test_global_disabled_blocks(self):
         result = evaluate_maintenance_action(
             _policy(enabled=False), "caspian_inference_restart", SAFE_ARGV
@@ -51,6 +63,21 @@ class TestMaintenanceActionDefaultDeny:
 
         assert result.allowed is False
         assert result.reason == "policy_disabled"
+
+    @pytest.mark.parametrize("enabled", [None, "false", "true", "no", "yes", 1, 0, [], {}])
+    def test_malformed_action_enabled_blocks(self, enabled):
+        policy = _policy()
+        policy["actions"]["caspian_inference_restart"]["enabled"] = enabled
+
+        result = evaluate_maintenance_action(
+            policy,
+            "caspian_inference_restart",
+            SAFE_ARGV,
+            current_user_approved=True,
+        )
+
+        assert result.allowed is False
+        assert result.reason == "action_enabled_invalid"
 
     def test_action_disabled_blocks(self):
         policy = _policy()

--- a/tools/maintenance_actions.py
+++ b/tools/maintenance_actions.py
@@ -13,7 +13,6 @@ from typing import Any
 
 
 _SHELL_WRAPPERS = {"sh", "bash", "zsh", "ksh", "fish", "python", "python3", "perl", "ruby"}
-_SHELL_INDIRECTORS = {"env"}
 _SHELL_EVAL_FLAGS = {"-c", "-lc", "-ec", "-e"}
 _UNATTENDED_CONTEXTS = {"cron", "unattended", "background", "scheduler"}
 _UNATTENDED_FORBIDDEN_VALUES = {"", "none", "false", "off", "disabled", "forbidden"}
@@ -70,18 +69,9 @@ def _basename(value: Any) -> str:
 
 
 def _looks_like_shell_wrapping(argv: list[Any]) -> bool:
-    if not argv:
-        return False
-
-    head = _basename(argv[0])
-    if head in _SHELL_WRAPPERS:
-        return any(str(part) in _SHELL_EVAL_FLAGS for part in argv[1:3])
-
-    if head in _SHELL_INDIRECTORS and len(argv) >= 3:
-        indirect_target = _basename(argv[1])
-        if indirect_target in _SHELL_WRAPPERS:
-            return any(str(part) in _SHELL_EVAL_FLAGS for part in argv[2:4])
-
+    for index, part in enumerate(argv):
+        if _basename(part) in _SHELL_WRAPPERS:
+            return any(str(later) in _SHELL_EVAL_FLAGS for later in argv[index + 1 :])
     return False
 
 
@@ -179,7 +169,10 @@ def evaluate_maintenance_action(
     if not _valid_profile_ref(postcheck_profile):
         return _blocked("invalid_postcheck_profile", action_id=action_id, action=action)
 
-    if policy.get("require_interactive_user_approval", True) and not current_user_approved:
+    require_approval = policy.get("require_interactive_user_approval", True)
+    if not isinstance(require_approval, bool):
+        return _blocked("invalid_approval_requirement", action_id=action_id, action=action)
+    if require_approval and not current_user_approved:
         return _requires_approval(action_id, action)
 
     return _approved(action_id, action)

--- a/tools/maintenance_actions.py
+++ b/tools/maintenance_actions.py
@@ -1,0 +1,152 @@
+"""Non-executing maintenance-action policy validation.
+
+This module intentionally does not run commands. It classifies whether a named
+maintenance action is blocked, eligible-but-needs-current-user-approval, or
+approved by policy. Execution, preflight probes, postchecks, and audit writes
+belong to later layers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+_SHELL_WRAPPERS = {"sh", "bash", "zsh", "ksh", "fish", "python", "python3", "perl", "ruby"}
+_SHELL_EVAL_FLAGS = {"-c", "-lc", "-ec", "-e"}
+_UNATTENDED_CONTEXTS = {"cron", "unattended", "background", "scheduler"}
+
+
+@dataclass(frozen=True)
+class MaintenanceActionDecision:
+    """Result of maintenance-action policy validation."""
+
+    allowed: bool
+    reason: str
+    eligible: bool = False
+    action_id: str = ""
+    command_id: str = ""
+    host_label: str = ""
+
+
+def _blocked(reason: str, *, action_id: str = "", action: dict[str, Any] | None = None) -> MaintenanceActionDecision:
+    action = action or {}
+    return MaintenanceActionDecision(
+        allowed=False,
+        reason=reason,
+        eligible=False,
+        action_id=action_id,
+        command_id=str(action.get("command_id", "") or ""),
+        host_label=str(action.get("host_label", "") or ""),
+    )
+
+
+def _requires_approval(action_id: str, action: dict[str, Any]) -> MaintenanceActionDecision:
+    return MaintenanceActionDecision(
+        allowed=False,
+        reason="requires_current_user_approval",
+        eligible=True,
+        action_id=action_id,
+        command_id=str(action.get("command_id", "") or ""),
+        host_label=str(action.get("host_label", "") or ""),
+    )
+
+
+def _approved(action_id: str, action: dict[str, Any]) -> MaintenanceActionDecision:
+    return MaintenanceActionDecision(
+        allowed=True,
+        reason="approved",
+        eligible=True,
+        action_id=action_id,
+        command_id=str(action.get("command_id", "") or ""),
+        host_label=str(action.get("host_label", "") or ""),
+    )
+
+
+def _looks_like_shell_wrapping(argv: list[Any]) -> bool:
+    if not argv:
+        return False
+    head = str(argv[0]).rsplit("/", 1)[-1]
+    if head not in _SHELL_WRAPPERS:
+        return False
+    return any(str(part) in _SHELL_EVAL_FLAGS for part in argv[1:3])
+
+
+def _valid_exact_argv(value: Any) -> bool:
+    return (
+        isinstance(value, list)
+        and bool(value)
+        and all(isinstance(part, str) and part for part in value)
+    )
+
+
+def _valid_requested_argv(value: Any) -> bool:
+    return (
+        isinstance(value, list)
+        and bool(value)
+        and all(isinstance(part, str) and part for part in value)
+    )
+
+
+def evaluate_maintenance_action(
+    policy: Any,
+    action_id: str,
+    requested_argv: Any,
+    *,
+    invocation_context: str = "interactive",
+    current_user_approved: bool = False,
+) -> MaintenanceActionDecision:
+    """Evaluate a named maintenance action without executing it.
+
+    The function is deliberately conservative. It does not run preflight or
+    postcheck probes; it only validates static policy gates and exact argv
+    matching. Later execution code must still perform live preflight,
+    current-user approval capture, command execution, postcheck verification,
+    and audit logging.
+    """
+
+    if not policy:
+        return _blocked("policy_absent", action_id=action_id)
+    if not isinstance(policy, dict):
+        return _blocked("policy_invalid", action_id=action_id)
+    if not policy.get("enabled", False):
+        return _blocked("policy_disabled", action_id=action_id)
+
+    if str(invocation_context or "").lower() in _UNATTENDED_CONTEXTS:
+        if policy.get("unattended_policy", "none") in (None, "none", False):
+            return _blocked("unattended_forbidden", action_id=action_id)
+
+    actions = policy.get("actions")
+    if not isinstance(actions, dict):
+        return _blocked("actions_invalid", action_id=action_id)
+
+    action = actions.get(action_id)
+    if action is None:
+        return _blocked("unknown_action", action_id=action_id)
+    if not isinstance(action, dict):
+        return _blocked("action_invalid", action_id=action_id)
+    if not action.get("enabled", False):
+        return _blocked("action_disabled", action_id=action_id, action=action)
+
+    expected_argv = action.get("exact_argv")
+    if not _valid_exact_argv(expected_argv):
+        return _blocked("exact_argv_invalid", action_id=action_id, action=action)
+
+    if not isinstance(requested_argv, list):
+        return _blocked("argv_must_be_list", action_id=action_id, action=action)
+    if not _valid_requested_argv(requested_argv):
+        return _blocked("argv_invalid", action_id=action_id, action=action)
+    if _looks_like_shell_wrapping(requested_argv):
+        return _blocked("shell_wrapping_forbidden", action_id=action_id, action=action)
+    if requested_argv != expected_argv:
+        return _blocked("argv_mismatch", action_id=action_id, action=action)
+
+    if not action.get("preflight_profile"):
+        return _blocked("missing_preflight_profile", action_id=action_id, action=action)
+    if not action.get("postcheck_profile"):
+        return _blocked("missing_postcheck_profile", action_id=action_id, action=action)
+
+    if policy.get("require_interactive_user_approval", True) and not current_user_approved:
+        return _requires_approval(action_id, action)
+
+    return _approved(action_id, action)

--- a/tools/maintenance_actions.py
+++ b/tools/maintenance_actions.py
@@ -69,6 +69,8 @@ def _basename(value: Any) -> str:
 
 
 def _looks_like_shell_wrapping(argv: list[Any]) -> bool:
+    if argv and _basename(argv[0]) == "env" and "-S" in argv[1:]:
+        return True
     for index, part in enumerate(argv):
         if _basename(part) in _SHELL_WRAPPERS:
             return any(str(later) in _SHELL_EVAL_FLAGS for later in argv[index + 1 :])
@@ -104,6 +106,10 @@ def _valid_profile_ref(value: Any) -> bool:
     return isinstance(value, str) and bool(value.strip())
 
 
+def _valid_action_id(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
 def evaluate_maintenance_action(
     policy: Any,
     action_id: str,
@@ -122,7 +128,9 @@ def evaluate_maintenance_action(
     """
 
     if not policy:
-        return _blocked("policy_absent", action_id=action_id)
+        return _blocked("policy_absent", action_id=str(action_id or ""))
+    if not _valid_action_id(action_id):
+        return _blocked("invalid_action_id")
     if not isinstance(policy, dict):
         return _blocked("policy_invalid", action_id=action_id)
     policy_enabled = policy.get("enabled")
@@ -131,8 +139,12 @@ def evaluate_maintenance_action(
     if policy_enabled is not True:
         return _blocked("policy_enabled_invalid", action_id=action_id)
 
-    if str(invocation_context or "").lower() in _UNATTENDED_CONTEXTS:
-        unattended_reason = _unattended_policy_reason(policy.get("unattended_policy", "none"))
+    unattended_reason = _unattended_policy_reason(policy.get("unattended_policy", "none"))
+    if unattended_reason == "unattended_policy_invalid":
+        return _blocked(unattended_reason, action_id=action_id)
+
+    invocation_context_normalized = str(invocation_context or "").strip().lower()
+    if invocation_context_normalized in _UNATTENDED_CONTEXTS:
         return _blocked(unattended_reason, action_id=action_id)
 
     actions = policy.get("actions")
@@ -178,7 +190,9 @@ def evaluate_maintenance_action(
     require_approval = policy.get("require_interactive_user_approval", True)
     if not isinstance(require_approval, bool):
         return _blocked("invalid_approval_requirement", action_id=action_id, action=action)
-    if require_approval and not current_user_approved:
+    if not isinstance(current_user_approved, bool):
+        return _blocked("invalid_current_user_approval", action_id=action_id, action=action)
+    if require_approval and current_user_approved is not True:
         return _requires_approval(action_id, action)
 
     return _approved(action_id, action)

--- a/tools/maintenance_actions.py
+++ b/tools/maintenance_actions.py
@@ -125,8 +125,11 @@ def evaluate_maintenance_action(
         return _blocked("policy_absent", action_id=action_id)
     if not isinstance(policy, dict):
         return _blocked("policy_invalid", action_id=action_id)
-    if not policy.get("enabled", False):
+    policy_enabled = policy.get("enabled")
+    if policy_enabled is False:
         return _blocked("policy_disabled", action_id=action_id)
+    if policy_enabled is not True:
+        return _blocked("policy_enabled_invalid", action_id=action_id)
 
     if str(invocation_context or "").lower() in _UNATTENDED_CONTEXTS:
         unattended_reason = _unattended_policy_reason(policy.get("unattended_policy", "none"))
@@ -141,8 +144,11 @@ def evaluate_maintenance_action(
         return _blocked("unknown_action", action_id=action_id)
     if not isinstance(action, dict):
         return _blocked("action_invalid", action_id=action_id)
-    if not action.get("enabled", False):
+    action_enabled = action.get("enabled")
+    if action_enabled is False:
         return _blocked("action_disabled", action_id=action_id, action=action)
+    if action_enabled is not True:
+        return _blocked("action_enabled_invalid", action_id=action_id, action=action)
 
     expected_argv = action.get("exact_argv")
     if not _valid_exact_argv(expected_argv):

--- a/tools/maintenance_actions.py
+++ b/tools/maintenance_actions.py
@@ -13,8 +13,10 @@ from typing import Any
 
 
 _SHELL_WRAPPERS = {"sh", "bash", "zsh", "ksh", "fish", "python", "python3", "perl", "ruby"}
+_SHELL_INDIRECTORS = {"env"}
 _SHELL_EVAL_FLAGS = {"-c", "-lc", "-ec", "-e"}
 _UNATTENDED_CONTEXTS = {"cron", "unattended", "background", "scheduler"}
+_UNATTENDED_FORBIDDEN_VALUES = {"", "none", "false", "off", "disabled", "forbidden"}
 
 
 @dataclass(frozen=True)
@@ -63,13 +65,24 @@ def _approved(action_id: str, action: dict[str, Any]) -> MaintenanceActionDecisi
     )
 
 
+def _basename(value: Any) -> str:
+    return str(value).rsplit("/", 1)[-1]
+
+
 def _looks_like_shell_wrapping(argv: list[Any]) -> bool:
     if not argv:
         return False
-    head = str(argv[0]).rsplit("/", 1)[-1]
-    if head not in _SHELL_WRAPPERS:
-        return False
-    return any(str(part) in _SHELL_EVAL_FLAGS for part in argv[1:3])
+
+    head = _basename(argv[0])
+    if head in _SHELL_WRAPPERS:
+        return any(str(part) in _SHELL_EVAL_FLAGS for part in argv[1:3])
+
+    if head in _SHELL_INDIRECTORS and len(argv) >= 3:
+        indirect_target = _basename(argv[1])
+        if indirect_target in _SHELL_WRAPPERS:
+            return any(str(part) in _SHELL_EVAL_FLAGS for part in argv[2:4])
+
+    return False
 
 
 def _valid_exact_argv(value: Any) -> bool:
@@ -77,6 +90,7 @@ def _valid_exact_argv(value: Any) -> bool:
         isinstance(value, list)
         and bool(value)
         and all(isinstance(part, str) and part for part in value)
+        and not _looks_like_shell_wrapping(value)
     )
 
 
@@ -86,6 +100,18 @@ def _valid_requested_argv(value: Any) -> bool:
         and bool(value)
         and all(isinstance(part, str) and part for part in value)
     )
+
+
+def _unattended_policy_reason(value: Any) -> str:
+    if value is None or value is False:
+        return "unattended_forbidden"
+    if isinstance(value, str) and value.strip().lower() in _UNATTENDED_FORBIDDEN_VALUES:
+        return "unattended_forbidden"
+    return "unattended_policy_invalid"
+
+
+def _valid_profile_ref(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
 
 
 def evaluate_maintenance_action(
@@ -113,8 +139,8 @@ def evaluate_maintenance_action(
         return _blocked("policy_disabled", action_id=action_id)
 
     if str(invocation_context or "").lower() in _UNATTENDED_CONTEXTS:
-        if policy.get("unattended_policy", "none") in (None, "none", False):
-            return _blocked("unattended_forbidden", action_id=action_id)
+        unattended_reason = _unattended_policy_reason(policy.get("unattended_policy", "none"))
+        return _blocked(unattended_reason, action_id=action_id)
 
     actions = policy.get("actions")
     if not isinstance(actions, dict):
@@ -141,10 +167,17 @@ def evaluate_maintenance_action(
     if requested_argv != expected_argv:
         return _blocked("argv_mismatch", action_id=action_id, action=action)
 
-    if not action.get("preflight_profile"):
+    if "preflight_profile" not in action or action.get("preflight_profile") is None:
         return _blocked("missing_preflight_profile", action_id=action_id, action=action)
-    if not action.get("postcheck_profile"):
+    preflight_profile = action.get("preflight_profile")
+    if not _valid_profile_ref(preflight_profile):
+        return _blocked("invalid_preflight_profile", action_id=action_id, action=action)
+
+    if "postcheck_profile" not in action or action.get("postcheck_profile") is None:
         return _blocked("missing_postcheck_profile", action_id=action_id, action=action)
+    postcheck_profile = action.get("postcheck_profile")
+    if not _valid_profile_ref(postcheck_profile):
+        return _blocked("invalid_postcheck_profile", action_id=action_id, action=action)
 
     if policy.get("require_interactive_user_approval", True) and not current_user_approved:
         return _requires_approval(action_id, action)

--- a/tools/maintenance_actions.py
+++ b/tools/maintenance_actions.py
@@ -150,3 +150,35 @@ def evaluate_maintenance_action(
         return _requires_approval(action_id, action)
 
     return _approved(action_id, action)
+
+
+def classify_maintenance_action(
+    policy: Any,
+    action_id: str,
+    requested_argv: Any,
+    *,
+    invocation_context: str = "interactive",
+    current_user_approved: bool = False,
+) -> dict[str, Any]:
+    """Return a JSON-serializable dry-run classification for an action.
+
+    This is intentionally a thin wrapper around ``evaluate_maintenance_action``.
+    It does not execute commands, load live config, run preflight/postcheck
+    probes, write audit logs, or integrate with the terminal tool.
+    """
+
+    decision = evaluate_maintenance_action(
+        policy,
+        action_id,
+        requested_argv,
+        invocation_context=invocation_context,
+        current_user_approved=current_user_approved,
+    )
+    return {
+        "allowed": decision.allowed,
+        "eligible": decision.eligible,
+        "reason": decision.reason,
+        "action_id": decision.action_id,
+        "command_id": decision.command_id,
+        "host_label": decision.host_label,
+    }


### PR DESCRIPTION
## Summary

Adds a non-executing maintenance-action policy validator and dry-run classifier for future maintenance action workflows.

This PR deliberately builds only the safety interlock, not an actuator:

- adds `tools/maintenance_actions.py` as a static classifier
- adds tests for default-deny policy behavior and bypass-shaped inputs
- adds docs describing the validator safety contract and future execution boundaries
- keeps execution, live config loading, preflight probes, postchecks, audit writes, terminal integration, and remote-host contact out of scope

## Safety contract

The validator defaults closed for:

- absent/disabled/malformed global policy
- malformed action IDs
- missing/malformed action maps and action bodies
- disabled/malformed action enabled flags
- missing/malformed exact argv
- malformed requested argv
- exact argv mismatches
- shell strings and shell-wrapper forms including `sh -c`, `bash -lc`, `/usr/bin/env bash -lc`, and `/usr/bin/env -S ...`
- unattended contexts such as cron/background/scheduler/unattended
- malformed unattended policy values
- missing/malformed preflight and postcheck metadata
- malformed approval-requirement policy values
- malformed current-user approval values
- missing current-user approval by default

## Scope boundaries

This is intentionally inert. It does not:

- execute commands
- load live `~/.hermes/config.yaml`
- run preflight or postcheck probes
- write audit logs
- contact remote hosts
- integrate with the terminal tool
- bypass existing hardline/Tirith/dangerous-command approval layers

Future execution integration should be a separate reviewed TDD slice.

## Test Plan

- [x] `venv/bin/python -m pytest tests/tools/test_maintenance_actions.py tests/tools/test_tirith_security.py tests/tools/test_approval.py -q -o 'addopts='` — 414 passed
- [x] `venv/bin/ruff check tools/maintenance_actions.py tests/tools/test_maintenance_actions.py` — All checks passed
- [x] `git diff --check` — clean
- [x] Added-line static scan for likely secrets, `shell=True`, `eval`/`exec`, `pickle`, SQL-format patterns, and `subprocess` usage — no findings