### PR TITLE
fix(feishu): ignore thread_id in DM quoted replies to prevent isolated sessions

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -3123,6 +3123,10 @@ class FeishuAdapter(BasePlatformAdapter):
                 text = f"{hint}\n\n{text}" if text else hint
 
         thread_id = getattr(message, "thread_id", None) or getattr(message, "root_id", None) or None
+        # Feishu DMs (p2p) do not support real threads; quoted replies populate
+        # thread_id/root_id but should not create isolated sessions (#44028).
+        if chat_type == "p2p":
+            thread_id = None
         reply_to_message_id = (
             getattr(message, "parent_id", None)
             or getattr(message, "upper_message_id", None)

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1952,6 +1952,50 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(event.reply_to_message_id, "om_parent")
         self.assertEqual(event.reply_to_text, "父消息内容")
 
+    def test_dm_quoted_reply_ignores_thread_id(self):
+        """Feishu DMs (p2p) do not support real threads; quoted replies
+        populate thread_id/root_id but should not create isolated sessions (#44028)."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._dispatch_inbound_event = AsyncMock()
+        adapter.get_chat_info = AsyncMock(
+            return_value={"chat_id": "oc_chat", "name": "Feishu DM", "type": "dm"}
+        )
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={"user_id": "ou_user", "user_name": "张三", "user_id_alt": None}
+        )
+        # Simulate a quoted reply in a DM: thread_id/root_id are populated
+        # by the Lark SDK but should NOT create an isolated session.
+        message = SimpleNamespace(
+            chat_id="oc_chat",
+            thread_id="om_thread_parent",
+            root_id="om_thread_parent",
+            parent_id="om_parent",
+            upper_message_id=None,
+            message_type="text",
+            content='{"text":"reply"}',
+            message_id="om_reply",
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=SimpleNamespace(event=SimpleNamespace(message=message)),
+                message=message,
+                sender_id=SimpleNamespace(open_id="ou_user", user_id=None, union_id=None),
+                is_bot=False,
+                chat_type="p2p",
+                message_id="om_reply",
+            )
+        )
+
+        event = adapter._dispatch_inbound_event.await_args.args[0]
+        # thread_id must be None in DMs despite the message having one
+        self.assertIsNone(event.source.thread_id)
+        # reply_to_message_id is still preserved for context
+        self.assertEqual(event.reply_to_message_id, "om_parent")
+
     @patch.dict(os.environ, {}, clear=True)
     def test_send_replies_in_thread_when_thread_metadata_present(self):
         from gateway.config import PlatformConfig


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where Feishu/Lark DM quoted replies (引用回复) create isolated thread sessions, causing the agent to lose all conversation context. The fix nullifies `thread_id` when `chat_type` is `"p2p"` (DM), since Feishu DMs do not support real threads.

## Related Issue

Fixes #44028

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/feishu.py`: Add 4-line guard to set `thread_id = None` when `chat_type == "p2p"`, preventing isolated session creation for DM quoted replies
- `tests/gateway/test_feishu.py`: Add `test_dm_quoted_reply_ignores_thread_id` — verifies that a DM message with `thread_id`/`root_id` populated by the Lark SDK does NOT produce an isolated session

## How to Test

1. Run the new test: `pytest tests/gateway/test_feishu.py -k test_dm_quoted_reply_ignores_thread_id -xvs`
2. Verify existing Feishu tests still pass: `pytest tests/gateway/test_feishu.py -x`
3. (Live test) In a Feishu DM with Hermes, quote-reply a previous message — the response should maintain full conversation context instead of starting fresh

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `_process_inbound_message` in `gateway/platforms/feishu.py` (callers: Feishu webhook handler → inbound processing pipeline → session key builder)
- Blast radius: LOW — only affects Feishu DM (p2p) message routing; group chats and thread handling unchanged
- Related patterns: `build_session_key()` in `gateway/session.py` uses `thread_id` to differentiate sessions; this fix ensures p2p messages always use the standard DM session key
