### PR TITLE
fix(desktop): handle OS-dropped folders — detect directories via stat, route to attachContextFolderPath

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -5814,6 +5814,16 @@ function disposeTerminalSession(id) {
 
 ipcMain.handle('hermes:fs:readDir', async (_event, dirPath) => readDirForIpc(dirPath))
 
+ipcMain.handle('hermes:fs:isDirectory', async (_event, filePath) => {
+  try {
+    const resolvedPath = resolveRequestedPathForIpc(filePath, { purpose: 'Path stat' })
+    const stat = await fs.promises.stat(resolvedPath)
+    return stat.isDirectory()
+  } catch {
+    return false
+  }
+})
+
 ipcMain.handle('hermes:fs:gitRoot', async (_event, startPath) => gitRootForIpc(startPath))
 
 ipcMain.handle('hermes:terminal:start', async (event, payload = {}) => {

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -51,6 +51,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   revealLogs: () => ipcRenderer.invoke('hermes:logs:reveal'),
   getRecentLogs: () => ipcRenderer.invoke('hermes:logs:recent'),
   readDir: dirPath => ipcRenderer.invoke('hermes:fs:readDir', dirPath),
+  isDirectory: filePath => ipcRenderer.invoke('hermes:fs:isDirectory', filePath),
   gitRoot: startPath => ipcRenderer.invoke('hermes:fs:gitRoot', startPath),
   terminal: {
     dispose: id => ipcRenderer.invoke('hermes:terminal:dispose', id),

--- a/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
+++ b/apps/desktop/src/app/chat/hooks/use-composer-actions.ts
@@ -485,6 +485,23 @@ export function useComposerActions({ activeSessionId, currentCwd, requestGateway
           !knownPath && window.hermesDesktop?.getPathForFile ? window.hermesDesktop.getPathForFile(file) : ''
 
         const filePath = knownPath || fallbackPath || ''
+
+        // Detect OS-dropped directories — the browser File API does not expose
+        // isDirectory, so we check via the Electron IPC stat call.
+        if (filePath && window.hermesDesktop?.isDirectory) {
+          try {
+            const isDir = await window.hermesDesktop.isDirectory(filePath)
+
+            if (isDir && attachContextFolderPath(filePath)) {
+              attached = true
+
+              continue
+            }
+          } catch {
+            // Fall through to normal file handling.
+          }
+        }
+
         const isImage = file.type.startsWith('image/') || isImagePath(file.name) || (filePath && isImagePath(filePath))
 
         if (isImage) {

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -64,6 +64,7 @@ declare global {
       revealLogs: () => Promise<{ ok: boolean; path: string; error?: string }>
       getRecentLogs: () => Promise<{ path: string; lines: string[] }>
       readDir: (path: string) => Promise<HermesReadDirResult>
+      isDirectory?: (path: string) => Promise<boolean>
       gitRoot?: (path: string) => Promise<string | null>
       terminal: {
         dispose: (id: string) => Promise<boolean>


### PR DESCRIPTION
## What

When a folder is dragged from Finder/Explorer into the Desktop composer, the browser `File` API does not expose `isDirectory`, so the drop handler treated it as a regular file. On submit, `readFileDataUrl` threw `EISDIR`, and the gateway received no `data_url` — producing:

```
file not found on gateway and no data_url provided
```

### Changes

1. **`main.cjs`** — new `hermes:fs:isDirectory` IPC handler that stat-checks the resolved path (uses existing `resolveRequestedPathForIpc` for path safety).

2. **`preload.cjs`** — expose the new IPC method as `window.hermesDesktop.isDirectory(path)`.

3. **`use-composer-actions.ts`** — in `attachDroppedItems`, before the image/file branch for OS drops, check `isDirectory` via the new IPC call. If true, route through `attachContextFolderPath` — matching the existing in-app folder drag behavior (creates a `kind: 'folder'` attachment with `@folder:` ref).

4. **`global.d.ts`** — add `isDirectory` to the `hermesDesktop` type definition.

## What is NOT included

- **Copy-paste of folders** — the clipboard handler (`handlePaste` in `composer/index.tsx`) only processes image blobs. Detecting folder paste events requires a different approach (the clipboard API doesn't expose file-system paths for pasted directories). This is a separate concern.
- **Remote gateway folder support** — when the gateway is remote, the folder path from the client machine won't resolve on the server. The existing in-app folder drag already has this limitation; extending it to OS drops is out of scope here.

## Testing

1. Drag a folder from Finder into the Desktop composer → should appear as a folder attachment (not a file)
2. Send a message → agent should receive the `@folder:` reference and be able to list its contents
3. Drag a file from Finder → should still work as before (image or file attachment)
4. In-app folder drag from project tree → should still work as before

Closes #44581