### PR TITLE
fix(weixin): enable native voice bubble delivery via SILK format conversion

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1834,7 +1834,7 @@ class WeixinAdapter(BasePlatformAdapter):
         local_files, final_content = self.extract_local_files(image_cleaned)
         local_files = self.filter_local_delivery_paths(local_files)
 
-        _AUDIO_EXTS = {".ogg", ".opus", ".mp3", ".wav", ".m4a", ".flac"}
+        _AUDIO_EXTS = {".ogg", ".opus", ".mp3", ".wav", ".m4a", ".flac", ".silk"}
         _VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".webm", ".3gp"}
         _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif"}
 
@@ -2045,9 +2045,35 @@ class WeixinAdapter(BasePlatformAdapter):
         if not self._send_session or not self._token:
             return SendResult(success=False, error="Not connected")
 
-        # Native outbound Weixin voice bubbles are not proven-working in the
-        # upstream reference implementation. Prefer a reliable file attachment
-        # fallback so users at least receive playable audio, even for .silk.
+        # If the audio is already in SILK format, send as native voice bubble.
+        if audio_path.endswith(".silk"):
+            try:
+                message_id = await self._send_file(
+                    chat_id,
+                    audio_path,
+                    caption="",
+                    force_file_attachment=False,
+                )
+                return SendResult(success=True, message_id=message_id)
+            except Exception as exc:
+                logger.error("[%s] send_voice (silk) failed to=%s: %s", self.name, _safe_id(chat_id), exc)
+                return SendResult(success=False, error=str(exc))
+
+        # Non-SILK audio: try to convert to SILK and send as voice bubble.
+        try:
+            silk_path = await self._convert_audio_to_silk(audio_path)
+            if silk_path:
+                message_id = await self._send_file(
+                    chat_id,
+                    silk_path,
+                    caption="",
+                    force_file_attachment=False,
+                )
+                return SendResult(success=True, message_id=message_id)
+        except Exception as exc:
+            logger.warning("[%s] SILK conversion failed, falling back to file: %s", self.name, exc)
+
+        # Fallback: send as file attachment
         fallback_caption = caption or "[voice message as attachment]"
         try:
             message_id = await self._send_file(
@@ -2060,6 +2086,46 @@ class WeixinAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.error("[%s] send_voice failed to=%s: %s", self.name, _safe_id(chat_id), exc)
             return SendResult(success=False, error=str(exc))
+
+    async def _convert_audio_to_silk(self, audio_path: str) -> Optional[str]:
+        """Convert an audio file to SILK format for native WeChat voice bubbles.
+
+        Uses ffmpeg to decode source audio to raw 16-bit PCM, then pilk to
+        encode to SILK with Tencent-compatible header (``\\x02#!SILK_V3``).
+        """
+        import subprocess
+        tmp_pcm = audio_path.rsplit(".", 1)[0] + "_pcm.raw"
+        tmp_silk = audio_path.rsplit(".", 1)[0] + ".silk"
+        try:
+            # Decode to 16kHz 16-bit mono raw PCM (no WAV header)
+            result = subprocess.run(
+                ["ffmpeg", "-y", "-i", audio_path,
+                 "-ar", "16000", "-ac", "1", "-f", "s16le", tmp_pcm],
+                capture_output=True, text=True, timeout=30,
+            )
+            if result.returncode != 0:
+                logger.warning("ffmpeg decode failed: %s", result.stderr[:200])
+                return None
+            if not os.path.isfile(tmp_pcm) or os.path.getsize(tmp_pcm) < 100:
+                return None
+
+            # Encode raw PCM to SILK with Tencent-compatible header
+            from pilk import _pilk
+            _pilk.encode(tmp_pcm, tmp_silk, 16000, 16000, True, 24000, 2, 20, 0, False, False)
+            if os.path.isfile(tmp_silk) and os.path.getsize(tmp_silk) > 100:
+                return tmp_silk
+        except ImportError:
+            logger.debug("pilk not installed, cannot convert to SILK")
+        except Exception as exc:
+            logger.warning("SILK conversion error: %s", exc)
+        finally:
+            # Clean up temp PCM file
+            try:
+                if os.path.isfile(tmp_pcm):
+                    os.unlink(tmp_pcm)
+            except Exception:
+                pass
+        return None
 
     async def _download_remote_media(self, url: str) -> str:
         from tools.url_safety import is_safe_url
@@ -2079,6 +2145,29 @@ class WeixinAdapter(BasePlatformAdapter):
         with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as handle:
             handle.write(data)
             return handle.name
+
+    @staticmethod
+    def _get_audio_duration(path: Path) -> int:
+        """Return playtime in seconds for an audio file (MP3/SILK)."""
+        # SILK can't be probed by ffprobe, so for SILK try the corresponding
+        # MP3 first, then fall back to ffprobe on whatever we have.
+        if path.suffix.lower() == ".silk":
+            mp3_path = path.with_suffix(".mp3")
+            if mp3_path.is_file():
+                path = mp3_path
+        try:
+            import subprocess
+            result = subprocess.run(
+                ["ffprobe", "-v", "quiet", "-show_entries", "format=duration",
+                 "-of", "csv=p=0", str(path)],
+                capture_output=True, text=True, timeout=10,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                duration = float(result.stdout.strip())
+                return max(1, round(duration))
+        except Exception:
+            pass
+        return 0
 
     async def _send_file(
         self,
@@ -2139,9 +2228,10 @@ class WeixinAdapter(BasePlatformAdapter):
             "rawfilemd5": rawfilemd5,
         }
         if media_type == MEDIA_VOICE and path.endswith(".silk"):
-            item_kwargs["encode_type"] = 6
-            item_kwargs["sample_rate"] = 24000
+            item_kwargs["encode_type"] = 0
+            item_kwargs["sample_rate"] = 16000
             item_kwargs["bits_per_sample"] = 16
+            item_kwargs["playtime"] = self._get_audio_duration(Path(path))
         media_item = item_builder(**item_kwargs)
 
         last_message_id = None
@@ -2299,6 +2389,8 @@ async def send_weixin_direct(
             ext = Path(media_path).suffix.lower()
             if ext in {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"}:
                 last_result = await live_adapter.send_image_file(chat_id, media_path)
+            elif ext in {".ogg", ".opus", ".mp3", ".wav", ".m4a", ".flac", ".silk"} or _is_voice:
+                last_result = await live_adapter.send_voice(chat_id, media_path)
             else:
                 last_result = await live_adapter.send_document(chat_id, media_path)
             if not last_result.success:
@@ -2344,6 +2436,8 @@ async def send_weixin_direct(
             ext = Path(media_path).suffix.lower()
             if ext in {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"}:
                 last_result = await adapter.send_image_file(chat_id, media_path)
+            elif ext in {".ogg", ".opus", ".mp3", ".wav", ".m4a", ".flac", ".silk"} or _is_voice:
+                last_result = await adapter.send_voice(chat_id, media_path)
             else:
                 last_result = await adapter.send_document(chat_id, media_path)
             if not last_result.success:


### PR DESCRIPTION
## Bug Description

WeChat/Weixin users cannot send voice messages through Hermes. The `send_voice()` method unconditionally falls back to file attachment mode, even for `.silk` files that WeChat supports natively as voice bubbles. Additionally, `send_weixin_direct()` routes all non-image media through `send_document()`, so any audio sent via `MEDIA:` tags arrives as a text-bubble containing the file path.

## Root Cause

Three issues in `gateway/platforms/weixin.py`:

1. **`send_voice()`** — hardcoded `force_file_attachment=True` with a comment that native voice bubbles were "not proven-working". The existing `_outbound_media_builder` already supports `ITEM_VOICE` via `.silk` files; it was never exercised.
2. **`send_weixin_direct()`** — both the live-adapter and one-shot session code paths use an `if image / else document` binary for media routing, so all audio lands as document attachments.
3. **No SILK conversion pipeline** — even if the routing were fixed, the adapter had no way to convert common audio formats (MP3, OGG, WAV) to the SILK format WeChat requires.

## Fix

- Refactor `send_voice()` to prefer native voice bubble delivery: `.silk` files are sent directly, other audio is auto-converted to SILK, file attachment is the fallback.
- Add `_convert_audio_to_silk()` — uses ffmpeg to decode source audio to raw 16-bit mono PCM ( `-f s16le`, 16kHz), then pilk's `_pilk.encode()` with `tencent=True` to produce the `\x02#!SILK_V3` header WeChat expects.
- Add `_get_audio_duration()` so SILK voice items carry a valid `playtime` field (probes sibling `.mp3` via ffprobe).
- Add `.silk` to `_AUDIO_EXTS` for correct MEDIA tag routing.
- Fix both media-routing branches in `send_weixin_direct()` to call `send_voice()` for audio files.
- Set correct SILK `item_kwargs`: `encode_type=0`, `sample_rate=16000` (WeChat standard).

## How to Verify

1. Run `text_to_speech` with any text: TTS generates MP3, `send_voice` converts to SILK, WeChat voice bubble delivered with audio.
2. Send `MEDIA:/path/to/audio.mp3` via `send_message`: same pipeline.
3. Send a pre-encoded `.silk` file: delivered directly as voice bubble.

## Test Plan

- [x] Manual end-to-end verification on WeChat iLink (voice bubble renders, plays audio correctly)
- [x] SILK encode/decode cycle verified (ffmpeg raw PCM -> pilk encode -> pilk decode -> ffmpeg MP3)
- [ ] Existing tests still pass (regression risk: confined to weixin.py, no core changes)

## Risk Assessment

**Low** — changes are confined to `gateway/platforms/weixin.py`. The non-SILK fallback path (file attachment) is preserved. All existing image/video/document paths are untouched. The `pilk` dependency is lazily imported with a graceful fallback.
