### PR TITLE
Prevent duplicate WeCom gateway instances

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -214,6 +214,8 @@ class WeComAdapter(BasePlatformAdapter):
             self._set_fatal_error("wecom_missing_credentials", message, retryable=True)
             logger.warning("[%s] %s", self.name, message)
             return False
+        if not self._acquire_platform_lock("wecom-bot-id", self._bot_id, "WeCom bot ID"):
+            return False
 
         try:
             # Tighter keepalive so idle CLOSE_WAIT drains promptly (#18451).
@@ -235,6 +237,7 @@ class WeComAdapter(BasePlatformAdapter):
             if self._http_client:
                 await self._http_client.aclose()
                 self._http_client = None
+            self._release_platform_lock()
             return False
 
     async def disconnect(self) -> None:
@@ -266,6 +269,7 @@ class WeComAdapter(BasePlatformAdapter):
             self._http_client = None
 
         self._dedup.clear()
+        self._release_platform_lock()
         logger.info("[%s] Disconnected", self.name)
 
     async def _cleanup_ws(self) -> None:

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -94,6 +94,29 @@ class TestWeComConnect:
         assert "WECOM_BOT_ID" in (adapter.fatal_error_message or "")
 
     @pytest.mark.asyncio
+    async def test_connect_rejects_same_bot_id_lock(self, monkeypatch):
+        import gateway.platforms.wecom as wecom_module
+        from gateway.platforms.wecom import WeComAdapter
+
+        monkeypatch.setattr(wecom_module, "AIOHTTP_AVAILABLE", True)
+        monkeypatch.setattr(wecom_module, "HTTPX_AVAILABLE", True)
+        monkeypatch.setattr(
+            "gateway.status.acquire_scoped_lock",
+            lambda scope, identity, metadata=None: (False, {"pid": 4242}),
+        )
+
+        adapter = WeComAdapter(
+            PlatformConfig(enabled=True, extra={"bot_id": "bot-1", "secret": "secret-1"})
+        )
+
+        success = await adapter.connect()
+
+        assert success is False
+        assert adapter.has_fatal_error is True
+        assert adapter.fatal_error_code == "wecom-bot-id_lock"
+        assert "already in use" in (adapter.fatal_error_message or "")
+
+    @pytest.mark.asyncio
     async def test_connect_records_handshake_failure_details(self, monkeypatch):
         import gateway.platforms.wecom as wecom_module
         from gateway.platforms.wecom import WeComAdapter
@@ -121,6 +144,43 @@ class TestWeComConnect:
         assert adapter.has_fatal_error is True
         assert adapter.fatal_error_code == "wecom_connect_error"
         assert "invalid secret" in (adapter.fatal_error_message or "")
+
+    @pytest.mark.asyncio
+    async def test_connect_releases_bot_lock_on_failure(self, monkeypatch):
+        import gateway.platforms.wecom as wecom_module
+        from gateway.platforms.wecom import WeComAdapter
+
+        class DummyClient:
+            async def aclose(self):
+                return None
+
+        release_calls = []
+
+        monkeypatch.setattr(wecom_module, "AIOHTTP_AVAILABLE", True)
+        monkeypatch.setattr(wecom_module, "HTTPX_AVAILABLE", True)
+        monkeypatch.setattr(
+            "gateway.status.acquire_scoped_lock",
+            lambda scope, identity, metadata=None: (True, None),
+        )
+        monkeypatch.setattr(
+            "gateway.status.release_scoped_lock",
+            lambda scope, identity: release_calls.append((scope, identity)),
+        )
+        monkeypatch.setattr(
+            wecom_module,
+            "httpx",
+            SimpleNamespace(AsyncClient=lambda **kwargs: DummyClient()),
+        )
+
+        adapter = WeComAdapter(
+            PlatformConfig(enabled=True, extra={"bot_id": "bot-1", "secret": "secret-1"})
+        )
+        adapter._open_connection = AsyncMock(side_effect=RuntimeError("boom"))
+
+        success = await adapter.connect()
+
+        assert success is False
+        assert release_calls == [("wecom-bot-id", "bot-1")]
 
 
 class TestWeComQrScan:


### PR DESCRIPTION
## Summary
- acquire a scoped lock per WeCom bot ID before opening the websocket subscription
- release that lock on failed startup and normal disconnect so retries can recover cleanly
- add regression tests for second-instance rejection and lock cleanup on connect failure

## Testing
- uv run --extra dev pytest tests/gateway/test_wecom.py -k 'test_connect_records_missing_credentials or test_connect_rejects_same_bot_id_lock or test_connect_records_handshake_failure_details or test_connect_releases_bot_lock_on_failure'
- uv run --extra dev ruff check gateway/platforms/wecom.py tests/gateway/test_wecom.py
- git diff --check

## Notes
- A broader run of `tests/gateway/test_wecom.py` is still red on an unrelated existing `aiohttp.ClientSession` patch-target assumption in `test_open_connection_includes_device_id_in_subscribe` when `aiohttp` is unavailable in the local venv.