### PR TITLE
fix(auth): share xAI OAuth root store across profiles

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -656,8 +656,9 @@ class CredentialPool:
         if self.provider != "xai-oauth" or entry.source != "loopback_pkce":
             return entry
         try:
-            with _auth_store_lock():
-                auth_store = _load_auth_store()
+            auth_file = auth_mod._xai_oauth_read_auth_file_path()
+            with _auth_store_lock(auth_file=auth_file):
+                auth_store = _load_auth_store(auth_file)
                 state = _load_provider_state(auth_store, "xai-oauth")
             if not isinstance(state, dict):
                 return entry
@@ -797,8 +798,12 @@ class CredentialPool:
         if entry.source not in {"device_code", "loopback_pkce"}:
             return
         try:
-            with _auth_store_lock():
-                auth_store = _load_auth_store()
+            auth_file = (
+                auth_mod._xai_oauth_write_auth_file_path()
+                if self.provider == "xai-oauth" else None
+            )
+            with _auth_store_lock(auth_file=auth_file):
+                auth_store = _load_auth_store(auth_file) if auth_file is not None else _load_auth_store()
                 if self.provider == "nous":
                     state = _load_provider_state(auth_store, "nous")
                     if state is None:
@@ -853,7 +858,7 @@ class CredentialPool:
                 else:
                     return
 
-                _save_auth_store(auth_store)
+                _save_auth_store(auth_store, auth_file=auth_file)
         except Exception as exc:
             logger.debug("Failed to sync %s pool entry back to auth store: %s", self.provider, exc)
 
@@ -1013,8 +1018,9 @@ class CredentialPool:
                         "xAI OAuth refresh token is terminally invalid; clearing local token state"
                     )
                     try:
-                        with _auth_store_lock():
-                            auth_store = _load_auth_store()
+                        auth_file = auth_mod._xai_oauth_write_auth_file_path()
+                        with _auth_store_lock(auth_file=auth_file):
+                            auth_store = _load_auth_store(auth_file)
                             state = _load_provider_state(auth_store, "xai-oauth") or {}
                             if isinstance(state, dict):
                                 tokens = state.get("tokens") or {}
@@ -1034,7 +1040,7 @@ class CredentialPool:
                                             "at": datetime.now(timezone.utc).isoformat(),
                                         }
                                         _save_provider_state(auth_store, "xai-oauth", state)
