### PR TITLE
feat(agent): add compact skills prompt index mode

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -11,7 +11,7 @@ import threading
 from collections import OrderedDict
 from pathlib import Path
 
-from hermes_constants import get_hermes_home, get_skills_dir, is_wsl
+from hermes_constants import get_config_path, get_hermes_home, get_skills_dir, is_wsl
 from typing import Optional
 
 from agent.runtime_cwd import resolve_agent_cwd
@@ -24,6 +24,7 @@ from agent.skill_utils import (
     parse_frontmatter,
     skill_matches_environment,
     skill_matches_platform,
+    yaml_load,
 )
 from utils import atomic_json_write
 
@@ -1098,10 +1099,64 @@ def _skill_should_show(
     return True
 
 
+def _skills_prompt_index_settings(
+    prompt_index_mode: "str | None" = None,
+    prompt_index_top_per_category: "int | None" = None,
+) -> tuple[str, int]:
+    """Resolve skills prompt-index rendering settings.
+
+    Kept local to prompt assembly and read directly from config.yaml to avoid
+    importing the full CLI config stack during agent startup. Defaults preserve
+    the historical full index unless the user explicitly opts into compact
+    rendering.
+    """
+    mode = "full"
+    top_per_category = 3
+
+    if prompt_index_mode is None or prompt_index_top_per_category is None:
+        config_path = get_config_path()
+        if config_path.exists():
+            try:
+                parsed = yaml_load(config_path.read_text(encoding="utf-8"))
+            except Exception as exc:
+                logger.debug("Could not read skills prompt-index config %s: %s", config_path, exc)
+                parsed = None
+            if isinstance(parsed, dict):
+                skills_cfg = parsed.get("skills")
+                if isinstance(skills_cfg, dict):
+                    if prompt_index_mode is None:
+                        prompt_index_mode = skills_cfg.get("prompt_index_mode")
+                    if prompt_index_top_per_category is None:
+                        prompt_index_top_per_category = skills_cfg.get(
+                            "prompt_index_top_per_category"
+                        )
+
+    if prompt_index_mode is not None:
+        requested = str(prompt_index_mode).strip().lower()
+        if requested in {"full", "compact"}:
+            mode = requested
+        elif requested:
+            logger.debug("Unknown skills.prompt_index_mode=%r; using full", prompt_index_mode)
+
+    if prompt_index_top_per_category is not None:
+        try:
+            top_per_category = max(0, int(prompt_index_top_per_category))
+        except (TypeError, ValueError):
+            logger.debug(
+                "Invalid skills.prompt_index_top_per_category=%r; using %s",
+                prompt_index_top_per_category,
+                top_per_category,
+            )
+
+    return mode, top_per_category
+
+
 def build_skills_system_prompt(
     available_tools: "set[str] | None" = None,
     available_toolsets: "set[str] | None" = None,
     compact_categories: "frozenset[str] | None" = None,
+    prompt_index_mode: "str | None" = None,
+    prompt_index_top_per_category: "int | None" = None,
 ) -> str:
     """Build a compact skill index for the system prompt.
 
@@ -1122,7 +1177,16 @@ def build_skills_system_prompt(
     the rendered index. Nothing is ever hidden: every skill name stays
     visible and loadable via ``skill_view`` / ``skills_list``; only the
     descriptions are dropped, and a footer note explains the demotion.
+
+    ``prompt_index_mode=\"compact\"`` is opt-in global rendering compression:
+    every skill name remains visible, but only the first N skills per category
+    keep descriptions and the rest are folded into a names-only continuation.
     """
+    prompt_index_mode, prompt_index_top_per_category = _skills_prompt_index_settings(
+        prompt_index_mode,
+        prompt_index_top_per_category,
+    )
+
     skills_dir = get_skills_dir()
     external_dirs = get_all_skills_dirs()[1:]  # skip local (index 0)
 
@@ -1147,6 +1211,8 @@ def build_skills_system_prompt(
         _platform_hint,
         tuple(sorted(disabled)),
         tuple(sorted(compact_categories or ())),
+        prompt_index_mode,
+        prompt_index_top_per_category,
     )
     with _SKILLS_PROMPT_CACHE_LOCK:
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)
@@ -1301,6 +1367,14 @@ def build_skills_system_prompt(
             "context, so their descriptions are omitted — the skills work "
             "normally and load with skill_view(name) as usual.)"
         )
+    compact_note = ""
+    if prompt_index_mode == "compact":
+        compact_note = (
+            "\n(Compact skills index mode is on: every skill name is still listed, "
+            "but some descriptions are folded to reduce prompt size. If a "
+            "names-only skill may be relevant, load it with skill_view(name) "
+            "or inspect the catalog with skills_list.)"
+        )
 
     if not skills_by_category:
         result = ""
