### PR TITLE
fix(skills-index): give the offline builder a walk budget the full ClawHub catalog fits in

### DIFF
--- a/scripts/build_skills_index.py
+++ b/scripts/build_skills_index.py
@@ -255,7 +255,12 @@ def main():
         "official": OptionalSkillSource(),
         "well-known": WellKnownSkillSource(),
         "github": GitHubSource(auth=auth),
-        "clawhub": ClawHubSource(),
+        # The interactive 12s walk budget truncates the full ~50k catalog at
+        # ~16 pages (~3.2k skills), which trips the EXPECTED_FLOORS health
+        # check below and blocks the deploy. The offline builder walks to
+        # exhaustion (~250 sequential pages, ~3-4 min), so give it a budget
+        # sized for that.
+        "clawhub": ClawHubSource(catalog_walk_budget_seconds=600),
         "claude-marketplace": ClaudeMarketplaceSource(auth=auth),
         "lobehub": LobeHubSource(),
         "browse-sh": BrowseShSource(),

--- a/tests/scripts/test_build_skills_index_health.py
+++ b/tests/scripts/test_build_skills_index_health.py
@@ -49,7 +49,11 @@ def _install_fake_sources(monkeypatch, *, github_count, claude_count=40,
         build_mod, "GitHubSource",
         lambda auth: _FakeSource("github", github_count, rate_limited=github_rate_limited),
     )
