### PR TITLE
fix(desktop): use managed Node path during updater rebuild

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/update.rs
+++ b/apps/bootstrap-installer/src-tauri/src/update.rs
@@ -596,12 +596,24 @@ fn update_child_env(install_root: &Path) -> Vec<(String, OsString)> {
         hermes_home.as_os_str().to_os_string(),
     )];
     if let Some(path) = path_with_prepended_entries(&[
-        hermes_home.join("node").join("bin"),
+        managed_node_dir(&hermes_home),
         venv_bin_dir(install_root),
     ]) {
         envs.push(("PATH".to_string(), path));
     }
     envs
+}
+
+fn managed_node_dir(hermes_home: &Path) -> PathBuf {
+    managed_node_dir_for(hermes_home, cfg!(target_os = "windows"))
+}
+
+fn managed_node_dir_for(hermes_home: &Path, windows: bool) -> PathBuf {
+    if windows {
+        hermes_home.join("node")
+    } else {
+        hermes_home.join("node").join("bin")
+    }
 }
 
 fn venv_bin_dir(install_root: &Path) -> PathBuf {
@@ -911,6 +923,22 @@ mod tests {
             Some(PathBuf::from("/Applications/Hermes.app"))
         );
         assert_eq!(target_app_from_args(["--target-app", "/tmp/not-an-app"]), None);
+    }
+
+    #[test]
+    fn managed_node_dir_matches_installer_layout() {
+        let hermes_home = Path::new("/tmp/hermes-home");
+
+        assert_eq!(
+            managed_node_dir_for(hermes_home, true),
+            hermes_home.join("node"),
+            "Windows portable Node is installed directly under HERMES_HOME/node"
+        );
+        assert_eq!(
+            managed_node_dir_for(hermes_home, false),
+            hermes_home.join("node").join("bin"),
+            "Unix-style managed Node installs expose binaries through node/bin"
+        );
     }
 
     // Helpers for the swap tests: make a throwaway dir tree we can rename.


### PR DESCRIPTION
## What does this PR do?

Fixes the Windows Desktop updater rebuild environment so it prepends the same Hermes-managed portable Node directory that the Windows installer actually creates.

The installer puts portable Node/npm directly under `%LOCALAPPDATA%\hermes\node` and persists that directory to PATH. The updater child process was prepending `%LOCALAPPDATA%\hermes\node\bin` instead, which made `hermes desktop --build-only` fail with `npm was not found on PATH` even after the installer had successfully installed managed Node.

This keeps the Unix-style `node/bin` path for non-Windows installs and uses the direct `node` directory only for Windows.

## Related Issue

Related support thread: https://discord.com/channels/1053877538025386074/1514602674501451877

Related PR: https://github.com/NousResearch/hermes-agent/pull/44262

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `apps/bootstrap-installer/src-tauri/src/update.rs` so `update_child_env()` prepends `%LOCALAPPDATA%\hermes\node` on Windows instead of `%LOCALAPPDATA%\hermes\node\bin`.
- Kept the existing `node/bin` path for non-Windows updater rebuilds.
- Added a unit test covering the Windows and non-Windows managed Node path layout.

## How to Test

1. On Windows, install Hermes Desktop so managed Node is present under `%LOCALAPPDATA%\hermes\node`.
2. Trigger the Desktop updater rebuild path.
3. Confirm the rebuild child process can resolve `npm` from the managed Node directory instead of failing with `Desktop GUI requires Node.js/npm, but npm was not found on PATH.`

Focused local validation:

- [x] `powershell.exe -NoProfile -Command '$env:CARGO_INCREMENTAL="0"; $env:CARGO_TARGET_DIR="C:\Users\btgil\AppData\Local\Temp\hermes-bootstrap-target-updater-nodepath"; Set-Location "\\wsl.localhost\Ubuntu\tmp\hermes-agent-updater-nodepath\apps\bootstrap-installer\src-tauri"; & "C:\Users\btgil\.cargo\bin\cargo.exe" test managed_node_dir_matches_installer_layout'`
  - `1 passed; 0 failed; 21 filtered out`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows Cargo from WSL against the bootstrap installer crate

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Support log excerpt from the Discord thread:

- `Node.js v22.22.3 installed to C:\Users\HoySa\AppData\Local\hermes\node\ (portable, user-scoped)`
- `Desktop GUI requires Node.js/npm, but npm was not found on PATH.`
