### PR TITLE
fix(runtime-provider): accept api_key_env alias in named custom providers

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -539,7 +539,8 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             # Match exact name or normalized name
             name_norm = _normalize_custom_provider_name(ep_name)
             # Resolve the API key from the env var name stored in key_env
-            key_env = str(entry.get("key_env", "") or "").strip()
+            # (accept both key_env and api_key_env — #44666)
+            key_env = (entry.get("key_env") or entry.get("api_key_env") or "").strip()
             resolved_api_key = os.getenv(key_env, "").strip() if key_env else ""
             # Fall back to inline api_key when key_env is absent or unresolvable
             if not resolved_api_key:
@@ -626,7 +627,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             "base_url": base_url.strip(),
             "api_key": str(entry.get("api_key", "") or "").strip(),
         }
-        key_env = str(entry.get("key_env", "") or "").strip()
+        key_env = (entry.get("key_env") or entry.get("api_key_env") or "").strip()
         if key_env:
             result["key_env"] = key_env
         if provider_key:
@@ -758,7 +759,7 @@ def _resolve_named_custom_runtime(
     api_key_candidates = [
         (explicit_api_key or "").strip(),
         str(custom_provider.get("api_key", "") or "").strip(),
-        os.getenv(str(custom_provider.get("key_env", "") or "").strip(), "").strip(),
+        os.getenv(str(custom_provider.get("key_env") or custom_provider.get("api_key_env") or "").strip(), "").strip(),
         # Gate provider env keys on their authoritative hosts — sending
         # OPENAI_API_KEY to a local-llm endpoint leaks credentials (#28660).
         (os.getenv("OPENAI_API_KEY", "").strip()     if _cp_is_openai_url  else ""),

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -1044,3 +1044,87 @@ def test_user_provider_override_rejects_mangled_private_models(
 
     assert result.success is False
     assert result.error_message == "not found"
+
+
+
+# =============================================================================
+# Regression tests for #44666: api_key_env alias in providers: dict
+# =============================================================================
+
+def test_get_named_custom_provider_honors_api_key_env_in_providers_dict(monkeypatch, tmp_path):
+    """providers: dict entry with api_key_env should resolve the env var.
+
+    Regression for #44666: _get_named_custom_provider only checked key_env,
+    silently ignoring api_key_env and falling through to no-key-required.
+    """
+    import yaml
+
+    config = {
+        "providers": {
+            "myprovider": {
+                "base_url": "http://127.0.0.1:56673/v1",
+                "api_key_env": "MY_API_KEY",
+            }
+        }
+    }
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump(config))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("MY_API_KEY", "sk-secret-from-env")
+
+    result = rp._get_named_custom_provider("myprovider")
+
+    assert result is not None
+    assert result["base_url"] == "http://127.0.0.1:56673/v1"
+    assert result["api_key"] == "sk-secret-from-env"
+
+
+def test_get_named_custom_provider_prefers_key_env_over_api_key_env(monkeypatch, tmp_path):
+    """When both key_env and api_key_env are set, key_env takes priority."""
+    import yaml
+
+    config = {
+        "providers": {
+            "myprovider": {
+                "base_url": "http://127.0.0.1:56673/v1",
+                "key_env": "PRIMARY_KEY",
+                "api_key_env": "FALLBACK_KEY",
+            }
+        }
+    }
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump(config))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("PRIMARY_KEY", "sk-primary")
+    monkeypatch.setenv("FALLBACK_KEY", "sk-fallback")
+
+    result = rp._get_named_custom_provider("myprovider")
+
+    assert result is not None
+    assert result["api_key"] == "sk-primary"
+
+
+def test_get_named_custom_provider_honors_api_key_env_in_legacy_custom_providers(monkeypatch, tmp_path):
+    """Legacy custom_providers: list entry with api_key_env should also resolve."""
+    import yaml
+
+    config = {
+        "custom_providers": [
+            {
+                "name": "legacy-provider",
+                "base_url": "http://legacy.example.com/v1",
+                "api_key_env": "LEGACY_API_KEY",
+            }
+        ]
+    }
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump(config))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("LEGACY_API_KEY", "sk-legacy-secret")
+
+    result = rp._get_named_custom_provider("legacy-provider")
+
+    assert result is not None
+    assert result["base_url"] == "http://legacy.example.com/v1"
+    # Legacy path stores key_env but resolves the env var downstream
+    assert result.get("key_env") == "LEGACY_API_KEY"


### PR DESCRIPTION
## What does this PR do?

Accepts the `api_key_env` config alias in `_get_named_custom_provider()`, so providers defined under `providers:` (or legacy `custom_providers:`) using the documented `api_key_env:` field correctly resolve the API key instead of silently falling through to `"no-key-required"` → 401.

## Related Issue

Fixes #44666

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/runtime_provider.py`: Accept `api_key_env` as an alias for `key_env` in three locations — the `providers:` dict scan (line 542), the legacy `custom_providers:` list scan (line 629), and the `_resolve_named_custom_runtime` key_env candidate (line 761). Matches the pattern already used in `auxiliary_client.py:3652`.
- `tests/hermes_cli/test_user_providers_model_switch.py`: Three regression tests — `api_key_env` in providers dict, priority when both `key_env` and `api_key_env` are set, and `api_key_env` in legacy custom_providers list.

## How to Test

1. Define a provider with `api_key_env:` in config.yaml:
   ```yaml
   providers:
     myprovider:
       base_url: http://127.0.0.1:56673/v1
       api_key_env: MY_API_KEY
   ```
2. Set `MY_API_KEY=sk-test` in `.env`
3. `hermes config set model.provider myprovider` — should NOT send `"no-key-required"` as bearer token
4. Run: `python -m pytest tests/hermes_cli/test_user_providers_model_switch.py -k api_key_env -xvs`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `hermes_cli/runtime_provider.py` — `_get_named_custom_provider()` (callers: 8), `_resolve_named_custom_runtime()` (callers: 3)
- Blast radius: LOW — adds alias acceptance; no behavioral change for existing `key_env` users
- Related patterns: `auxiliary_client.py:3652` already checks both `key_env` and `api_key_env`; `runtime_provider.py:1544` iterates both keys for error messages
