### PR TITLE
fix(curator): don't abort rollback on external skill symlinks

### DIFF
--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -526,6 +526,30 @@ def _restore_cron_skill_links(snapshot_dir: Path) -> Dict[str, Any]:
 
 
 
+def _rollback_extract_filter(member: tarfile.TarInfo, dest_path: str):
+    """Extraction filter for curator rollback.
+
+    Behaves like tarfile's built-in ``data`` filter (rejects absolute paths,
+    ``..`` traversal, device/special files, …), with one carve-out: a skill
+    entry that is a *symlink pointing outside the skills tree* is skipped with a
+    warning instead of aborting the whole rollback. External skill links are a
+    legitimate install layout, e.g. ``skills/<name> -> ../../.agents/skills/<name>``,
+    and ``data``'s blanket rejection makes rollback unusable exactly when the user
+    needs it (#44658). Skipping keeps the safety guarantee of #23794 — an
+    untrusted link is still never recreated from the archive — while every real
+    file/dir in the snapshot is restored. Non-link unsafe members still abort.
+    """
+    try:
+        return tarfile.data_filter(member, dest_path)
+    except (tarfile.LinkOutsideDestinationError, tarfile.AbsoluteLinkError):
+        logger.warning(
+            "curator rollback: skipping external skill link %s -> %s "
+            "(re-create it manually after rollback if you still need it)",
+            member.name, member.linkname,
+        )
+        return None
+
+
 def rollback(backup_id: Optional[str] = None) -> Tuple[bool, str, Optional[Path]]:
     """Restore ``~/.hermes/skills/`` from a snapshot.
 
@@ -612,7 +636,7 @@ def rollback(backup_id: Optional[str] = None) -> Tuple[bool, str, Optional[Path]
                         f"refusing to extract unsafe path: {name!r}"
                     )
             try:
-                tf.extractall(str(skills), filter="data")  # type: ignore[call-arg]
+                tf.extractall(str(skills), filter=_rollback_extract_filter)  # type: ignore[call-arg]
             except TypeError:
                 # Python < 3.12 — no filter kwarg
                 tf.extractall(str(skills))

--- a/tests/agent/test_curator_backup.py
+++ b/tests/agent/test_curator_backup.py
@@ -191,6 +191,41 @@ def test_rollback_restores_deleted_skill(backup_env):
     assert "important content" in (user_skill / "SKILL.md").read_text()
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="creates a symlink; symlink creation is restricted on Windows",
+)
+def test_rollback_skips_external_skill_symlink(backup_env):
+    """A snapshot can contain a skill entry that is a symlink to a package
+    OUTSIDE the skills tree (a legitimate layout, e.g.
+    ``skills/<name> -> ../../.agents/skills/<name>``). Rollback must restore the
+    real skills rather than aborting on that link (#44658); the external link is
+    skipped (never recreated from the archive) but everything else is restored.
+    """
+    cb = backup_env["cb"]
+    skills = backup_env["skills"]
+
+    _write_skill(skills, "local-skill", body="keep me")
+    external_root = backup_env["home"].parent / ".agents" / "skills"
+    _write_skill(external_root, "ext-skill")
+    (skills / "ext-skill").symlink_to(
+        os.path.relpath(external_root / "ext-skill", skills)
+    )
+
+    cb.snapshot_skills(reason="with-external-link")
+
+    # Simulate a bad curator run that deletes the real skill.
+    import shutil as _sh
+    _sh.rmtree(skills / "local-skill")
+    assert not (skills / "local-skill").exists()
+
+    ok, msg, _ = cb.rollback()
+    assert ok, f"rollback must not abort on an external skill symlink: {msg}"
+    assert "keep me" in (skills / "local-skill" / "SKILL.md").read_text()
+    # The external link is intentionally skipped, not recreated from the archive.
+    assert not (skills / "ext-skill").is_symlink()
+
+
 def test_rollback_is_itself_undoable(backup_env):
     """A rollback creates its own safety snapshot before replacing the
     tree, so the user can undo a mistaken rollback. The safety snapshot


### PR DESCRIPTION
## What does this PR do?

`hermes curator rollback` aborts completely when a snapshot contains a skill entry that is a symlink pointing outside `$HERMES_HOME/skills` — a legitimate layout, e.g. `skills/<name> -> ../../.agents/skills/<name>`. Rollback extracts with tar's `data` filter, which rejects every escaping symlink, so one external skill link makes rollback restore **nothing** — exactly when the user needs it after a bad curator run.

This wraps the `data` filter so an escaping skill *link* is skipped with a warning instead of aborting the whole extraction. The link is never recreated from the archive (the #23794 hardening still holds — an untrusted link can't be used to write outside `skills/`), but every real file/dir in the snapshot is restored. Non-link unsafe members (absolute paths, `..`, device files) still abort.

This is the minimal "skip-with-warning" option from the issue. I'm opening it as a **draft** because it sits right next to the #23794 / #23796 extraction-hardening work, and the issue lists a fuller alternative — recording external links in the manifest and recreating the safe ones on rollback. Happy to extend to that round-trip if you'd prefer it over skip-with-warning.

## Related Issue

Fixes #44658

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

(security-adjacent — keeps the #23794 extraction guarantee intact)

## Changes Made

- `agent/curator_backup.py`: add `_rollback_extract_filter` (wraps `tarfile.data_filter`; skips an escaping skill link with a warning rather than raising) and use it for the rollback `extractall`.
- `tests/agent/test_curator_backup.py`: regression test `test_rollback_skips_external_skill_symlink` — an external symlink in a snapshot now lets rollback restore the real skills instead of aborting. Guarded with `skipif(sys.platform == "win32")` per the symlink-test convention.

## How to Test

```
PYTHONPATH=. python -m pytest tests/agent/test_curator_backup.py -q
```

Before the fix the new test reproduces the reported failure:

```
snapshot extract failed (state restored): 'ext-skill' would link to
'.../.agents/skills/ext-skill', which is outside the destination
```

After, all 26 curator-backup tests pass. Verified on macOS (Apple Silicon), Python 3.12.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(curator): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the affected suite (`pytest tests/agent/test_curator_backup.py -q`) and all 26 pass
- [x] I've added a regression test (fails before / passes after)
- [x] I've tested on my platform: macOS 15 (Apple Silicon), Python 3.12

### Documentation & Housekeeping

- [x] Docs — N/A (behavior surfaced via a warning log; no API/config change)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — fix is pure stdlib `tarfile`; the symlink-creating test is `skipif(win32)`
- [x] Tool descriptions/schemas — N/A
