### PR TITLE
test(tui): cover slash worker protocol and startup

### DIFF
--- a/tests/tui_gateway/test_slash_worker.py
+++ b/tests/tui_gateway/test_slash_worker.py
@@ -1,51 +1,17 @@
 """Tests for tui_gateway/slash_worker.py — targeting ≥70% statement coverage.
 
-Covers:
-- _env_float: parsing env knobs with valid, missing, and malformed values
-- _is_orphaned: already covered in test_slash_worker_watchdog.py (imported here)
-- _run: slash command execution with mock CLI
+The module exposes two functions:
+- _run(cli, command): executes a slash command via HermesCLI, capturing stdout
+- main(): argparse entry point that reads JSON from stdin, dispatches _run, writes JSON to stdout
 """
 
 from __future__ import annotations
 
 import io
 import json
-import os
-import threading
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
-import pytest
-
-import psutil
 from tui_gateway import slash_worker
-
-
-# ─── _env_float ───────────────────────────────────────────────────────────────
-
-
-class TestEnvFloat:
-    """Tests for _env_float helper."""
-
-    def test_returns_default_when_env_unset(self):
-        with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("TEST_ENV_FLOAT_KEY", None)
-            assert slash_worker._env_float("TEST_ENV_FLOAT_KEY", 3.14) == 3.14
-
-    def test_parses_valid_float(self):
-        with patch.dict(os.environ, {"TEST_ENV_FLOAT_KEY": "1.5"}):
-            assert slash_worker._env_float("TEST_ENV_FLOAT_KEY", 0.0) == 1.5
-
-    def test_parses_valid_int_string(self):
-        with patch.dict(os.environ, {"TEST_ENV_FLOAT_KEY": "7"}):
-            assert slash_worker._env_float("TEST_ENV_FLOAT_KEY", 0.0) == 7.0
-
-    def test_returns_default_on_malformed_value(self):
-        with patch.dict(os.environ, {"TEST_ENV_FLOAT_KEY": "2s"}):
-            assert slash_worker._env_float("TEST_ENV_FLOAT_KEY", 9.9) == 9.9
-
-    def test_returns_default_on_empty_string(self):
-        with patch.dict(os.environ, {"TEST_ENV_FLOAT_KEY": ""}):
-            assert slash_worker._env_float("TEST_ENV_FLOAT_KEY", 42.0) == 42.0
 
 
 # ─── _run ─────────────────────────────────────────────────────────────────────
@@ -55,20 +21,21 @@ class TestRun:
     """Tests for _run() command execution."""
 
     def _make_mock_cli(self):
-        """Create a mock HermesCLI with a Rich Console-like interface."""
         cli = MagicMock()
         cli.console = MagicMock()
         cli.process_command = MagicMock()
         return cli
 
-    def test_empty_command_returns_empty(self):
+    def test_empty_string_returns_empty(self):
         cli = self._make_mock_cli()
         assert slash_worker._run(cli, "") == ""
+
+    def test_whitespace_only_returns_empty(self):
+        cli = self._make_mock_cli()
         assert slash_worker._run(cli, "   ") == ""
 
     def test_prepends_slash_to_bare_command(self):
         cli = self._make_mock_cli()
-        # process_command will be called; we capture what it was called with
         slash_worker._run(cli, "help")
         cli.process_command.assert_called_once_with("/help")
 
@@ -87,67 +54,38 @@ class TestRun:
         result = slash_worker._run(cli, "/echo")
         assert "hello from cli" in result
 
+    def test_strips_trailing_whitespace(self):
+        cli = self._make_mock_cli()
+
+        def fake_process(cmd):
+            print("output\n\n")
+
+        cli.process_command = fake_process
+        result = slash_worker._run(cli, "/test")
+        assert result == "output"
+
     def test_restores_original_cprint(self):
         import cli as cli_mod
 
         cli = self._make_mock_cli()
         original = getattr(cli_mod, "_cprint", None)
         slash_worker._run(cli, "/noop")
-        # _cprint should be restored after _run
         assert getattr(cli_mod, "_cprint", None) is original
 
+    def test_restores_cprint_even_on_error(self):
+        """cprint must be restored even if process_command raises."""
+        import cli as cli_mod
 
-# ─── _is_orphaned (re-export for completeness) ───────────────────────────────
+        cli = self._make_mock_cli()
+        cli.process_command.side_effect = RuntimeError("boom")
+        original = getattr(cli_mod, "_cprint", None)
 
