### PR TITLE
fix(discord): detect closed HTTP session before send (#44541)

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1566,6 +1566,22 @@ class DiscordAdapter(BasePlatformAdapter):
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
+        # Guard against sending through a stale client whose internal
+        # aiohttp session was closed during a reconnect.  Without this,
+        # channel.send() raises RuntimeError("Session is closed") which
+        # bubbles up as an unhandled exception from the cron delivery
+        # path instead of a clean SendResult failure.  (issue #44541)
+        try:
+            _http = getattr(self._client, "http", None)
+            _session = getattr(_http, "session", None) if _http else None
+            if _session is not None and _session.closed:
+                return SendResult(
+                    success=False,
+                    error="Discord client HTTP session is closed (reconnect in progress)",
+                )
+        except Exception:
+            pass  # defensive — don't block sends over a probe failure
+
         try:
             # Determine target channel: thread_id in metadata takes precedence.
             thread_id = None


### PR DESCRIPTION
Fixes #44541. After a Discord adapter reconnect, the old bot's internal aiohttp session is closed. When cron delivery tries to send via the stale adapter, channel.send() raises RuntimeError('Session is closed') instead of returning a clean failure. The fix adds an early check for a closed HTTP session in the send() method, returning a proper SendResult failure so the cron delivery path can fall back to standalone send.