### PR TITLE
feat(agent): retry malformed tool calls with forced tool_choice

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1333,6 +1333,17 @@ def init_agent(
     # conversation loop's intent-ack block.
     agent._intent_ack_continuation = _agent_section.get("intent_ack_continuation", "auto")
 
+    # Forced tool-choice retry: "auto" (default) re-requests a malformed
+    # tool call with tool_choice pinned to the failed tool so grammar-
+    # enforcing backends (vLLM) regenerate it schema-valid; "off" disables.
+    # The one-shot flag and per-turn counter live on the agent so the
+    # detection sites (chat_completion_helpers.py stream repair,
+    # tool_executor.py required-fields check) can arm a retry for
+    # conversation_loop.py to consume at the next kwargs build.
+    agent._forced_tool_retry = _agent_section.get("forced_tool_retry", "auto")
+    agent._forced_tool_choice = None
+    agent._forced_tool_retry_count = 0
+
     # Universal task-completion guidance toggle.  Default True.  Surfaced
     # as a separate flag from tool_use_enforcement because the guidance
     # applies to ALL models, not just the model families enforcement

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2273,6 +2273,13 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         else:
                             # Unrepairable — flag for truncation handling
                             has_truncated_tool_args = True
+                            # Also arm the forced tool_choice retry: the
+                            # truncation re-request rebuilds api_kwargs in
+                            # conversation_loop, which pins tool_choice to
+                            # this tool so grammar-enforcing backends (vLLM)
+                            # regenerate the call schema-valid.
+                            if getattr(agent, "_forced_tool_retry", "off") == "auto":
+                                agent._forced_tool_choice = tool_name
                 mock_tool_calls.append(SimpleNamespace(
                     id=tc["id"],
                     type=tc["type"],

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -103,6 +103,39 @@ def _image_error_max_dimension(error: Exception) -> Optional[int]:
     return None
 
 
+def _consume_forced_tool_choice(agent: Any, api_kwargs: dict) -> bool:
+    """Consume the one-shot forced tool_choice flag into ``api_kwargs``.
+
+    Armed by the malformed-call detection sites (stream repair in
+    chat_completion_helpers.py, required-fields check in tool_executor.py).
+    Pinning tool_choice to the failed tool makes grammar-enforcing backends
+    (vLLM) regenerate the call schema-valid by construction.  The flag is
+    always cleared on read; injection happens only when the config is
+    "auto", the tool exists, and the per-turn cap (3) isn't exhausted.
+    Returns True when tool_choice was injected.
+    """
+    forced = getattr(agent, "_forced_tool_choice", None)
+    if forced is None:
+        return False
+    agent._forced_tool_choice = None  # one-shot: always consume
+    if (
+        getattr(agent, "_forced_tool_retry", "off") == "auto"
+        and forced in agent.valid_tool_names
+        and getattr(agent, "_forced_tool_retry_count", 0) < 3
+    ):
+        api_kwargs["tool_choice"] = {
+            "type": "function",
+            "function": {"name": forced},
+        }
+        agent._forced_tool_retry_count += 1
+        logger.info(
+            f"{agent.log_prefix}Forced tool_choice retry "
+            f"#{agent._forced_tool_retry_count}: {forced}"
+        )
+        return True
+    return False
+
+
 def _ollama_context_limit_error(agent: Any, request_tokens: int) -> Optional[str]:
     """Return a user-facing error when Ollama is loaded with too little context."""
     if not getattr(agent, "tools", None):
@@ -605,6 +638,10 @@ def run_conversation(
     codex_ack_continuations = 0
     length_continue_retries = 0
     truncated_tool_call_retries = 0
+    # Per-turn cap for forced tool_choice retries (the one-shot flag itself
+    # lives on the agent — set by the malformed-call detection sites, consumed
+    # at the api_kwargs build below).
+    agent._forced_tool_retry_count = 0
     truncated_response_parts: List[str] = []
     compression_attempts = 0
     _turn_exit_reason = "unknown"  # Diagnostic: why the loop ended
@@ -1072,6 +1109,11 @@ def run_conversation(
                 # isn't sent with stale, primary-shaped reasoning fields.
                 agent._reapply_reasoning_echo_for_provider(api_messages)
                 api_kwargs = agent._build_api_kwargs(api_messages)
+                # Forced tool-choice retry (one-shot, armed by the
+                # malformed-call detection sites) — injected before
+                # middleware so middleware keeps veto power; provider
+                # rejections self-disable in the API-error path below.
+                _consume_forced_tool_choice(agent, api_kwargs)
                 if agent._force_ascii_payload:
                     _sanitize_structure_non_ascii(api_kwargs)
                 if agent.api_mode == "codex_responses":
@@ -2915,6 +2957,22 @@ def run_conversation(
                 # A 413 is a payload-size error — the correct response is to
                 # compress history and retry, not abort immediately.
                 status_code = getattr(api_error, "status_code", None)
+
+                # ── Forced tool_choice rejected by this backend ───────
+                # The forced-tool-retry injection (api_kwargs build above)
+                # is grammar-enforced on vLLM but other backends may
+                # reject a named tool_choice outright.  Disable the
+                # mechanism for the session and retry the call unforced
+                # (the rebuild at the top of the loop produces clean
+                # kwargs — the one-shot flag was already consumed).
+                if api_kwargs and api_kwargs.get("tool_choice") and "tool_choice" in str(api_error):
+                    agent._forced_tool_retry = "off"
+                    api_kwargs.pop("tool_choice", None)
+                    logger.warning(
+                        f"{agent.log_prefix}Provider rejected tool_choice; "
+                        f"forced_tool_retry disabled for this session."
+                    )
+                    continue
 
                 # ── Respect disabled auto-compaction on overflow ──────
                 # Ported from anomalyco/opencode#30749.  When the user has

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -111,13 +111,18 @@ def _consume_forced_tool_choice(agent: Any, api_kwargs: dict) -> bool:
     Pinning tool_choice to the failed tool makes grammar-enforcing backends
     (vLLM) regenerate the call schema-valid by construction.  The flag is
     always cleared on read; injection happens only when the config is
-    "auto", the tool exists, and the per-turn cap (3) isn't exhausted.
+    "auto", the tool exists, the per-turn cap (3) isn't exhausted, and
+    nothing upstream already set tool_choice for this request.
     Returns True when tool_choice was injected.
     """
     forced = getattr(agent, "_forced_tool_choice", None)
     if forced is None:
         return False
     agent._forced_tool_choice = None  # one-shot: always consume
+    if "tool_choice" in api_kwargs:
+        # An upstream layer already pinned tool_choice (e.g. a safety
+        # guard's "none"); never clobber it with a forced retry.
+        return False
     if (
         getattr(agent, "_forced_tool_retry", "off") == "auto"
         and forced in agent.valid_tool_names

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -303,6 +303,26 @@ def _run_agent_tool_execution_middleware(
     return result, observed_args
 
 
+def _missing_required_fields(agent, tool_name: str, args: dict) -> list[str]:
+    """Names of required parameters absent from ``args`` for ``tool_name``.
+
+    Schema source is ``agent.tools`` (OpenAI function schemas, see
+    agent_init.py).  Unknown tools and schema lookup errors return [] —
+    validation here must never block a tool the registry can't describe.
+    Detection of a non-empty result arms the forced tool_choice retry
+    (``agent._forced_tool_choice``, consumed in conversation_loop.py).
+    """
+    try:
+        for t in agent.tools or []:
+            fn = t.get("function", {})
+            if fn.get("name") == tool_name:
+                req = fn.get("parameters", {}).get("required", []) or []
+                return [k for k in req if k not in args]
+    except Exception:
+        pass
+    return []
+
+
 def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
     """Execute multiple tool calls concurrently using a thread pool.
 
@@ -393,6 +413,11 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             tool_call_id=getattr(tool_call, "id", "") or "",
         )
 
+        # Required-fields check (post-middleware, post-unwrap): valid-JSON
+        # args missing required fields — and unrepairable args repaired to
+        # {} upstream — are caught here before dispatch.
+        _missing_required = _missing_required_fields(agent, function_name, function_args)
+
         # ── Block evaluation (BEFORE checkpoint preflight) ───────────
         # We must know whether the tool will execute before touching
         # checkpoint state (dedup slot, real snapshots).
@@ -411,6 +436,31 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 status="blocked",
                 error_type="tool_scope_block",
                 error_message=_ts_scope_block,
+                middleware_trace=list(middleware_trace),
+            )
+        elif _missing_required:
+            # Malformed call: block before dispatch and arm the forced
+            # tool_choice retry (see conversation_loop.py) so the
+            # re-request is grammar-enforced where supported (vLLM).
+            if getattr(agent, "_forced_tool_retry", "off") == "auto":
+                agent._forced_tool_choice = function_name
+            block_result = json.dumps({
+                "error": (
+                    f"{function_name}: missing required field(s) "
+                    f"{', '.join(_missing_required)}. Re-emit the tool call "
+                    f"with every required field set."
+                ),
+            }, ensure_ascii=False)
+            _emit_terminal_post_tool_call(
+                agent,
+                function_name=function_name,
+                function_args=function_args,
+                result=block_result,
+                effective_task_id=effective_task_id,
+                tool_call_id=getattr(tool_call, "id", "") or "",
+                status="blocked",
+                error_type="missing_required_fields",
+                error_message=block_result,
                 middleware_trace=list(middleware_trace),
             )
         else:
@@ -1026,12 +1076,28 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             tool_call_id=getattr(tool_call, "id", "") or "",
         )
 
+        # Required-fields check (post-middleware, post-unwrap) — see
+        # execute_tool_calls_concurrent for rationale.
+        _missing_required = _missing_required_fields(agent, function_name, function_args)
+
         # Check plugin hooks for a block directive before executing.
         _block_msg: Optional[str] = None
         _block_error_type = "plugin_block"
         if _ts_scope_block is not None:
             _block_msg = _ts_scope_block
             _block_error_type = "tool_scope_block"
+        elif _missing_required:
+            # Malformed call: block before dispatch and arm the forced
+            # tool_choice retry (see conversation_loop.py) so the
+            # re-request is grammar-enforced where supported (vLLM).
+            if getattr(agent, "_forced_tool_retry", "off") == "auto":
+                agent._forced_tool_choice = function_name
+            _block_msg = (
+                f"{function_name}: missing required field(s) "
+                f"{', '.join(_missing_required)}. Re-emit the tool call "
+                f"with every required field set."
+            )
+            _block_error_type = "missing_required_fields"
         else:
             try:
                 from hermes_cli.plugins import get_pre_tool_call_block_message

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -615,6 +615,15 @@ agent:
   # Recommended: 20-30 for focused tasks, 50-100 for open exploration
   max_turns: 60
 
+  # Forced tool-choice retry: when the model emits a malformed tool call
+  # (unparseable JSON arguments, or arguments missing required fields),
+  # retry once with tool_choice pinned to the failed tool. Backends with
+  # grammar-enforced structured outputs (vLLM) regenerate the call
+  # schema-valid by construction; a backend that rejects named tool_choice
+  # gets the retry unforced and the mechanism disables for that session.
+  # Values: "auto" (default) | "off"
+  forced_tool_retry: auto
+
   # Inactivity timeout for gateway agent runs (seconds, 0 = unlimited).
   # The agent can run indefinitely when actively calling tools or receiving
   # API responses.  Only fires after the agent has been idle for this duration.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -954,6 +954,14 @@ DEFAULT_CONFIG = {
         # api_modes — fixes the Gemini/Claude "stops after stating intent" case),
         # false (never), or a list of model-name substrings to match.
         "intent_ack_continuation": "auto",
+        # Forced tool-choice retry: when the model emits a malformed tool
+        # call (unparseable JSON arguments, or arguments missing required
+        # fields), re-request once with tool_choice pinned to the failed
+        # tool.  Backends with grammar-enforced structured outputs (vLLM)
+        # then regenerate the call schema-valid by construction.  Values:
+        # "auto" (default — inject and self-disable for the session if the
+        # provider rejects tool_choice) or "off".
+        "forced_tool_retry": "auto",
         # Universal "finish the job" guidance — short prompt block applied to
         # all models that targets two cross-family failure modes: (1) stopping
         # after a stub instead of finishing the artifact, (2) fabricating

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -203,6 +203,7 @@ def _config_overrides(config: dict) -> dict[str, str]:
         ("agent", "max_turns"),
         ("agent", "gateway_timeout"),
         ("agent", "tool_use_enforcement"),
+        ("agent", "forced_tool_retry"),
         ("terminal", "backend"),
         ("terminal", "docker_image"),
         ("terminal", "persistent_shell"),

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -7607,3 +7607,175 @@ class TestMemoryProviderTurnStart:
         # The extracted body uses ``agent.X`` rather than ``self.X``;
         # assert the extracted-form spelling directly.
         assert "on_turn_start(agent._user_turn_count" in src
+
+
+class TestForcedToolRetry:
+    """Tests for agent.forced_tool_retry (forced tool_choice retry on
+    malformed tool calls) — config plumbing, the one-shot consume helper
+    in conversation_loop, and the required-fields check in tool_executor."""
+
+    def _make_agent(self, forced_tool_retry="auto"):
+        """Create an AIAgent with mocked dependencies and a specific config."""
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs("terminal", "web_search"),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={"agent": {"forced_tool_retry": forced_tool_retry}},
+            ),
+        ):
+            agent = AIAgent(
+                model="qwen/qwen-plus",
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            agent.client = MagicMock()
+            return agent
+
+    def test_default_config_is_auto(self):
+        """Fresh agent defaults to 'auto' retry mode with no pending choice."""
+        agent = self._make_agent()
+        assert agent._forced_tool_retry == "auto"
+        assert agent._forced_tool_choice is None
+        assert agent._forced_tool_retry_count == 0
+
+    def test_config_off_respected(self):
+        """Agent respects 'off' configuration for forced tool retry."""
+        agent = self._make_agent(forced_tool_retry="off")
+        assert agent._forced_tool_retry == "off"
+
+    def test_consume_injects_and_clears(self):
+        """Auto mode injects tool_choice for valid tools and clears the flag."""
+        from agent.conversation_loop import _consume_forced_tool_choice
+
+        agent = self._make_agent()
+        agent._forced_tool_choice = "terminal"
+        api_kwargs = {}
+
+        result = _consume_forced_tool_choice(agent, api_kwargs)
+
+        assert result is True
+        assert api_kwargs["tool_choice"]["function"]["name"] == "terminal"
+        assert agent._forced_tool_choice is None
+        assert agent._forced_tool_retry_count == 1
+
+    def test_consume_off_clears_without_injecting(self):
+        """Off mode clears the flag but does not inject tool_choice."""
+        from agent.conversation_loop import _consume_forced_tool_choice
+
+        agent = self._make_agent(forced_tool_retry="off")
+        agent._forced_tool_choice = "terminal"
+        api_kwargs = {}
+
+        result = _consume_forced_tool_choice(agent, api_kwargs)
+
+        assert result is False
+        assert "tool_choice" not in api_kwargs
+        assert agent._forced_tool_choice is None
+
+    def test_consume_unknown_tool_no_injection(self):
+        """Unknown tool names are ignored and the flag is still cleared."""
+        from agent.conversation_loop import _consume_forced_tool_choice
+
+        agent = self._make_agent()
+        agent._forced_tool_choice = "not_a_tool"
+        api_kwargs = {}
+
+        result = _consume_forced_tool_choice(agent, api_kwargs)
+
+        assert result is False
+        assert "tool_choice" not in api_kwargs
+        assert agent._forced_tool_choice is None
+
+    def test_consume_respects_per_turn_cap(self):
+        """Retry injection stops once the per-turn cap (3) is reached."""
+        from agent.conversation_loop import _consume_forced_tool_choice
+
+        agent = self._make_agent()
+        agent._forced_tool_choice = "terminal"
+        agent._forced_tool_retry_count = 3
+        api_kwargs = {}
+
+        result = _consume_forced_tool_choice(agent, api_kwargs)
+
+        assert result is False
+        assert "tool_choice" not in api_kwargs
+        assert agent._forced_tool_choice is None
+
+    def test_consume_noop_when_unarmed(self):
+        """No injection and no mutation when no tool choice is pending."""
+        from agent.conversation_loop import _consume_forced_tool_choice
+
+        agent = self._make_agent()
+        agent._forced_tool_choice = None
+        api_kwargs = {}
+
+        result = _consume_forced_tool_choice(agent, api_kwargs)
+
+        assert result is False
+        assert api_kwargs == {}
+
+    def test_missing_required_fields_reports_missing(self):
+        """Missing required fields are identified from the tool's schema."""
+        from agent.tool_executor import _missing_required_fields
+
+        agent = self._make_agent()
+        agent.tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "write_file",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "path": {"type": "string"},
+                            "content": {"type": "string"},
+                        },
+                        "required": ["path", "content"],
+                    },
+                },
+            }
+        ]
+
+        missing = _missing_required_fields(agent, "write_file", {"content": "x"})
+
+        assert missing == ["path"]
+
+    def test_missing_required_fields_unknown_tool_empty(self):
+        """Unknown tools return an empty missing-fields list (never block)."""
+        from agent.tool_executor import _missing_required_fields
+
+        agent = self._make_agent()
+
+        missing = _missing_required_fields(agent, "unknown_tool", {})
+
+        assert missing == []
+
+    def test_missing_required_fields_no_required_schema_empty(self):
+        """Schemas without a 'required' key return an empty list."""
+        from agent.tool_executor import _missing_required_fields
+
+        agent = self._make_agent()
+        agent.tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "simple_tool",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {},
+                    },
+                },
+            }
+        ]
+
+        missing = _missing_required_fields(agent, "simple_tool", {})
+
+        assert missing == []

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -7709,6 +7709,22 @@ class TestForcedToolRetry:
         assert "tool_choice" not in api_kwargs
         assert agent._forced_tool_choice is None
 
