### PR TITLE
fix(skills): let ClawHub index build walk past the 12s browse budget

### DIFF
--- a/scripts/build_skills_index.py
+++ b/scripts/build_skills_index.py
@@ -272,8 +272,9 @@ def main():
     # (well above current catalog size) lets the full catalog land in the
     # index instead of being truncated at an arbitrary build-time limit.
     SOURCE_LIMITS = {
-        # ClawHub had 49,698+ skills as of May 2026; 200k leaves headroom.
-        "clawhub": 200_000,
+        # 0 = unbounded catalog walk (max_items=0 in ClawHubSource). A positive
+        # limit bounds the walk and also enables the interactive 12s budget.
+        "clawhub": 0,
         "lobehub": 100_000,
         "browse-sh": 5_000,
         "claude-marketplace": 5_000,

--- a/tests/tools/test_skills_hub_clawhub.py
+++ b/tests/tools/test_skills_hub_clawhub.py
@@ -381,9 +381,10 @@ class TestClawHubSource(unittest.TestCase):
 
         mock_get.side_effect = side_effect
 
-        # Force the deadline to be in the past immediately.
+        # Force the deadline to be in the past immediately. Budget only applies
+        # to bounded browse walks (max_items > 0), not the index builder path.
         with patch.object(ClawHubSource, "CATALOG_WALK_BUDGET_SECONDS", -1):
-            results = self.src._load_catalog_index()
+            results = self.src._load_catalog_index(max_items=10)
 
         # Walk broke well before the 750-page cap.
         self.assertLess(page_calls["n"], 750)
@@ -479,6 +480,23 @@ class TestClawHubCatalogWalkBounded(unittest.TestCase):
         self.assertLess(page_calls["n"], 20, "should stop within a few pages of the bound")
         # Partial (bounded) walk must not be cached.
         mock_write_cache.assert_not_called()
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub.httpx.get")
+    def test_max_items_zero_ignores_wall_clock_budget(
+        self, mock_get, _mock_read_cache, _mock_write_cache
+    ):
+        """Index builder path (max_items=0) must not truncate on the browse budget."""
+        page_calls = {"n": 0}
+        mock_get.side_effect = self._infinite_pages(page_calls)
+
+        with patch.object(ClawHubSource, "CATALOG_WALK_BUDGET_SECONDS", -1):
+            results = self.src._load_catalog_index(max_items=0)
+
+        # No budget -> walks until the 750-page safety cap, not ~14 pages in 12s.
+        self.assertEqual(page_calls["n"], 750)
+        self.assertEqual(len(results), 750)
 
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2279,12 +2279,20 @@ class ClawHubSource(SkillSource):
         # terminates well before this on `nextCursor` going None — the cap is
         # a safety rail against an infinite-cursor loop.
         max_pages = 750
-        deadline = time.monotonic() + self.CATALOG_WALK_BUDGET_SECONDS
+        # Wall-clock budget is for interactive browse (max_items > 0) only.
+        # The offline index builder passes max_items=0 and must walk the full
+        # catalog — a 12s cap there ships ~3k skills and trips the deploy
+        # health floor (20k).
+        deadline = (
+            time.monotonic() + self.CATALOG_WALK_BUDGET_SECONDS
+            if max_items > 0
+            else None
+        )
         hit_deadline = False
         hit_max_items = False
 
         for _ in range(max_pages):
-            if time.monotonic() > deadline:
+            if deadline is not None and time.monotonic() > deadline:
                 hit_deadline = True
                 break
             params: Dict[str, Any] = {"limit": 200}


### PR DESCRIPTION
## What does this PR do?

Fixes the deploy-site `build_skills_index.py` failure where ClawHub returns ~2.8k skills instead of the 20k+ health floor.

PR #43395 added a 12s wall-clock budget to keep browse cold-starts fast, but that budget also applied to the offline index builder's full catalog walk. On a fresh CI checkout (no disk cache), the walk stops at ~12s (~14 pages × 200 skills) and the health check correctly refuses to ship a degenerate index.

This change:
- Applies `CATALOG_WALK_BUDGET_SECONDS` only when `max_items > 0` (bounded browse)
- Passes `limit=0` from `build_skills_index.py` for ClawHub so the builder uses the unbounded walk path

## Related Issue

Fixes deploy-site failure after #44470 merge (unrelated docs change; exposed by re-running deploy).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/skills_hub.py` — skip wall-clock budget when `max_items == 0`
- `scripts/build_skills_index.py` — ClawHub `SOURCE_LIMITS` set to `0` (unbounded)
- `tests/tools/test_skills_hub_clawhub.py` — regression test + fix budget-abort test to use bounded walk

## How to Test

1. `pytest tests/tools/test_skills_hub_clawhub.py tests/scripts/test_build_skills_index_health.py -q`
2. Re-run the failed Deploy Site workflow on `main` after merge (or run `python3 scripts/build_skills_index.py` locally with `GITHUB_TOKEN` and confirm `clawhub` count exceeds 20k)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (WSL2)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

CI failure symptom:
```
clawhub: 2795 < expected floor 20000
```
Root cause: 12s `CATALOG_WALK_BUDGET_SECONDS` truncating the full catalog walk on cold cache.

