### PR TITLE
fix(gateway): cache fetch_api_models per-provider with TTL and cap timeout to prevent model.options WS timeout

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3370,18 +3370,42 @@ def probe_api_models(
     }
 
 
+# ---------------------------------------------------------------------------
+# fetch_api_models — per-provider TTL cache to avoid blocking the WebSocket
+# handler with sequential synchronous HTTP calls (issue #44560).
+# ---------------------------------------------------------------------------
+
+_FETCH_API_MODELS_CACHE_TTL: float = 300.0  # 5 minutes
+# { (base_url, api_mode) -> (monotonic_timestamp, result) }
+_fetch_api_models_cache: dict[tuple, tuple[float, Optional[list[str]]]] = {}
+
+
 def fetch_api_models(
     api_key: Optional[str],
     base_url: Optional[str],
-    timeout: float = 5.0,
+    timeout: float = 3.0,
     api_mode: Optional[str] = None,
 ) -> Optional[list[str]]:
     """Fetch the list of available model IDs from the provider's ``/models`` endpoint.
 
+    Results are cached per ``(base_url, api_mode)`` for
+    :data:`_FETCH_API_MODELS_CACHE_TTL` seconds (default 5 min) to prevent the
+    ``model.options`` WebSocket handler from blocking on repeated sequential
+    HTTP round-trips.  The first call is always live.
+
     Returns a list of model ID strings, or ``None`` if the endpoint could not
     be reached (network error, timeout, auth failure, etc.).
     """
-    return probe_api_models(api_key, base_url, timeout=timeout, api_mode=api_mode).get("models")
+    cache_key = (base_url, api_mode)
+    now = time.monotonic()
+    cached_at, cached_result = _fetch_api_models_cache.get(cache_key, (0.0, None))
+    if cached_result is not None and (now - cached_at) < _FETCH_API_MODELS_CACHE_TTL:
+        return cached_result
+
+    result = probe_api_models(api_key, base_url, timeout=timeout, api_mode=api_mode).get("models")
+    if result is not None:
+        _fetch_api_models_cache[cache_key] = (now, result)
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -800,3 +800,71 @@ class TestProbeApiModelsUserAgent:
         assert ua and ua.startswith("hermes-cli/")
         # No Authorization was set, but UA must still be present.
         assert req.get_header("Authorization") is None
+
+
+# ---------------------------------------------------------------------------
+# fetch_api_models — TTL cache (issue #44560)
+# ---------------------------------------------------------------------------
+
+
+class TestFetchApiModelsCache:
+    """fetch_api_models must cache results per (base_url, api_mode) with TTL."""
+
+    def _clear_cache(self):
+        from hermes_cli import models as m
+        m._fetch_api_models_cache.clear()
+
+    def test_first_call_hits_network(self):
+        """First call always calls probe_api_models (live fetch)."""
+        self._clear_cache()
+        with patch("hermes_cli.models.probe_api_models", return_value={"models": ["m1"]}) as mock_probe:
+            result = fetch_api_models("key", "https://api.example.com/v1")
+        assert result == ["m1"]
+        mock_probe.assert_called_once()
+
+    def test_second_call_uses_cache(self):
+        """Repeated call within TTL must NOT call probe_api_models again."""
+        self._clear_cache()
+        with patch("hermes_cli.models.probe_api_models", return_value={"models": ["m1", "m2"]}) as mock_probe:
+            fetch_api_models("key", "https://api.example.com/v1")
+            result = fetch_api_models("key", "https://api.example.com/v1")
+        assert result == ["m1", "m2"]
+        assert mock_probe.call_count == 1, "probe_api_models must only be called once within TTL"
+
+    def test_expired_cache_refetches(self):
+        """After TTL expires the cache entry is ignored and a live call is made."""
+        import time as _time
+        self._clear_cache()
+        with patch("hermes_cli.models.probe_api_models", return_value={"models": ["m1"]}) as mock_probe:
+            fetch_api_models("key", "https://api.example.com/v1")
+            # Manually back-date the cache entry to simulate expiry.
+            from hermes_cli import models as m
+            url_key = ("https://api.example.com/v1", None)
+            old_ts, old_val = m._fetch_api_models_cache[url_key]
+            m._fetch_api_models_cache[url_key] = (old_ts - m._FETCH_API_MODELS_CACHE_TTL - 1, old_val)
+            # Second call should go live.
+            fetch_api_models("key", "https://api.example.com/v1")
+        assert mock_probe.call_count == 2, "probe_api_models must be called again after TTL expiry"
+
+    def test_cache_is_per_url(self):
+        """Different base URLs must have independent cache entries."""
+        self._clear_cache()
+        with patch("hermes_cli.models.probe_api_models", return_value={"models": ["m1"]}) as mock_probe:
+            fetch_api_models("key", "https://api.a.com/v1")
+            fetch_api_models("key", "https://api.b.com/v1")
+        assert mock_probe.call_count == 2, "Different URLs must each trigger a live fetch"
+
+    def test_none_result_not_cached(self):
+        """Failed fetches (None) must not be cached — retry is allowed next call."""
+        self._clear_cache()
+        with patch("hermes_cli.models.probe_api_models", return_value={"models": None}) as mock_probe:
+            fetch_api_models("key", "https://api.example.com/v1")
+            fetch_api_models("key", "https://api.example.com/v1")
+        assert mock_probe.call_count == 2, "Failed fetches must not be cached"
+
+    def test_default_timeout_is_at_most_3s(self):
+        """fetch_api_models default timeout must be ≤ 3 s to prevent WS block."""
+        import inspect
+        sig = inspect.signature(fetch_api_models)
+        default_timeout = sig.parameters["timeout"].default
+        assert default_timeout <= 3.0, f"Default timeout {default_timeout}s exceeds 3s cap"


### PR DESCRIPTION
## What does this PR do?

The `model.options` WebSocket handler calls `list_authenticated_providers()`, which calls `fetch_api_models()` for every configured custom provider. These are sequential synchronous `urllib` calls with no caching. When providers are slow (>2s each), the combined latency exceeds the 10-second WS write timeout (`_WS_WRITE_TIMEOUT_S`), causing the Desktop to show:

```
Error invoking remote method 'hermes:api': Error: Timed out connecting to Hermes backend after 15000ms
```

This PR adds a per-provider TTL cache (5 min, keyed by `(base_url, api_mode)`) to `fetch_api_models()` so repeated calls within the same session skip the network round-trip. It also reduces the per-call timeout from 5s to 3s. Failed fetches are not cached, allowing the next call to retry.

## Related Issue

Fixes #44560

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/models.py`: added `_fetch_api_models_cache` dict, `_FETCH_API_MODELS_CACHE_TTL = 300.0`, TTL cache logic in `fetch_api_models()`, default timeout 5s → 3s
- `tests/hermes_cli/test_model_validation.py`: added `TestFetchApiModelsCache` with 6 tests covering cache hit, TTL expiry, per-URL isolation, failure non-caching, and timeout cap

## How to Test

1. Configure 2+ slow custom providers in `config.yaml`
2. Open Hermes Desktop, open the model picker — should load without timeout
3. Open model picker again within 5 min — second call should be instant (no network)
4. Run `pytest tests/hermes_cli/test_model_validation.py -q -k TestFetchApiModelsCache`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before fix: `model.options` handler blocks ~17-18s total on 2 slow providers, exceeding 10s WS timeout.
After fix: First call capped at 3s/provider; subsequent calls within TTL window are instant (in-memory).