### PR TITLE
feat(agent): declarative per-fragment system-prompt overrides

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1452,6 +1452,11 @@ def init_agent(
     # single turn; the runtime already executes such batches concurrently.
     agent._parallel_tool_call_guidance = bool(_agent_section.get("parallel_tool_call_guidance", True))
 
+    # Declarative per-fragment system-prompt overrides (agent.prompt_overrides).
+    # Normalized once here; applied at prompt-build time in system_prompt.py.
+    from agent.prompt_overrides import normalize_overrides
+    agent._prompt_overrides = normalize_overrides(_agent_section.get("prompt_overrides", {}))
+
     # Local Python toolchain probe toggle.  Default True.  When False,
     # the probe is skipped entirely (no subprocess calls, no system-prompt
     # line).  Useful for users on exotic setups where the probe heuristics

--- a/agent/prompt_overrides.py
+++ b/agent/prompt_overrides.py
@@ -1,0 +1,173 @@
+"""Declarative, cache-safe overrides for named system-prompt fragments.
+
+Every Hermes-authored fragment in the stable tier of the system prompt
+carries a stable string *key* (see :data:`FRAGMENT_KEYS`).  Users reshape any
+of them from ``config.yaml`` under ``agent.prompt_overrides`` without editing
+source:
+
+.. code-block:: yaml
+
+    agent:
+      prompt_overrides:
+        task_completion:      {mode: replace, text: "..."}
+        tool_use_enforcement: {mode: append,  text: "..."}
+        google_operational:   {mode: remove}
+        # shorthand: a bare string means replace
+        steer_channel: "Use the steer channel sparingly."
+
+Design contract — **overrides are pure data, resolved once at prompt-build
+time**.  There is no callable hook and no conditional logic, by design: the
+assembled prompt must stay a deterministic function of (agent, config) so it
+is byte-stable across turns and the upstream prefix cache stays warm.  With no
+overrides configured the output is byte-identical to the un-overridden prompt.
+
+A fragment override only takes effect when that fragment is actually emitted
+this session (e.g. ``computer_use`` only ships when the computer-use tool is
+loaded).  ``append``/``prepend`` to a fragment that isn't present this session
+silently no-ops — there is nothing to append to.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+VALID_MODES = ("replace", "append", "prepend", "remove")
+
+# Canonical registry of every override-addressable fragment key.  Keep in sync
+# with the ``emit(...)`` call sites in ``agent/system_prompt.py``.  Surfaced to
+# users for discovery (``hermes`` docs / tooling) — an override map keyed by
+# string is only usable if the keys are enumerable.
+FRAGMENT_KEYS: Dict[str, str] = {
+    "identity": "Agent identity slot (SOUL.md content, or the default identity).",
+    "hermes_help": "Pointer to the hermes-agent skill/docs for questions about Hermes itself.",
+    "task_completion": "Universal 'finish the job' / no-fabrication guidance (all models).",
+    "tool_guidance": "Composed per-tool behavioral guidance (memory, session_search, skills, kanban).",
+    "steer_channel": "Note explaining the mid-turn steer channel in tool results.",
+    "computer_use": "macOS background computer-use workflow guidance.",
+    "nous_subscription": "Nous subscription / portal guidance block.",
+    "tool_use_enforcement": "Tells the model to actually call tools instead of describing intent.",
+    "google_operational": "Gemini/Gemma operational directives (absolute paths, parallel calls, etc.).",
+    "execution_discipline": "GPT/Codex/Grok execution discipline (tool persistence, verification).",
+    "skills": "Skills system-prompt block (available skills and how to load them).",
+    "model_identity": "Explicit model-identity line (Alibaba Coding Plan API name workaround).",
+    "environment_hints": "Execution-environment hints (WSL, Termux, embedder-supplied hint).",
+    "environment_probe": "Local Python/pip/uv/PEP-668 toolchain probe line.",
+    "active_profile": "Active Hermes profile note and cross-profile write guidance.",
+    "platform_hints": "Platform-specific operational hints (from PLATFORM_HINTS or a plugin).",
+}
+
+
+def normalize_overrides(raw: Any) -> Dict[str, Dict[str, str]]:
+    """Validate and normalize ``agent.prompt_overrides`` config into a clean map.
+
+    Accepts the loosely-typed YAML value and returns ``{key: {"mode": ...,
+    "text": ...}}`` containing only well-formed entries for known fragment
+    keys.  Malformed entries are dropped with a warning rather than raising —
+    a bad override should never block prompt assembly.
+    """
+    if not raw:
+        return {}
+    if not isinstance(raw, dict):
+        logger.warning(
+            "agent.prompt_overrides must be a mapping of fragment-key -> override; "
+            "got %s. Ignoring.", type(raw).__name__,
+        )
+        return {}
+
+    result: Dict[str, Dict[str, str]] = {}
+    for key, spec in raw.items():
+        if key not in FRAGMENT_KEYS:
+            logger.warning(
+                "agent.prompt_overrides: unknown fragment key %r (ignored). "
+                "Valid keys: %s", key, ", ".join(sorted(FRAGMENT_KEYS)),
+            )
+            continue
+
+        # Shorthand: a bare string is a full replacement.
+        if isinstance(spec, str):
+            result[key] = {"mode": "replace", "text": spec}
+            continue
+
+        if not isinstance(spec, dict):
+            logger.warning(
+                "agent.prompt_overrides[%r] must be a string or mapping; got %s. "
+                "Ignored.", key, type(spec).__name__,
+            )
+            continue
+
+        mode = str(spec.get("mode", "replace")).lower().strip()
+        if mode not in VALID_MODES:
+            logger.warning(
+                "agent.prompt_overrides[%r]: invalid mode %r (valid: %s). Ignored.",
+                key, mode, ", ".join(VALID_MODES),
+            )
+            continue
+
+        if mode == "remove":
+            result[key] = {"mode": "remove", "text": ""}
+            continue
+
+        text = spec.get("text", "")
+        if text is None:
+            text = ""
+        if not isinstance(text, str):
+            logger.warning(
+                "agent.prompt_overrides[%r].text must be a string; got %s. Ignored.",
+                key, type(text).__name__,
+            )
+            continue
+        if mode in ("append", "prepend") and not text.strip():
+            logger.warning(
+                "agent.prompt_overrides[%r]: %s mode with empty text is a no-op. "
+                "Ignored.", key, mode,
+            )
+            continue
+        result[key] = {"mode": mode, "text": text}
+
+    return result
+
+
+def apply_fragment_override(
+    overrides: Optional[Dict[str, Dict[str, str]]],
+    key: str,
+    text: Optional[str],
+) -> Optional[str]:
+    """Apply any configured override for ``key`` to ``text``.
+
+    Returns the (possibly transformed) fragment text, or ``None`` when the
+    fragment should be dropped (``remove`` mode, or an empty result).  ``text``
+    is the default fragment content Hermes would emit with no override.
+    """
+    if not overrides:
+        return text
+    spec = overrides.get(key)
+    if not spec:
+        return text
+
+    mode = spec.get("mode", "replace")
+    if mode == "remove":
+        return None
+
+    new = spec.get("text", "")
+    if mode == "replace":
+        return new
+    if mode == "append":
+        if not text or not text.strip():
+            return new
+        return f"{text}\n\n{new}"
+    if mode == "prepend":
+        if not text or not text.strip():
+            return new
+        return f"{new}\n\n{text}"
+    return text
+
+
+__all__ = [
+    "FRAGMENT_KEYS",
+    "VALID_MODES",
+    "normalize_overrides",
+    "apply_fragment_override",
+]

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -179,6 +179,19 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # ── Stable tier ────────────────────────────────────────────────
     stable_parts: List[str] = []
 
+    # Declarative, cache-safe per-fragment overrides (agent.prompt_overrides).
+    # ``emit`` routes every named stable-tier fragment through the override
+    # engine before appending — resolved once here, so the assembled prompt
+    # stays byte-stable and the prefix cache stays warm.  No overrides => the
+    # text is appended unchanged.  See agent/prompt_overrides.py.
+    from agent.prompt_overrides import apply_fragment_override
+    _overrides = getattr(agent, "_prompt_overrides", None) or {}
+
+    def emit(key: str, text: Optional[str]) -> None:
+        text = apply_fragment_override(_overrides, key, text)
+        if text and text.strip():
+            stable_parts.append(text)
+
     # Try SOUL.md as primary identity unless the caller explicitly skipped it.
     # Some execution modes (cron) still want HERMES_HOME persona while keeping
     # cwd project instructions disabled.
@@ -186,15 +199,15 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     if agent.load_soul_identity or not agent.skip_context_files:
         _soul_content = _r.load_soul_md(_ctx_len)
         if _soul_content:
-            stable_parts.append(_soul_content)
+            emit("identity", _soul_content)
             _soul_loaded = True
 
     if not _soul_loaded:
         # Fallback to hardcoded identity
-        stable_parts.append(DEFAULT_AGENT_IDENTITY)
+        emit("identity", DEFAULT_AGENT_IDENTITY)
 
     # Pointer to the hermes-agent skill + docs for user questions about Hermes itself.
-    stable_parts.append(HERMES_AGENT_HELP_GUIDANCE)
+    emit("hermes_help", HERMES_AGENT_HELP_GUIDANCE)
 
     # Universal task-completion / no-fabrication guidance.  Applied to ALL
     # models regardless of tool_use_enforcement gating — the failure modes
@@ -203,7 +216,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # config.yaml ``agent.task_completion_guidance`` (default True) so
     # users who want a leaner prompt can turn it off.
     if getattr(agent, "_task_completion_guidance", True) and agent.valid_tool_names:
-        stable_parts.append(TASK_COMPLETION_GUIDANCE)
+        emit("task_completion", TASK_COMPLETION_GUIDANCE)
 
     # Universal parallel-tool-call guidance.  Tells the model to batch
     # independent tool calls into one assistant turn rather than emitting one
@@ -235,12 +248,12 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         # Fallback for code paths that bypass agent_init (rare).
         tool_guidance.append(KANBAN_GUIDANCE)
     if tool_guidance:
-        stable_parts.append(" ".join(tool_guidance))
+        emit("tool_guidance", " ".join(tool_guidance))
 
     # Steering only lands inside tool results, so it's only reachable when the
     # agent has tools. Static text → byte-stable prompt (no cache hit).
     if agent.valid_tool_names:
-        stable_parts.append(STEER_CHANNEL_NOTE)
+        emit("steer_channel", STEER_CHANNEL_NOTE)
 
     # Computer-use — goes in as its own block rather than being merged into
     # tool_guidance because the content is multi-paragraph. The guidance is
@@ -248,11 +261,11 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # macOS-only wording (Mac, Space, cmd+s).
     if "computer_use" in agent.valid_tool_names:
         from agent.prompt_builder import computer_use_guidance
-        stable_parts.append(computer_use_guidance())
+        emit("computer_use", computer_use_guidance())
 
     nous_subscription_prompt = _r.build_nous_subscription_prompt(agent.valid_tool_names)
     if nous_subscription_prompt:
-        stable_parts.append(nous_subscription_prompt)
+        emit("nous_subscription", nous_subscription_prompt)
     # Tool-use enforcement: tells the model to actually call tools instead
     # of describing intended actions.  Controlled by config.yaml
     # agent.tool_use_enforcement:
@@ -275,19 +288,19 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             model_lower = (agent.model or "").lower()
             _inject = any(p in model_lower for p in TOOL_USE_ENFORCEMENT_MODELS)
         if _inject:
-            stable_parts.append(TOOL_USE_ENFORCEMENT_GUIDANCE)
+            emit("tool_use_enforcement", TOOL_USE_ENFORCEMENT_GUIDANCE)
             _model_lower = (agent.model or "").lower()
             # Google model operational guidance (conciseness, absolute
             # paths, parallel tool calls, verify-before-edit, etc.)
             if "gemini" in _model_lower or "gemma" in _model_lower:
-                stable_parts.append(GOOGLE_MODEL_OPERATIONAL_GUIDANCE)
+                emit("google_operational", GOOGLE_MODEL_OPERATIONAL_GUIDANCE)
             # OpenAI GPT/Codex execution discipline (tool persistence,
             # prerequisite checks, verification, anti-hallucination).
             # Also applied to xAI Grok — same failure modes (claims completion
             # without tool calls, suggests workarounds instead of using
             # existing tools, replies with plans instead of executing).
             if "gpt" in _model_lower or "codex" in _model_lower or "grok" in _model_lower:
-                stable_parts.append(OPENAI_MODEL_EXECUTION_GUIDANCE)
+                emit("execution_discipline", OPENAI_MODEL_EXECUTION_GUIDANCE)
 
     has_skills_tools = any(name in agent.valid_tool_names for name in ['skills_list', 'skill_view', 'skill_manage'])
     if has_skills_tools:
@@ -319,7 +332,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     else:
         skills_prompt = ""
     if skills_prompt:
-        stable_parts.append(skills_prompt)
+        emit("skills", skills_prompt)
 
     # Alibaba Coding Plan API always returns "glm-4.7" as model name regardless
     # of the requested model. Inject explicit model identity into the system prompt
@@ -328,11 +341,12 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # at construction time.
     if agent.provider == "alibaba":
         _model_short = agent.model.split("/")[-1] if "/" in agent.model else agent.model
-        stable_parts.append(
+        emit(
+            "model_identity",
             f"You are powered by the model named {_model_short}. "
             f"The exact model ID is {agent.model}. "
             f"When asked what model you are, always answer based on this information, "
-            f"not on any model name returned by the API."
+            f"not on any model name returned by the API.",
         )
 
     # Environment hints (WSL, Termux, etc.) — tell the agent about the
@@ -340,7 +354,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # Stable for the lifetime of the process.
     _env_hints = _r.build_environment_hints()
     if _env_hints:
-        stable_parts.append(_env_hints)
+        emit("environment_hints", _env_hints)
 
     # Coding posture (base Hermes, any interactive coding surface in a code
     # workspace — see agent/coding_context.py). The operating brief + the live
@@ -374,7 +388,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             from tools.env_probe import get_environment_probe_line
             _probe_line = get_environment_probe_line()
             if _probe_line:
-                stable_parts.append(_probe_line)
+                emit("environment_probe", _probe_line)
         except Exception:
             # Probe failure must never block prompt build.
             pass
@@ -392,7 +406,8 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     except Exception:
         active_profile = "default"
     if active_profile == "default":
-        stable_parts.append(
+        emit(
+            "active_profile",
             "Active Hermes profile: default. Other profiles (if any) live "
             "under ~/.hermes/profiles/<name>/. Each profile has its own "
             "skills/, plugins/, cron/, and memories/ that affect a different "
@@ -401,7 +416,8 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             "you to."
         )
     else:
-        stable_parts.append(
+        emit(
+            "active_profile",
             f"Active Hermes profile: {active_profile}. This session reads "
             f"and writes ~/.hermes/profiles/{active_profile}/. The default "
             f"profile's data lives at ~/.hermes/skills/, ~/.hermes/plugins/, "
@@ -433,7 +449,7 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     if platform_key == "tui" and _effective_hint:
         _effective_hint = _tui_embedded_pane_clarifier(_effective_hint)
     if _effective_hint:
-        stable_parts.append(_effective_hint)
+        emit("platform_hints", _effective_hint)
 
     # ── Context tier (cwd-dependent, may change between sessions) ─
     context_parts: List[str] = []

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -733,6 +733,35 @@ agent:
   # Default 3.
   # max_verify_nudges: 3
 
+  # Per-fragment system-prompt overrides (full context-engineering control).
+  # Reshape any named stable-tier prompt fragment without editing Hermes
+  # source. Each entry is `mode: replace|append|prepend|remove` + `text`
+  # (a bare string is shorthand for `replace`). Pure data, resolved once at
+  # prompt-build time — never busts the prefix cache. With no entries the
+  # assembled prompt is byte-identical to the default.
+  #
+  # Fragment keys: identity, hermes_help, task_completion, tool_guidance,
+  #   steer_channel, computer_use, nous_subscription, tool_use_enforcement,
+  #   google_operational, execution_discipline, skills, model_identity,
+  #   environment_hints, environment_probe, active_profile, platform_hints
+  #
+  # An override only applies when that fragment is actually emitted this
+  # session; append/prepend to an absent fragment is a no-op.
+  # prompt_overrides:
+  #   # Qualify the pushy "keep going / try alternatives" guidance so the
+  #   # agent stops and reports on environment friction instead of hacking
+  #   # around it:
+  #   task_completion:
+  #     mode: append
+  #     text: >-
+  #       Exception — environment friction: if a tool, filesystem, dependency,
+  #       credential, integration, or environment problem blocks the real
+  #       path, STOP immediately, report the exact failure, and wait for the
+  #       user to fix it at the source. Do NOT work around it or substitute an
+  #       alternative approach unless the user approves.
+  #   google_operational: { mode: remove }
+  #   steer_channel: "Use the steer channel only for urgent corrections."
+
   # Enable verbose logging
   verbose: false
   

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1036,6 +1036,15 @@ DEFAULT_CONFIG = {
         # compounds over a long conversation.  Costs ~70 tokens in the cached
         # system prompt.  Set False to disable globally.
         "parallel_tool_call_guidance": True,
+        # Declarative per-fragment system-prompt overrides.  A mapping of
+        # fragment key -> {mode: replace|append|prepend|remove, text: "..."}
+        # (a bare string is shorthand for replace).  Lets you reshape any
+        # named stable-tier prompt fragment from config without editing
+        # source — full context-engineering control.  Pure data, resolved
+        # once at prompt-build time, so it never busts the prefix cache.
+        # Empty by default (no overrides => byte-identical prompt).  See the
+        # fragment-key registry in agent/prompt_overrides.py.
+        "prompt_overrides": {},
         # Local-environment toolchain probe — surfaces Python/pip/uv/PEP-668
         # state in the system prompt when something non-default is detected
         # (e.g. python3 has no pip module, pip→python version mismatch, PEP

--- a/tests/agent/test_prompt_overrides.py
+++ b/tests/agent/test_prompt_overrides.py
@@ -1,0 +1,127 @@
+"""Unit tests for the declarative system-prompt fragment override engine
+(agent/prompt_overrides.py)."""
+
+from agent.prompt_overrides import (
+    FRAGMENT_KEYS,
+    VALID_MODES,
+    apply_fragment_override,
+    normalize_overrides,
+)
+
+
+class TestNormalizeOverrides:
+    def test_empty_and_none(self):
+        assert normalize_overrides(None) == {}
+        assert normalize_overrides({}) == {}
+
+    def test_non_mapping_ignored(self):
+        assert normalize_overrides("nope") == {}
+        assert normalize_overrides(["a", "b"]) == {}
+
+    def test_bare_string_is_replace_shorthand(self):
+        out = normalize_overrides({"steer_channel": "short note"})
+        assert out == {"steer_channel": {"mode": "replace", "text": "short note"}}
+
+    def test_full_spec(self):
+        out = normalize_overrides(
+            {"task_completion": {"mode": "append", "text": "more"}}
+        )
+        assert out == {"task_completion": {"mode": "append", "text": "more"}}
+
+    def test_remove_drops_text(self):
+        out = normalize_overrides({"google_operational": {"mode": "remove"}})
+        assert out == {"google_operational": {"mode": "remove", "text": ""}}
+
+    def test_unknown_key_dropped(self):
+        assert normalize_overrides({"bogus": "x"}) == {}
+
+    def test_invalid_mode_dropped(self):
+        assert normalize_overrides({"identity": {"mode": "sideways", "text": "x"}}) == {}
+
+    def test_mode_case_insensitive(self):
+        out = normalize_overrides({"identity": {"mode": "REPLACE", "text": "x"}})
+        assert out["identity"]["mode"] == "replace"
+
+    def test_missing_mode_defaults_replace(self):
+        out = normalize_overrides({"identity": {"text": "x"}})
+        assert out["identity"]["mode"] == "replace"
+
+    def test_append_empty_text_is_noop_dropped(self):
+        assert normalize_overrides({"identity": {"mode": "append", "text": "  "}}) == {}
+
+    def test_replace_empty_text_allowed(self):
+        # replace with "" is a legitimate way to blank a fragment via text
+        out = normalize_overrides({"identity": {"mode": "replace", "text": ""}})
+        assert out == {"identity": {"mode": "replace", "text": ""}}
+
+    def test_non_string_text_dropped(self):
+        assert normalize_overrides({"identity": {"mode": "replace", "text": 5}}) == {}
+
+    def test_non_dict_non_str_spec_dropped(self):
+        assert normalize_overrides({"identity": ["a"]}) == {}
+
+    def test_mixed_valid_and_invalid(self):
+        out = normalize_overrides(
+            {
+                "task_completion": "keep this",
+                "bogus": "drop this",
+                "google_operational": {"mode": "remove"},
+            }
+        )
+        assert set(out) == {"task_completion", "google_operational"}
+
+
+class TestApplyFragmentOverride:
+    def test_no_overrides_passthrough(self):
+        assert apply_fragment_override(None, "identity", "ID") == "ID"
+        assert apply_fragment_override({}, "identity", "ID") == "ID"
+
+    def test_unmatched_key_passthrough(self):
+        ov = normalize_overrides({"identity": "X"})
+        assert apply_fragment_override(ov, "task_completion", "ORIG") == "ORIG"
+
+    def test_replace(self):
+        ov = normalize_overrides({"identity": {"mode": "replace", "text": "NEW"}})
+        assert apply_fragment_override(ov, "identity", "OLD") == "NEW"
+
+    def test_remove_returns_none(self):
+        ov = normalize_overrides({"identity": {"mode": "remove"}})
+        assert apply_fragment_override(ov, "identity", "OLD") is None
+
+    def test_append(self):
+        ov = normalize_overrides({"identity": {"mode": "append", "text": "B"}})
+        assert apply_fragment_override(ov, "identity", "A") == "A\n\nB"
+
+    def test_prepend(self):
+        ov = normalize_overrides({"identity": {"mode": "prepend", "text": "B"}})
+        assert apply_fragment_override(ov, "identity", "A") == "B\n\nA"
+
+    def test_append_to_empty_default_yields_new(self):
+        ov = normalize_overrides({"identity": {"mode": "append", "text": "B"}})
+        assert apply_fragment_override(ov, "identity", "") == "B"
+        assert apply_fragment_override(ov, "identity", None) == "B"
+
+    def test_prepend_to_empty_default_yields_new(self):
+        ov = normalize_overrides({"identity": {"mode": "prepend", "text": "B"}})
+        assert apply_fragment_override(ov, "identity", "   ") == "B"
+
+
+class TestFragmentKeyRegistry:
+    def test_keys_present_and_documented(self):
+        assert len(FRAGMENT_KEYS) == 16
+        for key, desc in FRAGMENT_KEYS.items():
+            assert isinstance(key, str) and key
+            assert isinstance(desc, str) and desc.strip()
+
+    def test_core_pushy_blocks_addressable(self):
+        # The fragments that motivated this feature must be overridable.
+        for key in (
+            "task_completion",
+            "tool_use_enforcement",
+            "execution_discipline",
+            "google_operational",
+        ):
+            assert key in FRAGMENT_KEYS
+
+    def test_valid_modes(self):
+        assert VALID_MODES == ("replace", "append", "prepend", "remove")

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1602,6 +1602,94 @@ class TestTaskCompletionGuidance:
             assert TASK_COMPLETION_GUIDANCE not in a._build_system_prompt()
 
 
+class TestPromptOverridesIntegration:
+    """End-to-end wiring for declarative per-fragment overrides
+    (config.yaml ``agent.prompt_overrides``).  The resolution engine is
+    unit-tested in tests/agent/test_prompt_overrides.py; this class confirms
+    the overrides actually reshape the assembled system prompt."""
+
+    def _make_agent(self, model="anthropic/claude-opus-4.8", **extra_cfg):
+        agent_cfg = dict(extra_cfg)
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs("terminal", "web_search"),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={"agent": agent_cfg},
+            ),
+        ):
+            a = AIAgent(
+                model=model,
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            a.client = MagicMock()
+            return a
+
+    def test_no_overrides_byte_identical(self):
+        """Empty overrides must produce the exact same prompt as no
+        overrides at all — the cache-warmth guarantee."""
+        baseline = self._make_agent()._build_system_prompt()
+        with_empty = self._make_agent(prompt_overrides={})._build_system_prompt()
+        assert baseline == with_empty
+
+    def test_replace_swaps_fragment(self):
+        from agent.prompt_builder import TASK_COMPLETION_GUIDANCE
+
+        sentinel = "STOP-AND-REPORT-ON-FRICTION-XYZZY"
+        agent = self._make_agent(
+            prompt_overrides={
+                "task_completion": {"mode": "replace", "text": sentinel}
+            }
+        )
+        prompt = agent._build_system_prompt()
+        assert TASK_COMPLETION_GUIDANCE not in prompt
+        assert sentinel in prompt
+
+    def test_remove_drops_fragment(self):
+        from agent.prompt_builder import TASK_COMPLETION_GUIDANCE
+
+        agent = self._make_agent(
+            prompt_overrides={"task_completion": {"mode": "remove"}}
+        )
+        assert TASK_COMPLETION_GUIDANCE not in agent._build_system_prompt()
+
+    def test_append_keeps_original_and_adds(self):
+        from agent.prompt_builder import TASK_COMPLETION_GUIDANCE
+
+        sentinel = "FRICTION-CAVEAT-PLUGH"
+        agent = self._make_agent(
+            prompt_overrides={
+                "task_completion": {"mode": "append", "text": sentinel}
+            }
+        )
+        prompt = agent._build_system_prompt()
+        assert TASK_COMPLETION_GUIDANCE in prompt
+        assert sentinel in prompt
+
+    def test_unknown_key_ignored_no_crash(self):
+        from agent.prompt_builder import TASK_COMPLETION_GUIDANCE
+
+        agent = self._make_agent(prompt_overrides={"not_a_fragment": "x"})
+        prompt = agent._build_system_prompt()
+        assert TASK_COMPLETION_GUIDANCE in prompt  # baseline intact
+
+    def test_bare_string_shorthand_replaces(self):
+        from agent.prompt_builder import TASK_COMPLETION_GUIDANCE
+
+        agent = self._make_agent(prompt_overrides={"task_completion": "SHORTHAND-REPL"})
+        prompt = agent._build_system_prompt()
+        assert TASK_COMPLETION_GUIDANCE not in prompt
+        assert "SHORTHAND-REPL" in prompt
+
+
 class TestEnvironmentProbeIntegration:
     """Tests for the local Python toolchain probe wiring (config.yaml
     ``agent.environment_probe``).  The probe itself is unit-tested in

--- a/website/docs/developer-guide/prompt-assembly.md
+++ b/website/docs/developer-guide/prompt-assembly.md
@@ -282,6 +282,31 @@ Most users should treat `agent/prompt_builder.py` as implementation code, not a 
 - Optional system prompt config / API overrides — add deployment-specific instruction text without forking Hermes.
 - Ephemeral overlays such as `HERMES_EPHEMERAL_SYSTEM_PROMPT` or prefill messages — add turn-scoped guidance that should not become part of the cached prompt prefix.
 
+### Per-fragment overrides (`agent.prompt_overrides`)
+
+When you need to reshape a *specific* built-in guidance fragment — not your identity, not project rules, but one of the stable-tier blocks Hermes ships (e.g. the "Finishing the job" or "Tool-use enforcement" guidance) — use `agent.prompt_overrides` in `config.yaml`. Every named stable-tier fragment carries a stable key, and you can `replace`, `append`, `prepend`, or `remove` it without editing source:
+
+```yaml
+agent:
+  prompt_overrides:
+    # Append a stop-on-friction caveat to the universal completion guidance:
+    task_completion:
+      mode: append
+      text: >-
+        Exception — environment friction: if a tool, filesystem, dependency,
+        credential, integration, or environment problem blocks the real path,
+        STOP immediately, report the exact failure, and wait for the user to
+        fix it at the source. Do NOT work around it unless the user approves.
+    google_operational: { mode: remove }
+    steer_channel: "Use the steer channel only for urgent corrections."   # bare string = replace
+```
+
+This is **pure data, resolved once at prompt-build time** — there is no callable hook and no conditional logic, by design. The assembled prompt stays a deterministic function of (agent, config), so it remains byte-stable across turns and the provider prefix cache stays warm. With no overrides configured, the prompt is byte-identical to the default. An override only takes effect when the fragment is actually emitted this session, and `append`/`prepend` to an absent fragment is a no-op.
+
+Fragment keys (stable tier): `identity`, `hermes_help`, `task_completion`, `tool_guidance`, `steer_channel`, `computer_use`, `nous_subscription`, `tool_use_enforcement`, `google_operational`, `execution_discipline`, `skills`, `model_identity`, `environment_hints`, `environment_probe`, `active_profile`, `platform_hints`. The canonical registry (with one-line descriptions) lives in `agent/prompt_overrides.py` (`FRAGMENT_KEYS`).
+
+Prefer the higher-level surfaces above for identity and project rules; reach for `prompt_overrides` when you specifically need to reshape one of Hermes's own guidance blocks in place.
+
 ### When to edit code instead
 
 Edit `agent/prompt_builder.py` only if you are intentionally maintaining a fork or contributing upstream behavior changes. That file assembles the prompt plumbing, cache boundaries, and injection order for every session. Direct edits there are global product changes, not per-user prompt customization.


### PR DESCRIPTION
## What & why

Adds `agent.prompt_overrides` — a config surface to reshape any named **stable-tier** system-prompt fragment (`replace` / `append` / `prepend` / `remove`) without editing source.

Today the built-in guidance blocks are either hardcoded or gated by bespoke all-or-nothing booleans (`task_completion_guidance`, `tool_use_enforcement`, `environment_probe`). That only lets you *delete* a whole block, never *reshape* it — so the common need to qualify a block (e.g. append a "stop and report on environment friction instead of working around it" caveat to the "Finishing the job" guidance) has no clean path short of forking. This generalizes those one-off toggles into a uniform, discoverable override map and gives users real context-engineering control.

### Design: pure data, cache-safe by construction

Every stable-tier fragment now carries a stable key and is emitted through a single override-aware `emit()` choke point in `build_system_prompt_parts`. Overrides are **pure data resolved once at build time** — no callable hook, no conditional logic, by design. The assembled prompt stays a deterministic function of `(agent, config)`, so it remains byte-stable across turns and the provider prefix cache stays warm. With no overrides configured the prompt is **byte-identical** to the default (covered by a regression test). An override only applies when the fragment is actually emitted this session; `append`/`prepend` to an absent fragment is a no-op.

Scope is intentionally the stable tier (Hermes-authored guidance/identity). Context-tier (project files, system message) and volatile-tier (memory, timestamp) are user/session *data*, not prompt fragments; `emit()` is tier-agnostic so extending later is trivial.

### Example

```yaml
agent:
  prompt_overrides:
    task_completion:
      mode: append
      text: >-
        Exception — environment friction: if a tool, filesystem, dependency,
        credential, integration, or environment problem blocks the real path,
        STOP immediately, report the exact failure, and wait for the user to
        fix it at the source. Do NOT work around it unless the user approves.
    google_operational: { mode: remove }
    steer_channel: "Use the steer channel only for urgent corrections."  # bare string = replace
```

Fragment keys (16, stable tier): `identity`, `hermes_help`, `task_completion`, `tool_guidance`, `steer_channel`, `computer_use`, `nous_subscription`, `tool_use_enforcement`, `google_operational`, `execution_discipline`, `skills`, `model_identity`, `environment_hints`, `environment_probe`, `active_profile`, `platform_hints`. Canonical registry with descriptions lives in `agent/prompt_overrides.py` (`FRAGMENT_KEYS`).

Existing on/off toggles are untouched and still work.

## How to test

```bash
scripts/run_tests.sh tests/agent/test_prompt_overrides.py        # 25 engine unit tests
scripts/run_tests.sh tests/run_agent/test_run_agent.py           # 383, incl. 6 new integration tests
scripts/run_tests.sh tests/agent/test_prompt_builder.py          # 130, assembly regression
```

- `test_no_overrides_byte_identical` asserts the cache-warmth guarantee (empty overrides → identical prompt).
- Integration tests exercise replace / append / remove / bare-string-shorthand / unknown-key-ignored through the full `_build_system_prompt()` path.

Manual:
```yaml
# ~/.hermes/config.yaml
agent:
  prompt_overrides:
    task_completion: { mode: remove }
```
…then `hermes chat` and confirm the "Finishing the job" block is gone (and present again without the override).

## Platforms

Pure-Python config plumbing, no OS-specific code paths. Developed/tested on Linux.

## Files

- `agent/prompt_overrides.py` (new) — registry + `normalize_overrides` + `apply_fragment_override`
- `agent/system_prompt.py` — 16 stable-tier append sites routed through `emit()`
- `agent/agent_init.py` — load + normalize config
- `hermes_cli/config.py`, `cli-config.yaml.example` — default + worked example
- `website/docs/developer-guide/prompt-assembly.md` — override surface docs
- tests — 25 unit + 6 integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)