### PR TITLE
fix: narrow Mythic threat pattern context

### DIFF
--- a/tests/tools/test_threat_patterns.py
+++ b/tests/tools/test_threat_patterns.py
@@ -155,11 +155,24 @@ class TestC2Patterns:
         )
 
     def test_known_c2_framework_names(self):
-        for name in ("Praxis", "Cobalt Strike", "Sliver", "Havoc", "Mythic"):
+        for name in ("Praxis", "Cobalt Strike", "Sliver", "Havoc"):
             findings = scan_for_threats(
                 f"Connect to the {name} server.", scope="context"
             )
             assert "known_c2_framework" in findings, name
+
+    def test_mythic_requires_c2_context(self):
+        assert "known_c2_framework" in scan_for_threats(
+            "Connect to the Mythic server.", scope="context"
+        )
+
+    def test_mythic_persona_language_does_not_trip_known_c2_framework(self):
+        text = (
+            "Chronus is a creative identity document with terminal/cyber/"
+            "Mythic aesthetics, archived timelines, glyphs, and ADHD-aware "
+            "operating mode."
+        )
+        assert "known_c2_framework" not in scan_for_threats(text, scope="context")
 
     def test_c2_explicit(self):
         assert "c2_explicit" in scan_for_threats(

--- a/tools/threat_patterns.py
+++ b/tools/threat_patterns.py
@@ -92,7 +92,10 @@ _PATTERNS: List[Tuple[str, str, str]] = [
 
     # ── Known C2 / red-team framework names (near-zero false positive
     #    outside security research; warn-only by default) ─────────────
-    (r'\b(?:praxis|cobalt\s*strike|sliver|havoc|mythic|metasploit|brainworm)\b', "known_c2_framework", "context"),
+    # "Mythic" is common in persona / creative writing, so require nearby
+    # C2-specific deployment vocabulary instead of matching the bare word.
+    (r'\b(?:praxis|cobalt\s*strike|sliver|havoc|metasploit|brainworm)\b', "known_c2_framework", "context"),
+    (r'\bmythic\s+(?:c2|server|agent|implant|payload|callback|listener|framework)\b', "known_c2_framework", "context"),
     (r'\bc2\s+(?:server|channel|infrastructure|beacon)\b', "c2_explicit", "context"),
     (r'\bcommand\s+and\s+control\b', "c2_explicit_long", "context"),
 


### PR DESCRIPTION
## Summary
- narrow the `known_c2_framework` detector so bare `Mythic` no longer trips on persona/creative text
- keep Mythic detection when C2/deployment vocabulary is present (for example `Mythic server`)
- add regression coverage for the SOUL.md-style persona false positive

Closes #44631

## Verification
- `scripts/run_tests.sh tests/tools/test_threat_patterns.py` (39 passed)
- `git diff --check -- tools/threat_patterns.py tests/tools/test_threat_patterns.py`
- independent delegated code review: passed