+        try:
+            slash_worker._run(cli, "/fail")
+        except RuntimeError:
+            pass
 
-class TestIsOrphaned:
-    """Additional _is_orphaned edge cases."""
-
-    def test_returns_true_on_psutil_error(self):
-        """When psutil.pid_exists raises psutil.Error, treat as orphaned."""
-        with patch("tui_gateway.slash_worker.psutil") as mock_psutil:
-            mock_psutil.Error = psutil.Error
-            mock_psutil.pid_exists.side_effect = psutil.Error("test")
-            result = slash_worker._is_orphaned(12345, 1.0, getppid=lambda: 12345)
-            assert result is True
-
-
-# ─── _start_parent_death_watchdog ─────────────────────────────────────────────
-
-
-class TestWatchdog:
-    """Test that the watchdog thread starts."""
-
-    def test_watchdog_thread_is_daemon(self):
-        """The watchdog thread should be a daemon so it doesn't block exit."""
-        started = threading.Event()
-        original_loop = slash_worker._start_parent_death_watchdog
-
-        # We can't easily test the full watchdog without mocking time/psutil,
-        # but we can verify the thread starts as daemon
-        with patch.object(slash_worker, "_is_orphaned", return_value=False):
-            # Start the watchdog with a mock that will immediately orphan
-            with patch.object(slash_worker, "_is_orphaned", return_value=True):
-                with patch("os._exit"):
-                    # This will start the thread and immediately trigger orphan detection
-                    slash_worker._start_parent_death_watchdog(99999, 0.0)
-                    # Give thread a moment to start
-                    import time
-
-                    time.sleep(0.01)
-
-
-# ─── _in_flight event ─────────────────────────────────────────────────────────
-
-
-class TestInFlight:
-    """Test the _in_flight threading event."""
-
-    def test_in_flight_starts_cleared(self):
-        """Module-level _in_flight should start cleared."""
-        # Reset to known state
-        slash_worker._in_flight.clear()
-        assert not slash_worker._in_flight.is_set()
+        assert getattr(cli_mod, "_cprint", None) is original
 
 
 # ─── main() ───────────────────────────────────────────────────────────────────
@@ -156,9 +94,8 @@ class TestInFlight:
 class TestMain:
     """Tests for the main() entry point."""
 
-    def test_main_processes_stdin_json(self, monkeypatch, tmp_path):
-        """main() reads JSON lines from stdin and writes JSON responses."""
-        # Fake stdin with one JSON command
+    def test_processes_valid_json_command(self, monkeypatch):
+        """main() reads a JSON command from stdin and writes a JSON response."""
         fake_stdin = io.StringIO(json.dumps({"id": "r1", "command": "/help"}) + "\n")
         fake_stdout = io.StringIO()
 
@@ -166,37 +103,29 @@ class TestMain:
         monkeypatch.setattr("sys.stdout", fake_stdout)
         monkeypatch.setattr("sys.argv", ["slash_worker", "--session-key", "test-session", "--model", ""])
 
-        # Mock watchdog to prevent os._exit
-        monkeypatch.setattr("tui_gateway.slash_worker._start_parent_death_watchdog", lambda *a: None)
+        mock_cli = MagicMock()
+        mock_cli.console = MagicMock()
+        mock_cli.process_command = MagicMock()
+        monkeypatch.setattr("tui_gateway.slash_worker.HermesCLI", lambda **kwargs: mock_cli)
 
-        # Mock HermesCLI to avoid real initialization
-        mock_cli_instance = MagicMock()
-        mock_cli_instance.console = MagicMock()
-        mock_cli_instance.process_command = MagicMock()
-        monkeypatch.setattr("tui_gateway.slash_worker.HermesCLI", lambda **kwargs: mock_cli_instance)
-
-        # Run main — it should process one line then exit (stdin exhausted)
         slash_worker.main()
 
-        # Verify output
         output = fake_stdout.getvalue().strip()
-        assert output  # should have produced some JSON output
         parsed = json.loads(output)
         assert parsed["id"] == "r1"
         assert parsed["ok"] is True
 
-    def test_main_handles_invalid_json(self, monkeypatch):
-        """main() writes error response for invalid JSON."""
+    def test_handles_invalid_json(self, monkeypatch):
+        """main() writes an error response when stdin contains invalid JSON."""
         fake_stdin = io.StringIO("not json\n")
         fake_stdout = io.StringIO()
 
         monkeypatch.setattr("sys.stdin", fake_stdin)
         monkeypatch.setattr("sys.stdout", fake_stdout)
         monkeypatch.setattr("sys.argv", ["slash_worker", "--session-key", "test", "--model", ""])
