### PR TITLE
fix(hindsight): surface retain timeouts clearly

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import asyncio
 import atexit
+import concurrent.futures
 import importlib
 import json
 import logging
@@ -220,14 +221,18 @@ def _get_loop() -> asyncio.AbstractEventLoop:
         return _loop
 
 
-def _run_sync(coro, timeout: float = _DEFAULT_TIMEOUT):
+def _run_sync(coro, timeout: float = _DEFAULT_TIMEOUT, operation_name: str = "hindsight operation"):
     """Schedule *coro* on the shared loop and block until done."""
     from agent.async_utils import safe_schedule_threadsafe
     loop = _get_loop()
     future = safe_schedule_threadsafe(coro, loop)
     if future is None:
         raise RuntimeError("Hindsight loop unavailable")
-    return future.result(timeout=timeout)
+    try:
+        return future.result(timeout=timeout)
+    except concurrent.futures.TimeoutError as exc:
+        future.cancel()
+        raise TimeoutError(f"{operation_name} timed out after {timeout}s") from exc
 
 
 # ---------------------------------------------------------------------------
@@ -988,9 +993,9 @@ class HindsightMemoryProvider(MemoryProvider):
                 self._client = Hindsight(**kwargs)
         return self._client
 
-    def _run_sync(self, coro):
+    def _run_sync(self, coro, operation_name: str = "hindsight operation"):
         """Schedule *coro* on the shared loop using the configured timeout."""
-        return _run_sync(coro, timeout=self._timeout)
+        return _run_sync(coro, timeout=self._timeout, operation_name=operation_name)
 
     def _is_retriable_embedded_connection_error(self, exc: Exception) -> bool:
         """Return True for stale embedded-daemon connection failures."""
@@ -1078,7 +1083,7 @@ class HindsightMemoryProvider(MemoryProvider):
         """Run an async Hindsight client operation, retrying once after idle shutdown."""
         client = self._get_client()
         try:
-            return self._run_sync(operation(client))
+            return self._run_sync(operation(client), operation_name="hindsight client operation")
         except Exception as exc:
             if not self._is_retriable_embedded_connection_error(exc):
                 raise
@@ -1089,7 +1094,7 @@ class HindsightMemoryProvider(MemoryProvider):
             self._client = None
             client = self._get_client()
             self._client = client
-            return self._run_sync(operation(client))
+            return self._run_sync(operation(client), operation_name="hindsight client operation retry")
 
     def _probe_url(self) -> str:
         """Return the URL to probe /version on.
@@ -1612,10 +1617,12 @@ class HindsightMemoryProvider(MemoryProvider):
                     tags=args.get("tags"),
                 )
                 # aretain_batch takes bank_id/retain_async as call args, not item keys.
+                retain_async = item.pop("retain_async", None)
                 item.pop("bank_id", None)
-                item.pop("retain_async", None)
-                logger.debug("Tool hindsight_retain: bank=%s, content_len=%d, context=%s",
-                             self._bank_id, len(content), context)
+                logger.debug(
+                    "Tool hindsight_retain: bank=%s, url=%s, timeout=%s, async=%s, content_len=%d, context=%s",
+                    self._bank_id, self._api_url, self._timeout, retain_async, len(content), context,
+                )
                 self._run_hindsight_operation(
                     lambda client: client.aretain_batch(bank_id=self._bank_id, items=[item])
                 )
@@ -1623,7 +1630,8 @@ class HindsightMemoryProvider(MemoryProvider):
                 return json.dumps({"result": "Memory stored successfully."})
             except Exception as e:
                 logger.warning("hindsight_retain failed: %s", e, exc_info=True)
-                return tool_error(f"Failed to store memory: {e}")
+                detail = str(e) or type(e).__name__
+                return tool_error(f"Failed to store memory: {detail}")
 
         elif tool_name == "hindsight_recall":
             query = args.get("query", "")

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -5,6 +5,7 @@ prefetch (auto_recall, preamble, query truncation), sync_turn (auto_retain,
 turn counting, tags), and schema completeness.
 """
 
+import concurrent.futures
 import json
 import os
 import re
@@ -1653,6 +1654,30 @@ class TestSharedEventLoopLifecycle:
         assert hindsight_mod._run_sync(_still_working()) == 42
 
         provider_b.shutdown()
+
+    def test_run_sync_cancels_future_and_names_timeout(self, monkeypatch):
+        from plugins.memory import hindsight as hindsight_mod
+
+        class TimedOutFuture:
+            cancelled = False
+
+            def result(self, timeout=None):
+                raise concurrent.futures.TimeoutError()
+
+            def cancel(self):
+                self.cancelled = True
+
+        future = TimedOutFuture()
+        monkeypatch.setattr(hindsight_mod, "_get_loop", lambda: object())
+        monkeypatch.setattr(
+            "agent.async_utils.safe_schedule_threadsafe",
+            lambda coro, loop: future,
+        )
+
+        with pytest.raises(TimeoutError, match="hindsight retain timed out after 0.01s"):
+            hindsight_mod._run_sync(object(), timeout=0.01, operation_name="hindsight retain")
+
+        assert future.cancelled
 
     def test_client_aclose_called_on_cloud_mode_shutdown(self, provider):
         """Per-provider session cleanup still runs even though the shared


### PR DESCRIPTION
## Summary
- convert Hindsight shared-loop future timeouts into clear `TimeoutError` messages that name the operation and timeout
- cancel timed-out futures so stale retain/recall work does not keep running silently
- include retain endpoint/timeout/async details in debug logs and surface non-empty tool errors

## Root cause
The shared event-loop bridge could time out while leaving the submitted future ambiguous to callers. Manual retain failures then surfaced as generic or empty tool errors instead of a clear timeout tied to the Hindsight operation.

## Related reconnaissance
- Checked current `origin/main`; existing open Hindsight PR #29791 covers manual retain batch routing, not timeout surfacing.
- This is split from a local production carry into a focused timeout/error-reporting slice.

## Test plan
- `uv run --with pytest --with pyyaml --with aiohttp --with httpx --with fastapi python -m pytest tests/plugins/memory/test_hindsight_provider.py -q -o addopts=` → 103 passed
- `uv run --with pyyaml --with aiohttp --with httpx --with fastapi python -m py_compile plugins/memory/hindsight/__init__.py`
- `git diff --check origin/main...HEAD`
- added-line private/secret marker scan → 0
