### PR TITLE
feat(cron): optional threaded delivery (summary parent + detail in thread)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -15,6 +15,7 @@ import contextvars
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -154,6 +155,56 @@ from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_
 # response with this marker to suppress delivery.  Output is still saved
 # locally for audit.
 SILENT_MARKER = "[SILENT]"
+
+# Threaded cron delivery: platforms whose adapters support posting a summary
+# parent message and the full report in its thread (via metadata thread_id).
+THREADED_DELIVERY_PLATFORMS = frozenset({"slack"})
+
+# Accepted summary-marker prefixes on the first paragraph of a cron report.
+_SUMMARY_MARKERS = ("tl;dr:", "tldr:", "summary:")
+
+
+def _split_summary(content: str) -> tuple[str, Optional[str]]:
+    """Split a cron report into (summary, detail) for threaded delivery.
+
+    The summary is the first paragraph (up to the first blank line); a
+    leading TL;DR:/TLDR:/Summary: marker is stripped from it.  When there is
+    no second paragraph, returns ``(content.strip(), None)`` (no marker
+    stripping) so the caller delivers flat exactly as before; empty input
+    is returned as-is.
+    """
+    text = (content or "").strip()
+    if not text:
+        return (content or "", None)
+    parts = re.split(r"\n\s*\n", text, maxsplit=1)
+    first = parts[0].strip()
+    rest = parts[1].strip() if len(parts) > 1 else ""
+    if not rest:
+        return (text, None)
+    lowered = first.lower()
+    for marker in _SUMMARY_MARKERS:
+        if lowered.startswith(marker):
+            first = first[len(marker):].strip()
+            break
+    if not first:
+        return (text, None)
+    return (first, rest)
+
+
+def _threaded_delivery_enabled(job: dict) -> bool:
+    """True when this job should use summary-parent + thread-detail delivery.
+
+    Off by default (``cron.threaded_delivery`` config), with a per-job
+    ``"thread": false`` opt-out.  Any config error means off — threading is
+    best-effort and must never block a delivery.
+    """
+    if job.get("thread") is False:
+        return False
+    try:
+        return bool(load_config().get("cron", {}).get("threaded_delivery", False))
+    except Exception:
+        return False
+
 
 # ---------------------------------------------------------------------------
 # Persistent thread pool for parallel cron jobs.
