### PR TITLE
feat(cli): add 'hermes kanban board' terminal board view

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -190,6 +190,35 @@ def _check_dispatcher_presence() -> tuple[bool, str]:
 # Argparse builder
 # ---------------------------------------------------------------------------
 
+def _nonneg_int(value: str) -> int:
+    """argparse type for a limit: reject negatives (0 = unlimited is kept)."""
+    iv = int(value)
+    if iv < 0:
+        raise argparse.ArgumentTypeError("must be >= 0 (0 = unlimited)")
+    return iv
+
+
+def _positive_int(value: str) -> int:
+    """argparse type for a refresh interval: must be strictly positive.
+
+    A 0 would make the --tail loop time.sleep(0) and busy-spin; a negative
+    value only fails once Rich's Live alternate screen is already active.
+    Reject both at parse time.
+    """
+    iv = int(value)
+    if iv < 1:
+        raise argparse.ArgumentTypeError("must be a positive integer (seconds)")
+    return iv
+
+
+# Kanban subcommands that render an unbounded live view (a `while True` loop
+# exited only by Ctrl-C). run_slash captures stdout synchronously, so over the
+# slash / gateway path these never return and hang the worker thread; reject
+# them there. Keyed by (action, requires --tail): "board" only loops with
+# --tail, while "tail"/"watch" always loop.
+_SLASH_UNBOUNDED_ACTIONS = frozenset({"tail", "watch"})
+
+
 def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser:
     """Attach the ``kanban`` subcommand tree under an existing subparsers.
 
@@ -447,7 +476,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         description="Show all tasks grouped by status as columns in a Rich table.",
     )
     p_board.add_argument(
-        "--limit", type=int, default=5,
+        "--limit", type=_nonneg_int, default=5,
         help="Max tasks per column (default 5; 0 = unlimited)",
     )
     p_board.add_argument(
@@ -471,7 +500,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="Continuously refresh the board view (Ctrl+C to stop)",
     )
     p_board.add_argument(
-        "--refresh", type=int, default=5,
+        "--refresh", type=_positive_int, default=5,
         help="Seconds between refreshes in --tail mode (default 5)",
     )
     p_board.add_argument(
@@ -3069,6 +3098,19 @@ def run_slash(rest: str) -> str:
         return f"⚠ /kanban usage error\n{body}" if body else "⚠ /kanban usage error"
     except argparse.ArgumentError as exc:
         return f"⚠ /kanban usage error\n{_usage_for_error()}\n{exc}"
+
+    # Reject unbounded live views on the slash path: run_slash captures stdout
+    # synchronously, so a `while True` view never returns and hangs the gateway
+    # worker thread. "board" only loops with --tail; "tail"/"watch" always do.
+    _action = getattr(args, "kanban_action", None)
+    if _action in _SLASH_UNBOUNDED_ACTIONS or (
+        _action == "board" and getattr(args, "tail", False)
+    ):
+        _what = "board --tail" if _action == "board" else _action
+        return (
+            f"⚠ /kanban {_what} runs a live view that never returns here. "
+            f"Run it in an interactive terminal: hermes kanban {_what}."
+        )
 
     with contextlib.redirect_stdout(buf_out), contextlib.redirect_stderr(buf_err):
         try:

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1520,34 +1520,43 @@ def _cmd_board(args: argparse.Namespace) -> int:
 
     console = Console()
 
-    def _render_once() -> None:
+    def _build_view():
         tasks = _fetch_tasks()
         use_stack = args.layout == "stack" or (
             args.layout == "auto"
             and should_stack(console.size.width, show_all=args.show_all)
         )
         renderer = render_board_stacked if use_stack else render_board
-        view = renderer(
+        return renderer(
             tasks,
             board_slug=board_slug,
             other_board_count=other_count,
             show_all=args.show_all,
             limit=limit,
         )
-        if args.tail:
-            console.clear()
-        console.print(view)
 
     if args.tail:
+        from rich.live import Live
+
+        # Smooth in-place updates on the alternate screen (like top/htop),
+        # re-querying and re-rendering every --refresh seconds. screen=True
+        # restores the prior terminal contents on exit; auto_refresh=False
+        # stops Rich from redrawing the unchanged view between our updates.
         try:
-            while True:
-                _render_once()
-                time.sleep(args.refresh)
+            with Live(
+                _build_view(),
+                console=console,
+                screen=True,
+                auto_refresh=False,
+            ) as live:
+                while True:
+                    time.sleep(args.refresh)
+                    live.update(_build_view(), refresh=True)
         except KeyboardInterrupt:
-            print()  # tidy newline after ^C
+            pass
         return 0
 
-    _render_once()
+    console.print(_build_view())
     return 0
 
 

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -474,6 +474,11 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         "--refresh", type=int, default=5,
         help="Seconds between refreshes in --tail mode (default 5)",
     )
+    p_board.add_argument(
+        "--layout", choices=("auto", "columns", "stack"), default="auto",
+        help="auto (default: stack on narrow terminals), columns (force the "
+             "wide table), or stack (force the vertical list)",
+    )
 
     # --- assign ---
     p_assign = sub.add_parser("assign", help="Assign or reassign a task")
@@ -1469,7 +1474,11 @@ def _cmd_board(args: argparse.Namespace) -> int:
 
     from rich.console import Console
 
-    from hermes_cli.kanban_board_render import render_board
+    from hermes_cli.kanban_board_render import (
+        render_board,
+        render_board_stacked,
+        should_stack,
+    )
 
     board_slug = kb.get_current_board()
 
@@ -1513,7 +1522,12 @@ def _cmd_board(args: argparse.Namespace) -> int:
 
     def _render_once() -> None:
         tasks = _fetch_tasks()
-        table = render_board(
+        use_stack = args.layout == "stack" or (
+            args.layout == "auto"
+            and should_stack(console.size.width, show_all=args.show_all)
+        )
+        renderer = render_board_stacked if use_stack else render_board
+        view = renderer(
             tasks,
             board_slug=board_slug,
             other_board_count=other_count,
@@ -1522,7 +1536,7 @@ def _cmd_board(args: argparse.Namespace) -> int:
         )
         if args.tail:
             console.clear()
-        console.print(table)
+        console.print(view)
 
     if args.tail:
         try:

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -440,6 +440,41 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="With --state-type: keep runs whose column equals this value",
     )
 
+    # --- board (visual table view) ---
+    p_board = sub.add_parser(
+        "board",
+        help="Render the kanban board as a visual table",
+        description="Show all tasks grouped by status as columns in a Rich table.",
+    )
+    p_board.add_argument(
+        "--limit", type=int, default=5,
+        help="Max tasks per column (default 5; 0 = unlimited)",
+    )
+    p_board.add_argument(
+        "--show-all", "--all", action="store_true", dest="show_all",
+        help="Include the done and archived columns",
+    )
+    p_board.add_argument(
+        "--mine", action="store_true",
+        help="Only tasks assigned to $HERMES_PROFILE",
+    )
+    p_board.add_argument(
+        "--assignee", default=None,
+        help="Filter by assignee profile name",
+    )
+    p_board.add_argument(
+        "--json", action="store_true",
+        help="Output a flat JSON task list instead of the table",
+    )
+    p_board.add_argument(
+        "--tail", action="store_true",
+        help="Continuously refresh the board view (Ctrl+C to stop)",
+    )
+    p_board.add_argument(
+        "--refresh", type=int, default=5,
+        help="Seconds between refreshes in --tail mode (default 5)",
+    )
+
     # --- assign ---
     p_assign = sub.add_parser("assign", help="Assign or reassign a task")
     p_assign.add_argument("task_id")
@@ -963,6 +998,7 @@ def kanban_command(args: argparse.Namespace) -> int:
             "list":     _cmd_list,
             "ls":       _cmd_list,
             "show":     _cmd_show,
+            "board":    _cmd_board,
             "assign":   _cmd_assign,
             "reclaim":  _cmd_reclaim,
             "reassign": _cmd_reassign,
@@ -1420,6 +1456,84 @@ def _cmd_swarm(args: argparse.Namespace) -> int:
         print("Workers: " + ", ".join(created.worker_ids))
         print(f"Verifier: {created.verifier_id}")
         print(f"Synthesizer: {created.synthesizer_id}")
+    return 0
+
+
+def _cmd_board(args: argparse.Namespace) -> int:
+    """Handle ``hermes kanban board`` — render the board as a Rich table.
+
+    Board scope is already applied by ``kanban_command`` (the global
+    ``--board`` flag), so connections here open against the ambient board.
+    """
+    import time
+
+    from rich.console import Console
+
+    from hermes_cli.kanban_board_render import render_board
+
+    board_slug = kb.get_current_board()
+
+    assignee = args.assignee
+    if args.mine and not assignee:
+        assignee = _profile_author()
+
+    try:
+        other_count = max(0, len(kb.list_boards(include_archived=False)) - 1)
+    except Exception:
+        other_count = 0
+
+    limit = args.limit if (args.limit and args.limit > 0) else None
+
+    def _fetch_tasks() -> "list[kb.Task]":
+        with kb.connect_closing() as conn:
+            kb.recompute_ready(conn)
+            return kb.list_tasks(
+                conn, assignee=assignee, include_archived=args.show_all
+            )
+
+    if args.json:
+        tasks = _fetch_tasks()
+        print(json.dumps(
+            [
+                {
+                    "id": t.id,
+                    "title": t.title,
+                    "status": t.status,
+                    "assignee": t.assignee,
+                    "priority": t.priority,
+                }
+                for t in tasks
+            ],
+            indent=2,
+            ensure_ascii=False,
+        ))
+        return 0
+
+    console = Console()
+
+    def _render_once() -> None:
+        tasks = _fetch_tasks()
+        table = render_board(
+            tasks,
+            board_slug=board_slug,
+            other_board_count=other_count,
+            show_all=args.show_all,
+            limit=limit,
+        )
+        if args.tail:
+            console.clear()
+        console.print(table)
+
+    if args.tail:
+        try:
+            while True:
+                _render_once()
+                time.sleep(args.refresh)
+        except KeyboardInterrupt:
+            print()  # tidy newline after ^C
+        return 0
+
+    _render_once()
     return 0
 
 

--- a/hermes_cli/kanban_board_render.py
+++ b/hermes_cli/kanban_board_render.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 
 from typing import Optional
 
-from rich.console import Console
+from rich.console import Console, Group
 from rich.table import Table
+from rich.text import Text
 
 from hermes_cli import kanban_db as kb
 
@@ -118,13 +119,93 @@ def render_board(
     return table
 
 
-def _render_to_string(table: Table) -> str:
-    """Render a Table to a plain (uncolored) string for tests.
+# Rough min characters a single status column needs to stay readable.
+_MIN_COL_WIDTH = 16
 
