### PR TITLE
Enforce API session roots for file tools

### DIFF
--- a/agent/runtime_cwd.py
+++ b/agent/runtime_cwd.py
@@ -18,6 +18,7 @@ from typing import Any
 _UNSET: Any = object()
 
 _SESSION_CWD: ContextVar = ContextVar("HERMES_SESSION_CWD", default=_UNSET)
+_SESSION_FILE_ROOT: ContextVar = ContextVar("HERMES_SESSION_FILE_ROOT", default=_UNSET)
 
 
 def set_session_cwd(cwd: str | None) -> Token:
@@ -29,11 +30,35 @@ def clear_session_cwd() -> None:
     _SESSION_CWD.set("")
 
 
+def set_session_file_root(root: str | None) -> Token:
+    """Pin the filesystem root enforced by file tools for this context."""
+    return _SESSION_FILE_ROOT.set((root or "").strip())
+
+
+def clear_session_file_root() -> None:
+    _SESSION_FILE_ROOT.set("")
+
+
 def _session_cwd_override() -> str:
     value = _SESSION_CWD.get()
     if value is _UNSET:
         return ""
     return str(value).strip()
+
+
+def _session_file_root_override() -> str:
+    value = _SESSION_FILE_ROOT.get()
+    if value is _UNSET:
+        return ""
+    return str(value).strip()
+
+
+def resolve_session_file_root() -> Path | None:
+    """Return the request-scoped file-tool root, if one is enforced."""
+    override = _session_file_root_override()
+    if not override:
+        return None
+    return Path(override).expanduser()
 
 
 def resolve_agent_cwd() -> Path:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2,7 +2,7 @@
 OpenAI-compatible API server platform adapter.
 
 Exposes an HTTP server with endpoints:
-- POST /v1/chat/completions        — OpenAI Chat Completions format (stateless; opt-in session continuity via X-Hermes-Session-Id header; opt-in long-term memory scoping via X-Hermes-Session-Key header)
+- POST /v1/chat/completions        — OpenAI Chat Completions format (stateless; opt-in session continuity via X-Hermes-Session-Id header; opt-in long-term memory scoping via X-Hermes-Session-Key header; opt-in file root enforcement via X-Hermes-Session-Root header)
 - POST /v1/responses               — OpenAI Responses API format (stateful via previous_response_id; X-Hermes-Session-Key supported)
 - GET  /v1/responses/{response_id} — Retrieve a stored response
 - DELETE /v1/responses/{response_id} — Delete a stored response
@@ -926,6 +926,7 @@ class APIServerAdapter(BasePlatformAdapter):
     # (e.g. ``agent:main:webui:dm:user-42``) while staying small enough
     # that the sanitized form is safe to pass into Honcho / state.db.
     _MAX_SESSION_HEADER_LEN = 256
