### PR TITLE
fix: fallback to find for non-ASCII glob patterns in file search

### DIFF
--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2041,6 +2041,26 @@ class ShellFileOperations(FileOperations):
             result = self._exec(cmd_plain, timeout=60)
             all_files = [f for f in result.stdout.strip().split('\n') if f]
 
+        # rg glob engine silently fails on non-ASCII (e.g. CJK) patterns on
+        # Windows/MSYS -- returns exit 1 with no output even when matching
+        # files exist.  Fall back to `find -name` which handles CJK correctly.
+        if not all_files and any(ord(c) > 127 for c in glob_pattern):
+            find_cmd = (
+                f"find {self._escape_shell_arg(path)} -type f "
+                f"-name {self._escape_shell_arg(glob_pattern)} "
+                f"-printf '%T@ %p\\n' 2>/dev/null | sort -rn"
+            )
+            result = self._exec(find_cmd, timeout=60)
+            if result.stdout.strip():
+                for line in result.stdout.strip().split('\n'):
+                    if not line:
+                        continue
+                    parts = line.split(' ', 1)
+                    if len(parts) == 2 and parts[0].replace('.', '').isdigit():
+                        all_files.append(parts[1])
+                    else:
+                        all_files.append(line)
+
         page = all_files[offset:offset + limit]
 
         return SearchResult(


### PR DESCRIPTION
## Problem

`search_files(target="files")` returns empty results when the glob pattern contains non-ASCII characters (e.g. CJK/Japanese/Korean) on Windows with MSYS/Git Bash.

**Root cause**: ripgrep's glob engine silently returns exit 1 with no output when the glob pattern contains multi-byte Unicode characters. The files exist and are accessible via other tools, but rg's glob matcher fails to match them.

**Reproduction** (Windows 10 + MSYS2/Git Bash):
```bash
# Setup: create a file with CJK name
echo test > /tmp/test_dir/文件名.jsonl

# rg glob: fails silently
rg --files -g '*文件名*' /tmp/test_dir   # exit 1, empty

# find: works correctly  
find /tmp/test_dir -name '*文件名*'       # finds the file
```

This causes the agent to incorrectly conclude that files do not exist, leading to fabricated "file not found" conclusions.

## Fix

In `_search_files_rg()`, when both rg attempts (sorted + plain) return empty and the glob pattern contains non-ASCII characters, fall back to `find -name` which handles CJK correctly.

The fallback only triggers when:
1. rg returned no results (both sorted and plain attempts)
2. The glob pattern contains at least one non-ASCII character (`ord(c) > 127`)

ASCII-only patterns pay zero overhead.

## Testing

Verified on Windows 10 + MSYS2/Git Bash:
- `search_files(target="files", pattern="*CJK_chars*")` now returns results via find fallback
- `search_files(target="files", pattern="*.py")` still uses rg (fast path, no change)
- Content search (`target="content"`) is unaffected