### PR TITLE
fix(platforms): clean up websocket sessions on connect failure

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -281,31 +281,38 @@ class WeComAdapter(BasePlatformAdapter):
     async def _open_connection(self) -> None:
         """Open and authenticate a websocket connection."""
         await self._cleanup_ws()
-        self._session = aiohttp.ClientSession(trust_env=True)
-        self._ws = await self._session.ws_connect(
-            self._ws_url,
-            heartbeat=HEARTBEAT_INTERVAL_SECONDS * 2,
-            timeout=CONNECT_TIMEOUT_SECONDS,
-        )
+        if aiohttp is None:
+            raise RuntimeError("aiohttp is required for WeCom")
+        session = aiohttp.ClientSession(trust_env=True)
+        self._session = session
+        try:
+            self._ws = await session.ws_connect(
+                self._ws_url,
+                heartbeat=HEARTBEAT_INTERVAL_SECONDS * 2,
+                timeout=CONNECT_TIMEOUT_SECONDS,
+            )
 
-        req_id = self._new_req_id("subscribe")
-        await self._send_json(
-            {
-                "cmd": APP_CMD_SUBSCRIBE,
-                "headers": {"req_id": req_id},
-                "body": {
-                    "bot_id": self._bot_id,
-                    "secret": self._secret,
-                    "device_id": self._device_id,
-                },
-            }
-        )
+            req_id = self._new_req_id("subscribe")
+            await self._send_json(
+                {
+                    "cmd": APP_CMD_SUBSCRIBE,
+                    "headers": {"req_id": req_id},
+                    "body": {
+                        "bot_id": self._bot_id,
+                        "secret": self._secret,
+                        "device_id": self._device_id,
+                    },
+                }
+            )
 
-        auth_payload = await self._wait_for_handshake(req_id)
-        errcode = auth_payload.get("errcode", 0)
-        if errcode not in {0, None}:
-            errmsg = auth_payload.get("errmsg", "authentication failed")
-            raise RuntimeError(f"{errmsg} (errcode={errcode})")
+            auth_payload = await self._wait_for_handshake(req_id)
+            errcode = auth_payload.get("errcode", 0)
+            if errcode not in {0, None}:
+                errmsg = auth_payload.get("errmsg", "authentication failed")
+                raise RuntimeError(f"{errmsg} (errcode={errcode})")
+        except Exception:
+            await self._cleanup_ws()
+            raise
 
     async def _wait_for_handshake(self, req_id: str) -> Dict[str, Any]:
         """Wait for the subscribe acknowledgement."""

--- a/plugins/platforms/homeassistant/adapter.py
+++ b/plugins/platforms/homeassistant/adapter.py
@@ -142,47 +142,54 @@ class HomeAssistantAdapter(BasePlatformAdapter):
         ws_url = self._hass_url.replace("https://", "wss://").replace("http://", "ws://")
         ws_url = f"{ws_url}/api/websocket"
 
-        self._session = aiohttp.ClientSession(
+        if aiohttp is None:
+            return False
+        session = aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=30)
         )
-        self._ws = await self._session.ws_connect(ws_url, heartbeat=30, timeout=30)
+        self._session = session
+        try:
+            self._ws = await session.ws_connect(ws_url, heartbeat=30, timeout=30)
 
-        # Step 1: Receive auth_required
-        msg = await self._ws.receive_json()
-        if msg.get("type") != "auth_required":
-            logger.error("Expected auth_required, got: %s", msg.get("type"))
+            # Step 1: Receive auth_required
+            msg = await self._ws.receive_json()
+            if msg.get("type") != "auth_required":
+                logger.error("Expected auth_required, got: %s", msg.get("type"))
+                await self._cleanup_ws()
+                return False
+
+            # Step 2: Send auth
+            await self._ws.send_json({
+                "type": "auth",
+                "access_token": self._hass_token,
+            })
+
+            # Step 3: Wait for auth_ok
+            msg = await self._ws.receive_json()
+            if msg.get("type") != "auth_ok":
+                logger.error("Auth failed: %s", msg)
+                await self._cleanup_ws()
+                return False
+
+            # Step 4: Subscribe to state_changed events
+            sub_id = self._next_id()
+            await self._ws.send_json({
+                "id": sub_id,
+                "type": "subscribe_events",
+                "event_type": "state_changed",
+            })
+
+            # Verify subscription acknowledgement
+            msg = await self._ws.receive_json()
+            if not msg.get("success"):
+                logger.error("Failed to subscribe to events: %s", msg)
+                await self._cleanup_ws()
+                return False
+
+            return True
+        except Exception:
             await self._cleanup_ws()