+    _MAX_SESSION_ROOT_HEADER_LEN = 1024
 
     def _parse_session_key_header(
         self, request: "web.Request"
@@ -974,6 +975,53 @@ class APIServerAdapter(BasePlatformAdapter):
         if len(raw) > self._MAX_SESSION_HEADER_LEN:
             return None, web.json_response(
                 {"error": {"message": "Session key too long", "type": "invalid_request_error"}},
+                status=400,
+            )
+
+        return raw, None
+
+    def _parse_session_root_header(
+        self, request: "web.Request"
+    ) -> tuple[Optional[str], Optional["web.Response"]]:
+        """Extract and validate the internal ``X-Hermes-Session-Root`` header.
+
+        The root is not a user-facing session identifier and is never echoed.
+        It pins file tools to a request-scoped workspace root selected by a
+        trusted control plane.  Accepting it without API-key authentication
+        would let an unauthenticated local client choose arbitrary roots.
+        """
+        raw = request.headers.get("X-Hermes-Session-Root", "").strip()
+        if not raw:
+            return None, None
+
+        if not self._api_key:
+            logger.warning(
+                "X-Hermes-Session-Root rejected: no API key configured. "
+                "Set API_SERVER_KEY to enable session file root enforcement."
+            )
+            return None, web.json_response(
+                _openai_error(
+                    "X-Hermes-Session-Root requires API key authentication. "
+                    "Configure API_SERVER_KEY to enable this feature."
+                ),
+                status=403,
+            )
+
+        if re.search(r'[\r\n\x00]', raw):
+            return None, web.json_response(
+                {"error": {"message": "Invalid session root", "type": "invalid_request_error"}},
+                status=400,
+            )
+
+        if len(raw) > self._MAX_SESSION_ROOT_HEADER_LEN:
+            return None, web.json_response(
+                {"error": {"message": "Session root too long", "type": "invalid_request_error"}},
+                status=400,
+            )
+
+        if not Path(raw).expanduser().is_absolute():
+            return None, web.json_response(
+                {"error": {"message": "Session root must be absolute", "type": "invalid_request_error"}},
                 status=400,
             )
 
@@ -1170,6 +1218,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "realtime_voice": False,
                 "session_continuity_header": "X-Hermes-Session-Id",
                 "session_key_header": "X-Hermes-Session-Key",
+                "session_root_header": "X-Hermes-Session-Root",
                 "cors": bool(self._cors_origins),
             },
             "endpoints": {
@@ -1543,6 +1592,9 @@ class APIServerAdapter(BasePlatformAdapter):
         gateway_session_key, key_err = self._parse_session_key_header(request)
         if key_err is not None:
             return key_err
+        session_root, root_err = self._parse_session_root_header(request)
+        if root_err is not None:
+            return root_err
         session_id = request.match_info["session_id"]
         _, err = self._get_existing_session_or_404(session_id)
         if err:
@@ -1563,6 +1615,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ephemeral_system_prompt=system_prompt,
             session_id=session_id,
             gateway_session_key=gateway_session_key,
+            session_root=session_root,
         )
         effective_session_id = result.get("session_id") if isinstance(result, dict) else session_id
         final_response = result.get("final_response", "") if isinstance(result, dict) else ""
@@ -1587,6 +1640,9 @@ class APIServerAdapter(BasePlatformAdapter):
         gateway_session_key, key_err = self._parse_session_key_header(request)
         if key_err is not None:
             return key_err
+        session_root, root_err = self._parse_session_root_header(request)
+        if root_err is not None:
+            return root_err
         session_id = request.match_info["session_id"]
         _, err = self._get_existing_session_or_404(session_id)
         if err:
@@ -1654,6 +1710,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     stream_delta_callback=_delta,
                     tool_progress_callback=_tool_progress,
                     gateway_session_key=gateway_session_key,
+                    session_root=session_root,
                 )
                 final_response = result.get("final_response", "") if isinstance(result, dict) else ""
                 effective_session_id = result.get("session_id", session_id) if isinstance(result, dict) else session_id
@@ -1784,6 +1841,9 @@ class APIServerAdapter(BasePlatformAdapter):
         gateway_session_key, key_err = self._parse_session_key_header(request)
         if key_err is not None:
             return key_err
+        session_root, root_err = self._parse_session_root_header(request)
+        if root_err is not None:
+            return root_err
 
         # Allow caller to continue an existing session by passing X-Hermes-Session-Id.
         # When provided, history is loaded from state.db instead of from the request body.
@@ -1920,6 +1980,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
+                session_root=session_root,
             ))
             # Ensure SSE drain loops can terminate without relying on polling
             # agent_task.done(), which can race with queue timeout checks.
@@ -1939,6 +2000,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                session_root=session_root,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
@@ -2799,6 +2861,9 @@ class APIServerAdapter(BasePlatformAdapter):
         gateway_session_key, key_err = self._parse_session_key_header(request)
         if key_err is not None:
             return key_err
+        session_root, root_err = self._parse_session_root_header(request)
+        if root_err is not None:
+            return root_err
 
         # Parse request body
         try:
