### PR TITLE
fix(feishu): remove markdown-table plain-text fallback

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -154,9 +154,6 @@ _MARKDOWN_HINT_RE = re.compile(
     r"(^#{1,6}\s)|(^\s*[-*]\s)|(^\s*\d+\.\s)|(^\s*---+\s*$)|(```)|(`[^`\n]+`)|(\*\*[^*\n].+?\*\*)|(~~[^~\n].+?~~)|(<u>.+?</u>)|(\*[^*\n]+\*)|(\[[^\]]+\]\([^)]+\))|(^>\s)",
     re.MULTILINE,
 )
-# Detect markdown tables: a line starting with | followed by a separator line.
-# Feishu post-type 'md' elements do not render tables, so we force text mode.
-_MARKDOWN_TABLE_RE = re.compile(r"^\|.*\|\n\|[-|: ]+\|", re.MULTILINE)
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
 _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
@@ -4374,12 +4371,6 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
-        if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
         if _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}


### PR DESCRIPTION
## What

Removes the workaround introduced in 8e18d1031 ("fix(feishu): force text mode for markdown tables") that force-falls-back to plain text whenever a markdown table is detected.

## Why

That earlier fix was justified because Feishu's post-type `md` element rendered table-bearing messages as **blank** on the client. As of now, Feishu has fixed the renderer — tables display correctly inside `md` elements.

With the workaround still in place, any reply containing a table loses **all** markdown formatting (bold, headings, lists, inline code, links) and shows the raw markdown syntax to the user — a regression for every Hermes user on Feishu whose answer happens to include a comparison table.

## How verified

Removed the fallback locally, restarted the gateway, and sent a reply containing:

- two GFM pipe tables (one simple, one with mixed widths)
- a heading and sub-headings
- `**bold**` and `` `inline code` `` outside the tables

The Feishu client rendered both tables and the surrounding markdown correctly — the original blank-message bug appears to be gone.

<img src="https://raw.githubusercontent.com/wangmingliang-ms/hermes-agent/pr-44570-assets/feishu-table-render.jpg" alt="Feishu mobile client rendering two markdown tables alongside headings, bold text, and inline code" width="360">

*(Screenshot from Feishu mobile client. Both tables render with proper grid lines and column alignment; bold and inline code inside table cells also render correctly.)*

## Risk

Low. If a particular Feishu workspace or tenant still hits the old blank-message bug, the early-return is trivial to re-introduce — we'd want a feature-detect / opt-out flag rather than the blanket fallback, but I'd suggest waiting for an actual report before adding configuration surface.