@@ -655,6 +706,72 @@ def _send_media_via_adapter(
             logger.warning("Job '%s': failed to send media %s: %s", job.get("id", "?"), media_path, e)
 
 
+def _send_threaded_via_adapter(
+    adapter,
+    chat_id: str,
+    parent_text: str,
+    detail_text: str,
+    media_files: list,
+    metadata: dict | None,
+    loop,
+    job: dict,
+    platform=None,
+) -> bool:
+    """Post parent_text, then detail_text into its thread, via a live adapter.
+
+    Returns True only when both messages were posted.  Any failure returns
+    False so the caller falls back to the flat single-send path — the parent
+    may then remain as a stray summary, which is preferable to losing the
+    report body.  When ``metadata`` already carries a thread_id (job targets
+    an existing thread), both messages go to that thread instead of creating
+    a new parent.
+    """
+    from agent.async_utils import safe_schedule_threadsafe
+
+    def _run(coro):
+        future = safe_schedule_threadsafe(coro, loop)
+        if future is None:
+            return None
+        try:
+            return future.result(timeout=60)
+        except TimeoutError:
+            future.cancel()
+            raise
+
+    parent_result = _run(adapter.send(chat_id, parent_text, metadata=metadata))
+    if not parent_result or not getattr(parent_result, "success", False):
+        logger.debug(
+            "Job '%s': threaded parent send failed; falling back to flat",
+            job.get("id", "?"),
+        )
+        return False
+    parent_ts = getattr(parent_result, "message_id", None)
+    if not parent_ts:
+        logger.debug(
+            "Job '%s': threaded parent send returned no message_id; falling back to flat",
+            job.get("id", "?"),
+        )
+        return False
+
+    thread_meta = dict(metadata or {})
+    thread_meta.setdefault("thread_id", parent_ts)
+
+    detail_result = _run(adapter.send(chat_id, detail_text, metadata=thread_meta))
+    if not detail_result or not getattr(detail_result, "success", False):
+        logger.warning(
+            "Job '%s': thread detail send failed (%s); falling back to flat",
+            job.get("id", "?"), getattr(detail_result, "error", "no result"),
+        )
+        return False
+
+    if media_files:
+        _send_media_via_adapter(
+            adapter, chat_id, media_files, thread_meta, loop, job,
+            platform=platform,
+        )
+    return True
+
+
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
@@ -677,9 +794,16 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     from tools.send_message_tool import _send_to_platform
     from gateway.config import load_gateway_config, Platform
 
+    from gateway.platforms.base import BasePlatformAdapter
+
+    # Extract MEDIA: tags first so attachments are forwarded as files, not raw
+    # text, and so the summary/detail split never sees a MEDIA: line.
+    media_files, cleaned_content = BasePlatformAdapter.extract_media(content)
+    media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+
     # Optionally wrap the content with a header/footer so the user knows this
-    # is a cron delivery.  Wrapping is on by default; set cron.wrap_response: false
-    # in config.yaml for clean output.
+    # is a cron delivery.  Wrapping is on by default; set cron.wrap_response:
+    # false in config.yaml for clean output.
     wrap_response = True
     try:
         user_cfg = load_config()
@@ -687,23 +811,34 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     except Exception:
         pass
 
+    task_name = job.get("name", job["id"])
+    job_id = job.get("id", "")
+    manage_note = (
+        f"To stop or manage this job, send me a new message "
+        f"(e.g. \"stop reminder {task_name}\")."
+    )
     if wrap_response:
-        task_name = job.get("name", job["id"])
-        job_id = job.get("id", "")
-        delivery_content = (
+        cleaned_delivery_content = (
             f"Cronjob Response: {task_name}\n"
             f"(job_id: {job_id})\n"
             f"-------------\n\n"
-            f"{content}\n\n"
-            f"To stop or manage this job, send me a new message (e.g. \"stop reminder {task_name}\")."
+            f"{cleaned_content}\n\n"
+            f"{manage_note}"
         )
     else:
-        delivery_content = content
+        cleaned_delivery_content = cleaned_content
 
-    # Extract MEDIA: tags so attachments are forwarded as files, not raw text
-    from gateway.platforms.base import BasePlatformAdapter
-    media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(delivery_content)
-    media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+    # Threaded delivery texts: compact parent, full detail (footer moves to
+    # the thread).  detail_text is None for reports too short to split.
+    summary, detail = _split_summary(cleaned_content)
+    if detail:
+        if wrap_response:
+            parent_text = f"\U0001F4CB *{task_name}* — {summary}"
+            detail_text = f"{detail}\n\n(job_id: {job_id})\n{manage_note}"
+        else:
+            parent_text, detail_text = summary, detail
+    else:
+        parent_text, detail_text = None, None
 
     try:
         config = load_gateway_config()
@@ -761,7 +896,26 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # Send cleaned text (MEDIA tags stripped) — not the raw content
                 text_to_send = cleaned_delivery_content.strip()
                 adapter_ok = True
-                if text_to_send:
+                sent_threaded = False
+                if (
+                    text_to_send
+                    and detail_text
+                    and platform_name.lower() in THREADED_DELIVERY_PLATFORMS
+                    and _threaded_delivery_enabled(job)
+                ):
+                    try:
+                        sent_threaded = _send_threaded_via_adapter(
+                            runtime_adapter, chat_id, parent_text, detail_text,
+                            media_files, send_metadata, loop, job,
+                            platform=platform,
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            "Job '%s': threaded delivery to %s:%s failed (%s); "
+                            "falling back to flat",
+                            job["id"], platform_name, chat_id, e,
+                        )
+                if text_to_send and not sent_threaded:
                     from agent.async_utils import safe_schedule_threadsafe
                     future = safe_schedule_threadsafe(
                         runtime_adapter.send(chat_id, text_to_send, metadata=send_metadata),
@@ -797,7 +951,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                             delivery_errors.append(msg)
 
                 # Send extracted media files as native attachments via the live adapter
-                if adapter_ok and media_files:
+                if adapter_ok and media_files and not sent_threaded:
                     _send_media_via_adapter(
                         runtime_adapter,
                         chat_id,
@@ -809,7 +963,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     )
 
                 if adapter_ok:
-                    logger.info("Job '%s': delivered to %s:%s via live adapter", job["id"], platform_name, chat_id)
+                    logger.info(
+                        "Job '%s': delivered to %s:%s via live adapter%s",
+                        job["id"], platform_name, chat_id,
+                        " (threaded)" if sent_threaded else "",
+                    )
                     delivered = True
             except Exception as e:
                 logger.warning(

--- a/tests/cron/test_threaded_delivery.py
+++ b/tests/cron/test_threaded_delivery.py
@@ -1,0 +1,243 @@
+"""Tests for threaded cron delivery (summary/detail split + threaded send)."""
+
+import asyncio
+from concurrent.futures import Future
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from cron.scheduler import _deliver_result, _split_summary, _threaded_delivery_enabled
+
+
+class TestSplitSummary:
+    def test_tldr_marker_split_and_prefix_stripped(self):
+        content = "TL;DR: Markets flat, two alerts fired.\n\nFull report body\nwith details."
+        summary, detail = _split_summary(content)
+        assert summary == "Markets flat, two alerts fired."
+        assert detail == "Full report body\nwith details."
+
+    def test_marker_variants_case_insensitive(self):
+        for marker in ("TLDR:", "tl;dr:", "Summary:", "SUMMARY:"):
+            summary, detail = _split_summary(f"{marker} Short version.\n\nLong version.")
+            assert summary == "Short version.", marker
+            assert detail == "Long version.", marker
+
+    def test_no_marker_falls_back_to_first_paragraph(self):
+        content = "First paragraph acts as summary.\n\nRest of the report."
+        summary, detail = _split_summary(content)
+        assert summary == "First paragraph acts as summary."
+        assert detail == "Rest of the report."
+
+    def test_marker_not_on_first_line_uses_first_paragraph(self):
+        content = "Preamble line.\nTL;DR: buried marker.\n\nBody."
+        summary, detail = _split_summary(content)
+        assert summary == "Preamble line.\nTL;DR: buried marker."
+        assert detail == "Body."
+
+    def test_short_report_returns_no_detail(self):
+        content = "TL;DR: everything fine."
+        summary, detail = _split_summary(content)
+        assert summary == "TL;DR: everything fine."
+        assert detail is None
+
+    def test_multiline_summary_paragraph(self):
+        content = "TL;DR: line one\ncontinues here.\n\nDetail."
+        summary, detail = _split_summary(content)
+        assert summary == "line one\ncontinues here."
+        assert detail == "Detail."
+
+    def test_empty_and_whitespace_content(self):
+        assert _split_summary("") == ("", None)
+        assert _split_summary("   \n  ") == ("   \n  ", None)
+
+    def test_whitespace_only_detail_is_none(self):
+        summary, detail = _split_summary("TL;DR: brief.\n\n   \n")
+        assert summary == "TL;DR: brief."
+        assert detail is None
+
+    def test_crlf_line_endings(self):
+        content = "TL;DR: crlf summary.\r\n\r\nDetail line.\r\nMore."
+        summary, detail = _split_summary(content)
+        assert summary == "crlf summary."
+        assert detail == "Detail line.\r\nMore."
+
+    def test_bare_marker_first_paragraph_falls_back_flat(self):
+        summary, detail = _split_summary("TL;DR:\n\nActual body here.")
+        assert summary == "TL;DR:\n\nActual body here."
+        assert detail is None
+
+    def test_marker_without_space_after_colon(self):
+        summary, detail = _split_summary("Summary:3 signals fired.\n\nBody.")
+        assert summary == "3 signals fired."
+        assert detail == "Body."
+
+
+class TestThreadedDeliveryEnabled:
+    def test_default_off_when_config_absent(self):
+        with patch("cron.scheduler.load_config", return_value={}):
+            assert _threaded_delivery_enabled({"id": "j"}) is False
+
+    def test_enabled_via_config(self):
+        with patch("cron.scheduler.load_config",
+                   return_value={"cron": {"threaded_delivery": True}}):
+            assert _threaded_delivery_enabled({"id": "j"}) is True
+
+    def test_per_job_opt_out_beats_config(self):
+        with patch("cron.scheduler.load_config",
+                   return_value={"cron": {"threaded_delivery": True}}):
+            assert _threaded_delivery_enabled({"id": "j", "thread": False}) is False
+
+    def test_config_load_failure_means_off(self):
+        with patch("cron.scheduler.load_config", side_effect=RuntimeError("boom")):
+            assert _threaded_delivery_enabled({"id": "j"}) is False
+
+
+THREAD_CFG = {"cron": {"threaded_delivery": True}}
+
+
+def _fake_run_coro(coro, _loop):
+    future = Future()
+    future.set_result(asyncio.run(coro))
+    return future
+
+
+def _mk_env(platform_name="slack"):
+    """Gateway config + loop mocks for a single enabled platform."""
+    from gateway.config import Platform
+    pconfig = MagicMock()
+    pconfig.enabled = True
+    mock_cfg = MagicMock()
+    mock_cfg.platforms = {Platform(platform_name): pconfig}
+    loop = MagicMock()
+    loop.is_running.return_value = True
+    return Platform(platform_name), mock_cfg, loop
+
+
+def _mk_job(**extra):
+    job = {
+        "id": "tj-1",
+        "name": "daily-scan",
+        "deliver": "origin",
+        "origin": {"platform": "slack", "chat_id": "C123"},
+    }
+    job.update(extra)
+    return job
+
+
+REPORT = "TL;DR: All clear today.\n\nLong detail line 1.\nLong detail line 2."
+
+
+class TestThreadedDelivery:
+    def _run(self, adapter, job, content, cfg=THREAD_CFG, platform_name="slack"):
+        platform, mock_cfg, loop = _mk_env(platform_name)
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value=cfg), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=_fake_run_coro):
+            return _deliver_result(job, content,
+                                   adapters={platform: adapter}, loop=loop)
+
+    def test_threaded_sequence_parent_then_thread_detail(self):
+        adapter = AsyncMock()
+        adapter.send.side_effect = [
+            MagicMock(success=True, message_id="1718000.111", raw_response={}),
+            MagicMock(success=True, message_id="1718000.222", raw_response={}),
+        ]
+        err = self._run(adapter, _mk_job(), REPORT)
+        assert err is None
+        assert adapter.send.call_count == 2
+        parent_call, detail_call = adapter.send.call_args_list
+        parent_text = parent_call[0][1]
+        assert "All clear today." in parent_text
+        assert "daily-scan" in parent_text
+        assert "(job_id:" not in parent_text          # slim parent
+        assert "To stop or manage" not in parent_text
+        detail_text = detail_call[0][1]
+        assert "Long detail line 1." in detail_text
+        assert "(job_id: tj-1)" in detail_text         # footer moved to thread
+        assert detail_call[1]["metadata"]["thread_id"] == "1718000.111"
+
+    def test_parent_send_without_ts_falls_back_flat(self):
+        adapter = AsyncMock()
+        adapter.send.side_effect = [
+            MagicMock(success=True, message_id=None, raw_response={}),  # threaded attempt
+            MagicMock(success=True, message_id="1", raw_response={}),   # flat fallback
+        ]
+        err = self._run(adapter, _mk_job(), REPORT)
+        assert err is None
+        assert adapter.send.call_count == 2
+        flat_text = adapter.send.call_args_list[1][0][1]
+        assert "All clear today." in flat_text
+        assert "Long detail line 1." in flat_text      # full report, one message
+
+    def test_detail_send_failure_falls_back_flat(self):
+        adapter = AsyncMock()
+        adapter.send.side_effect = [
+            MagicMock(success=True, message_id="1718000.111", raw_response={}),
+            MagicMock(success=False, message_id=None, error="boom", raw_response={}),
+            MagicMock(success=True, message_id="2", raw_response={}),   # flat fallback
+        ]
+        err = self._run(adapter, _mk_job(), REPORT)
+        assert err is None
+        assert adapter.send.call_count == 3
+        flat_text = adapter.send.call_args_list[2][0][1]
+        assert "Long detail line 1." in flat_text      # report never lost
+
+    def test_job_opt_out_posts_flat(self):
+        adapter = AsyncMock()
+        adapter.send.return_value = MagicMock(success=True, message_id="1", raw_response={})
+        self._run(adapter, _mk_job(thread=False), REPORT)
+        adapter.send.assert_called_once()
+        text = adapter.send.call_args[0][1]
+        assert "Cronjob Response: daily-scan" in text   # classic wrapper intact
+
+    def test_config_off_posts_flat(self):
+        adapter = AsyncMock()
+        adapter.send.return_value = MagicMock(success=True, message_id="1", raw_response={})
+        self._run(adapter, _mk_job(), REPORT, cfg={"cron": {}})
+        adapter.send.assert_called_once()
+
+    def test_short_report_posts_flat(self):
+        adapter = AsyncMock()
+        adapter.send.return_value = MagicMock(success=True, message_id="1", raw_response={})
+        self._run(adapter, _mk_job(), "TL;DR: nothing else to say.")
+        adapter.send.assert_called_once()
+
+    def test_telegram_target_unaffected(self):
+        adapter = AsyncMock()
+        adapter.send.return_value = MagicMock(success=True, message_id="1", raw_response={})
+        job = _mk_job(origin={"platform": "telegram", "chat_id": "777"})
+        self._run(adapter, job, REPORT, platform_name="telegram")
+        adapter.send.assert_called_once()
+        assert "Cronjob Response: daily-scan" in adapter.send.call_args[0][1]
+
+    def test_existing_origin_thread_id_kept_for_both_sends(self):
+        adapter = AsyncMock()
+        adapter.send.side_effect = [
+            MagicMock(success=True, message_id="1718000.111", raw_response={}),
+            MagicMock(success=True, message_id="1718000.222", raw_response={}),
+        ]
+        job = _mk_job(origin={"platform": "slack", "chat_id": "C123",
+                              "thread_id": "1690.555"})
+        self._run(adapter, job, REPORT)
+        assert adapter.send.call_count == 2
+        parent_meta = adapter.send.call_args_list[0][1]["metadata"]
+        detail_meta = adapter.send.call_args_list[1][1]["metadata"]
+        assert parent_meta["thread_id"] == "1690.555"
+        assert detail_meta["thread_id"] == "1690.555"   # not the parent ts
+
+    def test_media_sent_with_thread_metadata(self, tmp_path, monkeypatch):
+        media = tmp_path / "chart.png"
+        media.write_bytes(b"\x89PNG fake")
+        monkeypatch.setattr("gateway.platforms.base.MEDIA_DELIVERY_SAFE_ROOTS",
+                            (tmp_path,))
+        adapter = AsyncMock()
+        adapter.send.side_effect = [
+            MagicMock(success=True, message_id="1718000.111", raw_response={}),
+            MagicMock(success=True, message_id="1718000.222", raw_response={}),
+        ]
+        adapter.send_image_file.return_value = MagicMock(success=True)
+        content = REPORT + f"\nMEDIA:{media.resolve()}"
+        self._run(adapter, _mk_job(), content)
+        adapter.send_image_file.assert_called_once()
+        meta = adapter.send_image_file.call_args[1]["metadata"]
+        assert meta["thread_id"] == "1718000.111"
+        for call in adapter.send.call_args_list:       # MEDIA tag never leaks
+            assert "MEDIA:" not in call[0][1]


### PR DESCRIPTION
## What does this PR do?

Cron reports currently post to channels as a flat burst — the whole report is sent in one `send()` call and the platform adapter splits it into multiple top-level messages. This adds an opt-in threaded delivery mode for platforms that support it (Slack initially):

- `cron.threaded_delivery: true` (config, default **false**) posts a compact parent message — the report's `TL;DR:`/`TLDR:`/`Summary:` first paragraph (marker stripped), or the first paragraph as fallback — and the full report as replies in its thread.
- Per-job opt-out with `"thread": false` on any job definition.
- Reports too short to split, non-Slack platforms, the standalone delivery path, and any threading failure all use the existing flat path unchanged. Threading is strictly best-effort: a report is never lost to it.
- The cron wrapper's job-id line and management footer move into the thread detail, keeping the channel-visible parent compact.

## Related Issue

Fixes #

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `cron/scheduler.py`: add `_split_summary()`, `_threaded_delivery_enabled()`, `_send_threaded_via_adapter()`; wire threaded path into `_deliver_result()` behind platform + config gate
- `tests/cron/test_threaded_delivery.py`: 24 new tests covering split semantics, config gate, threaded sequence, fallbacks, media-in-thread, origin-thread passthrough, and non-Slack unaffected

## How to Test

1. Add `cron: threaded_delivery: true` to `~/.hermes/config.yaml`
2. Run a cron job that delivers to a Slack channel; confirm the channel shows a compact summary parent with the full report in its thread
3. Add `"thread": false` to a specific job; confirm that job delivers flat even with the global flag on
4. Run `pytest tests/cron/test_threaded_delivery.py tests/cron/test_scheduler.py -q` — 158 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.0

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (`cron.wrap_response` is also undocumented in the example; following that precedent)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — threading is Slack-only; no OS-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Ran on a 4-profile deployment since 2026-06-11. Representative log line:

```
Job 'oil-morning-brief': delivered to slack:C08XXXXXXXX via live adapter (threaded)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)