+    def test_consume_never_overrides_existing_tool_choice(self):
+        """A tool_choice already present in api_kwargs (e.g. a safety
+        guard's "none") is never clobbered; the flag is still cleared."""
+        from agent.conversation_loop import _consume_forced_tool_choice
+
+        agent = self._make_agent()
+        agent._forced_tool_choice = "terminal"
+        api_kwargs = {"tool_choice": "none"}
+
+        result = _consume_forced_tool_choice(agent, api_kwargs)
+
+        assert result is False
+        assert api_kwargs["tool_choice"] == "none"
+        assert agent._forced_tool_choice is None
+        assert agent._forced_tool_retry_count == 0
+
     def test_consume_noop_when_unarmed(self):
         """No injection and no mutation when no tool choice is pending."""
         from agent.conversation_loop import _consume_forced_tool_choice


### PR DESCRIPTION
## What does this PR do?

Local/quantized models served through OpenAI-compatible backends intermittently emit **malformed tool calls** — arguments that don't parse as JSON, or parse fine but are missing required fields (`write_file` with no `path`, `terminal` with trailing-brace JSON, etc.). On our deployment (Qwen3.6-27B NVFP4 on vLLM 0.20.1), one day's `errors.log` showed 16 such payloads: 7 repaired by the existing sanitizer, 9 unrepairable (silently replaced with `{}`, which then *executes the tool with empty args*). Today's behavior bounces an error string back to the model and hopes — and the model frequently fails the same way again, burning turns and context.

