### PR TITLE
fix(deps): relax dev setuptools pin to 81.0.0 (torch caps setuptools<82)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,7 @@ edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 hindsight = ["hindsight-client==0.6.1"]
-dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "pytest-timeout==2.4.0", "mcp==1.26.0", "starlette==1.0.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==82.0.1"]  # starlette: CVE-2026-48710
+dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "pytest-timeout==2.4.0", "mcp==1.26.0", "starlette==1.0.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==81.0.0"]  # starlette: CVE-2026-48710; setuptools: latest <82 (torch >=2.11 caps setuptools<82)
 messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", "aiohttp==3.13.4", "brotlicffi==1.2.0.1", "slack-bolt==1.27.0", "slack-sdk==3.40.1", "qrcode==7.4.2"]  # aiohttp: CVE-2026-34513/34518/34519/34520/34525
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt==1.27.0", "slack-sdk==3.40.1", "aiohttp==3.13.4"]

--- a/uv.lock
+++ b/uv.lock
@@ -1676,7 +1676,7 @@ requires-dist = [
     { name = "rich", specifier = "==14.3.3" },
     { name = "ruamel-yaml", specifier = "==0.18.17" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.10" },
-    { name = "setuptools", marker = "extra == 'dev'", specifier = "==82.0.1" },
+    { name = "setuptools", marker = "extra == 'dev'", specifier = "==81.0.0" },
     { name = "simple-term-menu", marker = "extra == 'cli'", specifier = "==1.6.6" },
     { name = "slack-bolt", marker = "extra == 'messaging'", specifier = "==1.27.0" },
     { name = "slack-bolt", marker = "extra == 'slack'", specifier = "==1.27.0" },
@@ -3583,11 +3583,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "82.0.1"
+version = "81.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/1c/73e719955c59b8e424d015ab450f51c0af856ae46ea2da83eba51cc88de1/setuptools-81.0.0.tar.gz", hash = "sha256:487b53915f52501f0a79ccfd0c02c165ffe06631443a886740b91af4b7a5845a", size = 1198299, upload-time = "2026-02-06T21:10:39.601Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl", hash = "sha256:fdd925d5c5d9f62e4b74b30d6dd7828ce236fd6ed998a08d81de62ce5a6310d6", size = 1062021, upload-time = "2026-02-06T21:10:37.175Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What does this PR do?

Relaxes the `dev` extra's setuptools pin from `82.0.1` to `81.0.0`. torch (>= 2.11) publishes `Requires-Dist: setuptools<82`, so any environment that resolves the `dev` extra together with torch is unsatisfiable — e.g. developing hermes-agent in an env that also carries a local embedding/reranker stack. `81.0.0` is the latest release under torch's cap and stays inside the build-system support window already declared in `pyproject.toml` (`requires = ["setuptools>=77.0,<83"]`).

## Related Issue

Fixes #44692

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `pyproject.toml`: `dev` extra `setuptools==82.0.1` → `setuptools==81.0.0`, with a comment noting the torch cap (keeps the exact-pin style of the extra)
- `uv.lock`: regenerated via `uv lock`; the diff is scoped to the setuptools entry only (specifier, version, sdist, wheel — 8 lines)

## How to Test

1. On `main`, reproduce the conflict:
   ```console
   $ uv pip install --dry-run ".[dev]" "torch==2.12.0"
     × No solution found when resolving dependencies:
     ╰─▶ ... torch==2.12.0 and all versions of hermes-agent[dev] are incompatible.
   ```
2. On this branch, the same command resolves cleanly.
3. `uv sync --locked --python 3.11 --extra all --extra dev` succeeds (the same invocation CI uses), confirming manifest/lock consistency.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the full suite via `scripts/run_tests.sh` (~17k tests): 39 failures across 12 files on my dev box, all environment-dependent (a live Hermes gateway runs on the same machine) and **identical with the old `setuptools==82.0.1` pin re-installed in the same venv** (A/B-verified) — i.e. unrelated to this change
- [ ] I've added tests for my changes — N/A: dependency-metadata-only change; the regression gate is CI's `uv sync --locked`, which fails if pin and lock drift
- [x] I've tested on my platform: macOS 26.4 (arm64), Python 3.11, uv 0.9.29

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no behavior change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — dependency-metadata change, platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
