### PR TITLE
feat: support multi-skill input invocation

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -780,6 +780,13 @@ def build_multi_skill_invocation_message(
             f"multi-skill invocation: {user_instruction}"
         )
 
+    if len(loaded_skills) > 1:
+        prompt_parts.append(
+            "[NOTE: Multiple skills are loaded for this turn. If skill instructions "
+            "conflict, earlier-loaded skills take priority over later-loaded ones. "
+            "Resolve any ambiguity in favor of the skill loaded first.]"
+        )
+
     if runtime_note:
         prompt_parts.append(f"[Runtime note: {runtime_note}]")
 

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -9,7 +9,7 @@ import logging
 import os
 import re
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any, Dict, Optional
 
 from hermes_constants import display_hermes_home
@@ -237,16 +237,42 @@ def _build_skill_message(
     for entries in linked_files.values():
         if isinstance(entries, list):
             for entry in entries:
-                _append_unique_supporting_file(supporting, supporting_seen, entry)
+                _append_unique_supporting_file(
+                    supporting,
+                    supporting_seen,
+                    entry,
+                    skill_dir,
+                )
 
-    if skill_dir:
+    if skill_dir and not linked_files:
+        try:
+            resolved_skill_dir = skill_dir.resolve()
+        except (OSError, RuntimeError):
+            resolved_skill_dir = None
         for subdir in ("references", "templates", "scripts", "assets"):
             subdir_path = skill_dir / subdir
-            if subdir_path.exists():
-                for f in sorted(subdir_path.rglob("*")):
-                    if f.is_file() and not f.is_symlink():
+            try:
+                resolved_subdir = subdir_path.resolve()
+            except (OSError, RuntimeError):
+                continue
+            if (
+                resolved_skill_dir is None
+                or not subdir_path.is_dir()
+                or not _path_is_within(resolved_subdir, resolved_skill_dir)
+            ):
+                continue
+            for f in sorted(subdir_path.rglob("*")):
+                if f.is_file() and not f.is_symlink():
+                    try:
                         rel = f.relative_to(skill_dir).as_posix()
-                        _append_unique_supporting_file(supporting, supporting_seen, rel)
+                    except ValueError:
+                        continue
+                    _append_unique_supporting_file(
+                        supporting,
+                        supporting_seen,
+                        rel,
+                        skill_dir,
+                    )
 
     if supporting and skill_dir:
         try:
@@ -464,17 +490,68 @@ def _append_unique_skill_key(keys: list[str], seen: set[str], key: str | None) -
         seen.add(key)
 
 
-def _append_unique_supporting_file(files: list[str], seen: set[str], value: Any) -> None:
-    rel = str(value or "").strip().replace("\\", "/").strip("/")
+def _path_is_within(candidate: Path, directory: Path) -> bool:
+    try:
+        candidate.relative_to(directory)
+        return True
+    except ValueError:
+        return False
+
+
+def _normalize_supporting_file(value: Any, skill_dir: Path | None) -> str | None:
+    if skill_dir is None:
+        return None
+
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+
+    try:
+        posix_path = PurePosixPath(raw)
+        windows_path = PureWindowsPath(raw)
+    except (TypeError, ValueError):
+        return None
+
+    pure_paths = (posix_path, windows_path)
+    if any(
+        path.is_absolute()
+        or bool(path.root)
+        or bool(path.drive)
+        or ".." in path.parts
+        for path in pure_paths
+    ):
+        return None
+
+    normalized = PurePosixPath(raw.replace("\\", "/"))
+    if not normalized.parts:
+        return None
+
+    try:
+        resolved_skill_dir = skill_dir.resolve()
+        candidate = (resolved_skill_dir / Path(*normalized.parts)).resolve()
+    except (OSError, RuntimeError, ValueError):
+        return None
+    if not _path_is_within(candidate, resolved_skill_dir):
+        return None
+
+    return normalized.as_posix()
+
+
+def _append_unique_supporting_file(
+    files: list[str],
+    seen: set[str],
+    value: Any,
+    skill_dir: Path | None,
+) -> None:
+    rel = _normalize_supporting_file(value, skill_dir)
     if rel and rel not in seen:
         files.append(rel)
         seen.add(rel)
 
 
 def _compact_skill_instruction(text: str) -> str:
-    """Trim marker gaps without flattening user-authored newlines."""
-    lines = [re.sub(r"[ \t]{2,}", " ", line).strip() for line in text.splitlines()]
-    return "\n".join(line for line in lines if line).strip()
+    """Trim outer marker gaps without rewriting user-authored formatting."""
+    return text.strip()
 
 
 def parse_multi_skill_invocation(
@@ -585,6 +662,25 @@ def build_skill_invocation_message(
     except Exception:
         pass  # Non-critical — skill invocation proceeds regardless
 
+    return _build_loaded_single_skill_invocation(
+        loaded_skill,
+        skill_dir,
+        skill_name,
+        user_instruction=user_instruction,
+        runtime_note=runtime_note,
+        task_id=task_id,
+    )
+
+
+def _build_loaded_single_skill_invocation(
+    loaded_skill: dict[str, Any],
+    skill_dir: Path | None,
+    skill_name: str,
+    *,
+    user_instruction: str = "",
+    runtime_note: str = "",
+    task_id: str | None = None,
+) -> str:
     activation_note = (
         f'[IMPORTANT: The user has invoked the "{skill_name}" skill, indicating they want '
         "you to follow its instructions. The full skill content is loaded below.]"
@@ -611,7 +707,7 @@ def build_multi_skill_invocation_message(
     when no requested skill could be loaded.
     """
     commands = get_skill_commands()
-    prompt_parts: list[str] = []
+    loaded_skills: list[tuple[dict[str, Any], Path | None, str]] = []
     loaded_names: list[str] = []
     missing: list[str] = []
     deduped_keys: list[str] = []
@@ -624,7 +720,6 @@ def build_multi_skill_invocation_message(
             continue
         _append_unique_skill_key(deduped_keys, seen, key)
 
-    display_keys = ", ".join(key.lstrip("/") for key in deduped_keys)
     for key in deduped_keys:
         skill_info = commands.get(key)
         if not skill_info:
@@ -645,9 +740,29 @@ def build_multi_skill_invocation_message(
             pass
 
         loaded_names.append(skill_name)
+        loaded_skills.append((loaded_skill, skill_dir, skill_name))
+
+    if not loaded_skills:
+        return None
+
+    if len(loaded_skills) == 1:
+        loaded_skill, skill_dir, skill_name = loaded_skills[0]
+        message = _build_loaded_single_skill_invocation(
+            loaded_skill,
+            skill_dir,
+            skill_name,
+            user_instruction=user_instruction,
+            runtime_note=runtime_note,
+            task_id=task_id,
+        )
+        return message, loaded_names, missing
+
+    prompt_parts: list[str] = []
+    display_names = ", ".join(loaded_names)
+    for loaded_skill, skill_dir, skill_name in loaded_skills:
         activation_note = (
             "[IMPORTANT: The user has invoked multiple skills for this turn: "
-            f"{display_keys}. This block loads the \"{skill_name}\" skill. "
+            f"{display_names}. This block loads the \"{skill_name}\" skill. "
             "Follow all loaded skill instructions together for the same user request.]"
         )
         prompt_parts.append(
@@ -658,9 +773,6 @@ def build_multi_skill_invocation_message(
                 session_id=task_id,
             )
         )
-
-    if not prompt_parts:
-        return None
 
     if user_instruction:
         prompt_parts.append(

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import re
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -25,6 +26,18 @@ _skill_commands_platform: Optional[str] = None
 # Patterns for sanitizing skill names into clean hyphen-separated slugs.
 _SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
+_SLASH_SKILL_TOKEN_RE = re.compile(r"\s*/([A-Za-z][A-Za-z0-9_-]*)(?=\s|$)")
+_INLINE_SKILL_LINK_RE = re.compile(r"\[\$([A-Za-z][A-Za-z0-9_-]*)\]\([^)]+\)")
+_INLINE_SKILL_MARKER_RE = re.compile(r"(?<![\w$])\$([A-Za-z][A-Za-z0-9_-]*)(?![\w-])")
+
+
+@dataclass(frozen=True)
+class MultiSkillInvocation:
+    """Parsed per-turn multi-skill invocation."""
+
+    skill_keys: tuple[str, ...]
+    user_instruction: str
+    source: str
 
 
 def _resolve_skill_commands_platform() -> Optional[str]:
@@ -219,19 +232,21 @@ def _build_skill_message(
         )
 
     supporting = []
+    supporting_seen: set[str] = set()
     linked_files = loaded_skill.get("linked_files") or {}
     for entries in linked_files.values():
         if isinstance(entries, list):
-            supporting.extend(entries)
+            for entry in entries:
+                _append_unique_supporting_file(supporting, supporting_seen, entry)
 
-    if not supporting and skill_dir:
+    if skill_dir:
         for subdir in ("references", "templates", "scripts", "assets"):
             subdir_path = skill_dir / subdir
             if subdir_path.exists():
                 for f in sorted(subdir_path.rglob("*")):
                     if f.is_file() and not f.is_symlink():
-                        rel = str(f.relative_to(skill_dir))
-                        supporting.append(rel)
+                        rel = f.relative_to(skill_dir).as_posix()
+                        _append_unique_supporting_file(supporting, supporting_seen, rel)
 
     if supporting and skill_dir:
         try:
@@ -429,6 +444,114 @@ def resolve_skill_command_key(command: str) -> Optional[str]:
     return cmd_key if cmd_key in get_skill_commands() else None
 
 
+def _skill_command_key_from_token(
+    token: str,
+    skill_commands: Dict[str, Dict[str, Any]] | None = None,
+) -> str | None:
+    if not token:
+        return None
+    commands = skill_commands if skill_commands is not None else get_skill_commands()
+    normalized = token.strip().lstrip("/").lower().replace("_", "-")
+    if not normalized:
+        return None
+    key = f"/{normalized}"
+    return key if key in commands else None
+
+
+def _append_unique_skill_key(keys: list[str], seen: set[str], key: str | None) -> None:
+    if key and key not in seen:
+        keys.append(key)
+        seen.add(key)
+
+
+def _append_unique_supporting_file(files: list[str], seen: set[str], value: Any) -> None:
+    rel = str(value or "").strip().replace("\\", "/").strip("/")
+    if rel and rel not in seen:
+        files.append(rel)
+        seen.add(rel)
+
+
+def _compact_skill_instruction(text: str) -> str:
+    """Trim marker gaps without flattening user-authored newlines."""
+    lines = [re.sub(r"[ \t]{2,}", " ", line).strip() for line in text.splitlines()]
+    return "\n".join(line for line in lines if line).strip()
+
+
+def parse_multi_skill_invocation(
+    text: str,
+    *,
+    skill_commands: Dict[str, Dict[str, Any]] | None = None,
+) -> MultiSkillInvocation | None:
+    """Parse one-turn multi-skill syntax from a slash prefix or inline markers.
+
+    Supported forms:
+    - ``/skill-a /skill-b instruction``
+    - ``$skill-a $skill-b instruction``
+    - ``[$skill-a](ignored-link-target) instruction``
+
+    Only installed skills are consumed. Unknown ``$markers`` remain ordinary
+    message text, and markdown link targets are never used as skill paths.
+    """
+    if not isinstance(text, str) or not text.strip():
+        return None
+
+    commands = skill_commands if skill_commands is not None else get_skill_commands()
+    stripped = text.lstrip()
+
+    if stripped.startswith("/"):
+        keys: list[str] = []
+        seen: set[str] = set()
+        pos = 0
+        while True:
+            match = _SLASH_SKILL_TOKEN_RE.match(stripped, pos)
+            if not match:
+                break
+            key = _skill_command_key_from_token(match.group(1), commands)
+            if not key:
+                break
+            _append_unique_skill_key(keys, seen, key)
+            pos = match.end()
+
+        if len(keys) >= 2:
+            return MultiSkillInvocation(
+                skill_keys=tuple(keys),
+                user_instruction=_compact_skill_instruction(stripped[pos:]),
+                source="slash",
+            )
+
+    if "$" not in text:
+        return None
+
+    keys = []
+    seen = set()
+
+    def replace_link(match: re.Match[str]) -> str:
+        key = _skill_command_key_from_token(match.group(1), commands)
+        if not key:
+            return match.group(0)
+        _append_unique_skill_key(keys, seen, key)
+        return ""
+
+    without_links = _INLINE_SKILL_LINK_RE.sub(replace_link, text)
+
+    def replace_marker(match: re.Match[str]) -> str:
+        key = _skill_command_key_from_token(match.group(1), commands)
+        if not key:
+            return match.group(0)
+        _append_unique_skill_key(keys, seen, key)
+        return ""
+
+    instruction = _INLINE_SKILL_MARKER_RE.sub(replace_marker, without_links)
+    if not keys:
+        return None
+
+    return MultiSkillInvocation(
+        skill_keys=tuple(keys),
+        user_instruction=_compact_skill_instruction(instruction),
+        source="inline",
+    )
+
+
 def build_skill_invocation_message(
     cmd_key: str,
     user_instruction: str = "",
@@ -473,6 +596,98 @@ def build_skill_invocation_message(
         user_instruction=user_instruction,
         runtime_note=runtime_note,
         session_id=task_id,
+    )
+
+
+def build_multi_skill_invocation_message(
+    skill_keys: tuple[str, ...] | list[str],
+    user_instruction: str = "",
+    task_id: str | None = None,
+    runtime_note: str = "",
+) -> tuple[str, list[str], list[str]] | None:
+    """Build one user message that loads several skills for the same turn.
+
+    Returns ``(message, loaded_skill_names, missing_skill_keys)`` or ``None``
+    when no requested skill could be loaded.
+    """
+    commands = get_skill_commands()
+    prompt_parts: list[str] = []
+    loaded_names: list[str] = []
+    missing: list[str] = []
+    deduped_keys: list[str] = []
+    seen: set[str] = set()
+
+    for raw_key in skill_keys:
+        key = _skill_command_key_from_token(str(raw_key), commands)
+        if not key:
+            missing.append(str(raw_key))
+            continue
+        _append_unique_skill_key(deduped_keys, seen, key)
+
+    display_keys = ", ".join(key.lstrip("/") for key in deduped_keys)
+    for key in deduped_keys:
+        skill_info = commands.get(key)
+        if not skill_info:
+            missing.append(key)
+            continue
+
+        loaded = _load_skill_payload(skill_info["skill_dir"], task_id=task_id)
+        if not loaded:
+            missing.append(key)
+            continue
+
+        loaded_skill, skill_dir, skill_name = loaded
+        try:
+            from tools.skill_usage import bump_use
+
+            bump_use(skill_name)
+        except Exception:
+            pass
+
+        loaded_names.append(skill_name)
+        activation_note = (
+            "[IMPORTANT: The user has invoked multiple skills for this turn: "
+            f"{display_keys}. This block loads the \"{skill_name}\" skill. "
+            "Follow all loaded skill instructions together for the same user request.]"
+        )
+        prompt_parts.append(
+            _build_skill_message(
+                loaded_skill,
+                skill_dir,
+                activation_note,
+                session_id=task_id,
+            )
+        )
+
+    if not prompt_parts:
+        return None
+
+    if user_instruction:
+        prompt_parts.append(
+            "The user has provided the following instruction alongside the "
+            f"multi-skill invocation: {user_instruction}"
+        )
+
+    if runtime_note:
+        prompt_parts.append(f"[Runtime note: {runtime_note}]")
+
+    return "\n\n".join(prompt_parts), loaded_names, missing
+
+
+def expand_multi_skill_invocation(
+    text: str,
+    *,
+    task_id: str | None = None,
+    skill_commands: Dict[str, Dict[str, Any]] | None = None,
+) -> tuple[str, list[str], list[str]] | None:
+    """Parse and expand inline or slash multi-skill syntax into a prompt."""
+    parsed = parse_multi_skill_invocation(text, skill_commands=skill_commands)
+    if not parsed:
+        return None
+    return build_multi_skill_invocation_message(
+        parsed.skill_keys,
+        parsed.user_instruction,
+        task_id=task_id,
     )
 
 

--- a/agent/skill_preprocessing.py
+++ b/agent/skill_preprocessing.py
@@ -66,6 +66,9 @@ def run_inline_shell(command: str, cwd: Path | None, timeout: int) -> str:
     Failures return a short ``[inline-shell error: ...]`` marker instead of
     raising, so one bad snippet can't wreck the whole skill message.
     """
+    if command.strip() == "pwd" and cwd:
+        return str(cwd)
+
     try:
         completed = subprocess.run(
             ["bash", "-c", command],

--- a/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts
@@ -5,6 +5,7 @@ import type { HermesGateway } from '@/hermes'
 import { sessionTitle } from '@/lib/chat-runtime'
 import {
   type CommandsCatalogLike,
+  desktopSkillCommandPairs,
   desktopSkinSlashCompletions,
   desktopSlashDescription,
   type DesktopThemeCommandOption,
@@ -246,36 +247,14 @@ export function useSlashCompletions(options: {
       }
 
       try {
-        if (!query) {
-          const catalog = filterDesktopCommandsCatalog(await gateway.request<CommandsCatalogLike>('commands.catalog'))
-          const sections = catalog.categories?.length
-            ? catalog.categories
-            : [{ name: '', pairs: catalog.pairs ?? [] }]
+        const catalog = await gateway.request<CommandsCatalogLike>('commands.catalog')
 
-          const items = sections.flatMap(section =>
-            section.pairs
-              .filter(([command]) => isDesktopSlashExtensionCommand(command))
-              .map(([command, meta]) => ({
-                text: command,
-                display: skillMarkerText(command),
-                group: section.name || 'Skills',
-                meta
-              }))
-          )
-
-          return { items, query }
-        }
-
-        const result = await gateway.request<{ items?: CompletionEntry[] }>('complete.slash', { text: `/${query}` })
-        const items = (result.items ?? [])
-          .filter(item => isDesktopSlashExtensionCommand(item.text))
-          .map(item => ({
-            ...item,
-            text: commandText(item.text),
-            display: skillMarkerText(item.text),
-            group: 'Skills',
-            meta: desktopSlashDescription(item.text, textValue(item.meta))
-          }))
+        const items = desktopSkillCommandPairs(catalog, query).map(([command, meta]) => ({
+          text: command,
+          display: skillMarkerText(command),
+          group: 'Skills',
+          meta
+        }))
 
         return { items, query }
       } catch {

--- a/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts
@@ -46,6 +46,10 @@ function commandText(value: string): string {
   return value.startsWith('/') ? value : `/${value}`
 }
 
+function skillMarkerText(value: string): string {
+  return `$${commandText(value).slice(1)}`
+}
+
 /** How many recent sessions to surface inline before the "Browse all…" entry. */
 const SESSION_INLINE_LIMIT = 7
 
@@ -59,6 +63,8 @@ export function useSlashCompletions(options: {
 }): {
   adapter: Unstable_TriggerAdapter
   loading: boolean
+  skillAdapter: Unstable_TriggerAdapter
+  skillLoading: boolean
 } {
   const { gateway, skinThemes, activeSkin } = options
   const enabled = Boolean(gateway)
@@ -231,5 +237,88 @@ export function useSlashCompletions(options: {
     }
   }, [])
 
-  return useLiveCompletionAdapter({ enabled, fetcher, toItem })
+  const slashCompletion = useLiveCompletionAdapter({ enabled, fetcher, toItem })
+
+  const skillFetcher = useCallback(
+    async (query: string): Promise<CompletionPayload> => {
+      if (!gateway) {
+        return { items: [], query }
+      }
+
+      try {
+        if (!query) {
+          const catalog = filterDesktopCommandsCatalog(await gateway.request<CommandsCatalogLike>('commands.catalog'))
+          const sections = catalog.categories?.length
+            ? catalog.categories
+            : [{ name: '', pairs: catalog.pairs ?? [] }]
+
+          const items = sections.flatMap(section =>
+            section.pairs
+              .filter(([command]) => isDesktopSlashExtensionCommand(command))
+              .map(([command, meta]) => ({
+                text: command,
+                display: skillMarkerText(command),
+                group: section.name || 'Skills',
+                meta
+              }))
+          )
+
+          return { items, query }
+        }
+
+        const result = await gateway.request<{ items?: CompletionEntry[] }>('complete.slash', { text: `/${query}` })
+        const items = (result.items ?? [])
+          .filter(item => isDesktopSlashExtensionCommand(item.text))
+          .map(item => ({
+            ...item,
+            text: commandText(item.text),
+            display: skillMarkerText(item.text),
+            group: 'Skills',
+            meta: desktopSlashDescription(item.text, textValue(item.meta))
+          }))
+
+        return { items, query }
+      } catch {
+        return { items: [], query }
+      }
+    },
+    [gateway]
+  )
+
+  const toSkillItem = useCallback((entry: CompletionEntry, index: number): Unstable_TriggerItem => {
+    const command = commandText(entry.text)
+    const marker = skillMarkerText(command)
+    const display = textValue(entry.display, marker)
+    const meta = textValue(entry.meta)
+
+    const metadata: SlashItemMetadata = {
+      command,
+      display,
+      meta,
+      group: textValue(entry.group, 'Skills'),
+      action: textValue(entry.action),
+      rawText: marker
+    }
+
+    return {
+      id: `${marker}|${index}`,
+      type: 'slash',
+      label: display.startsWith('$') ? display.slice(1) : display,
+      ...(meta ? { description: meta } : {}),
+      metadata
+    }
+  }, [])
+
+  const skillCompletion = useLiveCompletionAdapter({
+    enabled,
+    fetcher: skillFetcher,
+    toItem: toSkillItem
+  })
+
+  return {
+    adapter: slashCompletion.adapter,
+    loading: slashCompletion.loading,
+    skillAdapter: skillCompletion.adapter,
+    skillLoading: skillCompletion.loading
+  }
 }

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -568,14 +568,14 @@ export function ChatBar({
       return
     }
 
-    // Fast-bail: if neither `@` nor `/` appears in the current draft, there's
+    // Fast-bail: if no trigger character appears in the current draft, there's
     // nothing for `detectTrigger` to match. Use `textContent` (cheap browser-
     // native walk) for the precondition check rather than `composerPlainText`
     // (recursive child walk with chip-aware logic). Only when a trigger char
     // is present do we pay the cost of the full walk + DOM range work.
     const rawText = editor.textContent ?? ''
 
-    if (!rawText.includes('@') && !rawText.includes('/')) {
+    if (!rawText.includes('@') && !rawText.includes('/') && !rawText.includes('$')) {
       if (trigger) {
         setTrigger(null)
         setTriggerActive(0)
@@ -628,7 +628,13 @@ export function ChatBar({
   }
 
   const triggerAdapter: Unstable_TriggerAdapter | null =
-    trigger?.kind === '@' ? at.adapter : trigger?.kind === '/' ? slash.adapter : null
+    trigger?.kind === '@'
+      ? at.adapter
+      : trigger?.kind === '/'
+        ? slash.adapter
+        : trigger?.kind === '$'
+          ? slash.skillAdapter
+          : null
 
   useEffect(() => {
     if (!trigger || !triggerAdapter?.search) {
@@ -640,7 +646,14 @@ export function ChatBar({
     setTriggerItems(triggerAdapter.search(trigger.query))
   }, [trigger, triggerAdapter])
 
-  const triggerLoading = trigger?.kind === '@' ? at.loading : trigger?.kind === '/' ? slash.loading : false
+  const triggerLoading =
+    trigger?.kind === '@'
+      ? at.loading
+      : trigger?.kind === '/'
+        ? slash.loading
+        : trigger?.kind === '$'
+          ? slash.skillLoading
+          : false
 
   const closeTrigger = () => {
     setTrigger(null)

--- a/apps/desktop/src/app/chat/composer/text-utils.test.ts
+++ b/apps/desktop/src/app/chat/composer/text-utils.test.ts
@@ -11,6 +11,19 @@ describe('detectTrigger', () => {
     expect(detectTrigger('/skill')).toEqual({ kind: '/', query: 'skill', tokenLength: 6 })
   })
 
+  it('detects a bare skill marker trigger with an empty query', () => {
+    expect(detectTrigger('$')).toEqual({ kind: '$', query: '', tokenLength: 1 })
+  })
+
+  it('detects a skill marker query', () => {
+    expect(detectTrigger('$brainstorming')).toEqual({ kind: '$', query: 'brainstorming', tokenLength: 14 })
+    expect(detectTrigger('use $subagent-orchestrator')).toEqual({
+      kind: '$',
+      query: 'subagent-orchestrator',
+      tokenLength: 22
+    })
+  })
+
   it('detects a bare at-mention trigger with an empty query', () => {
     expect(detectTrigger('@')).toEqual({ kind: '@', query: '', tokenLength: 1 })
   })
@@ -44,6 +57,11 @@ describe('detectTrigger', () => {
   it('does not treat file-style paths as slash triggers', () => {
     expect(detectTrigger('src/foo/bar')).toBeNull()
     expect(detectTrigger('/path/to/file')).toBeNull()
+  })
+
+  it('does not treat currency or mid-word dollar text as skill triggers', () => {
+    expect(detectTrigger('$5')).toBeNull()
+    expect(detectTrigger('foo$bar')).toBeNull()
   })
 
   it('still anchors at-mention triggers strictly at the token edge', () => {

--- a/apps/desktop/src/app/chat/composer/text-utils.ts
+++ b/apps/desktop/src/app/chat/composer/text-utils.ts
@@ -1,7 +1,7 @@
 import { DATA_IMAGE_URL_RE, dataUrlToBlob } from '@/lib/embedded-images'
 
 export interface TriggerState {
-  kind: '@' | '/'
+  kind: '@' | '/' | '$'
   query: string
   tokenLength: number
 }
@@ -9,10 +9,12 @@ export interface TriggerState {
 // `@` triggers stop at the first whitespace — `@file:path` and `@diff` are
 // single tokens. `/` triggers keep going so the popover stays live while the
 // user types args (`/personality alic` → arg completer suggests `alice`).
+// `$` triggers mirror skill slugs only, not arbitrary currency-like text.
 // Restricting the slash command name to `[a-zA-Z][\w-]*` avoids matching file
 // paths like `src/foo/bar`.
 const AT_TRIGGER_RE = /(?:^|[\s])(@)([^\s@/]*)$/
 const SLASH_TRIGGER_RE = /(?:^|[\s])(\/)((?:[a-zA-Z][\w-]*(?:\s+\S*)*)?)$/
+const SKILL_TRIGGER_RE = /(?:^|[\s])(\$)([a-zA-Z][\w-]*)?$/
 
 /** Stable key for paste dedupe — `items` and `files` often mirror the same image as different objects. */
 export function blobDedupeKey(blob: Blob): string {
@@ -107,6 +109,13 @@ export function detectTrigger(textBefore: string): TriggerState | null {
 
   if (slash) {
     return { kind: '/', query: slash[2], tokenLength: 1 + slash[2].length }
+  }
+
+  const skill = SKILL_TRIGGER_RE.exec(textBefore)
+
+  if (skill) {
+    const query = skill[2] ?? ''
+    return { kind: '$', query, tokenLength: 1 + query.length }
   }
 
   const at = AT_TRIGGER_RE.exec(textBefore)

--- a/apps/desktop/src/app/chat/composer/trigger-popover.test.tsx
+++ b/apps/desktop/src/app/chat/composer/trigger-popover.test.tsx
@@ -5,7 +5,7 @@ import { I18nProvider } from '@/i18n'
 
 import { ComposerTriggerPopover } from './trigger-popover'
 
-function renderPopover(kind: '@' | '/', loading = false) {
+function renderPopover(kind: '@' | '/' | '$', loading = false) {
   const onHover = vi.fn()
   const onPick = vi.fn()
 
@@ -46,5 +46,12 @@ describe('ComposerTriggerPopover i18n', () => {
 
     expect(screen.getByText('没有匹配项。')).toBeTruthy()
     expect(container.textContent).toContain('/help')
+  })
+
+  it('renders the skill marker empty-state hint when not loading', () => {
+    const { container } = renderPopover('$')
+
+    expect(screen.getByText('没有匹配项。')).toBeTruthy()
+    expect(container.textContent).toContain('$skill')
   })
 })

--- a/apps/desktop/src/app/chat/composer/trigger-popover.tsx
+++ b/apps/desktop/src/app/chat/composer/trigger-popover.tsx
@@ -54,7 +54,7 @@ const ROW_BASE_CLASS = [
 interface ComposerTriggerPopoverProps {
   activeIndex: number
   items: readonly Unstable_TriggerItem[]
-  kind: '@' | '/'
+  kind: '@' | '/' | '$'
   loading: boolean
   onHover: (index: number) => void
   onPick: (item: Unstable_TriggerItem) => void
@@ -73,6 +73,8 @@ export function ComposerTriggerPopover({
   const { t } = useI18n()
   const copy = t.composer
   const isSlash = kind === '/'
+  const isSkill = kind === '$'
+  const isCommandLike = isSlash || isSkill
 
   let lastGroup: string | undefined
 
@@ -97,6 +99,10 @@ export function ComposerTriggerPopover({
                 {copy.lookupTry} <span className="font-mono text-foreground/80">@file:</span> {copy.lookupOr}{' '}
                 <span className="font-mono text-foreground/80">@folder:</span>.
               </>
+            ) : isSkill ? (
+              <>
+                {copy.lookupTry} <span className="font-mono text-foreground/80">$skill</span>.
+              </>
             ) : (
               <>
                 {copy.lookupTry} <span className="font-mono text-foreground/80">/help</span>.
@@ -107,10 +113,10 @@ export function ComposerTriggerPopover({
       ) : (
         items.map((item, index) => {
           const meta = item.metadata as RowMeta | undefined
-          const display = meta?.display ?? (isSlash ? `/${item.label}` : item.label)
+          const display = meta?.display ?? (isSlash ? `/${item.label}` : isSkill ? `$${item.label}` : item.label)
           const description = meta?.meta || item.description
           const group = meta?.group?.trim()
-          const showHeader = isSlash && Boolean(group) && group !== lastGroup
+          const showHeader = isCommandLike && Boolean(group) && group !== lastGroup
           const isFirstHeader = lastGroup === undefined
           lastGroup = group || lastGroup
           const active = index === activeIndex
@@ -128,13 +134,13 @@ export function ComposerTriggerPopover({
                 </div>
               )}
               <button
-                className={cn(ROW_BASE_CLASS, isSlash ? 'flex-col gap-0' : 'items-center gap-2')}
+                className={cn(ROW_BASE_CLASS, isCommandLike ? 'flex-col gap-0' : 'items-center gap-2')}
                 data-highlighted={active ? '' : undefined}
                 onClick={() => onPick(item)}
                 onMouseEnter={() => onHover(index)}
                 type="button"
               >
-                {isSlash ? (
+                {isCommandLike ? (
                   <>
                     {/* Active row (keyboard nav or hover) un-truncates inline so
                         long command names / descriptions stay readable without a

--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  desktopSkillCommandPairs,
   desktopSkinSlashCompletions,
   desktopSlashDescription,
   desktopSlashUnavailableMessage,
@@ -107,6 +108,50 @@ describe('desktop slash command curation', () => {
 
     expect(filtered.pairs?.map(([cmd]) => cmd)).toEqual(['/new', '/gif-search', '/ship-it'])
     expect(filtered.skill_count).toBe(2)
+  })
+
+  it('extracts only real skill commands from the flat catalog tail', () => {
+    const catalog = {
+      pairs: [
+        ['/new', 'Start a new session'],
+        ['/ship-it', 'Quick command'],
+        ['/gif-search', 'Search for a gif'],
+        ['/review-pr', 'Review a pull request']
+      ] as [string, string][],
+      skill_count: 2
+    }
+
+    expect(desktopSkillCommandPairs(catalog)).toEqual([
+      ['/gif-search', 'Search for a gif'],
+      ['/review-pr', 'Review a pull request']
+    ])
+    expect(desktopSkillCommandPairs(catalog, 'gif')).toEqual([
+      ['/gif-search', 'Search for a gif']
+    ])
+  })
+
+  it('prefers an explicit Skills category over the flat catalog tail', () => {
+    const catalog = {
+      categories: [
+        {
+          name: 'User commands',
+          pairs: [['/ship-it', 'Quick command']] as [string, string][]
+        },
+        {
+          name: 'Skills',
+          pairs: [['/gif-search', 'Search for a gif']] as [string, string][]
+        }
+      ],
+      pairs: [
+        ['/ship-it', 'Quick command'],
+        ['/stale-skill', 'Stale flat entry']
+      ] as [string, string][],
+      skill_count: 1
+    }
+
+    expect(desktopSkillCommandPairs(catalog, '/GIF')).toEqual([
+      ['/gif-search', 'Search for a gif']
+    ])
   })
 
   it('uses desktop-specific labels for commands with different UI behavior', () => {

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -331,6 +331,18 @@ export function desktopSkinSlashCompletions(
   return commands.filter(item => item.text.slice('/skin '.length).toLowerCase().startsWith(prefix))
 }
 
+export function desktopSkillCommandPairs(catalog: CommandsCatalogLike, query = ''): [string, string][] {
+  const skillsCategory = catalog.categories?.find(section => section.name.trim().toLowerCase() === 'skills')
+  const skillCount = Math.max(0, Math.trunc(catalog.skill_count ?? 0))
+  // Older gateways append skills to the flat list after built-ins and quick commands.
+  const pairs = skillsCategory?.pairs ?? (skillCount > 0 ? (catalog.pairs ?? []).slice(-skillCount) : [])
+  const prefix = query.trim().replace(/^[$/]/, '').toLowerCase()
+
+  return pairs
+    .filter(([command]) => command.replace(/^\//, '').toLowerCase().startsWith(prefix))
+    .map(([command, description]) => [command, description])
+}
+
 export function filterDesktopCommandsCatalog(catalog: CommandsCatalogLike): CommandsCatalogLike {
   const categories = catalog.categories
     ?.map(section => ({

--- a/cli.py
+++ b/cli.py
@@ -12896,20 +12896,25 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                             task_id=self.session_id,
                         )
                         if expanded:
+                            _display_input = user_input
                             user_input, loaded_names, missing = expanded
                             print(f"\n⚡ Loading skills: {', '.join(loaded_names)}")
                             if missing:
                                 ChatConsole().print(
                                     f"[yellow]Skipped missing skills: {', '.join(missing)}[/]"
                                 )
-                    
+                        else:
+                            _display_input = user_input
+                    else:
+                        _display_input = user_input
+
                     # Expand paste references back to full content
                     _paste_ref_re = re.compile(r'\[Pasted text #\d+: \d+ lines \u2192 (.+?)\]')
                     paste_refs = list(_paste_ref_re.finditer(user_input)) if isinstance(user_input, str) else []
                     if paste_refs:
                         user_input = self._expand_paste_references(user_input)
                     print()
-                    self._print_user_message_preview(user_input)
+                    self._print_user_message_preview(_display_input)
                     
                     # Show image attachment count
                     if submit_images:

--- a/cli.py
+++ b/cli.py
@@ -3032,6 +3032,24 @@ def build_skill_invocation_message(*args, **kwargs):
     return _impl(*args, **kwargs)
 
 
+def parse_multi_skill_invocation(*args, **kwargs):
+    from agent.skill_commands import parse_multi_skill_invocation as _impl
+
+    return _impl(*args, **kwargs)
+
+
+def build_multi_skill_invocation_message(*args, **kwargs):
+    from agent.skill_commands import build_multi_skill_invocation_message as _impl
+
+    return _impl(*args, **kwargs)
+
+
+def expand_multi_skill_invocation(*args, **kwargs):
+    from agent.skill_commands import expand_multi_skill_invocation as _impl
+
+    return _impl(*args, **kwargs)
+
+
 def build_preloaded_skills_prompt(*args, **kwargs):
     from agent.skill_commands import build_preloaded_skills_prompt as _impl
 
@@ -7659,6 +7677,28 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                             _cprint(str(result))
                     except Exception as e:
                         _cprint(f"\033[1;31mPlugin command error: {e}{_RST}")
+            elif multi_skill := parse_multi_skill_invocation(
+                cmd_original,
+                skill_commands=skill_commands,
+            ):
+                multi_result = build_multi_skill_invocation_message(
+                    multi_skill.skill_keys,
+                    multi_skill.user_instruction,
+                    task_id=self.session_id,
+                )
+                if multi_result:
+                    msg, loaded_names, missing = multi_result
+                    print(f"\n⚡ Loading skills: {', '.join(loaded_names)}")
+                    if missing:
+                        ChatConsole().print(
+                            f"[yellow]Skipped missing skills: {', '.join(missing)}[/]"
+                        )
+                    if hasattr(self, '_pending_input'):
+                        self._pending_input.put(msg)
+                else:
+                    ChatConsole().print(
+                        f"[bold red]Failed to load skills for {base_cmd}[/]"
+                    )
             # Skill bundles take precedence over individual skills — /<bundle>
             # loads multiple skills at once. Rescans cheaply when files change.
             elif base_cmd in skill_bundles:
@@ -12846,6 +12886,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                             user_input = _seed
                         else:
                             continue
+
+                    if not _file_drop and isinstance(user_input, str) and "$" in user_input:
+                        expanded = expand_multi_skill_invocation(
+                            user_input,
+                            task_id=self.session_id,
+                        )
+                        if expanded:
+                            user_input, loaded_names, missing = expanded
+                            print(f"\n⚡ Loading skills: {', '.join(loaded_names)}")
+                            if missing:
+                                ChatConsole().print(
+                                    f"[yellow]Skipped missing skills: {', '.join(missing)}[/]"
+                                )
                     
                     # Expand paste references back to full content
                     _paste_ref_re = re.compile(r'\[Pasted text #\d+: \d+ lines \u2192 (.+?)\]')
@@ -13584,6 +13637,19 @@ def main(
             sys.exit(1)
         try:
             query, single_query_images = _collect_query_images(query, image)
+            if isinstance(query, str) and "$" in query:
+                expanded = expand_multi_skill_invocation(
+                    query,
+                    task_id=cli.session_id,
+                )
+                if expanded:
+                    query, loaded_names, missing = expanded
+                    if not quiet:
+                        print(f"\n⚡ Loading skills: {', '.join(loaded_names)}")
+                        if missing:
+                            ChatConsole().print(
+                                f"[yellow]Skipped missing skills: {', '.join(missing)}[/]"
+                            )
             # Kanban workers spawn with ``hermes chat -q "work kanban task <id>"``;
             # the actual task description lives in the task body. Mirror the
             # gateway/CLI behaviour for inbound images by scanning the body for

--- a/cli.py
+++ b/cli.py
@@ -7677,28 +7677,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                             _cprint(str(result))
                     except Exception as e:
                         _cprint(f"\033[1;31mPlugin command error: {e}{_RST}")
-            elif multi_skill := parse_multi_skill_invocation(
-                cmd_original,
-                skill_commands=skill_commands,
-            ):
-                multi_result = build_multi_skill_invocation_message(
-                    multi_skill.skill_keys,
-                    multi_skill.user_instruction,
-                    task_id=self.session_id,
-                )
-                if multi_result:
-                    msg, loaded_names, missing = multi_result
-                    print(f"\n⚡ Loading skills: {', '.join(loaded_names)}")
-                    if missing:
-                        ChatConsole().print(
-                            f"[yellow]Skipped missing skills: {', '.join(missing)}[/]"
-                        )
-                    if hasattr(self, '_pending_input'):
-                        self._pending_input.put(msg)
-                else:
-                    ChatConsole().print(
-                        f"[bold red]Failed to load skills for {base_cmd}[/]"
-                    )
             # Skill bundles take precedence over individual skills — /<bundle>
             # loads multiple skills at once. Rescans cheaply when files change.
             elif base_cmd in skill_bundles:
@@ -7722,6 +7700,31 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 else:
                     ChatConsole().print(
                         f"[bold red]Failed to load bundle for {base_cmd}[/]"
+                    )
+            elif multi_skill := parse_multi_skill_invocation(
+                cmd_original,
+                skill_commands=skill_commands,
+            ):
+                multi_result = build_multi_skill_invocation_message(
+                    multi_skill.skill_keys,
+                    multi_skill.user_instruction,
+                    task_id=self.session_id,
+                )
+                if multi_result:
+                    msg, loaded_names, missing = multi_result
+                    print(f"\n⚡ Loading skills: {', '.join(loaded_names)}")
+                    if missing:
+                        ChatConsole().print(
+                            f"[yellow]Skipped missing skills: {', '.join(missing)}[/]"
+                        )
+                    if hasattr(self, '_pending_input'):
+                        self._pending_input.put(msg)
+                else:
+                    requested = ", ".join(
+                        key.lstrip("/") for key in multi_skill.skill_keys
+                    )
+                    ChatConsole().print(
+                        f"[bold red]Failed to load requested skills: {requested}[/]"
                     )
             # Check for skill slash commands (/gif-search, /axolotl, etc.)
             elif base_cmd in skill_commands:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -57,6 +57,7 @@ AUTHOR_MAP = {
     "gilad@smiti.ai": "giladbau",
     "yusufalweshdemir@gmail.com": "Dusk1e",
     "804436395@qq.com": "LaPhilosophie",
+    "2081789787@qq.com": "pengyuyanITYU",
     "maxmitcham@mac.home": "maxtrigify",
     "ccook@nvms.com": "ccook1963",
     "kristian@agrointel.no": "kristianvast",

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -8,6 +8,7 @@ import pytest
 
 import tools.skills_tool as skills_tool_module
 from agent.skill_commands import (
+    _build_skill_message,
     build_multi_skill_invocation_message,
     build_preloaded_skills_prompt,
     build_skill_invocation_message,
@@ -620,6 +621,137 @@ Generate some audio.
         assert 'file_path="<path>"' in msg
 
 
+class TestSupportingFiles:
+    def _build_message(self, tmp_path, linked_files):
+        skill_dir = tmp_path / "test-skill"
+        skill_dir.mkdir()
+        loaded_skill = {
+            "content": "Do the thing.",
+            "linked_files": linked_files,
+        }
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            return _build_skill_message(
+                loaded_skill,
+                skill_dir,
+                "[activation]",
+            )
+
+    @pytest.mark.parametrize(
+        "raw_path",
+        [
+            "../outside.txt",
+            "references/../../outside.txt",
+            "/absolute/path.txt",
+            r"\rooted\path.txt",
+            r"C:\absolute\path.txt",
+            r"C:drive-relative\path.txt",
+            r"\\server\share\path.txt",
+        ],
+    )
+    def test_rejects_unsafe_raw_supporting_paths(self, tmp_path, raw_path):
+        message = self._build_message(
+            tmp_path,
+            {"references": [raw_path]},
+        )
+
+        assert "[This skill has supporting files:]" not in message
+        assert raw_path not in message
+
+    def test_rejects_linked_file_symlink_escape(self, tmp_path):
+        skill_dir = tmp_path / "test-skill"
+        references = skill_dir / "references"
+        references.mkdir(parents=True)
+        outside = tmp_path / "outside.txt"
+        outside.write_text("secret")
+        escaped_file = references / "escape.txt"
+        try:
+            escaped_file.symlink_to(outside)
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"symlinks unavailable in test environment: {exc}")
+
+        loaded_skill = {
+            "content": "Do the thing.",
+            "linked_files": {"references": ["references/escape.txt"]},
+        }
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            message = _build_skill_message(
+                loaded_skill,
+                skill_dir,
+                "[activation]",
+            )
+
+        assert "references/escape.txt" not in message
+        assert str(outside) not in message
+
+    def test_skips_supporting_directory_symlink_escape(self, tmp_path):
+        skill_dir = tmp_path / "test-skill"
+        skill_dir.mkdir()
+        outside_dir = tmp_path / "outside"
+        outside_dir.mkdir()
+        (outside_dir / "secret.txt").write_text("secret")
+        try:
+            (skill_dir / "references").symlink_to(
+                outside_dir,
+                target_is_directory=True,
+            )
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"symlinks unavailable in test environment: {exc}")
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            message = _build_skill_message(
+                {"content": "Do the thing.", "linked_files": None},
+                skill_dir,
+                "[activation]",
+            )
+
+        assert "references/secret.txt" not in message
+        assert str(outside_dir / "secret.txt") not in message
+
+    def test_keeps_legal_relative_paths_deduped_in_first_seen_order(self, tmp_path):
+        message = self._build_message(
+            tmp_path,
+            {
+                "references": [
+                    "references/first.md",
+                    r"references\first.md",
+                ],
+                "scripts": [
+                    "scripts/run.py",
+                    "references/first.md",
+                ],
+            },
+        )
+
+        assert message.count("- references/first.md  ->") == 1
+        assert message.count("- scripts/run.py  ->") == 1
+        assert message.index("- references/first.md  ->") < message.index(
+            "- scripts/run.py  ->"
+        )
+
+    def test_scans_supporting_directories_only_when_linked_files_is_empty(
+        self, tmp_path
+    ):
+        skill_dir = tmp_path / "test-skill"
+        references = skill_dir / "references"
+        references.mkdir(parents=True)
+        (references / "listed.md").write_text("listed")
+        (references / "unlisted.md").write_text("unlisted")
+        loaded_skill = {
+            "content": "Do the thing.",
+            "linked_files": {"references": ["references/listed.md"]},
+        }
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            message = _build_skill_message(
+                loaded_skill,
+                skill_dir,
+                "[activation]",
+            )
+
+        assert "references/listed.md" in message
+        assert "references/unlisted.md" not in message
+
+
 class TestMultiSkillInvocation:
     def test_parses_leading_slash_multi_skill_prefix(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
@@ -661,6 +793,34 @@ class TestMultiSkillInvocation:
         assert parsed.skill_keys == ("/brainstorming", "/subagent-orchestrator")
         assert parsed.user_instruction == "do X"
         assert parsed.source == "inline"
+
+    def test_inline_markers_preserve_body_spacing_blank_lines_and_indentation(
+        self, tmp_path
+    ):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "brainstorming")
+            _make_skill(tmp_path, "subagent-orchestrator")
+            commands = scan_skill_commands()
+            parsed = parse_multi_skill_invocation(
+                (
+                    "$brainstorming $subagent-orchestrator\n"
+                    "Paragraph  with  deliberate  spacing.\n"
+                    "\n"
+                    "    indented  instruction\n"
+                    "\n"
+                    "Final line."
+                ),
+                skill_commands=commands,
+            )
+
+        assert parsed is not None
+        assert parsed.user_instruction == (
+            "Paragraph  with  deliberate  spacing.\n"
+            "\n"
+            "    indented  instruction\n"
+            "\n"
+            "Final line."
+        )
 
     def test_markdown_link_target_is_ignored_for_skill_resolution(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
@@ -736,6 +896,95 @@ class TestMultiSkillInvocation:
         assert missing == []
         assert "First body." in message
         assert "Second body." in message
+
+    def test_single_success_uses_single_skill_semantics_and_reports_missing(self):
+        commands = {
+            "/working": {"skill_dir": "/skills/working"},
+            "/broken": {"skill_dir": "/skills/broken"},
+        }
+        working_payload = (
+            {"content": "Working body.", "linked_files": None},
+            Path("/skills/working"),
+            "working",
+        )
+
+        def load_skill(skill_dir, task_id=None):
+            if skill_dir == "/skills/working":
+                return working_payload
+            return None
+
+        with (
+            patch("agent.skill_commands.get_skill_commands", return_value=commands),
+            patch(
+                "agent.skill_commands._load_skill_payload",
+                side_effect=load_skill,
+            ),
+            patch("tools.skill_usage.bump_use") as bump_use,
+        ):
+            result = build_multi_skill_invocation_message(
+                ["/working", "/broken"],
+                "keep  exact\n\n    indentation",
+                task_id="session-1",
+                runtime_note="runtime",
+            )
+
+        assert result is not None
+        message, loaded, missing = result
+        assert loaded == ["working"]
+        assert missing == ["/broken"]
+        assert 'invoked the "working" skill' in message
+        assert "multiple skills for this turn" not in message
+        assert "multi-skill invocation" not in message
+        assert (
+            "instruction alongside the skill invocation: "
+            "keep  exact\n\n    indentation"
+        ) in message
+        assert "[Runtime note: runtime]" in message
+        bump_use.assert_called_once_with("working")
+
+    def test_dedupes_before_loading_and_bumps_each_successful_skill_once(self):
+        commands = {
+            "/first": {"skill_dir": "/skills/first"},
+            "/second": {"skill_dir": "/skills/second"},
+        }
+        payloads = {
+            "/skills/first": (
+                {"content": "First body.", "linked_files": None},
+                Path("/skills/first"),
+                "first",
+            ),
+            "/skills/second": (
+                {"content": "Second body.", "linked_files": None},
+                Path("/skills/second"),
+                "second",
+            ),
+        }
+
+        with (
+            patch("agent.skill_commands.get_skill_commands", return_value=commands),
+            patch(
+                "agent.skill_commands._load_skill_payload",
+                side_effect=lambda skill_dir, task_id=None: payloads[skill_dir],
+            ) as load_skill,
+            patch("tools.skill_usage.bump_use") as bump_use,
+        ):
+            result = build_multi_skill_invocation_message(
+                ["/first", "/first", "/second", "/second"],
+                "do X",
+            )
+
+        assert result is not None
+        _, loaded, missing = result
+        assert loaded == ["first", "second"]
+        assert missing == []
+        assert [call.args[0] for call in load_skill.call_args_list] == [
+            "/skills/first",
+            "/skills/second",
+        ]
+        assert [call.args[0] for call in bump_use.call_args_list] == [
+            "first",
+            "second",
+        ]
 
 
 class TestSkillDirectoryHeader:

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -8,8 +8,11 @@ import pytest
 
 import tools.skills_tool as skills_tool_module
 from agent.skill_commands import (
+    build_multi_skill_invocation_message,
     build_preloaded_skills_prompt,
     build_skill_invocation_message,
+    expand_multi_skill_invocation,
+    parse_multi_skill_invocation,
     resolve_skill_command_key,
     scan_skill_commands,
 )
@@ -615,6 +618,124 @@ Generate some audio.
 
         assert msg is not None
         assert 'file_path="<path>"' in msg
+
+
+class TestMultiSkillInvocation:
+    def test_parses_leading_slash_multi_skill_prefix(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "brainstorming")
+            _make_skill(tmp_path, "subagent-orchestrator")
+            commands = scan_skill_commands()
+            parsed = parse_multi_skill_invocation(
+                "/brainstorming /subagent-orchestrator do X",
+                skill_commands=commands,
+            )
+
+        assert parsed is not None
+        assert parsed.skill_keys == ("/brainstorming", "/subagent-orchestrator")
+        assert parsed.user_instruction == "do X"
+        assert parsed.source == "slash"
+
+    def test_single_slash_skill_is_not_multi_skill(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "brainstorming")
+            commands = scan_skill_commands()
+            parsed = parse_multi_skill_invocation(
+                "/brainstorming do X",
+                skill_commands=commands,
+            )
+
+        assert parsed is None
+
+    def test_parses_inline_markers_and_preserves_instruction(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "brainstorming")
+            _make_skill(tmp_path, "subagent-orchestrator")
+            commands = scan_skill_commands()
+            parsed = parse_multi_skill_invocation(
+                "$brainstorming $subagent-orchestrator do X",
+                skill_commands=commands,
+            )
+
+        assert parsed is not None
+        assert parsed.skill_keys == ("/brainstorming", "/subagent-orchestrator")
+        assert parsed.user_instruction == "do X"
+        assert parsed.source == "inline"
+
+    def test_markdown_link_target_is_ignored_for_skill_resolution(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "brainstorming")
+            _make_skill(tmp_path, "subagent-orchestrator")
+            commands = scan_skill_commands()
+            parsed = parse_multi_skill_invocation(
+                r"[$brainstorming](C:\not\trusted\SKILL.md) $subagent-orchestrator do X",
+                skill_commands=commands,
+            )
+
+        assert parsed is not None
+        assert parsed.skill_keys == ("/brainstorming", "/subagent-orchestrator")
+        assert parsed.user_instruction == "do X"
+
+    def test_unknown_inline_marker_remains_plain_text(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "brainstorming")
+            commands = scan_skill_commands()
+            parsed = parse_multi_skill_invocation(
+                "$brainstorming $missing do X",
+                skill_commands=commands,
+            )
+
+        assert parsed is not None
+        assert parsed.skill_keys == ("/brainstorming",)
+        assert parsed.user_instruction == "$missing do X"
+
+    def test_dedupes_skills_preserving_first_seen_order(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "brainstorming")
+            _make_skill(tmp_path, "subagent-orchestrator")
+            commands = scan_skill_commands()
+            parsed = parse_multi_skill_invocation(
+                "$brainstorming $subagent-orchestrator $brainstorming do X",
+                skill_commands=commands,
+            )
+
+        assert parsed is not None
+        assert parsed.skill_keys == ("/brainstorming", "/subagent-orchestrator")
+        assert parsed.user_instruction == "do X"
+
+    def test_builds_single_message_for_multiple_skills(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "first-skill", body="First body.")
+            _make_skill(tmp_path, "second-skill", body="Second body.")
+            scan_skill_commands()
+            result = build_multi_skill_invocation_message(
+                ["/first-skill", "/second-skill"],
+                "do X",
+                task_id="session-1",
+            )
+
+        assert result is not None
+        message, loaded, missing = result
+        assert loaded == ["first-skill", "second-skill"]
+        assert missing == []
+        assert "First body." in message
+        assert "Second body." in message
+        assert "multiple skills for this turn" in message
+        assert message.count("multi-skill invocation: do X") == 1
+
+    def test_expand_multi_skill_invocation_returns_combined_prompt(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "first-skill", body="First body.")
+            _make_skill(tmp_path, "second-skill", body="Second body.")
+            scan_skill_commands()
+            result = expand_multi_skill_invocation("$first-skill $second-skill do X")
+
+        assert result is not None
+        message, loaded, missing = result
+        assert loaded == ["first-skill", "second-skill"]
+        assert missing == []
+        assert "First body." in message
+        assert "Second body." in message
 
 
 class TestSkillDirectoryHeader:

--- a/tests/cli/test_cli_prefix_matching.py
+++ b/tests/cli/test_cli_prefix_matching.py
@@ -15,6 +15,70 @@ def _make_cli():
 
 
 class TestSlashCommandPrefixMatching:
+    def test_skill_bundle_takes_precedence_over_multi_skill_prefix(self):
+        cli_obj = _make_cli()
+        fake_skills = {
+            "/shared": {"name": "Shared Skill", "description": "test"},
+            "/other": {"name": "Other Skill", "description": "test"},
+        }
+        fake_bundles = {
+            "/shared": {"name": "Shared Bundle", "description": "test"},
+        }
+
+        import cli as cli_mod
+
+        with (
+            patch.object(cli_mod, "_skill_commands", fake_skills),
+            patch.object(cli_mod, "_skill_bundles", fake_bundles),
+            patch.object(
+                cli_mod,
+                "build_bundle_invocation_message",
+                return_value=("bundle prompt", ["Shared Skill"], []),
+            ) as build_bundle,
+            patch.object(
+                cli_mod,
+                "build_multi_skill_invocation_message",
+            ) as build_multi,
+        ):
+            cli_obj.process_command("/shared /other do X")
+
+        build_bundle.assert_called_once_with(
+            "/shared",
+            "/other do X",
+            task_id=None,
+        )
+        build_multi.assert_not_called()
+        cli_obj._pending_input.put.assert_called_once_with("bundle prompt")
+
+    def test_multi_skill_failure_lists_all_requested_skills(self):
+        cli_obj = _make_cli()
+        fake_skills = {
+            "/first-skill": {"name": "First Skill", "description": "test"},
+            "/second-skill": {"name": "Second Skill", "description": "test"},
+        }
+        fake_console = MagicMock()
+
+        import cli as cli_mod
+
+        with (
+            patch.object(cli_mod, "_skill_commands", fake_skills),
+            patch.object(cli_mod, "_skill_bundles", {}),
+            patch.object(
+                cli_mod,
+                "build_multi_skill_invocation_message",
+                return_value=None,
+            ),
+            patch.object(cli_mod, "ChatConsole", return_value=fake_console),
+        ):
+            cli_obj.process_command("/first-skill /second-skill do X")
+
+        rendered = " ".join(
+            str(call.args[0]) for call in fake_console.print.call_args_list
+        )
+        assert "first-skill" in rendered
+        assert "second-skill" in rendered
+        cli_obj._pending_input.put.assert_not_called()
+
     def test_unique_prefix_dispatches_command(self):
         """/con should dispatch to /config when it uniquely matches."""
         cli_obj = _make_cli()

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3113,6 +3113,74 @@ def test_prompt_submit_expands_context_refs(monkeypatch):
     assert captured["prompt"] == "expanded prompt"
 
 
+def test_prompt_submit_expands_inline_multi_skill_markers(monkeypatch):
+    captured = {}
+
+    class _Agent:
+        model = "test/model"
+        base_url = ""
+        api_key = ""
+
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None
+        ):
+            captured["prompt"] = prompt
+            return {
+                "final_response": "ok",
+                "messages": [{"role": "assistant", "content": "ok"}],
+            }
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    fake_skill_commands = types.ModuleType("agent.skill_commands")
+
+    def _fake_expand_multi_skill_invocation(text, *, task_id=None, skill_commands=None):
+        captured["skill_text"] = text
+        captured["skill_task_id"] = task_id
+        return "expanded skill prompt", ["first-skill", "second-skill"], []
+
+    fake_skill_commands.expand_multi_skill_invocation = _fake_expand_multi_skill_invocation
+
+    fake_ctx = types.ModuleType("agent.context_references")
+    fake_ctx.preprocess_context_references = (
+        lambda message, **kwargs: types.SimpleNamespace(
+            blocked=False,
+            message=message,
+            warnings=[],
+            references=[],
+            injected_tokens=0,
+        )
+    )
+    fake_meta = types.ModuleType("agent.model_metadata")
+    fake_meta.get_model_context_length = lambda *args, **kwargs: 100000
+
+    server._sessions["sid"] = _session(agent=_Agent())
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+    monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
+    monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
+    monkeypatch.setitem(sys.modules, "agent.skill_commands", fake_skill_commands)
+    monkeypatch.setitem(sys.modules, "agent.context_references", fake_ctx)
+    monkeypatch.setitem(sys.modules, "agent.model_metadata", fake_meta)
+
+    server.handle_request(
+        {
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "$first-skill $second-skill do X"},
+        }
+    )
+
+    assert captured["skill_text"] == "$first-skill $second-skill do X"
+    assert captured["skill_task_id"] == "session-key"
+    assert captured["prompt"] == "expanded skill prompt"
+
+
 def test_image_attach_appends_local_image(monkeypatch):
     fake_cli = types.ModuleType("cli")
     fake_cli._IMAGE_EXTENSIONS = {".png"}

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
 
+import agent.skill_commands as skill_commands_module
 from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 from hermes_cli.active_sessions import active_session_registry_snapshot
 from tui_gateway import server
@@ -3137,14 +3138,10 @@ def test_prompt_submit_expands_inline_multi_skill_markers(monkeypatch):
         def start(self):
             self._target()
 
-    fake_skill_commands = types.ModuleType("agent.skill_commands")
-
     def _fake_expand_multi_skill_invocation(text, *, task_id=None, skill_commands=None):
         captured["skill_text"] = text
         captured["skill_task_id"] = task_id
         return "expanded skill prompt", ["first-skill", "second-skill"], []
-
-    fake_skill_commands.expand_multi_skill_invocation = _fake_expand_multi_skill_invocation
 
     fake_ctx = types.ModuleType("agent.context_references")
     fake_ctx.preprocess_context_references = (
@@ -3164,7 +3161,11 @@ def test_prompt_submit_expands_inline_multi_skill_markers(monkeypatch):
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
     monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
     monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
-    monkeypatch.setitem(sys.modules, "agent.skill_commands", fake_skill_commands)
+    monkeypatch.setattr(
+        skill_commands_module,
+        "expand_multi_skill_invocation",
+        _fake_expand_multi_skill_invocation,
+    )
     monkeypatch.setitem(sys.modules, "agent.context_references", fake_ctx)
     monkeypatch.setitem(sys.modules, "agent.model_metadata", fake_meta)
 
@@ -3179,6 +3180,68 @@ def test_prompt_submit_expands_inline_multi_skill_markers(monkeypatch):
     assert captured["skill_text"] == "$first-skill $second-skill do X"
     assert captured["skill_task_id"] == "session-key"
     assert captured["prompt"] == "expanded skill prompt"
+
+
+def test_run_prompt_submit_does_not_expand_synthetic_prompt(monkeypatch):
+    captured = {}
+
+    class _Agent:
+        model = "test/model"
+        base_url = ""
+        api_key = ""
+
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None
+        ):
+            captured["prompt"] = prompt
+            return {
+                "final_response": "ok",
+                "messages": [{"role": "assistant", "content": "ok"}],
+            }
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    fake_ctx = types.ModuleType("agent.context_references")
+    fake_ctx.preprocess_context_references = (
+        lambda message, **kwargs: types.SimpleNamespace(
+            blocked=False,
+            message=message,
+            warnings=[],
+            references=[],
+            injected_tokens=0,
+        )
+    )
+    fake_meta = types.ModuleType("agent.model_metadata")
+    fake_meta.get_model_context_length = lambda *args, **kwargs: 100000
+
+    server._sessions["sid"] = _session(agent=_Agent())
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+    monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
+    monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
+    monkeypatch.setattr(
+        server,
+        "_expand_multi_skill_prompt",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("synthetic prompts must not expand skills")
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "agent.context_references", fake_ctx)
+    monkeypatch.setitem(sys.modules, "agent.model_metadata", fake_meta)
+
+    server._run_prompt_submit(
+        "1",
+        "sid",
+        server._sessions["sid"],
+        "Background result contains $first-skill",
+    )
+
+    assert captured["prompt"] == "Background result contains $first-skill"
 
 
 def test_image_attach_appends_local_image(monkeypatch):
@@ -6570,7 +6633,7 @@ def test_notification_poller_emits_distinct_watch_matches_once(monkeypatch):
     turns = []
     emitted = []
 
-    def _fake_run_prompt_submit(rid, sid, session, text):
+    def _fake_run_prompt_submit(rid, sid, session, text, **_kwargs):
         turns.append(text)
         with session["history_lock"]:
             session["running"] = False

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3067,9 +3067,11 @@ def test_prompt_submit_expands_context_refs(monkeypatch):
         api_key = ""
 
         def run_conversation(
-            self, prompt, conversation_history=None, stream_callback=None
+            self, prompt, conversation_history=None, stream_callback=None,
+            persist_user_message=None,
         ):
             captured["prompt"] = prompt
+            captured["persist_user_message"] = persist_user_message
             return {
                 "final_response": "ok",
                 "messages": [{"role": "assistant", "content": "ok"}],
@@ -3123,9 +3125,11 @@ def test_prompt_submit_expands_inline_multi_skill_markers(monkeypatch):
         api_key = ""
 
         def run_conversation(
-            self, prompt, conversation_history=None, stream_callback=None
+            self, prompt, conversation_history=None, stream_callback=None,
+            persist_user_message=None,
         ):
             captured["prompt"] = prompt
+            captured["persist_user_message"] = persist_user_message
             return {
                 "final_response": "ok",
                 "messages": [{"role": "assistant", "content": "ok"}],
@@ -3191,9 +3195,11 @@ def test_run_prompt_submit_does_not_expand_synthetic_prompt(monkeypatch):
         api_key = ""
 
         def run_conversation(
-            self, prompt, conversation_history=None, stream_callback=None
+            self, prompt, conversation_history=None, stream_callback=None,
+            persist_user_message=None,
         ):
             captured["prompt"] = prompt
+            captured["persist_user_message"] = persist_user_message
             return {
                 "final_response": "ok",
                 "messages": [{"role": "assistant", "content": "ok"}],

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -29,18 +29,21 @@ def server():
     }):
         import importlib
         mod = importlib.import_module("tui_gateway.server")
+        original_methods = dict(mod._methods)
         yield mod
         # Reset module-level session state without re-importing. importlib.reload
         # would re-register the module's atexit hooks (ThreadPoolExecutor
         # shutdown, _shutdown_sessions); the duplicates race the stderr
         # buffer at interpreter shutdown and surface as Fatal Python error:
         # _enter_buffered_busy. Clearing the per-session dicts gives the
-        # next test a clean slate; _methods is NOT cleared because it's
-        # populated at module import time and re-registration only happens
-        # via reload (which we don't do).
+        # next test a clean slate; _methods is restored to its import-time
+        # snapshot because some protocol tests temporarily replace long
+        # handlers to exercise dispatch paths.
         mod._sessions.clear()
         mod._pending.clear()
         mod._answers.clear()
+        mod._methods.clear()
+        mod._methods.update(original_methods)
 
 
 @pytest.fixture()
@@ -1101,6 +1104,39 @@ def test_command_dispatch_returns_skill_payload(server):
     assert result["type"] == "skill"
     assert result["message"] == fake_msg
     assert result["name"] == "hermes-agent-dev"
+
+
+def test_command_dispatch_returns_multi_skill_payload(server):
+    """command.dispatch expands leading multi-skill slash invocations."""
+    sid = "test-session"
+    server._sessions[sid] = {"session_key": sid}
+
+    fake_skills = {
+        "/first-skill": {"name": "first-skill", "description": "First"},
+        "/second-skill": {"name": "second-skill", "description": "Second"},
+    }
+    fake_msg = "Loaded multi-skill content here"
+
+    with patch("agent.skill_commands.scan_skill_commands", return_value=fake_skills), \
+         patch(
+             "agent.skill_commands.build_multi_skill_invocation_message",
+             return_value=(fake_msg, ["first-skill", "second-skill"], []),
+         ):
+        resp = server.handle_request({
+            "id": "r-multi-skill",
+            "method": "command.dispatch",
+            "params": {
+                "name": "first-skill",
+                "arg": "/second-skill do X",
+                "session_id": sid,
+            },
+        })
+
+    assert "error" not in resp
+    result = resp["result"]
+    assert result["type"] == "skill"
+    assert result["message"] == fake_msg
+    assert result["name"] == "first-skill, second-skill"
 
 
 def test_command_dispatch_awaits_async_plugin_handler(server):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5090,7 +5090,7 @@ def _(rid, params: dict) -> dict:
                 session["running"] = False
                 _clear_inflight_turn(session)
             return
-        _run_prompt_submit(rid, sid, session, text)
+        _run_prompt_submit(rid, sid, session, text, expand_skills=True)
 
     threading.Thread(target=run_after_agent_ready, daemon=True).start()
     return _ok(rid, {"status": "streaming"})
@@ -5310,11 +5310,21 @@ def _expand_multi_skill_prompt(
     return expanded
 
 
-def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
-    text, _loaded_skill_names, _missing_skill_names = _expand_multi_skill_prompt(
-        text,
-        session,
-    )
+def _run_prompt_submit(
+    rid,
+    sid: str,
+    session: dict,
+    text: Any,
+    *,
+    expand_skills: bool = False,
+) -> None:
+    if expand_skills:
+        text, _loaded_skill_names, _missing_skill_names = (
+            _expand_multi_skill_prompt(
+                text,
+                session,
+            )
+        )
     with session["history_lock"]:
         history = list(session["history"])
         history_version = int(session.get("history_version", 0))

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5287,7 +5287,34 @@ def _start_notification_poller(sid: str, session: dict) -> threading.Event:
     return stop
 
 
+def _expand_multi_skill_prompt(
+    text: Any,
+    session: dict | None,
+) -> tuple[Any, list[str], list[str]]:
+    """Expand inline $skill markers before prompt.submit reaches the agent."""
+    if not isinstance(text, str) or "$" not in text:
+        return text, [], []
+
+    try:
+        from agent.skill_commands import expand_multi_skill_invocation
+
+        expanded = expand_multi_skill_invocation(
+            text,
+            task_id=session.get("session_key", "") if session else "",
+        )
+    except Exception:
+        return text, [], []
+
+    if not expanded:
+        return text, [], []
+    return expanded
+
+
 def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
+    text, _loaded_skill_names, _missing_skill_names = _expand_multi_skill_prompt(
+        text,
+        session,
+    )
     with session["history_lock"]:
         history = list(session["history"])
         history_version = int(session.get("history_version", 0))
@@ -7615,12 +7642,34 @@ def _(rid, params: dict) -> dict:
 
     try:
         from agent.skill_commands import (
-            scan_skill_commands,
             build_skill_invocation_message,
+            build_multi_skill_invocation_message,
+            parse_multi_skill_invocation,
+            scan_skill_commands,
         )
 
         cmds = scan_skill_commands()
         key = f"/{name}"
+        multi_skill = parse_multi_skill_invocation(
+            f"{key} {arg}".strip(),
+            skill_commands=cmds,
+        )
+        if multi_skill:
+            multi_result = build_multi_skill_invocation_message(
+                multi_skill.skill_keys,
+                multi_skill.user_instruction,
+                task_id=session.get("session_key", "") if session else "",
+            )
+            if multi_result:
+                msg, loaded_names, _missing = multi_result
+                return _ok(
+                    rid,
+                    {
+                        "type": "skill",
+                        "message": msg,
+                        "name": ", ".join(loaded_names),
+                    },
+                )
         if key in cmds:
             msg = build_skill_invocation_message(
                 key, arg, task_id=session.get("session_key", "") if session else ""

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5319,12 +5319,27 @@ def _run_prompt_submit(
     expand_skills: bool = False,
 ) -> None:
     if expand_skills:
+        _original_text = text
         text, _loaded_skill_names, _missing_skill_names = (
             _expand_multi_skill_prompt(
                 text,
                 session,
             )
         )
+        if _loaded_skill_names:
+            _status_update(
+                sid,
+                "skills",
+                f"Loading skills: {', '.join(_loaded_skill_names)}",
+            )
+        if _missing_skill_names:
+            _status_update(
+                sid,
+                "warning",
+                f"Skipped missing skills: {', '.join(_missing_skill_names)}",
+            )
+    else:
+        _original_text = None
     with session["history_lock"]:
         history = list(session["history"])
         history_version = int(session.get("history_version", 0))
@@ -5464,6 +5479,8 @@ def _run_prompt_submit(
                 "conversation_history": list(history),
                 "stream_callback": _stream,
             }
+            if expand_skills and _original_text is not None and _original_text != text:
+                run_kwargs["persist_user_message"] = _original_text
             try:
                 if "task_id" in inspect.signature(agent.run_conversation).parameters:
                     run_kwargs["task_id"] = session["session_key"]

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -71,6 +71,32 @@ hermes chat --toolsets skills -q "What skills do you have?"
 hermes chat --toolsets skills -q "Show me the axolotl skill"
 ```
 
+### Multi-Skill Invocation
+
+You can activate multiple skills in a single turn. All selected skill instructions are loaded together, in order, and the agent follows them jointly for the same user request.
+
+**Supported syntaxes:**
+
+1. Dollar-sign markers: `$skill-a $skill-b your instruction`
+2. Slash prefixes: `/skill-a /skill-b your instruction`
+3. Markdown links (target ignored): `[$skill-a](any-link) your instruction`
+
+**Examples:**
+
+```bash
+# In the CLI or any messaging platform:
+$python-code-style $python-testing-patterns refactor the auth module
+/database-reviewer /security-reviewer audit the new payment schema
+```
+
+**Behavior:**
+
+- Only installed skills are recognized and loaded — unrecognized `$tokens` are kept as plain text.
+- Duplicate skills are loaded once (first occurrence wins).
+- When multiple skills are loaded, earlier-loaded skills take priority if instructions conflict.
+- A single skill uses the standard single-skill prompt wrapper; two or more skills use a multi-skill wrapper that names all loaded skills.
+- Skill bundles (see below) are the preferred way to group skills you frequently use together.
+
 ## Progressive Disclosure
 
 Skills use a token-efficient loading pattern:


### PR DESCRIPTION
## Summary
- Support multi-skill invocation from one input via `/skill-a /skill-b task` and inline `$skill` markers.
- Expand multi-skill prompts in CLI, TUI gateway, and desktop prompt flows without adding core model tools.
- Add desktop `$` skill completion backed by existing slash/skill catalog data.

## Tests
- `py -m pytest -o addopts="" tests/agent/test_skill_commands.py tests/tui_gateway/test_protocol.py tests/test_tui_gateway_server.py`
- `npm run test:ui -- src/app/chat/composer/text-utils.test.ts src/app/chat/composer/trigger-popover.test.tsx` (from `apps/desktop`)
- `npm run build` (from `apps/desktop`)