### PR TITLE
docs: fix Himalaya flag syntax

### DIFF
--- a/skills/email/himalaya/SKILL.md
+++ b/skills/email/himalaya/SKILL.md
@@ -236,13 +236,19 @@ himalaya message delete 42
 Add flag:
 
 ```bash
-himalaya flag add 42 --flag seen
+himalaya flag add 42 seen
 ```
 
 Remove flag:
 
 ```bash
-himalaya flag remove 42 --flag seen
+himalaya flag remove 42 seen
+```
+
+For multiple accounts, keep `--account` on the flag subcommand:
+
+```bash
+himalaya flag add 42 seen --account work
 ```
 
 ## Multiple Accounts

--- a/website/docs/user-guide/skills/bundled/email/email-himalaya.md
+++ b/website/docs/user-guide/skills/bundled/email/email-himalaya.md
@@ -251,13 +251,19 @@ himalaya message delete 42
 Add flag:
 
 ```bash
-himalaya flag add 42 --flag seen
+himalaya flag add 42 seen
 ```
 
 Remove flag:
 
 ```bash
-himalaya flag remove 42 --flag seen
+himalaya flag remove 42 seen
+```
+
+For multiple accounts, keep `--account` on the flag subcommand:
+
+```bash
+himalaya flag add 42 seen --account work
 ```
 
 ## Multiple Accounts

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/email/email-himalaya.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/email/email-himalaya.md
@@ -237,13 +237,19 @@ himalaya message delete 42
 添加标志：
 
 ```bash
-himalaya flag add 42 --flag seen
+himalaya flag add 42 seen
 ```
 
 移除标志：
 
 ```bash
-himalaya flag remove 42 --flag seen
+himalaya flag remove 42 seen
+```
+
+多账户场景下，请将 `--account` 保留在 flag 子命令上：
+
+```bash
+himalaya flag add 42 seen --account work
 ```
 
 ## 多账户


### PR DESCRIPTION
## Summary
- Fix Himalaya flag management examples to use positional flag arguments
- Add an account-specific example for multi-account setups

## Test Plan
- `! grep -n -- "--flag seen" skills/email/himalaya/SKILL.md`
- `himalaya flag add --help | grep -A8 "Usage:"`
