### PR TITLE
[codex] Hide dashboard sidecar sessions from history

### DIFF
--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -56,6 +56,7 @@ _SESSION_USER_ID: ContextVar = ContextVar("HERMES_SESSION_USER_ID", default=_UNS
 _SESSION_USER_NAME: ContextVar = ContextVar("HERMES_SESSION_USER_NAME", default=_UNSET)
 _SESSION_KEY: ContextVar = ContextVar("HERMES_SESSION_KEY", default=_UNSET)
 _SESSION_ID: ContextVar = ContextVar("HERMES_SESSION_ID", default=_UNSET)
+_SESSION_SOURCE: ContextVar = ContextVar("HERMES_SESSION_SOURCE", default=_UNSET)
 # ID of the message that triggered the current turn. Used as a reply anchor
 # so background-process notifications stay inside the originating Telegram
 # private-chat topic (those lanes route only with thread id + reply anchor).
@@ -76,6 +77,7 @@ _VAR_MAP = {
     "HERMES_SESSION_USER_NAME": _SESSION_USER_NAME,
     "HERMES_SESSION_KEY": _SESSION_KEY,
     "HERMES_SESSION_ID": _SESSION_ID,
+    "HERMES_SESSION_SOURCE": _SESSION_SOURCE,
     "HERMES_SESSION_MESSAGE_ID": _SESSION_MESSAGE_ID,
     "HERMES_CRON_AUTO_DELIVER_PLATFORM": _CRON_AUTO_DELIVER_PLATFORM,
     "HERMES_CRON_AUTO_DELIVER_CHAT_ID": _CRON_AUTO_DELIVER_CHAT_ID,
@@ -107,6 +109,7 @@ def set_session_vars(
     user_name: str = "",
     session_key: str = "",
     session_id: str = "",
+    session_source: str = "",
     message_id: str = "",
     cwd: str = "",
 ) -> list:
@@ -129,6 +132,7 @@ def set_session_vars(
         _SESSION_USER_NAME.set(user_name),
         _SESSION_KEY.set(session_key),
         _SESSION_ID.set(session_id),
+        _SESSION_SOURCE.set(session_source),
         _SESSION_MESSAGE_ID.set(message_id),
     ]
     try:
@@ -160,6 +164,7 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_USER_NAME,
         _SESSION_KEY,
         _SESSION_ID,
+        _SESSION_SOURCE,
         _SESSION_MESSAGE_ID,
     ):
         var.set("")

--- a/run_agent.py
+++ b/run_agent.py
@@ -63,6 +63,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from hermes_constants import get_hermes_home
+from gateway.session_context import get_session_env
 
 
 def _launch_cwd_for_session(source: str) -> Optional[str]:
@@ -87,6 +88,14 @@ def _launch_cwd_for_session(source: str) -> Optional[str]:
     except OSError:
         # cwd was unlinked out from under us — nothing meaningful to record.
         return None
+
+
+def _resolve_session_source(platform: str | None) -> str:
+    source = (get_session_env("HERMES_SESSION_SOURCE", "") or "").strip()
+    if source:
+        return source
+    platform = (platform or "").strip()
+    return platform or "cli"
 
 
 # OpenAI lazy proxy + safe stdio + proxy URL helpers — see agent/process_bootstrap.py.
@@ -510,7 +519,7 @@ class AIAgent:
         """Create session DB row on first use. Disables _session_db on failure."""
         if self._session_db_created or not self._session_db:
             return
-        source = self.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli")
+        source = _resolve_session_source(getattr(self, "platform", None))
         try:
             self._session_db.create_session(
                 session_id=self.session_id,
@@ -576,7 +585,7 @@ class AIAgent:
             start_context = {
                 "old_session_id": old_session_id,
                 "carry_over_context": carry_over_context,
-                "platform": getattr(self, "platform", None) or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                "platform": _resolve_session_source(getattr(self, "platform", None)),
                 "model": getattr(self, "model", ""),
                 "context_length": getattr(engine, "context_length", None),
                 "conversation_id": getattr(self, "_gateway_session_key", None),

--- a/tests/run_agent/test_860_dedup.py
+++ b/tests/run_agent/test_860_dedup.py
@@ -265,3 +265,33 @@ class TestFlushIdxInit:
         agent._flush_messages_to_session_db(messages, [])
         # Should not crash, idx should remain 0
         assert agent._last_flushed_db_idx == 0
+
+
+def test_ensure_db_session_prefers_session_source_over_platform(tmp_path):
+    """Gateway helper sessions can override the visible platform source."""
+    from hermes_state import SessionDB
+    from run_agent import AIAgent
+
+    db_path = tmp_path / "test.db"
+    db = SessionDB(db_path=db_path)
+    try:
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+            agent = AIAgent(
+                api_key="test-key",
+                base_url="https://openrouter.ai/api/v1",
+                model="test/model",
+                quiet_mode=True,
+                platform="tui",
+                session_db=db,
+                session_id="test-session-source",
+                skip_context_files=True,
+                skip_memory=True,
+            )
+        with patch("run_agent.get_session_env", return_value="tool"):
+            agent._ensure_db_session()
+
+        row = db.get_session("test-session-source")
+        assert row is not None
+        assert row["source"] == "tool"
+    finally:
+        db.close()

--- a/tests/test_dashboard_sidecar_close_on_disconnect.py
+++ b/tests/test_dashboard_sidecar_close_on_disconnect.py
@@ -6,8 +6,10 @@ CHAT_SIDEBAR = Path(__file__).resolve().parent.parent / "web/src/components/Chat
 
 def test_sidecar_session_create_requests_close_on_disconnect():
     """The sidecar must opt its session into close_on_disconnect so the gateway
-    reaps the slash_worker on WS disconnect (the #21370/#21467 leak)."""
+    reaps the slash_worker on WS disconnect (the #21370/#21467 leak) and tag
+    the helper lane as an internal tool session so it stays out of /resume."""
     source = CHAT_SIDEBAR.read_text(encoding="utf-8")
     call = re.search(r'"session\.create",\s*\{(.*?)\}', source, re.DOTALL)
     assert call, "sidecar session.create call not found"
     assert re.search(r"close_on_disconnect:\s*true", call.group(1))
+    assert re.search(r'source:\s*"tool"', call.group(1))

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -86,6 +86,29 @@ def test_session_context_uses_session_cwd(monkeypatch, tmp_path):
         server._sessions.pop(sid, None)
 
 
+def test_session_context_uses_session_source(tmp_path):
+    """Gateway context should carry per-session source tags into agent turns."""
+    from gateway.session_context import get_session_env
+
+    sid = "source-sid"
+    session_key = "source-key"
+    project = tmp_path / "project"
+    project.mkdir()
+
+    server._sessions[sid] = {
+        "session_key": session_key,
+        "cwd": str(project),
+        "source": "tool",
+    }
+
+    tokens = server._set_session_context(session_key)
+    try:
+        assert get_session_env("HERMES_SESSION_SOURCE") == "tool"
+    finally:
+        server._clear_session_context(tokens)
+        server._sessions.pop(sid, None)
+
+
 def test_handoff_fail_marks_only_inflight_rows(monkeypatch):
     class DbContext:
         def __init__(self, db):
@@ -1536,6 +1559,30 @@ def test_ensure_session_db_row_defaults_to_no_workspace(monkeypatch, tmp_path):
     server._ensure_session_db_row({"session_key": "k1", "cwd": str(tmp_path)})
 
     assert created == [{"key": "k1", "source": "tui", "model": "test-model", "cwd": None}]
+
+
+def test_ensure_session_db_row_preserves_session_source(monkeypatch, tmp_path):
+    created = []
+
+    class _FakeDB:
+        def create_session(self, key, source=None, model=None, cwd=None):
+            created.append({"key": key, "source": source, "model": model, "cwd": cwd})
+
+    monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
+
+    server._ensure_session_db_row(
+        {
+            "session_key": "k1",
+            "cwd": str(tmp_path),
+            "explicit_cwd": True,
+            "source": "tool",
+        }
+    )
+
+    assert created == [
+        {"key": "k1", "source": "tool", "model": "test-model", "cwd": str(tmp_path)}
+    ]
 
 
 def test_session_title_clears_pending_after_persist(monkeypatch):
@@ -6962,13 +7009,19 @@ def test_session_create_records_close_on_disconnect_flag(monkeypatch):
     server._sessions.clear()
     try:
         on = server.handle_request(
-            {"id": "1", "method": "session.create", "params": {"close_on_disconnect": True}}
+            {
+                "id": "1",
+                "method": "session.create",
+                "params": {"close_on_disconnect": True, "source": "tool"},
+            }
         )["result"]["session_id"]
         off = server.handle_request(
             {"id": "2", "method": "session.create", "params": {}}
         )["result"]["session_id"]
         assert server._sessions[on]["close_on_disconnect"]
+        assert server._sessions[on]["source"] == "tool"
         assert not server._sessions[off]["close_on_disconnect"]
+        assert server._sessions[off]["source"] == "tui"
     finally:
         server._sessions.clear()
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1158,7 +1158,7 @@ def _ensure_session_db_row(session: dict) -> None:
     try:
         db.create_session(
             key,
-            source="tui",
+            source=_session_source(session),
             model=_resolve_model(),
             cwd=_session_cwd(session) if session.get("explicit_cwd") else None,
         )
@@ -1297,7 +1297,25 @@ def _cwd_for_session_key(session_key: str) -> str:
     return ""
 
 
-def _set_session_context(session_key: str, cwd: str | None = None) -> list:
+def _source_for_session_key(session_key: str) -> str:
+    if not session_key:
+        return ""
+    with _sessions_lock:
+        for sess in list(_sessions.values()):
+            if sess.get("session_key") == session_key:
+                return _session_source(sess)
+    return ""
+
+
+def _session_source(session: dict) -> str:
+    return str(session.get("source") or "").strip() or "tui"
+
+
+def _set_session_context(
+    session_key: str,
+    cwd: str | None = None,
+    source: str | None = None,
+) -> list:
     try:
         from gateway.session_context import set_session_vars
 
@@ -1306,7 +1324,12 @@ def _set_session_context(session_key: str, cwd: str | None = None) -> list:
         # know the parent workspace pass it explicitly so spawned agents inherit
         # it instead of falling back to the gateway launch dir.
         resolved = cwd if cwd is not None else _cwd_for_session_key(session_key)
-        return set_session_vars(session_key=session_key, cwd=resolved)
+        resolved_source = source if source is not None else _source_for_session_key(session_key)
+        return set_session_vars(
+            session_key=session_key,
+            session_source=resolved_source,
+            cwd=resolved,
+        )
     except Exception:
         return []
 
@@ -3628,6 +3651,7 @@ def _(rid, params: dict) -> dict:
             "active_session_lease": lease,
             "cols": cols,
             "created_at": now,
+            "source": str(params.get("source") or "").strip() or "tui",
             "edit_snapshots": {},
             "explicit_cwd": explicit_cwd,
             "history": history,
@@ -4711,7 +4735,7 @@ def _(rid, params: dict) -> dict:
             )
         db.create_session(
             new_key,
-            source="tui",
+            source=_session_source(session),
             model=_resolve_model(),
             # Stable _branched_from marker so list_sessions_rich() keeps the
             # branch visible in /resume and /sessions. The TUI branch leaves

--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -124,6 +124,7 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
         // slash_worker subprocess) when the WS drops, instead of leaking it.
         return gw.request<{ session_id: string }>("session.create", {
           close_on_disconnect: true,
+          source: "tool",
         });
       })
       .then((created) => {


### PR DESCRIPTION
## Summary
- tag the dashboard ChatSidebar helper session as an internal `tool` source
- propagate per-session source tags through the TUI gateway context and lazy session persistence paths
- add regressions covering helper-session source propagation and hidden-session persistence

## Root cause
The dashboard sidebar opens a helper TUI gateway session for model-picker slash commands. That helper session was persisted as source `tui`, so it showed up as a normal empty chat session in history.

## Testing
- python3 -m pytest -o addopts='' -q tests/test_dashboard_sidecar_close_on_disconnect.py tests/test_tui_gateway_server.py::test_session_context_uses_session_source tests/test_tui_gateway_server.py::test_ensure_session_db_row_persists_explicit_cwd tests/test_tui_gateway_server.py::test_ensure_session_db_row_defaults_to_no_workspace tests/test_tui_gateway_server.py::test_ensure_session_db_row_preserves_session_source tests/test_tui_gateway_server.py::test_session_create_records_close_on_disconnect_flag tests/run_agent/test_860_dedup.py::test_ensure_db_session_prefers_session_source_over_platform tests/gateway/test_session_list_allowed_sources.py
- uv run --frozen ruff check gateway/session_context.py run_agent.py tui_gateway/server.py tests/test_dashboard_sidecar_close_on_disconnect.py tests/test_tui_gateway_server.py tests/run_agent/test_860_dedup.py
- git diff --check

Fixes #44343.
