### PR TITLE
[NS-365] Guard hosted file browser deletes

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -62,6 +62,7 @@ from hermes_cli.config import (
     recommended_update_command_for_method,
     redact_key,
 )
+from agent.file_safety import is_write_denied
 from gateway.status import get_running_pid, read_runtime_status
 from utils import env_var_enabled
 
@@ -911,6 +912,14 @@ _MEDIA_MAX_BYTES = 25 * 1024 * 1024
 _MANAGED_FILES_ROOT_ENV = "HERMES_DASHBOARD_FILES_ROOT"
 _MANAGED_FILE_MAX_BYTES = 100 * 1024 * 1024
 _HOSTED_MANAGED_FILES_ROOT = Path("/opt/data")
+_MANAGED_PROTECTED_FILE_NAMES = {
+    ".anthropic_oauth.json",
+    ".env",
+    "auth.json",
+    "config.yaml",
+    "webhook_subscriptions.json",
+}
+_MANAGED_PROTECTED_DIR_NAMES = {"mcp-tokens", "pairing"}
 
 
 @dataclass(frozen=True)
@@ -918,6 +927,7 @@ class ManagedFilesPolicy:
     default_path: Path
     locked_root: Path | None
     can_change_path: bool
+    can_delete: bool
 
 
 _FS_READDIR_HIDDEN = {
@@ -1179,6 +1189,46 @@ def _path_text(raw_path: str | None) -> str:
     return text
 
 
+def _profile_control_path_parts(parts: tuple[str, ...]) -> tuple[str, ...] | None:
+    if len(parts) < 3 or parts[0] != "profiles" or not parts[1]:
+        return None
+    profile_prefix = parts[:2]
+    profile_item = parts[2]
+    if profile_item in _MANAGED_PROTECTED_FILE_NAMES | _MANAGED_PROTECTED_DIR_NAMES:
+        return (*profile_prefix, profile_item)
+    return None
+
+
+def _locked_root_control_path(policy: ManagedFilesPolicy, target: Path) -> Path | None:
+    if policy.locked_root is None:
+        return None
+    try:
+        parts = target.relative_to(policy.locked_root).parts
+    except ValueError:
+        return None
+    if not parts:
+        return None
+
+    if parts[0] in _MANAGED_PROTECTED_FILE_NAMES | _MANAGED_PROTECTED_DIR_NAMES:
+        return policy.locked_root / parts[0]
+
+    profile_parts = _profile_control_path_parts(parts)
+    if profile_parts is not None:
+        return policy.locked_root.joinpath(*profile_parts)
+    return None
+
+
+def _ensure_managed_file_write_allowed(
+    policy: ManagedFilesPolicy,
+    target: Path,
+    *,
+    action: str,
+) -> None:
+    protected_path = _locked_root_control_path(policy, target)
+    if protected_path is not None or is_write_denied(str(target)):
+        raise HTTPException(status_code=403, detail=f"{action} denied for protected Hermes path")
+
+
 def _local_dashboard_request(request: Request) -> bool:
     if getattr(request.app.state, "auth_required", False):
         return False
@@ -1201,18 +1251,41 @@ def _default_hermes_root_is_opt_data() -> bool:
     return root == _HOSTED_MANAGED_FILES_ROOT
 
 
+def _is_hosted_managed_files_root(root: Path) -> bool:
+    try:
+        return root.expanduser().resolve(strict=False) == _HOSTED_MANAGED_FILES_ROOT.resolve(strict=False)
+    except (OSError, RuntimeError):
+        return root == _HOSTED_MANAGED_FILES_ROOT
+
+
 def _managed_files_policy(request: Request, *, create_root: bool = True) -> ManagedFilesPolicy:
     raw_forced_root = os.environ.get(_MANAGED_FILES_ROOT_ENV, "").strip()
     if raw_forced_root:
         root = _ensure_managed_root(raw_forced_root) if create_root else _canonical_path(Path(raw_forced_root))
-        return ManagedFilesPolicy(default_path=root, locked_root=root, can_change_path=False)
+        is_hosted_root = _is_hosted_managed_files_root(root)
+        return ManagedFilesPolicy(
+            default_path=root,
+            locked_root=root,
+            can_change_path=False,
+            can_delete=not is_hosted_root,
+        )
 
     if not _local_dashboard_request(request) or _default_hermes_root_is_opt_data():
         root = _ensure_managed_root(_HOSTED_MANAGED_FILES_ROOT) if create_root else _HOSTED_MANAGED_FILES_ROOT
-        return ManagedFilesPolicy(default_path=root, locked_root=root, can_change_path=False)
+        return ManagedFilesPolicy(
+            default_path=root,
+            locked_root=root,
+            can_change_path=False,
+            can_delete=False,
+        )
 
     home = _canonical_path(Path.home())
-    return ManagedFilesPolicy(default_path=home, locked_root=None, can_change_path=True)
+    return ManagedFilesPolicy(
+        default_path=home,
+        locked_root=None,
+        can_change_path=True,
+        can_delete=True,
+    )
 
 
 def _resolve_managed_path(
@@ -1259,6 +1332,7 @@ def _managed_response_meta(policy: ManagedFilesPolicy) -> Dict[str, Any]:
         "root": locked_root,
         "locked_root": locked_root,
         "can_change_path": policy.can_change_path,
+        "can_delete": policy.can_delete,
     }
 
 
@@ -1368,6 +1442,7 @@ async def read_managed_file(request: Request, path: str):
 @app.post("/api/files/upload")
 async def upload_managed_file(payload: ManagedFileUpload, request: Request):
     policy, target, display_path = _resolve_managed_path(payload.path, request, for_write=True)
+    _ensure_managed_file_write_allowed(policy, target, action="Upload")
     if target.exists() and target.is_dir():
         raise HTTPException(status_code=409, detail="A directory already exists at that path")
     if target.exists() and not payload.overwrite:
@@ -1393,6 +1468,7 @@ async def upload_managed_file(payload: ManagedFileUpload, request: Request):
 @app.post("/api/files/mkdir")
 async def create_managed_directory(payload: ManagedDirectoryCreate, request: Request):
     policy, target, display_path = _resolve_managed_path(payload.path, request, for_write=True)
+    _ensure_managed_file_write_allowed(policy, target, action="Create")
     if target.exists() and not target.is_dir():
         raise HTTPException(status_code=409, detail="A file already exists at that path")
 
@@ -1414,6 +1490,9 @@ async def create_managed_directory(payload: ManagedDirectoryCreate, request: Req
 @app.delete("/api/files")
 async def delete_managed_file(payload: ManagedFileDelete, request: Request):
     policy, target, display_path = _resolve_managed_path(payload.path, request)
+    if not policy.can_delete:
+        raise HTTPException(status_code=403, detail="File deletion is disabled for this dashboard")
+    _ensure_managed_file_write_allowed(policy, target, action="Delete")
     if policy.locked_root is not None and target == policy.locked_root:
         raise HTTPException(status_code=400, detail="Cannot delete the managed files root")
     if target.parent == target:

--- a/tests/hermes_cli/test_web_server_files.py
+++ b/tests/hermes_cli/test_web_server_files.py
@@ -41,6 +41,7 @@ def _close_client(client):
 def forced_files_client(monkeypatch, tmp_path):
     root = tmp_path / "data"
     monkeypatch.setenv("HERMES_DASHBOARD_FILES_ROOT", str(root))
+    monkeypatch.delenv("HERMES_WRITE_SAFE_ROOT", raising=False)
 
     client, prev_auth_required, prev_bound_host = _client_with_app_state()
     try:
@@ -55,6 +56,7 @@ def local_files_client(monkeypatch, tmp_path):
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.delenv("HERMES_DASHBOARD_FILES_ROOT", raising=False)
+    monkeypatch.delenv("HERMES_WRITE_SAFE_ROOT", raising=False)
     monkeypatch.delenv("HERMES_HOME", raising=False)
     monkeypatch.setenv("HOME", str(home))
 
@@ -81,6 +83,7 @@ def test_forced_root_file_upload_list_read_delete_roundtrip(forced_files_client)
     assert created.json()["entry"]["path"] == str(file_path)
     assert created.json()["locked_root"] == str(root)
     assert created.json()["can_change_path"] is False
+    assert created.json()["can_delete"] is True
     assert file_path.read_text() == "hello"
 
     listing = client.get("/api/files", params={"path": str(root / "out")})
@@ -171,6 +174,49 @@ def test_forced_root_paths_stay_under_root(forced_files_client, tmp_path):
     assert escaped.status_code == 403
 
 
+def test_file_browser_blocks_control_plane_uploads_under_locked_root(forced_files_client):
+    client, root = forced_files_client
+
+    root_config = client.post(
+        "/api/files/upload",
+        json={
+            "path": str(root / "config.yaml"),
+            "data_url": "data:text/plain;base64,bW9kZWw6IGV2aWw=",
+        },
+    )
+    assert root_config.status_code == 403
+    assert not (root / "config.yaml").exists()
+
+    profile_config = client.post(
+        "/api/files/upload",
+        json={
+            "path": str(root / "profiles" / "default" / "config.yaml"),
+            "data_url": "data:text/plain;base64,bW9kZWw6IGV2aWw=",
+        },
+    )
+    assert profile_config.status_code == 403
+    assert not (root / "profiles" / "default" / "config.yaml").exists()
+
+    mcp_tokens = client.post("/api/files/mkdir", json={"path": str(root / "mcp-tokens")})
+    assert mcp_tokens.status_code == 403
+    assert not (root / "mcp-tokens").exists()
+
+
+def test_file_browser_blocks_control_plane_delete_under_locked_root(forced_files_client):
+    client, root = forced_files_client
+    root.mkdir(exist_ok=True)
+    config_path = root / "config.yaml"
+    config_path.write_text("model: keep")
+
+    deleted = client.request(
+        "DELETE",
+        "/api/files",
+        json={"path": str(config_path)},
+    )
+    assert deleted.status_code == 403
+    assert config_path.read_text() == "model: keep"
+
+
 def test_local_mode_defaults_to_home_and_can_jump_to_absolute_path(local_files_client, tmp_path):
     client, home = local_files_client
     (home / "home.txt").write_text("home")
@@ -180,6 +226,7 @@ def test_local_mode_defaults_to_home_and_can_jump_to_absolute_path(local_files_c
     assert default_listing.json()["path"] == str(home)
     assert default_listing.json()["locked_root"] is None
     assert default_listing.json()["can_change_path"] is True
+    assert default_listing.json()["can_delete"] is True
     assert default_listing.json()["entries"][0]["path"] == str(home / "home.txt")
 
     other = tmp_path / "other"
@@ -202,6 +249,7 @@ def test_local_mode_upload_read_mkdir_delete_roundtrip(local_files_client):
     assert created_folder.status_code == 200
     assert created_folder.json()["locked_root"] is None
     assert created_folder.json()["can_change_path"] is True
+    assert created_folder.json()["can_delete"] is True
     assert folder.is_dir()
 
     uploaded = client.post(
@@ -229,6 +277,7 @@ def test_local_mode_upload_read_mkdir_delete_roundtrip(local_files_client):
 
 def test_hosted_policy_locks_to_opt_data(monkeypatch):
     monkeypatch.delenv("HERMES_DASHBOARD_FILES_ROOT", raising=False)
+    monkeypatch.delenv("HERMES_WRITE_SAFE_ROOT", raising=False)
     monkeypatch.setenv("HERMES_HOME", "/opt/data")
     client, prev_auth_required, prev_bound_host = _client_with_app_state()
     try:
@@ -244,3 +293,34 @@ def test_hosted_policy_locks_to_opt_data(monkeypatch):
 
     assert str(policy.locked_root) == "/opt/data"
     assert policy.can_change_path is False
+    assert policy.can_delete is False
+
+
+def test_hosted_data_root_blocks_file_browser_delete(monkeypatch, tmp_path):
+    root = tmp_path / "data"
+    monkeypatch.delenv("HERMES_DASHBOARD_FILES_ROOT", raising=False)
+    monkeypatch.delenv("HERMES_WRITE_SAFE_ROOT", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.setattr(web_server, "_HOSTED_MANAGED_FILES_ROOT", root)
+
+    client, prev_auth_required, prev_bound_host = _client_with_app_state()
+    try:
+        listing = client.get("/api/files")
+        assert listing.status_code == 200
+        assert listing.json()["path"] == str(root)
+        assert listing.json()["locked_root"] == str(root)
+        assert listing.json()["can_change_path"] is False
+        assert listing.json()["can_delete"] is False
+
+        file_path = root / "keep.txt"
+        file_path.write_text("keep")
+        deleted = client.request(
+            "DELETE",
+            "/api/files",
+            json={"path": str(file_path)},
+        )
+        assert deleted.status_code == 403
+        assert file_path.read_text() == "keep"
+    finally:
+        _close_client(client)
+        _restore_app_state(prev_auth_required, prev_bound_host)

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1663,6 +1663,7 @@ export interface ManagedFilesResponse {
   parent: string | null;
   locked_root: string | null;
   can_change_path: boolean;
+  can_delete: boolean;
   entries: ManagedFileEntry[];
 }
 
@@ -1675,6 +1676,7 @@ export interface ManagedFileReadResponse {
   root: string | null;
   locked_root: string | null;
   can_change_path: boolean;
+  can_delete: boolean;
 }
 
 export interface ManagedFileWriteResponse {
@@ -1684,6 +1686,7 @@ export interface ManagedFileWriteResponse {
   root: string | null;
   locked_root: string | null;
   can_change_path: boolean;
+  can_delete: boolean;
 }
 
 export interface AnalyticsDailyEntry {

--- a/web/src/pages/FilesPage.tsx
+++ b/web/src/pages/FilesPage.tsx
@@ -107,6 +107,7 @@ export default function FilesPage() {
 
   const activePath = listing?.path ?? currentPath ?? "";
   const canChangePath = listing?.can_change_path ?? false;
+  const canDelete = listing?.can_delete ?? false;
   const canUpload = Boolean(activePath) && !uploading;
   const headerPath = displayPath(listing?.locked_root ?? listing?.path ?? currentPath);
 
@@ -260,6 +261,11 @@ export default function FilesPage() {
 
   const confirmDelete = async () => {
     if (!pendingDelete) return;
+    if (!canDelete) {
+      setPendingDelete(null);
+      showToast("Delete is disabled for this dashboard", "error");
+      return;
+    }
     setDeleting(true);
     try {
       await api.deleteFile(pendingDelete.path, pendingDelete.is_directory);
@@ -451,16 +457,18 @@ export default function FilesPage() {
                       <Download />
                     </Button>
                   )}
-                  <Button
-                    ghost
-                    size="icon"
-                    type="button"
-                    onClick={() => setPendingDelete(entry)}
-                    aria-label={`Delete ${entry.name}`}
-                    className="text-destructive hover:text-destructive"
-                  >
-                    <Trash2 />
-                  </Button>
+                  {canDelete && (
+                    <Button
+                      ghost
+                      size="icon"
+                      type="button"
+                      onClick={() => setPendingDelete(entry)}
+                      aria-label={`Delete ${entry.name}`}
+                      className="text-destructive hover:text-destructive"
+                    >
+                      <Trash2 />
+                    </Button>
+                  )}
                 </span>
               </div>
             ))


### PR DESCRIPTION
## Summary

Refs NS-365.

- Derive hosted file-browser delete policy from the existing hosted data-root signal instead of new env vars.
- Advertise `can_delete` from `/api/files` and hide delete controls in the dashboard file browser when hosted delete is disabled.
- Reject stale or handcrafted raw delete requests server-side.
- Block raw file-browser upload/mkdir/delete against Hermes control-plane paths such as `config.yaml`, `auth.json`, `.env`, `mcp-tokens`, and `pairing`, while keeping ordinary workspace files editable.

## Validation

- `source .venv/bin/activate && pytest tests/hermes_cli/test_web_server_files.py -q`
- `source .venv/bin/activate && ruff check hermes_cli/web_server.py tests/hermes_cli/test_web_server_files.py`
- `npm --workspace web exec eslint -- src/pages/FilesPage.tsx src/lib/api.ts`
- `npm --workspace web run typecheck`
- `npm --workspace web run build` (passes with the existing large-chunk warning)

## Notes

Companion account-service PR: https://github.com/NousResearch/nous-account-service/pull/288
