### PR TITLE
fix(gateway): harden runtime response normalization

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -464,7 +464,10 @@ _PLATFORM_CONNECTED_CHECKERS: dict[Platform, Callable[[PlatformConfig], bool]] =
     Platform.WHATSAPP: lambda cfg: True,  # bridge handles auth
     Platform.SIGNAL: lambda cfg: bool(cfg.extra.get("http_url")),
     Platform.EMAIL: lambda cfg: bool(cfg.extra.get("address")),
-    Platform.SMS: lambda cfg: bool(os.getenv("TWILIO_ACCOUNT_SID")),
+    Platform.SMS: lambda cfg: (
+        bool(os.getenv("TWILIO_ACCOUNT_SID"))
+        and not is_truthy_value(os.getenv("HERMES_SMS_DISABLED"), default=False)
+    ),
     Platform.API_SERVER: lambda cfg: True,
     Platform.WEBHOOK: lambda cfg: True,
     Platform.MSGRAPH_WEBHOOK: lambda cfg: bool(
@@ -1565,8 +1568,12 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         )
 
     # SMS (Twilio)
+    sms_disabled = is_truthy_value(os.getenv("HERMES_SMS_DISABLED"), default=False)
     twilio_sid = os.getenv("TWILIO_ACCOUNT_SID")