@@ -2952,6 +3017,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
+                session_root=session_root,
             ))
             # Ensure SSE drain loops can terminate without relying on polling
             # agent_task.done(), which can race with queue timeout checks.
@@ -2985,6 +3051,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=instructions,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                session_root=session_root,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
@@ -3495,6 +3562,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_complete_callback=None,
         agent_ref: Optional[list] = None,
         gateway_session_key: Optional[str] = None,
+        session_root: Optional[str] = None,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -3517,6 +3585,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 chat_id=session_id or "",
                 session_key=gateway_session_key or session_id or "",
                 session_id=session_id or "",
+                cwd=session_root or "",
+                file_root=session_root or "",
             )
             try:
                 agent = self._create_agent(
@@ -3632,6 +3702,9 @@ class APIServerAdapter(BasePlatformAdapter):
         gateway_session_key, key_err = self._parse_session_key_header(request)
         if key_err is not None:
             return key_err
+        session_root, root_err = self._parse_session_root_header(request)
+        if root_err is not None:
+            return root_err
 
         # Enforce concurrency limit
         if len(self._run_streams) >= self._MAX_CONCURRENT_RUNS:
@@ -3785,6 +3858,9 @@ class APIServerAdapter(BasePlatformAdapter):
                         session_tokens = set_session_vars(
                             platform="api_server",
                             session_key=approval_session_key,
+                            session_id=session_id or "",
+                            cwd=session_root or "",
+                            file_root=session_root or "",
                         )
                         register_gateway_notify(approval_session_key, _approval_notify)
                         r = agent.run_conversation(

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -109,6 +109,7 @@ def set_session_vars(
     session_id: str = "",
     message_id: str = "",
     cwd: str = "",
+    file_root: str = "",
 ) -> list:
     """Set all session context variables and return reset tokens.
 
@@ -119,6 +120,7 @@ def set_session_vars(
     only for API compatibility.
 
     ``cwd`` pins the logical working directory for this context.
+    ``file_root`` pins the filesystem root enforced by file tools.
     """
     tokens = [
         _SESSION_PLATFORM.set(platform),
@@ -132,9 +134,10 @@ def set_session_vars(
         _SESSION_MESSAGE_ID.set(message_id),
     ]
     try:
-        from agent.runtime_cwd import set_session_cwd
+        from agent.runtime_cwd import set_session_cwd, set_session_file_root
 
         set_session_cwd(cwd)
+        set_session_file_root(file_root)
     except Exception:
         pass
     return tokens
@@ -164,9 +167,10 @@ def clear_session_vars(tokens: list) -> None:
     ):
         var.set("")
     try:
-        from agent.runtime_cwd import clear_session_cwd
+        from agent.runtime_cwd import clear_session_cwd, clear_session_file_root
 
         clear_session_cwd()
+        clear_session_file_root()
     except Exception:
         pass
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -3510,3 +3510,64 @@ class TestSessionKeyHeader:
             assert resp.status == 200
             data = await resp.json()
             assert data["features"]["session_key_header"] == "X-Hermes-Session-Key"
+            assert data["features"]["session_root_header"] == "X-Hermes-Session-Root"
+
+
+# ---------------------------------------------------------------------------
+# X-Hermes-Session-Root header (file-tool root enforcement)
+# ---------------------------------------------------------------------------
+
+
+class TestSessionRootHeader:
+    @pytest.mark.asyncio
+    async def test_session_root_passed_to_agent_but_not_echoed(self, auth_adapter, tmp_path):
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+        root = tmp_path / "workspace"
+        root.mkdir()
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={
+                        "X-Hermes-Session-Root": str(root),
+                        "Authorization": "Bearer sk-secret",
+                    },
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]},
+                )
+        assert resp.status == 200
+        assert "X-Hermes-Session-Root" not in resp.headers
+        call_kwargs = mock_run.call_args.kwargs
+        assert call_kwargs["session_root"] == str(root)
+
+    @pytest.mark.asyncio
+    async def test_session_root_rejected_without_api_key(self, adapter, tmp_path):
+        root = tmp_path / "workspace"
+        root.mkdir()
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                headers={"X-Hermes-Session-Root": str(root)},
+                json={"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]},
+            )
+        assert resp.status == 403
+
+    @pytest.mark.asyncio
+    async def test_session_root_rejects_control_chars(self, auth_adapter):
+        mock_request = MagicMock()
+        mock_request.headers = {"X-Hermes-Session-Root": "/workspace/root\rbad"}
+        root, err = auth_adapter._parse_session_root_header(mock_request)
+        assert root is None
+        assert err is not None
+        assert err.status == 400
+
+    @pytest.mark.asyncio
+    async def test_session_root_rejects_relative_paths(self, auth_adapter):
+        mock_request = MagicMock()
+        mock_request.headers = {"X-Hermes-Session-Root": "workspace/root"}
+        root, err = auth_adapter._parse_session_root_header(mock_request)
+        assert root is None
+        assert err is not None
+        assert err.status == 400

