### PR TITLE
fix(todo): reject empty content instead of substituting (no description) (#44496)

### DIFF
--- a/tests/tools/test_todo_tool.py
+++ b/tests/tools/test_todo_tool.py
@@ -205,6 +205,25 @@ class TestRejectEmptyContent:
         except ValueError as e:
             assert "empty or missing content" in str(e)
 
+    def test_partial_write_does_not_mutate_existing_list(self):
+        """A failed write with mixed valid/invalid items leaves the prior list
+        untouched (acceptance criterion #3 from #44496)."""
+        store = TodoStore()
+        store.write([
+            {"id": "1", "content": "Keep me", "status": "pending"},
+            {"id": "2", "content": "Also keep me", "status": "completed"},
+        ])
+        try:
+            store.write([
+                {"id": "1", "content": "Updated", "status": "pending"},  # valid
+                {"id": "2", "content": "",        "status": "pending"},  # invalid
+            ])
+        except ValueError:
+            pass
+        items = store.read()
+        assert [i["content"] for i in items] == ["Keep me", "Also keep me"]
+        assert [i["status"]  for i in items] == ["pending", "completed"]
+
     def test_todo_tool_returns_error_on_empty_content(self):
         result = json.loads(todo_tool(
             todos=[{"id": "1", "content": "", "status": "pending"}],
@@ -219,6 +238,16 @@ class TestRejectEmptyContent:
         store.write([{"id": "1", "content": "Existing", "status": "pending"}])
         try:
             store.write([{"id": "2", "content": "", "status": "pending"}], merge=True)
+            assert False, "should have raised ValueError"
+        except ValueError as e:
+            assert "empty or missing content" in str(e)
+
+    def test_merge_new_item_rejects_whitespace_content(self):
+        """Merge mode: new items with whitespace-only content are rejected."""
+        store = TodoStore()
+        store.write([{"id": "1", "content": "Existing", "status": "pending"}])
+        try:
+            store.write([{"id": "2", "content": "   ", "status": "pending"}], merge=True)
             assert False, "should have raised ValueError"
         except ValueError as e:
             assert "empty or missing content" in str(e)

--- a/tests/tools/test_todo_tool.py
+++ b/tests/tools/test_todo_tool.py
@@ -175,3 +175,67 @@ class TestTodoStoreBounds:
         items = store.read()
         assert [i["content"] for i in items] == ["write the report", "review PR"]
         assert "[truncated]" not in items[0]["content"]
+
+
+class TestRejectEmptyContent:
+    """Empty or missing content must fail the call instead of substituting
+    '(no description)'. See #44496."""
+
+    def test_write_rejects_empty_content(self):
+        store = TodoStore()
+        try:
+            store.write([{"id": "1", "content": "", "status": "pending"}])
+            assert False, "should have raised ValueError"
+        except ValueError as e:
+            assert "empty or missing content" in str(e)
+
+    def test_write_rejects_missing_content_key(self):
+        store = TodoStore()
+        try:
+            store.write([{"id": "2", "status": "pending"}])
+            assert False, "should have raised ValueError"
+        except ValueError as e:
+            assert "empty or missing content" in str(e)
+
+    def test_write_rejects_whitespace_content(self):
+        store = TodoStore()
+        try:
+            store.write([{"id": "3", "content": "   ", "status": "pending"}])
+            assert False, "should have raised ValueError"
+        except ValueError as e:
+            assert "empty or missing content" in str(e)
+
+    def test_todo_tool_returns_error_on_empty_content(self):
+        result = json.loads(todo_tool(
+            todos=[{"id": "1", "content": "", "status": "pending"}],
+            store=TodoStore(),
+        ))
+        assert "error" in result
+        assert "empty or missing content" in result["error"]
+
+    def test_merge_new_item_rejects_empty_content(self):
+        """Merge mode: new items with empty content are rejected."""
+        store = TodoStore()
+        store.write([{"id": "1", "content": "Existing", "status": "pending"}])
+        try:
+            store.write([{"id": "2", "content": "", "status": "pending"}], merge=True)
+            assert False, "should have raised ValueError"
+        except ValueError as e:
+            assert "empty or missing content" in str(e)
+
+    def test_merge_existing_item_keeps_content_on_status_only_update(self):
+        """Merge mode: updating only status (no content key) preserves existing content."""
+        store = TodoStore()
+        store.write([{"id": "1", "content": "Keep this", "status": "pending"}])
+        store.write([{"id": "1", "status": "completed"}], merge=True)
+        items = store.read()
+        assert items[0]["content"] == "Keep this"
+        assert items[0]["status"] == "completed"
+
+    def test_valid_content_still_works(self):
+        """Regression: valid items still pass through normally."""
+        store = TodoStore()
+        items = store.write([
+            {"id": "1", "content": "A real task", "status": "pending"},
+        ])
+        assert items[0]["content"] == "A real task"

--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -164,9 +164,11 @@ class TodoStore:
 
         content = str(item.get("content", "")).strip()
         if not content:
-            content = "(no description)"
-        else:
-            content = TodoStore._cap_content(content)
+            raise ValueError(
+                f"Todo item '{item_id}' has empty or missing content. "
+                "Each item must have a non-empty description."
+            )
+        content = TodoStore._cap_content(content)
 
         status = str(item.get("status", "pending")).strip().lower()
         if status not in VALID_STATUSES:
@@ -204,7 +206,10 @@ def todo_tool(
         return tool_error("TodoStore not initialized")
 
     if todos is not None:
-        items = store.write(todos, merge)
+        try:
+            items = store.write(todos, merge)
+        except ValueError as e:
+            return tool_error(str(e))
     else:
         items = store.read()
 


### PR DESCRIPTION
## What does this PR do?

Fixes `TodoStore._validate()` to **reject** todo items with empty or missing `content` instead of silently substituting the literal string `"(no description)"`. This prevents corrupted placeholder rows from appearing in the Desktop todo panel and post-compression re-injection.

## Related Issue

Fixes #44496

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/todo_tool.py`: `_validate()` now raises `ValueError` when content is empty/missing/whitespace-only, instead of substituting `"(no description)"`
- `tools/todo_tool.py`: `todo_tool()` catches `ValueError` from `store.write()` and returns a `tool_error()` so the model sees a clear error message
- `tests/tools/test_todo_tool.py`: Added `TestRejectEmptyContent` with 7 tests covering empty content, missing content key, whitespace-only content, tool-level error response, merge-mode new-item rejection, merge-mode status-only update (preserves content), and regression (valid content still works)

## How to Test

1. Run `pytest tests/tools/test_todo_tool.py -v` — all 24 tests pass (17 existing + 7 new)
2. Verify `TodoStore().write([{"id": "1", "content": "", "status": "pending"}])` raises `ValueError`
3. Verify `todo_tool(todos=[{"id": "1", "content": "", "status": "pending"}], store=TodoStore())` returns JSON with `"error"` key

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/tools/test_todo_tool.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `tools/todo_tool.py` (`_validate`, `todo_tool`, `write` — callers: 3, internal only)
- Blast radius: LOW — single tool module, no external consumers of `_validate()` beyond `write()`
- Related patterns: fail-closed validation matches schema's `"required": ["id", "content", "status"]` declaration
