### PR TITLE
fix(desktop): let the edit composer scroll long prompts

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
@@ -629,7 +629,7 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
               autoCapitalize="off"
               autoCorrect="off"
               className={cn(
-                'ui-prompt-input-editor__input max-h-48 w-full resize-none bg-transparent p-0 pr-7 text-[length:var(--conversation-text-font-size)] text-foreground/95 outline-none',
+                'ui-prompt-input-editor__input max-h-48 w-full resize-none overflow-y-auto bg-transparent p-0 pr-7 text-[length:var(--conversation-text-font-size)] text-foreground/95 outline-none',
                 'empty:before:content-[attr(data-placeholder)] empty:before:text-muted-foreground/60',
                 '**:data-ref-text:cursor-default',
                 expanded ? 'min-h-16' : 'min-h-[1.25rem]'

--- a/apps/desktop/src/components/assistant-ui/thread/user-message-edit.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message-edit.test.tsx
@@ -138,4 +138,26 @@ describe('click-to-edit user message', () => {
       expect(container.querySelector('[data-slot="aui_edit-composer-root"]')).toBeTruthy()
     })
   })
+
+  // A long previous prompt is capped at max-h-48 in the edit composer. Without
+  // an overflow rule the overflow is clipped with no way to scroll, hiding the
+  // tail of the prompt. The editor must scroll its own overflow (like the main
+  // composer's editor does).
+  it('keeps the edit composer editor scrollable when the prompt overflows the cap', async () => {
+    const { container } = render(<IncrementalHarness onEdit={async () => {}} />)
+
+    const bubble = await screen.findByRole('button', { name: 'Edit message' })
+
+    fireEvent.click(bubble)
+
+    const editor = await waitFor(() => {
+      const node = container.querySelector('[contenteditable="true"]')
+      expect(node).toBeTruthy()
+
+      return node as HTMLElement
+    })
+
+    expect(editor.className).toContain('max-h-48')
+    expect(editor.className).toContain('overflow-y-auto')
+  })
 })


### PR DESCRIPTION
## Symptom

When you click a previous prompt in Hermes Desktop, the bubble briefly expands to show the full text, then snaps back to a clipped view — and you can't scroll within the editor, so the tail of a long prompt becomes unreachable.

## Root cause

Clicking a read-only user bubble opens the inline edit composer. Its `contentEditable` editor (`apps/desktop/src/components/assistant-ui/thread.tsx`) caps its height at `max-h-48` but had **no overflow rule**, and its container is `overflow-hidden`. So a prompt taller than the cap is clipped with no scrollbar.

The "expands then shrinks" flash is the read-only bubble lifting its 2-line `sticky-human-clamp` on focus right before the edit composer mounts and clips.

The main chat composer's editor (`apps/desktop/src/app/chat/composer/index.tsx`) already pairs its height cap with `overflow-y-auto`; the edit composer simply missed it.

## Fix

Add `overflow-y-auto` to the edit composer editor — one class, matching the main composer. Overflow now scrolls within the capped height instead of being hidden.

## Test

Added a regression to `user-message-edit.test.tsx` asserting the edit composer editor keeps both the height cap (`max-h-48`) and a scroll affordance (`overflow-y-auto`). Confirmed RED before the fix, GREEN after.

## Verification

```
vitest run --environment jsdom src/components/assistant-ui/user-message-edit.test.tsx   # 3 passed
eslint src/components/assistant-ui/thread.tsx src/components/assistant-ui/user-message-edit.test.tsx   # clean
tsc -b   # clean
```