### PR TITLE
fix(desktop): clarify voice transcription setup errors

### DIFF
--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -108,10 +108,16 @@ export const en: Translations = {
       elevenLabsRejectedKey: 'ElevenLabs rejected the API key (401).',
       methodNotAllowed:
         'The desktop backend rejected that request (405 Method Not Allowed). Try restarting Hermes Desktop.',
+      localSttUnavailable:
+        'Local speech-to-text is not ready. Install faster-whisper or choose another STT provider in Settings.',
       microphonePermission: 'Microphone permission was denied.',
       openaiRejectedApiKey: 'OpenAI rejected the API key.',
       openaiRejectedApiKeyWithStatus: status => `OpenAI rejected the API key (${status} invalid_api_key).`,
-      openaiTtsNeedsKey: 'OpenAI TTS needs VOICE_TOOLS_OPENAI_KEY or OPENAI_API_KEY.'
+      openaiTtsNeedsKey: 'OpenAI TTS needs VOICE_TOOLS_OPENAI_KEY or OPENAI_API_KEY.',
+      sttProviderUnavailable:
+        'No speech-to-text provider is configured. Install local STT or add a transcription API key in Settings.',
+      voiceTranscriptionStillStarting:
+        'Transcription is still starting. First local STT setup can take a few minutes; try again once the model finishes loading.'
     },
     voice: {
       configureSpeechToText: 'Configure speech-to-text to use voice mode.',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -109,10 +109,16 @@ export const ja = defineLocale({
       elevenLabsRejectedKey: 'ElevenLabs が API キーを拒否しました (401)。',
       methodNotAllowed:
         'デスクトップバックエンドがそのリクエストを拒否しました (405 Method Not Allowed)。Hermes Desktop を再起動してください。',
+      localSttUnavailable:
+        'ローカル音声文字起こしの準備ができていません。faster-whisper をインストールするか、設定で別の STT プロバイダーを選択してください。',
       microphonePermission: 'マイクのアクセス許可が拒否されました。',
       openaiRejectedApiKey: 'OpenAI が API キーを拒否しました。',
       openaiRejectedApiKeyWithStatus: status => `OpenAI が API キーを拒否しました (${status} invalid_api_key)。`,
-      openaiTtsNeedsKey: 'OpenAI TTS には VOICE_TOOLS_OPENAI_KEY または OPENAI_API_KEY が必要です。'
+      openaiTtsNeedsKey: 'OpenAI TTS には VOICE_TOOLS_OPENAI_KEY または OPENAI_API_KEY が必要です。',
+      sttProviderUnavailable:
+        '音声文字起こしプロバイダーが設定されていません。ローカル STT をインストールするか、設定で文字起こし API キーを追加してください。',
+      voiceTranscriptionStillStarting:
+        '文字起こしはまだ起動中です。初回のローカル STT セットアップには数分かかることがあります。モデルの読み込みが終わってからもう一度お試しください。'
     },
     voice: {
       configureSpeechToText: '音声モードを使用するには音声認識を設定してください。',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -119,10 +119,13 @@ export interface Translations {
       elevenLabsNeedsKey: string
       elevenLabsRejectedKey: string
       methodNotAllowed: string
+      localSttUnavailable: string
       microphonePermission: string
       openaiRejectedApiKey: string
       openaiRejectedApiKeyWithStatus: (status: string) => string
       openaiTtsNeedsKey: string
+      sttProviderUnavailable: string
+      voiceTranscriptionStillStarting: string
     }
     voice: {
       configureSpeechToText: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -104,10 +104,13 @@ export const zhHant = defineLocale({
       elevenLabsNeedsKey: 'ElevenLabs STT 需要 ELEVENLABS_API_KEY。',
       elevenLabsRejectedKey: 'ElevenLabs 拒絕了該 API 金鑰 (401)。',
       methodNotAllowed: '桌面後端拒絕了該請求 (405 Method Not Allowed)。請嘗試重新啟動 Hermes Desktop。',
+      localSttUnavailable: '本機語音轉文字尚未就緒。請安裝 faster-whisper，或在設定中選擇其他 STT 提供者。',
       microphonePermission: '麥克風權限已被拒絕。',
       openaiRejectedApiKey: 'OpenAI 拒絕了該 API 金鑰。',
       openaiRejectedApiKeyWithStatus: status => `OpenAI 拒絕了該 API 金鑰 (${status} invalid_api_key)。`,
-      openaiTtsNeedsKey: 'OpenAI TTS 需要 VOICE_TOOLS_OPENAI_KEY 或 OPENAI_API_KEY。'
+      openaiTtsNeedsKey: 'OpenAI TTS 需要 VOICE_TOOLS_OPENAI_KEY 或 OPENAI_API_KEY。',
+      sttProviderUnavailable: '尚未設定語音轉文字提供者。請安裝本機 STT，或在設定中新增轉寫 API 金鑰。',
+      voiceTranscriptionStillStarting: '語音轉寫仍在啟動中。首次本機 STT 設定可能需要幾分鐘；請等模型載入完成後再試。'
     },
     voice: {
       configureSpeechToText: '設定語音轉文字後即可使用語音模式。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -104,10 +104,13 @@ export const zh: Translations = {
       elevenLabsNeedsKey: 'ElevenLabs STT 需要 ELEVENLABS_API_KEY。',
       elevenLabsRejectedKey: 'ElevenLabs 拒绝了该 API key (401)。',
       methodNotAllowed: '桌面后端拒绝了该请求 (405 Method Not Allowed)。请尝试重启 Hermes Desktop。',
+      localSttUnavailable: '本地语音转文字尚未就绪。请安装 faster-whisper，或在设置中选择其他 STT 提供方。',
       microphonePermission: '麦克风权限已被拒绝。',
       openaiRejectedApiKey: 'OpenAI 拒绝了该 API key。',
       openaiRejectedApiKeyWithStatus: status => `OpenAI 拒绝了该 API key (${status} invalid_api_key)。`,
-      openaiTtsNeedsKey: 'OpenAI TTS 需要 VOICE_TOOLS_OPENAI_KEY 或 OPENAI_API_KEY。'
+      openaiTtsNeedsKey: 'OpenAI TTS 需要 VOICE_TOOLS_OPENAI_KEY 或 OPENAI_API_KEY。',
+      sttProviderUnavailable: '尚未配置语音转文字提供方。请安装本地 STT，或在设置中添加转写 API key。',
+      voiceTranscriptionStillStarting: '语音转写仍在启动中。首次本地 STT 设置可能需要几分钟；请等模型加载完成后再试。'
     },
     voice: {
       configureSpeechToText: '配置语音转文字后即可使用语音模式。',

--- a/apps/desktop/src/store/notifications.test.ts
+++ b/apps/desktop/src/store/notifications.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { $notifications, clearNotifications, notifyError } from './notifications'
+
+describe('notifyError voice transcription summaries', () => {
+  afterEach(() => {
+    clearNotifications()
+  })
+
+  it('surfaces an actionable setup message when no STT provider is available', () => {
+    notifyError(
+      new Error(
+        '400: {"detail":"No STT provider available. Install faster-whisper for free local transcription, configure HERMES_LOCAL_STT_COMMAND or set an API key."}'
+      ),
+      'Voice transcription failed'
+    )
+
+    expect($notifications.get()[0]).toMatchObject({
+      kind: 'error',
+      title: 'Voice transcription failed',
+      message: 'No speech-to-text provider is configured. Install local STT or add a transcription API key in Settings.'
+    })
+  })
+
+  it('explains local STT dependency failures without hiding the backend detail', () => {
+    notifyError(new Error('400: {"detail":"Local transcription failed: faster-whisper not installed"}'), 'Voice transcription failed')
+
+    expect($notifications.get()[0]).toMatchObject({
+      message: 'Local speech-to-text is not ready. Install faster-whisper or choose another STT provider in Settings.',
+      detail: 'Local transcription failed: faster-whisper not installed'
+    })
+  })
+
+  it('explains configured local STT provider availability failures', () => {
+    notifyError(new Error("400: {\"detail\":\"STT provider 'local' configured but unavailable\"}"), 'Voice transcription failed')
+
+    expect($notifications.get()[0]).toMatchObject({
+      message: 'Local speech-to-text is not ready. Install faster-whisper or choose another STT provider in Settings.',
+      detail: "STT provider 'local' configured but unavailable"
+    })
+  })
+
+  it('explains first-run transcription timeouts as a setup/loading condition', () => {
+    notifyError(new Error('Timed out connecting to Hermes backend after 15000ms'), 'Voice transcription failed')
+
+    expect($notifications.get()[0]).toMatchObject({
+      message:
+        'Transcription is still starting. First local STT setup can take a few minutes; try again once the model finishes loading.',
+      detail: 'Timed out connecting to Hermes backend after 15000ms'
+    })
+  })
+})

--- a/apps/desktop/src/store/notifications.ts
+++ b/apps/desktop/src/store/notifications.ts
@@ -50,6 +50,14 @@ function cleanErrorText(value: string) {
 
 const ERROR_SUMMARIES: { test: (msg: string) => boolean; summarize: (msg: string) => string }[] = [
   {
+    test: msg => /No STT provider available/i.test(msg),
+    summarize: () => translateNow('notifications.errors.sttProviderUnavailable')
+  },
+  {
+    test: msg => /faster-whisper not installed/i.test(msg) || /STT provider 'local' configured but unavailable/i.test(msg),
+    summarize: () => translateNow('notifications.errors.localSttUnavailable')
+  },
+  {
     test: msg => /incorrect api key provided/i.test(msg) || /['"]code['"]\s*:\s*['"]invalid_api_key['"]/i.test(msg),
     summarize: msg => {
       const status = msg.match(/(?:error code|status(?:Code)?)[^\d]*(\d{3})/i)?.[1]
@@ -81,6 +89,10 @@ const ERROR_SUMMARIES: { test: (msg: string) => boolean; summarize: (msg: string
 ]
 
 function summarizeErrorMessage(message: string, fallback: string) {
+  if (/transcription/i.test(fallback) && /Timed out connecting to Hermes backend after \d+ms/i.test(message)) {
+    return translateNow('notifications.errors.voiceTranscriptionStillStarting')
+  }
+
   const rule = ERROR_SUMMARIES.find(r => r.test(message))
 
   if (rule) {


### PR DESCRIPTION
## Summary

- add actionable Desktop notification summaries for common voice transcription setup failures
- explain missing STT provider, unavailable local STT, and first-run backend timeout cases
- add localized strings and regression tests for the notification summaries

## Tests

```text
npm --workspace apps/desktop run test:ui -- src/store/notifications.test.ts
# 1 test file passed, 4 tests passed

npm --workspace apps/desktop run typecheck
# passed
```

## Preflight

- searched open PRs for overlapping Desktop voice transcription error-message work; no matching open PR found
- scanned the staged diff for private/local/user-specific terms: clean
- scanned for real secret values: clean
- independent review passed with no security, privacy, or logic blockers
