### PR TITLE
feat(slack): handle inbound reaction_added events

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -870,6 +870,21 @@ class SlackAdapter(BasePlatformAdapter):
             async def handle_app_mention(event, say):
                 await self._handle_slack_message(event)
 
+            # Inbound emoji reactions (e.g. a teammate reacting :white_check_mark:
+            # on a draft card to approve it). Slack delivers reaction_added over
+            # the Socket Mode connection; without this handler Bolt logs an
+            # "unhandled request" and the event is dropped. We route approval
+            # reactions into the normal message pipeline as a synthetic mention.
+            @self._app.event("reaction_added")
+            async def handle_reaction_added(event, say):
+                await self._handle_reaction_added(event)
+
+            # Acknowledge reaction_removed so Bolt doesn't log unhandled-request
+            # warnings; we don't act on un-reacting.
+            @self._app.event("reaction_removed")
+            async def handle_reaction_removed(event, say):
+                pass
+
             # File lifecycle events can arrive around snippet uploads even when
             # the actual user message is what we care about. Ack them so Slack
             # doesn't log noisy 404 "unhandled request" warnings.
@@ -2102,6 +2117,122 @@ class SlackAdapter(BasePlatformAdapter):
         metadata = self._extract_assistant_thread_metadata(event)
         self._cache_assistant_thread_metadata(metadata)
         self._seed_assistant_thread_session(metadata)
+
+    # Emoji names treated as an "approve" signal on a draft card.
+    _APPROVAL_REACTIONS = {"white_check_mark", "heavy_check_mark", "ballot_box_with_check"}
+
+    async def _handle_reaction_added(self, event: dict) -> None:
+        """Handle an inbound ``reaction_added`` event.
+
+        Slack delivers this over Socket Mode when a user reacts to a message.
+        We only act on an approval emoji placed on a *message* item, and we
+        ignore the bot's own reactions (the 👀/✅/❌ processing lifecycle would
+        otherwise loop). When it matches, we synthesize a mention-style message
+        event for the reacted message and feed it through the normal
+        ``_handle_slack_message`` pipeline so it inherits allowed-channel
+        gating, channel_prompt injection, session keying, and the reaction
+        lifecycle — no duplicated routing logic.
+        """
+        try:
+            reaction = (event.get("reaction") or "").lower()
+            item = event.get("item") or {}
+
+            # Only approval emojis on a message item.
+            if item.get("type") != "message":
+                return
+            if reaction not in self._APPROVAL_REACTIONS:
+                return
+
+            reactor = event.get("user") or ""
+            # Ignore our own reactions to prevent self-trigger loops.
+            if reactor and self._bot_user_id and reactor == self._bot_user_id:
+                return
+
+            channel_id = item.get("channel") or ""
+            message_ts = item.get("ts") or ""
+            if not channel_id or not message_ts:
+                return
+
+            team_id = (
+                event.get("team")
+                or event.get("item_user_team")
+                or event.get("user_team")
+                or self._channel_team.get(channel_id, "")
+            )
+
+            # Respect the allowed-channels whitelist up front so we don't even
+            # fetch context for channels we never act in.
+            allowed_channels = self._slack_allowed_channels()
+            if allowed_channels and channel_id not in allowed_channels:
+                logger.debug(
+                    "[Slack] Ignoring reaction in non-allowed channel: %s", channel_id
+                )
+                return
+
+            bot_uid = self._team_bot_user_ids.get(team_id, self._bot_user_id)
+            if not bot_uid:
+                bot_uid = self._bot_user_id or ""
+
+            # Pull the reacted message's text so the agent has context about
+            # which draft was approved. Best-effort — proceed even if it fails.
+            reacted_text = ""
+            try:
+                reacted_text = (
+                    await self._fetch_thread_parent_text(
+                        channel_id=channel_id,
+                        thread_ts=message_ts,
+                        team_id=team_id,
+                    )
+                    or ""
+                )
+            except Exception:  # pragma: no cover - defensive
+                reacted_text = ""
+
+            # Build a synthetic message instructing the agent to run its
+            # channel-defined approval flow on the reacted draft. Embedding the
+            # real bot mention token makes the existing require_mention gate in
+            # _handle_slack_message pass naturally (is_mentioned == True) without
+            # special-casing reactions there.
+            mention_token = f"<@{bot_uid}>" if bot_uid else ""
+            instruction = (
+                f"{mention_token} [APPROVAL REACTION] A teammate reacted "
+                f":{reaction}: on the draft card at message ts {message_ts}. "
+                f"Treat this as an APPROVE on that draft and run the approval "
+                f"flow defined in your channel instructions (post the approved "
+                f"draft to X, then confirm in-thread). Reacted message content:\n"
+                f"{reacted_text}".strip()
+            )
+
+            # Give the synthetic event a UNIQUE ts (the reaction's event_ts) so
+            # the MessageDeduplicator in _handle_slack_message does not mistake
+            # it for the already-seen draft message (whose ts == message_ts).
+            # Thread the reply under the reacted draft via thread_ts.
+            synthetic_event = {
+                "type": "message",
+                "text": instruction,
+                "user": reactor,
+                "channel": channel_id,
+                "channel_type": "channel",
+                "ts": event.get("event_ts") or f"{message_ts}-reaction",
+                "thread_ts": message_ts,
+                "team": team_id,
+                # Mark provenance so downstream/debugging can tell this came
+                # from a reaction rather than a typed message.
+                "_hermes_synthetic_reaction": reaction,
+            }
+
+            logger.info(
+                "[Slack] Approval reaction :%s: by %s on %s/%s → dispatching approval flow",
+                reaction,
+                reactor,
+                channel_id,
+                message_ts,
+            )
+            await self._handle_slack_message(synthetic_event)
+        except Exception as e:  # pragma: no cover - defensive
+            logger.error(
+                "[Slack] _handle_reaction_added failed: %s", e, exc_info=True
+            )
 
     async def _handle_slack_message(self, event: dict) -> None:
         """Handle an incoming Slack message event."""

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2499,6 +2499,83 @@ class TestReactions:
 
 
 # ---------------------------------------------------------------------------
