### PR TITLE
fix(agent): strip MEDIA directives from compressor summarizer input (salvages #15369)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -150,6 +150,11 @@ _AUTO_FOCUS_MAX_CHARS = 700
 
 _PATH_MENTION_RE = re.compile(r"(?:/|~/?|[A-Za-z]:\\)[^\s`'\")\]}<>]+")
 
+# MEDIA delivery directives must not reach the summarizer — if one leaks into
+# the summary, the downstream model may re-emit it as an active directive on
+# the next turn, triggering bogus attachment sends (#14665).
+_MEDIA_DIRECTIVE_RE = re.compile(r"MEDIA:\S+")
+
 
 def _dedupe_append(items: list[str], value: str, *, limit: int) -> None:
     value = value.strip()
@@ -1006,16 +1011,11 @@ class ContextCompressor(ContextEngine):
         (API keys, tokens, passwords) from leaking into the summary that
         gets sent to the auxiliary model and persisted across compactions.
         """
-        # Strip MEDIA directives before sending to the summarizer — if they
-        # leak into the summary, the downstream model may re-emit them as
-        # active directives on the next turn (#14665).
-        _MEDIA_RE = re.compile(r'MEDIA:\S+')
-
         parts = []
         for msg in turns:
             role = msg.get("role", "unknown")
             content = redact_sensitive_text(msg.get("content") or "")
-            content = _MEDIA_RE.sub("[media attachment]", content)
+            content = _MEDIA_DIRECTIVE_RE.sub("[media attachment]", content)
 
             # Tool results: keep enough content for the summarizer
             if role == "tool":

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1006,10 +1006,16 @@ class ContextCompressor(ContextEngine):
         (API keys, tokens, passwords) from leaking into the summary that
         gets sent to the auxiliary model and persisted across compactions.
         """
+        # Strip MEDIA directives before sending to the summarizer — if they
+        # leak into the summary, the downstream model may re-emit them as
+        # active directives on the next turn (#14665).
+        _MEDIA_RE = re.compile(r'MEDIA:\S+')
+
         parts = []
         for msg in turns:
             role = msg.get("role", "unknown")
             content = redact_sensitive_text(msg.get("content") or "")
+            content = _MEDIA_RE.sub("[media attachment]", content)
 
             # Tool results: keep enough content for the summarizer
             if role == "tool":

--- a/tests/agent/test_compressor_media_stripping.py
+++ b/tests/agent/test_compressor_media_stripping.py
@@ -1,0 +1,56 @@
+"""Tests for MEDIA directive stripping in context compaction (#14665).
+
+MEDIA directives in assistant messages must not leak into compaction
+summaries — if they do, the downstream model re-emits them as active
+directives on the next turn.
+"""
+import pytest
+from unittest.mock import patch
+from agent.context_compressor import ContextCompressor
+
+
+@pytest.fixture()
+def compressor():
+    with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+        return ContextCompressor(
+            model="test/model",
+            threshold_percent=0.85,
+            protect_first_n=2,
+            protect_last_n=2,
+            quiet_mode=True,
+        )
+
+
+class TestMediaDirectiveStripping:
+    """MEDIA directives must be stripped before summarization (#14665)."""
+
+    def test_media_directive_stripped_from_assistant(self, compressor):
+        turns = [
+            {"role": "assistant", "content": "Here is the audio MEDIA:/tmp/voice.ogg done."},
+        ]
+        result = compressor._serialize_for_summary(turns)
+        assert "MEDIA:/tmp/voice.ogg" not in result
+        assert "[media attachment]" in result
+
+    def test_media_directive_stripped_from_tool_result(self, compressor):
+        turns = [
+            {"role": "tool", "tool_call_id": "t1", "content": "Generated MEDIA:/tmp/out.mp3 successfully"},
+        ]
+        result = compressor._serialize_for_summary(turns)
+        assert "MEDIA:/tmp/out.mp3" not in result
+        assert "[media attachment]" in result
+
+    def test_non_media_content_preserved(self, compressor):
+        turns = [
+            {"role": "assistant", "content": "The file path is /tmp/test.txt and it works."},
+        ]
+        result = compressor._serialize_for_summary(turns)
+        assert "/tmp/test.txt" in result
+
+    def test_multiple_media_directives(self, compressor):
+        turns = [
+            {"role": "assistant", "content": "MEDIA:/a.ogg and MEDIA:/b.mp3"},
+        ]
+        result = compressor._serialize_for_summary(turns)
+        assert "MEDIA:" not in result
+        assert result.count("[media attachment]") == 2


### PR DESCRIPTION
## Summary
MEDIA delivery directives are stripped from the compressor's summarizer input, so compaction summaries can no longer carry `MEDIA:<path>` tags that downstream models re-emit as bogus attachment sends.

Root cause (#14665): `_serialize_for_summary` redacts secrets but passed `MEDIA:\S+` directives through verbatim; gateway adapters parse re-emitted tags and attempt attachment delivery for stale paths.

Closes #14665.

## Changes
- `agent/context_compressor.py`: `MEDIA:\S+` → `[media attachment]` in `_serialize_for_summary` — from #15369 by @Tranquil-Flow
- Follow-up: regex hoisted to module level (`_MEDIA_DIRECTIVE_RE`, beside `_PATH_MENTION_RE`) instead of recompiling per call
- `tests/agent/test_compressor_media_stripping.py`: 4 regression tests (from the contributor PR)

Note: the issue's second leg (todo snapshot injected as a user-role message) is partially mitigated by the historical-framing prefix work in #44454; tracking separately if it still reproduces.

## Validation
| | Before | After |
|---|---|---|
| `MEDIA:/path/img.png` in compacted turns | survives into summary, re-emitted by next model | `[media attachment]` placeholder |
| `scripts/run_tests.sh` media/compressor/prefix suites | — | 39 passed |

(test_context_compressor.py currently times out in the hermetic runner on origin/main as well — pre-existing env issue, not introduced here; the same file passed against this diff in a direct run earlier: 90/94 with the 4 failures reproducing identically on clean main.)

## Attribution
Salvages #15369 by @Tranquil-Flow — cherry-picked with authorship preserved; rebase-merge to keep per-commit credit.

## Infographic

![compression-media-directive-strip](https://v3b.fal.media/files/b/0a9df717/K3iz5zpsufXJbgr5Y8D1j_r7Q1pXDd.png)
