### PR TITLE
fix(docker): re-chown scripts/whatsapp-bridge on UID remap so WhatsApp setup's npm install works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -199,13 +199,19 @@ COPY --chown=hermes:hermes . .
 # /opt/hermes/gateway is runtime-writable: Python may create __pycache__ and
 # gateway state artifacts beneath the package after services drop privileges,
 # especially when the hermes UID is remapped at boot (#27221).
+# /opt/hermes/scripts/whatsapp-bridge is runtime-writable: the WhatsApp
+# setup wizard (hermes_cli/main.py) runs `npm install` there at first use
+# to build the Node bridge's node_modules, so the directory must stay
+# writable by the (possibly UID-remapped) hermes user — otherwise setup
+# fails with `EACCES: mkdir '.../whatsapp-bridge/node_modules'`. Mirrored
+# in docker/stage2-hook.sh's build-tree chown.
 # The .venv MUST remain hermes-writable so lazy_deps.py can install
 # remaining optional platform packages and future pin bumps at first use.
 # Without this, `uv pip install` fails with EACCES and adapters silently
 # fail to load.  See tools/lazy_deps.py.
 USER root
 RUN chmod -R a+rX /opt/hermes && \
-    chown -R hermes:hermes /opt/hermes/.venv /opt/hermes/ui-tui /opt/hermes/gateway /opt/hermes/node_modules
+    chown -R hermes:hermes /opt/hermes/.venv /opt/hermes/ui-tui /opt/hermes/gateway /opt/hermes/node_modules /opt/hermes/scripts/whatsapp-bridge
 # Start as root so the s6-overlay stage2 hook can usermod/groupmod and chown
 # the data volume. Each supervised service then drops to the hermes user via
 # `s6-setuidgid hermes` in its run script. If HERMES_UID is unset, services

--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -222,6 +222,14 @@ fi
 #     producing EACCES for the supervised gateway (#27221).
 #   - node_modules: root-level dependencies (puppeteer, web tooling)
 #     that runtime code may walk/update.
+#   - scripts/whatsapp-bridge: the WhatsApp setup wizard
+#     (hermes_cli/main.py, setup_whatsapp) runs `npm install` in this
+#     directory at first use to build the Node bridge's node_modules.
+#     After a UID remap the directory is still owned by the build UID
+#     (10000), so the install fails with
+#     `EACCES: permission denied, mkdir '.../whatsapp-bridge/node_modules'`.
+#     Re-chowning it lets the wizard create node_modules as the runtime
+#     hermes user.
 # The set mirrors the build-time `chown -R hermes:hermes` line in the
 # Dockerfile — keep them in sync if the Dockerfile chown set changes.
 # These are under $INSTALL_DIR (not $HERMES_HOME), so the bind-mount
@@ -247,6 +255,7 @@ if [ -n "$venv_owner" ] && [ "$venv_owner" != "$actual_hermes_uid" ]; then
         "$INSTALL_DIR/ui-tui" \
         "$INSTALL_DIR/gateway" \
         "$INSTALL_DIR/node_modules" \
+        "$INSTALL_DIR/scripts/whatsapp-bridge" \
         2>/dev/null || \
         echo "[stage2] Warning: chown of build trees failed (rootless container?) — continuing"
 fi


### PR DESCRIPTION
## Problem

Running the WhatsApp setup wizard on a container started with `HERMES_UID`/`PUID` != 10000 fails at the dependency-install step:

```
→ Installing WhatsApp bridge dependencies (this can take a few minutes)...
  ✗ npm install failed:
npm error code EACCES
npm error syscall mkdir
npm error path /opt/hermes/scripts/whatsapp-bridge/node_modules
npm error Error: EACCES: permission denied, mkdir '/opt/hermes/scripts/whatsapp-bridge/node_modules'
```

`/opt/hermes/scripts/whatsapp-bridge` ships owned by the build UID (10000) via `COPY --chown=hermes:hermes . .`. When the hermes user is remapped at boot — the supported path for a bind-mounted `/opt/data` owned by a host UID (PUID/NAS, or Compose with `HERMES_UID=$(id -u)`) — `docker/stage2-hook.sh` re-chowns the build trees the runtime writes to (`.venv`, `ui-tui`, `gateway`, `node_modules`), but **not** `scripts/whatsapp-bridge`. The WhatsApp setup wizard (`hermes_cli/main.py`, `setup_whatsapp`) runs `npm install` in that directory at first use, so it can't create `node_modules` and the wizard aborts.

This is the same class of EACCES already fixed dir-by-dir for `.venv` (#15012, #21100), `ui-tui` (#28851), and `gateway` (#27221). `scripts/whatsapp-bridge` is the remaining one.

## Fix

Add `/opt/hermes/scripts/whatsapp-bridge` to:

- the runtime re-chown set in `docker/stage2-hook.sh` (the actual fix), and
- the build-time `chown -R hermes:hermes` line in the `Dockerfile`,

keeping the two lists in sync as the surrounding comments require.

## Notes

- **No effect on the default-UID (10000) path** — the dir is already hermes-owned there, so this only changes behaviour after a UID remap.
- The re-chown is gated on `.venv` ownership (existing logic), so it runs once per UID change, not on every boot.
- **Reproduced and verified** on a production container running with `HERMES_UID=1000` (bind-mounted `/opt/data`): with the bridge dir owned by the runtime hermes user, the wizard's `npm install` succeeds and setup proceeds to the QR pairing step.