+# TestReactionAdded — inbound reaction_added → approval flow
+# ---------------------------------------------------------------------------
+
+
+class TestReactionAdded:
+    """Test the inbound reaction_added handler that drives the approval flow."""
+
+    def _reaction_event(self, reaction="white_check_mark", user="U_USER",
+                        channel="C123", item_ts="111.222"):
+        return {
+            "type": "reaction_added",
+            "user": user,
+            "reaction": reaction,
+            "item": {"type": "message", "channel": channel, "ts": item_ts},
+            "event_ts": "999.888",
+            "team": "T_TEAM",
+        }
+
+    @pytest.mark.asyncio
+    async def test_approval_reaction_dispatches_synthetic_message(self, adapter):
+        adapter._handle_slack_message = AsyncMock()
+        adapter._fetch_thread_parent_text = AsyncMock(return_value="Draft: hello world")
+
+        await adapter._handle_reaction_added(self._reaction_event())
+
+        adapter._handle_slack_message.assert_awaited_once()
+        synthetic = adapter._handle_slack_message.call_args.args[0]
+        # Routes as a normal channel message, threaded under the reacted draft.
+        assert synthetic["channel"] == "C123"
+        assert synthetic["thread_ts"] == "111.222"
+        # Unique ts (reaction event_ts) so dedup doesn't drop it as the draft.
+        assert synthetic["ts"] == "999.888"
+        assert synthetic["ts"] != "111.222"
+        # Embeds the bot mention so require_mention gate passes.
+        assert "<@U_BOT>" in synthetic["text"]
+        # Carries the reacted draft text for agent context.
+        assert "hello world" in synthetic["text"]
+
+    @pytest.mark.asyncio
+    async def test_non_approval_reaction_ignored(self, adapter):
+        adapter._handle_slack_message = AsyncMock()
+        await adapter._handle_reaction_added(self._reaction_event(reaction="thumbsup"))
+        adapter._handle_slack_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_bot_own_reaction_ignored(self, adapter):
+        adapter._handle_slack_message = AsyncMock()
+        await adapter._handle_reaction_added(self._reaction_event(user="U_BOT"))
+        adapter._handle_slack_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_non_message_item_ignored(self, adapter):
+        adapter._handle_slack_message = AsyncMock()
+        ev = self._reaction_event()
+        ev["item"] = {"type": "file", "file": "F123"}
+        await adapter._handle_reaction_added(ev)
+        adapter._handle_slack_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_reaction_in_non_allowed_channel_ignored(self, adapter):
+        adapter._handle_slack_message = AsyncMock()
+        adapter._fetch_thread_parent_text = AsyncMock(return_value="")
+        # Whitelist a different channel than the reaction lands in.
+        adapter._slack_allowed_channels = lambda: {"C_OTHER"}
+        await adapter._handle_reaction_added(self._reaction_event(channel="C123"))
+        adapter._handle_slack_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_reaction_survives_thread_text_fetch_failure(self, adapter):
+        adapter._handle_slack_message = AsyncMock()
+        adapter._fetch_thread_parent_text = AsyncMock(side_effect=Exception("boom"))
+        await adapter._handle_reaction_added(self._reaction_event())
+        # Still dispatches even when fetching the reacted text fails.
+        adapter._handle_slack_message.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
 # TestThreadReplyHandling
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

