### PR TITLE
fix(nix): replace deprecated MESSAGING_CWD with TERMINAL_CWD in NixOS module

### DIFF
--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -883,7 +883,7 @@
             HOME = cfg.stateDir;
             HERMES_HOME = "${cfg.stateDir}/.hermes";
             HERMES_MANAGED = "true";
-            MESSAGING_CWD = cfg.workingDirectory;
+            TERMINAL_CWD = cfg.workingDirectory;
           };
 
           serviceConfig = {
@@ -980,7 +980,7 @@
                 --env HERMES_HOME=${containerDataDir}/.hermes \
                 --env HERMES_MANAGED=true \
                 --env HOME=${containerHomeDir} \
-                --env MESSAGING_CWD=${containerWorkDir} \
+                --env TERMINAL_CWD=${containerWorkDir} \
                 ${lib.concatStringsSep " " cfg.container.extraOptions} \
                 ${cfg.container.image} \
                 ${containerDataDir}/current-package/bin/hermes gateway run --replace ${lib.concatStringsSep " " cfg.extraArgs}


### PR DESCRIPTION
## What does this PR do?

Replaces the deprecated `MESSAGING_CWD` environment variable with the canonical `TERMINAL_CWD` in the NixOS module (`nix/nixosModules.nix`). The gateway startup reads `TERMINAL_CWD` as the primary working directory source and falls back to `MESSAGING_CWD` only for backward compatibility — setting the deprecated name triggers a deprecation warning on every gateway startup.

## Related Issue

Fixes #44485

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `nix/nixosModules.nix`: Replaced `MESSAGING_CWD` with `TERMINAL_CWD` in the systemd service environment block (line 886)
- `nix/nixosModules.nix`: Replaced `--env MESSAGING_CWD=` with `--env TERMINAL_CWD=` in the container launch command (line 983)

## How to Test

1. On a NixOS system with the hermes-agent NixOS module enabled, build/switch to this configuration
2. Start the gateway: `systemctl start hermes-agent`
3. Verify the deprecation warning no longer appears in the logs: `journalctl -u hermes-agent | grep -i deprecated`
4. Verify the working directory is correctly set: check that `TERMINAL_CWD` appears in `/proc/$(pgrep -f "hermes gateway")/environ`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — or N/A (NixOS declarative config change, no Python tests affected)
- [x] I've added tests for my changes — or N/A (declarative NixOS module change, no testable Python runtime code)
- [x] I've tested on my platform: macOS (verified env var name correctness against gateway/run.py:1220-1227; NixOS runtime untested)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `nix/nixosModules.nix` (2 call sites), `gateway/run.py:1220-1227` (consumer)
- Blast radius: LOW — only affects NixOS-managed deployments; the env var name change is a 1:1 swap with identical semantics
- Related patterns: `TERMINAL_CWD` is the canonical env var bridged from `config.yaml terminal.cwd` (see `hermes_cli/config.py:3555`, `gateway/run.py:1020-1027`)
