### PR TITLE
fix(desktop): make file-preview source + markdown selectable

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-file.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.tsx
@@ -287,7 +287,7 @@ const MARKDOWN_COMPONENTS = {
 
 function MarkdownPreview({ text }: { text: string }) {
   return (
-    <div className="preview-markdown mx-auto max-w-3xl px-4 py-3 text-sm text-foreground">
+    <div className="preview-markdown mx-auto max-w-3xl px-4 py-3 text-sm text-foreground" data-selectable-text="true">
       <Streamdown components={MARKDOWN_COMPONENTS} controls={false} mode="static" parseIncompleteMarkdown={false}>
         {text}
       </Streamdown>
@@ -383,7 +383,10 @@ function SourceView({ filePath, language, text }: { filePath: string; language: 
           )
         })}
       </div>
-      <div className="relative [&_pre]:m-0 [&_pre]:px-3 [&_pre]:py-3 [&_pre]:bg-transparent!">
+      <div
+        className="relative [&_pre]:m-0 [&_pre]:px-3 [&_pre]:py-3 [&_pre]:bg-transparent!"
+        data-selectable-text="true"
+      >
         {selection && (
           <div
             aria-hidden


### PR DESCRIPTION
## Summary

Code and rendered markdown in the right-rail file preview couldn't be selected or copied. Root cause: `body` sets `user-select: none` (native-app feel) and the app opts text back in only via the unlayered `[data-selectable-text='true']` rule — the same mechanism chat messages use. The preview's `SourceView` (Shiki) and `MarkdownPreview` never set that attribute, so they inherited `user-select: none`.

- Tag the Shiki **code column** in `SourceView` with `data-selectable-text="true"`.
- Tag the `MarkdownPreview` root with `data-selectable-text="true"`.

The attribute is deliberately **not** on the `SourceView` grid root: the unlayered `[data-selectable-text='true'] *` rule would otherwise override the gutter's `select-none` and pull line numbers into copied text. Keeping it on the code column only means a copy yields clean source without the gutter.

## Test plan

- [x] `npm run typecheck` (desktop) — clean
- [x] `npx eslint .../preview-file.tsx` — clean
- [ ] Open a code file in the preview pane → drag-select + Cmd/Ctrl+C copies the source
- [ ] Open a markdown file (rendered) → prose is selectable/copyable
- [ ] Confirm line-number gutter is still NOT included when selecting code