-    monkeypatch.setattr(build_mod, "ClawHubSource", lambda: _FakeSource("clawhub", 69000))
+    monkeypatch.setattr(
+        build_mod,
+        "ClawHubSource",
+        lambda catalog_walk_budget_seconds=None: _FakeSource("clawhub", 69000),
+    )
     monkeypatch.setattr(
         build_mod, "ClaudeMarketplaceSource",
         lambda auth: _FakeSource("claude-marketplace", claude_count, rate_limited=github_rate_limited),

--- a/tests/tools/test_skills_hub_clawhub.py
+++ b/tests/tools/test_skills_hub_clawhub.py
@@ -422,6 +422,48 @@ class TestClawHubSource(unittest.TestCase):
         self.assertEqual(results[0].identifier, "only-skill")
         mock_write_cache.assert_called_once()
 
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub.httpx.get")
+    def test_catalog_walk_budget_instance_override_wins_over_class_default(
+        self, mock_get, _mock_read_cache, mock_write_cache
+    ):
+        """The offline index builder passes an explicit walk budget so the
+        interactive 12s default cannot truncate the full-catalog walk (which
+        shipped a degenerate ~3.2k-skill index and failed the EXPECTED_FLOORS
+        deploy check). With the class default forced to an already-expired
+        deadline, an instance constructed with its own budget must still walk
+        to natural termination and cache the result."""
+        pages = {"n": 0}
+
+        def side_effect(url, *args, **kwargs):
+            if url.endswith("/skills"):
+                idx = pages["n"]
+                pages["n"] += 1
+                last = idx == 2
+                return _MockResponse(
+                    status_code=200,
+                    json_data={
+                        "items": [
+                            {"slug": f"skill-{idx}", "displayName": f"Skill {idx}"}
+                        ],
+                        **({} if last else {"nextCursor": f"cursor-{idx + 1}"}),
+                    },
+                )
+            return _MockResponse(status_code=404, json_data={})
+
+        mock_get.side_effect = side_effect
+
+        with patch.object(ClawHubSource, "CATALOG_WALK_BUDGET_SECONDS", -1):
+            src = ClawHubSource(catalog_walk_budget_seconds=60)
+            results = src._load_catalog_index()
+
+        # Walked all three pages to natural termination despite the expired
+        # class-level deadline, and cached the complete catalog.
+        self.assertEqual(pages["n"], 3)
+        self.assertEqual(len(results), 3)
+        mock_write_cache.assert_called_once()
+
 
 class TestClawHubCatalogWalkBounded(unittest.TestCase):
     """max_items bounds the walk so browse's cold-start fallback renders one

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -1952,6 +1952,15 @@ class ClawHubSource(SkillSource):
     # minutes. Bound it so a slow/large catalog cannot hang the caller.
     CATALOG_WALK_BUDGET_SECONDS = 12
 
+    def __init__(self, catalog_walk_budget_seconds: Optional[float] = None):
+        # Interactive callers (browse/search cold start) keep the tight class
+        # default so a slow catalog cannot hang them. Walk-to-exhaustion
+        # callers — the offline index builder — need ~250 sequential pages for
+        # the full 50k+ catalog, which no interactive budget can cover, so
+        # they pass an explicit larger budget here.
+        if catalog_walk_budget_seconds is not None:
+            self.CATALOG_WALK_BUDGET_SECONDS = catalog_walk_budget_seconds
+
     def source_id(self) -> str:
         return "clawhub"
 


### PR DESCRIPTION
## What does this PR do?

Unblocks the skills index / docs-site deploys, which have failed on every run since 2026-06-10 06:22 UTC.

**Root cause:** the interactive 12-second `CATALOG_WALK_BUDGET_SECONDS` added in 105625d650 ("honour overall_timeout and bound ClawHub catalog walk", the #38459 hang fix) also applies to the offline index builder. The builder's walk-to-exhaustion over the ~50k-skill ClawHub catalog needs ~250 sequential pages (~260s at the observed ~1 page/s), so the 12s budget truncates it at ~16 pages. The `EXPECTED_FLOORS` health check from #42347 then correctly refuses to ship the degenerate index (`clawhub: 1797 < expected floor 20000` … `3195 < 20000`), failing `skills-index.yml` and `deploy-site.yml` ever since — the live docs site is frozen at the June 9 state and the watchdog keeps bumping #38240.

**Evidence**
- Last green index run: 2026-06-09 18:52 UTC; first red: 2026-06-10 07:41 UTC — the budget commit landed on main 2026-06-10 06:22 UTC, in between.
- First failing run logs `clawhub: 1797 skills (12.9s)` — the crawl stops at exactly the 12s budget; later runs report 3195, i.e. the count varies with network speed, which is a truncation signature, not a catalog shrink.
- Live repro: a 30s budget walks 5,788 skills; 12s walks ~3.2k — linear in the budget.

**Fix:** `ClawHubSource` now accepts an explicit per-instance `catalog_walk_budget_seconds`; `scripts/build_skills_index.py` passes 600s (≈2.3× the measured full-walk time). Interactive callers (browse/search cold start) keep the tight 12s default, so the #38459 hang fix is untouched.

## Related Issue

Fixes #38240

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skills_hub.py` — `ClawHubSource.__init__(catalog_walk_budget_seconds=None)` instance override of the class default
- `scripts/build_skills_index.py` — builder constructs `ClawHubSource(catalog_walk_budget_seconds=600)`
- `tests/tools/test_skills_hub_clawhub.py` — regression test: instance budget wins over an expired class-level deadline, walk completes and caches
- `tests/scripts/test_build_skills_index_health.py` — fake-source stub accepts the new kwarg

## How to Test

1. `pytest tests/tools/test_skills_hub_clawhub.py tests/scripts/test_build_skills_index_health.py -q` → 18 passed
2. `pytest tests/tools -k skills_hub -q` → 166 passed, 1 skipped
3. Live: `ClawHubSource(catalog_walk_budget_seconds=30)._load_catalog_index()` gathers ~5.8k skills vs ~3.2k at the 12s default; with 600s the walk reaches cursor exhaustion (~50k) and the health check floor passes
4. After merge, `gh workflow run skills-index.yml` should go green and the watchdog probe on #38240 should recover

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant tests and all pass (see How to Test)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal CI/index builder behavior)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

First failing run ([skills-index #27261057718](https://github.com/NousResearch/hermes-agent/actions/runs/27261057718)):
```
  clawhub: 1797 skills (12.9s)
ERROR: skills index health check failed — refusing to ship a degenerate index.
  clawhub: 1797 < expected floor 20000
```
Latest deploy-site failure ([#27366487914](https://github.com/NousResearch/hermes-agent/actions/runs/27366487914)): `clawhub: 3195 < expected floor 20000`