### PR TITLE
fix(cli,tui): wrap long approval commands instead of truncating

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9629,7 +9629,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         show_full = state.get("show_full", False)
 
         title = "⚠️  Dangerous Command"
-        cmd_display = command if show_full or len(command) <= 70 else command[:70] + '...'
+        cmd_display = command
         choice_labels = {
             "once": "Allow once",
             "session": "Allow for this session",
@@ -9653,6 +9653,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
         # Pre-wrap the mandatory content — command + choices must always render.
         cmd_wrapped = _wrap_panel_text(cmd_display, inner_text_width)
+        if not show_full and "view" in choices and len(cmd_wrapped) > 4:
+            cmd_wrapped = cmd_wrapped[:3] + ["… (choose Show full command)"]
 
         # (choice_index, wrapped_line) so we can re-apply selected styling below
         choice_wrapped: list[tuple[int, str]] = []

--- a/cli.py
+++ b/cli.py
@@ -9654,7 +9654,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # Pre-wrap the mandatory content — command + choices must always render.
         cmd_wrapped = _wrap_panel_text(cmd_display, inner_text_width)
         if not show_full and "view" in choices and len(cmd_wrapped) > 4:
-            cmd_wrapped = cmd_wrapped[:3] + ["… (choose Show full command)"]
+            cmd_wrapped = cmd_wrapped[:3] + _wrap_panel_text(
+                "… (choose Show full command)",
+                inner_text_width,
+            )
 
         # (choice_index, wrapped_line) so we can re-apply selected styling below
         choice_wrapped: list[tuple[int, str]] = []
@@ -9704,7 +9707,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         max_cmd_rows = max(1, available - chrome_rows - len(choice_wrapped))
         if len(cmd_wrapped) > max_cmd_rows:
             keep = max(1, max_cmd_rows - 1) if max_cmd_rows > 1 else 1
-            cmd_wrapped = cmd_wrapped[:keep] + ["… (command truncated — use /logs or /debug for full text)"]
+            cmd_wrapped = cmd_wrapped[:keep] + _wrap_panel_text(
+                "… (command truncated — use /logs or /debug for full text)",
+                inner_text_width,
+            )
 
         # Allocate any remaining rows to description. The extra -1 in full mode
         # accounts for the blank separator between choices and description.

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -154,7 +154,9 @@ class TestCliApprovalUi:
         assert "Dangerous Command" not in lines[0]
         assert any("Dangerous Command" in line for line in lines[1:3])
         assert "Show full command" in rendered
-        assert "githubcli-archive-keyring.gpg" not in rendered
+        assert "githubcli-archive-" in rendered
+        assert "keyring.gpg" in rendered
+        assert "status=progress" in rendered
 
     def test_approval_display_shows_full_command_after_view(self):
         cli = _make_cli_stub()

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -158,6 +158,30 @@ class TestCliApprovalUi:
         assert "keyring.gpg" in rendered
         assert "status=progress" in rendered
 
+    def test_approval_display_wraps_preview_hint_on_narrow_terminal(self):
+        cli = _make_cli_stub()
+        cli._approval_state = {
+            "command": "sudo " + ("very-long-command-segment-" * 8),
+            "description": "shell command via -c/-lc flag",
+            "choices": ["once", "session", "always", "deny", "view"],
+            "selected": 0,
+            "response_queue": queue.Queue(),
+        }
+
+        import shutil as _shutil
+
+        with patch("cli.shutil.get_terminal_size",
+                   return_value=_shutil.os.terminal_size((30, 24))):
+            fragments = cli._get_approval_display_fragments()
+
+        rendered = "".join(text for _style, text in fragments)
+        lines = rendered.splitlines()
+        border_width = len(lines[0])
+
+        assert "Show full" in rendered
+        assert "command)" in rendered
+        assert all(len(line) == border_width for line in lines)
+
     def test_approval_display_shows_full_command_after_view(self):
         cli = _make_cli_stub()
         full_command = "sudo dd if=/tmp/in of=/usr/share/keyrings/githubcli-archive-keyring.gpg bs=4M status=progress"

--- a/ui-tui/src/components/appOverlays.tsx
+++ b/ui-tui/src/components/appOverlays.tsx
@@ -30,7 +30,7 @@ export function PromptZone({
   if (overlay.approval) {
     return (
       <Box flexDirection="column" flexShrink={0} paddingX={1} paddingY={1}>
-        <ApprovalPrompt onChoice={onApprovalChoice} req={overlay.approval} t={theme} />
+        <ApprovalPrompt cols={cols} onChoice={onApprovalChoice} req={overlay.approval} t={theme} />
       </Box>
     )
   }

--- a/ui-tui/src/components/prompts.tsx
+++ b/ui-tui/src/components/prompts.tsx
@@ -1,4 +1,4 @@
-import { Box, Text, useInput } from '@hermes/ink'
+import { Box, Text, useInput, wrapAnsi } from '@hermes/ink'
 import { useState } from 'react'
 
 import { isMac } from '../lib/platform.js'
@@ -66,7 +66,7 @@ export function approvalAction(
   return { kind: 'noop' }
 }
 
-export function ApprovalPrompt({ onChoice, req, t }: ApprovalPromptProps) {
+export function ApprovalPrompt({ cols = 80, onChoice, req, t }: ApprovalPromptProps) {
   const [sel, setSel] = useState(0)
   const opts = req.allowPermanent === false ? APPROVAL_OPTS_NO_ALWAYS : APPROVAL_OPTS
 
@@ -80,7 +80,11 @@ export function ApprovalPrompt({ onChoice, req, t }: ApprovalPromptProps) {
     }
   })
 
-  const rawLines = req.command.split('\n')
+  // Wrap long single-line commands to the panel width instead of clipping the
+  // tail (mirrors the CLI approval panel fix — the full command must be
+  // reviewable before approving). Border + paddingX + inner padding ≈ 8 cols.
+  const innerWidth = Math.max(20, cols - 8)
+  const rawLines = req.command.split('\n').flatMap(line => wrapAnsi(line, innerWidth, { hard: true, trim: false }).split('\n'))
   const shown = rawLines.slice(0, CMD_PREVIEW_LINES)
   const overflow = rawLines.length - shown.length
 
@@ -264,6 +268,7 @@ export function ConfirmPrompt({ onCancel, onConfirm, req, t }: ConfirmPromptProp
 }
 
 interface ApprovalPromptProps {
+  cols?: number
   onChoice: (s: string) => void
   req: ApprovalReq
   t: Theme


### PR DESCRIPTION
## Summary
Long dangerous-command approval prompts now show the full (wrapped) command instead of hard-cutting at 70 characters — in both the CLI panel and the Ink TUI overlay.

Salvages #18384 by @BlackishGreen33 (cherry-picked, authorship preserved). Fixes #18376.

## Changes
- `cli.py`: stop truncating the approval command preview at 70 chars before wrapping; cap multi-line previews at 3 rows + "… (choose Show full command)" hint so choices stay visible; wrap both truncation-marker strings to the panel width (they previously overflowed the box on narrow terminals).
- `ui-tui/src/components/prompts.tsx` + `appOverlays.tsx` (follow-up): the TUI `ApprovalPrompt` rendered command lines with `wrap="truncate-end"`, losing the tail of long single-line commands — the exact symptom reported in #18376 (`--tui`). Now wraps via `wrapAnsi` to the panel width before the 10-line preview cap.

## Validation
| | Before | After |
|---|---|---|
| CLI, 80 cols, 130-char command | tail hidden behind 70-char cut | fully wrapped, all choices visible |
| CLI, 30 cols | marker string overflowed border | borders aligned, hint wrapped |
| TUI long one-line command | tail clipped at terminal width | wrapped across up to 10 lines |

- `tests/cli/test_cli_approval_ui.py`: 18/18 passed
- `ui-tui`: `tsc --noEmit` clean; vitest approval/prompt suites 15/15 passed
- E2E render of `_get_approval_display_fragments()` at 80 and 30 cols: borders aligned, command tail or "Show full" hint visible

Reported on Discord (VS Code terminal, dangerous-command prompt unreadable).

## Infographic

![approval-prompt-wrap-fix](https://v3b.fal.media/files/b/0a9df615/30j3oGyFdsPdbLOCOB2WI_Nf6aXXBt.png)
