### PR TITLE
fix(nix): use `TERMINAL_CWD` instead of deprecated `MESSAGING_CWD`

### DIFF
--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -883,7 +883,7 @@
             HOME = cfg.stateDir;
             HERMES_HOME = "${cfg.stateDir}/.hermes";
             HERMES_MANAGED = "true";
-            MESSAGING_CWD = cfg.workingDirectory;
+            TERMINAL_CWD = cfg.workingDirectory;
           };
 
           serviceConfig = {
@@ -980,7 +980,7 @@
                 --env HERMES_HOME=${containerDataDir}/.hermes \
                 --env HERMES_MANAGED=true \
                 --env HOME=${containerHomeDir} \
-                --env MESSAGING_CWD=${containerWorkDir} \
+                --env TERMINAL_CWD=${containerWorkDir} \
                 ${lib.concatStringsSep " " cfg.container.extraOptions} \
                 ${cfg.container.image} \
                 ${containerDataDir}/current-package/bin/hermes gateway run --replace ${lib.concatStringsSep " " cfg.extraArgs}


### PR DESCRIPTION
## What does this PR do?

The NixOS module set `MESSAGING_CWD` in two places — the systemd service environment and the `--env` flags of the container run command. `MESSAGING_CWD` is deprecated: the gateway now reads `TERMINAL_CWD` (bridged from `terminal.cwd` in `config.yaml`), and `hermes_cli/config.py` notes it was removed in favor of that. So every NixOS start logs:

```
⚠ Deprecated .env settings detected:
  ⚠ MESSAGING_CWD=... found in .env — this is deprecated.
```

This renames `MESSAGING_CWD` → `TERMINAL_CWD` in both spots, keeping the same working-directory value, which clears the warning while preserving behavior.

## Related Issue

Fixes #44485

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `nix/nixosModules.nix` — `MESSAGING_CWD = cfg.workingDirectory` → `TERMINAL_CWD = cfg.workingDirectory` (systemd env), and `--env MESSAGING_CWD=${containerWorkDir}` → `--env TERMINAL_CWD=${containerWorkDir}` (container run).

## How to Test

I don't have a NixOS host to build the module, so this is verified by inspection: `TERMINAL_CWD` is the live variable the runtime reads (`agent/runtime_cwd.py`, `gateway/runtime_footer.py`, …), and `MESSAGING_CWD` is the deprecated one per `hermes_cli/config.py`. On a NixOS host the deprecation warning should no longer appear and the working directory should be unchanged.

If you'd prefer the module write `terminal.cwd` into the generated `config.yaml` rather than set the bridged env var, happy to do that instead.

## Checklist

- [x] Bug fix is non-breaking (pure env-var rename to the documented replacement)
- [x] Resolves the deprecation warning for NixOS users
