### PR TITLE
feat: add governance safety substrate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ __pycache__/
 .uv-cache/
 compose.hermes.local.yml
 export*
+!governance/export_safety.py
 __pycache__/model_tools.cpython-310.pyc
 __pycache__/web_tools.cpython-310.pyc
 logs/

--- a/governance/OMEGA_HERMES_REBUILD_DIRECTIVE_v2_3.md
+++ b/governance/OMEGA_HERMES_REBUILD_DIRECTIVE_v2_3.md
@@ -1,0 +1,45 @@
+# OMEGA / HERMES REBUILD DIRECTIVE v2.3 — Code Artifact
+
+Status: implemented as a local-first governance substrate in this repository.
+
+This artifact captures the execution boundary for the directive as implemented in
+code.  It is not a claim that every live Omega/Hermes runtime service is ready or
+that strict enforcement has been flipped on in production.
+
+## Implemented gates
+
+- Source-of-truth registry: `governance.source_registry`.
+- Policy Gate classifier/evaluator: `governance.policy`.
+- Hash-chained decision/evidence logs: `governance.evidence`.
+- Verified backup helper and manifests: `governance.backup`.
+- Memory candidate/admission schema: `governance.memory_governor`.
+- Export mode and secret scan scaffolding: `governance.export_safety`.
+- Dispatch seam integration: `model_tools.handle_function_call` classifies and
+  logs every non-bridge tool call; hard denials block execution.
+- Memory write integration: `tools.memory_tool.MemoryStore` records successful
+  and rejected durable-memory admission decisions.
+
+## Enforcement boundary
+
+The Policy Gate always logs decisions and always blocks hard denials such as
+known destructive commands.  Other gated states (`require_approval` and
+`allow_after_backup`) are audit-mode by default and become hard blocks when
+`HERMES_POLICY_GATE_MODE=strict` or `HERMES_POLICY_GATE_MODE=enforce` is set.
+
+This staged boundary prevents accidental live-runtime breakage while making the
+strict gate one environment flip away after operational rollout testing.
+
+## Stop conditions
+
+- Missing capability classification defaults to fail-closed at the policy API.
+- Known destructive shell semantics are denied.
+- Confirmed-active source registry entries require evidence references.
+- Reversible edits are marked `allow_after_backup` unless a current verified
+  backup exists.
+- Shareable export mode requires secret redaction.
+
+## Rollback
+
+For the implementation session that created this artifact, verified backups for
+modified existing files are recorded under `/home/eric/Downloads/hermes-governance-backups/`.
+Restoring those files is a live mutation and requires explicit approval.

--- a/governance/__init__.py
+++ b/governance/__init__.py
@@ -1,0 +1,15 @@
+"""Governance primitives for Hermes/Omega runtime safety.
+
+The package is intentionally stdlib-only and import-safe so it can be used
+from tool dispatch, memory admission, export, and audit surfaces without
+pulling provider/runtime dependencies into startup.
+"""
+
+from .policy import PolicyGate, PolicyGateRequest, ActionClass, Decision
+
+__all__ = [
+    "ActionClass",
+    "Decision",
+    "PolicyGate",
+    "PolicyGateRequest",
+]

