### PR TITLE
fix(desktop): stop named-profile desktop backend boot loop

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10332,6 +10332,8 @@ def cmd_dashboard(args):
         _launch_profile not in ("default", "custom")
         and not getattr(args, "isolated", False)
         and not getattr(args, "open_profile", "")
+        # Desktop pool backends are intentionally per-profile.
+        and os.environ.get("HERMES_DESKTOP") != "1"
     ):
         url = f"http://{args.host or '127.0.0.1'}:{args.port}/?profile={_launch_profile}"
         if _dashboard_listening(args.host, args.port):

--- a/tests/hermes_cli/test_dashboard_unified_launch.py
+++ b/tests/hermes_cli/test_dashboard_unified_launch.py
@@ -82,6 +82,29 @@ class TestUnifiedDashboardRouting:
         # Profile HERMES_HOME dropped so the child binds the machine root.
         assert "HERMES_HOME" not in env
 
+    def test_desktop_profile_backend_skips_machine_dashboard_reroute(self, main_mod, monkeypatch):
+        """A desktop-spawned named-profile backend (HERMES_DESKTOP=1) must NOT
+        reroute into the machine dashboard. The reroute re-execs as the default
+        profile and exits, so the desktop never sees a ready backend → boot
+        loop. The guard keeps desktop pool backends per-profile."""
+        monkeypatch.setenv("HERMES_DESKTOP", "1")
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name", lambda: "worker_x"
+        )
+        listening_calls = []
+        monkeypatch.setattr(
+            main_mod, "_dashboard_listening",
+            lambda host, port: listening_calls.append(1) or False,
+        )
+        execs = []
+        monkeypatch.setattr(main_mod.os, "execvpe", lambda *a, **k: execs.append(a))
+        monkeypatch.setitem(sys.modules, "fastapi", None)
+
+        with pytest.raises((SystemExit, AttributeError, ImportError, TypeError)):
+            main_mod.cmd_dashboard(_args())
+        assert listening_calls == []
+        assert execs == []
+
     def test_isolated_flag_skips_routing(self, main_mod, monkeypatch):
         monkeypatch.setattr(
             "hermes_cli.profiles.get_active_profile_name", lambda: "worker_x"


### PR DESCRIPTION
Closes #44478 (this PR is the boot-loop-guard half of that split; the MCP-discovery half is #44512).

## What does this PR do?

Fixes the Windows desktop **boot loop** when a named profile is active (see the user post-mortem: repeated `Hermes backend exited before it became ready` / `Machine dashboard already running ... Managing profile 'work'`).

The desktop app spawns its dashboard backend with `--profile <name>` and `HERMES_DESKTOP=1` (both spawn sites in `apps/desktop/electron/main.cjs`). But `cmd_dashboard`'s unified-launch routing treats *any* named profile as a request for the shared **machine** dashboard:

- if one is already listening → it prints `Machine dashboard already running ... Managing profile '<name>'` and `sys.exit(0)`, or
- otherwise → it re-execs as the **default** profile (dropping `HERMES_HOME`).

Either way the desktop-spawned child the app is waiting on exits before a ready backend appears, so Desktop keeps retrying — the boot loop, plus the pile of orphaned dashboard processes the user reported.

## Changes Made

- `hermes_cli/main.py`: skip the machine-dashboard reroute when `HERMES_DESKTOP == "1"` so desktop pool backends stay per-profile (which is what the desktop backend pool expects).
- `tests/hermes_cli/test_dashboard_unified_launch.py`: regression test asserting a desktop-spawned named-profile backend neither probes for a listening dashboard nor re-execs.

## How to Test

1. Configure a named profile, set it active in the desktop app, and launch the app on Windows (or any platform).
2. Verify the desktop backend binds to its own profile/port and reaches "ready" instead of looping.
3. `scripts/run_tests.sh tests/hermes_cli/test_dashboard_unified_launch.py`

## Notes

Carved out of #44478 (the boot-loop guard half). The MCP-tool-discovery half ships as a separate PR. Credit to @aj47.
