### PR TITLE
feat: add AgentCard MCP catalog entry

### DIFF
--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -76,6 +76,7 @@ class TransportSpec:
     command: Optional[str] = None
     args: List[str] = field(default_factory=list)
     url: Optional[str] = None
+    headers: Dict[str, str] = field(default_factory=dict)
     version: Optional[str] = None  # informational, pinned
 
 
@@ -184,11 +185,26 @@ def _parse_manifest(path: Path) -> CatalogEntry:
     args = transport_raw.get("args") or []
     if not isinstance(args, list):
         raise CatalogError(f"{path}: transport.args must be a list")
+    headers_raw = transport_raw.get("headers", {})
+    if headers_raw is None:
+        headers_raw = {}
+    if not isinstance(headers_raw, dict):
+        raise CatalogError(f"{path}: transport.headers must be a mapping")
+    if headers_raw and t_type != "http":
+        raise CatalogError(f"{path}: transport.headers is only supported for http")
+    headers: Dict[str, str] = {}
+    for key, value in headers_raw.items():
+        if not isinstance(key, str) or not key:
+            raise CatalogError(f"{path}: transport.headers keys must be strings")
+        if not isinstance(value, str):
+            raise CatalogError(f"{path}: transport.headers values must be strings")
+        headers[key] = value
     transport = TransportSpec(
         type=t_type,
         command=transport_raw.get("command"),
         args=[str(a) for a in args],
         url=transport_raw.get("url"),
+        headers=headers,
         version=transport_raw.get("version"),
     )
     if t_type == "stdio" and not transport.command:
@@ -470,6 +486,8 @@ def _build_server_config(
             cfg["args"] = [_expand_install_dir(a, install_dir) for a in t.args]
     elif t.type == "http":
         cfg["url"] = t.url
+        if t.headers:
+            cfg["headers"] = dict(t.headers)
         if entry.auth.type == "oauth":
             cfg["auth"] = "oauth"
     return cfg

--- a/optional-mcps/agentcard/manifest.yaml
+++ b/optional-mcps/agentcard/manifest.yaml
@@ -1,0 +1,53 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: agentcard
+description: Use AgentCard virtual debit card tools with a conservative default tool set.
+source: https://www.agentcard.sh/agent.txt
+
+# AgentCard hosts a Streamable HTTP MCP server. The Authorization header uses
+# runtime environment interpolation so Hermes never stores the JWT in config.yaml.
+transport:
+  type: http
+  url: https://mcp.agentcard.sh/mcp
+  headers:
+    Authorization: "Bearer ${AGENT_CARDS_JWT}"
+
+auth:
+  type: api_key
+  env:
+    - name: AGENT_CARDS_JWT
+      prompt: "AgentCard JWT (run `npx -y agent-cards@0.5.22 login` first)"
+      required: true
+      secret: true
+
+# AgentCard can create cards, reveal card credentials, approve requests, fill
+# checkouts, close cards, and remove payment methods. Keep the default surface
+# to read-only/support-ish tools; users can opt into riskier tools explicitly
+# with `hermes mcp configure agentcard`.
+tools:
+  default_enabled:
+    - list_cards
+    - check_balance
+    - list_transactions
+    - detect_checkout
+    - start_support_chat
+    - send_support_message
+    - read_support_chat
+
+post_install: |
+  Log in to AgentCard with:
+    npx -y agent-cards@0.5.22 login
+
+  The AgentCard CLI stores its JWT in ~/.agent-cards/config.json and also
+  supports AGENT_CARDS_JWT. Copy the JWT into ~/.hermes/.env as
+  AGENT_CARDS_JWT; do not put it in config.yaml.
+
+  Restart Hermes after setting the secret so the MCP client can resolve:
+    Authorization: Bearer ${AGENT_CARDS_JWT}
+
+  This catalog entry enables only read-only/support-ish tools by default.
+  To opt into card creation, credential reveal, approval, checkout/fill,
+  close, or remove-payment-method tools, run:
+    hermes mcp configure agentcard

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -297,6 +297,7 @@ locales = ["locales/*.yaml"]
 # catalog iterates over (a shared `optional-mcps/*/*` glob would collapse all
 # manifests into one colliding optional-mcps/manifest.yaml). One target per
 # entry; tests/test_packaging_metadata.py enforces an entry per optional-mcps/<name>.
+"optional-mcps/agentcard" = ["optional-mcps/agentcard/manifest.yaml"]
 "optional-mcps/linear" = ["optional-mcps/linear/manifest.yaml"]
 "optional-mcps/n8n" = ["optional-mcps/n8n/manifest.yaml"]
 

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -143,6 +143,54 @@ class TestManifestParsing:
         assert e.auth.env[1].required is False
         assert e.auth.env[1].secret is False
 
+    def test_http_transport_headers(self, catalog_dir):
+        body = _basic_manifest(
+            transport={
+                "type": "http",
+                "url": "https://mcp.example.com/mcp",
+                "headers": {
+                    "Authorization": "Bearer ${DEMO_TOKEN}",
+                    "X-Demo": "demo",
+                },
+            }
+        )
+        _write_manifest(catalog_dir, "demo", body)
+        from hermes_cli.mcp_catalog import list_catalog
+
+        e = list_catalog()[0]
+        assert e.transport.type == "http"
+        assert e.transport.url == "https://mcp.example.com/mcp"
+        assert e.transport.headers == {
+            "Authorization": "Bearer ${DEMO_TOKEN}",
+            "X-Demo": "demo",
+        }
+
+    def test_stdio_transport_headers_rejected(self, catalog_dir):
+        body = _basic_manifest(
+            transport={
+                "type": "stdio",
+                "command": "npx",
+                "headers": {"Authorization": "Bearer ${DEMO_TOKEN}"},
+            }
+        )
+        _write_manifest(catalog_dir, "demo", body)
+        from hermes_cli.mcp_catalog import list_catalog
+
+        assert list_catalog() == []
+
+    def test_transport_headers_must_be_mapping(self, catalog_dir):
+        body = _basic_manifest(
+            transport={
+                "type": "http",
+                "url": "https://mcp.example.com/mcp",
+                "headers": [],
+            }
+        )
+        _write_manifest(catalog_dir, "demo", body)
+        from hermes_cli.mcp_catalog import list_catalog
+
+        assert list_catalog() == []
+
     def test_install_block(self, catalog_dir):
         body = _basic_manifest(
             install={
@@ -285,6 +333,25 @@ class TestInstall:
         server = load_config()["mcp_servers"]["demo"]
         assert server["url"] == "https://mcp.example.com/sse"
         assert server["auth"] == "oauth"
+
+    def test_install_http_writes_headers(self, catalog_dir):
+        body = _basic_manifest(
+            transport={
+                "type": "http",
+                "url": "https://mcp.example.com/mcp",
+                "headers": {"Authorization": "Bearer ${DEMO_TOKEN}"},
+            },
+        )
+        _write_manifest(catalog_dir, "demo", body)
+
+        from hermes_cli.mcp_catalog import install_entry
+        from hermes_cli.config import load_config
+
+        install_entry(_entry("demo"), enable=True)
+
+        server = load_config()["mcp_servers"]["demo"]
+        assert server["url"] == "https://mcp.example.com/mcp"
+        assert server["headers"] == {"Authorization": "Bearer ${DEMO_TOKEN}"}
 
     def test_install_required_env_missing_raises(self, catalog_dir, monkeypatch):
         body = _basic_manifest(
@@ -791,3 +858,46 @@ class TestShippedCatalog:
             assert entry.name
             assert entry.description
             assert entry.transport.type in ("stdio", "http")
+
+    def test_agentcard_manifest_contract(self, monkeypatch):
+        """AgentCard stays token-based and conservative by default."""
+        monkeypatch.delenv("HERMES_OPTIONAL_MCPS", raising=False)
+        from hermes_cli.mcp_catalog import _catalog_root, _parse_manifest
+
+        manifest = _catalog_root() / "agentcard" / "manifest.yaml"
+        if not manifest.exists():
+            pytest.skip("agentcard manifest not present in this checkout")
+
+        entry = _parse_manifest(manifest)
+        assert entry.name == "agentcard"
+        assert entry.transport.type == "http"
+        assert entry.transport.url == "https://mcp.agentcard.sh/mcp"
+        assert entry.transport.headers == {
+            "Authorization": "Bearer ${AGENT_CARDS_JWT}",
+        }
+        assert entry.auth.type == "api_key"
+        assert [spec.name for spec in entry.auth.env] == ["AGENT_CARDS_JWT"]
+        assert entry.auth.env[0].secret is True
+        assert entry.auth.env[0].required is True
+
+        enabled = set(entry.tools.default_enabled or [])
+        assert {
+            "list_cards",
+            "check_balance",
+            "list_transactions",
+            "detect_checkout",
+            "start_support_chat",
+            "send_support_message",
+            "read_support_chat",
+        } <= enabled
+        assert not {
+            "setup_payment_method",
+            "create_card",
+            "submit_user_info",
+            "get_card_details",
+            "close_card",
+            "approve_request",
+            "pay_checkout",
+            "fill_card",
+            "remove_payment_method",
+        } & enabled

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -62,6 +62,7 @@ want.
 hermes mcp                # interactive picker (default)
 hermes mcp catalog        # plain-text list, scriptable
 hermes mcp install n8n    # install a catalog entry by name
+hermes mcp install agentcard
 ```
 
 The picker shows each entry with its current status:
@@ -69,6 +70,7 @@ The picker shows each entry with its current status:
 ```
 n8n          available              Manage and inspect n8n workflows from Hermes
 linear       enabled                Linear issue/project management (remote OAuth)
+agentcard    available              AgentCard virtual debit card tools
 github       installed (disabled)   GitHub repo + PR tools
 ```
 
@@ -82,6 +84,9 @@ Catalog entries can require:
 
 - **API key** — Hermes prompts at install time and writes the value to
   `~/.hermes/.env`. Non-secret values (base URLs) go to the same file.
+- **Static bearer token** — same flow as API keys; manifests can write HTTP
+  authorization headers into `config.yaml` using `${ENV_VAR}` placeholders, with
+  the secret value itself kept in `~/.hermes/.env`.
 - **OAuth** (remote MCP) — written as `auth: oauth` in your config; the MCP
   client opens a browser on first connection.
 - **OAuth** (third-party provider like Google/GitHub) — Hermes points you at


### PR DESCRIPTION
## Summary
- add AgentCard to the optional MCP catalog with a conservative default tool selection
- add generic HTTP transport headers support for MCP catalog manifests
- document static bearer token catalog entries and package the new manifest

## Safety
- defaults only enable read-only/support-ish AgentCard tools
- card creation, credential reveal, approvals, checkout/fill, close, and payment-method removal stay opt-in via `hermes mcp configure agentcard`
- no AgentCard login/payment setup/API calls were run

## Tests
- `python3 -m pytest tests/hermes_cli/test_mcp_catalog.py tests/test_packaging_metadata.py -q -o 'addopts='`