### PR TITLE
fix(desktop): let the remote folder picker scroll long directory lists

### DIFF
--- a/apps/desktop/src/app/right-sidebar/files/remote-picker.tsx
+++ b/apps/desktop/src/app/right-sidebar/files/remote-picker.tsx
@@ -109,7 +109,9 @@ export function RemoteFolderPicker() {
 
   return (
     <Dialog onOpenChange={open => !open && close()} open={Boolean(pending)}>
-      <DialogContent className="max-w-lg gap-0 overflow-hidden p-0">
+      {/* flex-col (vs the base grid) keeps the folder column inside the dialog's
+          85vh cap so the list's overflow-y-auto can scroll long directories. */}
+      <DialogContent className="flex max-w-lg flex-col gap-0 overflow-hidden p-0">
         <div className="border-b border-border/70 px-4 py-3">
           <DialogTitle className="text-sm">{pending?.title || r.remotePickerTitle}</DialogTitle>
           <DialogDescription className="mt-1 text-xs">{r.remotePickerDescription}</DialogDescription>


### PR DESCRIPTION
## Problem

In remote-gateway mode, the "Change working directory" picker (added in #44326) clips long folder lists at the dialog's bottom edge — no scrollbar, wheel does nothing, entries below the fold are unreachable, and the Cancel/Select footer is pushed out of view.

## Cause

The picker's `DialogContent` overrides the base dialog's `overflow-y-auto` with `overflow-hidden` while keeping the base `display: grid`. The inner column's `min-h-[22rem]` is a floor with no cap, so as a grid child it grows to content height past the `max-h-[85vh]` cap and gets clipped. The entry list's `min-h-0 flex-1 overflow-y-auto` never engages because no ancestor constrains its height.

## Fix

Add `flex flex-col` to the picker's `DialogContent` className (tailwind-merge drops the base `grid`). In a flex column the inner column shrinks to fit the 85vh cap — its existing `min-h-[22rem]` already overrides the flex `min-height: auto` floor — so the list's existing `overflow-y-auto` takes over. One-line class change; header and footer keep their natural size via `min-height: auto`.

## Verification

- `tsc --noEmit` clean; eslint adds no new warnings on the file.
- Reproduced the exact DOM/class structure with 40 entries, before vs after:

| | grid (main) | flex-col (this PR) |
|---|---|---|
| list scrollable | ❌ | ✅ |
| last entry reachable | ❌ clipped | ✅ |
| footer visible | ❌ pushed out | ✅ |

Matches the reporter's DevTools-verified fix direction in #44522 (`display: flex; flex-direction: column` + letting the column shrink).

Fixes #44522
