### PR TITLE
fix(discord): resolve live adapter at cron delivery time to prevent Session is closed after reconnect

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -819,6 +819,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
         # Prefer the live adapter when the gateway is running — this supports E2EE
         # rooms (e.g. Matrix) where the standalone HTTP path cannot encrypt.
+        # Always resolve the adapter from the live adapters dict at delivery time
+        # (not at job-creation time) to avoid holding a stale reference after a
+        # platform reconnect.  Discord in particular replaces self._client on
+        # every reconnect; a cached adapter from before the reconnect will have a
+        # closed aiohttp session and raise RuntimeError: Session is closed (#44541).
         runtime_adapter = (adapters or {}).get(platform)
         delivered = False
         if runtime_adapter is not None and loop is not None and getattr(loop, "is_running", lambda: False)():
@@ -829,8 +834,27 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 adapter_ok = True
                 if text_to_send:
                     from agent.async_utils import safe_schedule_threadsafe
+
+                    # Wrap in a coroutine that re-resolves the live adapter at
+                    # execution time so a reconnect between now and when the
+                    # event-loop actually runs the send cannot produce a
+                    # "Session is closed" error from a stale client (#44541).
+                    _adapters_ref = adapters  # captured by closure below
+                    _platform_ref = platform
+
+                    async def _send_via_live_adapter(
+                        _chat_id=chat_id,
+                        _text=text_to_send,
+                        _meta=send_metadata,
+                    ):
+                        live = (_adapters_ref or {}).get(_platform_ref)
+                        if live is None:
+                            from gateway.platforms.base import SendResult
+                            return SendResult(success=False, error="adapter no longer live at send time")
+                        return await live.send(_chat_id, _text, metadata=_meta)
+
                     future = safe_schedule_threadsafe(
-                        runtime_adapter.send(chat_id, text_to_send, metadata=send_metadata),
+                        _send_via_live_adapter(),
                         loop,
                     )
                     if future is None:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1428,6 +1428,14 @@ class DiscordAdapter(BasePlatformAdapter):
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
+        # Guard against a stale client whose aiohttp session was closed during a
+        # reconnect cycle.  discord.py creates a brand-new Bot (and therefore a
+        # new aiohttp.ClientSession) on every reconnect; if cron delivery holds a
+        # reference to the pre-reconnect adapter and calls send() after the old
+        # session is closed it raises RuntimeError: Session is closed (#44541).
+        if getattr(self._client, "is_closed", lambda: False)():
+            return SendResult(success=False, error="Discord client session is closed (reconnecting)")
+
         try:
             # Determine target channel: thread_id in metadata takes precedence.
             thread_id = None

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2736,3 +2736,138 @@ class TestCronDeliveryTargets:
         monkeypatch.setattr(gateway_config, "load_gateway_config", _boom)
 
         assert cron_delivery_targets() == []
