### PR TITLE
fix(desktop): recover from transient assistant-ui index-lookup crash

### DIFF
--- a/apps/desktop/src/components/assistant-ui/message-render-boundary.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/message-render-boundary.test.tsx
@@ -1,0 +1,80 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { MessageRenderBoundary } from './message-render-boundary'
+
+afterEach(cleanup)
+
+function Boom({ error }: { error: Error | null }): null {
+  if (error) {
+    throw error
+  }
+
+  return null
+}
+
+const lookupError = new Error('tapClientLookup: Index 2 out of bounds (length: 2)')
+
+describe('MessageRenderBoundary', () => {
+  it('renders children when nothing throws', () => {
+    render(
+      <MessageRenderBoundary resetKey="a">
+        <div>content</div>
+      </MessageRenderBoundary>
+    )
+
+    expect(screen.getByText('content')).toBeTruthy()
+  })
+
+  it('swallows the transient tapClientLookup out-of-bounds store race', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    const { container } = render(
+      <MessageRenderBoundary resetKey="a">
+        <Boom error={lookupError} />
+      </MessageRenderBoundary>
+    )
+
+    expect(container.innerHTML).toBe('')
+    spy.mockRestore()
+  })
+
+  it('recovers on the next consistent snapshot when resetKey changes', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    const { rerender } = render(
+      <MessageRenderBoundary resetKey="a">
+        <Boom error={lookupError} />
+      </MessageRenderBoundary>
+    )
+
+    rerender(
+      <MessageRenderBoundary resetKey="b">
+        <Boom error={null} />
+      </MessageRenderBoundary>
+    )
+
+    rerender(
+      <MessageRenderBoundary resetKey="b">
+        <div>recovered</div>
+      </MessageRenderBoundary>
+    )
+
+    expect(screen.getByText('recovered')).toBeTruthy()
+    spy.mockRestore()
+  })
+
+  it('re-throws unrelated errors so real bugs still surface', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    expect(() =>
+      render(
+        <MessageRenderBoundary resetKey="a">
+          <Boom error={new Error('genuine render bug')} />
+        </MessageRenderBoundary>
+      )
+    ).toThrow('genuine render bug')
+
+    spy.mockRestore()
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/message-render-boundary.tsx
+++ b/apps/desktop/src/components/assistant-ui/message-render-boundary.tsx
@@ -1,0 +1,48 @@
+import { Component, type ReactNode } from 'react'
+
+// `@assistant-ui/store`'s index-keyed child-scope lookup (`tapClientLookup`)
+// throws — rather than returning undefined — when a subscriber reads an index
+// that the message/parts list no longer has. This races during high-frequency
+// store replacement (session switch mid-stream, gateway reconnect replay): a
+// subscriber from the previous, longer list is still in React's notification
+// queue and reads one slot past the new, shorter array before it can unmount.
+// The throw is transient and self-heals on the next consistent snapshot, but
+// without a local boundary it unwinds to the root and blanks the whole app.
+// Upstream-tracked: assistant-ui/assistant-ui#4051, #3652.
+const isTransientLookupError = (error: unknown): boolean =>
+  error instanceof Error && /tapClient(Lookup|Resource).*out of bounds/.test(error.message)
+
+interface Props {
+  // Changes whenever the message list mutates; remounting clears the caught
+  // error so the next consistent render recovers silently.
+  resetKey: string
+  children: ReactNode
+}
+
+export class MessageRenderBoundary extends Component<Props, { error: Error | null }> {
+  state: { error: Error | null } = { error: null }
+
+  static getDerivedStateFromError(error: Error) {
+    return { error }
+  }
+
+  componentDidUpdate(prev: Props) {
+    if (this.state.error && prev.resetKey !== this.props.resetKey) {
+      this.setState({ error: null })
+    }
+  }
+
+  render() {
+    if (this.state.error) {
+      // Only swallow the transient store race; re-throw anything else so real
+      // bugs still reach the root error boundary.
+      if (!isTransientLookupError(this.state.error)) {
+        throw this.state.error
+      }
+
+      return null
+    }
+
+    return this.props.children
+  }
+}

--- a/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
@@ -16,6 +16,8 @@ import { setMutableRef } from '@/lib/mutable-ref'
 import { cn } from '@/lib/utils'
 import { setThreadScrolledUp } from '@/store/thread-scroll'
 
+import { MessageRenderBoundary } from './message-render-boundary'
+
 const ESTIMATED_ITEM_HEIGHT = 220
 const OVERSCAN = 4
 const AT_BOTTOM_THRESHOLD = 4
@@ -180,18 +182,20 @@ const VirtualizedThreadInner: FC<VirtualizedThreadProps> = ({
                     key={virtualItem.key}
                     ref={virtualizer.measureElement}
                   >
-                    {group.kind === 'turn' ? (
-                      <div
-                        className="composer-human-ai-pair-container relative flex min-w-0 flex-col gap-(--conversation-turn-gap)"
-                        data-slot="aui_turn-pair"
-                      >
-                        {group.indices.map(index => (
-                          <ThreadPrimitive.MessageByIndex components={components} index={index} key={index} />
-                        ))}
-                      </div>
-                    ) : (
-                      <ThreadPrimitive.MessageByIndex components={components} index={group.index} />
-                    )}
+                    <MessageRenderBoundary resetKey={messageSignature}>
+                      {group.kind === 'turn' ? (
+                        <div
+                          className="composer-human-ai-pair-container relative flex min-w-0 flex-col gap-(--conversation-turn-gap)"
+                          data-slot="aui_turn-pair"
+                        >
+                          {group.indices.map(index => (
+                            <ThreadPrimitive.MessageByIndex components={components} index={index} key={index} />
+                          ))}
+                        </div>
+                      ) : (
+                        <ThreadPrimitive.MessageByIndex components={components} index={group.index} />
+                      )}
+                    </MessageRenderBoundary>
                   </div>
                 )
               })}


