### PR TITLE
fix(tui): guard @ context-reference expansion with REFERENCE_PATTERN check

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3081,6 +3081,8 @@ def test_prompt_submit_expands_context_refs(monkeypatch):
         def start(self):
             self._target()
 
+    from agent.context_references import REFERENCE_PATTERN as _real_ref
+
     fake_ctx = types.ModuleType("agent.context_references")
     fake_ctx.preprocess_context_references = (
         lambda message, **kwargs: types.SimpleNamespace(
@@ -3091,6 +3093,7 @@ def test_prompt_submit_expands_context_refs(monkeypatch):
             injected_tokens=0,
         )
     )
+    fake_ctx.REFERENCE_PATTERN = _real_ref
     fake_meta = types.ModuleType("agent.model_metadata")
     fake_meta.get_model_context_length = lambda *args, **kwargs: 100000
 
@@ -3111,6 +3114,70 @@ def test_prompt_submit_expands_context_refs(monkeypatch):
     )
 
     assert captured["prompt"] == "expanded prompt"
+
+
+def test_prompt_submit_skips_context_refs_for_email(monkeypatch):
+    """Messages with '@' but no context references (e.g. email) should skip preprocess."""
+    captured = {}
+
+    class _Agent:
+        model = "test/model"
+        base_url = ""
+        api_key = ""
+
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None
+        ):
+            captured["prompt"] = prompt
+            return {
+                "final_response": "ok",
+                "messages": [{"role": "assistant", "content": "ok"}],
+            }
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    from agent.context_references import REFERENCE_PATTERN as _real_ref
+
+    preprocess_called = {"count": 0}
+    fake_ctx = types.ModuleType("agent.context_references")
+    fake_ctx.preprocess_context_references = lambda message, **kwargs: (
+        preprocess_called.update(count=preprocess_called["count"] + 1)
+    ) or types.SimpleNamespace(
+        blocked=False,
+        message="expanded",
+        warnings=[],
+        references=[],
+        injected_tokens=0,
+    )
+    fake_ctx.REFERENCE_PATTERN = _real_ref
+    fake_meta = types.ModuleType("agent.model_metadata")
+    fake_meta.get_model_context_length = lambda *args, **kwargs: 100000
+
+    server._sessions["sid"] = _session(agent=_Agent())
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
+    monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
+    monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
+    monkeypatch.setitem(sys.modules, "agent.context_references", fake_ctx)
+    monkeypatch.setitem(sys.modules, "agent.model_metadata", fake_meta)
+
+    server.handle_request(
+        {
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "my email is user@domain.com"},
+        }
+    )
+
+    # preprocess_context_references should NOT have been called
+    assert preprocess_called["count"] == 0
+    # prompt should be unchanged — not expanded
+    assert captured["prompt"] == "my email is user@domain.com"
 
 
 def test_image_attach_appends_local_image(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5328,35 +5328,37 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             prompt = text
 
             if isinstance(prompt, str) and "@" in prompt:
-                from agent.context_references import preprocess_context_references
-                from agent.model_metadata import get_model_context_length
+                from agent.context_references import preprocess_context_references, REFERENCE_PATTERN
 
-                ctx_len = get_model_context_length(
-                    getattr(agent, "model", "") or _resolve_model(),
-                    base_url=getattr(agent, "base_url", "") or "",
-                    api_key=getattr(agent, "api_key", "") or "",
-                    provider=getattr(agent, "provider", "") or "",
-                    config_context_length=getattr(
-                        agent, "_config_context_length", None
-                    ),
-                )
-                ctx = preprocess_context_references(
-                    prompt,
-                    cwd=cwd,
-                    allowed_root=cwd,
-                    context_length=ctx_len,
-                )
-                if ctx.blocked:
-                    _emit(
-                        "error",
-                        sid,
-                        {
-                            "message": "\n".join(ctx.warnings)
-                            or "Context injection refused."
-                        },
+                if REFERENCE_PATTERN.search(prompt):
+                    from agent.model_metadata import get_model_context_length
+
+                    ctx_len = get_model_context_length(
+                        getattr(agent, "model", "") or _resolve_model(),
+                        base_url=getattr(agent, "base_url", "") or "",
+                        api_key=getattr(agent, "api_key", "") or "",
+                        provider=getattr(agent, "provider", "") or "",
+                        config_context_length=getattr(
+                            agent, "_config_context_length", None
+                        ),
                     )
-                    return
-                prompt = ctx.message
+                    ctx = preprocess_context_references(
+                        prompt,
+                        cwd=cwd,
+                        allowed_root=cwd,
+                        context_length=ctx_len,
+                    )
+                    if ctx.blocked:
+                        _emit(
+                            "error",
+                            sid,
+                            {
+                                "message": "\n".join(ctx.warnings)
+                                or "Context injection refused."
+                            },
+                        )
+                        return
+                    prompt = ctx.message
 
             # Decide image routing per-turn based on active provider/model.
             # "native" → pass pixels to the main model as OpenAI-style content


### PR DESCRIPTION
## What does this PR do?

Adds a `REFERENCE_PATTERN.search()` guard before entering the `preprocess_context_references` path in the TUI prompt handler, so that messages containing `@` but no actual context references (e.g. email addresses like `user@domain.com`) skip the expensive preprocessing and avoid the multi-threaded race condition that causes `error: timeout: config.get`.

## Related Issue

Fixes #44656

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py`: Added `REFERENCE_PATTERN.search(prompt)` check inside the `"@" in prompt` guard. Only enters `preprocess_context_references` when the prompt contains an actual context reference (`@diff`, `@staged`, `@file:`, `@folder:`, `@git:`, `@url:`). Moved `get_model_context_length` import inside the pattern-match branch to avoid unnecessary work.
- `tests/test_tui_gateway_server.py`: Updated existing test to provide `REFERENCE_PATTERN` on the fake module. Added `test_prompt_submit_skips_context_refs_for_email` to verify email addresses skip preprocessing.

## How to Test

1. Run the new test: `python -m pytest tests/test_tui_gateway_server.py::test_prompt_submit_skips_context_refs_for_email -v`
2. Run the existing test: `python -m pytest tests/test_tui_gateway_server.py::test_prompt_submit_expands_context_refs -v`
3. In TUI mode, send a message containing an email address like `user@domain.com` — it should not trigger `error: timeout: config.get`
4. In TUI mode, send `@diff` — context reference expansion should still work as before

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `tui_gateway/server.py::_run_prompt_submit` (callers: 1, the `prompt.submit` handler)
- Blast radius: LOW — only affects TUI prompt submission path; CLI and gateway use separate code paths
- Related patterns: `cli.py:9897` and `gateway/run.py:7728` have the same broad `"@" in message` guard but operate in single-threaded / async environments where the race condition does not occur. Those sites are inefficient but not buggy.
