### PR TITLE
test(gateway): compare media routing paths by file identity

### DIFF
--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -306,6 +306,15 @@ class TestRunBackgroundTask:
         for _p in (_ogg, _mp4, _png, _pdf):
             with open(_p, "wb") as _fh:
                 _fh.write(b"x")
+
+        def _assert_same_file_path(actual: str, expected: str) -> None:
+            try:
+                assert _os.path.samefile(actual, expected)
+            except (AttributeError, OSError):
+                assert _os.path.normcase(_os.path.abspath(actual)) == _os.path.normcase(
+                    _os.path.abspath(expected)
+                )
+
         # ogg flagged as voice, mp4 video, png image, pdf doc.
         media = [
             (_ogg, True),
@@ -338,13 +347,21 @@ class TestRunBackgroundTask:
             await runner._run_background_task("make stuff", source, "bg_test")
 
             mock_adapter.send_voice.assert_called_once()
-            assert mock_adapter.send_voice.call_args.kwargs["audio_path"] == _ogg
+            _assert_same_file_path(
+                mock_adapter.send_voice.call_args.kwargs["audio_path"], _ogg
+            )
             mock_adapter.send_video.assert_called_once()
-            assert mock_adapter.send_video.call_args.kwargs["video_path"] == _mp4
+            _assert_same_file_path(
+                mock_adapter.send_video.call_args.kwargs["video_path"], _mp4
+            )
             mock_adapter.send_image_file.assert_called_once()
-            assert mock_adapter.send_image_file.call_args.kwargs["image_path"] == _png
+            _assert_same_file_path(
+                mock_adapter.send_image_file.call_args.kwargs["image_path"], _png
+            )
             mock_adapter.send_document.assert_called_once()
-            assert mock_adapter.send_document.call_args.kwargs["file_path"] == _pdf
+            _assert_same_file_path(
+                mock_adapter.send_document.call_args.kwargs["file_path"], _pdf
+            )
         finally:
             import shutil as _shutil
             _shutil.rmtree(_tmpdir, ignore_errors=True)


### PR DESCRIPTION
## Summary

Fixes #44301.

The background media-routing test currently asserts exact path strings for the four routed media files. On Windows, the temporary directory can be observed through an 8.3 short path such as `IVANPE~1` while the gateway passes the long path spelling to the adapter, so the test can fail even though both paths refer to the same file.

This keeps the media-type assertions (`send_voice`, `send_video`, `send_image_file`, `send_document`) and changes only the path comparison to file identity via `os.path.samefile`, with a normcase/abspath fallback for platforms where samefile is unavailable.

## Verification

- `uv run --extra dev pytest tests/gateway/test_background_command.py::TestRunBackgroundTask::test_media_files_routed_by_type -q`
- `uv run ruff check tests/gateway/test_background_command.py`
- `git diff --check`
- Codex adversarial review: `VERDICT: approve`

Note: I did not run `ruff format` on this whole legacy test file because it would reflow unrelated pre-existing sections; the changed diff is whitespace-clean.