### PR TITLE
Fix gateway reset config and streamed transcript persistence

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -790,6 +790,14 @@ def load_gateway_config() -> GatewayConfig:
             if sr and isinstance(sr, dict):
                 gw_data["default_reset_policy"] = sr
 
+            rbt = yaml_cfg.get("reset_by_type")
+            if isinstance(rbt, dict):
+                gw_data["reset_by_type"] = rbt
+
+            rbp = yaml_cfg.get("reset_by_platform")
+            if isinstance(rbp, dict):
+                gw_data["reset_by_platform"] = rbp
+
             qc = yaml_cfg.get("quick_commands")
             if qc is not None:
                 if isinstance(qc, dict):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8833,6 +8833,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             else:
                 history_len = agent_result.get("history_offset", len(history))
                 new_messages = agent_messages[history_len:] if len(agent_messages) > history_len else []
+                response_text = str(response or "").strip()
+
+                def _message_content_text(content: Any) -> str:
+                    if isinstance(content, str):
+                        return content
+                    if isinstance(content, list):
+                        parts = []
+                        for part in content:
+                            if isinstance(part, str):
+                                parts.append(part)
+                            elif isinstance(part, dict) and part.get("text") is not None:
+                                parts.append(str(part.get("text")))
+                        return "\n".join(parts)
+                    if content is None:
+                        return ""
+                    return str(content)
+
+                def _has_assistant_after_last_user(messages: Any) -> bool:
+                    saw_assistant = False
+                    for entry in reversed(messages or []):
+                        if not isinstance(entry, dict):
+                            continue
+                        role = entry.get("role")
+                        if role == "assistant" and _message_content_text(entry.get("content")).strip():
+                            saw_assistant = True
+                        elif role == "user":
+                            return saw_assistant
+                    return saw_assistant
 
                 # If no new messages found (edge case), fall back to simple user/assistant
                 if not new_messages:
@@ -8873,6 +8901,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         self.session_store.append_to_transcript(
                             session_entry.session_id, entry,
                             skip_db=agent_persisted,
+                        )
+
+                if response_text:
+                    try:
+                        current_transcript = self.session_store.load_transcript(session_entry.session_id)
+                    except Exception as exc:
+                        logger.debug(
+                            "Could not verify assistant transcript row for %s: %s",
+                            session_entry.session_id,
+                            exc,
+                        )
+                        current_transcript = []
+                    if not _has_assistant_after_last_user(current_transcript):
+                        self.session_store.append_to_transcript(
+                            session_entry.session_id,
+                            {"role": "assistant", "content": response, "timestamp": ts},
+                            skip_db=False,
+                        )
+                        logger.info(
+                            "Backfilled assistant response into transcript: session_id=%s chars=%d",
+                            session_entry.session_id,
+                            len(response_text),
                         )
             
             # Token counts and model are now persisted by the agent directly.

--- a/tests/gateway/test_42039_duplicate_user_message.py
+++ b/tests/gateway/test_42039_duplicate_user_message.py
@@ -239,3 +239,87 @@ async def test_normal_path_skip_db_when_agent_has_session_db(
     _assert_user_call_has_skip_db(
         runner.session_store.append_to_transcript.call_args_list, True
     )
+
+
+# ── Test 5: streamed response with missing assistant message is backfilled ─
+
+
+@pytest.mark.asyncio
+async def test_streamed_response_backfills_missing_assistant_turn(
+    monkeypatch, tmp_path
+):
+    runner = _bootstrap(monkeypatch, tmp_path)
+    final_response = 'Heard you. Voice message came through: "Hello, just testing."'
+    runner.session_store.load_transcript.side_effect = [
+        [],
+        [{"role": "user", "content": "hello world"}],
+    ]
+
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": final_response,
+            "messages": [{"role": "user", "content": "hello world"}],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+            "already_sent": True,
+        }
+    )
+
+    await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    assistant_calls = [
+        call
+        for call in runner.session_store.append_to_transcript.call_args_list
+        if len(call.args) >= 2
+        and isinstance(call.args[1], dict)
+        and call.args[1].get("role") == "assistant"
+    ]
+    assert assistant_calls, runner.session_store.append_to_transcript.call_args_list
+    assert assistant_calls[-1].args[1]["content"] == final_response
+    assert assistant_calls[-1].kwargs.get("skip_db") is False
+
+
+# ── Test 6: successful non-streamed response also backfills DB cursor misses ─
+
+
+@pytest.mark.asyncio
+async def test_success_response_backfills_when_db_tail_lacks_assistant(
+    monkeypatch, tmp_path
+):
+    runner = _bootstrap(monkeypatch, tmp_path)
+    final_response = "Done."
+    runner.session_store.load_transcript.side_effect = [
+        [],
+        [{"role": "user", "content": "hello world"}],
+    ]
+
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": final_response,
+            "messages": [
+                {"role": "user", "content": "hello world"},
+                {"role": "assistant", "content": final_response},
+            ],
+            "tools": [],
+            "history_offset": 0,
+            "last_prompt_tokens": 0,
+        }
+    )
+
+    await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    assistant_calls = [
+        call
+        for call in runner.session_store.append_to_transcript.call_args_list
+        if len(call.args) >= 2
+        and isinstance(call.args[1], dict)
+        and call.args[1].get("role") == "assistant"
+    ]
+    assert assistant_calls, runner.session_store.append_to_transcript.call_args_list
+    assert assistant_calls[-1].args[1]["content"] == final_response
+    assert assistant_calls[-1].kwargs.get("skip_db") is False

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -639,6 +639,34 @@ class TestLoadGatewayConfig:
 
         assert config.default_reset_policy.notify is False
 
+    def test_bridges_reset_policy_overrides_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "reset_by_platform:\n"
+            "  discord:\n"
+            "    mode: idle\n"
+            "    idle_minutes: 45\n"
+            "    notify: false\n"
+            "reset_by_type:\n"
+            "  dm:\n"
+            "    mode: daily\n"
+            "    at_hour: 3\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        discord = config.reset_by_platform[Platform.DISCORD]
+        assert discord.mode == "idle"
+        assert discord.idle_minutes == 45
+        assert discord.notify is False
+        assert config.reset_by_type["dm"].mode == "daily"
+        assert config.reset_by_type["dm"].at_hour == 3
+
     def test_bridges_quoted_false_always_log_local_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()


### PR DESCRIPTION
## Summary
- load reset_by_type/reset_by_platform from config.yaml into GatewayConfig
- backfill the final assistant response when state.db has a latest user row without a non-empty assistant row after it, covering cursor/repair misses as well as streamed delivery
- add regression coverage for both behaviors

## Tests
- uv run --extra dev pytest tests/gateway/test_42039_duplicate_user_message.py tests/gateway/test_config.py -q