### PR TITLE
fix(discord): retry standalone send on 429 rate-limit instead of dropping chunks

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -6310,6 +6310,27 @@ def _standalone_sanitize_error(text) -> str:
     )
 
 
+# Maximum number of attempts for 429 retries in the standalone send path.
+_STANDALONE_MAX_RETRIES = 3
+
+
+def _standalone_parse_retry_after(body_text: str) -> Optional[float]:
+    """Extract ``retry_after`` from a Discord 429 JSON response body.
+
+    Returns the delay in seconds (floored at 0.5, capped at 10), or ``None``
+    if the body doesn't contain a parseable ``retry_after`` field.
+    """
+    try:
+        import json as _json
+        data = _json.loads(body_text)
+        raw = data.get("retry_after")
+        if raw is not None:
+            return max(0.5, min(10.0, float(raw)))
+    except Exception:
+        pass
+    return None
+
+
 async def _standalone_send(
     pconfig,
     chat_id: str,
@@ -6470,12 +6491,26 @@ async def _standalone_send(
 
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30), **_sess_kw) as session:
             # Send text message (skip if empty and media is present)
+            # Retries on 429 rate-limit using Discord's retry_after field.
             if message.strip() or not media_files:
-                async with session.post(url, headers=json_headers, json={"content": message}, **_req_kw) as resp:
-                    if resp.status not in {200, 201}:
-                        body = await resp.text()
-                        return {"error": f"Discord API error ({resp.status}): {body}"}
-                    last_data = await resp.json()
+                for _attempt in range(_STANDALONE_MAX_RETRIES):
+                    async with session.post(url, headers=json_headers, json={"content": message}, **_req_kw) as resp:
+                        if resp.status == 429:
+                            body = await resp.text()
+                            delay = _standalone_parse_retry_after(body)
+                            if delay is not None and _attempt < _STANDALONE_MAX_RETRIES - 1:
+                                logger.warning(
+                                    "Discord standalone send rate-limited (attempt %d/%d), retrying in %.1fs",
+                                    _attempt + 1, _STANDALONE_MAX_RETRIES, delay,
+                                )
+                                await asyncio.sleep(delay)
+                                continue
+                            return {"error": f"Discord API error (429): {body}"}
+                        if resp.status not in {200, 201}:
+                            body = await resp.text()
+                            return {"error": f"Discord API error ({resp.status}): {body}"}
+                        last_data = await resp.json()
+                        break
 
             # Send each media file as a separate multipart upload
             for media_path, _is_voice in media_files:
