### PR TITLE
fix(images): transcode HEIC/HEIF to JPEG at cache and vision boundaries

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -440,6 +440,17 @@ def _file_to_data_url(path: Path) -> Optional[str]:
         logger.warning("image_routing: failed to read %s — %s", path, exc)
         return None
     mime = _guess_mime(path, raw=raw)
+    if mime in ("image/heic", "image/heif"):
+        # Anthropic/OpenAI reject image/heic payloads outright. Transcode
+        # to JPEG when a decoder is available (pillow-heif or macOS sips);
+        # otherwise send the original bytes and let the provider error
+        # surface — same behaviour as before this fast-path existed.
+        from utils import transcode_heic_to_jpeg
+
+        jpeg = transcode_heic_to_jpeg(raw)
+        if jpeg is not None:
+            raw = jpeg
+            mime = "image/jpeg"
     b64 = base64.b64encode(raw).decode("ascii")
     return f"data:{mime};base64,{b64}"
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -20,7 +20,7 @@ import uuid
 from abc import ABC, abstractmethod
 from urllib.parse import urlsplit
 
-from utils import normalize_proxy_url
+from utils import looks_like_heic, normalize_proxy_url, transcode_heic_to_jpeg
 
 logger = logging.getLogger(__name__)
 
@@ -581,6 +581,8 @@ def _looks_like_image(data: bytes) -> bool:
         return True
     if data[:4] == b"RIFF" and len(data) >= 12 and data[8:12] == b"WEBP":
         return True
+    if looks_like_heic(data):
+        return True
     return False
 
 
@@ -605,6 +607,14 @@ def cache_image_from_bytes(data: bytes, ext: str = ".jpg") -> str:
             f"Refusing to cache non-image data as {ext} "
             f"(starts with: {snippet!r})"
         )
+    if looks_like_heic(data):
+        # Vision APIs (Anthropic, OpenAI) reject image/heic, so transcode
+        # to JPEG at the cache boundary. Falls back to caching the original
+        # bytes when no HEIC decoder is available (see utils).
+        jpeg = transcode_heic_to_jpeg(data)
+        if jpeg is not None:
+            data = jpeg
+            ext = ".jpg"
     cache_dir = get_image_cache_dir()
     filename = f"img_{uuid.uuid4().hex[:12]}{ext}"
     filepath = cache_dir / filename

