### PR TITLE
feat(agent): add optional understanding gate

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -135,12 +135,11 @@ def finalize_turn(
     # Clean up VM and browser for this task after conversation completes
     agent._cleanup_task_resources(effective_task_id)
 
-    # Persist session to both JSON log and SQLite only after private retry
-    # scaffolding has been removed. Otherwise a later user "continue" turn
-    # can replay assistant("(empty)") / recovery nudges and fall into the
-    # same empty-response loop again.
+    # Remove private retry scaffolding before any diagnostics, hooks, or
+    # persistence. Otherwise a later user "continue" turn can replay
+    # assistant("(empty)") / recovery nudges and fall into the same
+    # empty-response loop again.
     agent._drop_trailing_empty_response_scaffolding(messages)
-    agent._persist_session(messages, conversation_history)
 
     # ── Turn-exit diagnostic log ─────────────────────────────────────
     # Always logged at INFO so agent.log captures WHY every turn ended.
@@ -283,6 +282,28 @@ def finalize_turn(
                     break  # First non-empty string wins
         except Exception as exc:
             logger.warning("transform_llm_output hook failed: %s", exc)
+
+    # Understanding gate.
+    # Optional final-surface guard used by Peter-style profiles that want
+    # explicit closure discipline: if the assistant's final text lacks a
+    # parseable `status=... proof=...` line, append a partial-status footer.
+    # Keep this after other built-in footers and output transforms so the
+    # status/proof check sees the actual text returned to the user.
+    if final_response and not interrupted:
+        try:
+            final_response = agent._apply_understanding_gate_footer(
+                final_response,
+                messages,
+                turn_exit_reason=_turn_exit_reason,
+            )
+        except Exception as _ug_err:
+            logger.debug("understanding gate footer failed: %s", _ug_err)
+
+    # Persist session to both JSON log and SQLite after final-response
+    # footers have had a chance to synchronize the latest assistant message.
+    # This makes the optional understanding gate affect both the user-facing
+    # response and the durable transcript when enabled.
+    agent._persist_session(messages, conversation_history)
 
     # Plugin hook: post_llm_call
     # Fired once per turn after the tool-calling loop completes.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -853,6 +853,13 @@ DEFAULT_CONFIG = {
         # plausible-looking output when a real path is blocked.  Costs ~80
         # tokens in the cached system prompt.  Set False to disable globally.
         "task_completion_guidance": True,
+        # Final-response understanding gate. Disabled by default; set
+        # agent.understanding_gate.mode to "enforced" in a profile config to
+        # append a compact status/proof footer whenever the model's final
+        # answer lacks a parseable `status=... proof=...` line. This is a
+        # runtime final-surface guard against false completion, not evidence
+        # of subjective understanding.
+        "understanding_gate": {"mode": "off"},
         # Local-environment toolchain probe — surfaces Python/pip/uv/PEP-668
         # state in the system prompt when something non-default is detected
         # (e.g. python3 has no pip module, pip→python version mismatch, PEP

--- a/run_agent.py
+++ b/run_agent.py
@@ -2684,6 +2684,102 @@ class AIAgent:
         # which already surfaces its own message) — don't second-guess.
         return ""
 
+    _STATUS_PROOF_LINE_RE = re.compile(
+        r"(?im)^\s*status=(verified|partial|blocked|attempted|written|done)\s+proof=\S+\s*$"
+    )
+
+    def _understanding_gate_mode(self) -> str:
+        """Return the configured final-response understanding-gate mode.
+
+        Config path: ``agent.understanding_gate``.  Accepted shapes:
+        ``false``/missing/``{"mode": "off"}`` -> ``off``;
+        ``true`` -> ``enforced``; string modes ``off|advisory|enforced``;
+        or a dict with a ``mode`` field.
+
+        The default is off so normal Hermes behavior is unchanged unless a
+        profile explicitly opts in.  This is a final-surface closure gate, not
+        evidence of subjective understanding.
+        """
+        try:
+            from hermes_cli.config import load_config as _load_config
+
+            cfg = _load_config() or {}
+            agent_cfg = cfg.get("agent") if isinstance(cfg, dict) else None
+            gate_cfg = None
+            if isinstance(agent_cfg, dict):
+                gate_cfg = agent_cfg.get("understanding_gate")
+            if gate_cfg is True:
+                return "enforced"
+            if gate_cfg is False or gate_cfg is None:
+                return "off"
+            if isinstance(gate_cfg, str):
+                mode = gate_cfg.strip().lower()
+            elif isinstance(gate_cfg, dict):
+                mode = str(gate_cfg.get("mode") or "off").strip().lower()
+            else:
+                mode = "off"
+            if mode in {"on", "true", "yes"}:
+                return "enforced"
+            if mode in {"advisory", "enforced"}:
+                return mode
+        except Exception:
+            pass
+        return "off"
+
+    def _understanding_gate_enabled(self) -> bool:
+        return self._understanding_gate_mode() in {"advisory", "enforced"}
+
+    @classmethod
+    def _has_status_proof_line(cls, response: str) -> bool:
+        return bool(response and cls._STATUS_PROOF_LINE_RE.search(response))
+
+    @classmethod
+    def _format_understanding_gate_footer(cls, response: str) -> str:
+        """Render the status/proof footer when the final response lacks one."""
+        if cls._has_status_proof_line(response or ""):
+            return ""
+        return (
+            "⚠️ Understanding gate: this final response did not contain a "
+            "parseable `status=... proof=...` line. Treat the completion as "
+            "partial until proof is named and checked.\n"
+            "status=partial proof=understanding_gate_missing_status_proof"
+        )
+
+    @staticmethod
+    def _sync_latest_assistant_content(messages: List[Dict[str, Any]], content: str) -> bool:
+        """Replace the latest non-tool-call assistant message content in-place."""
+        if not isinstance(messages, list):
+            return False
+        for msg in reversed(messages):
+            if not isinstance(msg, dict):
+                continue
+            if msg.get("role") == "assistant" and not msg.get("tool_calls"):
+                msg["content"] = content
+                return True
+        return False
+
+    def _apply_understanding_gate_footer(
+        self,
+        final_response: str,
+        messages: List[Dict[str, Any]],
+        turn_exit_reason: str = "",
+    ) -> str:
+        """Append a closure footer when the enabled gate sees no status/proof.
+
+        The helper also synchronizes the latest assistant message so session
+        persistence and downstream hooks see the same text returned to the
+        caller.
+        """
+        if not final_response or not self._understanding_gate_enabled():
+            return final_response
+        footer = self._format_understanding_gate_footer(final_response)
+        if not footer:
+            self._sync_latest_assistant_content(messages, final_response)
+            return final_response
+        gated = final_response.rstrip() + "\n\n" + footer
+        self._sync_latest_assistant_content(messages, gated)
+        return gated
+
     def _apply_pending_steer_to_tool_results(self, messages: list, num_tool_msgs: int) -> None:
         """Forwarder — see ``agent.agent_runtime_helpers.apply_pending_steer_to_tool_results``."""
         from agent.agent_runtime_helpers import apply_pending_steer_to_tool_results

--- a/tests/run_agent/test_understanding_gate.py
+++ b/tests/run_agent/test_understanding_gate.py
@@ -1,0 +1,187 @@
+"""Tests for Peter's optional understanding-gate final-response footer.
+
+The gate is deliberately config-driven and disabled by default. When enabled,
+it prevents a model's final answer from reaching the user without a parseable
+status/proof surface. It is a small runtime check, not a claim of subjective
+understanding.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from run_agent import AIAgent
+
+
+def _bare_agent() -> AIAgent:
+    return object.__new__(AIAgent)
+
+
+def _force_understanding_gate(monkeypatch) -> None:
+    from hermes_cli import config as hermes_config
+
+    monkeypatch.setattr(
+        hermes_config,
+        "load_config",
+        lambda: {"agent": {"understanding_gate": {"mode": "enforced"}}},
+    )
+
+
+class TestUnderstandingGateConfig:
+    def test_disabled_by_default(self, monkeypatch):
+        from hermes_cli import config as hermes_config
+
+        monkeypatch.setattr(hermes_config, "load_config", lambda: {})
+        agent = _bare_agent()
+
+        assert agent._understanding_gate_mode() == "off"
+        assert agent._understanding_gate_enabled() is False
+
+    def test_enforced_from_agent_config_dict(self, monkeypatch):
+        _force_understanding_gate(monkeypatch)
+        agent = _bare_agent()
+
+        assert agent._understanding_gate_mode() == "enforced"
+        assert agent._understanding_gate_enabled() is True
+
+    def test_boolean_config_maps_to_enforced(self, monkeypatch):
+        from hermes_cli import config as hermes_config
+
+        monkeypatch.setattr(
+            hermes_config,
+            "load_config",
+            lambda: {"agent": {"understanding_gate": True}},
+        )
+        agent = _bare_agent()
+
+        assert agent._understanding_gate_mode() == "enforced"
+
+
+class TestUnderstandingGateFooter:
+    def test_footer_not_added_when_status_proof_exists(self):
+        response = "Done.\n\nstatus=verified proof=tests_run+artifact_reread"
+
+        assert AIAgent._format_understanding_gate_footer(response) == ""
+
+    def test_footer_marks_missing_status_proof_partial(self):
+        footer = AIAgent._format_understanding_gate_footer("Done.")
+
+        assert "Understanding gate" in footer
+        assert "status=partial proof=understanding_gate_missing_status_proof" in footer
+
+    def test_footer_handles_status_without_proof_as_missing(self):
+        footer = AIAgent._format_understanding_gate_footer("Done.\nstatus=verified")
+
+        assert "status=partial proof=understanding_gate_missing_status_proof" in footer
+
+    def test_apply_footer_updates_latest_assistant_message(self, monkeypatch):
+        _force_understanding_gate(monkeypatch)
+        agent = _bare_agent()
+        messages = [
+            {"role": "user", "content": "say done"},
+            {"role": "assistant", "content": "Done."},
+        ]
+
+        final = agent._apply_understanding_gate_footer(
+            "Done.",
+            messages,
+            turn_exit_reason="text_response(finish_reason=stop)",
+        )
+
+        assert final.endswith("status=partial proof=understanding_gate_missing_status_proof")
+        assert messages[-1]["content"] == final
+
+    def test_apply_footer_is_not_duplicated(self, monkeypatch):
+        _force_understanding_gate(monkeypatch)
+        agent = _bare_agent()
+        response = "Done.\n\nstatus=verified proof=tests_run+artifact_reread"
+        messages = [{"role": "assistant", "content": response}]
+
+        final = agent._apply_understanding_gate_footer(
+            response,
+            messages,
+            turn_exit_reason="text_response(finish_reason=stop)",
+        )
+
+        assert final == response
+        assert final.count("status=verified proof=") == 1
+
+    def test_finalizer_persists_gated_latest_assistant_message(self, monkeypatch):
+        from agent.turn_finalizer import finalize_turn
+
+        _force_understanding_gate(monkeypatch)
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *a, **k: [])
+        agent = _bare_agent()
+        dynamic_attrs = {
+            "max_iterations": 10,
+            "iteration_budget": SimpleNamespace(remaining=9, used=1, max_total=10),
+            "model": "test-model",
+            "provider": "test-provider",
+            "base_url": "",
+            "session_id": "session-understanding-gate",
+            "platform": None,
+            "_tool_guardrail_halt_decision": None,
+            "_skill_nudge_interval": 0,
+            "_iters_since_skill": 0,
+            "valid_tool_names": set(),
+            "context_compressor": SimpleNamespace(last_prompt_tokens=0),
+            "_response_was_previewed": False,
+            "session_cost_status": "unknown",
+            "session_cost_source": "unknown",
+            "_turn_failed_file_mutations": {},
+            "_save_trajectory": lambda *a, **k: None,
+            "_cleanup_task_resources": lambda *a, **k: None,
+            "_drop_trailing_empty_response_scaffolding": lambda *a, **k: None,
+            "_file_mutation_verifier_enabled": lambda: False,
+            "_turn_completion_explainer_enabled": lambda: False,
+            "_drain_pending_steer": lambda: None,
+            "clear_interrupt": lambda: None,
+            "_sync_external_memory_for_turn": lambda *a, **k: None,
+        }
+        for attr, value in dynamic_attrs.items():
+            setattr(agent, attr, value)
+        for attr in (
+            "session_input_tokens",
+            "session_output_tokens",
+            "session_cache_read_tokens",
+            "session_cache_write_tokens",
+            "session_reasoning_tokens",
+            "session_prompt_tokens",
+            "session_completion_tokens",
+            "session_total_tokens",
+            "session_estimated_cost_usd",
+        ):
+            setattr(agent, attr, 0)
+        persisted = {}
+
+        def _persist_session(messages, conversation_history=None):
+            persisted["messages"] = [dict(m) for m in messages]
+            persisted["conversation_history"] = conversation_history
+
+        setattr(agent, "_persist_session", _persist_session)
+        messages = [
+            {"role": "user", "content": "say done"},
+            {"role": "assistant", "content": "Done."},
+        ]
+
+        result = finalize_turn(
+            agent,
+            final_response="Done.",
+            api_call_count=1,
+            interrupted=False,
+            failed=False,
+            messages=messages,
+            conversation_history=None,
+            effective_task_id="task-1",
+            turn_id="turn-1",
+            user_message="say done",
+            original_user_message="say done",
+            _should_review_memory=False,
+            _turn_exit_reason="text_response(finish_reason=stop)",
+        )
+
+        assert result["final_response"].endswith(
+            "status=partial proof=understanding_gate_missing_status_proof"
+        )
+        assert persisted["messages"][-1]["content"] == result["final_response"]
+        assert result["messages"][-1]["content"] == result["final_response"]


### PR DESCRIPTION
## Summary
- Add optional runtime understanding gate configured via `agent.understanding_gate.mode`.
- Synchronize gated final response text before session persistence.
- Cover config parsing, footer formatting, message synchronization, and finalizer persistence.

## Verification
- Rebased onto `origin/main` `9102d4a588c84096f648a99d2a8fc10b154d118f`.
- `venv/bin/python -m py_compile agent/turn_finalizer.py hermes_cli/config.py run_agent.py tests/run_agent/test_understanding_gate.py` ✅
- `git show --check` ✅
- `git diff --check origin/main...HEAD` ✅
- `venv/bin/python -m pytest tests/run_agent/test_understanding_gate.py tests/run_agent/test_file_mutation_verifier.py tests/run_agent/test_turn_completion_explainer.py -q` ✅ — 55 passed, 1 warning in 2.48s
- Peter-profile smoke: `status=verified proof=HERMES_ACP_P025_SMOKE_20260611` ✅
- Persistence verification: marker found in Peter `state.db` session `20260611_191500_51fd9d` for both user and assistant messages ✅

## Notes
- Branch was pushed from fork because the authenticated account has READ permission on `NousResearch/hermes-agent` and ADMIN permission on `timwalterseh-max/hermes-agent`.
