### PR TITLE
fix: use delete journal mode for kanban db

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1419,8 +1419,9 @@ def connect(
 ) -> sqlite3.Connection:
     """Open (and initialize if needed) the kanban DB.
 
-    WAL mode is enabled on every connection; it's a no-op after the first
-    time but keeps the code robust if the DB file is ever re-created.
+    DELETE journal mode is selected on every connection so kanban.db avoids
+    WAL sidecar files on filesystems where shared-memory coordination is
+    unreliable.
 
     The first connection to a given path auto-runs :func:`init_db` so
     fresh installs and test harnesses that construct `connect()`
@@ -1453,18 +1454,17 @@ def connect(
         try:
             conn.row_factory = sqlite3.Row
             with _INIT_LOCK:
-                # WAL activation can take an exclusive lock while SQLite creates the
-                # sidecar files for a fresh database. Keep it in the same process-local
-                # critical section as schema initialization so concurrent gateway
-                # startup threads do not race before _INITIALIZED_PATHS is populated.
-                # WAL doesn't work on network filesystems (NFS/SMB/FUSE). Shared helper
-                # falls back to DELETE with one WARNING so kanban stays usable there.
-                # See hermes_state._WAL_INCOMPAT_MARKERS for detection logic.
-                from hermes_state import apply_wal_with_fallback
-                apply_wal_with_fallback(conn, db_label=f"kanban.db ({path.name})")
-                # FULL (was NORMAL): fsync before each checkpoint to narrow the
-                # crash window that can leave a b-tree page header torn.
+                # Keep journal-mode selection in the same process-local critical
+                # section as schema initialization so concurrent gateway startup
+                # threads do not race before _INITIALIZED_PATHS is populated.
+                # kanban.db deliberately uses DELETE mode to avoid WAL sidecar
+                # corruption on filesystems where shared-memory coordination is
+                # unreliable.
+                conn.execute("PRAGMA journal_mode=DELETE")
+                # FULL keeps rollback-journal commits durable in DELETE mode.
                 conn.execute("PRAGMA synchronous=FULL")
+                # Harmless no-op while DELETE mode is active; retained so this
+                # connection stays bounded if a caller ever switches to WAL.
                 conn.execute("PRAGMA wal_autocheckpoint=100")
                 conn.execute("PRAGMA foreign_keys=ON")
                 # Zero freed pages so a later torn write cannot expose stale

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -54,6 +54,7 @@ SCHEMA_VERSION = 15
 _WAL_INCOMPAT_MARKERS = (
     "locking protocol",       # SQLITE_PROTOCOL on NFS/SMB
     "not authorized",         # Some FUSE mounts block WAL pragma outright
+    "disk i/o error",         # Filesystems/containers can surface WAL setup this way
 )
 
 # Last SessionDB() init error, per-process.  Surfaced in /resume and

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2638,26 +2638,11 @@ def test_latest_summaries_batch_omits_tasks_without_summary(kanban_home):
 
 
 # ---------------------------------------------------------------------------
-# NFS / network-filesystem fallback (see hermes_state.apply_wal_with_fallback)
+# kanban.db journal mode
 # ---------------------------------------------------------------------------
 
-def test_connect_falls_back_to_delete_on_locking_protocol(tmp_path, monkeypatch, caplog):
-    """kanban_db.connect() must handle ``locking protocol`` on NFS/SMB.
-
-    Without this fallback, the gateway's kanban dispatcher crashes every
-    60s and the kanban migration (``consecutive_failures`` ADD COLUMN) is
-    retried forever — which is what the real-world user report shows
-    (see hermes-agent issue #22032).
-
-    NOTE: We do NOT use the ``kanban_home`` fixture here because that
-    fixture pre-initializes the DB via ``kb.init_db()`` — putting the
-    file in WAL on disk. The Bug D safety guard now refuses to downgrade
-    to DELETE when the on-disk header is already WAL, so testing the
-    NFS-fallback path requires a truly-fresh DB file (NFS scenario in
-    production: first connection of the first process ever to touch the
-    file, where downgrading is safe because nobody else has WAL state
-    yet).
-    """
+def test_connect_uses_delete_journal_mode_without_wal_fallback(tmp_path, monkeypatch, caplog):
+    """kanban_db.connect() selects DELETE directly and never attempts WAL."""
     import sqlite3 as _sqlite3
     from unittest.mock import patch as _patch
 
@@ -2666,40 +2651,51 @@ def test_connect_falls_back_to_delete_on_locking_protocol(tmp_path, monkeypatch,
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
-    # Clear module cache so a fresh connect() is attempted
+    # Clear module cache so a fresh connect() is attempted.
     kb._INITIALIZED_PATHS.clear()
 
     real_connect = _sqlite3.connect
+    traced_connections = []
 
     class _WalBlockingConnection(_sqlite3.Connection):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.executed = []
+            traced_connections.append(self)
+
         def execute(self, sql, *args, **kwargs):  # type: ignore[override]
+            self.executed.append(sql)
             if "journal_mode=wal" in sql.lower().replace(" ", ""):
                 raise _sqlite3.OperationalError("locking protocol")
             return super().execute(sql, *args, **kwargs)
 
     def wal_blocking_connect(*args, **kwargs):
-        return real_connect(
-            *args, factory=_WalBlockingConnection, **kwargs
-        )
+        return real_connect(*args, factory=_WalBlockingConnection, **kwargs)
 
     with _patch("hermes_cli.kanban_db.sqlite3.connect", side_effect=wal_blocking_connect):
         with caplog.at_level("WARNING", logger="hermes_state"):
             conn = kb.connect()
 
-    # One fallback warning, naming kanban.db
-    warnings = [
-        r for r in caplog.records
-        if r.levelname == "WARNING" and "kanban.db" in r.getMessage()
-    ]
-    assert len(warnings) >= 1, (
-        f"Expected a kanban.db WARNING, got: {[r.getMessage() for r in caplog.records]}"
-    )
+    try:
+        warnings = [
+            r for r in caplog.records
+            if r.levelname == "WARNING" and "kanban.db" in r.getMessage()
+        ]
+        assert warnings == []
+        assert traced_connections
+        executed = traced_connections[-1].executed
+        assert any("journal_mode=DELETE" in sql for sql in executed)
+        assert not any("journal_mode=WAL" in sql for sql in executed)
+        assert conn.execute("PRAGMA journal_mode").fetchone()[0] == "delete"
+        assert conn.execute("PRAGMA synchronous").fetchone()[0] == 2  # FULL
+        assert conn.execute("PRAGMA wal_autocheckpoint").fetchone()[0] == 100
 
-    # DB still usable end-to-end — create + list a task
-    t = kb.create_task(conn, title="post-fallback task")
-    tasks = kb.list_tasks(conn)
-    assert any(row.id == t for row in tasks)
-    conn.close()
+        # DB still usable end-to-end — create + list a task.
+        t = kb.create_task(conn, title="delete-mode task")
+        tasks = kb.list_tasks(conn)
+        assert any(row.id == t for row in tasks)
+    finally:
+        conn.close()
 
 
 def test_unlink_tasks_triggers_recompute_ready(kanban_home):

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3756,32 +3756,27 @@ class TestApplyWalProbe:
         # Despite probe failure, set-pragma must still run and succeed.
         assert result == "wal"
 
-    def test_no_downgrade_from_wal_to_delete_on_eio(self, tmp_path):
-        """OperationalError NOT in _WAL_INCOMPAT_MARKERS must propagate, not downgrade."""
+    def test_disk_io_error_falls_back_to_delete(self, tmp_path):
+        """disk I/O errors during WAL setup are treated as WAL-incompat errors."""
         import sqlite3
-        import pytest
         from hermes_state import apply_wal_with_fallback
 
         class _EIOConn(sqlite3.Connection):
-            def __init__(self, *a, **kw):
-                super().__init__(*a, **kw)
-                self._first = True
-
             def execute(self, sql, params=()):
-                # Let the probe succeed (returns "delete" for fresh DB).
+                # Let the probe succeed (returns "delete" for fresh DB), then
+                # raise the real-world error shape while trying to enable WAL.
                 if "journal_mode=WAL" in sql:
-                    raise sqlite3.OperationalError("some unexpected hardware failure")
+                    raise sqlite3.OperationalError("disk I/O error")
                 return super().execute(sql, params)
 
         db_path = tmp_path / "eio.db"
         conn = _EIOConn(str(db_path))
         try:
-            with pytest.raises(
-                sqlite3.OperationalError, match="some unexpected hardware failure"
-            ):
-                apply_wal_with_fallback(conn)
+            result = apply_wal_with_fallback(conn)
         finally:
             conn.close()
+
+        assert result == "delete"
 
     def test_returns_wal_not_delete_from_probe(self, tmp_path):
         """Early-return only on 'wal'; 'delete' or 'memory' must fall through to set-pragma."""


### PR DESCRIPTION
## Summary
- switch kanban.db connections from WAL fallback helper to direct DELETE journal mode
- keep synchronous/foreign-key/secure-delete/cell-size PRAGMAs active under DELETE mode
- add `disk i/o error` as a WAL fallback marker for state.db and any future WAL users
- update regression coverage for kanban DELETE mode and WAL disk I/O fallback

## Verification
- `python -m pytest tests/hermes_cli/test_kanban_db.py -x -q` — 214 passed
- `python -m pytest tests/test_hermes_state.py -x -q -k "wal"` — 9 passed, 253 deselected
- `sqlite3 /root/.hermes/kanban/kanban.db "PRAGMA journal_mode"` — delete
- no `/root/.hermes/kanban/kanban.db-wal` or `/root/.hermes/kanban/kanban.db-shm` sidecars present

Kanban: t_6d88dc1b