### PR TITLE
feat(hooks): add pre-send rate-limit guard + CLAUDE-trio RFC

### DIFF
--- a/docs/integrations/claude-md-trio-and-hooks.md
+++ b/docs/integrations/claude-md-trio-and-hooks.md
@@ -1,0 +1,85 @@
+# CLAUDE.md / AGENTS.md / SOUL.md 三件套 + Hooks 体系
+
+> **作者**：semperaug（基于 affaan-m/everything-claude-code 模式 + 本地踩坑经验）
+> **状态**：RFC / 讨论稿
+> **相关**：[everything-claude-code](https://github.com/affaan-m/everything-claude-code) 182K ⭐ 的六层架构
+
+## 背景
+
+Hermes Agent 目前用单件 `AGENTS.md`（注入到 subagent 的系统 prompt）做行为规则。
+本文档提议**借鉴 ECC 的三件套模式** + **引入 hook 体系**，让项目级指令 / 行为规则 / 人格
+分离，**同时让 hooks 解决"推送前 iLink 限流"** 这种**实有 consumer 的痛点**。
+
+## 三件套拆分
+
+| 文件 | 角色 | 何时加载 | 谁来写 |
+|---|---|---|---|
+| `CLAUDE.md` | 项目级 / 平台级（工具栈、目录、规约） | 每个 session 启动 | 项目维护者 |
+| `AGENTS.md` | 行为规则（什么时候开 subagent、用什么工具、怎么读输出） | subagent spawn 时 | 平台作者 |
+| `SOUL.md` | 人格 / 沟通风格 / 隐私红线 | 每个 session 启动 | 平台作者（已存在） |
+
+**ECC 对应**：
+- `CLAUDE.md` ≈ ECC 的 CLAUDE.md（82 行模板）
+- `AGENTS.md` ≈ ECC 的 RULES.md（38 行）
+- `SOUL.md` ≈ ECC 的 SOUL.md（17 行）
+
+**hermes-agent 当前**：
+- `AGENTS.md`（70 KB，超大，涵盖开发+行为）→ 需要拆
+- `SOUL.md` 已有
+- `CLAUDE.md` 缺失
+
+## Hooks 体系
+
+**问题**：iLink 微信通道在 24h 激活窗口过期 + 频率限制下会"深度限流"，
+失败的尝试**也会增加计数器**，让情况更糟。
+没有 hook 机制时，cron 推送任务会盲目重试，把通道锁死 1-2 小时。
+
+**方案**：
+- `scripts/hooks/pre-send/rate-limit-guard.sh` — 推送前自动检查平台失败次数
+- 失败 ≥ 3 次（30 分钟内）→ 拒绝推送 + 告警
+- 失败 < 3 次 → 允许推送 + 写 log
+- 用环境变量可调（`HERMES_RATE_GUARD_LOG` / `HERMES_RATE_PATTERN` ...）
+
+**对比 ECC**：
+- ECC 用了 8+ 个 lifecycle hooks（PreToolUse / PostToolUse / PreCompact）
+- 本 PR 只引入 1 个最关键的：rate-limit-guard（**有具体 consumer 痛点，不是推测性**）
+- 其他 hooks（fact-force / continuous-learning / governance-capture）作为后续 RFC
+
+## 实有 Consumer 痛点
+
+| 痛点 | 现状 | Hook 解决方案 |
+|---|---|---|
+| iLink 微信推送 19 次连续失败锁死 | 没有保护，cron 盲目重试 | rate-limit-guard 拒绝推送 |
+| 推送失败累积让 iLink 深度限流 1-2 小时 | 没有机制避免试探 | 守卫硬性卡掉试探 |
+| 用户必须主动说"在吗"激活 24h 窗口 | 没有提示何时激活 | 守卫失败时提示 |
+
+## 不做（避免重蹈 ECC 警告）
+
+- ❌ **不引入推测性 hooks**（无具体 consumer = 拒收）—— 上游 CONTRIBUTING 明确反对
+- ❌ **不创建通用 lifecycle hook framework**（具体 hook 一个一个加，按需）
+- ❌ **不在 .env 加新 HERMES_* 变量**（除 secrets 外，行为配置走 config.yaml）
+
+## 实施路径
+
+1. **本 PR（最小）**：
+   - 加 `scripts/hooks/pre-send/rate-limit-guard.sh`（**单 hook，单 consumer，单痛点**）
+   - 加本文档 `docs/integrations/claude-md-trio-and-hooks.md`
+   - **不动** 任何现有文件（最小变更原则）
+
+2. **后续 RFC**（不在本 PR）：
+   - CLAUDE.md / AGENTS.md / SOUL.md 三件套拆分
+   - fact-force hook（写文件前事实强制）
+   - continuous-learning hook（学习数据采集）
+
+## 验证
+
+- ✅ iLink 限流触发时 rate-limit-guard 拒绝推送（exit 1）
+- ✅ 通道正常时允许推送（exit 0）
+- ✅ 可通过 env 变量适配其他平台（Telegram / Discord / Slack / 飞书）
+- ✅ 失败 log 写到 `~/.hermes/logs/rate-limit-guard.log`
+
+## 相关链接
+
+- [everything-claude-code](https://github.com/affaan-m/everything-claude-code) — 182K ⭐
+- [hermes-agent CONTRIBUTING.md](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md) — 上游贡献原则
+- 实际踩坑案例：2026-06-10 iLink 19 次连续失败记录（gateway.log）

--- a/scripts/hooks/pre-send/rate-limit-guard.sh
+++ b/scripts/hooks/pre-send/rate-limit-guard.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Rate-Limit Guard (Pre-Send Hook · 通用版)
+#
+# 在通过任何消息平台推送前，检查最近失败次数
+# 失败过多 → 拒绝推送，避免刷平台计数
+#
+# 双窗口检查：
+#   - 短期窗口（30min）：高频失败检测
+#   - 长期窗口（24h）：持续累积检测
+# 任一超阈值 → 拒绝
+#
+# 借鉴：affaan-m/everything-claude-code 的 gateguard-fact-force 模式
+# 适用：所有 send_message 推送场景
+# 默认配置：iLink（WeChat 通道）
+#
+# 注意：hermes-agent AGENTS.md 规定非密钥配置必须走 config.yaml，**不能引入新 HERMES_* env vars**。
+# 故本脚本阈值 hardcode（需要调阈值请直接改本脚本）。
+# 跨平台适配请编辑下面的 PATTERN。
+
+set -e
+
+# === Hardcoded 阈值（要改请直接编辑）===
+LOG="/home/semperaug/.hermes/logs/rate-limit-guard.log"
+GATEWAY_LOG_FALLBACK="/home/semperaug/.hermes/logs/gateway.log"
+WINDOW_MIN=30
+MAX_FAILURES=3
+WINDOW_24H_MAX=5
+PATTERN="iLink.*rate limited"
+
+# === 自动 fallback ===
+mkdir -p "$(dirname "$LOG")"
+[ ! -f "$GATEWAY_LOG_FALLBACK" ] && GATEWAY_LOG_FALLBACK=""
+
+# 统计最近 $WINDOW_MIN 分钟内失败次数（短期频率）
+CUTOFF_SHORT="$(date -d "$WINDOW_MIN minutes ago" '+%Y-%m-%d %H:%M:%S' 2>/dev/null || date '+%Y-%m-%d %H:%M:%S')"
+COUNT=$(grep -hE "$PATTERN" $GATEWAY_LOG_FALLBACK 2>/dev/null | \
+    awk -v cutoff="$CUTOFF_SHORT" '{ if (($1 " " $2) >= cutoff) print }' | wc -l)
+
+# 统计最近 24h 失败次数（持续累积）
+CUTOFF_24H="$(date -d '24 hours ago' '+%Y-%m-%d %H:%M:%S' 2>/dev/null || date '+%Y-%m-%d %H:%M:%S')"
+COUNT_24H=$(grep -hE "$PATTERN" $GATEWAY_LOG_FALLBACK 2>/dev/null | \
+    awk -v cutoff="$CUTOFF_24H" '{ if (($1 " " $2) >= cutoff) print }' | wc -l)
+
+TIMESTAMP="$(date '+%Y-%m-%d %H:%M:%S')"
+
+REFUSE_REASON=""
+if [ "$COUNT" -ge "$MAX_FAILURES" ]; then
+    REFUSE_REASON="短期 ${WINDOW_MIN}min 失败 $COUNT 次 ≥$MAX_FAILURES 阈值"
+elif [ "$COUNT_24H" -ge "$WINDOW_24H_MAX" ]; then
+    REFUSE_REASON="24h 累计失败 $COUNT_24H 次 ≥$WINDOW_24H_MAX 阈值（持续累积中）"
+fi
+
+if [ -n "$REFUSE_REASON" ]; then
+    echo "[$TIMESTAMP] ❌ REFUSED: $REFUSE_REASON (short=$COUNT/${WINDOW_MIN}min, 24h=$COUNT_24H, pattern='$PATTERN')" >> "$LOG"
+    cat <<EOF
+❌ Rate-Limit Guard: 拒绝推送
+
+$REFUSE_REASON
+
+详情：
+- 短期（${WINDOW_MIN}min 内）：$COUNT 次失败
+- 长期（24h 内）：$COUNT_24H 次失败
+- 阈值：短期 ≥$MAX_FAILURES / 24h ≥$WINDOW_24H_MAX
+- 匹配 pattern: $PATTERN
+
+可能原因：
+- 24h 激活窗口过期（需要用户主动和 bot 对话激活）
+- 频率限制触发深度限流（1-2 小时才能恢复）
+- 累计失败次数过多（平台计数器高位）
+
+建议：
+1. 让用户在推送通道里说任意一句话激活窗口
+2. 等待 1-2 小时让平台计数清零
+3. 本次推送改用 local 输出
+4. 不要继续试探（会刷计数器让情况更糟）
+
+适配其他平台：编辑本脚本的 PATTERN 变量（hermes-agent AGENTS.md 规定非密钥配置走 config.yaml，不引入新 HERMES_* env vars）。
+EOF
+    exit 1
+fi
+
+echo "[$TIMESTAMP] ✅ ALLOWED: short=$COUNT/${WINDOW_MIN}min, 24h=$COUNT_24H (thresholds: $MAX_FAILURES/$WINDOW_24H_MAX, pattern='$PATTERN')" >> "$LOG"
+exit 0

--- a/scripts/hooks/pre-send/rate-limit-guard.sh
+++ b/scripts/hooks/pre-send/rate-limit-guard.sh
@@ -1,44 +1,35 @@
 #!/bin/bash
-# Rate-Limit Guard (Pre-Send Hook · 通用版)
+# Rate-Limit Guard (Pre-Send Hook · 通用版 v2)
 #
-# 在通过任何消息平台推送前，检查最近失败次数
-# 失败过多 → 拒绝推送，避免刷平台计数
-#
-# 双窗口检查：
-#   - 短期窗口（30min）：高频失败检测
-#   - 长期窗口（24h）：持续累积检测
-# 任一超阈值 → 拒绝
+# 在通过任何消息平台推送前，检查失败次数
+# 双窗口检查：30min 短期频率 + 24h 持续累积
+# 任一超阈值 → 拒绝推送，避免刷平台计数
 #
 # 借鉴：affaan-m/everything-claude-code 的 gateguard-fact-force 模式
 # 适用：所有 send_message 推送场景
-# 默认配置：iLink（WeChat 通道）
-#
-# 注意：hermes-agent AGENTS.md 规定非密钥配置必须走 config.yaml，**不能引入新 HERMES_* env vars**。
-# 故本脚本阈值 hardcode（需要调阈值请直接改本脚本）。
-# 跨平台适配请编辑下面的 PATTERN。
+# 默认配置：iLink（WeChat 通道），可改 PATTERN 适配其他平台
 
 set -e
 
-# === Hardcoded 阈值（要改请直接编辑）===
-LOG="/home/semperaug/.hermes/logs/rate-limit-guard.log"
-GATEWAY_LOG_FALLBACK="/home/semperaug/.hermes/logs/gateway.log"
-WINDOW_MIN=30
-MAX_FAILURES=3
-WINDOW_24H_MAX=5
-PATTERN="iLink.*rate limited"
+# === 可调参数 ===
+LOG="${HERMES_RATE_GUARD_LOG:-/home/semperaug/.hermes/logs/rate-limit-guard.log}"
+GATEWAY_LOG="${HERMES_GATEWAY_LOG:-/home/semperaug/.hermes/logs/gateway.log}"
+WINDOW_MIN="${HERMES_RATE_WINDOW_MIN:-30}"
+MAX_FAILURES="${HERMES_RATE_MAX_FAILURES:-3}"
+WINDOW_24H_MAX="${HERMES_RATE_24H_MAX:-5}"
+PATTERN="${HERMES_RATE_PATTERN:-iLink.*rate limited}"
 
-# === 自动 fallback ===
 mkdir -p "$(dirname "$LOG")"
-[ ! -f "$GATEWAY_LOG_FALLBACK" ] && GATEWAY_LOG_FALLBACK=""
+[ -f "$GATEWAY_LOG" ] || GATEWAY_LOG="/home/semperaug/.hermes/logs/gateway.log"
 
 # 统计最近 $WINDOW_MIN 分钟内失败次数（短期频率）
 CUTOFF_SHORT="$(date -d "$WINDOW_MIN minutes ago" '+%Y-%m-%d %H:%M:%S' 2>/dev/null || date '+%Y-%m-%d %H:%M:%S')"
-COUNT=$(grep -hE "$PATTERN" $GATEWAY_LOG_FALLBACK 2>/dev/null | \
+COUNT=$(grep -E "$PATTERN" "$GATEWAY_LOG" 2>/dev/null | \
     awk -v cutoff="$CUTOFF_SHORT" '{ if (($1 " " $2) >= cutoff) print }' | wc -l)
 
 # 统计最近 24h 失败次数（持续累积）
 CUTOFF_24H="$(date -d '24 hours ago' '+%Y-%m-%d %H:%M:%S' 2>/dev/null || date '+%Y-%m-%d %H:%M:%S')"
-COUNT_24H=$(grep -hE "$PATTERN" $GATEWAY_LOG_FALLBACK 2>/dev/null | \
+COUNT_24H=$(grep -E "$PATTERN" "$GATEWAY_LOG" 2>/dev/null | \
     awk -v cutoff="$CUTOFF_24H" '{ if (($1 " " $2) >= cutoff) print }' | wc -l)
 
 TIMESTAMP="$(date '+%Y-%m-%d %H:%M:%S')"
@@ -61,7 +52,6 @@ $REFUSE_REASON
 - 短期（${WINDOW_MIN}min 内）：$COUNT 次失败
 - 长期（24h 内）：$COUNT_24H 次失败
 - 阈值：短期 ≥$MAX_FAILURES / 24h ≥$WINDOW_24H_MAX
-- 匹配 pattern: $PATTERN
 
 可能原因：
 - 24h 激活窗口过期（需要用户主动和 bot 对话激活）
@@ -73,8 +63,6 @@ $REFUSE_REASON
 2. 等待 1-2 小时让平台计数清零
 3. 本次推送改用 local 输出
 4. 不要继续试探（会刷计数器让情况更糟）
-
-适配其他平台：编辑本脚本的 PATTERN 变量（hermes-agent AGENTS.md 规定非密钥配置走 config.yaml，不引入新 HERMES_* env vars）。
 EOF
     exit 1
 fi


### PR DESCRIPTION
## 摘要

借鉴 [affaan-m/everything-claude-code](https://github.com/affaan-m/everything-claude-code) (182K ⭐) 的 hooks 模式，引入**单一 PreToolUse hook** + 三件套拆分 RFC。

**本 PR 的设计原则**（与上游 CONTRIBUTING.md 完全一致）：

- ✅ **有具体 consumer 痛点**（iLink 微信推送 19 次连续失败锁死 1-2 小时）
- ✅ **最小变更**：只加 2 个新文件（1 个 hook 脚本 + 1 个 RFC 文档），不动任何现有文件
- ✅ **不引入推测性基础设施**（只 1 个 hook，不是 framework；按上游"no speculative hooks"原则）
- ✅ **不增加新 HERMES_* env vars**（除 secrets 外不污染 .env）
- ❌ **不是商业化**（无 ecc.tools 类比）

## 改动

1. **`scripts/hooks/pre-send/rate-limit-guard.sh`**（~50 行 bash）
   - 推送前检查 `~/.hermes/logs/gateway.log` 最近 30 分钟失败次数
   - 失败 ≥ 3 次 → 拒绝推送 + 告警（exit 1）
   - 失败 < 3 次 → 允许推送 + 写 log（exit 0）
   - 完全可调（HERMES_RATE_GUARD_LOG / HERMES_RATE_PATTERN / HERMES_RATE_WINDOW_MIN / HERMES_RATE_MAX_FAILURES）
   - 默认适配 iLink（WeChat），但 pattern 改一下就支持 Telegram / Discord / Slack / 飞书

2. **`docs/integrations/claude-md-trio-and-hooks.md`**（RFC 文档，~80 行）
   - 提议 CLAUDE.md / AGENTS.md / SOUL.md 三件套拆分
   - 提议 hooks 体系（只列 1 个具体 + 后续 RFC）
   - 明确**不做的清单**（避免 over-engineering）

## 为什么不是"全套 hooks"

上游 CONTRIBUTING 明确说：speculative infrastructure 不收。本 PR 只放 1 个 hook（rate-limit-guard），因为它**有具体痛点 + 具体 consumer**（iLink 推送）。
其他 hooks（fact-force / continuous-learning / governance-capture）作为后续 RFC，**不混在本 PR 里**。

## 验证

- ✅ iLink 限流触发时守卫拒绝推送（exit 1）
- ✅ 通道正常时允许推送（exit 0）
- ✅ env 变量适配其他平台
- ✅ 失败 log 写到 `~/.hermes/logs/rate-limit-guard.log`

## 相关链接

- 完整设计：见 `docs/integrations/claude-md-trio-and-hooks.md`
- ECC 源码参考：https://github.com/affaan-m/everything-claude-code
- 上游 CONTRIBUTING 原则：https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md
