### PR TITLE
fix(skills): linked reference docs no longer collide with real skills

### DIFF
--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -1243,6 +1243,35 @@ class TestSkillViewCollisionDetection:
         assert result["success"] is True
         assert "EXTERNAL BODY" in result["content"]
 
+    def test_support_reference_with_same_basename_does_not_collide(self, tmp_path):
+        """Linked reference docs are not standalone legacy skills.
+
+        A support file like ``other-skill/references/homeassistant-control.md``
+        must not make ``skill_view("homeassistant-control")`` ambiguous when a
+        real ``homeassistant-control/SKILL.md`` exists.
+        """
+        local_dir = tmp_path / "local"
+        local_dir.mkdir()
+
+        _make_skill(local_dir, "homeassistant-control", body="REAL SKILL")
+        other = local_dir / "devops" / "home-nas-operations"
+        refs = other / "references"
+        refs.mkdir(parents=True)
+        (other / "SKILL.md").write_text(
+            "---\nname: home-nas-operations\ndescription: NAS ops\n---\nBODY",
+            encoding="utf-8",
+        )
+        (refs / "homeassistant-control.md").write_text("REFERENCE ONLY", encoding="utf-8")
+
+        p1, p2 = self._patch_dirs(local_dir, [])
+        with p1, p2:
+            raw = skill_view("homeassistant-control")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert "REAL SKILL" in result["content"]
+        assert "REFERENCE ONLY" not in result["content"]
+
     def test_two_externals_same_name_also_refuse(self, tmp_path):
         """Collision detection is symmetric — two external dirs with
         same-name skills also trigger the refusal."""

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -93,6 +93,7 @@ SKILLS_DIR = HERMES_HOME / "skills"
 # Anthropic-recommended limits for progressive disclosure efficiency
 MAX_NAME_LENGTH = 64
 MAX_DESCRIPTION_LENGTH = 1024
+_SKILL_SUPPORT_DIR_NAMES = frozenset({"references", "templates", "assets", "scripts", "examples"})
 
 # Platform identifiers for the 'platforms' frontmatter field.
 # Maps user-friendly names to sys.platform prefixes.
@@ -513,6 +514,22 @@ def _get_category_from_path(skill_path: Path) -> Optional[str]:
         except ValueError:
             continue
     return None
+
+
+def _is_legacy_flat_skill_file(path: Path, root: Path) -> bool:
+    """Return True when ``path`` is a legacy ``<skill-name>.md`` skill file.
+
+    Legacy flat skills are supported for backwards compatibility, but linked
+    support documents under ``references/`` / ``templates/`` / etc. are not
+    standalone skills and must not collide with a real ``SKILL.md`` directory.
+    """
+    if path.name == "SKILL.md" or path.suffix != ".md":
+        return False
+    try:
+        rel = path.relative_to(root)
+    except ValueError:
+        return False
+    return not any(part in _SKILL_SUPPORT_DIR_NAMES for part in rel.parts[:-1])
 
 
 def _parse_tags(tags_value) -> List[str]:
@@ -1018,7 +1035,7 @@ def skill_view(
             direct_path = search_dir / name
             if direct_path.is_dir() and (direct_path / "SKILL.md").exists():
                 _record(direct_path, direct_path / "SKILL.md")
-            elif direct_path.with_suffix(".md").exists():
+            elif direct_path.with_suffix(".md").exists() and _is_legacy_flat_skill_file(direct_path.with_suffix(".md"), search_dir):
                 _record(None, direct_path.with_suffix(".md"))
 
             # Strategy 1b: categorized form for plugin namespace fall-through
@@ -1028,7 +1045,7 @@ def skill_view(
                 categorized_path = search_dir / local_category_name
                 if categorized_path.is_dir() and (categorized_path / "SKILL.md").exists():
                     _record(categorized_path, categorized_path / "SKILL.md")
-                elif categorized_path.with_suffix(".md").exists():
+                elif categorized_path.with_suffix(".md").exists() and _is_legacy_flat_skill_file(categorized_path.with_suffix(".md"), search_dir):
                     _record(None, categorized_path.with_suffix(".md"))
 
             # Strategy 2: recursive by directory name (catches nested skills
@@ -1050,11 +1067,25 @@ def skill_view(
 
             # Strategy 3: legacy flat <name>.md files anywhere under the dir.
             for found_md in search_dir.rglob(f"{name}.md"):
-                if found_md.name != "SKILL.md":
+                if _is_legacy_flat_skill_file(found_md, search_dir):
                     _record(None, found_md)
 
         if len(candidates) > 1:
             paths = [str(smd) for _, smd in candidates]
+            load_names: List[str] = []
+            for _sd, smd in candidates:
+                load_name: Optional[str] = None
+                for root in all_dirs:
+                    try:
+                        rel = smd.relative_to(root)
+                    except ValueError:
+                        continue
+                    if rel.name == "SKILL.md":
+                        load_name = "/".join(rel.parts[:-1])
+                    elif rel.suffix == ".md":
+                        load_name = str(rel.with_suffix(""))
+                    break
+                load_names.append(load_name or str(smd))
             logging.getLogger(__name__).warning(
                 "Skill name collision for '%s': %d candidates — %s",
                 name, len(candidates), "; ".join(paths),
@@ -1068,6 +1099,7 @@ def skill_view(
                         "Refusing to guess — load one explicitly by its categorized path."
                     ),
                     "matches": paths,
+                    "load_names": load_names,
                     "hint": (
                         "Pass the full relative path instead of the bare name "
                         "(e.g., 'category/skill-name'), or rename one of the "


### PR DESCRIPTION
## What

`skill_view`'s legacy flat-file lookup (`<name>.md`) treated **any** markdown file matching the requested name as a standalone skill. Support files living under a skill's `references/`, `templates/`, `assets/`, `scripts/` or `examples/` directory were therefore picked up as collision candidates.

## Why

With `other-skill/references/foo.md` on disk, `skill_view("foo")` refused to load the real `foo/SKILL.md` and returned an ambiguity error — a linked reference doc is not a standalone skill and should never block resolution of a real one. This is easy to hit in practice: any skill that ships a reference doc named after another skill (e.g. `home-nas-operations/references/homeassistant-control.md` next to a real `homeassistant-control` skill) breaks loading of that skill by bare name.

## How

- New `_is_legacy_flat_skill_file` helper: a markdown file only counts as a legacy flat skill when none of its parent directories (relative to the search root) is one of the well-known support dirs. Applied to all three lookup strategies (direct, categorized, recursive).
- Legacy flat skills outside support dirs keep working unchanged.
- The collision error response gained a `load_names` field listing the exact categorized names callers can pass to disambiguate, instead of only absolute paths.

## How to test

```
pytest tests/tools/test_skills_tool.py -q
```

Includes a new regression test (`test_support_reference_with_same_basename_does_not_collide`) that fails on main: a real `homeassistant-control/SKILL.md` plus an unrelated `devops/home-nas-operations/references/homeassistant-control.md` must resolve to the real skill, not an ambiguity error.

## Platforms tested

macOS (darwin 25.5). Pure path logic via `pathlib`, no platform-specific I/O.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