-        monkeypatch.setattr("tui_gateway.slash_worker._start_parent_death_watchdog", lambda *a: None)
 
-        mock_cli_instance = MagicMock()
-        monkeypatch.setattr("tui_gateway.slash_worker.HermesCLI", lambda **kwargs: mock_cli_instance)
+        mock_cli = MagicMock()
+        monkeypatch.setattr("tui_gateway.slash_worker.HermesCLI", lambda **kwargs: mock_cli)
 
         slash_worker.main()
 
@@ -204,3 +133,39 @@ class TestMain:
         parsed = json.loads(output)
         assert parsed["ok"] is False
         assert "error" in parsed
+
+    def test_skips_blank_lines(self, monkeypatch):
+        """main() skips blank lines in stdin without producing output."""
+        fake_stdin = io.StringIO("\n\n\n")
+        fake_stdout = io.StringIO()
+
+        monkeypatch.setattr("sys.stdin", fake_stdin)
+        monkeypatch.setattr("sys.stdout", fake_stdout)
+        monkeypatch.setattr("sys.argv", ["slash_worker", "--session-key", "test", "--model", ""])
+
+        mock_cli = MagicMock()
+        monkeypatch.setattr("tui_gateway.slash_worker.HermesCLI", lambda **kwargs: mock_cli)
+
+        slash_worker.main()
+
+        # No output — blank lines were skipped
+        assert fake_stdout.getvalue().strip() == ""
+
+    def test_sets_env_vars(self, monkeypatch):
+        """main() sets HERMES_SESSION_KEY and HERMES_INTERACTIVE env vars."""
+        import os
+
+        fake_stdin = io.StringIO("")
+        fake_stdout = io.StringIO()
+
+        monkeypatch.setattr("sys.stdin", fake_stdin)
+        monkeypatch.setattr("sys.stdout", fake_stdout)
+        monkeypatch.setattr("sys.argv", ["slash_worker", "--session-key", "my-session", "--model", "gpt-4"])
+
+        mock_cli = MagicMock()
+        monkeypatch.setattr("tui_gateway.slash_worker.HermesCLI", lambda **kwargs: mock_cli)
+
+        slash_worker.main()
+
+        assert os.environ.get("HERMES_SESSION_KEY") == "my-session"
+        assert os.environ.get("HERMES_INTERACTIVE") == "1"

