### PR TITLE
fix(runtime): handle api_key_env alias in _get_named_custom_provider

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -526,8 +526,10 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                 continue
             # Match exact name or normalized name
             name_norm = _normalize_custom_provider_name(ep_name)
-            # Resolve the API key from the env var name stored in key_env
-            key_env = str(entry.get("key_env", "") or "").strip()
+            # Resolve the API key from the env var name stored in key_env.
+            # Accept both `key_env` (canonical Hermes field) and
+            # `api_key_env` (documented alias, see #25091, #44666).
+            key_env = str((entry.get("key_env") or entry.get("api_key_env") or entry.get("keyEnv") or entry.get("apiKeyEnv") or "")).strip()
             resolved_api_key = os.getenv(key_env, "").strip() if key_env else ""
             # Fall back to inline api_key when key_env is absent or unresolvable
             if not resolved_api_key:
@@ -614,7 +616,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             "base_url": base_url.strip(),
             "api_key": str(entry.get("api_key", "") or "").strip(),
         }
-        key_env = str(entry.get("key_env", "") or "").strip()
+        key_env = str((entry.get("key_env") or entry.get("api_key_env") or entry.get("keyEnv") or entry.get("apiKeyEnv") or "")).strip()
         if key_env:
             result["key_env"] = key_env
         if provider_key:


### PR DESCRIPTION
## Summary

Fixes `_get_named_custom_provider()` silently ignoring the documented `api_key_env` alias when resolving API keys from the `providers:` config section.

## Root Cause

`_get_named_custom_provider()` in `hermes_cli/runtime_provider.py` reads raw YAML entry dicts and only checked `entry.get("key_env")`, missing `api_key_env` and its camelCase variants (`keyEnv`, `apiKeyEnv`).

When a user writes:
```yaml
providers:
  myprovider:
    base_url: http://127.0.0.1:56673/v1
    api_key_env: MY_API_KEY
```

The env var name is never read → `resolved_api_key` stays empty → the request is sent with the placeholder `"no-key-required"` → 401 on auth-required endpoints.

## Fix

Added fallback reads for `api_key_env`, `keyEnv`, and `apiKeyEnv` at both consumption sites in `_get_named_custom_provider()` (lines 530 and 617), matching the pattern used in `agent/auxiliary_client.py` line 3652 and the fix for `fallback_providers` in #25091.

## Related

- Fixes #44666
- Related: #25091 (same bug for `fallback_providers:`, fixed in commit `6ddc48b0`)