### PR TITLE
fix(agent): focus automatic compression on recent user turns (salvages #38155)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1630,11 +1630,9 @@ This compaction should PRIORITISE preserving all information related to the focu
     def _derive_auto_focus_topic(
         cls,
         messages: List[Dict[str, Any]],
-        tail_start: int,
     ) -> Optional[str]:
         """Infer a compact focus hint from the most recent real user turns."""
         candidates: list[str] = []
-        del tail_start  # Reserved for callers that already know the protected-tail boundary.
         for idx in range(len(messages) - 1, -1, -1):
             msg = messages[idx]
             if msg.get("role") != "user":
@@ -2108,7 +2106,7 @@ This compaction should PRIORITISE preserving all information related to the focu
             )
 
         # Phase 3: Generate structured summary
-        summary_focus_topic = focus_topic or self._derive_auto_focus_topic(messages, compress_end)
+        summary_focus_topic = focus_topic or self._derive_auto_focus_topic(messages)
         summary = self._generate_summary(turns_to_summarize, focus_topic=summary_focus_topic)
 
         # If summary generation failed, behavior splits on

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -143,6 +143,9 @@ _SUMMARY_FAILURE_COOLDOWN_SECONDS = 600
 # become another unbounded transcript copy after the LLM summarizer failed.
 _FALLBACK_SUMMARY_MAX_CHARS = 8_000
 _FALLBACK_TURN_MAX_CHARS = 700
+_AUTO_FOCUS_MAX_TURNS = 3
+_AUTO_FOCUS_TURN_MAX_CHARS = 260
+_AUTO_FOCUS_MAX_CHARS = 700
 
 
 _PATH_MENTION_RE = re.compile(r"(?:/|~/?|[A-Za-z]:\\)[^\s`'\")\]}<>]+")
