### PR TITLE
feat(desktop): add session notification badges

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -5453,11 +5453,26 @@ ipcMain.handle('hermes:api', async (_event, request) => {
 
 ipcMain.handle('hermes:notify', (_event, payload) => {
   if (!Notification.isSupported()) return false
-  new Notification({
+  const notification = new Notification({
     title: payload?.title || 'Hermes',
     body: payload?.body || '',
     silent: Boolean(payload?.silent)
-  }).show()
+  })
+  notification.show()
+  return true
+})
+
+ipcMain.handle('hermes:setBadgeCount', (_event, rawCount) => {
+  const count = Math.max(0, Number.isFinite(Number(rawCount)) ? Math.floor(Number(rawCount)) : 0)
+
+  if (typeof app.setBadgeCount === 'function') {
+    app.setBadgeCount(count)
+  }
+
+  if (app.dock && typeof app.dock.setBadge === 'function') {
+    app.dock.setBadge(count > 0 ? String(count) : '')
+  }
+
   return true
 })
 

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -20,6 +20,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   },
   api: request => ipcRenderer.invoke('hermes:api', request),
   notify: payload => ipcRenderer.invoke('hermes:notify', payload),
+  setBadgeCount: count => ipcRenderer.invoke('hermes:setBadgeCount', count),
   requestMicrophoneAccess: () => ipcRenderer.invoke('hermes:requestMicrophoneAccess'),
   readFileDataUrl: filePath => ipcRenderer.invoke('hermes:readFileDataUrl', filePath),
   readFileText: filePath => ipcRenderer.invoke('hermes:readFileText', filePath),

--- a/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
@@ -47,6 +47,14 @@ import {
   setShowAllProfiles,
   sortByProfileOrder
 } from '@/store/profile'
+import {
+  $attentionSessionIds,
+  $cronSessions,
+  $messagingSessions,
+  $notifiedSessionIds,
+  $sessions,
+  sessionNotificationProfileCounts
+} from '@/store/session'
 import type { ProfileInfo } from '@/types/hermes'
 
 import { CreateProfileDialog } from '../../profiles/create-profile-dialog'
@@ -94,6 +102,11 @@ export function ProfileRail() {
   const gatewayProfile = useStore($activeGatewayProfile)
   const order = useStore($profileOrder)
   const colors = useStore($profileColors)
+  const sessions = useStore($sessions)
+  const cronSessions = useStore($cronSessions)
+  const messagingSessions = useStore($messagingSessions)
+  const notifiedSessionIds = useStore($notifiedSessionIds)
+  const attentionSessionIds = useStore($attentionSessionIds)
   const navigate = useNavigate()
 
   const [createOpen, setCreateOpen] = useState(false)
@@ -133,6 +146,11 @@ export function ProfileRail() {
 
   const named = sortByProfileOrder(profiles.filter(profile => !profile.is_default), order)
   const multiProfile = profiles.length > 1
+  const profileNotificationCounts = sessionNotificationProfileCounts(
+    [...sessions, ...cronSessions, ...messagingSessions],
+    notifiedSessionIds,
+    attentionSessionIds
+  )
 
   // distance constraint: a small drag reorders, a tap still selects the profile.
   const sensors = useSensors(
@@ -207,6 +225,7 @@ export function ProfileRail() {
             active={isAll || onDefault}
             glyph={isAll ? 'layers' : 'home'}
             label={onDefault ? p.showAllProfiles : p.switchToProfile(defaultProfile.name)}
+            notificationCount={profileNotificationCounts[normalizeProfileKey(defaultProfile.name)] ?? 0}
             onSelect={() => (onDefault ? setShowAllProfiles(true) : selectProfile(defaultProfile.name))}
           />
         ) : (
@@ -219,6 +238,7 @@ export function ProfileRail() {
           active
           glyph="home"
           label={defaultProfile.name}
+          notificationCount={profileNotificationCounts[normalizeProfileKey(defaultProfile.name)] ?? 0}
           onSelect={() => selectProfile(defaultProfile.name)}
         />
       )}
@@ -246,6 +266,7 @@ export function ProfileRail() {
                     color={resolveProfileColor(profile.name, colors)}
                     key={profile.name}
                     label={profile.name}
+                    notificationCount={profileNotificationCounts[normalizeProfileKey(profile.name)] ?? 0}
                     onDelete={() => setPendingDelete(profile)}
                     onRecolor={color => setProfileColor(profile.name, color)}
                     onRename={() => setPendingRename(profile)}
@@ -308,17 +329,18 @@ interface ProfilePillProps {
   // home / All / Manage are glyph action buttons (navigation, not identity).
   glyph: string
   label: string
+  notificationCount?: number
   onSelect: () => void
 }
 
-function ProfilePill({ active, glyph, label, onSelect }: ProfilePillProps) {
+function ProfilePill({ active, glyph, label, notificationCount = 0, onSelect }: ProfilePillProps) {
   return (
     <Tip label={label}>
       <Button
         aria-label={label}
         aria-pressed={active}
         className={cn(
-          'bg-transparent text-(--ui-text-tertiary) hover:bg-(--ui-control-hover-background) hover:text-foreground',
+          'relative bg-transparent text-(--ui-text-tertiary) hover:bg-(--ui-control-hover-background) hover:text-foreground',
           active && 'bg-(--ui-control-active-background) text-foreground'
         )}
         onClick={onSelect}
@@ -327,8 +349,25 @@ function ProfilePill({ active, glyph, label, onSelect }: ProfilePillProps) {
         variant="ghost"
       >
         <Codicon name={glyph} size="0.875rem" />
+        <ProfileNotificationBadge count={notificationCount} />
       </Button>
     </Tip>
+  )
+}
+
+function ProfileNotificationBadge({ count }: { count: number }) {
+  if (count <= 0) {
+    return null
+  }
+
+  return (
+    <span
+      aria-label={`${count} sessions need attention`}
+      className="pointer-events-none absolute -right-1 -top-1 grid min-w-3.5 place-items-center rounded-full bg-rose-500 px-0.5 text-[0.5rem] font-bold leading-3 text-white ring ring-background"
+      role="status"
+    >
+      {count > 9 ? '9+' : count}
+    </span>
   )
 }
 
@@ -336,6 +375,7 @@ interface ProfileSquareProps {
   active: boolean
   color: null | string
   label: string
+  notificationCount?: number
   onSelect: () => void
   onRecolor: (color: null | string) => void
   onRename: () => void
@@ -353,7 +393,16 @@ const LONG_PRESS_MS = 450
 // right-click to rename/delete. The button carries both the tooltip and
 // context-menu triggers via nested asChild Slots, so a single element keeps the
 // dnd listeners, hover tip, and right-click menu.
-function ProfileSquare({ active, color, label, onDelete, onRecolor, onRename, onSelect }: ProfileSquareProps) {
+function ProfileSquare({
+  active,
+  color,
+  label,
+  notificationCount = 0,
+  onDelete,
+  onRecolor,
+  onRename,
+  onSelect
+}: ProfileSquareProps) {
   const { t } = useI18n()
   const p = t.profiles
   const hue = color ?? 'var(--ui-text-quaternary)'
@@ -402,7 +451,7 @@ function ProfileSquare({ active, color, label, onDelete, onRecolor, onRename, on
                 <TooltipTrigger asChild>
                   <button
                     className={cn(
-                      'grid size-5 shrink-0 cursor-grab touch-none select-none place-items-center rounded-[3px] text-[0.5625rem] font-semibold uppercase leading-none transition-opacity hover:opacity-100',
+                      'relative grid size-5 shrink-0 cursor-grab touch-none select-none place-items-center rounded-[3px] text-[0.5625rem] font-semibold uppercase leading-none transition-opacity hover:opacity-100',
                       active ? 'opacity-100' : 'opacity-55',
                       isDragging && 'z-10 cursor-grabbing opacity-100'
                     )}
@@ -453,6 +502,7 @@ function ProfileSquare({ active, color, label, onDelete, onRecolor, onRename, on
                     onPointerUp={clearPress}
                   >
                     {label.replace(/[^a-z0-9]/gi, '').charAt(0) || '?'}
+                    <ProfileNotificationBadge count={notificationCount} />
                   </button>
                 </TooltipTrigger>
               </ContextMenuTrigger>

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -12,7 +12,7 @@ import { sessionTitle } from '@/lib/chat-runtime'
 import { triggerHaptic } from '@/lib/haptics'
 import { handoffOriginSource, sessionSourceLabel } from '@/lib/session-source'
 import { cn } from '@/lib/utils'
-import { $attentionSessionIds } from '@/store/session'
+import { $attentionSessionIds, $notifiedSessionIds } from '@/store/session'
 import { canOpenSessionWindow, openSessionInNewWindow } from '@/store/windows'
 
 import { SessionActionsMenu, SessionContextMenu } from './session-actions-menu'
@@ -80,6 +80,7 @@ export function SidebarSessionRow({
   // the atom is tiny and rarely non-empty. True when a clarify prompt in this
   // session is waiting on the user.
   const needsInput = useStore($attentionSessionIds).includes(session.id)
+  const hasNotification = useStore($notifiedSessionIds).includes(session.id)
 
   return (
     <SessionContextMenu
@@ -168,8 +169,9 @@ export function SidebarSessionRow({
               data-reorder-handle
               onClick={event => event.stopPropagation()}
             >
-              <SidebarRowDot
+                <SidebarRowDot
                 className="transition-opacity group-hover/handle:opacity-0 group-focus-within/handle:opacity-0"
+                hasNotification={hasNotification}
                 isWorking={isWorking}
                 needsInput={needsInput}
               />
@@ -189,7 +191,7 @@ export function SidebarSessionRow({
                 needsInput ? 'overflow-visible' : 'overflow-hidden'
               )}
             >
-              <SidebarRowDot isWorking={isWorking} needsInput={needsInput} />
+              <SidebarRowDot hasNotification={hasNotification} isWorking={isWorking} needsInput={needsInput} />
             </span>
           )}
           {handoffSource && handoffLabel ? (
@@ -239,10 +241,12 @@ export function SidebarSessionRow({
 function SidebarRowDot({
   isWorking,
   needsInput = false,
+  hasNotification = false,
   className
 }: {
   isWorking: boolean
   needsInput?: boolean
+  hasNotification?: boolean
   className?: string
 }) {
   const { t } = useI18n()
@@ -259,6 +263,20 @@ function SidebarRowDot({
         className={cn('quest-glow relative size-1.5 rounded-full bg-amber-500', className)}
         role="status"
         title={r.waitingForAnswer}
+      />
+    )
+  }
+
+  if (hasNotification) {
+    return (
+      <span
+        aria-label={r.newNotification}
+        className={cn(
+          'relative size-1.5 rounded-full bg-(--ui-accent) shadow-[0_0_0.5rem_color-mix(in_srgb,var(--ui-accent)_45%,transparent)] after:absolute after:-right-0.5 after:-top-0.5 after:size-1 after:rounded-full after:bg-rose-500 after:ring after:ring-background after:content-[\'\']',
+          className
+        )}
+        role="status"
+        title={r.newNotification}
       />
     )
   }

--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -33,6 +33,7 @@ import {
   setCurrentReasoningEffort,
   setCurrentServiceTier,
   setCurrentUsage,
+  setSessionNotified,
   setTurnStartedAt,
   setYoloActive
 } from '@/store/session'
@@ -148,6 +149,28 @@ function completionErrorText(finalText: string): string | null {
   const text = finalText.trim()
 
   return text && COMPLETION_ERROR_PATTERNS.some(re => re.test(text)) ? text : null
+}
+
+function sendSessionDesktopNotification(
+  sessionId: string,
+  title: string,
+  body: string,
+  options: { isActiveEvent: boolean; silent?: boolean }
+) {
+  const visibleActive = options.isActiveEvent && typeof document !== 'undefined' && document.visibilityState === 'visible'
+
+  if (!visibleActive) {
+    setSessionNotified(sessionId, true)
+  }
+
+  // Do not interrupt the user with a native push while they are actively looking
+  // at the session. If the app is hidden/minimized, even the focused session
+  // should still surface through the OS notification center.
+  if (visibleActive) {
+    return
+  }
+
+  void window.hermesDesktop?.notify?.({ body, sessionId, silent: options.silent, title }).catch(() => undefined)
 }
 
 const SUBAGENT_EVENT_TYPES = new Set([
@@ -616,13 +639,6 @@ export function useMessageStream({
       if (shouldHydrate) {
         void hydrateFromStoredSession(3, completedState.storedSessionId, sessionId)
       }
-
-      if (document.hidden && sessionId === activeSessionIdRef.current) {
-        void window.hermesDesktop?.notify({
-          title: 'Hermes finished',
-          body: text.slice(0, 140) || 'The response is ready.'
-        })
-      }
     },
     [activeSessionIdRef, hydrateFromStoredSession, refreshSessions, updateSessionState]
   )
@@ -852,6 +868,10 @@ export function useMessageStream({
         const finalText = coerceGatewayText(payload?.text) || coerceGatewayText(payload?.rendered)
         completeAssistantMessage(sessionId, finalText)
 
+        if (!isActiveEvent || (typeof document !== 'undefined' && document.visibilityState !== 'visible')) {
+          sendSessionDesktopNotification(sessionId, 'Hermes reply ready', 'A background session has a new reply.', { isActiveEvent, silent: false })
+        }
+
         if (isActiveEvent) {
           setTurnStartedAt(null)
         }
@@ -923,6 +943,7 @@ export function useMessageStream({
           // too, and survives alt-tab / window blur (unlike a toast).
           if (sessionId) {
             updateSessionState(sessionId, state => ({ ...state, needsInput: true }))
+            sendSessionDesktopNotification(sessionId, 'Hermes needs input', 'A background session is waiting for your response.', { isActiveEvent, silent: false })
           }
         }
       } else if (event.type === 'approval.request') {
@@ -942,6 +963,10 @@ export function useMessageStream({
 
         if (sessionId) {
           updateSessionState(sessionId, state => ({ ...state, needsInput: true }))
+          sendSessionDesktopNotification(sessionId, 'Hermes needs approval', 'A command is waiting for approval.', {
+            isActiveEvent,
+            silent: false
+          })
         }
       } else if (event.type === 'sudo.request') {
         // Sudo password capture (tools/terminal_tool.py). Blocked on
@@ -953,6 +978,10 @@ export function useMessageStream({
 
           if (sessionId) {
             updateSessionState(sessionId, state => ({ ...state, needsInput: true }))
+            sendSessionDesktopNotification(sessionId, 'Hermes needs input', 'A secure prompt is waiting.', {
+              isActiveEvent,
+              silent: false
+            })
           }
         }
       } else if (event.type === 'secret.request') {
@@ -970,6 +999,10 @@ export function useMessageStream({
 
           if (sessionId) {
             updateSessionState(sessionId, state => ({ ...state, needsInput: true }))
+            sendSessionDesktopNotification(sessionId, 'Hermes needs input', 'A secure prompt is waiting.', {
+              isActiveEvent,
+              silent: false
+            })
           }
         }
       } else if (event.type === 'terminal.read.request') {

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -8,6 +8,7 @@ import { setMutableRef } from '@/lib/mutable-ref'
 import {
   $busy,
   $messages,
+  clearSessionNotification,
   noteSessionActivity,
   setCurrentFastMode,
   setCurrentModel,
@@ -90,7 +91,20 @@ export function useSessionStateCache({
 
   useEffect(() => {
     selectedStoredSessionIdRef.current = selectedStoredSessionId
+    clearSessionNotification(selectedStoredSessionId)
   }, [selectedStoredSessionId])
+
+  useEffect(() => {
+    const clearFocusedNotification = () => {
+      if (document.visibilityState === 'visible') {
+        clearSessionNotification(selectedStoredSessionIdRef.current)
+      }
+    }
+
+    document.addEventListener('visibilitychange', clearFocusedNotification)
+
+    return () => document.removeEventListener('visibilitychange', clearFocusedNotification)
+  }, [])
 
   const ensureSessionState = useCallback((sessionId: string, storedSessionId?: string | null) => {
     const existing = sessionStateByRuntimeIdRef.current.get(sessionId)

--- a/apps/desktop/src/app/shell/app-shell.tsx
+++ b/apps/desktop/src/app/shell/app-shell.tsx
@@ -1,6 +1,6 @@
 import { useStore } from '@nanostores/react'
 import type { CSSProperties, ReactNode } from 'react'
-import { useSyncExternalStore } from 'react'
+import { useEffect, useSyncExternalStore } from 'react'
 
 import { NotificationStack } from '@/components/notifications'
 import { PaneShell } from '@/components/pane-shell'
@@ -15,7 +15,7 @@ import {
   setSidebarOpen
 } from '@/store/layout'
 import { $paneWidthOverride } from '@/store/panes'
-import { $connection } from '@/store/session'
+import { $connection, $attentionSessionIds, $notifiedSessionIds } from '@/store/session'
 import { isSecondaryWindow } from '@/store/windows'
 
 import { SIDEBAR_COLLAPSE_MEDIA_QUERY } from '../layout-constants'
@@ -78,7 +78,14 @@ export function AppShell({
   const narrowViewport = useMediaQuery(SIDEBAR_COLLAPSE_MEDIA_QUERY)
   const fileBrowserWidthOverride = useStore($paneWidthOverride(FILE_BROWSER_PANE_ID))
   const connection = useStore($connection)
+  const notifiedSessionIds = useStore($notifiedSessionIds)
+  const attentionSessionIds = useStore($attentionSessionIds)
   const viewportFullscreen = useSyncExternalStore(subscribeWindowSize, viewportIsFullscreen, () => false)
+  const appBadgeCount = new Set([...notifiedSessionIds, ...attentionSessionIds]).size
+
+  useEffect(() => {
+    void window.hermesDesktop?.setBadgeCount?.(appBadgeCount).catch(() => undefined)
+  }, [appBadgeCount])
   const isFullscreen = Boolean(connection?.isFullscreen) || viewportFullscreen
   const titlebarControls = titlebarControlsPosition(connection?.windowButtonPosition, isFullscreen)
   // Width Windows/Linux reserve for the OS-painted min/max/close overlay (zero

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -39,6 +39,7 @@ declare global {
       }
       api: <T>(request: HermesApiRequest) => Promise<T>
       notify: (payload: HermesNotification) => Promise<boolean>
+      setBadgeCount?: (count: number) => Promise<boolean>
       requestMicrophoneAccess: () => Promise<boolean>
       readFileDataUrl: (filePath: string) => Promise<string>
       readFileText: (filePath: string) => Promise<HermesReadFileTextResult>
@@ -404,6 +405,7 @@ export interface HermesApiRequest {
 export interface HermesNotification {
   title?: string
   body?: string
+  sessionId?: string
   silent?: boolean
 }
 

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1111,6 +1111,7 @@ export const en: Translations = {
       sessionActions: 'Session actions',
       sessionRunning: 'Session running',
       needsInput: 'Needs your input',
+      newNotification: 'New response',
       waitingForAnswer: 'Waiting for your answer',
       handoffOrigin: platform => `Handed off from ${platform}`,
       renamed: 'Renamed',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1244,6 +1244,7 @@ export const ja = defineLocale({
       sessionActions: 'セッションアクション',
       sessionRunning: 'セッション実行中',
       needsInput: '入力が必要です',
+      newNotification: '新しい返信',
       waitingForAnswer: '回答を待っています',
       handoffOrigin: platform => `${platform} から引き継ぎ`,
       renamed: '名前を変更しました',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -858,6 +858,7 @@ export interface Translations {
       sessionActions: string
       sessionRunning: string
       needsInput: string
+      newNotification: string
       waitingForAnswer: string
       handoffOrigin: (platform: string) => string
       renamed: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1210,6 +1210,7 @@ export const zhHant = defineLocale({
       sessionActions: '工作階段動作',
       sessionRunning: '工作階段執行中',
       needsInput: '需要您的輸入',
+      newNotification: '新回覆',
       waitingForAnswer: '等待您的回答',
       handoffOrigin: platform => `從 ${platform} 轉接`,
       renamed: '已重新命名',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1297,6 +1297,7 @@ export const zh: Translations = {
       sessionActions: '会话操作',
       sessionRunning: '会话运行中',
       needsInput: '需要你输入',
+      newNotification: '新回复',
       waitingForAnswer: '正在等待你的回答',
       handoffOrigin: platform => `从 ${platform} 转接`,
       renamed: '已重命名',

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -7,13 +7,17 @@ import {
   $attentionSessionIds,
   $connection,
   $currentCwd,
+  $notifiedSessionIds,
   $workingSessionIds,
   applyConfiguredDefaultProjectDir,
+  clearSessionNotification,
   getRecentlySettledSessionIds,
   mergeSessionPage,
+  sessionNotificationProfileCounts,
   sessionPinId,
   setCurrentCwd,
   setSessionAttention,
+  setSessionNotified,
   setSessionWorking,
   workspaceCwdForNewSession
 } from './session'
@@ -62,6 +66,59 @@ describe('setSessionAttention', () => {
     setSessionAttention('', true)
     setSessionAttention('missing', false)
     expect($attentionSessionIds.get()).toEqual([])
+  })
+})
+
+describe('setSessionNotified', () => {
+  afterEach(() => {
+    $notifiedSessionIds.set([])
+  })
+
+  it('adds, removes, and clears a notified session id without duplicates', () => {
+    setSessionNotified('s1', true)
+    setSessionNotified('s1', true)
+    setSessionNotified('s2', true)
+
+    expect($notifiedSessionIds.get()).toEqual(['s1', 's2'])
+
+    clearSessionNotification('s1')
+    expect($notifiedSessionIds.get()).toEqual(['s2'])
+  })
+
+  it('ignores empty ids and no-op clears', () => {
+    setSessionNotified(null, true)
+    setSessionNotified(undefined, true)
+    setSessionNotified('', true)
+    setSessionNotified('missing', false)
+
+    expect($notifiedSessionIds.get()).toEqual([])
+  })
+})
+
+describe('sessionNotificationProfileCounts', () => {
+  it('counts the union of notified and attention sessions by profile without double-counting', () => {
+    const counts = sessionNotificationProfileCounts(
+      [
+        session({ id: 'a', profile: 'default' }),
+        session({ id: 'b', profile: 'music' }),
+        session({ id: 'b', profile: 'music' }),
+        session({ id: 'c', profile: 'music' }),
+        session({ id: 'd', profile: 'ops' })
+      ],
+      ['a', 'b', 'missing'],
+      ['b', 'c']
+    )
+
+    expect(counts).toEqual({ default: 1, music: 2 })
+  })
+
+  it('normalizes profile keys before counting badges', () => {
+    const counts = sessionNotificationProfileCounts(
+      [session({ id: 'a', profile: '' }), session({ id: 'b', profile: ' music ' })],
+      ['a', 'b']
+    )
+
+    expect(counts).toEqual({ default: 1, music: 1 })
   })
 })
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -4,6 +4,7 @@ import type { ContextSuggestion } from '@/app/types'
 import type { HermesConnection } from '@/global'
 import type { ChatMessage } from '@/lib/chat-messages'
 import { persistString, storedString } from '@/lib/storage'
+import { normalizeProfileKey } from '@/store/profile'
 import type { SessionInfo, UsageStats } from '@/types/hermes'
 
 type Updater<T> = T | ((current: T) => T)
@@ -192,6 +193,11 @@ export const $messagingTruncated = atom<boolean>(false)
 export const $sessionProfileTotals = atom<Record<string, number>>({})
 export const $sessionsLoading = atom(true)
 export const $workingSessionIds = atom<string[]>([])
+// Stored session ids with a completed/background notification the user has not
+// opened yet. These drive durable sidebar/profile badges, separate from
+// $attentionSessionIds (blocking clarify prompts) and $workingSessionIds
+// (active turns). Cleared when the session becomes the viewed chat.
+export const $notifiedSessionIds = atom<string[]>([])
 export const $activeSessionId = atom<string | null>(null)
 export const $selectedStoredSessionId = atom<string | null>(null)
 export const $messages = atom<ChatMessage[]>([])
@@ -238,6 +244,7 @@ export const setSessionProfileTotals = (next: Updater<Record<string, number>>) =
   updateAtom($sessionProfileTotals, next)
 export const setSessionsLoading = (next: Updater<boolean>) => updateAtom($sessionsLoading, next)
 export const setWorkingSessionIds = (next: Updater<string[]>) => updateAtom($workingSessionIds, next)
+export const setNotifiedSessionIds = (next: Updater<string[]>) => updateAtom($notifiedSessionIds, next)
 export const setActiveSessionId = (next: Updater<string | null>) => updateAtom($activeSessionId, next)
 export const setSelectedStoredSessionId = (next: Updater<string | null>) => updateAtom($selectedStoredSessionId, next)
 export const setMessages = (next: Updater<ChatMessage[]>) => updateAtom($messages, next)
@@ -389,6 +396,38 @@ export function setSessionAttention(sessionId: string | null | undefined, needsI
   if (sessionId) {
     toggleMembership(setAttentionSessionIds, sessionId, needsInput)
   }
+}
+
+export function setSessionNotified(sessionId: string | null | undefined, notified: boolean) {
+  if (sessionId) {
+    toggleMembership(setNotifiedSessionIds, sessionId, notified)
+  }
+}
+
+export function clearSessionNotification(sessionId: string | null | undefined) {
+  setSessionNotified(sessionId, false)
+}
+
+export function sessionNotificationProfileCounts(
+  sessions: Pick<SessionInfo, 'id' | 'profile'>[],
+  notifiedSessionIds: Iterable<string>,
+  attentionSessionIds: Iterable<string> = []
+): Record<string, number> {
+  const actionable = new Set([...notifiedSessionIds, ...attentionSessionIds])
+  const seenSessions = new Set<string>()
+  const counts: Record<string, number> = {}
+
+  for (const session of sessions) {
+    if (seenSessions.has(session.id) || !actionable.has(session.id)) {
+      continue
+    }
+
+    seenSessions.add(session.id)
+    const profile = normalizeProfileKey(session.profile)
+    counts[profile] = (counts[profile] ?? 0) + 1
+  }
+
+  return counts
 }
 
 export function setSessionWorking(sessionId: string | null | undefined, working: boolean) {


### PR DESCRIPTION
## Summary

- add persistent Desktop session notification state for background replies and input prompts
- show unread/attention badges on session rows and profile rail entries
- update the app/Dock badge count from unread/attention session state
- clear unread notification state when the affected stored session is opened
- keep native OS notification text generic by default to avoid leaking session titles, assistant response text, clarify questions, or credential prompt details into the OS notification center

## Tests

```text
npm --workspace apps/desktop run test:ui -- src/store/session.test.ts
# 1 test file passed, 24 tests passed

npm --workspace apps/desktop run typecheck
# passed
```

## Preflight

- searched open PRs for overlapping Desktop session/profile/app notification badge work; no relevant duplicate found
- scanned staged diff for private/local/user-specific terms: clean
- scanned staged diff for real secret values: clean
- scanned notification paths for content preview leakage: clean
- independent review passed with no security, privacy, logic, or duplicate blockers