The Slack adapter (`gateway/platforms/slack.py`) registers `@self._app.event(...)` handlers for `message`, `app_mention`, and the file lifecycle events — but **none for `reaction_added`**. In Socket Mode, Slack delivers the `reaction_added` event over the websocket, but with no handler bound, Bolt silently drops it (at most an "unhandled request" log).

The practical effect: reaction-driven workflows never fire. A common pattern — react :white_check_mark: on a bot-posted card to approve/trigger an action — does nothing, and there's no clear signal why. Users typically chase this on the Slack side (re-adding the `reactions:read` scope, re-subscribing the event, reinstalling the app) when in fact the scope/subscription are correct and the gap is purely that Hermes never listens for the event.

## Fix

Add a `reaction_added` handler that routes **approval emojis** through the existing `_handle_slack_message` pipeline by synthesizing a mention-shaped event. Reusing that pipeline means the reaction path inherits, for free:

- allowed-channel gating (`_slack_allowed_channels()`)
- `channel_prompt` injection and channel skills
- session keying / thread context
- the 👀/✅/❌ processing reaction lifecycle

Design details:

- **Approval set:** `white_check_mark`, `heavy_check_mark`, `ballot_box_with_check`. Other reactions are ignored.
- **Loop-safe:** ignores the bot's own reactions (the processing lifecycle adds ✅/❌ itself).
- **Only message items:** file/other reaction targets are skipped.
- **Synthetic event** embeds the real bot mention token (`<@bot_uid>`) so the existing `require_mention` gate passes naturally — no special-casing inside `_handle_slack_message`.
- **Dedup-safe ts:** the synthetic event's `ts` is the reaction's `event_ts`, *not* the reacted message's ts (the `MessageDeduplicator` keys on ts and would otherwise drop it as a duplicate of the already-seen card). `thread_ts` is set to the reacted message ts so the reply threads under the card.
- Also acks `reaction_removed` so Bolt stops logging unhandled-request warnings for it.

## Tests

New `TestReactionAdded` class in `tests/gateway/test_slack.py`:

- approval reaction dispatches a correctly-shaped synthetic message (channel, thread_ts, unique ts, embedded mention, reacted-text context)
- non-approval emoji → no dispatch
- bot's own reaction → no dispatch
- non-message item (e.g. file) → no dispatch
- reaction in a non-allowed channel → no dispatch
- survives `_fetch_thread_parent_text` raising (still dispatches)

Full Slack suite green locally: **200 passed** (194 existing + 6 new). `py_compile` clean.

## Notes

- Net `+208 / -0` across two files; no existing behavior changed (purely additive event handlers + the new method).
- The approval-emoji set is currently a module constant; happy to make it config-driven (e.g. `slack.approval_reactions`) if preferred.