### PR TITLE
fix(kanban): surface worker crash cause from log in detect_crashed_workers

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5543,6 +5543,12 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     error_text = f"pid {pid} killed by signal {code}"
                 else:
                     error_text = f"pid {pid} not alive"
+                # Read the worker log tail to surface the actual crash cause
+                # (e.g. "Error: Unknown skill(s): foo") instead of just
+                # "pid N exited with code 1".
+                log_cause = _extract_crash_cause_from_log(row["id"])
+                if log_cause:
+                    error_text = f"{error_text}\n  → {log_cause}"
                 event_kind = "crashed"
                 event_payload = {"pid": pid, "claimer": row["claim_lock"]}
                 if code is not None and kind != "unknown":
@@ -7523,6 +7529,37 @@ def read_worker_log(
         return data.decode("utf-8", errors="replace")
     except OSError:
         return None
+
+
+def _extract_crash_cause_from_log(
+    task_id: str, *, tail_bytes: int = 2048,
+) -> Optional[str]:
+    """Read the tail of a worker log and return the most relevant error line.
+
+    Looks for lines starting with common error prefixes (``Error:``,
+    ``Traceback``, ``Exception``, ``Fatal``). Falls back to the last
+    non-empty line if no error-pattern match is found.
+
+    Returns ``None`` when the log file does not exist or cannot be read.
+    """
+    log = read_worker_log(task_id, tail_bytes=tail_bytes)
+    if not log:
+        return None
+    # Scan backwards for an error-like line.
+    _ERROR_PREFIXES = ("error:", "traceback", "exception", "fatal")
+    for line in reversed(log.splitlines()):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        lower = stripped.lower()
+        if any(lower.startswith(p) for p in _ERROR_PREFIXES):
+            return stripped[:300]
+    # Fallback: last non-empty line (often the actual crash message).
+    for line in reversed(log.splitlines()):
+        stripped = line.strip()
+        if stripped:
+            return stripped[:300]
+    return None
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3950,6 +3950,41 @@ def read_worker_log(
         return None
 
 
+def _extract_crash_cause_from_log(
+    task_id: str, *, tail_bytes: int = 2048, board: Optional[str] = None,
+) -> Optional[str]:
+    """Read the tail of a worker log and return the most relevant error line.
+
+    Looks for lines starting with common error prefixes (``Error:``,
+    ``Traceback``, ``Exception``, ``Fatal``). Falls back to the last
+    non-empty line if no error-pattern match is found.
+
+    ``board`` must match the board the worker was dispatched on: worker logs
+    are per-board, so an omitted board resolves through the active-board chain
+    and can read the wrong board's task-ID-colliding log.
+
+    Returns ``None`` when the log file does not exist or cannot be read.
+    """
+    log = read_worker_log(task_id, tail_bytes=tail_bytes, board=board)
+    if not log:
+        return None
+    # Scan backwards for an error-like line.
+    _ERROR_PREFIXES = ("error:", "traceback", "exception", "fatal")
+    for line in reversed(log.splitlines()):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        lower = stripped.lower()
+        if any(lower.startswith(p) for p in _ERROR_PREFIXES):
+            return stripped[:300]
+    # Fallback: last non-empty line (often the actual crash message).
+    for line in reversed(log.splitlines()):
+        stripped = line.strip()
+        if stripped:
+            return stripped[:300]
+    return None
+
+
 # --- Assignee enumeration (known profiles + per-profile board stats) ---
 
 def list_profiles_on_disk() -> list[str]:

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -802,8 +802,15 @@ class _CrashSweep:
     exited_hook_payloads: list[dict] = field(default_factory=list)
 
 
-def _reclaim_dead_workers(conn: sqlite3.Connection) -> _CrashSweep:
-    """Release every host-local ``running`` task whose worker PID is dead."""
+def _reclaim_dead_workers(
+    conn: sqlite3.Connection, board: Optional[str] = None,
+) -> _CrashSweep:
+    """Release every host-local ``running`` task whose worker PID is dead.
+
+    ``board`` is the dispatch board (the gateway passes each board's slug
+    explicitly); worker logs live under the board's own directory, so the
+    crash-cause lookup must use the same board or it can attach no cause — or
+    the wrong board's task-ID-colliding log — to a crashed run."""
     sweep = _CrashSweep()
     with _kb.write_txn(conn):
         rows = conn.execute(
@@ -826,6 +833,15 @@ def _reclaim_dead_workers(conn: sqlite3.Connection) -> _CrashSweep:
 
             pid = int(row["worker_pid"])
             dead = _classify_dead_worker(pid, row["claim_lock"])
+            if not dead.rate_limited and not dead.protocol_violation:
+                # Surface the actual crash cause (e.g. "Error: Unknown
+                # skill(s): foo") from the worker log tail instead of only
+                # "pid N exited with code 1" / "pid N not alive".
+                log_cause = _kb._extract_crash_cause_from_log(
+                    row["id"], board=board,
+                )
+                if log_cause:
+                    dead.error_text = f"{dead.error_text}\n  → {log_cause}"
             retry_status = _kb._retry_status_for_run(conn, row["id"])
             dead.event_payload["retry_status"] = retry_status
             cur = conn.execute(
@@ -934,7 +950,9 @@ def _account_crashes(conn: sqlite3.Connection, crash_details: list) -> list[str]
     return auto_blocked
 
 
-def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
+def detect_crashed_workers(
+    conn: sqlite3.Connection, *, board: Optional[str] = None,
+) -> list[str]:
     """Reclaim ``running`` tasks whose worker PID is no longer alive.
 
     Restores the source phase immediately (no waiting for the claim TTL), for
@@ -944,7 +962,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     wall, released WITHOUT counting a failure and surfaced via the
     ``_last_rate_limited`` attribute (the return stays crashed-only).
     """
-    sweep = _reclaim_dead_workers(conn)
+    sweep = _reclaim_dead_workers(conn, board=board)
     # Outside the main txn: account each crash and maybe trip the breaker.
     auto_blocked = _account_crashes(conn, sweep.crash_details) if sweep.crash_details else []
     # Side-channel attributes keep the public ``list[str]`` return stable;
@@ -1631,6 +1649,7 @@ def _run_reclaim_phase(
     stale_timeout_seconds: int,
     failure_limit: int,
     reconcile_orphans: bool,
+    board: Optional[str] = None,
 ) -> None:
     """Reclaim stale/orphaned/crashed/timed-out running tasks, then promote."""
     reap_worker_zombies()
@@ -1638,7 +1657,7 @@ def _run_reclaim_phase(
     if reconcile_orphans:
         result.reconciled_orphans = reconcile_orphaned_running(conn)
     result.stale = detect_stale_running(conn, stale_timeout_seconds=stale_timeout_seconds)
-    result.crashed = detect_crashed_workers(conn)
+    result.crashed = detect_crashed_workers(conn, board=board)
     # Side-channel attributes (see detect_crashed_workers); rate-limited tasks
     # went back to ``ready`` and the respawn guard defers them until quota clears.
     result.auto_blocked.extend(getattr(detect_crashed_workers, "_last_auto_blocked", []))
@@ -1771,6 +1790,7 @@ def _dispatch_once_locked(
     _run_reclaim_phase(
         conn, result, stale_timeout_seconds=stale_timeout_seconds,
         failure_limit=failure_limit, reconcile_orphans=reconcile_orphans,
+        board=board,
     )
     may_spawn, spawn_budget = _tick_spawn_budget(
         conn, result, max_spawn=max_spawn, max_in_progress=max_in_progress, board=board,

--- a/tests/hermes_cli/test_kanban_crash_log_snippet.py
+++ b/tests/hermes_cli/test_kanban_crash_log_snippet.py
@@ -1,0 +1,200 @@
+"""Tests for crash-log snippet extraction in detect_crashed_workers."""
+
+from __future__ import annotations
+
+import os
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an empty kanban DB."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    # Disable crash grace period so tests see immediate reclaim.
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    kb.init_db()
+    return home
+
+
+# ---------------------------------------------------------------------------
+# _extract_crash_cause_from_log unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCrashCauseFromLog:
+    """Tests for ``_extract_crash_cause_from_log``."""
+
+    def test_returns_error_line_from_log(self, kanban_home):
+        """Picks the first error-prefixed line when scanning backwards."""
+        task_id = "t_err_skill"
+        log_path = kb.worker_log_path(task_id)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text(
+            "Starting worker...\n"
+            "Loading config...\n"
+            "Error: Unknown skill(s): org-design-pipeline\n"
+            "Error: Unknown skill(s): org-design-pipeline\n",
+            encoding="utf-8",
+        )
+        result = kb._extract_crash_cause_from_log(task_id)
+        assert result is not None
+        assert "Unknown skill" in result
+        assert result.startswith("Error:")
+
+    def test_returns_traceback_line(self, kanban_home):
+        """Matches 'Traceback' prefix."""
+        task_id = "t_traceback"
+        log_path = kb.worker_log_path(task_id)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text(
+            "ok\nTraceback (most recent call last):\n  File ...\n",
+            encoding="utf-8",
+        )
+        result = kb._extract_crash_cause_from_log(task_id)
+        assert result is not None
+        assert result.startswith("Traceback")
+
+    def test_returns_exception_line(self, kanban_home):
+        """Matches 'Exception' prefix."""
+        task_id = "t_exc"
+        log_path = kb.worker_log_path(task_id)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text(
+            "ok\nException: something broke\n",
+            encoding="utf-8",
+        )
+        result = kb._extract_crash_cause_from_log(task_id)
+        assert result is not None
+        assert result.startswith("Exception:")
+
+    def test_fallback_last_nonempty_line(self, kanban_home):
+        """Falls back to last non-empty line when no error prefix matches."""
+        task_id = "t_generic"
+        log_path = kb.worker_log_path(task_id)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text(
+            "line 1\nline 2\nsome other output\n",
+            encoding="utf-8",
+        )
+        result = kb._extract_crash_cause_from_log(task_id)
+        assert result is not None
+        assert result == "some other output"
+
+    def test_returns_none_when_no_log_file(self, kanban_home):
+        """Returns None when the log file doesn't exist."""
+        result = kb._extract_crash_cause_from_log("t_nonexistent")
+        assert result is None
+
+    def test_returns_none_for_empty_log(self, kanban_home):
+        """Returns None when the log file is empty."""
+        task_id = "t_empty"
+        log_path = kb.worker_log_path(task_id)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text("", encoding="utf-8")
+        result = kb._extract_crash_cause_from_log(task_id)
+        assert result is None
+
+    def test_truncates_long_line(self, kanban_home):
+        """Lines longer than 300 chars are truncated."""
+        task_id = "t_long"
+        log_path = kb.worker_log_path(task_id)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        long_line = "Error: " + "x" * 400
+        log_path.write_text(f"{long_line}\n", encoding="utf-8")
+        result = kb._extract_crash_cause_from_log(task_id)
+        assert result is not None
+        assert len(result) <= 300
+
+    def test_uses_tail_bytes(self, kanban_home):
+        """Only reads the last tail_bytes of the log."""
+        task_id = "t_tail"
+        log_path = kb.worker_log_path(task_id)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        # Write a large log with the error near the end.
+        padding = "padding line\n" * 200  # ~1400 bytes
+        log_path.write_text(
+            f"{padding}Error: the real cause\n",
+            encoding="utf-8",
+        )
+        result = kb._extract_crash_cause_from_log(task_id, tail_bytes=256)
+        assert result is not None
+        assert "the real cause" in result
+
+
+# ---------------------------------------------------------------------------
+# Integration: detect_crashed_workers surfaces log cause
+# ---------------------------------------------------------------------------
+
+
+class TestCrashWorkerLogSurfaced:
+    """Verify that ``detect_crashed_workers`` enriches the error text with
+    the crash cause extracted from the worker log file."""
+
+    def test_crash_error_includes_log_cause(self, kanban_home, monkeypatch):
+        """When a crashed worker has a log with an error line, the run error
+        includes that line appended after the pid/exit-code message."""
+        import hermes_cli.kanban_db as _kb
+
+        conn = kb.connect()
+        try:
+            tid = kb.create_task(conn, title="crash with log", assignee="worker")
+            kb.claim_task(conn, tid)
+            kb._set_worker_pid(conn, tid, 98765)
+
+            # Write a log file simulating the crash.
+            log_path = kb.worker_log_path(tid)
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            log_path.write_text(
+                "Loading worker...\n"
+                "Error: Unknown skill(s): org-design-pipeline\n",
+                encoding="utf-8",
+            )
+
+            monkeypatch.setattr(_kb, "_pid_alive", lambda pid: False)
+            kb.detect_crashed_workers(conn)
+
+            runs = kb.list_runs(conn, tid)
+            crashed_runs = [r for r in runs if r.outcome == "crashed"]
+            assert len(crashed_runs) >= 1
+            err = crashed_runs[0].error
+            assert err is not None
+            # Should contain the original pid message AND the log cause.
+            assert "98765" in err
+            assert "Unknown skill" in err
+            assert "→" in err  # arrow prefix for the log line
+        finally:
+            conn.close()
+
+    def test_crash_error_without_log_still_works(self, kanban_home, monkeypatch):
+        """When no log file exists, the error falls back to the default
+        pid/exit-code message without crashing."""
+        import hermes_cli.kanban_db as _kb
+
+        conn = kb.connect()
+        try:
+            tid = kb.create_task(conn, title="crash no log", assignee="worker")
+            kb.claim_task(conn, tid)
+            kb._set_worker_pid(conn, tid, 98765)
+
+            # No log file written.
+            monkeypatch.setattr(_kb, "_pid_alive", lambda pid: False)
+            kb.detect_crashed_workers(conn)
+
+            runs = kb.list_runs(conn, tid)
+            crashed_runs = [r for r in runs if r.outcome == "crashed"]
+            assert len(crashed_runs) >= 1
+            err = crashed_runs[0].error
+            assert err is not None
+            assert "98765" in err
+            # No arrow when there's no log cause.
+            assert "→" not in err
+        finally:
+            conn.close()

--- a/tests/hermes_cli/test_kanban_crash_log_snippet.py
+++ b/tests/hermes_cli/test_kanban_crash_log_snippet.py
@@ -1,0 +1,209 @@
+"""Crash-cause surfacing from worker logs in ``detect_crashed_workers``.
+
+A worker that dies before doing real work (e.g. ``--skill`` references a
+skill the worker profile cannot resolve) used to surface only
+``pid N exited with code 1`` / ``pid N not alive`` in ``hermes kanban show``
+and diagnostics; the actual error line was buried in the per-board worker
+log. The reclaim path now reads the worker log tail and appends the cause,
+and the dispatch ``board`` is threaded through so the lookup reads the right
+board's log even when the explicit dispatch board differs from the current
+board (worker logs are per-board precisely because task IDs can collide
+across boards).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import hermes_cli.kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+from hermes_cli import kanban_db_dispatch as kbd
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an empty kanban DB."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    # The reaped-exit registry is process-global; clear it so a pid recorded
+    # by an earlier test in the same run cannot reclassify this test's worker.
+    kbd._recent_worker_exits.clear()
+    kb.init_db()
+    return home
+
+
+def _exited_status(code: int) -> int:
+    """Raw wait-status for a WIFEXITED child with the given exit code."""
+    return code << 8
+
+
+def _plant_running_task(conn, *, pid: int) -> str:
+    """Create + claim a task and point it at a host-local dead PID."""
+    host = kb._claimer_id().split(":", 1)[0]
+    tid = kb.create_task(conn, title="crash-log", assignee="a")
+    kb.claim_task(conn, tid, claimer=f"{host}:w{pid}")
+    conn.execute(
+        "UPDATE tasks SET worker_pid=? WHERE id=?",
+        (pid, tid),
+    )
+    conn.commit()
+    return tid
+
+
+def _plant_worker_log(task_id: str, text: str, *, board=None) -> None:
+    path = kb.worker_log_path(task_id, board=board)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _last_run_error(conn, task_id: str):
+    row = conn.execute(
+        "SELECT error FROM task_runs WHERE task_id=? AND error IS NOT NULL "
+        "ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    return row["error"] if row else None
+
+
+def test_nonzero_exit_appends_cause_from_log(kanban_home, monkeypatch):
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+
+    with kbc.connect() as conn:
+        tid = _plant_running_task(conn, pid=91001)
+        kbd._record_worker_exit(91001, _exited_status(1))
+        _plant_worker_log(
+            tid,
+            "Query: work kanban task t1\nInitializing agent...\n"
+            "Error: Unknown skill(s): org-design-pipeline\n",
+        )
+
+        crashed = kbd.detect_crashed_workers(conn)
+        assert tid in crashed
+        error = _last_run_error(conn, tid)
+        assert error is not None
+        assert error.startswith("pid 91001 exited with code 1")
+        assert "→ Error: Unknown skill(s): org-design-pipeline" in error
+
+
+def test_not_alive_worker_also_surfaces_cause(kanban_home, monkeypatch):
+    """The shayani shape: the worker exits so fast the dispatcher never
+    reaps an exit status, so only ``pid N not alive`` was recorded."""
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+
+    with kbc.connect() as conn:
+        tid = _plant_running_task(conn, pid=91002)
+        # No _record_worker_exit call: classify falls to ("unknown", None).
+        _plant_worker_log(
+            tid,
+            "Warning: Unknown toolsets: messaging\nInitializing agent...\n"
+            "Error: Unknown skill(s): eventaservo-modernizacao\n",
+        )
+
+        crashed = kbd.detect_crashed_workers(conn)
+        assert tid in crashed
+        error = _last_run_error(conn, tid)
+        assert error is not None
+        assert error.startswith("pid 91002 not alive")
+        assert "→ Error: Unknown skill(s): eventaservo-modernizacao" in error
+
+
+def test_missing_log_keeps_plain_error(kanban_home, monkeypatch):
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+
+    with kbc.connect() as conn:
+        tid = _plant_running_task(conn, pid=91003)
+        kbd._record_worker_exit(91003, _exited_status(1))
+
+        crashed = kbd.detect_crashed_workers(conn)
+        assert tid in crashed
+        assert _last_run_error(conn, tid) == "pid 91003 exited with code 1"
+
+
+def test_rate_limited_and_protocol_violation_keep_own_message(
+    kanban_home, monkeypatch,
+):
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+
+    with kbc.connect() as conn:
+        tid = _plant_running_task(conn, pid=91004)
+        kbd._record_worker_exit(91004, _exited_status(0))
+        _plant_worker_log(tid, "Error: log noise that must not attach\n")
+
+        kbd.detect_crashed_workers(conn)
+        error = _last_run_error(conn, tid)
+        assert error is not None
+        assert "→" not in error
+        assert "log noise" not in error
+
+
+def test_explicit_board_reads_dispatch_board_log(kanban_home, monkeypatch):
+    """The gateway dispatches each board with ``board=slug``; the crash-cause
+    lookup must read that board's log, not the active-board chain's."""
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+
+    with kbc.connect() as conn:
+        tid = _plant_running_task(conn, pid=91005)
+        kbd._record_worker_exit(91005, _exited_status(1))
+        _plant_worker_log(
+            tid, "Error: Unknown skill(s): alpha-only-skill\n", board="alpha",
+        )
+
+        crashed = kbd.detect_crashed_workers(conn, board="alpha")
+        assert tid in crashed
+        error = _last_run_error(conn, tid)
+        assert error is not None
+        assert "→ Error: Unknown skill(s): alpha-only-skill" in error
+
+
+def test_board_mismatch_does_not_attach_colliding_log(kanban_home, monkeypatch):
+    """Worker logs are per-board because task IDs can collide across boards;
+    an explicit dispatch board must not pick up another board's log for the
+    same task ID (the non-default-board regression from the sweeper review)."""
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+
+    with kbc.connect() as conn:
+        tid = _plant_running_task(conn, pid=91006)
+        kbd._record_worker_exit(91006, _exited_status(1))
+        # Same task ID logged under BOTH boards with different causes.
+        _plant_worker_log(tid, "Error: WRONG-BOARD default-log\n")
+        _plant_worker_log(
+            tid, "Error: Unknown skill(s): right-board\n", board="alpha",
+        )
+
+        crashed = kbd.detect_crashed_workers(conn, board="alpha")
+        assert tid in crashed
+        error = _last_run_error(conn, tid)
+        assert error is not None
+        assert "→ Error: Unknown skill(s): right-board" in error
+        assert "WRONG-BOARD" not in error
+
+
+def test_dispatch_once_threads_board_to_reclaim(kanban_home, monkeypatch):
+    """End-to-end for the threading: ``dispatch_once(board=...)`` reaches the
+    reclaim-phase lookup (``_dispatch_once_locked`` → ``_run_reclaim_phase``
+    → ``detect_crashed_workers``)."""
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+
+    with kbc.connect() as conn:
+        tid = _plant_running_task(conn, pid=91007)
+        kbd._record_worker_exit(91007, _exited_status(1))
+        _plant_worker_log(
+            tid, "Error: Unknown skill(s): via-dispatch-once\n", board="beta",
+        )
+
+        result = kbd.dispatch_once(conn, board="beta")
+        assert tid in result.crashed
+        error = _last_run_error(conn, tid)
+        assert error is not None
+        assert "→ Error: Unknown skill(s): via-dispatch-once" in error


### PR DESCRIPTION
## What does this PR do?

Surfaces the actual crash cause from worker log files in `detect_crashed_workers()`. When a kanban worker crashes (e.g. `--skill` references a non-existent skill), the error stored in the run record is now enriched with the relevant log line instead of just showing "pid N exited with code 1".

## Related Issue

Fixes #44675

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py`: Added `_extract_crash_cause_from_log()` helper that reads the tail of a worker log file and extracts the most relevant error line (matching `Error:`, `Traceback`, `Exception:`, `Fatal` prefixes, falling back to last non-empty line). Called in `detect_crashed_workers()` after crash detection to append the log cause to the error text with a `→` prefix.
- `tests/hermes_cli/test_kanban_crash_log_snippet.py`: 10 new tests — 8 unit tests for the helper function (error line matching, traceback matching, fallback behavior, empty log, truncation, tail-bytes) and 2 integration tests verifying the full crash detection pipeline with and without log files.

## How to Test

1. Create a kanban task with a non-existent skill: `hermes kanban create "Test" --skill nonexistent-skill`
2. Run `hermes kanban dispatch` to trigger the worker
3. After the worker crashes, run `hermes kanban show <task_id>`
4. Verify the run error now shows: `pid N exited with code 1` followed by `→ Error: Unknown skill(s): nonexistent-skill`
5. Run tests: `pytest tests/hermes_cli/test_kanban_crash_log_snippet.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `detect_crashed_workers` in `kanban_db.py` (crash detection), `read_worker_log` (log file reading)
- Blast radius: LOW — only affects kanban crash error messages, no control-flow changes
- Related patterns: `read_worker_log(task_id, tail_bytes=N)` already existed for dashboard log viewing; this reuses it for crash diagnostics
