### PR TITLE
feat(desktop): surface safe shared-channel origins

### DIFF
--- a/apps/desktop/src/app/chat/index.test.tsx
+++ b/apps/desktop/src/app/chat/index.test.tsx
@@ -1,0 +1,81 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+import { $pinnedSessionIds } from '@/store/layout'
+import { $sessions } from '@/store/session'
+import type { SessionInfo } from '@/types/hermes'
+
+import { ChatHeader } from './index'
+
+function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    archived: false,
+    cwd: '/Users/example/Workspaces/hermes-agent',
+    ended_at: null,
+    id: 'shared-session',
+    input_tokens: 0,
+    is_active: false,
+    last_active: 1_000,
+    message_count: 2,
+    model: 'claude',
+    output_tokens: 0,
+    preview: 'Shared-channel chat',
+    source: 'webhook',
+    started_at: 1_000,
+    title: 'Release fix',
+    tool_call_count: 0,
+    ...overrides
+  }
+}
+
+function renderHeader(selectedSessionId = 'shared-session') {
+  return render(
+    <I18nProvider configClient={null}>
+      <ChatHeader
+        activeSessionId={null}
+        isRoutedSessionView={false}
+        onDeleteSelectedSession={vi.fn()}
+        onToggleSelectedPin={vi.fn()}
+        selectedSessionId={selectedSessionId}
+      />
+    </I18nProvider>
+  )
+}
+
+describe('ChatHeader', () => {
+  afterEach(() => {
+    cleanup()
+    $sessions.set([])
+    $pinnedSessionIds.set([])
+  })
+
+  it('shows safe shared-channel origin context for the open chat', () => {
+    $sessions.set([
+      makeSession({
+        channel_origin: {
+          chat_name: 'Build Room',
+          chat_topic: 'Release coordination',
+          chat_type: 'channel',
+          display_name: 'Build Room',
+          has_thread: true,
+          platform: 'webhook'
+        }
+      })
+    ])
+
+    renderHeader()
+
+    expect(screen.getByText('Release fix')).toBeTruthy()
+    expect(screen.getByText('Build Room · Release coordination')).toBeTruthy()
+  })
+
+  it('keeps ordinary open chats to the title-only header', () => {
+    $sessions.set([makeSession({ channel_origin: null })])
+
+    renderHeader()
+
+    expect(screen.getByText('Release fix')).toBeTruthy()
+    expect(screen.queryByText(/Build Room/)).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -21,7 +21,11 @@ import { useI18n } from '@/i18n'
 import type { ChatMessage } from '@/lib/chat-messages'
 import { quickModelOptions, sessionTitle } from '@/lib/chat-runtime'
 import { useIncrementalExternalStoreRuntime } from '@/lib/incremental-external-store-runtime'
+<<<<<<< HEAD
 import { modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
+=======
+import { sessionChannelOriginLabel } from '@/lib/session-channel-origin'
+>>>>>>> 9782c39b1 (Refresh on upstream/main: resolve conflicts (no behavior change))
 import { cn } from '@/lib/utils'
 import { migrateSessionDraft } from '@/store/composer'
 import { migrateQueuedPrompts, parkQueuedPrompts } from '@/store/composer-queue'
@@ -99,7 +103,7 @@ interface ChatHeaderProps {
   selectedSessionId: null | string
 }
 
-function ChatHeader({
+export function ChatHeader({
   activeSessionId,
   isRoutedSessionView,
   onDeleteSelectedSession,
@@ -114,6 +118,7 @@ function ChatHeader({
     (selectedSessionId && sessions.find(session => sessionMatchesStoredId(session, selectedSessionId))) || null
 
   const title = activeStoredSession ? sessionTitle(activeStoredSession) : 'New session'
+  const channelLabel = activeStoredSession ? sessionChannelOriginLabel(activeStoredSession.channel_origin) : null
 
   // Which agent/persona owns this chat — glanceable in the header once a
   // second profile exists, so the open session's ownership is never ambiguous
@@ -155,7 +160,28 @@ function ChatHeader({
           sideOffset={8}
           title={title}
         >
+<<<<<<< HEAD
           <TitleMenuTrigger>{title}</TitleMenuTrigger>
+=======
+          <Button
+            className={cn(
+              'pointer-events-auto flex min-w-0 max-w-full gap-1 overflow-hidden border border-transparent bg-transparent px-2 py-0 text-(--ui-text-secondary) hover:border-(--ui-stroke-tertiary) hover:bg-(--ui-control-hover-background) hover:text-foreground data-[state=open]:border-(--ui-stroke-tertiary) data-[state=open]:bg-(--ui-control-active-background) [-webkit-app-region:no-drag]',
+              channelLabel ? 'h-8 items-center' : 'h-6'
+            )}
+            type="button"
+            variant="ghost"
+          >
+            <span className="min-w-0 flex-1 text-left">
+              <h2 className="truncate text-[0.75rem] font-medium leading-none">{title}</h2>
+              {channelLabel ? (
+                <span className="mt-0.5 block truncate text-[0.625rem] font-normal leading-none text-(--ui-text-tertiary)">
+                  {channelLabel}
+                </span>
+              ) : null}
+            </span>
+            <Codicon className="shrink-0 text-(--ui-text-tertiary)" name="chevron-down" size="0.8125rem" />
+          </Button>
+>>>>>>> 9782c39b1 (Refresh on upstream/main: resolve conflicts (no behavior change))
         </SessionActionsMenu>
       </div>
     </header>

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -21,11 +21,8 @@ import { useI18n } from '@/i18n'
 import type { ChatMessage } from '@/lib/chat-messages'
 import { quickModelOptions, sessionTitle } from '@/lib/chat-runtime'
 import { useIncrementalExternalStoreRuntime } from '@/lib/incremental-external-store-runtime'
-<<<<<<< HEAD
 import { modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
-=======
 import { sessionChannelOriginLabel } from '@/lib/session-channel-origin'
->>>>>>> 9782c39b1 (Refresh on upstream/main: resolve conflicts (no behavior change))
 import { cn } from '@/lib/utils'
 import { migrateSessionDraft } from '@/store/composer'
 import { migrateQueuedPrompts, parkQueuedPrompts } from '@/store/composer-queue'
@@ -160,28 +157,18 @@ export function ChatHeader({
           sideOffset={8}
           title={title}
         >
-<<<<<<< HEAD
-          <TitleMenuTrigger>{title}</TitleMenuTrigger>
-=======
-          <Button
-            className={cn(
-              'pointer-events-auto flex min-w-0 max-w-full gap-1 overflow-hidden border border-transparent bg-transparent px-2 py-0 text-(--ui-text-secondary) hover:border-(--ui-stroke-tertiary) hover:bg-(--ui-control-hover-background) hover:text-foreground data-[state=open]:border-(--ui-stroke-tertiary) data-[state=open]:bg-(--ui-control-active-background) [-webkit-app-region:no-drag]',
-              channelLabel ? 'h-8 items-center' : 'h-6'
-            )}
-            type="button"
-            variant="ghost"
-          >
-            <span className="min-w-0 flex-1 text-left">
-              <h2 className="truncate text-[0.75rem] font-medium leading-none">{title}</h2>
-              {channelLabel ? (
+          <TitleMenuTrigger className={channelLabel ? 'h-8 items-center' : undefined}>
+            {channelLabel ? (
+              <span className="block whitespace-normal text-left">
+                <span className="block truncate text-[0.75rem] font-medium leading-none">{title}</span>
                 <span className="mt-0.5 block truncate text-[0.625rem] font-normal leading-none text-(--ui-text-tertiary)">
                   {channelLabel}
                 </span>
-              ) : null}
-            </span>
-            <Codicon className="shrink-0 text-(--ui-text-tertiary)" name="chevron-down" size="0.8125rem" />
-          </Button>
->>>>>>> 9782c39b1 (Refresh on upstream/main: resolve conflicts (no behavior change))
+              </span>
+            ) : (
+              title
+            )}
+          </TitleMenuTrigger>
         </SessionActionsMenu>
       </div>
     </header>

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -28,6 +28,7 @@ import { useI18n } from '@/i18n'
 import { comboTokens } from '@/lib/keybinds/combo'
 import { profileColor } from '@/lib/profile-color'
 import { sessionMatchesSearch } from '@/lib/session-search'
+import { searchResultToSession } from '@/lib/session-search-result'
 import { normalizeSessionSource, sessionSourceLabel } from '@/lib/session-source'
 import { cn } from '@/lib/utils'
 import { $cronJobs } from '@/store/cron'
@@ -195,29 +196,49 @@ const HEADER_ACTION_BTN =
 const HEADER_NAV_BTN =
   'text-(--ui-text-tertiary) opacity-70 transition-opacity hover:bg-(--ui-control-hover-background) hover:text-foreground hover:opacity-100 focus-visible:opacity-100'
 
-// FTS results cover sessions that aren't in the loaded page; synthesize a
-// minimal SessionInfo so they render in the same row component (resume works
-// by id; the snippet stands in for the preview).
-function searchResultToSession(result: SessionSearchResult): SessionInfo {
-  const ts = result.session_started ?? Date.now() / 1000
+function workspaceGroupsFor(
+  sessions: SessionInfo[],
+  noWorkspaceLabel: string,
+  options: { preserveSessionOrder?: boolean } = {}
+): SidebarSessionGroup[] {
+  const groups = new Map<string, SidebarSessionGroup>()
+
+  for (const session of sessions) {
+    const path = session.cwd?.trim() || ''
+    const id = path || '__no_workspace__'
+    const label = baseName(path) || path || noWorkspaceLabel
+
+    const group = groups.get(id) ?? { id, label, path: path || null, sessions: [] }
+    group.sessions.push(session)
+    groups.set(id, group)
+  }
+
+  if (!options.preserveSessionOrder) {
+    // Groups keep recency order (Map insertion = first-seen in the recency-sorted
+    // input, so an active project floats up), but rows *within* a group sort by
+    // creation time so they don't reshuffle every time a message lands — keeps
+    // muscle memory intact.
+    for (const group of groups.values()) {
+      group.sessions.sort((a, b) => b.started_at - a.started_at)
+    }
+  }
+
+  return [...groups.values()]
+}
+
+function useSortableBindings(id: string) {
+  const { attributes, isDragging, listeners, setNodeRef, transform, transition } = useSortable({ id })
 
   return {
-    archived: false,
-    cwd: null,
-    ended_at: null,
-    id: result.session_id,
-    _lineage_root_id: result.lineage_root ?? null,
-    input_tokens: 0,
-    is_active: false,
-    last_active: ts,
-    message_count: 0,
-    model: result.model ?? null,
-    output_tokens: 0,
-    preview: result.snippet?.trim() || null,
-    source: result.source ?? null,
-    started_at: ts,
-    title: null,
-    tool_call_count: 0
+    dragging: isDragging,
+    dragHandleProps: { ...attributes, ...listeners },
+    ref: setNodeRef,
+    reorderable: true as const,
+    style: {
+      transform: CSS.Transform.toString(transform),
+      transition: isDragging ? undefined : transition,
+      willChange: isDragging ? 'transform' : undefined
+    }
   }
 }
 

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -196,52 +196,6 @@ const HEADER_ACTION_BTN =
 const HEADER_NAV_BTN =
   'text-(--ui-text-tertiary) opacity-70 transition-opacity hover:bg-(--ui-control-hover-background) hover:text-foreground hover:opacity-100 focus-visible:opacity-100'
 
-function workspaceGroupsFor(
-  sessions: SessionInfo[],
-  noWorkspaceLabel: string,
-  options: { preserveSessionOrder?: boolean } = {}
-): SidebarSessionGroup[] {
-  const groups = new Map<string, SidebarSessionGroup>()
-
-  for (const session of sessions) {
-    const path = session.cwd?.trim() || ''
-    const id = path || '__no_workspace__'
-    const label = baseName(path) || path || noWorkspaceLabel
-
-    const group = groups.get(id) ?? { id, label, path: path || null, sessions: [] }
-    group.sessions.push(session)
-    groups.set(id, group)
-  }
-
-  if (!options.preserveSessionOrder) {
-    // Groups keep recency order (Map insertion = first-seen in the recency-sorted
-    // input, so an active project floats up), but rows *within* a group sort by
-    // creation time so they don't reshuffle every time a message lands — keeps
-    // muscle memory intact.
-    for (const group of groups.values()) {
-      group.sessions.sort((a, b) => b.started_at - a.started_at)
-    }
-  }
-
-  return [...groups.values()]
-}
-
-function useSortableBindings(id: string) {
-  const { attributes, isDragging, listeners, setNodeRef, transform, transition } = useSortable({ id })
-
-  return {
-    dragging: isDragging,
-    dragHandleProps: { ...attributes, ...listeners },
-    ref: setNodeRef,
-    reorderable: true as const,
-    style: {
-      transform: CSS.Transform.toString(transform),
-      transition: isDragging ? undefined : transition,
-      willChange: isDragging ? 'transform' : undefined
-    }
-  }
-}
-
 interface ChatSidebarProps extends React.ComponentProps<typeof Sidebar> {
   currentView: AppView
   onNavigate: (item: SidebarNavItem) => void

--- a/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
@@ -1,5 +1,4 @@
 import { cleanup, render, screen } from '@testing-library/react'
-<<<<<<< HEAD
 import { atom } from 'nanostores'
 import type * as React from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -184,58 +183,23 @@ describe('SidebarSessionRow', () => {
     const avatar = container.querySelector('span[aria-hidden="true"]')
     expect(avatar).toBeTruthy()
     expect(tipTrigger(avatar as HTMLElement)).toBeTruthy()
-=======
-import { afterEach, describe, expect, it, vi } from 'vitest'
+  })
+})
 
-import { I18nProvider } from '@/i18n'
-import { $attentionSessionIds } from '@/store/session'
-import type { SessionInfo } from '@/types/hermes'
-
-import { SidebarSessionRow } from './session-row'
-
-function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
-  return {
-    archived: false,
-    cwd: '/Users/example/Workspaces/hermes-agent',
-    ended_at: null,
-    id: '20260612_100000_row01',
-    input_tokens: 0,
-    is_active: false,
-    last_active: 1_000,
-    message_count: 2,
-    model: 'claude',
-    output_tokens: 0,
-    preview: 'Fix shared session row labels',
-    source: 'webhook',
-    started_at: 1_000,
-    title: 'Shared channel session',
-    tool_call_count: 0,
-    ...overrides
-  }
-}
-
-function renderRow(session: SessionInfo) {
-  return render(
-    <I18nProvider configClient={null}>
+describe('SidebarSessionRow shared-channel origin', () => {
+  const renderRow = (session: SessionInfo) =>
+    render(
       <SidebarSessionRow
         isPinned={false}
         isSelected={false}
         isWorking={false}
-        onArchive={vi.fn()}
-        onDelete={vi.fn()}
-        onPin={vi.fn()}
-        onResume={vi.fn()}
+        onArchive={noop}
+        onDelete={noop}
+        onPin={noop}
+        onResume={noop}
         session={session}
       />
-    </I18nProvider>
-  )
-}
-
-describe('SidebarSessionRow', () => {
-  afterEach(() => {
-    cleanup()
-    $attentionSessionIds.set([])
-  })
+    )
 
   it('renders safe shared-channel origin labels below the title', () => {
     renderRow(
@@ -247,7 +211,8 @@ describe('SidebarSessionRow', () => {
           display_name: 'Build Room',
           has_thread: true,
           platform: 'webhook'
-        }
+        },
+        title: 'Shared channel session'
       })
     )
 
@@ -256,10 +221,9 @@ describe('SidebarSessionRow', () => {
   })
 
   it('keeps ordinary sessions to the title-only row', () => {
-    renderRow(makeSession({ channel_origin: null }))
+    renderRow(makeSession({ channel_origin: null, title: 'Shared channel session' }))
 
     expect(screen.getByText('Shared channel session')).toBeTruthy()
     expect(screen.queryByText(/Build Room/)).toBeNull()
->>>>>>> 9782c39b1 (Refresh on upstream/main: resolve conflicts (no behavior change))
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, render, screen } from '@testing-library/react'
+<<<<<<< HEAD
 import { atom } from 'nanostores'
 import type * as React from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -183,5 +184,82 @@ describe('SidebarSessionRow', () => {
     const avatar = container.querySelector('span[aria-hidden="true"]')
     expect(avatar).toBeTruthy()
     expect(tipTrigger(avatar as HTMLElement)).toBeTruthy()
+=======
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+import { $attentionSessionIds } from '@/store/session'
+import type { SessionInfo } from '@/types/hermes'
+
+import { SidebarSessionRow } from './session-row'
+
+function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    archived: false,
+    cwd: '/Users/example/Workspaces/hermes-agent',
+    ended_at: null,
+    id: '20260612_100000_row01',
+    input_tokens: 0,
+    is_active: false,
+    last_active: 1_000,
+    message_count: 2,
+    model: 'claude',
+    output_tokens: 0,
+    preview: 'Fix shared session row labels',
+    source: 'webhook',
+    started_at: 1_000,
+    title: 'Shared channel session',
+    tool_call_count: 0,
+    ...overrides
+  }
+}
+
+function renderRow(session: SessionInfo) {
+  return render(
+    <I18nProvider configClient={null}>
+      <SidebarSessionRow
+        isPinned={false}
+        isSelected={false}
+        isWorking={false}
+        onArchive={vi.fn()}
+        onDelete={vi.fn()}
+        onPin={vi.fn()}
+        onResume={vi.fn()}
+        session={session}
+      />
+    </I18nProvider>
+  )
+}
+
+describe('SidebarSessionRow', () => {
+  afterEach(() => {
+    cleanup()
+    $attentionSessionIds.set([])
+  })
+
+  it('renders safe shared-channel origin labels below the title', () => {
+    renderRow(
+      makeSession({
+        channel_origin: {
+          chat_name: 'Build Room',
+          chat_topic: 'Release coordination',
+          chat_type: 'channel',
+          display_name: 'Build Room',
+          has_thread: true,
+          platform: 'webhook'
+        }
+      })
+    )
+
+    expect(screen.getByText('Shared channel session')).toBeTruthy()
+    expect(screen.getByText('Build Room · Release coordination')).toBeTruthy()
+  })
+
+  it('keeps ordinary sessions to the title-only row', () => {
+    renderRow(makeSession({ channel_origin: null }))
+
+    expect(screen.getByText('Shared channel session')).toBeTruthy()
+    expect(screen.queryByText(/Build Room/)).toBeNull()
+>>>>>>> 9782c39b1 (Refresh on upstream/main: resolve conflicts (no behavior change))
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -13,6 +13,7 @@ import type { SessionInfo } from '@/hermes'
 import { type Translations, useI18n } from '@/i18n'
 import { sessionTitle } from '@/lib/chat-runtime'
 import { triggerHaptic } from '@/lib/haptics'
+import { sessionChannelOriginLabel } from '@/lib/session-channel-origin'
 import { handoffOriginSource, sessionSourceLabel } from '@/lib/session-source'
 import { coarseElapsed } from '@/lib/time'
 import { cn } from '@/lib/utils'
@@ -80,6 +81,7 @@ function SidebarSessionRowImpl({
   const { cancelPrewarm, startPrewarm } = useProfilePrewarm(session.profile)
   const title = sessionTitle(session)
   const age = formatAge(session.last_active || session.started_at, r)
+  const channelLabel = sessionChannelOriginLabel(session.channel_origin)
   const handleLabel = `Reorder ${title}`
   // A handed-off session's live source is local, but it originated on a
   // messaging platform — surface that origin as a small badge so e.g. a
@@ -131,6 +133,7 @@ function SidebarSessionRowImpl({
         }
         className={cn(
           'group row-hover relative',
+          channelLabel && 'min-h-[2.25rem]',
           isSelected && 'bg-(--ui-row-active-background)',
           isWorking && 'text-foreground',
           // Opaque surface while lifted so the dragged row erases what's under
@@ -167,7 +170,7 @@ function SidebarSessionRowImpl({
           <span aria-hidden="true" className="arc-border arc-row" />
         )}
         <SidebarRowBody
-          className={cn('z-0 group-hover:pr-12', branchStem && 'pl-3.5')}
+          className={cn('z-0 group-hover:pr-12', branchStem && 'pl-3.5', channelLabel && 'py-1')}
           // Middle-click = open in a new tab (browser muscle memory). Swallow
           // the mousedown so Chromium doesn't enter autoscroll mode.
           onAuxClick={event => {
@@ -243,9 +246,19 @@ function SidebarSessionRowImpl({
               />
             </Tip>
           ) : null}
-          <SidebarRowLabel className="flex-1 font-normal group-hover:text-foreground group-data-[working=true]:text-foreground/90">
-            {title}
-          </SidebarRowLabel>
+          <span className="flex min-w-0 flex-1 flex-col justify-center">
+            <SidebarRowLabel className="font-normal group-hover:text-foreground group-data-[working=true]:text-foreground/90">
+              {title}
+            </SidebarRowLabel>
+            {channelLabel ? (
+              <span
+                className="mt-0.5 truncate text-[0.625rem] leading-none text-(--ui-text-tertiary) group-hover:text-(--ui-text-secondary)"
+                title={channelLabel}
+              >
+                {channelLabel}
+              </span>
+            ) : null}
+          </span>
           {showProfile && <ProfileTag profile={session.profile} />}
         </SidebarRowBody>
       </SidebarRowShell>

--- a/apps/desktop/src/lib/session-channel-origin.test.ts
+++ b/apps/desktop/src/lib/session-channel-origin.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { sessionChannelOriginLabel } from './session-channel-origin'
+
+describe('sessionChannelOriginLabel', () => {
+  it('joins distinct safe room and topic labels', () => {
+    expect(
+      sessionChannelOriginLabel({
+        chat_name: 'Build Room',
+        chat_topic: 'Release coordination',
+        chat_type: 'channel',
+        display_name: 'Build Room',
+        has_thread: true,
+        platform: 'webhook'
+      })
+    ).toBe('Build Room · Release coordination')
+  })
+
+  it('omits duplicate or missing topic text', () => {
+    expect(
+      sessionChannelOriginLabel({
+        chat_topic: 'Build Room',
+        display_name: 'Build Room',
+        has_thread: false
+      })
+    ).toBe('Build Room')
+    expect(sessionChannelOriginLabel(null)).toBeNull()
+  })
+})

--- a/apps/desktop/src/lib/session-channel-origin.ts
+++ b/apps/desktop/src/lib/session-channel-origin.ts
@@ -1,0 +1,17 @@
+import type { SessionChannelOrigin } from '@/types/hermes'
+
+export function sessionChannelOriginLabel(origin: null | SessionChannelOrigin | undefined): null | string {
+  const displayName = origin?.display_name?.trim()
+
+  if (!displayName) {
+    return null
+  }
+
+  const topic = origin?.chat_topic?.trim()
+
+  if (topic && topic.toLowerCase() !== displayName.toLowerCase()) {
+    return `${displayName} · ${topic}`
+  }
+
+  return displayName
+}

--- a/apps/desktop/src/lib/session-search-result.test.ts
+++ b/apps/desktop/src/lib/session-search-result.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import { searchResultToSession } from './session-search-result'
+
+describe('searchResultToSession', () => {
+  it('preserves safe shared-channel origin labels for search-only rows', () => {
+    const session = searchResultToSession({
+      channel_origin: {
+        chat_name: 'Build Room',
+        chat_topic: 'Release coordination',
+        chat_type: 'channel',
+        display_name: 'Build Room',
+        has_thread: true,
+        platform: 'webhook'
+      },
+      lineage_root: 'root-session',
+      model: 'claude',
+      role: null,
+      session_id: 'tip-session',
+      session_started: 1_234,
+      snippet: 'Shared channel: Build Room',
+      source: 'webhook'
+    })
+
+    expect(session.id).toBe('tip-session')
+    expect(session._lineage_root_id).toBe('root-session')
+    expect(session.channel_origin?.display_name).toBe('Build Room')
+    expect(session.channel_origin?.chat_topic).toBe('Release coordination')
+  })
+})

--- a/apps/desktop/src/lib/session-search-result.ts
+++ b/apps/desktop/src/lib/session-search-result.ts
@@ -1,0 +1,28 @@
+import type { SessionInfo, SessionSearchResult } from '@/types/hermes'
+
+// FTS results cover sessions that aren't in the loaded page; synthesize a
+// minimal SessionInfo so they render in the same row component (resume works
+// by id; the snippet stands in for the preview).
+export function searchResultToSession(result: SessionSearchResult): SessionInfo {
+  const ts = result.session_started ?? Date.now() / 1000
+
+  return {
+    archived: false,
+    channel_origin: result.channel_origin ?? null,
+    cwd: null,
+    ended_at: null,
+    id: result.session_id,
+    _lineage_root_id: result.lineage_root ?? null,
+    input_tokens: 0,
+    is_active: false,
+    last_active: ts,
+    message_count: 0,
+    model: result.model ?? null,
+    output_tokens: 0,
+    preview: result.snippet?.trim() || null,
+    source: result.source ?? null,
+    started_at: ts,
+    title: null,
+    tool_call_count: 0
+  }
+}

--- a/apps/desktop/src/lib/session-search.test.ts
+++ b/apps/desktop/src/lib/session-search.test.ts
@@ -66,6 +66,24 @@ describe('sessionMatchesSearch', () => {
     expect(sessionMatchesSearch(makeSession({ source: 'bluebubbles' }), 'imessage')).toBe(true)
   })
 
+  it('matches shared-channel sessions by safe origin room and topic labels', () => {
+    const session = makeSession({
+      channel_origin: {
+        chat_name: 'Build Room',
+        chat_topic: 'Release coordination',
+        chat_type: 'channel',
+        display_name: 'Build Room',
+        has_thread: true,
+        platform: 'webhook'
+      },
+      source: 'webhook'
+    })
+
+    expect(sessionMatchesSearch(session, 'build room')).toBe(true)
+    expect(sessionMatchesSearch(session, 'release coordination')).toBe(true)
+    expect(sessionMatchesSearch(session, 'channel')).toBe(true)
+  })
+
   it('does not match unrelated queries', () => {
     expect(sessionMatchesSearch(makeSession(), 'totally-unrelated')).toBe(false)
   })

--- a/apps/desktop/src/lib/session-search.ts
+++ b/apps/desktop/src/lib/session-search.ts
@@ -18,6 +18,11 @@ export function sessionMatchesSearch(session: SessionInfo, query: string): boole
     session.preview ?? '',
     session.cwd ?? '',
     session.git_branch ?? '',
+    session.channel_origin?.display_name ?? '',
+    session.channel_origin?.chat_name ?? '',
+    session.channel_origin?.chat_topic ?? '',
+    session.channel_origin?.chat_type ?? '',
+    session.channel_origin?.platform ?? '',
     ...sessionSourceSearchTerms(session.source)
   ].some(value => value.toLowerCase().includes(needle))
 }

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -445,8 +445,18 @@ export interface SessionCreateResponse {
   stored_session_id?: string
 }
 
+export interface SessionChannelOrigin {
+  chat_name?: string
+  chat_topic?: string
+  chat_type?: string
+  display_name: string
+  has_thread: boolean
+  platform?: string
+}
+
 export interface SessionInfo {
   archived?: boolean
+  channel_origin?: null | SessionChannelOrigin
   cwd?: null | string
   /** Git branch checked out in {@link cwd} when the session started/resumed.
    *  The sidebar groups main-checkout sessions by this so feature-branch work
@@ -1037,6 +1047,7 @@ export interface ComputerUseStatus {
 }
 
 export interface SessionSearchResult {
+  channel_origin?: null | SessionChannelOrigin
   /** Lineage root of the matched conversation. Stable across compression and
    *  used as the durable pin id; falls back to session_id when absent. */
   lineage_root?: string | null

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4722,6 +4722,112 @@ def _strip_session_list_rows(sessions: List[Dict[str, Any]]) -> List[Dict[str, A
     return sessions
 
 
+_CHANNEL_ORIGIN_TEXT_LIMIT = 96
+
+
+def _safe_channel_origin_text(value: Any, limit: int = _CHANNEL_ORIGIN_TEXT_LIMIT) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    text = re.sub(r"\s+", " ", value).strip()
+    if not text:
+        return None
+    text = text.replace("[", "(").replace("]", ")")
+    if len(text) > limit:
+        text = text[: max(0, limit - 3)].rstrip() + "..."
+    return text
+
+
+def _channel_origin_summary(origin: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    chat_name = _safe_channel_origin_text(origin.get("chat_name"))
+    chat_topic = _safe_channel_origin_text(origin.get("chat_topic"))
+    chat_type = _safe_channel_origin_text(origin.get("chat_type"), limit=32)
+    platform = _safe_channel_origin_text(origin.get("platform"), limit=48)
+    user_name = _safe_channel_origin_text(origin.get("user_name"))
+
+    display_name = chat_name or chat_topic
+    if not display_name and chat_type == "dm" and user_name:
+        display_name = f"DM with {user_name}"
+    if not display_name:
+        return None
+
+    summary: Dict[str, Any] = {"display_name": display_name}
+    if chat_name:
+        summary["chat_name"] = chat_name
+    if chat_topic:
+        summary["chat_topic"] = chat_topic
+    if chat_type:
+        summary["chat_type"] = chat_type
+    if platform:
+        summary["platform"] = platform
+    summary["has_thread"] = bool(origin.get("thread_id"))
+    return summary
+
+
+def _load_channel_origin_summaries(hermes_home: Path) -> Dict[str, Dict[str, Any]]:
+    sessions_file = Path(hermes_home) / "sessions" / "sessions.json"
+    try:
+        with sessions_file.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        return {}
+    except Exception:
+        _log.debug("Failed to read shared-channel session origins", exc_info=True)
+        return {}
+
+    if not isinstance(data, dict):
+        return {}
+
+    summaries: Dict[str, Dict[str, Any]] = {}
+    for entry in data.values():
+        if not isinstance(entry, dict):
+            continue
+        session_id = entry.get("session_id")
+        origin = entry.get("origin")
+        if not isinstance(session_id, str) or not isinstance(origin, dict):
+            continue
+        summary = _channel_origin_summary(origin)
+        if summary:
+            summaries[session_id] = summary
+    return summaries
+
+
+def _attach_channel_origin_summaries(rows: List[Dict[str, Any]], hermes_home: Path) -> None:
+    summaries = _load_channel_origin_summaries(hermes_home)
+    if not summaries:
+        return
+
+    for row in rows:
+        summary = None
+        for key in ("id", "session_id", "_lineage_root_id", "lineage_root"):
+            value = row.get(key)
+            if value:
+                summary = summaries.get(str(value))
+                if summary is not None:
+                    break
+        if summary is not None:
+            row["channel_origin"] = dict(summary)
+
+
+def _channel_origin_summary_matches(summary: Dict[str, Any], query: str) -> bool:
+    needle = query.strip().lower()
+    if not needle:
+        return False
+    for key in ("display_name", "chat_name", "chat_topic", "chat_type", "platform"):
+        value = summary.get(key)
+        if isinstance(value, str) and needle in value.lower():
+            return True
+    return False
+
+
+def _channel_origin_search_snippet(summary: Dict[str, Any]) -> str:
+    parts: List[str] = []
+    for key in ("display_name", "chat_topic"):
+        value = summary.get(key)
+        if isinstance(value, str) and value and value not in parts:
+            parts.append(value)
+    return "Shared channel: " + " · ".join(parts or ["session"])
+
+
 @app.get("/api/sessions")
 def get_sessions(
     limit: int = 20,
@@ -4813,6 +4919,7 @@ def get_sessions(
             # with the serving profile even when the request wasn't explicitly
             # scoped, so default-profile rows never circulate unowned.
             row_profile = profile_name or _cron_default_profile()
+            _attach_channel_origin_summaries(sessions, get_hermes_home())
             for s in sessions:
                 s["is_active"] = (
                     s.get("ended_at") is None
@@ -4927,6 +5034,7 @@ def get_profiles_sessions(
                 compact_rows=not full,
                 include_pinned=True,
             )
+            _attach_channel_origin_summaries(rows, Path(home))
             profile_total = db.session_count(
                 source=source_filter,
                 sources=source_list or None,
@@ -5137,6 +5245,7 @@ async def search_sessions(
     try:
         db = _open_session_db_for_profile(profile)
         try:
+            hermes_home = get_hermes_home()
             safe_limit = max(1, min(int(limit or 20), 100))
             source_filter = source or None
             source_list = [s.strip() for s in (sources or "").split(",") if s.strip()]
@@ -5287,6 +5396,27 @@ async def search_sessions(
                     },
                 )
 
+            origin_summaries = _load_channel_origin_summaries(hermes_home)
+            for sid, summary in origin_summaries.items():
+                if len(seen) >= safe_limit:
+                    break
+                if not _channel_origin_summary_matches(summary, q):
+                    continue
+                row = db.get_session(sid)
+                if not row:
+                    continue
+                add_lineage_result(
+                    sid,
+                    {
+                        "snippet": _channel_origin_search_snippet(summary),
+                        "role": None,
+                        "source": row.get("source"),
+                        "model": row.get("model"),
+                        "session_started": row.get("started_at"),
+                        "channel_origin": dict(summary),
+                    },
+                )
+
             # Auto-add prefix wildcards so partial words match
             # e.g. "nimb" → "nimb*" matches "nimby"
             # Preserve quoted phrases and existing wildcards as-is
@@ -5321,7 +5451,9 @@ async def search_sessions(
                         "session_started": m.get("session_started"),
                     },
                 )
-            return {"results": list(seen.values())}
+            results = list(seen.values())
+            _attach_channel_origin_summaries(results, hermes_home)
+            return {"results": results}
         finally:
             db.close()
     except HTTPException:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1901,6 +1901,110 @@ class TestWebServerEndpoints:
         row = next(s for s in resp.json()["sessions"] if s["id"] == "list-stamp")
         assert row["profile"] == "default"
         assert row["is_default_profile"] is True
+    def test_get_sessions_includes_safe_channel_origin_summary(self):
+        """Shared-channel rows expose room labels without raw origin IDs."""
+        from hermes_constants import get_hermes_home
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="shared-safe-session", source="webhook")
+        finally:
+            db.close()
+
+        sessions_dir = get_hermes_home() / "sessions"
+        sessions_dir.mkdir(parents=True, exist_ok=True)
+        (sessions_dir / "sessions.json").write_text(
+            json.dumps(
+                {
+                    "webhook:room-raw-123": {
+                        "session_id": "shared-safe-session",
+                        "origin": {
+                            "platform": "webhook",
+                            "chat_id": "room-raw-123",
+                            "chat_name": " Ops Room [Alpha] ",
+                            "chat_type": "group",
+                            "thread_id": "topic-raw-456",
+                            "chat_topic": "Incident planning",
+                            "user_id": "human-raw-789",
+                            "message_id": "message-raw-000",
+                        },
+                    }
+                }
+            )
+        )
+
+        resp = self.client.get("/api/sessions?limit=20&offset=0")
+        assert resp.status_code == 200
+        row = next(s for s in resp.json()["sessions"] if s["id"] == "shared-safe-session")
+
+        assert row["channel_origin"] == {
+            "display_name": "Ops Room (Alpha)",
+            "chat_name": "Ops Room (Alpha)",
+            "chat_topic": "Incident planning",
+            "chat_type": "group",
+            "platform": "webhook",
+            "has_thread": True,
+        }
+        payload = json.dumps(row)
+        assert "room-raw-123" not in payload
+        assert "topic-raw-456" not in payload
+        assert "human-raw-789" not in payload
+        assert "message-raw-000" not in payload
+
+    def test_profiles_sessions_includes_safe_channel_origin_summary(self, monkeypatch):
+        """The cross-profile desktop list enriches rows from each profile home."""
+        import hermes_state
+        from hermes_cli import profiles as profiles_mod
+        from hermes_constants import get_hermes_home
+        from hermes_state import SessionDB
+
+        home = get_hermes_home()
+        monkeypatch.setattr(
+            profiles_mod,
+            "list_profiles",
+            lambda: [SimpleNamespace(name="default", path=home)],
+        )
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", home / "state.db")
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="profile-shared-session", source="webhook")
+        finally:
+            db.close()
+
+        sessions_dir = home / "sessions"
+        sessions_dir.mkdir(parents=True, exist_ok=True)
+        (sessions_dir / "sessions.json").write_text(
+            json.dumps(
+                {
+                    "webhook:room-raw-profile": {
+                        "session_id": "profile-shared-session",
+                        "origin": {
+                            "platform": "webhook",
+                            "chat_id": "room-raw-profile",
+                            "chat_name": "Build Room",
+                            "chat_type": "channel",
+                            "chat_topic": "Release coordination",
+                            "user_id": "profile-user-raw",
+                        },
+                    }
+                }
+            )
+        )
+
+        resp = self.client.get("/api/profiles/sessions?limit=20&offset=0")
+        assert resp.status_code == 200
+        row = next(
+            s for s in resp.json()["sessions"] if s["id"] == "profile-shared-session"
+        )
+
+        assert row["channel_origin"]["display_name"] == "Build Room"
+        assert row["channel_origin"]["chat_topic"] == "Release coordination"
+        assert row["profile"] == "default"
+        payload = json.dumps(row)
+        assert "room-raw-profile" not in payload
+        assert "profile-user-raw" not in payload
 
     def test_get_sessions_forwards_min_messages(self, monkeypatch):
         """The ?min_messages= filter must reach SessionDB.
@@ -2671,6 +2775,64 @@ class TestWebServerEndpoints:
         assert {r["session_id"] for r in automation_resp.json()["results"]} == {
             "idmatch-cron"
         }
+
+    def test_search_matches_safe_channel_origin_summary(self):
+        """Shared-channel sessions can be found by room labels without leaking IDs."""
+        from hermes_constants import get_hermes_home
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="origin-search-session", source="webhook")
+            db.append_message(
+                session_id="origin-search-session",
+                role="user",
+                content="message body intentionally does not contain the room label",
+            )
+        finally:
+            db.close()
+
+        sessions_dir = get_hermes_home() / "sessions"
+        sessions_dir.mkdir(parents=True, exist_ok=True)
+        (sessions_dir / "sessions.json").write_text(
+            json.dumps(
+                {
+                    "webhook:origin-room-raw": {
+                        "session_id": "origin-search-session",
+                        "origin": {
+                            "platform": "webhook",
+                            "chat_id": "origin-room-raw",
+                            "chat_name": "Build Room",
+                            "chat_type": "channel",
+                            "thread_id": "origin-thread-raw",
+                            "chat_topic": "Release coordination",
+                            "user_id": "origin-user-raw",
+                            "message_id": "origin-message-raw",
+                        },
+                    }
+                }
+            )
+        )
+
+        resp = self.client.get("/api/sessions/search?q=Build%20Room")
+        assert resp.status_code == 200
+        results = resp.json()["results"]
+        hit = next(r for r in results if r["session_id"] == "origin-search-session")
+
+        assert hit["snippet"] == "Shared channel: Build Room \u00b7 Release coordination"
+        assert hit["channel_origin"] == {
+            "display_name": "Build Room",
+            "chat_name": "Build Room",
+            "chat_topic": "Release coordination",
+            "chat_type": "channel",
+            "platform": "webhook",
+            "has_thread": True,
+        }
+        payload = json.dumps(hit)
+        assert "origin-room-raw" not in payload
+        assert "origin-thread-raw" not in payload
+        assert "origin-user-raw" not in payload
+        assert "origin-message-raw" not in payload
 
     def test_get_session_messages_follows_compression_tip(self):
         """Reading a compressed session by its old id should hydrate from the


### PR DESCRIPTION
## Summary
- enrich desktop session list APIs with display-only shared-channel origin summaries from `sessions/sessions.json`
- make `/api/sessions/search` match safe room/topic/channel origin labels and return the same safe `channel_origin` summary on search hits
- expose the new `channel_origin` shape in desktop session types
- include safe room/topic/channel labels in desktop loaded-session search
- render safe room/topic labels as a subtle second line in desktop session rows, including backend-only search-result rows
- show the same safe room/topic context in the open chat header for shared-channel sessions
- add the contributor email mapping required by the attribution check for this branch

## Safety
- does not expose raw chat, thread, user, or message IDs from gateway origins
- handles missing or malformed `sessions.json` as a no-op
- keeps this to desktop API/search/sidebar/header surfaces; no agent prompt/runtime changes

## Verification
- `python3 -m pytest tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_get_sessions_uses_only_persisted_cwd tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_get_sessions_includes_safe_channel_origin_summary tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_profiles_sessions_includes_safe_channel_origin_summary tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_get_sessions_forwards_min_messages -q`
- `python3 -m pytest tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_search_dedupes_compression_lineage_to_tip tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_search_keeps_branch_specific_hits_on_branch tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_search_matches_safe_channel_origin_summary -q`
- `python3 -m compileall -q hermes_cli/web_server.py tests/hermes_cli/test_web_server.py`
- `uv tool run ruff check hermes_cli/web_server.py tests/hermes_cli/test_web_server.py`
- `python3 -m py_compile scripts/release.py`
- local contributor-email attribution-map emulation passed
- `git diff --check`
- `npm --prefix apps/desktop run test:ui -- src/app/chat/index.test.tsx src/lib/session-channel-origin.test.ts src/app/chat/sidebar/session-row.test.tsx src/lib/session-search-result.test.ts src/lib/session-search.test.ts`
- `npm --prefix apps/desktop run typecheck`
- `npx eslint src/app/chat/index.tsx src/app/chat/index.test.tsx src/app/chat/sidebar/session-row.tsx src/app/chat/sidebar/session-row.test.tsx src/lib/session-channel-origin.ts src/lib/session-channel-origin.test.ts src/lib/session-search.ts src/lib/session-search.test.ts src/lib/session-search-result.ts src/lib/session-search-result.test.ts src/types/hermes.ts` from `apps/desktop`
- provider-name scan over this diff found no new `discord`/`telegram` strings
- browser smoke at `http://127.0.0.1:5174/`: renderer loaded with title `Hermes`, DOM content present, no Vite overlay, no console warnings/errors. Screenshot capture timed out in the in-app browser runtime, so visual proof is covered by the header/row component tests plus DOM/console smoke.

Note: `npm --prefix apps/desktop run lint -- ...` invokes the package script's repo-wide `eslint src/ electron/ ...` prefix and still reports unrelated pre-existing desktop lint failures outside this slice, so the touched files were linted directly with `npx eslint`.