This PR adds a **forced tool-choice retry**: when a malformed call is detected, the next request pins `tool_choice` to the failed tool (`{"type": "function", "function": {"name": ...}}`). Backends with grammar-enforced structured outputs (vLLM compiles the named tool's JSON Schema to an xgrammar logit mask) regenerate the call **schema-valid by construction** — token-level enforcement, not advisory. Backends that reject a named `tool_choice` get the retry unforced and the mechanism self-disables for that session, so non-supporting providers degrade exactly to today's behavior.

Why this approach: the repair/sanitization layer already exists and stays; this targets the gap *after* repair fails. It reuses the provider's own enforcement rather than adding a client-side validator-and-reprompt loop, costs zero extra requests when the model behaves, and is one config key to turn off.

## Related Issue

Fixes # — no existing issue; happy to open one first if preferred. Pre-discussion in the Nous Discord (link TBD).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/config.py` — new `agent.forced_tool_retry` option (`"auto"` default | `"off"`), documented next to `tool_use_enforcement`
- `agent/agent_init.py` — reads the option; initializes the one-shot flag (`agent._forced_tool_choice`) and per-turn counter
- `agent/conversation_loop.py` — new module-level `_consume_forced_tool_choice(agent, api_kwargs)` (dependency-free, unit-testable): one-shot consume after `_build_api_kwargs()` (before middleware, so middleware keeps veto power); validates against `agent.valid_tool_names`; capped at 3 injections/turn; per-turn counter reset with the other loop counters; provider-rejection fallback in the API-error path (scrub + retry unforced + disable for session, guarded for the `api_kwargs = None` build-failure case)
- `agent/chat_completion_helpers.py` — streaming repair site arms the flag when `_repair_tool_call_arguments` returns the unrepairable sentinel (composes with the existing truncated-tool-call retry: the same re-request gets the boosted token budget *and* the grammar pin)
- `agent/tool_executor.py` — new module-level `_missing_required_fields(agent, tool_name, args)` + a central required-fields check in **both** dispatch paths (concurrent + sequential), post-middleware/post-tool-search-unwrap, wired into the existing block mechanism (`error_type: missing_required_fields`) — so a known-broken call is rejected *before* execution instead of running with `{}` args, and the retry is armed
- `cli-config.yaml.example` — documents the new key
- `tests/run_agent/test_run_agent.py` — new `TestForcedToolRetry` class (10 tests)

Deliberately **not** triggered by semantic tool errors (file-not-found, "Found 3 matches", runtime tracebacks) — the JSON was valid, the intent was wrong, and forcing a re-call can't help. Detection also deliberately avoids the message-history normalization path in `conversation_loop.py`, which re-processes old messages and would re-fire on stale broken calls.

## How to Test

1. `pytest tests/run_agent/test_run_agent.py::TestForcedToolRetry -q` — 10 tests cover config plumbing, consume semantics (inject/clear, off, unknown tool, per-turn cap, unarmed no-op), and the required-fields helper.
2. Full file: `pytest tests/run_agent/test_run_agent.py -q` (see test output below).
3. Live (vLLM backend): run any agent workload; on a malformed call you'll see `Forced tool_choice retry #N: <tool>` at INFO in the agent log, followed by a schema-valid call. `tool_choice` named-function forcing verified against vLLM 0.20.1 directly (grammar-constrained response contains all required fields, 100% of attempts).
4. Off switch: set `agent.forced_tool_retry: "off"` — detection sites stop arming; behavior identical to current main.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (single commit)
- [x] I've run `pytest tests/ -q` and all tests pass — full hermetic suite via `scripts/run_tests.sh` on Ubuntu 24.04 (WSL2), output below
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (live deployment) + Ubuntu 24.04 (full suite)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — `cli-config.yaml.example` + inline docstrings
- [x] I've updated `cli-config.yaml.example` (new `agent.forced_tool_retry` key)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact considered — pure-Python control flow, no platform APIs; `check-windows-footguns.py --diff` clean
- [x] Tool descriptions/schemas — N/A (no tool behavior change; schemas are read, not modified)

## Screenshots / Logs

**Targeted tests (`pytest tests/run_agent/test_run_agent.py::TestForcedToolRetry -q`):**
```
10 passed, 1 warning in 3.00s
```

**Full hermetic suite (`scripts/run_tests.sh`, Ubuntu 24.04, Python 3.12):**
```
[100.0% | 30415/30415 | ✓30423 | ✗   17]
```
The 17 failures (across `test_wecom_callback.py`, `test_gateway_service.py`, `test_pin_peer_name.py`, `test_agent_guardrails.py`, `test_search_error_guard.py`, `test_voice_mode.py`) plus 10 collection-error files (`tests/acp/*`, `test_browser_hardening.py`) were **each re-run on an unpatched `upstream/main` checkout in the identical environment: failure sets are byte-identical** — pre-existing/environmental, none introduced by this change. Happy to paste the side-by-side outputs.

**Live deployment (Windows 11, vLLM 0.20.1, qwen3.6-27b NVFP4):** running in production since 2026-06-11; detection + injection verified via unit tests and direct `tool_choice` forcing against the live server (named-function grammar constraint returned all required fields, 100% of attempts). Will update this section with captured `Forced tool_choice retry #N: <tool>` production log lines as they accrue.
