### PR TITLE
fix dashboard session stats profile scoping

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6254,15 +6254,15 @@ async def delete_empty_sessions_endpoint():
 
 
 @app.get("/api/sessions/stats")
-async def get_session_stats():
+async def get_session_stats(profile: Optional[str] = None):
     """Session-store statistics for the Sessions page (mirrors `hermes sessions stats`).
 
     Registered before ``/api/sessions/{session_id}`` so the literal ``stats``
-    path isn't captured as a session id by the parameterized route.
+    path isn't captured as a session id by the parameterized route.  ``profile``
+    scopes the read to another local profile's state.db; omitted preserves the
+    historical current-backend store behavior.
     """
-    from hermes_state import SessionDB
-
-    db = SessionDB()
+    db = _open_session_db_for_profile(profile)
     try:
         total = db.session_count(include_archived=True)
         active_store = db.session_count(include_archived=False)

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -414,6 +414,49 @@ class TestSessionManagementEndpoints:
         assert {"total", "active_store", "archived", "messages", "by_source"} <= set(body)
         assert body["total"] >= 1
 
+    def test_stats_without_profile_uses_current_backend_store(self):
+        r = self.client.get("/api/sessions/stats")
+
+        assert r.status_code == 200
+        body = r.json()
+        assert body["total"] == 1
+        assert body["by_source"] == {"cli": 1}
+
+    def test_stats_profile_query_uses_named_profile_store(self):
+        from hermes_constants import get_hermes_home
+        from hermes_state import SessionDB
+
+        profile_home = get_hermes_home() / "profiles" / "jimmy"
+        profile_home.mkdir(parents=True)
+        db = SessionDB(db_path=profile_home / "state.db")
+        db.create_session(session_id="jimmy-telegram", source="telegram")
+        db.create_session(session_id="jimmy-cli", source="cli")
+        db.close()
+
+        r = self.client.get("/api/sessions/stats?profile=jimmy")
+
+        assert r.status_code == 200
+        body = r.json()
+        assert body["total"] == 2
+        assert body["by_source"] == {"telegram": 1, "cli": 1}
+
+    def test_stats_profile_default_query_uses_default_store(self):
+        from hermes_constants import get_hermes_home
+        from hermes_state import SessionDB
+
+        profile_home = get_hermes_home() / "profiles" / "jimmy"
+        profile_home.mkdir(parents=True)
+        db = SessionDB(db_path=profile_home / "state.db")
+        db.create_session(session_id="jimmy-telegram", source="telegram")
+        db.close()
+
+        r = self.client.get("/api/sessions/stats?profile=default")
+
+        assert r.status_code == 200
+        body = r.json()
+        assert body["total"] == 1
+        assert body["by_source"] == {"cli": 1}
+
     def test_rename(self):
         r = self.client.patch("/api/sessions/sess-x", json={"title": "Renamed"})
         assert r.status_code == 200 and r.json()["title"] == "Renamed"

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -367,7 +367,10 @@ export const api = {
         body: JSON.stringify({ title }),
       },
     ),
-  getSessionStats: () => fetchJSON<SessionStoreStats>("/api/sessions/stats"),
+  getSessionStats: (profile?: string) => {
+    const query = profile ? `?profile=${encodeURIComponent(profile)}` : "";
+    return fetchJSON<SessionStoreStats>(`/api/sessions/stats${query}`);
+  },
   exportSessionUrl: (id: string) =>
     `/api/sessions/${encodeURIComponent(id)}/export`,
   pruneSessions: (older_than_days: number, source?: string) =>

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -65,6 +65,7 @@ import { useI18n } from "@/i18n";
 import { usePageHeader } from "@/contexts/usePageHeader";
 import { PluginSlot } from "@/plugins";
 import { isDashboardEmbeddedChatEnabled } from "@/lib/dashboard-flags";
+import { useProfileScope } from "@/contexts/useProfileScope";
 
 const SOURCE_CONFIG: Record<string, { icon: typeof Terminal; color: string }> =
   {
@@ -659,6 +660,7 @@ export default function SessionsPage() {
   const { setAfterTitle, setEnd } = usePageHeader();
   const { activeAction, actionStatus, dismissLog } = useSystemActions();
   const resumeInChatEnabled = isDashboardEmbeddedChatEnabled();
+  const { profile: selectedProfile } = useProfileScope();
 
   const refreshEmptyCount = useCallback(() => {
     api
@@ -718,10 +720,10 @@ export default function SessionsPage() {
 
   const loadStats = useCallback(() => {
     api
-      .getSessionStats()
+      .getSessionStats(selectedProfile || undefined)
       .then(setStats)
       .catch(() => {});
-  }, []);
+  }, [selectedProfile]);
 
   useEffect(() => {
     loadStats();


### PR DESCRIPTION
## Summary
- make /api/sessions/stats accept an optional profile query parameter
- open the selected profile session store for profiled stats while preserving unprofiled current-backend behavior
- pass the selected concrete dashboard profile when loading session stats
- do not implement all-profile aggregation or broaden session body/content access

## Validation
- uv run pytest tests/hermes_cli/test_dashboard_admin_endpoints.py::TestSessionManagementEndpoints -q — 7 passed
- npm --prefix web run typecheck — exit 0

FGD-175: profile-aware Hermes dashboard session stats so dashboard stats respect the selected concrete profile instead of showing default-profile stats when scoped to jimmy.