--- a/tests/tui_gateway/test_slash_worker.py
+++ b/tests/tui_gateway/test_slash_worker.py
@@ -64,7 +64,9 @@ def _invoke_main(
 
     slash_worker.main()
 
-    responses = [json.loads(line) for line in fake_stdout.getvalue().splitlines() if line.strip()]
+    responses = [
+        json.loads(line) for line in fake_stdout.getvalue().splitlines() if line.strip()
+    ]
     return calls, mock_cli, responses
 
 

--- a/tests/tui_gateway/test_slash_worker.py
+++ b/tests/tui_gateway/test_slash_worker.py
@@ -1,171 +1,210 @@
-"""Tests for tui_gateway/slash_worker.py — targeting ≥70% statement coverage.
-
-The module exposes two functions:
-- _run(cli, command): executes a slash command via HermesCLI, capturing stdout
-- main(): argparse entry point that reads JSON from stdin, dispatches _run, writes JSON to stdout
-"""
+"""Focused unit tests for the slash worker protocol and startup orchestration."""
 
 from __future__ import annotations
 
 import io
 import json
-from unittest.mock import MagicMock
+import sys
+from unittest.mock import MagicMock, call
 
+import pytest
+
+import cli as cli_mod
 from tui_gateway import slash_worker
 
 
-# ─── _run ─────────────────────────────────────────────────────────────────────
+_MISSING = object()
 
 
-class TestRun:
-    """Tests for _run() command execution."""
-
-    def _make_mock_cli(self):
-        cli = MagicMock()
-        cli.console = MagicMock()
-        cli.process_command = MagicMock()
-        return cli
-
-    def test_empty_string_returns_empty(self):
-        cli = self._make_mock_cli()
-        assert slash_worker._run(cli, "") == ""
-
-    def test_whitespace_only_returns_empty(self):
-        cli = self._make_mock_cli()
-        assert slash_worker._run(cli, "   ") == ""
-
-    def test_prepends_slash_to_bare_command(self):
-        cli = self._make_mock_cli()
-        slash_worker._run(cli, "help")
-        cli.process_command.assert_called_once_with("/help")
-
-    def test_preserves_existing_slash(self):
-        cli = self._make_mock_cli()
-        slash_worker._run(cli, "/status")
-        cli.process_command.assert_called_once_with("/status")
-
-    def test_captures_stdout_from_process_command(self):
-        cli = self._make_mock_cli()
-
-        def fake_process(cmd):
-            print("hello from cli")
-
-        cli.process_command = fake_process
-        result = slash_worker._run(cli, "/echo")
-        assert "hello from cli" in result
-
-    def test_strips_trailing_whitespace(self):
-        cli = self._make_mock_cli()
-
-        def fake_process(cmd):
-            print("output\n\n")
-
-        cli.process_command = fake_process
-        result = slash_worker._run(cli, "/test")
-        assert result == "output"
-
-    def test_restores_original_cprint(self):
-        import cli as cli_mod
-
-        cli = self._make_mock_cli()
-        original = getattr(cli_mod, "_cprint", None)
-        slash_worker._run(cli, "/noop")
-        assert getattr(cli_mod, "_cprint", None) is original
-
-    def test_restores_cprint_even_on_error(self):
-        """cprint must be restored even if process_command raises."""
-        import cli as cli_mod
-
-        cli = self._make_mock_cli()
-        cli.process_command.side_effect = RuntimeError("boom")
-        original = getattr(cli_mod, "_cprint", None)
-
-        try:
-            slash_worker._run(cli, "/fail")
-        except RuntimeError:
-            pass
-
-        assert getattr(cli_mod, "_cprint", None) is original
+@pytest.fixture(autouse=True)
+def _reset_in_flight_event():
+    slash_worker._in_flight.clear()
+    yield
+    slash_worker._in_flight.clear()
 
 
-# ─── main() ───────────────────────────────────────────────────────────────────
+def _make_cli() -> MagicMock:
+    cli = MagicMock()
+    cli.console = MagicMock()
+    cli.process_command = MagicMock()
+    return cli
 
 
-class TestMain:
-    """Tests for the main() entry point."""
+def _invoke_main(
+    monkeypatch,
+    stdin_text: str,
+    *,
+    session_key: str = "test-session",
+    model: str = "",
+    run_side_effect=_MISSING,
+):
+    fake_stdout = io.StringIO()
+    calls = MagicMock()
+    mock_cli = MagicMock(name="mock_cli")
+    calls.cli.return_value = mock_cli
+    if run_side_effect is _MISSING:
+        calls.run.return_value = "worker-output"
+    else:
+        calls.run.side_effect = run_side_effect
 
-    def test_processes_valid_json_command(self, monkeypatch):
-        """main() reads a JSON command from stdin and writes a JSON response."""
-        fake_stdin = io.StringIO(json.dumps({"id": "r1", "command": "/help"}) + "\n")
-        fake_stdout = io.StringIO()
+    monkeypatch.setattr(sys, "stdin", io.StringIO(stdin_text))
+    monkeypatch.setattr(sys, "stdout", fake_stdout)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["slash_worker", "--session-key", session_key, "--model", model],
+    )
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    monkeypatch.setattr(slash_worker.os, "getppid", lambda: 4242)
+    monkeypatch.setattr(slash_worker, "_start_parent_death_watchdog", calls.watchdog)
+    monkeypatch.setattr(slash_worker, "_prepare_slash_worker_runtime", calls.prepare)
+    monkeypatch.setattr(slash_worker, "HermesCLI", calls.cli)
+    monkeypatch.setattr(slash_worker, "_run", calls.run)
 
-        monkeypatch.setattr("sys.stdin", fake_stdin)
-        monkeypatch.setattr("sys.stdout", fake_stdout)
-        monkeypatch.setattr("sys.argv", ["slash_worker", "--session-key", "test-session", "--model", ""])
+    slash_worker.main()
 
-        mock_cli = MagicMock()
-        mock_cli.console = MagicMock()
-        mock_cli.process_command = MagicMock()
-        monkeypatch.setattr("tui_gateway.slash_worker.HermesCLI", lambda **kwargs: mock_cli)
+    responses = [json.loads(line) for line in fake_stdout.getvalue().splitlines() if line.strip()]
+    return calls, mock_cli, responses
 
-        slash_worker.main()
 
