### PR TITLE
fix(desktop): normalize multi-line display-math delimiters

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
@@ -306,4 +306,58 @@ describe('preprocessMarkdown', () => {
     expect(output).toContain('\\$5')
     expect(output).toContain('\\$10')
   })
+
+  it('moves hugging $$ delimiters of multiline display math onto their own lines', () => {
+    const input = [
+      '$$\\begin{aligned}',
+      '\\nabla \\cdot \\mathbf{E} &= \\frac{\\rho}{\\varepsilon_0} \\\\',
+      '\\nabla \\cdot \\mathbf{B} &= 0',
+      '\\end{aligned}$$'
+    ].join('\n')
+
+    const output = preprocessMarkdown(input)
+
+    expect(output).toBe(
+      [
+        '$$',
+        '\\begin{aligned}',
+        '\\nabla \\cdot \\mathbf{E} &= \\frac{\\rho}{\\varepsilon_0} \\\\',
+        '\\nabla \\cdot \\mathbf{B} &= 0',
+        '\\end{aligned}',
+        '$$'
+      ].join('\n')
+    )
+  })
+
+  it('keeps hugging display math inside its markdown container', () => {
+    const input = ['> $$\\begin{aligned}', '> a &= b', '> \\end{aligned}$$'].join('\n')
+
+    const output = preprocessMarkdown(input)
+
+    expect(output).toBe(['> $$', '> \\begin{aligned}', '> a &= b', '> \\end{aligned}', '> $$'].join('\n'))
+  })
+
+  it('splits the hugging $$ form that the bracket rewrite itself produces', () => {
+    const input = ['\\[\\begin{aligned}', 'a &= b', '\\end{aligned}\\]'].join('\n')
+
+    const output = preprocessMarkdown(input)
+
+    expect(output).toBe(['$$', '\\begin{aligned}', 'a &= b', '\\end{aligned}', '$$'].join('\n'))
+  })
+
+  it('keeps CRLF line endings consistent when splitting hugging delimiters', () => {
+    const input = '$$\\begin{aligned}\r\na &= b\r\n\\end{aligned}$$'
+
+    expect(preprocessMarkdown(input)).toBe('$$\r\n\\begin{aligned}\r\na &= b\r\n\\end{aligned}\r\n$$')
+  })
+
+  it('leaves single-line display math alone', () => {
+    expect(preprocessMarkdown('$$x^2 + y^2 = r^2$$')).toBe('$$x^2 + y^2 = r^2$$')
+  })
+
+  it('leaves a multiline $$ block that sits wholly inside one inline code span alone', () => {
+    const input = '`$$a\nb$$`'
+
+    expect(preprocessMarkdown(input)).toBe(input)
+  })
 })

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -14,6 +14,15 @@ const INLINE_CODE_SPLIT_RE = /(`[^`\n]+`)/g
 const LATEX_DISPLAY_OPEN_LINE_RE = /^([ \t]*(?:>[ \t]*)*(?:(?:[-+*]|\d+[.)])[ \t]+)?[ \t]*)\\{1,2}\[[ \t]*\r?$/
 const LATEX_DISPLAY_CLOSE_LINE_RE = /^([ \t]*(?:>[ \t]*)*(?:(?:[-+*]|\d+[.)])[ \t]+)?[ \t]*)\\{1,2}\][ \t]*\r?$/
 const CUSTOM_DISPLAY_MATH_LINE_RE = /^([ \t]*(?:>[ \t]*)*(?:(?:[-+*]|\d+[.)])[ \t]+)?[ \t]*)\[\/math\][ \t]*\r?$/
+
+// A `$$` that opens a block and is immediately followed by the first line of the
+// equation, e.g. `$$\begin{aligned}`. Both patterns anchor the `$$` to the start
+// of the line (modulo blockquote/list prefix), which is also what keeps them from
+// firing inside an inline code span — `` `$$a `` leads with a backtick.
+const HUGGING_DISPLAY_MATH_OPEN_RE =
+  /^([ \t]*(?:>[ \t]*)*(?:(?:[-+*]|\d+[.)])[ \t]+)?[ \t]*)\$\$[ \t]*(\S[^\n]*?)[ \t]*\r?$/
+
+const HUGGING_DISPLAY_MATH_CLOSE_RE = /^([ \t]*(?:>[ \t]*)*[ \t]*)(\S[^\n]*?)\$\$[ \t]*\r?$/
 // Bare-URL autolink matcher. The character classes EXCLUDE `*` so a URL that
 // abuts markdown emphasis with no separating space (e.g. `**label: https://x**`,
 // a very common LLM pattern) doesn't swallow the trailing `**` into the href.
@@ -271,6 +280,76 @@ function escapeCurrencyDollarsPreservingMath(text: string): string {
   return out + text.slice(copiedThrough)
 }
 
