### PR TITLE
fix(computer_use): support cua-driver 0.5.x capture API + vision override for custom providers

### DIFF
--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -277,9 +277,32 @@ class _CuaDriverSession:
         result = await self._session.call_tool(name, args)
         return _extract_tool_result(result)
 
+    def _restart(self) -> None:
+        """Tear down a dead session and spawn a fresh one.
+
+        Used to auto-recover when the cached MCP session has died (e.g. the
+        cua-driver binary was upgraded or its TCC permissions changed after
+        the session was first spawned). Without this, a stale session raises
+        an empty 'capture failed:' forever until the whole process restarts.
+        """
+        try:
+            self.stop()
+        except Exception as e:
+            logger.warning("cua-driver restart: stop failed: %s", e)
+        self.start()
+
     def call_tool(self, name: str, args: Dict[str, Any], timeout: float = 30.0) -> Dict[str, Any]:
-        self._require_started()
-        return self._bridge.run(self._call_tool_async(name, args), timeout=timeout)
+        # Lazily (re)start if the session was never started or has been torn down.
+        if not self._started:
+            self.start()
+        try:
+            return self._bridge.run(self._call_tool_async(name, args), timeout=timeout)
+        except Exception as e:
+            # Auto-recover once from a dead/broken session (binary upgrade,
+            # TCC permission change, bridge thread died, stdio pipe closed).
+            logger.warning("cua-driver call_tool(%s) failed, restarting session once: %s", name, e)
+            self._restart()
+            return self._bridge.run(self._call_tool_async(name, args), timeout=timeout)
 
 
 def _extract_tool_result(mcp_result: Any) -> Dict[str, Any]:
@@ -423,34 +446,52 @@ class CuaDriverBackend(ComputerUseBackend):
         elements: List[UIElement] = []
         width = height = 0
         window_title = ""
+        tree = ""
 
-        if mode == "vision":
-            # screenshot tool: just the PNG, no AX walk.
-            sc_out = self._session.call_tool(
-                "screenshot",
-                {"window_id": self._active_window_id, "format": "jpeg", "quality": 85},
-            )
-            if sc_out["images"]:
-                png_b64 = sc_out["images"][0]
+        # cua-driver 0.5.x unified capture: get_window_state takes a
+        # `capture_mode` enum (som=AX+screenshot, vision=screenshot only,
+        # ax=AX only). The standalone `screenshot` tool was removed. The
+        # screenshot rides in content[] as a base64 image part; the AX tree
+        # and dimensions arrive in structuredContent (tree_markdown,
+        # screenshot_width/height). Older builds embedded the tree in the
+        # text `data` field — we fall back to that when structured is absent.
+        cua_capture_mode = mode if mode in ("som", "vision", "ax") else "som"
+        gws_out = self._session.call_tool(
+            "get_window_state",
+            {
+                "pid": self._active_pid,
+                "window_id": self._active_window_id,
+                "capture_mode": cua_capture_mode,
+            },
+        )
+
+        sc = gws_out.get("structuredContent") or {}
+        # Screenshot: embedded image part (preferred) → base64.
+        if gws_out.get("images"):
+            png_b64 = gws_out["images"][0]
+
+        # Tree: structuredContent.tree_markdown (0.5.x) → text data (legacy).
+        if isinstance(sc, dict) and sc.get("tree_markdown"):
+            tree = sc["tree_markdown"]
+            summary = ""
         else:
-            # get_window_state: AX tree + optional screenshot.
-            gws_out = self._session.call_tool(
-                "get_window_state",
-                {"pid": self._active_pid, "window_id": self._active_window_id},
-            )
             text = gws_out["data"] if isinstance(gws_out["data"], str) else ""
             summary, tree = _split_tree_text(text)
 
-            # Parse element count from summary e.g. "✅ AppName — 42 elements, turn 3..."
-            m = re.search(r'(\d+)\s+elements?', summary)
-            if tree and not gws_out["images"]:
-                # ax mode — no screenshot
-                elements = _parse_elements_from_tree(tree)
-            elif gws_out["images"]:
-                png_b64 = gws_out["images"][0]
-                elements = _parse_elements_from_tree(tree)
+        # Dimensions from structuredContent when present.
+        if isinstance(sc, dict):
+            try:
+                width = int(sc.get("screenshot_width") or 0)
+                height = int(sc.get("screenshot_height") or 0)
+            except (TypeError, ValueError):
+                width = height = 0
 
