### PR TITLE
fix(desktop): honor agent.disabled_toolsets in the desktop/TUI gateway

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -874,6 +874,35 @@ def test_load_enabled_toolsets_honors_builtin_env_if_config_fails(monkeypatch):
     assert server._load_enabled_toolsets() == ["web"]
 
 
+def test_load_disabled_toolsets_reads_agent_config(monkeypatch):
+    import hermes_cli.config as config_mod
+
+    monkeypatch.setattr(
+        config_mod,
+        "load_config",
+        lambda: {"agent": {"disabled_toolsets": ["browser"]}},
+    )
+
+    assert server._load_disabled_toolsets() == ["browser"]
+
+
+def test_load_disabled_toolsets_none_when_unset_or_config_fails(monkeypatch):
+    import hermes_cli.config as config_mod
+
+    monkeypatch.setattr(
+        config_mod, "load_config", lambda: {"agent": {"disabled_toolsets": []}}
+    )
+    assert server._load_disabled_toolsets() is None
+
+    monkeypatch.setattr(config_mod, "load_config", lambda: {})
+    assert server._load_disabled_toolsets() is None
+
+    monkeypatch.setattr(
+        config_mod, "load_config", lambda: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+    assert server._load_disabled_toolsets() is None
+
+
 def test_load_enabled_toolsets_all_env_means_all(monkeypatch):
     monkeypatch.setenv("HERMES_TUI_TOOLSETS", "all")
 
@@ -1748,6 +1777,7 @@ def test_make_agent_passes_configured_fallback_chain(monkeypatch):
     )
     monkeypatch.setattr("run_agent.AIAgent", fake_agent)
     monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: ["file"])
+    monkeypatch.setattr(server, "_load_disabled_toolsets", lambda: ["browser"])
     monkeypatch.setattr(server, "_get_db", lambda: None)
 
     agent = server._make_agent("sid", "session-key")
@@ -1755,6 +1785,7 @@ def test_make_agent_passes_configured_fallback_chain(monkeypatch):
     assert agent.model == "gpt-5.5"
     assert captured["fallback_model"] == fallback_chain
     assert captured["platform"] == "tui"
+    assert captured["disabled_toolsets"] == ["browser"]
 
 
 def test_background_agent_kwargs_preserves_full_fallback_chain(monkeypatch):
@@ -1798,6 +1829,38 @@ def test_background_agent_kwargs_preserves_empty_fallback_chain(monkeypatch):
     kwargs = server._background_agent_kwargs(agent, "task-id")
 
     assert kwargs["fallback_model"] == []
