### PR TITLE
improve(hermes): sanitize cron context payloads

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -58,6 +58,32 @@ class CronPromptInjectionBlocked(Exception):
     """
 
 
+def _extract_cron_context_payload(output: str) -> str:
+    """Return the useful payload from a stored cron output artifact."""
+    text = (output or "").strip()
+    if not text:
+        return ""
+
+    if "\n## Response\n" in text:
+        payload = text.rsplit("\n## Response\n", 1)[1].strip()
+        return "" if payload == "(No response generated)" else payload
+
+    if "\n## Error\n" in text:
+        payload = text.rsplit("\n## Error\n", 1)[1].strip()
+        header = []
+        for line in text.splitlines():
+            if line.startswith("# Cron Job:") or line.startswith("**Job ID:**"):
+                header.append(line)
+            elif line.startswith("**Run Time:**") or line.startswith("**Schedule:**"):
+                header.append(line)
+        prefix = "\n".join(header).strip()
+        if prefix:
+            return f"{prefix}\n\n## Error\n\n{payload}".strip()
+        return f"## Error\n\n{payload}".strip()
+
+    return text
+
+
 def _resolve_cron_disabled_toolsets(cfg: dict) -> list[str]:
     """Toolsets a cron-spawned agent must never receive.
 
@@ -1107,7 +1133,9 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                 )
                 if not output_files:
                     continue  # silent skip — no output yet
-                latest_output = output_files[0].read_text(encoding="utf-8").strip()
+                latest_output = _extract_cron_context_payload(
+                    output_files[0].read_text(encoding="utf-8")
+                )
                 # Truncate to 8K characters to avoid prompt bloat
                 _MAX_CONTEXT_CHARS = 8000
                 if len(latest_output) > _MAX_CONTEXT_CHARS:

--- a/tests/cron/test_cron_context_from.py
+++ b/tests/cron/test_cron_context_from.py
@@ -102,6 +102,119 @@ class TestBuildJobPromptContextFrom:
         assert "Today's top story: AI is everywhere." in prompt
         assert f"Output from job '{job_a['id']}'" in prompt
 
+    def test_context_from_extracts_response_from_cron_artifact(self, cron_env):
+        """Downstream jobs should not inherit upstream prompts or cron hints."""
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        job_a = create_job(prompt="Find news", schedule="every 1h")
+        output_dir = OUTPUT_DIR / job_a["id"]
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "2026-04-22_10-00-00.md").write_text(
+            """# Cron Job: upstream
+
+**Job ID:** abc123
+**Run Time:** 2026-04-22 10:00:00
+**Schedule:** every 1h
+
+## Prompt
+
+[IMPORTANT: internal delivery instruction]
+
+Find private setup details.
+
+## Response
+
+Actionable upstream result.
+""",
+            encoding="utf-8",
+        )
+
+        job_b = create_job(
+            prompt="Summarize the news",
+            schedule="every 2h",
+            context_from=job_a["id"],
+        )
+
+        prompt = _build_job_prompt(job_b)
+        assert "Actionable upstream result." in prompt
+        assert "Find private setup details" not in prompt
+        assert prompt.count("[IMPORTANT:") == 1
+
+    def test_context_from_uses_outer_response_for_chained_artifact(self, cron_env):
+        """Nested upstream artifacts should not make context extraction stop early."""
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        job_a = create_job(prompt="Validate", schedule="every 1h")
+        output_dir = OUTPUT_DIR / job_a["id"]
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "2026-04-22_10-00-00.md").write_text(
+            """# Cron Job: validation
+
+## Prompt
+
+```
+# Cron Job: review
+
+## Response
+
+Nested review response.
+```
+
+## Response
+
+Final validation response.
+""",
+            encoding="utf-8",
+        )
+
+        job_b = create_job(
+            prompt="Queue actions",
+            schedule="every 2h",
+            context_from=job_a["id"],
+        )
+
+        prompt = _build_job_prompt(job_b)
+        assert "Final validation response." in prompt
+        assert "Nested review response." not in prompt
+
+    def test_context_from_extracts_error_from_failed_cron_artifact(self, cron_env):
+        """Failed upstream jobs should pass the failure, not the failed prompt."""
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        job_a = create_job(prompt="Find news", schedule="every 1h")
+        output_dir = OUTPUT_DIR / job_a["id"]
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "2026-04-22_10-00-00.md").write_text(
+            """# Cron Job: upstream (FAILED)
+
+**Job ID:** abc123
+
+## Prompt
+
+Run broad analysis.
+
+## Error
+
+```
+RuntimeError: upstream failed
+```
+""",
+            encoding="utf-8",
+        )
+
+        job_b = create_job(
+            prompt="Summarize the news",
+            schedule="every 2h",
+            context_from=job_a["id"],
+        )
+
+        prompt = _build_job_prompt(job_b)
+        assert "RuntimeError: upstream failed" in prompt
+        assert "Run broad analysis" not in prompt
+
     def test_uses_most_recent_output(self, cron_env):
         from cron.jobs import create_job, OUTPUT_DIR
         from cron.scheduler import _build_job_prompt


### PR DESCRIPTION
## Summary
- Fix cron context_from injection to pass only the upstream ## Response payload into downstream jobs
- Preserve failed upstream job errors without replaying the failed upstream prompt
- Add regression coverage for response extraction, nested cron artifacts, and failed artifacts

## Trigger
Hermes cron-review-evolve on 2026-06-11 found the weekday code-improvement chain marked ok while validation/action-queue consumed full upstream cron artifacts, including ## Prompt sections, producing non-actionable output.

## Verification
- /Users/bryanmassenzo/.hermes/hermes-agent/venv/bin/python -m pytest tests/cron/test_cron_context_from.py -q
- /Users/bryanmassenzo/.hermes/hermes-agent/venv/bin/python -m pytest tests/cron -q
- Live prompt smoke: weekday-code-action-queue context contains no prior prompt text and exactly one cron hint

Order authority: none. No broker, order-placement, credential, sandbox, or kill-switch behavior changed.