### PR TITLE
fix(desktop): remote-mode chat file links download via the fs bridge instead of dead file:// URLs

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -16,6 +16,7 @@ import { normalizeExternalUrl, openExternalLink, PrettyLink } from '@/lib/extern
 import { createMemoizedMathPlugin } from '@/lib/katex-memo'
 import { preprocessMarkdown } from '@/lib/markdown-preprocess'
 import {
+  downloadGatewayMediaFile,
   filePathFromMediaPath,
   gatewayMediaDataUrl,
   isRemoteGateway,
@@ -66,21 +67,55 @@ async function mediaSrc(path: string): Promise<string> {
   return window.hermesDesktop.readFileDataUrl(filePathFromMediaPath(path))
 }
 
-function OpenMediaButton({ kind, path }: { kind: 'audio' | 'video'; path: string }) {
+// Click-to-open for media paths. Local mode hands the path to the OS via a
+// file:// URL. In remote-gateway mode that URL would name the gateway's path
+// on *this* machine — a silent dead end — so the file is fetched over the
+// authenticated REST bridge as a download instead, with an error state when
+// the gateway refuses the read.
+function useOpenMediaFile(path: string) {
+  const [openFailed, setOpenFailed] = useState(false)
+
+  const open = () => {
+    if (window.hermesDesktop && isRemoteGateway()) {
+      setOpenFailed(false)
+      void downloadGatewayMediaFile(path).catch(() => setOpenFailed(true))
+    } else {
+      openExternalLink(mediaExternalUrl(path))
+    }
+  }
+
+  return { open, openFailed }
+}
+
+function OpenMediaFailedNote({ name }: { name: string }) {
   return (
-    <button
-      className="mt-2 bg-transparent text-xs font-medium text-muted-foreground underline underline-offset-4 decoration-current/20 hover:text-foreground"
-      onClick={() => void window.hermesDesktop?.openExternal(mediaExternalUrl(path))}
-      type="button"
-    >
-      Open {kind} file
-    </button>
+    <span className="mt-1 block text-xs text-muted-foreground">
+      Couldn&apos;t fetch {name} from the gateway (missing, unreadable, or too large).
+    </span>
+  )
+}
+
+function OpenMediaButton({ kind, path }: { kind: 'audio' | 'video'; path: string }) {
+  const { open, openFailed } = useOpenMediaFile(path)
+
+  return (
+    <span className="block">
+      <button
+        className="mt-2 bg-transparent text-xs font-medium text-muted-foreground underline underline-offset-4 decoration-current/20 hover:text-foreground"
+        onClick={open}
+        type="button"
+      >
+        Open {kind} file
+      </button>
+      {openFailed && <OpenMediaFailedNote name={mediaName(path)} />}
+    </span>
   )
 }
 
 function MediaAttachment({ path }: { path: string }) {
   const [src, setSrc] = useState('')
   const [failed, setFailed] = useState(false)
+  const { open, openFailed } = useOpenMediaFile(path)
   const kind = mediaKind(path)
   const name = mediaName(path)
 
@@ -151,16 +186,19 @@ function MediaAttachment({ path }: { path: string }) {
   }
 
   return (
-    <a
-      className="font-semibold text-foreground underline underline-offset-4 decoration-current/20 wrap-anywhere"
-      href="#"
-      onClick={event => {
-        event.preventDefault()
-        openExternalLink(mediaExternalUrl(path))
-      }}
-    >
-      {failed ? `Open ${name}` : `Loading ${name}...`}
-    </a>
+    <span className="wrap-anywhere">
+      <a
+        className="font-semibold text-foreground underline underline-offset-4 decoration-current/20 wrap-anywhere"
+        href="#"
+        onClick={event => {
+          event.preventDefault()
+          open()
+        }}
+      >
+        {failed ? `Open ${name}` : `Loading ${name}...`}
+      </a>
+      {openFailed && <OpenMediaFailedNote name={name} />}
+    </span>
   )
 }
 

--- a/apps/desktop/src/lib/media.test.ts
+++ b/apps/desktop/src/lib/media.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $connection } from '@/store/session'
+
+import { downloadGatewayMediaFile } from './media'
+
+const api = vi.fn(async ({ path }: { path: string }) => {
+  if (path.startsWith('/api/fs/read-data-url?')) {
+    return { dataUrl: 'data:application/pdf;base64,cGRm' }
+  }
+
+  throw new Error(`unexpected path ${path}`)
+})
+
+describe('downloadGatewayMediaFile', () => {
+  let clickSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    $connection.set({ mode: 'remote' } as never)
+    vi.stubGlobal('window', { hermesDesktop: { api }, setTimeout: vi.fn() })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ blob: async () => new Blob(['pdf'], { type: 'application/pdf' }) }))
+    )
+    URL.createObjectURL = vi.fn(() => 'blob:media-test')
+    URL.revokeObjectURL = vi.fn()
+    clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+    clickSpy.mockRestore()
+    $connection.set(null)
+  })
+
+  it('fetches the file over /api/fs/read-data-url and triggers a download', async () => {
+    await downloadGatewayMediaFile('/home/user/.hermes/cache/report.pdf')
+
+    expect(api).toHaveBeenCalledWith({
+      path: `/api/fs/read-data-url?path=${encodeURIComponent('/home/user/.hermes/cache/report.pdf')}`
+    })
+    expect(clickSpy).toHaveBeenCalledOnce()
+  })
+
+  it('strips a file:// prefix before asking the gateway', async () => {
+    await downloadGatewayMediaFile('file:///home/user/.hermes/cache/report.pdf')
+
+    expect(api).toHaveBeenCalledWith({
+      path: `/api/fs/read-data-url?path=${encodeURIComponent('/home/user/.hermes/cache/report.pdf')}`
+    })
+  })
+
+  it('rejects when the gateway refuses the read', async () => {
+    api.mockRejectedValueOnce(new Error('413 File too large'))
+
+    await expect(downloadGatewayMediaFile('/home/user/huge.pdf')).rejects.toThrow('413')
+    expect(clickSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects when the gateway returns no data', async () => {
+    api.mockResolvedValueOnce({ dataUrl: '' })
+
+    await expect(downloadGatewayMediaFile('/home/user/empty.pdf')).rejects.toThrow('no file data')
+    expect(clickSpy).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -1,3 +1,4 @@
+import { readDesktopFileDataUrl } from '@/lib/desktop-fs'
 import { $connection } from '@/store/session'
 
 export type MediaKind = 'audio' | 'image' | 'video' | 'file'
@@ -109,6 +110,31 @@ export async function gatewayMediaDataUrl(path: string): Promise<string> {
   })
 
   return result.data_url
+}
+
+// Fetch a gateway-side file over the authenticated REST bridge and hand it to
+// the user as a browser download. Remote-mode replacement for the `file://`
+// fallback link: that URL names the gateway's absolute path on the *client*
+// machine, so clicking it silently does nothing. Unlike /api/media this path
+// also serves non-images (PDFs etc.) — /api/fs/read-data-url is the same
+// endpoint the remote file browser preview reads through, with its size cap.
+// Rejects when the gateway refuses the read so callers can show a real error.
+export async function downloadGatewayMediaFile(path: string): Promise<void> {
+  const dataUrl = await readDesktopFileDataUrl(filePathFromMediaPath(path))
+
+  if (!dataUrl) {
+    throw new Error('Gateway returned no file data')
+  }
+
+  const blobUrl = URL.createObjectURL(await (await fetch(dataUrl)).blob())
+  const anchor = document.createElement('a')
+  anchor.href = blobUrl
+  anchor.download = mediaName(path)
+  anchor.rel = 'noopener noreferrer'
+  document.body.appendChild(anchor)
+  anchor.click()
+  anchor.remove()
+  window.setTimeout(() => URL.revokeObjectURL(blobUrl), 30_000)
 }
 
 export function mediaDisplayLabel(path: string): string {


### PR DESCRIPTION
Fixes #44523

## Problem

In remote-gateway mode, the chat's file-link fallback (`MediaAttachment`'s final branch in `apps/desktop/src/components/assistant-ui/markdown-text.tsx`) renders an anchor whose click handler opens `mediaExternalUrl(path)` — a `file://` URL built from the **gateway's** absolute path. On the client machine that path doesn't exist, so the click silently does nothing.

Two inputs funnel into this dead end:

1. **Images outside the `/api/media` roots** — the endpoint 403s (intentionally; the fence is unchanged here), inline render fails, and the fallback anchor is the only affordance left.
2. **Non-image files (e.g. PDFs), even inside the media roots** — `/api/media` is image-extension-allowlisted (415), so there is no remote display path for them at all.

The audio/video `OpenMediaButton` shown when playback fails had the same dead `file://` handler.

## Fix

In remote mode, route the fallback through the existing authenticated **`GET /api/fs/read-data-url`** endpoint (added with the remote file browser in #44326 — the Files-panel preview already reads these same files over it), and hand the bytes to the user as a browser download (same fetch→blob→anchor pattern as `zoomable-image.tsx` / `session-export.ts`). The endpoint's existing size cap is honored: when the gateway refuses the read (413/403/404), the UI now shows an explicit "couldn't fetch from the gateway" note instead of silently no-opping.

Local mode is unchanged — `file://` URLs are correct there and open with the OS default app.

The `/api/media` roots fence is **not** widened (per the issue: that behavior is deliberate, and #42778 tracks configurability). No server-side changes at all.

## Changes

- `apps/desktop/src/lib/media.ts`: new `downloadGatewayMediaFile()` — fetches via `readDesktopFileDataUrl` (the `/api/fs/read-data-url` facade) and triggers a client-side download.
- `apps/desktop/src/components/assistant-ui/markdown-text.tsx`: shared `useOpenMediaFile` hook branches remote→download / local→`file://`; used by both the fallback anchor and `OpenMediaButton`; renders a failure note when the fetch fails.
- `apps/desktop/src/lib/media.test.ts`: new unit tests (download path, `file://` prefix stripping, gateway-refusal and empty-response rejection).

## Testing

- `npx vitest run --environment jsdom src/lib/media.test.ts src/lib/desktop-fs.test.ts src/components/assistant-ui/markdown-text.test.ts` — 23/23 pass.
- `tsc -p . --noEmit` and `eslint` on changed files — clean.
- Full desktop vitest suite: the only failures (pane-shell width override, model-settings, streaming reasoning card, toolset-config, gateway-boot reconnect) fail identically on unmodified `main` in this environment — pre-existing, unrelated.