-            return False
-
-        # Step 2: Send auth
-        await self._ws.send_json({
-            "type": "auth",
-            "access_token": self._hass_token,
-        })
-
-        # Step 3: Wait for auth_ok
-        msg = await self._ws.receive_json()
-        if msg.get("type") != "auth_ok":
-            logger.error("Auth failed: %s", msg)
-            await self._cleanup_ws()
-            return False
-
-        # Step 4: Subscribe to state_changed events
-        sub_id = self._next_id()
-        await self._ws.send_json({
-            "id": sub_id,
-            "type": "subscribe_events",
-            "event_type": "state_changed",
-        })
-
-        # Verify subscription acknowledgement
-        msg = await self._ws.receive_json()
-        if not msg.get("success"):
-            logger.error("Failed to subscribe to events: %s", msg)
-            await self._cleanup_ws()
-            return False
-
-        return True
+            raise
 
     async def _cleanup_ws(self) -> None:
         """Close WebSocket and session."""

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -122,6 +122,30 @@ class TestWeComConnect:
         assert adapter.fatal_error_code == "wecom_connect_error"
         assert "invalid secret" in (adapter.fatal_error_message or "")
 
+    @pytest.mark.asyncio
+    async def test_open_connection_cleans_up_session_when_ws_connect_fails(self, monkeypatch):
+        import gateway.platforms.wecom as wecom_module
+        from gateway.platforms.wecom import WeComAdapter
+
+        class FailingSession:
+            def ws_connect(self, *args, **kwargs):
+                raise RuntimeError("dial failed")
+
+        monkeypatch.setattr(
+            wecom_module,
+            "aiohttp",
+            SimpleNamespace(ClientSession=lambda **kwargs: FailingSession()),
+        )
+        adapter = WeComAdapter(
+            PlatformConfig(enabled=True, extra={"bot_id": "bot-1", "secret": "secret-1"})
+        )
+        adapter._cleanup_ws = AsyncMock()
+
+        with pytest.raises(RuntimeError, match="dial failed"):
+            await adapter._open_connection()
+
+        assert adapter._cleanup_ws.await_count == 2
+
 
 class TestWeComQrScan:
     @patch("gateway.platforms.wecom.time")

--- a/tests/plugins/platforms/test_homeassistant_adapter.py
+++ b/tests/plugins/platforms/test_homeassistant_adapter.py
@@ -1,0 +1,40 @@
+"""Tests for the Home Assistant platform adapter."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.homeassistant.adapter import HomeAssistantAdapter
+
+
+@pytest.mark.asyncio
+async def test_connect_websocket_cleans_up_session_when_ws_connect_fails(monkeypatch):
+    import plugins.platforms.homeassistant.adapter as ha_module
+
+    class FailingSession:
+        def ws_connect(self, *args, **kwargs):
+            raise RuntimeError("dial failed")
+
+    monkeypatch.setattr(
+        ha_module,
+        "aiohttp",
+        SimpleNamespace(
+            ClientSession=lambda **kwargs: FailingSession(),
+            ClientTimeout=lambda **kwargs: object(),
+        ),
+    )
+    adapter = HomeAssistantAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="token-1",
+            extra={"url": "http://homeassistant.local:8123"},
+        )
+    )
+    adapter._cleanup_ws = AsyncMock()
+
+    with pytest.raises(RuntimeError, match="dial failed"):
+        await adapter._ws_connect()
+
+    adapter._cleanup_ws.assert_awaited_once()


### PR DESCRIPTION
## Summary
- clean up partially-opened WeCom websocket sessions when connect/auth handshake setup fails
- clean up partially-opened Home Assistant websocket sessions on connect/auth/subscribe failures
- add focused regression coverage for both adapters' connect-failure cleanup paths

## Root cause
The connect paths could create a websocket/session object before a later setup step failed. Without an explicit cleanup path, those partially-opened sessions could survive past the failed connect attempt.

## Related reconnaissance
- Checked current `origin/main`; no open upstream PR was found for `fix/platform-websocket-connect-cleanup`.
- This is split from a local production carry into a focused adapter-cleanup slice.

## Test plan
- `uv run --with pytest --with pytest-asyncio --with pyyaml --with aiohttp --with httpx --with fastapi python -m pytest tests/gateway/test_wecom.py tests/plugins/platforms/test_homeassistant_adapter.py -q -o addopts=` → 48 passed
- `uv run --with pyyaml --with aiohttp --with httpx --with fastapi python -m py_compile gateway/platforms/wecom.py plugins/platforms/homeassistant/adapter.py`
- `git diff --check origin/main...HEAD`
- added-line private/secret marker scan → 0
