### PR TITLE
feat(kanban): stamp created_by from gateway sender

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -892,6 +892,90 @@ def test_create_session_id_arg_overrides_env(monkeypatch, worker_env):
         conn.close()
 
 
+def test_create_stamps_gateway_sender_when_not_a_worker(monkeypatch, worker_env):
+    """In a top-level gateway turn (no HERMES_KANBAN_TASK), the card's
+    created_by records the originating human as ``<platform>:<uid>/<name>``
+    so the board audit spine attributes work to the human, not the profile.
+    """
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setenv("HERMES_PROFILE", "hermes")
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "slack")
+    monkeypatch.setenv("HERMES_SESSION_USER_ID", "U12345")
+    monkeypatch.setenv("HERMES_SESSION_USER_NAME", "ada")
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+    d = json.loads(kt._handle_create({"title": "from slack", "assignee": "peer"}))
+    assert d["ok"] is True
+    conn = kb.connect()
+    try:
+        new_task = kb.get_task(conn, d["task_id"])
+        assert new_task.created_by == "slack:U12345/ada"
+    finally:
+        conn.close()
+
+
+def test_create_gateway_sender_without_name(monkeypatch, worker_env):
+    """When the gateway carries a user id but no display name, created_by
+    falls back to ``<platform>:<uid>`` (no trailing slash)."""
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "slack")
+    monkeypatch.setenv("HERMES_SESSION_USER_ID", "U999")
+    monkeypatch.delenv("HERMES_SESSION_USER_NAME", raising=False)
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+    d = json.loads(kt._handle_create({"title": "no name", "assignee": "peer"}))
+    assert d["ok"] is True
+    conn = kb.connect()
+    try:
+        new_task = kb.get_task(conn, d["task_id"])
+        assert new_task.created_by == "slack:U999"
+    finally:
+        conn.close()
+
+
+def test_create_worker_keeps_profile_created_by_for_parent_gate(monkeypatch, worker_env):
+    """A dispatcher-spawned worker (HERMES_KANBAN_TASK set) must keep its
+    profile in created_by even when a gateway sender is present — the
+    parent-completion gate (``_verify_created_cards``) trusts ``created_by
+    == <assignee profile>``. Overwriting it with a human id would break that
+    gate, so the human-sender stamp is suppressed for workers.
+    """
+    # worker_env already sets HERMES_KANBAN_TASK + HERMES_PROFILE=test-worker.
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "slack")
+    monkeypatch.setenv("HERMES_SESSION_USER_ID", "U12345")
+    monkeypatch.setenv("HERMES_SESSION_USER_NAME", "ada")
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+    d = json.loads(kt._handle_create({
+        "title": "worker child", "assignee": "peer", "parents": [worker_env],
+    }))
+    assert d["ok"] is True
+    conn = kb.connect()
+    try:
+        new_task = kb.get_task(conn, d["task_id"])
+        assert new_task.created_by == "test-worker"
+    finally:
+        conn.close()
+
+
+def test_create_falls_back_to_profile_without_gateway(monkeypatch, worker_env):
+    """No gateway sender (CLI/cron/ACP) → created_by uses HERMES_PROFILE."""
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setenv("HERMES_PROFILE", "techlead")
+    monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_USER_ID", raising=False)
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+    d = json.loads(kt._handle_create({"title": "cli child", "assignee": "peer"}))
+    assert d["ok"] is True
+    conn = kb.connect()
+    try:
+        new_task = kb.get_task(conn, d["task_id"])
+        assert new_task.created_by == "techlead"
+    finally:
+        conn.close()
+
+
 def test_create_session_id_absent_when_env_unset(monkeypatch, worker_env):
     """No env var, no arg → session_id stays NULL. Important for backwards
     compatibility: pre-ACP-propagation hosts and CLI-driven creates must

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -720,6 +720,44 @@ def _handle_comment(args: dict, **kw) -> str:
         return tool_error(f"kanban_comment: {e}")
 
 
+def _resolve_created_by() -> str:
+    """Resolve the principal to stamp on a newly-created card.
+
+    Precedence:
+
+    1. **Gateway human sender** — when the agent is answering a gateway
+       conversation (Slack/Telegram/etc.) *and* is not itself a
+       dispatcher-spawned worker (``HERMES_KANBAN_TASK`` unset), stamp the
+       originating human as ``<platform>:<user_id>/<display-name>`` so the
+       board's audit spine records who actually asked for the work, not
+       just the answering profile. The shared multi-user server deployment
+       relies on this attribution.
+    2. **Profile** — the historic default (``HERMES_PROFILE``), used for
+       dispatcher-spawned worker fan-out and CLI/dashboard paths.
+
+    Workers (``HERMES_KANBAN_TASK`` set) intentionally keep the profile
+    value: ``_verify_created_cards`` trusts ``created_by == <assignee
+    profile>`` to gate parent completion, so overwriting it with a human
+    identity there would break the gate. The human-sender stamp only
+    applies to top-level gateway turns, which are not subject to that gate.
+    """
+    # Dispatcher-spawned workers always stamp their profile (parent-gate).
+    if not os.environ.get("HERMES_KANBAN_TASK"):
+        try:
+            from gateway.session_context import get_session_env
+
+            platform = get_session_env("HERMES_SESSION_PLATFORM", "").strip()
+            user_id = get_session_env("HERMES_SESSION_USER_ID", "").strip()
+            if platform and user_id:
+                user_name = get_session_env("HERMES_SESSION_USER_NAME", "").strip()
+                return f"{platform}:{user_id}/{user_name}" if user_name else f"{platform}:{user_id}"
+        except Exception:
+            # No gateway context (CLI/cron/ACP) or import unavailable —
+            # fall through to the profile default.
+            pass
+    return os.environ.get("HERMES_PROFILE") or "worker"
+
+
 def _handle_create(args: dict, **kw) -> str:
     """Create a child task. Orchestrator workers use this to fan out.
 