--- a/tests/tools/test_file_tools_session_root.py
+++ b/tests/tools/test_file_tools_session_root.py
@@ -1,0 +1,162 @@
+import json
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def session_root_cleanup(monkeypatch):
+    from agent.runtime_cwd import clear_session_cwd, clear_session_file_root
+    from tools import file_tools
+
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    monkeypatch.setattr(
+        file_tools,
+        "_SENSITIVE_PATH_PREFIXES",
+        tuple(
+            prefix
+            for prefix in file_tools._SENSITIVE_PATH_PREFIXES
+            if prefix != "/private/var/"
+        ),
+    )
+    clear_session_cwd()
+    clear_session_file_root()
+    file_tools.clear_file_ops_cache()
+    yield
+    clear_session_cwd()
+    clear_session_file_root()
+    file_tools.clear_file_ops_cache()
+
+
+def _set_file_root(path):
+    from agent.runtime_cwd import set_session_cwd, set_session_file_root
+
+    set_session_cwd(str(path))
+    set_session_file_root(str(path))
+
+
+def _payload(raw):
+    return json.loads(raw)
+
+
+def test_session_root_allows_relative_write_and_read(tmp_path):
+    from tools.file_tools import read_file_tool, write_file_tool
+
+    root = tmp_path / "user-a"
+    root.mkdir()
+    _set_file_root(root)
+
+    written = _payload(
+        write_file_tool("notes/sentinel.md", "user-a only\n", task_id="root-allow")
+    )
+
+    assert "error" not in written
+    assert (root / "notes" / "sentinel.md").read_text() == "user-a only\n"
+
+    read = _payload(read_file_tool("notes/sentinel.md", task_id="root-allow"))
+
+    assert "error" not in read
+    assert "user-a only" in read["content"]
+
+
+def test_session_root_rejects_absolute_and_dotdot_escapes(tmp_path):
+    from tools.file_tools import patch_tool, read_file_tool, search_tool, write_file_tool
+
+    root = tmp_path / "user-a"
+    root.mkdir()
+    outside = tmp_path / "user-b-secret.txt"
+    outside.write_text("outside\n")
+    _set_file_root(root)
+
+    read = _payload(read_file_tool(str(outside), task_id="root-escape"))
+    write = _payload(write_file_tool("../user-b-secret.txt", "pwned\n", task_id="root-escape"))
+    search = _payload(search_tool("outside", path=str(outside), task_id="root-escape"))
+    patch = _payload(
+        patch_tool(
+            mode="replace",
+            path=str(outside),
+            old_string="outside",
+            new_string="pwned",
+            task_id="root-escape",
+        )
+    )
+
+    assert "current session file root" in read["error"]
+    assert "current session file root" in write["error"]
+    assert "current session file root" in search["error"]
+    assert "current session file root" in patch["error"]
+    assert outside.read_text() == "outside\n"
+
+
+def test_session_root_rejects_symlink_escape(tmp_path):
+    from tools.file_tools import read_file_tool, search_tool, write_file_tool
+
+    root = tmp_path / "user-a"
+    root.mkdir()
+    outside = tmp_path / "user-b-secret.txt"
+    outside.write_text("outside\n")
+    (root / "link.txt").symlink_to(outside)
+    _set_file_root(root)
+
+    read = _payload(read_file_tool("link.txt", task_id="root-symlink"))
+    write = _payload(write_file_tool("link.txt", "pwned\n", task_id="root-symlink"))
+    search = _payload(search_tool("outside", path=".", task_id="root-symlink"))
+
+    assert "current session file root" in read["error"]
+    assert "current session file root" in write["error"]
+    assert "symlink" in search["error"]
+    assert outside.read_text() == "outside\n"
+
+
+def test_session_root_rewrites_v4a_patch_paths_to_validated_root(tmp_path):
+    from tools.file_tools import patch_tool
+
+    root = tmp_path / "user-a"
+    root.mkdir()
+    target = root / "app.py"
+    target.write_text("print('old')\n")
+    _set_file_root(root)
+
+    result = _payload(
+        patch_tool(
+            mode="patch",
+            patch=(
+                "*** Begin Patch\n"
+                "*** Update File: app.py\n"
+                "@@\n"
+                "-print('old')\n"
+                "+print('new')\n"
+                "*** End Patch\n"
+            ),
+            task_id="root-v4a",
+        )
+    )
+
+    assert result["success"] is True
+    assert target.read_text() == "print('new')\n"
+    assert result["files_modified"] == [str(target.resolve())]
+
+
+def test_session_root_rejects_hardlink_aliases(tmp_path):
+    from tools.file_tools import read_file_tool, search_tool, write_file_tool
+
+    root = tmp_path / "user-a"
+    root.mkdir()
+    outside = tmp_path / "user-b-secret.txt"
+    outside.write_text("outside\n")
+    link = root / "linked.txt"
+    try:
+        os.link(outside, link)
+    except OSError as exc:
+        pytest.skip(f"hardlinks unavailable on this filesystem: {exc}")
+    _set_file_root(root)
+
+    read = _payload(read_file_tool("linked.txt", task_id="root-hardlink"))
+    write = _payload(write_file_tool("linked.txt", "pwned\n", task_id="root-hardlink"))
+    search = _payload(search_tool("outside", path=".", task_id="root-hardlink"))
+
+    assert "multiple filesystem links" in read["error"]
+    assert "multiple filesystem links" in write["error"]
+    assert "multiple filesystem links" in search["error"]
+    assert outside.read_text() == "outside\n"

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -5,6 +5,7 @@ import errno
 import json
 import logging
 import os
