### PR TITLE
Resume descendant sessions in TUI gateway

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -876,6 +876,9 @@ def test_session_resume_uses_parent_lineage_for_display(monkeypatch):
         def get_session(self, target):
             return {"id": target}
 
+        def resolve_resume_session_id(self, target):
+            return target
+
         def reopen_session(self, target):
             captured["reopened"] = target
 
@@ -919,6 +922,61 @@ def test_session_resume_uses_parent_lineage_for_display(monkeypatch):
     assert captured["history_calls"] == [("tip", False), ("tip", True)]
 
 
+def test_session_resume_resolves_to_descendant_before_reopening(monkeypatch):
+    captured = {}
+
+    class FakeDB:
+        def get_session(self, target):
+            captured.setdefault("get_session_calls", []).append(target)
+            if target == "parent":
+                return {"id": "parent"}
+            if target == "child":
+                return {"id": "child", "model": "gpt-5.4"}
+            return None
+
+        def resolve_resume_session_id(self, target):
+            captured["resolved_from"] = target
+            return "child"
+
+        def reopen_session(self, target):
+            captured["reopened"] = target
+
+        def get_messages_as_conversation(self, target, include_ancestors=False):
+            captured.setdefault("history_calls", []).append((target, include_ancestors))
+            return [{"role": "user", "content": f"{target}:{include_ancestors}"}]
+
+    def fake_make_agent(_sid, key, session_id=None, session_db=None, **kwargs):
+        captured["agent_key"] = key
+        captured["agent_session_id"] = session_id
+        captured["agent_kwargs"] = kwargs
+        return types.SimpleNamespace(model="test")
+
+    def fake_init_session(sid, key, agent, history, cols=80):
+        captured["init_key"] = key
+        server._sessions[sid] = {"agent": agent, "session_key": key}
+
+    monkeypatch.setattr(server, "_get_db", lambda: FakeDB())
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_set_session_context", lambda target: [])
+    monkeypatch.setattr(server, "_clear_session_context", lambda tokens: None)
+    monkeypatch.setattr(server, "_make_agent", fake_make_agent)
+    monkeypatch.setattr(server, "_session_info", lambda agent, *a: {"model": "test"})
+    monkeypatch.setattr(server, "_init_session", fake_init_session)
+
+    resp = server.handle_request(
+        {"id": "1", "method": "session.resume", "params": {"session_id": "parent"}}
+    )
+
+    assert resp["result"]["resumed"] == "child"
+    assert resp["result"]["session_key"] == "child"
+    assert captured["resolved_from"] == "parent"
+    assert captured["reopened"] == "child"
+    assert captured["history_calls"] == [("child", False), ("child", True)]
+    assert captured["agent_key"] == "child"
+    assert captured["agent_session_id"] == "child"
+    assert captured["init_key"] == "child"
+
+
 def test_session_resume_passes_stored_runtime_to_agent(monkeypatch):
     captured = {}
 
@@ -930,6 +988,9 @@ def test_session_resume_passes_stored_runtime_to_agent(monkeypatch):
                 "billing_provider": "openai-codex",
                 "model_config": '{"reasoning_config":{"enabled":true,"effort":"high"},"service_tier":"priority","base_url":"https://custom.example/v1","api_mode":"chat_completions"}',
             }
+
+        def resolve_resume_session_id(self, target):
+            return target
 
         def reopen_session(self, target):
             pass

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -301,6 +301,9 @@ def test_session_resume_returns_hydrated_messages(server, monkeypatch):
         def get_session_by_title(self, _title):
             return None
 
+        def resolve_resume_session_id(self, target):
+            return target
+
         def reopen_session(self, _sid):
             return None
 
@@ -359,6 +362,9 @@ def test_session_resume_handles_multimodal_list_content(server, monkeypatch):
         def get_session_by_title(self, _title):
             return None
 
+        def resolve_resume_session_id(self, target):
+            return target
+
         def reopen_session(self, _sid):
             return None
 
@@ -409,6 +415,9 @@ def test_session_resume_reuses_existing_live_session(server, monkeypatch):
 
         def get_session_by_title(self, _title):
             return None
+
+        def resolve_resume_session_id(self, current):
+            return current
 
         def reopen_session(self, _sid):
             return None
@@ -530,6 +539,9 @@ def test_session_resume_live_payload_uses_current_history_with_ancestors(server,
 
         def get_session_by_title(self, _title):
             return None
+
+        def resolve_resume_session_id(self, current):
+            return current
 
         def reopen_session(self, _sid):
             return None

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3811,6 +3811,14 @@ def _(rid, params: dict) -> dict:
             target = found["id"]
         else:
             return _err(rid, 4007, "session not found")
+    # Resume the active descendant that actually owns the current transcript.
+    # Desktop/sidebar routes may still point at an older lineage id, but the
+    # live gateway session must re-anchor to the continuation target so follow-up
+    # turns, live-session reuse, and transcript hydration all agree.
+    resolved_target = db.resolve_resume_session_id(target)
+    if resolved_target:
+        target = resolved_target
+        found = db.get_session(target) or found
     # Fast path: if the session is already live, reuse it under the lock.
     with _session_resume_lock:
         live = _find_live_session_by_key(target)


### PR DESCRIPTION
## Summary
- resolve `session.resume` targets through `resolve_resume_session_id()` before live-session lookup, history hydration, and agent construction
- re-anchor resumed gateway sessions to the descendant that actually owns the transcript so follow-up turns keep using the right logical session
- cover the stale-parent resume case and update existing resume test doubles to the current SessionDB contract

## Testing
- `uv run --extra dev pytest tests/test_tui_gateway_server.py tests/tui_gateway/test_protocol.py -k 'session_resume'`\n- `uv run --extra dev ruff check tui_gateway/server.py tests/test_tui_gateway_server.py tests/tui_gateway/test_protocol.py`\n- `git diff --check`\n\nFixes #44640