### PR TITLE
fix(whatsapp): forward reply context from bridge to agent

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -1376,6 +1376,8 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 message_id=data.get("messageId"),
                 media_urls=cached_urls,
                 media_types=media_types,
+                reply_to_message_id=data.get("quotedMessageId"),
+                reply_to_text=data.get("quotedMessageText"),
             )
         except Exception as e:
             print(f"[{self.name}] Error building event: {e}")


### PR DESCRIPTION
## Problem

When a user replies to a WhatsApp message (using WhatsApp's built-in reply feature), the agent receives only the new message text with no information about which prior message the user is referencing. The agent has to guess the context.

## Solution

The WhatsApp bridge (bridge.js) already captures `quotedMessageId`, `quotedMessageText`, `hasQuotedMessage`, `quotedParticipant`, and `quotedRemoteJid` from Baileys `contextInfo` and includes them in every event. However, `_build_message_event()` in `whatsapp.py` never forwarded these to the `MessageEvent`.

The core `MessageEvent` class (`base.py` lines 1318-1319) already defines `reply_to_message_id` and `reply_to_text` fields, and the message handler in `run.py` (lines 8286-8294) already injects reply context into the agent prompt when these fields are set.

This PR adds the two missing lines to wire the bridge data into the existing infrastructure.

## Changes

**`gateway/platforms/whatsapp.py`** — +2 lines in `_build_message_event()`:
- `reply_to_message_id=data.get("quotedMessageId")`
- `reply_to_text=data.get("quotedMessageText")`

## Impact

When a user replies to a message on WhatsApp, the agent now sees:
`[Replying to: "the quoted text"]`
prepended to their message. No other platform is affected — Telegram/Discord already populate these fields through their own adapters.
