### PR TITLE
fix(tui_gateway): pass live session context to plugin slash-command handlers

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -422,6 +422,10 @@ class PluginContext:
         """Register a slash command (e.g. ``/lcm``) available in CLI and gateway sessions.
 
         The handler signature is ``fn(raw_args: str) -> str | None``.
+        Handlers may additionally declare ``session_id`` / ``session_key``
+        keyword parameters (or ``**kwargs``) to receive the invoking Hermes
+        session key where the dispatch site knows it; legacy handlers that
+        accept only ``raw_args`` are called unchanged.
         It may also be an async callable — the gateway dispatch handles both.
 
         Unlike ``register_cli_command()`` (which creates ``hermes <subcommand>``
@@ -1839,6 +1843,50 @@ def get_plugin_command_handler(name: str) -> Optional[Callable]:
     """Return the handler for a plugin-registered slash command, or ``None``."""
     entry = _ensure_plugins_discovered()._plugin_commands.get(name)
     return entry["handler"] if entry else None
+
+
+def call_plugin_command_handler(
+    handler: Callable,
+    raw_args: str,
+    *,
+    session_id: str = "",
+    session_key: str = "",
+) -> Any:
+    """Call a plugin slash-command handler, passing session context it accepts.
+
+    The documented handler contract is ``fn(raw_args)``. Session-sensitive
+    handlers may additionally declare ``session_id`` and/or ``session_key``
+    keyword parameters (or ``**kwargs``) to receive the invoking Hermes
+    session key; legacy handlers are called unchanged. Dispatch sites pass
+    the context as explicit kwargs rather than mutating ``HERMES_SESSION_*``
+    environment variables, because gateway handlers can run concurrently and
+    process-global state would let one session's command bind to another's.
+    """
+    context = {"session_id": session_id, "session_key": session_key}
+    kwargs: dict[str, Any] = {}
+    try:
+        parameters = inspect.signature(handler).parameters
+    except (TypeError, ValueError):
+        parameters = None
+    if parameters is not None:
+        accepts_var_keyword = any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD
+            for parameter in parameters.values()
+        )
+        for name, value in context.items():
+            if not value:
+                continue
+            parameter = parameters.get(name)
+            if accepts_var_keyword or (
+                parameter is not None
+                and parameter.kind
+                in (
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    inspect.Parameter.KEYWORD_ONLY,
+                )
+            ):
+                kwargs[name] = value
+    return handler(raw_args, **kwargs)
 
 
 _PLUGIN_COMMAND_AWAIT_TIMEOUT_SECS = 30.0

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -15,6 +15,7 @@ from hermes_cli.plugins import (
     PluginContext,
     PluginManager,
     PluginManifest,
+    call_plugin_command_handler,
     get_plugin_command_handler,
     get_plugin_commands,
     get_pre_tool_call_block_message,
@@ -1587,6 +1588,71 @@ class TestPluginCommandResultResolution:
 
         with pytest.raises(TimeoutError):
             resolve_plugin_command_result(_slow_handler())
+
+
+# ── TestCallPluginCommandHandler ──────────────────────────────────────────
+
+
+class TestCallPluginCommandHandler:
+    """Tests for call_plugin_command_handler() — session context pass-through."""
+
+    def test_legacy_handler_called_with_args_only(self):
+        def handler(raw_args):
+            return f"legacy:{raw_args}"
+
+        result = call_plugin_command_handler(
+            handler, "hello", session_id="sess-1", session_key="sess-1"
+        )
+        assert result == "legacy:hello"
+
+    def test_declared_kwargs_receive_session_context(self):
+        seen = {}
+
+        def handler(raw_args, *, session_id="", session_key=""):
+            seen.update(session_id=session_id, session_key=session_key)
+            return raw_args
+
+        call_plugin_command_handler(handler, "x", session_id="s-1", session_key="s-1")
+        assert seen == {"session_id": "s-1", "session_key": "s-1"}
+
+    def test_var_keyword_handler_receives_session_context(self):
+        seen = {}
+
+        def handler(raw_args, **kwargs):
+            seen.update(kwargs)
+            return raw_args
+
+        call_plugin_command_handler(handler, "x", session_id="s-2", session_key="s-2")
+        assert seen == {"session_id": "s-2", "session_key": "s-2"}
+
+    def test_empty_context_values_are_not_passed(self):
+        """No session ⇒ handler defaults apply instead of explicit empty strings."""
+        seen = {}
+
+        def handler(raw_args, **kwargs):
+            seen.update(kwargs)
+            return raw_args
+
+        call_plugin_command_handler(handler, "x")
+        assert seen == {}
+
+    def test_uninspectable_handler_falls_back_to_args_only(self, monkeypatch):
+        def handler(raw_args):
+            return f"bare:{raw_args}"
+
+        def _raise(_):
+            raise ValueError("no signature")
+
+        monkeypatch.setattr("hermes_cli.plugins.inspect.signature", _raise)
+        result = call_plugin_command_handler(handler, "x", session_id="s-3")
+        assert result == "bare:x"
+
+    def test_async_handler_result_resolves(self):
+        async def handler(raw_args, *, session_key=""):
+            return f"{raw_args}:{session_key}"
+
+        result = call_plugin_command_handler(handler, "x", session_key="s-4")
+        assert resolve_plugin_command_result(result) == "x:s-4"
 
 
 # ── TestPluginDispatchTool ────────────────────────────────────────────────

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -2,6 +2,7 @@
 
 import io
 import json
+import os
 import sys
 import threading
 import time
@@ -898,6 +899,95 @@ def test_slash_exec_plugin_handler_error_returns_output(server):
     assert "error" not in resp
     assert resp["result"] == {"output": "Plugin command error: handler boom: hello"}
     assert worker.calls == []
+
+
+def test_slash_exec_plugin_gets_live_tui_session_context(server, monkeypatch):
+    """Session-aware plugin handlers receive the invoking session key as kwargs.
+
+    Stale HERMES_SESSION_* env must neither be consulted nor mutated: the
+    gateway process can carry no (or wrong) session env, and concurrent
+    handlers must not see another session's context.
+    """
+    sid = "rpc-session"
+    server._sessions[sid] = {"session_key": "live-tui-session", "agent": None}
+    monkeypatch.setenv("HERMES_SESSION_KEY", "stale-env-session")
+    monkeypatch.setenv("HERMES_SESSION_ID", "stale-env-session")
+
+    received = {}
+
+    def handler(arg, *, session_id="", session_key=""):
+        received.update(arg=arg, session_id=session_id, session_key=session_key)
+        return f"ctx:{session_key}"
+
+    with patch(
+        "hermes_cli.plugins.get_plugin_command_handler",
+        lambda name: handler if name == "plugin-cmd" else None,
+    ):
+        resp = server.handle_request({
+            "id": "r-plugin-slash-ctx",
+            "method": "slash.exec",
+            "params": {"command": "plugin-cmd hello", "session_id": sid},
+        })
+
+    assert "error" not in resp
+    assert resp["result"] == {"output": "ctx:live-tui-session"}
+    assert received == {
+        "arg": "hello",
+        "session_id": "live-tui-session",
+        "session_key": "live-tui-session",
+    }
+    assert os.environ["HERMES_SESSION_KEY"] == "stale-env-session"
+    assert os.environ["HERMES_SESSION_ID"] == "stale-env-session"
+
+
+def test_command_dispatch_plugin_gets_live_tui_session_context(server):
+    """command.dispatch's plugin fallback passes the live session context too."""
+    sid = "rpc-session"
+    server._sessions[sid] = {"session_key": "live-tui-session", "agent": None}
+
+    received = {}
+
+    def handler(arg, **kwargs):
+        received.update(kwargs)
+        received["arg"] = arg
+        return "dispatched"
+
+    with patch(
+        "hermes_cli.plugins.get_plugin_command_handler",
+        lambda name: handler if name == "plugin-cmd" else None,
+    ):
+        resp = server.handle_request({
+            "id": "r-plugin-dispatch-ctx",
+            "method": "command.dispatch",
+            "params": {"name": "plugin-cmd", "arg": "hello", "session_id": sid},
+        })
+
+    assert "error" not in resp
+    assert resp["result"] == {"type": "plugin", "output": "dispatched"}
+    assert received == {
+        "arg": "hello",
+        "session_id": "live-tui-session",
+        "session_key": "live-tui-session",
+    }
+
+
+def test_command_dispatch_plugin_legacy_handler_called_unchanged(server):
+    """Legacy fn(raw_args) plugin handlers keep working without session kwargs."""
+    sid = "rpc-session"
+    server._sessions[sid] = {"session_key": "live-tui-session", "agent": None}
+
+    with patch(
+        "hermes_cli.plugins.get_plugin_command_handler",
+        lambda name: (lambda arg: f"plugin:{arg}") if name == "plugin-cmd" else None,
+    ):
+        resp = server.handle_request({
+            "id": "r-plugin-dispatch-legacy",
+            "method": "command.dispatch",
+            "params": {"name": "plugin-cmd", "arg": "hello", "session_id": sid},
+        })
+
+    assert "error" not in resp
+    assert resp["result"] == {"type": "plugin", "output": "plugin:hello"}
 
 
 @pytest.mark.parametrize("cmd", ["retry", "queue hello", "q hello", "steer fix the test", "plan"])

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7602,13 +7602,19 @@ def _(rid, params: dict) -> dict:
 
     try:
         from hermes_cli.plugins import (
+            call_plugin_command_handler,
             get_plugin_command_handler,
             resolve_plugin_command_result,
         )
 
         handler = get_plugin_command_handler(name)
         if handler:
-            result = resolve_plugin_command_result(handler(arg))
+            session_key = str((session or {}).get("session_key") or "")
+            result = resolve_plugin_command_result(
+                call_plugin_command_handler(
+                    handler, arg, session_id=session_key, session_key=session_key
+                )
+            )
             return _ok(rid, {"type": "plugin", "output": str(result or "")})
     except Exception:
         pass
@@ -8666,10 +8672,12 @@ def _(rid, params: dict) -> dict:
         pass
 
     plugin_handler = None
+    call_plugin_command_handler = None
     resolve_plugin_command_result = None
     if _cmd_base:
         try:
             from hermes_cli.plugins import (
+                call_plugin_command_handler,
                 get_plugin_command_handler,
                 resolve_plugin_command_result,
             )
@@ -8677,11 +8685,20 @@ def _(rid, params: dict) -> dict:
             plugin_handler = get_plugin_command_handler(_cmd_base)
         except Exception:
             plugin_handler = None
+            call_plugin_command_handler = None
             resolve_plugin_command_result = None
 
-    if plugin_handler and resolve_plugin_command_result:
+    if plugin_handler and call_plugin_command_handler and resolve_plugin_command_result:
         try:
-            result = resolve_plugin_command_result(plugin_handler(_cmd_arg))
+            session_key = str(session.get("session_key") or "")
+            result = resolve_plugin_command_result(
+                call_plugin_command_handler(
+                    plugin_handler,
+                    _cmd_arg,
+                    session_id=session_key,
+                    session_key=session_key,
+                )
+            )
             return _ok(rid, {"output": str(result or "(no output)")})
         except Exception as e:
             return _ok(rid, {"output": f"Plugin command error: {e}"})