+
+
+class TestDiscordCronStaleSession:
+    """Regression tests for #44541 — cron delivery must not hold a stale Discord
+    client reference after the adapter reconnects.
+
+    When Discord reconnects the gateway replaces ``self._client`` with a fresh
+    ``commands.Bot`` instance; the old instance's aiohttp session is closed.
+    Any cron send coroutine that was bound to the pre-reconnect adapter would
+    have raised ``RuntimeError: Session is closed``.
+
+    The fix applies two guards:
+    1. ``_deliver_result`` wraps the send in a closure that re-resolves the live
+       adapter from the ``adapters`` dict at coroutine-execution time (#44541).
+    2. ``DiscordAdapter.send()`` returns a ``SendResult(success=False)`` when
+       ``self._client.is_closed()`` instead of propagating the aiohttp error.
+    """
+
+    def test_deliver_result_resolves_live_adapter_at_execution_time(self):
+        """The send coroutine must look up the adapter from the live dict when it
+        runs, not capture the adapter object at scheduling time.
+
+        Simulate a reconnect: the initial adapter is replaced in the dict between
+        the scheduling call and the loop executing the coroutine.  The new adapter
+        must be the one that actually receives the send() call.
+        """
+        from gateway.config import Platform
+        from gateway.platforms.base import SendResult
+        from concurrent.futures import Future
+
+        old_adapter = AsyncMock()
+        old_adapter.send = AsyncMock(return_value=SendResult(success=True))
+        new_adapter = AsyncMock()
+        new_adapter.send = AsyncMock(return_value=SendResult(success=True))
+
+        # adapters dict starts with old_adapter; we'll swap it before "execution"
+        live_adapters = {Platform.DISCORD: old_adapter}
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.DISCORD: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        executed_coro = []
+
+        def fake_schedule_threadsafe(coro, _loop):
+            # Simulate reconnect: swap to new_adapter before the coro runs
+            live_adapters[Platform.DISCORD] = new_adapter
+            executed_coro.append(coro)
+            import asyncio
+            result = asyncio.get_event_loop().run_until_complete(coro)
+            f = Future()
+            f.set_result(result)
+            return f
+
+        job = {
+            "id": "discord-stale-test",
+            "deliver": "origin",
+            "origin": {"platform": "discord", "chat_id": "111222333"},
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("agent.async_utils.safe_schedule_threadsafe", side_effect=fake_schedule_threadsafe), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock()):
+            result = _deliver_result(
+                job,
+                "Hello from cron",
+                adapters=live_adapters,
+                loop=loop,
+            )
+
+        # Delivery should succeed (no error string returned)
+        assert result is None, f"Expected successful delivery, got: {result!r}"
+        # The NEW (live) adapter must have been used, not the stale pre-reconnect one
+        new_adapter.send.assert_awaited_once()
+        old_adapter.send.assert_not_awaited()
+
+    def test_deliver_result_falls_back_when_adapter_removed_during_reconnect(self):
+        """If the adapter is removed from the dict (during the reconnect window
+        before the new adapter is installed), the cron delivery path must fall
+        back to the standalone HTTP path rather than crashing.
+        """
+        from gateway.config import Platform
+        from gateway.platforms.base import SendResult
+        from concurrent.futures import Future
+
+        initial_adapter = AsyncMock()
+        initial_adapter.send = AsyncMock(return_value=SendResult(success=True))
+
+        # Adapter dict that will be emptied before coroutine execution
+        live_adapters = {Platform.DISCORD: initial_adapter}
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.DISCORD: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        standalone_send = AsyncMock(return_value={"success": True})
+
+        def fake_schedule_threadsafe(coro, _loop):
+            # Simulate reconnect window: adapter temporarily absent
+            live_adapters.pop(Platform.DISCORD, None)
+            import asyncio
+            result = asyncio.get_event_loop().run_until_complete(coro)
+            f = Future()
+            f.set_result(result)
+            return f
+
+        job = {
+            "id": "discord-absent-test",
+            "deliver": "origin",
+            "origin": {"platform": "discord", "chat_id": "444555666"},
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("agent.async_utils.safe_schedule_threadsafe", side_effect=fake_schedule_threadsafe), \
+             patch("tools.send_message_tool._send_to_platform", new=standalone_send):
+            result = _deliver_result(
+                job,
+                "Hello from cron (fallback)",
+                adapters=live_adapters,
+                loop=loop,
+            )
+
+        # When live adapter not found the send returns success=False and
+        # _deliver_result falls back to standalone — no hard crash
+        assert result is None, f"Standalone fallback should succeed, got: {result!r}"


### PR DESCRIPTION
## What does this PR do?

After the Discord adapter reconnects, cron job delivery fails with:

```
RuntimeError: Session is closed
```

The root cause: `cron/scheduler.py`'s `_deliver_result` resolves the Discord adapter once at schedule time. When Discord reconnects, the gateway creates a **new** `DiscordAdapter` instance and closes the old one's `aiohttp` session. The cron coroutine, when it eventually runs on the event loop, still holds the stale adapter and hits the closed session.

Interactive chat replies are unaffected because the gateway always does a live `self.adapters.get(platform)` lookup on each inbound message.

**Fix:** In `_deliver_result`, defer the adapter lookup inside a `_send_via_live_adapter()` wrapper coroutine that resolves `adapters[platform]` at actual execution time. If the adapter is temporarily absent during a reconnect window, it returns `SendResult(success=False)` and falls back to standalone HTTP delivery. Additionally, `DiscordAdapter.send()` now checks `self._client.is_closed()` defensively and returns a clean error instead of letting `RuntimeError` propagate.

## Related Issue

Fixes #44541

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py`: added `_send_via_live_adapter()` wrapper coroutine; `_deliver_result` now defers adapter resolution to execution time
- `plugins/platforms/discord/adapter.py`: added `self._client.is_closed()` guard in `send()`, returning `SendResult(success=False)` instead of propagating `RuntimeError`
- `tests/cron/test_scheduler.py`: added `TestDiscordCronStaleSession` with 2 tests covering live adapter re-resolution and reconnect-window fallback

## How to Test

1. Run `hermes gateway` as a launchd service with Discord connected
2. Let Discord reconnect (restart gateway, or wait overnight)
3. Trigger a cron job with `--deliver discord:<channel_id>` via `hermes cron run <job_id>`
4. Verify delivery succeeds (previously failed with `Session is closed`)
5. Run `pytest tests/cron/test_scheduler.py -q -k TestDiscordCronStaleSession`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
# Before fix — cron delivery after Discord reconnect:
ERROR hermes_plugins.discord_platform.adapter: [Discord] Failed to send Discord message: Session is closed
RuntimeError: Session is closed

# After fix — adapter re-resolved at execution time, delivery succeeds
```