-    if twilio_sid:
+    if sms_disabled:
+        if Platform.SMS in config.platforms:
+            config.platforms[Platform.SMS].enabled = False
+    elif twilio_sid:
         if Platform.SMS not in config.platforms:
             config.platforms[Platform.SMS] = PlatformConfig()
         config.platforms[Platform.SMS].enabled = True

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1835,7 +1835,14 @@ def _normalize_empty_agent_response(
     Fix for #18765.
     """
     if response:
-        return response
+        raw_error = str(agent_result.get("error", "") or "").strip()
+        raw_error_variants = {raw_error, f"⚠️ {raw_error}"} if raw_error else set()
+        if not (
+            raw_error_variants
+            and response.strip() in raw_error_variants
+            and (agent_result.get("failed") or agent_result.get("partial"))
+        ):
+            return response
 
     if agent_result.get("failed"):
         error_detail = agent_result.get("error", "unknown error")
@@ -14503,7 +14510,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _stream_consumer is not None:
                 _stream_consumer.finish()
             
-            # Return final response, or a message if something went wrong
+            # Return the model-visible final response.  Do not synthesize
+            # `⚠️ {error}` here for partial/failed turns: the outer gateway
+            # normalizer has the full result dict and can convert those cases
+            # into user-facing recovery text.  Pre-wrapping the raw error here
+            # bypasses that normalizer and leaks internal provider messages such
+            # as "Codex response remained incomplete after 3 continuation
+            # attempts" directly into chat.
             final_response = result.get("final_response")
 
             # Extract actual token counts from the agent instance used for this run
@@ -14520,9 +14533,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _resolved_model = getattr(_agent, "model", None) if _agent else None
 
             if not final_response:
-                error_msg = f"⚠️ {result['error']}" if result.get("error") else ""
                 return {
-                    "final_response": error_msg,
+                    "final_response": "",
                     "messages": result.get("messages", []),
                     "api_calls": result.get("api_calls", 0),
                     "failed": result.get("failed", False),

--- a/tests/gateway/test_empty_agent_response_normalization.py
+++ b/tests/gateway/test_empty_agent_response_normalization.py
@@ -1,0 +1,59 @@
+from gateway.run import _normalize_empty_agent_response
+
+
+def test_partial_empty_response_becomes_actionable_message():
+    result = {
+        "api_calls": 3,
+        "partial": True,
+        "error": "Codex response remained incomplete after 3 continuation attempts",
+    }
+
+    message = _normalize_empty_agent_response(result, "")
+
+    assert message == (
+        "⚠️ Processing stopped: Codex response remained incomplete after 3 "
+        "continuation attempts. Try again."
+    )
+
+
+def test_partial_synthetic_raw_error_is_not_sent_directly():
+    result = {
+        "api_calls": 3,
+        "partial": True,
+        "error": "Codex response remained incomplete after 3 continuation attempts",
+    }
+
+    message = _normalize_empty_agent_response(
+        result,
+        "⚠️ Codex response remained incomplete after 3 continuation attempts",
+    )
+
+    assert message == (
+        "⚠️ Processing stopped: Codex response remained incomplete after 3 "
+        "continuation attempts. Try again."
+    )
+
+
+def test_failed_synthetic_raw_error_is_normalized():
+    result = {
+        "api_calls": 1,
+        "failed": True,
+        "error": "provider exploded",
+    }
+
+    message = _normalize_empty_agent_response(result, "⚠️ provider exploded")
+
+    assert message == (
+        "The request failed: provider exploded\n"
+        "Try again or use /reset to start a fresh session."
+    )
+
+
+def test_real_nonempty_response_is_preserved():
+    result = {
+        "api_calls": 1,
+        "partial": True,
+        "error": "provider exploded",
+    }
+
+    assert _normalize_empty_agent_response(result, "I recovered and finished.") == "I recovered and finished."

--- a/tests/gateway/test_platform_connected_checkers.py
+++ b/tests/gateway/test_platform_connected_checkers.py
@@ -75,6 +75,7 @@ def test_checker_returns_true_when_configured(platform, checker, monkeypatch):
         mock_config.extra = {"address": "hermes@example.com"}
     elif platform == Platform.SMS:
         monkeypatch.setenv("TWILIO_ACCOUNT_SID", "ACtest")
+        monkeypatch.setenv("HERMES_SMS_DISABLED", "false")
         mock_config.extra = {}
     elif platform in {
         Platform.API_SERVER,
@@ -103,3 +104,16 @@ def test_checker_returns_true_when_configured(platform, checker, monkeypatch):
 
     result = checker(mock_config)
     assert result is True, f"{platform.value} checker should return True with valid-looking config"
+
+
+def test_sms_checker_respects_disabled_env(monkeypatch):
+    """Twilio credentials should not make SMS look connected when locally disabled."""
+    monkeypatch.setenv("TWILIO_ACCOUNT_SID", "ACtest")
+    monkeypatch.setenv("HERMES_SMS_DISABLED", "true")
+    mock_config = MagicMock()
+    mock_config.extra = {}
+    mock_config.token = None
+    mock_config.api_key = None
+    mock_config.enabled = True
+
+    assert _PLATFORM_CONNECTED_CHECKERS[Platform.SMS](mock_config) is False

--- a/tests/gateway/test_sms.py
+++ b/tests/gateway/test_sms.py
@@ -24,9 +24,10 @@ class TestSmsConfigLoading:
         from gateway.config import load_gateway_config
 
         env = {
+            "HERMES_SMS_DISABLED": "false",
             "TWILIO_ACCOUNT_SID": "ACtest123",
             "TWILIO_AUTH_TOKEN": "token_abc",
-            "TWILIO_PHONE_NUMBER": "+15551234567",
+            "TWILIO_PHONE_NUMBER": "+155****4567",
         }
         with patch.dict(os.environ, env, clear=False):
             config = load_gateway_config()
@@ -35,10 +36,27 @@ class TestSmsConfigLoading:
             assert pc.enabled is True
             assert pc.api_key == "token_abc"
 
+    def test_env_overrides_do_not_enable_sms_when_disabled(self):
+        from gateway.config import load_gateway_config
+
+        env = {
+            "HERMES_SMS_DISABLED": "true",
+            "TWILIO_ACCOUNT_SID": "ACtest123",
+            "TWILIO_AUTH_TOKEN": "token_abc",
+            "TWILIO_PHONE_NUMBER": "+155****4567",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            config = load_gateway_config()
+            assert (
+                Platform.SMS not in config.platforms
+                or config.platforms[Platform.SMS].enabled is False
+            )
+
     def test_env_overrides_set_home_channel(self):
         from gateway.config import load_gateway_config
 
         env = {
+            "HERMES_SMS_DISABLED": "false",
             "TWILIO_ACCOUNT_SID": "ACtest123",
             "TWILIO_AUTH_TOKEN": "token_abc",
             "TWILIO_PHONE_NUMBER": "+15551234567",


### PR DESCRIPTION
## Summary
- Harden gateway platform-connected checker handling.
- Normalize raw empty/partial agent response errors into actionable user-facing gateway messages.
- Cover SMS startup guard and empty-response normalization behavior.

## Verification
- Rebased onto `origin/main` `9102d4a588c84096f648a99d2a8fc10b154d118f`.
- `venv/bin/python -m py_compile gateway/config.py gateway/run.py tests/gateway/test_empty_agent_response_normalization.py tests/gateway/test_platform_connected_checkers.py tests/gateway/test_sms.py` ✅
- `git show --check` ✅
- `git diff --check origin/main...HEAD` ✅
- `venv/bin/python -m pytest tests/gateway/test_platform_connected_checkers.py tests/gateway/test_sms.py tests/gateway/test_empty_agent_response_normalization.py -q` ✅ — 76 passed, 6 warnings in 0.90s

## Notes
- Branch was pushed from fork because the authenticated account has READ permission on `NousResearch/hermes-agent` and ADMIN permission on `timwalterseh-max/hermes-agent`.
