### PR TITLE
fix(matrix): record DM rooms in m.direct on invite to prevent group misclassification

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2872,15 +2872,25 @@ class MatrixAdapter(BasePlatformAdapter):
         await self.handle_message(msg_event)
 
     async def _on_invite(self, event: Any) -> None:
-        """Auto-join rooms when invited."""
+        """Auto-join rooms when invited, recording DM rooms in m.direct."""
 
         room_id = str(getattr(event, "room_id", ""))
+        content = getattr(event, "content", None)
+        is_direct = bool(getattr(content, "is_direct", False))
+        inviter = str(getattr(event, "sender", ""))
 
         logger.info(
-            "Matrix: invited to %s — joining",
+            "Matrix: invited to %s — joining (is_direct=%s)",
             room_id,
+            is_direct,
         )
-        await self._join_room_by_id(room_id)
+        joined = await self._join_room_by_id(room_id)
+
+        # If the invite declares this as a DM, persist it in m.direct
+        # account data so that _resolve_room_identity treats it correctly
+        # even when the bot account has no prior DM history.
+        if joined and is_direct and inviter:
+            await self._record_dm_room(room_id, inviter)
 
     async def _join_room_by_id(self, room_id: str) -> bool:
         """Join a room by ID and refresh local caches on success."""
@@ -3724,6 +3734,47 @@ class MatrixAdapter(BasePlatformAdapter):
         self._dm_rooms = {rid: (rid in dm_room_ids) for rid in self._joined_rooms}
         self._room_identities.clear()
         self._room_identity_cached_at.clear()
+
+    async def _record_dm_room(self, room_id: str, inviter: str) -> None:
+        """Persist a room as DM in m.direct account data after an invite.
+
+        When the bot account has never been used for DMs, ``m.direct`` is
+        absent (404).  This method fetches the current mapping (if any),
+        appends *room_id* under the *inviter*'s entry, and writes it back
+        so that subsequent ``_refresh_dm_cache`` calls treat the room as a
+        DM without requiring manual ``m.direct`` setup.
+        """
+        if not self._client:
+            return
+
+        dm_data: Dict[str, list] = {}
+        try:
+            resp = await self._client.get_account_data("m.direct")
+            if hasattr(resp, "content") and isinstance(resp.content, dict):
+                dm_data = resp.content
+            elif isinstance(resp, dict):
+                dm_data = resp
+        except Exception:
+            pass  # m.direct doesn't exist yet — start fresh
+
+        rooms_for_user = dm_data.get(inviter, [])
+        if not isinstance(rooms_for_user, list):
+            rooms_for_user = []
+        if room_id not in rooms_for_user:
+            rooms_for_user.append(room_id)
+            dm_data[inviter] = rooms_for_user
+            try:
+                await self._client.set_account_data("m.direct", dm_data)
+                logger.info(
+                    "Matrix: recorded %s as DM room (inviter=%s)", room_id, inviter
+                )
+            except Exception as exc:
+                logger.warning("Matrix: failed to update m.direct: %s", exc)
+
+        # Update local cache so _resolve_room_identity sees it immediately.
+        self._dm_rooms[room_id] = True
+        self._room_identities.pop(room_id, None)
+        self._room_identity_cached_at.pop(room_id, None)
 
     # ------------------------------------------------------------------
     # Mention detection helpers

