### PR TITLE
docs(contributing): recommend scripts/run_tests.sh over direct pytest

### DIFF
--- a/website/docs/developer-guide/contributing.md
+++ b/website/docs/developer-guide/contributing.md
@@ -81,7 +81,7 @@ hermes chat -q "Hello"
 ### Run Tests
 
 ```bash
-pytest tests/ -v
+scripts/run_tests.sh
 ```
 
 ## Code Style
@@ -185,7 +185,7 @@ refactor/description   # Code restructuring
 
 ### Before Submitting
 
-1. **Run tests**: `pytest tests/ -v`
+1. **Run tests**: `scripts/run_tests.sh`
 2. **Test manually**: Run `hermes` and exercise the code path you changed
 3. **Check cross-platform impact**: Consider macOS and different Linux distros
 4. **Keep PRs focused**: One logical change per PR


### PR DESCRIPTION
## What

Replace `pytest tests/ -v` with `scripts/run_tests.sh` in the website contributing guide (`website/docs/developer-guide/contributing.md`, both the "Run Tests" section and the "Before Submitting" checklist).

## Why

The published docs page (https://hermes-agent.nousresearch.com/docs/developer-guide/contributing#run-tests) still tells contributors to run `pytest tests/` directly, but the repo's own guidance has since moved on:

- `AGENTS.md`: "**ALWAYS use `scripts/run_tests.sh`** — do not call `pytest` directly."
- `CONTRIBUTING.md`: lists `scripts/run_tests.sh` as the preferred, CI-matching runner.
- `tests/conftest.py`: documents that the suite relies on per-file process isolation provided by `scripts/run_tests_parallel.py`.

Following the website instructions as written actually breaks: several fixtures evict `hermes_cli*` modules from `sys.modules` (e.g. `tests/hermes_cli/test_kanban_*.py`), so in a monolithic `pytest tests/` run, later test files' `monkeypatch.setattr` calls land on re-imported module objects and silently miss. Mocked network calls then escape for real and hang in `socket.getaddrinfo` until pytest-timeout fires. Reproducible with just two files:

```bash
pytest tests/hermes_cli/test_kanban_default_assignee.py tests/hermes_cli/test_nous_account.py
# -> test_expired_jwt_falls_back_to_fresh_account times out in getaddrinfo
```

Same class of order-dependent `sys.modules` poisoning as #33079, but hitting anyone who follows the published docs.

## How to test

Docs-only change; `scripts/run_tests.sh` is the existing canonical runner documented in `AGENTS.md` and `CONTRIBUTING.md`.