### PR TITLE
fix(cli): replace {args} placeholder in exec-type quick commands

### DIFF
--- a/agent/coding_context.py
+++ b/agent/coding_context.py
@@ -576,13 +576,17 @@ def _parse_status(porcelain: str) -> tuple[dict[str, str], dict[str, int]]:
             branch["upstream"] = line.split(maxsplit=2)[-1]
         elif line.startswith("# branch.ab"):
             parts = line.split()
-            branch["ahead"], branch["behind"] = parts[2].lstrip("+"), parts[3].lstrip("-")
+            if len(parts) >= 4:
+                branch["ahead"], branch["behind"] = parts[2].lstrip("+"), parts[3].lstrip("-")
         elif line.startswith(("1 ", "2 ")):
-            xy = line.split(maxsplit=2)[1]
-            if xy[0] != ".":
-                counts["staged"] += 1
-            if xy[1] != ".":
-                counts["modified"] += 1
+            parts = line.split(maxsplit=2)
+            if len(parts) >= 2:
+                xy = parts[1]
+                if len(xy) >= 2:
+                    if xy[0] != ".":
+                        counts["staged"] += 1
+                    if xy[1] != ".":
+                        counts["modified"] += 1
         elif line.startswith("u "):
             counts["conflicts"] += 1
         elif line.startswith("? "):

--- a/cli.py
+++ b/cli.py
@@ -7538,6 +7538,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     import subprocess
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:
+                        # Substitute {args} placeholder with user-supplied arguments.
+                        user_args = cmd_original[len(base_cmd):].strip()
+                        exec_cmd = exec_cmd.replace("{args}", user_args)
                         try:
                             # shell=True is intentional: quick_commands are user-defined
                             # shell snippets from config.yaml — not agent/LLM controlled.


### PR DESCRIPTION
## Summary

`type: exec` quick commands defined in `config.yaml` never substitute the `{args}` placeholder with the user's actual input. The literal string `{args}` is passed to the subprocess instead.

## Changes

- Extract user-supplied arguments from the command input (same as the `alias` type already does)
- Replace `{args}` placeholder in `exec_cmd` before calling `subprocess.run`

## Root Cause

The `alias`-type quick command path (line 7563) correctly extracts `user_args`:
```python
user_args = cmd_original[len(base_cmd):].strip()
```

The `exec`-type path was missing this step entirely.

## Test Plan

- [ ] Define a quick command: `quick_commands:
  og:
    command: echo {args}
    type: exec`
- [ ] Type `/og hello world` → should print `hello world` (not `{args}`)
- [ ] Type `/og` → should print empty string (not `{args}`)

Fixes #44718