### PR TITLE
fix: recover gateway sessions from durable state

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -781,6 +781,55 @@ class SessionStore:
             group_sessions_per_user=getattr(self.config, "group_sessions_per_user", True),
             thread_sessions_per_user=getattr(self.config, "thread_sessions_per_user", False),
         )
+
+    def _recover_session_from_db(
+        self,
+        *,
+        session_key: str,
+        source: SessionSource,
+        now: datetime,
+    ) -> Optional[SessionEntry]:
+        """Recover session_key -> session_id mapping from SQLite.
+
+        sessions.json is only a lightweight routing cache.  After a pod
+        restart or cache loss, SQLite is the durable transcript source and
+        should be consulted before creating a brand-new conversation lane.
+        """
+        if not self._db:
+            return None
+        finder = getattr(self._db, "find_latest_session_for_peer", None)
+        if finder is None:
+            return None
+        try:
+            recovered = finder(
+                source=source.platform.value,
+                user_id=source.user_id,
+                session_key=session_key,
+                chat_id=source.chat_id,
+                chat_type=source.chat_type,
+                thread_id=source.thread_id,
+            )
+        except Exception as exc:
+            logger.debug("session_continuity_recovery_failed key=%s: %s", session_key, exc)
+            return None
+        if not recovered:
+            return None
+
+        started_at = recovered.get("started_at")
+        try:
+            created_at = datetime.fromtimestamp(float(started_at)) if started_at else now
+        except (TypeError, ValueError, OSError):
+            created_at = now
+        return SessionEntry(
+            session_key=session_key,
+            session_id=recovered["id"],
+            created_at=created_at,
+            updated_at=now,
+            origin=source,
+            display_name=source.chat_name,
+            platform=source.platform,
+            chat_type=source.chat_type,
+        )
     
     def _is_session_expired(self, entry: SessionEntry) -> bool:
         """Check if a session has expired based on its reset policy.
@@ -934,6 +983,12 @@ class SessionStore:
                 if not reset_reason:
                     entry.updated_at = now
                     self._save()
+                    logger.info(
+                        "session_continuity_cache_hit source=%s chat_type=%s session_id=%s",
+                        source.platform.value,
+                        source.chat_type,
+                        entry.session_id,
+                    )
                     return entry
                 else:
                     # Session is being auto-reset.
@@ -946,6 +1001,23 @@ class SessionStore:
                 was_auto_reset = False
                 auto_reset_reason = None
                 reset_had_activity = False
+
+            if not force_new:
+                recovered_entry = self._recover_session_from_db(
+                    session_key=session_key,
+                    source=source,
+                    now=now,
+                )
+                if recovered_entry is not None:
+                    self._entries[session_key] = recovered_entry
+                    self._save()
+                    logger.info(
+                        "session_continuity_db_recovered source=%s chat_type=%s session_id=%s",
+                        source.platform.value,
+                        source.chat_type,
+                        recovered_entry.session_id,
+                    )
+                    return recovered_entry
 
             # Create new session
             session_id = f"{now.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
@@ -970,7 +1042,17 @@ class SessionStore:
                 "session_id": session_id,
                 "source": source.platform.value,
                 "user_id": source.user_id,
+                "session_key": session_key,
+                "chat_id": source.chat_id,
+                "chat_type": source.chat_type,
+                "thread_id": source.thread_id,
             }
+            logger.info(
+                "session_continuity_new source=%s chat_type=%s session_id=%s",
+                source.platform.value,
+                source.chat_type,
+                session_id,
+            )
 
         # SQLite operations outside the lock
         if self._db and db_end_session_id:
@@ -1196,6 +1278,10 @@ class SessionStore:
                 "session_id": session_id,
                 "source": old_entry.platform.value if old_entry.platform else "unknown",
                 "user_id": old_entry.origin.user_id if old_entry.origin else None,
+                "session_key": session_key,
+                "chat_id": old_entry.origin.chat_id if old_entry.origin else None,
+                "chat_type": old_entry.origin.chat_type if old_entry.origin else None,
+                "thread_id": old_entry.origin.thread_id if old_entry.origin else None,
             }
 
         if self._db and db_end_session_id:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -474,6 +474,17 @@ CREATE TABLE IF NOT EXISTS sessions (
     FOREIGN KEY (parent_session_id) REFERENCES sessions(id)
 );
 
+CREATE TABLE IF NOT EXISTS session_peer_keys (
+    session_key TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL REFERENCES sessions(id),
+    source TEXT NOT NULL,
+    user_id TEXT,
+    chat_id TEXT,
+    chat_type TEXT,
+    thread_id TEXT,
+    updated_at REAL NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS messages (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     session_id TEXT NOT NULL REFERENCES sessions(id),
@@ -511,6 +522,10 @@ CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
 CREATE INDEX IF NOT EXISTS idx_sessions_source_id ON sessions(source, id);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_session_peer_keys_session
+    ON session_peer_keys(session_id);
+CREATE INDEX IF NOT EXISTS idx_session_peer_keys_peer
+    ON session_peer_keys(source, user_id, chat_id, chat_type, thread_id);
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestamp);
 CREATE INDEX IF NOT EXISTS idx_compression_locks_expires ON compression_locks(expires_at);
 """