--- a/tests/test_heic_transcoding.py
+++ b/tests/test_heic_transcoding.py
@@ -1,0 +1,196 @@
+"""Tests for HEIC/HEIF image handling (utils.transcode_heic_to_jpeg and
+the cache/data-URL choke points that use it).
+
+HEIC is the default iPhone camera format; vision APIs (Anthropic, OpenAI)
+reject ``image/heic`` payloads, so Hermes transcodes to JPEG at three choke
+points: gateway image cache, agent data-URL builder, and the vision tool.
+These tests use a synthetic in-memory HEIC header for detection tests and
+mock the transcoder for wiring tests — no decoder dependency in CI.
+"""
+
+import base64
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from utils import HEIC_FTYP_BRANDS, looks_like_heic, transcode_heic_to_jpeg
+
+# Minimal ISO-BMFF prefix carrying the 'heic' brand — enough for magic-byte
+# detection without a real (decodable) image payload.
+FAKE_HEIC = b"\x00\x00\x00\x24ftypheic\x00\x00\x00\x00mif1MiPr" + b"\x00" * 64
+JPEG_BYTES = b"\xff\xd8\xff\xe0" + b"\x00" * 32
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+
+
+class TestLooksLikeHeic:
+    def test_detects_heic_brand(self):
+        assert looks_like_heic(FAKE_HEIC) is True
+
+    @pytest.mark.parametrize("brand", sorted(HEIC_FTYP_BRANDS))
+    def test_detects_all_brands(self, brand):
+        data = b"\x00\x00\x00\x24ftyp" + brand + b"\x00" * 16
+        assert looks_like_heic(data) is True
+
+    def test_rejects_jpeg(self):
+        assert looks_like_heic(JPEG_BYTES) is False
+
+    def test_rejects_png(self):
+        assert looks_like_heic(PNG_BYTES) is False
+
+    def test_rejects_short_data(self):
+        assert looks_like_heic(b"\x00\x00") is False
+
+    def test_rejects_mp4_brand(self):
+        # mp42 is ISO-BMFF too but not a HEIF brand.
+        assert looks_like_heic(b"\x00\x00\x00\x24ftypmp42" + b"\x00" * 16) is False
+
+
+class TestTranscodeHeicToJpeg:
+    def test_non_heic_returns_none(self):
+        assert transcode_heic_to_jpeg(JPEG_BYTES) is None
+
+    def test_returns_none_when_no_decoder(self):
+        """With pillow-heif missing and sips absent, falls back to None."""
+        with mock.patch("shutil.which", return_value=None), \
+             mock.patch.dict("sys.modules", {"pillow_heif": None}):
+            assert transcode_heic_to_jpeg(FAKE_HEIC) is None
+
+    def test_real_transcode_if_decoder_available(self):
+        """End-to-end conversion when a real decoder exists on this host."""
+        import shutil
+        try:
+            import pillow_heif  # noqa: F401
+            have_decoder = True
+        except ImportError:
+            have_decoder = shutil.which("sips") is not None
+        if not have_decoder:
+            pytest.skip("no HEIC decoder on this host")
+        # Build a real HEIC via Pillow→sips only on macOS; otherwise skip.
+        if not shutil.which("sips"):
+            pytest.skip("sips unavailable to build fixture")
+        from PIL import Image
+        import subprocess, tempfile
+        with tempfile.TemporaryDirectory() as td:
+            png = Path(td) / "src.png"
+            heic = Path(td) / "src.heic"
+            Image.new("RGB", (32, 24), (10, 200, 100)).save(png)
+            subprocess.run(
+                ["sips", "-s", "format", "heic", str(png), "--out", str(heic)],
+                check=True, capture_output=True,
+            )
+            out = transcode_heic_to_jpeg(heic.read_bytes())
+        assert out is not None
+        assert out[:3] == b"\xff\xd8\xff"  # JPEG magic
+
+
+class TestCacheImageFromBytes:
+    def test_heic_accepted_and_transcoded(self, tmp_path, monkeypatch):
+        from gateway.platforms import base as gw_base
+
+        monkeypatch.setattr(gw_base, "get_image_cache_dir", lambda: tmp_path)
+        with mock.patch.object(
+            gw_base, "transcode_heic_to_jpeg", return_value=JPEG_BYTES,
+        ) as transcoder:
+            path = gw_base.cache_image_from_bytes(FAKE_HEIC, ".heic")
+        transcoder.assert_called_once()
+        assert path.endswith(".jpg")
+        assert Path(path).read_bytes() == JPEG_BYTES
+
+    def test_heic_kept_when_no_decoder(self, tmp_path, monkeypatch):
+        """No decoder → original bytes cached (pre-fix behaviour, no regression)."""
+        from gateway.platforms import base as gw_base
+
+        monkeypatch.setattr(gw_base, "get_image_cache_dir", lambda: tmp_path)
+        with mock.patch.object(
+            gw_base, "transcode_heic_to_jpeg", return_value=None,
+        ):
+            path = gw_base.cache_image_from_bytes(FAKE_HEIC, ".heic")
+        assert path.endswith(".heic")
+        assert Path(path).read_bytes() == FAKE_HEIC
+
+    def test_non_image_still_rejected(self):
+        from gateway.platforms.base import cache_image_from_bytes
+
+        with pytest.raises(ValueError):
+            cache_image_from_bytes(b"<html>error page</html>", ".jpg")
+
+    def test_jpeg_passthrough_untouched(self, tmp_path, monkeypatch):
+        from gateway.platforms import base as gw_base
+
+        monkeypatch.setattr(gw_base, "get_image_cache_dir", lambda: tmp_path)
+        path = gw_base.cache_image_from_bytes(JPEG_BYTES, ".jpg")
+        assert Path(path).read_bytes() == JPEG_BYTES
+
+
+class TestFileToDataUrl:
+    def test_heic_transcoded_to_jpeg_data_url(self, tmp_path):
+        from agent import image_routing
+
+        heic_file = tmp_path / "photo.heic"
+        heic_file.write_bytes(FAKE_HEIC)
+        with mock.patch(
+            "utils.transcode_heic_to_jpeg", return_value=JPEG_BYTES,
+        ):
+            url = image_routing._file_to_data_url(heic_file)
+        assert url is not None
+        assert url.startswith("data:image/jpeg;base64,")
+        assert base64.b64decode(url.split(",", 1)[1]) == JPEG_BYTES
+
+    def test_heic_unchanged_when_no_decoder(self, tmp_path):
+        from agent import image_routing
+
+        heic_file = tmp_path / "photo.heic"
+        heic_file.write_bytes(FAKE_HEIC)
+        with mock.patch(
+            "utils.transcode_heic_to_jpeg", return_value=None,
+        ):
+            url = image_routing._file_to_data_url(heic_file)
+        assert url is not None
+        assert url.startswith("data:image/heic;base64,")
+
+    def test_jpeg_not_routed_through_transcoder(self, tmp_path):
+        from agent import image_routing
+
+        jpg_file = tmp_path / "photo.jpg"
+        jpg_file.write_bytes(JPEG_BYTES)
+        with mock.patch(
+            "utils.transcode_heic_to_jpeg",
+        ) as transcoder:
+            url = image_routing._file_to_data_url(jpg_file)
+        transcoder.assert_not_called()
+        assert url is not None and url.startswith("data:image/jpeg;base64,")
+
+
+class TestVisionToolHeic:
+    def test_detect_image_mime_type_heic(self, tmp_path):
+        from tools.vision_tools import _detect_image_mime_type
+
+        f = tmp_path / "img.heic"
+        f.write_bytes(FAKE_HEIC)
+        assert _detect_image_mime_type(f) == "image/heic"
+
+    def test_maybe_transcode_heic_swaps_path_and_mime(self, tmp_path, monkeypatch):
+        from tools import vision_tools
+
+        f = tmp_path / "img.heic"
+        f.write_bytes(FAKE_HEIC)
+        monkeypatch.setattr(
+            vision_tools, "get_hermes_dir", lambda *a, **k: tmp_path,
+        )
+        with mock.patch(
+            "utils.transcode_heic_to_jpeg", return_value=JPEG_BYTES,
+        ):
+            new_path, new_mime = vision_tools._maybe_transcode_heic(
+                f, "image/heic",
+            )
+        assert new_mime == "image/jpeg"
+        assert new_path != f
+        assert new_path.read_bytes() == JPEG_BYTES
+
+    def test_maybe_transcode_noop_for_other_mimes(self, tmp_path):
+        from tools.vision_tools import _maybe_transcode_heic
+
+        f = tmp_path / "img.png"
+        f.write_bytes(PNG_BYTES)
+        assert _maybe_transcode_heic(f, "image/png") == (f, "image/png")

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -121,11 +121,36 @@ def _detect_image_mime_type(image_path: Path) -> Optional[str]:
         return "image/bmp"
     if len(header) >= 12 and header[:4] == b"RIFF" and header[8:12] == b"WEBP":
         return "image/webp"
