### PR TITLE
fix(discord): retry 429s in the standalone send path, honoring retry_after

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -7873,6 +7873,87 @@ async def _standalone_read_json_limited(resp: Any, limit_bytes: int) -> dict:
     return data if isinstance(data, dict) else {}
 
 
+# Bounded 429 retry for the standalone REST path — parity with the Telegram
+# retry helper in tools/send_message_tool (3 attempts, honors retry_after).
+_STANDALONE_RETRY_ATTEMPTS = 3
+# A retry_after above this is a long-lived (likely global) rate limit; the
+# standalone path is a blocking CLI/tool call, so give up instead of stalling.
+_STANDALONE_MAX_RETRY_AFTER = 10.0
+
+
+def _standalone_retry_after_seconds(resp, body: str) -> Optional[float]:
+    """Extract retry_after seconds from a Discord 429: JSON body first
+    (Discord reports it there with sub-second precision), headers second.
+    """
+    try:
+        parsed = json.loads(body)
+        if isinstance(parsed, dict) and parsed.get("retry_after") is not None:
+            return max(float(parsed["retry_after"]), 0.0)
+    except (ValueError, TypeError):
+        pass
+    header = resp.headers.get("Retry-After") or resp.headers.get("X-RateLimit-Reset-After")
+    if header is None:
+        return None
+    try:
+        return max(float(header), 0.0)
+    except (TypeError, ValueError):
+        return None
+
+
+async def _standalone_post_with_retry(
+    session,
+    url: str,
+    *,
+    headers: Dict[str, str],
+    req_kw: Dict[str, Any],
+    json_payload: Optional[dict] = None,
+    form_factory: Optional[Callable[[], Any]] = None,
+    attempts: int = _STANDALONE_RETRY_ATTEMPTS,
+) -> Tuple[int, Any]:
+    """POST with bounded retry on 429s, honoring Discord's ``retry_after``.
+
+    Returns ``(status, data)``: parsed JSON on 200/201, raw body text
+    otherwise.  ``form_factory`` rebuilds the multipart body per attempt —
+    an aiohttp ``FormData`` cannot be sent twice.
+
+    Response bodies are read through the standalone bounded-read helpers
+    (``_standalone_read_json_limited`` / ``_standalone_read_text_limited``)
+    so an oversized or hostile body is capped on the retry path exactly as
+    it is on the single-shot path.
+    """
+    body = ""
+    for attempt in range(attempts):
+        kwargs = dict(req_kw)
+        if json_payload is not None:
+            kwargs["json"] = json_payload
+        if form_factory is not None:
+            kwargs["data"] = form_factory()
+        async with session.post(url, headers=headers, **kwargs) as resp:
+            status = resp.status
+            if status in {200, 201}:
+                return status, await _standalone_read_json_limited(
+                    resp, _DISCORD_STANDALONE_JSON_BODY_LIMIT_BYTES
+                )
+            body = await _standalone_read_text_limited(
+                resp, _DISCORD_STANDALONE_ERROR_BODY_LIMIT_BYTES
+            )
+            if status != 429 or attempt >= attempts - 1:
+                return status, body
+            delay = _standalone_retry_after_seconds(resp, body)
+        if delay is None:
+            delay = float(2 ** attempt)
+        if delay > _STANDALONE_MAX_RETRY_AFTER:
+            return status, body
+        logger.warning(
+            "Discord standalone send rate limited (attempt %d/%d), retrying in %.2fs",
+            attempt + 1,
+            attempts,
+            delay,
+        )
+        await asyncio.sleep(delay)
+    return 429, body
+
+
 async def _standalone_send(
     pconfig,
     chat_id: str,
@@ -7985,52 +8066,50 @@ async def _standalone_send(
                         starter_message = {"content": (caption or message), "attachments": attachments_meta}
                         payload_json = json.dumps({"name": thread_name, "message": starter_message})
 
-                        form = aiohttp.FormData()
-                        form.add_field("payload_json", payload_json, content_type="application/json")
-
                         try:
+                            # Read each file once up front: FormData can't be
+                            # re-sent, so the retry wrapper rebuilds the body
+                            # per attempt from these buffered payloads.
+                            file_payloads = []
                             for idx, media_path in enumerate(valid_media):
                                 with open(media_path, "rb") as fh:
-                                    form.add_field(
-                                        f"files[{idx}]",
-                                        fh.read(),
-                                        filename=os.path.basename(media_path),
+                                    file_payloads.append(
+                                        (idx, os.path.basename(media_path), fh.read())
                                     )
-                            async with session.post(thread_url, headers=auth_headers, data=form, **_req_kw) as resp:
-                                if resp.status not in {200, 201}:
-                                    body = await _standalone_read_text_limited(
-                                        resp,
-                                        _DISCORD_STANDALONE_ERROR_BODY_LIMIT_BYTES,
-                                    )
-                                    return {"error": f"Discord forum thread creation error ({resp.status}): {body}"}
-                                data = await _standalone_read_json_limited(
-                                    resp,
-                                    _DISCORD_STANDALONE_JSON_BODY_LIMIT_BYTES,
-                                )
+
+                            def _build_thread_form():
+                                form = aiohttp.FormData()
+                                form.add_field("payload_json", payload_json, content_type="application/json")
+                                for idx, filename, payload in file_payloads:
+                                    form.add_field(f"files[{idx}]", payload, filename=filename)
+                                return form
+
+                            status, data = await _standalone_post_with_retry(
+                                session,
+                                thread_url,
+                                headers=auth_headers,
+                                req_kw=_req_kw,
+                                form_factory=_build_thread_form,
+                            )
+                            if status not in {200, 201}:
+                                return {"error": f"Discord forum thread creation error ({status}): {data}"}
                         except Exception as e:
                             return {"error": _standalone_sanitize_error(f"Discord forum thread upload failed: {e}")}
                     else:
                         # No media — simple JSON POST creates the thread with
                         # just the text starter.
-                        async with session.post(
+                        status, data = await _standalone_post_with_retry(
+                            session,
                             thread_url,
                             headers=json_headers,
-                            json={
+                            req_kw=_req_kw,
+                            json_payload={
                                 "name": thread_name,
                                 "message": {"content": message},
                             },
-                            **_req_kw,
-                        ) as resp:
-                            if resp.status not in {200, 201}:
-                                body = await _standalone_read_text_limited(
-                                    resp,
-                                    _DISCORD_STANDALONE_ERROR_BODY_LIMIT_BYTES,
-                                )
-                                return {"error": f"Discord forum thread creation error ({resp.status}): {body}"}
-                            data = await _standalone_read_json_limited(
-                                resp,
-                                _DISCORD_STANDALONE_JSON_BODY_LIMIT_BYTES,
-                            )
+                        )
+                        if status not in {200, 201}:
+                            return {"error": f"Discord forum thread creation error ({status}): {data}"}
 
                 thread_id_created = data.get("id")
                 starter_msg_id = (data.get("message") or {}).get("id", thread_id_created)
@@ -8050,17 +8129,16 @@ async def _standalone_send(
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
             # Send text message (skip if empty and media is present)
             if message.strip() or not media_files:
-                async with session.post(url, headers=json_headers, json={"content": message}, **_req_kw) as resp:
-                    if resp.status not in {200, 201}:
-                        body = await _standalone_read_text_limited(
-                            resp,
-                            _DISCORD_STANDALONE_ERROR_BODY_LIMIT_BYTES,
-                        )
-                        return {"error": f"Discord API error ({resp.status}): {body}"}
-                    last_data = await _standalone_read_json_limited(
-                        resp,
-                        _DISCORD_STANDALONE_JSON_BODY_LIMIT_BYTES,
-                    )
+                status, data = await _standalone_post_with_retry(
+                    session,
+                    url,
+                    headers=json_headers,
+                    req_kw=_req_kw,
+                    json_payload={"content": message},
+                )
+                if status not in {200, 201}:
+                    return {"error": f"Discord API error ({status}): {data}"}
+                last_data = data
 
             # Send each media file as a separate multipart upload. When a
             # MEDIA:<path> caption was supplied, ride it as the message content

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -1844,6 +1844,101 @@ class TestSendDiscordThreadId:
         )
 
 
+class TestSendDiscord429Retry:
+    """The standalone Discord path retries 429s, honoring retry_after (#44468)."""
+
+    @staticmethod
+    def _resp(status, json_data=None, text=""):
+        resp = MagicMock()
+        resp.status = status
+        resp.json = AsyncMock(return_value=json_data or {"id": "msg123"})
+        resp.text = AsyncMock(return_value=text)
+        resp.headers = {}
+        resp.__aenter__ = AsyncMock(return_value=resp)
+        resp.__aexit__ = AsyncMock(return_value=None)
+        return resp
+
+    @staticmethod
+    def _session(responses):
+        session = MagicMock()
+        session.__aenter__ = AsyncMock(return_value=session)
+        session.__aexit__ = AsyncMock(return_value=None)
+        session.post = MagicMock(side_effect=responses)
+        return session
+
+    @staticmethod
+    def _429_body(retry_after):
+        return json.dumps(
+            {"message": "You are being rate limited.", "retry_after": retry_after, "global": False}
+        )
+
+    def test_429_then_success_retries_chunk(self):
+        """A transient 429 is retried after retry_after and the send succeeds."""
+        mock_session = self._session([
+            self._resp(429, text=self._429_body(0.3)),
+            self._resp(200, json_data={"id": "777"}),
+        ])
+        sleep_mock = AsyncMock()
+        with patch("aiohttp.ClientSession", return_value=mock_session), \
+             patch("asyncio.sleep", sleep_mock):
+            result = asyncio.run(_send_discord("tok", "111", "hi", thread_id="999"))
+        assert result["success"] is True
+        assert result["message_id"] == "777"
+        assert mock_session.post.call_count == 2
+        sleep_mock.assert_awaited_once_with(0.3)
+
+    def test_429_exhausts_attempts_returns_error(self):
+        """Persistent 429s give up after 3 attempts and surface the error."""
+        mock_session = self._session([
+            self._resp(429, text=self._429_body(0.1)) for _ in range(3)
+        ])
+        with patch("aiohttp.ClientSession", return_value=mock_session), \
+             patch("asyncio.sleep", AsyncMock()):
+            result = asyncio.run(_send_discord("tok", "111", "hi", thread_id="999"))
+        assert "error" in result
+        assert "429" in result["error"]
+        assert mock_session.post.call_count == 3
+
+    def test_huge_retry_after_gives_up_immediately(self):
+        """A retry_after beyond the cap (long/global limit) is not waited on."""
+        mock_session = self._session([
+            self._resp(429, text=self._429_body(3600.0)),
+        ])
+        sleep_mock = AsyncMock()
+        with patch("aiohttp.ClientSession", return_value=mock_session), \
+             patch("asyncio.sleep", sleep_mock):
+            result = asyncio.run(_send_discord("tok", "111", "hi", thread_id="999"))
+        assert "error" in result
+        assert mock_session.post.call_count == 1
+        sleep_mock.assert_not_awaited()
+
+    def test_non_429_error_is_not_retried(self):
+        """Non-rate-limit errors keep the old single-attempt behavior."""
+        mock_session = self._session([
+            self._resp(403, text='{"message": "Forbidden"}'),
+        ])
+        with patch("aiohttp.ClientSession", return_value=mock_session), \
+             patch("asyncio.sleep", AsyncMock()):
+            result = asyncio.run(_send_discord("tok", "111", "hi", thread_id="999"))
+        assert "error" in result
+        assert "403" in result["error"]
+        assert mock_session.post.call_count == 1
+
+    def test_429_without_retry_after_uses_backoff(self):
+        """A 429 with no parseable retry_after falls back to exponential backoff."""
+        mock_session = self._session([
+            self._resp(429, text="not json"),
+            self._resp(200, json_data={"id": "888"}),
+        ])
+        sleep_mock = AsyncMock()
+        with patch("aiohttp.ClientSession", return_value=mock_session), \
+             patch("asyncio.sleep", sleep_mock):
+            result = asyncio.run(_send_discord("tok", "111", "hi", thread_id="999"))
+        assert result["success"] is True
+        assert mock_session.post.call_count == 2
+        sleep_mock.assert_awaited_once_with(1.0)
+
+
 class TestSendToPlatformDiscordThread:
     """_send_to_platform passes thread_id through to _send_discord."""
 


### PR DESCRIPTION
## Summary

Fixes #44468 — `hermes send --to discord:...` dropped all remaining chunks of a multi-chunk message when one chunk hit a 429, because the standalone REST path (`plugins/platforms/discord/adapter.py::_standalone_send`) converted any 429 straight into an error dict with no retry, and the Discord chunk loop in `tools/send_message_tool.py` returns on the first error.

This adds `_standalone_post_with_retry` to the Discord plugin and applies it to the standalone text-message POST and both forum thread-creation POSTs:

- **Bounded retry**: 3 attempts (same as the Telegram helper `_send_telegram_message_with_retry`).
- **Honors `retry_after`**: parsed from the 429 JSON body first (Discord reports sub-second precision there, e.g. the `retry_after: 0.3` from the issue), falling back to the `Retry-After` / `X-RateLimit-Reset-After` headers, then to exponential backoff (1s, 2s) when neither parses.
- **Capped**: a `retry_after` above 10s (long/global rate limit) fails fast instead of stalling the blocking CLI/tool call.
- **No behavior change otherwise**: non-429 errors keep single-attempt behavior, and error dict formats are byte-identical, so the chunk loop and other consumers see the same shapes.
- The forum multipart body is rebuilt per attempt via a form factory — an aiohttp `FormData` cannot be sent twice.

With retry inside `_standalone_send`, the chunk loop in `send_message_tool.py` needs no change: a transient 429 on chunk N now retries and succeeds, and the remaining chunks proceed — parity with the Telegram path, which retries inside `_send_telegram`. (The per-media upload loop is left as-is: its failures are already non-fatal warnings that don't drop subsequent sends, and wrapping it would change its streaming-from-disk memory profile.)

## Tests

New `TestSendDiscord429Retry` in `tests/tools/test_send_message_tool.py`:
- 429 then success → retried after exactly `retry_after` (0.3s), send succeeds, 2 POSTs
- persistent 429 → gives up after 3 attempts, surfaces the 429 error dict
- `retry_after: 3600` → fails fast, no sleep, 1 POST
- 403 → not retried (old behavior preserved)
- unparseable 429 body → exponential backoff fallback (1s)

`tests/tools/test_send_message_tool.py`: **138 passed** (35 Discord-related, 5 new).
