### PR TITLE
Fix desktop handoff session grouping after restart

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -40,7 +40,7 @@ import { searchSessions, type SessionInfo, type SessionSearchResult } from '@/he
 import { useI18n } from '@/i18n'
 import { profileColor } from '@/lib/profile-color'
 import { sessionMatchesSearch } from '@/lib/session-search'
-import { normalizeSessionSource, sessionSourceLabel } from '@/lib/session-source'
+import { logicalSessionSource, sessionSourceLabel } from '@/lib/session-source'
 import { cn } from '@/lib/utils'
 import { $cronJobs } from '@/store/cron'
 import {
@@ -583,7 +583,7 @@ export function ChatSidebar({
     const bySource = new Map<string, SessionInfo[]>()
 
     for (const session of messagingSessions) {
-      const sourceId = normalizeSessionSource(session.source)
+      const sourceId = logicalSessionSource(session)
 
       if (!sourceId) {
         continue

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -11,15 +11,14 @@ import { Pane, PaneMain } from '@/components/pane-shell'
 import { useMediaQuery } from '@/hooks/use-media-query'
 import { useSkinCommand } from '@/themes/use-skin-command'
 
-import { requestComposerFocus, requestComposerInsert } from './chat/composer/focus'
 import { formatRefValue } from '../components/assistant-ui/directive-text'
 import { getCronJobs, getSessionMessages, listAllProfileSessions, type SessionInfo, triggerCronJob } from '../hermes'
 import { preserveLocalAssistantErrors, toChatMessages } from '../lib/chat-messages'
 import {
   isMessagingSource,
   LOCAL_SESSION_SOURCE_IDS,
-  MESSAGING_SESSION_SOURCE_IDS,
-  normalizeSessionSource
+  logicalSessionSource,
+  MESSAGING_SESSION_SOURCE_IDS
 } from '../lib/session-source'
 import { setCronFocusJobId, setCronJobs } from '../store/cron'
 import {
@@ -80,6 +79,7 @@ import { openUpdatesWindow, startUpdatePoller, stopUpdatePoller } from '../store
 import { isSecondaryWindow } from '../store/windows'
 
 import { ChatView } from './chat'
+import { requestComposerFocus, requestComposerInsert } from './chat/composer/focus'
 import { useComposerActions } from './chat/hooks/use-composer-actions'
 import {
   ChatPreviewRail,
@@ -277,18 +277,24 @@ export function DesktopController() {
       if (!payload || payload.kind !== 'blueprint' || !payload.name) {
         return
       }
+
       const slots = Object.entries(payload.params || {})
         .map(([k, v]) => {
           const sval = /\s/.test(v) ? `"${v.replace(/"/g, '\\"')}"` : v
+
           return `${k}=${sval}`
         })
         .join(' ')
+
       const command = `/blueprint ${payload.name}${slots ? ' ' + slots : ''}`
+
       requestComposerInsert(command, { mode: 'block', target: 'main' })
       requestComposerFocus('main')
     })
+
     // Tell the main process the renderer is ready to receive deep links.
     void window.hermesDesktop?.signalDeepLinkReady?.()
+
     return () => unsubscribe?.()
   }, [])
 
@@ -338,12 +344,13 @@ export function DesktopController() {
   const refreshMessagingSessions = useCallback(async () => {
     try {
       const result = await listAllProfileSessions(MESSAGING_SECTION_LIMIT, 1, 'exclude', 'recent', 'all', {
-        excludeSources: MESSAGING_EXCLUDED_SOURCES
+        excludeLogicalSources: MESSAGING_EXCLUDED_SOURCES
       })
 
-      // Drop any non-messaging source the broad exclude didn't catch (custom
-      // sources) — those stay in local recents, not a platform section.
-      const rows = result.sessions.filter(s => isMessagingSource(s.source))
+      // Drop any non-messaging logical source the broad exclude didn't catch
+      // (custom/local sources) — those stay in local recents, not a platform
+      // section.
+      const rows = result.sessions.filter(s => isMessagingSource(logicalSessionSource(s)))
 
       setMessagingSessions(prev => (sameCronSignature(prev, rows) ? prev : rows))
       // Hit the cap → at least one platform may have more on disk than loaded,
@@ -358,14 +365,14 @@ export function DesktopController() {
   // pager): fetch that source's next window and merge it back in place, leaving
   // every other platform's rows untouched. Resolves the platform's exact total.
   const loadMoreMessagingForPlatform = useCallback(async (platform: string) => {
-    const inPlatform = (s: SessionInfo) => normalizeSessionSource(s.source) === platform
+    const inPlatform = (s: SessionInfo) => logicalSessionSource(s) === platform
     const loaded = $messagingSessions.get().filter(inPlatform).length
 
     const result = await listAllProfileSessions(loaded + SIDEBAR_SESSIONS_PAGE_SIZE, 1, 'exclude', 'recent', 'all', {
-      source: platform
+      logicalSource: platform
     })
 
-    const incoming = result.sessions.filter(s => normalizeSessionSource(s.source) === platform)
+    const incoming = result.sessions.filter(s => logicalSessionSource(s) === platform)
 
     setMessagingSessions(prev => [
       ...prev.filter(s => !inPlatform(s)),
@@ -412,7 +419,7 @@ export function DesktopController() {
       const sessionProfile = profileScope === ALL_PROFILES ? 'all' : profileScope
 
       const result = await listAllProfileSessions(limit, 1, 'exclude', 'recent', sessionProfile, {
-        excludeSources: SIDEBAR_EXCLUDED_SOURCES
+        excludeLogicalSources: SIDEBAR_EXCLUDED_SOURCES
       })
 
       if (refreshSessionsRequestRef.current === requestId) {
@@ -444,7 +451,7 @@ export function DesktopController() {
     const loaded = $sessions.get().filter(inKey).length
 
     const result = await listAllProfileSessions(loaded + SIDEBAR_SESSIONS_PAGE_SIZE, 1, 'exclude', 'recent', key, {
-      excludeSources: SIDEBAR_EXCLUDED_SOURCES
+      excludeLogicalSources: SIDEBAR_EXCLUDED_SOURCES
     })
 
     const keep = sessionsToKeep(key)

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -47,6 +47,22 @@ describe('Hermes REST session helpers', () => {
     )
   })
 
+  it('passes logical source filters for handoff-aware session slices', async () => {
+    await listAllProfileSessions(50, 1, 'exclude', 'recent', 'all', {
+      excludeLogicalSources: ['cron', 'cli'],
+      logicalSource: 'weixin'
+    })
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path:
+          '/api/profiles/sessions?limit=50&offset=0&min_messages=1&archived=exclude&order=recent&profile=all' +
+          '&logical_source=weixin&exclude_logical_sources=cron%2Ccli',
+        timeoutMs: 60_000
+      })
+    )
+  })
+
   it('tags cross-profile message reads for Electron routing and backend lookup', async () => {
     api.mockResolvedValue({ messages: [], session_id: 'session-1' })
 

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -161,6 +161,8 @@ export async function listSessions(
 export interface SessionSourceFilter {
   source?: string
   excludeSources?: string[]
+  logicalSource?: string
+  excludeLogicalSources?: string[]
 }
 
 export async function listAllProfileSessions(
@@ -172,15 +174,21 @@ export async function listAllProfileSessions(
   filter: SessionSourceFilter = {}
 ): Promise<PaginatedSessions> {
   const sourceParam = filter.source ? `&source=${encodeURIComponent(filter.source)}` : ''
+  const logicalSourceParam = filter.logicalSource ? `&logical_source=${encodeURIComponent(filter.logicalSource)}` : ''
 
   const excludeParam = filter.excludeSources?.length
     ? `&exclude_sources=${encodeURIComponent(filter.excludeSources.join(','))}`
     : ''
 
+  const excludeLogicalParam = filter.excludeLogicalSources?.length
+    ? `&exclude_logical_sources=${encodeURIComponent(filter.excludeLogicalSources.join(','))}`
+    : ''
+
   const result = await window.hermesDesktop.api<PaginatedSessions>({
     path:
       `/api/profiles/sessions?limit=${limit}&offset=0&min_messages=${Math.max(0, minMessages)}` +
-      `&archived=${archived}&order=${order}&profile=${encodeURIComponent(profile)}${sourceParam}${excludeParam}`,
+      `&archived=${archived}&order=${order}&profile=${encodeURIComponent(profile)}` +
+      `${sourceParam}${logicalSourceParam}${excludeParam}${excludeLogicalParam}`,
     timeoutMs: SESSION_LIST_REQUEST_TIMEOUT_MS
   })
 

--- a/apps/desktop/src/lib/session-source.test.ts
+++ b/apps/desktop/src/lib/session-source.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SessionInfo } from '@/types/hermes'
+
+import { isMessagingSource, logicalSessionSource } from './session-source'
+
+const session = (
+  over: Partial<Pick<SessionInfo, 'handoff_platform' | 'handoff_state' | 'source'>> = {}
+): Pick<SessionInfo, 'handoff_platform' | 'handoff_state' | 'source'> => ({
+  handoff_platform: null,
+  handoff_state: null,
+  source: null,
+  ...over
+})
+
+describe('logicalSessionSource', () => {
+  it('uses the completed handoff platform for restored messaging sessions', () => {
+    expect(
+      logicalSessionSource(
+        session({
+          handoff_platform: 'weixin',
+          handoff_state: 'completed',
+          source: 'desktop'
+        })
+      )
+    ).toBe('weixin')
+  })
+
+  it('ignores local handoff origins and falls back to the live source', () => {
+    expect(
+      logicalSessionSource(
+        session({
+          handoff_platform: 'desktop',
+          handoff_state: 'completed',
+          source: 'desktop'
+        })
+      )
+    ).toBe('desktop')
+  })
+
+  it('treats completed handoff origins as messaging sources', () => {
+    expect(
+      isMessagingSource(
+        logicalSessionSource(
+          session({
+            handoff_platform: 'weixin',
+            handoff_state: 'completed',
+            source: 'desktop'
+          })
+        )
+      )
+    ).toBe(true)
+  })
+})

--- a/apps/desktop/src/lib/session-source.ts
+++ b/apps/desktop/src/lib/session-source.ts
@@ -1,3 +1,5 @@
+import type { SessionInfo } from '@/types/hermes'
+
 const SOURCE_LABELS: Record<string, string> = {
   api_server: 'API',
   bluebubbles: 'iMessage',
@@ -102,6 +104,12 @@ export function handoffOriginSource(
   }
 
   return id
+}
+
+export function logicalSessionSource(
+  session: Pick<SessionInfo, 'handoff_platform' | 'handoff_state' | 'source'>
+): string | null {
+  return handoffOriginSource(session.handoff_state, session.handoff_platform) ?? normalizeSessionSource(session.source)
 }
 
 export function sessionSourceLabel(source: null | string | undefined): string | null {

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2532,6 +2532,8 @@ async def get_sessions(
     order: str = "created",
     source: str = None,
     exclude_sources: str = None,
+    logical_source: str = None,
+    exclude_logical_sources: str = None,
 ):
     """List sessions.
 
@@ -2567,9 +2569,12 @@ async def get_sessions(
             # uses these to split recents (exclude=cron) from the cron-jobs
             # section (source=cron) into two independent lists.
             exclude_list = [s for s in (exclude_sources or "").split(",") if s.strip()]
+            exclude_logical_list = [s for s in (exclude_logical_sources or "").split(",") if s.strip()]
             sessions = db.list_sessions_rich(
                 source=source or None,
                 exclude_sources=exclude_list or None,
+                logical_source=logical_source or None,
+                exclude_logical_sources=exclude_logical_list or None,
                 limit=limit,
                 offset=offset,
                 min_message_count=min_message_count,
@@ -2580,6 +2585,8 @@ async def get_sessions(
             total = db.session_count(
                 source=source or None,
                 exclude_sources=exclude_list or None,
+                logical_source=logical_source or None,
+                exclude_logical_sources=exclude_logical_list or None,
                 min_message_count=min_message_count,
                 include_archived=include_archived,
                 archived_only=archived_only,
@@ -2611,6 +2618,8 @@ async def get_profiles_sessions(
     profile: str = "all",
     source: str = None,
     exclude_sources: str = None,
+    logical_source: str = None,
+    exclude_logical_sources: str = None,
 ):
     """Unified, read-only session list aggregated across ALL profiles.
 
@@ -2651,6 +2660,8 @@ async def get_profiles_sessions(
     # newest cron sessions can't starve the recents page.
     source_filter = source or None
     exclude_list = [s for s in (exclude_sources or "").split(",") if s.strip()]
+    logical_source_filter = logical_source or None
+    exclude_logical_list = [s for s in (exclude_logical_sources or "").split(",") if s.strip()]
     # Over-fetch per profile so the merged+sorted window is correct for the
     # requested page. Capped so a huge profile can't blow up the response.
     per_profile = min(max(limit + offset, limit), 500)
@@ -2676,6 +2687,8 @@ async def get_profiles_sessions(
             rows = db.list_sessions_rich(
                 source=source_filter,
                 exclude_sources=exclude_list or None,
+                logical_source=logical_source_filter,
+                exclude_logical_sources=exclude_logical_list or None,
                 limit=per_profile,
                 offset=0,
                 min_message_count=min_message_count,
@@ -2686,6 +2699,8 @@ async def get_profiles_sessions(
             profile_total = db.session_count(
                 source=source_filter,
                 exclude_sources=exclude_list or None,
+                logical_source=logical_source_filter,
+                exclude_logical_sources=exclude_logical_list or None,
                 min_message_count=min_message_count,
                 include_archived=include_archived,
                 archived_only=archived_only,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -35,6 +35,29 @@ DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
 SCHEMA_VERSION = 15
 
+# Completed handoffs keep their live source on a local surface (desktop/tui),
+# but sidebar/session-list consumers often need to treat them as belonging to
+# the original messaging platform instead.
+_LOCAL_LOGICAL_SESSION_SOURCES = ("cli", "codex", "desktop", "gateway", "local", "tui")
+
+
+def _logical_session_source_sql(alias: str = "s") -> str:
+    local_placeholders = ",".join("?" for _ in _LOCAL_LOGICAL_SESSION_SOURCES)
+
+    return (
+        "CASE "
+        f"WHEN {alias}.handoff_state = 'completed' "
+        f"AND lower(trim(coalesce({alias}.handoff_platform, ''))) NOT IN ({local_placeholders}) "
+        f"AND trim(coalesce({alias}.handoff_platform, '')) != '' "
+        f"THEN lower(trim({alias}.handoff_platform)) "
+        f"ELSE lower(trim(coalesce({alias}.source, ''))) "
+        "END"
+    )
+
+
+def _normalized_sources(sources: List[str]) -> List[str]:
+    return [s.strip().lower() for s in sources if s and s.strip()]
+
 # ---------------------------------------------------------------------------
 # WAL-compatibility fallback
 # ---------------------------------------------------------------------------
@@ -1876,6 +1899,8 @@ class SessionDB:
         self,
         source: str = None,
         exclude_sources: List[str] = None,
+        logical_source: str = None,
+        exclude_logical_sources: List[str] = None,
         limit: int = 20,
         offset: int = 0,
         include_children: bool = False,
@@ -1947,6 +1972,14 @@ class SessionDB:
             placeholders = ",".join("?" for _ in exclude_sources)
             where_clauses.append(f"s.source NOT IN ({placeholders})")
             params.extend(exclude_sources)
+        if logical_source:
+            where_clauses.append(f"{_logical_session_source_sql()} = ?")
+            params.extend([*_LOCAL_LOGICAL_SESSION_SOURCES, logical_source.strip().lower()])
+        normalized_exclude_logical = _normalized_sources(exclude_logical_sources or [])
+        if normalized_exclude_logical:
+            placeholders = ",".join("?" for _ in normalized_exclude_logical)
+            where_clauses.append(f"{_logical_session_source_sql()} NOT IN ({placeholders})")
+            params.extend([*_LOCAL_LOGICAL_SESSION_SOURCES, *normalized_exclude_logical])
         if min_message_count > 0:
             where_clauses.append("s.message_count >= ?")
             params.append(min_message_count)
@@ -3531,11 +3564,13 @@ class SessionDB:
     def session_count(
         self,
         source: str = None,
+        logical_source: str = None,
         min_message_count: int = 0,
         include_archived: bool = False,
         archived_only: bool = False,
         exclude_children: bool = False,
         exclude_sources: List[str] = None,
+        exclude_logical_sources: List[str] = None,
     ) -> int:
         """Count sessions, optionally filtered by source.
 
@@ -3572,6 +3607,14 @@ class SessionDB:
             placeholders = ",".join("?" for _ in exclude_sources)
             where_clauses.append(f"s.source NOT IN ({placeholders})")
             params.extend(exclude_sources)
+        if logical_source:
+            where_clauses.append(f"{_logical_session_source_sql()} = ?")
+            params.extend([*_LOCAL_LOGICAL_SESSION_SOURCES, logical_source.strip().lower()])
+        normalized_exclude_logical = _normalized_sources(exclude_logical_sources or [])
+        if normalized_exclude_logical:
+            placeholders = ",".join("?" for _ in normalized_exclude_logical)
+            where_clauses.append(f"{_logical_session_source_sql()} NOT IN ({placeholders})")
+            params.extend([*_LOCAL_LOGICAL_SESSION_SOURCES, *normalized_exclude_logical])
         if min_message_count > 0:
             where_clauses.append("s.message_count >= ?")
             params.append(min_message_count)

--- a/tests/hermes_state/test_logical_session_source_filters.py
+++ b/tests/hermes_state/test_logical_session_source_filters.py
@@ -1,0 +1,58 @@
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    database = SessionDB(tmp_path / "state.db")
+    try:
+        yield database
+    finally:
+        database.close()
+
+
+def _seed_session(
+    db: SessionDB,
+    session_id: str,
+    source: str,
+    *,
+    handoff_platform: str | None = None,
+    handoff_state: str | None = None,
+):
+    db.create_session(session_id=session_id, source=source)
+    db.append_message(session_id, role="user", content=f"{session_id} message")
+    if handoff_platform is not None or handoff_state is not None:
+        db._conn.execute(
+            "UPDATE sessions SET handoff_platform = ?, handoff_state = ? WHERE id = ?",
+            (handoff_platform, handoff_state, session_id),
+        )
+        db._conn.commit()
+
+
+def test_logical_source_matches_completed_handoff_origin(db):
+    _seed_session(db, "desktop-wechat", "desktop", handoff_platform="weixin", handoff_state="completed")
+    _seed_session(db, "plain-desktop", "desktop")
+
+    rows = db.list_sessions_rich(logical_source="weixin", order_by_last_active=True)
+
+    assert [row["id"] for row in rows] == ["desktop-wechat"]
+    assert db.session_count(logical_source="weixin", exclude_children=True) == 1
+
+
+def test_exclude_logical_sources_keeps_local_and_messaging_slices_distinct(db):
+    _seed_session(db, "desktop-wechat", "desktop", handoff_platform="weixin", handoff_state="completed")
+    _seed_session(db, "local-chat", "desktop")
+    _seed_session(db, "slack-chat", "slack")
+
+    local_rows = db.list_sessions_rich(
+        exclude_logical_sources=["cron", "weixin", "slack"],
+        order_by_last_active=True,
+    )
+    messaging_rows = db.list_sessions_rich(
+        exclude_logical_sources=["cron", "cli", "codex", "desktop", "gateway", "local", "tui"],
+        order_by_last_active=True,
+    )
+
+    assert [row["id"] for row in local_rows] == ["local-chat"]
+    assert {row["id"] for row in messaging_rows} == {"desktop-wechat", "slack-chat"}


### PR DESCRIPTION
Fixes #44377

## Summary
- add a logical session source that falls back to the completed handoff origin platform
- let desktop recents and messaging slices query by logical source so restored handoff chats stay in the right sidebar section
- group desktop messaging sections by logical source and cover the regression in Python and desktop tests

## Testing
- uv run --extra dev pytest tests/hermes_state/test_logical_session_source_filters.py
- uv run --extra dev ruff check hermes_state.py hermes_cli/web_server.py tests/hermes_state/test_logical_session_source_filters.py
- npm run test:ui -- src/hermes.test.ts src/lib/session-source.test.ts
- npx eslint src/app/chat/sidebar/index.tsx src/app/desktop-controller.tsx src/hermes.test.ts src/hermes.ts src/lib/session-source.ts src/lib/session-source.test.ts
- git diff --check