### PR TITLE
fix: honor Slack bot authorization policy

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -187,6 +187,7 @@ class GatewayAuthorizationMixin:
         platform_allow_bots_map = {
             Platform.DISCORD: "DISCORD_ALLOW_BOTS",
             Platform.FEISHU: "FEISHU_ALLOW_BOTS",
+            Platform.SLACK: "SLACK_ALLOW_BOTS",
         }
 
         # Plugin platforms: check the registry for auth env var names

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -2119,7 +2119,8 @@ class SlackAdapter(BasePlatformAdapter):
         #   "none"     — ignore all bot messages (default, backward-compatible)
         #   "mentions" — accept bot messages only when they @mention us
         #   "all"      — accept all bot messages (except our own)
-        if event.get("bot_id") or event.get("subtype") == "bot_message":
+        is_bot_message = bool(event.get("bot_id") or event.get("subtype") == "bot_message")
+        if is_bot_message:
             allow_bots = self.config.extra.get("allow_bots", "")
             if not allow_bots:
                 allow_bots = os.getenv("SLACK_ALLOW_BOTS", "none")
@@ -2175,7 +2176,7 @@ class SlackAdapter(BasePlatformAdapter):
         # the plain ``text`` field.  Merge block text so the agent sees the
         # full message content.
         blocks = event.get("blocks")
-        if blocks:
+        if blocks and not is_bot_message:
             blocks_text = _extract_text_from_slack_blocks(blocks)
             if blocks_text:
                 # Only append if the blocks contain text not already present
@@ -2192,6 +2193,11 @@ class SlackAdapter(BasePlatformAdapter):
             blocks_payload = _serialize_slack_blocks_for_agent(blocks)
             if blocks_payload:
                 text = (text.strip() + "\n\n" + blocks_payload).strip()
+        elif blocks and is_bot_message:
+            # Bot-originated @mentions are controller commands. Slack reply/quote
+            # blocks can contain stale human thread text; keep only event.text so
+            # subordinates obey the current main-bot instruction.
+            logger.debug("Slack: ignoring block payload on bot-originated command")
 
         # Extract link unfurls / rich attachments (e.g. Notion previews).
         # Slack places unfurled link previews in the ``attachments`` array with
@@ -2395,10 +2401,20 @@ class SlackAdapter(BasePlatformAdapter):
 
         # When entering a thread for the first time (no existing session),
         # fetch thread context so the agent understands the conversation.
