### PR TITLE
fix(kanban): harden review-required mission loops

### DIFF
--- a/docs/kanban-reports/t_10a731c7/report.json
+++ b/docs/kanban-reports/t_10a731c7/report.json
@@ -1,0 +1,77 @@
+{
+  "task_id": "t_10a731c7",
+  "status": "review_required",
+  "summary": "Implemented deterministic Kanban review verdict transition handling in hermes_cli.kanban_db.apply_review_verdict with tests for PASS, REQUEST_CHANGES, PARTIAL, BLOCKED, NEEDS_HUMAN_APPROVAL, and high-risk gating.",
+  "workspace": "/Users/chrischo/.hermes/hermes-agent",
+  "changed_files": [
+    "hermes_cli/kanban_db.py",
+    "tests/hermes_cli/test_kanban_db.py",
+    "docs/kanban-reports/t_10a731c7/report.json"
+  ],
+  "commands": [
+    {
+      "command": "HOME=/Users/chrischo CODEX_HOME=/Users/chrischo/.codex omx exec \"Inspect hermes_cli/kanban_db.py and tests/hermes_cli/test_kanban_db.py for task t_10a731c7. Goal: deterministic structured review verdict transition helper for PASS, REQUEST_CHANGES, PARTIAL, BLOCKED, NEEDS_HUMAN_APPROVAL. Do not edit files. Return concise implementation recommendations and edge cases.\"",
+      "exit_code": 0,
+      "summary": "OMX route used for inspection/recommendations; no file edits requested."
+    },
+    {
+      "command": "venv/bin/python -m pytest tests/hermes_cli/test_kanban_db.py -k 'apply_review_verdict or review_status_in_valid_statuses' -q",
+      "exit_code": 0,
+      "summary": "7 passed, 216 deselected"
+    },
+    {
+      "command": "venv/bin/python -m pytest tests/hermes_cli/test_kanban_db.py -q",
+      "exit_code": 0,
+      "summary": "229 passed"
+    },
+    {
+      "command": "venv/bin/python -m py_compile hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_db.py",
+      "exit_code": 0,
+      "summary": "py_compile succeeded"
+    }
+  ],
+  "pre_existing_dirty_files": [
+    "hermes_cli/doctor.py",
+    "hermes_cli/web_server.py",
+    "package-lock.json",
+    "hermes_cli/status_warnings.py",
+    "tests/hermes_cli/test_status_warnings.py"
+  ],
+  "current_additional_dirty_files_observed": [
+    "gateway/kanban_watchers.py",
+    "hermes_cli/commands.py",
+    "hermes_cli/kanban.py",
+    "tests/hermes_cli/test_kanban_cli.py",
+    "website/docs/user-guide/features/kanban.md",
+    "docs/kanban/reports/",
+    "tests/docs/"
+  ],
+  "schema_changed": false,
+  "migration": {
+    "needed": false,
+    "backup_path": null,
+    "rollback_notes": "Revert hermes_cli/kanban_db.py and tests/hermes_cli/test_kanban_db.py changes for this task; no DB migration or status column change was introduced."
+  },
+  "migration_status_model_risks": [
+    "No SQLite schema migration was added.",
+    "The engine reuses existing statuses: done, blocked, ready, running, review.",
+    "REQUEST_CHANGES and PARTIAL block running/ready sources to preserve unresolved state; sources already in todo/review/blocked get typed verdict events rather than forced status changes.",
+    "PASS calls existing complete_task paths, preserving child promotion and cleanup side effects."
+  ],
+  "residual_risks": [
+    "apply_review_verdict is a deterministic library entrypoint; external watchdog/CLI callers must pass structured reviewer verdict payloads into it.",
+    "Follow-up contracts default to parent-free ready tasks so fixes are not blocked by the unresolved source; callers can pass explicit parents when they want dependency gating.",
+    "Workspace has unrelated dirty files from other work; reviewer should scope diff review to changed_files above."
+  ],
+  "route_used": "OMX-assisted inspection via omx exec; implementation and verification completed directly in Hermes/Liz after OMX returned recommendations.",
+  "production_actions": {
+    "deploy": false,
+    "restart": false,
+    "live_smoke": false,
+    "summary": "No production actions executed."
+  },
+  "risk_gate": {
+    "requires_human_approval": false,
+    "reason": null
+  }
+}

--- a/docs/kanban-reports/t_14b7b8a7/report.json
+++ b/docs/kanban-reports/t_14b7b8a7/report.json
@@ -1,0 +1,61 @@
+{
+  "task_id": "t_14b7b8a7",
+  "status": "review_required",
+  "summary": "Fixed apply_review_verdict so payloads with both source_task_id and legacy task_id now raise when the two ids differ, before any review/source state mutation. Added a focused regression that verifies the review, source, and conflicting target statuses remain unchanged.",
+  "workspace": "/Users/chrischo/.hermes/hermes-agent",
+  "route_used": "OMX exec for code patch, parent Liz verification for tests/report",
+  "changed_files": [
+    "hermes_cli/kanban_db.py",
+    "tests/hermes_cli/test_kanban_db.py",
+    "docs/kanban-reports/t_14b7b8a7/report.json"
+  ],
+  "pre_existing_dirty_files_observed": [
+    "gateway/kanban_watchers.py",
+    "hermes_cli/commands.py",
+    "hermes_cli/doctor.py",
+    "hermes_cli/kanban.py",
+    "hermes_cli/kanban_db.py",
+    "hermes_cli/web_server.py",
+    "tests/hermes_cli/test_kanban_cli.py",
+    "tests/hermes_cli/test_kanban_db.py",
+    "website/docs/user-guide/features/kanban.md",
+    "docs/kanban-reports/",
+    "docs/kanban/reports/",
+    "hermes_cli/status_warnings.py",
+    "tests/docs/",
+    "tests/hermes_cli/test_status_warnings.py"
+  ],
+  "behavior_verified": [
+    "When source_task_id and task_id are both present and differ, apply_review_verdict raises ValueError matching source_task_id/task_id mismatch.",
+    "The mismatch is checked before source lookup/completion/blocking, so review, source, and conflicting task statuses remain unchanged.",
+    "Existing schema/docs coverage already asserts task_id is a legacy alias and examples keep task_id equal to source_task_id; no schema/doc edit was needed for this narrow engine fix."
+  ],
+  "verification": [
+    {
+      "command": "uv run python -m pytest tests/hermes_cli/test_kanban_db.py -q -k 'mismatched_source_and_legacy_task_id' -o 'addopts='",
+      "exit_code": 0,
+      "summary": "1 passed, 233 deselected"
+    },
+    {
+      "command": "uv run python -m pytest tests/hermes_cli/test_kanban_db.py tests/docs/test_kanban_report_schemas.py -q -k 'apply_review_verdict or kanban_report_schemas' -o 'addopts='",
+      "exit_code": 0,
+      "summary": "14 passed, 224 deselected"
+    }
+  ],
+  "production_actions": {
+    "deploy": false,
+    "restart": false,
+    "migration": false,
+    "secrets_read": false,
+    "summary": "Local repo edits/tests only; no commit, push, DB migration, service restart, deploy, or secret reads."
+  },
+  "residual_risks": [
+    "The shared workspace already contained broad dirty/untracked Kanban-loop changes from prior tasks; this handoff scopes only the alias mismatch fix, regression test, and this report."
+  ],
+  "review": {
+    "required": true,
+    "report_path": "docs/kanban-reports/t_14b7b8a7/report.json",
+    "marker": "review_required: docs/kanban-reports/t_14b7b8a7/report.json",
+    "summary": "Please review the narrow source_task_id/task_id alias mismatch guard and regression test."
+  }
+}

--- a/docs/kanban-reports/t_16d50bfc/report.json
+++ b/docs/kanban-reports/t_16d50bfc/report.json
@@ -1,0 +1,68 @@
+{
+  "task_id": "t_16d50bfc",
+  "status": "review_required",
+  "summary": "Narrowed Kanban review-required auto-unblock so the source->reviewer bypass no longer catches finalizers/fan-in children merely because they mention review, and preserved non-source parent gates.",
+  "workspace": "/Users/chrischo/.hermes/hermes-agent",
+  "changed_files": [
+    "hermes_cli/kanban_db.py",
+    "tests/hermes_cli/test_kanban_db.py",
+    "docs/kanban-reports/t_16d50bfc/report.json"
+  ],
+  "pre_existing_dirty_files": [
+    "gateway/kanban_watchers.py",
+    "hermes_cli/commands.py",
+    "hermes_cli/doctor.py",
+    "hermes_cli/kanban.py",
+    "hermes_cli/kanban_db.py",
+    "hermes_cli/web_server.py",
+    "package-lock.json",
+    "tests/hermes_cli/test_kanban_cli.py",
+    "tests/hermes_cli/test_kanban_db.py",
+    "website/docs/user-guide/features/kanban.md",
+    "docs/kanban-reports/",
+    "docs/kanban/reports/",
+    "hermes_cli/status_warnings.py",
+    "tests/docs/",
+    "tests/hermes_cli/test_status_warnings.py"
+  ],
+  "schema_changed": false,
+  "migration": {"needed": false, "backup_path": null, "rollback_notes": null},
+  "verification": [
+    {
+      "command": "uv run pytest tests/hermes_cli/test_kanban_db.py::test_dispatch_review_required_does_not_promote_finalizer_with_pending_reviewer -q",
+      "exit_code": 1,
+      "summary": "RED before fix: finalizer was included in review_unblocked alongside reviewer."
+    },
+    {
+      "command": "uv run pytest tests/hermes_cli/test_kanban_db.py::test_dispatch_review_required_does_not_promote_finalizer_with_pending_reviewer tests/hermes_cli/test_kanban_db.py::test_dispatch_valid_review_required_marker_promotes_and_spawns_reviewer tests/hermes_cli/test_kanban_db.py::test_dispatch_dry_run_reports_review_required_without_mutating tests/hermes_cli/test_kanban_db.py::test_dispatch_structured_review_required_report_promotes_reviewer tests/hermes_cli/test_kanban_db.py::test_dispatch_review_required_is_idempotent_and_no_high_risk_escalation -q",
+      "exit_code": 0,
+      "summary": "5 passed in 0.18s"
+    },
+    {
+      "command": "uv run pytest tests/hermes_cli/test_kanban_db.py -q",
+      "exit_code": 0,
+      "summary": "236 passed in 5.64s"
+    },
+    {
+      "command": "uv run ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_db.py",
+      "exit_code": 0,
+      "summary": "All checks passed"
+    },
+    {
+      "command": "git diff --check -- hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_db.py",
+      "exit_code": 0,
+      "summary": "No whitespace errors"
+    }
+  ],
+  "decisions": [
+    "Reviewer-child detection now uses title/assignee reviewer hints only; body text is excluded because downstream finalizers mention review PASS as sequencing context.",
+    "Review auto-unblock bypasses only the review-required source parent; any additional parents must already be done or archived before the child can be moved to review.",
+    "Explicit finalizer/closeout/fan-in title hints are excluded from review handoff detection."
+  ],
+  "production_actions": {"deploy": false, "restart": false, "live_smoke": false, "summary": "No gateway restart, deploy, or destructive DB mutation performed."},
+  "residual_risks": [
+    "The workspace had substantial pre-existing dirty Kanban loop changes; this patch intentionally touched only hermes_cli/kanban_db.py and tests/hermes_cli/test_kanban_db.py plus this report."
+  ],
+  "recommended_next_contracts": [],
+  "risk_gate": {"requires_human_approval": false, "reason": null}
+}

--- a/docs/kanban-reports/t_3896c3cb-report.json
+++ b/docs/kanban-reports/t_3896c3cb-report.json
@@ -1,0 +1,75 @@
+{
+  "task_id": "t_3896c3cb",
+  "status": "review_required",
+  "summary": "Implemented deterministic Kanban dispatcher review-required auto-unblock: linked review children move to review when a running/blocked source publishes a valid review_required marker or structured report; dry-run reports the transition without mutation; CLI/gateway logs expose review_unblocked counts.",
+  "workspace": "/Users/chrischo/.hermes/hermes-agent",
+  "route_used": "OMX-assisted read-only analysis via `omx exec -s read-only`; Liz implemented and verified the patch directly after parent-side inspection.",
+  "changed_files": [
+    "gateway/kanban_watchers.py",
+    "hermes_cli/kanban.py",
+    "hermes_cli/kanban_db.py",
+    "tests/hermes_cli/test_kanban_db.py"
+  ],
+  "commands": [
+    {
+      "command": "HOME=/Users/chrischo CODEX_HOME=/Users/chrischo/.codex zsh -lic 'omx exec -C /Users/chrischo/.hermes/hermes-agent -s read-only --output-last-message /tmp/omx-kanban-review-required-plan.txt ...'",
+      "exit_code": 0,
+      "summary": "OMX available at /opt/homebrew/bin/omx; produced read-only implementation plan."
+    },
+    {
+      "command": "python -m pytest tests/hermes_cli/test_kanban_db.py -q -k 'review_required or dispatch_dry_run_does_not_claim or dispatch_promotes_ready_and_spawns' -o 'addopts='",
+      "exit_code": 1,
+      "summary": "System Python lacked pytest; switched to project uv environment."
+    },
+    {
+      "command": "uv run python -m pytest tests/hermes_cli/test_kanban_db.py -q -k 'review_required or dispatch_dry_run_does_not_claim or dispatch_promotes_ready_and_spawns' -o 'addopts='",
+      "exit_code": 1,
+      "summary": "Initial regression run found task_runs has no result column; fixed query to summary/metadata only."
+    },
+    {
+      "command": "uv run python -m pytest tests/hermes_cli/test_kanban_db.py -q -k 'review_required or dispatch_dry_run_does_not_claim or dispatch_promotes_ready_and_spawns' -o 'addopts='",
+      "exit_code": 0,
+      "summary": "8 passed, 221 deselected."
+    },
+    {
+      "command": "uv run python -m pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py tests/gateway/test_kanban_watchers_mixin.py -q -o 'addopts='",
+      "exit_code": 0,
+      "summary": "236 passed in 6.26s."
+    }
+  ],
+  "pre_existing_dirty_files": [
+    "hermes_cli/doctor.py",
+    "hermes_cli/web_server.py",
+    "package-lock.json",
+    "hermes_cli/status_warnings.py",
+    "tests/hermes_cli/test_status_warnings.py"
+  ],
+  "additional_dirty_files_observed_after_start_not_modified_by_this_run": [
+    "hermes_cli/commands.py",
+    "tests/hermes_cli/test_kanban_cli.py",
+    "website/docs/user-guide/features/kanban.md",
+    "docs/kanban/reports/",
+    "tests/docs/"
+  ],
+  "schema_changed": false,
+  "migration": {
+    "needed": false,
+    "backup_path": null,
+    "rollback_notes": "Revert the changes in the four changed_files listed above; no database migration or data cleanup was performed."
+  },
+  "production_actions": {
+    "deploy": false,
+    "restart": false,
+    "live_smoke": false,
+    "summary": "No production action; local code and test execution only."
+  },
+  "residual_risks": [
+    "Repository had unrelated dirty work before and during this run; review should separate this patch from pre-existing mission-state/status-warning changes before merge.",
+    "Review-child detection is conservative and text-based: child title/body must contain review/reviewer/reviewing to avoid auto-promoting arbitrary blocked children.",
+    "Structured reports are parsed from task result, comments, and run summary/metadata only; report paths are treated as evidence pointers and are not opened/executed."
+  ],
+  "risk_gate": {
+    "requires_human_approval": false,
+    "reason": null
+  }
+}

