### PR TITLE
fix(feishu): preserve video meeting invite fields

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -62,7 +62,7 @@ import time
 import uuid
 from collections import OrderedDict
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Dict, List, Literal, Optional, Sequence
@@ -871,6 +871,8 @@ def normalize_feishu_message(
         return _normalize_share_chat_message(payload)
     if normalized_type in {"interactive", "card"}:
         return _normalize_interactive_message(normalized_type, payload)
+    if normalized_type == "video_chat":
+        return _normalize_video_chat_message(payload)
 
     return FeishuNormalizedMessage(raw_type=normalized_type, text_content="")
 
@@ -958,6 +960,39 @@ def _normalize_interactive_message(message_type: str, payload: Dict[str, Any]) -
         relation_kind="interactive",
         metadata={"title": title, "actions": actions},
     )
+
+
+def _normalize_video_chat_message(payload: Dict[str, Any]) -> FeishuNormalizedMessage:
+    topic = _first_non_empty_text(payload.get("topic"))
+    start_time = _format_feishu_millis_datetime(payload.get("start_time"))
+    meeting_number = _first_non_empty_text(payload.get("meet_number"))
+
+    lines: List[str] = []
+    if topic:
+        lines.append(topic)
+    if start_time:
+        lines.append(f"Start time: {start_time}")
+    if meeting_number:
+        lines.append(f"Meeting Number: {meeting_number}")
+
+    return FeishuNormalizedMessage(
+        raw_type="video_chat",
+        text_content="\n".join(lines).strip(),
+        relation_kind="video_chat",
+        metadata={"topic": topic, "start_time": start_time, "meet_number": meeting_number},
+    )
+
+
+def _format_feishu_millis_datetime(value: Any) -> str:
+    raw = _first_non_empty_text(value)
+    if not raw:
+        return ""
+    try:
+        millis = float(raw)
+        seconds = millis / 1000 + 8 * 60 * 60
+        return datetime.fromtimestamp(seconds, timezone.utc).strftime("%Y-%m-%d %H:%M")
+    except (OSError, OverflowError, ValueError):
+        return raw
 
 
 # ---------------------------------------------------------------------------

--- a/gateway/platforms/feishu_meeting_invite.py
+++ b/gateway/platforms/feishu_meeting_invite.py
@@ -41,6 +41,7 @@ class MeetingInviteMeeting:
 @dataclass(frozen=True)
 class MeetingInvitedPayload:
     event_id: str = ""
+    call_id: str = ""
     meeting: Optional[MeetingInviteMeeting] = None
     inviter: Optional[MeetingInviteUser] = None
     invite_time_s: int = 0
