### PR TITLE
fix(dashboard): show Windows 11 in host panel

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1638,6 +1638,49 @@ async def get_status():
     }
 
 
+_WINDOWS_11_MIN_BUILD = 22000
+
+
+def _windows_build_number(version: str, platform_label: str) -> Optional[int]:
+    """Extract the Windows NT build number from stdlib platform strings."""
+    for value in (version or "", platform_label or ""):
+        match = re.search(r"(?:^|[^\d])10\.0\.(\d{5,})(?:[^\d]|$)", value)
+        if not match:
+            continue
+        try:
+            return int(match.group(1))
+        except ValueError:
+            continue
+    return None
+
+
+def _display_system_platform(
+    *,
+    system: str,
+    release: str,
+    version: str,
+    platform_label: str,
+) -> Dict[str, str]:
+    """Return host OS fields for display while preserving stdlib detail."""
+    if system == "Windows" and release == "10":
+        build = _windows_build_number(version, platform_label)
+        if build is not None and build >= _WINDOWS_11_MIN_BUILD:
+            platform_label = re.sub(
+                r"^Windows-10(?=-)",
+                "Windows-11",
+                platform_label,
+                count=1,
+            )
+            release = "11"
+
+    return {
+        "os": system,
+        "os_release": release,
+        "os_version": version,
+        "platform": platform_label,
+    }
+
+
 @app.get("/api/system/stats")
 async def get_system_stats():
     """Host + process system stats for the System page.
@@ -1649,10 +1692,12 @@ async def get_system_stats():
     import platform as _platform
 
     info: Dict[str, Any] = {
-        "os": _platform.system(),
-        "os_release": _platform.release(),
-        "os_version": _platform.version(),
-        "platform": _platform.platform(),
+        **_display_system_platform(
+            system=_platform.system(),
+            release=_platform.release(),
+            version=_platform.version(),
+            platform_label=_platform.platform(),
+        ),
         "arch": _platform.machine(),
         "hostname": _platform.node(),
         "python_version": _platform.python_version(),

--- a/tests/hermes_cli/test_system_stats_platform.py
+++ b/tests/hermes_cli/test_system_stats_platform.py
@@ -1,0 +1,44 @@
+from hermes_cli.web_server import _display_system_platform
+
+
+def test_windows_11_build_displays_as_windows_11():
+    info = _display_system_platform(
+        system="Windows",
+        release="10",
+        version="10.0.26200",
+        platform_label="Windows-10-10.0.26200-SP0",
+    )
+
+    assert info["os"] == "Windows"
+    assert info["os_release"] == "11"
+    assert info["os_version"] == "10.0.26200"
+    assert info["platform"] == "Windows-11-10.0.26200-SP0"
+
+
+def test_windows_10_build_keeps_windows_10_label():
+    info = _display_system_platform(
+        system="Windows",
+        release="10",
+        version="10.0.19045",
+        platform_label="Windows-10-10.0.19045-SP0",
+    )
+
+    assert info["os"] == "Windows"
+    assert info["os_release"] == "10"
+    assert info["platform"] == "Windows-10-10.0.19045-SP0"
+
+
+def test_non_windows_platform_unchanged():
+    info = _display_system_platform(
+        system="Linux",
+        release="6.8.0",
+        version="#1 SMP",
+        platform_label="Linux-6.8.0-x86_64-with-glibc2.39",
+    )
+
+    assert info == {
+        "os": "Linux",
+        "os_release": "6.8.0",
+        "os_version": "#1 SMP",
+        "platform": "Linux-6.8.0-x86_64-with-glibc2.39",
+    }


### PR DESCRIPTION
## What does this PR do?

Normalizes the dashboard System page host OS label for Windows 11 machines. Python stdlib platform fields can report Windows 11 as `Windows-10-10.0.<build>-SP0` because Windows 11 still uses the NT 10.x version family, so the Host card can show `Windows 10` on Windows 11.

This keeps the existing `/api/system/stats` response shape, but adjusts the display fields when the host is Windows, `platform.release()` is `10`, and the NT build number is `>= 22000`. Detailed `os_version` remains unchanged.

## Related Issue

Fixes support thread: https://discord.com/channels/1053877538025386074/1514741928443252736

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Added `_display_system_platform()` in `hermes_cli/web_server.py` to normalize Windows 11 display labels by build number.
- Updated `/api/system/stats` to use the normalized display fields while preserving the existing response keys.
- Added focused coverage for Windows 11, Windows 10, and non-Windows platform labels in `tests/hermes_cli/test_system_stats_platform.py`.

## How to Test

1. On a Windows 11 host with build `>= 22000`, open the dashboard System page and confirm the Host card shows `Windows 11` instead of `Windows 10`.
2. Verify Windows 10 builds such as `10.0.19045` still display as Windows 10.
3. Verify non-Windows platform labels are unchanged.

Focused verification run locally:

- `.venv/bin/python - <<'PY' ... _display_system_platform(...) assertions ... PY`
- `python3 -m py_compile hermes_cli/web_server.py tests/hermes_cli/test_system_stats_platform.py`
- `git diff --check -- hermes_cli/web_server.py tests/hermes_cli/test_system_stats_platform.py`

I did not run the full pytest suite in this checkout because local operator instructions currently prohibit pytest runs here due known WSL resource/deadlock risk.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

User-provided evidence in the support thread showed:

- Windows `OsName = Microsoft Windows 11 Pro`
- Windows build `26200`
- Python stdlib reporting `platform.release() = 10` and `platform.platform() = Windows-10-10.0.26200-SP0`