+import stat
 import threading
 from pathlib import Path
 
@@ -94,6 +95,10 @@ def _resolve_path(filepath: str, task_id: str = "default") -> Path:
 # (gateway/run.py); the file/terminal-tool layer must do likewise so CLI
 # sessions get the same protection. See references/worktree-cwd-discipline.md.
 _TERMINAL_CWD_SENTINELS = frozenset({"", ".", "./", "auto", "cwd"})
+
+
+class SessionRootPathError(ValueError):
+    """Raised when a file tool request escapes the request-scoped root."""
 
 
 def _configured_terminal_cwd() -> str | None:
@@ -196,13 +201,92 @@ def _resolve_base_dir(task_id: str = "default") -> Path:
     return base.resolve()
 
 
+def _session_file_root() -> Path | None:
+    try:
+        from agent.runtime_cwd import resolve_session_file_root
+
+        root = resolve_session_file_root()
+    except Exception:
+        return None
+    if root is None:
+        return None
+    try:
+        resolved = root.expanduser().resolve()
+    except (OSError, ValueError) as exc:
+        raise SessionRootPathError("Configured session file root is invalid") from exc
+    if not resolved.is_dir():
+        raise SessionRootPathError("Configured session file root is not available")
+    return resolved
+
+
+def _ensure_under_session_root(path: Path, root: Path) -> Path:
+    try:
+        resolved = path.expanduser().resolve()
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise SessionRootPathError("Path escapes current session file root") from exc
+    except OSError as exc:
+        raise SessionRootPathError("Path cannot be resolved within current session file root") from exc
+    return resolved
+
+
+def _session_root_hardlink_error(path: Path) -> str | None:
+    if _session_file_root() is None:
+        return None
+    try:
+        st = path.stat()
+    except FileNotFoundError:
+        return None
+    except OSError:
+        return "Path cannot be verified within current session file root"
+    if stat.S_ISREG(st.st_mode) and st.st_nlink > 1:
+        return "Path has multiple filesystem links and is unsafe in this session file root"
+    return None
+
+
+def _session_root_tree_error(path: Path) -> str | None:
+    root = _session_file_root()
+    if root is None:
+        return None
+    hardlink_error = _session_root_hardlink_error(path)
+    if hardlink_error:
+        return hardlink_error
+    if not path.is_dir():
+        return None
+    for current, dirnames, filenames in os.walk(path, followlinks=False):
+        current_path = Path(current)
+        for name in list(dirnames):
+            candidate = current_path / name
+            if candidate.is_symlink():
+                try:
+                    _ensure_under_session_root(candidate, root)
+                except SessionRootPathError:
+                    return "Search path contains a symlink that escapes current session file root"
+        for name in filenames:
+            candidate = current_path / name
+            if candidate.is_symlink():
+                try:
+                    _ensure_under_session_root(candidate, root)
+                except SessionRootPathError:
+                    return "Search path contains a symlink that escapes current session file root"
+                continue
+            hardlink_error = _session_root_hardlink_error(candidate)
+            if hardlink_error:
+                return hardlink_error
+    return None
+
+
 def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path:
     """Resolve *filepath* against the task's absolute base directory.
 
     See :func:`_resolve_base_dir` for how the base is chosen. Absolute input
     paths are returned resolved-but-unanchored.
     """
