### PR TITLE
fix(mcp): capability-gate tools/list so prompt-only MCP servers can connect (port opencode#31271)

### DIFF
--- a/tests/tools/test_mcp_capability_gating.py
+++ b/tests/tools/test_mcp_capability_gating.py
@@ -1,0 +1,158 @@
+"""Tests for capability-gated MCP tool discovery and keepalive.
+
+Prompt-only / resource-only MCP servers do not implement the ``tools/*``
+request family. Per the MCP spec, ``InitializeResult.capabilities.tools``
+is non-None iff the server supports it. Before this fix, Hermes always
+called ``tools/list`` during discovery and as the keepalive probe — both
+raised ``McpError(-32601 Method not found)`` against such servers, so a
+prompt-only server could never stay connected.
+
+Ported from anomalyco/opencode#31271.
+"""
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tools.mcp_tool import MCPServerTask
+
+
+def _caps(tools=None, prompts=None, resources=None):
+    """Build a fake InitializeResult with the given capability sub-objects."""
+    return SimpleNamespace(
+        capabilities=SimpleNamespace(tools=tools, prompts=prompts, resources=resources)
+    )
+
+
+class TestAdvertisesTools:
+    def test_true_when_tools_capability_present(self):
+        task = MCPServerTask("test")
+        task.initialize_result = _caps(tools=SimpleNamespace(listChanged=True))
+        assert task._advertises_tools() is True
+
+    def test_false_for_prompt_only_server(self):
+        task = MCPServerTask("test")
+        task.initialize_result = _caps(prompts=SimpleNamespace(listChanged=None))
+        assert task._advertises_tools() is False
+
+    def test_false_for_resource_only_server(self):
+        task = MCPServerTask("test")
+        task.initialize_result = _caps(resources=SimpleNamespace())
+        assert task._advertises_tools() is False
+
+    def test_legacy_fallback_no_initialize_result(self):
+        """No captured capabilities → preserve old always-list_tools behavior."""
+        task = MCPServerTask("test")
+        assert task.initialize_result is None
+        assert task._advertises_tools() is True
+
+    def test_legacy_fallback_no_capabilities_attr(self):
+        task = MCPServerTask("test")
+        task.initialize_result = SimpleNamespace()  # no .capabilities
+        assert task._advertises_tools() is True
+
+
+@pytest.mark.asyncio
+class TestDiscoverToolsGating:
+    async def test_skips_list_tools_for_prompt_only_server(self):
+        task = MCPServerTask("test")
+        task.initialize_result = _caps(prompts=SimpleNamespace())
+        task.session = SimpleNamespace(list_tools=AsyncMock())
+        task._tools = ["stale"]
+
+        await task._discover_tools()
+
+        task.session.list_tools.assert_not_called()
+        assert task._tools == []
+
+    async def test_calls_list_tools_for_tool_capable_server(self):
+        task = MCPServerTask("test")
+        task.initialize_result = _caps(tools=SimpleNamespace())
+        fake_tool = SimpleNamespace(name="echo")
+        task.session = SimpleNamespace(
+            list_tools=AsyncMock(return_value=SimpleNamespace(tools=[fake_tool]))
+        )
+
+        await task._discover_tools()
+
+        task.session.list_tools.assert_awaited_once()
+        assert task._tools == [fake_tool]
+
+    async def test_legacy_fallback_still_calls_list_tools(self):
+        task = MCPServerTask("test")
+        task.session = SimpleNamespace(
+            list_tools=AsyncMock(return_value=SimpleNamespace(tools=[]))
+        )
+
+        await task._discover_tools()
+
+        task.session.list_tools.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+class TestRefreshToolsGating:
+    async def test_refresh_noop_for_prompt_only_server(self):
+        task = MCPServerTask("test")
+        task.initialize_result = _caps(prompts=SimpleNamespace())
+        task.session = SimpleNamespace(list_tools=AsyncMock())
+
+        await task._refresh_tools()
+
+        task.session.list_tools.assert_not_called()
+
+
+@pytest.mark.asyncio
+class TestKeepaliveProbe:
+    async def _run_one_keepalive_cycle(self, task):
+        """Drive _wait_for_lifecycle_event through exactly one keepalive
+        timeout, then fire shutdown so it returns."""
+        real_wait = asyncio.wait
+        cycles = {"n": 0}
+
+        async def fake_wait(tasks, timeout=None, return_when=None):
+            cycles["n"] += 1
+            if cycles["n"] == 1:
+                # Simulate keepalive timeout: nothing completed.
+                return set(), set(tasks)
+            # Second cycle: let shutdown win.
+            task._shutdown_event.set()
+            return await real_wait(
+                tasks, timeout=0.5, return_when=return_when or asyncio.FIRST_COMPLETED
+            )
+
+        import tools.mcp_tool as mcp_mod
+        orig = mcp_mod.asyncio.wait
+        mcp_mod.asyncio.wait = fake_wait
+        try:
+            return await task._wait_for_lifecycle_event()
+        finally:
+            mcp_mod.asyncio.wait = orig
+
+    async def test_keepalive_uses_ping_for_prompt_only_server(self):
+        task = MCPServerTask("test")
+        task.initialize_result = _caps(prompts=SimpleNamespace())
+        task.session = SimpleNamespace(
+            list_tools=AsyncMock(),
+            send_ping=AsyncMock(),
+        )
+
+        reason = await self._run_one_keepalive_cycle(task)
+
+        assert reason == "shutdown"
+        task.session.send_ping.assert_awaited_once()
+        task.session.list_tools.assert_not_called()
+
+    async def test_keepalive_uses_list_tools_for_tool_capable_server(self):
+        task = MCPServerTask("test")
+        task.initialize_result = _caps(tools=SimpleNamespace())
+        task.session = SimpleNamespace(
+            list_tools=AsyncMock(return_value=SimpleNamespace(tools=[])),
+            send_ping=AsyncMock(),
+        )
+
+        reason = await self._run_one_keepalive_cycle(task)
+
+        assert reason == "shutdown"
+        task.session.list_tools.assert_awaited_once()
+        task.session.send_ping.assert_not_called()

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1202,6 +1202,26 @@ class MCPServerTask:
         """Check if this server uses HTTP transport."""
         return "url" in self._config
 
+    def _advertises_tools(self) -> bool:
+        """Whether the server advertises the ``tools`` capability.
+
+        Per the MCP spec, ``InitializeResult.capabilities.tools`` is non-None
+        iff the server implements the ``tools/*`` request family. Prompt-only
+        or resource-only servers omit it, and calling ``tools/list`` against
+        them raises ``McpError(-32601 Method not found)`` — which previously
+        killed the connection during discovery and made every keepalive fail.
+        (Ported from anomalyco/opencode#31271.)
+
+        Returns True when no capability info was captured (legacy fallback:
+        preserve the old always-call-list_tools behavior rather than regress
+        any server that was working before this gate).
+        """
+        init_result = self.initialize_result
+        caps = getattr(init_result, "capabilities", None) if init_result is not None else None
+        if caps is None:
+            return True
+        return getattr(caps, "tools", None) is not None
+
     # ----- Dynamic tool discovery (notifications/tools/list_changed) -----
 
     async def _refresh_tools_task(self):
@@ -1272,6 +1292,12 @@ class MCPServerTask:
         — atomic from the event loop's perspective.
         """
         from tools.registry import registry
+
+        if not self._advertises_tools():
+            # A server that doesn't implement tools/* should never send
+            # tools/list_changed, but guard anyway — calling tools/list
+            # would raise McpError(-32601).
+            return
 
         async with self._refresh_lock:
             # Capture old tool names for change diff
@@ -1360,12 +1386,22 @@ class MCPServerTask:
 
                 # Timeout — no lifecycle event fired.  Send a keepalive
                 # to exercise the connection and detect stale sockets.
+                # Prompt-only / resource-only servers don't implement
+                # ``tools/list`` (McpError -32601), so use the universal
+                # ``ping`` request for them instead — otherwise every
+                # keepalive cycle would trigger a spurious reconnect.
                 if self.session:
                     try:
-                        await asyncio.wait_for(
-                            self.session.list_tools(),
-                            timeout=30.0,
-                        )
+                        if self._advertises_tools():
+                            await asyncio.wait_for(
+                                self.session.list_tools(),
+                                timeout=30.0,
+                            )
+                        else:
+                            await asyncio.wait_for(
+                                self.session.send_ping(),
+                                timeout=30.0,
+                            )
                     except Exception as exc:
                         logger.warning(
                             "MCP server '%s' keepalive failed, "
@@ -1778,8 +1814,24 @@ class MCPServerTask:
                         )
 
     async def _discover_tools(self):
-        """Discover tools from the connected session."""
+        """Discover tools from the connected session.
+
+        Capability-gated: prompt-only / resource-only MCP servers don't
+        implement ``tools/list``, and calling it raises ``McpError(-32601)``,
+        which previously aborted the connection — those servers could never
+        stay connected for their prompts/resources. Skip the call when the
+        server doesn't advertise the ``tools`` capability.
+        (Ported from anomalyco/opencode#31271.)
+        """
         if self.session is None:
+            return
+        if not self._advertises_tools():
+            logger.info(
+                "MCP server '%s': does not advertise 'tools' capability — "
+                "skipping tools/list (prompts/resources remain available)",
+                self.name,
+            )
+            self._tools = []
             return
         async with self._rpc_lock:
             tools_result = await self.session.list_tools()


### PR DESCRIPTION
## Summary
Prompt-only and resource-only MCP servers can now connect and stay connected — previously they failed permanently because Hermes unconditionally called `tools/list` during discovery and keepalive, which raises `McpError(-32601 Method not found)` on servers that don't implement the `tools/*` family.

Port of [anomalyco/opencode#31271](https://github.com/anomalyco/opencode/pull/31271) ("respect MCP server capabilities"), adapted to Hermes's `MCPServerTask` lifecycle.

## Root cause
Per the MCP spec, `InitializeResult.capabilities.tools` is non-None iff the server implements `tools/*`. Hermes already used this gate for the prompts/resources *utility tool* registration (`_select_utility_schemas`, #18051) but never for the `tools/list` calls themselves:

- `_discover_tools()` called `session.list_tools()` unconditionally right after `initialize()` → the -32601 error aborted the connection, burning all 3 initial-connect retries → server permanently dead.
- The 180s keepalive probed with `list_tools()` → even a connected prompt-only server got torn down on the first keepalive cycle.

## Changes
- `tools/mcp_tool.py`: new `MCPServerTask._advertises_tools()` (capability check, legacy fallback to old behavior when no `InitializeResult` was captured); `_discover_tools()` skips `tools/list` for non-tool servers; keepalive uses the universal `ping` request instead for them; `_refresh_tools()` guards against spurious `tools/list_changed`.
- `tests/tools/test_mcp_capability_gating.py`: 10 tests covering the capability check, discovery gating, refresh gating, and both keepalive probe paths.

## Validation
| | Before (main) | After |
|---|---|---|
| Real stdio prompt-only server (E2E) | fails all 3 connect attempts with Method-not-found, `_error` set | connects, `list_prompts` returns prompts, `ping` keepalive OK, clean shutdown |
| Tool-capable servers | unchanged | unchanged (`list_tools` still used for discovery + keepalive) |
| `tests/tools/test_mcp_tool.py` + `test_mcp_sse_transport.py` + `test_mcp_reconnect_signal.py` | — | 219 passed |

E2E used a real `mcp.server.Server` exposing only `list_prompts` over stdio, driven through `MCPServerTask.run()` with an isolated `HERMES_HOME`.

## Architectural notes vs the source PR
OpenCode gates via the TS SDK's `client.getServerCapabilities()`; Hermes captures `InitializeResult` on `MCPServerTask.initialize_result` (already present since #18051) and reads `capabilities.tools` from it. OpenCode returns `[]` tools for non-tool servers; we do the same and additionally swap the keepalive to `ping` (OpenCode has no equivalent keepalive loop). Their warn-not-error log change maps to the existing -32601 handling discussion in #10292 and is out of scope here.


## Infographic

![mcp-capability-gate](https://v3b.fal.media/files/b/0a9deedb/gvBitHVcuTy7sGwm0HF35_PwONqyg8.png)
