### PR TITLE
Fix Discord guild slash command visibility

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -818,6 +818,37 @@ def _read_discord_prompt_timeout() -> int:
     return seconds
 
 
+def _discord_app_command_scope_kwargs() -> Dict[str, Any]:
+    """Return explicit slash-command install/context defaults for discord.py.
+
+    Discord application defaults can be user-install only. If Hermes lets
+    discord.py inherit those defaults, global slash commands can register with
+    ``integration_types=[1]`` and disappear from guild slash menus even while
+    the bot handles normal server messages. Pin both install scopes and all
+    supported contexts at bot construction so newly synced commands are visible
+    in guilds, DMs, and user/private contexts.
+    """
+    if not DISCORD_AVAILABLE or discord is None:
+        return {}
+    app_commands = getattr(discord, "app_commands", None)
+    installation_type = getattr(app_commands, "AppInstallationType", None)
+    command_context = getattr(app_commands, "AppCommandContext", None)
+    if installation_type is None or command_context is None:
+        return {}
+    try:
+        return {
+            "allowed_installs": installation_type(guild=True, user=True),
+            "allowed_contexts": command_context(
+                guild=True,
+                dm_channel=True,
+                private_channel=True,
+            ),
+        }
+    except Exception:
+        logger.debug("Discord app-command scope defaults are unavailable", exc_info=True)
+        return {}
+
+
 class DiscordAdapter(BasePlatformAdapter):
     """
     Discord bot adapter.
@@ -1148,6 +1179,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 command_prefix="!",  # Not really used, we handle raw messages
                 intents=intents,
                 allowed_mentions=_build_allowed_mentions(),
+                **_discord_app_command_scope_kwargs(),
                 **proxy_kwargs_for_bot(proxy_url),
             )
             adapter_self = self  # capture for closure
@@ -2664,6 +2696,8 @@ class DiscordAdapter(BasePlatformAdapter):
             "name": canonical["name"],
             "description": canonical["description"],
             "options": canonical["options"],
+            "contexts": canonical["contexts"],
+            "integration_types": canonical["integration_types"],
         }
 
     async def _safe_sync_slash_commands(self) -> Dict[str, int]:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -2696,8 +2696,6 @@ class DiscordAdapter(BasePlatformAdapter):
             "name": canonical["name"],
             "description": canonical["description"],
             "options": canonical["options"],
-            "contexts": canonical["contexts"],
-            "integration_types": canonical["integration_types"],
         }
 
     async def _safe_sync_slash_commands(self) -> Dict[str, int]:

--- a/tests/gateway/test_discord_command_scopes.py
+++ b/tests/gateway/test_discord_command_scopes.py
@@ -1,0 +1,44 @@
+"""Discord slash-command scope defaults through real discord.py serialization."""
+
+import subprocess
+import sys
+import textwrap
+
+
+def test_bot_defaults_serialize_guild_and_user_command_scopes():
+    """A real Bot/tree applies Hermes scope defaults to registered commands."""
+    probe = textwrap.dedent(
+        """
+        import discord
+        from discord.ext import commands
+
+        from gateway.config import PlatformConfig
+        from plugins.platforms.discord.adapter import (
+            DiscordAdapter,
+            _discord_app_command_scope_kwargs,
+        )
+
+        bot = commands.Bot(
+            command_prefix="!",
+            intents=discord.Intents.default(),
+            **_discord_app_command_scope_kwargs(),
+        )
+        adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+        adapter._client = bot
+        adapter._register_slash_commands()
+
+        payloads = [command.to_dict(bot.tree) for command in bot.tree.get_commands()]
+        assert payloads
+        assert {tuple(p["integration_types"]) for p in payloads} == {(0, 1)}
+        assert {tuple(p["contexts"]) for p in payloads} == {(0, 1, 2)}
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/gateway/test_discord_command_scopes.py
+++ b/tests/gateway/test_discord_command_scopes.py
@@ -4,6 +4,8 @@ import subprocess
 import sys
 import textwrap
 
+import pytest
+
 
 def test_bot_defaults_serialize_guild_and_user_command_scopes():
     """A real Bot/tree applies Hermes scope defaults to registered commands."""
@@ -40,5 +42,8 @@ def test_bot_defaults_serialize_guild_and_user_command_scopes():
         capture_output=True,
         text=True,
     )