-        output = fake_stdout.getvalue().strip()
-        parsed = json.loads(output)
-        assert parsed["id"] == "r1"
-        assert parsed["ok"] is True
+def _startup_calls(mock_cli: MagicMock, model: str | None):
+    return [
+        call.watchdog(4242),
+        call.prepare(),
+        call.cli(model=model, compact=True, resume="test-session", verbose=False),
+    ]
 
-    def test_handles_invalid_json(self, monkeypatch):
-        """main() writes an error response when stdin contains invalid JSON."""
-        fake_stdin = io.StringIO("not json\n")
-        fake_stdout = io.StringIO()
 
-        monkeypatch.setattr("sys.stdin", fake_stdin)
-        monkeypatch.setattr("sys.stdout", fake_stdout)
-        monkeypatch.setattr("sys.argv", ["slash_worker", "--session-key", "test", "--model", ""])
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, 1.5),
+        ("", 1.5),
+        ("2.25", 2.25),
+        ("not-a-number", 1.5),
+    ],
+)
+def test_env_float_uses_valid_values_or_default(monkeypatch, raw, expected):
+    name = "HERMES_TEST_SLASH_FLOAT"
+    if raw is None:
+        monkeypatch.delenv(name, raising=False)
+    else:
+        monkeypatch.setenv(name, raw)
 
-        mock_cli = MagicMock()
-        monkeypatch.setattr("tui_gateway.slash_worker.HermesCLI", lambda **kwargs: mock_cli)
+    assert slash_worker._env_float(name, 1.5) == expected
 
-        slash_worker.main()
 
-        output = fake_stdout.getvalue().strip()
-        parsed = json.loads(output)
-        assert parsed["ok"] is False
-        assert "error" in parsed
+@pytest.mark.parametrize("command", ["", "   ", None])
+def test_run_ignores_empty_commands(command):
+    cli = _make_cli()
 
-    def test_skips_blank_lines(self, monkeypatch):
-        """main() skips blank lines in stdin without producing output."""
-        fake_stdin = io.StringIO("\n\n\n")
-        fake_stdout = io.StringIO()
+    assert slash_worker._run(cli, command) == ""
+    cli.process_command.assert_not_called()
 
-        monkeypatch.setattr("sys.stdin", fake_stdin)
-        monkeypatch.setattr("sys.stdout", fake_stdout)
-        monkeypatch.setattr("sys.argv", ["slash_worker", "--session-key", "test", "--model", ""])
 
-        mock_cli = MagicMock()
-        monkeypatch.setattr("tui_gateway.slash_worker.HermesCLI", lambda **kwargs: mock_cli)
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [("help", "/help"), ("/status", "/status")],
+)
+def test_run_normalizes_command_prefix(command, expected):
+    cli = _make_cli()
 
-        slash_worker.main()
+    slash_worker._run(cli, command)
 
-        # No output — blank lines were skipped
-        assert fake_stdout.getvalue().strip() == ""
+    cli.process_command.assert_called_once_with(expected)
 
-    def test_sets_env_vars(self, monkeypatch):
-        """main() sets HERMES_SESSION_KEY and HERMES_INTERACTIVE env vars."""
-        import os
 
-        fake_stdin = io.StringIO("")
-        fake_stdout = io.StringIO()
+def test_run_restores_cprint_and_strips_trailing_whitespace(monkeypatch):
+    cli = _make_cli()
+    original_cprint = MagicMock(name="original_cprint")
+    monkeypatch.setattr(cli_mod, "_cprint", original_cprint, raising=False)
 
-        monkeypatch.setattr("sys.stdin", fake_stdin)
-        monkeypatch.setattr("sys.stdout", fake_stdout)
-        monkeypatch.setattr("sys.argv", ["slash_worker", "--session-key", "my-session", "--model", "gpt-4"])
+    def process_command(_command):
+        assert cli_mod._cprint is not original_cprint
+        print("output\n")
 
-        mock_cli = MagicMock()
-        monkeypatch.setattr("tui_gateway.slash_worker.HermesCLI", lambda **kwargs: mock_cli)
+    cli.process_command.side_effect = process_command
 
-        slash_worker.main()
+    assert slash_worker._run(cli, "/test") == "output"
+    assert cli_mod._cprint is original_cprint
 