### PR DESCRIPTION
## What does this PR do?

Plugin slash commands registered via `ctx.register_command()` can't tell which session invoked them when dispatched through the TUI gateway. Both dispatch paths (`slash.exec`'s inline plugin fast path and `command.dispatch`'s plugin fallback) call `handler(arg)` with only the raw argument string, and the gateway process doesn't reliably carry `HERMES_SESSION_*` env the way the CLI process does (where `agent_init` sets it in-process). I hit this building a session-scoped bookmark command: the handler either fails closed or, worse, resolves a session from profile-global state and binds the action to the wrong conversation.

This adds `call_plugin_command_handler()` to `hermes_cli.plugins`: it inspects the handler signature and passes `session_id`/`session_key` kwargs only to handlers that declare them (or `**kwargs`). Legacy `fn(raw_args)` handlers are called exactly as before. Both TUI dispatch sites now resolve the gateway session's `session_key` and route through it.

Explicit kwargs rather than an env-var bridge because gateway handlers can run concurrently — process-global mutation could bind one session's command to another session's context.

Scoped deliberately to the TUI gateway, the path with no working fallback. The CLI and messaging-gateway dispatch sites could adopt the same helper as a follow-up; #42416 is in flight covering those plus hook propagation, and I'm happy to converge with it whichever way you prefer (the helper here is intentionally compatible with that PR's design).

## Related Issue

No existing issue found (searched for plugin session context). #42416 overlaps on the command-handler half — see note above.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/plugins.py` — new `call_plugin_command_handler()`; `register_command()` docstring documents the optional context kwargs
- `tui_gateway/server.py` — both plugin dispatch sites (`slash.exec` fast path, `command.dispatch` fallback) pass the live session key
- `tests/tui_gateway/test_protocol.py` — regression tests: both paths deliver kwargs to declaring handlers, legacy handlers stay untouched, stale `HERMES_SESSION_*` env is neither consulted nor mutated
- `tests/hermes_cli/test_plugins.py` — unit tests for the helper (legacy, declared-kwargs, `**kwargs`, empty-context skip, uninspectable-handler fallback, async)

## How to Test

1. `scripts/run_tests.sh tests/tui_gateway/test_protocol.py tests/hermes_cli/test_plugins.py` — 152 tests, green
2. Manual: register a plugin command whose handler declares `session_key=""`, run it from the TUI, and check the handler receives the live session key (before this change it gets `""`)
3. The first commit adds the regression tests alone — they fail on main, pass with the fix

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#42416 is adjacent; cross-referenced above)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the test suite (`scripts/run_tests.sh`): the touched suites are fully green (152/152). A full local run has a handful of environment-dependent failures (browser/vision/provider-credential tests) that reproduce byte-identically on the unmodified base commit — verified by A/B at 880107ab2 — so none are introduced by this change.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`register_command()` docstring) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config changes)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — stdlib `inspect` only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