@@ -814,7 +852,7 @@ def _handle_create(args: dict, **kw) -> str:
                     int(goal_max_turns) if goal_max_turns is not None else None
                 ),
                 initial_status=str(initial_status),
-                created_by=os.environ.get("HERMES_PROFILE") or "worker",
+                created_by=_resolve_created_by(),
                 session_id=session_id,
             )
             new_task = kb.get_task(conn, new_tid)


### PR DESCRIPTION
## What does this PR do?

When an agent creates a kanban card during a top-level gateway conversation (Slack/Telegram/etc.), the card's `created_by` currently records only the answering profile (`HERMES_PROFILE`). On shared/multi-user gateway deployments this loses the most useful piece of audit information: **which human asked for the work**.

This PR stamps the originating human as `<platform>:<user_id>/<display-name>` (e.g. `slack:U0123ABCD/jane`) on cards created in top-level gateway turns, while deliberately preserving the historic profile stamp everywhere it is load-bearing:

- **Dispatcher-spawned workers** (`HERMES_KANBAN_TASK` set) keep `created_by = <profile>`: the parent-completion gate (`_verify_created_cards`) trusts `created_by == <assignee profile>`, so the human stamp is suppressed there to avoid breaking the gate.
- **CLI / cron / ACP** paths (no gateway session context) fall back to `HERMES_PROFILE`, unchanged.

The resolver reads the sender from the existing per-session env (`HERMES_SESSION_PLATFORM` / `HERMES_SESSION_USER_ID` / `HERMES_SESSION_USER_NAME`) via `gateway.session_context.get_session_env`, and fails closed to the old behavior on any error.

## Related Issue

N/A — small, self-contained audit improvement; happy to file one if preferred.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/kanban_tools.py` — new `_resolve_created_by()` (documented precedence: gateway human sender → profile) and a one-line change in `_handle_create` to use it.
- `tests/tools/test_kanban_tools.py` — 4 new behavioral tests: human stamp on top-level gateway turns (with and without display name), profile stamp preserved for dispatcher workers, profile fallback when no gateway context.

## How to Test

1. `pytest tests/tools/test_kanban_tools.py -q` — all pass (including the 4 new tests).
2. Manual: run a gateway (e.g. Slack), ask the agent to create a kanban card in a top-level turn, then `hermes kanban show <id>` — `created_by` reads `slack:<uid>/<name>`.
3. Manual (gate intact): let the dispatcher fan out a child card from a worker — `created_by` is still the worker's profile, and parent completion verification behaves as before.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(kanban): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the test suite via `scripts/run_tests.sh`; the only failures (22 across 10 files) are environment-related and reproduce identically on the base commit `d02a59b6` on this machine — zero regressions from this change
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Darwin 25.4)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the new resolver carries a full docstring; no user-facing docs describe `created_by` semantics today — or N/A
- [x] `cli-config.yaml.example` — N/A (no config keys added)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact considered — pure-Python env/context reads, no platform-specific calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)
