### PR TITLE
fix(desktop): move tool-row copy control into expanded body

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool-fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool-fallback.tsx
@@ -279,11 +279,14 @@ function ToolEntry({ part }: ToolEntryProps) {
 
   const copyAction = useMemo(() => toolCopyPayload(part, view), [part, view])
 
+  // The header trailing slot only carries the live duration timer while the
+  // tool is running. The copy control used to live here too, but an
+  // `opacity-0` (yet still clickable) button straddling the caret/duration made
+  // the disclosure caret hard to hit. Copy now lives in the expanded body's
+  // top-right, where it can't fight the caret for the right edge.
   const trailing =
     isPending && !embedded ? (
       <ActivityTimerText className={TOOL_HEADER_DURATION_CLASS} seconds={elapsed} />
-    ) : !isPending && copyAction.text ? (
-      <CopyButton appearance="tool-row" label={copyAction.label} stopPropagation text={copyAction.text} />
     ) : undefined
 
   return (
@@ -322,7 +325,18 @@ function ToolEntry({ part }: ToolEntryProps) {
       </div>
       {isPending && <PendingToolApproval part={part} />}
       {open && (
-        <div className="grid w-full min-w-0 max-w-full gap-1.5 overflow-hidden p-1.5">
+        <div className="relative grid w-full min-w-0 max-w-full gap-1.5 overflow-hidden p-1.5">
+          {copyAction.text && (
+            <CopyButton
+              appearance="inline"
+              className="absolute right-1.5 top-1.5 z-10 h-5 gap-0 rounded-md border border-(--ui-stroke-tertiary) bg-background/80 px-1 opacity-60 backdrop-blur-sm transition-opacity hover:opacity-100 focus-visible:opacity-100"
+              iconClassName="size-3"
+              label={copyAction.label}
+              showLabel={false}
+              stopPropagation
+              text={copyAction.text}
+            />
+          )}
           {!embedded && view.previewTarget && isPreviewableTarget(view.previewTarget) && (
             <PreviewAttachment source="tool-result" target={view.previewTarget} />
           )}


### PR DESCRIPTION
## Summary

Fit-and-finish fix for a reported Desktop chat issue: on a tool/command row, the disclosure caret (`>`) is hard to click without accidentally triggering the copy control.

**Root cause:** the per-row copy button lived in the header's trailing slot (`absolute right-1`, 24px) and its visibility depended on `group-hover/tool-row` — a group class that exists **nowhere** in the tree. So the button stayed `opacity-0` yet remained clickable: an invisible hit-target straddling the caret + duration. A long command title pushed the caret under that invisible button, so clicking the caret fired a copy instead of expanding. The Thinking row was unaffected precisely because it has no copy button competing for the right edge.

**Fix:** move copy into the expanded body's top-right (matching the existing code-block copy convention), where it can't fight the caret for the right edge — and make it actually visible (subtle at rest, full on hover/focus). The header right edge now belongs solely to the duration label + caret, which is cleanly clickable again.

## Notes / tradeoff

- Copy is now only reachable once a row is expanded.
- Rows with no expandable body no longer surface a copy control.

This was a deliberate UX choice (expanded-block placement) over keeping a fixed-up header control, since the expanded top-right matches the established code-block pattern and fully removes the caret/copy collision.

## Test plan

- [x] `tsc --noEmit` passes
- [x] eslint clean on the changed file
- [ ] Manual: expand a `terminal`/`execute_code` row → copy button visible top-right, copies output/command
- [ ] Manual: collapsed row → caret/duration clickable to expand with no accidental copy
- [ ] Manual: Thinking row still toggles via caret as before