-        assert os.environ.get("HERMES_SESSION_KEY") == "my-session"
-        assert os.environ.get("HERMES_INTERACTIVE") == "1"
+
+def test_run_restores_cprint_when_command_fails(monkeypatch):
+    cli = _make_cli()
+    original_cprint = MagicMock(name="original_cprint")
+    monkeypatch.setattr(cli_mod, "_cprint", original_cprint, raising=False)
+
+    def process_command(_command):
+        assert cli_mod._cprint is not original_cprint
+        raise RuntimeError("boom")
+
+    cli.process_command.side_effect = process_command
+
+    with pytest.raises(RuntimeError, match="boom"):
+        slash_worker._run(cli, "/fail")
+
+    assert cli_mod._cprint is original_cprint
+
+
+@pytest.mark.parametrize(("model", "expected_model"), [("", None), ("gpt-4", "gpt-4")])
+def test_main_runs_valid_command_after_ordered_startup(
+    monkeypatch,
+    model,
+    expected_model,
+):
+    def run_command(_cli, _command):
+        assert slash_worker._in_flight.is_set()
+        return "worker-output"
+
+    calls, mock_cli, responses = _invoke_main(
+        monkeypatch,
+        json.dumps({"id": "r1", "command": "/help"}) + "\n",
+        model=model,
+        run_side_effect=run_command,
+    )
+
+    assert responses == [{"id": "r1", "ok": True, "output": "worker-output"}]
+    assert calls.mock_calls == [
+        *_startup_calls(mock_cli, expected_model),
+        call.run(mock_cli, "/help"),
+    ]
+    assert slash_worker.os.environ["HERMES_SESSION_KEY"] == "test-session"
+    assert slash_worker.os.environ["HERMES_INTERACTIVE"] == "1"
+    assert not slash_worker._in_flight.is_set()
+
+
+def test_main_reports_invalid_json_without_dispatch(monkeypatch):
+    calls, mock_cli, responses = _invoke_main(monkeypatch, "not json\n")
+
+    assert len(responses) == 1
+    assert responses[0]["id"] is None
+    assert responses[0]["ok"] is False
+    assert responses[0]["error"]
+    assert calls.mock_calls == _startup_calls(mock_cli, None)
+    calls.run.assert_not_called()
+    assert not slash_worker._in_flight.is_set()
+
+
+def test_main_skips_blank_lines(monkeypatch):
+    calls, mock_cli, responses = _invoke_main(monkeypatch, "\n\n\n")
+
+    assert responses == []
+    assert calls.mock_calls == _startup_calls(mock_cli, None)
+    calls.run.assert_not_called()
+    assert not slash_worker._in_flight.is_set()
+
+
+def test_main_preserves_request_id_and_clears_in_flight_on_error(monkeypatch):
+    calls, mock_cli, responses = _invoke_main(
+        monkeypatch,
+        json.dumps({"id": "r1", "command": "/fail"}) + "\n",
+        run_side_effect=RuntimeError("boom"),
+    )
+
+    assert responses == [{"id": "r1", "ok": False, "error": "boom"}]
+    assert calls.mock_calls == [
+        *_startup_calls(mock_cli, None),
+        call.run(mock_cli, "/fail"),
+    ]
+    assert not slash_worker._in_flight.is_set()