### PR DESCRIPTION
## Symptom

Hermes Desktop intermittently shows the root error boundary — **"Something broke in the interface"** with the message:

```
tapClientLookup: Index 2 out of bounds (length: 2)
```

The whole window goes blank; the only escape is Retry / Reload. It tends to fire when a chat is opened/switched or the gateway reconnects (e.g. sleep/wake) **while a response is streaming**.

## Root cause

The error is **not** Hermes code — it is thrown by `@assistant-ui/store`'s index-keyed child-scope lookup (`tapClientLookup` / `useClientLookup`), which **throws instead of returning `undefined`** when a subscriber reads an index the list no longer has.

Hermes renders messages via `ThreadPrimitive.MessageByIndex index={i}` in the virtualized thread (`thread-virtualizer.tsx`) and content via `MessagePrimitive.Parts` — both ride that index-lookup path. During high-frequency store replacement (session switch mid-stream, gateway reconnect replay) a subscriber from the *previous, longer* message/parts list is still in React's notification queue and reads one slot past the new, shorter array before it can unmount. The signature `Index N out of bounds (length: N)` is the classic `index === length` off-by-one.

The throw self-heals on the very next consistent snapshot, but with only the root boundary in the render path it unwinds all the way up and blanks the entire app.

This is a known, still-open upstream bug:
- assistant-ui/assistant-ui#4051 — index-out-of-bounds on React 19 from high-frequency external-store replacement
- assistant-ui/assistant-ui#3652 — thread switch crash (`tapClientLookup: Index 0 out of bounds`)

## Fix

Wrap each virtualized message group in a small purpose-built boundary that:

1. Swallows **only** the transient `tapClient(Lookup|Resource) … out of bounds` store race (renders nothing for that frame).
2. **Re-throws everything else** to the root boundary, so genuine render bugs still surface.
3. Auto-recovers when `messageSignature` changes — the list-mutation key the virtualizer already computes — so the next consistent snapshot remounts cleanly with no user action.

Minimal footprint: one new ~48-line component + a 2-line wrap in the existing render site. No new deps, no i18n strings, no runtime/protocol changes.

## Tests

`message-render-boundary.test.tsx` asserts the behavior contract: renders children normally, swallows the transient lookup error, recovers on `resetKey` change, and re-throws unrelated errors. Verified the re-throw test fails if the discrimination is removed (non-vacuous).

```
npm run test:ui -- src/components/assistant-ui/message-render-boundary.test.tsx   # 4 passed
eslint <changed files>                                                            # clean
tsc -b                                                                            # clean
```
