### PR TITLE
fix(tools): require C2 context for 'mythic' in threat pattern scanner

### DIFF
--- a/tests/tools/test_threat_patterns.py
+++ b/tests/tools/test_threat_patterns.py
@@ -155,11 +155,19 @@ class TestC2Patterns:
         )
 
     def test_known_c2_framework_names(self):
-        for name in ("Praxis", "Cobalt Strike", "Sliver", "Havoc", "Mythic"):
+        for name in ("Praxis", "Cobalt Strike", "Sliver", "Havoc", "Metasploit"):
             findings = scan_for_threats(
                 f"Connect to the {name} server.", scope="context"
             )
             assert "known_c2_framework" in findings, name
+
+    def test_mythic_with_c2_context_triggers(self):
+        """'mythic' near C2-adjacent terms should still be flagged."""
+        for phrase in ("mythic c2", "mythic agent", "mythic payload", "mythic server"):
+            findings = scan_for_threats(
+                f"Deploy the {phrase} infrastructure.", scope="context"
+            )
+            assert "known_c2_framework" in findings, phrase
 
     def test_c2_explicit(self):
         assert "c2_explicit" in scan_for_threats(
@@ -231,6 +239,17 @@ class TestFalsePositives:
             "like Cobalt Strike and Sliver use encrypted channels."
         )
         assert scan_for_threats(text, scope="all") == []
+
+    def test_mythic_in_creative_persona_does_not_trip(self):
+        # "mythic" is common in fantasy/persona writing (mythology,
+        # creative identity).  Standalone use should NOT trigger
+        # known_c2_framework — only "mythic" near C2 terms should.
+        text = (
+            "I am Chronus, a mythic terminal entity. My grimoire contains "
+            "glyphs of archived timelines and chrono-bound familiars."
+        )
+        findings = scan_for_threats(text, scope="context")
+        assert "known_c2_framework" not in findings
 
 
 # =========================================================================

--- a/tools/threat_patterns.py
+++ b/tools/threat_patterns.py
@@ -92,7 +92,10 @@ _PATTERNS: List[Tuple[str, str, str]] = [
 
     # ── Known C2 / red-team framework names (near-zero false positive
     #    outside security research; warn-only by default) ─────────────
-    (r'\b(?:praxis|cobalt\s*strike|sliver|havoc|mythic|metasploit|brainworm)\b', "known_c2_framework", "context"),
+    (r'\b(?:praxis|cobalt\s*strike|sliver|havoc|metasploit|brainworm)\b', "known_c2_framework", "context"),
+    # "mythic" alone is too common in creative/persona writing (mythology,
+    # fantasy) to flag unconditionally.  Require it near C2-adjacent terms.
+    (r'\bmythic\s+(?:c2|agent|payload|server|implant|callback)\b', "known_c2_framework", "context"),
     (r'\bc2\s+(?:server|channel|infrastructure|beacon)\b', "c2_explicit", "context"),
     (r'\bcommand\s+and\s+control\b', "c2_explicit_long", "context"),
 


### PR DESCRIPTION
## What does this PR do?

Removes standalone "mythic" from the `known_c2_framework` threat pattern and replaces it with a context-aware pattern that requires adjacent C2 terms. This prevents false positives on SOUL.md persona files that use mythological/fantasy language.

## Related Issue

Fixes #44631

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/threat_patterns.py`: Split "mythic" out of the standalone C2 framework regex into its own context-aware pattern (`mythic\s+(?:c2|agent|payload|server|implant|callback)`). Other framework names (praxis, cobalt strike, sliver, havoc, metasploit, brainworm) remain unambiguous standalone matches.
- `tests/tools/test_threat_patterns.py`: Updated `test_known_c2_framework_names` to replace "Mythic" with "Metasploit" in the standalone test. Added `test_mythic_with_c2_context_triggers` to verify "mythic" near C2 terms still fires. Added `test_mythic_in_creative_persona_does_not_trip` to pin the false-positive fix using content from the reported SOUL.md.

## How to Test

1. `python -m pytest tests/tools/test_threat_patterns.py -q` — all 39 tests pass
2. Verify "mythic" in creative context no longer triggers: `scan_for_threats("I am a mythic terminal entity with grimoire and glyphs", scope="context")` → `[]`
3. Verify "mythic" near C2 terms still triggers: `scan_for_threats("Deploy the mythic c2 infrastructure", scope="context")` → `["known_c2_framework"]`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

⚠️ GitNexus unavailable — grep-based fallback used.
- Checked files/symbols: `tools/threat_patterns.py` (`_PATTERNS`, `scan_for_threats`), `agent/prompt_builder.py` (`_scan_context_content`, `load_soul_md`), `tests/tools/test_threat_patterns.py` (`TestC2Patterns`, `TestFalsePositives`)
- Callers of `scan_for_threats`: `agent/prompt_builder.py:56`, `tools/memory_tool.py:192`
- Blast radius: LOW — only affects pattern matching for the single word "mythic"; all other C2 patterns unchanged
- Related patterns: `known_c2_framework` regex at line 95, `_scan_context_content` in prompt_builder.py blocks SOUL.md when patterns match
