### PR TITLE
docs(i18n): fix cron troubleshooting skill-name mismatch example

### DIFF
--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/cron-troubleshooting.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/guides/cron-troubleshooting.md
@@ -111,7 +111,7 @@ Skill 必须先安装才能附加到 cron 任务。若 skill 缺失，先用 `he
 
 ### 检查 2：检查 skill 名称与 skill 文件夹名称
 
-Skill 名称区分大小写，必须与已安装 skill 的文件夹名称完全匹配。若任务指定的是 `ai-funding-daily-report`，但 skill 文件夹也是 `ai-funding-daily-report`，请从 `hermes skills list` 确认确切名称。
+Skill 名称区分大小写，必须与已安装 skill 的文件夹名称完全匹配。若任务指定的是 `ai-funding-report`，但 skill 文件夹是 `ai-funding-daily-report`，请从 `hermes skills list` 确认确切名称。
 
 ### 检查 3：依赖交互式工具的 skill
 


### PR DESCRIPTION
## Summary

- Fixes the zh-Hans cron troubleshooting example so it shows an actual mismatch between the job skill name and installed skill folder.
- Mirrors the English docs fix for #36048 item 27.
- Keeps the translated docs consistent with the source example.

## Validation

- Manually verified this only updates the zh-Hans cron troubleshooting docs example.

Docs/i18n-only change; runtime behavior is unchanged.