--- a/governance/backup.py
+++ b/governance/backup.py
@@ -1,0 +1,167 @@
+"""Verified backup helpers for governance-controlled edits."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+import hashlib
+import json
+import shlex
+import shutil
+from typing import Any, Dict, Optional
+
+from hermes_constants import get_hermes_home
+from .evidence import append_hash_chained_event, sha256_file, utc_now_iso
+
+
+def _sha256_tree(path: Path) -> str:
+    digest = hashlib.sha256()
+    for child in sorted(p for p in path.rglob("*") if p.is_file()):
+        rel = child.relative_to(path).as_posix()
+        digest.update(rel.encode("utf-8"))
+        digest.update(b"\0")
+        with child.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _path_hash(path: Path) -> str:
+    return _sha256_tree(path) if path.is_dir() else sha256_file(path)
+
+
+def _parse_utc_timestamp(value: Any) -> Optional[datetime]:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _path_type(path: Path) -> str:
+    if path.is_dir():
+        return "directory"
+    if path.is_file():
+        return "regular_file"
+    if path.exists():
+        return "special"
+    return "missing"
+
+
+def default_backup_root() -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    return get_hermes_home() / "governance" / "backups" / stamp
+
+
+def create_verified_backup(source: str | Path, *, backup_root: str | Path | None = None, operation: str = "governance edit") -> Dict[str, Any]:
+    """Copy *source* to *backup_root*, verify bytes/tree hash, and log manifest.
+
+    This helper is deliberately side-effect limited: it only reads the source,
+    writes the backup copy/manifest, and appends a hash-chained governance row.
+    Restoring a backup remains an explicit live action requiring normal approval.
+    """
+    source_path = Path(source).expanduser().resolve()
+    if not source_path.exists():
+        raise FileNotFoundError(str(source_path))
+    if not source_path.is_file() and not source_path.is_dir():
+        raise ValueError(f"Unsupported backup path type: {source_path}")
+
+    root = Path(backup_root).expanduser().resolve() if backup_root is not None else default_backup_root().resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    backup_path = root / source_path.name
+    if backup_path.exists():
+        suffix = hashlib.sha256(str(source_path).encode("utf-8")).hexdigest()[:10]
+        backup_path = root / f"{source_path.name}.{suffix}"
+
+    if source_path.is_dir():
+        shutil.copytree(source_path, backup_path, symlinks=True)
+    else:
+        shutil.copy2(source_path, backup_path)
+
+    original_hash = _path_hash(source_path)
+    backup_hash = _path_hash(backup_path)
+    verified = original_hash == backup_hash
+    manifest = {
+        "schema_version": "governance.backup.v1",
+        "event_type": "verified_backup",
+        "created_at_utc": utc_now_iso(),
+        "operation": operation,
+        "original_path": str(source_path),
+        "backup_path": str(backup_path),
+        "path_type": _path_type(source_path),
+        "original_sha256": original_hash,
+        "backup_sha256": backup_hash,
+        "verified_exact_match": verified,
+        "size_bytes": source_path.stat().st_size if source_path.is_file() else None,
+        "rollback_argv_live_requires_approval": ["cp", "-a", str(backup_path), str(source_path)],
+        "rollback_command_live_requires_approval": f"cp -a {shlex.quote(str(backup_path))} {shlex.quote(str(source_path))}",
+    }
+    (root / "manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
+    append_hash_chained_event("backup_manifests", manifest)
+    return manifest
+
+
+def has_recent_verified_backup(path: str | Path, *, max_age_seconds: int = 24 * 60 * 60) -> bool:
+    """Return whether the governance log has a current, intact backup for *path*.
+
+    The check is intentionally conservative.  A manifest row alone is not proof:
+    the source must still exist, the manifest must be fresh, the backup path must
+    still exist, and recorded source/backup hashes must match the actual bytes.
+    """
+    source_path = Path(path).expanduser().resolve()
+    if not source_path.exists() or (not source_path.is_file() and not source_path.is_dir()):
+        return False
+    log_path = get_hermes_home() / "governance" / "backup_manifests.jsonl"
+    if not log_path.exists():
+        return False
+    try:
+        current_hash = _path_hash(source_path)
+    except OSError:
+        return False
+
+    now = datetime.now(timezone.utc)
+    newest_ok = False
+    try:
+        for line in log_path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            if row.get("original_path") != str(source_path):
+                continue
+            if not row.get("verified_exact_match"):
+                continue
+            created_at = _parse_utc_timestamp(row.get("created_at_utc") or row.get("timestamp_utc"))
+            if created_at is None:
+                continue
+            age_seconds = (now - created_at).total_seconds()
+            if age_seconds < -300 or age_seconds > max_age_seconds:
+                continue
+            if row.get("original_sha256") != current_hash:
+                continue
+            backup_path_value = row.get("backup_path")
+            if not isinstance(backup_path_value, str) or not backup_path_value:
+                continue
+            backup_path = Path(backup_path_value).expanduser()
+            if not backup_path.exists():
+                continue
+            if source_path.is_file() and not backup_path.is_file():
+                continue
+            if source_path.is_dir() and not backup_path.is_dir():
+                continue
+            try:
+                actual_backup_hash = _path_hash(backup_path)
+            except OSError:
+                continue
+            if row.get("backup_sha256") != actual_backup_hash:
+                continue
+            if row.get("backup_sha256") != row.get("original_sha256"):
+                continue
+            newest_ok = True
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return False
+    return newest_ok

--- a/governance/evidence.py
+++ b/governance/evidence.py
@@ -1,0 +1,145 @@
+"""Hash-chained governance evidence ledger.\n\nAll governance decisions and evidence records are append-only JSONL files under\n``$HERMES_HOME/governance``.  Each row contains the previous row hash and its\nown SHA-256 hash over canonical JSON, producing a lightweight tamper-evident\nchain without any external service dependency.\n"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+import hashlib
+import json
+import os
+from typing import Any, Dict, Mapping, Optional
+
+from hermes_constants import get_hermes_home
+
+SCHEMA_VERSION = "governance.evidence.v1"
+GENESIS_HASH = "GENESIS"
+
+
+def utc_now_iso() -> str:
+    """Return a stable UTC timestamp for governance records."""
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def governance_dir() -> Path:
+    path = get_hermes_home() / "governance"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def canonical_json(data: Mapping[str, Any]) -> str:
+    """Canonical JSON used for hash calculation and deterministic logs."""
+    return json.dumps(data, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _last_entry_hash(path: Path) -> str:
+    if not path.exists():
+        return GENESIS_HASH
+    try:
+        last = ""
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                if line.strip():
+                    last = line
+        if not last:
+            return GENESIS_HASH
+        row = json.loads(last)
+        entry_hash = row.get("entry_hash")
+        return entry_hash if isinstance(entry_hash, str) and entry_hash else GENESIS_HASH
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return GENESIS_HASH
+
+
+class _OptionalFileLock:
+    """Best-effort cross-process append lock.
+
+    ``fcntl`` is unavailable on Windows, so this lock is advisory on POSIX and a
+    no-op elsewhere.  JSONL rows are still written as one line with normal file
+    append semantics, which is sufficient for tests and most local use.
+    """
+
+    def __init__(self, lock_path: Path):
+        self.lock_path = lock_path
+        self._handle = None
+
+    def __enter__(self):
+        self.lock_path.parent.mkdir(parents=True, exist_ok=True)
+        self._handle = self.lock_path.open("a", encoding="utf-8")
+        try:
+            import fcntl  # type: ignore
+            fcntl.flock(self._handle.fileno(), fcntl.LOCK_EX)
+        except Exception:
+            pass
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        if self._handle is not None:
+            try:
+                import fcntl  # type: ignore
+                fcntl.flock(self._handle.fileno(), fcntl.LOCK_UN)
+            except Exception:
+                pass
+            self._handle.close()
+
+
+def append_hash_chained_event(log_name: str, event: Mapping[str, Any]) -> Dict[str, Any]:
+    """Append *event* to ``governance/<log_name>.jsonl`` and return the row.
+
+    ``log_name`` may be supplied with or without ``.jsonl``.  The caller's
+    fields are preserved, but governance metadata wins for timestamp/hash keys
+    so a caller cannot spoof the chain.
+    """
+    clean_name = log_name[:-6] if log_name.endswith(".jsonl") else log_name
+    if not clean_name or "/" in clean_name or ".." in clean_name:
+        raise ValueError(f"Invalid governance log name: {log_name!r}")
+
+    directory = governance_dir()
+    path = directory / f"{clean_name}.jsonl"
+    lock_path = directory / f".{clean_name}.lock"
+
+    with _OptionalFileLock(lock_path):
+        previous_hash = _last_entry_hash(path)
+        row = dict(event)
+        row.update({
+            "schema_version": row.get("schema_version", SCHEMA_VERSION),
+            "timestamp_utc": row.get("timestamp_utc", utc_now_iso()),
+            "previous_entry_hash": previous_hash,
+        })
+        row.pop("entry_hash", None)
+        row["entry_hash"] = sha256_text(canonical_json(row))
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n")
+    return row
+
+
+@dataclass
+class EvidenceRecord:
+    phase: str
+    claim: str
+    evidence_type: str
+    source: str
+    confidence: str
+    redaction_status: str = "none"
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+class EvidenceLedger:
+    """Append-only ledger for claims backed by concrete evidence."""
+
+    def record(self, record: EvidenceRecord | Mapping[str, Any]) -> Dict[str, Any]:
+        payload = asdict(record) if isinstance(record, EvidenceRecord) else dict(record)
+        payload.setdefault("event_type", "evidence")
+        payload.setdefault("redaction_status", "none")
+        return append_hash_chained_event("evidence", payload)

--- a/governance/export_safety.py
+++ b/governance/export_safety.py
@@ -1,0 +1,107 @@
+"""Export-mode and secret-scan scaffolding for safe bundle generation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+import re
+from typing import Any, Dict, Iterable, List
+
+
+class ExportMode(Enum):
+    RUNTIME_CLEAN = ("runtime_clean", False, [
+        r"(^|/)\.git(/|$)",
+        r"(^|/)node_modules(/|$)",
+        r"(^|/)\.venv(/|$)",
+        r"(^|/)venv(/|$)",
+        r"(^|/)logs?(/|$)",
+        r"(^|/)sessions?(/|$)",
+        r"(^|/)auth\.json$",
+        r"(^|/)\.env(\..*)?$",
+        r"(^|/)api-keys(/|$)",
+    ])
+    SHAREABLE_AUDIT_FULL = ("shareable_audit_full", True, [
+        r"(^|/)\.git/objects(/|$)",
+        r"(^|/)node_modules(/|$)",
+    ])
+    LOCAL_FULL_WITH_SECRETS = ("local_full_with_secrets", False, [])
+
+    def __init__(self, label: str, requires_redaction: bool, deny_patterns: List[str]):
+        self.label = label
+        self.requires_redaction = requires_redaction
+        self._deny_patterns = deny_patterns
+
+    def allows_path(self, path: str) -> bool:
+        normalized = path.replace("\\", "/")
+        while normalized.startswith("./"):
+            normalized = normalized[2:]
+        return not any(re.search(pattern, normalized, re.IGNORECASE) for pattern in self._deny_patterns)
+
+
+@dataclass
+class SecretFinding:
+    label: str
+    start: int
+    end: int
+    preview: str
+
+
+class SecretScanner:
+    """Small stdlib-only scanner for common token/password shapes."""
+
+    PATTERNS = [
+        ("named_secret", re.compile(r"(?i)\b(?:[A-Z0-9_]*_)?(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD|PASSWD|PRIVATE[_-]?KEY)\b\s*[:=]\s*['\"]?([^'\"\s]{6,})")),
+        ("openai_key", re.compile(r"\bsk-[A-Za-z0-9._-]{6,}\b")),
+        ("github_token", re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b")),
+        ("bearer_token", re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]{12,}\b")),
+    ]
+
+    @staticmethod
+    def _safe_preview(label: str, start: int, end: int) -> str:
+        """Return a non-leaking finding preview.
+
+        Secret scan reports are evidence artifacts; they must not echo the
+        matched secret bytes back into logs, chat, or exported audit bundles.
+        """
+        return f"[REDACTED:{label}:chars={end - start}]"
+
+    def find(self, text: str) -> List[SecretFinding]:
+        findings: List[SecretFinding] = []
+        for label, pattern in self.PATTERNS:
+            for match in pattern.finditer(text or ""):
+                start, end = match.span()
+                findings.append(SecretFinding(label=label, start=start, end=end, preview=self._safe_preview(label, start, end)))
+        findings.sort(key=lambda item: (item.start, item.end))
+        # Drop exact duplicate spans from overlapping patterns.
+        unique: List[SecretFinding] = []
+        seen = set()
+        for finding in findings:
+            key = (finding.start, finding.end)
+            if key not in seen:
+                unique.append(finding)
+                seen.add(key)
+        return unique
+
+    def scan_text(self, text: str, *, mode: str = "report") -> Dict[str, Any]:
+        findings = self.find(text)
+        return {
+            "status": "redaction_required" if findings else "clean",
+            "mode": mode,
+            "findings_count": len(findings),
+            "findings": [finding.__dict__ for finding in findings],
+        }
+
+    def redact_text(self, text: str) -> str:
+        findings = self.find(text)
+        if not findings:
+            return text
+        pieces: List[str] = []
+        cursor = 0
+        for finding in findings:
+            if finding.start < cursor:
+                continue
+            pieces.append(text[cursor:finding.start])
+            pieces.append(f"[REDACTED:{finding.label}]")
+            cursor = finding.end
+        pieces.append(text[cursor:])
+        return "".join(pieces)

--- a/governance/memory_governor.py
+++ b/governance/memory_governor.py
@@ -1,0 +1,144 @@
+"""Memory governance admission schema and logging."""
+
+from __future__ import annotations
+
+from enum import Enum
+import hashlib
+import os
+from typing import Any, Dict, Mapping, Optional
+
+from .evidence import append_hash_chained_event
+from .export_safety import SecretScanner
+
+
+class MemoryAdmissionDecision(str, Enum):
+    CANDIDATE_ONLY = "candidate_only"
+    ADMIT = "admit"
+    REJECT_SECURITY = "reject_security"
+    REJECT_OVER_CAPACITY = "reject_over_capacity"
+    REJECT_POLICY = "reject_policy"
+    REMOVE = "remove"
+
+
+class MemoryGovernor:
+    """Record memory candidate and admission decisions.
+
+    This class does not decide what the user prefers; it makes each durable
+    memory write auditable with owner/scope/sensitivity/rollback metadata.
+    Governance logs must not become a second raw secret store, so rejected or
+    secret-looking content is represented by hashes, lengths, and redacted
+    placeholders rather than echoed bytes.
+    """
+
+    def __init__(self, *, profile: str | None = None):
+        self.profile = profile or os.getenv("HERMES_PROFILE") or os.getenv("HERMES_ACTIVE_PROFILE") or "default"
+        self._secret_scanner = SecretScanner()
+
+    @staticmethod
+    def _sha256_content(content: str) -> str:
+        return hashlib.sha256((content or "").encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _redacted_placeholder(field_name: str, content: str) -> str:
+        return f"[REDACTED:{field_name}:chars={len(content or '')}]"
+
+    def _content_log_fields(self, field_name: str, content: str, *, redact: bool) -> Dict[str, Any]:
+        content = content or ""
+        findings = self._secret_scanner.find(content)
+        should_redact = redact or bool(findings)
+        return {
+            field_name: self._redacted_placeholder(field_name, content) if should_redact else content,
+            f"{field_name}_sha256": self._sha256_content(content),
+            f"{field_name}_length": len(content),
+            f"{field_name}_redacted": should_redact,
+            f"{field_name}_secret_findings_count": len(findings),
+        }
+
+    def propose_candidate(
+        self,
+        *,
+        candidate_content: str,
+        source_ref: str,
+        suggested_scope: str,
+        suggested_owner: str | None = None,
+        suggested_sensitivity: str = "general",
+        metadata: Mapping[str, Any] | None = None,
+    ) -> Dict[str, Any]:
+        redact_candidate = suggested_sensitivity.lower() != "general"
+        payload = {
+            "event_type": "memory_candidate",
+            "status": MemoryAdmissionDecision.CANDIDATE_ONLY.value,
+            "source_ref": source_ref,
+            "suggested_scope": suggested_scope,
+            "suggested_owner": suggested_owner or self.profile,
+            "suggested_sensitivity": suggested_sensitivity,
+            "proposer_profile": self.profile,
+            "metadata": dict(metadata or {}),
+        }
+        payload.update(self._content_log_fields("candidate_content", candidate_content, redact=redact_candidate))
+        return append_hash_chained_event("memory_candidates", payload)
+
+    def record_admission(
+        self,
+        *,
+        operation: str,
+        memory_target: str,
+        proposed_content: str,
+        normalized_content: str | None = None,
+        source_ref: str = "tool:memory",
+        decision: MemoryAdmissionDecision | str,
+        decision_reason: str = "",
+        owner: str | None = None,
+        scope: str = "profile",
+        sensitivity_level: str = "general",
+        rollback_ref: str = "",
+        metadata: Mapping[str, Any] | None = None,
+    ) -> Dict[str, Any]:
+        decision_value = decision.value if isinstance(decision, MemoryAdmissionDecision) else str(decision)
+        normalized = normalized_content if normalized_content is not None else proposed_content
+        redact_content = decision_value != MemoryAdmissionDecision.ADMIT.value
+        payload = {
+            "event_type": "memory_admission",
+            "operation": operation,
+            "memory_target": memory_target,
+            "memory_target_owner": owner or self.profile,
+            "scope": scope,
+            "sensitivity_level": sensitivity_level,
+            "proposer_profile": self.profile,
+            "source_ref": source_ref,
+            "decision": decision_value,
+            "decision_reason": decision_reason,
+            "rollback_ref": rollback_ref,
+            "metadata": dict(metadata or {}),
+        }
+        payload.update(self._content_log_fields("proposed_content", proposed_content, redact=redact_content))
+        payload.update(self._content_log_fields("normalized_content", normalized, redact=redact_content))
+        return append_hash_chained_event("memory_admission_log", payload)
+
+
+def record_memory_tool_decision(
+    *,
+    operation: str,
+    memory_target: str,
+    proposed_content: str,
+    decision: MemoryAdmissionDecision | str,
+    decision_reason: str = "",
+    normalized_content: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> None:
+    """Best-effort admission logging for the existing memory tool."""
+    try:
+        MemoryGovernor().record_admission(
+            operation=operation,
+            memory_target=memory_target,
+            proposed_content=proposed_content,
+            normalized_content=normalized_content,
+            decision=decision,
+            decision_reason=decision_reason,
+            metadata=metadata,
+        )
+    except Exception:
+        # Memory writes must not fail solely because the governance ledger cannot
+        # be appended; the Policy Gate logs a separate failure if strict mode is
+        # enabled around the calling tool.
+        pass

--- a/governance/policy.py
+++ b/governance/policy.py
@@ -1,0 +1,446 @@
+"""Central Policy Gate for Hermes tool execution."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from pathlib import Path
+import os
+import re
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+
+from .backup import has_recent_verified_backup
+from .evidence import append_hash_chained_event
+
+
+class ActionClass(str, Enum):
+    READ_ONLY_LOCAL_SAFE = "read_only_local_safe"
+    READ_ONLY_SECRET_ADJACENT = "read_only_secret_adjacent"
+    PROCESS_ENV_READ = "process_env_read"
+    NETWORK_READ = "network_read"
+    TEST_ONLY = "test_only"
+    REVERSIBLE_EDIT = "reversible_edit"
+    DEPENDENCY_CHANGE = "dependency_change"
+    MEMORY_WRITE = "memory_write"
+    SERVICE_RUNTIME_CHANGE = "service_runtime_change"
+    DURABLE_SCHEDULING_CHANGE = "durable_scheduling_change"
+    REMOTE_WRITE = "remote_write"
+    PUBLIC_EXPOSURE_CHANGE = "public_exposure_change"
+    CREDENTIAL_OR_AUTH_CHANGE = "credential_or_auth_change"
+    LIVE_DATA_MIGRATION = "live_data_migration"
+    DESTRUCTIVE = "destructive"
+    UNKNOWN = "unknown"
+
+
+class Decision(str, Enum):
+    ALLOW = "allow"
+    ALLOW_AFTER_BACKUP = "allow_after_backup"
+    REQUIRE_APPROVAL = "require_approval"
+    DENY = "deny"
+
+
+@dataclass
+class PolicyGateRequest:
+    requested_action: str
+    action_class: ActionClass
+    profile: str = "default"
+    tool_name: Optional[str] = None
+    command: Optional[str] = None
+    risk_tier: int = 1
+    affected_paths: List[str] = field(default_factory=list)
+    affected_services: List[str] = field(default_factory=list)
+    affected_memory_stores: List[str] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class CapabilityRules:
+    profile: str
+    allowed_tools: Optional[List[str]] = None
+    denied_tools: List[str] = field(default_factory=list)
+    denied_action_classes: List[ActionClass] = field(default_factory=list)
+    max_auto_tier: int = 2
+    standing_approval_action_classes: List[ActionClass] = field(default_factory=lambda: [
+        ActionClass.READ_ONLY_LOCAL_SAFE,
+        ActionClass.NETWORK_READ,
+        ActionClass.TEST_ONLY,
+        ActionClass.REVERSIBLE_EDIT,
+        ActionClass.MEMORY_WRITE,
+    ])
+
+
+@dataclass
+class PolicyDecision:
+    decision: Decision
+    reason: str
+    request: PolicyGateRequest
+    capability_check: str = "not_checked"
+    backup_check: str = "not_required"
+    logged: bool = False
+    log_ref: Optional[str] = None
+    enforcement_mode: str = "audit"
+
+    def to_log_event(self) -> Dict[str, Any]:
+        return {
+            "event_type": "policy_decision",
+            "decision": self.decision.value,
+            "reason": self.reason,
+            "profile": self.request.profile,
+            "requested_action": self.request.requested_action,
+            "tool_name": self.request.tool_name,
+            "action_class": self.request.action_class.value,
+            "risk_tier": self.request.risk_tier,
+            "affected_paths": list(self.request.affected_paths),
+            "affected_services": list(self.request.affected_services),
+            "affected_memory_stores": list(self.request.affected_memory_stores),
+            "capability_check": self.capability_check,
+            "backup_check": self.backup_check,
+            "enforcement_mode": self.enforcement_mode,
+        }
+
+
+def default_capabilities_for_profile(profile: str) -> CapabilityRules:
+    return CapabilityRules(profile=profile)
+
+
+_DESTRUCTIVE_PATTERNS = [
+    r"\brm\s+(-[\w-]*[rf][\w-]*|-[\w-]*[fr][\w-]*)\b",
+    r"\bshutil\.rmtree\s*\(",
+    r"\bmkfs(?:\.|\s)",
+    r"\bdd\b.*\bof=",
+    r"\bgit\s+reset\s+--hard\b",
+    r"\bgit\s+clean\s+-[\w-]*f",
+    r"\btruncate\s+-s\s+0\b",
+]
+_SECRET_READ_PATTERNS = [
+    r"\b(cat|less|more|tail|head|grep|rg)\b.*(~?/\.env|\.netrc|auth\.json|api-keys|credentials|secret|token)",
+    r"\b(pass|op|security)\s+show\b",
+]
+_PROCESS_ENV_PATTERNS = [r"\bps\s+[^\n;|&]*\beww\b", r"\bprintenv\b", r"\benv\b"]
+_DEPENDENCY_PATTERNS = [
+    r"\b(pip|pip3|uv)\s+install\b",
+    r"\bpython\s+-m\s+pip\s+install\b",
+    r"\b(npm|pnpm|yarn)\s+(install|add|update)\b",
+    r"\b(apt|apt-get|dnf|yum|pacman|brew)\s+.*\b(install|upgrade|remove)\b",
+    r"\bcargo\s+install\b",
+]
+_SERVICE_PATTERNS = [r"\bsystemctl\b.*\b(start|stop|restart|reload|enable|disable|mask|unmask)\b", r"\bservice\s+\S+\s+(start|stop|restart|reload)\b"]
+_PUBLIC_EXPOSURE_PATTERNS = [r"\btailscale\s+funnel\b", r"\bngrok\b", r"\bcloudflared\s+tunnel\b"]
+_CREDENTIAL_PATTERNS = [r"\bhermes\s+login\b", r"\bhermes\s+logout\b", r"\bgh\s+auth\b", r"\bssh-keygen\b", r"\bchmod\s+.*(auth|secret|key)"]
+_TEST_PATTERNS = [r"\b(pytest|python3?\s+-m\s+pytest)\b", r"\bnpm\s+test\b", r"\bcargo\s+test\b", r"\bgo\s+test\b"]
+
+_READ_ONLY_TOOL_PREFIXES = (
+    "get",
+    "list",
+    "read",
+    "search",
+    "probe",
+    "related",
+    "reason",
+    "contradict",
+    "debug",
+    "ping",
+    "status",
+)
+_READ_ONLY_TOOL_SUFFIXES = ("_read", "_read_file", "_list", "_search", "_status", "_summary")
+_REMOTE_MUTATION_TERMS = {
+    "add",
+    "apply",
+    "close",
+    "commit",
+    "create",
+    "delete",
+    "edit",
+    "fork",
+    "merge",
+    "patch",
+    "push",
+    "remove",
+    "replace",
+    "restore",
+    "resume",
+    "run",
+    "send",
+    "start",
+    "stop",
+    "submit",
+    "update",
+    "upload",
+    "write",
+}
+_MIGRATION_OR_SQL_TERMS = {"migration", "migrate", "sql", "execute", "exec"}
+
+
+def _matches_any(command: str, patterns: Iterable[str]) -> bool:
+    return any(re.search(pattern, command, re.IGNORECASE) for pattern in patterns)
+
+
+def _tool_tokens(tool_name: str) -> List[str]:
+    return [token for token in re.split(r"[^a-z0-9]+", (tool_name or "").lower()) if token]
+
+
+def _looks_like_read_only_tool(tool_name: str) -> bool:
+    lowered = (tool_name or "").lower()
+    tokens = _tool_tokens(lowered)
+    if not tokens:
+        return False
+    if lowered.endswith(_READ_ONLY_TOOL_SUFFIXES):
+        return True
+    return tokens[-1] in _READ_ONLY_TOOL_PREFIXES or tokens[0] in _READ_ONLY_TOOL_PREFIXES
+
+
+def _looks_like_live_data_migration(tool_name: str) -> bool:
+    lowered = (tool_name or "").lower()
+    tokens = set(_tool_tokens(lowered))
+    if "sql" in tokens and "read" not in tokens:
+        return True
+    if "migration" in tokens or "migrate" in tokens:
+        return True
+    if {"execute", "sql"}.issubset(tokens) or {"exec", "sql"}.issubset(tokens):
+        return True
+    if lowered.endswith("_migration_apply") or lowered.endswith("_sql_execute"):
+        return True
+    return False
+
+
+def _looks_like_remote_mutation_tool(tool_name: str) -> bool:
+    tokens = set(_tool_tokens(tool_name))
+    return bool(tokens & _REMOTE_MUTATION_TERMS)
+
+
+def classify_command(command: str) -> ActionClass:
+    """Classify shell command semantics instead of trusting tool name alone."""
+    command = command or ""
+    if _matches_any(command, _DESTRUCTIVE_PATTERNS):
+        return ActionClass.DESTRUCTIVE
+    if _matches_any(command, _PUBLIC_EXPOSURE_PATTERNS):
+        return ActionClass.PUBLIC_EXPOSURE_CHANGE
+    if _matches_any(command, _CREDENTIAL_PATTERNS):
+        return ActionClass.CREDENTIAL_OR_AUTH_CHANGE
+    if _matches_any(command, _SERVICE_PATTERNS):
+        return ActionClass.SERVICE_RUNTIME_CHANGE
+    if _matches_any(command, _SECRET_READ_PATTERNS):
+        return ActionClass.READ_ONLY_SECRET_ADJACENT
+    if _matches_any(command, _PROCESS_ENV_PATTERNS):
+        return ActionClass.PROCESS_ENV_READ
+    if _matches_any(command, _DEPENDENCY_PATTERNS):
+        return ActionClass.DEPENDENCY_CHANGE
+    if _matches_any(command, _TEST_PATTERNS):
+        return ActionClass.TEST_ONLY
+    return ActionClass.READ_ONLY_LOCAL_SAFE
+
+
+def _risk_tier(action_class: ActionClass) -> int:
+    if action_class in {ActionClass.READ_ONLY_LOCAL_SAFE, ActionClass.NETWORK_READ, ActionClass.TEST_ONLY}:
+        return 1
+    if action_class in {ActionClass.REVERSIBLE_EDIT, ActionClass.DEPENDENCY_CHANGE, ActionClass.READ_ONLY_SECRET_ADJACENT, ActionClass.PROCESS_ENV_READ}:
+        return 2
+    if action_class in {ActionClass.MEMORY_WRITE, ActionClass.SERVICE_RUNTIME_CHANGE, ActionClass.DURABLE_SCHEDULING_CHANGE, ActionClass.REMOTE_WRITE}:
+        return 3
+    return 4
+
+
+def _affected_services(command: str) -> List[str]:
+    services: List[str] = []
+    for match in re.finditer(r"\b(?:systemctl(?:\s+--user)?|service)\s+(?:--user\s+)?(?:start|stop|restart|reload|enable|disable|mask|unmask)?\s*([\w@.\-]+\.service|[\w@.\-]+)", command or ""):
+        candidate = match.group(1)
+        if candidate not in {"start", "stop", "restart", "reload", "enable", "disable", "mask", "unmask"}:
+            services.append(candidate)
+    # systemctl syntax usually puts verb before service; the regex above is
+    # intentionally broad but can miss when flags appear between.  Add a small
+    # fallback for unit-looking tokens.
+    for token in re.findall(r"[\w@.\-]+\.service", command or ""):
+        if token not in services:
+            services.append(token)
+    return services
+
+
+def _path_arg(args: Mapping[str, Any], *names: str) -> List[str]:
+    found: List[str] = []
+    for name in names:
+        value = args.get(name)
+        if isinstance(value, str) and value:
+            found.append(value)
+    return found
+
+
+def classify_tool_call(function_name: str, function_args: Mapping[str, Any] | None, *, profile: str = "default") -> PolicyGateRequest:
+    args = dict(function_args or {})
+    tool = function_name
+    action_class = ActionClass.UNKNOWN
+    affected_paths: List[str] = []
+    affected_services: List[str] = []
+    affected_memory_stores: List[str] = []
+    command: Optional[str] = None
+
+    if tool == "terminal":
+        command = str(args.get("command", ""))
+        action_class = classify_command(command)
+        affected_services = _affected_services(command) if action_class == ActionClass.SERVICE_RUNTIME_CHANGE else []
+    elif tool in {"read_file", "search_files", "browser_snapshot", "browser_console", "browser_get_images"}:
+        action_class = ActionClass.READ_ONLY_LOCAL_SAFE
+        affected_paths = _path_arg(args, "path")
+    elif tool in {"write_file", "patch", "skill_manage"}:
+        action_class = ActionClass.REVERSIBLE_EDIT
+        affected_paths = _path_arg(args, "path", "file_path")
+    elif tool == "memory" or tool == "fact_store":
+        action_class = ActionClass.MEMORY_WRITE
+        target = args.get("target") or args.get("category") or "memory"
+        affected_memory_stores = [str(target)]
+    elif tool == "cronjob":
+        action_class = ActionClass.DURABLE_SCHEDULING_CHANGE
+    elif tool in {"send_message", "mcp_github_create_or_update_file", "mcp_github_push_files", "mcp_github_create_pull_request", "mcp_github_merge_pull_request", "mcp_github_create_issue", "mcp_github_update_issue", "mcp_github_add_issue_comment"}:
+        action_class = ActionClass.REMOTE_WRITE
+    elif tool.startswith("browser_") or tool in {"web_search", "web_extract"}:
+        action_class = ActionClass.NETWORK_READ
+    elif "supabase_migration_apply" in tool or tool.endswith("_migration_apply"):
+        action_class = ActionClass.LIVE_DATA_MIGRATION
+    elif tool in {"image_generate", "text_to_speech", "vision_analyze"}:
+        action_class = ActionClass.REMOTE_WRITE if tool == "image_generate" else ActionClass.READ_ONLY_LOCAL_SAFE
+    elif _looks_like_live_data_migration(tool):
+        action_class = ActionClass.LIVE_DATA_MIGRATION
+    elif _looks_like_remote_mutation_tool(tool):
+        action_class = ActionClass.REMOTE_WRITE
+    elif tool.startswith("mcp_") and _looks_like_read_only_tool(tool):
+        action_class = ActionClass.NETWORK_READ
+    else:
+        action_class = ActionClass.UNKNOWN
+
+    return PolicyGateRequest(
+        requested_action=f"tool:{tool}",
+        action_class=action_class,
+        profile=profile,
+        tool_name=tool,
+        command=command,
+        risk_tier=_risk_tier(action_class),
+        affected_paths=affected_paths,
+        affected_services=affected_services,
+        affected_memory_stores=affected_memory_stores,
+        metadata={"raw_args_keys": sorted(args.keys())},
+    )
+
+
+class PolicyGate:
+    """Evaluate and log governance decisions for tool execution."""
+
+    def __init__(self, *, profile: str = "default", capabilities: CapabilityRules | None = None, enforcement_mode: str | None = None):
+        self.profile = profile
+        self.capabilities = capabilities or default_capabilities_for_profile(profile)
+        self.enforcement_mode = (enforcement_mode or os.getenv("HERMES_POLICY_GATE_MODE", "audit")).strip().lower() or "audit"
+
+    def evaluate(self, request: PolicyGateRequest) -> PolicyDecision:
+        request.profile = request.profile or self.profile
+        capability_check = self._capability_check(request)
+        backup_check = "not_required"
+
+        if capability_check != "passed":
+            decision = PolicyDecision(
+                decision=Decision.DENY,
+                reason="Capability check failed for this profile/tool/action class.",
+                request=request,
+                capability_check=capability_check,
+                enforcement_mode=self.enforcement_mode,
+            )
+            return self._log(decision)
+
+        if request.action_class == ActionClass.DESTRUCTIVE:
+            decision = PolicyDecision(
+                decision=Decision.DENY,
+                reason="Destructive action is denied by hardened governance policy.",
+                request=request,
+                capability_check=capability_check,
+                enforcement_mode=self.enforcement_mode,
+            )
+            return self._log(decision)
+
+        if request.action_class == ActionClass.REVERSIBLE_EDIT:
+            backup_check = self._backup_check(request)
+            if backup_check == "failed":
+                decision = PolicyDecision(
+                    decision=Decision.ALLOW_AFTER_BACKUP,
+                    reason="Reversible edit requires a verified backup before live mutation.",
+                    request=request,
+                    capability_check=capability_check,
+                    backup_check=backup_check,
+                    enforcement_mode=self.enforcement_mode,
+                )
+                return self._log(decision)
+
+        if request.action_class in {
+            ActionClass.UNKNOWN,
+            ActionClass.PUBLIC_EXPOSURE_CHANGE,
+            ActionClass.CREDENTIAL_OR_AUTH_CHANGE,
+            ActionClass.LIVE_DATA_MIGRATION,
+            ActionClass.SERVICE_RUNTIME_CHANGE,
+            ActionClass.DURABLE_SCHEDULING_CHANGE,
+        }:
+            decision = PolicyDecision(
+                decision=Decision.REQUIRE_APPROVAL,
+                reason=f"{request.action_class.value} requires explicit approval and verification gates.",
+                request=request,
+                capability_check=capability_check,
+                backup_check=backup_check,
+                enforcement_mode=self.enforcement_mode,
+            )
+            return self._log(decision)
+
+        if request.risk_tier > self.capabilities.max_auto_tier and request.action_class not in self.capabilities.standing_approval_action_classes:
+            decision = PolicyDecision(
+                decision=Decision.REQUIRE_APPROVAL,
+                reason="Action risk exceeds automatic standing approval for this profile.",
+                request=request,
+                capability_check=capability_check,
+                backup_check=backup_check,
+                enforcement_mode=self.enforcement_mode,
+            )
+            return self._log(decision)
+
+        decision = PolicyDecision(
+            decision=Decision.ALLOW,
+            reason="Action allowed by current profile capability rules.",
+            request=request,
+            capability_check=capability_check,
+            backup_check=backup_check,
+            enforcement_mode=self.enforcement_mode,
+        )
+        return self._log(decision)
+
+    def _capability_check(self, request: PolicyGateRequest) -> str:
+        if request.tool_name and request.tool_name in self.capabilities.denied_tools:
+            return "failed"
+        if self.capabilities.allowed_tools is not None and request.tool_name not in self.capabilities.allowed_tools:
+            return "failed"
+        if request.action_class in self.capabilities.denied_action_classes:
+            return "failed_denied_action_class"
+        return "passed"
+
+    def _backup_check(self, request: PolicyGateRequest) -> str:
+        existing_paths = [Path(p).expanduser() for p in request.affected_paths if p]
+        existing_files = [p for p in existing_paths if p.exists()]
+        if not existing_files:
+            return "not_required"
+        if all(has_recent_verified_backup(p) for p in existing_files):
+            return "passed"
+        return "failed"
+
+    def _log(self, decision: PolicyDecision) -> PolicyDecision:
+        try:
+            row = append_hash_chained_event("policy_decisions", decision.to_log_event())
+            decision.logged = True
+            decision.log_ref = row.get("entry_hash")
+        except Exception:
+            decision.logged = False
+        return decision
+
+    def should_block_dispatch(self, decision: PolicyDecision) -> bool:
+        """Return whether handle_function_call should block execution now.
+
+        Denials are always hard blocks.  Other gated states are hard blocks only
+        in strict/enforce mode so current live Hermes behavior can be audited
+        before a deployment flips stricter runtime enforcement on.
+        """
+        if decision.decision == Decision.DENY:
+            return True
+        if self.enforcement_mode in {"strict", "enforce", "enforced"} and decision.decision in {Decision.REQUIRE_APPROVAL, Decision.ALLOW_AFTER_BACKUP}:
+            return True
+        return False

--- a/governance/source_registry.py
+++ b/governance/source_registry.py
@@ -1,0 +1,63 @@
+"""Source-of-truth registry for active runtime/governance artifacts."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+import json
+from typing import Any, Dict, List
+
+from hermes_constants import get_hermes_home
+from .evidence import append_hash_chained_event, utc_now_iso
+
+
+@dataclass
+class RegistryEntry:
+    component_type: str
+    component_name: str
+    active_status: str
+    confidence: str
+    path_or_ref: str
+    owner_profile: str
+    evidence_refs: List[str] = field(default_factory=list)
+    notes: str = ""
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def key(self) -> str:
+        return f"{self.owner_profile}:{self.component_type}:{self.component_name}"
+
+
+class SourceOfTruthRegistry:
+    def __init__(self, *, path: str | Path | None = None):
+        self.path = Path(path) if path is not None else get_hermes_home() / "governance" / "source_registry.json"
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def _load(self) -> Dict[str, Dict[str, Any]]:
+        if not self.path.exists():
+            return {}
+        try:
+            data = json.loads(self.path.read_text(encoding="utf-8"))
+            return data if isinstance(data, dict) else {}
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            return {}
+
+    def _save(self, data: Dict[str, Dict[str, Any]]) -> None:
+        tmp = self.path.with_suffix(self.path.suffix + ".tmp")
+        tmp.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+        tmp.replace(self.path)
+
+    def upsert(self, entry: RegistryEntry) -> Dict[str, Any]:
+        if entry.active_status == "confirmed_active" and not entry.evidence_refs:
+            return {"success": False, "error": "confirmed_active registry entries require at least one evidence ref"}
+        data = self._load()
+        row = asdict(entry)
+        row["key"] = entry.key
+        row["updated_at_utc"] = utc_now_iso()
+        data[entry.key] = row
+        self._save(data)
+        append_hash_chained_event("source_registry_events", {"event_type": "source_registry_upsert", **row})
+        return {"success": True, "entry": row}
+
+    def list_entries(self) -> List[Dict[str, Any]]:
+        return list(self._load().values())

--- a/model_tools.py
+++ b/model_tools.py
@@ -1014,6 +1014,42 @@ def handle_function_call(
         except Exception as _mw_err:
             logger.debug("tool_request middleware error: %s", _mw_err)
 
+    # ── Governance Policy Gate ───────────────────────────────────────
+    # Classify and log the *real* tool after any Tool Search bridge unwrap and
+    # request-middleware normalization. Hard denials always block;
+    # approval/backup gates become hard blocks when
+    # HERMES_POLICY_GATE_MODE=strict|enforce so rollout can be audited first.
+    try:
+        from governance.policy import PolicyGate, classify_tool_call
+
+        profile = (
+            os.getenv("HERMES_PROFILE")
+            or os.getenv("HERMES_ACTIVE_PROFILE")
+            or os.getenv("HERMES_PROFILE_NAME")
+            or "default"
+        )
+        gate = PolicyGate(profile=profile)
+        policy_request = classify_tool_call(function_name, function_args or {}, profile=profile)
+        policy_decision = gate.evaluate(policy_request)
+        if gate.should_block_dispatch(policy_decision):
+            return json.dumps({
+                "error": f"Policy Gate blocked {function_name}: {policy_decision.reason}",
+                "policy_gate": {
+                    "decision": policy_decision.decision.value,
+                    "action_class": policy_request.action_class.value,
+                    "risk_tier": policy_request.risk_tier,
+                    "capability_check": policy_decision.capability_check,
+                    "backup_check": policy_decision.backup_check,
+                    "log_ref": policy_decision.log_ref,
+                },
+            }, ensure_ascii=False)
+    except Exception as _policy_err:
+        logger.debug("Policy Gate error for %s: %s", function_name, _policy_err)
+        if os.getenv("HERMES_POLICY_GATE_FAIL_CLOSED", "").strip().lower() in {"1", "true", "yes"}:
+            return json.dumps({
+                "error": f"Policy Gate failed closed for {function_name}: {_sanitize_tool_error(str(_policy_err))}",
+            }, ensure_ascii=False)
+
     try:
         if function_name in _AGENT_LOOP_TOOLS:
             return json.dumps({"error": f"{function_name} must be handled by the agent loop"})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -319,7 +319,7 @@ plugins = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "cron.*", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]
+include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "cron.*", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*", "governance", "governance.*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/governance/test_evidence_and_backups.py
+++ b/tests/governance/test_evidence_and_backups.py
@@ -1,0 +1,88 @@
+import json
+from pathlib import Path
+
+from governance.backup import create_verified_backup, has_recent_verified_backup
+from governance.evidence import EvidenceLedger, EvidenceRecord, append_hash_chained_event
+
+
+def _read_jsonl(path: Path):
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def test_hash_chained_events_are_tamper_evident(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    first = append_hash_chained_event("test_events", {"event_type": "first", "decision": "allow"})
+    second = append_hash_chained_event("test_events", {"event_type": "second", "decision": "deny"})
+    assert first["previous_entry_hash"] == "GENESIS"
+    assert second["previous_entry_hash"] == first["entry_hash"]
+    assert first["entry_hash"] != second["entry_hash"]
+
+    rows = _read_jsonl(tmp_path / "governance" / "test_events.jsonl")
+    assert rows[0]["entry_hash"] == first["entry_hash"]
+    assert rows[1]["previous_entry_hash"] == rows[0]["entry_hash"]
+
+
+def test_evidence_ledger_records_canonical_object(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    ledger = EvidenceLedger()
+    record = EvidenceRecord(
+        phase="test",
+        claim="policy gate blocks destructive commands",
+        evidence_type="test_result",
+        source="pytest",
+        confidence="verified",
+    )
+    written = ledger.record(record)
+    assert written["claim"] == "policy gate blocks destructive commands"
+    assert written["redaction_status"] == "none"
+    assert (tmp_path / "governance" / "evidence.jsonl").exists()
+
+
+def test_create_verified_backup_preserves_bytes_and_records_manifest(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+    source = tmp_path / "source.txt"
+    source.write_text("important bytes\n", encoding="utf-8")
+    backup_root = tmp_path / "backups"
+
+    manifest = create_verified_backup(source, backup_root=backup_root, operation="unit test")
+
+    backup_path = Path(manifest["backup_path"])
+    assert backup_path.exists()
+    assert backup_path.read_bytes() == source.read_bytes()
+    assert manifest["verified_exact_match"] is True
+    assert manifest["original_sha256"] == manifest["backup_sha256"]
+    assert manifest["path_type"] == "regular_file"
+    assert manifest["rollback_command_live_requires_approval"]
+    assert manifest["rollback_argv_live_requires_approval"] == ["cp", "-a", str(backup_path), str(source)]
+
+
+def test_has_recent_verified_backup_rejects_missing_or_tampered_backup(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+    source = tmp_path / "source.txt"
+    source.write_text("important bytes\n", encoding="utf-8")
+
+    manifest = create_verified_backup(source, backup_root=tmp_path / "backup-one", operation="unit test")
+    assert has_recent_verified_backup(source) is True
+
+    Path(manifest["backup_path"]).unlink()
+    assert has_recent_verified_backup(source) is False
+
+    manifest = create_verified_backup(source, backup_root=tmp_path / "backup-two", operation="unit test")
+    Path(manifest["backup_path"]).write_text("tampered backup\n", encoding="utf-8")
+    assert has_recent_verified_backup(source) is False
+
+
+def test_has_recent_verified_backup_rejects_stale_manifest(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes_home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    source = tmp_path / "source.txt"
+    source.write_text("important bytes\n", encoding="utf-8")
+
+    create_verified_backup(source, backup_root=tmp_path / "backup", operation="unit test")
+    log_path = hermes_home / "governance" / "backup_manifests.jsonl"
+    rows = _read_jsonl(log_path)
+    rows[-1]["created_at_utc"] = "1970-01-01T00:00:00Z"
+    rows[-1]["timestamp_utc"] = "1970-01-01T00:00:00Z"
+    log_path.write_text("\n".join(json.dumps(row, sort_keys=True) for row in rows) + "\n", encoding="utf-8")
+
+    assert has_recent_verified_backup(source) is False

--- a/tests/governance/test_memory_governance.py
+++ b/tests/governance/test_memory_governance.py
@@ -1,0 +1,98 @@
+import json
+import hashlib
+from pathlib import Path
+
+from governance.memory_governor import MemoryAdmissionDecision, MemoryGovernor
+from tools.memory_tool import MemoryStore
+
+
+def _read_jsonl(path: Path):
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def test_memory_governor_candidate_then_promotion_log(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    governor = MemoryGovernor(profile="omega")
+    candidate = governor.propose_candidate(
+        candidate_content="User prefers clickable Telegram links",
+        source_ref="session:test",
+        suggested_scope="user",
+        suggested_owner="omega",
+        suggested_sensitivity="personal",
+    )
+    assert candidate["status"] == "candidate_only"
+    assert candidate["proposer_profile"] == "omega"
+
+    decision = governor.record_admission(
+        operation="add",
+        memory_target="user",
+        proposed_content="User prefers clickable Telegram links",
+        normalized_content="User prefers clickable Telegram links.",
+        source_ref="session:test",
+        decision=MemoryAdmissionDecision.ADMIT,
+        owner="omega",
+        scope="user",
+        sensitivity_level="personal",
+        rollback_ref="memory://rollback/test",
+    )
+    assert decision["decision"] == "admit"
+    assert decision["rollback_ref"] == "memory://rollback/test"
+
+    rows = _read_jsonl(tmp_path / "governance" / "memory_admission_log.jsonl")
+    assert rows[-1]["memory_target_owner"] == "omega"
+    assert rows[-1]["sensitivity_level"] == "personal"
+
+
+def test_memory_tool_writes_are_admitted_through_governor(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    store = MemoryStore(memory_char_limit=500, user_char_limit=500)
+    store.load_from_disk()
+
+    result = store.add("memory", "Project uses pytest for governance tests")
+    assert result["success"] is True
+
+    rows = _read_jsonl(tmp_path / "governance" / "memory_admission_log.jsonl")
+    assert rows[-1]["operation"] == "add"
+    assert rows[-1]["decision"] == "admit"
+    assert rows[-1]["memory_target"] == "memory"
+    assert rows[-1]["proposed_content"] == "Project uses pytest for governance tests"
+
+
+def test_memory_tool_rejection_is_logged_without_durable_write(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    store = MemoryStore(memory_char_limit=20, user_char_limit=20)
+    store.load_from_disk()
+
+    result = store.add("memory", "This memory entry is too large for the tiny test limit")
+    assert result["success"] is False
+
+    rows = _read_jsonl(tmp_path / "governance" / "memory_admission_log.jsonl")
+    assert rows[-1]["decision"] == "reject_over_capacity"
+    assert "exceed" in rows[-1]["decision_reason"]
+
+
+def test_memory_governance_redacts_rejected_secret_payloads(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    governor = MemoryGovernor(profile="omega")
+    sample_api_label = "OPENAI_" + "API_" + "KEY"
+    sample_pw_label = "pass" + "word"
+    sample_a = "sk-" + "testsecret3456"
+    sample_b = "hunter" + "2hunter2"
+    secret_content = f"{sample_api_label}={sample_a} and {sample_pw_label}={sample_b}"
+
+    governor.record_admission(
+        operation="add",
+        memory_target="memory",
+        proposed_content=secret_content,
+        decision=MemoryAdmissionDecision.REJECT_SECURITY,
+        decision_reason="secret-looking memory content is not durable context",
+    )
+
+    rows = _read_jsonl(tmp_path / "governance" / "memory_admission_log.jsonl")
+    row_dump = json.dumps(rows[-1], sort_keys=True)
+    assert sample_a not in row_dump
+    assert sample_b not in row_dump
+    assert rows[-1]["proposed_content"].startswith("[REDACTED:")
+    assert rows[-1]["normalized_content"].startswith("[REDACTED:")
+    assert rows[-1]["proposed_content_sha256"] == hashlib.sha256(secret_content.encode("utf-8")).hexdigest()
+    assert rows[-1]["proposed_content_redacted"] is True

--- a/tests/governance/test_policy_gate.py
+++ b/tests/governance/test_policy_gate.py
@@ -1,0 +1,108 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from governance.policy import (
+    ActionClass,
+    Decision,
+    PolicyGate,
+    PolicyGateRequest,
+    classify_command,
+    classify_tool_call,
+    default_capabilities_for_profile,
+)
+
+
+def _read_jsonl(path: Path):
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+class TestCommandClassification:
+    def test_command_semantics_not_name_only(self):
+        assert classify_command("python -c 'import shutil; shutil.rmtree(\"/tmp/x\")'") == ActionClass.DESTRUCTIVE
+        assert classify_command("cat ~/.env") == ActionClass.READ_ONLY_SECRET_ADJACENT
+        assert classify_command("ps eww") == ActionClass.PROCESS_ENV_READ
+        assert classify_command("pip install requests") == ActionClass.DEPENDENCY_CHANGE
+        assert classify_command("python -m pytest tests/governance -q") == ActionClass.TEST_ONLY
+        assert classify_command("true") == ActionClass.READ_ONLY_LOCAL_SAFE
+
+    def test_tool_call_classification_covers_raw_bypass_surfaces(self):
+        terminal_req = classify_tool_call("terminal", {"command": "systemctl --user restart hermes-gateway.service"}, profile="omega")
+        assert terminal_req.action_class == ActionClass.SERVICE_RUNTIME_CHANGE
+        assert terminal_req.affected_services == ["hermes-gateway.service"]
+        assert terminal_req.requested_action == "tool:terminal"
+
+        write_req = classify_tool_call("write_file", {"path": "/tmp/demo.txt", "content": "x"}, profile="omega")
+        assert write_req.action_class == ActionClass.REVERSIBLE_EDIT
+        assert write_req.affected_paths == ["/tmp/demo.txt"]
+
+        memory_req = classify_tool_call("memory", {"action": "add", "target": "memory", "content": "User prefers concise replies"}, profile="omega")
+        assert memory_req.action_class == ActionClass.MEMORY_WRITE
+        assert memory_req.affected_memory_stores == ["memory"]
+
+    def test_unknown_and_mutation_looking_tools_fail_closed(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        unknown_req = classify_tool_call("unregistered_experimental_tool", {}, profile="omega")
+        assert unknown_req.action_class == ActionClass.UNKNOWN
+        unknown_decision = PolicyGate(profile="omega").evaluate(unknown_req)
+        assert unknown_decision.decision == Decision.REQUIRE_APPROVAL
+
+        assert classify_tool_call("mcp_example_delete_record", {}, profile="omega").action_class == ActionClass.REMOTE_WRITE
+        assert classify_tool_call("mcp_example_update_record", {}, profile="omega").action_class == ActionClass.REMOTE_WRITE
+        assert classify_tool_call("mcp_example_write_file", {}, profile="omega").action_class == ActionClass.REMOTE_WRITE
+        assert classify_tool_call("mcp_example_apply_patch", {}, profile="omega").action_class == ActionClass.REMOTE_WRITE
+        assert classify_tool_call("mcp_example_sql_execute", {}, profile="omega").action_class == ActionClass.LIVE_DATA_MIGRATION
+        assert classify_tool_call("mcp_example_migration_apply", {}, profile="omega").action_class == ActionClass.LIVE_DATA_MIGRATION
+
+
+class TestPolicyGate:
+    def test_denies_unapproved_tier4_and_logs_hash_chained_decision(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        gate = PolicyGate(profile="omega")
+        req = classify_tool_call("terminal", {"command": "rm -rf /"}, profile="omega")
+        decision = gate.evaluate(req)
+
+        assert decision.decision == Decision.DENY
+        assert decision.logged is True
+        assert "destructive" in decision.reason.lower()
+
+        log_path = tmp_path / "governance" / "policy_decisions.jsonl"
+        rows = _read_jsonl(log_path)
+        assert len(rows) == 1
+        assert rows[0]["event_type"] == "policy_decision"
+        assert rows[0]["decision"] == "deny"
+        assert rows[0]["previous_entry_hash"] == "GENESIS"
+        assert len(rows[0]["entry_hash"]) == 64
+
+    def test_fail_closed_on_unknown_action_or_missing_capability(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        capabilities = default_capabilities_for_profile("omega")
+        capabilities.allowed_tools = ["read_file"]
+        gate = PolicyGate(profile="omega", capabilities=capabilities)
+        req = classify_tool_call("terminal", {"command": "pwd"}, profile="omega")
+        decision = gate.evaluate(req)
+        assert decision.decision == Decision.DENY
+        assert decision.capability_check == "failed"
+
+    def test_reversible_edit_requires_backup_status_but_stays_under_standing_approval(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        target = tmp_path / "note.txt"
+        target.write_text("old", encoding="utf-8")
+        gate = PolicyGate(profile="omega")
+        req = classify_tool_call("write_file", {"path": str(target), "content": "new"}, profile="omega")
+        decision = gate.evaluate(req)
+        assert decision.decision == Decision.ALLOW_AFTER_BACKUP
+        assert "verified backup" in decision.reason.lower()
+        assert decision.backup_check == "failed"
+
+    def test_safe_read_allows_and_logs(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        gate = PolicyGate(profile="omega")
+        req = classify_tool_call("read_file", {"path": str(tmp_path / "note.txt")}, profile="omega")
+        decision = gate.evaluate(req)
+        assert decision.decision == Decision.ALLOW
+        assert decision.capability_check == "passed"
+        rows = _read_jsonl(tmp_path / "governance" / "policy_decisions.jsonl")
+        assert rows[-1]["decision"] == "allow"

--- a/tests/governance/test_registry_export_secret_scan.py
+++ b/tests/governance/test_registry_export_secret_scan.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+from governance.export_safety import ExportMode, SecretScanner
+from governance.source_registry import RegistryEntry, SourceOfTruthRegistry
+
+
+def test_secret_scanner_finds_and_redacts_common_secret_shapes():
+    scanner = SecretScanner()
+    sample_api_label = "OPENAI_" + "API_" + "KEY"
+    sample_pw_label = "pass" + "word"
+    sample_a = "sk-" + "tes...cdef"
+    sample_b = "hunter" + "2hunter2"
+    text = f"{sample_api_label}={sample_a}\n{sample_pw_label} = \"{sample_b}\"\nnormal text"
+    result = scanner.scan_text(text, mode="report")
+    assert result["status"] == "redaction_required"
+    assert result["findings_count"] >= 2
+    redacted = scanner.redact_text(text)
+    assert "sk-test" not in redacted
+    assert "hunter2" not in redacted
+    assert "[REDACTED:" in redacted
+    report_dump = str(result["findings"])
+    assert sample_a not in report_dump
+    assert sample_b not in report_dump
+    assert all(finding["preview"].startswith("[REDACTED:") for finding in result["findings"])
+
+
+def test_secret_scanner_does_not_flag_normal_schema_identifiers():
+    scanner = SecretScanner()
+    text = '{"schema_version": "governance.evidence.v1", "policy_decision": "reject_policy"}'
+    result = scanner.scan_text(text, mode="report")
+    assert result["status"] == "clean"
+    assert result["findings_count"] == 0
+
+
+def test_runtime_clean_export_excludes_known_unsafe_paths():
+    assert ExportMode.RUNTIME_CLEAN.allows_path("src/app.py") is True
+    assert ExportMode.RUNTIME_CLEAN.allows_path(".git/config") is False
+    assert ExportMode.RUNTIME_CLEAN.allows_path("node_modules/pkg/index.js") is False
+    assert ExportMode.RUNTIME_CLEAN.allows_path("logs/gateway.log") is False
+    assert ExportMode.RUNTIME_CLEAN.allows_path(r".git\\config") is False
+    assert ExportMode.SHAREABLE_AUDIT_FULL.requires_redaction is True
+
+
+def test_source_registry_requires_evidence_for_confirmed_active(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    registry = SourceOfTruthRegistry()
+    entry = RegistryEntry(
+        component_type="startup_file",
+        component_name="Omega start",
+        active_status="confirmed_active",
+        confidence="verified_runtime",
+        path_or_ref="/tmp/start.md",
+        owner_profile="omega",
+        evidence_refs=[],
+    )
+    result = registry.upsert(entry)
+    assert result["success"] is False
+    assert "evidence" in result["error"].lower()
+
+    entry.evidence_refs = ["evidence:test"]
+    result = registry.upsert(entry)
+    assert result["success"] is True
+    rows = registry.list_entries()
+    assert rows[0]["active_status"] == "confirmed_active"
+
+
+def test_governance_export_safety_is_packaged_and_not_gitignored():
+    root = Path(__file__).resolve().parents[2]
+    assert (root / "governance" / "export_safety.py").exists()
+    assert '"governance", "governance.*"' in (root / "pyproject.toml").read_text(encoding="utf-8")
+    assert "!governance/export_safety.py" in (root / ".gitignore").read_text(encoding="utf-8")

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -80,6 +80,36 @@ def _scan_memory_content(content: str) -> Optional[str]:
     return _first_threat_message(content, scope="strict")
 
 
+def _record_memory_governance(
+    *,
+    operation: str,
+    memory_target: str,
+    proposed_content: str,
+    decision: str,
+    decision_reason: str = "",
+    normalized_content: Optional[str] = None,
+) -> None:
+    """Best-effort durable-memory admission logging.
+
+    The memory tool is itself part of the user's continuity substrate; ledger
+    failures must not clobber or block the memory file unless the caller has
+    separately enabled strict Policy Gate enforcement around the tool call.
+    """
+    try:
+        from governance.memory_governor import record_memory_tool_decision
+
+        record_memory_tool_decision(
+            operation=operation,
+            memory_target=memory_target,
+            proposed_content=proposed_content,
+            normalized_content=normalized_content,
+            decision=decision,
+            decision_reason=decision_reason,
+        )
+    except Exception:
+        logger.debug("memory governance logging failed", exc_info=True)
+
+
 def _drift_error(path: "Path", bak_path: str) -> Dict[str, Any]:
     """Build the error dict returned when external drift is detected.
 
@@ -298,11 +328,25 @@ class MemoryStore:
         """Append a new entry. Returns error if it would exceed the char limit."""
         content = content.strip()
         if not content:
+            _record_memory_governance(
+                operation="add",
+                memory_target=target,
+                proposed_content=content,
+                decision="reject_policy",
+                decision_reason="Content cannot be empty.",
+            )
             return {"success": False, "error": "Content cannot be empty."}
 
         # Scan for injection/exfiltration before accepting
         scan_error = _scan_memory_content(content)
         if scan_error:
+            _record_memory_governance(
+                operation="add",
+                memory_target=target,
+                proposed_content=content,
+                decision="reject_security",
+                decision_reason=scan_error,
+            )
             return {"success": False, "error": scan_error}
 
         with self._file_lock(self._path_for(target)):
@@ -327,15 +371,23 @@ class MemoryStore:
 
             if new_total > limit:
                 current = self._char_count(target)
+                error = (
+                    f"Memory at {current:,}/{limit:,} chars. "
+                    f"Adding this entry ({len(content)} chars) would exceed the limit. "
+                    f"Consolidate now: use 'replace' to merge overlapping entries into "
+                    f"shorter ones or 'remove' stale or less important entries (see "
+                    f"current_entries below), then retry this add — all in this turn."
+                )
+                _record_memory_governance(
+                    operation="add",
+                    memory_target=target,
+                    proposed_content=content,
+                    decision="reject_over_capacity",
+                    decision_reason=error,
+                )
                 return {
                     "success": False,
-                    "error": (
-                        f"Memory at {current:,}/{limit:,} chars. "
-                        f"Adding this entry ({len(content)} chars) would exceed the limit. "
-                        f"Consolidate now: use 'replace' to merge overlapping entries into "
-                        f"shorter ones or 'remove' stale or less important entries (see "
-                        f"current_entries below), then retry this add — all in this turn."
-                    ),
+                    "error": error,
                     "current_entries": entries,
                     "usage": f"{current:,}/{limit:,}",
                 }
@@ -344,6 +396,13 @@ class MemoryStore:
             self._set_entries(target, entries)
             self.save_to_disk(target)
 
+        _record_memory_governance(
+            operation="add",
+            memory_target=target,
+            proposed_content=content,
+            normalized_content=content,
+            decision="admit",
+        )
         return self._success_response(target, "Entry added.")
 
     def replace(self, target: str, old_text: str, new_content: str) -> Dict[str, Any]:
@@ -351,13 +410,34 @@ class MemoryStore:
         old_text = old_text.strip()
         new_content = new_content.strip()
         if not old_text:
+            _record_memory_governance(
+                operation="replace",
+                memory_target=target,
+                proposed_content=new_content,
+                decision="reject_policy",
+                decision_reason="old_text cannot be empty.",
+            )
             return {"success": False, "error": "old_text cannot be empty."}
         if not new_content:
+            _record_memory_governance(
+                operation="replace",
+                memory_target=target,
+                proposed_content=new_content,
+                decision="reject_policy",
+                decision_reason="new_content cannot be empty. Use 'remove' to delete entries.",
+            )
             return {"success": False, "error": "new_content cannot be empty. Use 'remove' to delete entries."}
 
         # Scan replacement content for injection/exfiltration
         scan_error = _scan_memory_content(new_content)
         if scan_error:
+            _record_memory_governance(
+                operation="replace",
+                memory_target=target,
+                proposed_content=new_content,
+                decision="reject_security",
+                decision_reason=scan_error,
+            )
             return {"success": False, "error": scan_error}
 
         with self._file_lock(self._path_for(target)):
@@ -393,14 +473,22 @@ class MemoryStore:
 
             if new_total > limit:
                 current = self._char_count(target)
+                error = (
+                    f"Replacement would put memory at {new_total:,}/{limit:,} chars. "
+                    f"Shorten the new content, or 'remove' other stale or less important "
+                    f"entries to make room (see current_entries below), then retry — all "
+                    f"in this turn."
+                )
+                _record_memory_governance(
+                    operation="replace",
+                    memory_target=target,
+                    proposed_content=new_content,
+                    decision="reject_over_capacity",
+                    decision_reason=error,
+                )
                 return {
                     "success": False,
-                    "error": (
-                        f"Replacement would put memory at {new_total:,}/{limit:,} chars. "
-                        f"Shorten the new content, or 'remove' other stale or less important "
-                        f"entries to make room (see current_entries below), then retry — all "
-                        f"in this turn."
-                    ),
+                    "error": error,
                     "current_entries": entries,
                     "usage": f"{current:,}/{limit:,}",
                 }
@@ -409,12 +497,27 @@ class MemoryStore:
             self._set_entries(target, entries)
             self.save_to_disk(target)
 
+        _record_memory_governance(
+            operation="replace",
+            memory_target=target,
+            proposed_content=new_content,
+            normalized_content=new_content,
+            decision="admit",
+            decision_reason=f"replaced entry matching {old_text!r}",
+        )
         return self._success_response(target, "Entry replaced.")
 
     def remove(self, target: str, old_text: str) -> Dict[str, Any]:
         """Remove the entry containing old_text substring."""
         old_text = old_text.strip()
         if not old_text:
+            _record_memory_governance(
+                operation="remove",
+                memory_target=target,
+                proposed_content=old_text,
+                decision="reject_policy",
+                decision_reason="old_text cannot be empty.",
+            )
             return {"success": False, "error": "old_text cannot be empty."}
 
         with self._file_lock(self._path_for(target)):
@@ -441,10 +544,18 @@ class MemoryStore:
                 # All identical -- safe to remove just the first
 
             idx = matches[0][0]
-            entries.pop(idx)
+            removed = entries.pop(idx)
             self._set_entries(target, entries)
             self.save_to_disk(target)
 
+        _record_memory_governance(
+            operation="remove",
+            memory_target=target,
+            proposed_content=removed,
+            normalized_content="",
+            decision="remove",
+            decision_reason=f"removed entry matching {old_text!r}",
+        )
         return self._success_response(target, "Entry removed.")
 
     def format_for_system_prompt(self, target: str) -> Optional[str]:


### PR DESCRIPTION
## Summary
- Add a local-first governance substrate with Policy Gate classification/evaluation, evidence hash-chain logging, verified backup helpers, source registry, export safety/secret scan scaffolding, and memory admission governance.
- Wire the Policy Gate into `model_tools.handle_function_call` after tool-search bridge resolution and tool-request middleware normalization.
- Record memory-tool add/replace/remove admission decisions with rejected secret-looking payloads redacted but hash/length retained.
- Include `governance` in wheel packaging and add focused regression tests for policy, backups/evidence, memory governance, registry/export safety, and packaging inclusion.

## Test Plan
- `PYTHONPATH=. python -m pytest tests/governance tests/tools/test_memory_tool.py tests/test_model_tools.py -q` → 116 passed, 1 warning
- `PYTHONPATH=. python -m compileall -q governance model_tools.py tools/memory_tool.py`
- `git diff --check origin/main HEAD`
- `PYTHONPATH=. python -m pip wheel . --no-deps -w /tmp/hermes-gov-pr-wheel` + wheel contents audit → governance modules included
- committed-file governance secret scan → 0 findings

## CI note
GitHub Actions currently reports `action_required` for this fork PR, so a maintainer may need to approve workflow execution before hosted CI jobs run.
