### PR TITLE
feat(desktop): auto-detect RTL/bidi text direction in chat

### DIFF
--- a/apps/desktop/src/components/assistant-ui/user-message-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/user-message-text.tsx
@@ -127,7 +127,9 @@ const InlineSegmentView: FC<{ text: string }> = ({ text }) => {
   const nodes = useMemo(() => splitInlineCode(text), [text])
 
   return (
-    <span className="wrap-anywhere block whitespace-pre-line">
+    // styles.css bidi hook (#44150); whitespace-pre-line makes each line its own
+    // UAX#9 paragraph so it resolves direction independently.
+    <span className="wrap-anywhere block whitespace-pre-line" data-slot="aui_user-inline-text">
       {nodes.map((node, nodeIndex) =>
         node.kind === 'inline-code' ? (
           <code

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -823,6 +823,37 @@ canvas {
    content's --message-text-indent). No extra prose indent — a single gutter
    reads cleaner than a ragged tool-vs-reply column. */
 
+/* RTL/bidi chat text (#44150): each block resolves its own base direction from
+   its first strong char (UAX#9 plaintext). text-align:start makes that resolved
+   direction drive alignment too — load-bearing, since the user bubble pins
+   text-left. direction is never set, so chrome/layout/list-indent stay LTR (the
+   issue asks not to flip the whole UI). Covers assistant prose, user lines, and
+   both composers (main + edit share composer-rich-input). */
+[data-slot='aui_assistant-message-content'] .aui-md :where(p, h1, h2, h3, h4, h5, h6, li, blockquote),
+[data-slot='aui_user-inline-text'],
+[data-slot='composer-rich-input'] {
+  unicode-bidi: plaintext;
+  text-align: start;
+}
+
+/* Inline code/KaTeX don't vote on direction and keep their own order: isolate
+   makes bidi treat each as one neutral, so a block that *starts* with `./run.sh`
+   then Arabic still resolves RTL, and the command's neutrals (dots/slashes)
+   aren't reordered by the surrounding RTL run. */
+[data-slot='aui_assistant-message-content'] .aui-md :where(:not(pre) > code),
+[data-slot='aui_user-inline-code'],
+[data-slot='aui_assistant-message-content'] .aui-md .katex {
+  direction: ltr;
+  unicode-bidi: isolate;
+}
+
+/* Fenced code stays LTR even inside an RTL list item/blockquote — never mirrors. */
+[data-slot='aui_assistant-message-content'] .aui-md [data-slot='code-card'],
+[data-slot='aui_user-fence'] {
+  direction: ltr;
+  text-align: left;
+}
+
 [data-slot='aui_user-message-root'] {
   top: var(--sticky-human-top);
 }


### PR DESCRIPTION
## What does this PR do?

Adds automatic bidirectional text direction to the desktop chat, so Arabic/Hebrew/Persian/Urdu — and the common mixed RTL/English technical case — read and align correctly instead of running left-to-right with mangled punctuation order.

Each chat block resolves its own base direction from its first strong character (UAX#9), **purely in CSS**, scoped to the chat surfaces only:

- `unicode-bidi: plaintext` + `text-align: start` on assistant prose blocks (`p`, `h1`–`h6`, `li`, `blockquote`), the user bubble's text lines, and both composers (main + edit share the `composer-rich-input` slot). RTL blocks read and right-align RTL; English stays LTR; mixed conversations resolve per block. The `text-align: start` is load-bearing — the user bubble hardcodes `text-left` (`USER_BUBBLE_BASE_CLASS`), so without it RTL prose would read right-to-left but cling to the left edge.
- Inline `code` and KaTeX are pinned `direction: ltr; unicode-bidi: isolate`. `isolate` makes the bidi first-strong heuristic treat each as a single neutral, so a block that **starts** with a command (`` `./run.sh -v` `` followed by Arabic) still resolves RTL, and the command's own neutrals (dots/slashes/dashes) keep their order.
- Fenced code surfaces (`code-card`, user fences) are pinned LTR so they never mirror or right-align inside an RTL list item or blockquote.

`direction` is never set, so app chrome, layout, and list indent stay LTR (the issue explicitly asks not to flip the whole UI). List markers stay on the left by design. English-only content is byte-for-byte unchanged.

## Supersedes

This **supersedes #44065 and #44169** and unifies them into one minimal change (credited via `Co-authored-by`):

- **#44065** (`feat/desktop-rtl-bidi`) took the JS route — a `text-direction.ts` first-strong resolver plus `dir`-attribute plumbing across `markdown-text.tsx`, `user-message-text.tsx`, `thread.tsx`, and the composer (~280 lines) — specifically to handle the "code-first" paragraph (a block starting with a command shouldn't flip LTR). I verified in Chromium (Electron's engine) that `unicode-bidi: isolate` already removes inline code from the paragraph's first-strong vote, so that case is handled in CSS and the JS is unnecessary.
- **#44169** (`fix/44150-chat-rtl-bidi`) was the right pure-CSS approach but didn't `text-align: start` (so RTL user bubbles read RTL but stayed left-pinned under the bubble's `text-left`) and didn't pin fenced code blocks against mirroring inside RTL list items.

This PR keeps #44169's CSS-only footprint and fixes both gaps. Please close #44065 and #44169 in favor of this.

## Related (out of scope, no overlap)

- #29047 — same symptom in the web dashboard chat pane
- #41462 — RTL/bidi for the TUI
- #29795 / web dashboard Arabic locale — locale work, not direction
- Dashboard `/chat` is an xterm.js terminal; xterm has no upstream bidi support, so it can't be fixed at this layer.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## How to Test

1. Run the desktop app, send an Arabic message such as `مرحبا كيف حالك` — the bubble right-aligns.
2. Ask for an Arabic answer with a heading, a list, and a fenced code block — prose/headings/bullets right-align; the code block stays LTR and un-mirrored even inside an RTL list item.
3. Send a message that **starts** with a command, e.g. `` `./scripts/run.sh -v` ماذا يفعل هذا الأمر؟ `` — it still right-aligns (code doesn't vote on direction) and the chip keeps its internal order.
4. Type Arabic in the composer — it right-aligns as you type; switch to English and it flips back. Same for the edit composer.
5. Send English messages — rendering is identical to `main`.

## Verification

- `npm run typecheck` — clean
- `eslint` on touched files — clean
- Empirically validated the bidi behavior (alignment + isolate skipping the code-first vote) in Chromium before implementing.
- Desktop `vitest` failures on this branch are identical to clean `main` (pre-existing, unrelated).

Fixes #44150