@@ -6485,18 +6520,34 @@ async def _standalone_send(
                     warnings.append(warning)
                     continue
                 try:
-                    form = aiohttp.FormData()
                     filename = os.path.basename(media_path)
-                    with open(media_path, "rb") as f:
-                        form.add_field("files[0]", f, filename=filename)
-                        async with session.post(url, headers=auth_headers, data=form, **_req_kw) as resp:
-                            if resp.status not in {200, 201}:
-                                body = await resp.text()
-                                warning = _standalone_sanitize_error(f"Failed to send media {media_path}: Discord API error ({resp.status}): {body}")
-                                logger.error(warning)
-                                warnings.append(warning)
-                                continue
-                            last_data = await resp.json()
+                    for _m_attempt in range(_STANDALONE_MAX_RETRIES):
+                        form = aiohttp.FormData()
+                        with open(media_path, "rb") as f:
+                            form.add_field("files[0]", f, filename=filename)
+                            async with session.post(url, headers=auth_headers, data=form, **_req_kw) as resp:
+                                if resp.status == 429:
+                                    body = await resp.text()
+                                    delay = _standalone_parse_retry_after(body)
+                                    if delay is not None and _m_attempt < _STANDALONE_MAX_RETRIES - 1:
+                                        logger.warning(
+                                            "Discord media upload rate-limited (attempt %d/%d), retrying in %.1fs",
+                                            _m_attempt + 1, _STANDALONE_MAX_RETRIES, delay,
+                                        )
+                                        await asyncio.sleep(delay)
+                                        continue
+                                    warning = _standalone_sanitize_error(f"Failed to send media {media_path}: Discord API error (429): {body}")
+                                    logger.error(warning)
+                                    warnings.append(warning)
+                                    break
+                                if resp.status not in {200, 201}:
+                                    body = await resp.text()
+                                    warning = _standalone_sanitize_error(f"Failed to send media {media_path}: Discord API error ({resp.status}): {body}")
+                                    logger.error(warning)
+                                    warnings.append(warning)
+                                    break
+                                last_data = await resp.json()
+                                break
                 except Exception as e:
                     warning = _standalone_sanitize_error(f"Failed to send media {media_path}: {e}")
                     logger.error(warning)

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -1414,6 +1414,116 @@ class TestSendDiscordThreadId:
         assert "403" in result["error"]
 
 
+class TestStandaloneParseRetryAfter:
+    """_standalone_parse_retry_after extracts retry_after from 429 bodies."""
+
+    def test_parses_retry_after_float(self):
+        from plugins.platforms.discord.adapter import _standalone_parse_retry_after
+        body = '{"message": "You are being rate limited.", "retry_after": 0.3}'
+        assert _standalone_parse_retry_after(body) == 0.5  # floored at 0.5
+
+    def test_parses_retry_after_large_value(self):
+        from plugins.platforms.discord.adapter import _standalone_parse_retry_after
+        body = '{"retry_after": 15.0}'
+        assert _standalone_parse_retry_after(body) == 10.0  # capped at 10
+
+    def test_returns_none_on_missing_field(self):
+        from plugins.platforms.discord.adapter import _standalone_parse_retry_after
+        body = '{"message": "You are being rate limited."}'
+        assert _standalone_parse_retry_after(body) is None
+
+    def test_returns_none_on_invalid_json(self):
+        from plugins.platforms.discord.adapter import _standalone_parse_retry_after
+        assert _standalone_parse_retry_after("not json") is None
+
+    def test_returns_none_on_non_numeric(self):
+        from plugins.platforms.discord.adapter import _standalone_parse_retry_after
+        body = '{"retry_after": "abc"}'
+        assert _standalone_parse_retry_after(body) is None
+
+
+class TestSendDiscord429Retry:
+    """_standalone_send retries on 429 rate-limit responses."""
+
+    @staticmethod
+    def _build_mock_sequence(responses):
+        """Build a mock aiohttp session that returns different responses per call.
+
+        ``responses`` is a list of (status, json_data, text_body) tuples.
+        """
+        mock_session = MagicMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+
+        call_count = 0
+
+        def _make_resp(status, data, text_body):
+            resp = MagicMock()
+            resp.status = status
+            resp.json = AsyncMock(return_value=data)
+            resp.text = AsyncMock(return_value=text_body)
+            resp.__aenter__ = AsyncMock(return_value=resp)
+            resp.__aexit__ = AsyncMock(return_value=None)
+            return resp
+
+        def _post(*args, **kwargs):
+            nonlocal call_count
+            idx = min(call_count, len(responses) - 1)
+            call_count += 1
+            s, d, t = responses[idx]
+            return _make_resp(s, d, t)
+
+        mock_session.post = MagicMock(side_effect=_post)
+        return mock_session
+
+    def test_429_then_success_retries_and_succeeds(self):
+        """A 429 with retry_after followed by 200 should succeed."""
+        mock_session = self._build_mock_sequence([
+            (429, {"retry_after": 0.5}, '{"retry_after": 0.5}'),
+            (200, {"id": "msg123"}, '{}'),
+        ])
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            result = asyncio.run(_send_discord("tok", "111", "hello"))
+        assert result["success"] is True
+        assert result["message_id"] == "msg123"
+        assert mock_session.post.call_count == 2
+
+    def test_429_exhausted_retries_returns_error(self):
+        """Three consecutive 429s should return an error."""
+        mock_session = self._build_mock_sequence([
+            (429, {"retry_after": 0.5}, '{"retry_after": 0.5}'),
+            (429, {"retry_after": 0.5}, '{"retry_after": 0.5}'),
+            (429, {"retry_after": 0.5}, '{"retry_after": 0.5}'),
+        ])
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            result = asyncio.run(_send_discord("tok", "111", "hello"))
+        assert "error" in result
+        assert "429" in result["error"]
+        assert mock_session.post.call_count == 3
+
+    def test_429_no_retry_after_returns_error_immediately(self):
+        """429 without parseable retry_after should return error on first attempt."""
+        mock_session = self._build_mock_sequence([
+            (429, {"message": "rate limited"}, '{"message": "rate limited"}'),
+        ])
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            result = asyncio.run(_send_discord("tok", "111", "hello"))
+        assert "error" in result
+        assert "429" in result["error"]
+        assert mock_session.post.call_count == 1
+
+    def test_non_429_error_returns_immediately(self):
+        """Non-429 errors (e.g. 403) should not retry."""
+        mock_session = self._build_mock_sequence([
+            (403, {"message": "Forbidden"}, '{"message": "Forbidden"}'),
+        ])
+        with patch("aiohttp.ClientSession", return_value=mock_session):
+            result = asyncio.run(_send_discord("tok", "111", "hello"))
+        assert "error" in result
+        assert "403" in result["error"]
+        assert mock_session.post.call_count == 1
+
+
 class TestSendToPlatformDiscordThread:
     """_send_to_platform passes thread_id through to _send_discord."""
 


### PR DESCRIPTION
## What does this PR do?

Adds 429 rate-limit retry logic to the standalone Discord send path (`_standalone_send`), preventing multi-chunk messages from being silently truncated when a rate limit is hit mid-delivery.

## Related Issue

Fixes #44468

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/discord/adapter.py`: Add `_standalone_parse_retry_after()` helper to extract `retry_after` from Discord 429 JSON responses. Wrap both the text POST and per-media POST in `_standalone_send` with a retry loop (3 attempts, honouring `retry_after` with 0.5s floor and 10s cap).
- `tests/tools/test_send_message_tool.py`: Add `TestStandaloneParseRetryAfter` (5 unit tests for the parser) and `TestSendDiscord429Retry` (4 integration tests covering retry-on-429, exhausted retries, missing `retry_after`, and non-429 error paths).

## How to Test

1. Run `pytest tests/tools/test_send_message_tool.py::TestStandaloneParseRetryAfter tests/tools/test_send_message_tool.py::TestSendDiscord429Retry -v` — all 9 tests should pass.
2. Run `pytest tests/tools/test_send_message_tool.py -v` — all 142 tests should pass (no regressions).
3. Run `pytest tests/e2e/test_discord_adapter.py -v` — all 6 tests should pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `plugins/platforms/discord/adapter.py::_standalone_send` (callers: 1 via `standalone_sender_fn` registry entry, flows: `send_message_tool._send_to_platform` → `entry.standalone_sender_fn`)
- Blast radius: LOW — changes are confined to the standalone send path; the live adapter path is unaffected
- Related patterns: Mirrors the existing retry pattern in `_send_telegram_message_with_retry()` and the adapter's `_extract_discord_retry_after()` / `_is_discord_rate_limit()` helpers
