### PR TITLE
fix: [99992402] cron delivery sends thread_id as receive_id_type

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -565,6 +565,7 @@ def create_job(
     workdir: Optional[str] = None,
     profile: Optional[str] = None,
     no_agent: bool = False,
+    script_args: Optional[List[str]] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -644,6 +645,14 @@ def create_job(
     normalized_base_url = normalized_base_url or None
     normalized_script = str(script).strip() if isinstance(script, str) else None
     normalized_script = normalized_script or None
+    if script_args is None:
+        normalized_script_args: List[str] = []
+    elif isinstance(script_args, list):
+        normalized_script_args = [str(a) for a in script_args]
+    else:
+        raise TypeError(
+            f"script_args must be a list of strings, got {type(script_args).__name__}"
+        )
     normalized_toolsets = [str(t).strip() for t in enabled_toolsets if str(t).strip()] if enabled_toolsets else None
     normalized_toolsets = normalized_toolsets or None
     normalized_workdir = _normalize_workdir(workdir)
@@ -679,6 +688,7 @@ def create_job(
         "provider": normalized_provider,
         "base_url": normalized_base_url,
         "script": normalized_script,
+        "script_args": normalized_script_args,
         "no_agent": normalized_no_agent,
         "context_from": context_from,
         "schedule": parsed_schedule,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -931,13 +931,6 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             if result and result.get("error"):
                 msg = f"delivery error: {result['error']}"
                 logger.error("Job '%s': %s", job["id"], msg)
-                if "dependencies not installed" in result["error"]:
-                    import traceback
-                    try:
-                        import gateway.platforms.feishu
-                        logger.info("Job '%s': feishu import succeeded at scheduler level", job["id"])
-                    except Exception:
-                        logger.error("Job '%s': feishu import TRACEBACK at scheduler level:\n%s", job["id"], traceback.format_exc())
                 delivery_errors.append(msg)
                 continue
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -784,6 +784,9 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         platform_name = target["platform"]
         chat_id = target["chat_id"]
         thread_id = target.get("thread_id")
+        # Normalize empty string to None so downstream _send_to_platform +
+        # _build_create_message_body do not write root_id="" to the Feishu API.
+        thread_id = thread_id or None
 
         # Diagnostic: log thread_id for topic-aware delivery debugging
         origin = _resolve_origin(job) or {}
@@ -821,7 +824,15 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         # rooms (e.g. Matrix) where the standalone HTTP path cannot encrypt.
         runtime_adapter = (adapters or {}).get(platform)
         delivered = False
-        if runtime_adapter is not None and loop is not None and getattr(loop, "is_running", lambda: False)():
+        _live_loop_running = getattr(loop, "is_running", lambda: False)() if loop is not None else False
+        logger.debug(
+            "Job '%s': live adapter delivery check for %s — runtime_adapter=%s loop=%s loop_running=%s",
+            job["id"], platform_name,
+            "present" if runtime_adapter is not None else "absent",
+            "present" if loop is not None else "absent",
+            _live_loop_running,
+        )
+        if runtime_adapter is not None and loop is not None and _live_loop_running:
             send_metadata = {"thread_id": thread_id} if thread_id else None
             try:
                 # Send cleaned text (MEDIA tags stripped) — not the raw content
@@ -920,6 +931,13 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             if result and result.get("error"):
                 msg = f"delivery error: {result['error']}"
                 logger.error("Job '%s': %s", job["id"], msg)
+                if "dependencies not installed" in result["error"]:
+                    import traceback
+                    try:
+                        import gateway.platforms.feishu
+                        logger.info("Job '%s': feishu import succeeded at scheduler level", job["id"])
+                    except Exception:
+                        logger.error("Job '%s': feishu import TRACEBACK at scheduler level:\n%s", job["id"], traceback.format_exc())
                 delivery_errors.append(msg)
                 continue
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -834,6 +834,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                         loop,
                     )
                     if future is None:
+                        logger.warning(
+                            "Job '%s': live adapter schedule failed for %s:%s, falling back to standalone",
+                            job["id"], platform_name, chat_id,
+                        )
                         adapter_ok = False
                     else:
                         try:
@@ -882,6 +886,16 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     "Job '%s': live adapter delivery to %s:%s failed (%s), falling back to standalone",
                     job["id"], platform_name, chat_id, e,
                 )
+
+        elif runtime_adapter is not None:
+            # Gateway is running (adapter exists) but the event loop is
+            # unavailable — this is unexpected and means live delivery
+            # can't be attempted.  Fall through to standalone.
+            reason = "loop is None" if loop is None else "loop is not running"
+            logger.warning(
+                "Job '%s': live adapter exists for %s but %s, falling back to standalone",
+                job["id"], platform_name, reason,
+            )
 
         if not delivered:
             # Standalone path: run the async send in a fresh event loop (safe from any thread)
@@ -954,7 +968,7 @@ def _get_script_timeout() -> int:
     return _DEFAULT_SCRIPT_TIMEOUT
 
 
-def _run_job_script(script_path: str) -> tuple[bool, str]:
+def _run_job_script(script_path: str, script_args: Optional[list[str]] = None) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
     Scripts must reside within HERMES_HOME/scripts/.  Both relative and
@@ -981,6 +995,9 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         (success, output) — on failure *output* contains the error message so the
         LLM can report the problem to the user.
     """
+    if not script_path:
+        return False, "Script path is empty or None"
+
     scripts_dir = _get_hermes_home() / "scripts"
     scripts_dir.mkdir(parents=True, exist_ok=True)
     scripts_dir_resolved = scripts_dir.resolve()
@@ -1031,6 +1048,9 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         argv = [_bash, str(path)]
     else:
         argv = [sys.executable, str(path)]
+
+    if script_args:
+        argv.extend(script_args)
 
     run_env = os.environ.copy()
     run_env["HERMES_HOME"] = str(_get_hermes_home())
@@ -1123,11 +1143,12 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
 
     # Run data-collection script if configured, inject output as context.
     script_path = job.get("script")
+    script_args = job.get("script_args")
     if script_path:
         if prerun_script is not None:
             success, script_output = prerun_script
         else:
-            success, script_output = _run_job_script(script_path)
+            success, script_output = _run_job_script(script_path, script_args)
         if success:
             if script_output:
                 prompt = (
@@ -1378,6 +1399,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
     #                               is no agent to wake
     if job.get("no_agent"):
         script_path = job.get("script")
+        script_args = job.get("script_args")
         if not script_path:
             err = "no_agent=True but no script is set for this job"
             logger.error("Job '%s': %s", job_id, err)
@@ -1396,7 +1418,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 _prior_cwd = None
 
         try:
-            ok, output = _run_job_script(script_path)
+            ok, output = _run_job_script(script_path, script_args)
         finally:
             if _prior_cwd is not None:
                 try:
@@ -1484,8 +1506,9 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
     # the script is only executed once.
     prerun_script = None
     script_path = job.get("script")
+    script_args = job.get("script_args")
     if script_path:
-        prerun_script = _run_job_script(script_path)
+        prerun_script = _run_job_script(script_path, script_args)
         _ran_ok, _script_output = prerun_script
         if _ran_ok and not _parse_wake_gate(_script_output):
             logger.info(

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -4459,7 +4459,9 @@ class FeishuAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]],
     ) -> Any:
         effective_reply_to = reply_to
-        if not effective_reply_to and metadata and metadata.get("thread_id"):
+        # Only reply_to_message_id in metadata acts as a reply target.
+        # thread_id is handled via root_id on the create path below.
+        if not effective_reply_to and metadata:
             effective_reply_to = metadata.get("reply_to_message_id")
         reply_in_thread = bool((metadata or {}).get("thread_id"))
         if effective_reply_to:
@@ -4472,34 +4474,25 @@ class FeishuAdapter(BasePlatformAdapter):
             request = self._build_reply_message_request(effective_reply_to, body)
             return await asyncio.to_thread(self._client.im.v1.message.reply, request)
 
-        # For topic/thread messages that fell back from reply→create, use
-        # thread_id as receive_id so the message lands in the topic instead of
-        # the main chat.
-        _thread_id = (metadata or {}).get("thread_id")
-        if _thread_id:
-            body = self._build_create_message_body(
-                receive_id=_thread_id,
-                msg_type=msg_type,
-                content=payload,
-                uuid_value=str(uuid.uuid4()),
-            )
-            request = self._build_create_message_request("thread_id", body)
-        else:
-            receive_id = chat_id
-            receive_id_type = "chat_id"
-            if chat_id.startswith("feishu_user_id:"):
-                receive_id = chat_id.split(":", 1)[1]
-                receive_id_type = "user_id"
-            elif chat_id.startswith("ou_"):
-                receive_id_type = "open_id"
+        # Determine receive_id and receive_id_type from chat_id.
+        receive_id = chat_id
+        receive_id_type = "chat_id"
+        if chat_id.startswith("feishu_user_id:"):
+            receive_id = chat_id.split(":", 1)[1]
+            receive_id_type = "user_id"
+        elif chat_id.startswith("ou_"):
+            receive_id_type = "open_id"
 
-            body = self._build_create_message_body(
-                receive_id=receive_id,
-                msg_type=msg_type,
-                content=payload,
-                uuid_value=str(uuid.uuid4()),
-            )
-            request = self._build_create_message_request(receive_id_type, body)
+        root_id = (metadata or {}).get("thread_id")
+        body = self._build_create_message_body(
+            receive_id=receive_id,
+            msg_type=msg_type,
+            content=payload,
+            uuid_value=str(uuid.uuid4()),
+            root_id=root_id,
+        )
+
+        request = self._build_create_message_request(receive_id_type, body)
         return await asyncio.to_thread(self._client.im.v1.message.create, request)
 
     @staticmethod
@@ -4785,9 +4778,9 @@ class FeishuAdapter(BasePlatformAdapter):
         return SimpleNamespace(message_id=message_id, request_body=request_body)
 
     @staticmethod
-    def _build_create_message_body(*, receive_id: str, msg_type: str, content: str, uuid_value: str) -> Any:
+    def _build_create_message_body(*, receive_id: str, msg_type: str, content: str, uuid_value: str, root_id: Optional[str] = None) -> Any:
         if "CreateMessageRequestBody" in globals():
-            return (
+            body = (
                 CreateMessageRequestBody.builder()
                 .receive_id(receive_id)
                 .msg_type(msg_type)
@@ -4795,11 +4788,15 @@ class FeishuAdapter(BasePlatformAdapter):
                 .uuid(uuid_value)
                 .build()
             )
+            if root_id:
+                body.root_id = root_id
+            return body
         return SimpleNamespace(
             receive_id=receive_id,
             msg_type=msg_type,
             content=content,
             uuid=uuid_value,
+            root_id=root_id,
         )
 
     @staticmethod

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7531,8 +7531,8 @@ class GatewayRunner:
         # (e.g. customer handover ingest) without triggering the pairing flow.
         if not is_internal:
             try:
-                from hermes_cli.plugins import invoke_hook as _invoke_hook
-                _hook_results = _invoke_hook(
+                from hermes_cli.plugins import invoke_hook as _invoke_hook, invoke_hook_async as _invoke_hook_async
+                _hook_results = await _invoke_hook_async(
                     "pre_gateway_dispatch",
                     event=event,
                     gateway=self,
@@ -7560,6 +7560,34 @@ class GatewayRunner:
                         event = dataclasses.replace(event, text=_new_text)
                         source = event.source
                     break
+                # ── NEW: reply action ───────────────────────────────────
+                if _action == "reply":
+                    _reply_text = _result.get("text")
+                    if isinstance(_reply_text, str) and _reply_text.strip():
+                        adapter = self.adapters.get(source.platform)
+                        if adapter is not None:
+                            try:
+                                await adapter.send(
+                                    source.chat_id,
+                                    _reply_text,
+                                )
+                            except Exception:
+                                logger.warning(
+                                    "pre_gateway_dispatch reply send failed: "
+                                    "platform=%s chat=%s",
+                                    source.platform.value if source.platform else "?",
+                                    source.chat_id,
+                                    exc_info=True,
+                                )
+                        else:
+                            logger.warning(
+                                "pre_gateway_dispatch reply: no adapter for "
+                                "platform=%s chat=%s",
+                                source.platform.value if source.platform else "?",
+                                source.chat_id,
+                            )
+                    return None  # message handled — terminate dispatch
+                # ────────────────────────────────────────────────────────
                 if _action == "allow":
                     break
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1698,7 +1698,37 @@ def _format_gateway_process_notification(evt: dict) -> "str | None":
         text += "]"
         return text
 
-    return None
+
+def _normalize_gateway_process_preview(text: str, limit: int = 80) -> str:
+    collapsed = " ".join(str(text or "").split())
+    if not collapsed:
+        return "(no output)"
+    if len(collapsed) > limit:
+        return collapsed[:limit] + "..."
+    return collapsed
+
+
+def _completion_event_for_session(session_id: str, session: Any) -> dict:
+    from tools.ansi_strip import strip_ansi
+
+    raw = ""
+    output_path = getattr(session, "output_path", None)
+    if output_path and os.path.isfile(output_path):
+        try:
+            with open(output_path, "r", encoding="utf-8", errors="replace") as fh:
+                raw = strip_ansi(fh.read(512))
+        except OSError:
+            raw = ""
+    if not raw:
+        raw = strip_ansi(getattr(session, "output_buffer", "") or "")
+    return {
+        "type": "completion",
+        "session_id": session_id,
+        "command": getattr(session, "command", "unknown"),
+        "exit_code": getattr(session, "exit_code", None),
+        "preview": _normalize_gateway_process_preview(raw, limit=80),
+        "output_path": output_path,
+    }
 
 
 # Module-level weak reference to the active GatewayRunner instance.
@@ -3865,7 +3895,12 @@ class GatewayRunner:
                     e,
                 )
 
-    def _finalize_shutdown_agents(self, active_agents: Dict[str, Any]) -> None:
+    def _finalize_shutdown_agents(
+        self,
+        active_agents: Dict[str, Any],
+        *,
+        preserve_runtime_state: bool = False,
+    ) -> None:
         for agent in active_agents.values():
             try:
                 from hermes_cli.plugins import invoke_hook as _invoke_hook
@@ -3877,9 +3912,17 @@ class GatewayRunner:
                 )
             except Exception:
                 pass
-            self._cleanup_agent_resources(agent)
+            self._cleanup_agent_resources(
+                agent,
+                preserve_runtime_state=preserve_runtime_state,
+            )
 
-    def _cleanup_agent_resources(self, agent: Any) -> None:
+    def _cleanup_agent_resources(
+        self,
+        agent: Any,
+        *,
+        preserve_runtime_state: bool = False,
+    ) -> None:
         """Best-effort cleanup for temporary or cached agent instances."""
         if agent is None:
             return
@@ -3906,7 +3949,13 @@ class GatewayRunner:
         # background processes, httpx clients) to prevent zombie
         # process accumulation.
         try:
-            if hasattr(agent, "close"):
+            if preserve_runtime_state:
+                release_clients = getattr(agent, "release_clients", None)
+                if callable(release_clients):
+                    release_clients()
+                elif hasattr(agent, "close"):
+                    agent.close(preserve_runtime_state=True)
+            elif hasattr(agent, "close"):
                 agent.close()
         except Exception:
             pass
@@ -6492,7 +6541,9 @@ class GatewayRunner:
                 """
                 try:
                     from tools.process_registry import process_registry
-                    _killed = process_registry.kill_all()
+                    _killed = process_registry.kill_all(
+                        include_preserved=not self._restart_requested,
+                    )
                     if _killed:
                         logger.info(
                             "Shutdown (%s): killed %d tool subprocess(es)",
@@ -6644,7 +6695,10 @@ class GatewayRunner:
                 except Exception as e:
                     logger.error("Failed to launch detached gateway restart: %s", e)
 
-            self._finalize_shutdown_agents(active_agents)
+            self._finalize_shutdown_agents(
+                active_agents,
+                preserve_runtime_state=self._restart_requested,
+            )
 
             # Also shut down memory providers on idle cached agents.
             # _finalize_shutdown_agents only handles agents that were
@@ -6661,7 +6715,10 @@ class GatewayRunner:
                     _agent = (
                         _entry[0] if isinstance(_entry, tuple) else _entry
                     )
-                    self._cleanup_agent_resources(_agent)
+                    self._cleanup_agent_resources(
+                        _agent,
+                        preserve_runtime_state=self._restart_requested,
+                    )
 
             for platform, adapter in list(self.adapters.items()):
                 _adapter_started_at = time.monotonic()
@@ -16144,26 +16201,10 @@ class GatewayRunner:
                 # Skip if the agent already consumed the result via wait/poll/log
                 from tools.process_registry import process_registry as _pr_check
                 if agent_notify and not _pr_check.is_completion_consumed(session_id):
-                    from tools.ansi_strip import strip_ansi
-                    _raw = strip_ansi(session.output_buffer) if session.output_buffer else ""
-                    # Truncate at line boundaries so notifications never start
-                    # mid-line (fixes #23284). Keep the last ~2000 chars but
-                    # snap to the nearest preceding newline, then prepend a
-                    # truncation marker when output was cut.
-                    _LIMIT = 2000
-                    if len(_raw) > _LIMIT:
-                        _tail = _raw[-_LIMIT:]
-                        _nl = _tail.find("\n")
-                        _tail = _tail[_nl + 1:] if _nl != -1 else _tail
-                        _out = f"[… output truncated — showing last {len(_tail)} chars]\n{_tail}"
-                    else:
-                        _out = _raw
-                    synth_text = (
-                        f"[IMPORTANT: Background process {session_id} completed "
-                        f"(exit code {session.exit_code}).\n"
-                        f"Command: {session.command}\n"
-                        f"Output:\n{_out}]"
-                    )
+                    from tools.process_registry import format_process_notification
+
+                    completion_evt = _completion_event_for_session(session_id, session)
+                    synth_text = format_process_notification(completion_evt)
                     source = self._build_process_event_source({
                         "session_id": session_id,
                         "session_key": session_key,
@@ -16213,11 +16254,10 @@ class GatewayRunner:
                     or (notify_mode == "error" and session.exit_code not in {0, None})
                 )
                 if should_notify:
-                    new_output = session.output_buffer[-1000:] if session.output_buffer else ""
-                    message_text = (
-                        f"[Background process {session_id} finished with exit code {session.exit_code}~ "
-                        f"Here's the final output:\n{new_output}]"
-                    )
+                    from tools.process_registry import format_process_notification
+
+                    completion_evt = _completion_event_for_session(session_id, session)
+                    message_text = format_process_notification(completion_evt)
                     adapter = None
                     for p, a in self.adapters.items():
                         if p.value == platform_name:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -209,8 +209,48 @@ def _is_pid_ancestor_of_current_process(target_pid: int) -> bool:
     return False
 
 
+def _is_running_inside_gateway() -> bool:
+    """Return True if the current process is running inside a Hermes gateway.
+
+    Dual detection:
+      (a) ``_HERMES_GATEWAY`` env var — set by gateway/run.py on the gateway process.
+      (b) Ancestry walk — checks whether the current process is a descendant of
+          any running gateway PID (PID file → process scan fallback).
+
+    Either signal is sufficient to indicate we are inside the gateway; the check
+    is designed to be called BEFORE any kill/stop/restart operations.
+    """
+    if os.getenv("_HERMES_GATEWAY") == "1":
+        return True
+
+    # Ancestry-based detection: check if current process is a descendant
+    # of a running gateway.  Catches edge cases where _HERMES_GATEWAY may
+    # be cleared but the process hierarchy still traces back to the gateway.
+    try:
+        from gateway.status import get_running_pid
+
+        gw_pid = get_running_pid()
+        if gw_pid and _is_pid_ancestor_of_current_process(gw_pid):
+            return True
+    except ImportError:
+        pass  # gateway.status module not available
+    except (FileNotFoundError, OSError):
+        pass  # PID file missing or unreadable
+    except (RuntimeError, ValueError, UnicodeDecodeError, AttributeError):
+        logger.debug(
+            "Unexpected error during gateway ancestry check", exc_info=True
+        )
+    return False
+
+
 def _request_gateway_self_restart(pid: int) -> bool:
-    """Ask a running gateway ancestor to restart itself asynchronously."""
+    """Ask a running gateway ancestor to restart itself asynchronously.
+
+    This function is only used in service-manager mode (systemd/launchd),
+    where SIGUSR1 triggers a drain-aware restart via the service supervisor.
+    Direct in-process calls should be intercepted at the CLI layer
+    (see ``hermes gateway restart`` defense check).
+    """
     if not hasattr(signal, "SIGUSR1"):
         return False
     if not _is_pid_ancestor_of_current_process(pid):
@@ -6391,7 +6431,10 @@ def _gateway_command_inner(args):
     elif subcmd == "stop":
         # Defense: refuse self-targeting gateway stop from inside the gateway.
         # Prevents agent-initiated kill loops when combined with supervisor KeepAlive.
-        if os.getenv("_HERMES_GATEWAY") == "1":
+        # Dual detection via _is_running_inside_gateway():
+        #   (a) _HERMES_GATEWAY env var
+        #   (b) Ancestry walk against running gateway PID
+        if _is_running_inside_gateway():
             print_error(
                 "Refusing to stop the gateway from inside the gateway process.\n"
                 "This command was blocked to prevent restart loops.\n"
@@ -6484,10 +6527,16 @@ def _gateway_command_inner(args):
     elif subcmd == "restart":
         # Defense: refuse self-targeting gateway restart from inside the gateway.
         # Prevents agent-initiated kill loops when combined with supervisor KeepAlive.
-        if os.getenv("_HERMES_GATEWAY") == "1":
+        # Dual detection via _is_running_inside_gateway():
+        #   (a) _HERMES_GATEWAY env var
+        #   (b) Ancestry walk against running gateway PID
+        # Either signal is sufficient to block the restart; the defense runs BEFORE
+        # any kill/stop operations, so the existing gateway process stays alive.
+        if _is_running_inside_gateway():
             print_error(
                 "Refusing to restart the gateway from inside the gateway process.\n"
                 "This command was blocked to prevent restart loops.\n"
+                "The gateway process is still alive — no action was taken.\n"
                 "Use `hermes gateway restart` from a shell outside the running gateway."
             )
             sys.exit(1)

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3497,7 +3497,7 @@ def launchd_restart():
 
     try:
         pid = get_running_pid()
-        if pid is not None and _request_gateway_self_restart(pid):
+        if pid is not None and _graceful_restart_via_sigusr1(pid, drain_timeout=drain_timeout):
             print("✓ Service restart requested")
             return
         if pid is not None:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -150,6 +150,7 @@ VALID_HOOKS: Set[str] = {
     # dispatch. Plugins may return a dict to influence flow:
     #   {"action": "skip",    "reason": "..."}  -> drop message (no reply)
     #   {"action": "rewrite", "text": "..."}    -> replace event.text, continue
+    #   {"action": "reply",   "text": "..."}    -> send text as reply, terminate
     #   {"action": "allow"}  /  None             -> normal dispatch
     # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
     "pre_gateway_dispatch",
@@ -1608,6 +1609,48 @@ class PluginManager:
                 )
         return results
 
+    async def invoke_hook_async(self, hook_name: str, **kwargs: Any) -> List[Any]:
+        """Invoke all registered callbacks for a hook (async-safe).
+
+        Behaves identically to ``invoke_hook``, but runs in an async context
+        so that both sync and async callbacks work correctly:
+
+        - If a callback returns an awaitable (coroutine, Future, Task), it is
+          ``await``-ed and the resolved value is used.
+        - If a callback returns a plain value, it is used as-is.
+        - Each callback is wrapped in its own try/except; a single failing
+          callback does not prevent remaining callbacks from running.
+
+        Parameters
+        ----------
+        hook_name : str
+            Name of the hook to invoke (e.g. ``"pre_gateway_dispatch"``).
+        **kwargs : Any
+            Keyword arguments forwarded to every registered callback.
+
+        Returns
+        -------
+        List[Any]
+            Non-None return values from each callback, in registration order.
+        """
+        callbacks = self._hooks.get(hook_name, [])
+        results: List[Any] = []
+        for cb in callbacks:
+            try:
+                ret = cb(**kwargs)
+                if ret is not None:
+                    # Detect coroutine and await it; sync return value is used as-is.
+                    if inspect.isawaitable(ret):
+                        ret = await ret
+                if ret is not None:
+                    results.append(ret)
+            except Exception as exc:
+                logger.warning(
+                    "Hook '%s' callback %s raised: %s",
+                    hook_name, getattr(cb, "__name__", repr(cb)), exc,
+                )
+        return results
+
     def has_hook(self, hook_name: str) -> bool:
         """Return True when at least one callback is registered for a hook."""
         return bool(self._hooks.get(hook_name))
@@ -1718,6 +1761,15 @@ def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
     Returns a list of non-``None`` return values from plugin callbacks.
     """
     return get_plugin_manager().invoke_hook(hook_name, **kwargs)
+
+
+async def invoke_hook_async(hook_name: str, **kwargs: Any) -> List[Any]:
+    """Async-safe module-level wrapper around PluginManager.invoke_hook_async.
+
+    Convenience function so callers (e.g. gateway/run.py) don't need to
+    fetch the plugin manager themselves.
+    """
+    return await get_plugin_manager().invoke_hook_async(hook_name, **kwargs)
 
 
 def invoke_middleware(kind: str, **kwargs: Any) -> List[Any]:

--- a/pharma_compliance/__init__.py
+++ b/pharma_compliance/__init__.py
@@ -6,3 +6,16 @@ pharmaceutical representative visit compliance tracking.
 """
 
 __version__ = "1.0.0"
+
+
+def register(ctx):
+    """Register the pharma compliance plugin with Hermes plugin system.
+
+    Called by the Hermes plugin loader at startup.  Registers a single
+    ``pre_gateway_dispatch`` hook that intercepts incoming QQbot messages
+    before they reach the Agent.
+    """
+    from pharma_compliance.plugin_adapter import PharmaCompliancePlugin
+
+    plugin = PharmaCompliancePlugin()
+    ctx.register_hook("pre_gateway_dispatch", plugin.on_gateway_dispatch)

--- a/pharma_compliance/__init__.py
+++ b/pharma_compliance/__init__.py
@@ -1,0 +1,8 @@
+"""
+Pharma Compliance Agent — multimodal QQbot handler.
+
+Handles text, voice (STT), and photo (Vision+OCR+EXIF) messages for
+pharmaceutical representative visit compliance tracking.
+"""
+
+__version__ = "1.0.0"

--- a/pharma_compliance/bot_handler.py
+++ b/pharma_compliance/bot_handler.py
@@ -1,0 +1,783 @@
+"""
+QQbot message handler for pharma compliance.
+
+Handles text, voice (STT), and photo (Vision+OCR+EXIF) messages.
+Merges multimodal messages within a 5-minute window into one task record.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import tempfile
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+# Lazy imports for Hermes modules (imported at module level so tests can patch)
+try:
+    from tools.transcription_tools import transcribe_audio
+except ImportError:
+    transcribe_audio = None
+
+try:
+    from tools.vision_tools import vision_analyze_tool
+except ImportError:
+    vision_analyze_tool = None
+
+from pharma_compliance.session import (
+    MERGE_WINDOW_SECONDS,
+    MessageType,
+    SessionManager,
+    VisitSession,
+)
+from pharma_compliance.extractor import extract_fields, fields_to_summary, get_missing_core_fields
+from pharma_compliance.persistence import save_record
+
+logger = logging.getLogger(__name__)
+
+
+class ComplianceBotHandler:
+    """Handles incoming QQbot messages for pharma compliance tracking.
+
+    Key flows:
+    - Text → extract fields directly
+    - Voice → download → STT → extract fields
+    - Photo → download → Vision+OCR → EXIF → cross-check
+    - Multi-message merge within 5-min window
+    """
+
+    def __init__(
+        self,
+        session_manager: Optional[SessionManager] = None,
+        on_task_complete: Optional[Callable] = None,
+    ):
+        self.sessions = session_manager or SessionManager()
+        self.on_task_complete = on_task_complete
+        self._merge_timers: Dict[str, asyncio.Task] = {}
+
+    # ── Public entry point ──────────────────────────────────────────────────
+
+    async def handle_message(
+        self,
+        user_id: str,
+        msg_type: str,  # "text", "voice", "photo"
+        content: str,   # text content or URL/path for voice/photo
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Handle an incoming message and return extracted results.
+
+        Returns:
+            dict with:
+              - "merged": bool — whether a full task was completed
+              - "task": dict or None — extracted fields if merged
+              - "warnings": list[str] — any compliance warnings
+              - "pending_count": int — messages still pending
+              - "text_preview": str or None — preview text for user confirmation
+        """
+        warnings: List[str] = []
+        metadata = metadata or {}
+        session = self.sessions.get_or_create_session(user_id)
+
+        # Check for manual merge trigger in text messages
+        if msg_type == "text" and session.check_manual_merge(content):
+            return await self._force_merge(session)
+
+        try:
+            if msg_type == "voice":
+                result = await self._handle_voice(user_id, content, metadata, session)
+            elif msg_type == "photo":
+                result = await self._handle_photo(user_id, content, metadata, session)
+            else:
+                result = await self._handle_text(user_id, content, metadata, session)
+        except Exception as e:
+            logger.error("handle_message failed for user %s: %s", user_id, e)
+            return {
+                "merged": False,
+                "task": None,
+                "warnings": [f"处理失败: {e}"],
+                "pending_count": len(session.pending_messages),
+                "text_preview": None,
+                "missing_fields": [],
+            }
+
+        # Schedule background merge timer (reset on each new message)
+        self._schedule_merge_timeout(session.user_id)
+
+        # Check if session should auto-merge immediately (5-min timeout from last message)
+        if session.should_merge():
+            return await self._do_merge(session, warnings)
+
+        result["warnings"] = result.get("warnings", []) + warnings
+        return result
+
+    # ── Text handler ────────────────────────────────────────────────────────
+
+    async def _handle_text(
+        self,
+        user_id: str,
+        text: str,
+        metadata: Dict[str, Any],
+        session: VisitSession,
+    ) -> Dict[str, Any]:
+        session.add_message(MessageType.TEXT, text, metadata=metadata)
+        fields = extract_fields(text)
+        return {
+            "merged": False,
+            "task": None,
+            "warnings": [],
+            "pending_count": len(session.pending_messages),
+            "text_preview": text,
+            "missing_fields": get_missing_core_fields(fields),
+        }
+
+    # ── Voice handler ───────────────────────────────────────────────────────
+
+    async def _handle_voice(
+        self,
+        user_id: str,
+        content: str,  # file path or URL to audio file
+        metadata: Dict[str, Any],
+        session: VisitSession,
+    ) -> Dict[str, Any]:
+        transcript = ""
+        confidence = 0.0
+        stt_used = False
+        downloaded = False
+
+        try:
+            if not os.path.exists(content):
+                # Could be URL — download to temp
+                content = await self._download_file(content, suffix=".ogg")
+                downloaded = True
+
+            # When STT module is unavailable, give a clear suggestion
+            if transcribe_audio is None:
+                return {
+                    "merged": False,
+                    "task": None,
+                    "warnings": [
+                        "语音识别暂不可用，请用文字描述拜访情况，或发送门头照+文字"
+                    ],
+                    "pending_count": len(session.pending_messages),
+                    "text_preview": None,
+                    "missing_fields": [],
+                }
+
+            # Use Hermes STT module
+            try:
+                result = transcribe_audio(content)
+                if result.get("success"):
+                    transcript = result.get("transcript", "")
+                    stt_used = True
+                    # Use explicit confidence from result if available, otherwise infer
+                    if "confidence" in result:
+                        confidence = float(result["confidence"])
+                    else:
+                        confidence = 0.85 if transcript else 0.0
+                    logger.info(
+                        "STT success (provider=%s): %s",
+                        result.get("provider", "?"), transcript[:80],
+                    )
+                else:
+                    logger.warning("STT failed: %s", result.get("error", "unknown"))
+                    return {
+                        "merged": False,
+                        "task": None,
+                        "warnings": [f"语音识别失败: {result.get('error', '')}"],
+                        "pending_count": len(session.pending_messages),
+                        "text_preview": None,
+                        "missing_fields": [],
+                    }
+            except ImportError:
+                logger.warning("Hermes STT not available")
+                transcript = "[语音消息 — 无法识别]"
+            except Exception as e:
+                logger.error("STT call failed: %s", e)
+                transcript = "[语音消息 — 识别异常]"
+
+        finally:
+            # Only delete temp files that were downloaded, never local files
+            if downloaded:
+                self._safe_delete(content)
+
+        # Handle long transcript — save raw text in metadata for potential segmentation
+        if transcript and len(transcript) > 2000:
+            metadata["stt_raw"] = transcript
+
+        # Low-confidence check — ask user to confirm; keep message pending for force-merge
+        if confidence < 0.6:
+            if transcript:
+                session.add_message(MessageType.VOICE, transcript, metadata=metadata)
+            fields = extract_fields(transcript) if transcript else {}
+            return {
+                "merged": False,
+                "task": None,
+                "warnings": [],
+                "pending_count": len(session.pending_messages),
+                "text_preview": transcript,
+                "needs_confirmation": True,
+                "missing_fields": get_missing_core_fields(fields),
+            }
+
+        session.add_message(MessageType.VOICE, transcript, metadata=metadata)
+        fields = extract_fields(transcript)
+        return {
+            "merged": False,
+            "task": None,
+            "warnings": [],
+            "pending_count": len(session.pending_messages),
+            "text_preview": transcript,
+            "missing_fields": get_missing_core_fields(fields),
+        }
+
+    # ── Photo handler ───────────────────────────────────────────────────────
+
+    async def _handle_photo(
+        self,
+        user_id: str,
+        content: str,  # file path or URL to image
+        metadata: Dict[str, Any],
+        session: VisitSession,
+    ) -> Dict[str, Any]:
+        warnings: List[str] = []
+        ocr_text = ""
+        exif_data: Dict[str, Any] = {}
+        downloaded = False
+
+        # Step 1: Ensure file is local
+        local_path = content
+        if content.startswith("http://") or content.startswith("https://"):
+            local_path = await self._download_file(content, suffix=".jpg")
+            downloaded = True
+
+        # Step 2: Vision + OCR via Hermes vision_tools
+        ocr_text = await self._ocr_via_vision(local_path)
+        if not ocr_text:
+            ocr_text = self._ocr_via_pil_fallback(local_path)
+
+        # Step 3: Extract EXIF (GPS + timestamp)
+        exif_data = self._extract_exif(local_path)
+
+        # Step 4: Store photo data in session
+        photo_metadata = {
+            "ocr_text": ocr_text,
+            "exif": exif_data,
+            "file_path": local_path,
+            "is_temp": downloaded,
+        }
+        session.add_message(
+            MessageType.PHOTO,
+            ocr_text or "[门头照]",
+            metadata=photo_metadata,
+        )
+
+        return {
+            "merged": False,
+            "task": None,
+            "warnings": warnings,
+            "pending_count": len(session.pending_messages),
+            "text_preview": f"[门头照] {ocr_text}" if ocr_text else "[门头照]",
+            "photo_exif": exif_data,
+            "missing_fields": get_missing_core_fields(extract_fields(ocr_text or "[门头照]")),
+        }
+
+    # ── Vision+OCR ──────────────────────────────────────────────────────────
+
+    async def _ocr_via_vision(self, image_path: str) -> str:
+        """Use Hermes vision_tools (qwen-vl-max via DashScope) for OCR."""
+        try:
+            prompt = (
+                "请识别这张图片中的所有文字，特别关注：\n"
+                "1. 店名/机构名称\n"
+                "2. 门牌号\n"
+                "3. 任何地址信息\n"
+                "4. 电话号码\n\n"
+                "请以JSON格式返回：\n"
+                '{"store_name": "店名", "address": "地址", "phone": "电话", "other_text": "其他文字"}'
+            )
+            result = await vision_analyze_tool(
+                image_url=image_path,
+                user_prompt=prompt,
+            )
+            # vision_analyze_tool returns JSON string with {"success": bool, "analysis": str}
+            parsed = json.loads(result)
+            if parsed.get("success"):
+                analysis = parsed.get("analysis", "")
+                # Try to parse structured JSON from analysis
+                try:
+                    structured = json.loads(analysis)
+                    store_name = structured.get("store_name", "")
+                    address = structured.get("address", "")
+                    phone = structured.get("phone", "")
+                    other = structured.get("other_text", "")
+                    parts = [p for p in [store_name, address, phone, other] if p]
+                    return " ".join(parts) if parts else analysis
+                except (json.JSONDecodeError, TypeError):
+                    return analysis
+            return ""
+        except ImportError:
+            logger.warning("Hermes vision_tools not available")
+            return ""
+        except Exception as e:
+            logger.error("Vision+OCR failed: %s", e)
+            return ""
+
+    def _ocr_via_pil_fallback(self, image_path: str) -> str:
+        """Fallback OCR using PIL/Pillow for basic text extraction."""
+        try:
+            from PIL import Image
+
+            img = Image.open(image_path)
+            return f"[图片: {img.width}x{img.height}]"
+        except ImportError:
+            return "[图片 — 无法分析]"
+        except Exception as e:
+            logger.error("PIL fallback failed: %s", e)
+            return ""
+
+    # ── EXIF extraction ─────────────────────────────────────────────────────
+
+    def _extract_exif(self, image_path: str) -> Dict[str, Any]:
+        """Extract EXIF metadata: GPS coordinates and capture time."""
+        result: Dict[str, Any] = {"gps": None, "datetime": None}
+
+        try:
+            from PIL import Image
+            from PIL.ExifTags import Base as ExifBase, GPSTAGS
+
+            img = Image.open(image_path)
+            exif_raw = img.getexif()
+            if not exif_raw:
+                return result
+
+            exif = {ExifBase(k).name: v for k, v in exif_raw.items() if k in ExifBase}
+
+            # Capture time
+            dt_str = exif.get("DateTimeOriginal") or exif.get("DateTime")
+            if dt_str:
+                try:
+                    dt = datetime.strptime(str(dt_str), "%Y:%m:%d %H:%M:%S")
+                    result["datetime"] = dt.isoformat()
+                except ValueError:
+                    result["datetime"] = str(dt_str)
+
+            # GPS coordinates
+            gps_info = exif_raw.get_ifd(0x8825)  # GPSInfo IFD
+            if gps_info:
+                gps = {}
+                for tag_id, value in gps_info.items():
+                    tag_name = GPSTAGS.get(tag_id, str(tag_id))
+                    gps[tag_name] = value
+                result["gps"] = self._parse_gps(gps)
+
+        except ImportError:
+            logger.debug("PIL/Pillow not available for EXIF")
+        except Exception as e:
+            logger.warning("EXIF extraction failed: %s", e)
+
+        return result
+
+    def _parse_gps(self, gps: Dict[str, Any]) -> Optional[Dict[str, float]]:
+        """Parse GPS data from EXIF into lat/lon."""
+        try:
+            lat_ref = gps.get("GPSLatitudeRef", "N")
+            lat = gps.get("GPSLatitude")
+            lon_ref = gps.get("GPSLongitudeRef", "E")
+            lon = gps.get("GPSLongitude")
+
+            if not lat or not lon:
+                return None
+
+            def _to_decimal(dms) -> float:
+                if isinstance(dms, (tuple, list)) and len(dms) >= 3:
+                    return float(dms[0]) + float(dms[1]) / 60.0 + float(dms[2]) / 3600.0
+                return float(dms)
+
+            lat_dd = _to_decimal(lat)
+            lon_dd = _to_decimal(lon)
+            if lat_ref == "S":
+                lat_dd = -lat_dd
+            if lon_ref == "W":
+                lon_dd = -lon_dd
+
+            return {"latitude": round(lat_dd, 6), "longitude": round(lon_dd, 6)}
+        except Exception as e:
+            logger.warning("GPS parse failed: %s", e)
+            return None
+
+    # ── Cross-check logic ───────────────────────────────────────────────────
+
+    def cross_check(
+        self,
+        claimed_store: str,
+        ocr_store: str,
+        claimed_location: Optional[Dict[str, float]] = None,
+        exif_gps: Optional[Dict[str, float]] = None,
+        claimed_time: Optional[str] = None,
+        exif_time: Optional[str] = None,
+    ) -> List[str]:
+        """Cross-check claimed info against photo metadata. Returns warnings."""
+        warnings: List[str] = []
+
+        # Check 1: store name mismatch
+        if ocr_store and claimed_store:
+            if not self._fuzzy_match(claimed_store, ocr_store):
+                warnings.append(
+                    f"⚠️ 地址不匹配: 声称'{claimed_store}' vs OCR'{ocr_store}'"
+                )
+
+        # Check 2: GPS deviation > 500m
+        if claimed_location and exif_gps:
+            dist = self._haversine_distance(
+                claimed_location.get("latitude", 0),
+                claimed_location.get("longitude", 0),
+                exif_gps.get("latitude", 0),
+                exif_gps.get("longitude", 0),
+            )
+            if dist > 500:
+                warnings.append(
+                    f"⚠️ 位置偏差: {dist:.0f}m"
+                )
+
+        # Check 3: time deviation > 30 min
+        if claimed_time and exif_time:
+            try:
+                ct = datetime.fromisoformat(claimed_time)
+                et = datetime.fromisoformat(exif_time)
+                diff = abs((ct - et).total_seconds())
+                if diff > 1800:
+                    warnings.append(
+                        f"⚠️ 时间偏差: {diff/60:.0f}分钟"
+                    )
+            except (ValueError, TypeError):
+                pass
+
+        return warnings
+
+    @staticmethod
+    def _fuzzy_match(a: str, b: str, threshold: float = 0.6) -> bool:
+        """Simple fuzzy matching between two names."""
+        a_clean = "".join(c for c in a if c.isalnum())
+        b_clean = "".join(c for c in b if c.isalnum())
+        if not a_clean or not b_clean:
+            return False
+        # Check if one is a substring of the other
+        if a_clean in b_clean or b_clean in a_clean:
+            return True
+        # Character overlap ratio
+        overlap = len(set(a_clean) & set(b_clean))
+        max_len = max(len(set(a_clean)), len(set(b_clean)))
+        return overlap / max_len >= threshold if max_len > 0 else False
+
+    @staticmethod
+    def _haversine_distance(
+        lat1: float, lon1: float, lat2: float, lon2: float
+    ) -> float:
+        """Calculate haversine distance in meters between two GPS points."""
+        import math
+
+        R = 6371000  # Earth radius in meters
+        phi1 = math.radians(lat1)
+        phi2 = math.radians(lat2)
+        dphi = math.radians(lat2 - lat1)
+        dlam = math.radians(lon2 - lon1)
+
+        a = (
+            math.sin(dphi / 2) ** 2
+            + math.cos(phi1) * math.cos(phi2) * math.sin(dlam / 2) ** 2
+        )
+        return R * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+
+    # ── Merge logic ─────────────────────────────────────────────────────────
+
+    async def _do_merge(
+        self, session: VisitSession, extra_warnings: Optional[List[str]] = None
+    ) -> Dict[str, Any]:
+        """Merge pending messages into a task record and run extraction."""
+        warnings = list(extra_warnings or [])
+        merged_text = session.merge_contents()
+
+        # Extract fields from merged text
+        fields = extract_fields(merged_text)
+
+        # Extract claimed_location from any message's metadata (rep-shared GPS)
+        claimed_location = self._extract_claimed_location(session)
+
+        # Cross-check photo vs text claims
+        photo_metas = self._collect_photo_metadata(session)
+        if photo_metas:
+            warnings.extend(
+                self._run_cross_checks(fields, photo_metas, claimed_location)
+            )
+
+        task = {
+            "fields": fields,
+            "summary": fields_to_summary(fields),
+            "warnings": warnings,
+            "message_count": len(session.pending_messages),
+            "merged_text": merged_text,
+        }
+
+        # Collect photo paths BEFORE any archival/deletion
+        photo_paths = self._collect_photo_paths(session)
+
+        # Persist record + photos to disk FIRST (before archive may delete temp files)
+        persist_ok = False
+        try:
+            save_record(task, photo_paths)
+            persist_ok = True
+        except Exception as e:
+            logger.error("Failed to persist record: %s", e)
+
+        if persist_ok:
+            # Only archive (which may delete temp files) after successful persistence
+            self._archive_photos(session)
+            # Clear pending messages ONLY after successful persistence
+            session.clear()
+        else:
+            logger.warning(
+                "Persistence failed for user %s — session NOT cleared, data retained for retry",
+                session.user_id,
+            )
+
+        # Cancel any pending merge timer for this session
+        self._cancel_merge_timer(session.user_id)
+
+        # Check feedback field completeness — 反馈必填引导追问
+        feedback = fields.get("feedback", "")
+        feedback_missing = not feedback or (isinstance(feedback, str) and not feedback.strip())
+        followup_msg = None
+        if feedback_missing:
+            followup_msg = (
+                "好的，记录下来了～再补充一下：这次的拜访对象有什么具体的反馈吗？"
+                "比如对产品的评价、销量变化、提出的建议等等。"
+            )
+            logger.info("Feedback field missing for user %s, requesting follow-up", session.user_id)
+
+        if self.on_task_complete:
+            try:
+                result = self.on_task_complete(task)
+                if asyncio.iscoroutine(result):
+                    await result
+            except Exception as e:
+                logger.error("on_task_complete callback failed: %s", e)
+
+        missing_fields = get_missing_core_fields(fields)
+        if feedback_missing and "feedback" not in missing_fields:
+            missing_fields.append("feedback")
+
+        return {
+            "merged": True,
+            "task": task,
+            "warnings": warnings,
+            "pending_count": 0,
+            "text_preview": fields_to_summary(fields),
+            "missing_fields": missing_fields,
+            "needs_followup": feedback_missing,
+            "followup_field": "feedback" if feedback_missing else None,
+            "followup_message": followup_msg,
+        }
+
+    async def _force_merge(self, session: VisitSession) -> Dict[str, Any]:
+        """Force merge triggered by manual phrase ('完了' etc.)."""
+        if not session.pending_messages:
+            return {
+                "merged": False,
+                "task": None,
+                "warnings": [],
+                "pending_count": 0,
+                "text_preview": None,
+                "missing_fields": [],
+            }
+        logger.info("Manual merge triggered for user %s", session.user_id)
+        return await self._do_merge(session)
+
+    @staticmethod
+    def _extract_claimed_location(session: VisitSession) -> Optional[Dict[str, float]]:
+        """Extract claimed GPS location from any pending message's metadata."""
+        for msg in session.pending_messages:
+            loc = msg.metadata.get("claimed_location")
+            if loc and isinstance(loc, dict):
+                lat = loc.get("latitude")
+                lon = loc.get("longitude")
+                if isinstance(lat, (int, float)) and isinstance(lon, (int, float)):
+                    return {"latitude": float(lat), "longitude": float(lon)}
+        return None
+
+    def _collect_photo_metadata(self, session: VisitSession) -> List[Dict[str, Any]]:
+        return [
+            msg.metadata
+            for msg in session.pending_messages
+            if msg.msg_type == MessageType.PHOTO
+        ]
+
+    def _run_cross_checks(
+        self,
+        fields: Dict[str, Any],
+        photo_metas: List[Dict[str, Any]],
+        claimed_location: Optional[Dict[str, float]] = None,
+    ) -> List[str]:
+        warnings: List[str] = []
+        claimed_store = fields.get("org_name", "")
+        claimed_address = fields.get("org_address", "")
+        claimed_date = fields.get("visit_date", "")
+        claimed_time = fields.get("visit_time", "")
+        claimed_dt = f"{claimed_date}T{claimed_time}" if claimed_date and claimed_time else None
+
+        for pm in photo_metas:
+            ocr_text = pm.get("ocr_text", "")
+            exif = pm.get("exif", {})
+
+            # Extract store name from OCR text
+            ocr_store = self._extract_store_from_ocr(ocr_text)
+
+            cross_warnings = self.cross_check(
+                claimed_store=claimed_store,
+                ocr_store=ocr_store,
+                claimed_location=claimed_location,
+                exif_gps=exif.get("gps"),
+                claimed_time=claimed_dt,
+                exif_time=exif.get("datetime"),
+            )
+            warnings.extend(cross_warnings)
+
+        return warnings
+
+    @staticmethod
+    def _extract_store_from_ocr(ocr_text: str) -> str:
+        """Extract store name from OCR output."""
+        if not ocr_text:
+            return ""
+        # OCR text often starts with the store name
+        for suffix in ["大药房", "药房", "药店", "医院", "诊所", "连锁"]:
+            idx = ocr_text.find(suffix)
+            if idx >= 0:
+                start = max(0, idx - 10)
+                return ocr_text[start:idx + len(suffix)].strip()
+        return ""
+
+    def _archive_photos(self, session: VisitSession) -> None:
+        """Move photos to session archive directory."""
+        archive_dir = Path(tempfile.gettempdir()) / "pharma_archive" / session.user_id
+        try:
+            archive_dir.mkdir(parents=True, exist_ok=True)
+            for msg in session.pending_messages:
+                if msg.msg_type == MessageType.PHOTO:
+                    src = msg.metadata.get("file_path", "")
+                    if src and os.path.exists(src):
+                        dst = archive_dir / os.path.basename(src)
+                        import shutil
+                        shutil.copy2(src, dst)
+                        logger.debug("Archived photo: %s → %s", src, dst)
+                        if msg.metadata.get("is_temp"):
+                            ComplianceBotHandler._safe_delete(src)
+        except Exception as e:
+            logger.error("Photo archive failed: %s", e)
+
+    @staticmethod
+    def _collect_photo_paths(session: VisitSession) -> List[str]:
+        """Collect file paths of all photos in the session for persistence."""
+        paths: List[str] = []
+        for msg in session.pending_messages:
+            if msg.msg_type == MessageType.PHOTO:
+                src = msg.metadata.get("file_path", "")
+                if src and os.path.exists(src):
+                    paths.append(src)
+        return paths
+
+    # ── Background merge timer ──────────────────────────────────────────────
+
+    def _schedule_merge_timeout(self, session_id: str, timeout: float = 300.0) -> None:
+        """Schedule a background merge after `timeout` seconds of inactivity.
+
+        Cancels any existing timer for the session and creates a new one.
+        When the timer fires, triggers merge_and_finalize.
+        """
+        self._cancel_merge_timer(session_id)
+
+        async def _delayed_merge():
+            await asyncio.sleep(timeout)
+            session = self.sessions.get_session(session_id)
+            if session and session.pending_messages:
+                logger.info(
+                    "Background merge timer fired for user %s (%d pending)",
+                    session_id, len(session.pending_messages),
+                )
+                try:
+                    await self._do_merge(session)
+                except Exception as e:
+                    logger.error("Background merge failed for user %s: %s", session_id, e)
+
+        self._merge_timers[session_id] = asyncio.create_task(_delayed_merge())
+        logger.debug("Scheduled merge timer for user %s (%.0fs)", session_id, timeout)
+
+    def _cancel_merge_timer(self, session_id: str) -> None:
+        """Cancel the pending merge timer for a session."""
+        timer = self._merge_timers.pop(session_id, None)
+        if timer and not timer.done():
+            timer.cancel()
+            logger.debug("Cancelled merge timer for user %s", session_id)
+
+    # ── Utilities ────────────────────────────────────────────────────────────
+
+    async def _download_file(self, url: str, suffix: str = ".tmp") -> str:
+        """Download a file from URL to temp directory. Returns local path.
+
+        Cleans up the temp file on failure.
+        """
+        path = None
+        try:
+            import aiohttp
+        except ImportError:
+            aiohttp = None
+
+        if aiohttp is not None:
+            fd, path = tempfile.mkstemp(suffix=suffix)
+            os.close(fd)
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.get(url) as resp:
+                        if resp.status == 200:
+                            with open(path, "wb") as f:
+                                f.write(await resp.read())
+                            return path
+                        else:
+                            raise IOError(f"Download failed: HTTP {resp.status}")
+            except Exception:
+                self._safe_delete(path)
+                raise
+        else:
+            import urllib.request
+            fd, path = tempfile.mkstemp(suffix=suffix)
+            os.close(fd)
+            try:
+                urllib.request.urlretrieve(url, path)
+                return path
+            except Exception:
+                self._safe_delete(path)
+                raise
+
+    @staticmethod
+    def _safe_delete(file_path: str) -> None:
+        """Safely delete a temporary file."""
+        try:
+            if file_path and os.path.exists(file_path):
+                os.unlink(file_path)
+                logger.debug("Deleted temp file: %s", file_path)
+        except Exception as e:
+            logger.warning("Failed to delete temp file %s: %s", file_path, e)
+
+
+# ── Convenience function ────────────────────────────────────────────────────
+
+async def process_message(
+    user_id: str,
+    msg_type: str,
+    content: str,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Convenience function to process a single message."""
+    handler = ComplianceBotHandler()
+    return await handler.handle_message(user_id, msg_type, content, metadata)

--- a/pharma_compliance/bot_handler.py
+++ b/pharma_compliance/bot_handler.py
@@ -32,10 +32,85 @@ from pharma_compliance.session import (
     SessionManager,
     VisitSession,
 )
-from pharma_compliance.extractor import extract_fields, fields_to_summary, get_missing_core_fields
-from pharma_compliance.persistence import save_record
+from pharma_compliance.extractor import (
+    extract_fields,
+    fields_to_summary,
+    get_missing_core_fields,
+    CORE_FIELDS_PRIORITY,
+    CORE_FIELD_LABELS,
+    _extract_date,
+    _extract_time,
+    _extract_org_name,
+    _extract_person,
+    _extract_products,
+    _extract_topic,
+    _extract_feedback,
+    _extract_next_steps,
+    _extract_competitor,
+    detect_task_type,
+)
+from pharma_compliance.persistence import save_record, update_record
 
 logger = logging.getLogger(__name__)
+
+# ── Progressive field questioning ───────────────────────────────────────────
+
+# Priority order for progressive follow-up: date → time → core fields (deduped)
+_PROGRESSIVE_FIELD_PRIORITY = ["visit_date", "visit_time"] + [
+    f for f in CORE_FIELDS_PRIORITY if f not in ("visit_date",)
+]
+
+# Natural-language question templates for each field
+_FIELD_QUESTION_TEMPLATES: Dict[str, str] = {
+    "visit_date": "好的，记录下来了～请问这次拜访是什么时候去的呢？",
+    "visit_time": "了解～具体是几点左右去的呢？",
+    "task_type": "请问这次的任务类型是什么呢？（药店拜访 / 医疗机构拜访 / 学术推广）",
+    "org_name": "请问拜访的是哪家药店或机构呢？",
+    "contact_person": "请问拜访对象是哪位呢？",
+    "products": "主要涉及了哪些产品呢？",
+    "topic": "这次拜访主要聊了什么主题呢？",
+    "content_summary": "能简单描述一下拜访内容吗？",
+    "next_steps": "接下来有什么计划或下一步安排吗？",
+    "feedback": "这次的拜访对象有什么具体的反馈吗？比如对产品的评价、销量变化、提出的建议等等。",
+    "competitor_info": "有了解到什么竞品信息吗？",
+}
+
+
+def _get_field_question(field_name: str) -> Optional[str]:
+    """Return a natural-language follow-up question for a given field."""
+    return _FIELD_QUESTION_TEMPLATES.get(field_name)
+
+
+def _extract_single_field(text: str, field_name: str) -> str:
+    """Extract a single field value from user's reply text."""
+    if not text or not text.strip():
+        return ""
+    if field_name == "visit_date":
+        return _extract_date(text)
+    elif field_name == "visit_time":
+        return _extract_time(text)
+    elif field_name == "org_name":
+        return _extract_org_name(text)
+    elif field_name == "contact_person":
+        name, _ = _extract_person(text)
+        return name
+    elif field_name == "products":
+        return _extract_products(text)
+    elif field_name == "topic":
+        return _extract_topic(text)
+    elif field_name == "feedback":
+        return _extract_feedback(text)
+    elif field_name == "next_steps":
+        return _extract_next_steps(text)
+    elif field_name == "competitor_info":
+        return _extract_competitor(text)
+    elif field_name == "task_type":
+        return detect_task_type(text)
+    elif field_name == "content_summary":
+        return text.strip()
+    else:
+        # Generic: use the raw text
+        return text.strip()
 
 
 class ComplianceBotHandler:
@@ -78,11 +153,71 @@ class ComplianceBotHandler:
         """
         warnings: List[str] = []
         metadata = metadata or {}
+        # ── Check for stale session BEFORE touching activity ──
+        # get_or_create_session calls touch_activity() which would reset last_activity,
+        # so we must check staleness first using get_session (which does NOT touch activity).
+        existing = self.sessions.get_session(user_id)
+        if existing and (existing.pending_field is not None or (
+            existing.merged_fields is not None and existing.pending_questions
+        )):
+            if existing.is_stale():
+                existing.clear()
+                return {
+                    "merged": False,
+                    "task": None,
+                    "warnings": ["上次对话已超时，请重新开始"],
+                    "pending_count": 0,
+                    "text_preview": None,
+                    "missing_fields": [],
+                    "needs_followup": False,
+                    "followup_field": None,
+                    "followup_message": None,
+                }
         session = self.sessions.get_or_create_session(user_id)
 
-        # Check for manual merge trigger in text messages
+        # Check for manual merge trigger in text messages FIRST (takes priority over progressive routing)
         if msg_type == "text" and session.check_manual_merge(content):
             return await self._force_merge(session)
+
+        # ── Progressive questioning: user is answering a field follow-up ──
+        # Two scenarios trigger this path:
+        # 1. session.pending_field is set → actively answering a progressive question
+        # 2. merged_fields exists but no pending_field → answering feedback from _do_merge
+        #    (feedback was asked in merge response, now transitioning to progressive)
+        if session.pending_field is not None or (
+            session.merged_fields is not None and session.pending_questions
+        ):
+            # Check if session has been inactive for too long
+            if session.is_stale():
+                session.clear()
+                return {
+                    "merged": False,
+                    "task": None,
+                    "warnings": ["上次对话已超时，请重新开始"],
+                    "pending_count": 0,
+                    "text_preview": None,
+                    "missing_fields": [],
+                    "needs_followup": False,
+                    "followup_field": None,
+                    "followup_message": None,
+                }
+            if msg_type != "text":
+                # Non-text messages in progressive mode: briefly acknowledge
+                return {
+                    "merged": False,
+                    "task": None,
+                    "warnings": [],
+                    "pending_count": 0,
+                    "text_preview": None,
+                    "missing_fields": session.pending_questions,
+                    "needs_followup": True,
+                    "followup_field": session.pending_field,
+                    "followup_message": (
+                        f"收到啦～不过刚才在问的「{CORE_FIELD_LABELS.get(session.pending_field or '信息', '信息')}」"
+                        f"方便用文字回复一下吗？"
+                    ),
+                }
+            return await self._handle_progressive_answer(user_id, content, session)
 
         try:
             if msg_type == "voice":
@@ -525,8 +660,9 @@ class ComplianceBotHandler:
 
         # Persist record + photos to disk FIRST (before archive may delete temp files)
         persist_ok = False
+        record_id = None
         try:
-            save_record(task, photo_paths)
+            record_id = save_record(task, photo_paths)
             persist_ok = True
         except Exception as e:
             logger.error("Failed to persist record: %s", e)
@@ -534,27 +670,97 @@ class ComplianceBotHandler:
         if persist_ok:
             # Only archive (which may delete temp files) after successful persistence
             self._archive_photos(session)
-            # Clear pending messages ONLY after successful persistence
-            session.clear()
         else:
             logger.warning(
-                "Persistence failed for user %s — session NOT cleared, data retained for retry",
+                "Persistence failed for user %s — session cleared, data retained in memory only (retry will produce new visit record)",
                 session.user_id,
             )
 
         # Cancel any pending merge timer for this session
         self._cancel_merge_timer(session.user_id)
 
-        # Check feedback field completeness — 反馈必填引导追问
+        # ── Bail out if persist failed ──
+        if not record_id:
+            session.clear()
+            return {
+                "merged": False,
+                "task": None,
+                "warnings": warnings + ["持久化失败，请重试"],
+                "pending_count": 0,
+                "text_preview": None,
+                "missing_fields": [],
+                "needs_followup": False,
+                "followup_field": None,
+                "followup_message": None,
+            }
+
+        # ── Build progressive questioning queue ──────────────────────────
+        # Check ALL missing fields in priority order (date → time → core fields)
+        progressive_missing = self._build_progressive_queue(fields)
+
+        # Feedback is handled specially (existing behavior): if feedback missing,
+        # it's asked first via the return value. Remaining fields go to session.
         feedback = fields.get("feedback", "")
-        feedback_missing = not feedback or (isinstance(feedback, str) and not feedback.strip())
-        followup_msg = None
-        if feedback_missing:
-            followup_msg = (
-                "好的，记录下来了～再补充一下：这次的拜访对象有什么具体的反馈吗？"
-                "比如对产品的评价、销量变化、提出的建议等等。"
-            )
-            logger.info("Feedback field missing for user %s, requesting follow-up", session.user_id)
+        is_feedback_missing = not feedback or (isinstance(feedback, str) and not feedback.strip())
+        needs_followup = is_feedback_missing  # Default: needs follow-up if feedback missing
+
+        if progressive_missing:
+            # ── Setup progressive state (don't clear session) ──────────
+
+            if is_feedback_missing:
+                # Feedback comes first (existing behavior), queue the rest
+                # Remove feedback from progressive queue since it's asked separately
+                other_missing = [f for f in progressive_missing if f != "feedback"]
+
+                if other_missing:
+                    # Both feedback + other fields missing: enter progressive mode
+                    session.merged_fields = dict(fields)
+                    if record_id:
+                        session.merged_record_id = record_id
+                    session.pending_questions = other_missing
+                    session.pending_field = None  # Will be set after user answers feedback
+                    followup_msg = (
+                        "好的，记录下来了～再补充一下：这次的拜访对象有什么具体的反馈吗？"
+                        "比如对产品的评价、销量变化、提出的建议等等。"
+                    )
+                    logger.info(
+                        "Merge for user %s: feedback missing + %d other fields queued: %s",
+                        session.user_id, len(other_missing), other_missing,
+                    )
+                else:
+                    # ONLY feedback missing, no other progressive fields → progressive follow-up
+                    session.merged_fields = dict(fields)
+                    if record_id:
+                        session.merged_record_id = record_id
+                    session.pending_questions = []
+                    session.pending_field = "feedback"  # Will be answered in progressive flow, then update_record
+                    followup_msg = (
+                        "好的，记录下来了～再补充一下：这次的拜访对象有什么具体的反馈吗？"
+                        "比如对产品的评价、销量变化、提出的建议等等。"
+                    )
+                    logger.info(
+                        "Merge for user %s: only feedback missing, progressive follow-up with record_id=%s",
+                        session.user_id, record_id,
+                    )
+            else:
+                # No feedback missing — start progressive immediately
+                session.merged_fields = dict(fields)
+                if record_id:
+                    session.merged_record_id = record_id
+                first_field = progressive_missing.pop(0)
+                session.pending_field = first_field
+                session.pending_questions = progressive_missing
+                followup_msg = _get_field_question(first_field)
+                needs_followup = True  # Signal needs_followup (non-feedback field when feedback was OK)
+                logger.info(
+                    "Merge for user %s: progressive start with '%s', %d more queued: %s",
+                    session.user_id, first_field, len(progressive_missing), progressive_missing,
+                )
+        else:
+            # No missing fields at all — clean up normally
+            session.clear()
+            followup_msg = None
+            needs_followup = False
 
         if self.on_task_complete:
             try:
@@ -564,8 +770,9 @@ class ComplianceBotHandler:
             except Exception as e:
                 logger.error("on_task_complete callback failed: %s", e)
 
+        # Build missing_fields for the response (for backward compat)
         missing_fields = get_missing_core_fields(fields)
-        if feedback_missing and "feedback" not in missing_fields:
+        if is_feedback_missing and "feedback" not in missing_fields:
             missing_fields.append("feedback")
 
         return {
@@ -575,8 +782,8 @@ class ComplianceBotHandler:
             "pending_count": 0,
             "text_preview": fields_to_summary(fields),
             "missing_fields": missing_fields,
-            "needs_followup": feedback_missing,
-            "followup_field": "feedback" if feedback_missing else None,
+            "needs_followup": needs_followup,
+            "followup_field": "feedback" if (is_feedback_missing and not session.pending_field) else session.pending_field,
             "followup_message": followup_msg,
         }
 
@@ -593,6 +800,173 @@ class ComplianceBotHandler:
             }
         logger.info("Manual merge triggered for user %s", session.user_id)
         return await self._do_merge(session)
+
+    # ── Progressive field questioning (post-merge multi-round) ──────────────
+
+    def _build_progressive_queue(self, fields: Dict[str, Any]) -> List[str]:
+        """Build ordered list of missing fields from merged result.
+
+        Priority: visit_date → visit_time → CORE_FIELDS_PRIORITY (deduped).
+        Excludes fields already present (non-empty).
+        """
+        missing: List[str] = []
+        for field in _PROGRESSIVE_FIELD_PRIORITY:
+            value = fields.get(field, "")
+            if not value or (isinstance(value, str) and not value.strip()):
+                missing.append(field)
+        return missing
+
+    async def _handle_progressive_answer(
+        self, user_id: str, text: str, session: VisitSession
+    ) -> Dict[str, Any]:
+        """Handle user's answer to a progressive field question.
+
+        Extracts the field value from user's reply, updates merged_fields,
+        and asks the next pending question. When all fields are collected,
+        updates the persisted record and finalizes.
+        """
+        merged = session.merged_fields or {}
+        current_field = session.pending_field
+
+        # ── Phase 1: Answering the current progressive question ──────────
+        if current_field:
+            extracted = _extract_single_field(text, current_field)
+            if extracted:
+                merged[current_field] = extracted
+                session.retry_count = 0  # reset on success
+                logger.info(
+                    "Progressive: user %s answered field '%s': %s",
+                    user_id, current_field, extracted,
+                )
+            else:
+                if session.retry_count >= 2:
+                    # Retry count exhausted, skip this field
+                    logger.info(
+                        "Progressive: user %s failed field '%s' after 2 retries, skipping",
+                        user_id, current_field,
+                    )
+                else:
+                    session.retry_count += 1
+                    logger.info(
+                        "Progressive: user %s replied to '%s' but no value extracted (retry %d/2): %s",
+                        user_id, current_field, session.retry_count, text[:80],
+                    )
+                    # Re-ask the same field with a retry prompt
+                    field_label = CORE_FIELD_LABELS.get(current_field, current_field)
+                    retry_msg = (
+                        f"信息不清晰，能否重新补充一下{field_label}？"
+                        f"比如{CORE_FIELD_LABELS.get(current_field, '具体说明一下')}..."
+                    )
+                    return {
+                        "merged": False,
+                        "task": None,
+                        "warnings": [],
+                        "pending_count": 0,
+                        "text_preview": None,
+                        "missing_fields": session.pending_questions,
+                        "needs_followup": True,
+                        "followup_field": current_field,
+                        "followup_message": retry_msg,
+                    }
+
+        # ── Phase 2: Also extract feedback if we were awaiting it ────────
+        # (feedback flagged as missing in _do_merge but no pending_field was set)
+        if not current_field and "feedback" in merged and not merged.get("feedback"):
+            extracted = _extract_single_field(text, "feedback")
+            if extracted:
+                merged["feedback"] = extracted
+                logger.info(
+                    "Progressive: user %s provided feedback: %s", user_id, extracted[:80],
+                )
+
+        session.merged_fields = merged
+
+        # ── Phase 3: Move to next question or finalize ───────────────────
+        next_field = None
+        if session.pending_questions:
+            next_field = session.pending_questions.pop(0)
+
+        if next_field:
+            session.pending_field = next_field
+            question = _get_field_question(next_field) or f"请补充一下「{CORE_FIELD_LABELS.get(next_field, next_field)}」的信息～"
+            logger.info(
+                "Progressive: user %s → next question for field '%s'", user_id, next_field,
+            )
+            return {
+                "merged": False,
+                "task": None,
+                "warnings": [],
+                "pending_count": 0,
+                "text_preview": None,
+                "missing_fields": session.pending_questions,
+                "needs_followup": True,
+                "followup_field": next_field,
+                "followup_message": question,
+            }
+
+        # ── Phase 4: All questions answered — update persisted record ────
+        session.pending_field = None
+        record_id = session.merged_record_id
+        if record_id:
+            try:
+                update_record(record_id, merged)
+                logger.info(
+                    "Progressive: updated record %s for user %s with %d completed fields",
+                    record_id, user_id, len(merged),
+                )
+                # Build final summary
+                final_summary = fields_to_summary(merged)
+
+                # Clean up session state (only on success)
+                session.clear()
+
+                # Cancel merge timer
+                self._cancel_merge_timer(session.user_id)
+
+                return {
+                    "merged": True,
+                    "task": {"fields": merged, "summary": final_summary, "warnings": [], "message_count": 0},
+                    "warnings": [],
+                    "pending_count": 0,
+                    "text_preview": f"✅ 记录已完善～\n{final_summary}",
+                    "missing_fields": [],
+                    "needs_followup": False,
+                    "followup_field": None,
+                    "followup_message": None,
+                }
+            except Exception as e:
+                logger.error("Progressive: failed to update record %s: %s", record_id, e)
+                # Do NOT clear session — data retained for retry
+                return {
+                    "merged": False,
+                    "task": None,
+                    "warnings": [f"记录更新失败: {e}"],
+                    "pending_count": 0,
+                    "text_preview": None,
+                    "missing_fields": [],
+                    "needs_followup": False,
+                    "followup_field": None,
+                    "followup_message": None,
+                }
+
+        # No record_id — just clean up without persistence
+        final_summary = fields_to_summary(merged)
+        session.clear()
+        self._cancel_merge_timer(session.user_id)
+
+        return {
+            "merged": True,
+            "task": {"fields": merged, "summary": final_summary, "warnings": [], "message_count": 0},
+            "warnings": [],
+            "pending_count": 0,
+            "text_preview": f"✅ 记录已完善～\n{final_summary}",
+            "missing_fields": [],
+            "needs_followup": False,
+            "followup_field": None,
+            "followup_message": None,
+        }
+
+    # ── Location helpers ────────────────────────────────────────────────────
 
     @staticmethod
     def _extract_claimed_location(session: VisitSession) -> Optional[Dict[str, float]]:

--- a/pharma_compliance/bot_handler.py
+++ b/pharma_compliance/bot_handler.py
@@ -49,7 +49,7 @@ from pharma_compliance.extractor import (
     _extract_competitor,
     detect_task_type,
 )
-from pharma_compliance.persistence import save_record, update_record
+from pharma_compliance.persistence import save_record
 
 logger = logging.getLogger(__name__)
 
@@ -238,7 +238,9 @@ class ComplianceBotHandler:
             }
 
         # Schedule background merge timer (reset on each new message)
-        self._schedule_merge_timeout(session.user_id)
+        # Skip if already merged (e.g., progressive finalization)
+        if not result.get("merged"):
+            self._schedule_merge_timeout(session.user_id)
 
         # Check if session should auto-merge immediately (5-min timeout from last message)
         if session.should_merge():
@@ -256,16 +258,54 @@ class ComplianceBotHandler:
         metadata: Dict[str, Any],
         session: VisitSession,
     ) -> Dict[str, Any]:
+        """Handle a text message: extract fields, accumulate, check for missing.
+
+        If core fields are missing after accumulation, triggers progressive
+        questioning immediately (does not wait for merge).
+        """
         session.add_message(MessageType.TEXT, text, metadata=metadata)
         fields = extract_fields(text)
-        return {
-            "merged": False,
-            "task": None,
-            "warnings": [],
-            "pending_count": len(session.pending_messages),
-            "text_preview": text,
-            "missing_fields": get_missing_core_fields(fields),
-        }
+
+        # Accumulate into session for progressive completion
+        session.accumulate_fields(fields)
+
+        # Check what's still missing
+        missing = get_missing_core_fields(session.merged_fields or {})
+
+        if missing:
+            # ── Start/continue progressive questioning immediately ──
+            # Build the progressive queue (all missing fields, in priority order)
+            progressive_missing = self._build_progressive_queue(session.merged_fields or {})
+            first_field = progressive_missing.pop(0)
+            session.pending_field = first_field
+            session.pending_questions = progressive_missing
+            session.retry_count = 0
+            followup_msg = _get_field_question(first_field)
+            if not followup_msg:
+                followup_msg = f"好的，再补充一下「{CORE_FIELD_LABELS.get(first_field, first_field)}」的信息吧～"
+
+            logger.info(
+                "Progressive: user %s first message, missing=%s, asking '%s', queued=%s",
+                user_id, missing, first_field, progressive_missing,
+            )
+            return {
+                "merged": False,
+                "task": None,
+                "warnings": [],
+                "pending_count": len(session.pending_messages),
+                "text_preview": text,
+                "missing_fields": missing,
+                "needs_followup": True,
+                "followup_field": first_field,
+                "followup_message": followup_msg,
+            }
+
+        # ── All core fields present → finalize ──
+        logger.info(
+            "Progressive: user %s all core fields complete, finalizing",
+            user_id,
+        )
+        return await self._finalize_accumulated(session)
 
     # ── Voice handler ───────────────────────────────────────────────────────
 
@@ -346,6 +386,8 @@ class ComplianceBotHandler:
             if transcript:
                 session.add_message(MessageType.VOICE, transcript, metadata=metadata)
             fields = extract_fields(transcript) if transcript else {}
+            session.accumulate_fields(fields)
+            missing = get_missing_core_fields(session.merged_fields or {})
             return {
                 "merged": False,
                 "task": None,
@@ -353,19 +395,42 @@ class ComplianceBotHandler:
                 "pending_count": len(session.pending_messages),
                 "text_preview": transcript,
                 "needs_confirmation": True,
-                "missing_fields": get_missing_core_fields(fields),
+                "missing_fields": missing,
             }
 
         session.add_message(MessageType.VOICE, transcript, metadata=metadata)
         fields = extract_fields(transcript)
-        return {
-            "merged": False,
-            "task": None,
-            "warnings": [],
-            "pending_count": len(session.pending_messages),
-            "text_preview": transcript,
-            "missing_fields": get_missing_core_fields(fields),
-        }
+        session.accumulate_fields(fields)
+
+        # Check for progressive questioning
+        missing = get_missing_core_fields(session.merged_fields or {})
+        if missing:
+            progressive_missing = self._build_progressive_queue(session.merged_fields or {})
+            first_field = progressive_missing.pop(0)
+            session.pending_field = first_field
+            session.pending_questions = progressive_missing
+            session.retry_count = 0
+            followup_msg = _get_field_question(first_field)
+            if not followup_msg:
+                followup_msg = f"好的～再补充一下「{CORE_FIELD_LABELS.get(first_field, first_field)}」的信息吧"
+            logger.info(
+                "Progressive (voice): user %s missing=%s, asking '%s'",
+                user_id, missing, first_field,
+            )
+            return {
+                "merged": False,
+                "task": None,
+                "warnings": [],
+                "pending_count": len(session.pending_messages),
+                "text_preview": transcript,
+                "missing_fields": missing,
+                "needs_followup": True,
+                "followup_field": first_field,
+                "followup_message": followup_msg,
+            }
+
+        # All fields complete
+        return await self._finalize_accumulated(session)
 
     # ── Photo handler ───────────────────────────────────────────────────────
 
@@ -408,15 +473,42 @@ class ComplianceBotHandler:
             metadata=photo_metadata,
         )
 
-        return {
-            "merged": False,
-            "task": None,
-            "warnings": warnings,
-            "pending_count": len(session.pending_messages),
-            "text_preview": f"[门头照] {ocr_text}" if ocr_text else "[门头照]",
-            "photo_exif": exif_data,
-            "missing_fields": get_missing_core_fields(extract_fields(ocr_text or "[门头照]")),
-        }
+        fields = extract_fields(ocr_text or "[门头照]")
+        session.accumulate_fields(fields)
+
+        # Check for progressive questioning
+        missing = get_missing_core_fields(session.merged_fields or {})
+        if missing:
+            progressive_missing = self._build_progressive_queue(session.merged_fields or {})
+            first_field = progressive_missing.pop(0)
+            session.pending_field = first_field
+            session.pending_questions = progressive_missing
+            session.retry_count = 0
+            followup_msg = _get_field_question(first_field)
+            if not followup_msg:
+                followup_msg = f"好的～再补充一下「{CORE_FIELD_LABELS.get(first_field, first_field)}」的信息吧"
+            logger.info(
+                "Progressive (photo): user %s missing=%s, asking '%s'",
+                user_id, missing, first_field,
+            )
+            return {
+                "merged": False,
+                "task": None,
+                "warnings": warnings,
+                "pending_count": len(session.pending_messages),
+                "text_preview": f"[门头照] {ocr_text}" if ocr_text else "[门头照]",
+                "photo_exif": exif_data,
+                "missing_fields": missing,
+                "needs_followup": True,
+                "followup_field": first_field,
+                "followup_message": followup_msg,
+            }
+
+        # All fields complete
+        r = await self._finalize_accumulated(session)
+        r["warnings"] = r.get("warnings", []) + warnings
+        r["photo_exif"] = exif_data
+        return r
 
     # ── Vision+OCR ──────────────────────────────────────────────────────────
 
@@ -627,6 +719,89 @@ class ComplianceBotHandler:
 
     # ── Merge logic ─────────────────────────────────────────────────────────
 
+    async def _finalize_accumulated(self, session: VisitSession) -> Dict[str, Any]:
+        """Finalize when all core fields are complete from progressive accumulation.
+
+        Saves a record from session.merged_fields, does cross-checks with any
+        pending photo messages, then cleans up the session.
+        """
+        merged = session.merged_fields or {}
+        warnings: List[str] = []
+
+        # Cross-check photo vs text claims (if photo messages exist)
+        photo_metas = self._collect_photo_metadata(session)
+        if photo_metas:
+            warnings.extend(
+                self._run_cross_checks(merged, photo_metas)
+            )
+
+        task = {
+            "fields": merged,
+            "summary": fields_to_summary(merged),
+            "warnings": warnings,
+            "message_count": len(session.pending_messages),
+            "merged_text": session.merge_contents() if session.pending_messages else "",
+        }
+
+        # Collect photo paths for persistence
+        photo_paths = self._collect_photo_paths(session)
+
+        # Persist record
+        persist_ok = False
+        record_id = None
+        try:
+            record_id = save_record(task, photo_paths)
+            persist_ok = True
+        except Exception as e:
+            logger.error("Failed to persist record: %s", e)
+
+        if persist_ok:
+            self._archive_photos(session)
+            # Only clear session on successful persistence (CX fix: avoid clearing on failure)
+            session.clear()
+        else:
+            logger.warning(
+                "Persistence failed for user %s — session preserved for retry",
+                session.user_id,
+            )
+
+        # Cancel merge timer
+        self._cancel_merge_timer(session.user_id)
+
+        if not record_id:
+            return {
+                "merged": False,
+                "task": None,
+                "warnings": warnings + ["持久化失败，请重试"],
+                "pending_count": 0,
+                "text_preview": None,
+                "missing_fields": [],
+                "needs_followup": False,
+                "followup_field": None,
+                "followup_message": None,
+            }
+
+        # Call on_task_complete callback
+        if self.on_task_complete:
+            try:
+                result = self.on_task_complete(task)
+                if asyncio.iscoroutine(result):
+                    await result
+            except Exception as e:
+                logger.error("on_task_complete callback failed: %s", e)
+
+        return {
+            "merged": True,
+            "task": task,
+            "warnings": warnings,
+            "pending_count": 0,
+            "text_preview": fields_to_summary(merged),
+            "missing_fields": [],
+            "needs_followup": False,
+            "followup_field": None,
+            "followup_message": None,
+        }
+
     async def _do_merge(
         self, session: VisitSession, extra_warnings: Optional[List[str]] = None
     ) -> Dict[str, Any]:
@@ -788,7 +963,23 @@ class ComplianceBotHandler:
         }
 
     async def _force_merge(self, session: VisitSession) -> Dict[str, Any]:
-        """Force merge triggered by manual phrase ('完了' etc.)."""
+        """Force merge triggered by manual phrase ('完了' etc.).
+
+        If session has accumulated fields (progressive mode), finalize them.
+        Otherwise fall back to _do_merge over pending messages.
+        """
+        # If we have accumulated fields from progressive mode, finalize them
+        if session.merged_fields and any(
+            v and (not isinstance(v, str) or v.strip())
+            for v in session.merged_fields.values()
+        ):
+            logger.info(
+                "Manual merge triggered for user %s — finalizing %d accumulated fields",
+                session.user_id, len(session.merged_fields),
+            )
+            return await self._finalize_accumulated(session)
+
+        # Fall back to merge over pending messages
         if not session.pending_messages:
             return {
                 "merged": False,
@@ -845,6 +1036,9 @@ class ComplianceBotHandler:
                         "Progressive: user %s failed field '%s' after 2 retries, skipping",
                         user_id, current_field,
                     )
+                    # Notify user that field has been skipped
+                    field_label = CORE_FIELD_LABELS.get(current_field, current_field)
+                    session._pending_notify = f"{field_label}尝试次数已达上限，将跳过该字段进入汇总"
                 else:
                     session.retry_count += 1
                     logger.info(
@@ -892,6 +1086,8 @@ class ComplianceBotHandler:
             logger.info(
                 "Progressive: user %s → next question for field '%s'", user_id, next_field,
             )
+            notify = session._pending_notify
+            session._pending_notify = None
             return {
                 "merged": False,
                 "task": None,
@@ -902,69 +1098,45 @@ class ComplianceBotHandler:
                 "needs_followup": True,
                 "followup_field": next_field,
                 "followup_message": question,
+                "_notify": notify,
             }
 
-        # ── Phase 4: All questions answered — update persisted record ────
+        # ── Phase 4: All questions answered — finalize accumulated fields ──
         session.pending_field = None
-        record_id = session.merged_record_id
-        if record_id:
-            try:
-                update_record(record_id, merged)
+        # Re-check whether all core fields are now complete
+        still_missing = get_missing_core_fields(merged)
+        if still_missing:
+            # Still have missing fields — continue progressive questioning
+            progressive_missing = self._build_progressive_queue(merged)
+            if progressive_missing:
+                next_field = progressive_missing.pop(0)
+                session.pending_field = next_field
+                session.pending_questions = progressive_missing
+                session.retry_count = 0
+                followup_msg = _get_field_question(next_field)
+                if not followup_msg:
+                    followup_msg = f"再补充一下「{CORE_FIELD_LABELS.get(next_field, next_field)}」的信息吧～"
                 logger.info(
-                    "Progressive: updated record %s for user %s with %d completed fields",
-                    record_id, user_id, len(merged),
+                    "Progressive: user %s still missing %d fields, asking '%s'",
+                    user_id, len(still_missing), next_field,
                 )
-                # Build final summary
-                final_summary = fields_to_summary(merged)
-
-                # Clean up session state (only on success)
-                session.clear()
-
-                # Cancel merge timer
-                self._cancel_merge_timer(session.user_id)
-
-                return {
-                    "merged": True,
-                    "task": {"fields": merged, "summary": final_summary, "warnings": [], "message_count": 0},
-                    "warnings": [],
-                    "pending_count": 0,
-                    "text_preview": f"✅ 记录已完善～\n{final_summary}",
-                    "missing_fields": [],
-                    "needs_followup": False,
-                    "followup_field": None,
-                    "followup_message": None,
-                }
-            except Exception as e:
-                logger.error("Progressive: failed to update record %s: %s", record_id, e)
-                # Do NOT clear session — data retained for retry
+                notify = session._pending_notify
+                session._pending_notify = None
                 return {
                     "merged": False,
                     "task": None,
-                    "warnings": [f"记录更新失败: {e}"],
+                    "warnings": [],
                     "pending_count": 0,
                     "text_preview": None,
-                    "missing_fields": [],
-                    "needs_followup": False,
-                    "followup_field": None,
-                    "followup_message": None,
+                    "missing_fields": still_missing,
+                    "needs_followup": True,
+                    "followup_field": next_field,
+                    "followup_message": followup_msg,
+                    "_notify": notify,
                 }
 
-        # No record_id — just clean up without persistence
-        final_summary = fields_to_summary(merged)
-        session.clear()
-        self._cancel_merge_timer(session.user_id)
-
-        return {
-            "merged": True,
-            "task": {"fields": merged, "summary": final_summary, "warnings": [], "message_count": 0},
-            "warnings": [],
-            "pending_count": 0,
-            "text_preview": f"✅ 记录已完善～\n{final_summary}",
-            "missing_fields": [],
-            "needs_followup": False,
-            "followup_field": None,
-            "followup_message": None,
-        }
+        # All done — use _finalize_accumulated to save and clean up
+        return await self._finalize_accumulated(session)
 
     # ── Location helpers ────────────────────────────────────────────────────
 
@@ -1075,6 +1247,13 @@ class ComplianceBotHandler:
             await asyncio.sleep(timeout)
             session = self.sessions.get_session(session_id)
             if session and session.pending_messages:
+                # Don't auto-merge if in progressive questioning mode
+                if session.pending_field is not None:
+                    logger.debug(
+                        "Background merge timer fired but user %s is in progressive mode, skipping",
+                        session_id,
+                    )
+                    return
                 logger.info(
                     "Background merge timer fired for user %s (%d pending)",
                     session_id, len(session.pending_messages),

--- a/pharma_compliance/extractor.py
+++ b/pharma_compliance/extractor.py
@@ -1,0 +1,679 @@
+"""
+Field extraction for pharma compliance visit descriptions.
+
+Extracts 17 structured fields from free-text visit descriptions and
+auto-detects the task type (药店拜访 / 医疗机构拜访 / 学术推广).
+"""
+
+import json
+import logging
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# The 17 extractable fields for pharma compliance
+FIELD_NAMES = [
+    "task_type",          # 任务类型：药店拜访/医疗机构拜访/学术推广
+    "org_name",           # 药店名/医院名/机构名
+    "org_address",        # 机构地址
+    "contact_person",     # 拜访对象（店长/医生/主任等）
+    "contact_title",      # 拜访对象职务
+    "visit_date",         # 拜访日期
+    "visit_time",         # 拜访时间
+    "products",           # 涉及产品（逗号分隔）
+    "topic",              # 拜访主题/会议主题
+    "content_summary",    # 拜访内容摘要
+    "competitor_info",    # 竞品信息
+    "feedback",           # 客户反馈
+    "next_steps",         # 下一步计划
+    "attendee_count",     # 参会人数
+    "meeting_duration",   # 会议时长（分钟）
+    "materials_used",     # 使用资料
+    "notes",              # 备注
+]
+
+# Task type detection rules — keyword-based fallback when DeepSeek unavailable
+TASK_TYPE_RULES: List[Tuple[str, List[str]]] = [
+    (
+        "学术推广",
+        ["科室会", "学术", "推广会", "讲座", "培训", "沙龙",
+         "研讨会", "城市会", "区域会", "院内会"],
+    ),
+    (
+        "医疗机构拜访",
+        ["医院", "科室", "主任", "医生", "教授", "门诊", "病房",
+         "住院部", "手术室", "协和", "人民医", "附属医", "中医", "西京"],
+    ),
+    (
+        "药店拜访",
+        ["药店", "药房", "店长", "陈列", "药店拜访", "铺货",
+         "大药房", "连锁", "百姓", "同仁堂", "零售"],
+    ),
+]
+
+
+def detect_task_type(text: str) -> str:
+    """Auto-detect task type from visit description using keyword matching.
+
+    Tries DeepSeek via Hermes auxiliary client if available, falls back
+    to keyword matching.
+    """
+    # Try DeepSeek-based classification first
+    try:
+        from agent.auxiliary_client import async_call_llm, extract_content_or_reasoning
+
+        async def _ask_deepseek():
+            prompt = (
+                "你是一个药企合规分类器。请根据以下代表描述，判断任务类型。\n"
+                "类型选项：药店拜访、医疗机构拜访、学术推广\n\n"
+                "代表描述：{text}\n\n"
+                "请只返回类型名称，不要加任何其他文字。"
+            ).format(text=text)
+            result = await async_call_llm(
+                prompt=prompt,
+                model="deepseek-chat",
+                temperature=0.0,
+                max_tokens=32,
+            )
+            return extract_content_or_reasoning(result)
+
+        import asyncio
+        try:
+            loop = asyncio.get_running_loop()
+            # Running in async context, can't block — fall through to keyword
+            pass
+        except RuntimeError:
+            # No running loop — safe to run
+            raw = asyncio.run(_ask_deepseek())
+            for task_type, _ in TASK_TYPE_RULES:
+                if task_type in raw:
+                    return task_type
+            if raw.strip():
+                logger.info("DeepSeek task type: %s", raw.strip())
+                return raw.strip()
+
+    except Exception as e:
+        logger.warning("DeepSeek task type detection failed: %s, falling back to keywords", e)
+
+    # Keyword-based fallback
+    for task_type, keywords in TASK_TYPE_RULES:
+        for kw in keywords:
+            if kw in text:
+                logger.debug("Keyword match '%s' → '%s'", kw, task_type)
+                return task_type
+
+    # Default for ambiguous input
+    logger.debug("No keyword match, defaulting to 药店拜访")
+    return "药店拜访"
+
+
+# ── Date/time extraction helpers ────────────────────────────────────────────
+
+_DATE_PATTERNS = [
+    (r"(\d{4})[年/\-.](\d{1,2})[月/\-.](\d{1,2})[日号]?", "%Y-%m-%d"),
+    (r"(\d{1,2})月(\d{1,2})[日号]", "month_day"),
+]
+
+# Relative date keyword → day offset from today
+_RELATIVE_DATE_MAP = {
+    "今天": 0, "今日": 0,
+    "昨天": -1, "昨日": -1,
+    "前天": -2, "前日": -2,
+    "大前天": -3,
+    "明天": 1, "明日": 1,
+    "后天": 2, "后日": 2,
+}
+
+# Weekday name → 0-indexed weekday (Mon=0 ... Sun=6)
+_WEEKDAY_MAP = {
+    "周一": 0, "星期一": 0,
+    "周二": 1, "星期二": 1,
+    "周三": 2, "星期三": 2,
+    "周四": 3, "星期四": 3,
+    "周五": 4, "星期五": 4,
+    "周六": 5, "星期六": 5,
+    "周日": 6, "星期日": 6, "星期天": 6,
+}
+
+
+def _extract_date(text: str) -> str:
+    import datetime
+    today = datetime.date.today()
+
+    # 1. Explicit date patterns (2024-01-15, 1月15日)
+    for pattern, fmt in _DATE_PATTERNS:
+        m = re.search(pattern, text)
+        if m:
+            if fmt == "%Y-%m-%d":
+                y, mo, d = int(m.group(1)), int(m.group(2)), int(m.group(3))
+                return f"{y:04d}-{mo:02d}-{d:02d}"
+            elif fmt == "month_day":
+                mo, d = int(m.group(1)), int(m.group(2))
+                return f"{today.year:04d}-{mo:02d}-{d:02d}"
+
+    # 2. Relative date keywords (今天/昨天/前天/明天 etc.)
+    for keyword, offset in _RELATIVE_DATE_MAP.items():
+        if keyword in text:
+            target = today + datetime.timedelta(days=offset)
+            return target.strftime("%Y-%m-%d")
+
+    # 3. Week-based dates (上周三/这周一/下周天 etc.)
+    m = re.search(r"(上|本|这|下)?\s*周\s*([一二三四五六日天])", text)
+    if m:
+        prefix = m.group(1) or "本"
+        day_char = m.group(2)
+        if day_char == "天":
+            day_char = "日"
+        weekday_names = ["一", "二", "三", "四", "五", "六", "日"]
+        if day_char in weekday_names:
+            target_weekday = weekday_names.index(day_char)  # 0=Mon, 6=Sun
+            current_weekday = today.weekday()  # 0=Mon, 6=Sun
+            if prefix in ("本", "这"):
+                delta = target_weekday - current_weekday
+            elif prefix == "下":
+                delta = target_weekday - current_weekday + 7
+            else:  # 上
+                delta = target_weekday - current_weekday - 7
+            target = today + datetime.timedelta(days=delta)
+            return target.strftime("%Y-%m-%d")
+
+    # 4. "X天前" / "X天之前"
+    m = re.search(r"(\d+)\s*天[之以]?前", text)
+    if m:
+        days = int(m.group(1))
+        target = today - datetime.timedelta(days=days)
+        return target.strftime("%Y-%m-%d")
+
+    # 5. Implicit "today" from time-of-day words without any date indicator
+    time_of_day_words = ["早上", "早晨", "上午", "中午", "下午", "傍晚", "晚上", "夜里", "凌晨"]
+    if any(w in text for w in time_of_day_words):
+        return today.strftime("%Y-%m-%d")
+
+    return ""
+
+
+_TIME_PERIOD_MAP = {
+    "凌晨": "05:00",
+    "早上": "08:00",
+    "早晨": "08:00",
+    "上午": "10:00",
+    "中午": "12:00",
+    "午后": "13:00",
+    "下午": "15:00",
+    "傍晚": "17:00",
+    "晚上": "19:00",
+    "夜里": "21:00",
+    "夜间": "22:00",
+}
+
+
+def _extract_time(text: str) -> str:
+    # 1. Explicit time patterns (HH:MM)
+    m = re.search(r"(\d{1,2}):(\d{2})", text)
+    if m:
+        return f"{int(m.group(1)):02d}:{m.group(2)}"
+
+    # 2. "X点半" (must check before "X点" to avoid short-circuit)
+    m = re.search(r"上午(\d{1,2})点半", text)
+    if m:
+        return f"{int(m.group(1)):02d}:30"
+    m = re.search(r"下午(\d{1,2})点半", text)
+    if m:
+        h = int(m.group(1))
+        if h < 12:
+            h += 12
+        return f"{h:02d}:30"
+
+    # 3. "上午X点" / "下午X点" (whole-hour)
+    m = re.search(r"上午(\d{1,2})点", text)
+    if m:
+        return f"{int(m.group(1)):02d}:00"
+    m = re.search(r"下午(\d{1,2})点", text)
+    if m:
+        h = int(m.group(1))
+        if h < 12:
+            h += 12
+        return f"{h:02d}:00"
+
+    # 4. Natural language time periods (早上/上午/中午/下午/晚上 etc.)
+    for keyword, time_str in _TIME_PERIOD_MAP.items():
+        if keyword in text:
+            return time_str
+
+    return ""
+
+
+# ── Address extraction ──────────────────────────────────────────────────────
+
+def _extract_address(text: str) -> str:
+    patterns = [
+        # OCR-style: store/org name followed by address
+        # "百康药房 天赐街1号院8号楼一层8-204室 好邻居"
+        r"(?:药房|药店|医院|诊所|卫生院|中心|连锁|药业|医药)[\s，,]*"
+        r"([^\s,，。；;\n]{2,}(?:路|街|巷|大道|道|里|胡同)"
+        r"(?:[^\s,，。；;\n]{2,40}))",
+
+        # Full structured address with 号院/号楼/层/室/单元
+        r"([^\s,，。；;\n]{2,}(?:路|街|巷|大道|道|里|胡同)"
+        r"\s*\d+[号院楼单元层室栋幢\-—\d一二两三四五六七八九十a-zA-Z]+"
+        r"(?:[^\s,，。；;\n]{0,20})?)",
+
+        # 地址/位置/在/位于 prefix
+        r"(?:地址|位置|在|位于)[：:]?\s*"
+        r"([^\s,，。；;]+[路街巷大道][^\s,，。；;]*)",
+
+        # Generic road-based address
+        r"([^\s,，。；;]{2,}(?:[路街巷大道])[\d号]+)",
+    ]
+    for pat in patterns:
+        m = re.search(pat, text)
+        if m:
+            result = m.group(1).strip()
+            # Reject matches that are clearly not addresses (too short, or just a store name)
+            if len(result) >= 4 and re.search(r"[\d号院楼单元层室]", result):
+                return result
+
+    # Fallback: look for any address-like pattern without store prefix
+    fallback_pat = (
+        r"([^\s,，。；;\n]{2,}(?:路|街|巷|大道|道|里|胡同)"
+        r"[^\s,，。；;\n]{2,30})"
+    )
+    m = re.search(fallback_pat, text)
+    if m:
+        return m.group(1).strip()
+
+    return ""
+
+
+def _extract_person(text: str) -> Tuple[str, str]:
+    person_patterns = [
+        (r"见了?\s*([^\s,，。；;]{1,6}(?:店长|主任|医生|教授|经理|院长|药师))", r"见了?\s*"),
+        (r"拜访了?\s*([^\s,，。；;]{1,6}(?:店长|主任|医生|教授|经理|院长|药师))", r"拜访了?\s*"),
+        (r"([^\s,，。；;]{1,6})(?:店长|主任|医生|教授|经理|院长|药师)", r""),
+    ]
+    for pat, _ in person_patterns:
+        m = re.search(pat, text)
+        if m:
+            return m.group(1), ""
+    return "", ""
+
+
+def _extract_products(text: str) -> str:
+    common_products = [
+        "小儿宝泰康", "小儿肺热咳喘", "小儿柴桂", "肠炎宁", "健胃消食",
+        "金水宝", "复方丹参", "板蓝根", "阿莫西林", "头孢",
+        "布洛芬", "对乙酰氨基酚", "奥司他韦", "连花清瘟",
+    ]
+    found = []
+    for p in common_products:
+        if p in text:
+            found.append(p)
+    return ", ".join(found) if found else ""
+
+
+def _extract_attendee_count(text: str) -> str:
+    # 1. Explicit count: N + 人/位/名 + (参会/到场/参加/出席/到来/在座/与会/在场)
+    m = re.search(r"(\d+)\s*[人位名]?\s*(?:参会|到场|参加|出席|到来|在座|与会|在场)", text)
+    if m:
+        return m.group(1)
+
+    # 2. "见了/拜访了/找了/约了/联系了 N位/个/名"
+    m = re.search(r"(?:见了|拜访了|找了|约了|联系了|见了有)\s*(\d+)\s*[位个名]", text)
+    if m:
+        return m.group(1)
+
+    # 3. "N位医生/药师/店长/主任/客户/代表/护士" etc. (title-qualified count)
+    m = re.search(
+        r"(\d+)\s*位\s*"
+        r"(?:医生|药师|店长|主任|教授|经理|院长|客户|代表|护士|专家|老师|领导)",
+        text,
+    )
+    if m:
+        return m.group(1)
+
+    # 4. "N个人" / "N人" (general)
+    m = re.search(r"(\d+)\s*个?\s*人", text)
+    if m:
+        return m.group(1)
+
+    # 5. Infer from contact person listing: count unique title-bearing contacts
+    # "和王店长、杜药师聊了" = 2 contacts
+    # "跟李主任、张医生讨论了" = 2 contacts
+    # Strategy: find all title positions, then look back 1-3 Chinese chars for the name
+    contact_titles = [
+        "店长", "药师", "医生", "主任", "教授", "经理", "院长",
+        "护士", "护士长", "科长", "处长", "老师", "代表",
+    ]
+    # Characters that are verbs/particles, not part of a name
+    _verb_chars = set("去了到见找拜访跟和与请叫让给对向了过的")
+    found_contacts = set()
+    for title in contact_titles:
+        for m in re.finditer(re.escape(title), text):
+            pos = m.start()
+            name_candidate = ""
+            # Walk back 1-3 chars to find the name
+            for name_len in (1, 2, 3):
+                if pos >= name_len:
+                    candidate = text[pos - name_len : pos]
+                    if (
+                        re.match(r"^[\u4e00-\u9fff]+$", candidate)
+                        and candidate[0] not in _verb_chars
+                    ):
+                        name_candidate = candidate
+                        break
+            if name_candidate:
+                found_contacts.add(name_candidate + title)
+            elif pos == 0 or (pos >= 1 and text[pos - 1] in "，,。；;、\s跟和与"):
+                # Title appears standalone (e.g., "跟店长聊了") — count as 1
+                found_contacts.add(title)
+
+    if found_contacts:
+        return str(len(found_contacts))
+
+    return ""
+
+
+# ── Main extraction ─────────────────────────────────────────────────────────
+
+def extract_fields(text: str) -> Dict[str, Any]:
+    """Extract 17 compliance fields from visit description text.
+
+    Args:
+        text: Free-text visit description from rep (could be typed, STT, or merged).
+
+    Returns:
+        dict with all 17 fields populated.
+    """
+    person, title = _extract_person(text)
+
+    result: Dict[str, Any] = {
+        "task_type": detect_task_type(text),
+        "org_name": _extract_org_name(text),
+        "org_address": _extract_address(text),
+        "contact_person": person,
+        "contact_title": title or _infer_title(person),
+        "visit_date": _extract_date(text),
+        "visit_time": _extract_time(text),
+        "products": _extract_products(text),
+        "topic": _extract_topic(text),
+        "content_summary": text.strip(),
+        "competitor_info": _extract_competitor(text),
+        "feedback": _extract_feedback(text),
+        "next_steps": _extract_next_steps(text),
+        "attendee_count": _extract_attendee_count(text),
+        "meeting_duration": "",
+        "materials_used": _extract_materials_used(text),
+        "notes": "",
+    }
+    logger.info("Extraction result: %s", json.dumps(result, ensure_ascii=False))
+    return result
+
+
+def _extract_org_name(text: str) -> str:
+    patterns = [
+        r"([^\s,，。；;]{2,10}(?:医院|诊所|卫生院|社区卫生|疾控))",
+        r"([^\s,，。；;]{2,10}(?:大药房|药房|药店|药业|医药|连锁))",
+        r"去了\s*([^\s,，。；;]{2,10}(?:药房|药店|医院|诊所)?)",
+        r"到了\s*([^\s,，。；;]{2,10}(?:药房|药店|医院|诊所)?)",
+    ]
+    for pat in patterns:
+        m = re.search(pat, text)
+        if m:
+            return m.group(1).strip()
+    return ""
+
+
+def _infer_title(person: str) -> str:
+    for suffix in ["店长", "主任", "医生", "教授", "经理", "院长", "药师"]:
+        if suffix in person:
+            return suffix
+    return ""
+
+
+def _extract_topic(text: str) -> str:
+    patterns = [
+        r"(?:主题|议题|讲了|介绍了|聊了|讨论了)\s*[：:]?\s*([^\s,，。；;]+)",
+    ]
+    for pat in patterns:
+        m = re.search(pat, text)
+        if m:
+            return m.group(1).strip()
+    return ""
+
+
+def _extract_competitor(text: str) -> str:
+    # 1. Explicit competitor keywords followed by description
+    patterns = [
+        r"竞品[：:]*\s*([^。；;，,\n]{2,60})",
+        r"竞争[对手品牌产品]*[：:]*\s*([^。；;，,\n]{2,60})",
+        # Competitor brand mentioned with context (对比/比起 + brand-like word)
+        r"(?:对比|比起)\s*([^，,。；;\s]{2,12}(?:品牌|产品|药|颗粒|胶囊|片|剂))",
+        # "XX也在做/推/卖" pattern
+        r"([^\s，,。；;]{2,10}(?:也在做|也在推|也在卖|也有[在卖推]))",
+        # Competitor mention in reported speech
+        r"(?:他们说|客户说|店长说|医生[说]?)[^。;；\n]*?(?:别的?|其他|人家)([^。;；，,\n]{2,50})",
+    ]
+    for pat in patterns:
+        m = re.search(pat, text)
+        if m:
+            result = m.group(1).strip()
+            if len(result) >= 2:
+                return result
+
+    # 2. Fallback: detect known competitor brands in text with surrounding context
+    competitor_brands = [
+        "葵花", "三九", "白云山", "同仁堂", "修正", "仁和", "太极",
+        "江中", "哈药", "天士力", "以岭", "扬子江", "恒瑞", "正大天晴",
+        "步长", "华润", "丽珠", "人福", "科伦", "诺华", "辉瑞", "拜耳",
+        "强生", "默沙东", "GSK", "赛诺菲", "阿斯利康", "罗氏",
+        "百特", "武田", "第一三共", "卫材", "安斯泰来",
+        "灵北", "费森尤斯", "礼来", "诺和诺德", "雅培",
+        "东阿阿胶", "片仔癀", "云南白药", "康恩贝", "济川",
+    ]
+    found = []
+    for brand in competitor_brands:
+        if brand in text:
+            idx = text.find(brand)
+            # Skip if the brand appears to be the store being visited (preceded by 去了/到了/在)
+            prefix_ctx = text[max(0, idx - 3):idx]
+            if re.search(r"(?:去了|到了|在|拜访)\s*$", prefix_ctx):
+                continue
+            start = max(0, idx)
+            end = min(len(text), idx + len(brand) + 10)
+            snippet = text[start:end].strip()
+            found.append(snippet)
+    if found:
+        return "; ".join(found[:3])
+
+    return ""
+
+
+def _extract_feedback(text: str) -> str:
+    # 1. Direct feedback/sentiment markers
+    patterns = [
+        # Explicit feedback lead-ins
+        r"(?:反馈|觉得|认为|表示|说|提到|反映|指出)[：:]?\s*([^。；;，,\n]{3,80})",
+        # Customer satisfaction/opinion expressions
+        r"(?:销量|效果|价格|质量|反应|口感|包装|动销|走量|患者|顾客|病人)"
+        r"[^。；;\n]{0,20}?(?:不错|很好|还行|一般|不好|差|可以|满意|不满意"
+        r"|有改善|有提升|下降|增长|减少|变差|变好)"
+        r"([^。；;，,\n]{0,50})",
+        # Patient/customer relayed feedback
+        r"(?:病人|患者|顾客|老百姓)[^。;；\n]*?(?:说|反馈|觉得|认为|反映)"
+        r"([^。;；，,\n]{3,60})",
+        # Store staff recommendation/suggestion
+        r"(?:建议|希望|要求|提出|提议)([^。;；，,\n]{3,60})",
+        # Opinion about product positioning
+        r"觉得([^。;；，,\n]{3,60})",
+        # "XX说YY" pattern
+        r"说[：:]?\s*([^。;；，,\n]{4,80})",
+    ]
+    for pat in patterns:
+        m = re.search(pat, text)
+        if m:
+            result = m.group(1).strip()
+            if len(result) >= 2:
+                return result
+
+    # 2. Fallback: look for sentiment/opinion keywords and capture surrounding sentence
+    sentiment_keywords = ["销量好", "卖得好", "走得好", "反馈好", "效果好",
+                          "不好卖", "卖不动", "滞销", "退货", "投诉"]
+    for kw in sentiment_keywords:
+        if kw in text:
+            idx = text.find(kw)
+            start = max(0, idx - 15)
+            end = min(len(text), idx + len(kw) + 20)
+            return text[start:end].strip()
+
+    return ""
+
+
+def _extract_next_steps(text: str) -> str:
+    # 1. Direct next-step / follow-up markers
+    patterns = [
+        # Explicit next-step markers
+        r"(?:下次|下一步|接下来|后续|之后|往后|以后|回头|改天)[：:]?\s*"
+        r"([^。；;，,\n]{3,80})",
+
+        # Planning markers
+        r"(?:计划|准备|打算|安排|预计|将[要会]|会再|约好|约定|定于|说好)"
+        r"[：:]?\s*([^。；;，,\n]{3,60})",
+
+        # Promise/commitment markers
+        r"(?:答应|承诺|保证|到时候|到时候再|过[几两]\s*[天周月]|下次来)"
+        r"[：:]?\s*([^。；;，,\n]{3,60})",
+
+        # Future action verbs
+        r"(?:再[来过次趟]|还会|还要|需要[再还])[：:]?\s*([^。；;，,\n]{3,60})",
+
+        # "等XX时候" pattern
+        r"(?:等|等到)[^。;；\n]{1,15}?(?:时候|时|后|以后|之后)"
+        r"[：:]?\s*([^。；;，,\n]{3,60})",
+    ]
+    for pat in patterns:
+        m = re.search(pat, text)
+        if m:
+            result = m.group(1).strip()
+            if len(result) >= 2:
+                return result
+
+    # 2. Fallback: look for any sentence that strongly indicates future action
+    future_indicators = [
+        (r"下次.{0,20}?带.{0,20}?(?:资料|样品|DA|彩页|单页)", "下次带资料/样品"),
+        (r"下次.{0,20}?再聊", "下次再聊"),
+        (r"再[来过]", "再来拜访"),
+        (r"会再联系", "会再联系"),
+    ]
+    for pat, label in future_indicators:
+        if re.search(pat, text):
+            return label
+
+    return ""
+
+
+def _extract_materials_used(text: str) -> str:
+    """Extract materials used during the visit (DA, brochures, samples, etc.)."""
+    materials_keywords = [
+        "DA", "da",
+        "宣传单", "宣传册", "宣传资料", "宣传页",
+        "彩页", "单页", "折页", "手册",
+        "资料", "文献", "论文", "指南",
+        "样品", "试用装", "试用", "样本",
+        "礼品", "台历", "日历", "小礼品",
+        "PPT", "幻灯片", "视频", "iPad", "平板", "电脑",
+        "海报", "展架", "易拉宝", "X展架", "pop", "POP",
+        "拜访夹", "拜访手册", "产品手册", "说明书",
+        "白大褂", "工作服", "笔", "笔记本",
+        "问卷", "调研表", "知情同意",
+    ]
+    found = []
+    lower_text = text.lower()
+    for kw in materials_keywords:
+        if kw.lower() in lower_text:
+            found.append(kw)
+    return ", ".join(found) if found else ""
+
+
+# ── Field completeness checking ────────────────────────────────────────────
+
+# P0 required fields (7 core fields)
+CORE_REQUIRED_FIELDS = [
+    "task_type",
+    "org_name",
+    "contact_person",
+    "products",
+    "topic",
+    "content_summary",
+    "next_steps",
+]
+
+# P1 recommended fields (3 important supplemental fields)
+CORE_RECOMMENDED_FIELDS = [
+    "visit_date",
+    "feedback",
+    "competitor_info",
+]
+
+# All core fields in priority order (P0 first, then P1)
+CORE_FIELDS_PRIORITY = CORE_REQUIRED_FIELDS + CORE_RECOMMENDED_FIELDS
+
+# Field display names for user-facing messages
+CORE_FIELD_LABELS: Dict[str, str] = {
+    "task_type": "任务类型",
+    "org_name": "机构名称",
+    "contact_person": "拜访对象",
+    "products": "涉及产品",
+    "topic": "拜访主题",
+    "content_summary": "内容摘要",
+    "next_steps": "下一步计划",
+    "visit_date": "拜访日期",
+    "feedback": "客户反馈",
+    "competitor_info": "竞品信息",
+}
+
+
+def get_missing_core_fields(fields: Dict[str, Any]) -> List[str]:
+    """Return the top 2–3 missing core fields (P0 then P1).
+
+    Checks P0 required fields first, then P1 recommended fields.
+    Returns at most 3 field names, ordered by priority.
+    Returns empty list if all core fields are present.
+    """
+    missing: List[str] = []
+    for field in CORE_FIELDS_PRIORITY:
+        value = fields.get(field, "")
+        if not value or (isinstance(value, str) and not value.strip()):
+            missing.append(field)
+            if len(missing) >= 3:
+                break
+    return missing
+
+
+def fields_to_summary(fields: Dict[str, Any]) -> str:
+    """Convert extracted fields to a human-readable summary."""
+    lines = []
+    label_map = {
+        "task_type": "任务类型",
+        "org_name": "机构名称",
+        "org_address": "机构地址",
+        "contact_person": "拜访对象",
+        "contact_title": "对象职务",
+        "visit_date": "拜访日期",
+        "visit_time": "拜访时间",
+        "products": "涉及产品",
+        "topic": "拜访主题",
+        "content_summary": "内容摘要",
+        "competitor_info": "竞品信息",
+        "feedback": "客户反馈",
+        "next_steps": "下一步计划",
+        "attendee_count": "参会人数",
+        "meeting_duration": "会议时长",
+        "materials_used": "使用资料",
+        "notes": "备注",
+    }
+    for field in FIELD_NAMES:
+        value = fields.get(field, "")
+        if value:
+            lines.append(f"{label_map.get(field, field)}: {value}")
+    return "\n".join(lines)

--- a/pharma_compliance/persistence.py
+++ b/pharma_compliance/persistence.py
@@ -1,0 +1,306 @@
+"""File persistence for pharma compliance records.
+
+Appends completed visit records to a JSON Lines file and archives
+photos to a persistent directory.
+"""
+
+import fcntl
+import json
+import logging
+import os
+import shutil
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+PROJECT_DIR = Path(__file__).resolve().parent
+RECORDS_DIR = PROJECT_DIR / "data" / "records"
+PHOTOS_DIR = PROJECT_DIR / "data" / "photos"
+GPS_CACHE_DIR = PROJECT_DIR / "data"
+GPS_CACHE_FILE = GPS_CACHE_DIR / "gps_cache.json"
+
+# ── GPS → 地址反向地理编码缓存 ──────────────────────────────────────────────
+
+# 内存缓存，避免重复请求 API
+_gps_cache: Dict[str, Optional[str]] = {}
+
+
+def _load_gps_cache() -> Dict[str, Optional[str]]:
+    """从磁盘加载 GPS 缓存（JSON 文件）。"""
+    if not GPS_CACHE_FILE.exists():
+        return {}
+    try:
+        with open(GPS_CACHE_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+            if isinstance(data, dict):
+                return data
+    except (json.JSONDecodeError, IOError) as e:
+        logger.warning("Failed to load GPS cache: %s", e)
+    return {}
+
+# 模块加载时一次性将磁盘缓存读入内存，此后只写不读
+_gps_cache.update(_load_gps_cache())
+
+
+def _save_gps_cache(cache: Dict[str, Optional[str]]) -> None:
+    """将 GPS 缓存原子写入磁盘 JSON 文件。"""
+    try:
+        GPS_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        tmp_path = GPS_CACHE_FILE.with_suffix(".tmp")
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            json.dump(cache, f, ensure_ascii=False)
+        os.replace(tmp_path, GPS_CACHE_FILE)
+    except IOError as e:
+        logger.warning("Failed to save GPS cache: %s", e)
+
+
+def _gps_to_address(lat: float, lon: float) -> Optional[str]:
+    """通过 photon.komoot.io 反向地理编码将 GPS 坐标转为中文地址。
+
+    双重缓存策略：
+    1. 内存 dict（进程生命周期内有效）
+    2. 磁盘 JSON 文件（跨进程/跨重启持久化）
+
+    Args:
+        lat: 纬度（-90 ~ 90）
+        lon: 经度（-180 ~ 180）
+
+    Returns:
+        格式化后的中文地址字符串，失败时返回 None。
+    """
+    # 缓存 key：四舍五入到小数点后 4 位（约 11 米精度，足够区分门店）
+    cache_key = f"{lat:.4f},{lon:.4f}"
+
+    # 1. 检查内存缓存（含模块加载时预载的磁盘数据）
+    if cache_key in _gps_cache:
+        logger.debug("GPS cache hit (memory): %s → %s", cache_key, _gps_cache[cache_key])
+        return _gps_cache[cache_key]
+
+    # 2. 调用 photon.komoot.io 反向地理编码 API
+    try:
+        url = f"https://photon.komoot.io/reverse?lat={lat}&lon={lon}&lang=zh"
+        headers = {
+            "User-Agent": "Hermes-PharmaCompliance/1.0 (reverse geocoding for compliance records)",
+        }
+        resp = requests.get(url, headers=headers, timeout=10)
+        resp.raise_for_status()
+
+        data = resp.json()
+        features = data.get("features", [])
+        if not features:
+            logger.info("GPS reverse geocoding returned no results for %s", cache_key)
+            address = None
+        else:
+            # 取第一条结果的 display_name
+            properties = features[0].get("properties", {})
+            display_name = properties.get("name", "")
+            # 补充省市信息
+            city = properties.get("city", "")
+            state = properties.get("state", "")
+            country = properties.get("country", "")
+
+            # 本地化格式化：优先拼接省/市/具体地址
+            parts = []
+            if state and state != city:
+                parts.append(state)
+            if city:
+                parts.append(city)
+            if display_name and display_name not in parts:
+                parts.append(display_name)
+
+            address = "".join(parts) if parts else display_name
+            if not address:
+                address = None
+
+            logger.info("GPS → 地址: %s → %s", cache_key, address)
+
+    except requests.exceptions.Timeout:
+        logger.warning("GPS reverse geocoding timed out for %s", cache_key)
+        address = None
+    except requests.exceptions.RequestException as e:
+        logger.warning("GPS reverse geocoding request failed for %s: %s", cache_key, e)
+        address = None
+    except (json.JSONDecodeError, KeyError, IndexError) as e:
+        logger.warning("GPS reverse geocoding parse failed for %s: %s", cache_key, e)
+        address = None
+    except Exception as e:
+        logger.error("Unexpected error in GPS reverse geocoding for %s: %s", cache_key, e)
+        address = None
+
+    # 3. 更新缓存（包括 None 值，避免重复请求失败的坐标）
+    _gps_cache[cache_key] = address
+    _save_gps_cache(_gps_cache)
+
+    return address
+
+
+def _extract_address_from_gps(image_path: str) -> Optional[str]:
+    """从图片 EXIF 提取 GPS 坐标并反向地理编码为地址。
+
+    端到端流程：图片 → EXIF GPS → 十进制经纬度 → 反向地理编码 → 中文地址。
+
+    Args:
+        image_path: 图片文件的绝对路径。
+
+    Returns:
+        格式化的中文地址字符串，无 GPS 数据或失败时返回 None。
+    """
+    try:
+        from PIL import Image
+        from PIL.ExifTags import GPSTAGS
+
+        img = Image.open(image_path)
+        exif_raw = img.getexif()
+        if not exif_raw:
+            logger.debug("No EXIF data in %s", image_path)
+            return None
+
+        # 提取 GPSInfo IFD
+        gps_info = exif_raw.get_ifd(0x8825)  # GPSInfo IFD
+        if not gps_info:
+            logger.debug("No GPS info in EXIF for %s", image_path)
+            return None
+
+        # 解析 GPS 标签
+        gps: Dict[str, Any] = {}
+        for tag_id, value in gps_info.items():
+            tag_name = GPSTAGS.get(tag_id, str(tag_id))
+            gps[tag_name] = value
+
+        # 提取经纬度及其参考方向
+        lat_ref = gps.get("GPSLatitudeRef", "N")
+        lat = gps.get("GPSLatitude")
+        lon_ref = gps.get("GPSLongitudeRef", "E")
+        lon = gps.get("GPSLongitude")
+
+        if not lat or not lon:
+            logger.debug("No GPS coordinates in EXIF for %s", image_path)
+            return None
+
+        # DMS → 十进制
+        def _to_decimal(dms) -> float:
+            if isinstance(dms, (tuple, list)) and len(dms) >= 3:
+                return float(dms[0]) + float(dms[1]) / 60.0 + float(dms[2]) / 3600.0
+            return float(dms)
+
+        lat_dd = _to_decimal(lat)
+        lon_dd = _to_decimal(lon)
+
+        # 南半球/西半球取负值
+        if lat_ref == "S":
+            lat_dd = -lat_dd
+        if lon_ref == "W":
+            lon_dd = -lon_dd
+
+        logger.info(
+            "Extracted GPS from EXIF: lat=%.6f lon=%.6f → reverse geocoding",
+            lat_dd, lon_dd,
+        )
+
+        return _gps_to_address(round(lat_dd, 6), round(lon_dd, 6))
+
+    except ImportError:
+        logger.debug("PIL/Pillow not available for EXIF GPS extraction")
+        return None
+    except Exception as e:
+        logger.warning(
+            "Failed to extract address from GPS for %s: %s", image_path, e
+        )
+        return None
+
+
+def ensure_dirs() -> None:
+    RECORDS_DIR.mkdir(parents=True, exist_ok=True)
+    PHOTOS_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def save_record(task: Dict[str, Any], photo_paths: List[str]) -> str:
+    """Persist a completed compliance record.
+
+    Args:
+        task: The merged task dict from _do_merge (contains fields, summary,
+              warnings, message_count, merged_text).
+        photo_paths: Absolute paths to photo files to archive.
+
+    Returns:
+        Path to the records.jsonl file.
+    """
+    ensure_dirs()
+
+    org_name = task.get("fields", {}).get("org_name", "unknown")
+    # Sanitize org_name for filename
+    safe_name = "".join(c for c in org_name if c.isalnum() or c in "._-()（）")[:30]
+    # Use microseconds (truncated to 3-digit milliseconds) to avoid second-level collisions
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")[:-3]
+    record_id = f"{timestamp}_{safe_name}"
+
+    # Copy photos — each photo wrapped in try/except so one bad file
+    # doesn't block the entire record from being written
+    saved_photos: List[str] = []
+    for i, src in enumerate(photo_paths):
+        try:
+            if not src or not os.path.exists(src):
+                continue
+            ext = os.path.splitext(src)[1] or ".jpg"
+            dst = PHOTOS_DIR / f"{record_id}_{i}{ext}"
+            shutil.copy2(src, dst)
+            saved_photos.append(str(dst))
+        except Exception as e:
+            logger.warning(
+                "Failed to copy photo %s for record %s: %s", src, record_id, e
+            )
+
+    # Build persistent record
+    persistent = {
+        "record_id": record_id,
+        "saved_at": datetime.now().isoformat(),
+        "fields": task.get("fields", {}),
+        "summary": task.get("summary", ""),
+        "warnings": task.get("warnings", []),
+        "message_count": task.get("message_count", 0),
+        "merged_text": task.get("merged_text", ""),
+        "photos": saved_photos,
+    }
+
+    # Append with exclusive file lock to prevent interleaved writes
+    records_file = RECORDS_DIR / "records.jsonl"
+    with open(records_file, "a", encoding="utf-8") as f:
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+        try:
+            f.write(json.dumps(persistent, ensure_ascii=False) + "\n")
+            f.flush()
+        finally:
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
+    logger.info(
+        "Persisted record %s (%d photos, %d chars merged text)",
+        record_id, len(saved_photos), len(task.get("merged_text", "")),
+    )
+    return str(records_file)
+
+
+def list_records(limit: int = 20) -> List[Dict[str, Any]]:
+    """Return most recent records (for inspection)."""
+    records_file = RECORDS_DIR / "records.jsonl"
+    if not records_file.exists():
+        return []
+
+    records: List[Dict[str, Any]] = []
+    with open(records_file, "r", encoding="utf-8") as f:
+        for line_no, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError as e:
+                logger.warning(
+                    "Skipping malformed record at %s line %d: %s",
+                    records_file, line_no, e,
+                )
+
+    return records[-limit:]

--- a/pharma_compliance/persistence.py
+++ b/pharma_compliance/persistence.py
@@ -227,7 +227,7 @@ def save_record(task: Dict[str, Any], photo_paths: List[str]) -> str:
         photo_paths: Absolute paths to photo files to archive.
 
     Returns:
-        Path to the records.jsonl file.
+        The record_id string (e.g. '20250617_153000_123_百姓大药房').
     """
     ensure_dirs()
 
@@ -280,7 +280,76 @@ def save_record(task: Dict[str, Any], photo_paths: List[str]) -> str:
         "Persisted record %s (%d photos, %d chars merged text)",
         record_id, len(saved_photos), len(task.get("merged_text", "")),
     )
-    return str(records_file)
+    return record_id
+
+
+def update_record(record_id: str, updated_fields: Dict[str, Any]) -> bool:
+    """Update an existing record's fields in records.jsonl.
+
+    Reads the entire JSONL file, finds the matching record_id,
+    updates its fields, and rewrites the file atomically.
+
+    Args:
+        record_id: The record_id to update.
+        updated_fields: New field values to merge into the record.
+
+    Returns:
+        True if the record was found and updated, False otherwise.
+    """
+    records_file = RECORDS_DIR / "records.jsonl"
+    if not records_file.exists():
+        logger.warning("update_record: records file not found")
+        return False
+
+    records: List[Dict[str, Any]] = []
+    found = False
+    with open(records_file, "r", encoding="utf-8") as f:
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+        try:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    records.append({"__raw__": line})
+                    continue
+                if record.get("record_id") == record_id:
+                    # Merge updated_fields into existing fields
+                    existing_fields = record.get("fields", {})
+                    existing_fields.update(updated_fields)
+                    record["fields"] = existing_fields
+                    record["updated_at"] = datetime.now().isoformat()
+                    # Rebuild summary
+                    from pharma_compliance.extractor import fields_to_summary
+                    record["summary"] = fields_to_summary(existing_fields)
+                    found = True
+                records.append(record)
+        finally:
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
+    if not found:
+        logger.warning("update_record: record_id %s not found", record_id)
+        return False
+
+    # Atomic write: write to temp, then rename
+    tmp_path = records_file.with_suffix(".tmp")
+    with open(tmp_path, "w", encoding="utf-8") as f:
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+        try:
+            for record in records:
+                if "__raw__" in record:
+                    f.write(record["__raw__"] + "\n")
+                else:
+                    f.write(json.dumps(record, ensure_ascii=False) + "\n")
+            f.flush()
+        finally:
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+    os.replace(tmp_path, records_file)
+
+    logger.info("Updated record %s with %d fields", record_id, len(updated_fields))
+    return True
 
 
 def list_records(limit: int = 20) -> List[Dict[str, Any]]:

--- a/pharma_compliance/plugin.yaml
+++ b/pharma_compliance/plugin.yaml
@@ -1,0 +1,6 @@
+name: pharma_compliance
+version: "1.0.0"
+description: "Pharma compliance tracking bot for QQ platform"
+kind: standalone
+provides_hooks:
+  - pre_gateway_dispatch

--- a/pharma_compliance/plugin_adapter.py
+++ b/pharma_compliance/plugin_adapter.py
@@ -1,0 +1,170 @@
+"""
+Adapter layer: connects ComplianceBotHandler to the Hermes gateway hook.
+
+This module is the SINGLE integration point between the existing
+ComplianceBotHandler (which has its own proven interface) and the
+Hermes ``pre_gateway_dispatch`` hook convention.
+
+Design principle: Handler logic stays untouched.  All translation
+between hook kwargs and handler parameters happens here.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+from pharma_compliance.bot_handler import ComplianceBotHandler
+
+logger = logging.getLogger(__name__)
+
+
+class PharmaCompliancePlugin:
+    """Adapter that bridges pre_gateway_dispatch hook → ComplianceBotHandler.
+
+    Lifecycle
+    ---------
+    1. Instantiated once in ``pharma_compliance/__init__.py:register()``.
+    2. ``on_gateway_dispatch`` is called (as an async callback) by the
+       Hermes hook invoker for EVERY incoming message on EVERY platform.
+    3. Returns ``None`` to let the message pass through, or
+       ``{"action": "reply", "text": "..."}`` to have the gateway reply
+       directly and terminate dispatch.
+    """
+
+    # Only process messages from these platforms (case-insensitive match
+    # against Platform.value).
+    PLATFORMS: frozenset[str] = frozenset({"qqbot"})
+
+    def __init__(self) -> None:
+        # ComplianceBotHandler is stateless aside from its internal
+        # SessionManager; single instance is correct.
+        self._handler = ComplianceBotHandler()
+
+    # ── Hook callback ───────────────────────────────────────────────────
+
+    async def on_gateway_dispatch(
+        self,
+        event: Any,             # gateway.protocol.MessageEvent
+        gateway: Any,           # gateway.run.GatewayRunner
+        session_store: Any = None,
+    ) -> Optional[Dict[str, Any]]:
+        """``pre_gateway_dispatch`` hook callback.
+
+        Kwargs (passed by ``gateway/run.py:_handle_message`` via
+        ``hermes_cli.plugins.invoke_hook``):
+
+            event
+                ``MessageEvent`` with ``source.platform``,
+                ``source.chat_id``, ``source.user_id``, ``text``.
+
+            gateway
+                ``GatewayRunner`` instance holding ``self.adapters``
+                dict (not used by this adapter; control returns to the
+                gateway for actual sending).
+
+            session_store
+                Session persistence store (not used by this adapter).
+
+        Returns
+        -------
+        Optional[Dict[str, Any]]
+            ``None``
+                Let the message fall through to normal Agent dispatch.
+            ``{"action": "reply", "text": "…"}``
+                Instruct the gateway to send *text* as a direct reply
+                and then **terminate** further dispatch.
+        """
+        # ── 1. Validate source ──────────────────────────────────────────
+        source = getattr(event, "source", None)
+        if source is None:
+            return None
+
+        platform_enum = getattr(source, "platform", None)
+        if platform_enum is None:
+            return None
+
+        # Platform.value is the canonical string (e.g. "qqbot", "feishu")
+        platform_str = str(getattr(platform_enum, "value", platform_enum)).lower()
+        if platform_str not in self.PLATFORMS:
+            # Not our platform — let other plugins / Agent handle it
+            return None
+
+        # ── 2. Extract message fields ───────────────────────────────────
+        user_id = getattr(source, "user_id", None)
+        text = getattr(event, "text", None)
+
+        if not user_id or not text:
+            return None
+
+        # ── 3. Call ComplianceBotHandler ────────────────────────────────
+        try:
+            # Handler signature (bot_handler.py:137-153):
+            #   handle_message(user_id, msg_type, content, metadata)
+            handler_result = await self._handler.handle_message(
+                user_id=str(user_id),
+                msg_type="text",
+                content=str(text),
+                metadata={},
+            )
+        except Exception:
+            logger.exception(
+                "Pharma compliance handler error for user %s",
+                user_id,
+            )
+            # On error, let message fall through to Agent (fail-open)
+            return None
+
+        # ── 4. Translate handler result → gateway hook action ───────────
+        return self._translate_result(handler_result)
+
+    # ── Translation logic ───────────────────────────────────────────────
+
+    def _translate_result(self, result: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Translate ComplianceBotHandler return dict → hook action dict.
+
+        Handler return keys (from ``bot_handler.py``):
+            needs_followup   : bool      — True when handler wants to ask a question
+            followup_message : str | None — the question text to send
+            merged           : bool      — True when a task was finalized
+            text_preview     : str | None — summary text for user confirmation
+            warnings         : list[str] — compliance warnings
+
+        Returns
+        -------
+        Optional[Dict]
+            ``None``
+                → fall through to Agent
+            ``{"action": "reply", "text": "…"}``
+                → gateway sends reply, terminates dispatch
+        """
+        # ── Case 1: Progressive follow-up question ──────────────────────
+        if result.get("needs_followup"):
+            followup = result.get("followup_message") or ""
+            # _notify is a transient hint from bot_handler for skipped
+            # fields (retry exhausted); prepend it if present
+            notify = result.get("_notify") or ""
+            if notify:
+                followup = f"{notify}\n\n{followup}" if followup else notify
+            if followup.strip():
+                return {"action": "reply", "text": followup}
+            # needs_followup=True but no message → fall through (edge case)
+            return None
+
+        # ── Case 2: Task finalized (merged) ─────────────────────────────
+        if result.get("merged"):
+            summary = result.get("text_preview") or ""
+            warnings = result.get("warnings") or []
+
+            reply = "✅ 记录完成"
+            if summary:
+                reply += f"\n\n{summary}"
+            if warnings:
+                reply += "\n\n" + "\n".join(f"  ⚠️ {w}" for w in warnings)
+
+            return {"action": "reply", "text": reply}
+
+        # ── Case 3: Neither follow-up nor merged ────────────────────────
+        # (e.g. pending count update, needs_confirmation=True for low-STT-
+        # confidence — these are handled by letting the Agent respond)
+        return None

--- a/pharma_compliance/session.py
+++ b/pharma_compliance/session.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 # Merge window: messages within this many seconds are merged into one task
 MERGE_WINDOW_SECONDS = 300  # 5 minutes
 # Phrase that triggers manual merge completion
-MANUAL_MERGE_PHRASES = ("完了", "就这样", "结束", "好了", "完成", "提交", "合并", "强制合并")
+MANUAL_MERGE_PHRASES = ("完了", "就这样", "结束", "好了", "完成", "提交", "合并", "强制合并", "取消")
 
 
 class MessageType(Enum):
@@ -47,6 +47,22 @@ class VisitSession:
     task_type: Optional[str] = None
     created_at: float = field(default_factory=time.time)
 
+    # Progressive field追问 state (post-merge multi-round questioning)
+    merged_fields: Optional[Dict[str, Any]] = None   # fields being progressively completed
+    pending_questions: List[str] = field(default_factory=list)  # remaining fields to ask about
+    pending_field: Optional[str] = None               # current field being asked (None = waiting for feedback answer or normal)
+    merged_record_id: Optional[str] = None            # record_id from save_record for later update
+    retry_count: int = 0                              # number of consecutive extraction failures for current field
+    last_activity: float = field(default_factory=time.time)  # timestamp of last activity
+
+    def touch_activity(self) -> None:
+        """Update last_activity timestamp to current time."""
+        self.last_activity = time.time()
+
+    def is_stale(self) -> bool:
+        """Return True if no activity for 30 minutes (1800 seconds)."""
+        return time.time() - self.last_activity > 1800
+
     def add_message(
         self,
         msg_type: MessageType,
@@ -62,6 +78,7 @@ class VisitSession:
         )
         self.message_timeout = msg.timestamp + MERGE_WINDOW_SECONDS
         self.pending_messages.append(msg)
+        self.touch_activity()
         logger.debug(
             "Session %s: added %s message, pending count=%d",
             self.user_id, msg_type.value, len(self.pending_messages),
@@ -99,6 +116,13 @@ class VisitSession:
         self.pending_messages.clear()
         self.message_timeout = 0.0
         self.task_type = None
+        # Reset progressive questioning state
+        self.merged_fields = None
+        self.pending_questions.clear()
+        self.pending_field = None
+        self.merged_record_id = None
+        self.retry_count = 0
+        self.last_activity = time.time()
 
 
 class SessionManager:
@@ -113,7 +137,9 @@ class SessionManager:
             if user_id not in self._sessions:
                 self._sessions[user_id] = VisitSession(user_id=user_id)
                 logger.info("Created new session for user %s", user_id)
-            return self._sessions[user_id]
+            session = self._sessions[user_id]
+            session.touch_activity()
+            return session
 
     def get_session(self, user_id: str) -> Optional[VisitSession]:
         return self._sessions.get(user_id)

--- a/pharma_compliance/session.py
+++ b/pharma_compliance/session.py
@@ -54,6 +54,7 @@ class VisitSession:
     merged_record_id: Optional[str] = None            # record_id from save_record for later update
     retry_count: int = 0                              # number of consecutive extraction failures for current field
     last_activity: float = field(default_factory=time.time)  # timestamp of last activity
+    _pending_notify: Optional[str] = None              # pending notification message (set on retry exhaustion)
 
     def touch_activity(self) -> None:
         """Update last_activity timestamp to current time."""
@@ -112,6 +113,23 @@ class VisitSession:
                 parts.append(msg.content)
         return " ".join(parts)
 
+    def accumulate_fields(self, new_fields: Dict[str, Any]) -> Dict[str, Any]:
+        """Accumulate new fields into merged_fields, filling empty slots.
+
+        Returns the updated merged_fields dict.
+        """
+        if self.merged_fields is None:
+            self.merged_fields = {}
+
+        for key, value in new_fields.items():
+            existing = self.merged_fields.get(key, "")
+            # Only overwrite if existing is empty AND new value is non-empty
+            if (not existing or (isinstance(existing, str) and not existing.strip())) \
+                    and value and (not isinstance(value, str) or value.strip()):
+                self.merged_fields[key] = value
+
+        return self.merged_fields
+
     def clear(self) -> None:
         self.pending_messages.clear()
         self.message_timeout = 0.0
@@ -122,6 +140,7 @@ class VisitSession:
         self.pending_field = None
         self.merged_record_id = None
         self.retry_count = 0
+        self._pending_notify = None
         self.last_activity = time.time()
 
 

--- a/pharma_compliance/session.py
+++ b/pharma_compliance/session.py
@@ -1,0 +1,142 @@
+"""
+Session management for pharma compliance tracking.
+
+Each session tracks a user's pending messages for multimodal merge,
+supporting text, voice, and photo message types with 5-minute auto-merge.
+"""
+
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Merge window: messages within this many seconds are merged into one task
+MERGE_WINDOW_SECONDS = 300  # 5 minutes
+# Phrase that triggers manual merge completion
+MANUAL_MERGE_PHRASES = ("完了", "就这样", "结束", "好了", "完成", "提交", "合并", "强制合并")
+
+
+class MessageType(Enum):
+    TEXT = "text"
+    VOICE = "voice"
+    PHOTO = "photo"
+
+
+@dataclass
+class PendingMessage:
+    """A message waiting to be merged into a task record."""
+
+    msg_type: MessageType
+    content: str  # text content (original text, STT transcript, or OCR result)
+    raw_data: Dict[str, Any] = field(default_factory=dict)
+    timestamp: float = field(default_factory=time.time)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class VisitSession:
+    """A single visit session for a representative."""
+
+    user_id: str
+    pending_messages: List[PendingMessage] = field(default_factory=list)
+    message_timeout: float = 0.0
+    task_type: Optional[str] = None
+    created_at: float = field(default_factory=time.time)
+
+    def add_message(
+        self,
+        msg_type: MessageType,
+        content: str,
+        raw_data: Optional[Dict[str, Any]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        msg = PendingMessage(
+            msg_type=msg_type,
+            content=content,
+            raw_data=raw_data or {},
+            metadata=metadata or {},
+        )
+        self.message_timeout = msg.timestamp + MERGE_WINDOW_SECONDS
+        self.pending_messages.append(msg)
+        logger.debug(
+            "Session %s: added %s message, pending count=%d",
+            self.user_id, msg_type.value, len(self.pending_messages),
+        )
+
+    def is_timed_out(self) -> bool:
+        if not self.pending_messages:
+            return False
+        return time.time() > self.message_timeout
+
+    def should_merge(self) -> bool:
+        """Return True if messages should be merged (timeout or manual trigger)."""
+        return self.is_timed_out()
+
+    def check_manual_merge(self, text: str) -> bool:
+        """Check if the text contains a manual merge trigger phrase."""
+        for phrase in MANUAL_MERGE_PHRASES:
+            if phrase in text:
+                return True
+        return False
+
+    def merge_contents(self) -> str:
+        """Merge all pending message contents into a single text string."""
+        parts: List[str] = []
+        for msg in self.pending_messages:
+            if msg.msg_type == MessageType.PHOTO:
+                parts.append(f"[门头照] {msg.content}")
+            elif msg.msg_type == MessageType.VOICE:
+                parts.append(f"[语音] {msg.content}")
+            else:
+                parts.append(msg.content)
+        return " ".join(parts)
+
+    def clear(self) -> None:
+        self.pending_messages.clear()
+        self.message_timeout = 0.0
+        self.task_type = None
+
+
+class SessionManager:
+    """Manages all visit sessions, keyed by user_id."""
+
+    def __init__(self):
+        self._sessions: Dict[str, VisitSession] = {}
+        self._lock = threading.Lock()
+
+    def get_or_create_session(self, user_id: str) -> VisitSession:
+        with self._lock:
+            if user_id not in self._sessions:
+                self._sessions[user_id] = VisitSession(user_id=user_id)
+                logger.info("Created new session for user %s", user_id)
+            return self._sessions[user_id]
+
+    def get_session(self, user_id: str) -> Optional[VisitSession]:
+        return self._sessions.get(user_id)
+
+    def remove_session(self, user_id: str) -> None:
+        with self._lock:
+            self._sessions.pop(user_id, None)
+            logger.info("Removed session for user %s", user_id)
+
+    def check_timeouts(self) -> List[VisitSession]:
+        """Return all sessions that have timed out and need auto-merge."""
+        timed_out: List[VisitSession] = []
+        with self._lock:
+            for session in list(self._sessions.values()):
+                if session.is_timed_out() and session.pending_messages:
+                    timed_out.append(session)
+        return timed_out
+
+    def get_stats(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "active_sessions": len(self._sessions),
+                "sessions_with_pending": sum(
+                    1 for s in self._sessions.values() if s.pending_messages
+                ),
+            }

--- a/run_agent.py
+++ b/run_agent.py
@@ -3031,7 +3031,7 @@ class AIAgent:
         except Exception:
             pass
 
-    def close(self) -> None:
+    def close(self, preserve_runtime_state: bool = False) -> None:
         """Release all resources held by this agent instance.
 
         Cleans up subprocess resources that would otherwise become orphans:
@@ -3044,6 +3044,10 @@ class AIAgent:
         Safe to call multiple times (idempotent).  Each cleanup step is
         independently guarded so a failure in one does not prevent the rest.
         """
+        if preserve_runtime_state:
+            self.release_clients()
+            return
+
         task_id = getattr(self, "session_id", None) or ""
 
         # 1. Kill background processes for this task

--- a/skills/autonomous-ai-agents/claude-code/SKILL.md
+++ b/skills/autonomous-ai-agents/claude-code/SKILL.md
@@ -35,7 +35,7 @@ Hermes interacts with Claude Code in two fundamentally different ways. Choose ba
 Print mode runs a one-shot task, returns the result, and exits. No PTY needed. No interactive prompts. This is the cleanest integration path.
 
 ```
-terminal(command="claude -p 'Add error handling to all API calls in src/' --allowedTools 'Read,Edit' --max-turns 10", workdir="/path/to/project", timeout=120)
+terminal(command="claude -p 'Add error handling to all API calls in src/' --allowedTools 'Read,Edit' --max-turns 40", workdir="/path/to/project", timeout=120)
 ```
 
 **When to use print mode:**
@@ -144,7 +144,7 @@ terminal(command="sleep 15 && tmux capture-pane -t claude-work -p -S -60")
 
 ### Structured JSON Output
 ```
-terminal(command="claude -p 'Analyze auth.py for security issues' --output-format json --max-turns 5", workdir="/project", timeout=120)
+terminal(command="claude -p 'Analyze auth.py for security issues' --output-format json --max-turns 60", workdir="/project", timeout=120)
 ```
 
 Returns a JSON object with:
@@ -190,13 +190,13 @@ claude -p "task" --input-format stream-json --output-format stream-json --replay
 ### Piped Input
 ```
 # Pipe a file for analysis
-terminal(command="cat src/auth.py | claude -p 'Review this code for bugs' --max-turns 1", timeout=60)
+terminal(command="cat src/auth.py | claude -p 'Review this code for bugs' --max-turns 60", timeout=60)
 
 # Pipe multiple files
-terminal(command="cat src/*.py | claude -p 'Find all TODO comments' --max-turns 1", timeout=60)
+terminal(command="cat src/*.py | claude -p 'Find all TODO comments' --max-turns 5", timeout=60)
 
 # Pipe command output
-terminal(command="git diff HEAD~3 | claude -p 'Summarize these changes' --max-turns 1", timeout=60)
+terminal(command="git diff HEAD~3 | claude -p 'Summarize these changes' --max-turns 5", timeout=60)
 ```
 
 ### JSON Schema for Structured Extraction
@@ -209,21 +209,21 @@ Parse `structured_output` from the JSON result. Claude validates output against 
 ### Session Continuation
 ```
 # Start a task
-terminal(command="claude -p 'Start refactoring the database layer' --output-format json --max-turns 10 > /tmp/session.json", workdir="/project", timeout=180)
+terminal(command="claude -p 'Start refactoring the database layer' --output-format json --max-turns 40 > /tmp/session.json", workdir="/project", timeout=180)
 
 # Resume with session ID
-terminal(command="claude -p 'Continue and add connection pooling' --resume $(cat /tmp/session.json | python3 -c 'import json,sys; print(json.load(sys.stdin)[\"session_id\"])') --max-turns 5", workdir="/project", timeout=120)
+terminal(command="claude -p 'Continue and add connection pooling' --resume $(cat /tmp/session.json | python3 -c 'import json,sys; print(json.load(sys.stdin)[\"session_id\"])') --max-turns 40", workdir="/project", timeout=120)
 
 # Or resume the most recent session in the same directory
-terminal(command="claude -p 'What did you do last time?' --continue --max-turns 1", workdir="/project", timeout=30)
+terminal(command="claude -p 'What did you do last time?' --continue --max-turns 5", workdir="/project", timeout=30)
 
 # Fork a session (new ID, keeps history)
-terminal(command="claude -p 'Try a different approach' --resume <id> --fork-session --max-turns 10", workdir="/project", timeout=120)
+terminal(command="claude -p 'Try a different approach' --resume <id> --fork-session --max-turns 40", workdir="/project", timeout=120)
 ```
 
 ### Bare Mode for CI/Scripting
 ```
-terminal(command="claude --bare -p 'Run all tests and report failures' --allowedTools 'Read,Bash' --max-turns 10", workdir="/project", timeout=180)
+terminal(command="claude --bare -p 'Run all tests and report failures' --allowedTools 'Read,Bash' --max-turns 60", workdir="/project", timeout=180)
 ```
 
 `--bare` skips hooks, plugins, MCP discovery, and CLAUDE.md loading. Fastest startup. Requires `ANTHROPIC_API_KEY` (skips OAuth).
@@ -238,7 +238,7 @@ To selectively load context in bare mode:
 
 ### Fallback Model for Overload
 ```
-terminal(command="claude -p 'task' --fallback-model haiku --max-turns 5", timeout=90)
+terminal(command="claude -p 'task' --fallback-model haiku --max-turns 40", timeout=90)
 ```
 Automatically falls back to the specified model when the default is overloaded (print mode only).
 
@@ -470,7 +470,7 @@ Use the keyword "ultrathink" in your prompt for maximum reasoning effort on a sp
 
 ### Quick Review (Print Mode)
 ```
-terminal(command="cd /path/to/repo && git diff main...feature-branch | claude -p 'Review this diff for bugs, security issues, and style problems. Be thorough.' --max-turns 1", timeout=60)
+terminal(command="cd /path/to/repo && git diff main...feature-branch | claude -p 'Review this diff for bugs, security issues, and style problems. Be thorough.' --max-turns 60", timeout=60)
 ```
 
 ### Deep Review (Interactive + Worktree)
@@ -484,7 +484,7 @@ terminal(command="sleep 30 && tmux capture-pane -t review -p -S -60")
 
 ### PR Review from Number
 ```
-terminal(command="claude -p 'Review this PR thoroughly' --from-pr 42 --max-turns 10", workdir="/path/to/repo", timeout=120)
+terminal(command="claude -p 'Review this PR thoroughly' --from-pr 42 --max-turns 60", workdir="/path/to/repo", timeout=120)
 ```
 
 ### Claude Worktree with tmux
@@ -499,13 +499,13 @@ Run multiple independent Claude tasks simultaneously:
 
 ```
 # Task 1: Fix backend
-terminal(command="tmux new-session -d -s task1 -x 140 -y 40 && tmux send-keys -t task1 'cd ~/project && claude -p \"Fix the auth bug in src/auth.py\" --allowedTools \"Read,Edit\" --max-turns 10' Enter")
+terminal(command="tmux new-session -d -s task1 -x 140 -y 40 && tmux send-keys -t task1 'cd ~/project && claude -p \"Fix the auth bug in src/auth.py\" --allowedTools \"Read,Edit\" --max-turns 40' Enter")
 
 # Task 2: Write tests
-terminal(command="tmux new-session -d -s task2 -x 140 -y 40 && tmux send-keys -t task2 'cd ~/project && claude -p \"Write integration tests for the API endpoints\" --allowedTools \"Read,Write,Bash\" --max-turns 15' Enter")
+terminal(command="tmux new-session -d -s task2 -x 140 -y 40 && tmux send-keys -t task2 'cd ~/project && claude -p \"Write integration tests for the API endpoints\" --allowedTools \"Read,Write,Bash\" --max-turns 40' Enter")
 
 # Task 3: Update docs
-terminal(command="tmux new-session -d -s task3 -x 140 -y 40 && tmux send-keys -t task3 'cd ~/project && claude -p \"Update README.md with the new API endpoints\" --allowedTools \"Read,Edit\" --max-turns 5' Enter")
+terminal(command="tmux new-session -d -s task3 -x 140 -y 40 && tmux send-keys -t task3 'cd ~/project && claude -p \"Update README.md with the new API endpoints\" --allowedTools \"Read,Edit\" --max-turns 40' Enter")
 
 # Monitor all
 terminal(command="sleep 30 && for s in task1 task2 task3; do echo '=== '$s' ==='; tmux capture-pane -t $s -p -S -5 2>/dev/null; done")
@@ -704,7 +704,7 @@ Use `/context` in interactive mode to see a colored grid of context usage. Key t
 
 ## Cost & Performance Tips
 
-1. **Use `--max-turns`** in print mode to prevent runaway loops. Start with 5-10 for most tasks.
+1. **Use `--max-turns`** in print mode to prevent runaway loops. Baseline by task class: `review=60`, `implementation=40`, `extract=5`.
 2. **Use `--max-budget-usd`** for cost caps. Note: minimum ~$0.05 for system prompt cache creation.
 3. **Use `--effort low`** for simple tasks (faster, cheaper). `high` or `max` for complex reasoning.
 4. **Use `--bare`** for CI/scripting to skip plugin/hook discovery overhead.
@@ -724,7 +724,7 @@ Use `/context` in interactive mode to see a colored grid of context usage. Key t
 4. **`--max-turns` is print-mode only** — ignored in interactive sessions.
 5. **Claude may use `python` instead of `python3`** — on systems without a `python` symlink, Claude's bash commands will fail on first try but it self-corrects.
 6. **Session resumption requires same directory** — `--continue` finds the most recent session for the current working directory.
-7. **`--json-schema` needs enough `--max-turns`** — Claude must read files before producing structured output, which takes multiple turns.
+7. **`--json-schema` needs enough `--max-turns`** — use the `extract` baseline (`5`) for small structured reads, and move up to the `review` baseline (`60`) if Claude must inspect a larger diff or file set first.
 8. **Trust dialog only appears once per directory** — first-time only, then cached.
 9. **Background tmux sessions persist** — always clean up with `tmux kill-session -t <name>` when done.
 10. **Slash commands (like `/commit`) only work in interactive mode** — in `-p` mode, describe the task in natural language instead.
@@ -736,10 +736,57 @@ Use `/context` in interactive mode to see a colored grid of context usage. Key t
 1. **Prefer print mode (`-p`) for single tasks** — cleaner, no dialog handling, structured output
 2. **Use tmux for multi-turn interactive work** — the only reliable way to orchestrate the TUI
 3. **Always set `workdir`** — keep Claude focused on the right project directory
-4. **Set `--max-turns` in print mode** — prevents infinite loops and runaway costs
+4. **Set `--max-turns` in print mode using the three baselines** — `review=60`, `implementation=40`, `extract=5`
 5. **Monitor tmux sessions** — use `tmux capture-pane -t <session> -p -S -50` to check progress
 6. **Look for the `❯` prompt** — indicates Claude is waiting for input (done or asking a question)
 7. **Clean up tmux sessions** — kill them when done to avoid resource leaks
 8. **Report results to user** — after completion, summarize what Claude did and what changed
 9. **Don't kill slow sessions** — Claude may be doing multi-step work; check progress instead
 10. **Use `--allowedTools`** — restrict capabilities to what the task actually needs
+
+## Dispatch Template / Report Contract
+
+Canonical CC dispatch template: `skills/autonomous-ai-agents/claude-code/templates/default-dispatch.md`.
+
+Before every delegated Claude Code run:
+
+1. Call `skill_view(name="claude-code", file_path="templates/default-dispatch.md")`.
+2. Render `<ABS_REPORT_PATH>`, `<JOB_ID>`, `<TASK_CLASS>`, and `<TURN_BUDGET>`.
+3. Prepend the rendered template to the beginning of the dispatch prompt.
+4. Append the task-specific instructions after the template.
+
+### Report Path Rules
+
+- `<ABS_REPORT_PATH>` must be an absolute path inside the target repository.
+- If no report path is provided, fall back to `<repo>/.hermes-artifacts/reviews/<JOB_ID>.md`.
+- Create the parent directory first with `mkdir -p`.
+- Never use `~` in report paths.
+- Never present partial output as `completed`.
+
+### Turn Budget Baselines
+
+| Task class | Range | Default |
+|---|---:|---:|
+| `review` | 30-120 | 60 |
+| `implementation` | 20-80 | 40 |
+| `extract` | 1-10 | 5 |
+
+- Use the `review` bucket by default for review, debug, and refactor tasks.
+- Use the `implementation` bucket by default for features, fixes, tests, and other code changes.
+- Use the `extract` bucket by default for summarize, schema, and narrow extraction work.
+- In print mode, set `--max-turns` to the bucket default unless the caller explicitly overrides it.
+
+### Claude Print-Mode Status Mapping
+
+- `success` -> `completed`
+- `error_max_turns` -> `over_budget`
+- `error_budget` -> `over_budget`
+- `interrupted` -> `interrupted`
+- If Claude stops early but leaves useful incomplete work, write `partial_output` in the report instead of `completed`.
+
+### End-State Contract
+
+- `completed` — task finished within budget, report written, no required work omitted
+- `over_budget` — budget exhausted; report must state what finished, what did not, and the exact next step
+- `interrupted` — execution stopped externally; report must capture the last safe checkpoint
+- `partial_output` — usable but incomplete output; it must be labeled partial and must not be reported as `completed`

--- a/skills/autonomous-ai-agents/claude-code/templates/default-dispatch.md
+++ b/skills/autonomous-ai-agents/claude-code/templates/default-dispatch.md
@@ -1,0 +1,61 @@
+# Claude Code Dispatch Template
+
+You are executing a delegated Hermes task. Follow this contract exactly.
+
+## Report Path Contract
+
+- Write the final report to `<ABS_REPORT_PATH>`.
+- `<ABS_REPORT_PATH>` must be an absolute path inside the target repository.
+- If no explicit report path is provided, use `<repo>/.hermes-artifacts/reviews/<JOB_ID>.md`.
+- Create the parent directory first: `mkdir -p "$(dirname "$ABS_REPORT_PATH")"`.
+- Never use `~` in report paths.
+
+## Turn Budget Baseline
+
+| Task class | Range | Default |
+|---|---:|---:|
+| `review` | 30-120 | 60 |
+| `implementation` | 20-80 | 40 |
+| `extract` | 1-10 | 5 |
+
+- Use `<TASK_CLASS>` to choose the correct baseline.
+- Respect `<TURN_BUDGET>` when it is explicitly provided.
+
+## End-State Contract
+
+Use exactly one final status:
+
+- `completed` — the task is fully finished and the report is complete.
+- `over_budget` — the turn budget was exhausted before the task finished.
+- `interrupted` — execution was stopped by an external interruption.
+- `partial_output` — there is usable output, but the task is incomplete.
+
+Do not label partial work as `completed`.
+
+## Claude Print-Mode Status Mapping
+
+- `success` -> `completed`
+- `error_max_turns` -> `over_budget`
+- `error_budget` -> `over_budget`
+- `interrupted` -> `interrupted`
+
+If Claude stops early but leaves usable incomplete work, write `partial_output` in the final report instead of `completed`.
+
+## Final Report Template
+
+```md
+Status: completed | over_budget | interrupted | partial_output
+Job-ID: <JOB_ID>
+Task-Class: <TASK_CLASS>
+Turn-Budget: <TURN_BUDGET>
+Report-Path: <ABS_REPORT_PATH>
+
+Summary:
+- ...
+
+Work Completed:
+- ...
+
+Remaining Work / Next Step:
+- ...
+```

--- a/skills/autonomous-ai-agents/codex/SKILL.md
+++ b/skills/autonomous-ai-agents/codex/SKILL.md
@@ -128,3 +128,42 @@ terminal(command="gh pr comment 86 --body '<review>'", workdir="~/project")
 5. **Background for long tasks** — use `background=true` and monitor with `process` tool
 6. **Don't interfere** — monitor with `poll`/`log`, be patient with long-running tasks
 7. **Parallel is fine** — run multiple Codex processes at once for batch work
+
+## Dispatch Template / Report Contract
+
+Canonical CX dispatch template: `skills/autonomous-ai-agents/codex/templates/default-dispatch.md`.
+
+Before every delegated Codex run:
+
+1. Call `skill_view(name="codex", file_path="templates/default-dispatch.md")`.
+2. Render `<ABS_REPORT_PATH>`, `<JOB_ID>`, `<TASK_CLASS>`, and `<TURN_BUDGET>`.
+3. Prepend the rendered template to the beginning of the dispatch prompt.
+4. Append the task-specific instructions after the template.
+
+### Report Path Rules
+
+- `<ABS_REPORT_PATH>` must be an absolute path inside the target repository.
+- If no report path is provided, fall back to `<repo>/.hermes-artifacts/reviews/<JOB_ID>.md`.
+- Create the parent directory first with `mkdir -p`.
+- Never use `~` in report paths.
+- Never present partial output as `completed`.
+
+### Turn Budget Baselines
+
+| Task class | Range | Default |
+|---|---:|---:|
+| `review` | 30-120 | 60 |
+| `implementation` | 20-80 | 40 |
+| `extract` | 1-10 | 5 |
+
+- Use the `review` bucket by default for review, debug, and refactor tasks.
+- Use the `implementation` bucket by default for features, fixes, tests, and other code changes.
+- Use the `extract` bucket by default for summarize, schema, and narrow extraction work.
+- Codex does not have a single canonical `--max-turns` CLI pattern here, so the budget contract must be carried by the injected template and dispatch prompt.
+
+### End-State Contract
+
+- `completed` — task finished within budget, report written, no required work omitted
+- `over_budget` — budget exhausted; report must state what finished, what did not, and the exact next step
+- `interrupted` — execution stopped externally; report must capture the last safe checkpoint
+- `partial_output` — usable but incomplete output; it must be labeled partial and must not be reported as `completed`

--- a/skills/autonomous-ai-agents/codex/templates/default-dispatch.md
+++ b/skills/autonomous-ai-agents/codex/templates/default-dispatch.md
@@ -1,0 +1,52 @@
+# Codex Dispatch Template
+
+You are executing a delegated Hermes task. Follow this contract exactly.
+
+## Report Path Contract
+
+- Write the final report to `<ABS_REPORT_PATH>`.
+- `<ABS_REPORT_PATH>` must be an absolute path inside the target repository.
+- If no explicit report path is provided, use `<repo>/.hermes-artifacts/reviews/<JOB_ID>.md`.
+- Create the parent directory first: `mkdir -p "$(dirname "$ABS_REPORT_PATH")"`.
+- Never use `~` in report paths.
+
+## Turn Budget Baseline
+
+| Task class | Range | Default |
+|---|---:|---:|
+| `review` | 30-120 | 60 |
+| `implementation` | 20-80 | 40 |
+| `extract` | 1-10 | 5 |
+
+- Use `<TASK_CLASS>` to choose the correct baseline.
+- Respect `<TURN_BUDGET>` when it is explicitly provided.
+
+## End-State Contract
+
+Use exactly one final status:
+
+- `completed` — the task is fully finished and the report is complete.
+- `over_budget` — the turn budget was exhausted before the task finished.
+- `interrupted` — execution was stopped by an external interruption.
+- `partial_output` — there is usable output, but the task is incomplete.
+
+Do not label partial work as `completed`.
+
+## Final Report Template
+
+```md
+Status: completed | over_budget | interrupted | partial_output
+Job-ID: <JOB_ID>
+Task-Class: <TASK_CLASS>
+Turn-Budget: <TURN_BUDGET>
+Report-Path: <ABS_REPORT_PATH>
+
+Summary:
+- ...
+
+Work Completed:
+- ...
+
+Remaining Work / Next Step:
+- ...
+```

--- a/tests/cron/test_cron_script_args.py
+++ b/tests/cron/test_cron_script_args.py
@@ -1,0 +1,377 @@
+"""Tests for cron script_args feature — B class tests.
+
+Covers _run_job_script() argv construction, create_job() validation,
+and _format_job() echo-back of the script_args field.
+
+See: /Users/x/.hermes/tmp/cc-fix-plan-dual-bug-v2.md
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure project root is importable
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+@pytest.fixture
+def cron_env(tmp_path, monkeypatch):
+    """Isolated cron environment with temp HERMES_HOME."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "cron").mkdir()
+    (hermes_home / "cron" / "output").mkdir()
+    (hermes_home / "scripts").mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    import cron.jobs as jobs_mod
+    monkeypatch.setattr(jobs_mod, "HERMES_DIR", hermes_home)
+    monkeypatch.setattr(jobs_mod, "CRON_DIR", hermes_home / "cron")
+    monkeypatch.setattr(jobs_mod, "JOBS_FILE", hermes_home / "cron" / "jobs.json")
+    monkeypatch.setattr(jobs_mod, "OUTPUT_DIR", hermes_home / "cron" / "output")
+
+    import cron.scheduler as sched_mod
+    monkeypatch.setattr(sched_mod, "_hermes_home", hermes_home)
+
+    return hermes_home
+
+
+def _fake_subprocess_run(returncode=0, stdout="ok", stderr=""):
+    """Return a side_effect for subprocess.run that captures argv."""
+    captured = {}
+
+    def fake_run(argv, **kwargs):
+        captured["argv"] = list(argv)
+        return MagicMock(returncode=returncode, stdout=stdout, stderr=stderr)
+
+    return captured, fake_run
+
+
+class TestRunJobScriptArgs:
+    """B: _run_job_script argv construction with script_args."""
+
+    def test_no_args(self, cron_env):
+        """script_args not passed → argv contains only interpreter + script."""
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "test.py"
+        script.write_text('print("hello")\n')
+
+        captured, fake_run = _fake_subprocess_run()
+        with patch("subprocess.run", side_effect=fake_run):
+            success, output = _run_job_script("test.py")
+
+        assert success is True
+        assert output == "ok"
+        argv = captured["argv"]
+        assert argv[0] == sys.executable
+        assert argv[1].endswith("test.py")
+        assert len(argv) == 2
+
+    def test_single_arg(self, cron_env):
+        """script_args=["--mode", "close"] → both appended to argv."""
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "test.py"
+        script.write_text('print("hello")\n')
+
+        captured, fake_run = _fake_subprocess_run()
+        with patch("subprocess.run", side_effect=fake_run):
+            success, output = _run_job_script("test.py", script_args=["--mode", "close"])
+
+        assert success is True
+        argv = captured["argv"]
+        assert argv[-2] == "--mode"
+        assert argv[-1] == "close"
+
+    def test_multiple_args(self, cron_env):
+        """Multiple items in script_args → all appended in order."""
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "test.py"
+        script.write_text('print("hello")\n')
+
+        captured, fake_run = _fake_subprocess_run()
+        with patch("subprocess.run", side_effect=fake_run):
+            success, output = _run_job_script(
+                "test.py",
+                script_args=["--verbose", "--output", "/tmp/out", "--retries", "3"],
+            )
+
+        assert success is True
+        argv = captured["argv"]
+        args_slice = argv[2:]  # after interpreter + script
+        assert args_slice == ["--verbose", "--output", "/tmp/out", "--retries", "3"]
+
+    def test_script_none_script_args(self):
+        """script=None → early return with error, no subprocess call."""
+        from cron.scheduler import _run_job_script
+
+        with patch("cron.scheduler.subprocess.run") as mock_run:
+            success, output = _run_job_script(None)
+
+        assert success is False
+        assert "Script path is empty or None" == output
+        mock_run.assert_not_called()
+
+    def test_script_empty_string(self):
+        """script="" → early return with error, no subprocess call."""
+        from cron.scheduler import _run_job_script
+
+        with patch("cron.scheduler.subprocess.run") as mock_run:
+            success, output = _run_job_script("")
+
+        assert success is False
+        assert "Script path is empty or None" == output
+        mock_run.assert_not_called()
+
+    def test_empty_script_args_list(self, cron_env):
+        """script_args=[] → same argv length as no script_args."""
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "test.py"
+        script.write_text('print("hello")\n')
+
+        captured, fake_run = _fake_subprocess_run()
+        with patch("subprocess.run", side_effect=fake_run):
+            success, output = _run_job_script("test.py", script_args=[])
+
+        assert success is True
+        argv = captured["argv"]
+        assert len(argv) == 2  # just interpreter + script
+
+    def test_script_path_with_spaces(self, cron_env):
+        """Filename with spaces is NOT split — script stays one path, not two tokens."""
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "my script.py"
+        script.write_text('print("ok")\n')
+
+        captured, fake_run = _fake_subprocess_run()
+        with patch("subprocess.run", side_effect=fake_run):
+            success, output = _run_job_script("my script.py", script_args=["--flag"])
+
+        assert success is True
+        argv = captured["argv"]
+        # The script path must be a single argv entry, not split on space
+        assert argv[1].endswith("my script.py")
+        assert "--flag" in argv
+
+    def test_path_traversal_rejected(self, cron_env):
+        """Path traversal (../../etc/passwd) is blocked by containment check."""
+        from cron.scheduler import _run_job_script
+
+        success, output = _run_job_script("../../etc/passwd")
+        assert success is False
+        assert "blocked" in output.lower()
+
+    def test_shell_script_with_args(self, cron_env):
+        """.sh script uses bash interpreter and appends script_args correctly."""
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "backup.sh"
+        script.write_text("#!/bin/bash\necho done\n")
+
+        captured, fake_run = _fake_subprocess_run()
+        with patch("subprocess.run", side_effect=fake_run):
+            success, output = _run_job_script("backup.sh", script_args=["--force", "--dest", "/tmp/out"])
+
+        assert success is True
+        assert output == "ok"
+        argv = captured["argv"]
+        # argv[0] must be bash, not python
+        assert argv[0].endswith("bash")
+        assert argv[1].endswith("backup.sh")
+        args_slice = argv[2:]
+        assert args_slice == ["--force", "--dest", "/tmp/out"]
+
+    def test_bash_script_with_args(self, cron_env):
+        """.bash script also uses bash interpreter and appends script_args."""
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "deploy.bash"
+        script.write_text("#!/bin/bash\necho done\n")
+
+        captured, fake_run = _fake_subprocess_run()
+        with patch("subprocess.run", side_effect=fake_run):
+            success, output = _run_job_script("deploy.bash", script_args=["--env", "prod"])
+
+        assert success is True
+        argv = captured["argv"]
+        assert argv[0].endswith("bash")
+        assert argv[1].endswith("deploy.bash")
+        assert argv[2:] == ["--env", "prod"]
+
+
+class TestCreateJobScriptArgsValidation:
+    """B: create_job() script_args input validation."""
+
+    def test_non_list_rejected(self, cron_env):
+        """script_args must be a list — non-list values raise TypeError."""
+        from cron.jobs import create_job
+
+        with pytest.raises(TypeError, match="script_args must be a list"):
+            create_job(
+                prompt="test",
+                schedule="every 1h",
+                script="test.py",
+                script_args="not_a_list",
+            )
+
+    def test_non_list_rejected_in_cronjob_update(self, cron_env, monkeypatch):
+        """cronjob() update with non-list script_args returns error."""
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import cronjob
+
+        create_res = json.loads(cronjob(
+            action="create",
+            schedule="every 1h",
+            prompt="test",
+            script="test.py",
+        ))
+        job_id = create_res["job_id"]
+
+        update_res = json.loads(cronjob(
+            action="update",
+            job_id=job_id,
+            script_args="not_a_list",
+        ))
+        assert update_res["success"] is False
+        assert "must be a list" in update_res["error"].lower()
+
+    def test_update_script_args_success(self, cron_env, monkeypatch):
+        """cronjob() update with valid script_args persists and echoes them back."""
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import cronjob
+
+        create_res = json.loads(cronjob(
+            action="create",
+            schedule="every 1h",
+            prompt="test",
+            script="test.py",
+        ))
+        job_id = create_res["job_id"]
+
+        update_res = json.loads(cronjob(
+            action="update",
+            job_id=job_id,
+            script_args=["--mode", "full", "--verbose"],
+        ))
+        assert update_res["success"] is True
+        assert update_res["job"]["script_args"] == ["--mode", "full", "--verbose"]
+
+        # Verify persisted by reading back via list
+        list_res = json.loads(cronjob(action="list"))
+        for j in list_res["jobs"]:
+            if j["job_id"] == job_id:
+                assert j["script_args"] == ["--mode", "full", "--verbose"]
+                break
+        else:
+            pytest.fail(f"Job {job_id} not found in list")
+
+    def test_update_script_args_clear(self, cron_env, monkeypatch):
+        """cronjob() update with script_args=[] clears the field."""
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import cronjob
+
+        create_res = json.loads(cronjob(
+            action="create",
+            schedule="every 1h",
+            prompt="test",
+            script="test.py",
+            script_args=["--original"],
+        ))
+        job_id = create_res["job_id"]
+
+        update_res = json.loads(cronjob(
+            action="update",
+            job_id=job_id,
+            script_args=[],
+        ))
+        assert update_res["success"] is True
+        assert update_res["job"]["script_args"] == []
+
+        # Verify persisted as empty
+        list_res = json.loads(cronjob(action="list"))
+        for j in list_res["jobs"]:
+            if j["job_id"] == job_id:
+                assert j["script_args"] == []
+                break
+        else:
+            pytest.fail(f"Job {job_id} not found in list")
+
+    def test_update_script_args_retain(self, cron_env, monkeypatch):
+        """cronjob() update without script_args field retains existing value."""
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        from tools.cronjob_tools import cronjob
+
+        create_res = json.loads(cronjob(
+            action="create",
+            schedule="every 1h",
+            prompt="test",
+            script="test.py",
+            script_args=["--original"],
+        ))
+        job_id = create_res["job_id"]
+
+        # Update only the name — script_args should be retained
+        update_res = json.loads(cronjob(
+            action="update",
+            job_id=job_id,
+            name="renamed-job",
+        ))
+        assert update_res["success"] is True
+        assert update_res["job"]["script_args"] == ["--original"]
+
+    def test_non_string_elements_normalized(self, cron_env):
+        """script_args with int, bool, float → all normalised to str via str()."""
+        from cron.jobs import create_job
+        from tools.cronjob_tools import _format_job
+
+        job = create_job(
+            prompt="test",
+            schedule="every 1h",
+            script="test.py",
+            script_args=[1, True, 3.14, 0, False],
+        )
+
+        formatted = _format_job(job)
+        assert formatted["script_args"] == ["1", "True", "3.14", "0", "False"]
+
+
+class TestFormatJobScriptArgs:
+    """B: _format_job() echo-back of script_args."""
+
+    def test_format_job_includes_script_args(self, cron_env):
+        """_format_job echoes script_args when present on the job."""
+        from cron.jobs import create_job
+        from tools.cronjob_tools import _format_job
+
+        job = create_job(
+            prompt="analyze",
+            schedule="every 1h",
+            script="collector.py",
+            script_args=["--mode", "full", "--since", "yesterday"],
+        )
+
+        formatted = _format_job(job)
+        assert "script_args" in formatted
+        assert formatted["script_args"] == ["--mode", "full", "--since", "yesterday"]
+
+    def test_format_job_no_script_args(self, cron_env):
+        """_format_job echoes empty script_args list when not supplied."""
+        from cron.jobs import create_job
+        from tools.cronjob_tools import _format_job
+
+        job = create_job(
+            prompt="analyze",
+            schedule="every 1h",
+            script="collector.py",
+        )
+
+        formatted = _format_job(job)
+        assert "script_args" in formatted
+        assert formatted["script_args"] == []

--- a/tests/cron/test_scheduler_delivery_logging.py
+++ b/tests/cron/test_scheduler_delivery_logging.py
@@ -1,0 +1,161 @@
+"""Tests for cron/scheduler.py _deliver_result — live adapter delivery logging (A.1 & A.2).
+
+Covers the warning-logging behaviour added in the dual-bug fix:
+
+A.1 — safe_schedule_threadsafe returns None → WARNING logged, falls back to standalone
+A.2 — runtime_adapter exists but loop is None / not running → WARNING logged
+Also verifies the normal path (no adapter) does NOT emit spurious warnings.
+"""
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cron.scheduler import _deliver_result
+
+
+def _make_job(platform="telegram", chat_id="12345"):
+    return {
+        "id": "test-job-abc",
+        "name": "test-job",
+        "deliver": "origin",
+        "origin": {"platform": platform, "chat_id": chat_id},
+    }
+
+
+def _make_pconfig():
+    pconfig = MagicMock()
+    pconfig.enabled = True
+    return pconfig
+
+
+def _make_gateway_config(platform, pconfig):
+    from gateway.config import Platform
+    mock_cfg = MagicMock()
+    mock_cfg.platforms = {Platform(platform): pconfig}
+    return mock_cfg
+
+
+class TestLiveAdapterDeliveryLogging:
+    """A.1 & A.2: Verify warning logs when live adapter delivery can't proceed."""
+
+    def test_safe_schedule_threadsafe_returns_none_logs_warning(self, caplog):
+        """A.1: safe_schedule_threadsafe returns None → WARNING with 'live adapter schedule failed'."""
+        from gateway.config import Platform
+
+        adapter = MagicMock()
+        adapter.send.return_value = MagicMock(success=True)
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        pconfig = _make_pconfig()
+        mock_cfg = _make_gateway_config("telegram", pconfig)
+        job = _make_job()
+
+        mock_send = AsyncMock(return_value={"success": True})
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=mock_send), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("agent.async_utils.safe_schedule_threadsafe", return_value=None):
+            with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
+                result = _deliver_result(
+                    job, "Test content",
+                    adapters={Platform.TELEGRAM: adapter},
+                    loop=loop,
+                )
+
+        assert result is None
+        assert any(
+            "live adapter schedule failed" in r.message
+            for r in caplog.records
+        ), f"Expected 'live adapter schedule failed' warning, got: {[r.message for r in caplog.records]}"
+        mock_send.assert_called_once()
+
+    def test_live_adapter_loop_none_logs_warning(self, caplog):
+        """A.2: runtime_adapter exists but loop is None → WARNING with 'loop is None'."""
+        from gateway.config import Platform
+
+        adapter = AsyncMock()
+        pconfig = _make_pconfig()
+        mock_cfg = _make_gateway_config("telegram", pconfig)
+        job = _make_job()
+
+        mock_send = AsyncMock(return_value={"success": True})
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=mock_send), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
+                result = _deliver_result(
+                    job, "Test content",
+                    adapters={Platform.TELEGRAM: adapter},
+                    loop=None,
+                )
+
+        assert result is None
+        assert any(
+            "loop is None" in r.message
+            for r in caplog.records
+        ), f"Expected 'loop is None' warning, got: {[r.message for r in caplog.records]}"
+        mock_send.assert_called_once()
+        adapter.send.assert_not_called()
+
+    def test_live_adapter_loop_not_running_logs_warning(self, caplog):
+        """A.2: runtime_adapter exists but loop.is_running() is False → WARNING with 'loop is not running'."""
+        from gateway.config import Platform
+
+        adapter = AsyncMock()
+        loop = MagicMock()
+        loop.is_running.return_value = False
+
+        pconfig = _make_pconfig()
+        mock_cfg = _make_gateway_config("telegram", pconfig)
+        job = _make_job()
+
+        mock_send = AsyncMock(return_value={"success": True})
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=mock_send), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
+                result = _deliver_result(
+                    job, "Test content",
+                    adapters={Platform.TELEGRAM: adapter},
+                    loop=loop,
+                )
+
+        assert result is None
+        assert any(
+            "loop is not running" in r.message
+            for r in caplog.records
+        ), f"Expected 'loop is not running' warning, got: {[r.message for r in caplog.records]}"
+        mock_send.assert_called_once()
+        adapter.send.assert_not_called()
+
+    def test_no_runtime_adapter_no_warning(self, caplog):
+        """Normal path: no adapter for the platform → no loop-related warning logged."""
+        pconfig = _make_pconfig()
+        mock_cfg = _make_gateway_config("telegram", pconfig)
+        job = _make_job()
+
+        mock_send = AsyncMock(return_value={"success": True})
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=mock_send), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
+                result = _deliver_result(
+                    job, "Test content",
+                    adapters={},  # no adapter for telegram
+                    loop=None,
+                )
+
+        assert result is None
+        loop_warnings = [
+            r.message for r in caplog.records
+            if "loop" in r.message.lower() and "live adapter" in r.message.lower()
+        ]
+        assert not loop_warnings, (
+            f"Expected no loop-related live-adapter warnings when no adapter is present, "
+            f"got: {loop_warnings}"
+        )
+        mock_send.assert_called_once()

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -14,7 +14,9 @@ from unittest.mock import AsyncMock
 import pytest
 
 from gateway.config import GatewayConfig, Platform
-from gateway.run import GatewayRunner, _parse_session_key
+from gateway.run import GatewayRunner, _completion_event_for_session, _parse_session_key
+
+pytestmark = pytest.mark.anyio
 
 
 # ---------------------------------------------------------------------------
@@ -63,6 +65,23 @@ def _watcher_dict(session_id="proc_test", thread_id=""):
     if thread_id:
         d["thread_id"] = thread_id
     return d
+
+
+def test_completion_event_preview_strips_ansi_from_output_path(tmp_path):
+    output_path = tmp_path / "proc.log"
+    output_path.write_text("\x1b[31merror:\x1b[0m failed\n", encoding="utf-8")
+
+    session = SimpleNamespace(
+        command="sleep 1",
+        exit_code=1,
+        output_path=str(output_path),
+        output_buffer="",
+    )
+
+    evt = _completion_event_for_session("proc_test", session)
+
+    assert "\x1b" not in evt["preview"]
+    assert "error: failed" in evt["preview"]
 
 
 # ---------------------------------------------------------------------------
@@ -118,7 +137,7 @@ class TestLoadBackgroundNotificationsMode:
 # _run_process_watcher integration tests
 # ---------------------------------------------------------------------------
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 @pytest.mark.parametrize(
     ("mode", "sessions", "expected_calls", "expected_fragment"),
     [
@@ -145,37 +164,37 @@ class TestLoadBackgroundNotificationsMode:
         # off mode: exited process → no notification
         (
             "off",
-            [SimpleNamespace(output_buffer="done\n", exited=True, exit_code=0)],
+            [SimpleNamespace(output_buffer="done\n", exited=True, exit_code=0, command="sleep 1", output_path="/tmp/proc.log")],
             0,
             None,
         ),
         # result mode: exited → notifies
         (
             "result",
-            [SimpleNamespace(output_buffer="done\n", exited=True, exit_code=0)],
+            [SimpleNamespace(output_buffer="done\n", exited=True, exit_code=0, command="sleep 1", output_path="/tmp/proc.log")],
             1,
-            "finished with exit code 0",
+            "Full output saved to: /tmp/proc.log",
         ),
         # error mode: exit 0 → no notification
         (
             "error",
-            [SimpleNamespace(output_buffer="done\n", exited=True, exit_code=0)],
+            [SimpleNamespace(output_buffer="done\n", exited=True, exit_code=0, command="sleep 1", output_path="/tmp/proc.log")],
             0,
             None,
         ),
         # error mode: exit 1 → notifies
         (
             "error",
-            [SimpleNamespace(output_buffer="traceback\n", exited=True, exit_code=1)],
+            [SimpleNamespace(output_buffer="traceback\n", exited=True, exit_code=1, command="sleep 1", output_path="/tmp/proc.log")],
             1,
-            "finished with exit code 1",
+            "Full output saved to: /tmp/proc.log",
         ),
         # all mode: exited → notifies
         (
             "all",
-            [SimpleNamespace(output_buffer="ok\n", exited=True, exit_code=0)],
+            [SimpleNamespace(output_buffer="ok\n", exited=True, exit_code=0, command="sleep 1", output_path="/tmp/proc.log")],
             1,
-            "finished with exit code 0",
+            "Full output saved to: /tmp/proc.log",
         ),
     ],
 )
@@ -202,14 +221,17 @@ async def test_run_process_watcher_respects_notification_mode(
     if expected_fragment is not None:
         sent_message = adapter.send.await_args.args[1]
         assert expected_fragment in sent_message
+        if "Full output saved to:" in expected_fragment:
+            assert "Preview:" in sent_message
+            assert "Here's the final output" not in sent_message
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_thread_id_passed_to_send(monkeypatch, tmp_path):
     """thread_id from watcher dict is forwarded as metadata to adapter.send()."""
     import tools.process_registry as pr_module
 
-    sessions = [SimpleNamespace(output_buffer="done\n", exited=True, exit_code=0)]
+    sessions = [SimpleNamespace(output_buffer="done\n", exited=True, exit_code=0, command="sleep 1", output_path="/tmp/proc.log")]
     monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
 
     async def _instant_sleep(*_a, **_kw):
@@ -226,12 +248,12 @@ async def test_thread_id_passed_to_send(monkeypatch, tmp_path):
     assert kwargs["metadata"] == {"thread_id": "42"}
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_no_thread_id_sends_no_metadata(monkeypatch, tmp_path):
     """When thread_id is empty, metadata should be None (general topic)."""
     import tools.process_registry as pr_module
 
-    sessions = [SimpleNamespace(output_buffer="done\n", exited=True, exit_code=0)]
+    sessions = [SimpleNamespace(output_buffer="done\n", exited=True, exit_code=0, command="sleep 1", output_path="/tmp/proc.log")]
     monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
 
     async def _instant_sleep(*_a, **_kw):
@@ -248,7 +270,7 @@ async def test_no_thread_id_sends_no_metadata(monkeypatch, tmp_path):
     assert kwargs["metadata"] is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_inject_watch_notification_routes_from_session_store_origin(monkeypatch, tmp_path):
     from gateway.session import SessionSource
 
@@ -283,7 +305,7 @@ async def test_inject_watch_notification_routes_from_session_store_origin(monkey
     assert synth_event.source.user_name == "Emiliyan"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_notification_carries_message_id_reply_anchor(monkeypatch, tmp_path):
     """notify_on_complete injection carries the triggering message_id so the
     synthetic event can be reply-anchored back into a Telegram DM topic.
@@ -293,7 +315,7 @@ async def test_agent_notification_carries_message_id_reply_anchor(monkeypatch, t
     import tools.process_registry as pr_module
 
     sessions = [SimpleNamespace(
-        output_buffer="SMOKE_OK\n", exited=True, exit_code=0, command="sleep 1",
+        output_buffer="SMOKE_OK\n", exited=True, exit_code=0, command="sleep 1", output_path="/tmp/proc.log",
     )]
     monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
 
@@ -321,16 +343,17 @@ async def test_agent_notification_carries_message_id_reply_anchor(monkeypatch, t
     assert synth_event.internal is True
     assert synth_event.message_id == "555"
     assert synth_event.source.thread_id == "24296"
+    assert "Full output saved to: /tmp/proc.log" in synth_event.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_agent_notification_no_message_id_is_tolerated(monkeypatch, tmp_path):
     """A watcher dict without message_id (CLI spawn, pre-upgrade checkpoint)
     still injects — message_id is simply None."""
     import tools.process_registry as pr_module
 
     sessions = [SimpleNamespace(
-        output_buffer="done\n", exited=True, exit_code=0, command="sleep 1",
+        output_buffer="done\n", exited=True, exit_code=0, command="sleep 1", output_path="/tmp/proc.log",
     )]
     monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
 
@@ -357,7 +380,7 @@ async def test_agent_notification_no_message_id_is_tolerated(monkeypatch, tmp_pa
     assert synth_event.message_id is None
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_inject_watch_notification_carries_message_id_reply_anchor(monkeypatch, tmp_path):
     from gateway.session import SessionSource
 
@@ -446,7 +469,7 @@ def test_build_process_event_source_uses_cached_live_source_before_session_key_p
     assert source.user_name == "alice"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_inject_watch_notification_ignores_foreground_event_source(monkeypatch, tmp_path):
     """Negative test: watch notification must NOT route to the foreground thread."""
     from gateway.session import SessionSource

--- a/tests/gateway/test_clean_shutdown_marker.py
+++ b/tests/gateway/test_clean_shutdown_marker.py
@@ -10,9 +10,12 @@ After a crash (no marker), suspension still fires as a safety net for stuck sess
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 
 from gateway.config import GatewayConfig, Platform
 from gateway.session import SessionSource, SessionStore
+
+pytestmark = pytest.mark.anyio
 
 
 # ---------------------------------------------------------------------------
@@ -130,6 +133,7 @@ class TestCleanShutdownMarker:
             asyncio.get_event_loop().run_until_complete(runner.stop())
 
         assert marker.exists(), ".clean_shutdown marker should exist after graceful stop"
+        mock_proc_reg.kill_all.assert_called_with(include_preserved=True)
 
     def test_marker_skips_suspension_on_startup(self, tmp_path, monkeypatch):
         """If .clean_shutdown exists, suspend_recently_active should NOT be called."""
@@ -223,3 +227,4 @@ class TestCleanShutdownMarker:
             asyncio.get_event_loop().run_until_complete(runner.stop(restart=True))
 
         assert marker.exists(), ".clean_shutdown marker should exist after restart-stop too"
+        mock_proc_reg.kill_all.assert_called_with(include_preserved=False)

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2033,6 +2033,79 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertTrue(captured["request"].request_body.reply_in_thread)
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_send_thread_id_without_reply_to_uses_create_with_root_id(self):
+        """When metadata has thread_id but no reply_to, send must use
+        message.create with root_id, not message.reply."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["request"] = request
+                captured["method"] = "create"
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_create"),
+                )
+
+            def reply(self, request):
+                captured["method"] = "reply"
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_reply"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI()))
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content="hello",
+                    metadata={"thread_id": "omt-thread"},
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "om_create")
+        self.assertEqual(captured["method"], "create")
+        self.assertEqual(captured["request"].receive_id_type, "chat_id")
+        self.assertEqual(captured["request"].request_body.root_id, "omt-thread")
+
+    @unittest.skipUnless(_HAS_LARK_OAPI, "lark_oapi not available")
+    def test_create_message_request_body_serialization_includes_root_id(self):
+        """When body.root_id is set dynamically, the attribute must appear in
+        the serialized representation (__dict__) so the SDK includes it in
+        the HTTP request body sent to the Feishu API."""
+        from lark_oapi.api.im.v1 import CreateMessageRequestBody
+
+        body = (
+            CreateMessageRequestBody.builder()
+            .receive_id("oc_test")
+            .msg_type("text")
+            .content("{}")
+            .uuid("test-uuid")
+            .build()
+        )
+        body.root_id = "omt_test_thread"
+
+        self.assertEqual(body.root_id, "omt_test_thread")
+        self.assertIn("root_id", body.__dict__)
+        self.assertEqual(body.__dict__["root_id"], "omt_test_thread")
+
+        from lark_oapi.core.json import JSON
+        marshalled = JSON.marshal(body)
+        self.assertEqual(json.loads(marshalled)["root_id"], "omt_test_thread")
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_send_retries_transient_failure(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -10,8 +10,10 @@ from gateway.restart import GATEWAY_SERVICE_RESTART_EXIT_CODE
 from gateway.session import build_session_key
 from tests.gateway.restart_test_helpers import make_restart_runner, make_restart_source
 
+pytestmark = pytest.mark.anyio
 
-@pytest.mark.asyncio
+
+@pytest.mark.anyio
 async def test_cancel_background_tasks_cancels_inflight_message_processing():
     _runner, adapter = make_restart_runner()
     release = asyncio.Event()
@@ -49,7 +51,20 @@ def test_cleanup_agent_resources_reaps_stale_aux_clients():
     cleanup_mock.assert_called_once()
 
 
-@pytest.mark.asyncio
+def test_cleanup_agent_resources_preserve_runtime_state_releases_clients():
+    runner, _adapter = make_restart_runner()
+    agent = MagicMock()
+
+    with patch("agent.auxiliary_client.cleanup_stale_async_clients") as cleanup_mock:
+        runner._cleanup_agent_resources(agent, preserve_runtime_state=True)
+
+    agent.shutdown_memory_provider.assert_called_once()
+    agent.release_clients.assert_called_once()
+    agent.close.assert_not_called()
+    cleanup_mock.assert_called_once()
+
+
+@pytest.mark.anyio
 async def test_gateway_stop_interrupts_running_agents_and_cancels_adapter_tasks():
     runner, adapter = make_restart_runner()
     runner._pending_messages = {"session": "pending text"}
@@ -91,7 +106,7 @@ async def test_gateway_stop_interrupts_running_agents_and_cancels_adapter_tasks(
     assert runner._shutdown_event.is_set() is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_gateway_stop_drains_running_agents_before_disconnect():
     runner, adapter = make_restart_runner()
     disconnect_mock = AsyncMock()
@@ -114,7 +129,7 @@ async def test_gateway_stop_drains_running_agents_before_disconnect():
     assert runner._shutdown_event.is_set() is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_gateway_stop_interrupts_after_drain_timeout():
     runner, adapter = make_restart_runner()
     runner._restart_drain_timeout = 0.05
@@ -133,7 +148,7 @@ async def test_gateway_stop_interrupts_after_drain_timeout():
     assert runner._shutdown_event.is_set() is True
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_gateway_stop_systemd_service_restart_exits_cleanly(tmp_path, monkeypatch):
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     runner, adapter = make_restart_runner()
@@ -141,7 +156,9 @@ async def test_gateway_stop_systemd_service_restart_exits_cleanly(tmp_path, monk
     monkeypatch.setenv("INVOCATION_ID", "systemd-test")
     runner._launch_systemd_restart_shortcut = MagicMock()
 
-    with patch("gateway.status.remove_pid_file"), patch("gateway.status.write_runtime_status"):
+    with patch("gateway.run.sys.platform", "linux"), \
+         patch("gateway.status.remove_pid_file"), \
+         patch("gateway.status.write_runtime_status"):
         await runner.stop(restart=True, service_restart=True)
 
     runner._launch_systemd_restart_shortcut.assert_called_once_with()
@@ -149,7 +166,7 @@ async def test_gateway_stop_systemd_service_restart_exits_cleanly(tmp_path, monk
     assert (tmp_path / ".restart_pending.json").exists()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_gateway_stop_launchd_service_restart_keeps_nonzero_exit(tmp_path, monkeypatch):
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     runner, adapter = make_restart_runner()
@@ -163,7 +180,7 @@ async def test_gateway_stop_launchd_service_restart_keeps_nonzero_exit(tmp_path,
     assert runner._exit_code == GATEWAY_SERVICE_RESTART_EXIT_CODE
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_restart_shutdown_warning_uses_restart_command_reply_anchor_for_active_session():
     runner, adapter = make_restart_runner()
     source = make_restart_source(thread_id="42")
@@ -193,7 +210,7 @@ async def test_restart_shutdown_warning_uses_restart_command_reply_anchor_for_ac
     assert metadata["telegram_reply_to_message_id"] == "restart-command"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_in_chat_restart_skips_home_shutdown_even_with_active_session():
     runner, adapter = make_restart_runner()
     source = make_restart_source(thread_id="42")
@@ -219,7 +236,7 @@ async def test_in_chat_restart_skips_home_shutdown_even_with_active_session():
     assert metadata["telegram_reply_to_message_id"] == "restart-command"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_idle_in_chat_restart_does_not_send_interruption_warning():
     runner, adapter = make_restart_runner()
     source = make_restart_source(thread_id="42")
@@ -238,7 +255,7 @@ async def test_idle_in_chat_restart_does_not_send_interruption_warning():
     assert adapter.sent_calls == []
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_in_chat_restart_does_not_write_home_startup_marker(tmp_path, monkeypatch):
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     runner, adapter = make_restart_runner()
@@ -255,7 +272,7 @@ async def test_in_chat_restart_does_not_write_home_startup_marker(tmp_path, monk
     assert not (tmp_path / ".restart_pending.json").exists()
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_drain_active_agents_throttles_status_updates():
     runner, _adapter = make_restart_runner()
     runner._update_runtime_status = MagicMock()
@@ -277,7 +294,7 @@ async def test_drain_active_agents_throttles_status_updates():
     assert 3 <= runner._update_runtime_status.call_count <= 4
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_gateway_stop_kills_tool_subprocesses_before_adapter_disconnect_on_timeout(monkeypatch):
     """On drain timeout, tool subprocesses must be killed BEFORE adapter
     disconnect so systemd's TimeoutStopSec doesn't SIGKILL the cgroup with
@@ -287,8 +304,11 @@ async def test_gateway_stop_kills_tool_subprocesses_before_adapter_disconnect_on
 
     call_order: list[str] = []
 
-    def _fake_kill_all(task_id=None):
+    kill_calls: list[bool] = []
+
+    def _fake_kill_all(task_id=None, include_preserved=True):
         call_order.append("kill_all")
+        kill_calls.append(include_preserved)
         return 2
 
     def _fake_cleanup_envs():
@@ -313,7 +333,7 @@ async def test_gateway_stop_kills_tool_subprocesses_before_adapter_disconnect_on
     runner._running_agents = {"session": MagicMock()}
 
     with patch("gateway.status.remove_pid_file"), patch("gateway.status.write_runtime_status"):
-        await runner.stop()
+        await runner.stop(restart=True)
 
     # First kill_all must precede the first disconnect.  (Both the eager
     # post-interrupt cleanup and the final catch-all call _kill_tool_
@@ -326,11 +346,12 @@ async def test_gateway_stop_kills_tool_subprocesses_before_adapter_disconnect_on
         f"Tool subprocesses must be killed before adapter disconnect on "
         f"drain timeout, got order: {call_order}"
     )
+    assert kill_calls and all(flag is False for flag in kill_calls)
     # Defense-in-depth final cleanup still runs.
     assert call_order.count("kill_all") >= 2
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_gateway_stop_kills_tool_subprocesses_on_graceful_path(monkeypatch):
     """Graceful shutdown (no drain timeout) must still kill tool subprocesses
     exactly once via the final catch-all — regression guard against
@@ -340,9 +361,12 @@ async def test_gateway_stop_kills_tool_subprocesses_on_graceful_path(monkeypatch
 
     kill_count = 0
 
-    def _fake_kill_all(task_id=None):
+    kill_calls: list[bool] = []
+
+    def _fake_kill_all(task_id=None, include_preserved=True):
         nonlocal kill_count
         kill_count += 1
+        kill_calls.append(include_preserved)
         return 0
 
     import tools.process_registry as _pr
@@ -358,3 +382,4 @@ async def test_gateway_stop_kills_tool_subprocesses_on_graceful_path(monkeypatch
 
     # Only the final catch-all fires on the graceful path.
     assert kill_count == 1
+    assert kill_calls == [True]

--- a/tests/gateway/test_internal_event_bypass_pairing.py
+++ b/tests/gateway/test_internal_event_bypass_pairing.py
@@ -18,6 +18,8 @@ from gateway.platforms.base import MessageEvent
 from gateway.run import GatewayRunner
 from gateway.session import SessionSource
 
+pytestmark = pytest.mark.anyio
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -72,14 +74,18 @@ def _watcher_dict_with_notify():
 # Tests
 # ---------------------------------------------------------------------------
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notify_on_complete_sets_internal_flag(monkeypatch, tmp_path):
     """Synthetic completion event must have internal=True."""
     import tools.process_registry as pr_module
 
     sessions = [
         SimpleNamespace(
-            output_buffer="done\n", exited=True, exit_code=0, command="echo test"
+            output_buffer="done\n",
+            exited=True,
+            exit_code=0,
+            command="echo test",
+            output_path="/tmp/proc.log",
         ),
     ]
     monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
@@ -97,9 +103,10 @@ async def test_notify_on_complete_sets_internal_flag(monkeypatch, tmp_path):
     event = adapter.handle_message.await_args.args[0]
     assert isinstance(event, MessageEvent)
     assert event.internal is True, "Synthetic completion event must be marked internal"
+    assert "Full output saved to: /tmp/proc.log" in event.text
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_internal_event_bypasses_authorization(monkeypatch, tmp_path):
     """An internal event should skip _is_user_authorized entirely."""
     import gateway.run as gateway_run
@@ -148,7 +155,7 @@ async def test_internal_event_bypasses_authorization(monkeypatch, tmp_path):
     )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_internal_event_does_not_trigger_pairing(monkeypatch, tmp_path):
     """An internal event with no user_id must not generate a pairing code."""
     import gateway.run as gateway_run
@@ -199,14 +206,18 @@ async def test_internal_event_does_not_trigger_pairing(monkeypatch, tmp_path):
     )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notify_on_complete_preserves_user_identity(monkeypatch, tmp_path):
     """Synthetic completion event should carry user_id and user_name from the watcher."""
     import tools.process_registry as pr_module
 
     sessions = [
         SimpleNamespace(
-            output_buffer="done\n", exited=True, exit_code=0, command="echo test"
+            output_buffer="done\n",
+            exited=True,
+            exit_code=0,
+            command="echo test",
+            output_path="/tmp/proc.log",
         ),
     ]
     monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
@@ -230,14 +241,18 @@ async def test_notify_on_complete_preserves_user_identity(monkeypatch, tmp_path)
     assert event.source.user_name == "alice"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_notify_on_complete_uses_session_store_origin_for_group_topic(monkeypatch, tmp_path):
     import tools.process_registry as pr_module
     from gateway.session import SessionSource
 
     sessions = [
         SimpleNamespace(
-            output_buffer="done\n", exited=True, exit_code=0, command="echo test"
+            output_buffer="done\n",
+            exited=True,
+            exit_code=0,
+            command="echo test",
+            output_path="/tmp/proc.log",
         ),
     ]
     monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
@@ -283,7 +298,7 @@ async def test_notify_on_complete_uses_session_store_origin_for_group_topic(monk
     assert event.source.user_name == "alice"
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_none_user_id_skips_pairing(monkeypatch, tmp_path):
     """A non-internal event with user_id=None should be silently dropped."""
     import gateway.run as gateway_run
@@ -314,7 +329,7 @@ async def test_none_user_id_skips_pairing(monkeypatch, tmp_path):
     assert adapter.send.await_count == 0
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_none_user_id_does_not_generate_pairing_code(monkeypatch, tmp_path):
     """A message with user_id=None must never call generate_code."""
     import gateway.run as gateway_run
@@ -351,7 +366,7 @@ async def test_none_user_id_does_not_generate_pairing_code(monkeypatch, tmp_path
     )
 
 
-@pytest.mark.asyncio
+@pytest.mark.anyio
 async def test_non_internal_event_without_user_triggers_pairing(monkeypatch, tmp_path):
     """Verify the normal (non-internal) path still triggers pairing for unknown users."""
     import gateway.run as gateway_run

--- a/tests/gateway/test_stream_consumer_thread_routing.py
+++ b/tests/gateway/test_stream_consumer_thread_routing.py
@@ -142,7 +142,7 @@ class TestFeishuFallbackThreadRouting:
     @pytest.mark.asyncio
     async def test_create_uses_thread_id_when_available(self):
         """When reply_to=None and metadata has thread_id, message.create
-        should use receive_id_type='thread_id'."""
+        should use chat_id as receive_id and pass thread_id as root_id."""
         from gateway.platforms.feishu import FeishuAdapter
 
         # We test the _send_raw_message method directly by mocking the client
@@ -175,25 +175,31 @@ class TestFeishuFallbackThreadRouting:
         # Verify message.create was called (not message.reply)
         mock_client.im.v1.message.create.assert_called_once()
 
-        # The request should have receive_id_type="thread_id"
+        # The request should have receive_id_type="chat_id"
         call_args = mock_client.im.v1.message.create.call_args[0][0]
         # Lark SDK builder exposes .body; the in-tree fallback exposes .request_body.
         # The contributor's branch had the lark SDK installed, the test environment
         # may not — handle both shapes.
         body = getattr(call_args, "body", None) or getattr(call_args, "request_body", None)
         assert body is not None, "request has neither .body nor .request_body"
-        # receive_id should be the thread_id, not the chat_id
+        # receive_id should be the chat_id, not the thread_id
         receive_id = getattr(body, "receive_id", None)
         if receive_id is None and isinstance(body, str):
             import json as _json
             receive_id = _json.loads(body).get("receive_id")
-        assert receive_id == "omt_topic_abc", (
-            f"Expected receive_id='omt_topic_abc', got '{receive_id}'"
+        assert receive_id == "oc_main_chat", (
+            f"Expected receive_id='oc_main_chat' (chat_id), got '{receive_id}'"
         )
-        # And receive_id_type must be 'thread_id', not 'chat_id'
+        # And receive_id_type must be 'chat_id', not 'thread_id'
         receive_id_type = getattr(call_args, "receive_id_type", None)
-        assert receive_id_type == "thread_id", (
-            f"Expected receive_id_type='thread_id', got '{receive_id_type}'"
+        assert receive_id_type == "chat_id", (
+            f"Expected receive_id_type='chat_id', got '{receive_id_type}'"
+        )
+
+        # thread_id should be passed as root_id, not as receive_id
+        root_id = getattr(body, "root_id", None)
+        assert root_id == "omt_topic_abc", (
+            f"Expected root_id='omt_topic_abc' (thread_id), got '{root_id}'"
         )
 
     @pytest.mark.asyncio

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -193,6 +193,97 @@ class TestCronCreateLifecycleBlock:
 # Defense 1: gateway stop/restart refuse inside gateway
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# _is_running_inside_gateway() unit tests
+# ---------------------------------------------------------------------------
+
+class TestIsRunningInsideGateway:
+    """Verify _is_running_inside_gateway() dual detection and error handling."""
+
+    # Scenario 1: _HERMES_GATEWAY=1 → immediate True, no ancestry check
+    def test_env_var_set_returns_true_immediately(self, monkeypatch):
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        from hermes_cli.gateway import _is_running_inside_gateway
+
+        # Prove get_running_pid is never called by monkeypatching it to blow up
+        import hermes_cli.gateway as gw
+        monkeypatch.setattr(gw, "_is_pid_ancestor_of_current_process",
+                            lambda pid: exec('raise AssertionError("should not be called")'))
+        assert _is_running_inside_gateway() is True
+
+    # Scenario 2: env var unset + ancestor → True
+    def test_env_var_unset_ancestor_match_returns_true(self, monkeypatch):
+        monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+        from hermes_cli.gateway import _is_running_inside_gateway
+        import hermes_cli.gateway as gw
+
+        grandparent_pid = os.getppid()  # real parent will work as ancestor on real system
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: grandparent_pid)
+        monkeypatch.setattr(gw, "_is_pid_ancestor_of_current_process",
+                            lambda pid: True)
+        assert _is_running_inside_gateway() is True
+
+    # Scenario 3: env var unset + no ancestor match → False
+    def test_env_var_unset_no_ancestor_returns_false(self, monkeypatch):
+        monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+        from hermes_cli.gateway import _is_running_inside_gateway
+        import hermes_cli.gateway as gw
+
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 99999)
+        monkeypatch.setattr(gw, "_is_pid_ancestor_of_current_process",
+                            lambda pid: False)
+        assert _is_running_inside_gateway() is False
+
+    # Scenario 4: get_running_pid() returns None → False
+    def test_get_running_pid_returns_none(self, monkeypatch):
+        monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+        from hermes_cli.gateway import _is_running_inside_gateway
+        import hermes_cli.gateway as gw
+
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+        # _is_pid_ancestor should never be called when gw_pid is None
+        monkeypatch.setattr(gw, "_is_pid_ancestor_of_current_process",
+                            lambda pid: exec('raise AssertionError("should not be called")'))
+        assert _is_running_inside_gateway() is False
+
+    # Scenario 5: ImportError from gateway.status → False (graceful)
+    def test_import_error_returns_false(self, monkeypatch):
+        monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+        from hermes_cli.gateway import _is_running_inside_gateway
+
+        # Simulate gateway.status being unavailable by making the import fail
+        import builtins
+        _original_import = builtins.__import__
+
+        def _failing_import(name, *args, **kwargs):
+            if name == "gateway.status" or name.startswith("gateway.status"):
+                raise ImportError("No module named 'gateway.status'")
+            return _original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _failing_import)
+        assert _is_running_inside_gateway() is False
+
+    # Scenario 6: get_running_pid() throws FileNotFoundError → False
+    def test_get_running_pid_file_not_found(self, monkeypatch):
+        monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+        from hermes_cli.gateway import _is_running_inside_gateway
+
+        monkeypatch.setattr("gateway.status.get_running_pid",
+                            lambda: exec('raise FileNotFoundError("PID file missing")'))
+        assert _is_running_inside_gateway() is False
+
+    # Scenario 7: _is_pid_ancestor_of_current_process() throws unexpected exception → False (fail-safe)
+    def test_ancestor_check_unexpected_exception(self, monkeypatch):
+        monkeypatch.delenv("_HERMES_GATEWAY", raising=False)
+        from hermes_cli.gateway import _is_running_inside_gateway
+        import hermes_cli.gateway as gw
+
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 12345)
+        monkeypatch.setattr(gw, "_is_pid_ancestor_of_current_process",
+                            lambda pid: exec('raise RuntimeError("unexpected failure")'))
+        assert _is_running_inside_gateway() is False
+
+
 class TestGatewaySelfTargetingGuard:
     """Verify hermes gateway stop/restart refuse when _HERMES_GATEWAY=1."""
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -55,9 +55,10 @@ def test_is_destructive_command_treats_install_as_mutating():
 
 
 @pytest.fixture()
-def agent():
+def agent(tmp_path):
     """Minimal AIAgent with mocked OpenAI client and tool loading."""
     with (
+        patch("run_agent._hermes_home", tmp_path),
         patch(
             "run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")
         ),
@@ -76,9 +77,10 @@ def agent():
 
 
 @pytest.fixture()
-def agent_with_memory_tool():
+def agent_with_memory_tool(tmp_path):
     """Agent whose valid_tool_names includes 'memory'."""
     with (
+        patch("run_agent._hermes_home", tmp_path),
         patch(
             "run_agent.get_tool_definitions",
             return_value=_make_tool_defs("web_search", "memory"),
@@ -151,6 +153,38 @@ def test_aiagent_reuses_existing_errors_log_handler():
                 handler.close()
         for handler in original_handlers:
             root_logger.addHandler(handler)
+
+
+class TestCloseBehavior:
+    def test_close_kills_background_processes_by_default(self, agent):
+        agent.session_id = "task-close"
+
+        with (
+            patch("tools.process_registry.process_registry.kill_all") as kill_all,
+            patch("run_agent.cleanup_vm") as cleanup_vm_mock,
+            patch("run_agent.cleanup_browser") as cleanup_browser_mock,
+            patch.object(agent, "_close_openai_client") as close_client,
+        ):
+            agent.close()
+
+        kill_all.assert_called_once_with(task_id="task-close")
+        cleanup_vm_mock.assert_called_once_with("task-close")
+        cleanup_browser_mock.assert_called_once_with("task-close")
+        close_client.assert_called_once()
+
+    def test_close_preserve_runtime_state_skips_tool_teardown(self, agent):
+        with (
+            patch("tools.process_registry.process_registry.kill_all") as kill_all,
+            patch("run_agent.cleanup_vm") as cleanup_vm_mock,
+            patch("run_agent.cleanup_browser") as cleanup_browser_mock,
+        ):
+            agent.release_clients = MagicMock()
+            agent.close(preserve_runtime_state=True)
+
+        agent.release_clients.assert_called_once_with()
+        kill_all.assert_not_called()
+        cleanup_vm_mock.assert_not_called()
+        cleanup_browser_mock.assert_not_called()
 
 
 class TestProviderModelNormalization:

--- a/tests/test_pharma_compliance.py
+++ b/tests/test_pharma_compliance.py
@@ -923,3 +923,330 @@ class TestDegradation:
         assert len(warnings) == 1
         assert "语音识别暂不可用" in warnings[0]
         assert "文字" in warnings[0]
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# NEW: Progressive questioning defect fix tests (tests 79–89)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestPersistLocking:
+    """Test 79: update_record uses fcntl.flock for both read and write."""
+
+    def test_update_record_locks_file(self):
+        """update_record acquires exclusive locks on read and write."""
+        # Verify the source code contains 4+ fcntl.flock calls total
+        persist_path = PROJECT_ROOT / "pharma_compliance" / "persistence.py"
+        content = persist_path.read_text()
+        flock_count = content.count("fcntl.flock")
+        assert flock_count >= 4, f"Expected >= 4 fcntl.flock calls, found {flock_count}"
+
+
+class TestRetryOnExtractionFail:
+    """Tests 80-81: Field extraction failure → retry logic with retry_count."""
+
+    @pytest.mark.asyncio
+    async def test_retry_count_less_than_2_retries_same_field(self, handler):
+        """Test 80: Field extraction fails with retry_count < 2 → re-ask same field."""
+        manager = SessionManager()
+        session = manager.get_or_create_session("retry_user")
+        session.merged_fields = {"org_name": "百姓大药房"}
+        session.pending_field = "contact_person"
+        session.pending_questions = ["products"]
+        session.retry_count = 0
+
+        result = await handler._handle_progressive_answer(
+            "retry_user", "嗯嗯就是这样", session
+        )
+        # Should re-ask the same field with retry message
+        assert result["merged"] is False
+        assert result["needs_followup"] is True
+        assert result["followup_field"] == "contact_person"
+        assert "信息不清晰" in result["followup_message"]
+        assert session.retry_count == 1
+
+    @pytest.mark.asyncio
+    async def test_retry_count_exhausted_skips_field(self, handler):
+        """Test 81: Field extraction fails with retry_count >= 2 → skip to next field."""
+        manager = SessionManager()
+        session = manager.get_or_create_session("retry_exhausted_user")
+        session.merged_fields = {"org_name": "百姓大药房"}
+        session.pending_field = "contact_person"
+        session.pending_questions = ["products"]
+        session.retry_count = 2
+
+        result = await handler._handle_progressive_answer(
+            "retry_exhausted_user", "还是不清楚", session
+        )
+        # Should skip to next field (products)
+        assert result["merged"] is False
+        assert result["needs_followup"] is True
+        assert result["followup_field"] == "products"
+        assert session.retry_count == 2  # unchanged, field skipped
+
+
+class TestUpdateRecordExceptionNoClear:
+    """Test 82: update_record exception does NOT clear session."""
+
+    @pytest.mark.asyncio
+    async def test_update_record_exception_preserves_session(self, handler):
+        """When update_record raises, session is NOT cleared."""
+        manager = SessionManager()
+        session = manager.get_or_create_session("exception_user")
+        session.merged_fields = {
+            "org_name": "百姓大药房",
+            "contact_person": "王店长",
+        }
+        session.merged_record_id = "test_record_123"
+        session.pending_field = None
+        session.pending_questions = []
+
+        with patch(
+            "pharma_compliance.bot_handler.update_record",
+            side_effect=Exception("disk full"),
+        ):
+            result = await handler._handle_progressive_answer(
+                "exception_user", "补充好了", session
+            )
+
+        # Should return failure, NOT clear session
+        assert result["merged"] is False
+        assert "记录更新失败" in result["warnings"][0]
+        # Session state should be preserved
+        assert session.merged_fields is not None
+        assert session.merged_record_id == "test_record_123"
+
+
+class TestPersistFailureNoProgressive:
+    """Test 83: persist_ok=False prevents progressive questioning."""
+
+    @pytest.mark.asyncio
+    async def test_persist_failure_returns_early(self, handler):
+        """When save_record returns None, _do_merge returns failure early."""
+        manager = SessionManager()
+        session = manager.get_or_create_session("persist_fail_user")
+        session.add_message(MessageType.TEXT, "去了百姓大药房见王店长 2025年6月15日 下午14:30")
+
+        with patch(
+            "pharma_compliance.bot_handler.save_record",
+            return_value=None,
+        ):
+            result = await handler._do_merge(session)
+
+        assert result["merged"] is False
+        warnings_text = " ".join(result.get("warnings", []))
+        assert "持久化失败" in warnings_text
+
+
+class TestSessionStale:
+    """Test 84: is_stale triggers session cleanup on progressive entry."""
+
+    def test_is_stale_returns_true_after_30_minutes(self):
+        """is_stale returns True when last_activity > 30 min ago."""
+        manager = SessionManager()
+        session = manager.get_or_create_session("stale_user")
+        session.last_activity = time.time() - 1801  # 30 min + 1 sec
+        assert session.is_stale() is True
+
+    def test_is_stale_returns_false_within_window(self):
+        """is_stale returns False when recently active."""
+        manager = SessionManager()
+        session = manager.get_or_create_session("active_user")
+        session.last_activity = time.time() - 60  # 1 min ago
+        assert session.is_stale() is False
+
+    @pytest.mark.asyncio
+    async def test_stale_session_cleared_on_progressive_entry(self, handler):
+        """Stale session gets cleared at progressive routing entry."""
+        manager = handler.sessions
+        session = manager.get_or_create_session("stale_progressive_user")
+        session.pending_field = "contact_person"
+        session.merged_fields = {"org_name": "百姓大药房"}
+        session.pending_questions = ["products"]
+        session.last_activity = time.time() - 1801  # stale
+
+        result = await handler.handle_message(
+            user_id="stale_progressive_user",
+            msg_type="text",
+            content="王店长",
+        )
+        assert result["merged"] is False
+        assert "上次对话已超时" in result["warnings"][0]
+        # Session should be cleared
+        assert session.pending_field is None
+        assert session.merged_fields is None
+
+
+class TestManualMergePriority:
+    """Test 85: Manual merge trigger takes priority over progressive routing."""
+
+    @pytest.mark.asyncio
+    async def test_manual_merge_before_progressive(self, handler):
+        """'完了' triggers force_merge even during progressive questioning."""
+        manager = handler.sessions
+        session = manager.get_or_create_session("merge_priority_user")
+        session.add_message(MessageType.TEXT, "去了百姓大药房见王店长")
+        session.pending_field = "products"  # Simulate progressive mode
+        session.merged_fields = {"org_name": "百姓大药房"}
+        session.pending_questions = ["feedback"]
+
+        with patch.object(handler, "_force_merge", new_callable=AsyncMock) as mock_fm:
+            mock_fm.return_value = {"merged": True, "task": {}, "warnings": [], "pending_count": 0}
+            await handler.handle_message(
+                user_id="merge_priority_user",
+                msg_type="text",
+                content="完了",
+            )
+            # _force_merge should have been called (manual merge took priority)
+            mock_fm.assert_called_once()
+
+
+class TestEscExitProgressive:
+    """Test 86: ESC keyword exits progressive mode."""
+
+    def test_esc_keyword_in_manual_merge_phrases(self):
+        """'取消' is in manual merge phrases and can exit progressive."""
+        from pharma_compliance.session import MANUAL_MERGE_PHRASES
+        # Verify that common exit phrases exist
+        assert len(MANUAL_MERGE_PHRASES) > 0
+
+    @pytest.mark.asyncio
+    async def test_esc_via_force_merge_exits_progressive(self, handler):
+        """Sending a manual merge phrase during progressive mode triggers force merge."""
+        manager = handler.sessions
+        session = manager.get_or_create_session("esc_user")
+        session.add_message(MessageType.TEXT, "去了百姓大药房")
+        session.pending_field = "contact_person"
+        session.merged_fields = {"org_name": "百姓大药房"}
+        session.pending_questions = ["products"]
+
+        with patch.object(handler, "_force_merge", new_callable=AsyncMock) as mock_fm:
+            mock_fm.return_value = {
+                "merged": True,
+                "task": {"fields": session.merged_fields},
+                "warnings": [],
+                "pending_count": 0,
+            }
+            result = await handler.handle_message(
+                user_id="esc_user",
+                msg_type="text",
+                content="取消",
+            )
+            mock_fm.assert_called_once()
+
+
+class TestFeedbackOnlyUpdateRecord:
+    """Test 87: When only feedback is missing, it goes through progressive flow and update_record."""
+
+    @pytest.mark.asyncio
+    async def test_feedback_only_triggers_progressive_with_record_id(self, handler):
+        """Only feedback missing → session has pending_field='feedback', update_record called."""
+        manager = handler.sessions
+        session = manager.get_or_create_session("feedback_only_user")
+        session.add_message(
+            MessageType.TEXT,
+            "药店拜访 百姓大药房 王店长 2025年6月15日 下午14:30 小儿宝泰康 主题产品推广 竞品有太极 下次带样品",
+        )
+
+        with patch(
+            "pharma_compliance.bot_handler.save_record",
+            return_value="20250615_test_fb_record",
+        ):
+            result = await handler._do_merge(session)
+
+        # Check that session is in progressive mode for feedback
+        assert session.pending_field == "feedback"
+        assert session.merged_record_id == "20250615_test_fb_record"
+        assert session.merged_fields is not None
+        # Should have feedback follow-up
+        assert result.get("needs_followup") or "feedback" in str(result.get("missing_fields", []))
+
+    @pytest.mark.asyncio
+    async def test_feedback_answer_updates_record(self, handler):
+        """When user answers the feedback question, update_record is called."""
+        manager = SessionManager()
+        session = manager.get_or_create_session("feedback_answer_user")
+        session.merged_fields = {
+            "org_name": "百姓大药房",
+            "contact_person": "王店长",
+        }
+        session.merged_record_id = "fb_record_123"
+        session.pending_field = "feedback"
+        session.pending_questions = []
+
+        with patch(
+            "pharma_compliance.bot_handler.update_record",
+            return_value=True,
+        ) as mock_update:
+            result = await handler._handle_progressive_answer(
+                "feedback_answer_user",
+                "王店长说小儿宝泰康卖得不错，建议多备货",
+                session,
+            )
+            # update_record should have been called with the feedback
+            mock_update.assert_called_once()
+            call_args = mock_update.call_args[0]
+            assert call_args[0] == "fb_record_123"
+            assert "feedback" in call_args[1]
+            assert result["merged"] is True
+
+
+class TestRetryCountReset:
+    """Test 88: retry_count resets to 0 on successful extraction."""
+
+    @pytest.mark.asyncio
+    async def test_retry_count_resets_on_success(self, handler):
+        """After a retry, successful extraction resets retry_count to 0."""
+        manager = SessionManager()
+        session = manager.get_or_create_session("reset_user")
+        session.merged_fields = {"org_name": "百姓大药房"}
+        session.pending_field = "contact_person"
+        session.pending_questions = ["products"]
+        session.retry_count = 1  # Had one failed attempt
+
+        result = await handler._handle_progressive_answer(
+            "reset_user", "见了王店长", session
+        )
+        assert result["merged"] is False
+        assert result["needs_followup"] is True
+        assert result["followup_field"] == "products"
+        assert session.retry_count == 0  # Reset after success
+
+
+class TestTouchActivity:
+    """Test 89: touch_activity updates last_activity timestamp."""
+
+    def test_touch_activity_updates_timestamp(self):
+        """touch_activity() sets last_activity to current time.time()."""
+        manager = SessionManager()
+        session = manager.get_or_create_session("activity_user")
+        old_time = session.last_activity
+        # Small delay to ensure timestamp changes
+        time.sleep(0.01)
+        session.touch_activity()
+        new_time = session.last_activity
+        assert new_time > old_time
+
+    def test_add_message_touches_activity(self):
+        """add_message() calls touch_activity automatically."""
+        manager = SessionManager()
+        session = manager.get_or_create_session("msg_activity_user")
+        old_time = session.last_activity
+        time.sleep(0.01)
+        session.add_message(MessageType.TEXT, "test message")
+        new_time = session.last_activity
+        assert new_time > old_time
+
+    def test_get_or_create_touches_activity(self):
+        """get_or_create_session() calls touch_activity."""
+        manager = SessionManager()
+        session = manager.get_or_create_session("create_activity_user")
+        # last_activity should be set (just after creation)
+        assert session.last_activity > 0
+        # Calling again should update
+        old_time = session.last_activity
+        time.sleep(0.01)
+        session2 = manager.get_or_create_session("create_activity_user")
+        assert session2 is session
+        # Activity should be refreshed
+        assert session.last_activity >= old_time

--- a/tests/test_pharma_compliance.py
+++ b/tests/test_pharma_compliance.py
@@ -561,7 +561,10 @@ class TestScenarioB_PhotoAndVoice:
                 msg_type="voice",
                 content=voice_path,
             )
-            assert r2["pending_count"] == 2
+            # New behavior: voice in progressive mode (after photo started it)
+            # returns needs_followup with missing_fields, not accumulating pending_count
+            assert r2["needs_followup"] is True
+            assert len(r2["missing_fields"]) > 0
 
 
 class TestScenarioC_MultiRoundMixed:
@@ -985,36 +988,34 @@ class TestRetryOnExtractionFail:
         assert session.retry_count == 2  # unchanged, field skipped
 
 
-class TestUpdateRecordExceptionNoClear:
-    """Test 82: update_record exception does NOT clear session."""
+class TestPersistFailurePreservesSession:
+    """Test 82: _finalize_accumulated persist failure preserves session."""
 
     @pytest.mark.asyncio
-    async def test_update_record_exception_preserves_session(self, handler):
-        """When update_record raises, session is NOT cleared."""
-        manager = SessionManager()
-        session = manager.get_or_create_session("exception_user")
+    async def test_persist_failure_preserves_session(self, handler):
+        """When save_record raises in _finalize_accumulated, session is cleared but returns failure."""
+        manager = handler.sessions
+        session = manager.get_or_create_session("persist_exception_user")
         session.merged_fields = {
             "org_name": "百姓大药房",
             "contact_person": "王店长",
+            "task_type": "药店拜访",
+            "products": "小儿宝泰康",
+            "topic": "产品推广",
+            "content_summary": "拜访内容",
+            "next_steps": "下次再聊",
         }
-        session.merged_record_id = "test_record_123"
-        session.pending_field = None
-        session.pending_questions = []
+        session.add_message(MessageType.TEXT, "test message")
 
         with patch(
-            "pharma_compliance.bot_handler.update_record",
+            "pharma_compliance.bot_handler.save_record",
             side_effect=Exception("disk full"),
         ):
-            result = await handler._handle_progressive_answer(
-                "exception_user", "补充好了", session
-            )
+            result = await handler._finalize_accumulated(session)
 
-        # Should return failure, NOT clear session
+        # Should return failure
         assert result["merged"] is False
-        assert "记录更新失败" in result["warnings"][0]
-        # Session state should be preserved
-        assert session.merged_fields is not None
-        assert session.merged_record_id == "test_record_123"
+        assert "持久化失败" in result["warnings"][0]
 
 
 class TestPersistFailureNoProgressive:
@@ -1135,59 +1136,62 @@ class TestEscExitProgressive:
             mock_fm.assert_called_once()
 
 
-class TestFeedbackOnlyUpdateRecord:
-    """Test 87: When only feedback is missing, it goes through progressive flow and update_record."""
+class TestFeedbackOnlyFinalize:
+    """Test 87: When only feedback is missing, it goes through progressive flow to _finalize_accumulated."""
 
     @pytest.mark.asyncio
-    async def test_feedback_only_triggers_progressive_with_record_id(self, handler):
-        """Only feedback missing → session has pending_field='feedback', update_record called."""
+    async def test_feedback_only_triggers_progressive_from_handle_text(self, handler):
+        """First message with most fields → starts progressive on first missing field."""
         manager = handler.sessions
-        session = manager.get_or_create_session("feedback_only_user")
-        session.add_message(
-            MessageType.TEXT,
-            "药店拜访 百姓大药房 王店长 2025年6月15日 下午14:30 小儿宝泰康 主题产品推广 竞品有太极 下次带样品",
-        )
+        session = manager.get_or_create_session("fb_new_user")
 
         with patch(
             "pharma_compliance.bot_handler.save_record",
-            return_value="20250615_test_fb_record",
+            return_value="record_new",
         ):
-            result = await handler._do_merge(session)
+            result = await handler.handle_message(
+                user_id="fb_new_user",
+                msg_type="text",
+                content="药店拜访 百姓大药房 王店长 2025年6月15日 下午14:30 小儿宝泰康 主题产品推广 竞品有太极 下次带样品",
+            )
 
-        # Check that session is in progressive mode for feedback
-        assert session.pending_field == "feedback"
-        assert session.merged_record_id == "20250615_test_fb_record"
-        assert session.merged_fields is not None
-        # Should have feedback follow-up
-        assert result.get("needs_followup") or "feedback" in str(result.get("missing_fields", []))
+        # Should trigger progressive for first missing field (feedback or others)
+        assert result["needs_followup"] is True
+        assert result["followup_field"] is not None
+        assert result["followup_message"] is not None
 
     @pytest.mark.asyncio
-    async def test_feedback_answer_updates_record(self, handler):
-        """When user answers the feedback question, update_record is called."""
-        manager = SessionManager()
-        session = manager.get_or_create_session("feedback_answer_user")
+    async def test_feedback_answer_finalizes(self, handler):
+        """When the last progressive answer completes all fields, _finalize_accumulated is called."""
+        manager = handler.sessions
+        session = manager.get_or_create_session("fb_last_field_user")
         session.merged_fields = {
+            "task_type": "药店拜访",
             "org_name": "百姓大药房",
             "contact_person": "王店长",
+            "products": "小儿宝泰康",
+            "topic": "产品推广",
+            "content_summary": "拜访内容",
+            "next_steps": "下次再聊",
+            "visit_date": "2026-06-17",
+            "visit_time": "14:30",
+            "competitor_info": "竞品有太极",
         }
-        session.merged_record_id = "fb_record_123"
         session.pending_field = "feedback"
         session.pending_questions = []
+        session.add_message(MessageType.TEXT, "initial message")
 
         with patch(
-            "pharma_compliance.bot_handler.update_record",
-            return_value=True,
-        ) as mock_update:
+            "pharma_compliance.bot_handler.save_record",
+            return_value="fb_final_record",
+        ) as mock_save:
             result = await handler._handle_progressive_answer(
-                "feedback_answer_user",
+                "fb_last_field_user",
                 "王店长说小儿宝泰康卖得不错，建议多备货",
                 session,
             )
-            # update_record should have been called with the feedback
-            mock_update.assert_called_once()
-            call_args = mock_update.call_args[0]
-            assert call_args[0] == "fb_record_123"
-            assert "feedback" in call_args[1]
+            # save_record should have been called via _finalize_accumulated
+            mock_save.assert_called_once()
             assert result["merged"] is True
 
 
@@ -1211,6 +1215,187 @@ class TestRetryCountReset:
         assert result["needs_followup"] is True
         assert result["followup_field"] == "products"
         assert session.retry_count == 0  # Reset after success
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# NEW: Progressive questioning from first message tests (tests 90-95)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestProgressiveFirstMessage:
+    """Tests 90-91: Progressive questioning starts from the first message."""
+
+    @pytest.mark.asyncio
+    async def test_first_message_triggers_progressive(self, handler):
+        """Test 90: First text message with partial info → triggers progressive follow-up."""
+        manager = handler.sessions
+        session = manager.get_or_create_session("prog_first_user")
+
+        with patch(
+            "pharma_compliance.bot_handler.save_record",
+            return_value="record_prog_1",
+        ):
+            result = await handler.handle_message(
+                user_id="prog_first_user",
+                msg_type="text",
+                content="去了保和康药房",
+            )
+
+        # Should have started progressive questioning
+        assert result["merged"] is False
+        assert result["needs_followup"] is True
+        assert result["followup_field"] is not None
+        assert result["followup_message"] is not None
+        # Session should have accumulated fields
+        assert session.merged_fields is not None
+        assert session.merged_fields.get("org_name") or "保和康" in str(session.merged_fields)
+
+    @pytest.mark.asyncio
+    async def test_progressive_reply_extracts_and_continues(self, handler):
+        """Test 91: User reply to progressive question → extract → continue to next field."""
+        manager = handler.sessions
+        session = manager.get_or_create_session("prog_reply_user")
+        # Simulate after first message ("去了保和康药房") extracted org_name
+        session.merged_fields = {
+            "task_type": "药店拜访",
+            "org_name": "保和康药房",
+        }
+        session.pending_field = "contact_person"
+        session.pending_questions = ["products"]
+        session.add_message(MessageType.TEXT, "去了保和康药房")
+
+        result = await handler._handle_progressive_answer(
+            "prog_reply_user",
+            "见了王药师",  # provides contact_person
+            session,
+        )
+
+        assert result["merged"] is False
+        assert result["needs_followup"] is True
+        # Should move to next missing field
+        assert result["followup_field"] == "products"
+        assert session.merged_fields.get("contact_person") is not None
+
+
+class TestProgressiveAllFieldsComplete:
+    """Test 92: When all fields are complete, finalize immediately."""
+
+    @pytest.mark.asyncio
+    async def test_all_fields_complete_triggers_finalize(self, handler):
+        """Test 92: Message that fills all missing fields → immediate finalize."""
+        manager = handler.sessions
+        session = manager.get_or_create_session("prog_complete_user")
+
+        with patch(
+            "pharma_compliance.bot_handler.save_record",
+            return_value="record_complete",
+        ) as mock_save:
+            result = await handler.handle_message(
+                user_id="prog_complete_user",
+                msg_type="text",
+                content=(
+                    "药店拜访 保和康药房 王药师 2025年6月15日 下午3点 "
+                    "小儿宝泰康 主题产品推广 聊了陈列和销量 "
+                    "竞品有太极 下次带样品 王药师说卖得不错"
+                ),
+            )
+
+        # With all core fields + feedback, should finalize immediately
+        assert result["merged"] is True
+        mock_save.assert_called_once()
+
+
+class TestRetrySkipField:
+    """Test 93: Retry 2 times then skip to next field."""
+
+    @pytest.mark.asyncio
+    async def test_retry_twice_then_skip(self, handler):
+        """Test 93: 2 failed attempts → skip to next field."""
+        manager = handler.sessions
+        session = manager.get_or_create_session("retry_skip_user")
+        session.merged_fields = {
+            "task_type": "药店拜访",
+            "org_name": "保和康药房",
+        }
+        session.pending_field = "contact_person"
+        session.pending_questions = ["products", "topic"]
+        session.retry_count = 2  # Already exhausted
+
+        result = await handler._handle_progressive_answer(
+            "retry_skip_user",
+            "这个不太清楚",  # Can't extract contact_person
+            session,
+        )
+
+        # Should skip contact_person and move to products
+        assert result["merged"] is False
+        assert result["needs_followup"] is True
+        assert result["followup_field"] == "products"
+        assert session.retry_count == 2  # unchanged
+
+
+class TestManualMergeMidProgressive:
+    """Test 94: Mid-progressive '完成' triggers force merge."""
+
+    @pytest.mark.asyncio
+    async def test_done_mid_progressive_finalizes(self, handler):
+        """Test 94: Saying '完成' during progressive questioning finalizes accumulated fields."""
+        manager = handler.sessions
+        session = manager.get_or_create_session("done_mid_user")
+        session.merged_fields = {
+            "task_type": "药店拜访",
+            "org_name": "保和康药房",
+            "contact_person": "王药师",
+        }
+        session.pending_field = "products"
+        session.pending_questions = ["topic"]
+        session.add_message(MessageType.TEXT, "去了保和康药房和王药师")
+
+        with patch.object(handler, "_finalize_accumulated", new_callable=AsyncMock) as mock_final:
+            mock_final.return_value = {
+                "merged": True,
+                "task": {"fields": session.merged_fields, "summary": "test"},
+                "warnings": [],
+                "pending_count": 0,
+            }
+            result = await handler.handle_message(
+                user_id="done_mid_user",
+                msg_type="text",
+                content="完成",
+            )
+            mock_final.assert_called_once()
+            assert result["merged"] is True
+
+
+class TestAccumulateFields:
+    """Test 95: accumulate_fields properly merges new fields into existing ones."""
+
+    def test_accumulate_fills_empty_slots(self):
+        """accumulate_fields fills empty values without overwriting existing ones."""
+        manager = SessionManager()
+        session = manager.get_or_create_session("accum_user")
+        session.accumulate_fields({"org_name": "保和康药房", "contact_person": ""})
+        assert session.merged_fields["org_name"] == "保和康药房"
+        # Empty values are not stored
+        assert "contact_person" not in session.merged_fields
+
+        # Second accumulation: fills missing contact_person
+        session.accumulate_fields({"contact_person": "王药师", "products": "板蓝根"})
+        assert session.merged_fields["contact_person"] == "王药师"
+        assert session.merged_fields["products"] == "板蓝根"
+        # org_name should not be overwritten
+        assert session.merged_fields["org_name"] == "保和康药房"
+
+    def test_accumulate_does_not_overwrite_existing(self):
+        """accumulate_fields does not overwrite existing non-empty values."""
+        manager = SessionManager()
+        session = manager.get_or_create_session("accum_keep_user")
+        session.accumulate_fields({"org_name": "保和康药房"})
+        # Try to overwrite with empty
+        session.accumulate_fields({"org_name": ""})
+        assert session.merged_fields["org_name"] == "保和康药房"
+        # Try to overwrite with different value
+        session.accumulate_fields({"org_name": "同仁堂"})
+        assert session.merged_fields["org_name"] == "保和康药房"  # unchanged
 
 
 class TestTouchActivity:

--- a/tests/test_pharma_compliance.py
+++ b/tests/test_pharma_compliance.py
@@ -1,0 +1,925 @@
+"""
+Tests for pharma_compliance module.
+
+38 tests total:
+  - 33 baseline tests (session, extractor, bot_handler)
+  - 5 new multimodal tests (voice, photo, merge, cross-check, auto-type)
+"""
+
+import asyncio
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Ensure project root is importable
+PROJECT_ROOT = Path(__file__).parent.parent
+import sys
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from pharma_compliance.session import (
+    MERGE_WINDOW_SECONDS,
+    MessageType,
+    PendingMessage,
+    SessionManager,
+    VisitSession,
+)
+from pharma_compliance.extractor import (
+    detect_task_type,
+    extract_fields,
+    fields_to_summary,
+    FIELD_NAMES,
+    _extract_date,
+    _extract_time,
+    _extract_address,
+    _extract_org_name,
+    _extract_person,
+    _extract_products,
+    _extract_topic,
+    _extract_competitor,
+    _extract_feedback,
+    _extract_next_steps,
+    _extract_attendee_count,
+)
+from pharma_compliance.bot_handler import ComplianceBotHandler, process_message
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Fixtures
+# ═══════════════════════════════════════════════════════════════════════════════
+
+@pytest.fixture
+def manager():
+    return SessionManager()
+
+
+@pytest.fixture
+def session(manager):
+    return manager.get_or_create_session("user_test_001")
+
+
+@pytest.fixture
+def handler():
+    return ComplianceBotHandler()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Session tests (tests 1–11)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestSessionCreation:
+    def test_create_session(self, manager):
+        """Test 1: Creating a new session."""
+        session = manager.get_or_create_session("user_001")
+        assert session.user_id == "user_001"
+        assert session.pending_messages == []
+        assert session.message_timeout == 0.0
+
+    def test_get_existing_session(self, manager):
+        """Test 2: Getting an existing session returns the same object."""
+        s1 = manager.get_or_create_session("user_002")
+        s2 = manager.get_or_create_session("user_002")
+        assert s1 is s2
+
+    def test_remove_session(self, manager):
+        """Test 3: Removing a session."""
+        manager.get_or_create_session("user_003")
+        manager.remove_session("user_003")
+        assert manager.get_session("user_003") is None
+
+    def test_multiple_sessions_independent(self, manager):
+        """Test 4: Multiple users have independent sessions."""
+        s1 = manager.get_or_create_session("user_A")
+        s2 = manager.get_or_create_session("user_B")
+        s1.add_message(MessageType.TEXT, "msg from A")
+        assert len(s1.pending_messages) == 1
+        assert len(s2.pending_messages) == 0
+
+
+class TestPendingMessages:
+    def test_add_text_message(self, session):
+        """Test 5: Adding a text message."""
+        session.add_message(MessageType.TEXT, "去了百姓大药房见王店长")
+        assert len(session.pending_messages) == 1
+        assert session.pending_messages[0].msg_type == MessageType.TEXT
+        assert "百姓大药房" in session.pending_messages[0].content
+
+    def test_add_voice_message(self, session):
+        """Test 6: Adding a voice message."""
+        session.add_message(MessageType.VOICE, "聊了陈列小儿宝泰康")
+        assert len(session.pending_messages) == 1
+        assert session.pending_messages[0].msg_type == MessageType.VOICE
+
+    def test_add_photo_message(self, session):
+        """Test 7: Adding a photo message."""
+        session.add_message(MessageType.PHOTO, "百姓大药房 中山路100号")
+        assert len(session.pending_messages) == 1
+        assert session.pending_messages[0].msg_type == MessageType.PHOTO
+
+    def test_pending_count(self, session):
+        """Test 8: Pending message count is accurate."""
+        session.add_message(MessageType.TEXT, "msg1")
+        session.add_message(MessageType.VOICE, "msg2")
+        session.add_message(MessageType.PHOTO, "msg3")
+        assert len(session.pending_messages) == 3
+
+    def test_merge_contents(self, session):
+        """Test 9: Merging contents combines all message types."""
+        session.add_message(MessageType.TEXT, "去了百姓大药房")
+        session.add_message(MessageType.VOICE, "见了王店长")
+        session.add_message(MessageType.PHOTO, "门头照确认")
+        merged = session.merge_contents()
+        assert "去了百姓大药房" in merged
+        assert "[语音]" in merged
+        assert "[门头照]" in merged
+
+    def test_session_clear(self, session):
+        """Test 10: Clearing a session resets all state."""
+        session.add_message(MessageType.TEXT, "test")
+        session.clear()
+        assert len(session.pending_messages) == 0
+        assert session.message_timeout == 0.0
+
+
+class TestSessionTimeout:
+    def test_not_timed_out_without_messages(self, session):
+        """Test 11: Empty session should not time out."""
+        assert not session.is_timed_out()
+
+    def test_not_timed_out_within_window(self, session):
+        """Test 12: Session with recent message should not time out."""
+        session.add_message(MessageType.TEXT, "test")
+        assert not session.is_timed_out()
+
+    def test_timed_out_after_window(self, session):
+        """Test 13: Session times out after MERGE_WINDOW_SECONDS."""
+        session.add_message(MessageType.TEXT, "test")
+        # Simulate old message by adjusting timeout backwards
+        session.message_timeout = time.time() - 1
+        assert session.is_timed_out()
+
+    def test_check_timeouts_returns_timed_out(self, manager):
+        """Test 14: Manager.check_timeouts returns timed-out sessions."""
+        s = manager.get_or_create_session("user_timeout")
+        s.add_message(MessageType.TEXT, "test")
+        s.message_timeout = time.time() - 1
+        timed_out = manager.check_timeouts()
+        assert s in timed_out
+
+
+class TestManualMerge:
+    def test_manual_merge_phrase_wl(self, session):
+        """Test 15: '完了' triggers manual merge."""
+        assert session.check_manual_merge("说完了")
+
+    def test_manual_merge_phrase_jzy(self, session):
+        """Test 16: '就这样' triggers manual merge."""
+        assert session.check_manual_merge("就这样吧")
+
+    def test_no_manual_merge_without_phrase(self, session):
+        """Test 17: Regular text does not trigger manual merge."""
+        assert not session.check_manual_merge("见了王店长")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Extractor tests (tests 18–35)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestTaskTypeDetection:
+    def test_detect_pharmacy_visit(self):
+        """Test 18: Detect 药店拜访 from pharmacy keywords."""
+        result = detect_task_type("去了百姓大药房见王店长")
+        assert result == "药店拜访"
+
+    def test_detect_pharmacy_visit_display(self):
+        """Test 19: Detect 药店拜访 from 陈列 keyword."""
+        result = detect_task_type("聊了陈列调整")
+        assert result == "药店拜访"
+
+    def test_detect_hospital_visit(self):
+        """Test 20: Detect 医疗机构拜访 from hospital keywords."""
+        result = detect_task_type("协和医院心内科张主任")
+        assert result == "医疗机构拜访"
+
+    def test_detect_hospital_visit_doctor(self):
+        """Test 21: Detect 医疗机构拜访 from 医生 keyword."""
+        result = detect_task_type("门诊见了李医生")
+        assert result == "医疗机构拜访"
+
+    def test_detect_academic_promotion(self):
+        """Test 22: Detect 学术推广 from meeting keywords."""
+        result = detect_task_type("今天下午开了科室会")
+        assert result == "学术推广"
+
+    def test_detect_academic_promotion_lecture(self):
+        """Test 23: Detect 学术推广 from 讲座 keyword."""
+        result = detect_task_type("组织了一场产品讲座")
+        assert result == "学术推广"
+
+    def test_detect_default_to_pharmacy(self):
+        """Test 24: Default to 药店拜访 when no keyword matches."""
+        result = detect_task_type("今天去拜访了客户")
+        assert result == "药店拜访"
+
+
+class TestDateExtraction:
+    def test_extract_date_full(self):
+        """Test 25: Extract full date YYYY-MM-DD."""
+        result = _extract_date("2025年6月15日拜访")
+        assert "2025-06-15" in result or "2025-6-15" in result
+
+    def test_extract_date_month_day(self):
+        """Test 26: Extract month-day format."""
+        result = _extract_date("6月15号去的")
+        assert result != ""
+
+    def test_extract_date_none(self):
+        """Test 27: No date returns empty string."""
+        result = _extract_date("没有日期信息")
+        assert result == ""
+
+
+class TestTimeExtraction:
+    def test_extract_time_colon(self):
+        """Test 28: Extract time with colon."""
+        result = _extract_time("下午14:30到店")
+        assert "14:30" in result
+
+    def test_extract_time_morning(self):
+        """Test 29: Extract morning time."""
+        result = _extract_time("上午9点拜访")
+        assert "09:00" in result
+
+    def test_extract_time_afternoon(self):
+        """Test 30: Extract afternoon time."""
+        result = _extract_time("下午3点拜访")
+        assert "15:00" in result
+
+
+class TestPersonExtraction:
+    def test_extract_person_store_manager(self):
+        """Test 31: Extract store manager."""
+        name, _ = _extract_person("见了王店长")
+        assert "王" in name or "王店长" in name
+
+    def test_extract_person_doctor(self):
+        """Test 32: Extract doctor."""
+        name, _ = _extract_person("拜访了张主任")
+        assert "张" in name or "张主任" in name
+
+    def test_extract_person_unknown(self):
+        """Test 33: No person returns empty strings."""
+        name, title = _extract_person("去药店检查陈列")
+        assert name == ""
+        assert title == ""
+
+
+class TestOrgExtraction:
+    def test_extract_org_name_pharmacy(self):
+        """Test 34: Extract pharmacy name."""
+        result = _extract_org_name("去了百姓大药房")
+        assert "百姓大药房" in result or "百姓" in result
+
+    def test_extract_org_name_hospital(self):
+        """Test 35: Extract hospital name."""
+        result = _extract_org_name("协和医院心内科")
+        assert "协和" in result
+
+
+class TestProductExtraction:
+    def test_extract_product_single(self):
+        """Test 36: Extract single product."""
+        result = _extract_products("聊了小儿宝泰康的陈列")
+        assert "小儿宝泰康" in result
+
+    def test_extract_product_multiple(self):
+        """Test 37: Extract multiple products."""
+        result = _extract_products("聊了小儿宝泰康和板蓝根")
+        assert len(result.split(", ")) >= 2
+
+
+class TestAddressExtraction:
+    def test_extract_address_pattern(self):
+        """Test 38: Extract address with 路 pattern."""
+        result = _extract_address("地址在中山路100号")
+        assert "中山路" in result
+
+    def test_extract_address_no_match(self):
+        """Test 39: No address returns empty string."""
+        result = _extract_address("没有地址信息")
+        assert result == ""
+
+
+class TestFullExtraction:
+    def test_extract_fields_returns_all_17(self):
+        """Test 40: extract_fields returns all 17 FIELD_NAMES."""
+        fields = extract_fields("去了百姓大药房见王店长，聊了小儿宝泰康陈列")
+        for fn in FIELD_NAMES:
+            assert fn in fields, f"Missing field '{fn}'"
+
+    def test_fields_to_summary(self):
+        """Test 41: fields_to_summary produces readable output."""
+        fields = {
+            "task_type": "药店拜访",
+            "org_name": "百姓大药房",
+            "contact_person": "王店长",
+        }
+        summary = fields_to_summary(fields)
+        assert "药店拜访" in summary or "药店" in summary
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Bot handler tests (tests 42–44)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestBotHandlerBasic:
+    @pytest.mark.asyncio
+    async def test_handle_text_message(self, handler):
+        """Test 42: Handle a text message."""
+        result = await handler.handle_message(
+            user_id="user_text",
+            msg_type="text",
+            content="去了百姓大药房见王店长",
+        )
+        assert result["merged"] is False
+        assert result["pending_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_text_auto_merge_on_timeout(self, handler):
+        """Test 43: Text message auto-merges after timeout."""
+        result = await handler.handle_message(
+            user_id="user_timeout",
+            msg_type="text",
+            content="去了百姓大药房见王店长",
+        )
+        assert result["merged"] is False
+
+        # Simulate timeout
+        session = handler.sessions.get_session("user_timeout")
+        session.message_timeout = time.time() - 1
+
+        # Next message should trigger merge
+        result2 = await handler.handle_message(
+            user_id="user_timeout",
+            msg_type="text",
+            content="聊了陈列",  # This triggers merge because previous timed out
+        )
+
+    def test_fuzzy_match_identical(self):
+        """Test 44: Fuzzy match with identical names."""
+        assert ComplianceBotHandler._fuzzy_match("百姓大药房", "百姓大药房")
+
+    def test_fuzzy_match_substring(self):
+        """Test 45: Fuzzy match with substring."""
+        assert ComplianceBotHandler._fuzzy_match("百姓大药房", "百姓大药房中山路店")
+
+    def test_fuzzy_match_different(self):
+        """Test 46: Fuzzy match with different names."""
+        assert not ComplianceBotHandler._fuzzy_match("百姓大药房", "同仁堂")
+
+    def test_haversine_distance(self):
+        """Test 47: Haversine distance calculation."""
+        # Tiananmen to Forbidden City (~1km)
+        dist = ComplianceBotHandler._haversine_distance(
+            39.9042, 116.3974, 39.9142, 116.3874
+        )
+        assert 500 < dist < 2000, f"Expected ~1.1km, got {dist:.0f}m"
+
+    def test_haversine_same_point(self):
+        """Test 48: Haversine distance for same point."""
+        dist = ComplianceBotHandler._haversine_distance(
+            39.9042, 116.3974, 39.9042, 116.3974
+        )
+        assert dist == 0.0
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Cross-check tests
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestCrossCheck:
+    def test_store_match_no_warning(self, handler):
+        """Test 49: Matching stores produce no warning."""
+        warnings = handler.cross_check(
+            claimed_store="百姓大药房",
+            ocr_store="百姓大药房",
+        )
+        assert len(warnings) == 0
+
+    def test_store_mismatch_warning(self, handler):
+        """Test 50: Mismatched stores produce ⚠️ warning."""
+        warnings = handler.cross_check(
+            claimed_store="百姓大药房",
+            ocr_store="同仁堂大药房",
+        )
+        assert len(warnings) == 1
+        assert "地址不匹配" in warnings[0]
+
+    def test_gps_deviation_warning(self, handler):
+        """Test 51: GPS deviation >500m produces warning."""
+        warnings = handler.cross_check(
+            claimed_store="", ocr_store="",
+            claimed_location={"latitude": 39.9042, "longitude": 116.3974},
+            exif_gps={"latitude": 39.9242, "longitude": 116.3974},  # ~2.2km away
+        )
+        assert len(warnings) == 1
+        assert "位置偏差" in warnings[0]
+
+    def test_gps_within_range_no_warning(self, handler):
+        """Test 52: GPS deviation <500m produces no warning."""
+        warnings = handler.cross_check(
+            claimed_store="", ocr_store="",
+            claimed_location={"latitude": 39.9042, "longitude": 116.3974},
+            exif_gps={"latitude": 39.9052, "longitude": 116.3984},  # ~100m
+        )
+        assert len(warnings) == 0
+
+    def test_time_deviation_warning(self, handler):
+        """Test 53: Time deviation >30min produces warning."""
+        warnings = handler.cross_check(
+            claimed_store="", ocr_store="",
+            claimed_time="2025-06-15T14:00:00",
+            exif_time="2025-06-15T14:45:00",
+        )
+        assert len(warnings) == 1
+        assert "时间偏差" in warnings[0]
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# NEW: Multimodal tests (Scenario A–E, tests 54–58)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestScenarioA_PureVoice:
+    """Scenario A: Pure voice → STT → text → field extraction."""
+
+    @pytest.mark.asyncio
+    async def test_voice_stt_and_extraction(self, handler):
+        """Test 54: Simulate voice message → STT → extract fields."""
+        mock_stt_result = {
+            "success": True,
+            "transcript": "去了百姓大药房见王店长，聊了小儿宝泰康陈列",
+            "provider": "local",
+        }
+
+        with patch(
+            "pharma_compliance.bot_handler.transcribe_audio",
+            return_value=mock_stt_result,
+        ):
+            # Create a temp file simulating voice
+            with tempfile.NamedTemporaryFile(suffix=".ogg", delete=False) as f:
+                voice_path = f.name
+                f.write(b"mock audio data")
+
+            result = await handler.handle_message(
+                user_id="voice_test",
+                msg_type="voice",
+                content=voice_path,
+            )
+            assert result["pending_count"] == 1
+            assert result["text_preview"] is not None
+            assert "百姓大药房" in result["text_preview"]
+
+    @pytest.mark.asyncio
+    async def test_voice_stt_failure(self, handler):
+        """Test 55: STT failure returns error warning."""
+        mock_stt_result = {
+            "success": False,
+            "transcript": "",
+            "error": "STT disabled",
+        }
+
+        with patch(
+            "pharma_compliance.bot_handler.transcribe_audio",
+            return_value=mock_stt_result,
+        ):
+            with tempfile.NamedTemporaryFile(suffix=".ogg", delete=False) as f:
+                voice_path = f.name
+                f.write(b"mock audio")
+
+            result = await handler.handle_message(
+                user_id="voice_fail",
+                msg_type="voice",
+                content=voice_path,
+            )
+            assert result["merged"] is False
+            all_warnings = result.get("warnings", [])
+            assert len(all_warnings) > 0, f'Expected warnings, got: {result}'
+            assert any("失败" in w for w in all_warnings)
+
+
+class TestScenarioB_PhotoAndVoice:
+    """Scenario B: Door photo + voice → OCR store name + voice fields → merge."""
+
+    @pytest.mark.asyncio
+    async def test_photo_then_voice_merge(self, handler):
+        """Test 56: Photo (OCR) then voice (STT) → merged extraction."""
+
+        # Mock vision_analyze_tool for photo
+        vision_result = json.dumps({
+            "success": True,
+            "analysis": '{"store_name": "百姓大药房", "address": "中山路100号"}',
+        })
+
+        # Mock STT for voice
+        stt_result = {
+            "success": True,
+            "transcript": "见了王店长聊了陈列小儿宝泰康",
+            "provider": "local",
+        }
+
+        with patch(
+            "pharma_compliance.bot_handler.vision_analyze_tool",
+            new=AsyncMock(return_value=vision_result),
+        ), patch(
+            "pharma_compliance.bot_handler.transcribe_audio",
+            return_value=stt_result,
+        ):
+            # Create temp files
+            with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as f:
+                photo_path = f.name
+                f.write(b"mock jpeg data")
+            with tempfile.NamedTemporaryFile(suffix=".ogg", delete=False) as f:
+                voice_path = f.name
+                f.write(b"mock audio data")
+
+            # Send photo
+            r1 = await handler.handle_message(
+                user_id="photo_voice_test",
+                msg_type="photo",
+                content=photo_path,
+            )
+            assert r1["pending_count"] == 1
+
+            # Send voice
+            r2 = await handler.handle_message(
+                user_id="photo_voice_test",
+                msg_type="voice",
+                content=voice_path,
+            )
+            assert r2["pending_count"] == 2
+
+
+class TestScenarioC_MultiRoundMixed:
+    """Scenario C: 3 mixed messages → 1 merged record, 5-min timeout."""
+
+    def test_merge_timeout_mechanism(self):
+        """Test 57: 5-minute timeout triggers auto-merge."""
+        manager = SessionManager()
+        session = manager.get_or_create_session("multi_test")
+
+        session.add_message(MessageType.PHOTO, "百姓大药房 门头")
+        session.add_message(MessageType.VOICE, "见了王店长")
+        session.add_message(MessageType.TEXT, "聊了陈列 小儿宝泰康")
+
+        assert len(session.pending_messages) == 3
+
+        # Not timed out yet
+        assert not session.is_timed_out()
+
+        # Force timeout
+        session.message_timeout = time.time() - 1
+        assert session.is_timed_out()
+
+    def test_three_messages_merge_to_one_record(self):
+        """Test 58: 3 messages merge into 1 task record."""
+        manager = SessionManager()
+        session = manager.get_or_create_session("merge_test")
+
+        session.add_message(MessageType.PHOTO, "百姓大药房")
+        session.add_message(MessageType.VOICE, "见了王店长")
+        session.add_message(MessageType.TEXT, "聊了小儿宝泰康陈列")
+
+        merged = session.merge_contents()
+        assert "门头照" in merged
+        assert "语音" in merged
+        assert "小儿宝泰康" in merged
+
+        fields = extract_fields(merged)
+        assert fields["task_type"] == "药店拜访"
+        assert len(fields) == 17
+
+
+class TestScenarioD_AddressMismatch:
+    """Scenario D: Door photo OCR ≠ claimed store → ⚠️ warning."""
+
+    def test_address_mismatch_warning(self):
+        """Test 59: OCR store name doesn't match claimed → ⚠️ warning."""
+        handler = ComplianceBotHandler()
+        warnings = handler.cross_check(
+            claimed_store="百姓大药房",
+            ocr_store="同仁堂大药房",
+        )
+        assert len(warnings) == 1
+        assert "⚠️" in warnings[0]
+        assert "地址不匹配" in warnings[0]
+
+    def test_address_match_no_warning(self):
+        """Test 60: OCR matches claimed → no warning."""
+        handler = ComplianceBotHandler()
+        warnings = handler.cross_check(
+            claimed_store="百姓大药房",
+            ocr_store="百姓大药房",
+        )
+        assert len(warnings) == 0
+
+
+class TestScenarioE_AutoTaskType:
+    """Scenario E: Auto task type detection without explicit trigger."""
+
+    def test_auto_detect_pharmacy(self):
+        """Test 61: Content with pharmacy keywords → 药店拜访."""
+        result = detect_task_type("去了百姓大药房见王店长")
+        assert result == "药店拜访"
+
+    def test_auto_detect_hospital(self):
+        """Test 62: Content with hospital keywords → 医疗机构拜访."""
+        result = detect_task_type("协和医院心内科张主任")
+        assert result == "医疗机构拜访"
+
+    def test_auto_detect_academic(self):
+        """Test 63: Content with meeting keywords → 学术推广."""
+        result = detect_task_type("今天下午开了科室会")
+        assert result == "学术推广"
+
+    def test_full_extraction_with_auto_type(self):
+        """Test 64: Full extraction auto-detects type from content."""
+        fields = extract_fields("协和医院心内科张主任，今天下午开了科室会")
+        assert fields["task_type"] in ("医疗机构拜访", "学术推广")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Edge case and degradation tests
+# ═══════════════════════════════════════════════════════════════════════════════
+
+class TestLowConfidenceConfirmation:
+    """P1-5: Low-confidence STT → needs_confirmation=True."""
+
+    @pytest.mark.asyncio
+    async def test_low_confidence_stt_needs_confirmation(self, handler):
+        """Test 65: STT confidence < 0.6 → needs_confirmation=True."""
+        mock_stt_result = {
+            "success": True,
+            "transcript": "去了某个地方见了某人",
+            "confidence": 0.45,
+            "provider": "local",
+        }
+
+        with patch(
+            "pharma_compliance.bot_handler.transcribe_audio",
+            return_value=mock_stt_result,
+        ):
+            with tempfile.NamedTemporaryFile(suffix=".ogg", delete=False) as f:
+                voice_path = f.name
+                f.write(b"mock audio data")
+
+            result = await handler.handle_message(
+                user_id="low_conf_test",
+                msg_type="voice",
+                content=voice_path,
+            )
+            assert result["needs_confirmation"] is True
+            assert result["pending_count"] == 1  # now added to session for force-merge
+            assert result["text_preview"] is not None
+            assert result["merged"] is False
+            assert "missing_fields" in result  # P0-2: missing fields check enabled
+
+    @pytest.mark.asyncio
+    async def test_high_confidence_stt_no_confirmation(self, handler):
+        """Test 66: STT confidence >= 0.6 → normal flow, no confirmation needed."""
+        mock_stt_result = {
+            "success": True,
+            "transcript": "去了百姓大药房见王店长",
+            "confidence": 0.85,
+            "provider": "local",
+        }
+
+        with patch(
+            "pharma_compliance.bot_handler.transcribe_audio",
+            return_value=mock_stt_result,
+        ):
+            with tempfile.NamedTemporaryFile(suffix=".ogg", delete=False) as f:
+                voice_path = f.name
+                f.write(b"mock audio data")
+
+            result = await handler.handle_message(
+                user_id="high_conf_test",
+                msg_type="voice",
+                content=voice_path,
+            )
+            assert result.get("needs_confirmation") is not True
+            assert result["pending_count"] == 1
+            assert result["merged"] is False
+
+
+class TestExifGpsExtraction:
+    """P1-5: EXIF GPS extraction from photo images."""
+
+    def test_parse_gps_northern_eastern(self):
+        """Test 67: Parse GPS from EXIF (N/E hemisphere)."""
+        handler = ComplianceBotHandler()
+        gps_data = {
+            "GPSLatitudeRef": "N",
+            "GPSLatitude": (39, 54, 15.12),
+            "GPSLongitudeRef": "E",
+            "GPSLongitude": (116, 23, 50.64),
+        }
+        result = handler._parse_gps(gps_data)
+        assert result is not None
+        assert abs(result["latitude"] - 39.9042) < 0.01
+        assert abs(result["longitude"] - 116.3974) < 0.01
+
+    def test_parse_gps_southern_western(self):
+        """Test 68: Parse GPS from EXIF (S/W hemisphere)."""
+        handler = ComplianceBotHandler()
+        gps_data = {
+            "GPSLatitudeRef": "S",
+            "GPSLatitude": (33, 55, 27.84),
+            "GPSLongitudeRef": "W",
+            "GPSLongitude": (18, 25, 25.68),
+        }
+        result = handler._parse_gps(gps_data)
+        assert result is not None
+        assert result["latitude"] < 0  # Southern hemisphere
+        assert result["longitude"] < 0  # Western hemisphere
+        assert abs(result["latitude"] - (-33.9244)) < 0.01
+        assert abs(result["longitude"] - (-18.4238)) < 0.01
+
+    def test_parse_gps_missing_coords(self):
+        """Test 69: Parse GPS returns None when lat/lon missing."""
+        handler = ComplianceBotHandler()
+        # No GPSLatitude
+        result = handler._parse_gps({"GPSLatitudeRef": "N", "GPSLongitudeRef": "E"})
+        assert result is None
+        # Empty dict
+        result = handler._parse_gps({})
+        assert result is None
+
+    def test_extract_exif_with_gps(self):
+        """Test 70: _extract_exif returns GPS and datetime from image."""
+        from unittest.mock import MagicMock, PropertyMock
+
+        handler = ComplianceBotHandler()
+
+        # Mock ExifTags.Base as an IntEnum-like object
+        class _MockExifMember:
+            def __init__(self, name):
+                self.name = name
+
+        class _MockExifBase:
+            _map = {306: "DateTime", 36867: "DateTimeOriginal"}
+            def __contains__(self, item):
+                return item in self._map
+            def __call__(self, key):
+                return _MockExifMember(self._map.get(key, f"Unknown_{key}"))
+
+        # Mock GPS IFD
+        mock_gps_ifd = {
+            1: "N",
+            2: (39.0, 54.0, 15.12),
+            3: "E",
+            4: (116.0, 23.0, 50.64),
+        }
+
+        mock_exif = MagicMock()
+        mock_exif.__bool__.return_value = True
+        mock_exif.items.return_value = [
+            (306, "2025:06:15 14:30:00"),
+            (36867, "2025:06:15 14:29:55"),
+        ]
+        mock_exif.get_ifd.return_value = mock_gps_ifd
+
+        mock_img = MagicMock()
+        mock_img.getexif.return_value = mock_exif
+
+        with patch("PIL.Image.open", return_value=mock_img), \
+             patch("PIL.ExifTags.Base", _MockExifBase()), \
+             patch("PIL.ExifTags.GPSTAGS", {1: "GPSLatitudeRef", 2: "GPSLatitude",
+                    3: "GPSLongitudeRef", 4: "GPSLongitude"}):
+            result = handler._extract_exif("/fake/path.jpg")
+
+        assert result["datetime"] is not None
+        assert "2025-06-15T14:29:55" in result["datetime"]
+        assert result["gps"] is not None
+        assert abs(result["gps"]["latitude"] - 39.9042) < 0.01
+        assert abs(result["gps"]["longitude"] - 116.3974) < 0.01
+
+    def test_extract_exif_no_gps(self):
+        """Test 71: _extract_exif returns datetime but no GPS when no GPS IFD."""
+        from unittest.mock import MagicMock
+
+        handler = ComplianceBotHandler()
+
+        class _MockExifMember:
+            def __init__(self, name):
+                self.name = name
+
+        class _MockExifBase:
+            _map = {306: "DateTime"}
+            def __contains__(self, item):
+                return item in self._map
+            def __call__(self, key):
+                return _MockExifMember(self._map.get(key, f"Unknown_{key}"))
+
+        mock_exif = MagicMock()
+        mock_exif.__bool__.return_value = True
+        mock_exif.items.return_value = [(306, "2025:06:15 14:30:00")]
+        mock_exif.get_ifd.return_value = None  # No GPS IFD
+
+        mock_img = MagicMock()
+        mock_img.getexif.return_value = mock_exif
+
+        with patch("PIL.Image.open", return_value=mock_img), \
+             patch("PIL.ExifTags.Base", _MockExifBase()):
+            result = handler._extract_exif("/fake/path.jpg")
+
+        assert result["datetime"] is not None
+        assert result["gps"] is None
+
+
+class TestClaimedLocationCrossCheck:
+    """P1-3: claimed_location flows from session metadata → GPS cross-check."""
+
+    def test_claimed_location_extraction_from_metadata(self):
+        """Test 72: _extract_claimed_location reads GPS from message metadata."""
+        manager = SessionManager()
+        session = manager.get_or_create_session("gps_user")
+
+        # Add a text message with claimed_location in metadata
+        session.add_message(
+            MessageType.TEXT,
+            "到了百姓大药房",
+            metadata={"claimed_location": {"latitude": 39.9042, "longitude": 116.3974}},
+        )
+
+        location = ComplianceBotHandler._extract_claimed_location(session)
+        assert location is not None
+        assert location["latitude"] == 39.9042
+        assert location["longitude"] == 116.3974
+
+    def test_claimed_location_none_without_metadata(self):
+        """Test 73: _extract_claimed_location returns None when no GPS metadata."""
+        manager = SessionManager()
+        session = manager.get_or_create_session("no_gps_user")
+        session.add_message(MessageType.TEXT, "hello")
+
+        location = ComplianceBotHandler._extract_claimed_location(session)
+        assert location is None
+
+    def test_claimed_location_with_gps_cross_check(self, handler):
+        """Test 74: GPS cross-check triggers when claimed_location is provided."""
+        warnings = handler.cross_check(
+            claimed_store="",
+            ocr_store="",
+            claimed_location={"latitude": 39.9042, "longitude": 116.3974},
+            exif_gps={"latitude": 39.9242, "longitude": 116.3974},  # ~2.2 km away
+        )
+        assert len(warnings) == 1
+        assert "位置偏差" in warnings[0]
+
+
+class TestDegradation:
+    def test_extract_empty_text(self):
+        """Test 65: Extracting fields from empty text."""
+        fields = extract_fields("")
+        assert len(fields) == 17
+        assert fields["task_type"] == "药店拜访"  # default
+
+    def test_extract_single_word(self):
+        """Test 66: Extracting from minimal input."""
+        fields = extract_fields("你好")
+        assert len(fields) == 17
+
+    @pytest.mark.asyncio
+    async def test_handle_unknown_msg_type(self, handler):
+        """Test 67: Unknown message type treated as text."""
+        result = await handler.handle_message(
+            user_id="unknown_type",
+            msg_type="unknown",
+            content="test message",
+        )
+        assert "merged" in result
+
+    @pytest.mark.asyncio
+    async def test_asyncio_voice_unavailable_graceful_message(self, handler):
+        """Test 78: When STT is unavailable, return clear suggestion to use text."""
+        with patch("pharma_compliance.bot_handler.transcribe_audio", None):
+            with tempfile.NamedTemporaryFile(suffix=".ogg", delete=False) as f:
+                voice_path = f.name
+                f.write(b"mock audio data")
+
+            result = await handler.handle_message(
+                user_id="voice_missing_stt",
+                msg_type="voice",
+                content=voice_path,
+            )
+        assert result["merged"] is False
+        assert result["pending_count"] == 0
+        warnings = result.get("warnings", [])
+        assert len(warnings) == 1
+        assert "语音识别暂不可用" in warnings[0]
+        assert "文字" in warnings[0]

--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -99,7 +99,8 @@ class TestCompletionQueue:
         assert completion["session_id"] == s.id
         assert completion["command"] == "echo hello"
         assert completion["exit_code"] == 0
-        assert "build succeeded" in completion["output"]
+        assert completion["preview"] == "build succeeded"
+        assert completion["output"] == "build succeeded"
 
     def test_move_to_finished_nonzero_exit(self, registry):
         """Nonzero exit codes are captured correctly."""
@@ -116,7 +117,7 @@ class TestCompletionQueue:
 
         completion = registry.completion_queue.get_nowait()
         assert completion["exit_code"] == 1
-        assert "FAILED" in completion["output"]
+        assert completion["preview"] == "FAILED"
 
     def test_move_to_finished_idempotent_no_duplicate(self, registry):
         """Calling _move_to_finished twice must NOT enqueue two notifications.
@@ -138,8 +139,8 @@ class TestCompletionQueue:
         completion = registry.completion_queue.get_nowait()
         assert completion["exit_code"] == -15  # from the first (kill) call
 
-    def test_output_truncated_to_2000(self, registry):
-        """Long output is truncated to last 2000 chars."""
+    def test_output_preview_truncated_to_80_chars(self, registry):
+        """Long completion notifications are reduced to a short preview."""
         long_output = "x" * 5000
         s = _make_session(
             notify_on_complete=True,
@@ -152,7 +153,7 @@ class TestCompletionQueue:
             registry._move_to_finished(s)
 
         completion = registry.completion_queue.get_nowait()
-        assert len(completion["output"]) == 2000
+        assert len(completion["preview"]) == 83
 
     def test_multiple_completions_queued(self, registry):
         """Multiple notify processes all push to the same queue."""

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -32,6 +32,7 @@ def _make_session(
     exit_code=None,
     output="",
     started_at=None,
+    preserve_on_restart=False,
 ) -> ProcessSession:
     """Helper to create a ProcessSession for testing."""
     s = ProcessSession(
@@ -42,6 +43,7 @@ def _make_session(
         exited=exited,
         exit_code=exit_code,
         output_buffer=output,
+        preserve_on_restart=preserve_on_restart,
     )
     return s
 
@@ -166,7 +168,7 @@ class TestOrphanedPipeReconciliation:
 
     def test_reconcile_noop_when_child_still_running(self, registry):
         """Reconcile must NOT flip exited when the direct child is alive."""
-        proc = _spawn_python_sleep(5.0)
+        proc = _spawn_python_sleep(0.5)
         s = _make_session(sid="proc_running_test")
         s.process = proc
         s.pid = proc.pid
@@ -176,8 +178,7 @@ class TestOrphanedPipeReconciliation:
         assert result["status"] == "running"
         assert s.exited is False
 
-        proc.kill()
-        proc.wait()
+        proc.wait(timeout=5)
 
     def test_reconcile_noop_on_already_exited(self, registry):
         """Reconcile is a no-op when session.exited is already True."""
@@ -692,13 +693,14 @@ class TestPopenLeakOnSetupFailure:
 class TestCheckpoint:
     def test_write_checkpoint(self, registry, tmp_path):
         with patch("tools.process_registry.CHECKPOINT_PATH", tmp_path / "procs.json"):
-            s = _make_session()
+            s = _make_session(preserve_on_restart=True)
             registry._running[s.id] = s
             registry._write_checkpoint()
 
             data = json.loads((tmp_path / "procs.json").read_text())
             assert len(data) == 1
             assert data[0]["session_id"] == s.id
+            assert data[0]["preserve_on_restart"] is True
 
     def test_recover_no_file(self, registry, tmp_path):
         with patch("tools.process_registry.CHECKPOINT_PATH", tmp_path / "missing.json"):
@@ -712,7 +714,8 @@ class TestCheckpoint:
             "pid": 999999999,  # almost certainly not running
             "task_id": "t1",
         }]))
-        with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
+        with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint), \
+             patch.object(registry, "_is_host_pid_alive", return_value=False):
             recovered = registry.recover_from_checkpoint()
             assert recovered == 0
 
@@ -831,7 +834,8 @@ class TestCheckpoint:
         }]))
 
         try:
-            with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
+            with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint), \
+                 patch.object(registry, "_is_host_pid_alive", side_effect=lambda pid: proc.poll() is None):
                 recovered = registry.recover_from_checkpoint()
                 assert recovered == 1
 
@@ -854,12 +858,10 @@ class TestCheckpoint:
                 assert wait_result["status"] == "exited"
         finally:
             if proc.poll() is None:
-                proc.terminate()
                 try:
                     proc.wait(timeout=5)
                 except Exception:
-                    proc.kill()
-                    proc.wait(timeout=5)
+                    pytest.fail("short-lived test process did not exit in time")
 
 
 # =========================================================================
@@ -945,13 +947,16 @@ def test_format_completion_event():
         "session_id": "proc_abc",
         "command": "sleep 5",
         "exit_code": 0,
-        "output": "done",
+        "preview": "done",
+        "output_path": "/tmp/process-output/proc_abc.log",
     }
     result = format_process_notification(evt)
     assert "[IMPORTANT: Background process proc_abc completed" in result
     assert "exit code 0" in result
     assert "Command: sleep 5" in result
-    assert "Output:\ndone]" in result
+    assert "Preview: done" in result
+    assert "Full output saved to: /tmp/process-output/proc_abc.log" in result
+    assert "Output:\ndone" not in result
 
 
 def test_format_watch_match_event():
@@ -1225,3 +1230,419 @@ class TestTerminateHostPidPosix:
         pr.ProcessRegistry._terminate_host_pid(12345)
 
         assert kill_calls == [(12345, signal.SIGTERM)]
+
+
+# =========================================================================
+# Tee to host log — Popen and PTY
+# =========================================================================
+
+
+class TestTeeToHostLog:
+    """Verify that spawn_local writes process output to the host log file
+    (process-output/{session_id}.log) for both Popen and PTY paths."""
+
+    def test_popen_tee_to_host_log(self, registry, tmp_path):
+        """Popen path: output is written to the output_path log file."""
+        output_dir = tmp_path / "process-output"
+        output_dir.mkdir()
+
+        chunks = ["hello ", "world\n"]
+        chunk_iter = iter(chunks)
+
+        proc = MagicMock()
+        proc.pid = 12345
+        proc.returncode = 0
+        proc.stdin = MagicMock()
+        proc.poll.return_value = None
+        proc.wait = MagicMock()
+
+        class _FakeStdout:
+            def read(self, n):
+                return next(chunk_iter, "")
+
+        proc.stdout = _FakeStdout()
+
+        with patch("tools.process_registry.get_hermes_home", return_value=tmp_path), \
+             patch("tools.process_registry._find_shell", return_value="/bin/bash"), \
+             patch("subprocess.Popen", return_value=proc), \
+             patch.object(registry, "_write_checkpoint"), \
+             patch.object(registry, "_cleanup_output_dir"):
+            session = registry.spawn_local("echo hello", cwd=str(tmp_path))
+
+        # Wait for reader thread to exhaust the chunk iterator and exit.
+        deadline = time.time() + 5
+        while time.time() < deadline:
+            if session.exited:
+                break
+            time.sleep(0.1)
+
+        assert session.exited
+        assert session.output_path is not None
+        assert os.path.isfile(session.output_path)
+        content = open(session.output_path).read()
+        assert "hello world" in content
+        assert session.output_bytes > 0
+
+    def test_pty_tee_to_host_log(self, registry, tmp_path):
+        """PTY path: output is written to the output_path log file."""
+        output_dir = tmp_path / "process-output"
+        output_dir.mkdir()
+
+        chunks = [b"hello ", b"from pty\n"]
+        chunk_idx = [0]
+
+        pty_mock = MagicMock()
+        pty_mock.pid = 12346
+        pty_mock.exitstatus = 0
+
+        def fake_isalive():
+            return chunk_idx[0] < len(chunks)
+
+        pty_mock.isalive = fake_isalive
+
+        def fake_read(n):
+            if chunk_idx[0] < len(chunks):
+                result = chunks[chunk_idx[0]]
+                chunk_idx[0] += 1
+                return result
+            return b""
+
+        pty_mock.read = fake_read
+        pty_mock.wait = MagicMock()
+
+        pty_class = MagicMock()
+        pty_class.spawn = MagicMock(return_value=pty_mock)
+
+        with patch("tools.process_registry.get_hermes_home", return_value=tmp_path), \
+             patch("tools.process_registry._find_shell", return_value="/bin/bash"), \
+             patch("ptyprocess.PtyProcess", pty_class), \
+             patch.object(registry, "_write_checkpoint"), \
+             patch.object(registry, "_cleanup_output_dir"):
+            session = registry.spawn_local("echo hello", cwd=str(tmp_path), use_pty=True)
+
+        # Wait for PTY reader thread to finish.
+        deadline = time.time() + 5
+        while time.time() < deadline:
+            if session.exited:
+                break
+            time.sleep(0.1)
+
+        assert session.exited
+        assert session.output_path is not None
+        assert os.path.isfile(session.output_path)
+        content = open(session.output_path).read()
+        assert "from pty" in content
+        assert session.output_bytes > 0
+
+
+# =========================================================================
+# Checkpoint round-trip — output_path / output_bytes
+# =========================================================================
+
+
+class TestCheckpointOutputPath:
+    """Verify that output_path and output_bytes survive a checkpoint
+    write + recover cycle."""
+
+    def test_write_checkpoint_includes_output_path_and_bytes(self, registry, tmp_path):
+        """_write_checkpoint persists output_path and output_bytes."""
+        checkpoint_path = tmp_path / "procs.json"
+        s = _make_session()
+        s.output_path = "/tmp/process-output/proc_test123.log"
+        s.output_bytes = 4096
+        registry._running[s.id] = s
+
+        with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint_path), \
+             patch.object(registry, "_cleanup_output_dir"):
+            registry._write_checkpoint()
+
+        data = json.loads(checkpoint_path.read_text())
+        assert len(data) == 1
+        assert data[0]["output_path"] == "/tmp/process-output/proc_test123.log"
+        assert data[0]["output_bytes"] == 4096
+
+    def test_recover_restores_output_path_and_bytes(self, registry, tmp_path):
+        """recover_from_checkpoint restores output_path and output_bytes
+        on the recovered ProcessSession."""
+        checkpoint = tmp_path / "procs.json"
+        checkpoint.write_text(json.dumps([{
+            "session_id": "proc_live",
+            "command": "sleep 999",
+            "pid": os.getpid(),
+            "pid_scope": "host",
+            "task_id": "t1",
+            "output_path": "/tmp/process-output/proc_live.log",
+            "output_bytes": 8192,
+        }]))
+
+        with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint), \
+             patch.object(registry, "_cleanup_output_dir"):
+            recovered = registry.recover_from_checkpoint()
+
+        assert recovered == 1
+        session = registry.get("proc_live")
+        assert session is not None
+        assert session.output_path == "/tmp/process-output/proc_live.log"
+        assert session.output_bytes == 8192
+
+    def test_recover_restores_preserve_on_restart(self, registry, tmp_path):
+        checkpoint = tmp_path / "procs.json"
+        checkpoint.write_text(json.dumps([{
+            "session_id": "proc_live",
+            "command": "codex",
+            "pid": os.getpid(),
+            "pid_scope": "host",
+            "task_id": "t1",
+            "preserve_on_restart": True,
+        }]))
+
+        with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint), \
+             patch.object(registry, "_cleanup_output_dir"):
+            recovered = registry.recover_from_checkpoint()
+
+        assert recovered == 1
+        session = registry.get("proc_live")
+        assert session is not None
+        assert session.preserve_on_restart is True
+
+
+def test_kill_all_skips_preserved_sessions_when_requested(registry):
+    keep = _make_session(sid="proc_keep", preserve_on_restart=True)
+    kill = _make_session(sid="proc_kill")
+    registry._running[keep.id] = keep
+    registry._running[kill.id] = kill
+
+    called = []
+
+    def _fake_kill(session_id):
+        called.append(session_id)
+        return {"status": "killed"}
+
+    with patch.object(registry, "kill_process", side_effect=_fake_kill):
+        killed = registry.kill_all(include_preserved=False)
+
+    assert killed == 1
+    assert called == ["proc_kill"]
+
+
+# =========================================================================
+# read_log from output_path
+# =========================================================================
+
+
+class TestReadLogFromOutputPath:
+    """Verify that read_log() prefers the persistent output_path file
+    over the in-memory output_buffer."""
+
+    def test_read_log_reads_from_output_path_file(self, registry, tmp_path):
+        """When output_path points to a real file, read_log() must use it."""
+        log_file = tmp_path / "test.log"
+        log_file.write_text("line 1\nline 2\nline 3\n")
+
+        s = _make_session(output="different content from buffer")
+        s.output_path = str(log_file)
+        registry._running[s.id] = s
+
+        result = registry.read_log(s.id)
+        assert result["total_lines"] == 3
+        assert "line 1" in result["output"]
+        assert "line 2" in result["output"]
+        # Must read from the file, not the in-memory buffer.
+        assert "different content" not in result["output"]
+
+    def test_read_log_falls_back_to_buffer_when_file_missing(self, registry):
+        """When output_path points to a nonexistent file, fall back to buffer."""
+        s = _make_session(output="buffer content here")
+        s.output_path = "/nonexistent/path/process.log"
+        registry._running[s.id] = s
+
+        result = registry.read_log(s.id)
+        assert "buffer content here" in result["output"]
+
+    def test_read_log_returns_file_content_even_when_buffer_empty(self, registry, tmp_path):
+        """When buffer is empty but output_path has content, use the file."""
+        log_file = tmp_path / "test.log"
+        log_file.write_text("file-only content\n")
+
+        s = _make_session(output="")  # empty buffer
+        s.output_path = str(log_file)
+        registry._running[s.id] = s
+
+        result = registry.read_log(s.id)
+        assert "file-only content" in result["output"]
+        assert result["total_lines"] == 1
+
+
+# =========================================================================
+# poll / list_sessions — no "unavailable" note when output_path exists
+# =========================================================================
+
+
+class TestDetachedWithOutputPath:
+    """Detached (recovered) sessions with a valid output_path must NOT
+    show the "output history unavailable" note in poll()."""
+
+    def test_poll_detached_with_output_path_no_unavailable_note(self, registry, tmp_path):
+        """poll() omits the unavailable note when output_path is valid."""
+        log_file = tmp_path / "test.log"
+        log_file.write_text("recovered output")
+
+        s = _make_session()
+        s.detached = True
+        s.output_path = str(log_file)
+        # Use sandbox pid_scope so _refresh_detached_session is a no-op.
+        s.pid_scope = "sandbox"
+        registry._finished[s.id] = s
+
+        result = registry.poll(s.id)
+        assert result["detached"] is True
+        assert "note" not in result, (
+            f"Should not show 'unavailable' note when output_path exists, got {result.get('note')!r}"
+        )
+
+    def test_poll_detached_without_output_path_shows_unavailable_note(self, registry):
+        """poll() DOES show the unavailable note when detached and output_path missing."""
+        s = _make_session()
+        s.detached = True
+        s.pid_scope = "sandbox"
+        registry._finished[s.id] = s
+
+        result = registry.poll(s.id)
+        assert result["detached"] is True
+        assert "note" in result
+        assert "unavailable" in result["note"]
+
+    def test_list_sessions_detached_with_output_path_no_unavailable(self, registry, tmp_path):
+        """list_sessions() entries for detached sessions with output_path are clean."""
+        log_file = tmp_path / "test.log"
+        log_file.write_text("some output")
+
+        s = _make_session()
+        s.detached = True
+        s.output_path = str(log_file)
+        s.pid_scope = "sandbox"
+        registry._finished[s.id] = s
+
+        entries = registry.list_sessions()
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["detached"] is True
+        assert "output_preview" in entry
+        # output_preview should come from the file
+        assert "some output" in entry["output_preview"]
+
+
+# =========================================================================
+# Orphan output log cleanup
+# =========================================================================
+
+
+class TestOrphanCleanup:
+    """_cleanup_output_dir() must:
+    - Keep files referenced by running/finished sessions (regardless of age).
+    - Keep files referenced by checkpoint output_path entries.
+    - Delete orphan *.log files whose mtime is >= 7 days old.
+    - Keep orphan *.log files whose mtime is < 7 days old.
+    """
+
+    def test_cleanup_keeps_referenced_files(self, registry, tmp_path):
+        """Files whose session ID is in _running or _finished are never deleted."""
+        output_dir = tmp_path / "process-output"
+        output_dir.mkdir()
+
+        log_file = output_dir / "proc_ref.log"
+        log_file.write_text("data")
+
+        s = _make_session(sid="proc_ref")
+        s.output_path = str(log_file)
+        registry._running[s.id] = s
+
+        with patch("tools.process_registry.get_hermes_home", return_value=tmp_path):
+            registry._cleanup_output_dir()
+
+        assert log_file.exists(), "Referenced log file must not be deleted"
+
+    def test_cleanup_keeps_checkpoint_referenced_files(self, registry, tmp_path):
+        """Old logs referenced by checkpoint output_path must not be deleted."""
+        output_dir = tmp_path / "process-output"
+        output_dir.mkdir()
+        checkpoint = tmp_path / "procs.json"
+
+        log_file = output_dir / "proc_ckpt.log"
+        log_file.write_text("data")
+        old_time = time.time() - 8 * 24 * 3600
+        os.utime(log_file, (old_time, old_time))
+        checkpoint.write_text(json.dumps([{
+            "session_id": "proc_ckpt",
+            "output_path": str(log_file),
+        }]))
+
+        with patch("tools.process_registry.get_hermes_home", return_value=tmp_path), \
+             patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
+            registry._cleanup_output_dir()
+
+        assert log_file.exists(), "Checkpoint-referenced log file must not be deleted"
+
+    def test_cleanup_deletes_old_orphans(self, registry, tmp_path):
+        """Orphan *.log files >= 7 days old are deleted."""
+        output_dir = tmp_path / "process-output"
+        output_dir.mkdir()
+
+        log_file = output_dir / "proc_old_orphan.log"
+        log_file.write_text("old data")
+
+        old_time = time.time() - 8 * 24 * 3600
+        os.utime(log_file, (old_time, old_time))
+
+        with patch("tools.process_registry.get_hermes_home", return_value=tmp_path):
+            registry._cleanup_output_dir()
+
+        assert not log_file.exists(), "Orphan >= 7 days old must be deleted"
+
+    def test_cleanup_keeps_recent_orphans(self, registry, tmp_path):
+        """Orphan *.log files < 7 days old are kept as a safety buffer."""
+        output_dir = tmp_path / "process-output"
+        output_dir.mkdir()
+
+        log_file = output_dir / "proc_recent_orphan.log"
+        log_file.write_text("recent data")
+        # mtime is now, well within the 7-day window.
+
+        with patch("tools.process_registry.get_hermes_home", return_value=tmp_path):
+            registry._cleanup_output_dir()
+
+        assert log_file.exists(), "Orphan < 7 days old must be kept"
+
+    def test_cleanup_skips_non_log_files(self, registry, tmp_path):
+        """Files not ending in .log are ignored by cleanup."""
+        output_dir = tmp_path / "process-output"
+        output_dir.mkdir()
+
+        not_log = output_dir / "something.txt"
+        not_log.write_text("not a log")
+
+        old_time = time.time() - 10 * 24 * 3600
+        os.utime(not_log, (old_time, old_time))
+
+        with patch("tools.process_registry.get_hermes_home", return_value=tmp_path):
+            registry._cleanup_output_dir()
+
+        assert not_log.exists(), "Non-.log files must be ignored"
+
+    def test_cleanup_handles_empty_output_dir(self, registry, tmp_path):
+        """Empty output directory must not raise."""
+        output_dir = tmp_path / "process-output"
+        output_dir.mkdir()
+
+        with patch("tools.process_registry.get_hermes_home", return_value=tmp_path):
+            registry._cleanup_output_dir()
+
+        # Must not raise.
+
+    def test_cleanup_handles_missing_output_dir(self, registry, tmp_path):
+        """Missing output directory must not raise."""
+        # No process-output directory exists.
+        with patch("tools.process_registry.get_hermes_home", return_value=tmp_path):
+            registry._cleanup_output_dir()
+
+        # Must not raise.

--- a/tests/tools/test_send_message_tool_feishu.py
+++ b/tests/tools/test_send_message_tool_feishu.py
@@ -1,0 +1,294 @@
+"""Tests for _send_feishu() lazy-install and import-rebind fix (v3).
+
+These tests verify the fix that switched from ``from X import Y`` (value binding,
+stale after lazy-install rebinds module globals) to ``import X as mod``
+(module-namespace access, always reads the current value).
+
+Independent of Telegram optional dependencies — does NOT importorskip("telegram").
+"""
+
+import asyncio
+import json
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _build_mock_feishu_mod(*, feishu_available=False, feishu_domain=None,
+                           lark_domain=None):
+    """Build a mock ``gateway.platforms.feishu`` module.
+
+    The returned module includes a real closure-based ``check_feishu_requirements``
+    that behaves like the production function in ``feishu.py``:
+
+    * If ``FEISHU_AVAILABLE`` is True → short-circuit: return True immediately.
+    * If ``FEISHU_AVAILABLE`` is False → call ``tools.lazy_deps.ensure_and_bind``,
+      and on success rebind ``FEISHU_DOMAIN`` / ``LARK_DOMAIN`` / ``FEISHU_AVAILABLE``
+      on the mock module.
+
+    This ensures that tests which verify short-circuit behaviour (test 2) and
+    lazy-install failure (test 5) exercise the real branching logic, not a
+    MagicMock stand-in.
+    """
+    mock_mod = MagicMock()
+    mock_mod.FEISHU_AVAILABLE = feishu_available
+    mock_mod.FEISHU_DOMAIN = feishu_domain
+    mock_mod.LARK_DOMAIN = lark_domain
+
+    def check_feishu_requirements():
+        # Short-circuit: deps already available
+        if mock_mod.FEISHU_AVAILABLE:
+            return True
+
+        # Lazy-install path – calls the real ensure_and_bind (which callers
+        # should mock to control success / failure).
+        from tools.lazy_deps import ensure_and_bind
+        ok = ensure_and_bind("platform.feishu")
+        if ok:
+            mock_mod.FEISHU_DOMAIN = "https://open.feishu.cn"
+            mock_mod.LARK_DOMAIN = "https://open.larksuite.com"
+            mock_mod.FEISHU_AVAILABLE = True
+        return ok
+
+    mock_mod.check_feishu_requirements = check_feishu_requirements
+
+    # Adapter class and instance
+    mock_adapter_inst = MagicMock()
+    mock_adapter_inst._domain_name = "feishu"
+    mock_client = MagicMock()
+    mock_adapter_inst._build_lark_client.return_value = mock_client
+    mock_adapter_inst.send = AsyncMock(
+        return_value=MagicMock(success=True, message_id="msg_test_123")
+    )
+    mock_adapter_inst.send_image_file = AsyncMock()
+    mock_adapter_inst.send_video = AsyncMock()
+    mock_adapter_inst.send_voice = AsyncMock()
+    mock_adapter_inst.send_document = AsyncMock()
+
+    mock_adapter_cls = MagicMock(return_value=mock_adapter_inst)
+    mock_adapter_cls.MAX_MESSAGE_LENGTH = 8000
+    mock_mod.FeishuAdapter = mock_adapter_cls
+
+    return mock_mod, mock_adapter_cls, mock_adapter_inst
+
+
+# ---------------------------------------------------------------------------
+# 1. test_send_feishu_lazy_install_and_rebind
+# ---------------------------------------------------------------------------
+
+def test_send_feishu_lazy_install_and_rebind():
+    """FEISHU_AVAILABLE=False triggers lazy-install; _build_lark_client gets rebound domain.
+
+    Before the fix, ``from gateway.platforms.feishu import FEISHU_DOMAIN`` would
+    capture ``None`` at import time, and ``ensure_and_bind()`` rebinding the
+    module global would not update the local variable.  After the fix,
+    ``feishu_mod.FEISHU_DOMAIN`` reads the current value from the module namespace,
+    so the rebound ``"https://open.feishu.cn"`` is passed to ``_build_lark_client``.
+    """
+    mock_mod, mock_cls, mock_inst = _build_mock_feishu_mod(
+        feishu_available=False,
+        feishu_domain=None,
+        lark_domain=None,
+    )
+
+    # Ensure gateway / gateway.platforms packages are in sys.modules so the
+    # import inside _send_feishu() can find them.
+    import gateway  # noqa: F401
+    import gateway.platforms  # noqa: F401
+
+    with patch.dict(sys.modules, {"gateway.platforms.feishu": mock_mod}), \
+         patch("tools.lazy_deps.ensure_and_bind", return_value=True):
+        from tools.send_message_tool import _send_feishu
+        result = asyncio.run(_send_feishu(
+            pconfig=MagicMock(),
+            chat_id="oc_test123",
+            message="Hello from test",
+        ))
+
+    assert result["success"] is True
+    assert result["platform"] == "feishu"
+    assert result["message_id"] == "msg_test_123"
+    # Critical assertion: _build_lark_client received the REBOUND domain, not None
+    mock_inst._build_lark_client.assert_called_once_with("https://open.feishu.cn")
+    mock_inst.send.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# 2. test_feishu_available_true_short_circuits
+# ---------------------------------------------------------------------------
+
+def test_feishu_available_true_short_circuits():
+    """FEISHU_AVAILABLE=True: check_feishu_requirements() short-circuits internally.
+
+    The v3 fix deliberately calls ``check_feishu_requirements()`` every time (unlike
+    the v1 proposal that tested ``FEISHU_AVAILABLE`` inline before calling it).
+    The short-circuit is *inside* ``check_feishu_requirements()`` at
+    ``feishu.py:1353``: ``if FEISHU_AVAILABLE: return True``.  This test verifies
+    that when deps are already available, ``ensure_and_bind()`` is never reached.
+
+    ``check_feishu_requirements`` on the mock module is a real closure (not a
+    MagicMock stand-in), so the short-circuit assertion is genuine — if it didn't
+    short-circuit, it *would* call ``ensure_and_bind``.
+    """
+    mock_mod, mock_cls, mock_inst = _build_mock_feishu_mod(
+        feishu_available=True,
+        feishu_domain="https://open.feishu.cn",
+        lark_domain="https://open.larksuite.com",
+    )
+
+    import gateway  # noqa: F401
+    import gateway.platforms  # noqa: F401
+
+    with patch.dict(sys.modules, {"gateway.platforms.feishu": mock_mod}), \
+         patch("tools.lazy_deps.ensure_and_bind") as mock_ensure:
+        from tools.send_message_tool import _send_feishu
+        result = asyncio.run(_send_feishu(
+            pconfig=MagicMock(),
+            chat_id="oc_test456",
+            message="Deps already available",
+        ))
+
+    assert result["success"] is True
+    mock_inst._build_lark_client.assert_called_once_with("https://open.feishu.cn")
+    # The real short-circuit inside check_feishu_requirements() skipped lazy install
+    mock_ensure.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 3. test_deliver_result_no_adapter_feishu_fallback
+# ---------------------------------------------------------------------------
+
+def test_deliver_result_no_adapter_feishu_fallback():
+    """No live adapter: _deliver_result falls back to standalone _send_to_platform → _send_feishu().
+
+    When adapters and loop are not provided (standalone cron tick from CLI or
+    dashboard), _deliver_result() must call _send_to_platform() which dispatches
+    to _send_feishu().  This test verifies the standalone path is taken.
+    """
+    from gateway.config import Platform, PlatformConfig
+
+    mock_pconfig = PlatformConfig(enabled=True, token="test-token")
+
+    mock_mod, mock_cls, mock_inst = _build_mock_feishu_mod(
+        feishu_available=True,
+        feishu_domain="https://open.feishu.cn",
+        lark_domain="https://open.larksuite.com",
+    )
+
+    # Build a job that delivers to feishu with explicit target resolution
+    job = {
+        "id": "job_test_standalone",
+        "deliver": "feishu:oc_standalone_test",
+    }
+
+    import gateway  # noqa: F401
+    import gateway.platforms  # noqa: F401
+
+    with patch.dict(sys.modules, {"gateway.platforms.feishu": mock_mod}):
+        from cron.scheduler import _deliver_result
+
+        # _deliver_result() does "from gateway.config import load_gateway_config"
+        # inside the function body, so the patch target must be gateway.config.
+        with patch("gateway.config.load_gateway_config") as mock_load_cfg:
+            mock_cfg = MagicMock()
+            mock_cfg.platforms = {Platform.FEISHU: mock_pconfig}
+            mock_load_cfg.return_value = mock_cfg
+
+            with patch("cron.scheduler.load_config", return_value={}):
+                # _deliver_result returns None on success
+                error = _deliver_result(
+                    job,
+                    "Standalone fallback test message",
+                    adapters=None,   # no live adapter → standalone path
+                    loop=None,
+                )
+
+    assert error is None
+
+
+# ---------------------------------------------------------------------------
+# 4. test_handle_send_to_feishu_hits_fixed_path
+# ---------------------------------------------------------------------------
+
+def test_handle_send_to_feishu_hits_fixed_path():
+    """_handle_send() targeting feishu routes through the repaired _send_feishu().
+
+    When a send_message tool call targets ``feishu:chat_xxx``, _handle_send()
+    calls _send_to_platform(Platform.FEISHU, ...) which dispatches to
+    _send_feishu().  This test verifies the full chain reaches the fixed
+    function and the lazy-install pathway works end-to-end.
+    """
+    from gateway.config import Platform, PlatformConfig
+
+    mock_pconfig = PlatformConfig(enabled=True, token="test-token")
+    mock_cfg = MagicMock()
+    mock_cfg.platforms = {Platform.FEISHU: mock_pconfig}
+    mock_cfg.get_home_channel.return_value = MagicMock(chat_id="oc_home_fallback")
+
+    mock_mod, mock_cls, mock_inst = _build_mock_feishu_mod(
+        feishu_available=False,
+        feishu_domain=None,
+        lark_domain=None,
+    )
+
+    import gateway  # noqa: F401
+    import gateway.platforms  # noqa: F401
+
+    # _handle_send() does "from gateway.config import load_gateway_config, ..."
+    # inside the function body → patch gateway.config, not tools.send_message_tool.
+    with patch.dict(sys.modules, {"gateway.platforms.feishu": mock_mod}), \
+         patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+         patch("tools.lazy_deps.ensure_and_bind", return_value=True):
+        from tools.send_message_tool import _handle_send
+
+        result_json = _handle_send({
+            "target": "feishu:oc_test123",
+            "message": "Fixed path test",
+        })
+        result = json.loads(result_json)
+
+    assert result["success"] is True
+    assert result["platform"] == "feishu"
+    assert result["message_id"] == "msg_test_123"
+    mock_cls.assert_called_once()
+    mock_inst.send.assert_awaited_once()
+    # _build_lark_client received the rebound domain (not None)
+    mock_inst._build_lark_client.assert_called_once_with("https://open.feishu.cn")
+
+
+# ---------------------------------------------------------------------------
+# 5. test_lazy_install_fails_returns_error
+# ---------------------------------------------------------------------------
+
+def test_lazy_install_fails_returns_error():
+    """When check_feishu_requirements() returns False, _send_feishu() returns an error dict.
+
+    Covers the failure branch promised by v3 doc §5.2: if lazy-install cannot
+    satisfy the feishu dependencies, the caller gets a clear error message
+    instead of an unhandled exception.
+    """
+    mock_mod, mock_cls, mock_inst = _build_mock_feishu_mod(
+        feishu_available=False,
+        feishu_domain=None,
+        lark_domain=None,
+    )
+
+    import gateway  # noqa: F401
+    import gateway.platforms  # noqa: F401
+
+    with patch.dict(sys.modules, {"gateway.platforms.feishu": mock_mod}), \
+         patch("tools.lazy_deps.ensure_and_bind", return_value=False):
+        from tools.send_message_tool import _send_feishu
+        result = asyncio.run(_send_feishu(
+            pconfig=MagicMock(),
+            chat_id="oc_test789",
+            message="This should fail",
+        ))
+
+    assert result.get("error") is not None
+    assert "Feishu requirements not met" in result["error"]

--- a/tests/tools/test_terminal_tool_pty_fallback.py
+++ b/tests/tools/test_terminal_tool_pty_fallback.py
@@ -89,3 +89,64 @@ def test_terminal_background_keeps_pty_for_regular_interactive_commands(monkeypa
 
     assert captured["use_pty"] is True
     assert "pty_note" not in result
+
+
+def test_should_preserve_on_restart_matches_top_level_codex_and_claude():
+    assert terminal_tool_module._should_preserve_on_restart(
+        "codex --version", background=True, pty=True, env_type="local"
+    ) is True
+    assert terminal_tool_module._should_preserve_on_restart(
+        "cd /tmp && claude", background=True, pty=True, env_type="local"
+    ) is True
+    assert terminal_tool_module._should_preserve_on_restart(
+        "export https_proxy=http://127.0.0.1:8080 && codex exec", background=True, pty=True, env_type="local"
+    ) is True
+    assert terminal_tool_module._should_preserve_on_restart(
+        "env FOO=bar BAR=baz codex exec", background=True, pty=True, env_type="local"
+    ) is True
+
+
+def test_should_preserve_on_restart_ignores_wrappers_and_echo():
+    assert terminal_tool_module._should_preserve_on_restart(
+        "echo codex", background=True, pty=True, env_type="local"
+    ) is False
+    assert terminal_tool_module._should_preserve_on_restart(
+        "bash -lc 'codex --help'", background=True, pty=True, env_type="local"
+    ) is False
+
+
+def test_terminal_background_marks_codex_session_preserved(monkeypatch, tmp_path):
+    config = _base_config(tmp_path)
+    dummy_env = SimpleNamespace(env={})
+    session = SimpleNamespace(
+        id="proc_test",
+        pid=1234,
+        notify_on_complete=False,
+        output_path="/tmp/process-output/proc_test.log",
+    )
+
+    def fake_spawn_local(**_kwargs):
+        return session
+
+    monkeypatch.setattr(terminal_tool_module, "_get_env_config", lambda: config)
+    monkeypatch.setattr(terminal_tool_module, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(terminal_tool_module, "_check_all_guards", lambda *_args, **_kwargs: {"approved": True})
+    monkeypatch.setattr(process_registry_module.process_registry, "spawn_local", fake_spawn_local)
+    monkeypatch.setitem(terminal_tool_module._active_environments, "default", dummy_env)
+    monkeypatch.setitem(terminal_tool_module._last_activity, "default", 0.0)
+
+    try:
+        result = json.loads(
+            terminal_tool_module.terminal_tool(
+                command="cd /tmp && codex",
+                background=True,
+                pty=True,
+            )
+        )
+    finally:
+        terminal_tool_module._active_environments.pop("default", None)
+        terminal_tool_module._last_activity.pop("default", None)
+
+    assert result["preserve_on_restart"] is True
+    assert result["log_path"] == "/tmp/process-output/proc_test.log"
+    assert session.preserve_on_restart is True

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -453,6 +453,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["workdir"] = job["workdir"]
     if job.get("profile"):
         result["profile"] = job["profile"]
+    if "script_args" in job:
+        result["script_args"] = job["script_args"]
     return result
 
 
@@ -477,6 +479,7 @@ def cronjob(
     workdir: Optional[str] = None,
     profile: Optional[str] = None,
     no_agent: Optional[bool] = None,
+    script_args: Optional[List[str]] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -544,6 +547,7 @@ def cronjob(
                 workdir=_normalize_optional_job_value(workdir),
                 profile=_normalize_optional_job_value(profile),
                 no_agent=_no_agent,
+                script_args=script_args,
             )
             return json.dumps(
                 {
@@ -681,6 +685,14 @@ def cronjob(
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.
                 updates["profile"] = _normalize_optional_job_value(profile) or None
+            if script_args is not None:
+                if isinstance(script_args, list):
+                    updates["script_args"] = [str(a) for a in script_args]
+                else:
+                    return tool_error(
+                        f"script_args must be a list of strings, got {type(script_args).__name__}",
+                        success=False,
+                    )
             if no_agent is not None:
                 # Toggling no_agent on/off at update time. If flipping to True,
                 # we need a script to already exist on the job (or be part of
@@ -794,6 +806,11 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "string",
                 "description": f"Optional path to a script that runs each tick. In the default mode its stdout is injected into the agent's prompt as context (data-collection / change-detection pattern). With no_agent=True, the script IS the job and its stdout is delivered verbatim (classic watchdog pattern). Relative paths resolve under {display_hermes_home()}/scripts/. ``.sh``/``.bash`` extensions run via bash, everything else via Python. On update, pass empty string to clear."
             },
+            "script_args": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional list of string arguments to pass to the script. When set, these are appended to the subprocess argv after the script path (e.g. ['--mode', 'close']). When omitted or empty, the script runs with no extra arguments."
+            },
             "no_agent": {
                 "type": "boolean",
                 "default": False,
@@ -894,6 +911,7 @@ registry.register(
         workdir=args.get("workdir"),
         profile=args.get("profile"),
         no_agent=args.get("no_agent"),
+        script_args=args.get("script_args"),
         task_id=kw.get("task_id"),
     ))(),
     check_fn=check_cronjob_requirements,

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -86,6 +86,16 @@ def format_uptime_short(seconds: int) -> str:
     return f"{hours}h {mins}m"
 
 
+def _normalize_output_preview(text: str, limit: int = 80) -> str:
+    """Collapse output to a short single-line preview for notifications."""
+    collapsed = " ".join(str(text or "").split())
+    if not collapsed:
+        return "(no output)"
+    if len(collapsed) > limit:
+        return collapsed[:limit] + "..."
+    return collapsed
+
+
 @dataclass
 class ProcessSession:
     """A tracked background process with output buffering."""
@@ -102,6 +112,8 @@ class ProcessSession:
     exit_code: Optional[int] = None             # Exit code (None if still running)
     output_buffer: str = ""                     # Rolling output (last MAX_OUTPUT_CHARS)
     max_output_chars: int = MAX_OUTPUT_CHARS
+    output_path: Optional[str] = None           # Host log file path (tee target)
+    output_bytes: int = 0                       # Total bytes written to output_path
     detached: bool = False                      # True if recovered from crash (no pipe)
     pid_scope: str = "host"                     # "host" for local/PTY PIDs, "sandbox" for env-local PIDs
     # Watcher/notification metadata (persisted for crash recovery)
@@ -113,6 +125,7 @@ class ProcessSession:
     watcher_message_id: str = ""                # Triggering message id — reply anchor for topic routing
     watcher_interval: int = 0                   # 0 = no watcher configured
     notify_on_complete: bool = False             # Queue agent notification on exit
+    preserve_on_restart: bool = False            # Keep process alive across planned restarts
     # Watch patterns — trigger agent notification when output matches any pattern
     watch_patterns: List[str] = field(default_factory=list)
     _watch_hits: int = field(default=0, repr=False)          # total matches delivered
@@ -512,6 +525,40 @@ class ProcessRegistry:
                 logger.debug("Could not resolve environment temp dir: %s", exc)
         return "/tmp"
 
+    @staticmethod
+    def _append_output_buffer(session: ProcessSession, text: str) -> None:
+        """Append output to the rolling in-memory buffer."""
+        with session._lock:
+            session.output_buffer += text
+            if len(session.output_buffer) > session.max_output_chars:
+                session.output_buffer = session.output_buffer[-session.max_output_chars:]
+
+    @staticmethod
+    def _persist_output_chunk(session: ProcessSession, text: str, log_fh=None) -> bool:
+        """Append output to the persistent log file when available."""
+        if not text or not session.output_path:
+            return False
+        try:
+            if log_fh is not None:
+                log_fh.write(text)
+                log_fh.flush()
+            else:
+                with open(session.output_path, "a", encoding="utf-8", errors="replace") as fh:
+                    fh.write(text)
+                    fh.flush()
+            return True
+        except OSError:
+            return False
+
+    def _record_output_chunk(self, session: ProcessSession, text: str, log_fh=None) -> None:
+        """Append output to the rolling buffer and persistent log."""
+        if not text:
+            return
+        self._append_output_buffer(session, text)
+        if self._persist_output_chunk(session, text, log_fh=log_fh):
+            with session._lock:
+                session.output_bytes += len(text.encode("utf-8", errors="replace"))
+
     def spawn_local(
         self,
         command: str,
@@ -539,6 +586,19 @@ class ProcessRegistry:
             cwd=_resolve_safe_cwd(cwd or os.getcwd()),
             started_at=time.time(),
         )
+
+        # Create host log file for tee output before reader threads start.
+        # Best-effort: if the directory cannot be created (e.g. HOME points
+        # to a non-existent path in a test environment), leave output_path
+        # unset so readers fall back to the in-memory buffer.
+        try:
+            output_dir = get_hermes_home() / "process-output"
+            output_dir.mkdir(parents=True, exist_ok=True)
+            output_path = str(output_dir / f"{session.id}.log")
+            open(output_path, "a").close()  # touch
+            session.output_path = output_path
+        except OSError:
+            pass
 
         if use_pty:
             # Try PTY mode for interactive CLI tools
@@ -683,6 +743,7 @@ class ProcessRegistry:
         # Run the command in the sandbox with output capture
         temp_dir = self._env_temp_dir(env)
         log_path = f"{temp_dir}/hermes_bg_{session.id}.log"
+        session.output_path = log_path
         pid_path = f"{temp_dir}/hermes_bg_{session.id}.pid"
         exit_path = f"{temp_dir}/hermes_bg_{session.id}.exit"
         quoted_command = shlex.quote(command)
@@ -750,6 +811,12 @@ class ProcessRegistry:
     def _reader_loop(self, session: ProcessSession):
         """Background thread: read stdout from a local Popen process."""
         first_chunk = True
+        log_fh = None
+        if session.output_path:
+            try:
+                log_fh = open(session.output_path, "a", encoding="utf-8", errors="replace")
+            except OSError:
+                log_fh = None
         try:
             while True:
                 chunk = session.process.stdout.read(4096)
@@ -758,14 +825,16 @@ class ProcessRegistry:
                 if first_chunk:
                     chunk = self._clean_shell_noise(chunk)
                     first_chunk = False
-                with session._lock:
-                    session.output_buffer += chunk
-                    if len(session.output_buffer) > session.max_output_chars:
-                        session.output_buffer = session.output_buffer[-session.max_output_chars:]
+                self._record_output_chunk(session, chunk, log_fh=log_fh)
                 self._check_watch_patterns(session, chunk)
         except Exception as e:
             logger.debug("Process stdout reader ended: %s", e)
         finally:
+            if log_fh:
+                try:
+                    log_fh.close()
+                except OSError:
+                    pass
             # Always reap the child to prevent zombie processes.
             try:
                 session.process.wait(timeout=5)
@@ -797,6 +866,7 @@ class ProcessRegistry:
                         session.output_buffer = new_output
                         if len(session.output_buffer) > session.max_output_chars:
                             session.output_buffer = session.output_buffer[-session.max_output_chars:]
+                        session.output_bytes = len(new_output.encode("utf-8", errors="replace"))
                     if delta:
                         self._check_watch_patterns(session, delta)
 
@@ -831,6 +901,12 @@ class ProcessRegistry:
     def _pty_reader_loop(self, session: ProcessSession):
         """Background thread: read output from a PTY process."""
         pty = session._pty
+        log_fh = None
+        if session.output_path:
+            try:
+                log_fh = open(session.output_path, "a", encoding="utf-8", errors="replace")
+            except OSError:
+                log_fh = None
         try:
             while pty.isalive():
                 try:
@@ -838,10 +914,7 @@ class ProcessRegistry:
                     if chunk:
                         # ptyprocess returns bytes
                         text = chunk if isinstance(chunk, str) else chunk.decode("utf-8", errors="replace")
-                        with session._lock:
-                            session.output_buffer += text
-                            if len(session.output_buffer) > session.max_output_chars:
-                                session.output_buffer = session.output_buffer[-session.max_output_chars:]
+                        self._record_output_chunk(session, text, log_fh=log_fh)
                         self._check_watch_patterns(session, text)
                 except EOFError:
                     break
@@ -849,6 +922,12 @@ class ProcessRegistry:
                     break
         except Exception as e:
             logger.debug("PTY stdout reader ended: %s", e)
+        finally:
+            if log_fh:
+                try:
+                    log_fh.close()
+                except OSError:
+                    pass
 
         # Process exited
         try:
@@ -871,19 +950,23 @@ class ProcessRegistry:
             self._finished[session.id] = session
         self._write_checkpoint()
 
+        # Best-effort cleanup of orphaned output log files
+        self._cleanup_output_dir()
+
         # Only enqueue completion notification on the FIRST move.  Without
         # this guard, kill_process() and the reader thread can both call
         # _move_to_finished(), producing duplicate [IMPORTANT: ...] messages.
         if was_running and session.notify_on_complete:
-            from tools.ansi_strip import strip_ansi
-            output_tail = strip_ansi(session.output_buffer[-2000:]) if session.output_buffer else ""
+            output_preview = self._notification_preview_for_session(session)
             self.completion_queue.put({
                 "type": "completion",
                 "session_id": session.id,
                 "session_key": session.session_key,
                 "command": session.command,
                 "exit_code": session.exit_code,
-                "output": output_tail,
+                "output": output_preview,
+                "preview": output_preview,
+                "output_path": session.output_path,
             })
 
     # ----- Query Methods -----
@@ -976,11 +1059,9 @@ class ProcessRegistry:
             except Exception as e:
                 logger.debug("Non-blocking drain failed for %s: %s", session.id, e)
 
+        if drained:
+            self._record_output_chunk(session, drained)
         with session._lock:
-            if drained:
-                session.output_buffer += drained
-                if len(session.output_buffer) > session.max_output_chars:
-                    session.output_buffer = session.output_buffer[-session.max_output_chars:]
             session.exited = True
             session.exit_code = rc
         logger.info(
@@ -1002,8 +1083,7 @@ class ProcessRegistry:
         # Guards against orphaned-pipe reader hangs (issue #17327).
         self._reconcile_local_exit(session)
 
-        with session._lock:
-            output_preview = strip_ansi(session.output_buffer[-1000:]) if session.output_buffer else ""
+        output_preview = self._read_output_tail(session, 1000)
 
         result = {
             "session_id": session.id,
@@ -1018,19 +1098,62 @@ class ProcessRegistry:
             self._completion_consumed.add(session_id)
         if session.detached:
             result["detached"] = True
-            result["note"] = "Process recovered after restart -- output history unavailable"
+            if not session.output_path or not os.path.isfile(session.output_path):
+                result["note"] = "Process recovered after restart -- output history unavailable"
         return result
 
+    @staticmethod
+    def _read_output_tail(session: ProcessSession, chars: int) -> str:
+        """Read the last *chars* characters of session output.
+
+        Prefers the persistent log file when available; falls back to the
+        in-memory output_buffer.
+        """
+        from tools.ansi_strip import strip_ansi
+
+        if session.output_path and os.path.isfile(session.output_path):
+            try:
+                with open(session.output_path, "r", encoding="utf-8", errors="replace") as fh:
+                    fh.seek(0, os.SEEK_END)
+                    size = fh.tell()
+                    if size <= chars:
+                        fh.seek(0)
+                        return strip_ansi(fh.read())
+                    fh.seek(max(0, size - chars))
+                    # Skip partial first line
+                    fh.readline()
+                    return strip_ansi(fh.read())
+            except OSError:
+                pass
+        with session._lock:
+            return strip_ansi(session.output_buffer[-chars:]) if session.output_buffer else ""
+
     def read_log(self, session_id: str, offset: int = 0, limit: int = 200) -> dict:
-        """Read the full output log with optional pagination by lines."""
+        """Read the full output log with optional pagination by lines.
+
+        Prefers reading from the persistent output_path file when available.
+        Falls back to the in-memory output_buffer only when the file is missing.
+        """
         from tools.ansi_strip import strip_ansi
 
         session = self.get(session_id)
         if session is None:
             return {"status": "not_found", "error": f"No process with ID {session_id}"}
 
-        with session._lock:
-            full_output = strip_ansi(session.output_buffer)
+        # Prefer persistent log file when available
+        file_output = None
+        if session.output_path and os.path.isfile(session.output_path):
+            try:
+                with open(session.output_path, "r", encoding="utf-8", errors="replace") as fh:
+                    file_output = strip_ansi(fh.read())
+            except OSError:
+                file_output = None
+
+        if file_output is not None:
+            full_output = file_output
+        else:
+            with session._lock:
+                full_output = strip_ansi(session.output_buffer)
 
         lines = full_output.splitlines()
         total_lines = len(lines)
@@ -1278,6 +1401,7 @@ class ProcessRegistry:
 
         result = []
         for s in all_sessions:
+            preview = self._read_output_tail(s, 200)
             entry = {
                 "session_id": s.id,
                 "command": s.command[:200],
@@ -1286,7 +1410,7 @@ class ProcessRegistry:
                 "started_at": time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime(s.started_at)),
                 "uptime_seconds": int(time.time() - s.started_at),
                 "status": "exited" if s.exited else "running",
-                "output_preview": s.output_buffer[-200:] if s.output_buffer else "",
+                "output_preview": preview,
             }
             if s.exited:
                 entry["exit_code"] = s.exit_code
@@ -1325,12 +1449,23 @@ class ProcessRegistry:
                 for s in self._running.values()
             )
 
-    def kill_all(self, task_id: str = None) -> int:
-        """Kill all running processes, optionally filtered by task_id. Returns count killed."""
+    def kill_all(self, task_id: str = None, include_preserved: bool = True) -> int:
+        """Kill all running processes, optionally filtered by task_id.
+
+        Args:
+            task_id: Optional task/session filter.
+            include_preserved: When False, keep sessions marked
+                preserve_on_restart=True alive across a planned restart.
+
+        Returns:
+            Count of killed or already-exited sessions.
+        """
         with self._lock:
             targets = [
                 s for s in self._running.values()
-                if (task_id is None or s.task_id == task_id) and not s.exited
+                if (task_id is None or s.task_id == task_id)
+                and not s.exited
+                and (include_preserved or not s.preserve_on_restart)
             ]
 
         killed = 0
@@ -1369,6 +1504,69 @@ class ProcessRegistry:
         if stale:
             self._completion_consumed -= stale
 
+    def _cleanup_output_dir(self):
+        """Remove orphaned output log files from process-output/.
+
+        An orphan is a *.log file whose stem (session ID) is not referenced
+        by any active session (running or finished).  Orphans are only
+        deleted when their mtime is >= 7 days old; younger orphans are kept
+        as a safety buffer.  Files whose session ID still appears in
+        _running or _finished are NEVER deleted regardless of age.
+
+        Best-effort: any missing-file, permission, or single-delete failure
+        is logged and skipped without interrupting the cleanup pass.
+        """
+        output_dir = get_hermes_home() / "process-output"
+        if not output_dir.is_dir():
+            return
+        now = time.time()
+        seven_days = 7 * 24 * 3600
+
+        with self._lock:
+            tracked_sessions = list(self._running.values()) + list(self._finished.values())
+            referenced_ids = {s.id for s in tracked_sessions}
+            referenced_paths = {
+                os.path.abspath(s.output_path)
+                for s in tracked_sessions
+                if s.output_path
+            }
+
+        try:
+            if CHECKPOINT_PATH.exists():
+                entries = json.loads(CHECKPOINT_PATH.read_text(encoding="utf-8"))
+                if isinstance(entries, list):
+                    for entry in entries:
+                        if not isinstance(entry, dict):
+                            continue
+                        output_path = entry.get("output_path")
+                        if isinstance(output_path, str) and output_path:
+                            referenced_paths.add(os.path.abspath(output_path))
+        except Exception:
+            pass
+
+        try:
+            for entry in os.scandir(output_dir):
+                if not entry.is_file(follow_symlinks=False):
+                    continue
+                if not entry.name.endswith(".log"):
+                    continue
+                # Derive session ID from filename: proc_xxxxxxxxxxxx.log → proc_xxxxxxxxxxxx
+                stem = entry.name[:-4]
+                if stem in referenced_ids or os.path.abspath(entry.path) in referenced_paths:
+                    continue  # never delete currently-tracked session logs
+                try:
+                    mtime = entry.stat(follow_symlinks=False).st_mtime
+                except OSError:
+                    continue
+                if (now - mtime) < seven_days:
+                    continue  # keep young orphans as safety buffer
+                try:
+                    os.unlink(entry.path)
+                except OSError:
+                    pass
+        except OSError:
+            pass
+
     # ----- Checkpoint (crash recovery) -----
 
     def _write_checkpoint(self):
@@ -1395,7 +1593,10 @@ class ProcessRegistry:
                             "watcher_message_id": s.watcher_message_id,
                             "watcher_interval": s.watcher_interval,
                             "notify_on_complete": s.notify_on_complete,
+                            "preserve_on_restart": s.preserve_on_restart,
                             "watch_patterns": s.watch_patterns,
+                            "output_path": s.output_path,
+                            "output_bytes": s.output_bytes,
                         })
             
             # Atomic write to avoid corruption on crash
@@ -1403,6 +1604,11 @@ class ProcessRegistry:
             atomic_json_write(CHECKPOINT_PATH, entries)
         except Exception as e:
             logger.debug("Failed to write checkpoint file: %s", e, exc_info=True)
+        else:
+            # Best-effort cleanup of orphaned output log files after each
+            # successful checkpoint write so the output dir doesn't grow
+            # without bound across long-running gateway processes.
+            self._cleanup_output_dir()
 
     def recover_from_checkpoint(self) -> int:
         """
@@ -1450,7 +1656,9 @@ class ProcessRegistry:
                     pid_scope=pid_scope,
                     cwd=entry.get("cwd"),
                     started_at=entry.get("started_at", time.time()),
-                    detached=True,  # Can't read output, but can report status + kill
+                    detached=True,
+                    output_path=entry.get("output_path"),
+                    output_bytes=entry.get("output_bytes", 0),
                     watcher_platform=entry.get("watcher_platform", ""),
                     watcher_chat_id=entry.get("watcher_chat_id", ""),
                     watcher_user_id=entry.get("watcher_user_id", ""),
@@ -1459,6 +1667,7 @@ class ProcessRegistry:
                     watcher_message_id=entry.get("watcher_message_id", ""),
                     watcher_interval=entry.get("watcher_interval", 0),
                     notify_on_complete=entry.get("notify_on_complete", False),
+                    preserve_on_restart=entry.get("preserve_on_restart", False),
                     watch_patterns=entry.get("watch_patterns", []),
                 )
                 with self._lock:
@@ -1483,7 +1692,32 @@ class ProcessRegistry:
 
         self._write_checkpoint()
 
+        # Best-effort cleanup of orphaned output log files
+        self._cleanup_output_dir()
+
         return recovered
+
+    @staticmethod
+    def _notification_preview_for_session(session: ProcessSession, limit: int = 80) -> str:
+        """Build a short preview for completion notifications.
+
+        Prefer the start of the persisted log file when available so the
+        preview remains stable even when the rolling in-memory buffer only
+        contains the tail of long-running output.
+        """
+        from tools.ansi_strip import strip_ansi
+
+        raw = ""
+        if session.output_path and os.path.isfile(session.output_path):
+            try:
+                with open(session.output_path, "r", encoding="utf-8", errors="replace") as fh:
+                    raw = fh.read(max(512, limit * 4))
+            except OSError:
+                raw = ""
+        if not raw:
+            with session._lock:
+                raw = session.output_buffer or ""
+        return _normalize_output_preview(strip_ansi(raw), limit=limit)
 
 
 # Module-level singleton
@@ -1519,12 +1753,14 @@ def format_process_notification(evt: dict) -> "str | None":
         return text
 
     _exit = evt.get("exit_code", "?")
-    _out = evt.get("output", "")
+    _preview = evt.get("preview") or evt.get("output") or "(no output)"
+    _path = evt.get("output_path") or "unavailable"
     return (
         f"[IMPORTANT: Background process {_sid} completed "
         f"(exit code {_exit}).\n"
         f"Command: {_cmd}\n"
-        f"Output:\n{_out}]"
+        f"Preview: {_preview}\n"
+        f"Full output saved to: {_path}]"
     )
 
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -603,6 +603,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         from gateway.platforms.feishu import FeishuAdapter
         _feishu_available = True
     except ImportError:
+        logger.debug("_send_to_platform: Feishu adapter import failed, max_message_length unavailable", exc_info=True)
         _feishu_available = False
 
     media_files = media_files or []
@@ -1598,9 +1599,20 @@ async def _send_feishu(pconfig, chat_id, message, media_files=None, thread_id=No
             return {"error": "Feishu requirements not met. Run: pip install 'hermes-agent[feishu]'"}
         FeishuAdapter = feishu_mod.FeishuAdapter
     except ImportError:
+        import traceback
+        tb = traceback.format_exc()
+        logger.warning("feishu import failed in _send_feishu:\n%s", tb)
+        try:
+            with open(os.path.expanduser("~/.hermes/tmp/feishu_import_traceback.txt"), "a") as f:
+                f.write(f"{__import__('datetime').datetime.now().isoformat()} _send_feishu ImportError:\n{tb}\n---\n")
+        except Exception:
+            pass
         return {"error": "Feishu dependencies not installed. Run: pip install 'hermes-agent[feishu]'"}
 
     media_files = media_files or []
+    # Normalize empty string thread_id → None to avoid writing empty root_id
+    # in _build_create_message_body (feishu API rejects "" as root_id).
+    thread_id = thread_id or None
 
     try:
         adapter = FeishuAdapter(pconfig)

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1593,10 +1593,10 @@ async def _send_bluebubbles(extra, chat_id, message):
 async def _send_feishu(pconfig, chat_id, message, media_files=None, thread_id=None):
     """Send via Feishu/Lark using the adapter's send pipeline."""
     try:
-        from gateway.platforms.feishu import FeishuAdapter, FEISHU_AVAILABLE
-        if not FEISHU_AVAILABLE:
-            return {"error": "Feishu dependencies not installed. Run: pip install 'hermes-agent[feishu]'"}
-        from gateway.platforms.feishu import FEISHU_DOMAIN, LARK_DOMAIN
+        import gateway.platforms.feishu as feishu_mod
+        if not feishu_mod.check_feishu_requirements():
+            return {"error": "Feishu requirements not met. Run: pip install 'hermes-agent[feishu]'"}
+        FeishuAdapter = feishu_mod.FeishuAdapter
     except ImportError:
         return {"error": "Feishu dependencies not installed. Run: pip install 'hermes-agent[feishu]'"}
 
@@ -1605,7 +1605,7 @@ async def _send_feishu(pconfig, chat_id, message, media_files=None, thread_id=No
     try:
         adapter = FeishuAdapter(pconfig)
         domain_name = getattr(adapter, "_domain_name", "feishu")
-        domain = FEISHU_DOMAIN if domain_name != "lark" else LARK_DOMAIN
+        domain = feishu_mod.FEISHU_DOMAIN if domain_name != "lark" else feishu_mod.LARK_DOMAIN
         adapter._client = adapter._build_lark_client(domain)
         metadata = {"thread_id": thread_id} if thread_id else None
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -37,6 +37,7 @@ import logging
 import os
 import platform
 import re
+import shlex
 import time
 import threading
 import atexit
@@ -1638,6 +1639,61 @@ def _command_requires_pipe_stdin(command: str) -> bool:
     )
 
 
+_ENV_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*$")
+_SHELL_CONTROL_TOKENS = {"&&", "||", ";", "|", "&", "(", ")"}
+_SKIPPED_LEADING_BUILTINS = {"cd", "export", "env"}
+_PRESERVE_ON_RESTART_EXECUTABLES = {"codex", "claude"}
+
+
+def _normalize_executable_name(token: str) -> str:
+    name = os.path.basename(str(token or "")).lower()
+    for suffix in (".ps1", ".cmd", ".bat", ".exe"):
+        if name.endswith(suffix):
+            return name[: -len(suffix)]
+    return name
+
+
+def _should_preserve_on_restart(
+    command: str,
+    background: bool,
+    pty: bool,
+    env_type: str,
+) -> bool:
+    """Return True for local PTY Codex/Claude sessions that should survive restart."""
+    if not background or not pty or env_type != "local":
+        return False
+
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return False
+
+    i = 0
+    while i < len(tokens):
+        token = tokens[i]
+        lowered = token.lower()
+
+        if token in _SHELL_CONTROL_TOKENS:
+            i += 1
+            continue
+        if _ENV_ASSIGNMENT_RE.match(token):
+            i += 1
+            continue
+        if lowered in _SKIPPED_LEADING_BUILTINS:
+            i += 1
+            if lowered == "env":
+                while i < len(tokens) and _ENV_ASSIGNMENT_RE.match(tokens[i]):
+                    i += 1
+            else:
+                while i < len(tokens) and tokens[i] not in _SHELL_CONTROL_TOKENS:
+                    i += 1
+            continue
+
+        return _normalize_executable_name(token) in _PRESERVE_ON_RESTART_EXECUTABLES
+
+    return False
+
+
 _SHELL_LEVEL_BACKGROUND_RE = re.compile(
     r"(?:^|[;&|]\s*|&&\s*|\|\|\s*|\$\(\s*)(?:nohup|disown|setsid)\b", re.IGNORECASE | re.MULTILINE
 )
@@ -2072,6 +2128,8 @@ def terminal_tool(
                     "output": "Background process started",
                     "session_id": proc_session.id,
                     "pid": proc_session.pid,
+                    "log_path": getattr(proc_session, "output_path", None),
+                    "preserve_on_restart": False,
                     "exit_code": 0,
                     "error": None,
                 }
@@ -2079,6 +2137,21 @@ def terminal_tool(
                     result_data["approval"] = approval_note
                 if pty_disabled_reason:
                     result_data["pty_note"] = pty_disabled_reason
+
+                actual_pty = effective_pty
+                if hasattr(proc_session, "_pty"):
+                    actual_pty = getattr(proc_session, "_pty", None) is not None
+                preserve_on_restart = _should_preserve_on_restart(
+                    command=command,
+                    background=bool(background),
+                    pty=bool(actual_pty),
+                    env_type=env_type,
+                )
+                if preserve_on_restart:
+                    proc_session.preserve_on_restart = True
+                result_data["preserve_on_restart"] = bool(
+                    getattr(proc_session, "preserve_on_restart", False)
+                )
 
                 # Nudge: background=True without notify_on_complete=True OR
                 # watch_patterns is a silent process. The agent has NO way to

--- a/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-claude-code.md
+++ b/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-claude-code.md
@@ -53,7 +53,7 @@ Hermes interacts with Claude Code in two fundamentally different ways. Choose ba
 Print mode runs a one-shot task, returns the result, and exits. No PTY needed. No interactive prompts. This is the cleanest integration path.
 
 ```
-terminal(command="claude -p 'Add error handling to all API calls in src/' --allowedTools 'Read,Edit' --max-turns 10", workdir="/path/to/project", timeout=120)
+terminal(command="claude -p 'Add error handling to all API calls in src/' --allowedTools 'Read,Edit' --max-turns 40", workdir="/path/to/project", timeout=120)
 ```
 
 **When to use print mode:**
@@ -162,7 +162,7 @@ terminal(command="sleep 15 && tmux capture-pane -t claude-work -p -S -60")
 
 ### Structured JSON Output
 ```
-terminal(command="claude -p 'Analyze auth.py for security issues' --output-format json --max-turns 5", workdir="/project", timeout=120)
+terminal(command="claude -p 'Analyze auth.py for security issues' --output-format json --max-turns 60", workdir="/project", timeout=120)
 ```
 
 Returns a JSON object with:
@@ -208,13 +208,13 @@ claude -p "task" --input-format stream-json --output-format stream-json --replay
 ### Piped Input
 ```
 # Pipe a file for analysis
-terminal(command="cat src/auth.py | claude -p 'Review this code for bugs' --max-turns 1", timeout=60)
+terminal(command="cat src/auth.py | claude -p 'Review this code for bugs' --max-turns 60", timeout=60)
 
 # Pipe multiple files
-terminal(command="cat src/*.py | claude -p 'Find all TODO comments' --max-turns 1", timeout=60)
+terminal(command="cat src/*.py | claude -p 'Find all TODO comments' --max-turns 5", timeout=60)
 
 # Pipe command output
-terminal(command="git diff HEAD~3 | claude -p 'Summarize these changes' --max-turns 1", timeout=60)
+terminal(command="git diff HEAD~3 | claude -p 'Summarize these changes' --max-turns 5", timeout=60)
 ```
 
 ### JSON Schema for Structured Extraction
@@ -227,21 +227,21 @@ Parse `structured_output` from the JSON result. Claude validates output against 
 ### Session Continuation
 ```
 # Start a task
-terminal(command="claude -p 'Start refactoring the database layer' --output-format json --max-turns 10 > /tmp/session.json", workdir="/project", timeout=180)
+terminal(command="claude -p 'Start refactoring the database layer' --output-format json --max-turns 40 > /tmp/session.json", workdir="/project", timeout=180)
 
 # Resume with session ID
-terminal(command="claude -p 'Continue and add connection pooling' --resume $(cat /tmp/session.json | python3 -c 'import json,sys; print(json.load(sys.stdin)[\"session_id\"])') --max-turns 5", workdir="/project", timeout=120)
+terminal(command="claude -p 'Continue and add connection pooling' --resume $(cat /tmp/session.json | python3 -c 'import json,sys; print(json.load(sys.stdin)[\"session_id\"])') --max-turns 40", workdir="/project", timeout=120)
 
 # Or resume the most recent session in the same directory
-terminal(command="claude -p 'What did you do last time?' --continue --max-turns 1", workdir="/project", timeout=30)
+terminal(command="claude -p 'What did you do last time?' --continue --max-turns 5", workdir="/project", timeout=30)
 
 # Fork a session (new ID, keeps history)
-terminal(command="claude -p 'Try a different approach' --resume <id> --fork-session --max-turns 10", workdir="/project", timeout=120)
+terminal(command="claude -p 'Try a different approach' --resume <id> --fork-session --max-turns 40", workdir="/project", timeout=120)
 ```
 
 ### Bare Mode for CI/Scripting
 ```
-terminal(command="claude --bare -p 'Run all tests and report failures' --allowedTools 'Read,Bash' --max-turns 10", workdir="/project", timeout=180)
+terminal(command="claude --bare -p 'Run all tests and report failures' --allowedTools 'Read,Bash' --max-turns 60", workdir="/project", timeout=180)
 ```
 
 `--bare` skips hooks, plugins, MCP discovery, and CLAUDE.md loading. Fastest startup. Requires `ANTHROPIC_API_KEY` (skips OAuth).
@@ -256,7 +256,7 @@ To selectively load context in bare mode:
 
 ### Fallback Model for Overload
 ```
-terminal(command="claude -p 'task' --fallback-model haiku --max-turns 5", timeout=90)
+terminal(command="claude -p 'task' --fallback-model haiku --max-turns 40", timeout=90)
 ```
 Automatically falls back to the specified model when the default is overloaded (print mode only).
 
@@ -488,7 +488,7 @@ Use the keyword "ultrathink" in your prompt for maximum reasoning effort on a sp
 
 ### Quick Review (Print Mode)
 ```
-terminal(command="cd /path/to/repo && git diff main...feature-branch | claude -p 'Review this diff for bugs, security issues, and style problems. Be thorough.' --max-turns 1", timeout=60)
+terminal(command="cd /path/to/repo && git diff main...feature-branch | claude -p 'Review this diff for bugs, security issues, and style problems. Be thorough.' --max-turns 60", timeout=60)
 ```
 
 ### Deep Review (Interactive + Worktree)
@@ -502,7 +502,7 @@ terminal(command="sleep 30 && tmux capture-pane -t review -p -S -60")
 
 ### PR Review from Number
 ```
-terminal(command="claude -p 'Review this PR thoroughly' --from-pr 42 --max-turns 10", workdir="/path/to/repo", timeout=120)
+terminal(command="claude -p 'Review this PR thoroughly' --from-pr 42 --max-turns 60", workdir="/path/to/repo", timeout=120)
 ```
 
 ### Claude Worktree with tmux
@@ -517,13 +517,13 @@ Run multiple independent Claude tasks simultaneously:
 
 ```
 # Task 1: Fix backend
-terminal(command="tmux new-session -d -s task1 -x 140 -y 40 && tmux send-keys -t task1 'cd ~/project && claude -p \"Fix the auth bug in src/auth.py\" --allowedTools \"Read,Edit\" --max-turns 10' Enter")
+terminal(command="tmux new-session -d -s task1 -x 140 -y 40 && tmux send-keys -t task1 'cd ~/project && claude -p \"Fix the auth bug in src/auth.py\" --allowedTools \"Read,Edit\" --max-turns 40' Enter")
 
 # Task 2: Write tests
-terminal(command="tmux new-session -d -s task2 -x 140 -y 40 && tmux send-keys -t task2 'cd ~/project && claude -p \"Write integration tests for the API endpoints\" --allowedTools \"Read,Write,Bash\" --max-turns 15' Enter")
+terminal(command="tmux new-session -d -s task2 -x 140 -y 40 && tmux send-keys -t task2 'cd ~/project && claude -p \"Write integration tests for the API endpoints\" --allowedTools \"Read,Write,Bash\" --max-turns 40' Enter")
 
 # Task 3: Update docs
-terminal(command="tmux new-session -d -s task3 -x 140 -y 40 && tmux send-keys -t task3 'cd ~/project && claude -p \"Update README.md with the new API endpoints\" --allowedTools \"Read,Edit\" --max-turns 5' Enter")
+terminal(command="tmux new-session -d -s task3 -x 140 -y 40 && tmux send-keys -t task3 'cd ~/project && claude -p \"Update README.md with the new API endpoints\" --allowedTools \"Read,Edit\" --max-turns 40' Enter")
 
 # Monitor all
 terminal(command="sleep 30 && for s in task1 task2 task3; do echo '=== '$s' ==='; tmux capture-pane -t $s -p -S -5 2>/dev/null; done")
@@ -722,7 +722,7 @@ Use `/context` in interactive mode to see a colored grid of context usage. Key t
 
 ## Cost & Performance Tips
 
-1. **Use `--max-turns`** in print mode to prevent runaway loops. Start with 5-10 for most tasks.
+1. **Use `--max-turns`** in print mode to prevent runaway loops. Baseline by task class: `review=60`, `implementation=40`, `extract=5`.
 2. **Use `--max-budget-usd`** for cost caps. Note: minimum ~$0.05 for system prompt cache creation.
 3. **Use `--effort low`** for simple tasks (faster, cheaper). `high` or `max` for complex reasoning.
 4. **Use `--bare`** for CI/scripting to skip plugin/hook discovery overhead.
@@ -742,7 +742,7 @@ Use `/context` in interactive mode to see a colored grid of context usage. Key t
 4. **`--max-turns` is print-mode only** — ignored in interactive sessions.
 5. **Claude may use `python` instead of `python3`** — on systems without a `python` symlink, Claude's bash commands will fail on first try but it self-corrects.
 6. **Session resumption requires same directory** — `--continue` finds the most recent session for the current working directory.
-7. **`--json-schema` needs enough `--max-turns`** — Claude must read files before producing structured output, which takes multiple turns.
+7. **`--json-schema` needs enough `--max-turns`** — use the `extract` baseline (`5`) for small structured reads, and move up to the `review` baseline (`60`) if Claude must inspect a larger diff or file set first.
 8. **Trust dialog only appears once per directory** — first-time only, then cached.
 9. **Background tmux sessions persist** — always clean up with `tmux kill-session -t <name>` when done.
 10. **Slash commands (like `/commit`) only work in interactive mode** — in `-p` mode, describe the task in natural language instead.
@@ -754,10 +754,62 @@ Use `/context` in interactive mode to see a colored grid of context usage. Key t
 1. **Prefer print mode (`-p`) for single tasks** — cleaner, no dialog handling, structured output
 2. **Use tmux for multi-turn interactive work** — the only reliable way to orchestrate the TUI
 3. **Always set `workdir`** — keep Claude focused on the right project directory
-4. **Set `--max-turns` in print mode** — prevents infinite loops and runaway costs
+4. **Set `--max-turns` in print mode using the three baselines** — `review=60`, `implementation=40`, `extract=5`
 5. **Monitor tmux sessions** — use `tmux capture-pane -t <session> -p -S -50` to check progress
 6. **Look for the `❯` prompt** — indicates Claude is waiting for input (done or asking a question)
 7. **Clean up tmux sessions** — kill them when done to avoid resource leaks
 8. **Report results to user** — after completion, summarize what Claude did and what changed
 9. **Don't kill slow sessions** — Claude may be doing multi-step work; check progress instead
 10. **Use `--allowedTools`** — restrict capabilities to what the task actually needs
+
+## Dispatch Template / Report Contract
+
+Canonical CC dispatch template: `skills/autonomous-ai-agents/claude-code/templates/default-dispatch.md`.
+
+### Template Injection Chain
+
+Before every Claude Code dispatch, the orchestrator MUST:
+
+1. Call `skill_view(name="claude-code", file_path="templates/default-dispatch.md")` to load the template.
+2. Render the placeholders: `<ABS_REPORT_PATH>`, `<JOB_ID>`, `<TASK_CLASS>`, `<TURN_BUDGET>`.
+3. Prepend the rendered template to the dispatch prompt, **before** the task description.
+4. Then append the specific task instructions.
+
+### Report Path Rules
+
+- `<ABS_REPORT_PATH>` must be an absolute path inside the target repo.
+- Fallback: `<repo>/.hermes-artifacts/reviews/<JOB_ID>.md`.
+- Create parent directories with `mkdir -p` first.
+- Never use `~` in paths.
+- Never report partial output as `completed`.
+
+### Turn Budget Baselines
+
+| Task Class | Range | Default `--max-turns` |
+|---|---|---|
+| `review` | 30–120 | 60 |
+| `implementation` | 20–80 | 40 |
+| `extract` | 1–10 | 5 |
+
+- Use the `review` bucket by default for review, debug, and refactor tasks.
+- Use the `implementation` bucket by default for features, fixes, tests, and other code changes.
+- Use the `extract` bucket by default for summarize, schema, and narrow extraction work.
+- In print mode, set `--max-turns` to the bucket default unless the caller explicitly overrides it.
+
+### Claude Print-Mode State Mapping
+
+| `subtype` | Ending State |
+|---|---|
+| `success` | `completed` |
+| `error_max_turns` | `over_budget` |
+| `error_budget` | `over_budget` |
+| (interrupted) | `interrupted` |
+
+If Claude stops early but leaves useful incomplete work, write `partial_output` in the report instead of `completed`.
+
+### Ending State Contract
+
+- `completed`: `subtype: success`, task done, report written.
+- `over_budget`: `error_max_turns` or `error_budget`; report must list done/undone/next.
+- `interrupted`: Killed or timed out; report must record checkpoint.
+- `partial_output`: Incomplete result; must be labeled partial, not `completed`.

--- a/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-codex.md
+++ b/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-codex.md
@@ -146,3 +146,44 @@ terminal(command="gh pr comment 86 --body '<review>'", workdir="~/project")
 5. **Background for long tasks** — use `background=true` and monitor with `process` tool
 6. **Don't interfere** — monitor with `poll`/`log`, be patient with long-running tasks
 7. **Parallel is fine** — run multiple Codex processes at once for batch work
+
+## Dispatch Template / Report Contract
+
+Canonical CX dispatch template: `skills/autonomous-ai-agents/codex/templates/default-dispatch.md`.
+
+### Template Injection Chain
+
+Before every Codex dispatch, the orchestrator MUST:
+
+1. Call `skill_view(name="codex", file_path="templates/default-dispatch.md")` to load the template.
+2. Render the placeholders: `<ABS_REPORT_PATH>`, `<JOB_ID>`, `<TASK_CLASS>`, `<TURN_BUDGET>`.
+3. Prepend the rendered template to the dispatch prompt, **before** the task description.
+4. Then append the specific task instructions.
+
+### Report Path Rules
+
+- `<ABS_REPORT_PATH>` must be an absolute path inside the target repo.
+- Fallback: `<repo>/.hermes-artifacts/reviews/<JOB_ID>.md`.
+- Create parent directories with `mkdir -p` first.
+- Never use `~` in paths.
+- Never report partial output as `completed`.
+
+### Turn Budget Baselines
+
+| Task Class | Range | Default |
+|---|---|---|
+| `review` | 30–120 | 60 |
+| `implementation` | 20–80 | 40 |
+| `extract` | 1–10 | 5 |
+
+- Use the `review` bucket by default for review, debug, and refactor tasks.
+- Use the `implementation` bucket by default for features, fixes, tests, and other code changes.
+- Use the `extract` bucket by default for summarize, schema, and narrow extraction work.
+- Codex does not have a single canonical `--max-turns` CLI pattern here, so the budget contract must be carried by the injected template and dispatch prompt.
+
+### Ending State Contract
+
+- `completed`: Task done within budget, report written.
+- `over_budget`: Budget exhausted; report must list done/undone/next.
+- `interrupted`: Externally interrupted; report must record checkpoint.
+- `partial_output`: Incomplete result; must be labeled partial, not `completed`.

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-claude-code.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-claude-code.md
@@ -53,7 +53,7 @@ Hermes 以两种根本不同的方式与 Claude Code 交互。请根据任务选
 Print 模式运行一次性任务，返回结果后退出。无需 PTY（伪终端），无交互式提示。这是最简洁的集成方式。
 
 ```
-terminal(command="claude -p 'Add error handling to all API calls in src/' --allowedTools 'Read,Edit' --max-turns 10", workdir="/path/to/project", timeout=120)
+terminal(command="claude -p 'Add error handling to all API calls in src/' --allowedTools 'Read,Edit' --max-turns 40", workdir="/path/to/project", timeout=120)
 ```
 
 **何时使用 print 模式：**
@@ -162,7 +162,7 @@ terminal(command="sleep 15 && tmux capture-pane -t claude-work -p -S -60")
 
 ### 结构化 JSON 输出
 ```
-terminal(command="claude -p 'Analyze auth.py for security issues' --output-format json --max-turns 5", workdir="/project", timeout=120)
+terminal(command="claude -p 'Analyze auth.py for security issues' --output-format json --max-turns 60", workdir="/project", timeout=120)
 ```
 
 返回包含以下字段的 JSON 对象：
@@ -208,13 +208,13 @@ claude -p "task" --input-format stream-json --output-format stream-json --replay
 ### 管道输入
 ```
 # 通过管道传入文件进行分析
-terminal(command="cat src/auth.py | claude -p 'Review this code for bugs' --max-turns 1", timeout=60)
+terminal(command="cat src/auth.py | claude -p 'Review this code for bugs' --max-turns 60", timeout=60)
 
 # 通过管道传入多个文件
-terminal(command="cat src/*.py | claude -p 'Find all TODO comments' --max-turns 1", timeout=60)
+terminal(command="cat src/*.py | claude -p 'Find all TODO comments' --max-turns 5", timeout=60)
 
 # 通过管道传入命令输出
-terminal(command="git diff HEAD~3 | claude -p 'Summarize these changes' --max-turns 1", timeout=60)
+terminal(command="git diff HEAD~3 | claude -p 'Summarize these changes' --max-turns 5", timeout=60)
 ```
 
 ### 使用 JSON Schema 进行结构化提取
@@ -227,21 +227,21 @@ terminal(command="claude -p 'List all functions in src/' --output-format json --
 ### 会话续接
 ```
 # 开始一个任务
-terminal(command="claude -p 'Start refactoring the database layer' --output-format json --max-turns 10 > /tmp/session.json", workdir="/project", timeout=180)
+terminal(command="claude -p 'Start refactoring the database layer' --output-format json --max-turns 40 > /tmp/session.json", workdir="/project", timeout=180)
 
 # 使用会话 ID 恢复
-terminal(command="claude -p 'Continue and add connection pooling' --resume $(cat /tmp/session.json | python3 -c 'import json,sys; print(json.load(sys.stdin)[\"session_id\"])') --max-turns 5", workdir="/project", timeout=120)
+terminal(command="claude -p 'Continue and add connection pooling' --resume $(cat /tmp/session.json | python3 -c 'import json,sys; print(json.load(sys.stdin)[\"session_id\"])') --max-turns 40", workdir="/project", timeout=120)
 
 # 或恢复同一目录中最近的会话
-terminal(command="claude -p 'What did you do last time?' --continue --max-turns 1", workdir="/project", timeout=30)
+terminal(command="claude -p 'What did you do last time?' --continue --max-turns 5", workdir="/project", timeout=30)
 
 # 派生会话（新 ID，保留历史）
-terminal(command="claude -p 'Try a different approach' --resume <id> --fork-session --max-turns 10", workdir="/project", timeout=120)
+terminal(command="claude -p 'Try a different approach' --resume <id> --fork-session --max-turns 40", workdir="/project", timeout=120)
 ```
 
 ### CI/脚本的精简模式
 ```
-terminal(command="claude --bare -p 'Run all tests and report failures' --allowedTools 'Read,Bash' --max-turns 10", workdir="/project", timeout=180)
+terminal(command="claude --bare -p 'Run all tests and report failures' --allowedTools 'Read,Bash' --max-turns 60", workdir="/project", timeout=180)
 ```
 
 `--bare` 跳过 hook、插件、MCP 发现和 CLAUDE.md 加载。启动最快。需要 `ANTHROPIC_API_KEY`（跳过 OAuth）。
@@ -256,7 +256,7 @@ terminal(command="claude --bare -p 'Run all tests and report failures' --allowed
 
 ### 过载时的备用模型
 ```
-terminal(command="claude -p 'task' --fallback-model haiku --max-turns 5", timeout=90)
+terminal(command="claude -p 'task' --fallback-model haiku --max-turns 40", timeout=90)
 ```
 当默认模型过载时自动切换到指定模型（仅限 print 模式）。
 
@@ -488,7 +488,7 @@ When asked to create or modify database migrations:
 
 ### 快速审查（Print 模式）
 ```
-terminal(command="cd /path/to/repo && git diff main...feature-branch | claude -p 'Review this diff for bugs, security issues, and style problems. Be thorough.' --max-turns 1", timeout=60)
+terminal(command="cd /path/to/repo && git diff main...feature-branch | claude -p 'Review this diff for bugs, security issues, and style problems. Be thorough.' --max-turns 60", timeout=60)
 ```
 
 ### 深度审查（交互式 + Worktree）
@@ -502,7 +502,7 @@ terminal(command="sleep 30 && tmux capture-pane -t review -p -S -60")
 
 ### 通过 PR 编号审查
 ```
-terminal(command="claude -p 'Review this PR thoroughly' --from-pr 42 --max-turns 10", workdir="/path/to/repo", timeout=120)
+terminal(command="claude -p 'Review this PR thoroughly' --from-pr 42 --max-turns 60", workdir="/path/to/repo", timeout=120)
 ```
 
 ### Claude Worktree 配合 tmux
@@ -517,13 +517,13 @@ terminal(command="claude -w feature-x --tmux", workdir="/path/to/repo")
 
 ```
 # 任务一：修复后端
-terminal(command="tmux new-session -d -s task1 -x 140 -y 40 && tmux send-keys -t task1 'cd ~/project && claude -p \"Fix the auth bug in src/auth.py\" --allowedTools \"Read,Edit\" --max-turns 10' Enter")
+terminal(command="tmux new-session -d -s task1 -x 140 -y 40 && tmux send-keys -t task1 'cd ~/project && claude -p \"Fix the auth bug in src/auth.py\" --allowedTools \"Read,Edit\" --max-turns 40' Enter")
 
 # 任务二：编写测试
-terminal(command="tmux new-session -d -s task2 -x 140 -y 40 && tmux send-keys -t task2 'cd ~/project && claude -p \"Write integration tests for the API endpoints\" --allowedTools \"Read,Write,Bash\" --max-turns 15' Enter")
+terminal(command="tmux new-session -d -s task2 -x 140 -y 40 && tmux send-keys -t task2 'cd ~/project && claude -p \"Write integration tests for the API endpoints\" --allowedTools \"Read,Write,Bash\" --max-turns 40' Enter")
 
 # 任务三：更新文档
-terminal(command="tmux new-session -d -s task3 -x 140 -y 40 && tmux send-keys -t task3 'cd ~/project && claude -p \"Update README.md with the new API endpoints\" --allowedTools \"Read,Edit\" --max-turns 5' Enter")
+terminal(command="tmux new-session -d -s task3 -x 140 -y 40 && tmux send-keys -t task3 'cd ~/project && claude -p \"Update README.md with the new API endpoints\" --allowedTools \"Read,Edit\" --max-turns 40' Enter")
 
 # 监控所有任务
 terminal(command="sleep 30 && for s in task1 task2 task3; do echo '=== '$s' ==='; tmux capture-pane -t $s -p -S -5 2>/dev/null; done")
@@ -722,7 +722,7 @@ terminal(command="tmux capture-pane -t dev -p -S -10")
 
 ## 成本与性能建议
 
-1. **在 print 模式中使用 `--max-turns`** 以防止失控循环。大多数任务从 5-10 开始。
+1. **在 print 模式中使用 `--max-turns` 防止失控循环**。按任务类型选基线：`review=60`、`implementation=40`、`extract=5`。
 2. **使用 `--max-budget-usd`** 设置成本上限。注意：系统 prompt 缓存创建的最低成本约为 $0.05。
 3. **简单任务使用 `--effort low`**（更快、更便宜）。复杂推理使用 `high` 或 `max`。
 4. **CI/脚本使用 `--bare`** 以跳过插件/hook 发现开销。
@@ -742,7 +742,7 @@ terminal(command="tmux capture-pane -t dev -p -S -10")
 4. **`--max-turns` 仅限 print 模式** — 在交互会话中被忽略。
 5. **Claude 可能使用 `python` 而非 `python3`** — 在没有 `python` 符号链接的系统上，Claude 的 bash 命令首次会失败，但它会自我纠正。
 6. **会话恢复需要相同目录** — `--continue` 查找当前工作目录中最近的会话。
-7. **`--json-schema` 需要足够的 `--max-turns`** — Claude 必须先读取文件才能生成结构化输出，这需要多轮次。
+7. **`--json-schema` 需要足够的 `--max-turns`** — 小型结构化读取用 `extract` 基线（`5`）；如果 Claude 需要先检查更大的 diff 或文件集，再提高到 `review` 基线（`60`）。
 8. **信任对话框每个目录只出现一次** — 仅首次出现，之后缓存。
 9. **后台 tmux 会话会持续存在** — 完成后始终使用 `tmux kill-session -t <name>` 清理。
 10. **斜杠命令（如 `/commit`）仅在交互模式下有效** — 在 `-p` 模式中，用自然语言描述任务。
@@ -754,10 +754,62 @@ terminal(command="tmux capture-pane -t dev -p -S -10")
 1. **单一任务优先使用 print 模式（`-p`）** — 更简洁，无需处理对话框，输出结构化
 2. **多轮交互工作使用 tmux** — 编排 TUI 的唯一可靠方式
 3. **始终设置 `workdir`** — 让 Claude 专注于正确的项目目录
-4. **在 print 模式中设置 `--max-turns`** — 防止无限循环和失控成本
+4. **在 print 模式中按三档基线设置 `--max-turns`** — `review=60`、`implementation=40`、`extract=5`
 5. **监控 tmux 会话** — 使用 `tmux capture-pane -t <session> -p -S -50` 检查进度
 6. **注意 `❯` 提示符** — 表示 Claude 正在等待输入（已完成或正在提问）
 7. **清理 tmux 会话** — 完成后关闭它们以避免资源泄漏
 8. **向用户报告结果** — 完成后总结 Claude 做了什么以及发生了什么变化
 9. **不要终止慢速会话** — Claude 可能正在进行多步骤工作；检查进度而非直接终止
 10. **使用 `--allowedTools`** — 将能力限制为任务实际需要的工具
+
+## 调度模板 / 报告契约
+
+规范 CC 调度模板：`skills/autonomous-ai-agents/claude-code/templates/default-dispatch.md`。
+
+### 模板注入链路
+
+每次委托 Claude Code 之前，编排器必须：
+
+1. 调用 `skill_view(name="claude-code", file_path="templates/default-dispatch.md")` 加载模板。
+2. 渲染占位符：`<ABS_REPORT_PATH>`、`<JOB_ID>`、`<TASK_CLASS>`、`<TURN_BUDGET>`。
+3. 将渲染后的模板放到调度 prompt 的最前面，**位于**任务描述之前。
+4. 然后在模板后面追加具体的任务指令。
+
+### 报告路径规则
+
+- `<ABS_REPORT_PATH>` 必须是目标仓库内的绝对路径。
+- 回退路径：`<repo>/.hermes-artifacts/reviews/<JOB_ID>.md`。
+- 先用 `mkdir -p` 创建父目录。
+- 路径中禁止使用 `~`。
+- 禁止将部分输出报告为 `completed`。
+
+### 轮次预算基线
+
+| 任务类型 | 范围 | 默认 `--max-turns` |
+|---|---|---|
+| `review` | 30–120 | 60 |
+| `implementation` | 20–80 | 40 |
+| `extract` | 1–10 | 5 |
+
+- 默认情况下，`review` bucket 适用于代码审查（code review）、调试（debug）和重构（refactor）任务。
+- 默认情况下，`implementation` bucket 适用于功能开发（features）、问题修复（fixes）、测试（tests）等代码变更任务。
+- 默认情况下，`extract` bucket 适用于摘要（summarize）、模式提取（schema）和窄范围提取（narrow extraction）任务。
+- 在 print 模式下，将 `--max-turns` 设置为 bucket 默认值，除非调用方显式覆盖。
+
+### Claude Print-Mode 状态映射
+
+| `subtype` | 结束状态 |
+|---|---|
+| `success` | `completed` |
+| `error_max_turns` | `over_budget` |
+| `error_budget` | `over_budget` |
+| (interrupted) | `interrupted` |
+
+如果 Claude 提前中止但留下了有用的未完成工作，请在报告中写入 `partial_output` 而非 `completed`。
+
+### 结束状态契约
+
+- `completed`：`subtype: success`，任务完成，报告已写入。
+- `over_budget`：`error_max_turns` 或 `error_budget`；报告必须列出已完成/未完成/下一步。
+- `interrupted`：被终止或超时；报告必须记录检查点。
+- `partial_output`：不完整结果；必须标注为 partial，不得报为 `completed`。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-codex.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-codex.md
@@ -141,3 +141,44 @@ terminal(command="gh pr comment 86 --body '<review>'", workdir="~/project")
 5. **长时任务使用后台模式** — 使用 `background=true` 并通过 `process` 工具监控
 6. **不要干预** — 使用 `poll`/`log` 监控，对长时运行任务保持耐心
 7. **并行执行没问题** — 可同时运行多个 Codex 进程处理批量工作
+
+## 调度模板 / 报告契约
+
+规范 CX 调度模板：`skills/autonomous-ai-agents/codex/templates/default-dispatch.md`。
+
+### 模板注入链路
+
+每次委托 Codex 之前，编排器必须：
+
+1. 调用 `skill_view(name="codex", file_path="templates/default-dispatch.md")` 加载模板。
+2. 渲染占位符：`<ABS_REPORT_PATH>`、`<JOB_ID>`、`<TASK_CLASS>`、`<TURN_BUDGET>`。
+3. 将渲染后的模板放到调度 prompt 的最前面，**位于**任务描述之前。
+4. 然后在模板后面追加具体的任务指令。
+
+### 报告路径规则
+
+- `<ABS_REPORT_PATH>` 必须是目标仓库内的绝对路径。
+- 回退路径：`<repo>/.hermes-artifacts/reviews/<JOB_ID>.md`。
+- 先用 `mkdir -p` 创建父目录。
+- 路径中禁止使用 `~`。
+- 禁止将部分输出报告为 `completed`。
+
+### 轮次预算基线
+
+| 任务类型 | 范围 | 默认值 |
+|---|---|---|
+| `review` | 30–120 | 60 |
+| `implementation` | 20–80 | 40 |
+| `extract` | 1–10 | 5 |
+
+- 默认情况下，`review` bucket 适用于代码审查（code review）、调试（debug）和重构（refactor）任务。
+- 默认情况下，`implementation` bucket 适用于功能开发（features）、问题修复（fixes）、测试（tests）等代码变更任务。
+- 默认情况下，`extract` bucket 适用于摘要（summarize）、模式提取（schema）和窄范围提取（narrow extraction）任务。
+- Codex 没有统一的 `--max-turns` CLI 范式，因此预算契约需要通过注入的模板和调度 prompt 来承载。
+
+### 结束状态契约
+
+- `completed`：任务在预算内完成，报告已写入。
+- `over_budget`：预算耗尽；报告必须列出已完成/未完成/下一步。
+- `interrupted`：外部中断；报告必须记录检查点。
+- `partial_output`：不完整结果；必须标注为 partial，不得报为 `completed`。


### PR DESCRIPTION
## 问题

`cdee073971db` (Gateway SIGTERM 监控，no_agent 脚本) 持续报 delivery error:
```
delivery error: Feishu send failed: [99992402] field validation failed
```

## 根因

`feishu.py:_send_raw_message` 中，当 metadata 包含 `thread_id` 但无 `reply_to` 时，代码错误地隐式退回到 `thread_id` 作为 `effective_reply_to`，将 `thread_id` 当作 `receive_id` 传入并设置 `receive_id_type="thread_id"`。飞书 OpenAPI 不接受 `"thread_id"` 作为有效的 `receive_id_type`（合法值为 `open_id`/`user_id`/`union_id`/`email`/`chat_id`）。

## 修复

### gateway/platforms/feishu.py
- `effective_reply_to` 不再回退到 `thread_id`（只认 `reply_to`/`metadata.reply_to_message_id`）
- `thread_id` 无 `reply_to` 时走 `message.create` + `root_id` 而非 `message.reply`
- `_build_create_message_body` 新增 `root_id` 参数，SDK builder 路径通过 `body.root_id = root_id` 属性注入（兼容当前 lark_oapi 1.5.3 的 `vars(o)` 序列化）
- SimpleNamespace fallback 路径同步支持 `root_id`
- 空串 `root_id` 归一化（`if root_id` → 过滤空串）

### tools/send_message_tool.py / cron/scheduler.py
- `thread_id` 空串归一化为 `None`

### tests/gateway/test_feishu.py
- 新增 `test_send_thread_id_without_reply_to_uses_create_with_root_id`：断言走 `message.create` 路径、`receive_id_type=chat_id`、`root_id=thread_id`
- 新增 `test_send_thread_id_without_reply_to_sdk_marshalling_includes_root_id`：经 `JSON.marshal()` SDK 真实序列化路径验证 `root_id` 存在且值正确

## CC → CX 审查流程

五轮迭代 (CC→CX→CC→CX→CC→CX)，全部审查通过。