--- a/tests/tui_gateway/test_slash_worker.py
+++ b/tests/tui_gateway/test_slash_worker.py
@@ -1,0 +1,206 @@
+"""Tests for tui_gateway/slash_worker.py — targeting ≥70% statement coverage.
+
+Covers:
+- _env_float: parsing env knobs with valid, missing, and malformed values
+- _is_orphaned: already covered in test_slash_worker_watchdog.py (imported here)
+- _run: slash command execution with mock CLI
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import psutil
+from tui_gateway import slash_worker
+
+
+# ─── _env_float ───────────────────────────────────────────────────────────────
+
+
+class TestEnvFloat:
+    """Tests for _env_float helper."""
+
+    def test_returns_default_when_env_unset(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("TEST_ENV_FLOAT_KEY", None)
+            assert slash_worker._env_float("TEST_ENV_FLOAT_KEY", 3.14) == 3.14
+
+    def test_parses_valid_float(self):
+        with patch.dict(os.environ, {"TEST_ENV_FLOAT_KEY": "1.5"}):
+            assert slash_worker._env_float("TEST_ENV_FLOAT_KEY", 0.0) == 1.5
+
+    def test_parses_valid_int_string(self):
+        with patch.dict(os.environ, {"TEST_ENV_FLOAT_KEY": "7"}):
+            assert slash_worker._env_float("TEST_ENV_FLOAT_KEY", 0.0) == 7.0
+
+    def test_returns_default_on_malformed_value(self):
+        with patch.dict(os.environ, {"TEST_ENV_FLOAT_KEY": "2s"}):
+            assert slash_worker._env_float("TEST_ENV_FLOAT_KEY", 9.9) == 9.9
+
+    def test_returns_default_on_empty_string(self):
+        with patch.dict(os.environ, {"TEST_ENV_FLOAT_KEY": ""}):
+            assert slash_worker._env_float("TEST_ENV_FLOAT_KEY", 42.0) == 42.0
+
+
+# ─── _run ─────────────────────────────────────────────────────────────────────
+
+
+class TestRun:
+    """Tests for _run() command execution."""
+
+    def _make_mock_cli(self):
+        """Create a mock HermesCLI with a Rich Console-like interface."""
+        cli = MagicMock()
+        cli.console = MagicMock()
+        cli.process_command = MagicMock()
+        return cli
+
+    def test_empty_command_returns_empty(self):
+        cli = self._make_mock_cli()
+        assert slash_worker._run(cli, "") == ""
+        assert slash_worker._run(cli, "   ") == ""
+
+    def test_prepends_slash_to_bare_command(self):
+        cli = self._make_mock_cli()
+        # process_command will be called; we capture what it was called with
+        slash_worker._run(cli, "help")
+        cli.process_command.assert_called_once_with("/help")
+
+    def test_preserves_existing_slash(self):
+        cli = self._make_mock_cli()
+        slash_worker._run(cli, "/status")
+        cli.process_command.assert_called_once_with("/status")
+
+    def test_captures_stdout_from_process_command(self):
+        cli = self._make_mock_cli()
+
+        def fake_process(cmd):
+            print("hello from cli")
+
+        cli.process_command = fake_process
+        result = slash_worker._run(cli, "/echo")
+        assert "hello from cli" in result
+
+    def test_restores_original_cprint(self):
+        import cli as cli_mod
+
+        cli = self._make_mock_cli()
+        original = getattr(cli_mod, "_cprint", None)
+        slash_worker._run(cli, "/noop")
+        # _cprint should be restored after _run
+        assert getattr(cli_mod, "_cprint", None) is original
+
+
+# ─── _is_orphaned (re-export for completeness) ───────────────────────────────
+
+
+class TestIsOrphaned:
+    """Additional _is_orphaned edge cases."""
+
+    def test_returns_true_on_psutil_error(self):
+        """When psutil.pid_exists raises psutil.Error, treat as orphaned."""
+        with patch("tui_gateway.slash_worker.psutil") as mock_psutil:
+            mock_psutil.Error = psutil.Error
+            mock_psutil.pid_exists.side_effect = psutil.Error("test")
+            result = slash_worker._is_orphaned(12345, 1.0, getppid=lambda: 12345)
+            assert result is True
+
+
+# ─── _start_parent_death_watchdog ─────────────────────────────────────────────
+
+
+class TestWatchdog:
+    """Test that the watchdog thread starts."""
+
+    def test_watchdog_thread_is_daemon(self):
+        """The watchdog thread should be a daemon so it doesn't block exit."""
+        started = threading.Event()
+        original_loop = slash_worker._start_parent_death_watchdog
+
+        # We can't easily test the full watchdog without mocking time/psutil,
+        # but we can verify the thread starts as daemon
+        with patch.object(slash_worker, "_is_orphaned", return_value=False):
+            # Start the watchdog with a mock that will immediately orphan
+            with patch.object(slash_worker, "_is_orphaned", return_value=True):
+                with patch("os._exit"):
+                    # This will start the thread and immediately trigger orphan detection
+                    slash_worker._start_parent_death_watchdog(99999, 0.0)
+                    # Give thread a moment to start
+                    import time
+
+                    time.sleep(0.01)
+
+
+# ─── _in_flight event ─────────────────────────────────────────────────────────
+
+
+class TestInFlight:
+    """Test the _in_flight threading event."""
+
+    def test_in_flight_starts_cleared(self):
+        """Module-level _in_flight should start cleared."""
+        # Reset to known state
+        slash_worker._in_flight.clear()
+        assert not slash_worker._in_flight.is_set()
+
+
+# ─── main() ───────────────────────────────────────────────────────────────────
+
+
+class TestMain:
+    """Tests for the main() entry point."""
+
+    def test_main_processes_stdin_json(self, monkeypatch, tmp_path):
+        """main() reads JSON lines from stdin and writes JSON responses."""
+        # Fake stdin with one JSON command
+        fake_stdin = io.StringIO(json.dumps({"id": "r1", "command": "/help"}) + "\n")
+        fake_stdout = io.StringIO()
+
+        monkeypatch.setattr("sys.stdin", fake_stdin)
+        monkeypatch.setattr("sys.stdout", fake_stdout)
+        monkeypatch.setattr("sys.argv", ["slash_worker", "--session-key", "test-session", "--model", ""])
+
+        # Mock watchdog to prevent os._exit
+        monkeypatch.setattr("tui_gateway.slash_worker._start_parent_death_watchdog", lambda *a: None)
+
+        # Mock HermesCLI to avoid real initialization
+        mock_cli_instance = MagicMock()
+        mock_cli_instance.console = MagicMock()
+        mock_cli_instance.process_command = MagicMock()
+        monkeypatch.setattr("tui_gateway.slash_worker.HermesCLI", lambda **kwargs: mock_cli_instance)
+
+        # Run main — it should process one line then exit (stdin exhausted)
+        slash_worker.main()
+
+        # Verify output
+        output = fake_stdout.getvalue().strip()
+        assert output  # should have produced some JSON output
+        parsed = json.loads(output)
+        assert parsed["id"] == "r1"
+        assert parsed["ok"] is True
+
+    def test_main_handles_invalid_json(self, monkeypatch):
+        """main() writes error response for invalid JSON."""
+        fake_stdin = io.StringIO("not json\n")
+        fake_stdout = io.StringIO()
+
+        monkeypatch.setattr("sys.stdin", fake_stdin)
+        monkeypatch.setattr("sys.stdout", fake_stdout)
+        monkeypatch.setattr("sys.argv", ["slash_worker", "--session-key", "test", "--model", ""])
+        monkeypatch.setattr("tui_gateway.slash_worker._start_parent_death_watchdog", lambda *a: None)
+
+        mock_cli_instance = MagicMock()
+        monkeypatch.setattr("tui_gateway.slash_worker.HermesCLI", lambda **kwargs: mock_cli_instance)
+
+        slash_worker.main()
+
+        output = fake_stdout.getvalue().strip()
+        parsed = json.loads(output)
+        assert parsed["ok"] is False
+        assert "error" in parsed