--- a/docs/kanban-reports/t_67cfbab0-mission-state-summary.md
+++ b/docs/kanban-reports/t_67cfbab0-mission-state-summary.md
@@ -1,0 +1,86 @@
+# t_67cfbab0 review report — mission-state summary
+
+review_required: /Users/chrischo/.hermes/hermes-agent/docs/kanban-reports/t_67cfbab0-mission-state-summary.md
+
+## Outcome
+
+Implemented a deterministic `hermes kanban mission-state <root_task_id>` CLI/slash surface for root-task mission summaries. It traverses the existing task graph from `task_links`, reads existing task/run/comment rows only, supports `--json`, and does not alter board state unless explicitly invoked.
+
+## route_used
+
+- OMX available at `/opt/homebrew/bin/omx`.
+- Used OMX route for read-only codebase inspection and implementation plan:
+  `HOME=/Users/chrischo CODEX_HOME=/Users/chrischo/.codex omx exec -C /Users/chrischo/.hermes/hermes-agent -s read-only ...`
+- Applied patch and verification directly as Liz after parent-side review/control.
+
+## changed_files
+
+- `hermes_cli/kanban_db.py`
+  - Added `mission_state(conn, root_task_id)` and deterministic text extractors for mission_id/north_star/current metric floors/risk gates/stop conditions.
+  - Returns compact JSON-ready fields: mission_id, root_task_id, north_star, current_metric_floors, active_tasks, blocked_tasks, next_tasks, risk_gates, stop_conditions, status counts, progress, leaves, tasks.
+- `hermes_cli/kanban.py`
+  - Added `mission-state` parser and handler.
+  - Added compact human formatter and `--json` output path.
+  - Added slash help line.
+- `hermes_cli/commands.py`
+  - Added `mission-state` to `/kanban` subcommand registry/autocomplete.
+- `tests/hermes_cli/test_kanban_db.py`
+  - Added DB helper coverage for missing roots, descendant graph summaries, and shared descendant dedupe.
+- `tests/hermes_cli/test_kanban_cli.py`
+  - Added slash/CLI JSON and human-output coverage plus autocomplete assertion.
+- `website/docs/user-guide/features/kanban.md`
+  - Documented `hermes kanban mission-state t_<root>` and `--json` usage plus no-LLM/no-mutation behavior.
+- `docs/kanban-reports/t_67cfbab0-mission-state-summary.md`
+  - This review handoff.
+
+## pre_existing_dirty_files
+
+Observed before this task's edits:
+
+- `hermes_cli/doctor.py`
+- `hermes_cli/web_server.py`
+- `package-lock.json`
+- `hermes_cli/status_warnings.py` (untracked)
+- `tests/hermes_cli/test_status_warnings.py` (untracked)
+
+Also observed dirty/concurrent during final status, not touched intentionally for this task:
+
+- `gateway/kanban_watchers.py`
+- `docs/kanban-reports/` existing untracked directory before this report write
+- `docs/kanban/reports/`
+- `tests/docs/`
+
+Note: `hermes_cli/kanban.py` and `hermes_cli/kanban_db.py` currently include unrelated concurrent/pre-existing review-loop changes in addition to this task's mission-state patch. Review the scoped hunks around `mission-state` separately from those existing changes.
+
+## commands_and_exit_codes
+
+- `pwd && git status --short && git branch --show-current && command -v omx || true && command -v codex || true` — exit 0
+- `HOME=/Users/chrischo omx --help | head -80` — exit 0
+- `HOME=/Users/chrischo CODEX_HOME=/Users/chrischo/.codex omx exec -C /Users/chrischo/.hermes/hermes-agent -s read-only -o /tmp/omx-mission-state-plan.txt "Inspect Hermes kanban CLI/db code ..."` — exit 0
+- `python -m pytest ...` — exit 1 (`/opt/homebrew/opt/python@3.14/bin/python3.14: No module named pytest`; switched to repo venv)
+- `venv/bin/python -m pytest tests/hermes_cli/test_kanban_db.py::test_mission_state_missing_root_returns_none ... tests/hermes_cli/test_kanban_cli.py::test_kanban_in_autocomplete_table -q` — first run exit 1, fixed test expectation; final run exit 0 (`7 passed in 0.30s`)
+- `venv/bin/python -m py_compile hermes_cli/kanban.py hermes_cli/kanban_db.py hermes_cli/commands.py && venv/bin/python -m pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_cli.py -q` — exit 0 (`279 passed in 5.35s`)
+- `git diff --check -- hermes_cli/commands.py hermes_cli/kanban.py hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_db.py website/docs/user-guide/features/kanban.md` — exit 0
+- `HOME=/Users/chrischo HERMES_HOME=/Users/chrischo/.hermes venv/bin/python -m hermes_cli.main kanban mission-state t_67cfbab0 > /tmp/mission-state-example.txt` — exit 0
+
+## example_output
+
+Path: `/tmp/mission-state-example.txt`
+
+```text
+Mission t_67cfbab0: Loop automation: mission-state summary
+Progress: 0/2 done (0%) | open=2 | running=2
+Active tasks:
+  t_67cfbab0 running   @liz             Loop automation: mission-state summary
+  t_21272739 running   @sage            Review loop-engineering automation replacements
+Blocked tasks:
+  (none)
+Next tasks:
+  (none)
+```
+
+## residual_risks
+
+- Mission-state field extraction is intentionally syntax-light: it recognizes `mission_id:`, `north_star:` / `objective:`, and named Markdown/YAML-ish sections in the root task body/comments. It does not infer semantic equivalents with an LLM.
+- The report is additive and explicit-invocation only, but the current worktree has concurrent Kanban review-loop changes in `kanban.py`/`kanban_db.py`; final review should isolate the `mission-state` hunks.
+- i18n docs were not updated; this mirrors nearby Kanban reference changes that often land in English docs first.

--- a/docs/kanban-reports/t_8530f965/report.json
+++ b/docs/kanban-reports/t_8530f965/report.json
@@ -1,0 +1,84 @@
+{
+  "task_id": "t_8530f965",
+  "status": "review_required",
+  "summary": "Removed the hardcoded sdlc-review injection from review dispatch, preserved explicit task/profile skill ownership, and aligned reviewer verdict schema/sample/tests with apply_review_verdict semantics.",
+  "workspace": "/Users/chrischo/.hermes/hermes-agent",
+  "changed_files": [
+    "hermes_cli/kanban_db.py",
+    "tests/hermes_cli/test_kanban_db.py",
+    "tests/docs/test_kanban_report_schemas.py",
+    "docs/kanban/reports/README.md",
+    "docs/kanban/reports/schemas/reviewer-verdict.schema.json",
+    "docs/kanban/reports/samples/reviewer-verdict.example.json",
+    "docs/kanban-reports/t_8530f965/report.json"
+  ],
+  "pre_existing_dirty_files": [
+    "gateway/kanban_watchers.py",
+    "hermes_cli/commands.py",
+    "hermes_cli/doctor.py",
+    "hermes_cli/kanban.py",
+    "hermes_cli/kanban_db.py",
+    "hermes_cli/web_server.py",
+    "tests/hermes_cli/test_kanban_cli.py",
+    "tests/hermes_cli/test_kanban_db.py",
+    "website/docs/user-guide/features/kanban.md",
+    "docs/kanban-reports/",
+    "docs/kanban/reports/",
+    "hermes_cli/status_warnings.py",
+    "tests/docs/",
+    "tests/hermes_cli/test_status_warnings.py"
+  ],
+  "schema_changed": true,
+  "migration": {
+    "needed": false,
+    "backup_path": null,
+    "rollback_notes": "Revert the scoped diffs in hermes_cli/kanban_db.py, tests/hermes_cli/test_kanban_db.py, tests/docs/test_kanban_report_schemas.py, and docs/kanban/reports/*. No DB migration or gateway restart was performed."
+  },
+  "verification": [
+    {
+      "command": "uv run python -m pytest tests/hermes_cli/test_kanban_db.py tests/docs/test_kanban_report_schemas.py -q -k 'review_required or dispatch_review or apply_review_verdict or kanban_report_schemas' -o 'addopts='",
+      "exit_code": 0,
+      "summary": "27 passed, 210 deselected"
+    },
+    {
+      "command": "uv run python -m pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py tests/gateway/test_kanban_watchers_mixin.py tests/docs/test_kanban_report_schemas.py -q -o 'addopts='",
+      "exit_code": 0,
+      "summary": "294 passed in 5.59s"
+    },
+    {
+      "command": "uv run python -m py_compile hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_db.py tests/docs/test_kanban_report_schemas.py",
+      "exit_code": 0,
+      "summary": "Compilation completed with no output other than the VIRTUAL_ENV warning"
+    },
+    {
+      "command": "search_files(pattern='sdlc-review')",
+      "exit_code": 0,
+      "summary": "Only remaining sdlc-review reference is a negative regression assertion in tests/hermes_cli/test_kanban_db.py"
+    }
+  ],
+  "decisions": [
+    "Review dispatch no longer mutates claimed.skills for status=review tasks; explicit task skills remain intact and profile defaults are left to the assignee profile.",
+    "Reviewer verdict schema now requires review_task_id and source_task_id. task_id is documented as a legacy alias for source_task_id only.",
+    "apply_review_verdict now rejects a payload review_task_id that disagrees with its review_task_id argument, removing ambiguity for automation."
+  ],
+  "production_actions": {
+    "deploy": false,
+    "restart": false,
+    "live_smoke": false,
+    "summary": "Local repo edits and tests only; no DB schema migration, gateway restart, deploy, or secret reads."
+  },
+  "residual_risks": [
+    "The workspace already contained broad dirty/untracked Kanban-loop changes from the parent mission; this task only scoped the review-dispatch and verdict-schema follow-up files listed in changed_files."
+  ],
+  "recommended_next_contracts": [],
+  "risk_gate": {
+    "requires_human_approval": false,
+    "reason": null
+  },
+  "review": {
+    "required": true,
+    "report_path": "docs/kanban-reports/t_8530f965/report.json",
+    "marker": "review_required: docs/kanban-reports/t_8530f965/report.json",
+    "summary": "Please review the review-dispatch skill fix and reviewer-verdict schema compatibility changes."
+  }
+}

--- a/docs/kanban/reports/README.md
+++ b/docs/kanban/reports/README.md
@@ -1,0 +1,63 @@
+# Kanban worker reports
+
+Kanban workers that need review should write a durable JSON handoff report and
+then leave a short task summary containing this marker:
+
+```text
+review_required: <report_path>
+<one- or two-sentence summary of what changed and why review is needed>
+```
+
+`<report_path>` should be repo-relative when the report lives in the task
+workspace, or an absolute path only when the report is outside the repository.
+The marker is intentionally plain text so it works in CLI summaries, comments,
+dashboard cards, and future reviewer automation without a DB status migration.
+
+## Files
+
+- [`schemas/worker-handoff-report.schema.json`](schemas/worker-handoff-report.schema.json)
+  defines the worker report contract.
+- [`schemas/reviewer-verdict.schema.json`](schemas/reviewer-verdict.schema.json)
+  defines the reviewer verdict contract.
+- [`samples/worker-handoff-report.example.json`](samples/worker-handoff-report.example.json)
+  is a complete worker handoff example.
+- [`samples/reviewer-verdict.example.json`](samples/reviewer-verdict.example.json)
+  is a complete reviewer verdict example.
+
+## Worker handoff rules
+
+1. Write the report before completing or commenting on the task.
+2. Include evidence that the reviewer can reproduce locally: commands with exit
+   codes, file paths, pre-existing dirty files, schema changes, residual risks,
+   and the route used to do the work.
+3. Mark the task summary or comment with `review_required: <report_path>` plus a
+   short human-readable summary.
+4. Do not encode lifecycle state in the marker. The Kanban task remains in its
+   normal CLI/DB status; the marker only points reviewers to the report.
+
+## Reviewer verdict rules
+
+Reviewer verdict JSON must use one of these values:
+
+- `PASS` — the handoff is accepted.
+- `REQUEST_CHANGES` — specific worker changes are required before acceptance.
+- `PARTIAL` — part of the work is accepted, but documented follow-up remains.
+- `BLOCKED` — review cannot finish because evidence, access, or prerequisites
+  are missing.
+- `NEEDS_HUMAN_APPROVAL` — the next step is credentialed, destructive,
+  production-facing, or otherwise requires explicit human approval.
+
+Required automation fields are intentionally unambiguous:
+
+- `review_task_id` is the reviewer task that produced the verdict. It must
+  match the `review_task_id` argument passed to `apply_review_verdict()`.
+- `source_task_id` is the worker/source task being reviewed and the task that
+  `apply_review_verdict()` completes, blocks, or uses for follow-up routing.
+- `task_id` is only a legacy alias for `source_task_id`; new automation should
+  emit both only when they are identical.
+- `safe_to_merge`, `safe_to_deploy`, `blocking_findings`,
+  `non_blocking_findings`, `evidence`, and `next_action` are required so a
+  transition engine can act without scraping prose.
+
+Reviewers should write the verdict as a separate JSON file, then comment with a
+short summary and the verdict path.

--- a/docs/kanban/reports/samples/reviewer-verdict.example.json
+++ b/docs/kanban/reports/samples/reviewer-verdict.example.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": "kanban.reviewer_verdict.v1",
+  "report_type": "reviewer_verdict",
+  "review_task_id": "t_review123",
+  "source_task_id": "t_source456",
+  "task_id": "t_source456",
+  "reviewed_report_path": "docs/kanban/reports/samples/worker-handoff-report.example.json",
+  "reviewer": {
+    "profile": "reviewer",
+    "agent": "codex"
+  },
+  "verdict": "PASS",
+  "summary": "The source handoff satisfies the acceptance criteria and the focused schema tests pass.",
+  "safe_to_merge": true,
+  "safe_to_deploy": false,
+  "blocking_findings": [],
+  "non_blocking_findings": [
+    {
+      "severity": "info",
+      "message": "Deployment remains false because this verdict only reviewed local docs/schema changes."
+    }
+  ],
+  "evidence": [
+    {
+      "command": "uv run python -m pytest tests/docs/test_kanban_report_schemas.py -q -o 'addopts='",
+      "exit_code": 0,
+      "summary": "Kanban report schema tests passed"
+    }
+  ],
+  "commands": [
+    {
+      "command": "uv run python -m pytest tests/docs/test_kanban_report_schemas.py -q -o 'addopts='",
+      "exit_code": 0,
+      "summary": "Kanban report schema tests passed"
+    }
+  ],
+  "next_action": {
+    "type": "complete_source_and_promote_children",
+    "summary": "Complete the source task and promote any children whose parents have passed.",
+    "children_to_promote": []
+  }
+}

--- a/docs/kanban/reports/samples/worker-handoff-report.example.json
+++ b/docs/kanban/reports/samples/worker-handoff-report.example.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": "kanban.worker_handoff_report.v1",
+  "report_type": "worker_handoff",
+  "task_id": "t_bdf859a7",
+  "title": "Document Kanban handoff reports",
+  "worker": {
+    "profile": "liz",
+    "agent": "codex",
+    "run_id": "example-run-42"
+  },
+  "summary": "Added the Kanban handoff report and reviewer verdict contracts with samples and validation tests.",
+  "changed_files": [
+    "docs/kanban/reports/README.md",
+    "docs/kanban/reports/schemas/worker-handoff-report.schema.json",
+    "docs/kanban/reports/schemas/reviewer-verdict.schema.json",
+    "docs/kanban/reports/samples/worker-handoff-report.example.json",
+    "docs/kanban/reports/samples/reviewer-verdict.example.json",
+    "tests/docs/test_kanban_report_schemas.py"
+  ],
+  "pre_existing_dirty_files": [
+    "hermes_cli/doctor.py",
+    "hermes_cli/web_server.py",
+    "package-lock.json",
+    "hermes_cli/status_warnings.py",
+    "tests/hermes_cli/test_status_warnings.py"
+  ],
+  "commands": [
+    {
+      "command": "scripts/run_tests.sh tests/docs/test_kanban_report_schemas.py",
+      "exit_code": 0,
+      "summary": "3 tests passed"
+    }
+  ],
+  "schema_changed": true,
+  "residual_risks": [],
+  "route_used": "OMX Codex exec from Chris real HOME/CODEX_HOME, with Liz parent verification and cleanup",
+  "review": {
+    "required": true,
+    "marker": "review_required: docs/kanban/reports/samples/worker-handoff-report.example.json",
+    "report_path": "docs/kanban/reports/samples/worker-handoff-report.example.json",
+    "summary": "Please review the documented report contracts and samples."
+  }
+}

