### PR TITLE
Fix MCP OAuth token exchange Accept header

### DIFF
--- a/tests/tools/test_mcp_oauth_manager.py
+++ b/tests/tools/test_mcp_oauth_manager.py
@@ -14,6 +14,7 @@ pytest.importorskip(
     "mcp.client.auth.oauth2",
     reason="MCP SDK 1.26.0+ required for OAuth support",
 )
+from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
 
 
 def test_manager_is_singleton():
@@ -139,3 +140,65 @@ def test_manager_builds_hermes_provider_subclass(tmp_path, monkeypatch):
     assert isinstance(provider, _HERMES_PROVIDER_CLS)
     assert provider._hermes_server_name == "srv"
 
+
+@pytest.mark.asyncio
+async def test_provider_requests_json_on_auth_code_exchange(tmp_path, monkeypatch):
+    """Authorization-code token requests must ask providers for JSON."""
+    from tools.mcp_oauth_manager import MCPOAuthManager, reset_manager_for_tests
+
+    reset_manager_for_tests()
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    mgr = MCPOAuthManager()
+    provider = mgr.get_or_build_provider(
+        "srv",
+        "https://example.com/mcp",
+        {"client_id": "test-client"},
+    )
+
+    provider.context.client_info = OAuthClientInformationFull.model_validate({
+        "client_id": "test-client",
+        "redirect_uris": provider.context.client_metadata.redirect_uris,
+        "grant_types": provider.context.client_metadata.grant_types,
+        "response_types": provider.context.client_metadata.response_types,
+        "token_endpoint_auth_method": provider.context.client_metadata.token_endpoint_auth_method,
+    })
+
+    request = await provider._exchange_token_authorization_code("code", "verifier")
+
+    assert request.headers["Content-Type"] == "application/x-www-form-urlencoded"
+    assert request.headers["Accept"] == "application/json"
+
+
+@pytest.mark.asyncio
+async def test_provider_requests_json_on_refresh_token_exchange(tmp_path, monkeypatch):
+    """Refresh-token requests must ask providers for JSON."""
+    from tools.mcp_oauth_manager import MCPOAuthManager, reset_manager_for_tests
+
+    reset_manager_for_tests()
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    mgr = MCPOAuthManager()
+    provider = mgr.get_or_build_provider(
+        "srv",
+        "https://example.com/mcp",
+        {"client_id": "test-client"},
+    )
+
+    provider.context.client_info = OAuthClientInformationFull.model_validate({
+        "client_id": "test-client",
+        "redirect_uris": provider.context.client_metadata.redirect_uris,
+        "grant_types": provider.context.client_metadata.grant_types,
+        "response_types": provider.context.client_metadata.response_types,
+        "token_endpoint_auth_method": provider.context.client_metadata.token_endpoint_auth_method,
+    })
+    provider.context.current_tokens = OAuthToken.model_validate({
+        "access_token": "access-token",
+        "token_type": "Bearer",
+        "refresh_token": "refresh-token",
+    })
+
+    request = await provider._refresh_token()
+
+    assert request.headers["Content-Type"] == "application/x-www-form-urlencoded"
+    assert request.headers["Accept"] == "application/json"

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -111,6 +111,19 @@ def _make_hermes_provider_class() -> Optional[type]:
             super().__init__(*args, **kwargs)
             self._hermes_server_name = server_name
 
+        @staticmethod
+        def _prefer_json_token_response(request):
+            """Ask OAuth token endpoints for JSON even if they default to forms.
+
+            Some providers, including GitHub's OAuth token endpoint, return
+            ``application/x-www-form-urlencoded`` unless the client explicitly
+            asks for JSON. The MCP SDK only parses JSON token responses, so
+            Hermes sets ``Accept: application/json`` on both authorization-code
+            and refresh-token exchanges.
+            """
+            request.headers.setdefault("Accept", "application/json")
+            return request
+
         async def _initialize(self) -> None:
             """Load stored tokens + client info AND seed token_expiry_time.
 
@@ -323,6 +336,24 @@ def _make_hermes_provider_class() -> Optional[type]:
                 # 401 branch so a subsequent cold-load skips discovery.
                 self._persist_oauth_metadata_if_changed()
                 return
+
+        async def _exchange_token_authorization_code(  # type: ignore[override]
+            self,
+            auth_code: str,
+            code_verifier: str,
+            *,
+            token_data: dict[str, Any] | None = None,
+        ):
+            request = await super()._exchange_token_authorization_code(
+                auth_code,
+                code_verifier,
+                token_data=token_data,
+            )
+            return self._prefer_json_token_response(request)
+
+        async def _refresh_token(self):  # type: ignore[override]
+            request = await super()._refresh_token()
+            return self._prefer_json_token_response(request)
 
     return HermesMCPOAuthProvider
 


### PR DESCRIPTION
## Summary
- send `Accept: application/json` on Hermes-managed MCP OAuth token exchanges
- cover both authorization-code and refresh-token request builders in `HermesMCPOAuthProvider`
- add focused manager tests proving both requests ask providers for JSON

Closes #44592