### PR TITLE
fix: dashboard PTY WebSocket code 1006 异常断开

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -9697,103 +9697,121 @@ async def pty_ws(ws: WebSocket) -> None:
     await ws.accept()
     _log.info("pty accepted peer=%s mode=%s cred=%s", peer, mode, cred)
 
-    # On native Windows, the POSIX PTY bridge can't be imported.  Tell the
-    # client and close cleanly rather than pretending the feature works.
-    if not _PTY_BRIDGE_AVAILABLE:
-        await ws.send_text(
-            "\r\n\x1b[31mChat unavailable: the embedded terminal requires a "
-            "POSIX PTY, which native Windows Python doesn't provide.\x1b[0m\r\n"
-            "\x1b[33mInstall Hermes inside WSL2 to use the dashboard's /chat "
-            "tab — the rest of the dashboard works here.\x1b[0m\r\n"
-        )
-        await ws.close(code=1011)
-        return
+    # Yield to the event loop so uvicorn flushes the HTTP 101 Switching
+    # Protocols response before we block it with the synchronous
+    # _resolve_chat_argv() call (which runs subprocess / npm install).
+    await asyncio.sleep(0)
 
-    # --- spawn PTY ------------------------------------------------------
-    resume = ws.query_params.get("resume") or None
-    profile = ws.query_params.get("profile") or None
-    channel = _channel_or_close_code(ws)
-    sidecar_url = _build_sidecar_url(channel) if channel else None
-
+    # Wrap the rest in a top-level try so any unhandled exception (e.g. in
+    # query-param access, URL building, or PTY spawn) is logged and closes
+    # the WebSocket cleanly instead of dropping the connection abnormally,
+    # which the browser would report as a cryptic code-1006 error.
     try:
-        argv, cwd, env = _resolve_chat_argv(
-            resume=resume, sidecar_url=sidecar_url, profile=profile
-        )
-    except HTTPException as exc:
-        # Unknown/invalid profile from _resolve_profile_dir.
-        await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc.detail}\x1b[0m\r\n")
-        await ws.close(code=1011)
-        return
-    except SystemExit as exc:
-        # _make_tui_argv calls sys.exit(1) when node/npm is missing.
-        await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
-        await ws.close(code=1011)
-        return
-
-
-    try:
-        bridge = PtyBridge.spawn(argv, cwd=cwd, env=env)
-    except PtyUnavailableError as exc:
-        await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
-        await ws.close(code=1011)
-        return
-    except (FileNotFoundError, OSError) as exc:
-        await ws.send_text(f"\r\n\x1b[31mChat failed to start: {exc}\x1b[0m\r\n")
-        await ws.close(code=1011)
-        return
-
-    loop = asyncio.get_running_loop()
-
-    # --- reader task: PTY master → WebSocket ----------------------------
-    async def pump_pty_to_ws() -> None:
-        while True:
-            chunk = await loop.run_in_executor(
-                None, bridge.read, _PTY_READ_CHUNK_TIMEOUT
+        # On native Windows, the POSIX PTY bridge can't be imported.  Tell the
+        # client and close cleanly rather than pretending the feature works.
+        if not _PTY_BRIDGE_AVAILABLE:
+            await ws.send_text(
+                "\r\n\x1b[31mChat unavailable: the embedded terminal requires a "
+                "POSIX PTY, which native Windows Python doesn't provide.\x1b[0m\r\n"
+                "\x1b[33mInstall Hermes inside WSL2 to use the dashboard's /chat "
+                "tab — the rest of the dashboard works here.\x1b[0m\r\n"
             )
-            if chunk is None:  # EOF
-                return
-            if not chunk:  # no data this tick; yield control and retry
-                await asyncio.sleep(0)
-                continue
-            try:
-                await ws.send_bytes(chunk)
-            except Exception:
-                return
+            await ws.close(code=1011)
+            return
 
-    reader_task = asyncio.create_task(pump_pty_to_ws())
+        # --- spawn PTY ------------------------------------------------------
+        resume = ws.query_params.get("resume") or None
+        profile = ws.query_params.get("profile") or None
+        channel = _channel_or_close_code(ws)
+        sidecar_url = _build_sidecar_url(channel) if channel else None
 
-    # --- writer loop: WebSocket → PTY master ----------------------------
-    try:
-        while True:
-            msg = await ws.receive()
-            msg_type = msg.get("type")
-            if msg_type == "websocket.disconnect":
-                break
-            raw = msg.get("bytes")
-            if raw is None:
-                text = msg.get("text")
-                raw = text.encode("utf-8") if isinstance(text, str) else b""
-            if not raw:
-                continue
+        _log.info("pty: resolving chat argv resume=%s profile=%s channel=%s",
+                   resume, profile, channel)
 
-            # Resize escape is consumed locally, never written to the PTY.
-            match = _RESIZE_RE.match(raw)
-            if match and match.end() == len(raw):
-                cols = int(match.group(1))
-                rows = int(match.group(2))
-                bridge.resize(cols=cols, rows=rows)
-                continue
-
-            bridge.write(raw)
-    except WebSocketDisconnect:
-        pass
-    finally:
-        reader_task.cancel()
         try:
-            await reader_task
-        except (asyncio.CancelledError, Exception):
+            argv, cwd, env = _resolve_chat_argv(
+                resume=resume, sidecar_url=sidecar_url, profile=profile
+            )
+        except HTTPException as exc:
+            # Unknown/invalid profile from _resolve_profile_dir.
+            await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc.detail}\x1b[0m\r\n")
+            await ws.close(code=1011)
+            return
+        except SystemExit as exc:
+            # _make_tui_argv calls sys.exit(1) when node/npm is missing.
+            await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
+            await ws.close(code=1011)
+            return
+
+        try:
+            bridge = PtyBridge.spawn(argv, cwd=cwd, env=env)
+        except PtyUnavailableError as exc:
+            await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
+            await ws.close(code=1011)
+            return
+        except (FileNotFoundError, OSError) as exc:
+            await ws.send_text(f"\r\n\x1b[31mChat failed to start: {exc}\x1b[0m\r\n")
+            await ws.close(code=1011)
+            return
+
+        loop = asyncio.get_running_loop()
+
+        # --- reader task: PTY master → WebSocket ----------------------------
+        async def pump_pty_to_ws() -> None:
+            while True:
+                chunk = await loop.run_in_executor(
+                    None, bridge.read, _PTY_READ_CHUNK_TIMEOUT
+                )
+                if chunk is None:  # EOF
+                    return
+                if not chunk:  # no data this tick; yield control and retry
+                    await asyncio.sleep(0)
+                    continue
+                try:
+                    await ws.send_bytes(chunk)
+                except Exception:
+                    return
+
+        reader_task = asyncio.create_task(pump_pty_to_ws())
+
+        # --- writer loop: WebSocket → PTY master ----------------------------
+        try:
+            while True:
+                msg = await ws.receive()
+                msg_type = msg.get("type")
+                if msg_type == "websocket.disconnect":
+                    break
+                raw = msg.get("bytes")
+                if raw is None:
+                    text = msg.get("text")
+                    raw = text.encode("utf-8") if isinstance(text, str) else b""
+                if not raw:
+                    continue
+
+                # Resize escape is consumed locally, never written to the PTY.
+                match = _RESIZE_RE.match(raw)
+                if match and match.end() == len(raw):
+                    cols = int(match.group(1))
+                    rows = int(match.group(2))
+                    bridge.resize(cols=cols, rows=rows)
+                    continue
+
+                bridge.write(raw)
+        except WebSocketDisconnect:
             pass
-        bridge.close()
+        finally:
+            reader_task.cancel()
+            try:
+                await reader_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            bridge.close()
+    except Exception:
+        _log.exception("pty ws handler crashed: unhandled exception")
+        try:
+            await ws.close(code=1011)
+        except Exception:
+            pass
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 修复：dashboard "对话" 标签页 WebSocket code 1006 异常断开

**文件：** `hermes_cli/web_server.py`

### 问题

在 dashboard 中点击"对话"（Chat 标签页）时，浏览器 WebSocket 连接以 `code 1006` (Abnormal Closure) 断开，终端中显示：

```
[session ended (code 1006)]
```

### 根因

`await ws.accept()` 在 Starlette 中只是**排队**了一个 ASGI `http.response.start` 事件到 event loop 中，实际的 HTTP 101 Switching Protocols 响应需要 event loop 运行才能写入 socket。

紧接着的 `_resolve_chat_argv()` 内部调用 `_make_tui_argv()`，后者用 `subprocess.run()` **同步阻塞 event loop** 约 1-2 秒（运行 `npm run build` 构建 TUI bundle）。在这段时间内 uvicorn 无法 flush 101 响应到 socket，客户端等待响应头超时 → 断开连接。

### 修复

两个改动：

#### 1. 核心修复：让 event loop 先 flush 101 响应

```python
await ws.accept()
+ await asyncio.sleep(0)  # yield 让 uvicorn flush 101 响应
```

`await asyncio.sleep(0)` 让出控制权给 event loop，uvicorn 在 event loop 被后续同步调用阻塞之前，有机会完成 101 响应头的写入。

#### 2. 兜底保护：顶层 try/except 防止未来复发

```python
+ try:
      # ... 原有的所有逻辑（PTY 检查、spawn、reader/writer loops）
+ except Exception:
+     _log.exception("pty ws handler crashed: unhandled exception")
+     try:
+         await ws.close(code=1011)
+     except Exception:
+         pass
```

如果 PTY handler 中任何位置抛出未捕获的异常（如 `app.state` 访问、query params 解析、`_build_sidecar_url` 中的任意错误），FastAPI/Starlette 会直接断开 TCP 连接而不发送 WebSocket 关闭帧 → 浏览器看到 `code 1006`。这个兜底确保：
- 异常被完整记录到日志（`_log.exception` 包含 traceback）
- WebSocket 用 code 1011 (Internal Error) 优雅关闭，用户看到可读的错误信息而非神秘的 `[session ended (code 1006)]`

### 测试结果

| 场景 | 修复前 | 修复后 |
|------|--------|--------|
| `websockets` 库连接 | `InvalidMessage: did not receive a valid HTTP response` | ✅ 连接成功，收到 TUI ANSI 输出 |
| `aiohttp` 库连接 | `ServerDisconnectedError` | ✅ 连接成功，收到 Hermes 欢迎界面 |

### 注意事项

该问题仅影响新版 Hermes dashboard 中的嵌入式 TUI（"对话"标签页）。每次连接都会运行 `npm run build` 构建 TUI bundle（约 1-2 秒），这在 RK3588（ARM64）等设备上会稍微延长首次响应时间。后续可以进一步优化为缓存构建产物。
