### PR TITLE
Filter leaked memory context from IM replies

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -59,10 +59,22 @@ _INTERNAL_NOTE_RE = re.compile(
 )
 
 
-def sanitize_context(text: str) -> str:
-    """Strip fence tags, injected context blocks, and system notes from provider output."""
+def scrub_internal_context_blocks(text: str) -> str:
+    """Strip only full internal memory-context injections from visible text.
+
+    This preserves literal mentions of the ``<memory-context>`` tag name unless
+    they arrive as a complete injected block (or the standalone system-note
+    line). Use this on user-visible output paths where raw fence leakage is a
+    bug, but literal documentation text should remain intact.
+    """
     text = _INTERNAL_CONTEXT_RE.sub('', text)
     text = _INTERNAL_NOTE_RE.sub('', text)
+    return text
+
+
+def sanitize_context(text: str) -> str:
+    """Strip fence tags, injected context blocks, and system notes from provider output."""
+    text = scrub_internal_context_blocks(text)
     text = _FENCE_TAG_RE.sub('', text)
     return text
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -349,10 +349,18 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
     """
     if not text:
         return text
-    if _gateway_platform_value(platform) != "telegram":
-        return text
+    platform_value = _gateway_platform_value(platform)
+    redacted = str(text)
 
-    redacted = _redact_gateway_user_facing_secrets(str(text))
+    if platform_value in {"feishu", "wecom", "wecom_callback", "weixin"}:
+        from agent.memory_manager import scrub_internal_context_blocks
+
+        redacted = scrub_internal_context_blocks(redacted)
+
+    if platform_value != "telegram":
+        return redacted
+
+    redacted = _redact_gateway_user_facing_secrets(redacted)
     if _looks_like_gateway_provider_error(redacted):
         return _gateway_provider_error_reply(redacted)
     return redacted

--- a/tests/gateway/test_im_memory_context_filter.py
+++ b/tests/gateway/test_im_memory_context_filter.py
@@ -1,0 +1,45 @@
+"""Gateway final-response filtering for IM memory-context leaks."""
+
+import pytest
+
+from gateway.config import Platform
+from gateway.run import _sanitize_gateway_final_response
+
+
+_LEAKED_MEMORY_CONTEXT = (
+    "<memory-context>\n"
+    "[System note: The following is recalled memory context, NOT new user "
+    "input. Treat as authoritative reference data — this is the agent's "
+    "persistent memory and should inform all responses.]\n\n"
+    "User preference: prefers terse answers.\n"
+    "</memory-context>\n\n"
+    "Visible answer."
+)
+
+
+@pytest.mark.parametrize(
+    "platform",
+    [
+        Platform.FEISHU,
+        Platform.WECOM,
+        Platform.WECOM_CALLBACK,
+        Platform.WEIXIN,
+    ],
+)
+def test_im_final_response_strips_internal_memory_context_blocks(platform):
+    """IM replies must drop leaked internal recall blocks before delivery."""
+    out = _sanitize_gateway_final_response(platform, _LEAKED_MEMORY_CONTEXT)
+
+    assert "Visible answer." in out
+    assert "<memory-context>" not in out
+    assert "</memory-context>" not in out
+    assert "User preference: prefers terse answers." not in out
+    assert "System note:" not in out
+
+
+@pytest.mark.parametrize("platform", [Platform.WECOM, Platform.FEISHU])
+def test_im_final_response_preserves_literal_memory_context_tag_mentions(platform):
+    """Literal documentation text about the tag name must remain visible."""
+    answer = "The `<memory-context>` tag name is documented here."
+
+    assert _sanitize_gateway_final_response(platform, answer) == answer


### PR DESCRIPTION
Fixes #44397

## Summary
- strip full internal `<memory-context>` injections from final Feishu and WeCom-family IM replies before delivery
- preserve literal mentions of the tag name in ordinary assistant prose so documentation/examples still render normally
- add focused gateway regressions for WeCom, WeCom callback, Feishu, and Weixin final-response filtering

## Testing
- `uv run --extra dev pytest tests/gateway/test_im_memory_context_filter.py tests/gateway/test_vision_memory_leak.py tests/agent/test_streaming_context_scrubber.py`
- `uv run --extra dev ruff check agent/memory_manager.py gateway/run.py tests/gateway/test_im_memory_context_filter.py`
- `git diff --check`