+/**
+ * Moves the `$$` delimiters of a MULTI-LINE display-math block onto their own
+ * lines: `$$\begin{aligned}` … `\end{aligned}$$` becomes a `$$`-only line, the
+ * body, then a `$$`-only line.
+ *
+ * remark-math's flow-math construct is fence-shaped: whatever follows the
+ * opening `$$` on the same line is read as an info string and DISCARDED, and the
+ * closing `$$` is only recognized alone on its own line. So the hugging form
+ * loses its first line, never closes, and KaTeX paints the remains as raw source
+ * text. Models emit this form constantly.
+ *
+ * Single-line `$$…$$` is left alone — it routes through the inline math-text
+ * construct and already renders.
+ */
+function splitHuggingDisplayMath(text: string): string {
+  const lines = text.split('\n')
+  const out: string[] = []
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const openingMatch = lines[index].match(HUGGING_DISPLAY_MATH_OPEN_RE)
+
+    // `$$x^2$$` closes on the same line — not our case.
+    if (!openingMatch || openingMatch[2].endsWith('$$')) {
+      out.push(lines[index])
+
+      continue
+    }
+
+    let closingIndex = -1
+
+    for (let candidate = index + 1; candidate < lines.length; candidate += 1) {
+      if (HUGGING_DISPLAY_MATH_CLOSE_RE.test(lines[candidate])) {
+        closingIndex = candidate
+
+        break
+      }
+    }
+
+    if (closingIndex === -1) {
+      out.push(lines[index])
+
+      continue
+    }
+
+    const closingMatch = lines[closingIndex].match(HUGGING_DISPLAY_MATH_CLOSE_RE) as RegExpMatchArray
+    const openingCarriageReturn = lines[index].endsWith('\r') ? '\r' : ''
+    const closingCarriageReturn = lines[closingIndex].endsWith('\r') ? '\r' : ''
+
+    // The container prefix (blockquote marker, list bullet) has to be replayed
+    // onto the delimiter lines, or the block falls out of its container.
+    out.push(
+      `${openingMatch[1]}$$${openingCarriageReturn}`,
+      `${openingMatch[1]}${openingMatch[2]}${openingCarriageReturn}`
+    )
+    out.push(...lines.slice(index + 1, closingIndex))
+    // The break this split INTRODUCES takes the block's own line ending, not the
+    // closing line's — a final `\end{aligned}$$` with no trailing CRLF (it's the
+    // last line of the message) would otherwise emit a bare LF into an
+    // otherwise-CRLF block.
+    out.push(
+      `${closingMatch[1]}${closingMatch[2]}${openingCarriageReturn}`,
+      `${closingMatch[1]}$$${closingCarriageReturn}`
+    )
+
+    index = closingIndex
+  }
+
+  return out.join('\n')
+}
+
 function normalizeDisplayMathForMarkdown(text: string): string {
   const lines = text.split('\n')
 
@@ -313,7 +392,12 @@ function normalizeProseMath(text: string): string {
   // Normalize those locally before the dependency handles inline forms;
   // its compact `$$body$$` rewrite makes the first equation line metadata
   // and leaks the trailing `$$` into KaTeX's error fallback.
-  const normalized = normalizeMathDelimiters(normalizeDisplayMathForMarkdown(text))
+  //
+  // splitHuggingDisplayMath runs LAST because normalizeMathDelimiters is itself
+  // a source of the hugging form: a multi-line `\[…\]` comes out of it as
+  // `$$\begin{aligned}…\end{aligned}$$`. Running afterwards catches both the
+  // hugging math the model emitted and the hugging math the rewrite produced.
+  const normalized = splitHuggingDisplayMath(normalizeMathDelimiters(normalizeDisplayMathForMarkdown(text)))
 
   return escapeCurrencyDollarsPreservingMath(normalized)
 }


### PR DESCRIPTION
## What does this PR do?

Multi-line display math whose `$$` delimiters hug the body renders as raw, muted error text instead of an equation:

```
$$\begin{aligned}
\nabla \cdot \mathbf{E} &= \frac{\rho}{\varepsilon_0} \\
\nabla \cdot \mathbf{B} &= 0
\end{aligned}$$
```

remark-math's display ("flow") math construct is fence-shaped: text after the opening `$$` on the same line is treated as a meta/info string and **discarded**, and the closing `$$` is only recognized when it sits alone on its own line. So `$$\begin{aligned}` loses `\begin{aligned}` to the meta string, the block never closes, and KaTeX receives a mangled fragment that its lenient fallback paints as raw source text. Inline `$x$` and single-line `$$x$$` are unaffected — they route through the inline math-text construct.

`splitHuggingDisplayMath` moves those delimiters onto their own lines, replaying any container prefix (blockquote marker, list bullet) so the block doesn't fall out of its container.

**The ordering is the part worth reviewing.** It runs *after* `normalizeMathDelimiters`, not before, because that rewrite is itself a source of the hugging form: a multi-line `\[…\]` comes out of it as `$$\begin{aligned}…\end{aligned}$$`. Running last catches both the hugging math the model emitted and the hugging math the delimiter rewrite produced — so this also covers multi-line `\[…\]`, which reached the same broken state without the user ever typing a `$$`.

Two properties keep the pass narrow:

- Single-line `$$…$$` is skipped — it already renders, and rewriting it would be churn.
- Both patterns anchor `$$` to the start of the line (modulo container prefix). That is what keeps them from firing inside an inline code span: `` `$$a `` leads with a backtick, so it never matches.

## Related Issue

Related to #80821 — deliberately not using a closing keyword, because that issue also reports a **separate** bug this PR does not fix: `\sqrt[3]{x}` loses its index. Different cause — `CITATION_MARKER_RE` strips `[3]` as a citation marker in `normalizeVisibleProse`, so the index never reaches KaTeX. That one needs its own fix and #80821 should stay open for it.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/lib/markdown-preprocess.ts`
  - add `splitHuggingDisplayMath`, which moves hugging `$$` delimiters of a multi-line block onto their own lines
  - run it after `normalizeMathDelimiters` in `normalizeProseMath`, so it also catches the hugging form that the `\[…\]` rewrite produces
  - preserve container prefixes and CRLF line endings across the split
- `apps/desktop/src/components/assistant-ui/markdown-text.test.ts`
  - six cases: the `\begin{aligned}` repro, the same form in a blockquote, the multi-line `\[…\]` path, CRLF consistency, and regression guards for single-line `$$…$$` and for a multi-line `$$…$$` sitting wholly inside one inline code span

## How to Test

1. Run the focused suite:
   ```
   cd apps/desktop
   npm run test:ui -- src/components/assistant-ui/markdown-text.test.ts
   ```
   41/41 pass.
2. Confirm the repro renders as an aligned equation rather than gray source text — paste a multi-line `$$\begin{aligned}…\end{aligned}$$` block into a chat.
3. Confirm single-line `$$5x = 10$$` and prose prices like `$5 and $10` are unchanged.

Validation completed:

- Focused suite: **41 passed** (Ubuntu 24.04 / Node 22 and Windows 11 / Node 24)
- Full desktop UI suite: **3595 passed / 402 files**, no failures
- `npx tsc -p . --noEmit`: clean
- ESLint on both changed files: clean
- Prettier `--check` on both changed files: clean
- End-to-end rather than string-level only: feeding the repro through `remark-math` + `rehype-katex` emits `katex-error` before this change and does not after
- **In the real Electron renderer**, via the repo's own mock-backend Playwright harness (`setupMockBackend` + the full electron → `hermes serve` → provider → renderer chain), with the repro as the canned reply. The same run was taken twice against the same build, differing only in whether `markdown-preprocess.ts` carried this commit:

  | DOM measure | without this fix | with this fix |
  |---|---|---|
  | `.katex-error` nodes | **3** | **0** |
  | `.katex-display` nodes | 0 | 3 |
  | `∇` present as rendered math | no | yes |

  The three errors are the mechanism stated verbatim by KaTeX — e.g. `ParseError: Expected 'EOF', got '&' at position 25: …dot \mathbf{E} &̲= …`, on a body that begins at `\nabla` (the `\begin{aligned}` line having been consumed as the info string) and ends with a stray `\end{aligned}$$`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: desktop TypeScript-only change, no Python touched
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 / Node 22 and Windows 11 / Node 24

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure string preprocessing with no OS-specific code paths. The one platform-relevant detail is line endings: the break this split introduces takes the block's own ending, so a CRLF message doesn't get a bare LF spliced into it. Covered by a test, and the rendered-output check above was run on Windows. `scripts/check-windows-footguns.py` only scans `.py`/`.pyw`/`.pyi`, so it reports 0 files on this diff rather than passing it.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Both captures are the same build in the same harness, one with this commit's `markdown-preprocess.ts` and one without.

Without the fix, the `\begin{aligned}` line is missing outright — it was eaten as the info string — and the remainder is painted as muted source text ending in a stray `\end{aligned}$$`:

```
\nabla \cdot \mathbf{E} &= \frac{\rho}{\varepsilon_0} \\ \nabla \cdot \mathbf{B} &= 0 \end{aligned}$$
```

With the fix, the same reply renders as an aligned two-line equation, the `\[…\]` block renders, the blockquoted block renders inside its quote bar, and `$5 and $10` stays literal prose.

The regression tests use those exact raw Markdown shapes, including the `\begin{aligned}` block from the original report.