+
+    if result.returncode != 0 and "No module named 'discord'" in result.stderr:
+        pytest.skip("discord.py optional dependency is not installed")
 
     assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -75,7 +75,11 @@ def _ensure_discord_mock():
 
 _ensure_discord_mock()
 
-from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+from plugins.platforms.discord.adapter import (  # noqa: E402
+    DiscordAdapter,
+    _discord_app_command_scope_kwargs,
+)
+import plugins.platforms.discord.adapter as discord_adapter_module  # noqa: E402
 
 
 class FakeTree:
@@ -97,7 +101,12 @@ class FakeTree:
 
 
 @pytest.fixture
-def adapter():
+def adapter(monkeypatch):
+    monkeypatch.delenv("DISCORD_ALLOWED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_SMART_THREAD_TITLES", raising=False)
     config = PlatformConfig(enabled=True, token="***")
     adapter = DiscordAdapter(config)
     adapter._client = SimpleNamespace(
@@ -112,6 +121,59 @@ def adapter():
     # construct a full auth context (allowlist / channel scope).
     adapter._check_slash_authorization = AsyncMock(return_value=True)
     return adapter
+
+
+def test_discord_bot_scope_kwargs_enable_guild_and_user_installs(monkeypatch):
+    calls = {}
+
+    class FakeInstallationType:
+        def __init__(self, **kwargs):
+            calls["installs"] = kwargs
+
+    class FakeCommandContext:
+        def __init__(self, **kwargs):
+            calls["contexts"] = kwargs
+
+    monkeypatch.setattr(discord_adapter_module, "DISCORD_AVAILABLE", True)
+    monkeypatch.setattr(
+        discord_adapter_module,
+        "discord",
+        SimpleNamespace(
+            app_commands=SimpleNamespace(
+                AppInstallationType=FakeInstallationType,
+                AppCommandContext=FakeCommandContext,
+            )
+        ),
+    )
+
+    kwargs = _discord_app_command_scope_kwargs()
+
+    assert set(kwargs) == {"allowed_installs", "allowed_contexts"}
+    assert calls["installs"] == {"guild": True, "user": True}
+    assert calls["contexts"] == {
+        "guild": True,
+        "dm_channel": True,
+        "private_channel": True,
+    }
+
+
+def test_patchable_payload_includes_install_and_context_metadata(adapter):
+    payload = {
+        "type": 1,
+        "name": "status",
+        "description": "Show Hermes session status",
+        "options": [],
+        "contexts": [2, 0, 1],
+        "integration_types": [1, 0],
+    }
+
+    assert adapter._patchable_app_command_payload(payload) == {
+        "name": "status",
+        "description": "Show Hermes session status",
+        "options": [],
+        "contexts": [0, 1, 2],
+        "integration_types": [0, 1],
+    }
 
 
 # ------------------------------------------------------------------

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -157,7 +157,7 @@ def test_discord_bot_scope_kwargs_enable_guild_and_user_installs(monkeypatch):
     }
 
 
-def test_patchable_payload_includes_install_and_context_metadata(adapter):
+def test_patchable_payload_excludes_install_and_context_metadata(adapter):
     payload = {
         "type": 1,
         "name": "status",
@@ -171,8 +171,6 @@ def test_patchable_payload_includes_install_and_context_metadata(adapter):
         "name": "status",
         "description": "Show Hermes session status",
         "options": [],
-        "contexts": [0, 1, 2],
-        "integration_types": [0, 1],
     }
 
 


### PR DESCRIPTION
## Summary
- construct the Discord bot with explicit global-command defaults for guild + user installs and guild + DM + private contexts
- keep `contexts` and `integration_types` out of the patchable payload so scope drift remains delete-and-upsert reconciliation
- retain the existing regression that requires recreation on scope drift
- add real discord.py Bot/tree serialization coverage proving newly registered commands receive `integration_types=[0,1]` and `contexts=[0,1,2]`

## Verification
- `/home/pi/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_discord_slash_commands.py tests/gateway/test_discord_connect.py tests/gateway/test_discord_command_scopes.py -q -o addopts=` — **64 passed**
- `ruff check` on all touched production/test files — passed
- `git diff --check origin/main...HEAD` — passed

Rebased onto current `main` before publication. No live Discord API calls are made by the regression tests.