-            # Extract window title from the AX tree first AXWindow line.
+        # Elements only for som/ax (vision is screenshot-only by contract).
+        if mode != "vision" and tree:
+            elements = _parse_elements_from_tree(tree)
+
+        # Window title from the AX tree first AXWindow line.
+        if tree:
             wt = re.search(r'AXWindow\s+"([^"]+)"', tree)
             if wt:
                 window_title = wt.group(1)

--- a/tools/computer_use/vision_routing.py
+++ b/tools/computer_use/vision_routing.py
@@ -137,6 +137,15 @@ def should_route_capture_to_aux_vision(
     if _explicit_aux_vision_override(cfg):
         return True
 
+    # User escape hatch for custom/local providers not in the static
+    # allowlist (e.g. a proxy whose backend is a vision-capable frontier
+    # model like Claude Opus). When the user explicitly declares
+    # model.supports_vision: true, keep the screenshot as a multimodal
+    # tool result for the main model instead of routing to aux vision.
+    # Mirrors the vision_analyze fast-path override semantics.
+    if _user_declared_supports_vision(cfg):
+        return False
+
     accepts_tool_image = _provider_accepts_multimodal_tool_result(provider, model)
     if accepts_tool_image is None or accepts_tool_image is False:
         return True
@@ -145,6 +154,21 @@ def should_route_capture_to_aux_vision(
     if supports_vision is True:
         return False
     return True
+
+
+def _user_declared_supports_vision(cfg: Optional[Dict[str, Any]]) -> bool:
+    """True when the user set ``model.supports_vision: true`` in config.
+
+    Escape hatch for custom/local providers (e.g. a proxy) whose backend
+    is a vision-capable model that Hermes can't detect from the provider
+    name or models.dev. Best-effort: any unexpected shape returns False.
+    """
+    if not isinstance(cfg, dict):
+        return False
+    mcfg = cfg.get("model") or {}
+    if not isinstance(mcfg, dict):
+        return False
+    return bool(mcfg.get("supports_vision") is True)
 
 
 __all__ = [


### PR DESCRIPTION
## Problem

`computer_use` was effectively broken on macOS with current cua-driver (0.5.x). Three independent bugs stacked:

1. **API drift** — cua-driver 0.5.x removed the standalone `screenshot` MCP tool and unified capture under `get_window_state(capture_mode=som|vision|ax)`. The AX tree now arrives in `structuredContent.tree_markdown`, dimensions in `screenshot_width/height`, and the PNG as a base64 image part in `content[]`. The existing backend called the now-removed `screenshot` tool (→ `Unknown tool: screenshot`) and never passed `capture_mode` (→ 0×0 capture, no image).

2. **Dead cached session never recovers** — Hermes caches the MCP session in-process. If the cua-driver binary was upgraded or its TCC permissions changed *after* the agent process started, the cached session stays dead and every capture returns an empty `capture failed:` until a full process restart.

3. **Vision mis-detection for custom providers** — `should_route_capture_to_aux_vision` defaults `supports_vision=False` for any provider not in the static allowlist (openrouter, nous, anthropic, openai, vertex…). A `custom` provider whose backend is a vision-capable frontier model (e.g. Claude Opus via a proxy) gets its screenshots wrongly shunted to aux vision. The `model.supports_vision: true` override existed but was only honored by `vision_analyze`, not the computer_use capture path.

## Fix

- `cua_backend.py::capture` — call `get_window_state` with `capture_mode`, read `structuredContent` (tree_markdown + screenshot_width/height), keep a legacy text-data fallback.
- `cua_backend.py::_CuaDriverSession.call_tool` — auto-restart the session once on failure (recovers from binary upgrade / TCC change / dead bridge).
- `vision_routing.py::should_route_capture_to_aux_vision` — honor `model.supports_vision: true` so the screenshot stays multimodal for the main model. Mirrors the existing `vision_analyze` override semantics.

## Verification

Tested end-to-end against cua-driver 0.5.3 on macOS (M1 Max), all three capture modes through the patched backend:

```
som    -> png:139407B | elems:481 | 1567x916 | title:'…'
vision -> png:139407B | elems:0   | 1567x916
ax     -> png:0       | elems:481 | 0x0
```

Session auto-recovery verified by killing the live session mid-run and confirming the next `call_tool` transparently respawns and returns 481 elements.

## Notes

- No new dependencies. `mode=ax` path is unchanged in behavior (still no screenshot).
- The `supports_vision` override is opt-in and best-effort (any unexpected config shape returns False), so it can't accidentally enable images for a truly text-only backend.