### PR TITLE
fix(dashboard): sdk.d.ts registerSlot param order matches runtime

### DIFF
--- a/web/src/plugins/sdk.d.ts
+++ b/web/src/plugins/sdk.d.ts
@@ -83,8 +83,8 @@ export type BuildWsAuthParam = () => Promise<[string, string]>;
 export interface PluginRegistry {
   /** Register the plugin's main tab component by manifest name. */
   register(name: string, component: ComponentType<Record<string, never>>): void;
-  /** Register a component into a named host slot. */
-  registerSlot(slot: string, name: string, component: ComponentType): void;
+  /** Register a component into a named host slot (plugin name FIRST — matches slots.ts). */
+  registerSlot(plugin: string, slot: string, component: ComponentType): void;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`web/src/plugins/sdk.d.ts` documents the plugin registry as:

```ts
registerSlot(slot: string, name: string, component: ComponentType): void;
```

but the runtime implementation (`web/src/plugins/slots.ts::registerSlot`,
exposed via `registry.ts::exposePluginSDK`) is:

```ts
registerSlot(plugin: string, slot: string, component: React.ComponentType): void;
```

— plugin name **first**, slot **second**.

## Why it matters

A plugin author following the typed contract calls
`registerSlot("sessions:top", "my-plugin", Component)`, which registers the
component into a slot literally named after their plugin. The shell never
renders it: no error, no warning, the slot is just silently empty. This cost
real debugging time building a dashboard plugin against the documented
signature.

## Change

One-line doc fix to match the runtime. No behavior change, no runtime code
touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