-                                        _save_auth_store(auth_store)
+                                        _save_auth_store(auth_store, auth_file=auth_file)
                     except Exception as clear_exc:
                         logger.debug(
                             "Failed to clear terminal xAI OAuth state: %s", clear_exc

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -941,11 +941,71 @@ def _load_global_auth_store() -> Dict[str, Any]:
         return {}
 
 
-def _auth_lock_path() -> Path:
-    return _auth_file_path().with_suffix(".lock")
+def _load_global_provider_state(provider_id: str) -> Optional[Dict[str, Any]]:
+    """Return one provider state from the global-root auth store, if present."""
+    global_store = _load_global_auth_store()
+    if not global_store:
+        return None
+    global_providers = global_store.get("providers")
+    if isinstance(global_providers, dict):
+        global_state = global_providers.get(provider_id)
+        if isinstance(global_state, dict):
+            return dict(global_state)
+    return None
+
+
+def _xai_oauth_state_has_runtime_tokens(state: Any) -> bool:
+    tokens = state.get("tokens") if isinstance(state, dict) else None
+    return bool(
+        isinstance(tokens, dict)
+        and str(tokens.get("access_token") or "").strip()
+        and str(tokens.get("refresh_token") or "").strip()
+    )
+
+
+def _xai_oauth_global_auth_file_path() -> Optional[Path]:
+    """Return the canonical shared xAI OAuth auth.json in profile mode."""
+    return _global_auth_file_path()
+
+
+def _xai_oauth_write_auth_file_path() -> Path:
+    """xAI OAuth is profile-shared; profile processes write the root auth.json."""
+    return _xai_oauth_global_auth_file_path() or _auth_file_path()
+
+
+def _xai_oauth_read_auth_file_path() -> Path:
+    """Prefer the shared root xAI OAuth store when it already has tokens."""
+    global_path = _xai_oauth_global_auth_file_path()
+    if global_path is not None and global_path.exists():
+        try:
+            global_store = _load_auth_store(global_path)
+            providers = global_store.get("providers")
+            state = providers.get("xai-oauth") if isinstance(providers, dict) else None
+            if _xai_oauth_state_has_runtime_tokens(state):
+                return global_path
+        except Exception:
+            pass
+    return _auth_file_path()
+
+
+def _auth_lock_path(auth_file: Optional[Path] = None) -> Path:
+    return (auth_file or _auth_file_path()).with_suffix(".lock")
 
 
 _auth_lock_holder = threading.local()
+_auth_lock_holders_by_path: Dict[str, threading.local] = {}
+_auth_lock_holders_guard = threading.Lock()
+
+
+def _auth_lock_holder_for_path(lock_path: Path) -> threading.local:
+    """Return a reentrancy holder scoped to one auth-store lock file."""
+    key = str(lock_path.resolve(strict=False))
+    with _auth_lock_holders_guard:
+        holder = _auth_lock_holders_by_path.get(key)
+        if holder is None:
+            holder = threading.local()
+            _auth_lock_holders_by_path[key] = holder
+        return holder
 
 
 @contextmanager
@@ -1021,7 +1081,10 @@ def _file_lock(
 
 
 @contextmanager
-def _auth_store_lock(timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS):
+def _auth_store_lock(
+    timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS,
+    auth_file: Optional[Path] = None,
+):
     """Cross-process advisory lock for auth.json reads+writes.  Reentrant.
 
     Lock ordering invariant: when this lock is held together with
@@ -1031,8 +1094,8 @@ def _auth_store_lock(timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS):
     against a concurrent import on the shared store.
     """
     with _file_lock(
-        _auth_lock_path(),
-        _auth_lock_holder,
+        _auth_lock_path(auth_file),
+        _auth_lock_holder_for_path(_auth_lock_path(auth_file)),
         timeout_seconds,
         "Timed out waiting for auth store lock",
     ):
@@ -1079,8 +1142,22 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
     return {"version": AUTH_STORE_VERSION, "providers": {}}
 
 
-def _save_auth_store(auth_store: Dict[str, Any]) -> Path:
-    auth_file = _auth_file_path()
+def _save_auth_store(auth_store: Dict[str, Any], auth_file: Optional[Path] = None) -> Path:
+    auth_file = auth_file or _auth_file_path()
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        real_home_env = os.environ.get("HOME", "")
+        if real_home_env:
+            real_auth = (Path(real_home_env) / ".hermes" / "auth.json").resolve(strict=False)
+            try:
+                if auth_file.resolve(strict=False) == real_auth:
+                    raise RuntimeError(
+                        f"Refusing to touch real user auth store during test run: {auth_file}. "
+                        "Set HERMES_HOME/HOME to a tmp_path in your test fixture."
+                    )
+            except RuntimeError:
+                raise
+            except Exception:
+                pass
     auth_file.parent.mkdir(parents=True, exist_ok=True)
     # Tighten parent dir to 0o700 so siblings can't traverse to creds.
     # No-op on Windows (POSIX mode bits not enforced); ignore failures.
@@ -1138,7 +1215,17 @@ def _load_provider_state(auth_store: Dict[str, Any], provider_id: str) -> Option
     global scope. Once the user runs ``hermes auth login <provider>`` inside
     the profile, the profile state fully shadows the global state on the next
     read. See issue #18594 follow-up.
+
+    Exception: ``xai-oauth`` uses single-use refresh tokens and must be shared
+    across named profiles.  When the global-root xAI singleton has runtime
+    tokens, it is canonical even if a profile still has a stale legacy
+    ``providers.xai-oauth`` block.
     """
+    if provider_id == "xai-oauth":
+        global_state = _load_global_provider_state(provider_id)
+        if _xai_oauth_state_has_runtime_tokens(global_state):
+            return global_state
+
     providers = auth_store.get("providers")
     if isinstance(providers, dict):
         state = providers.get(provider_id)
@@ -1212,7 +1299,7 @@ def get_auth_provider_display_name(provider_id: str) -> str:
     return SERVICE_PROVIDER_NAMES.get(normalized, provider_id)
 
 
-def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
+def read_credential_pool(provider_id: Optional[str] = None) -> Any:
     """Return the persisted credential pool, or one provider slice.
 
     In profile mode, the profile's credential pool is authoritative. If a
@@ -1225,7 +1312,12 @@ def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
     ``hermes auth add <provider>`` inside the profile, profile entries
     fully shadow global for that provider on the next read.
 
-    Writes always go to the profile (``write_credential_pool`` is unchanged).
+    Exception: ``xai-oauth`` is global-root canonical in profile mode because
+    its OAuth refresh tokens are single-use.  Named profiles borrow the root
+    xAI pool when present instead of shadowing it with stale legacy copies.
+
+    Writes always go to the profile (``write_credential_pool`` is unchanged),
+    except ``xai-oauth`` writes in profile mode go to the shared root store.
     See issue #18594 follow-up.
     """
     auth_store = _load_auth_store()
@@ -1244,6 +1336,12 @@ def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
         for gp_key, gp_entries in global_pool.items():
             if not isinstance(gp_entries, list) or not gp_entries:
                 continue
+            # xAI OAuth refresh tokens are single-use and shared across named
+            # profiles.  The global-root pool is canonical whenever it exists;
+            # stale profile-local xai-oauth pools must not shadow it.
+            if gp_key == "xai-oauth":
+                merged[gp_key] = list(gp_entries)
+                continue
             # Per-provider shadowing: profile wins whenever it has ANY entries.
             existing = merged.get(gp_key)
             if isinstance(existing, list) and existing:
@@ -1251,11 +1349,14 @@ def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
             merged[gp_key] = list(gp_entries)
         return merged
 
+    global_entries = global_pool.get(provider_id)
+    if provider_id == "xai-oauth" and isinstance(global_entries, list) and global_entries:
+        return list(global_entries)
+
     provider_entries = pool.get(provider_id)
     if isinstance(provider_entries, list) and provider_entries:
         return list(provider_entries)
     # Profile has no entries for this provider — fall back to global.
-    global_entries = global_pool.get(provider_id)
     return list(global_entries) if isinstance(global_entries, list) else []
 
 
@@ -1266,8 +1367,9 @@ def write_credential_pool(provider_id: str, entries: List[Dict[str, Any]]) -> Pa
     credentials. Callers may pass raw dictionaries, so sanitize here even when
     ``PooledCredential.to_dict()`` already did the same work upstream.
     """
-    with _auth_store_lock():
-        auth_store = _load_auth_store()
+    auth_file = _xai_oauth_write_auth_file_path() if provider_id == "xai-oauth" else _auth_file_path()
+    with _auth_store_lock(auth_file=auth_file):
+        auth_store = _load_auth_store(auth_file)
         pool = auth_store.get("credential_pool")
         if not isinstance(pool, dict):
             pool = {}
@@ -1277,7 +1379,7 @@ def write_credential_pool(provider_id: str, entries: List[Dict[str, Any]]) -> Pa
             if isinstance(entry, dict) else entry
             for entry in entries
         ]
-        return _save_auth_store(auth_store)
+        return _save_auth_store(auth_store, auth_file=auth_file)
 
 
 def suppress_credential_source(provider_id: str, source: str) -> None:
@@ -3825,11 +3927,12 @@ def _pool_codex_access_token() -> str:
 # =============================================================================
 
 def _read_xai_oauth_tokens(*, _lock: bool = True) -> Dict[str, Any]:
+    auth_file = _xai_oauth_read_auth_file_path()
     if _lock:
-        with _auth_store_lock():
-            auth_store = _load_auth_store()
+        with _auth_store_lock(auth_file=auth_file):
+            auth_store = _load_auth_store(auth_file)
     else:
-        auth_store = _load_auth_store()
+        auth_store = _load_auth_store(auth_file)
     state = _load_provider_state(auth_store, "xai-oauth")
     if not state:
         raise AuthError(
@@ -3879,8 +3982,9 @@ def _save_xai_oauth_tokens(
 ) -> None:
     if last_refresh is None:
         last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-    with _auth_store_lock():
-        auth_store = _load_auth_store()
+    auth_file = _xai_oauth_write_auth_file_path()
+    with _auth_store_lock(auth_file=auth_file):
+        auth_store = _load_auth_store(auth_file)
         state = _load_provider_state(auth_store, "xai-oauth") or {}
         state["tokens"] = tokens
         state["last_refresh"] = last_refresh
@@ -3890,7 +3994,7 @@ def _save_xai_oauth_tokens(
         if redirect_uri:
             state["redirect_uri"] = redirect_uri
         _save_provider_state(auth_store, "xai-oauth", state)
-        _save_auth_store(auth_store)
+        _save_auth_store(auth_store, auth_file=auth_file)
 
 
 def _xai_access_token_is_expiring(access_token: str, skew_seconds: int = 0) -> bool:
@@ -4204,7 +4308,11 @@ def resolve_xai_oauth_runtime_credentials(
     if (not should_refresh) and refresh_if_expiring:
         should_refresh = _xai_access_token_is_expiring(access_token, refresh_skew_seconds)
     if should_refresh:
-        with _auth_store_lock(timeout_seconds=max(float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0)):
+        xai_auth_file = _xai_oauth_write_auth_file_path()
+        with _auth_store_lock(
+            timeout_seconds=max(float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0),
+            auth_file=xai_auth_file,
+        ):
             data = _read_xai_oauth_tokens(_lock=False)
             tokens = dict(data["tokens"])
             access_token = str(tokens.get("access_token", "") or "").strip()
@@ -4231,7 +4339,8 @@ def resolve_xai_oauth_runtime_credentials(
                         # Clear dead tokens from auth.json so subsequent sessions fail fast
                         # without a network retry. Mirrors credential_pool.py quarantine.
                         try:
-                            _q_store = _load_auth_store()
+                            _q_auth_file = _xai_oauth_write_auth_file_path()
+                            _q_store = _load_auth_store(_q_auth_file)
                             _q_state = _load_provider_state(_q_store, "xai-oauth") or {}
                             _q_tokens = dict(_q_state.get("tokens") or {})
                             _q_tokens.pop("access_token", None)
@@ -4246,7 +4355,7 @@ def resolve_xai_oauth_runtime_credentials(
                                 "at": datetime.now(timezone.utc).isoformat(),
                             }
                             _store_provider_state(_q_store, "xai-oauth", _q_state, set_active=False)
-                            _save_auth_store(_q_store)
+                            _save_auth_store(_q_store, auth_file=_q_auth_file)
                         except Exception as _save_exc:
                             logger.debug(
                                 "xAI OAuth: failed to persist quarantined state: %s", _save_exc,

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -6,6 +6,7 @@ import base64
 import json
 import time
 from datetime import datetime, timezone
+from pathlib import Path
 
 import pytest
 
@@ -2824,6 +2825,58 @@ def test_xai_oauth_terminal_refresh_clears_auth_json_and_removes_pool_entries(
     # (pool is now empty of loopback entries and current is None).
     assert pool.try_refresh_current() is None
     assert refresh_calls["count"] == 1
+
+
+def test_xai_oauth_terminal_refresh_clears_global_auth_from_profile(
+    tmp_path, monkeypatch
+):
+    """Profile workers must quarantine the shared root xAI singleton, not their local copy."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    global_root = tmp_path / ".hermes"
+    profile_home = global_root / "profiles" / "coder"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    monkeypatch.delenv("XAI_OAUTH_ACCESS_TOKEN", raising=False)
+
+    global_auth = global_root / "auth.json"
+    global_auth.write_text(json.dumps(_xai_auth_store("root-access", "root-refresh"), indent=2))
+    profile_auth = profile_home / "auth.json"
+    profile_auth.write_text(json.dumps(_xai_auth_store("profile-access", "profile-refresh"), indent=2))
+
+    from agent.credential_pool import load_pool
+    import hermes_cli.auth as auth_mod
+    from hermes_cli.auth import AuthError
+
+    pool = load_pool("xai-oauth")
+    selected = pool.select()
+    assert selected is not None
+    assert selected.source == "loopback_pkce"
+    assert selected.refresh_token == "root-refresh"
+
+    def _terminal_refresh_failure(*_args, **_kwargs):
+        raise AuthError(
+            "Refresh session has been revoked",
+            provider="xai-oauth",
+            code="xai_refresh_failed",
+            relogin_required=True,
+        )
+
+    monkeypatch.setattr(auth_mod, "refresh_xai_oauth_pure", _terminal_refresh_failure)
+
+    assert pool.try_refresh_current() is None
+
+    global_payload = json.loads(global_auth.read_text())
+    global_tokens = global_payload["providers"]["xai-oauth"].get("tokens", {})
+    assert not global_tokens.get("access_token")
+    assert not global_tokens.get("refresh_token")
+    assert global_payload["providers"]["xai-oauth"]["last_auth_error"]["code"] == "xai_refresh_failed"
+    assert global_payload["credential_pool"]["xai-oauth"] == []
+
+    profile_payload = json.loads(profile_auth.read_text())
+    profile_tokens = profile_payload["providers"]["xai-oauth"]["tokens"]
+    assert profile_tokens["access_token"] == "profile-access"
+    assert profile_tokens["refresh_token"] == "profile-refresh"
 
 
 def test_xai_oauth_nonterminal_refresh_does_not_quarantine(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -319,6 +319,98 @@ def test_load_provider_state_profile_wins_over_global(profile_env):
     assert state["access_token"] == "profile-token"
 
 
+def test_xai_oauth_provider_state_prefers_global_over_stale_profile(profile_env):
+    """xAI OAuth is shared across profiles; stale profile state must not shadow root."""
+    from hermes_cli.auth import _load_auth_store, _load_provider_state
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(providers={
+        "xai-oauth": {"tokens": {"access_token": "global-access", "refresh_token": "global-refresh"}},
+    }))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(providers={
+        "xai-oauth": {"tokens": {"access_token": "profile-access", "refresh_token": "profile-refresh"}},
+    }))
+
+    auth_store = _load_auth_store()
+    state = _load_provider_state(auth_store, "xai-oauth")
+    assert state is not None
+    assert state["tokens"]["access_token"] == "global-access"
+
+
+def test_xai_oauth_pool_prefers_global_over_profile_entries(profile_env):
+    """A profile-local xai-oauth pool is legacy shadow state; root is canonical."""
+    from hermes_cli.auth import read_credential_pool
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
+        "xai-oauth": [{
+            "id": "global-xai",
+            "label": "root",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "loopback_pkce",
+            "access_token": "global-access",
+            "refresh_token": "global-refresh",
+        }],
+    }))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
+        "xai-oauth": [{
+            "id": "profile-xai",
+            "label": "stale-profile",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "loopback_pkce",
+            "access_token": "profile-access",
+            "refresh_token": "profile-refresh",
+        }],
+    }))
+
+    entries = read_credential_pool("xai-oauth")
+    assert [entry["id"] for entry in entries] == ["global-xai"]
+
+    merged = read_credential_pool(None)
+    assert [entry["id"] for entry in merged["xai-oauth"]] == ["global-xai"]
+
+
+def test_xai_oauth_writes_target_global_store_from_profile(profile_env):
+    """Profile refreshes must rotate the shared root xAI singleton/pool, not fork."""
+    from hermes_cli.auth import _save_xai_oauth_tokens, write_credential_pool
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(providers={}))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(providers={
+        "xai-oauth": {"tokens": {"access_token": "old-profile", "refresh_token": "old-profile-rt"}},
+    }, pool={
+        "xai-oauth": [{
+            "id": "profile-xai",
+            "label": "stale-profile",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "loopback_pkce",
+            "access_token": "old-profile",
+            "refresh_token": "old-profile-rt",
+        }],
+    }))
+
+    _save_xai_oauth_tokens(
+        {"access_token": "new-global", "refresh_token": "new-global-rt"},
+        last_refresh="2026-06-12T00:00:00Z",
+    )
+    write_credential_pool("xai-oauth", [{
+        "id": "global-xai",
+        "label": "root",
+        "auth_type": "oauth",
+        "priority": 0,
+        "source": "loopback_pkce",
+        "access_token": "new-global",
+        "refresh_token": "new-global-rt",
+    }])
+
+    global_data = json.loads((profile_env["global"] / "auth.json").read_text())
+    profile_data = json.loads((profile_env["profile"] / "auth.json").read_text())
+    assert global_data["providers"]["xai-oauth"]["tokens"]["access_token"] == "new-global"
+    assert global_data["credential_pool"]["xai-oauth"][0]["id"] == "global-xai"
+    assert profile_data["providers"]["xai-oauth"]["tokens"]["access_token"] == "old-profile"
+    assert profile_data["credential_pool"]["xai-oauth"][0]["id"] == "profile-xai"
+
+
 def test_load_provider_state_returns_none_when_neither_has_it(profile_env):
     from hermes_cli.auth import _load_auth_store, _load_provider_state
 


### PR DESCRIPTION
## Summary
- Route xAI OAuth reads, writes, and auth-store locks through the shared root auth.json when running from named profiles.
- Keep stale profile-local xai-oauth singleton/pool state from shadowing the canonical root credentials.
- Add regression coverage for profile fallback, global-root writes, and terminal refresh quarantine from profile workers.

## Test Plan
- `scripts/run_tests.sh tests/agent/test_credential_pool.py tests/hermes_cli/test_auth_profile_fallback.py tests/hermes_cli/test_auth_xai_oauth_provider.py tests/hermes_cli/test_xai_oauth_pkce_token_exchange.py tests/run_agent/test_codex_xai_oauth_recovery.py tests/agent/test_auxiliary_client_xai_oauth_recovery.py` (252 passed)
- Manual filtered status check for profiles `test-writer`, `frontend-engineer`, and `code-reviewer`: xAI OAuth status logged in and runtime credential resolution used `/home/hirakitomohiko/.hermes/auth.json` for both read/write routing. Token values were not printed.

Source kanban follow-through: t_ada9abd3 / t_0276f271.