+    root = _session_file_root()
     p = Path(filepath).expanduser()
+    if root is not None:
+        candidate = p if p.is_absolute() else root / p
+        return _ensure_under_session_root(candidate, root)
     if p.is_absolute():
         return p.resolve()
     return (_resolve_base_dir(task_id) / p).resolve()
@@ -316,6 +400,8 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
     """Return an error message if the path targets a sensitive system location."""
     try:
         resolved = str(_resolve_path_for_task(filepath, task_id))
+    except SessionRootPathError as exc:
+        return str(exc)
     except (OSError, ValueError):
         resolved = filepath
     normalized = os.path.normpath(os.path.expanduser(filepath))
@@ -419,6 +505,8 @@ def _check_cross_profile_path(filepath: str, task_id: str = "default") -> str | 
     # classified against the right base.
     try:
         resolved = str(_resolve_path_for_task(filepath, task_id))
+    except SessionRootPathError as exc:
+        return str(exc)
     except (OSError, ValueError):
         resolved = filepath
 
@@ -759,6 +847,16 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
             })
 
         _resolved = _resolve_path_for_task(path, task_id)
+        if _is_blocked_device(str(_resolved)):
+            return json.dumps({
+                "error": (
+                    f"Cannot read '{path}': this is a device file that would "
+                    "block or produce infinite output."
+                ),
+            })
+        hardlink_error = _session_root_hardlink_error(_resolved)
+        if hardlink_error:
+            return json.dumps({"error": hardlink_error})
 
         # ── Binary file guard ─────────────────────────────────────────
         # Block binary files by extension (no I/O).
@@ -844,7 +942,8 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
 
         # ── Perform the read ──────────────────────────────────────────
         file_ops = _get_file_ops(task_id)