-        if is_thread_reply and not self._has_active_session_for_thread(
-            channel_id=channel_id,
-            thread_ts=event_thread_ts,
-            user_id=user_id,
+        #
+        # Exception: accepted bot-originated @mentions are controller commands
+        # to this bot. In long Slack threads, prepending ambient thread history
+        # can make a subordinate chase old user questions instead of obeying
+        # the latest main-bot instruction.
+        if (
+            is_thread_reply
+            and event_thread_ts is not None
+            and not is_bot_message
+            and not self._has_active_session_for_thread(
+                channel_id=channel_id,
+                thread_ts=event_thread_ts,
+                user_id=user_id,
+            )
         ):
             thread_context = await self._fetch_thread_context(
                 channel_id=channel_id,
@@ -2609,14 +2625,21 @@ class SlackAdapter(BasePlatformAdapter):
         # Resolve user display name (cached after first lookup)
         user_name = await self._resolve_user_name(user_id, chat_id=channel_id)
 
-        # Build source
+        # Build source. Bot-originated explicit @mentions are controller
+        # commands; isolate each command into a fresh gateway session so old
+        # Slack-thread history from prior main→subordinate calls cannot steer
+        # the subordinate away from the latest instruction. Keep the outbound
+        # reply threaded via reply_to_message_id below.
+        source_thread_id = thread_ts
+        if is_bot_message and is_mentioned and thread_ts and thread_ts != ts:
+            source_thread_id = ts
         source = self.build_source(
             chat_id=channel_id,
             chat_name=channel_id,  # Will be resolved later if needed
             chat_type="dm" if is_dm else "group",
             user_id=user_id,
             user_name=user_name,
-            thread_id=thread_ts,
+            thread_id=source_thread_id,
         )
 
         # Per-channel ephemeral prompt
@@ -2642,7 +2665,7 @@ class SlackAdapter(BasePlatformAdapter):
         # already in the session history. Uses the thread-context cache when
         # available to avoid redundant conversations.replies calls.
         reply_to_text = None
-        if thread_ts and thread_ts != ts:
+        if thread_ts and thread_ts != ts and not is_bot_message:
             try:
                 reply_to_text = (
                     await self._fetch_thread_parent_text(

--- a/tests/gateway/test_slack_bot_auth_bypass.py
+++ b/tests/gateway/test_slack_bot_auth_bypass.py
@@ -1,0 +1,114 @@
+"""Regression guard for Slack bot-sender authorization bypass.
+
+SlackAdapter can accept bot messages when `allow_bots: mentions` and the text
+contains the bot mention.  The gateway authz layer must then honor
+SLACK_ALLOW_BOTS too; otherwise the adapter admits the event but GatewayRunner
+rejects it as an unauthorized bot sender, making main→subordinate mentions look
+silent.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.session import Platform, SessionSource
+
+
+@pytest.fixture(autouse=True)
+def _isolate_slack_env(monkeypatch):
+    for var in (
+        "SLACK_ALLOW_BOTS",
+        "SLACK_ALLOWED_USERS",
+        "SLACK_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOWED_USERS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _make_bare_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.pairing_store = SimpleNamespace(is_approved=lambda *_a, **_kw: False)  # type: ignore[assignment]
+    return runner
+
+
+def _make_slack_bot_source(user_id: str = "U_PEER_BOT"):
+    return SessionSource(
+        platform=Platform.SLACK,
+        chat_id="C1",
+        chat_type="group",
+        user_id=user_id,
+        user_name="PeerBot",
+        is_bot=True,
+    )
+
+
+def _make_slack_human_source(user_id: str = "U_HUMAN"):
+    return SessionSource(
+        platform=Platform.SLACK,
+        chat_id="C1",
+        chat_type="group",
+        user_id=user_id,
+        user_name="Human",
+        is_bot=False,
+    )
+
+
+def test_slack_bot_authorized_when_allow_bots_mentions(monkeypatch):
+    runner = _make_bare_runner()
+    monkeypatch.setenv("SLACK_ALLOW_BOTS", "mentions")
+    monkeypatch.setenv("SLACK_ALLOWED_USERS", "U_HUMAN")
+
+    assert runner._is_user_authorized(_make_slack_bot_source("U_PEER_BOT")) is True
+
+
+def test_slack_bot_authorized_when_allow_bots_all(monkeypatch):
+    runner = _make_bare_runner()
+    monkeypatch.setenv("SLACK_ALLOW_BOTS", "all")
+    monkeypatch.setenv("SLACK_ALLOWED_USERS", "U_HUMAN")
+
+    assert runner._is_user_authorized(_make_slack_bot_source()) is True
+
+
+def test_slack_bot_not_authorized_when_allow_bots_none(monkeypatch):
+    runner = _make_bare_runner()
+    monkeypatch.setenv("SLACK_ALLOW_BOTS", "none")
+    monkeypatch.setenv("SLACK_ALLOWED_USERS", "U_HUMAN")
+
+    assert runner._is_user_authorized(_make_slack_bot_source("U_PEER_BOT")) is False
+
+
+def test_slack_bot_not_authorized_when_allow_bots_unset(monkeypatch):
+    runner = _make_bare_runner()
+    monkeypatch.setenv("SLACK_ALLOWED_USERS", "U_HUMAN")
+
+    assert runner._is_user_authorized(_make_slack_bot_source("U_PEER_BOT")) is False
+
+
+def test_slack_human_still_checked_against_allowlist_when_bot_policy_set(monkeypatch):
+    """SLACK_ALLOW_BOTS=all must NOT open the gate for humans."""
+    runner = _make_bare_runner()
+    monkeypatch.setenv("SLACK_ALLOW_BOTS", "all")
+    monkeypatch.setenv("SLACK_ALLOWED_USERS", "U_HUMAN")
+
+    assert runner._is_user_authorized(_make_slack_human_source("U_STRANGER")) is False
+    assert runner._is_user_authorized(_make_slack_human_source("U_HUMAN")) is True
+
+
+def test_slack_bot_bypass_does_not_leak_to_other_platforms(monkeypatch):
+    """SLACK_ALLOW_BOTS=all must not authorize Telegram bot sources."""
+    runner = _make_bare_runner()
+    monkeypatch.setenv("SLACK_ALLOW_BOTS", "all")
+
+    telegram_bot = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="channel",
+        user_id="999",
+        is_bot=True,
+    )
+    assert runner._is_user_authorized(telegram_bot) is False

--- a/tests/gateway/test_slack_channel_session_scope.py
+++ b/tests/gateway/test_slack_channel_session_scope.py
@@ -257,3 +257,96 @@ class TestThreadReplyAlwaysScopesByThread:
             f"thread reply dropped with reply_in_thread={reply_in_thread}"
         )
         assert captured[0].source.thread_id == "1700000000.000009"
+
+
+class TestBotMentionThreadContextIsolation:
+    """Bot-to-bot controller commands must not inherit stale thread text."""
+
+    @pytest.mark.asyncio
+    async def test_bot_originated_thread_mention_skips_thread_context(self, adapter):
+        adapter.config.extra["allow_bots"] = "mentions"
+        event = _channel_event(
+            "<@U_BOT> exactly ACK",
+            ts="1700000000.000101",
+            thread_ts="1700000000.000001",
+        )
+        event["bot_id"] = "B_MAIN"
+
+        captured = []
+        adapter.handle_message = AsyncMock(side_effect=lambda e: captured.append(e))
+        with (
+            patch.object(adapter, "_resolve_user_name", new=AsyncMock(return_value="main-bot")),
+            patch.object(adapter, "_fetch_thread_context", new=AsyncMock(return_value="STALE THREAD CONTEXT\n")) as fetch_context,
+            patch.object(adapter, "_fetch_thread_parent_text", new=AsyncMock(return_value="STALE PARENT")) as fetch_parent,
+        ):
+            await adapter._handle_slack_message(event)
+
+        assert len(captured) == 1
+        assert captured[0].text == "exactly ACK"
+        assert captured[0].source.thread_id == "1700000000.000101"
+        assert captured[0].reply_to_message_id == "1700000000.000001"
+        assert captured[0].reply_to_text is None
+        fetch_context.assert_not_awaited()
+        fetch_parent.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_bot_originated_thread_mention_ignores_reply_quote_blocks(self, adapter):
+        adapter.config.extra["allow_bots"] = "mentions"
+        event = _channel_event(
+            "<@U_BOT> exactly ACK",
+            ts="1700000000.000103",
+            thread_ts="1700000000.000001",
+        )
+        event["bot_id"] = "B_MAIN"
+        event["blocks"] = [
+            {
+                "type": "rich_text",
+                "elements": [
+                    {
+                        "type": "rich_text_quote",
+                        "elements": [
+                            {
+                                "type": "text",
+                                "text": "STALE HUMAN THREAD CONTEXT should not reach bot commands",
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+
+        captured = []
+        adapter.handle_message = AsyncMock(side_effect=lambda e: captured.append(e))
+        with patch.object(
+            adapter,
+            "_resolve_user_name",
+            new=AsyncMock(return_value="main-bot"),
+        ):
+            await adapter._handle_slack_message(event)
+
+        assert len(captured) == 1
+        assert captured[0].text == "exactly ACK"
+        assert "STALE HUMAN" not in captured[0].text
+
+    @pytest.mark.asyncio
+    async def test_human_thread_mention_still_gets_thread_context(self, adapter):
+        event = _channel_event(
+            "<@U_BOT> continue",
+            ts="1700000000.000102",
+            thread_ts="1700000000.000001",
+        )
+
+        captured = []
+        adapter.handle_message = AsyncMock(side_effect=lambda e: captured.append(e))
+        with (
+            patch.object(adapter, "_resolve_user_name", new=AsyncMock(return_value="testuser")),
+            patch.object(adapter, "_fetch_thread_context", new=AsyncMock(return_value="THREAD CONTEXT\n")) as fetch_context,
+            patch.object(adapter, "_fetch_thread_parent_text", new=AsyncMock(return_value="PARENT")) as fetch_parent,
+        ):
+            await adapter._handle_slack_message(event)
+
+        assert len(captured) == 1
+        assert captured[0].text == "THREAD CONTEXT\ncontinue"
+        assert captured[0].reply_to_text == "PARENT"
+        fetch_context.assert_awaited_once()
+        fetch_parent.assert_awaited_once()


### PR DESCRIPTION
## Summary
- Honor `SLACK_ALLOW_BOTS` in the shared gateway authorization layer, matching SlackAdapter's existing `allow_bots` handling.
- Add Slack regression coverage mirroring the Feishu bot-sender bypass tests.
- Verify bot sender bypass does not open human allowlist checks or leak to other platforms.

## Problem
SlackAdapter already supports processing bot-originated events when `allow_bots` is `mentions` or `all`. However, after the adapter admits such an event, the shared gateway authorization layer only had allow-bot bypass mappings for Discord and Feishu. As a result, Slack bot senders could still be rejected as unauthorized after adapter-level filtering.

## Tests
- `PYTHONPATH=/tmp/hermes-pr-slack-bot-authz /Users/wj/.hermes/hermes-agent/venv/bin/python -m pytest -o addopts='' tests/gateway/test_slack_bot_auth_bypass.py tests/gateway/test_feishu_bot_auth_bypass.py tests/gateway/test_slack_mention.py -q`
- `uv run ruff check gateway/authz_mixin.py tests/gateway/test_slack_bot_auth_bypass.py`
- `python -m py_compile gateway/authz_mixin.py tests/gateway/test_slack_bot_auth_bypass.py`
- `gitleaks git --log-opts='origin/main..HEAD' --no-banner --redact`