+    from utils import looks_like_heic
+    if looks_like_heic(header):
+        return "image/heic"
     if image_path.suffix.lower() == ".svg":
         head = image_path.read_text(encoding="utf-8", errors="ignore")[:4096].lower()
         if "<svg" in head:
             return "image/svg+xml"
     return None
+
+
+def _maybe_transcode_heic(image_path: Path, mime: str) -> "tuple[Path, str]":
+    """Transcode a HEIC/HEIF image to a JPEG temp file for vision APIs.
+
+    Anthropic and OpenAI reject ``image/heic`` payloads, so when detection
+    reports HEIC we convert to JPEG (via utils.transcode_heic_to_jpeg —
+    pillow-heif or macOS sips) and return the new path + mime. The original
+    file is never modified. When no decoder is available, returns the
+    inputs unchanged so the provider error surfaces as before.
+    """
+    if mime not in ("image/heic", "image/heif"):
+        return image_path, mime
+    from utils import transcode_heic_to_jpeg
+
+    jpeg = transcode_heic_to_jpeg(image_path.read_bytes())
+    if jpeg is None:
+        return image_path, mime
+    temp_dir = get_hermes_dir("cache/vision", "temp_vision_images")
+    out_path = temp_dir / f"heic_transcoded_{uuid.uuid4()}.jpg"
+    out_path.write_bytes(jpeg)
+    return out_path, "image/jpeg"
 
 
 def _is_retryable_download_error(error: Exception) -> bool:
