### PR TITLE
fix(tui): show full subagent summaries

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -555,6 +555,46 @@ class TestDelegateObservability(unittest.TestCase):
             self.assertIn("result_bytes", entry["tool_trace"][0])
             self.assertEqual(entry["tool_trace"][0]["status"], "ok")
 
+    def test_completion_event_keeps_full_summary_for_tui_detail_view(self):
+        """The TUI /agents detail pane needs the full child summary.
+
+        The compact preview may be truncated, but the structured completion
+        payload should not be capped; otherwise the Summary section cuts off
+        long subagent findings even though the scrollable detail view can show
+        them.
+        """
+        parent = _make_mock_parent(depth=0)
+        parent.tool_progress_callback = MagicMock()
+        full_summary = "section-start " + ("detail line " * 80) + "section-end"
+
+        def _factory(*_args, **kwargs):
+            mock_child = MagicMock()
+            mock_child.model = "claude-sonnet-4-6"
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.tool_progress_callback = kwargs.get("tool_progress_callback")
+            mock_child.run_conversation.return_value = {
+                "final_response": full_summary,
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": [],
+            }
+            return mock_child
+
+        with patch("run_agent.AIAgent", side_effect=_factory):
+            delegate_task(goal="Long summary", parent_agent=parent)
+
+        complete_calls = [
+            call for call in parent.tool_progress_callback.call_args_list
+            if call.args and call.args[0] == "subagent.complete"
+        ]
+        self.assertEqual(len(complete_calls), 1)
+        self.assertEqual(complete_calls[0].kwargs["summary"], full_summary)
+        self.assertTrue(complete_calls[0].args[2].startswith("section-start"))
+        self.assertLessEqual(len(complete_calls[0].args[2]), 160)
+        self.assertNotEqual(complete_calls[0].args[2], full_summary)
+
     def test_tool_trace_handles_list_content_blocks(self):
         """Tool-result content blocks should not crash observability metadata."""
         parent = _make_mock_parent(depth=0)

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -590,10 +590,48 @@ class TestDelegateObservability(unittest.TestCase):
             if call.args and call.args[0] == "subagent.complete"
         ]
         self.assertEqual(len(complete_calls), 1)
-        self.assertEqual(complete_calls[0].kwargs["summary"], full_summary)
-        self.assertTrue(complete_calls[0].args[2].startswith("section-start"))
-        self.assertLessEqual(len(complete_calls[0].args[2]), 160)
-        self.assertNotEqual(complete_calls[0].args[2], full_summary)
+        complete_call = complete_calls[0]
+        self.assertEqual(complete_call.kwargs["summary"], full_summary)
+        preview = complete_call.kwargs.get("preview") or complete_call.args[2]
+        self.assertTrue(preview.startswith("section-start"))
+        self.assertLessEqual(len(preview), 160)
+        self.assertNotEqual(preview, full_summary)
+
+    @patch("tools.delegate_tool._load_config", return_value={"subagent_complete_summary_max_chars": 600})
+    def test_completion_event_bounds_extreme_summary_payload(self, _mock_cfg):
+        """Runaway child summaries should not create unbounded UI events."""
+        parent = _make_mock_parent(depth=0)
+        parent.tool_progress_callback = MagicMock()
+        full_summary = "section-start " + ("detail line " * 120) + "section-end"
+
+        def _factory(*_args, **kwargs):
+            mock_child = MagicMock()
+            mock_child.model = "claude-sonnet-4-6"
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.tool_progress_callback = kwargs.get("tool_progress_callback")
+            mock_child.run_conversation.return_value = {
+                "final_response": full_summary,
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": [],
+            }
+            return mock_child
+
+        with patch("run_agent.AIAgent", side_effect=_factory):
+            result = json.loads(delegate_task(goal="Huge summary", parent_agent=parent))
+
+        complete_calls = [
+            call for call in parent.tool_progress_callback.call_args_list
+            if call.args and call.args[0] == "subagent.complete"
+        ]
+        self.assertEqual(result["results"][0]["summary"], full_summary)
+        self.assertEqual(len(complete_calls), 1)
+        event_summary = complete_calls[0].kwargs["summary"]
+        self.assertLessEqual(len(event_summary), 600)
+        self.assertTrue(event_summary.startswith("section-start"))
+        self.assertIn("summary truncated to 600 chars", event_summary)
 
     def test_tool_trace_handles_list_content_blocks(self):
         """Tool-result content blocks should not crash observability metadata."""

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -424,6 +424,41 @@ def _get_child_timeout() -> float:
     return float(DEFAULT_CHILD_TIMEOUT)
 
 