@@ -1180,14 +1195,20 @@ class SessionDB:
         model_config: Dict[str, Any] = None,
         system_prompt: str = None,
         user_id: str = None,
+        session_key: str = None,
+        chat_id: str = None,
+        chat_type: str = None,
+        thread_id: str = None,
         parent_session_id: str = None,
         cwd: str = None,
     ) -> None:
         """Shared INSERT OR IGNORE for session rows."""
         def _do(conn):
             conn.execute(
-                """INSERT OR IGNORE INTO sessions (id, source, user_id, model, model_config,
-                   system_prompt, parent_session_id, cwd, started_at)
+                """INSERT OR IGNORE INTO sessions (
+                   id, source, user_id, model, model_config, system_prompt,
+                   parent_session_id, cwd, started_at
+                )
                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
@@ -1201,12 +1222,100 @@ class SessionDB:
                     time.time(),
                 ),
             )
+            if session_key:
+                conn.execute(
+                    """INSERT OR REPLACE INTO session_peer_keys (
+                       session_key, session_id, source, user_id, chat_id,
+                       chat_type, thread_id, updated_at
+                    )
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        session_key,
+                        session_id,
+                        source,
+                        user_id,
+                        chat_id,
+                        chat_type,
+                        thread_id,
+                        time.time(),
+                    ),
+                )
         self._execute_write(_do)
 
     def create_session(self, session_id: str, source: str, **kwargs) -> str:
         """Create a new session record. Returns the session_id."""
         self._insert_session_row(session_id, source, **kwargs)
         return session_id
+
+    def find_latest_session_for_peer(
+        self,
+        *,
+        source: str,
+        user_id: Optional[str] = None,
+        session_key: Optional[str] = None,
+        chat_id: Optional[str] = None,
+        chat_type: Optional[str] = None,
+        thread_id: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Find the best active session to continue for a gateway peer.
+
+        Newer rows persist ``session_key`` and can be recovered exactly when
+        the lightweight sessions.json key cache is missing after a restart.
+        Legacy rows did not store that key, so we fall back to the most recent
+        active source/user session with messages.  The legacy fallback is
+        intentionally conservative: it is only for continuity recovery on
+        existing databases and never crosses source or user boundaries.
+        """
+
+        def _fetch(sql: str, params: tuple[Any, ...]) -> Optional[Dict[str, Any]]:
+            with self._lock:
+                row = self._conn.execute(sql, params).fetchone()
+            return dict(row) if row else None
+
+        has_messages = (
+            "(COALESCE(message_count, 0) > 0 OR "
+            "EXISTS (SELECT 1 FROM messages WHERE messages.session_id = sessions.id LIMIT 1))"
+        )
+        if session_key:
+            row = _fetch(
+                f"""
+                SELECT sessions.*
+                FROM session_peer_keys
+                JOIN sessions ON sessions.id = session_peer_keys.session_id
+                WHERE session_peer_keys.session_key = ?
+                  AND sessions.ended_at IS NULL
+                  AND {has_messages}
+                ORDER BY sessions.started_at DESC
+                LIMIT 1
+                """,
+                (session_key,),
+            )
+            if row:
+                return row
+
+        if thread_id is not None:
+            # Legacy sessions did not persist thread identity. Without an
+            # exact session_key mapping, falling back by source/user would
+            # recover the parent DM/group and bleed unrelated context.
+            return None
+
+        clauses = ["source = ?", "ended_at IS NULL", has_messages]
+        params: list[Any] = [source]
+        if user_id is None:
+            clauses.append("user_id IS NULL")
+        else:
+            clauses.append("user_id = ?")
+            params.append(user_id)
+
+        return _fetch(
+            f"""
+            SELECT * FROM sessions
+            WHERE {' AND '.join(clauses)}
+            ORDER BY started_at DESC
+            LIMIT 1
+            """,
+            tuple(params),
+        )
     def end_session(self, session_id: str, end_reason: str) -> None:
         """Mark a session as ended.
 

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -572,6 +572,105 @@ class TestLoadTranscriptDBOnly:
         assert result[1]["content"] == "db-a"
 
 
+class TestSessionStoreDbContinuityRecovery:
+    """Restart continuity when the sessions.json cache is missing/stale."""
+
+    def test_recovers_session_mapping_from_db_session_key(self, tmp_path, monkeypatch, caplog):
+        import hermes_state
+
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+        config = GatewayConfig()
+        sessions_dir = tmp_path / "sessions"
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="chat-123",
+            chat_type="dm",
+            user_id="patrick",
+            user_name="Patrick",
+        )
+
+        first_store = SessionStore(sessions_dir=sessions_dir, config=config)
+        first_entry = first_store.get_or_create_session(source)
+        first_store.append_to_transcript(
+            first_entry.session_id,
+            {"role": "user", "content": "remember this across restart"},
+        )
+
+        (sessions_dir / "sessions.json").unlink()
+
+        second_store = SessionStore(sessions_dir=sessions_dir, config=config)
+        with caplog.at_level("INFO"):
+            recovered = second_store.get_or_create_session(source)
+
+        assert recovered.session_id == first_entry.session_id
+        transcript = second_store.load_transcript(recovered.session_id)
+        assert transcript[0]["content"] == "remember this across restart"
+        assert "session_continuity_db_recovered" in caplog.text
+
+    def test_recovers_legacy_session_without_session_key_by_peer(self, tmp_path, monkeypatch):
+        import hermes_state
+
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+        config = GatewayConfig()
+        sessions_dir = tmp_path / "sessions"
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="chat-456",
+            chat_type="dm",
+            user_id="reid-user",
+            user_name="Patrick",
+        )
+
+        store = SessionStore(sessions_dir=sessions_dir, config=config)
+        store._db.create_session(
+            session_id="legacy-session",
+            source="telegram",
+            user_id="reid-user",
+        )
+        store._db.append_message(
+            session_id="legacy-session",
+            role="user",
+            content="legacy tracked fact",
+        )
+
+        recovered = store.get_or_create_session(source)
+
+        assert recovered.session_id == "legacy-session"
+        assert store.load_transcript(recovered.session_id)[0]["content"] == "legacy tracked fact"
+
+    def test_legacy_fallback_does_not_recover_parent_for_thread(self, tmp_path, monkeypatch):
+        import hermes_state
+
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+        config = GatewayConfig()
+        sessions_dir = tmp_path / "sessions"
+        thread_source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="chat-456",
+            chat_type="dm",
+            thread_id="thread-1",
+            user_id="reid-user",
+            user_name="Patrick",
+        )
+
+        store = SessionStore(sessions_dir=sessions_dir, config=config)
+        store._db.create_session(
+            session_id="legacy-parent-session",
+            source="telegram",
+            user_id="reid-user",
+        )
+        store._db.append_message(
+            session_id="legacy-parent-session",
+            role="user",
+            content="parent-only context",
+        )
+
+        recovered = store.get_or_create_session(thread_source)
+
+        assert recovered.session_id != "legacy-parent-session"
+        assert store.load_transcript(recovered.session_id) == []
+
+
 class TestSessionStoreSwitchSession:
     """Regression coverage for gateway /resume session switching semantics."""
 


### PR DESCRIPTION
## Summary
- persist gateway session peer keys in SQLite alongside sessions
- recover the session_key -> session_id mapping from durable state when the lightweight sessions.json cache is missing after a restart
- log cache-hit/db-recovered/new-session outcomes so restart continuity is observable

## Why
Long-running gateway deployments can lose the lightweight sessions.json routing cache across pod/container restarts even though the durable SQLite transcript remains intact. When that happens, the gateway starts a fresh conversation lane for the same peer instead of continuing the existing transcript.

## Tests
- `python3 -m pytest -q -o addopts='' tests/gateway/test_session.py::TestSessionStoreDbContinuityRecovery` -> 3 passed
- `python3 -m pytest -q -o addopts='' tests/gateway/test_session.py` -> 79 passed, 3 environment errors from missing local dependency `httpx` while importing pre-existing GatewayRunner tests; the new continuity regression class passes.

This PR is intentionally core-only: no downstream image workflow, skills bundle, or deployment overlay changes are included.