--- a/tests/gateway/test_matrix_dm_invite_recording.py
+++ b/tests/gateway/test_matrix_dm_invite_recording.py
@@ -1,0 +1,238 @@
+"""Tests for Matrix DM room recording on invite (issue #44679).
+
+When the bot's Matrix account has no ``m.direct`` account data (common for
+accounts created solely for Hermes), DM rooms are silently treated as groups.
+This tests the fix that records DM rooms in ``m.direct`` when the invite
+event carries ``is_direct: true``.
+"""
+
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _make_adapter(tmp_path=None):
+    """Create a MatrixAdapter with mocked config."""
+    from plugins.platforms.matrix.adapter import MatrixAdapter
+
+    config = PlatformConfig(
+        enabled=True,
+        token="syt_test_token",
+        extra={
+            "homeserver": "https://matrix.example.org",
+            "user_id": "@hermes:example.org",
+        },
+    )
+    adapter = MatrixAdapter(config)
+    adapter._text_batch_delay_seconds = 0
+    adapter.handle_message = AsyncMock()
+    adapter._startup_ts = time.time() - 10
+    return adapter
+
+
+def _make_invite_event(
+    room_id="!dm_room:example.org",
+    sender="@alice:example.org",
+    is_direct=True,
+):
+    """Create a fake invite event with is_direct in content."""
+    content = SimpleNamespace(is_direct=is_direct)
+    return SimpleNamespace(
+        room_id=room_id,
+        sender=sender,
+        content=content,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _on_invite DM recording
+# ---------------------------------------------------------------------------
+
+
+class TestOnInviteRecordsDM:
+    """_on_invite should call _record_dm_room when is_direct is True."""
+
+    @pytest.mark.asyncio
+    async def test_dm_invite_records_room(self):
+        adapter = _make_adapter()
+        adapter._join_room_by_id = AsyncMock(return_value=True)
+        adapter._record_dm_room = AsyncMock()
+
+        event = _make_invite_event(is_direct=True, sender="@alice:example.org")
+        await adapter._on_invite(event)
+
+        adapter._join_room_by_id.assert_awaited_once_with("!dm_room:example.org")
+        adapter._record_dm_room.assert_awaited_once_with(
+            "!dm_room:example.org", "@alice:example.org"
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_dm_invite_does_not_record(self):
+        adapter = _make_adapter()
+        adapter._join_room_by_id = AsyncMock(return_value=True)
+        adapter._record_dm_room = AsyncMock()
+
+        event = _make_invite_event(is_direct=False)
+        await adapter._on_invite(event)
+
+        adapter._join_room_by_id.assert_awaited_once()
+        adapter._record_dm_room.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_missing_is_direct_does_not_record(self):
+        """Invite events without is_direct attribute should not trigger recording."""
+        adapter = _make_adapter()
+        adapter._join_room_by_id = AsyncMock(return_value=True)
+        adapter._record_dm_room = AsyncMock()
+
+        event = SimpleNamespace(
+            room_id="!room:example.org",
+            sender="@alice:example.org",
+            content=SimpleNamespace(),  # no is_direct attr
+        )
+        await adapter._on_invite(event)
+
+        adapter._record_dm_room.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_join_failure_does_not_record(self):
+        adapter = _make_adapter()
+        adapter._join_room_by_id = AsyncMock(return_value=False)
+        adapter._record_dm_room = AsyncMock()
+
+        event = _make_invite_event(is_direct=True)
+        await adapter._on_invite(event)
+
+        adapter._record_dm_room.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_empty_inviter_does_not_record(self):
+        adapter = _make_adapter()
+        adapter._join_room_by_id = AsyncMock(return_value=True)
+        adapter._record_dm_room = AsyncMock()
+
+        event = SimpleNamespace(
+            room_id="!room:example.org",
+            sender="",
+            content=SimpleNamespace(is_direct=True),
+        )
+        await adapter._on_invite(event)
+
+        adapter._record_dm_room.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# _record_dm_room
+# ---------------------------------------------------------------------------
+
+
+class TestRecordDMRoom:
+    """_record_dm_room should update m.direct account data and local cache."""
+
+    @pytest.mark.asyncio
+    async def test_creates_m_direct_when_absent(self):
+        """When m.direct doesn't exist (404), creates it from scratch."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._client.get_account_data = AsyncMock(side_effect=Exception("M_NOT_FOUND"))
+        adapter._client.set_account_data = AsyncMock()
+
+        await adapter._record_dm_room("!new:example.org", "@alice:example.org")
+
+        adapter._client.set_account_data.assert_awaited_once_with(
+            "m.direct", {"@alice:example.org": ["!new:example.org"]}
+        )
+        assert adapter._dm_rooms.get("!new:example.org") is True
+
+    @pytest.mark.asyncio
+    async def test_appends_to_existing_m_direct(self):
+        """When m.direct exists with other rooms, appends the new room."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        existing_data = {"@bob:example.org": ["!old:example.org"]}
+        adapter._client.get_account_data = AsyncMock(return_value=existing_data)
+        adapter._client.set_account_data = AsyncMock()
+
+        await adapter._record_dm_room("!new:example.org", "@alice:example.org")
+
+        expected = {
+            "@bob:example.org": ["!old:example.org"],
+            "@alice:example.org": ["!new:example.org"],
+        }
+        adapter._client.set_account_data.assert_awaited_once_with("m.direct", expected)
+
+    @pytest.mark.asyncio
+    async def test_no_duplicate_room_in_m_direct(self):
+        """If room is already in m.direct, does not append again."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        existing_data = {"@alice:example.org": ["!room:example.org"]}
+        adapter._client.get_account_data = AsyncMock(return_value=existing_data)
+        adapter._client.set_account_data = AsyncMock()
+
+        await adapter._record_dm_room("!room:example.org", "@alice:example.org")
+
+        adapter._client.set_account_data.assert_not_awaited()
+        assert adapter._dm_rooms.get("!room:example.org") is True
+
+    @pytest.mark.asyncio
+    async def test_set_failure_is_handled_gracefully(self):
+        """If set_account_data fails, local cache is still updated."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._client.get_account_data = AsyncMock(side_effect=Exception("not found"))
+        adapter._client.set_account_data = AsyncMock(
+            side_effect=Exception("M_FORBIDDEN")
+        )
+
+        # Should not raise
+        await adapter._record_dm_room("!room:example.org", "@alice:example.org")
+
+        # Local cache updated despite server error
+        assert adapter._dm_rooms.get("!room:example.org") is True
+
+    @pytest.mark.asyncio
+    async def test_clears_room_identity_cache(self):
+        """After recording a DM, room identity cache should be invalidated."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._client.get_account_data = AsyncMock(side_effect=Exception("404"))
+        adapter._client.set_account_data = AsyncMock()
+
+        adapter._room_identities["!room:example.org"] = "stale"
+        adapter._room_identity_cached_at["!room:example.org"] = time.monotonic()
+
+        await adapter._record_dm_room("!room:example.org", "@alice:example.org")
+
+        assert "!room:example.org" not in adapter._room_identities
+        assert "!room:example.org" not in adapter._room_identity_cached_at
+
+    @pytest.mark.asyncio
+    async def test_no_client_is_noop(self):
+        """If _client is None, does nothing."""
+        adapter = _make_adapter()
+        adapter._client = None
+
+        # Should not raise
+        await adapter._record_dm_room("!room:example.org", "@alice:example.org")
+
+    @pytest.mark.asyncio
+    async def test_m_direct_response_with_content_attr(self):
+        """get_account_data may return an object with .content attribute."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        resp = SimpleNamespace(content={"@bob:example.org": ["!old:example.org"]})
+        adapter._client.get_account_data = AsyncMock(return_value=resp)
+        adapter._client.set_account_data = AsyncMock()
+
+        await adapter._record_dm_room("!new:example.org", "@alice:example.org")
+
+        expected = {
+            "@bob:example.org": ["!old:example.org"],
+            "@alice:example.org": ["!new:example.org"],
+        }
+        adapter._client.set_account_data.assert_awaited_once_with("m.direct", expected)


### PR DESCRIPTION
## What does this PR do?

Records DM rooms in `m.direct` account data when the bot receives an invite with `is_direct: true`. This fixes DM misclassification for bot accounts that have never had DMs set up — without this, `_resolve_room_identity` falls back to treating DMs as group rooms, causing them to be swallowed by `MATRIX_REQUIRE_MENTION`.

## Related Issue

Fixes #44679

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/matrix/adapter.py`: Modified `_on_invite` to check `is_direct` on invite events and call `_record_dm_room`. Added `_record_dm_room` method that persists the room in `m.direct` account data and updates local cache.
- `tests/gateway/test_matrix_dm_invite_recording.py`: 12 tests covering invite DM recording, non-DM invites, missing attributes, join failures, and `_record_dm_room` edge cases (absent m.direct, append, dedup, error handling, cache invalidation).

## How to Test

1. Run `python -m pytest tests/gateway/test_matrix_dm_invite_recording.py -q` — all 12 tests should pass
2. On a Matrix server: invite the bot to a DM room with `is_direct: true` in the invite content
3. Verify the bot treats the room as a DM (no mention requirement)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `plugins/platforms/matrix/adapter.py::_on_invite`, `plugins/platforms/matrix/adapter.py::_record_dm_room`, `plugins/platforms/matrix/adapter.py::_refresh_dm_cache`
- Blast radius: LOW — changes only affect invite handling path; existing DM classification logic unchanged
- Related patterns: `_refresh_dm_cache` reads from `m.direct`; `_record_dm_room` writes to it. `_resolve_room_identity` consumes the cache.