+def _get_subagent_complete_summary_max_chars() -> int:
+    """Bound the TUI completion-event summary payload.
+
+    The parent tool result can still include the complete child response, but
+    live UI/event payloads need a safety valve so a runaway child cannot push
+    arbitrarily large WebSocket/log/in-memory messages.
+    """
+    cfg = _load_config()
+    val = cfg.get("subagent_complete_summary_max_chars")
+    if val is None:
+        val = os.getenv("DELEGATION_SUBAGENT_COMPLETE_SUMMARY_MAX_CHARS")
+    if val is None:
+        return _DEFAULT_SUBAGENT_COMPLETE_SUMMARY_MAX_CHARS
+    try:
+        return max(_MIN_SUBAGENT_COMPLETE_SUMMARY_MAX_CHARS, int(val))
+    except (TypeError, ValueError):
+        logger.warning(
+            "delegation.subagent_complete_summary_max_chars=%r is not a valid integer; "
+            "using default %d",
+            val,
+            _DEFAULT_SUBAGENT_COMPLETE_SUMMARY_MAX_CHARS,
+        )
+        return _DEFAULT_SUBAGENT_COMPLETE_SUMMARY_MAX_CHARS
+
+
+def _cap_subagent_complete_summary(summary: str) -> str:
+    limit = _get_subagent_complete_summary_max_chars()
+    if len(summary) <= limit:
+        return summary
+
+    suffix = f"\n\n[summary truncated to {limit} chars for subagent event payload]"
+    keep = max(0, limit - len(suffix))
+    return summary[:keep].rstrip() + suffix
+
+
 def _get_max_spawn_depth() -> int:
     """Read delegation.max_spawn_depth from config, floored at 1 (no ceiling).
 
@@ -545,6 +580,8 @@ def _preserve_parent_mcp_toolsets(
 
 DEFAULT_MAX_ITERATIONS = 50
 DEFAULT_CHILD_TIMEOUT = 600  # seconds before a child agent is considered stuck
+_DEFAULT_SUBAGENT_COMPLETE_SUMMARY_MAX_CHARS = 20_000
+_MIN_SUBAGENT_COMPLETE_SUMMARY_MAX_CHARS = 500
 _HEARTBEAT_INTERVAL = 30  # seconds between parent activity heartbeats during delegation
 # Stale-heartbeat thresholds. A child with no API-call progress is either:
 #   - idle between turns (no current_tool) — probably stuck on a slow API call
@@ -1833,13 +1870,13 @@ def _run_single_child(
         _output_tail = _extract_output_tail(result, max_entries=8, max_chars=600)
 
         complete_kwargs: Dict[str, Any] = {
-            # Keep preview compact for status lines, but send the full summary
-            # in the structured payload.  The TUI /agents detail pane is
-            # scrollable and uses this field for its Summary section.
+            # Keep preview compact for status lines, but send a much larger
+            # bounded summary in the structured payload.  The TUI /agents detail
+            # pane is scrollable; the cap prevents runaway event/log payloads.
             "preview": summary[:160] if summary else entry.get("error", ""),
             "status": status,
             "duration_seconds": duration,
-            "summary": summary if summary else entry.get("error", ""),
+            "summary": _cap_subagent_complete_summary(summary) if summary else entry.get("error", ""),
             "input_tokens": (
                 int(_input_tokens) if isinstance(_input_tokens, (int, float)) else 0
             ),

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1833,10 +1833,13 @@ def _run_single_child(
         _output_tail = _extract_output_tail(result, max_entries=8, max_chars=600)
 
         complete_kwargs: Dict[str, Any] = {
+            # Keep preview compact for status lines, but send the full summary
+            # in the structured payload.  The TUI /agents detail pane is
+            # scrollable and uses this field for its Summary section.
             "preview": summary[:160] if summary else entry.get("error", ""),
             "status": status,
             "duration_seconds": duration,
-            "summary": summary[:500] if summary else entry.get("error", ""),
+            "summary": summary if summary else entry.get("error", ""),
             "input_tokens": (
                 int(_input_tokens) if isinstance(_input_tokens, (int, float)) else 0
             ),


### PR DESCRIPTION
## Summary
- stop truncating the structured subagent completion summary sent to the TUI
- keep the compact preview capped for status/display lines
- add a regression test that verifies the /agents detail payload keeps the full summary

## Test plan
- `python -m pytest tests/tools/test_delegate.py::TestDelegateObservability -q -o addopts='' -p no:timeout`
- `python -m py_compile tools/delegate_tool.py tests/tools/test_delegate.py`
- `git diff --check`
- `python C:/Users/Jaime/.hermes/scripts/public_artifact_leak_scan.py --git`