+
+
+def test_background_agent_kwargs_forwards_agent_disabled_toolsets(monkeypatch):
+    agent = types.SimpleNamespace(
+        model="gpt-5.5",
+        provider="anthropic",
+        _fallback_chain=[],
+        disabled_toolsets=["browser"],
+    )
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"max_turns": 25})
+    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: ["file"])
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+
+    kwargs = server._background_agent_kwargs(agent, "task-id")
+
+    assert kwargs["disabled_toolsets"] == ["browser"]
+
+
+def test_background_agent_kwargs_falls_back_to_config_disabled_toolsets(monkeypatch):
+    agent = types.SimpleNamespace(
+        model="gpt-5.5",
+        provider="anthropic",
+        _fallback_chain=[],
+    )
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"max_turns": 25})
+    monkeypatch.setattr(server, "_load_enabled_toolsets", lambda: ["file"])
+    monkeypatch.setattr(server, "_load_disabled_toolsets", lambda: ["browser"])
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+
+    kwargs = server._background_agent_kwargs(agent, "task-id")
+
+    assert kwargs["disabled_toolsets"] == ["browser"]
 
 
 def test_startup_runtime_resolves_short_alias_without_network(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2754,6 +2754,29 @@ def _load_enabled_toolsets() -> list[str] | None:
         return None
 
 
+def _load_disabled_toolsets() -> list[str] | None:
+    """``agent.disabled_toolsets`` from config.yaml, or ``None``.
+
+    The classic CLI (cli.py) and the messaging gateway (gateway/run.py) both
+    forward this list to AIAgent, where get_tool_definitions() strips the
+    named toolsets even out of composite toolsets like ``hermes-cli``
+    (#17309).  The desktop/TUI gateway historically dropped it, so e.g.
+    ``disabled_toolsets: [browser]`` silently had no effect on Desktop —
+    the only consumer was _get_platform_tools()'s name-level subtraction,
+    which can't reach inside a composite default toolset (#44499).
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        agent_cfg = load_config().get("agent") or {}
+        disabled = agent_cfg.get("disabled_toolsets") or None
+        if not disabled:
+            return None
+        return [str(ts) for ts in disabled]
+    except Exception:
+        return None
+
+
 def _session_tool_progress_mode(sid: str) -> str:
     return str(_sessions.get(sid, {}).get("tool_progress_mode", "all") or "all")
 
@@ -4162,6 +4185,8 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
         "max_iterations": _cfg_max_turns(cfg, 25),
         "enabled_toolsets": getattr(agent, "enabled_toolsets", None)
         or _load_enabled_toolsets(),
+        "disabled_toolsets": getattr(agent, "disabled_toolsets", None)
+        or _load_disabled_toolsets(),
         "quiet_mode": True,
         "verbose_logging": False,
         "ephemeral_system_prompt": getattr(agent, "ephemeral_system_prompt", None)
@@ -4614,6 +4639,7 @@ def _make_agent(
             else _load_service_tier()
         ),
         enabled_toolsets=_load_enabled_toolsets(),
+        disabled_toolsets=_load_disabled_toolsets(),
         # OpenRouter provider-routing prefs (config.yaml `provider_routing`).
         # Mirrors the messaging gateway + CLI so the desktop/TUI honors the same
         # routing instead of letting OpenRouter pick providers at random.
@@ -11534,11 +11560,15 @@ def _(rid, params: dict) -> dict:
             try:
                 from tools.mcp_tool import refresh_agent_mcp_tools
 
-                # Explicit reload: re-resolve enabled toolsets so a server the
-                # user just enabled in config this session is picked up.
+                # Explicit reload: re-resolve enabled AND disabled toolsets so a
+                # server the user just enabled/disabled in config this session is
+                # picked up. refresh_agent_mcp_tools honors both overrides and the
+                # agent's stored disabled_toolsets (#44499).
                 refresh_agent_mcp_tools(
                     agent,
                     enabled_override=_load_enabled_toolsets(),
+                    disabled_override=getattr(agent, "disabled_toolsets", None)
+                    or _load_disabled_toolsets(),
                     quiet_mode=True,
                 )
             except Exception as _exc:
@@ -13889,7 +13919,16 @@ def _(rid, params: dict) -> dict:
             if session
             else _load_enabled_toolsets()
         )
-        tools = get_tool_definitions(enabled_toolsets=enabled, quiet_mode=True)
+        disabled = (
+            getattr(session["agent"], "disabled_toolsets", None)
+            if session
+            else _load_disabled_toolsets()
+        )
+        tools = get_tool_definitions(
+            enabled_toolsets=enabled,
+            disabled_toolsets=disabled,
+            quiet_mode=True,
+        )
         sections = {}
 
         for tool in sorted(tools, key=lambda t: t["function"]["name"]):


### PR DESCRIPTION
## Summary

`agent.disabled_toolsets` in `config.yaml` is honored by the classic CLI (`cli.py` reads it and forwards to `AIAgent`) and by the messaging gateway (`gateway/run.py`), where `get_tool_definitions()` strips the named toolsets even out of composite toolsets like `hermes-cli` (#17309 semantics). The desktop/TUI gateway (`tui_gateway/server.py`) never passed it, so on Hermes Desktop `disabled_toolsets: [browser]` silently had no effect: the only consumer on that path was `_get_platform_tools()`'s name-level set subtraction, which can't reach inside a composite default toolset.

Net effect (as reported in #44499): a Desktop user who wants browser automation routed exclusively through an MCP server (e.g. BrowserOS, for authenticated browser profiles) has no working config-level way to suppress the built-in `browser_*` tools — the model sees both tool families and picks the built-ins.

## Changes

- New `_load_disabled_toolsets()` in `tui_gateway/server.py` reading `agent.disabled_toolsets` from config (mirrors `gateway/run.py`).
- Forwarded at every agent/tool-surface build site:
  - `_make_agent` (main session agent)
  - `_background_agent_kwargs` (background + ephemeral preview agents; prefers the live agent's value, falls back to config)
  - the `/reload-mcp` tool-snapshot rebuild
  - the `tools.show` RPC, so the displayed tool list matches the real surface

With this, `agent.disabled_toolsets: [browser]` on Desktop strips all 12 built-in `browser_*` tools (`navigate`, `snapshot`, `click`, `type`, `scroll`, `back`, `press`, `get_images`, `vision`, `console`, `cdp`, `dialog`) while MCP server tools stay available — exactly the denylist requested in the issue, behaving the same as on the CLI and messaging platforms.

Note: the `browser` toolset definition also contains `web_search`, so disabling it drops `web_search` too (pre-existing #17309 strict-subtraction semantics, same as on the CLI — not changed here).

## Testing

- New tests: `_load_disabled_toolsets()` config read + unset/error fallback; `_background_agent_kwargs` forwarding (agent attr and config fallback); `_make_agent` pass-through assertion added to the existing capture test.
- `tests/test_tui_gateway_server.py`: 260 passed, 1 failed — `test_browser_manage_connect_default_local_reports_launch_hint` fails identically on clean `main` on this machine (it assumes no Chromium-family browser is installed), unrelated to this change.
- Verified the subtraction end-to-end: `get_tool_definitions(enabled_toolsets=['hermes-cli'], disabled_toolsets=['browser'])` removes every `browser_*` tool from the composite.

Fixes #44499