@@ -1318,14 +1392,31 @@ def build_skills_system_prompt(
                 index_lines.append(f"  {category}: {cat_desc}")
             else:
                 index_lines.append(f"  {category}:")
+
+            entries = []
             for name, desc in sorted(skills_by_category[category], key=lambda x: x[0]):
                 if name in seen:
                     continue
                 seen.add(name)
+                entries.append((name, desc))
+
+            if prompt_index_mode == "compact":
+                described = entries[:prompt_index_top_per_category]
+                names_only = entries[prompt_index_top_per_category:]
+            else:
+                described = entries
+                names_only = []
+
+            for name, desc in described:
                 if desc:
                     index_lines.append(f"    - {name}: {desc}")
                 else:
                     index_lines.append(f"    - {name}")
+            if names_only:
+                names = ", ".join(name for name, _ in names_only)
+                index_lines.append(
+                    f"    + {len(names_only)} more names-only: {names}"
+                )
 
         result = (
             "## Skills (mandatory)\n"
@@ -1355,6 +1446,7 @@ def build_skills_system_prompt(
             "\n"
             "Only proceed without loading a skill if genuinely none are relevant to the task."
             + hidden_note
+            + compact_note
         )
 
     # ── Store in LRU cache ────────────────────────────────────────────

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -585,6 +585,13 @@ skills:
   #   - ~/.agents/skills
   #   - /home/shared/team-skills
 
+  # Prompt index rendering. "full" keeps historical behavior. "compact" keeps
+  # every skill name visible but folds lower entries in each category into a
+  # names-only line to reduce fixed prompt size; skill_view still loads the full
+  # instructions for any listed skill.
+  prompt_index_mode: full
+  prompt_index_top_per_category: 3
+
 # =============================================================================
 # Agent Behavior
 # =============================================================================

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1800,6 +1800,14 @@ DEFAULT_CONFIG = {
     # always goes to ~/.hermes/skills/.
     "skills": {
         "external_dirs": [],   # e.g. ["~/.agents/skills", "/shared/team-skills"]
+        # How much of the skills catalog appears in the system prompt.
+        #   "full"    — historical behavior: every listed skill includes its description.
+        #   "compact" — every skill name stays visible, but only the first N
+        #                skills per category keep descriptions; the rest are
+        #                folded into a names-only line. Full skill instructions
+        #                still load via skill_view(name).
+        "prompt_index_mode": "full",
+        "prompt_index_top_per_category": 3,
         # Substitute ${HERMES_SKILL_DIR} and ${HERMES_SESSION_ID} in SKILL.md
         # content with the absolute skill directory and the active session id
         # before the agent sees it.  Lets skill authors reference bundled

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -324,6 +324,58 @@ class TestBuildSkillsSystemPrompt:
         full = build_skills_system_prompt()
         assert "Write threads" in full
 
+    def test_prompt_index_compact_mode_keeps_all_names_and_folds_descriptions(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        for name in ["alpha", "bravo", "charlie", "delta"]:
+            d = tmp_path / "skills" / "coding" / name
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(
+                f"---\nname: {name}\ndescription: Description for {name}\n---\n"
+            )
+
+        result = build_skills_system_prompt(
+            prompt_index_mode="compact",
+            prompt_index_top_per_category=2,
+        )
+
+        assert "alpha: Description for alpha" in result
+        assert "bravo: Description for bravo" in result
+        # Names remain visible even when descriptions are folded away.
+        assert "+ 2 more names-only: charlie, delta" in result
+        assert "Description for charlie" not in result
+        assert "Description for delta" not in result
+        assert "Compact skills index mode is on" in result
+        assert "skill_view(name)" in result
+        assert "skills_list" in result
+
+    def test_prompt_index_compact_mode_from_config_misses_full_cache(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        for name in ["alpha", "bravo", "charlie"]:
+            d = tmp_path / "skills" / "coding" / name
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(
+                f"---\nname: {name}\ndescription: Description for {name}\n---\n"
+            )
+
+        full = build_skills_system_prompt()
+        assert "Description for charlie" in full
+
+        (tmp_path / "config.yaml").write_text(
+            "skills:\n"
+            "  prompt_index_mode: compact\n"
+            "  prompt_index_top_per_category: 1\n"
+        )
+        compact = build_skills_system_prompt()
+
+        assert "alpha: Description for alpha" in compact
+        assert "+ 2 more names-only: bravo, charlie" in compact
+        assert "Description for bravo" not in compact
+        assert "Description for charlie" not in compact
+
     def test_excludes_incompatible_platform_skills(self, monkeypatch, tmp_path):
         """Skills with platforms: [macos] should not appear on Linux."""
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in compact rendering mode for the skills prompt index.

By default, Hermes keeps the historical full skills index behavior. Users can opt into compact rendering with:

```yaml
skills:
  prompt_index_mode: compact
  prompt_index_top_per_category: 3
```

In compact mode:

- every skill name remains visible in the system prompt;
- only the first N skills per category keep descriptions;
- remaining skills are folded into a names-only line;
- `skills_list` / `skill_view(name)` behavior is unchanged;
- the prompt explicitly tells the model that names-only skills still load normally.

This is intended to reduce fixed prompt size without disabling or hiding any skill capability.

## Related Issue

Fixes #44641

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/prompt_builder.py`
  - Added config resolution for `skills.prompt_index_mode`.
  - Added `compact` rendering mode.
  - Included compact mode settings in the skills prompt cache key.
  - Added prompt disclosure text explaining names-only folded skills.
- `hermes_cli/config.py`
  - Added default config keys:
    - `skills.prompt_index_mode: "full"`
    - `skills.prompt_index_top_per_category: 3`
- `cli-config.yaml.example`
  - Documented the new config keys.
- `tests/agent/test_prompt_builder.py`
  - Added tests for compact rendering and cache separation.

## How to Test

```bash
scripts/run_tests.sh tests/agent/test_prompt_builder.py -- -q
scripts/run_tests.sh tests/agent/test_system_prompt.py -- -q
```

Local results:

```text
tests/agent/test_prompt_builder.py: 133 passed
tests/agent/test_system_prompt.py: 5 passed
```

Also ran:

```bash
git diff --check
```

## Platforms Tested

- Windows 11 / Git Bash
- Python 3.12.8 via conda `llm` environment

## Design Notes

This follows the existing Hermes prompt-cache and skill-discovery design:

- Default behavior remains `full`.
- Compact mode is discovery-only rendering; it does not disable skills.
- Skill instructions are still loaded in full via `skill_view(name)`.
- The system prompt remains stable for the session.
- No new model tools are added.
