### PR TITLE
fix(xai-oauth): use msvcrt.kbhit() on Windows for non-blocking stdin check

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2710,6 +2710,14 @@ def _read_ready_stdin_line() -> Optional[str]:
     try:
         if not sys.stdin.isatty():
             return None
+
+        if sys.platform == "win32":
+            import msvcrt
+
+            if not msvcrt.kbhit():
+                return None
+            return sys.stdin.readline()
+
         import select
 
         ready, _, _ = select.select([sys.stdin], [], [], 0)


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

_read_ready_stdin_line() used select.select() to check for pending stdin input without blocking. On Windows, select.select() only works with sockets, not file descriptors like sys.stdin, so the function silently returned None every time. This caused the "if xAI shows a Grok Build code instead of redirecting" prompt in _xai_wait_for_callback() to display but never actually read user input — the loop just spun on time.sleep(0.1) until the user pressed Ctrl+C.

Fix by adding a Windows-specific code path using msvcrt.kbhit(), which correctly detects available console input without blocking. The Unix path using select.select() remains unchanged.





## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

No open issues

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- auth.py

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

reproduction:
1. In Windows, run `hermes auth add xai-oauth --no-browser`
2. navigate to the OAuth /authorize endpoint
3. try pasting the Grok Build code into the console

fix:
1. In Windows, run `hermes auth add xai-oauth --no-browser`
2. navigate to the OAuth /authorize endpoint
3. try pasting the Grok Build code into the console

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