@@ -1454,7 +1457,7 @@ Use this exact structure:
             prompt += f"""
 
 FOCUS TOPIC: "{focus_topic}"
-The user has requested that this compaction PRIORITISE preserving all information related to the focus topic above. For content related to "{focus_topic}", include full detail — exact values, file paths, command outputs, error messages, and decisions. For content NOT related to the focus topic, summarise more aggressively (brief one-liners or omit if truly irrelevant). The focus topic sections should receive roughly 60-70% of the summary token budget. Even for the focus topic, NEVER preserve API keys, tokens, passwords, or credentials — use [REDACTED]."""
+This compaction should PRIORITISE preserving all information related to the focus topic above. For content related to "{focus_topic}", include full detail — exact values, file paths, command outputs, error messages, and decisions. For content NOT related to the focus topic, summarise more aggressively (brief one-liners or omit if truly irrelevant). The focus topic sections should receive roughly 60-70% of the summary token budget. Even for the focus topic, NEVER preserve API keys, tokens, passwords, or credentials — use [REDACTED]."""
 
         try:
             call_kwargs = {
@@ -1622,6 +1625,41 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         if text.startswith(SUMMARY_PREFIX) or text.startswith(LEGACY_SUMMARY_PREFIX):
             return True
         return any(text.startswith(p) for p in _HISTORICAL_SUMMARY_PREFIXES)
+
+    @classmethod
+    def _derive_auto_focus_topic(
+        cls,
+        messages: List[Dict[str, Any]],
+        tail_start: int,
+    ) -> Optional[str]:
+        """Infer a compact focus hint from the most recent real user turns."""
+        candidates: list[str] = []
+        del tail_start  # Reserved for callers that already know the protected-tail boundary.
+        for idx in range(len(messages) - 1, -1, -1):
+            msg = messages[idx]
+            if msg.get("role") != "user":
+                continue
+            content = msg.get("content")
+            if cls._is_context_summary_content(content):
+                continue
+            text = redact_sensitive_text(_content_text_for_contains(content).strip())
+            if not text:
+                continue
+            text = " ".join(text.split())
+            if len(text) > _AUTO_FOCUS_TURN_MAX_CHARS:
+                text = text[: _AUTO_FOCUS_TURN_MAX_CHARS - 1].rstrip() + "…"
+            candidates.append(text)
+            if len(candidates) >= _AUTO_FOCUS_MAX_TURNS:
+                break
+
+        if not candidates:
+            return None
+
+        candidates.reverse()
+        focus = "Recent user focus:\n" + "\n".join(f"- {item}" for item in candidates)
+        if len(focus) > _AUTO_FOCUS_MAX_CHARS:
+            focus = focus[: _AUTO_FOCUS_MAX_CHARS - 1].rstrip() + "…"
+        return focus
 
     @classmethod
     def _find_latest_context_summary(
@@ -2070,7 +2108,8 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             )
 
         # Phase 3: Generate structured summary
-        summary = self._generate_summary(turns_to_summarize, focus_topic=focus_topic)
+        summary_focus_topic = focus_topic or self._derive_auto_focus_topic(messages, compress_end)
+        summary = self._generate_summary(turns_to_summarize, focus_topic=summary_focus_topic)
 
         # If summary generation failed, behavior splits on
         # ``abort_on_summary_failure`` (config: compression.abort_on_summary_failure):

--- a/tests/agent/test_compress_focus.py
+++ b/tests/agent/test_compress_focus.py
@@ -166,7 +166,7 @@ def test_auto_focus_skips_context_summary_handoff():
         {"role": "assistant", "content": "Latest tail response"},
     ]
 
-    focus_topic = compressor._derive_auto_focus_topic(messages, tail_start=1)
+    focus_topic = compressor._derive_auto_focus_topic(messages)
 
     assert "OpenViking" in focus_topic
     assert "Bybit" not in focus_topic

--- a/tests/agent/test_compress_focus.py
+++ b/tests/agent/test_compress_focus.py
@@ -116,7 +116,7 @@ def test_compress_passes_focus_to_generate_summary():
 
 
 def test_compress_none_focus_by_default():
-    """compress() passes None focus_topic by default."""
+    """Auto compression derives focus_topic from recent user turns by default."""
     compressor = _make_compressor()
 
     received_kwargs = {}
@@ -141,4 +141,32 @@ def test_compress_none_focus_by_default():
 
     compressor.compress(messages, current_tokens=100000)
 
-    assert received_kwargs.get("focus_topic") is None
+    focus_topic = received_kwargs.get("focus_topic")
+    assert focus_topic.startswith("Recent user focus:")
+    assert "- second" in focus_topic
+    assert "- third" in focus_topic
+    assert "- fourth" in focus_topic
+
+
+def test_auto_focus_skips_context_summary_handoff():
+    """Persisted handoff messages should not become the inferred focus."""
+    compressor = _make_compressor()
+    messages = [
+        {"role": "system", "content": "System prompt"},
+        {
+            "role": "user",
+            "content": "[CONTEXT COMPACTION — REFERENCE ONLY] stale Bybit topic",
+        },
+        {"role": "assistant", "content": "handoff acknowledged"},
+        {"role": "user", "content": "Can OpenViking support sqlite backends?"},
+        {"role": "assistant", "content": "Let's inspect that."},
+        {"role": "user", "content": "Compare OpenViking postgres and sqlite options."},
+        {"role": "assistant", "content": "Working on it."},
+        {"role": "user", "content": "Now focus on OpenViking database support."},
+        {"role": "assistant", "content": "Latest tail response"},
+    ]
+
+    focus_topic = compressor._derive_auto_focus_topic(messages, tail_start=1)
+
+    assert "OpenViking" in focus_topic
+    assert "Bybit" not in focus_topic


### PR DESCRIPTION
## Summary
Automatic compaction now derives a focus topic from the last 3 real user turns, so iterative summaries stop keeping completed topics alive and overriding the active one.

Root cause (#9631): the iterative-update prompt says "PRESERVE all existing information", so dead topics accrete across compactions with no recency weighting — only manual `/compress <topic>` ever set a focus; automatic compaction passed `focus_topic=None`.

Closes #9631.

## Changes
- `agent/context_compressor.py`: `_derive_auto_focus_topic()` — last ≤3 real user turns (skips persisted handoff summaries), redacted, 260 chars/turn, 700 chars total; used by `compress()` whenever no explicit focus is given — from #38155 by @konsisumer
- `agent/context_compressor.py`: focus-prompt wording no longer claims "the user has requested" when the focus is auto-derived
- Follow-up: dropped the reserved-but-unused `tail_start` parameter (YAGNI)

## Validation
| | Before | After |
|---|---|---|
| Auto compaction focus | none — all topics weighted equally, completed topics accrete | last 3 real user turns get 60-70% of summary budget |
| Handoff summaries in transcript | could be picked as "user focus" | skipped via `_is_context_summary_content` |
| `pytest test_compress_focus.py + compressor suites` | — | 107 passed |

## Attribution
Salvages #38155 by @konsisumer — cherry-picked with authorship preserved; rebase-merge to keep per-commit credit. Rebased onto the #44454 prompt consolidation.

## Infographic

![compression-auto-focus-topic](https://v3b.fal.media/files/b/0a9df5fc/uNBOOQeARjqb4nfiBqYrH_h4JBn9WS.png)