-        result = file_ops.read_file(path, offset, limit)
+        file_ops_path = resolved_str if _session_file_root() is not None else path
+        result = file_ops.read_file(file_ops_path, offset, limit)
         result_dict = result.to_dict()
 
         # ── Character-count guard ─────────────────────────────────────
@@ -1022,7 +1121,7 @@ def _invalidate_dedup_for_path(filepath: str, task_id: str) -> None:
     internally.
     """
     try:
-        resolved = str(_resolve_path(filepath))
+        resolved = str(_resolve_path_for_task(filepath, task_id))
     except (OSError, ValueError):
         return
     with _read_tracker_lock:
@@ -1121,6 +1220,8 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
         # check below still runs.
         try:
             _resolved = str(_resolve_path_for_task(path, task_id))
+        except SessionRootPathError as exc:
+            return tool_error(str(exc))
         except Exception:
             _resolved = None
 
@@ -1138,6 +1239,9 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
         # subagents can't interleave on the same file.  Different paths
         # remain fully parallel.
         with file_state.lock_path(_resolved):
+            hardlink_error = _session_root_hardlink_error(Path(_resolved))
+            if hardlink_error:
+                return tool_error(hardlink_error)
             # Cross-agent staleness wins over per-task warning when both
             # fire — its message names the sibling subagent.
             cross_warning = file_state.check_stale(task_id, _resolved)
@@ -1171,6 +1275,34 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
         return tool_error(str(e))
 
 
+def _rewrite_v4a_patch_paths(patch_content: str, path_to_resolved: dict[str, str | None]) -> str:
+    """Rewrite V4A file headers to already-validated absolute paths."""
+    import re as _re
+
+    def _lookup(raw: str) -> str:
+        key = raw.strip()
+        return path_to_resolved.get(key) or key
+
+    def _file_repl(match) -> str:
+        return f"{match.group(1)}{_lookup(match.group(2))}"
+
+    def _move_repl(match) -> str:
+        return f"{match.group(1)}{_lookup(match.group(2))} -> {_lookup(match.group(3))}"
+
+    rewritten = _re.sub(
+        r"^(\*\*\*\s*(?:Update|Add|Delete)\s+File:\s*)(.+?)\s*$",
+        _file_repl,
+        patch_content,
+        flags=_re.MULTILINE,
+    )
+    return _re.sub(
+        r"^(\*\*\*\s*Move\s+File:\s*)(.+?)\s*->\s*(.+?)\s*$",
+        _move_repl,
+        rewritten,
+        flags=_re.MULTILINE,
+    )
+
+
 def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                new_string: str = None, replace_all: bool = False, patch: str = None,
                task_id: str = "default", cross_profile: bool = False) -> str:
@@ -1187,8 +1319,9 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
     if mode == "patch" and patch:
         import re as _re
         from tools.path_security import has_traversal_component
-        for _m in _re.finditer(r'^\*\*\*\s+(?:Update|Add|Delete)\s+File:\s*(.+)$', patch, _re.MULTILINE):
-            v4a_path = _m.group(1).strip()
+
+        def _append_v4a_path(v4a_path: str) -> str | None:
+            v4a_path = v4a_path.strip()
             # V4A path headers come from patch CONTENT, not the explicit
             # ``path=`` arg — so they're more attacker-influenceable (skill
             # content, web extract, prompt injection). Reject ``..`` traversal
@@ -1204,6 +1337,19 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                     "path in '*** Update File:' / '*** Add File:' / '*** Delete File:' headers."
                 )
             _paths_to_check.append(v4a_path)
+            return None
+
+        for _m in _re.finditer(r'^\*\*\*\s+(?:Update|Add|Delete)\s+File:\s*(.+)$', patch, _re.MULTILINE):
+            _err = _append_v4a_path(_m.group(1))
+            if _err:
+                return _err
+        for _m in _re.finditer(r'^\*\*\*\s+Move\s+File:\s*(.+?)\s*->\s*(.+)$', patch, _re.MULTILINE):
+            _err = _append_v4a_path(_m.group(1))
+            if _err:
+                return _err
+            _err = _append_v4a_path(_m.group(2))
+            if _err:
+                return _err
     for _p in _paths_to_check:
         sensitive_err = _check_sensitive_path(_p, task_id)
         if sensitive_err:
@@ -1221,6 +1367,8 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         for _p in _paths_to_check:
             try:
                 _r = str(_resolve_path_for_task(_p, task_id))
+            except SessionRootPathError as exc:
+                return tool_error(str(exc))
             except Exception:
                 _r = None
             if _r and _r not in _seen:
@@ -1243,9 +1391,15 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             for _p in _paths_to_check:
                 try:
                     _r = str(_resolve_path_for_task(_p, task_id))
+                except SessionRootPathError as exc:
+                    return tool_error(str(exc))
                 except Exception:
                     _r = None
                 _path_to_resolved[_p] = _r
+                if _r:
+                    hardlink_error = _session_root_hardlink_error(Path(_r))
+                    if hardlink_error:
+                        return tool_error(hardlink_error)
                 _cross = file_state.check_stale(task_id, _r) if _r else None
                 _sw = _cross or _check_file_staleness(_p, task_id)
                 if not _sw and _r:
@@ -1272,7 +1426,12 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             elif mode == "patch":
                 if not patch:
                     return tool_error("patch content required")
-                result = file_ops.patch_v4a(patch)
+                patch_payload = (
+                    _rewrite_v4a_patch_paths(patch, _path_to_resolved)
+                    if _session_file_root() is not None
+                    else patch
+                )
+                result = file_ops.patch_v4a(patch_payload)
             else:
                 return tool_error(f"Unknown mode: {mode}")
 
@@ -1384,9 +1543,15 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
                 "already_searched": count,
             }, ensure_ascii=False)
 
+        resolved_path = _resolve_path_for_task(path, task_id)
+        tree_error = _session_root_tree_error(resolved_path)
+        if tree_error:
+            return tool_error(tree_error)
+
         file_ops = _get_file_ops(task_id)
+        file_ops_path = str(resolved_path) if _session_file_root() is not None else path
         result = file_ops.search(
-            pattern=pattern, path=path, target=target, file_glob=file_glob,
+            pattern=pattern, path=file_ops_path, target=target, file_glob=file_glob,
             limit=limit, offset=offset, output_mode=output_mode, context=context
         )
         if hasattr(result, 'matches'):


### PR DESCRIPTION
## Summary

This draft PR adds an internal API-server header contract for request-scoped file-tool roots:

- accepts `X-Hermes-Session-Root` only when API key auth is configured;
- pins the value into contextvars separately from the logical cwd;
- makes file tools resolve relative, absolute, `..`, symlink, and existing hardlink-alias paths against the current session file root;
- keeps the header out of response headers and public DTOs.

## Boundaries

- This is file-tool root enforcement only.
- It does not claim to sandbox arbitrary `code_execution`; cwd alone is not a filesystem isolation boundary for arbitrary Python code.
- Normal CLI/gateway cwd behavior remains unchanged unless a session file root is explicitly set.

## Validation

Used the shared Hermes venv because this checkout's `.venv` does not have `pytest` installed.

- `python3 -m py_compile agent/runtime_cwd.py gateway/session_context.py gateway/platforms/api_server.py tools/file_tools.py tests/gateway/test_api_server.py tests/tools/test_file_tools_session_root.py`
- `git diff --check`
- `env -i PATH="$PATH" HOME="$HOME" TZ=UTC LANG=C.UTF-8 LC_ALL=C.UTF-8 PYTHONHASHSEED=0 $HOME/.hermes/hermes-agent/venv/bin/python scripts/run_tests_parallel.py tests/tools/test_file_tools_session_root.py tests/gateway/test_api_server.py tests/gateway/test_session_env.py tests/tools/test_gateway_cwd_contract.py`

Result: 183 tests passed across 4 files under per-file subprocess isolation.