-    Width 200 keeps the nine-column show_all layout from truncating
-    headers, so substring assertions on labels stay reliable.
+
+def _needed_width(show_all: bool) -> int:
+    """Approximate terminal width the columnar board needs to fit."""
+    n = len([c for c in COLUMNS if show_all or c[0] not in _COLLAPSED])
+    return n * _MIN_COL_WIDTH
+
+
+def should_stack(width: int, *, show_all: bool = False) -> bool:
+    """True when the columnar board won't fit ``width`` and the caller
+    should fall back to the vertical stacked layout."""
+    return width < _needed_width(show_all)
+
+
+def render_board_stacked(
+    tasks: list[kb.Task],
+    *,
+    board_slug: str = "default",
+    other_board_count: int = 0,
+    show_all: bool = False,
+    limit: Optional[int] = 5,
+) -> Group:
+    """Vertical board layout for narrow terminals.
+
+    Each non-empty status becomes a section header followed by its task
+    lines, one per line. Fits any width (titles wrap instead of truncating),
+    which makes it the readable choice over SSH from a phone. Same grouping
+    and collapse rules as ``render_board``.
     """
+    visible_statuses = [
+        (status, label, style)
+        for status, label, style in COLUMNS
+        if show_all or status not in _COLLAPSED
+    ]
+
+    title = f"Board: {board_slug}"
+    if other_board_count:
+        plural = "s" if other_board_count != 1 else ""
+        title += f"  (+{other_board_count} other board{plural}; 'hermes kanban boards list')"
+
+    blocks: list = [Text(title, style="bold")]
+
+    if not tasks:
+        blocks.append(Text("(no tasks)", style="dim"))
+        return Group(*blocks)
+
+    grouped: dict[str, list[kb.Task]] = {status: [] for status, _, _ in visible_statuses}
+    for t in tasks:
+        if t.status in grouped:
+            grouped[t.status].append(t)
+        elif t.status in _COLLAPSED:
+            continue  # hidden unless show_all
+        else:
+            grouped.setdefault("todo", []).append(t)
+
+    any_section = False
+    for status, label, style in visible_statuses:
+        col_tasks = grouped[status]
+        if not col_tasks:
+            continue  # skip empty sections — vertical noise
+        any_section = True
+        icon = _STATUS_ICON.get(status, "?")
+        section = Text()
+        section.append(f"\n{icon} {label} ({len(col_tasks)})", style=f"bold {style}")
+        shown = col_tasks if limit is None else col_tasks[:limit]
+        hidden = len(col_tasks) - len(shown)
+        for t in shown:
+            line = f"\n  {t.id} {t.title}" + (f" [{t.assignee}]" if t.assignee else "")
+            section.append(line)
+        if hidden > 0:
+            section.append(f"\n  … (+{hidden} hidden)", style="dim")
+        blocks.append(section)
+
+    if not any_section:
+        # Everything was collapsed (e.g. only done/archived without show_all).
+        blocks.append(Text("(no tasks)", style="dim"))
+
+    return Group(*blocks)
+
+
+def _render_to_string(renderable) -> str:
+    """Render any Rich renderable (Table or Group) to a plain, uncolored
+    string for tests. Width 200 keeps the wide table from truncating its
+    headers, so substring assertions stay reliable."""
     console = Console(width=200, force_terminal=False, color_system=None)
     with console.capture() as capture:
-        console.print(table)
+        console.print(renderable)
     return capture.get()

--- a/hermes_cli/kanban_board_render.py
+++ b/hermes_cli/kanban_board_render.py
@@ -1,0 +1,130 @@
+"""Board-view rendering for the ``hermes kanban board`` subcommand.
+
+Pure render layer: ``render_board`` takes a list of ``kanban_db.Task`` and
+returns a ``rich.table.Table``. No database access, no stdout side effects.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from rich.console import Console
+from rich.table import Table
+
+from hermes_cli import kanban_db as kb
+
+# Canonical column order: (status, header label, Rich style). Covers every
+# member of kanban_db.VALID_STATUSES so no task can be silently dropped.
+COLUMNS: list[tuple[str, str, str]] = [
+    ("triage",    "Triage",    "magenta"),
+    ("todo",      "Todo",      "white"),
+    ("ready",     "Ready",     "cyan"),
+    ("running",   "Running",   "green"),
+    ("scheduled", "Scheduled", "blue"),
+    ("blocked",   "Blocked",   "red"),
+    ("review",    "Review",    "yellow"),
+    ("done",      "Done",      "dim green"),
+    ("archived",  "Archived",  "bright_black"),
+]
+
+# Hidden unless show_all=True (usually noise at a glance).
+_COLLAPSED = frozenset({"done", "archived"})
+
+_STATUS_ICON = {
+    "triage": "△", "todo": "◻", "ready": "▷", "running": "●",
+    "scheduled": "⏱", "blocked": "⊘", "review": "⊙", "done": "✓", "archived": "▤",
+}
+
+
+def render_board(
+    tasks: list[kb.Task],
+    *,
+    board_slug: str = "default",
+    other_board_count: int = 0,
+    show_all: bool = False,
+    limit: Optional[int] = 5,
+) -> Table:
+    """Build a Rich Table view of the kanban board.
+
+    Parameters
+    ----------
+    tasks:
+        Tasks for the current board (already filtered by the caller).
+    board_slug:
+        Active board identifier, shown in the table title.
+    other_board_count:
+        Number of *other* boards; >0 appends a hint to the title.
+    show_all:
+        Include the collapsed ``done``/``archived`` columns.
+    limit:
+        Max tasks shown per column; ``None`` means unlimited. Overflow
+        appends a ``… (+N hidden)`` line.
+    """
+    visible_columns = [
+        (status, label, style)
+        for status, label, style in COLUMNS
+        if show_all or status not in _COLLAPSED
+    ]
+
+    # Title (+ optional multi-board hint).
+    title = f"Board: {board_slug}"
+    if other_board_count:
+        plural = "s" if other_board_count != 1 else ""
+        title += f"  (+{other_board_count} other board{plural}; 'hermes kanban boards list')"
+
+    table = Table(title=title, title_style="bold", min_width=80)
+
+    if not tasks:
+        table.add_column("Board", style="dim", min_width=12)
+        table.add_row("(no tasks)")
+        return table
+
+    # Group tasks into the visible columns. Hidden collapsed tasks are
+    # dropped by design; truly-unknown statuses (shouldn't happen given
+    # VALID_STATUSES) fall into todo so they are never lost.
+    grouped: dict[str, list[kb.Task]] = {status: [] for status, _, _ in visible_columns}
+    for t in tasks:
+        if t.status in grouped:
+            grouped[t.status].append(t)
+        elif t.status in _COLLAPSED:
+            continue  # hidden unless show_all
+        else:
+            grouped.setdefault("todo", []).append(t)
+
+    for status, label, style in visible_columns:
+        count = len(grouped[status])
+        icon = _STATUS_ICON.get(status, "?")
+        header = f"{icon} {label}" + (f" ({count})" if count else "")
+        table.add_column(header, style=style, no_wrap=True, overflow="ellipsis")
+
+    # Build each column's cell as a list of lines, then emit aligned rows.
+    cells: list[list[str]] = []
+    for status, _, _ in visible_columns:
+        col_tasks = grouped[status]
+        shown = col_tasks if limit is None else col_tasks[:limit]
+        hidden = len(col_tasks) - len(shown)
+        lines = [
+            f"{t.id} {t.title}" + (f" [{t.assignee}]" if t.assignee else "")
+            for t in shown
+        ]
+        if hidden > 0:
+            lines.append(f"… (+{hidden} hidden)")
+        cells.append(lines)
+
+    max_rows = max((len(c) for c in cells), default=0)
+    for i in range(max_rows):
+        table.add_row(*[(c[i] if i < len(c) else "") for c in cells])
+
+    return table
+
+
+def _render_to_string(table: Table) -> str:
+    """Render a Table to a plain (uncolored) string for tests.
+
+    Width 200 keeps the nine-column show_all layout from truncating
+    headers, so substring assertions on labels stay reliable.
+    """
+    console = Console(width=200, force_terminal=False, color_system=None)
+    with console.capture() as capture:
+        console.print(table)
+    return capture.get()

--- a/tests/hermes_cli/test_kanban_board_cli.py
+++ b/tests/hermes_cli/test_kanban_board_cli.py
@@ -95,3 +95,62 @@ def test_board_layout_columns():
 def test_board_layout_rejects_unknown():
     with pytest.raises(SystemExit):
         _parse(["board", "--layout", "grid"])
+
+
+# --- hermes-sweeper review: bounded args + slash-safe interactive modes ---
+
+def test_board_limit_rejects_negative():
+    # A negative --limit was truthy-but-not->0, silently becoming unlimited.
+    with pytest.raises(SystemExit):
+        _parse(["board", "--limit", "-1"])
+
+
+def test_board_limit_zero_still_unlimited():
+    # 0 remains the documented "unlimited" sentinel and must still parse.
+    ns = _parse(["board", "--limit", "0"])
+    assert ns.limit == 0
+
+
+def test_board_refresh_rejects_zero():
+    # --refresh 0 -> time.sleep(0) busy loop; must be rejected at parse time.
+    with pytest.raises(SystemExit):
+        _parse(["board", "--refresh", "0"])
+
+
+def test_board_refresh_rejects_negative():
+    with pytest.raises(SystemExit):
+        _parse(["board", "--refresh", "-1"])
+
+
+def _run_slash_no_dispatch(monkeypatch, rest):
+    """Run a /kanban slash string with kanban_command mocked so an unbounded
+    interactive command cannot actually hang the test; return (output, dispatched)."""
+    dispatched = []
+    monkeypatch.setattr(
+        k, "kanban_command",
+        lambda args: (dispatched.append(getattr(args, "kanban_action", None)), 0)[1],
+    )
+    out = k.run_slash(rest)
+    return out, dispatched
+
+
+def test_slash_rejects_board_tail(monkeypatch):
+    # board --tail runs an unbounded live view; over the slash path run_slash
+    # captures stdout synchronously, so it would hang the gateway worker.
+    out, dispatched = _run_slash_no_dispatch(monkeypatch, "board --tail")
+    assert not dispatched, "board --tail must not dispatch over slash (would hang)"
+    assert "interactive terminal" in out.lower()
+
+
+def test_slash_allows_board_without_tail(monkeypatch):
+    # The bounded board render must still dispatch normally over slash.
+    _out, dispatched = _run_slash_no_dispatch(monkeypatch, "board")
+    assert dispatched == ["board"]
+
+
+def test_slash_rejects_tail_and_watch(monkeypatch):
+    # Pre-existing sibling hangs closed by the same guard.
+    out_tail, disp_tail = _run_slash_no_dispatch(monkeypatch, "tail 5")
+    assert not disp_tail and "interactive terminal" in out_tail.lower()
+    out_watch, disp_watch = _run_slash_no_dispatch(monkeypatch, "watch")
+    assert not disp_watch and "interactive terminal" in out_watch.lower()

--- a/tests/hermes_cli/test_kanban_board_cli.py
+++ b/tests/hermes_cli/test_kanban_board_cli.py
@@ -78,3 +78,20 @@ def test_board_json_dispatch(kanban_home, capsys):
     assert rc == 0
     data = json.loads(out)
     assert any(t["title"] == "hello world" for t in data)
+
+
+def test_board_layout_default_is_auto():
+    assert _parse(["board"]).layout == "auto"
+
+
+def test_board_layout_stack():
+    assert _parse(["board", "--layout", "stack"]).layout == "stack"
+
+
+def test_board_layout_columns():
+    assert _parse(["board", "--layout", "columns"]).layout == "columns"
+
+
+def test_board_layout_rejects_unknown():
+    with pytest.raises(SystemExit):
+        _parse(["board", "--layout", "grid"])

--- a/tests/hermes_cli/test_kanban_board_cli.py
+++ b/tests/hermes_cli/test_kanban_board_cli.py
@@ -1,0 +1,80 @@
+"""Tests for the 'kanban board' CLI subcommand: parsing + dispatch."""
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban as k
+from hermes_cli import kanban_db as kb
+
+
+def _parse(argv: list[str]) -> argparse.Namespace:
+    """Parse a kanban argv through the real build_parser path."""
+    parser = argparse.ArgumentParser(prog="hermes")
+    sub = parser.add_subparsers(dest="command")
+    k.build_parser(sub)
+    return parser.parse_args(["kanban", *argv])
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Isolated HERMES_HOME with an empty kanban DB."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def test_board_action_registered():
+    ns = _parse(["board"])
+    assert ns.kanban_action == "board"
+
+
+def test_board_defaults():
+    ns = _parse(["board"])
+    assert ns.limit == 5
+    assert ns.show_all is False
+    assert ns.mine is False
+    assert ns.assignee is None
+    assert ns.json is False
+    assert ns.tail is False
+    assert ns.refresh == 5
+
+
+def test_board_flags():
+    ns = _parse([
+        "board", "--limit", "10", "--show-all", "--mine",
+        "--json", "--tail", "--refresh", "3",
+    ])
+    assert ns.limit == 10
+    assert ns.show_all is True
+    assert ns.mine is True
+    assert ns.json is True
+    assert ns.tail is True
+    assert ns.refresh == 3
+
+
+def test_board_assignee():
+    ns = _parse(["board", "--assignee", "researcher"])
+    assert ns.assignee == "researcher"
+
+
+def test_board_global_board_flag_precedes_subcommand():
+    # --board is a GLOBAL flag and must come before the subcommand.
+    ns = _parse(["--board", "default", "board"])
+    assert ns.board == "default"
+    assert ns.kanban_action == "board"
+
+
+def test_board_json_dispatch(kanban_home, capsys):
+    with kb.connect() as conn:
+        kb.create_task(conn, title="hello world")
+    rc = k.kanban_command(_parse(["board", "--json"]))
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(out)
+    assert any(t["title"] == "hello world" for t in data)

--- a/tests/hermes_cli/test_kanban_board_render.py
+++ b/tests/hermes_cli/test_kanban_board_render.py
@@ -101,3 +101,82 @@ def test_render_shows_multi_board_hint():
 def test_render_no_hint_for_single_board():
     out = r._render_to_string(r.render_board([], board_slug="default", other_board_count=0))
     assert "other board" not in out.lower()
+
+
+# ── Stacked (narrow-terminal) layout ──────────────────────────────────
+
+
+def test_should_stack_narrow_is_true():
+    assert r.should_stack(50, show_all=False) is True
+
+
+def test_should_stack_wide_is_false():
+    assert r.should_stack(200, show_all=False) is False
+
+
+def test_should_stack_show_all_needs_more_width():
+    # 9 columns need more room than 7; a width that fits 7 may not fit 9.
+    assert r.should_stack(120, show_all=True) is True
+    assert r.should_stack(120, show_all=False) is False
+
+
+def test_stacked_returns_group():
+    result = r.render_board_stacked([_make_task("t_001", "x", "todo")], board_slug="default")
+    assert "Group" in type(result).__name__
+
+
+def test_stacked_lists_tasks_under_status_headers():
+    tasks = [
+        _make_task("t_001", "first todo", "todo"),
+        _make_task("t_002", "the runner", "running"),
+    ]
+    out = r._render_to_string(r.render_board_stacked(tasks, board_slug="default"))
+    assert "todo" in out.lower()
+    assert "running" in out.lower()
+    assert "first todo" in out.lower()
+    assert "the runner" in out.lower()
+
+
+def test_stacked_omits_empty_sections():
+    out = r._render_to_string(
+        r.render_board_stacked([_make_task("t_001", "only todo", "todo")], board_slug="default")
+    )
+    assert "todo" in out.lower()
+    # ready/running/blocked sections have no tasks → not printed
+    assert "ready" not in out.lower()
+    assert "blocked" not in out.lower()
+
+
+def test_stacked_collapses_excess():
+    tasks = [_make_task(f"t_{i:03d}", f"task {i}", "todo") for i in range(10)]
+    out = r._render_to_string(r.render_board_stacked(tasks, board_slug="default", limit=5))
+    assert "(+5 hidden)" in out.lower()
+
+
+def test_stacked_show_all_includes_done():
+    tasks = [_make_task("t_001", "finished", "done")]
+    out = r._render_to_string(
+        r.render_board_stacked(tasks, board_slug="default", show_all=True)
+    )
+    assert "done" in out.lower()
+    assert "finished" in out.lower()
+
+
+def test_stacked_done_hidden_by_default():
+    tasks = [_make_task("t_001", "finished", "done")]
+    out = r._render_to_string(r.render_board_stacked(tasks, board_slug="default"))
+    # done is collapsed; with no other tasks the board reads as empty
+    assert "finished" not in out.lower()
+    assert "(no tasks)" in out.lower()
+
+
+def test_stacked_empty_board():
+    out = r._render_to_string(r.render_board_stacked([], board_slug="default"))
+    assert "(no tasks)" in out.lower()
+
+
+def test_stacked_multi_board_hint():
+    out = r._render_to_string(
+        r.render_board_stacked([], board_slug="default", other_board_count=2)
+    )
+    assert "other board" in out.lower()

--- a/tests/hermes_cli/test_kanban_board_render.py
+++ b/tests/hermes_cli/test_kanban_board_render.py
@@ -1,0 +1,103 @@
+"""Tests for kanban_board_render.py (pure render layer, no DB)."""
+
+from hermes_cli import kanban_board_render as r
+from hermes_cli.kanban_db import Task
+
+
+def _make_task(task_id: str, title: str, status: str, assignee: str = None) -> Task:
+    """Build a Task with all required (no-default) fields, matching the
+    live dataclass field set. Everything else uses dataclass defaults."""
+    return Task(
+        id=task_id,
+        title=title,
+        body="",
+        assignee=assignee,
+        status=status,
+        priority=0,
+        created_by="test",
+        created_at=0,
+        started_at=None,
+        completed_at=None,
+        workspace_kind="scratch",
+        workspace_path=None,
+        claim_lock=None,
+        claim_expires=None,
+        tenant=None,
+    )
+
+
+def test_render_returns_rich_table():
+    result = r.render_board([_make_task("t_001", "test task", "todo")], board_slug="default")
+    assert "Table" in type(result).__name__
+
+
+def test_render_column_count():
+    tasks = [
+        _make_task("t_001", "todo task", "todo"),
+        _make_task("t_002", "ready task", "ready"),
+        _make_task("t_003", "running task", "running"),
+    ]
+    out = r._render_to_string(r.render_board(tasks, board_slug="default"))
+    assert "todo" in out.lower()
+    assert "ready" in out.lower()
+    assert "running" in out.lower()
+    # done/archived collapsed by default
+    assert "archived" not in out.lower()
+
+
+def test_render_includes_triage_and_review_columns():
+    """triage and review are valid statuses and must never be dropped."""
+    out = r._render_to_string(r.render_board([], board_slug="default", other_board_count=0))
+    # empty board short-circuits to a placeholder, so check a populated board instead
+    tasks = [
+        _make_task("t_001", "needs triage", "triage"),
+        _make_task("t_002", "in review", "review"),
+    ]
+    out = r._render_to_string(r.render_board(tasks, board_slug="default"))
+    assert "triage" in out.lower()
+    assert "review" in out.lower()
+    assert "needs triage" in out.lower()
+    assert "in review" in out.lower()
+
+
+def test_render_groups_tasks_by_status():
+    tasks = [
+        _make_task("t_001", "first", "todo"),
+        _make_task("t_002", "second", "todo"),
+        _make_task("t_003", "runner", "running"),
+    ]
+    out = r._render_to_string(r.render_board(tasks, board_slug="default"))
+    assert "first" in out
+    assert "second" in out
+    assert "runner" in out
+
+
+def test_render_collapses_excess():
+    tasks = [_make_task(f"t_{i:03d}", f"task {i}", "todo") for i in range(10)]
+    out = r._render_to_string(r.render_board(tasks, board_slug="default", limit=5))
+    assert "(+5 hidden)" in out.lower()
+
+
+def test_render_all_statuses():
+    tasks = [
+        _make_task("t_001", "d", "done"),
+        _make_task("t_002", "a", "archived"),
+    ]
+    out = r._render_to_string(r.render_board(tasks, board_slug="default", show_all=True))
+    assert "done" in out.lower()
+    assert "archived" in out.lower()
+
+
+def test_render_empty_board():
+    out = r._render_to_string(r.render_board([], board_slug="default"))
+    assert "(no tasks)" in out.lower()
+
+
+def test_render_shows_multi_board_hint():
+    out = r._render_to_string(r.render_board([], board_slug="default", other_board_count=2))
+    assert "other board" in out.lower()
+
+
+def test_render_no_hint_for_single_board():
+    out = r._render_to_string(r.render_board([], board_slug="default", other_board_count=0))
+    assert "other board" not in out.lower()


### PR DESCRIPTION
## What does this PR do?

Adds a `hermes kanban board` subcommand that renders the kanban board in the terminal, grouped by status, so headless/SSH users get a visual board without the web dashboard.

It ships two layouts, chosen automatically by terminal width:

- **Columns**: the classic board, one column per status, for wide terminals.
- **Stacked**: each non-empty status becomes a section header with its tasks listed below, one per line. Titles wrap instead of truncating, so it stays readable on a narrow terminal (e.g. SSH from a phone).

`--layout {auto,columns,stack}` controls this. `auto` (the default) falls back to stacked when the columns would not fit. `--tail` gives a live, in-place updating view via `rich.live.Live` (alternate screen, like `top`/`htop`) and re-checks width on each refresh, so a resize is handled live.

The design mirrors the existing kanban CLI: a pure render module (`hermes_cli/kanban_board_render.py`, no DB or I/O) plus a `_cmd_board` handler wired into the existing dispatch dict. Board scope comes from the existing global `--board` flag, so there is no new board-resolution path.

## Related Issue

No related issue; this is a self-contained new feature.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/kanban_board_render.py` (new): pure render layer. `render_board` (columns, returns a `rich.table.Table`), `render_board_stacked` (vertical, returns a `rich.console.Group`), and `should_stack` (width heuristic). No DB access or stdout side effects.
- `hermes_cli/kanban.py`: adds the `board` subparser (`--limit / --show-all / --mine / --assignee / --json / --tail / --refresh / --layout`); the `_cmd_board` handler picks the layout from terminal width and drives the `--tail` live loop; `"board": _cmd_board` added to the existing dispatch dict.
- `tests/hermes_cli/test_kanban_board_render.py` (new): render-layer coverage (columns, stacked, collapse, width heuristic, empty/multi-board).
- `tests/hermes_cli/test_kanban_board_cli.py` (new): subcommand parsing and dispatch (defaults, flags, `--layout`, JSON dispatch).

## How to Test

1. Create a few tasks: `hermes kanban create "task one"`, `hermes kanban create "task two"`.
2. `hermes kanban board` renders the board. On a wide terminal it shows columns; on a narrow one it auto-stacks.
3. `hermes kanban board --layout stack` and `--layout columns` force each layout. `--show-all` adds the done/archived columns; `--json` prints a flat list.
4. `hermes kanban board --tail` gives a live view that refreshes in place; Ctrl+C exits and restores the terminal.
5. Tests: `scripts/run_tests.sh tests/hermes_cli/test_kanban_board_render.py tests/hermes_cli/test_kanban_board_cli.py` (30 passed).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04.4 LTS, Python 3.12.3

Note on the full-suite box: the scoped board tests pass (30 via `scripts/run_tests.sh`). I'm relying on CI for the full `pytest tests/ -q` run.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings), or N/A: docstrings included on the new module; no README/docs change needed.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys, or N/A: no new config keys.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows, or N/A: no architecture change.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility): Rich handles color and box rendering across platforms; no platform-specific terminal calls.
- [x] I've updated tool descriptions/schemas if I changed tool behavior, or N/A: no tool behavior change.

## Screenshots / Logs

Stacked layout (narrow terminal):

```
Board: default

▷ Ready (3)
  t_15cf9c43 Draft upstream PR description
  t_e107eb66 Investigate silence watchdog Track 2
  t_3b7b223c Review group-chat Apple limitation

⏱ Scheduled (1)
  t_34d59fb7 Backfill Tier-2 adapter tests

⊘ Blocked (1)
  t_424f5cfc Wire up Sendblue media parity
```