@@ -743,6 +768,9 @@ async def _vision_analyze_native(
                 "Only real image files are supported for vision analysis.",
                 success=False,
             )
+        temp_image_path, detected_mime_type = _maybe_transcode_heic(
+            temp_image_path, detected_mime_type,
+        )
 
         image_data_url = _image_to_base64_data_url(
             temp_image_path, mime_type=detected_mime_type,
@@ -898,6 +926,9 @@ async def vision_analyze_tool(
         detected_mime_type = _detect_image_mime_type(temp_image_path)
         if not detected_mime_type:
             raise ValueError("Only real image files are supported for vision analysis.")
+        temp_image_path, detected_mime_type = _maybe_transcode_heic(
+            temp_image_path, detected_mime_type,
+        )
         
         # Convert image to base64 — send at full resolution first.
         # If the provider rejects it as too large, we auto-resize and retry.

--- a/utils.py
+++ b/utils.py
@@ -412,3 +412,95 @@ def base_url_host_matches(base_url: str, domain: str) -> bool:
     if not domain:
         return False
     return hostname == domain or hostname.endswith("." + domain)
+
+
+# ---------------------------------------------------------------------------
+# HEIC/HEIF → JPEG transcoding
+#
+# Most vision APIs (Anthropic, OpenAI) reject image/heic payloads, and
+# Pillow cannot decode HEIC without the optional pillow-heif plugin, yet
+# HEIC is the default camera format on iPhones — any iMessage/Photon (or
+# email/AirDrop) photo arrives as HEIC. We transcode at the choke points
+# (image cache write, data-URL build) so every platform adapter and the
+# vision path get JPEG for free.
+
+HEIC_FTYP_BRANDS = frozenset({
+    b"heic", b"heix", b"hevc", b"hevx", b"mif1", b"msf1", b"heim", b"heis",
+})
+
+
+def looks_like_heic(data: bytes) -> bool:
+    """Return True when *data* starts with an ISO-BMFF ftyp box carrying a
+    HEIC/HEIF brand (the magic shared by iPhone photos)."""
+    return (
+        len(data) >= 12
+        and data[4:8] == b"ftyp"
+        and data[8:12] in HEIC_FTYP_BRANDS
+    )
+
+
+def transcode_heic_to_jpeg(data: bytes) -> "bytes | None":
+    """Convert HEIC/HEIF bytes to JPEG bytes, or None when no decoder exists.
+
+    Tries, in order:
+      1. ``pillow-heif`` + Pillow (cross-platform, optional dependency)
+      2. macOS ``sips`` (ships with the OS, zero install)
+
+    Returns None when neither backend is available or conversion fails;
+    callers should fall back to their pre-existing behaviour (e.g. caching
+    the original bytes) so this never makes things worse.
+    """
+    if not looks_like_heic(data):
+        return None
+
+    # 1. pillow-heif (optional dep) — works on Linux/macOS/Windows.
+    try:
+        import io
+
+        import pillow_heif  # type: ignore[import-not-found]
+        from PIL import Image
+
+        pillow_heif.register_heif_opener()
+        img = Image.open(io.BytesIO(data))
+        buf = io.BytesIO()
+        img.convert("RGB").save(buf, format="JPEG", quality=90)
+        return buf.getvalue()
+    except ImportError:
+        pass
+    except Exception as exc:  # pragma: no cover - corrupt file etc.
+        logger.warning("pillow-heif HEIC transcode failed: %s", exc)
+
+    # 2. sips — built into macOS, no Python deps.
+    import shutil
+    import subprocess
+
+    if shutil.which("sips"):
+        src = dst = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                suffix=".heic", delete=False
+            ) as f:
+                f.write(data)
+                src = f.name
+            dst = src + ".jpg"
+            subprocess.run(
+                ["sips", "-s", "format", "jpeg", "-s", "formatOptions", "90",
+                 src, "--out", dst],
+                check=True, capture_output=True, timeout=30,
+            )
+            return Path(dst).read_bytes()
+        except Exception as exc:
+            logger.warning("sips HEIC transcode failed: %s", exc)
+        finally:
+            for p in (src, dst):
+                if p:
+                    try:
+                        os.unlink(p)
+                    except OSError:
+                        pass
+
+    logger.info(
+        "HEIC image received but no transcoder available "
+        "(install pillow-heif for cross-platform support)"
+    )
+    return None


### PR DESCRIPTION
## Symptom

iPhone photos sent over iMessage (Photon plugin) — or any HEIC arriving by email/AirDrop — never reach the model as images:

1. `_looks_like_image()` in `gateway/platforms/base.py` doesn't recognize HEIC magic bytes, so `cache_image_from_bytes` raises `ValueError` and the photo is demoted to a **document** attachment (`cache/documents/doc_*.heic`). The agent gets a file path instead of a vision attachment.
2. Even when a `.heic` file path is fed to `vision_analyze` or `_file_to_data_url` directly, it's sent as `data:image/heic`, which Anthropic and OpenAI reject (HTTP 400).

`agent/image_routing.py` already sniffs HEIC correctly (line ~391), and `bluebubbles.py` works around the problem per-adapter with a `image/heic → .jpg` extension map — evidence this keeps getting solved locally instead of once.

Reproduced on current `main` by sending iPhone photos through the Photon/iMessage gateway: all four arrived as `doc_*.heic` documents and required manual `sips` conversion before vision could read them.

## Fix

Transcode at the choke points so every platform adapter and call path benefits:

- **`utils.py`**: `looks_like_heic()` (ISO-BMFF ftyp brand check, same brand set image_routing already uses) + `transcode_heic_to_jpeg()` — tries `pillow-heif` if importable, falls back to macOS `sips` (ships with the OS), returns `None` when neither exists so callers keep their pre-existing behaviour. **No new required dependency.**
- **`gateway/platforms/base.py`**: accept HEIC in `_looks_like_image()`; transcode in `cache_image_from_bytes()` — fixes the document-demotion for all gateway platforms at once.
- **`agent/image_routing.py`**: transcode in `_file_to_data_url()` before base64 — covers HEIC file paths handed to the agent.
- **`tools/vision_tools.py`**: detect HEIC mime + transcode to a temp JPEG in both `vision_analyze` paths.

Worst case (Linux, no pillow-heif): behaviour is unchanged from today — original bytes pass through and the existing provider-error path surfaces, with an info log suggesting `pip install pillow-heif`.

## Tests

`tests/test_heic_transcoding.py` — 26 tests:
- magic-byte detection across all HEIF ftyp brands, negative cases (JPEG/PNG/MP4/short data)
- wiring tests for all three choke points with a mocked transcoder (no decoder dependency in CI)
- real-decoder round-trip tests that auto-skip when neither pillow-heif nor sips is available

`pytest tests/test_heic_transcoding.py tests/tools/test_vision_tools.py` → 104 passed. The 18 failures in a broader `tests/agent/` run are pre-existing test-ordering flakiness — identical failure set on untouched `main` (verified by stash + re-run).

Also verified end-to-end with real iPhone HEIC bytes: detection → transcode (112 KB HEIC → 240 KB JPEG) → `cache_image_from_bytes` now writes `img_*.jpg` with valid JPEG magic.