### PR TITLE
docs(mcp): document ${ENV_VAR} substitution in user env: blocks

### DIFF
--- a/website/docs/guides/use-mcp-with-hermes.md
+++ b/website/docs/guides/use-mcp-with-hermes.md
@@ -102,7 +102,7 @@ mcp_servers:
     command: "npx"
     args: ["-y", "@modelcontextprotocol/server-github"]
     env:
-      GITHUB_PERSONAL_ACCESS_TOKEN: "***"
+      GITHUB_PERSONAL_ACCESS_TOKEN: ${GITHUB_PERSONAL_ACCESS_TOKEN}
     tools:
       include: [list_issues, create_issue, search_code]
 ```
@@ -272,7 +272,7 @@ mcp_servers:
     command: "npx"
     args: ["-y", "@modelcontextprotocol/server-github"]
     env:
-      GITHUB_PERSONAL_ACCESS_TOKEN: "***"
+      GITHUB_PERSONAL_ACCESS_TOKEN: ${GITHUB_PERSONAL_ACCESS_TOKEN}
     tools:
       include: [list_issues, create_issue, update_issue, search_code]
       prompts: false
@@ -346,7 +346,7 @@ mcp_servers:
     command: "npx"
     args: ["-y", "@modelcontextprotocol/server-github"]
     env:
-      GITHUB_PERSONAL_ACCESS_TOKEN: "***"
+      GITHUB_PERSONAL_ACCESS_TOKEN: ${GITHUB_PERSONAL_ACCESS_TOKEN}
     tools:
       include: [list_issues, create_issue, search_code]
       prompts: false
@@ -382,7 +382,7 @@ mcp_servers:
     command: "npx"
     args: ["-y", "@modelcontextprotocol/server-github"]
     env:
-      GITHUB_PERSONAL_ACCESS_TOKEN: "***"
+      GITHUB_PERSONAL_ACCESS_TOKEN: ${GITHUB_PERSONAL_ACCESS_TOKEN}
     tools:
       include: [list_issues, create_issue, update_issue, search_code]
       prompts: false

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -47,7 +47,7 @@ mcp_servers:
 |---|---|---|---|
 | `command` | string | stdio | Executable to launch |
 | `args` | list | stdio | Arguments for the subprocess |
-| `env` | mapping | stdio | Environment passed to the subprocess |
+| `env` | mapping | stdio | Environment passed to the subprocess. Values support `${VAR}` placeholders resolved from the process environment (including `~/.hermes/.env`) — see [Runtime `${ENV_VAR}` substitution](/user-guide/features/mcp#runtime-env_var-substitution) |
 | `url` | string | HTTP | Remote MCP endpoint |
 | `headers` | mapping | HTTP | Headers for remote server requests |
 | `ssl_verify` | bool or string | HTTP | TLS verification. `true` (default) uses system CAs, `false` disables verification (insecure), or a string path to a custom CA bundle (PEM) |
@@ -168,7 +168,9 @@ mcp_servers:
     command: "npx"
     args: ["-y", "@modelcontextprotocol/server-github"]
     env:
-      GITHUB_PERSONAL_ACCESS_TOKEN: "***"
+      # Resolved from GITHUB_PERSONAL_ACCESS_TOKEN in ~/.hermes/.env — no
+      # need to duplicate the token value here.
+      GITHUB_PERSONAL_ACCESS_TOKEN: ${GITHUB_PERSONAL_ACCESS_TOKEN}
     tools:
       include: [list_issues, create_issue, update_issue, search_code]
       resources: false

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -150,6 +150,30 @@ from environment variables (which include everything in `~/.hermes/.env`).
 This is useful when a catalog entry wants to reference a value the user
 configured elsewhere — e.g. `${HOME}/foo` or `${MY_PROVIDER_TOKEN}`.
 
+The same substitution applies to `mcp_servers.<name>` entries you write
+yourself in `config.yaml` — including the `env`, `headers`, `args`, and `url`
+keys. This means secrets can live only in `~/.hermes/.env` and be referenced
+by name, instead of being duplicated into `config.yaml`:
+
+```yaml
+mcp_servers:
+  github:
+    command: "npx"
+    args: ["-y", "@modelcontextprotocol/server-github"]
+    env:
+      GITHUB_PERSONAL_ACCESS_TOKEN: ${GITHUB_PERSONAL_ACCESS_TOKEN}
+```
+
+`stdio` MCP servers otherwise run with a filtered environment (see
+[Stdio env filtering](#stdio-env-filtering) below), so this is the supported
+way to give a specific server access to a secret without exposing the
+gateway's entire environment to it.
+
+If a `${VAR}` placeholder can't be resolved (the variable isn't set), it is
+left in the config as a literal string rather than raising an error — a
+typo'd variable name fails silently, so double-check the resolved value if a
+server can't authenticate.
+
 Note this is distinct from `${INSTALL_DIR}` in catalog manifests, which is
 substituted at install-time with the path the catalog cloned the entry's
 repo into.
@@ -184,7 +208,7 @@ mcp_servers:
     command: "npx"
     args: ["-y", "@modelcontextprotocol/server-github"]
     env:
-      GITHUB_PERSONAL_ACCESS_TOKEN: "***"
+      GITHUB_PERSONAL_ACCESS_TOKEN: ${GITHUB_PERSONAL_ACCESS_TOKEN}
 ```
 
 Use stdio servers when:
@@ -407,7 +431,7 @@ mcp_servers:
     command: "npx"
     args: ["-y", "@modelcontextprotocol/server-github"]
     env:
-      GITHUB_PERSONAL_ACCESS_TOKEN: "***"
+      GITHUB_PERSONAL_ACCESS_TOKEN: ${GITHUB_PERSONAL_ACCESS_TOKEN}
     tools:
       include: [create_issue, list_issues]
 ```
@@ -463,7 +487,7 @@ mcp_servers:
     command: "npx"
     args: ["-y", "@modelcontextprotocol/server-github"]
     env:
-      GITHUB_PERSONAL_ACCESS_TOKEN: "***"
+      GITHUB_PERSONAL_ACCESS_TOKEN: ${GITHUB_PERSONAL_ACCESS_TOKEN}
     tools:
       include: [create_issue, list_issues, search_code]
       prompts: false
@@ -546,7 +570,7 @@ mcp_servers:
     command: "npx"
     args: ["-y", "@modelcontextprotocol/server-github"]
     env:
-      GITHUB_PERSONAL_ACCESS_TOKEN: "***"
+      GITHUB_PERSONAL_ACCESS_TOKEN: ${GITHUB_PERSONAL_ACCESS_TOKEN}
     tools:
       include: [list_issues, create_issue, update_issue]
       prompts: false


### PR DESCRIPTION
## Summary

Closes the docs gap identified in #44548.

The MCP docs only described `${VAR}` placeholder resolution for catalog manifest fields (`transport.command`/`args`/`url`/`headers`), and every `env:` example across the MCP guide and config reference showed a literal token value (`GITHUB_PERSONAL_ACCESS_TOKEN: "***"`).

In reality, `_load_mcp_config`/`_interpolate_env_vars` (`tools/mcp_tool.py`) already resolve `${VAR}` placeholders in user-written `mcp_servers.<name>` entries — including `env:` — from the process environment, which includes `~/.hermes/.env` (force-loaded before interpolation). This is the exact "per-server passthrough by reference" mechanism requested in #44548, but it was undiscoverable from the docs, leading users to duplicate secrets between `.env` and `config.yaml`.

## Changes

- [`website/docs/user-guide/features/mcp.md`](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/features/mcp.md): expand "Runtime `${ENV_VAR}` substitution" to cover user `config.yaml` entries (`env`, `headers`, `args`, `url`), cross-link to "Stdio env filtering", and document that an unresolved `${VAR}` is left as a literal string rather than erroring (so typos fail silently).
- [`website/docs/reference/mcp-config-reference.md`](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/reference/mcp-config-reference.md): note `${VAR}` support on the `env` key and cross-link to the new section.
- All `GITHUB_PERSONAL_ACCESS_TOKEN: "***"` examples (8 total across both guides + the config reference) switched to `GITHUB_PERSONAL_ACCESS_TOKEN: ${GITHUB_PERSONAL_ACCESS_TOKEN}`, resolved from `~/.hermes/.env`.

## Test plan

- [ ] Docs-only change — no code paths affected
- [ ] Verified `${VAR}` interpolation behavior against `_interpolate_env_vars`/`_load_mcp_config` in `tools/mcp_tool.py` (lines ~289, ~2573-2651)
- [ ] Confirmed examples follow the repo convention that `.env` is for credentials only (per `AGENTS.md`)
