### PR TITLE
Reuse MCP OAuth callback listener addresses

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -2,8 +2,11 @@
 
 import json
 import os
+import socket
 import stat
 import sys
+import threading
+import time
 from io import BytesIO
 from unittest.mock import patch, MagicMock
 
@@ -21,6 +24,7 @@ from tools.mcp_oauth import (
     _is_interactive,
     _wait_for_callback,
     _make_callback_handler,
+    _make_callback_server,
     _redirect_handler,
     _paste_callback_reader,
 )
@@ -474,6 +478,60 @@ class TestWaitForCallbackNoBlocking:
             with patch("builtins.input", side_effect=AssertionError("input() must not be called")):
                 with pytest.raises(OAuthNonInteractiveError, match="callback timed out"):
                     asyncio.run(_wait_for_callback())
+
+
+class TestCallbackServerReuse:
+    """Callback listener should tolerate sequential flows on a fixed port."""
+
+    def test_callback_server_enables_address_reuse(self):
+        handler_cls, _ = _make_callback_handler()
+        port = _find_free_port()
+        server = _make_callback_server(port, handler_cls)
+        try:
+            assert server.allow_reuse_address is True
+            assert server.__class__.allow_reuse_address is True
+        finally:
+            server.server_close()
+
+    def test_wait_for_callback_can_rebind_same_port(self, monkeypatch):
+        import tools.mcp_oauth as mod
+
+        monkeypatch.setattr(mod, "_is_interactive", lambda: False)
+        port = _find_free_port()
+        mod._oauth_port = port
+
+        def run_round(code: str) -> tuple[str, str | None]:
+            errors: list[Exception] = []
+
+            def send_callback():
+                deadline = time.time() + 5
+                while time.time() < deadline:
+                    try:
+                        with socket.create_connection(("127.0.0.1", port), timeout=0.2) as sock:
+                            request = (
+                                f"GET /callback?code={code}&state=state-{code} HTTP/1.1\r\n"
+                                f"Host: 127.0.0.1:{port}\r\n"
+                                "Connection: close\r\n\r\n"
+                            )
+                            sock.sendall(request.encode())
+                            sock.recv(4096)
+                            return
+                    except OSError:
+                        time.sleep(0.01)
+                errors.append(TimeoutError(f"callback sender timed out for {code}"))
+
+            sender = threading.Thread(target=send_callback, daemon=True)
+            sender.start()
+            result = asyncio.run(_wait_for_callback())
+            sender.join(timeout=1)
+            assert not errors, errors
+            return result
+
+        first = run_round("first")
+        second = run_round("second")
+
+        assert first == ("first", "state-first")
+        assert second == ("second", "state-second")
 
 
 class TestBuildOAuthAuthNonInteractive:

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -392,6 +392,22 @@ def _make_callback_handler() -> tuple[type, dict]:
     return _Handler, result
 
 
+class _ReusableCallbackHTTPServer(HTTPServer):
+    """One-shot callback server that can immediately rebind the same port."""
+
+    allow_reuse_address = True
+
+
+def _make_callback_server(port: int, handler_cls: type[BaseHTTPRequestHandler]) -> HTTPServer:
+    """Build the ephemeral callback server with address reuse enabled.
+
+    OAuth flows often reuse a fixed redirect port. Explicitly enabling
+    ``SO_REUSEADDR`` avoids spurious ``Address already in use`` failures when
+    the previous one-shot listener just accepted a callback on the same port.
+    """
+    return _ReusableCallbackHTTPServer(("127.0.0.1", port), handler_cls)
+
+
 # ---------------------------------------------------------------------------
 # Async redirect + callback handlers for OAuthClientProvider
 # ---------------------------------------------------------------------------
@@ -480,7 +496,7 @@ async def _wait_for_callback() -> tuple[str, str | None]:
 
     # Start a temporary server on the known port
     try:
-        server = HTTPServer(("127.0.0.1", _oauth_port), handler_cls)
+        server = _make_callback_server(_oauth_port, handler_cls)
     except OSError:
         # Port already in use — the server from build_oauth_auth is running.
         # Fall back to polling the server started by build_oauth_auth.


### PR DESCRIPTION
## Summary
- make the one-shot MCP OAuth callback server reuse its address on fixed redirect ports
- route callback server creation through a dedicated helper
- add a real same-port regression test for sequential callback flows

Closes #44590