--- a/tests/tui_gateway/test_slash_worker.py
+++ b/tests/tui_gateway/test_slash_worker.py
@@ -11,6 +11,7 @@ import pytest
 
 import cli as cli_mod
 from tui_gateway import slash_worker
+from tui_gateway._env import env_float
 
 
 _MISSING = object()
@@ -94,7 +95,7 @@ def test_env_float_uses_valid_values_or_default(monkeypatch, raw, expected):
     else:
         monkeypatch.setenv(name, raw)
 
-    assert slash_worker._env_float(name, 1.5) == expected
+    assert env_float(name, 1.5) == expected
 
 
 @pytest.mark.parametrize("command", ["", "   ", None])


### PR DESCRIPTION
## Summary

- Adds focused unit coverage for the current `tui_gateway/slash_worker.py` protocol and startup orchestration.
- Covers environment parsing, command normalization, `_cprint` restoration, JSON success/error responses, blank-line handling, request-id preservation, and `_in_flight` cleanup.
- Patches and asserts the current startup order: parent PID → watchdog → MCP runtime preparation → `HermesCLI`.

## Current-main adaptation

- The worker now has 89 statements rather than the former 51-statement/76-line implementation.
- Existing focused tests remain responsible for ANSI stripping, MCP discovery integration, profile-home propagation, import/sys.path hardening, and watchdog internals; this PR does not duplicate them.

## Coverage

Measured on the current worker with the new unit suite plus the existing ANSI and watchdog tests:

```text
Name                          Stmts   Miss  Cover   Missing
tui_gateway/slash_worker.py      89     14    84%   63-75, 79-87, 164
```

This exceeds the issue's 70% acceptance threshold without claiming the obsolete 98% result.

## Duplicate check

- No other open PR references #36615 outside this branch.
- Open slash-worker PRs found by path search address runtime fixes, not equivalent coverage.

## Test Plan

```bash
python -m py_compile tests/tui_gateway/test_slash_worker.py
ruff format --check tests/tui_gateway/test_slash_worker.py
ruff check tests/tui_gateway/test_slash_worker.py
ty check tests/tui_gateway/test_slash_worker.py
python -m pytest   tests/tui_gateway/test_slash_worker.py   tests/tui_gateway/test_slash_worker_ansi.py   tests/test_slash_worker_watchdog.py   --cov=tui_gateway.slash_worker --cov-report=term-missing
scripts/run_tests.sh tests/tui_gateway/ tests/test_slash_worker_watchdog.py
```

Closes #36615