--- a/docs/kanban/reports/schemas/reviewer-verdict.schema.json
+++ b/docs/kanban/reports/schemas/reviewer-verdict.schema.json
@@ -1,0 +1,197 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hermes-agent.local/schemas/kanban/reviewer-verdict.v1.json",
+  "title": "Kanban Reviewer Verdict",
+  "description": "Structured reviewer output consumed by apply_review_verdict(review_task_id, verdict_payload). review_task_id is the task that ran the review; source_task_id is the worker/source task being reviewed. task_id, when present for legacy readers, MUST mean the same value as source_task_id.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "report_type",
+    "review_task_id",
+    "source_task_id",
+    "reviewed_report_path",
+    "reviewer",
+    "verdict",
+    "summary",
+    "safe_to_merge",
+    "safe_to_deploy",
+    "blocking_findings",
+    "non_blocking_findings",
+    "evidence",
+    "next_action"
+  ],
+  "properties": {
+    "schema_version": {"type": "string", "const": "kanban.reviewer_verdict.v1"},
+    "report_type": {"type": "string", "const": "reviewer_verdict"},
+    "review_task_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The Kanban task id of the reviewer task that produced this verdict. Must match the review_task_id argument passed to apply_review_verdict."
+    },
+    "source_task_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The Kanban task id of the source/worker task whose handoff report was reviewed. apply_review_verdict uses this as the task to complete/block/promote."
+    },
+    "task_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Legacy alias for source_task_id; do not use for new automation unless both fields are emitted with identical values."
+    },
+    "reviewed_report_path": {"type": "string", "minLength": 1},
+    "reviewer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["profile", "agent"],
+      "properties": {
+        "profile": {"type": "string", "minLength": 1},
+        "agent": {"type": "string", "minLength": 1}
+      }
+    },
+    "verdict": {
+      "type": "string",
+      "enum": [
+        "PASS",
+        "REQUEST_CHANGES",
+        "PARTIAL",
+        "BLOCKED",
+        "NEEDS_HUMAN_APPROVAL"
+      ]
+    },
+    "summary": {"type": "string", "minLength": 1},
+    "safe_to_merge": {
+      "type": "boolean",
+      "description": "True only when the reviewed source can be merged/completed without additional changes."
+    },
+    "safe_to_deploy": {
+      "type": "boolean",
+      "description": "True only when production deployment/restart is safe and authorized by the mission contract."
+    },
+    "blocking_findings": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/finding"}
+    },
+    "non_blocking_findings": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/finding"}
+    },
+    "findings": {
+      "type": "array",
+      "description": "Legacy combined finding list; prefer blocking_findings and non_blocking_findings.",
+      "items": {"$ref": "#/$defs/finding"}
+    },
+    "evidence": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/evidence_command"}
+    },
+    "commands": {
+      "type": "array",
+      "description": "Legacy alias for evidence; prefer evidence.",
+      "items": {"$ref": "#/$defs/evidence_command"}
+    },
+    "next_action": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["type", "summary"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "complete_source_and_promote_children",
+            "request_changes",
+            "partial_followup",
+            "blocked_waiting_on_input",
+            "needs_human_approval",
+            "no_action",
+            "deploy",
+            "restart",
+            "delete_data",
+            "credential_change",
+            "external_commitment",
+            "paid_provider"
+          ]
+        },
+        "summary": {"type": "string", "minLength": 1},
+        "children_to_promote": {"type": "array", "items": {"type": "string"}},
+        "requires_human_approval": {"type": "boolean"},
+        "reason": {"type": "string", "minLength": 1},
+        "contract": {"$ref": "#/$defs/next_contract"}
+      }
+    },
+    "next_actions": {
+      "type": "array",
+      "description": "Legacy prose next-action list; prefer next_action.",
+      "items": {"type": "string"}
+    },
+    "next_contract": {"$ref": "#/$defs/next_contract"},
+    "risk_gate": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "requires_human_approval": {"type": "boolean"},
+        "reason": {"type": "string", "minLength": 1}
+      }
+    },
+    "production_actions": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "deploy": {"type": "boolean"},
+        "restart": {"type": "boolean"},
+        "delete_data": {"type": "boolean"},
+        "credential_change": {"type": "boolean"}
+      }
+    },
+    "human_approval": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "reason"],
+      "properties": {
+        "required": {"type": "boolean"},
+        "reason": {"type": "string", "minLength": 1},
+        "approver_role": {"type": "string"}
+      }
+    }
+  },
+  "$defs": {
+    "finding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["severity", "message"],
+      "properties": {
+        "severity": {"type": "string", "enum": ["blocker", "major", "minor", "info"]},
+        "path": {"type": "string"},
+        "line": {"type": "integer"},
+        "message": {"type": "string", "minLength": 1},
+        "required_change": {"type": "string"}
+      }
+    },
+    "evidence_command": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["command", "exit_code", "summary"],
+      "properties": {
+        "command": {"type": "string", "minLength": 1},
+        "exit_code": {"type": "integer"},
+        "summary": {"type": "string", "minLength": 1}
+      }
+    },
+    "next_contract": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "title": {"type": "string", "minLength": 1},
+        "body": {"type": "string"},
+        "assignee": {"type": "string", "minLength": 1},
+        "workspace_kind": {"type": "string"},
+        "workspace_path": {"type": "string"},
+        "priority": {"type": "integer"},
+        "parents": {"type": "array", "items": {"type": "string"}},
+        "skills": {"type": "array", "items": {"type": "string"}},
+        "goal_mode": {"type": "boolean"},
+        "goal_max_turns": {"type": "integer"}
+      }
+    }
+  }
+}

--- a/docs/kanban/reports/schemas/worker-handoff-report.schema.json
+++ b/docs/kanban/reports/schemas/worker-handoff-report.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hermes-agent.local/schemas/kanban/worker-handoff-report.v1.json",
+  "title": "Kanban Worker Handoff Report",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "report_type",
+    "task_id",
+    "worker",
+    "summary",
+    "changed_files",
+    "pre_existing_dirty_files",
+    "commands",
+    "schema_changed",
+    "residual_risks",
+    "route_used",
+    "review"
+  ],
+  "properties": {
+    "schema_version": {"type": "string", "const": "kanban.worker_handoff_report.v1"},
+    "report_type": {"type": "string", "const": "worker_handoff"},
+    "task_id": {"type": "string", "minLength": 1},
+    "title": {"type": "string"},
+    "worker": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["profile", "agent"],
+      "properties": {
+        "profile": {"type": "string", "minLength": 1},
+        "agent": {"type": "string", "minLength": 1},
+        "run_id": {"type": ["integer", "string", "null"]}
+      }
+    },
+    "summary": {"type": "string", "minLength": 1},
+    "changed_files": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1}
+    },
+    "pre_existing_dirty_files": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1}
+    },
+    "observed_concurrent_dirty_files_not_owned_by_this_task": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1}
+    },
+    "commands": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["command", "exit_code", "summary"],
+        "properties": {
+          "command": {"type": "string", "minLength": 1},
+          "exit_code": {"type": "integer"},
+          "summary": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "schema_changed": {"type": "boolean"},
+    "residual_risks": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "route_used": {"type": "string", "minLength": 1},
+    "review": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "marker", "report_path"],
+      "properties": {
+        "required": {"type": "boolean", "const": true},
+        "marker": {"type": "string", "pattern": "^review_required: .+"},
+        "report_path": {"type": "string", "minLength": 1},
+        "summary": {"type": "string"}
+      }
+    }
+  }
+}

