### PR TITLE
fix(cli): honor api_key_env for custom providers

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -38,6 +38,11 @@ def _normalize_custom_provider_name(value: str) -> str:
     return value.strip().lower().replace(" ", "-")
 
 
+def _custom_provider_key_env(entry: Dict[str, Any]) -> str:
+    """Return the configured API-key env var hint for a custom provider."""
+    return str(entry.get("key_env") or entry.get("api_key_env") or "").strip()
+
+
 def _loopback_hostname(host: str) -> bool:
     h = (host or "").lower().rstrip(".")
     return h in {"localhost", "127.0.0.1", "::1", "0.0.0.0"}
@@ -539,7 +544,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             # Match exact name or normalized name
             name_norm = _normalize_custom_provider_name(ep_name)
             # Resolve the API key from the env var name stored in key_env
-            key_env = str(entry.get("key_env", "") or "").strip()
+            key_env = _custom_provider_key_env(entry)
             resolved_api_key = os.getenv(key_env, "").strip() if key_env else ""
             # Fall back to inline api_key when key_env is absent or unresolvable
             if not resolved_api_key:
@@ -626,7 +631,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             "base_url": base_url.strip(),
             "api_key": str(entry.get("api_key", "") or "").strip(),
         }
-        key_env = str(entry.get("key_env", "") or "").strip()
+        key_env = _custom_provider_key_env(entry)
         if key_env:
             result["key_env"] = key_env
         if provider_key:

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -863,6 +863,46 @@ def test_named_custom_provider_uses_key_env_from_providers_dict(monkeypatch):
     assert resolved["model"] == "acme-large"
 
 
+def test_named_custom_provider_uses_api_key_env_alias_from_providers_dict(monkeypatch):
+    """providers dict entries should honor api_key_env as an alias for key_env."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("MYCORP_API_KEY", "env-secret")
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "mycorp-proxy": {
+                    "base_url": "https://proxy.example.com/v1",
+                    "default_model": "acme-large",
+                    "api_key_env": "MYCORP_API_KEY",
+                    "name": "MyCorp Proxy",
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError(
+                "resolve_provider should not be called for named custom providers"
+            )
+        ),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="mycorp-proxy")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["base_url"] == "https://proxy.example.com/v1"
+    assert resolved["api_key"] == "env-secret"
+    assert resolved["requested_provider"] == "mycorp-proxy"
+    assert resolved["source"] == "custom_provider:MyCorp Proxy"
+    assert resolved["model"] == "acme-large"
+
+
 def test_named_custom_provider_same_url_uses_matching_key_env_and_api_mode(monkeypatch):
     """Named custom providers on one gateway must keep their own credentials and protocol."""
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)


### PR DESCRIPTION
## Summary
- Honor `api_key_env` as an alias for `key_env` when resolving named custom providers from `providers:` entries.
- Reuse the alias handling for legacy custom provider entries too, so env-var hints stay consistent across custom-provider schemas.
- Add a regression test that would previously resolve to `no-key-required` instead of the configured env secret.

## Test Plan
- [x] `/Users/clawuser/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py::test_named_custom_provider_uses_api_key_env_alias_from_providers_dict tests/hermes_cli/test_runtime_provider_resolution.py::test_named_custom_provider_uses_key_env_from_providers_dict -q`
- [x] `/Users/clawuser/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py -q`
- [x] `/Users/clawuser/.hermes/hermes-agent/venv/bin/python -m ruff check hermes_cli/runtime_provider.py tests/hermes_cli/test_runtime_provider_resolution.py`

Fixes #44666
