### PR TITLE
fix(desktop): serve dashboard bundle from desktop backend

### DIFF
--- a/apps/desktop/electron/dashboard-web-dist.cjs
+++ b/apps/desktop/electron/dashboard-web-dist.cjs
@@ -1,0 +1,68 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+function directoryExists(dir) {
+  try {
+    return fs.statSync(dir).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+function hasDashboardBundle(dir) {
+  try {
+    return fs.statSync(path.join(dir, 'index.html')).isFile()
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Resolve the web bundle served by `hermes dashboard` when it is spawned by
+ * Desktop as the local backend.
+ *
+ * This must be the dashboard bundle (`hermes_cli/web_dist`), not the Electron
+ * renderer bundle (`apps/desktop/dist` or the packaged `app.asar.unpacked/dist`).
+ * The Electron renderer is loaded by BrowserWindow from file://; the dashboard
+ * backend is also reachable in a normal browser, where serving the Desktop
+ * renderer produces a broken page (`Desktop IPC bridge is unavailable`).
+ */
+function resolveDashboardWebDist(options = {}) {
+  const env = options.env || process.env
+  const override = env.HERMES_DESKTOP_DASHBOARD_WEB_DIST
+  if (override && directoryExists(path.resolve(override))) {
+    return path.resolve(override)
+  }
+
+  const candidates = []
+
+  if (options.activeHermesRoot) {
+    candidates.push(path.join(options.activeHermesRoot, 'hermes_cli', 'web_dist'))
+  }
+
+  if (options.appRoot) {
+    // Dev/source layout: <repo>/apps/desktop/electron/main.cjs has APP_ROOT at
+    // <repo>/apps/desktop. Packaged layout can put APP_ROOT under resources/app.asar;
+    // this candidate is harmless there and useful in tests/source checkouts.
+    candidates.push(path.resolve(options.appRoot, '..', '..', 'hermes_cli', 'web_dist'))
+  }
+
+  for (const candidate of candidates) {
+    if (hasDashboardBundle(candidate)) {
+      return candidate
+    }
+  }
+
+  // Fall back to the canonical active install path even if it does not exist so
+  // the child `hermes dashboard --skip-build` fails with its explicit missing
+  // dist error instead of silently serving the wrong Desktop bundle.
+  if (options.activeHermesRoot) {
+    return path.join(options.activeHermesRoot, 'hermes_cli', 'web_dist')
+  }
+
+  return path.resolve('hermes_cli', 'web_dist')
+}
+
+module.exports = {
+  resolveDashboardWebDist
+}

--- a/apps/desktop/electron/dashboard-web-dist.test.cjs
+++ b/apps/desktop/electron/dashboard-web-dist.test.cjs
@@ -1,0 +1,61 @@
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const test = require('node:test')
+
+const { resolveDashboardWebDist } = require('./dashboard-web-dist.cjs')
+
+function touchIndex(dir) {
+  fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(path.join(dir, 'index.html'), '<!doctype html>')
+}
+
+test('desktop-spawned dashboard resolves hermes_cli/web_dist, not Desktop renderer dist', t => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-dashboard-web-dist-'))
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+
+  const activeHermesRoot = path.join(root, 'hermes-agent')
+  const desktopDist = path.join(activeHermesRoot, 'apps', 'desktop', 'release', 'win-unpacked', 'resources', 'app.asar.unpacked', 'dist')
+  const dashboardDist = path.join(activeHermesRoot, 'hermes_cli', 'web_dist')
+
+  touchIndex(desktopDist)
+  touchIndex(dashboardDist)
+
+  assert.equal(
+    resolveDashboardWebDist({
+      activeHermesRoot,
+      appRoot: path.join(activeHermesRoot, 'apps', 'desktop'),
+      env: {}
+    }),
+    dashboardDist
+  )
+})
+
+test('explicit dashboard dist override wins when it exists', t => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-dashboard-web-dist-'))
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+
+  const override = path.join(root, 'custom-dashboard-dist')
+  touchIndex(override)
+
+  assert.equal(
+    resolveDashboardWebDist({
+      activeHermesRoot: path.join(root, 'hermes-agent'),
+      env: { HERMES_DESKTOP_DASHBOARD_WEB_DIST: override }
+    }),
+    override
+  )
+})
+
+test('missing dashboard bundle falls back to canonical path for a clear child error', t => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-dashboard-web-dist-'))
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }))
+
+  const activeHermesRoot = path.join(root, 'hermes-agent')
+
+  assert.equal(
+    resolveDashboardWebDist({ activeHermesRoot, env: {} }),
+    path.join(activeHermesRoot, 'hermes_cli', 'web_dist')
+  )
+})

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -27,6 +27,7 @@ const { execFileSync, spawn } = require('node:child_process')
 const { detectRemoteDisplay, isWindowsBinaryPathInWsl, isWslEnvironment } = require('./bootstrap-platform.cjs')
 const { runBootstrap } = require('./bootstrap-runner.cjs')
 const { buildSessionWindowUrl, createSessionWindowRegistry } = require('./session-windows.cjs')
+const { resolveDashboardWebDist } = require('./dashboard-web-dist.cjs')
 const { canImportHermesCli, verifyHermesCli } = require('./backend-probes.cjs')
 const { probeGatewayWebSocket } = require('./gateway-ws-probe.cjs')
 const { adoptServedDashboardToken } = require('./dashboard-token.cjs')
@@ -4552,7 +4553,11 @@ async function spawnPoolBackend(profile, entry) {
   try {
     backend = await ensureRuntime(resolveHermesBackend(dashboardArgs))
     hermesCwd = resolveHermesCwd()
-    webDist = resolveWebDist()
+    webDist = resolveDashboardWebDist({
+      activeHermesRoot: ACTIVE_HERMES_ROOT,
+      appRoot: APP_ROOT,
+      env: process.env
+    })
   } catch (error) {
     // These run before the child exists / its exit handler is attached, so a
     // throw here would otherwise leak the reservation and slowly exhaust the
@@ -4773,7 +4778,11 @@ async function startHermes() {
     await advanceBootProgress('backend.runtime', 'Resolving Hermes runtime', 28)
     const backend = await ensureRuntime(resolveHermesBackend(dashboardArgs))
     const hermesCwd = resolveHermesCwd()
-    const webDist = resolveWebDist()
+    const webDist = resolveDashboardWebDist({
+      activeHermesRoot: ACTIVE_HERMES_ROOT,
+      appRoot: APP_ROOT,
+      env: process.env
+    })
 
     await advanceBootProgress('backend.spawn', `Starting Hermes backend via ${backend.label}`, 84)
     rememberLog(`Starting Hermes backend via ${backend.label}`)


### PR DESCRIPTION
## Summary
- resolve the dashboard web bundle separately from the Electron Desktop renderer bundle
- make Desktop-spawned `hermes dashboard` backends serve `hermes_cli/web_dist`
- add regression tests covering the Desktop renderer dist vs dashboard dist split

## Why
Opening the Desktop-spawned dashboard backend in a normal browser could render the Electron Desktop app instead of the full dashboard. That page then failed with `Desktop IPC bridge is unavailable` because `window.hermesDesktop` only exists inside Electron.

## Test Plan
- `node --test apps/desktop/electron/dashboard-web-dist.test.cjs`
- `node -c apps/desktop/electron/dashboard-web-dist.cjs`
- `node -c apps/desktop/electron/main.cjs`
- smoke-tested resolver against the live checkout; it resolved to `hermes_cli/web_dist`