--- a/docs/kanban/reports/task-t_7afc87b0-worker-handoff.json
+++ b/docs/kanban/reports/task-t_7afc87b0-worker-handoff.json
@@ -1,0 +1,54 @@
+{
+  "schema_version": "kanban.worker_handoff.v1",
+  "report_type": "worker_handoff",
+  "task_id": "t_7afc87b0",
+  "status": "review_required",
+  "summary": "Fixed reviewer-verdict approval gating so schema-shaped PASS payloads with human_approval.required=true block the review instead of completing review/source; aligned reviewer-verdict schema with transition-engine gate fields.",
+  "changed_files": [
+    "hermes_cli/kanban_db.py",
+    "tests/hermes_cli/test_kanban_db.py",
+    "docs/kanban/reports/schemas/reviewer-verdict.schema.json",
+    "tests/docs/test_kanban_report_schemas.py",
+    "docs/kanban/reports/task-t_7afc87b0-worker-handoff.json"
+  ],
+  "pre_existing_dirty_files": [
+    "gateway/kanban_watchers.py",
+    "hermes_cli/commands.py",
+    "hermes_cli/doctor.py",
+    "hermes_cli/kanban.py",
+    "hermes_cli/kanban_db.py",
+    "hermes_cli/web_server.py",
+    "package-lock.json",
+    "tests/hermes_cli/test_kanban_cli.py",
+    "tests/hermes_cli/test_kanban_db.py",
+    "website/docs/user-guide/features/kanban.md",
+    "docs/kanban-reports/",
+    "docs/kanban/reports/",
+    "hermes_cli/status_warnings.py",
+    "tests/docs/",
+    "tests/hermes_cli/test_status_warnings.py"
+  ],
+  "commands": [
+    {
+      "command": "venv/bin/python -m pytest tests/docs/test_kanban_report_schemas.py tests/hermes_cli/test_kanban_db.py -q -o 'addopts='",
+      "exit_code": 0,
+      "summary": "234 passed in 4.49s"
+    },
+    {
+      "command": "git diff --check -- hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_db.py tests/docs/test_kanban_report_schemas.py docs/kanban/reports/schemas/reviewer-verdict.schema.json",
+      "exit_code": 0,
+      "summary": "No whitespace errors reported"
+    }
+  ],
+  "decisions": [
+    "human_approval.required is now the first deterministic approval gate checked by apply_review_verdict.",
+    "Approval-gated PASS verdicts block only the review task and leave the source task ready, matching existing NEEDS_HUMAN_APPROVAL/high-risk behavior.",
+    "The reviewer-verdict schema now includes engine-supported risk_gate, production_actions, next_action, and next_contract fields so supported transition vocabulary is explicit."
+  ],
+  "review": {
+    "required": true,
+    "report_path": "docs/kanban/reports/task-t_7afc87b0-worker-handoff.json",
+    "marker": "review_required: docs/kanban/reports/task-t_7afc87b0-worker-handoff.json",
+    "summary": "Review human_approval gate behavior and schema-vocabulary alignment before completing t_7afc87b0."
+  }
+}

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1024,13 +1024,15 @@ class GatewayKanbanWatchersMixin:
                         # happened, so an idle gateway stays silent.
                         logger.info(
                             "kanban dispatcher [%s]: spawned=%d reclaimed=%d "
-                            "crashed=%d timed_out=%d promoted=%d auto_blocked=%d",
+                            "crashed=%d timed_out=%d promoted=%d review_unblocked=%d "
+                            "auto_blocked=%d",
                             slug,
                             len(res.spawned),
                             res.reclaimed,
                             len(res.crashed) if hasattr(res.crashed, "__len__") else 0,
                             len(res.timed_out) if hasattr(res.timed_out, "__len__") else 0,
                             res.promoted,
+                            len(res.review_unblocked) if hasattr(res.review_unblocked, "__len__") else 0,
                             len(res.auto_blocked) if hasattr(res.auto_blocked, "__len__") else 0,
                         )
                 # Health telemetry (aggregate across boards)

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -189,7 +189,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
                subcommands=("status", "run", "pause", "resume", "pin", "unpin", "restore", "list-archived")),
     CommandDef("kanban", "Multi-profile collaboration board (tasks, links, comments)",
                "Tools & Skills", args_hint="[subcommand]",
-               subcommands=("init", "boards", "create", "list", "ls", "show", "assign",
+               subcommands=("init", "boards", "create", "list", "ls", "show", "mission-state", "assign",
                             "reclaim", "reassign", "diagnostics", "diag", "link", "unlink",
                             "claim", "comment", "complete", "edit", "block", "unblock",
                             "archive", "tail", "dispatch", "stats", "notify-subscribe",

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -350,6 +350,30 @@ def _check_gateway_service_linger(issues: list[str]) -> None:
         check_warn("Could not verify systemd linger", f"({linger_detail})")
 
 
+def _check_launchd_gateway_state(issues: list[str]) -> None:
+    """Warn when macOS launchd metadata disagrees with a live gateway PID."""
+    if sys.platform != "darwin":
+        return
+    try:
+        from gateway.status import get_running_pid
+        from hermes_cli.status_warnings import collect_launchd_gateway_warning
+
+        warning = collect_launchd_gateway_warning(gateway_pid=get_running_pid())
+    except Exception:
+        return
+    if not warning:
+        return
+    _section("Gateway Service")
+    check_warn(
+        "Launchd gateway state mismatch",
+        "(pid={gateway_pid}, launchctl_status={launchctl_status}, "
+        "LastExitStatus={last_exit_status})".format(**warning),
+    )
+    check_info(
+        "Inspect `launchctl list <label>` and gateway logs before deciding whether to restart."
+    )
+
+
 _APIKEY_PROVIDERS_CACHE: list | None = None
 
 
@@ -861,6 +885,22 @@ def run_doctor(args):
         except Exception:
             pass
 
+        try:
+            from hermes_cli.status_warnings import collect_config_version_drift
+
+            drift = collect_config_version_drift()
+            if drift.get("behind"):
+                detail = ", ".join(
+                    f"{item['profile']} v{item['config_version']}→v{item['latest_config_version']}"
+                    for item in drift["behind"][:8]
+                )
+                extra = len(drift["behind"]) - 8
+                if extra > 0:
+                    detail = f"{detail}, +{extra} more"
+                check_warn("Config version drift across profiles", f"({detail})")
+        except Exception:
+            pass
+
         # Detect stale root-level model keys (known bug source — PR #4329)
         try:
             import yaml
@@ -1070,6 +1110,31 @@ def run_doctor(args):
     except Exception:
         pass
 
+    try:
+        from hermes_cli.status_warnings import collect_provider_auth_diagnostic
+
+        auth_diag = collect_provider_auth_diagnostic()
+        pool = auth_diag.get("credential_pool") or {}
+        if auth_diag.get("config_provider"):
+            detail_parts = [
+                f"pool_source={pool.get('source', 'none')}",
+                f"entries={pool.get('entries', 0)}",
+            ]
+            entry_statuses = pool.get("entry_statuses") or []
+            if entry_statuses:
+                first_status = entry_statuses[0]
+                for key in ("last_status", "last_error_code", "last_error_reason"):
+                    if first_status.get(key) is not None:
+                        detail_parts.append(f"{key}={first_status[key]}")
+            check_info(
+                f"Default provider auth diagnostic: {auth_diag.get('config_provider')} "
+                f"({', '.join(detail_parts)})"
+            )
+        for warning in auth_diag.get("warnings", []):
+            check_warn(str(warning.get("message") or warning.get("code")))
+    except Exception:
+        pass
+
     _section("Directory Structure")
     hermes_home = HERMES_HOME
     if hermes_home.exists():
@@ -1227,6 +1292,7 @@ def run_doctor(args):
             pass
 
     _check_gateway_service_linger(issues)
+    _check_launchd_gateway_state(issues)
     _check_s6_supervision(issues)
 
     if sys.platform != "win32":

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -435,6 +435,13 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="With --state-type: keep runs whose column equals this value",
     )
 
+    p_mission = sub.add_parser(
+        "mission-state",
+        help="Summarize a root task and descendant mission graph without LLMs",
+    )
+    p_mission.add_argument("root_task_id")
+    p_mission.add_argument("--json", action="store_true")
+
     # --- assign ---
     p_assign = sub.add_parser("assign", help="Assign or reassign a task")
     p_assign.add_argument("task_id")
@@ -927,6 +934,7 @@ def kanban_command(args: argparse.Namespace) -> int:
             "list":     _cmd_list,
             "ls":       _cmd_list,
             "show":     _cmd_show,
+            "mission-state": _cmd_mission_state,
             "assign":   _cmd_assign,
             "reclaim":  _cmd_reclaim,
             "reassign": _cmd_reassign,
@@ -2155,6 +2163,7 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             "stale": res.stale,
             "auto_blocked": res.auto_blocked,
             "promoted": res.promoted,
+            "review_unblocked": res.review_unblocked,
             "spawned": [
                 {"task_id": tid, "assignee": who, "workspace": ws}
                 for (tid, who, ws) in res.spawned
@@ -2182,6 +2191,12 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
     if res.auto_blocked:
         print(f"  {', '.join(res.auto_blocked)}")
     print(f"Promoted:     {res.promoted}")
+    print(f"Review ready: {len(res.review_unblocked)}")
+    for item in res.review_unblocked:
+        print(
+            f"  - {item['task_id']} from {item['source_task_id']} "
+            f"@ {item['report_path']} ({item['marker_source']})"
+        )
     print(f"Spawned:      {len(res.spawned)}")
     for tid, who, ws in res.spawned:
         tag = " (dry)" if args.dry_run else ""
@@ -2302,15 +2317,15 @@ def _cmd_daemon(args: argparse.Namespace) -> int:
             return
         did_work = (
             res.reclaimed or res.crashed or res.timed_out or res.promoted
-            or res.spawned or res.auto_blocked or res.stale
+            or res.spawned or res.auto_blocked or res.stale or res.review_unblocked
         )
         if did_work:
             print(
                 f"[{_fmt_ts(int(time.time()))}] "
                 f"reclaimed={res.reclaimed} crashed={len(res.crashed)} "
                 f"timed_out={len(res.timed_out)} stale={len(res.stale)} "
-                f"promoted={res.promoted} spawned={len(res.spawned)} "
-                f"auto_blocked={len(res.auto_blocked)}",
+                f"promoted={res.promoted} review_unblocked={len(res.review_unblocked)} "
+                f"spawned={len(res.spawned)} auto_blocked={len(res.auto_blocked)}",
                 flush=True,
             )
 
@@ -2394,6 +2409,62 @@ def _cmd_watch(args: argparse.Namespace) -> int:
     except KeyboardInterrupt:
         print("\n(stopped)")
         return 0
+
+
+def _fmt_mission_task(task: dict[str, Any]) -> str:
+    assignee = f"@{task['assignee']}" if task.get("assignee") else "@-"
+    summary = task.get("latest_summary") or task.get("last_failure_error") or task["title"]
+    return f"  {task['id']} {task['status']:<9s} {assignee:<16s} {summary.splitlines()[0][:100]}"
+
+
+def _print_mission_section(title: str, tasks: list[dict[str, Any]]) -> None:
+    print(f"{title}:")
+    if not tasks:
+        print("  (none)")
+        return
+    for task in tasks:
+        print(_fmt_mission_task(task))
+
+
+def _cmd_mission_state(args: argparse.Namespace) -> int:
+    with kb.connect_closing() as conn:
+        state = kb.mission_state(conn, args.root_task_id)
+    if state is None:
+        print(f"no such task: {args.root_task_id}", file=sys.stderr)
+        return 1
+    if getattr(args, "json", False):
+        print(json.dumps(state, indent=2, ensure_ascii=False))
+        return 0
+
+    counts = ", ".join(
+        f"{status}={count}" for status, count in state["by_status"].items()
+    ) or "none"
+    print(
+        f"Mission {state['mission_id']} "
+        f"[board={state.get('board', kb.get_current_board())}]: {state['north_star']}"
+    )
+    print(
+        f"Progress: {state['done_tasks']}/{state['total_tasks']} done "
+        f"({state['progress_percent']}%) | open={state['open_tasks']} | {counts}"
+    )
+    if state["current_metric_floors"]:
+        print("Current metric floors:")
+        for item in state["current_metric_floors"]:
+            print(f"  - {item}")
+    _print_mission_section("Active tasks", state["active_tasks"])
+    _print_mission_section("Blocked tasks", state["blocked_tasks"])
+    _print_mission_section("Next tasks", state["next_tasks"])
+    if state["risk_gates"]:
+        print("Risk gates:")
+        for item in state["risk_gates"]:
+            print(f"  - {item}")
+    if state["stop_conditions"]:
+        print("Stop conditions:")
+        for item in state["stop_conditions"]:
+            print(f"  - {item}")
+    if state.get("cycle_guarded"):
+        print("Cycle guard: duplicate/cyclic links were suppressed.")
+    return 0
 
 
 def _cmd_stats(args: argparse.Namespace) -> int:
@@ -2736,6 +2807,7 @@ Common subcommands:
   `list` (alias `ls`)   List tasks on the current board
   `show <id>`           Task details + comments + events
   `stats`               Per-status / per-assignee counts
+  `mission-state <id>`   Deterministic root + descendant mission summary
   `create <title>…`     Create a task (auto-subscribes you to events)
   `comment <id> <msg>`  Append a comment
   `complete <id>…`      Mark task(s) done

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -86,7 +86,7 @@ import time
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Iterable, Optional
+from typing import Any, Iterable, Mapping, Optional
 
 from toolsets import get_toolset_names
 
@@ -100,6 +100,13 @@ _log = logging.getLogger(__name__)
 VALID_STATUSES = {"triage", "todo", "scheduled", "ready", "running", "blocked", "review", "done", "archived"}
 VALID_INITIAL_STATUSES = {"running", "blocked"}
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
+VALID_REVIEW_VERDICTS = {
+    "PASS",
+    "REQUEST_CHANGES",
+    "PARTIAL",
+    "BLOCKED",
+    "NEEDS_HUMAN_APPROVAL",
+}
 KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
 _IS_WINDOWS = sys.platform == "win32"
 
@@ -3559,6 +3566,224 @@ class HallucinatedCardsError(ValueError):
         )
 
 
+_HIGH_RISK_NEXT_ACTION_TYPES = {
+    "deploy",
+    "restart",
+    "delete_data",
+    "credential_change",
+    "external_commitment",
+    "paid_provider",
+}
+
+
+def _clean_verdict_text(value: object, default: str) -> str:
+    text = str(value).strip() if value is not None else ""
+    return text or default
+
+
+def _review_verdict_requires_human_approval(payload: Mapping[str, Any]) -> Optional[str]:
+    human_approval = payload.get("human_approval")
+    if isinstance(human_approval, Mapping) and human_approval.get("required"):
+        return _clean_verdict_text(human_approval.get("reason"), "review verdict requires human approval")
+    risk_gate = payload.get("risk_gate")
+    if isinstance(risk_gate, Mapping) and risk_gate.get("requires_human_approval"):
+        return _clean_verdict_text(risk_gate.get("reason"), "review verdict requires human approval")
+    production = payload.get("production_actions")
+    if isinstance(production, Mapping):
+        for key in ("deploy", "restart", "delete_data", "credential_change"):
+            if production.get(key):
+                return f"high-risk production action requested: {key}"
+    next_action = payload.get("next_action")
+    if isinstance(next_action, Mapping):
+        action_type = str(next_action.get("type") or "").strip().lower()
+        if action_type in _HIGH_RISK_NEXT_ACTION_TYPES:
+            return f"high-risk next_action requested: {action_type}"
+        if next_action.get("requires_human_approval"):
+            return _clean_verdict_text(next_action.get("reason"), "next_action requires human approval")
+    return None
+
+
+def _review_followup_contract(payload: Mapping[str, Any]) -> Optional[Mapping[str, Any]]:
+    contract = payload.get("next_contract")
+    if isinstance(contract, Mapping):
+        return contract
+    next_action = payload.get("next_action")
+    if isinstance(next_action, Mapping):
+        nested = next_action.get("contract")
+        if isinstance(nested, Mapping):
+            return nested
+    return None
+
+
+def _create_review_followup_task(
+    conn: sqlite3.Connection,
+    *,
+    source: Task,
+    review_task_id: str,
+    verdict: str,
+    payload: Mapping[str, Any],
+    actor: str,
+) -> Optional[str]:
+    contract = _review_followup_contract(payload)
+    if contract is None:
+        return None
+    title = _clean_verdict_text(
+        contract.get("title"),
+        f"{verdict.lower().replace('_', ' ')} follow-up for {source.id}",
+    )
+    body = contract.get("body")
+    if body is None:
+        body = (
+            f"Follow-up generated from review verdict {verdict} on {source.id}.\n"
+            f"Review task: {review_task_id}\n"
+            f"Reason: {_clean_verdict_text(payload.get('reason') or payload.get('summary'), 'not specified')}"
+        )
+    assignee = _clean_verdict_text(contract.get("assignee"), source.assignee or actor)
+    workspace_kind = _clean_verdict_text(
+        contract.get("workspace_kind"),
+        source.workspace_kind if source.workspace_kind in VALID_WORKSPACE_KINDS else "scratch",
+    )
+    workspace_path = contract.get("workspace_path")
+    parents = contract.get("parents")
+    if not isinstance(parents, Iterable) or isinstance(parents, (str, bytes)):
+        parents = ()
+    skills = contract.get("skills")
+    if isinstance(skills, (str, bytes)) or not isinstance(skills, Iterable):
+        skills = None
+    return create_task(
+        conn,
+        title=title,
+        body=str(body),
+        assignee=assignee,
+        created_by=actor,
+        workspace_kind=workspace_kind,
+        workspace_path=str(workspace_path) if workspace_path else None,
+        priority=int(contract.get("priority") or source.priority),
+        parents=tuple(str(p) for p in parents if p),
+        skills=skills,
+        goal_mode=bool(contract.get("goal_mode", True)),
+        goal_max_turns=int(contract["goal_max_turns"]) if contract.get("goal_max_turns") is not None else None,
+    )
+
+
+def _record_review_verdict_event(conn: sqlite3.Connection, task_id: str, payload: dict[str, Any]) -> None:
+    with write_txn(conn):
+        _append_event(conn, task_id, "review_verdict_applied", payload)
+
+
+def apply_review_verdict(
+    conn: sqlite3.Connection,
+    review_task_id: str,
+    verdict_payload: Mapping[str, Any],
+    *,
+    actor: str = "kanban-review-engine",
+) -> dict[str, Any]:
+    """Apply a structured reviewer verdict as deterministic Kanban state."""
+    if not isinstance(verdict_payload, Mapping):
+        raise ValueError("verdict_payload must be a mapping")
+    verdict = str(verdict_payload.get("verdict") or "").strip().upper()
+    if verdict not in VALID_REVIEW_VERDICTS:
+        raise ValueError(f"verdict must be one of {sorted(VALID_REVIEW_VERDICTS)}")
+    if get_task(conn, review_task_id) is None:
+        raise ValueError(f"review task not found: {review_task_id}")
+    payload_review_task_id = _clean_verdict_text(verdict_payload.get("review_task_id"), "")
+    if payload_review_task_id and payload_review_task_id != review_task_id:
+        raise ValueError(
+            f"review_task_id mismatch: payload has {payload_review_task_id}, "
+            f"argument has {review_task_id}"
+        )
+    payload_source_task_id = _clean_verdict_text(verdict_payload.get("source_task_id"), "")
+    payload_task_id = _clean_verdict_text(verdict_payload.get("task_id"), "")
+    if payload_source_task_id and payload_task_id and payload_source_task_id != payload_task_id:
+        raise ValueError(
+            f"source_task_id/task_id mismatch: payload has source_task_id {payload_source_task_id}, "
+            f"task_id {payload_task_id}"
+        )
+    source_task_id = _clean_verdict_text(
+        payload_source_task_id or payload_task_id or verdict_payload.get("source"),
+        "",
+    )
+    source_task = get_task(conn, source_task_id) if source_task_id else None
+    if source_task_id and source_task is None:
+        raise ValueError(f"source task not found: {source_task_id}")
+    reason = _clean_verdict_text(
+        verdict_payload.get("reason") or verdict_payload.get("summary"),
+        verdict.lower().replace("_", " "),
+    )
+    event_payload: dict[str, Any] = {
+        "verdict": verdict,
+        "review_task_id": review_task_id,
+        "source_task_id": source_task_id or None,
+        "actor": actor,
+        "reason": reason,
+        "evidence": verdict_payload.get("evidence") or [],
+    }
+    approval_reason = _review_verdict_requires_human_approval(verdict_payload)
+    if verdict == "NEEDS_HUMAN_APPROVAL" or approval_reason:
+        block_reason = _clean_verdict_text(approval_reason or reason, "review verdict needs human approval")
+        blocked = block_task(conn, review_task_id, reason=f"needs_human_approval: {block_reason}")
+        event_payload.update({"action": "blocked_review", "blocked": blocked})
+        _record_review_verdict_event(conn, review_task_id, event_payload)
+        if source_task_id:
+            _record_review_verdict_event(conn, source_task_id, event_payload)
+        return event_payload
+    if verdict == "PASS":
+        review_done = complete_task(
+            conn,
+            review_task_id,
+            summary=f"review verdict PASS: {reason}",
+            metadata={"review_verdict": dict(verdict_payload)},
+        )
+        source_done = False
+        if source_task is not None and source_task.status != "done":
+            source_done = complete_task(
+                conn,
+                source_task.id,
+                summary=f"review PASS via {review_task_id}: {reason}",
+                metadata={"review_verdict": dict(verdict_payload)},
+            )
+        event_payload.update({"action": "completed_review_and_source", "review_done": review_done, "source_done": source_done})
+        _record_review_verdict_event(conn, review_task_id, event_payload)
+        if source_task_id:
+            _record_review_verdict_event(conn, source_task_id, event_payload)
+        recompute_ready(conn)
+        return event_payload
+    if verdict in {"REQUEST_CHANGES", "PARTIAL"}:
+        followup_id = _create_review_followup_task(
+            conn,
+            source=source_task,
+            review_task_id=review_task_id,
+            verdict=verdict,
+            payload=verdict_payload,
+            actor=actor,
+        ) if source_task is not None else None
+        source_blocked = False
+        if source_task is not None and source_task.status in {"running", "ready"}:
+            source_blocked = block_task(conn, source_task.id, reason=f"{verdict.lower()}: {reason}")
+        review_done = complete_task(
+            conn,
+            review_task_id,
+            summary=f"review verdict {verdict}: {reason}",
+            metadata={"review_verdict": dict(verdict_payload), "followup_task_id": followup_id},
+        )
+        event_payload.update({
+            "action": "created_followup_or_recorded_unresolved",
+            "followup_task_id": followup_id,
+            "source_blocked": source_blocked,
+            "review_done": review_done,
+        })
+        _record_review_verdict_event(conn, review_task_id, event_payload)
+        if source_task_id:
+            _record_review_verdict_event(conn, source_task_id, event_payload)
+        return event_payload
+    blocked = block_task(conn, review_task_id, reason=f"blocked: {reason}")
+    event_payload.update({"action": "blocked_review", "blocked": blocked})
+    _record_review_verdict_event(conn, review_task_id, event_payload)
+    if source_task_id:
+        _record_review_verdict_event(conn, source_task_id, event_payload)
+    return event_payload
+
+
 def complete_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -4859,6 +5084,14 @@ _RESPAWN_GUARD_PR_URL_RE = re.compile(
     re.IGNORECASE,
 )
 
+_REVIEW_REQUIRED_MARKER_RE = re.compile(
+    r"(?:^|\n)\s*review_required\s*:\s*(?P<path>\S+)\s*",
+    re.IGNORECASE,
+)
+
+_REVIEW_TASK_TITLE_RE = re.compile(r"^\s*review(?:er|ing)?\b", re.IGNORECASE)
+_REVIEW_TASK_ASSIGNEE_RE = re.compile(r"\breview(?:er|ing)?\b", re.IGNORECASE)
+
 
 @dataclass
 class DispatchResult:
@@ -4912,6 +5145,10 @@ class DispatchResult:
     (EX_TEMPFAIL sentinel exit) and were released back to ``ready`` WITHOUT
     counting a failure. These never trip the circuit breaker — a long quota
     window just makes the task bounce cheaply until the window clears."""
+    review_unblocked: list[dict[str, str]] = field(default_factory=list)
+    """Review child tasks moved to ``review`` from a parent/source
+    ``review_required`` handoff. Each dict includes ``task_id``,
+    ``source_task_id``, ``report_path``, and ``marker_source``."""
 
 
 # Bounded registry of recently-reaped worker child exits, populated by the
@@ -5965,6 +6202,238 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
     return None
 
 
+def _safe_review_report_path(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    path = value.strip()
+    if not path or len(path) > 2048:
+        return None
+    if any(ch in path for ch in ("\x00", "\r", "\n")):
+        return None
+    if path.startswith("-"):
+        return None
+    return path
+
+
+def _review_required_from_mapping(data: Any) -> Optional[dict[str, str]]:
+    if not isinstance(data, dict):
+        return None
+    report_path = None
+    if data.get("status") == "review_required":
+        report_path = data.get("report_path") or data.get("path")
+    review = data.get("review")
+    if isinstance(review, dict):
+        required = review.get("required") is True or review.get("status") == "review_required"
+        if required:
+            report_path = report_path or review.get("report_path") or review.get("path")
+        marker = review.get("marker")
+        if isinstance(marker, str):
+            matched = _REVIEW_REQUIRED_MARKER_RE.search(marker)
+            if matched:
+                report_path = report_path or matched.group("path")
+    safe_path = _safe_review_report_path(report_path)
+    if safe_path:
+        return {"report_path": safe_path, "marker_source": "structured_report"}
+    return None
+
+
+def _review_required_from_text(text: Any, marker_source: str) -> Optional[dict[str, str]]:
+    if not isinstance(text, str) or not text.strip():
+        return None
+    matched = _REVIEW_REQUIRED_MARKER_RE.search(text)
+    if matched:
+        safe_path = _safe_review_report_path(matched.group("path"))
+        if safe_path:
+            return {"report_path": safe_path, "marker_source": marker_source}
+    stripped = text.strip()
+    if not stripped.startswith(("{", "[")):
+        return None
+    try:
+        parsed = json.loads(stripped)
+    except Exception:
+        return None
+    if isinstance(parsed, list):
+        for item in parsed:
+            found = _review_required_from_mapping(item)
+            if found:
+                found["marker_source"] = marker_source
+                return found
+        return None
+    found = _review_required_from_mapping(parsed)
+    if found:
+        found["marker_source"] = marker_source
+    return found
+
+
+def _extract_review_required_handoff(
+    conn: sqlite3.Connection, source_task_id: str,
+) -> Optional[dict[str, str]]:
+    task = conn.execute(
+        "SELECT result FROM tasks WHERE id = ?", (source_task_id,)
+    ).fetchone()
+    if task is not None:
+        found = _review_required_from_text(task["result"], "task_result")
+        if found:
+            return found
+
+    comments = conn.execute(
+        "SELECT body FROM task_comments WHERE task_id = ? ORDER BY id DESC",
+        (source_task_id,),
+    ).fetchall()
+    for comment in comments:
+        found = _review_required_from_text(comment["body"], "comment")
+        if found:
+            return found
+
+    runs = conn.execute(
+        """
+        SELECT summary, metadata
+          FROM task_runs
+         WHERE task_id = ?
+         ORDER BY COALESCE(ended_at, started_at, 0) DESC, id DESC
+        """,
+        (source_task_id,),
+    ).fetchall()
+    for run in runs:
+        found = _review_required_from_text(run["summary"], "run_summary")
+        if found:
+            return found
+        if run["metadata"]:
+            try:
+                metadata = json.loads(run["metadata"])
+            except Exception:
+                metadata = None
+            found = _review_required_from_mapping(metadata)
+            if found:
+                found["marker_source"] = "run_metadata"
+                return found
+    return None
+
+
+def _is_review_handoff_task(row: sqlite3.Row) -> bool:
+    """Return True only for explicit reviewer children.
+
+    Review-required auto-unblock is only the source -> reviewer escape hatch.
+    Downstream fan-in/finalizer tasks often mention "review" in their titles
+    or bodies because they run after a PASS; incidental review text is not
+    reviewer identity. Treat a child as a reviewer only when its title leads
+    with a reviewer label or its assignee is a reviewer lane.
+    """
+    title = row["title"] or ""
+    assignee = row["assignee"] if "assignee" in row.keys() else ""
+    assignee = assignee or ""
+    return bool(
+        _REVIEW_TASK_TITLE_RE.search(title)
+        or _REVIEW_TASK_ASSIGNEE_RE.search(assignee)
+    )
+
+
+def _has_review_handoff_parent_gate_clear(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    source_task_id: str,
+) -> bool:
+    """Only bypass the source parent; preserve all other parent gates."""
+    rows = conn.execute(
+        """
+        SELECT p.id, p.status
+          FROM tasks p
+          JOIN task_links l ON l.parent_id = p.id
+         WHERE l.child_id = ?
+           AND p.id != ?
+        """,
+        (task_id, source_task_id),
+    ).fetchall()
+    return all(row["status"] in ("done", "archived") for row in rows)
+
+
+def auto_unblock_review_required_tasks(
+    conn: sqlite3.Connection, *, dry_run: bool = False,
+) -> list[dict[str, str]]:
+    """Move blocked/todo review children to ``review`` when the source is ready.
+
+    This is a narrow deterministic escape hatch for review-required handoffs:
+    the source task remains blocked/running, but a linked reviewer task may be
+    dispatched once the source publishes ``review_required: <report_path>`` or
+    structured ``status=review_required`` evidence. No report instructions are
+    executed; the path/status are audit evidence only.
+    """
+    candidates = conn.execute(
+        """
+        SELECT c.id, c.title, c.body, c.assignee, l.parent_id AS source_task_id
+          FROM tasks c
+          JOIN task_links l ON l.child_id = c.id
+          JOIN tasks p ON p.id = l.parent_id
+         WHERE c.status IN ('todo', 'blocked')
+           AND c.claim_lock IS NULL
+           AND p.status IN ('running', 'blocked')
+         ORDER BY c.priority DESC, c.created_at ASC, c.id ASC
+        """
+    ).fetchall()
+    planned: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for row in candidates:
+        task_id = row["id"]
+        if task_id in seen or not _is_review_handoff_task(row):
+            continue
+        if not _has_review_handoff_parent_gate_clear(
+            conn,
+            task_id=task_id,
+            source_task_id=row["source_task_id"],
+        ):
+            continue
+        handoff = _extract_review_required_handoff(conn, row["source_task_id"])
+        if not handoff:
+            continue
+        item = {
+            "task_id": task_id,
+            "source_task_id": row["source_task_id"],
+            "report_path": handoff["report_path"],
+            "marker_source": handoff["marker_source"],
+        }
+        planned.append(item)
+        seen.add(task_id)
+
+    if dry_run or not planned:
+        return planned
+
+    now = int(time.time())
+    applied: list[dict[str, str]] = []
+    with write_txn(conn):
+        for item in planned:
+            stale = conn.execute(
+                "SELECT current_run_id FROM tasks WHERE id = ? AND status IN ('todo', 'blocked')",
+                (item["task_id"],),
+            ).fetchone()
+            if stale and stale["current_run_id"]:
+                conn.execute(
+                    """
+                    UPDATE task_runs
+                       SET status = 'reclaimed', outcome = 'reclaimed',
+                           summary = COALESCE(summary, 'invariant recovery on review handoff'),
+                           ended_at = ?, claim_lock = NULL, claim_expires = NULL,
+                           worker_pid = NULL
+                     WHERE id = ? AND ended_at IS NULL
+                    """,
+                    (now, int(stale["current_run_id"])),
+                )
+            cur = conn.execute(
+                """
+                UPDATE tasks
+                   SET status = 'review', claim_lock = NULL, claim_expires = NULL,
+                       current_run_id = NULL
+                 WHERE id = ? AND status IN ('todo', 'blocked') AND claim_lock IS NULL
+                """,
+                (item["task_id"],),
+            )
+            if cur.rowcount != 1:
+                continue
+            _append_event(conn, item["task_id"], "review_required_auto_unblocked", item)
+            applied.append(item)
+    return applied
+
+
 def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
     """Return True iff there is at least one ready+assigned+unclaimed task
     whose assignee maps to a real Hermes profile.
@@ -6092,6 +6561,7 @@ def dispatch_once(
         result.rate_limited.extend(_crash_rate_limited)
     result.timed_out = enforce_max_runtime(conn)
     result.promoted = recompute_ready(conn, failure_limit=failure_limit)
+    result.review_unblocked = auto_unblock_review_required_tasks(conn, dry_run=dry_run)
 
     # Count tasks already running so max_spawn enforces concurrency rather
     # than a per-tick spawn budget. See the docstring above for the full
@@ -6336,10 +6806,11 @@ def dispatch_once(
                 result.auto_blocked.append(claimed.id)
 
     # ---- review column dispatch ----
-    # Review tasks are tasks that a worker moved to 'review' after
-    # creating a PR.  The dispatcher spawns a review agent (loading
-    # sdlc-review skill) that verifies the PR and either merges (→ done)
-    # or rejects (→ back to running for the worker to fix).
+    # Review tasks are tasks that a worker/review loop moved to 'review'.
+    # The dispatcher must not inject profile-unknown review skills here:
+    # forced missing skills abort the child process before task logic runs.
+    # Review behavior belongs in the assignee profile defaults or explicit
+    # per-task skills supplied by the task creator.
     #
     # Same concurrency model as ready dispatch: review spawns count
     # against max_spawn alongside ready tasks, so the total number of
@@ -6381,12 +6852,11 @@ def dispatch_once(
         # Persist the resolved workspace path so the worker can cd there.
         set_workspace_path(conn, claimed.id, str(workspace))
         _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
-        # Force-load sdlc-review skill for review agents.  The
-        # _default_spawn function already auto-loads kanban-worker, and
-        # appends task.skills via --skills.  Setting task.skills here
-        # means the review agent gets both kanban-worker (lifecycle)
-        # and sdlc-review (review logic: AC verification, merge, etc.).
-        claimed.skills = ["sdlc-review"]
+        # Preserve explicit per-task skills from the task record. Do not
+        # inject a review-specific default here unless it is a real skill
+        # configured on the task/profile: an unknown forced skill makes the
+        # spawned Hermes process fail during startup before it can block or
+        # complete the review task.
         _spawn = spawn_fn if spawn_fn is not None else _default_spawn
         try:
             import inspect
@@ -7675,6 +8145,175 @@ def latest_summary(conn: sqlite3.Connection, task_id: str) -> Optional[str]:
         (task_id,),
     ).fetchone()
     return row["summary"] if row else None
+
+
+def _extract_named_line(text: Optional[str], names: Iterable[str]) -> Optional[str]:
+    if not text:
+        return None
+    wanted = {n.lower().replace(" ", "_").replace("-", "_") for n in names}
+    for raw_line in str(text).splitlines():
+        line = raw_line.strip().lstrip("-*").strip()
+        if not line or ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        normalized = key.strip().lower().replace(" ", "_").replace("-", "_")
+        if normalized in wanted and value.strip():
+            return value.strip()
+    return None
+
+
+def _extract_named_section(text: Optional[str], names: Iterable[str]) -> list[str]:
+    if not text:
+        return []
+    wanted = {n.lower().replace(" ", "_").replace("-", "_") for n in names}
+    items: list[str] = []
+    collecting = False
+    for raw_line in str(text).splitlines():
+        stripped = raw_line.strip()
+        normalized = stripped.strip("#").strip().rstrip(":").lower()
+        normalized = normalized.replace(" ", "_").replace("-", "_")
+        is_heading = stripped.startswith("#") or (
+            stripped.endswith(":") and not stripped.startswith(("-", "*"))
+        )
+        if normalized in wanted:
+            collecting = True
+            if ":" in stripped and not stripped.endswith(":"):
+                value = stripped.split(":", 1)[1].strip()
+                if value:
+                    items.append(value)
+            continue
+        if collecting and is_heading:
+            break
+        if not collecting or not stripped:
+            continue
+        item = stripped.lstrip("-*0123456789. ").strip()
+        if item:
+            items.append(item)
+    return items
+
+
+def _task_brief_for_mission_state(
+    task: Task,
+    *,
+    depth: int,
+    parents: list[str],
+    children: list[str],
+    latest_summary_value: Optional[str],
+) -> dict[str, Any]:
+    return {
+        "id": task.id,
+        "title": task.title,
+        "status": task.status,
+        "assignee": task.assignee,
+        "depth": depth,
+        "parents": parents,
+        "children": children,
+        "latest_summary": latest_summary_value,
+        "last_failure_error": task.last_failure_error,
+    }
+
+
+def mission_state(conn: sqlite3.Connection, root_task_id: str) -> Optional[dict[str, Any]]:
+    """Return a deterministic summary for a root task's mission graph."""
+    root = get_task(conn, root_task_id)
+    if root is None:
+        return None
+    board_slug = get_current_board()
+
+    edge_rows = conn.execute(
+        "SELECT parent_id, child_id FROM task_links ORDER BY parent_id, child_id"
+    ).fetchall()
+    children_by_parent: dict[str, list[str]] = {}
+    parents_by_child: dict[str, list[str]] = {}
+    for row in edge_rows:
+        parent_id = row["parent_id"]
+        child_id = row["child_id"]
+        children_by_parent.setdefault(parent_id, []).append(child_id)
+        parents_by_child.setdefault(child_id, []).append(parent_id)
+
+    ordered_ids: list[str] = []
+    depths: dict[str, int] = {root_task_id: 0}
+    seen: set[str] = set()
+    queue: list[str] = [root_task_id]
+    cycle_guarded = False
+    while queue:
+        task_id = queue.pop(0)
+        if task_id in seen:
+            cycle_guarded = True
+            continue
+        seen.add(task_id)
+        ordered_ids.append(task_id)
+        for child_id in children_by_parent.get(task_id, []):
+            next_depth = depths[task_id] + 1
+            depths[child_id] = min(depths.get(child_id, next_depth), next_depth)
+            if child_id not in seen:
+                queue.append(child_id)
+
+    placeholders = ",".join("?" for _ in ordered_ids)
+    task_rows = conn.execute(
+        f"SELECT * FROM tasks WHERE id IN ({placeholders})", ordered_ids
+    ).fetchall()
+    tasks_by_id: dict[str, Task] = {}
+    for row in task_rows:
+        task = Task.from_row(row)
+        tasks_by_id[task.id] = task
+    ordered_ids = [task_id for task_id in ordered_ids if task_id in tasks_by_id]
+    summaries = latest_summaries(conn, ordered_ids)
+
+    by_status: dict[str, int] = {}
+    task_items: list[dict[str, Any]] = []
+    for task_id in ordered_ids:
+        task = tasks_by_id[task_id]
+        by_status[task.status] = by_status.get(task.status, 0) + 1
+        task_items.append(
+            _task_brief_for_mission_state(
+                task,
+                depth=depths.get(task_id, 0),
+                parents=sorted(
+                    p for p in parents_by_child.get(task_id, []) if p in tasks_by_id
+                ),
+                children=sorted(
+                    c for c in children_by_parent.get(task_id, []) if c in tasks_by_id
+                ),
+                latest_summary_value=summaries.get(task_id),
+            )
+        )
+
+    done_count = by_status.get("done", 0)
+    total = len(ordered_ids)
+    open_count = sum(
+        count for status, count in by_status.items()
+        if status not in {"done", "archived"}
+    )
+    comments_text = "\n".join(c.body for c in list_comments(conn, root_task_id))
+    scan_text = (root.body or "") + "\n" + comments_text
+
+    return {
+        "board": board_slug,
+        "board_path": str(kanban_db_path(board=board_slug)),
+        "mission_id": _extract_named_line(scan_text, ("mission_id", "mission id")) or root_task_id,
+        "root_task_id": root_task_id,
+        "north_star": _extract_named_line(scan_text, ("north_star", "north star", "objective")) or root.title,
+        "current_metric_floors": _extract_named_section(
+            scan_text,
+            ("current_metric_floors", "current metric floors", "metric_floors", "metric floors"),
+        ),
+        "risk_gates": _extract_named_section(scan_text, ("risk_gates", "risk gates")),
+        "stop_conditions": _extract_named_section(scan_text, ("stop_conditions", "stop conditions")),
+        "total_tasks": total,
+        "done_tasks": done_count,
+        "open_tasks": open_count,
+        "progress_percent": int((done_count / total) * 100) if total else 0,
+        "by_status": dict(sorted(by_status.items())),
+        "active_tasks": [t for t in task_items if t["status"] in {"running", "review"}],
+        "blocked_tasks": [t for t in task_items if t["status"] == "blocked"],
+        "next_tasks": [
+            t for t in task_items if t["status"] in {"ready", "todo", "scheduled"}
+        ],
+        "leaves": [t["id"] for t in task_items if not t["children"]],
+        "tasks": task_items,
+        "cycle_guarded": cycle_guarded,
+    }
 
 
 def latest_summaries(

--- a/hermes_cli/status_warnings.py
+++ b/hermes_cli/status_warnings.py
@@ -1,0 +1,331 @@
+"""Ops-safe Hermes status/doctor drift diagnostics.
+
+These helpers intentionally return only configuration metadata and credential
+health summaries. They must never surface access tokens, refresh tokens, API
+keys, or raw exception messages that can contain secrets.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+import yaml
+
+from hermes_cli.config import check_config_version, get_hermes_home, load_config
+from hermes_constants import get_default_hermes_root
+
+_SAFE_CREDENTIAL_STATUS_KEYS = (
+    "last_status",
+    "last_error_code",
+    "last_error_reason",
+)
+
+_SECRETISH_KEYS = frozenset({
+    "access_token",
+    "refresh_token",
+    "api_key",
+    "token",
+    "key",
+    "secret",
+    "client_secret",
+})
+
+
+RunCallable = Callable[..., subprocess.CompletedProcess[str]]
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return raw if isinstance(raw, dict) else {}
+
+
+def _read_yaml(path: Path) -> dict[str, Any]:
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return raw if isinstance(raw, dict) else {}
+
+
+def _auth_store(home: Path) -> dict[str, Any]:
+    return _read_json(home / "auth.json")
+
+
+def _provider_pool_entries(store: dict[str, Any], provider: str) -> list[dict[str, Any]]:
+    pool = store.get("credential_pool")
+    if not isinstance(pool, dict):
+        return []
+    entries = pool.get(provider)
+    if not isinstance(entries, list):
+        return []
+    return [entry for entry in entries if isinstance(entry, dict)]
+
+
+def _credential_pool_source(
+    provider: str,
+    *,
+    hermes_home: Path | None = None,
+    default_root: Path | None = None,
+) -> tuple[str, list[dict[str, Any]]]:
+    """Return provider-slice pool source plus entries without changing auth semantics."""
+    home = hermes_home or get_hermes_home()
+    root = default_root or get_default_hermes_root()
+    local_entries = _provider_pool_entries(_auth_store(home), provider)
+    if local_entries:
+        return "local", local_entries
+
+    try:
+        same_home = home.resolve(strict=False) == root.resolve(strict=False)
+    except Exception:
+        same_home = home == root
+    if not same_home:
+        global_entries = _provider_pool_entries(_auth_store(root), provider)
+        if global_entries:
+            return "global-fallback", global_entries
+    return "none", []
+
+
+def _sanitize_pool_status(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    statuses: list[dict[str, Any]] = []
+    for entry in entries:
+        status = {
+            key: entry.get(key)
+            for key in _SAFE_CREDENTIAL_STATUS_KEYS
+            if entry.get(key) is not None
+        }
+        if status:
+            statuses.append(status)
+    return statuses
+
+
+def _profile_name_for_home(home: Path, root: Path) -> str:
+    try:
+        if home.resolve(strict=False) == root.resolve(strict=False):
+            return "default"
+        profiles_root = root / "profiles"
+        rel = home.resolve(strict=False).relative_to(profiles_root.resolve(strict=False))
+        return rel.parts[0] if rel.parts else home.name
+    except Exception:
+        return home.name or "default"
+
+
+def collect_provider_auth_diagnostic(
+    *,
+    config: dict[str, Any] | None = None,
+    hermes_home: Path | None = None,
+    default_root: Path | None = None,
+) -> dict[str, Any]:
+    """Collect non-secret auth/config drift diagnostics for the default provider."""
+    cfg = config if config is not None else load_config()
+    raw_model_cfg = cfg.get("model")
+    model_cfg = raw_model_cfg if isinstance(raw_model_cfg, dict) else {}
+    config_provider = str(model_cfg.get("provider") or "").strip().lower()
+    home = hermes_home or get_hermes_home()
+    root = default_root or get_default_hermes_root()
+    auth_store = _auth_store(home)
+    active_provider = auth_store.get("active_provider")
+    if isinstance(active_provider, str):
+        active_provider = active_provider.strip().lower() or None
+    else:
+        active_provider = None
+
+    source, entries = _credential_pool_source(
+        config_provider,
+        hermes_home=home,
+        default_root=root,
+    ) if config_provider else ("none", [])
+
+    profile_name = _profile_name_for_home(home, root)
+    warnings: list[dict[str, Any]] = []
+    if config_provider == "openai-codex" and active_provider != config_provider:
+        warnings.append({
+            "code": "auth_active_provider_drift",
+            "severity": "warning",
+            "message": (
+                "model.provider is openai-codex but auth.active_provider is "
+                f"{active_provider or 'unset'}"
+            ),
+            "config_provider": config_provider,
+            "auth_active_provider": active_provider,
+            "credential_pool_source": source,
+        })
+    if profile_name != "default" and config_provider and source == "global-fallback":
+        warnings.append({
+            "code": "profile_global_auth_fallback",
+            "severity": "warning",
+            "message": (
+                f"profile {profile_name} is using global-root credential_pool "
+                f"fallback for default provider {config_provider}"
+            ),
+            "profile": profile_name,
+            "config_provider": config_provider,
+            "credential_pool_source": source,
+        })
+
+    return {
+        "profile": profile_name,
+        "config_provider": config_provider or None,
+        "auth_active_provider": active_provider,
+        "credential_pool": {
+            "provider": config_provider or None,
+            "source": source,
+            "entries": len(entries),
+            "entry_statuses": _sanitize_pool_status(entries),
+        },
+        "warnings": warnings,
+    }
+
+
+def _profile_config_paths(default_root: Path) -> list[tuple[str, Path]]:
+    paths: list[tuple[str, Path]] = []
+    default_config = default_root / "config.yaml"
+    if default_config.exists():
+        paths.append(("default", default_config))
+    profiles_root = default_root / "profiles"
+    if profiles_root.is_dir():
+        for entry in sorted(profiles_root.iterdir()):
+            if not entry.is_dir() or entry.name == "default":
+                continue
+            config_path = entry / "config.yaml"
+            if config_path.exists():
+                paths.append((entry.name, config_path))
+    return paths
+
+
+def collect_config_version_drift(
+    *,
+    default_root: Path | None = None,
+    latest_config_version: int | None = None,
+) -> dict[str, Any]:
+    """Collect profile config-version drift without reading secrets."""
+    root = default_root or get_default_hermes_root()
+    if latest_config_version is None:
+        _, resolved_latest = check_config_version()
+        latest_config_version = int(resolved_latest)
+
+    profiles: list[dict[str, Any]] = []
+    behind: list[dict[str, Any]] = []
+    for name, config_path in _profile_config_paths(root):
+        raw = _read_yaml(config_path)
+        version = raw.get("_config_version", 0)
+        try:
+            version_int = int(version or 0)
+        except (TypeError, ValueError):
+            version_int = 0
+        item = {"profile": name, "config_version": version_int}
+        profiles.append(item)
+        if version_int < latest_config_version:
+            behind.append({
+                "profile": name,
+                "config_version": version_int,
+                "latest_config_version": latest_config_version,
+            })
+
+    warning = None
+    if behind:
+        warning = {
+            "code": "profile_config_version_drift",
+            "severity": "warning",
+            "message": (
+                f"{len(behind)} profile(s) behind latest_config_version="
+                f"{latest_config_version}"
+            ),
+            "behind": behind,
+        }
+    return {
+        "latest_config_version": latest_config_version,
+        "profiles": profiles,
+        "behind": behind,
+        "warning": warning,
+    }
+
+
+def _parse_launchctl_list(stdout: str) -> dict[str, int | None]:
+    pid_match = re.search(r'"PID"\s*=\s*(\d+)', stdout)
+    last_exit_match = re.search(r'"LastExitStatus"\s*=\s*(-?\d+)', stdout)
+    return {
+        "pid": int(pid_match.group(1)) if pid_match else None,
+        "last_exit_status": int(last_exit_match.group(1)) if last_exit_match else None,
+    }
+
+
+def collect_launchd_gateway_warning(
+    *,
+    gateway_pid: int | None,
+    run: RunCallable = subprocess.run,
+) -> dict[str, Any] | None:
+    """Warn when launchd status disagrees with a live gateway PID.
+
+    Read-only: does not restart, bootout, bootstrap, or kickstart services.
+    """
+    if sys.platform != "darwin" or gateway_pid is None:
+        return None
+    try:
+        from hermes_cli.gateway import get_launchd_label
+
+        label = get_launchd_label()
+        result = run(
+            ["launchctl", "list", label],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+    except Exception:
+        return None
+
+    parsed = _parse_launchctl_list(result.stdout or "")
+    last_exit = parsed.get("last_exit_status")
+    if result.returncode == 0 and (last_exit is None or last_exit == 0):
+        return None
+    return {
+        "code": "launchd_gateway_state_mismatch",
+        "severity": "warning",
+        "message": (
+            "gateway PID is running but launchd reports a nonzero "
+            "status/LastExitStatus"
+        ),
+        "label": label,
+        "gateway_pid": gateway_pid,
+        "launchctl_status": result.returncode,
+        "launchd_pid": parsed.get("pid"),
+        "last_exit_status": last_exit,
+    }
+
+
+def collect_status_warnings(*, gateway_pid: int | None = None) -> dict[str, Any]:
+    """Aggregate all ops-safe warning families for doctor/dashboard status."""
+    provider_auth = collect_provider_auth_diagnostic()
+    config_versions = collect_config_version_drift()
+    warnings: list[dict[str, Any]] = []
+    warnings.extend(provider_auth["warnings"])
+    if config_versions["warning"]:
+        warnings.append(config_versions["warning"])
+    launchd_warning = collect_launchd_gateway_warning(gateway_pid=gateway_pid)
+    if launchd_warning:
+        warnings.append(launchd_warning)
+    return {
+        "warnings": warnings,
+        "provider_auth": provider_auth,
+        "config_versions": config_versions,
+    }
+
+
+def assert_no_secretish_keys(payload: Any) -> None:
+    """Test helper: raise when a diagnostic payload exposes secret-shaped keys."""
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            if str(key).lower() in _SECRETISH_KEYS:
+                raise AssertionError(f"secret key leaked in diagnostic: {key}")
+            assert_no_secretish_keys(value)
+    elif isinstance(payload, list):
+        for item in payload:
+            assert_no_secretish_keys(item)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1637,6 +1637,16 @@ async def get_status():
         # Module not importable yet (early startup) — leave as [].
         pass
 
+    status_warnings: dict[str, Any] = {"warnings": []}
+    try:
+        from hermes_cli.status_warnings import collect_status_warnings
+
+        status_warnings = collect_status_warnings(gateway_pid=gateway_pid)
+    except Exception:
+        # Status must remain a liveness endpoint. Diagnostics are best-effort
+        # and non-blocking so dashboard/portal health checks keep working.
+        status_warnings = {"warnings": []}
+
     return {
         "version": __version__,
         "release_date": __release_date__,
@@ -1655,6 +1665,8 @@ async def get_status():
         "active_sessions": active_sessions,
         "auth_required": auth_required,
         "auth_providers": auth_providers,
+        "warnings": status_warnings.get("warnings", []),
+        "diagnostics": status_warnings,
     }
 
 

--- a/tests/docs/test_kanban_report_schemas.py
+++ b/tests/docs/test_kanban_report_schemas.py
@@ -1,0 +1,119 @@
+import json
+from pathlib import Path
+
+from hermes_cli import kanban_db as kb
+
+ROOT = Path(__file__).resolve().parents[2]
+REPORTS = ROOT / "docs" / "kanban" / "reports"
+
+
+def _load_json(path: Path):
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _assert_required_fields(schema: dict, example: dict, prefix: str = "") -> None:
+    for field in schema.get("required", []):
+        assert field in example, f"{prefix}{field} is required"
+
+    for name, subschema in schema.get("properties", {}).items():
+        if name not in example:
+            continue
+        value = example[name]
+        location = f"{prefix}{name}."
+        if "const" in subschema:
+            assert value == subschema["const"], f"{prefix}{name} must match const"
+        if "enum" in subschema:
+            assert value in subschema["enum"], f"{prefix}{name} must be in enum"
+        if subschema.get("type") == "object":
+            assert isinstance(value, dict), f"{prefix}{name} must be object"
+            _assert_required_fields(subschema, value, location)
+        if subschema.get("type") == "array":
+            assert isinstance(value, list), f"{prefix}{name} must be array"
+            item_schema = subschema.get("items")
+            if isinstance(item_schema, dict):
+                for index, item in enumerate(value):
+                    if item_schema.get("type") == "object":
+                        assert isinstance(item, dict), f"{prefix}{name}[{index}] must be object"
+                        _assert_required_fields(item_schema, item, f"{prefix}{name}[{index}].")
+                    elif "enum" in item_schema:
+                        assert item in item_schema["enum"], f"{prefix}{name}[{index}] must be in enum"
+
+
+def test_worker_handoff_example_matches_required_schema_fields_and_marker():
+    schema = _load_json(REPORTS / "schemas" / "worker-handoff-report.schema.json")
+    example = _load_json(REPORTS / "samples" / "worker-handoff-report.example.json")
+
+    _assert_required_fields(schema, example)
+
+    assert example["changed_files"]
+    assert example["pre_existing_dirty_files"]
+    assert example["commands"]
+    assert all(isinstance(command["exit_code"], int) for command in example["commands"])
+    assert example["schema_changed"] is True
+    assert "OMX" in example["route_used"]
+
+    review = example["review"]
+    assert review["required"] is True
+    assert review["marker"] == f"review_required: {review['report_path']}"
+    assert review["marker"].startswith("review_required: ")
+    assert review["summary"]
+
+
+def test_reviewer_verdict_example_matches_required_schema_fields_and_enums():
+    schema = _load_json(REPORTS / "schemas" / "reviewer-verdict.schema.json")
+    example = _load_json(REPORTS / "samples" / "reviewer-verdict.example.json")
+
+    _assert_required_fields(schema, example)
+
+    assert set(schema["properties"]["verdict"]["enum"]) == {
+        "PASS",
+        "REQUEST_CHANGES",
+        "PARTIAL",
+        "BLOCKED",
+        "NEEDS_HUMAN_APPROVAL",
+    }
+    assert example["review_task_id"]
+    assert example["source_task_id"]
+    assert example.get("task_id", example["source_task_id"]) == example["source_task_id"]
+    assert isinstance(example["safe_to_merge"], bool)
+    assert isinstance(example["safe_to_deploy"], bool)
+    assert isinstance(example["blocking_findings"], list)
+    assert isinstance(example["non_blocking_findings"], list)
+    assert example["evidence"]
+    assert all(isinstance(command["exit_code"], int) for command in example["evidence"])
+    assert example["commands"]
+    assert all(isinstance(command["exit_code"], int) for command in example["commands"])
+    assert example["next_action"]["type"] in schema["properties"]["next_action"]["properties"]["type"]["enum"]
+    assert example["verdict"] in schema["properties"]["verdict"]["enum"]
+
+
+def test_reviewer_verdict_schema_covers_transition_engine_gate_fields():
+    schema = _load_json(REPORTS / "schemas" / "reviewer-verdict.schema.json")
+    properties = schema["properties"]
+
+    assert {
+        "review_task_id",
+        "source_task_id",
+        "safe_to_merge",
+        "safe_to_deploy",
+        "blocking_findings",
+        "non_blocking_findings",
+        "evidence",
+        "next_action",
+    } <= set(schema["required"])
+    assert "Legacy alias for source_task_id" in properties["task_id"]["description"]
+    assert "required" in properties["human_approval"]["required"]
+    assert "reason" in properties["human_approval"]["required"]
+    assert {
+        "deploy",
+        "restart",
+        "delete_data",
+        "credential_change",
+    } <= set(properties["production_actions"]["properties"])
+    assert kb._HIGH_RISK_NEXT_ACTION_TYPES <= set(properties["next_action"]["properties"]["type"]["enum"])
+
+
+def test_all_kanban_report_json_files_are_valid_json():
+    for path in sorted(REPORTS.rglob("*.json")):
+        assert _load_json(path), f"{path} should contain a JSON object"

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -167,6 +167,58 @@ def test_run_slash_json_output(kanban_home):
     assert payload["status"] == "ready"
 
 
+def test_run_slash_mission_state_json(kanban_home):
+    with kb.connect() as conn:
+        root = kb.create_task(
+            conn,
+            title="root mission",
+            body="""
+mission_id: mission-beta
+objective: ship deterministic state
+metric_floors:
+- pass_rate >= 99%
+risk_gates:
+- no production deploy
+stop_conditions:
+- all checks pass
+""",
+            assignee="lead",
+        )
+        ready = kb.create_task(conn, title="ready child", assignee="liz", parents=[root])
+        blocked = kb.create_task(conn, title="blocked child", assignee="ellie", parents=[root])
+        kb.complete_task(conn, root)
+        kb.block_task(conn, blocked, reason="needs approval")
+
+    raw = kc.run_slash(f"mission-state {root} --json")
+    payload = json.loads(raw)
+    assert payload["board"] == "default"
+    assert payload["mission_id"] == "mission-beta"
+    assert payload["north_star"] == "ship deterministic state"
+    assert payload["current_metric_floors"] == ["pass_rate >= 99%"]
+    assert payload["risk_gates"] == ["no production deploy"]
+    assert payload["stop_conditions"] == ["all checks pass"]
+    assert payload["by_status"] == {"blocked": 1, "done": 1, "ready": 1}
+    assert [task["id"] for task in payload["blocked_tasks"]] == [blocked]
+    assert [task["id"] for task in payload["next_tasks"]] == [ready]
+
+
+def test_run_slash_mission_state_human_output(kanban_home):
+    with kb.connect() as conn:
+        root = kb.create_task(conn, title="human mission")
+    out = kc.run_slash(f"mission-state {root}")
+    assert "Mission" in out
+    assert "[board=default]" in out
+    assert "Progress:" in out
+    assert "Active tasks:" in out
+    assert "Blocked tasks:" in out
+    assert "Next tasks:" in out
+
+
+def test_run_slash_mission_state_missing_root(kanban_home):
+    out = kc.run_slash("mission-state t_missing")
+    assert "no such task: t_missing" in out
+
+
 def test_run_slash_dispatch_dry_run_counts(kanban_home):
     kc.run_slash("create 'a' --assignee alice")
     kc.run_slash("create 'b' --assignee bob")
@@ -335,6 +387,7 @@ def test_kanban_in_autocomplete_table():
     subs = SUBCOMMANDS.get("/kanban") or []
     assert "create" in subs
     assert "dispatch" in subs
+    assert "mission-state" in subs
 
 
 def test_kanban_autocomplete_includes_live_subcommands():

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import json
 import os
 import sqlite3
 import sys
@@ -344,6 +345,80 @@ def test_recompute_ready_fan_in_waits_for_all_parents(kanban_home):
         assert kb.get_task(conn, c).status == "todo"
         kb.complete_task(conn, b)
         assert kb.get_task(conn, c).status == "ready"
+
+
+def test_mission_state_missing_root_returns_none(kanban_home):
+    with kb.connect() as conn:
+        assert kb.mission_state(conn, "t_missing") is None
+
+
+def test_mission_state_summarizes_descendant_graph(kanban_home):
+    body = """
+mission_id: mission-alpha
+north_star: keep recall SLO green
+current_metric_floors:
+- trusted_recall >= 0.95
+risk_gates:
+- no DB deletes without approval
+stop_conditions:
+- repeated identical failure
+"""
+    with kb.connect() as conn:
+        root = kb.create_task(conn, title="root", body=body, assignee="lead")
+        active = kb.create_task(conn, title="active", assignee="liz", parents=[root])
+        blocked = kb.create_task(conn, title="blocked", assignee="ellie", parents=[root])
+        done = kb.create_task(conn, title="done", assignee="sage", parents=[root])
+        kb.complete_task(conn, root)
+        kb.claim_task(conn, active)
+        kb.block_task(conn, blocked, reason="waiting on credential")
+        kb.complete_task(conn, done, summary="verified metric floor")
+
+        state = kb.mission_state(conn, root)
+
+    assert state is not None
+    assert state["mission_id"] == "mission-alpha"
+    assert state["north_star"] == "keep recall SLO green"
+    assert state["current_metric_floors"] == ["trusted_recall >= 0.95"]
+    assert state["risk_gates"] == ["no DB deletes without approval"]
+    assert state["stop_conditions"] == ["repeated identical failure"]
+    assert state["total_tasks"] == 4
+    assert state["done_tasks"] == 2
+    assert state["by_status"] == {"blocked": 1, "done": 2, "running": 1}
+    assert [task["id"] for task in state["active_tasks"]] == [active]
+    assert [task["id"] for task in state["blocked_tasks"]] == [blocked]
+    done_task = next(task for task in state["tasks"] if task["id"] == done)
+    assert done_task["depth"] == 1
+    assert done_task["latest_summary"] == "verified metric floor"
+
+
+def test_mission_state_names_active_board_for_named_board_tasks(kanban_home):
+    kb.create_board("brain-quality")
+    with kb.scoped_current_board("brain-quality"):
+        with kb.connect() as conn:
+            root = kb.create_task(conn, title="brain quality mission")
+            active = kb.create_task(conn, title="active reviewer", assignee="sage", parents=[root])
+            kb.complete_task(conn, root)
+            kb.claim_task(conn, active)
+            state = kb.mission_state(conn, root)
+
+    assert state is not None
+    assert state["board"] == "brain-quality"
+    assert state["board_path"].endswith("/kanban/boards/brain-quality/kanban.db")
+    assert [task["id"] for task in state["active_tasks"]] == [active]
+
+
+def test_mission_state_deduplicates_shared_descendant(kanban_home):
+    with kb.connect() as conn:
+        root = kb.create_task(conn, title="root")
+        left = kb.create_task(conn, title="left", parents=[root])
+        right = kb.create_task(conn, title="right", parents=[root])
+        shared = kb.create_task(conn, title="shared", parents=[left, right])
+        state = kb.mission_state(conn, root)
+
+    assert state is not None
+    assert [task["id"] for task in state["tasks"]].count(shared) == 1
+    shared_task = next(task for task in state["tasks"] if task["id"] == shared)
+    assert shared_task["parents"] == sorted([left, right])
 
 
 # ---------------------------------------------------------------------------
@@ -1468,6 +1543,177 @@ def test_dispatch_dry_run_does_not_claim(kanban_home, all_assignees_spawnable):
         # Dry run must NOT mutate status.
         assert kb.get_task(conn, t1).status == "ready"
         assert kb.get_task(conn, t2).status == "ready"
+
+
+
+
+def test_dispatch_dry_run_reports_review_required_without_mutating(
+    kanban_home, all_assignees_spawnable
+):
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="implement", assignee="liz")
+        reviewer = kb.create_task(
+            conn, title="Review implementation", assignee="reviewer", parents=[source]
+        )
+        kb.claim_task(conn, source)
+        assert kb.block_task(conn, source, reason="review-required: done")
+        kb.add_comment(
+            conn, source, "liz", "review_required: docs/kanban-reports/source.json"
+        )
+
+        res = kb.dispatch_once(conn, dry_run=True)
+
+        assert res.review_unblocked == [{
+            "task_id": reviewer,
+            "source_task_id": source,
+            "report_path": "docs/kanban-reports/source.json",
+            "marker_source": "comment",
+        }]
+        assert kb.get_task(conn, reviewer).status == "todo"
+
+
+def test_dispatch_no_review_required_marker_is_noop(kanban_home, all_assignees_spawnable):
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="implement", assignee="liz")
+        reviewer = kb.create_task(
+            conn, title="Review implementation", assignee="reviewer", parents=[source]
+        )
+        kb.claim_task(conn, source)
+        assert kb.block_task(conn, source, reason="waiting")
+
+        res = kb.dispatch_once(conn, dry_run=True)
+
+        assert res.review_unblocked == []
+        assert kb.get_task(conn, reviewer).status == "todo"
+
+
+def test_dispatch_malformed_review_required_marker_is_noop(
+    kanban_home, all_assignees_spawnable
+):
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="implement", assignee="liz")
+        reviewer = kb.create_task(
+            conn, title="Review implementation", assignee="reviewer", parents=[source]
+        )
+        kb.claim_task(conn, source)
+        assert kb.block_task(conn, source, reason="review-required")
+        kb.add_comment(conn, source, "liz", "review_required: --dangerous")
+
+        res = kb.dispatch_once(conn, dry_run=True)
+
+        assert res.review_unblocked == []
+        assert kb.get_task(conn, reviewer).status == "todo"
+
+
+def test_dispatch_valid_review_required_marker_promotes_and_spawns_reviewer(
+    kanban_home, all_assignees_spawnable
+):
+    spawns = []
+
+    def fake_spawn(task, workspace):
+        spawns.append((task.id, task.assignee, task.skills, workspace))
+
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="implement", assignee="liz")
+        reviewer = kb.create_task(
+            conn, title="Review implementation", assignee="reviewer", parents=[source]
+        )
+        kb.claim_task(conn, source)
+        assert kb.block_task(conn, source, reason="review-required: done")
+        kb.add_comment(conn, source, "liz", "review_required: reports/source.json")
+
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+
+        assert res.review_unblocked[0]["task_id"] == reviewer
+        reviewer_task = kb.get_task(conn, reviewer)
+        assert reviewer_task is not None
+        assert spawns == [(reviewer, "reviewer", None, reviewer_task.workspace_path)]
+        assert reviewer_task.status == "running"
+        events = kb.list_events(conn, reviewer)
+        assert any(ev.kind == "review_required_auto_unblocked" for ev in events)
+
+
+def test_dispatch_review_required_does_not_promote_finalizer_with_pending_reviewer(
+    kanban_home, all_assignees_spawnable
+):
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="implement", assignee="liz")
+        reviewer = kb.create_task(
+            conn, title="Review implementation", assignee="reviewer", parents=[source]
+        )
+        finalizer = kb.create_task(
+            conn,
+            title="Finalizer after Sage review PASS",
+            body="Runs after Sage review PASS and closes the source task.",
+            assignee="finalizer",
+            parents=[source, reviewer],
+        )
+        kb.claim_task(conn, source)
+        assert kb.block_task(conn, source, reason="review-required: done")
+        kb.add_comment(conn, source, "liz", "review_required: reports/source.json")
+
+        res = kb.dispatch_once(conn, dry_run=True)
+
+        assert res.review_unblocked == [{
+            "task_id": reviewer,
+            "source_task_id": source,
+            "report_path": "reports/source.json",
+            "marker_source": "comment",
+        }]
+        reviewer_task = kb.get_task(conn, reviewer)
+        finalizer_task = kb.get_task(conn, finalizer)
+        assert reviewer_task is not None
+        assert finalizer_task is not None
+        assert reviewer_task.status == "todo"
+        assert finalizer_task.status == "todo"
+
+
+def test_dispatch_structured_review_required_report_promotes_reviewer(
+    kanban_home, all_assignees_spawnable
+):
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="implement", assignee="liz")
+        reviewer = kb.create_task(
+            conn, title="Reviewer task", assignee="reviewer", parents=[source]
+        )
+        kb.claim_task(conn, source)
+        report = {"status": "review_required", "report_path": "reports/structured.json"}
+        assert kb.block_task(conn, source, reason=json.dumps(report))
+
+        res = kb.dispatch_once(conn, dry_run=True)
+
+        assert res.review_unblocked == [{
+            "task_id": reviewer,
+            "source_task_id": source,
+            "report_path": "reports/structured.json",
+            "marker_source": "run_summary",
+        }]
+
+
+def test_dispatch_review_required_is_idempotent_and_no_high_risk_escalation(
+    kanban_home, all_assignees_spawnable
+):
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="implement", assignee="liz")
+        reviewer = kb.create_task(
+            conn, title="Review implementation", assignee="reviewer", parents=[source]
+        )
+        kb.claim_task(conn, source)
+        report = {
+            "status": "review_required",
+            "report_path": "reports/high-risk.json",
+            "production_actions": {"deploy": True, "restart": True},
+            "risk_gate": {"requires_human_approval": True},
+        }
+        assert kb.block_task(conn, source, reason=json.dumps(report))
+
+        first = kb.dispatch_once(conn, dry_run=True)
+        second = kb.dispatch_once(conn, dry_run=True)
+
+        assert first.review_unblocked == second.review_unblocked
+        assert first.review_unblocked[0]["task_id"] == reviewer
+        assert kb.get_task(conn, source).status == "blocked"
+        assert kb.get_task(conn, reviewer).status == "todo"
 
 
 def test_dispatch_skips_unassigned(kanban_home):
@@ -3321,10 +3567,10 @@ def test_dispatch_review_dry_run(kanban_home, all_assignees_spawnable):
         assert kb.get_task(conn, t).status == "review"
 
 
-def test_dispatch_review_spawns_with_correct_skills(
+def test_dispatch_review_spawns_with_task_skills_only(
     kanban_home, all_assignees_spawnable,
 ):
-    """Review tasks get sdlc-review skill set before spawning."""
+    """Review dispatch preserves explicit task skills without forcing unknown defaults."""
     spawned_tasks = []
 
     def capture_spawn(task, workspace, board=None):
@@ -3332,12 +3578,32 @@ def test_dispatch_review_spawns_with_correct_skills(
         return 42  # fake PID
 
     with kb.connect() as conn:
+        t = kb.create_task(conn, title="review me", assignee="alice", skills=["existing-review-skill"])
+        _set_task_status(conn, t, "review")
+        res = kb.dispatch_once(conn, spawn_fn=capture_spawn)
+    assert len(res.spawned) == 1
+    assert len(spawned_tasks) == 1
+    assert spawned_tasks[0].skills == ["existing-review-skill"]
+
+
+def test_dispatch_review_does_not_force_missing_review_skill(
+    kanban_home, all_assignees_spawnable,
+):
+    """A plain review task must not request a hardcoded missing skill."""
+    spawned_tasks = []
+
+    def capture_spawn(task, workspace, board=None):
+        spawned_tasks.append(task)
+        return 42
+
+    with kb.connect() as conn:
         t = kb.create_task(conn, title="review me", assignee="alice")
         _set_task_status(conn, t, "review")
         res = kb.dispatch_once(conn, spawn_fn=capture_spawn)
     assert len(res.spawned) == 1
     assert len(spawned_tasks) == 1
-    assert spawned_tasks[0].skills == ["sdlc-review"]
+    assert spawned_tasks[0].skills in (None, [])
+    assert spawned_tasks[0].skills != ["sdlc-review"]
 
 
 def test_dispatch_review_skips_unassigned(kanban_home):
@@ -3443,6 +3709,268 @@ def test_dispatch_review_does_not_claim_ready_tasks(
         # claim_review_task should NOT claim a ready task
         claimed = kb.claim_review_task(conn, t)
     assert claimed is None
+
+
+def _must_get_task(conn: sqlite3.Connection, task_id: str) -> kb.Task:
+    task = kb.get_task(conn, task_id)
+    assert task is not None
+    return task
+
+
+def _running_review(conn: sqlite3.Connection, *, source: str | None = None) -> str:
+    review = kb.create_task(conn, title="review", assignee="reviewer")
+    _set_task_status(conn, review, "review")
+    claimed = kb.claim_review_task(conn, review)
+    assert claimed is not None
+    if source:
+        conn.execute("UPDATE tasks SET body = ? WHERE id = ?", (f"source: {source}", review))
+    return review
+
+
+def test_apply_review_verdict_schema_valid_pass_payload_completes_source(kanban_home):
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="source", assignee="alice")
+        child = kb.create_task(conn, title="dependent", assignee="bob", parents=[source])
+        review = _running_review(conn, source=source)
+
+        payload = {
+            "schema_version": "kanban.reviewer_verdict.v1",
+            "report_type": "reviewer_verdict",
+            "review_task_id": review,
+            "source_task_id": source,
+            "task_id": source,
+            "reviewed_report_path": "docs/kanban-reports/source.json",
+            "reviewer": {"profile": "reviewer", "agent": "codex"},
+            "verdict": "PASS",
+            "summary": "Focused checks pass and no blockers remain.",
+            "safe_to_merge": True,
+            "safe_to_deploy": False,
+            "blocking_findings": [],
+            "non_blocking_findings": [{"severity": "info", "message": "Deploy not reviewed."}],
+            "evidence": [{"command": "pytest tests/docs", "exit_code": 0, "summary": "passed"}],
+            "next_action": {
+                "type": "complete_source_and_promote_children",
+                "summary": "Complete the source and promote dependents.",
+                "children_to_promote": [child],
+            },
+        }
+
+        result = kb.apply_review_verdict(conn, review, payload)
+
+        assert result["action"] == "completed_review_and_source"
+        assert result["review_task_id"] == review
+        assert result["source_task_id"] == source
+        assert result["evidence"] == payload["evidence"]
+        assert _must_get_task(conn, review).status == "done"
+        assert _must_get_task(conn, source).status == "done"
+        assert _must_get_task(conn, child).status == "ready"
+
+
+def test_apply_review_verdict_rejects_mismatched_review_task_id(kanban_home):
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="source", assignee="alice")
+        review = _running_review(conn, source=source)
+
+        with pytest.raises(ValueError, match="review_task_id mismatch"):
+            kb.apply_review_verdict(
+                conn,
+                review,
+                {"verdict": "PASS", "review_task_id": "t_other", "source_task_id": source},
+            )
+
+
+def test_apply_review_verdict_rejects_mismatched_source_and_legacy_task_id(kanban_home):
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="source", assignee="alice")
+        conflicting = kb.create_task(conn, title="conflicting", assignee="bob")
+        review = _running_review(conn, source=source)
+
+        before = {
+            review: _must_get_task(conn, review).status,
+            source: _must_get_task(conn, source).status,
+            conflicting: _must_get_task(conn, conflicting).status,
+        }
+
+        with pytest.raises(ValueError, match="source_task_id/task_id mismatch"):
+            kb.apply_review_verdict(
+                conn,
+                review,
+                {"verdict": "PASS", "source_task_id": source, "task_id": conflicting},
+            )
+
+        assert _must_get_task(conn, review).status == before[review]
+        assert _must_get_task(conn, source).status == before[source]
+        assert _must_get_task(conn, conflicting).status == before[conflicting]
+
+
+def test_apply_review_verdict_pass_completes_review_source_and_promotes_child(kanban_home):
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="source", assignee="alice")
+        child = kb.create_task(conn, title="dependent", assignee="bob", parents=[source])
+        review = _running_review(conn, source=source)
+
+        result = kb.apply_review_verdict(
+            conn,
+            review,
+            {"verdict": "PASS", "source_task_id": source, "reason": "tests green"},
+        )
+
+        assert result["review_done"] is True
+        assert result["source_done"] is True
+        assert _must_get_task(conn, review).status == "done"
+        assert _must_get_task(conn, source).status == "done"
+        assert _must_get_task(conn, child).status == "ready"
+
+
+def test_apply_review_verdict_schema_human_approval_pass_blocks_review_only(kanban_home):
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="source", assignee="alice")
+        review = _running_review(conn, source=source)
+
+        result = kb.apply_review_verdict(
+            conn,
+            review,
+            {
+                "schema_version": "kanban.reviewer_verdict.v1",
+                "report_type": "reviewer_verdict",
+                "task_id": source,
+                "reviewed_report_path": "docs/kanban/reports/samples/worker-handoff-report.example.json",
+                "reviewer": {"profile": "reviewer", "agent": "codex"},
+                "verdict": "PASS",
+                "summary": "Implementation is correct, but release approval is still required.",
+                "findings": [],
+                "commands": [],
+                "human_approval": {
+                    "required": True,
+                    "reason": "Chris must approve production release",
+                },
+            },
+        )
+
+        assert result["action"] == "blocked_review"
+        assert _must_get_task(conn, review).status == "blocked"
+        assert _must_get_task(conn, source).status == "ready"
+        events = [e for e in kb.list_events(conn, review) if e.kind == "blocked"]
+        assert events[-1].payload is not None
+        assert "Chris must approve production release" in events[-1].payload["reason"]
+
+
+def test_apply_review_verdict_request_changes_blocks_source_and_creates_fix_contract(kanban_home):
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="source", assignee="alice")
+        review = _running_review(conn, source=source)
+
+        result = kb.apply_review_verdict(
+            conn,
+            review,
+            {
+                "verdict": "REQUEST_CHANGES",
+                "source_task_id": source,
+                "reason": "missing regression test",
+                "next_contract": {
+                    "title": "Add regression test",
+                    "assignee": "alice",
+                    "body": "Cover the failing edge case only.",
+                },
+            },
+        )
+
+        followup = result["followup_task_id"]
+        assert followup
+        assert _must_get_task(conn, review).status == "done"
+        assert _must_get_task(conn, source).status == "blocked"
+        followup_task = _must_get_task(conn, followup)
+        assert followup_task.status == "ready"
+        assert followup_task.assignee == "alice"
+        assert "regression" in followup_task.title.lower()
+
+
+def test_apply_review_verdict_partial_preserves_evidence_and_routes_next_contract(kanban_home):
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="source", assignee="alice")
+        review = _running_review(conn, source=source)
+
+        result = kb.apply_review_verdict(
+            conn,
+            review,
+            {
+                "verdict": "PARTIAL",
+                "source_task_id": source,
+                "reason": "unit tests pass, integration remains",
+                "evidence": [{"command": "pytest tests/unit", "exit_code": 0}],
+                "next_contract": {"title": "Finish integration coverage", "assignee": "bob"},
+            },
+        )
+
+        events = [e for e in kb.list_events(conn, source) if e.kind == "review_verdict_applied"]
+        assert events
+        assert events[-1].payload is not None
+        assert events[-1].payload["verdict"] == "PARTIAL"
+        assert events[-1].payload["evidence"] == [{"command": "pytest tests/unit", "exit_code": 0}]
+        assert _must_get_task(conn, result["followup_task_id"]).assignee == "bob"
+        assert _must_get_task(conn, source).status == "blocked"
+
+
+def test_apply_review_verdict_blocked_stores_typed_reevaluable_reason(kanban_home):
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="source", assignee="alice")
+        review = _running_review(conn, source=source)
+
+        result = kb.apply_review_verdict(
+            conn,
+            review,
+            {"verdict": "BLOCKED", "source_task_id": source, "reason": "blocked: missing fixture"},
+        )
+
+        assert result["blocked"] is True
+        assert _must_get_task(conn, review).status == "blocked"
+        assert _must_get_task(conn, source).status == "ready"
+        events = [e for e in kb.list_events(conn, review) if e.kind == "blocked"]
+        assert events[-1].payload is not None
+        assert events[-1].payload["reason"].startswith("blocked:")
+
+
+def test_apply_review_verdict_needs_human_approval_blocks_review_only(kanban_home):
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="source", assignee="alice")
+        review = _running_review(conn, source=source)
+
+        kb.apply_review_verdict(
+            conn,
+            review,
+            {
+                "verdict": "NEEDS_HUMAN_APPROVAL",
+                "source_task_id": source,
+                "reason": "production deploy approval required",
+            },
+        )
+
+        assert _must_get_task(conn, review).status == "blocked"
+        assert _must_get_task(conn, source).status == "ready"
+        events = [e for e in kb.list_events(conn, review) if e.kind == "blocked"]
+        assert events[-1].payload is not None
+        assert "needs_human_approval" in events[-1].payload["reason"]
+
+
+def test_apply_review_verdict_high_risk_pass_does_not_auto_complete_or_deploy(kanban_home):
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="source", assignee="alice")
+        review = _running_review(conn, source=source)
+
+        result = kb.apply_review_verdict(
+            conn,
+            review,
+            {
+                "verdict": "PASS",
+                "source_task_id": source,
+                "reason": "looks good but deploy requested",
+                "production_actions": {"deploy": True},
+            },
+        )
+
+        assert result["action"] == "blocked_review"
+        assert _must_get_task(conn, review).status == "blocked"
+        assert _must_get_task(conn, source).status == "ready"
 
 # Stale detection — detect_stale_running
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_status_warnings.py
+++ b/tests/hermes_cli/test_status_warnings.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import status_warnings
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def _write_config(path: Path, *, provider: str = "openai-codex", version: int = 28) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"_config_version: {version}\nmodel:\n  provider: {provider}\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture()
+def profile_layout(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "liz"
+    root.mkdir(parents=True)
+    profile.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile))
+    _write_config(profile / "config.yaml")
+    return {"root": root, "profile": profile}
+
+
+def test_provider_auth_diagnostic_reports_profile_local_pool_and_unset_active_provider(profile_layout):
+    _write_json(profile_layout["profile"] / "auth.json", {
+        "version": 1,
+        "credential_pool": {
+            "openai-codex": [{
+                "id": "local-1",
+                "access_token": "should-not-leak",
+                "refresh_token": "should-not-leak",
+                "last_status": "ok",
+            }],
+        },
+    })
+
+    diag = status_warnings.collect_provider_auth_diagnostic(
+        config={"model": {"provider": "openai-codex"}},
+        hermes_home=profile_layout["profile"],
+        default_root=profile_layout["root"],
+    )
+
+    assert diag["credential_pool"]["source"] == "local"
+    assert diag["credential_pool"]["entry_statuses"] == [{"last_status": "ok"}]
+    assert [w["code"] for w in diag["warnings"]] == ["auth_active_provider_drift"]
+    rendered = json.dumps(diag)
+    assert "should-not-leak" not in rendered
+    status_warnings.assert_no_secretish_keys(diag)
+
+
+def test_provider_auth_diagnostic_reports_global_fallback_for_named_profile(profile_layout):
+    _write_json(profile_layout["root"] / "auth.json", {
+        "version": 1,
+        "credential_pool": {
+            "openai-codex": [{
+                "id": "global-1",
+                "api_key": "should-not-leak",
+                "last_error_code": "expired_token",
+                "last_error_reason": "refresh_failed",
+            }],
+        },
+    })
+    _write_json(profile_layout["profile"] / "auth.json", {
+        "version": 1,
+        "active_provider": "openai-codex",
+        "credential_pool": {},
+    })
+
+    diag = status_warnings.collect_provider_auth_diagnostic(
+        config={"model": {"provider": "openai-codex"}},
+        hermes_home=profile_layout["profile"],
+        default_root=profile_layout["root"],
+    )
+
+    assert diag["credential_pool"]["source"] == "global-fallback"
+    assert diag["credential_pool"]["entry_statuses"] == [{
+        "last_error_code": "expired_token",
+        "last_error_reason": "refresh_failed",
+    }]
+    assert [w["code"] for w in diag["warnings"]] == ["profile_global_auth_fallback"]
+    assert "should-not-leak" not in json.dumps(diag)
+    status_warnings.assert_no_secretish_keys(diag)
+
+
+def test_provider_auth_diagnostic_reports_none_when_no_pool(profile_layout):
+    _write_json(profile_layout["profile"] / "auth.json", {
+        "version": 1,
+        "active_provider": "anthropic",
+    })
+
+    diag = status_warnings.collect_provider_auth_diagnostic(
+        config={"model": {"provider": "openai-codex"}},
+        hermes_home=profile_layout["profile"],
+        default_root=profile_layout["root"],
+    )
+
+    assert diag["credential_pool"]["source"] == "none"
+    assert diag["credential_pool"]["entries"] == 0
+    assert [w["code"] for w in diag["warnings"]] == ["auth_active_provider_drift"]
+
+
+def test_config_version_drift_lists_profiles_without_secrets(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    root = tmp_path / ".hermes"
+    _write_config(root / "config.yaml", version=27)
+    _write_config(root / "profiles" / "liz" / "config.yaml", version=24)
+    _write_config(root / "profiles" / "ellie" / "config.yaml", version=28)
+    _write_json(root / "profiles" / "liz" / "auth.json", {"access_token": "should-not-leak"})
+
+    drift = status_warnings.collect_config_version_drift(
+        default_root=root,
+        latest_config_version=28,
+    )
+
+    assert drift["behind"] == [
+        {"profile": "default", "config_version": 27, "latest_config_version": 28},
+        {"profile": "liz", "config_version": 24, "latest_config_version": 28},
+    ]
+    assert drift["warning"]["code"] == "profile_config_version_drift"
+    assert "should-not-leak" not in json.dumps(drift)
+
+
+def test_launchd_warning_when_pid_running_but_last_exit_status_nonzero(monkeypatch):
+    monkeypatch.setattr(status_warnings.sys, "platform", "darwin")
+    monkeypatch.setattr("hermes_cli.gateway.get_launchd_label", lambda: "ai.hermes.gateway-liz")
+
+    def fake_run(*args, **kwargs):
+        assert args[0] == ["launchctl", "list", "ai.hermes.gateway-liz"]
+        return subprocess.CompletedProcess(
+            args=args[0],
+            returncode=1,
+            stdout='''{
+    "Label" = "ai.hermes.gateway-liz";
+    "LastExitStatus" = 256;
+    "PID" = 97157;
+}''',
+            stderr="",
+        )
+
+    warning = status_warnings.collect_launchd_gateway_warning(
+        gateway_pid=97157,
+        run=fake_run,
+    )
+
+    assert warning == {
+        "code": "launchd_gateway_state_mismatch",
+        "severity": "warning",
+        "message": "gateway PID is running but launchd reports a nonzero status/LastExitStatus",
+        "label": "ai.hermes.gateway-liz",
+        "gateway_pid": 97157,
+        "launchctl_status": 1,
+        "launchd_pid": 97157,
+        "last_exit_status": 256,
+    }
+
+
+def test_launchd_no_warning_when_launchd_status_clean(monkeypatch):
+    monkeypatch.setattr(status_warnings.sys, "platform", "darwin")
+    monkeypatch.setattr("hermes_cli.gateway.get_launchd_label", lambda: "ai.hermes.gateway-liz")
+
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=args[0],
+            returncode=0,
+            stdout='''{
+    "LastExitStatus" = 0;
+    "PID" = 97157;
+}''',
+            stderr="",
+        )
+
+    assert status_warnings.collect_launchd_gateway_warning(
+        gateway_pid=97157,
+        run=fake_run,
+    ) is None

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -205,7 +205,13 @@ hermes kanban watch
 # 5. See the board (you)
 hermes kanban list
 hermes kanban stats
+
+# 6. Summarize a long-running root mission without changing the board
+hermes kanban mission-state t_<root>
+hermes kanban mission-state t_<root> --json
 ```
+
+`mission-state` is deterministic: it walks the root task plus linked descendants from `task_links` and reads existing task/run/comment rows. It does not call an LLM and does not alter dispatcher behavior. The compact output includes the mission id, north star, current metric floors, active tasks, blocked tasks, next tasks, risk gates, and stop conditions when those fields appear in the root task body or comments.
 
 When the dispatcher picks up `t_abcd` and spawns the `researcher` profile, the very first thing that worker's model does is call `kanban_show()` to read its task. It doesn't run `hermes kanban show t_abcd`.
 


### PR DESCRIPTION
## Summary
- harden Kanban review-required auto-unblock so only explicit reviewer children run
- preserve finalizer/fan-in parent gates until reviewer PASS
- add structured worker/reviewer report schemas/docs and diagnostics/status warnings

## Verification
- 371 Kanban/status/docs tests passed after rebase
- ruff on touched Kanban/status files passed
- git diff --check passed

## Notes
- no gateway restart/deploy/DB mutation performed
- generated from Chris Cho Hermes Kanban hardening mission