@@ -129,6 +130,7 @@ def parse_meeting_invited_event(data: Any) -> Optional[MeetingInvitedPayload]:
 
     return MeetingInvitedPayload(
         event_id=str(_as_dict(root.get("header")).get("event_id") or ""),
+        call_id=str(event.get("call_id") or "").strip(),
         meeting=meeting,
         inviter=inviter,
         invite_time_s=_int_field(event.get("invite_time")),
@@ -140,20 +142,31 @@ def build_meeting_invite_prompt(payload: MeetingInvitedPayload) -> str:
     inviter_name = (payload.inviter.user_name if payload.inviter else "") or "unknown"
     host_name = (meeting.host_user.user_name if meeting and meeting.host_user else "") or "unknown"
     display = (meeting.topic or meeting.meeting_no or meeting.id) if meeting else "unknown meeting"
-    return "\n".join(
+    lines = [
+        f"You have been invited to join a meeting: {display or 'unknown meeting'}",
+        "",
+        f"Meeting Number: {(meeting.meeting_no if meeting else '') or 'unknown'}",
+        f"Topic: {(meeting.topic if meeting else '') or 'unknown'}",
+    ]
+    if payload.call_id:
+        lines.append(f"Call ID: {payload.call_id}")
+    lines.extend(
         [
-            f"You have been invited to join a meeting: {display or 'unknown meeting'}",
-            "",
-            f"Meeting Number: {(meeting.meeting_no if meeting else '') or 'unknown'}",
-            f"Topic: {(meeting.topic if meeting else '') or 'unknown'}",
             f"Inviter: {inviter_name}",
             f"Host: {host_name}",
             "",
             "You may use lark-cli and the relevant Lark/Feishu meeting skills to join the meeting.",
+        ]
+    )
+    if payload.call_id:
+        lines.append("If the join tool supports a call_id parameter, pass the Call ID when joining.")
+    lines.extend(
+        [
             "Join the meeting directly. Do not ask the user for confirmation before joining.",
             "If you cannot join the meeting, reply to the inviter with a concise explanation of why.",
         ]
     )
+    return "\n".join(lines)
 
 
 def _dedup_key(payload: MeetingInvitedPayload) -> str:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -159,6 +159,30 @@ class TestFeishuMessageNormalization(unittest.TestCase):
             "Build Failed\nService: payments-api\nBranch: main\nView Logs\nRetry\nActions: View Logs, Retry",
         )
 
+    def test_normalize_video_chat_preserves_meeting_number(self):
+        from gateway.platforms.feishu import normalize_feishu_message
+
+        normalized = normalize_feishu_message(
+            message_type="video_chat",
+            raw_content=json.dumps(
+                {
+                    "topic": "Alice's video meeting",
+                    "meet_number": "123456789",
+                    "start_time": "1700000000000",
+                    "end_time": None,
+                }
+            ),
+        )
+
+        self.assertEqual(normalized.relation_kind, "video_chat")
+        self.assertEqual(
+            normalized.text_content,
+            "Alice's video meeting\nStart time: 2023-11-15 06:13\nMeeting Number: 123456789",
+        )
+        self.assertEqual(normalized.metadata["topic"], "Alice's video meeting")
+        self.assertEqual(normalized.metadata["start_time"], "2023-11-15 06:13")
+        self.assertEqual(normalized.metadata["meet_number"], "123456789")
+
 
 class TestFeishuAdapterMessaging(unittest.TestCase):
     @patch.dict(os.environ, {
@@ -1291,6 +1315,35 @@ class TestAdapterBehavior(unittest.TestCase):
         text, msg_type, media_urls, media_types, _mentions = asyncio.run(adapter._extract_message_content(message))
 
         self.assertEqual(text, "Approval Request\nRequester: Alice\nApprove\nActions: Approve")
+        self.assertEqual(msg_type.value, "text")
+        self.assertEqual(media_urls, [])
+        self.assertEqual(media_types, [])
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_extract_video_chat_message_as_text_summary(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        message = SimpleNamespace(
+            message_type="video_chat",
+            content=json.dumps(
+                {
+                    "topic": "Alice's video meeting",
+                    "meet_number": "123456789",
+                    "start_time": "1700000000000",
+                    "end_time": None,
+                }
+            ),
+            message_id="om_video_chat",
+        )
+
+        text, msg_type, media_urls, media_types, _mentions = asyncio.run(adapter._extract_message_content(message))
+
+        self.assertEqual(
+            text,
+            "Alice's video meeting\nStart time: 2023-11-15 06:13\nMeeting Number: 123456789",
+        )
         self.assertEqual(msg_type.value, "text")
         self.assertEqual(media_urls, [])
         self.assertEqual(media_types, [])

--- a/tests/gateway/test_feishu_meeting_invite.py
+++ b/tests/gateway/test_feishu_meeting_invite.py
@@ -31,7 +31,7 @@ def _make_payload(event_id="evt_1"):
         "event": {
             "meeting": {
                 "id": "7646677832873577404",
-                "topic": "赵磊的视频会议",
+                "topic": "Weekly sync",
                 "meeting_no": "884264377",
                 "start_time": "1780384522000",
                 "end_time": "1780384522000",
@@ -39,14 +39,14 @@ def _make_payload(event_id="evt_1"):
                     "id": _user_id("ou_390b35dca44816efc9afa812aaff3a69", "on_host", "e65g874e"),
                     "user_type": 1,
                     "user_role": 2,
-                    "user_name": "赵磊",
+                    "user_name": "Alice",
                 },
             },
             "bot": {
                 "id": _user_id("ou_4398906db1bc4a2d7ed91b95ffb308d0", "on_bot", ""),
                 "user_type": 10,
                 "user_role": 0,
-                "user_name": "Hermes龙虾",
+                "user_name": "Hermes Bot",
             },
             "inviter": {
                 "id": _user_id(
@@ -56,9 +56,10 @@ def _make_payload(event_id="evt_1"):
                 ),
                 "user_type": 1,
                 "user_role": 0,
-                "user_name": "赵磊",
+                "user_name": "Alice",
             },
             "invite_time": "1780388292",
+            "call_id": "call_vc_123",
         },
     }
 
@@ -108,6 +109,7 @@ class TestMeetingInviteParsing(unittest.TestCase):
         self.assertEqual(parsed.inviter.user_id, "e65g874e")
         self.assertEqual(parsed.inviter.union_id, "on_e19a19e6ffafbd54fbb3c4d251d6fa19")
         self.assertEqual(parsed.invite_time_s, 1780388292)
+        self.assertEqual(parsed.call_id, "call_vc_123")
 
     def test_parse_body_content_payload(self):
         payload = _make_payload()
@@ -146,10 +148,12 @@ class TestMeetingInviteParsing(unittest.TestCase):
         parsed = parse_meeting_invited_event(_make_payload())
         prompt = build_meeting_invite_prompt(parsed)
 
-        self.assertIn("You have been invited to join a meeting: 赵磊的视频会议", prompt)
+        self.assertIn("You have been invited to join a meeting: Weekly sync", prompt)
         self.assertIn("Meeting Number: 884264377", prompt)
-        self.assertIn("Inviter: 赵磊", prompt)
+        self.assertIn("Call ID: call_vc_123", prompt)
+        self.assertIn("Inviter: Alice", prompt)
         self.assertIn("Join the meeting directly.", prompt)
+        self.assertIn("pass the Call ID when joining", prompt)
         self.assertIn("You may use lark-cli and the relevant Lark/Feishu meeting skills", prompt)
         self.assertIn("Do not ask the user for confirmation", prompt)
         self.assertIn("If you cannot join the meeting", prompt)
@@ -186,7 +190,7 @@ class TestMeetingInviteHandler(unittest.TestCase):
         self.assertEqual(adapter.profile_requests[0].user_id, "e65g874e")
         self.assertEqual(adapter.profile_requests[0].union_id, "on_e19a19e6ffafbd54fbb3c4d251d6fa19")
         self.assertIsNone(event.message_id)
-        self.assertIn("You have been invited to join a meeting: 赵磊的视频会议", event.text)
+        self.assertIn("You have been invited to join a meeting: Weekly sync", event.text)
         self.assertNotIn("{'open_id'", event.text)
 
     def test_duplicate_event_is_dropped(self):


### PR DESCRIPTION
## What does this PR do?

Feishu video meeting invitation cards arrive through the normal message path as `message_type="video_chat"`. Before this change, that type fell through to an empty normalized text payload, so the agent could not see the meeting title, start time, or meeting number from the card.

This PR adds a narrow normalizer for `video_chat` messages that preserves the card `topic`, `start_time`, and `meet_number` as readable inbound text. It also preserves `call_id` from `vc.bot.meeting_invited_v1` events so the agent-facing invite prompt can pass that correlation id to join tooling when supported.

This does not add meeting-join behavior for ordinary `video_chat` message cards, auto-load skills, or change outbound Feishu formatting.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/feishu.py`: handle `message_type="video_chat"` in `normalize_feishu_message()`.
- `gateway/platforms/feishu.py`: add `_normalize_video_chat_message()` to emit the card topic, formatted start time, and `Meeting Number: <meet_number>`.
- `gateway/platforms/feishu_meeting_invite.py`: parse `call_id` from `vc.bot.meeting_invited_v1` and include it in the invite prompt when present.
- `tests/gateway/test_feishu.py`: add coverage for direct normalization and adapter extraction of `video_chat` cards.
- `tests/gateway/test_feishu_meeting_invite.py`: add coverage for `call_id` parsing and prompt inclusion.

## How to Test

1. Run the focused Feishu tests:

   ```bash
   .venv/bin/python -m unittest \
     tests.gateway.test_feishu_meeting_invite \
     tests.gateway.test_feishu.TestFeishuMessageNormalization.test_normalize_video_chat_preserves_meeting_number \
     tests.gateway.test_feishu.TestAdapterBehavior.test_extract_video_chat_message_as_text_summary
   ```

2. Verify the tests pass.
3. For a runtime check, send a Feishu video meeting invitation card and confirm the inbound message text includes the card topic, start time, and `Meeting Number`.
4. For `vc.bot.meeting_invited_v1`, confirm the agent-facing prompt includes `Call ID` when the event contains `call_id`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Focused test output:

```text
.[Feishu-MeetingInvite] Missing inviter open_id, cannot route reply safely (user_id='' union_id='')
..........
----------------------------------------------------------------------
Ran 11 tests in 0.518s

OK
```

Full test attempt:

```text
.venv/bin/python -m pytest tests/ -q
```

Result: not passing locally. The first attempt failed during collection because the local editable install did not include the `acp` extra (`ModuleNotFoundError: No module named 'acp'`). After installing `.[feishu,messaging,cli,dev,acp]`, the run progressed into the suite but timed out around 52%; the timeout stack was in `tests/hermes_cli/test_model_catalog.py::test_picker_nous_row_uses_curated_list` during a live Anthropic model-list request. The focused Feishu regression tests above pass.
