### PR TITLE
fix(model): use provider default for provider-only switch

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -625,7 +625,7 @@ def switch_model(
         a. Resolve provider via resolve_provider_full()
         b. Resolve credentials
         c. If model given, resolve alias on target provider or use as-is
-        d. If no model, auto-detect from endpoint
+        d. If no model, use provider default, falling back to endpoint auto-detect
 
       If no --provider:
         a. Try alias resolution on current provider
@@ -700,9 +700,16 @@ def switch_model(
 
         target_provider = pdef.id
 
-        # If no model specified, try auto-detect from endpoint
+        # If no model specified, prefer the provider's curated/default model.
+        # Hosted providers often have a base_url but no listable local model;
+        # endpoint autodetection is only a fallback for custom/local servers.
         if not new_model:
-            if pdef.base_url:
+            from hermes_cli.models import get_default_model_for_provider
+
+            default_model = get_default_model_for_provider(target_provider)
+            if default_model:
+                new_model = default_model
+            elif pdef.base_url:
                 from hermes_cli.runtime_provider import _auto_detect_local_model
                 detected = _auto_detect_local_model(pdef.base_url)
                 if detected:

--- a/tests/hermes_cli/test_model_switch_provider_default.py
+++ b/tests/hermes_cli/test_model_switch_provider_default.py
@@ -1,0 +1,50 @@
+"""Regression tests for provider-only /model switches."""
+
+from hermes_cli.model_switch import switch_model
+
+
+_MOCK_VALIDATION = {
+    "accepted": True,
+    "persist": True,
+    "recognized": True,
+    "message": None,
+}
+
+
+def test_explicit_openai_codex_provider_without_model_uses_provider_default(monkeypatch):
+    """`/model --provider openai-codex` should choose a Codex model.
+
+    This path previously tried local endpoint model autodetection against
+    chatgpt.com and failed with "No model detected" before consulting the
+    provider's curated/default model list.
+    """
+    monkeypatch.setattr(
+        "hermes_cli.models.get_default_model_for_provider",
+        lambda provider: "gpt-5.4" if provider == "openai-codex" else "",
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "api_key": "codex-token",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_mode": "codex_app_server",
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model",
+        lambda *args, **kwargs: _MOCK_VALIDATION,
+    )
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *args, **kwargs: None)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_capabilities", lambda *args, **kwargs: None)
+
+    result = switch_model(
+        raw_input="",
+        current_provider="openrouter",
+        current_model="anthropic/claude-sonnet-4.6",
+        explicit_provider="openai-codex",
+    )
+
+    assert result.success is True
+    assert result.new_model == "gpt-5.4"
+    assert result.target_provider == "openai-codex"
+    assert result.api_mode == "codex_app_server"


### PR DESCRIPTION
## Summary
- Make provider-only `/model --provider ...` switches choose the provider's curated/default model first
- Keep endpoint autodetection as a fallback for local/custom endpoints
- Add regression coverage for `--provider openai-codex` without an explicit model

## Test Plan
- `python -m pytest tests/hermes_cli/test_model_switch_provider_default.py -q`
