### PR TITLE
feat: add completion auditor plugin

### DIFF
--- a/plugins/completion-auditor/README.md
+++ b/plugins/completion-auditor/README.md
@@ -1,0 +1,84 @@
+# completion-auditor
+
+`completion-auditor` is a disabled-by-default, audit-only Hermes plugin that records local JSONL metadata about whether an assistant's final completion claim is supported by same-turn tool evidence.
+
+It does **not** block, repair, rewrite, or judge the user-visible final response.
+
+## Enable
+
+Add the plugin id to Hermes config:
+
+```yaml
+plugins:
+  enabled:
+    - completion-auditor
+  completion_auditor:
+    mode: audit
+    log_verdicts: true
+```
+
+The runtime config key may also be written as `completion-auditor`, but `completion_auditor` is the documented form.
+
+Restart Hermes after changing plugin config.
+
+## Logs
+
+Default log directory:
+
+```text
+~/.hermes/logs/completion-auditor/
+```
+
+Records are JSONL and use schema:
+
+```text
+hermes-completion-audit-v1
+```
+
+Files are created with private permissions where POSIX mode bits apply:
+
+- directory: `0700`
+- log files: `0600`
+
+## Configuration
+
+```yaml
+plugins:
+  completion_auditor:
+    mode: audit
+    log_verdicts: true
+    log_dir: ~/.hermes/logs/completion-auditor
+    include_tool_result_excerpt: false
+    max_result_excerpt_chars: 800
+    redact_secrets: true
+    log_retention_days: 7
+    max_log_size_mb: 10
+```
+
+Notes:
+
+- `mode` supports only `audit` in the MVP. Other modes are treated as disabled.
+- Tool result excerpts are off by default.
+- If excerpts are enabled, common secret shapes are redacted before writing.
+- Logs rotate by size and prune old `completion-audit-*.jsonl*` files by modification time.
+
+## Verdicts
+
+- `supported`: the specific claim is supported by same-turn direct/strong evidence.
+- `weak`: a claim exists, but evidence is missing, indirect, ambiguous, or scope-mismatched.
+- `fail`: direct evidence contradicts the claim.
+- `not_applicable`: no checkable completion claim was detected.
+- `audit_error`: the auditor could not run correctly, such as missing turn/session identity.
+
+## Evidence tiers
+
+- `tier_1`: direct structured evidence for the claim, such as `exit_code=0` for a test claim or matching `patch`/`write_file` path for a file-modification claim.
+- `tier_2`: strong but indirect evidence.
+- `tier_3`: weak contextual evidence.
+- `tier_4`: missing or unusable evidence.
+
+## What this does not prove
+
+`completion-auditor` does not guarantee semantic task correctness, full user-goal completion, or absence of hidden bugs. `supported` only means the available Hermes hook metadata supports the specific final-response claim.
+
+The plugin is intentionally local-only and deterministic by default. It does not run verifier commands or call an LLM judge.

--- a/plugins/completion-auditor/__init__.py
+++ b/plugins/completion-auditor/__init__.py
@@ -1,0 +1,77 @@
+"""completion-auditor — audit-only evidence-alignment observer.
+
+The first implementation slice is intentionally small:
+
+* plugin loading is opt-in through ``plugins.enabled``;
+* ``post_tool_call`` records metadata-only evidence per ``session_id``/``turn_id``;
+* ``post_llm_call`` writes one ``hermes-completion-audit-v1`` JSONL record;
+* no hook returns replacement text, so user-visible final responses are not
+  mutated by this plugin.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .config import load_settings
+from .evidence import clear as _clear_evidence
+from .evidence import pop_turn, record_tool_call, size as _ledger_size
+from .report import build_record, write_record
+
+logger = logging.getLogger(__name__)
+
+
+def _on_post_tool_call(**kwargs: Any) -> None:
+    settings = load_settings()
+    if not settings.audit_enabled:
+        return None
+    ok = record_tool_call(
+        include_result_excerpt=settings.include_tool_result_excerpt,
+        max_result_excerpt_chars=settings.max_result_excerpt_chars,
+        redact_secrets=settings.redact_secrets,
+        **kwargs,
+    )
+    if not ok:
+        logger.debug("completion-auditor: uncorrelatable post_tool_call payload")
+    return None
+
+
+def _on_post_llm_call(
+    *,
+    session_id: str | None = None,
+    turn_id: str | None = None,
+    task_id: str | None = None,
+    assistant_response: str | None = None,
+    **_: Any,
+) -> None:
+    settings = load_settings()
+    if not settings.audit_enabled:
+        return None
+    evidence = pop_turn(session_id, turn_id)
+    record = build_record(
+        settings=settings,
+        session_id=session_id,
+        turn_id=turn_id,
+        task_id=task_id,
+        assistant_response=assistant_response,
+        evidence=evidence,
+    )
+    try:
+        write_record(settings, record)
+    except Exception as exc:  # pragma: no cover - fail-open runtime guard
+        logger.warning("completion-auditor: failed to write audit record: %s", exc)
+    return None
+
+
+def register(ctx: Any) -> None:
+    ctx.register_hook("post_tool_call", _on_post_tool_call)
+    ctx.register_hook("post_llm_call", _on_post_llm_call)
+
+
+# Test helpers; intentionally private so runtime users stick to plugin hooks.
+def _reset_for_tests() -> None:
+    _clear_evidence()
+
+
+def _ledger_size_for_tests() -> int:
+    return _ledger_size()

--- a/plugins/completion-auditor/classifier.py
+++ b/plugins/completion-auditor/classifier.py
@@ -1,0 +1,173 @@
+"""Deterministic completion-claim classifier for completion-auditor.
+
+This module intentionally stays conservative. It detects explicit claims in the
+assistant's final response, while filtering common false positives such as
+planning-only text, future-tense promises, conditionals, and blocker reports.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class Claim:
+    claim_text: str
+    claim_type: str
+    claim_scope: str | None = None
+
+
+_CLAIM_TYPES = {
+    "tested",
+    "modified",
+    "created",
+    "verified",
+    "deployed",
+    "implemented",
+    "completed",
+    "other",
+}
+
+# Short-circuit phrases that are usually not completion claims.
+_BLOCKER_RE = re.compile(
+    r"\b(blocked|cannot|can't|could not|unable to|missing credentials|no credentials)\b"
+    r"|막혔|불가능|할 수 없|できません|できない|ブロック",
+    re.IGNORECASE,
+)
+_PLAN_ONLY_RE = re.compile(
+    r"\b(plan|proposal|next steps?|would|should|recommend)\b"
+    r"|계획|제안|다음 단계|おすすめ|推奨|予定",
+    re.IGNORECASE,
+)
+_FUTURE_RE = re.compile(
+    r"\b(i will|i'll|will run|will update|will create|will implement|going to)\b"
+    r"|하겠|할게|할 예정|진행할|実行します|します予定|予定です",
+    re.IGNORECASE,
+)
+_CONDITIONAL_RE = re.compile(
+    r"\b(if|when|assuming|provided that|once)\b.{0,80}\b(pass|passes|succeed|success|works)\b"
+    r"|통과하면|성공하면|되면|なら|場合",
+    re.IGNORECASE,
+)
+
+_SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?。！？\n])\s+|\n+")
+_PATH_RE = re.compile(r"(?:[\w.-]+/)+[\w.@-]+|[\w.-]+\.(?:py|js|ts|tsx|json|ya?ml|md|txt|toml|ini|sh|bash|css|html)")
+_FENCED_CODE_RE = re.compile(r"```.*?```", re.DOTALL)
+_INLINE_CODE_RE = re.compile(r"`[^`]+`")
+
+_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    (
+        "verified",
+        re.compile(
+            r"\b(verif(?:y|ied|ication)|checked|validated|confirmed)\b.{0,80}\b(pass(?:ed)?|ok|success|working|clean)\b"
+            r"|검증.{0,40}(완료|통과|성공)|확인.{0,40}(완료|통과|성공)|確認.{0,40}(完了|成功)",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "tested",
+        re.compile(
+            r"\b(test(?:ed|s)?|pytest|unit tests?|integration tests?)\b.{0,80}\b(pass(?:ed|es)?|green|ok|success|succeeded)\b"
+            r"|\b(pass(?:ed|es)?)\b.{0,80}\b(test(?:ed|s)?|pytest|unit tests?)\b"
+            r"|테스트.{0,40}(통과|성공|완료)|テスト.{0,40}(通過|成功|完了)",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "deployed",
+        re.compile(
+            r"\b(deployed|published|released|sent|posted|uploaded)\b"
+            r"|배포(했| 완료)|공개(했| 완료)|전송(했| 완료)|보냈|送信|デプロイ|公開しました",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "modified",
+        re.compile(
+            r"\b(updated|modified|edited|changed|patched|rewrote|refactored)\b"
+            r"|수정(했| 완료)|변경(했| 완료)|업데이트(했| 완료)|更新しました|修正しました|変更しました",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "created",
+        re.compile(
+            r"\b(created|added|wrote|generated|scaffolded)\b"
+            r"|생성(했| 완료)|추가(했| 완료)|작성(했| 완료)|作成しました|追加しました",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "implemented",
+        re.compile(
+            r"\b(implemented|built|fixed|resolved)\b"
+            r"|구현(했| 완료)|빌드(했| 완료)|고쳤|해결(했| 완료)|実装しました|修正しました|解決しました",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "completed",
+        re.compile(
+            r"\b(done|completed|finished|all set)\b"
+            r"|완료(했|됐|입니다)?|끝났|完了しました|完了です",
+            re.IGNORECASE,
+        ),
+    ),
+]
+
+
+def _sentences(text: str) -> Iterable[str]:
+    text = _INLINE_CODE_RE.sub(" ", _FENCED_CODE_RE.sub(" ", text))
+    for part in _SENTENCE_SPLIT_RE.split(text.strip()):
+        sentence = part.strip(" \t-•*")
+        if sentence:
+            yield sentence
+
+
+def _is_false_positive(sentence: str) -> bool:
+    if _BLOCKER_RE.search(sentence):
+        return True
+    if _FUTURE_RE.search(sentence):
+        return True
+    if _CONDITIONAL_RE.search(sentence):
+        return True
+    # Treat plan/proposal words as false positives only when no explicit past
+    # completion marker is present in the same sentence.
+    if _PLAN_ONLY_RE.search(sentence) and not re.search(
+        r"\b(done|completed|finished|updated|created|implemented|fixed|passed)\b|완료|수정했|구현했|作成しました|完了",
+        sentence,
+        re.IGNORECASE,
+    ):
+        return True
+    return False
+
+
+def _scope_from_sentence(sentence: str) -> str | None:
+    match = _PATH_RE.search(sentence)
+    if match:
+        return match.group(0).rstrip(".,;:。！？!)）]")
+    return None
+
+
+def classify_response(text: str | None) -> Claim | None:
+    """Return the first explicit completion claim, or ``None``.
+
+    The classifier is deterministic and intentionally low-recall/high-precision:
+    it prefers missing a vague claim over flagging explanations or plans.
+    """
+    if not text or not text.strip():
+        return None
+    for sentence in _sentences(text):
+        if _is_false_positive(sentence):
+            continue
+        for claim_type, pattern in _PATTERNS:
+            if pattern.search(sentence):
+                if claim_type not in _CLAIM_TYPES:
+                    claim_type = "other"
+                return Claim(
+                    claim_text=sentence,
+                    claim_type=claim_type,
+                    claim_scope=_scope_from_sentence(sentence),
+                )
+    return None

--- a/plugins/completion-auditor/config.py
+++ b/plugins/completion-auditor/config.py
@@ -1,0 +1,127 @@
+"""Configuration helpers for the completion-auditor plugin."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+SCHEMA = "hermes-completion-audit-v1"
+_DEFAULT_MAX_RESULT_EXCERPT_CHARS = 800
+_DEFAULT_LOG_RETENTION_DAYS = 7
+_DEFAULT_MAX_LOG_SIZE_MB = 10
+
+
+def _default_log_dir() -> Path:
+    return get_hermes_home() / "logs" / "completion-auditor"
+
+
+@dataclass(frozen=True)
+class AuditorConfig:
+    """Runtime settings for audit-only completion auditing."""
+
+    mode: str = "audit"
+    log_verdicts: bool = True
+    log_dir: Path = field(default_factory=_default_log_dir)
+    include_tool_result_excerpt: bool = False
+    max_result_excerpt_chars: int = _DEFAULT_MAX_RESULT_EXCERPT_CHARS
+    redact_secrets: bool = True
+    log_retention_days: int = _DEFAULT_LOG_RETENTION_DAYS
+    max_log_size_mb: int = _DEFAULT_MAX_LOG_SIZE_MB
+
+    @property
+    def audit_enabled(self) -> bool:
+        return self.mode == "audit" and self.log_verdicts
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _cfg_get(config: dict[str, Any], key: str, default: Any) -> Any:
+    plugins_cfg = config.get("plugins", {})
+    if not isinstance(plugins_cfg, dict):
+        return default
+    underscore_cfg = plugins_cfg.get("completion_auditor", {})
+    hyphen_cfg = plugins_cfg.get("completion-auditor", {})
+    if not isinstance(underscore_cfg, dict):
+        underscore_cfg = {}
+    if not isinstance(hyphen_cfg, dict):
+        hyphen_cfg = {}
+    # Prefer the documented Python-friendly key, but accept the plugin id as an
+    # alias because users naturally copy it from `hermes plugins enable`.
+    merged = {**hyphen_cfg, **underscore_cfg}
+    return merged.get(key, default)
+
+
+def _load_config() -> dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+
+        loaded = load_config()
+        return loaded if isinstance(loaded, dict) else {}
+    except Exception:
+        return {}
+
+
+def _resolve_log_dir(raw: Any) -> Path:
+    if raw is None or str(raw).strip() == "":
+        return _default_log_dir()
+    expanded = Path(os.path.expandvars(os.path.expanduser(str(raw))))
+    if not expanded.is_absolute():
+        expanded = get_hermes_home() / expanded
+    return expanded
+
+
+def _positive_int(value: Any, default: int) -> int:
+    try:
+        return max(0, int(value))
+    except Exception:
+        return default
+
+
+def load_settings() -> AuditorConfig:
+    """Load profile-safe settings from config.yaml plus env test overrides.
+
+    The plugin itself is opt-in through ``plugins.enabled``. These settings are
+    a second, runtime-level configuration surface used only after the plugin has
+    loaded.
+    """
+    config = _load_config()
+    raw_log_dir = os.getenv("HERMES_COMPLETION_AUDITOR_LOG_DIR") or _cfg_get(
+        config, "log_dir", None
+    )
+    mode = str(_cfg_get(config, "mode", "audit")).strip().lower() or "audit"
+    # MVP is audit-only; fail closed to disabled semantics for future modes.
+    if mode != "audit":
+        mode = "unsupported"
+
+    max_chars = _positive_int(
+        _cfg_get(config, "max_result_excerpt_chars", _DEFAULT_MAX_RESULT_EXCERPT_CHARS),
+        _DEFAULT_MAX_RESULT_EXCERPT_CHARS,
+    )
+
+    return AuditorConfig(
+        mode=mode,
+        log_verdicts=_truthy(_cfg_get(config, "log_verdicts", True)),
+        log_dir=_resolve_log_dir(raw_log_dir),
+        include_tool_result_excerpt=_truthy(
+            _cfg_get(config, "include_tool_result_excerpt", False)
+        ),
+        max_result_excerpt_chars=max_chars,
+        redact_secrets=_truthy(_cfg_get(config, "redact_secrets", True)),
+        log_retention_days=_positive_int(
+            _cfg_get(config, "log_retention_days", _DEFAULT_LOG_RETENTION_DAYS),
+            _DEFAULT_LOG_RETENTION_DAYS,
+        ),
+        max_log_size_mb=_positive_int(
+            _cfg_get(config, "max_log_size_mb", _DEFAULT_MAX_LOG_SIZE_MB),
+            _DEFAULT_MAX_LOG_SIZE_MB,
+        ),
+    )

--- a/plugins/completion-auditor/evidence.py
+++ b/plugins/completion-auditor/evidence.py
@@ -1,0 +1,289 @@
+"""In-memory evidence ledger for completion-auditor."""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+_DEFAULT_LEDGER_TTL_SECONDS = 60 * 60
+_DEFAULT_MAX_LEDGER_TURNS = 512
+
+_KEY_VALUE_SECRET_RE = re.compile(
+    r"(?i)\b(?P<key>api[_-]?key|token|secret|password|passwd|pwd|authorization)\b"
+    r"(?P<sep>\s*[:=]\s*)(?P<quote>['\"]?)(?P<value>[^'\"\s,;}]+)(?P=quote)"
+)
+_QUOTED_KEY_VALUE_SECRET_RE = re.compile(
+    r"(?i)(?P<prefix>['\"](?:api[_-]?key|token|secret|password|passwd|pwd|authorization)['\"]\s*:\s*)"
+    r"(?P<quote>['\"])[^'\"]+(?P=quote)"
+)
+_BEARER_SECRET_RE = re.compile(r"(?i)\bbearer\s+[a-z0-9._~+/=-]{12,}")
+_OPENAI_KEY_RE = re.compile(r"\bsk-[A-Za-z0-9_-]{12,}\b")
+_GITHUB_TOKEN_RE = re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{12,}\b")
+_VERIFICATION_COMMAND_RE = re.compile(
+    r"\b(pytest|unittest|tox|nox|ruff|mypy|pyright)\b"
+    r"|\b(python\d?(?:\.\d+)?|uv)\s+(?:run\s+)?(?:-m\s+)?pytest\b"
+    r"|\b(npm|pnpm|yarn)\s+(?:run\s+)?(test|lint|typecheck|build)\b"
+    r"|\b(cargo|go|swift|gradle|mvn|make)\s+test\b",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class EvidenceRef:
+    """Metadata-only reference to a tool call observed in the current turn."""
+
+    evidence_id: str
+    tool_name: str
+    status: str
+    tool_call_id: str | None = None
+    duration_ms: float | int | None = None
+    exit_code: int | None = None
+    arg_refs: list[str] = field(default_factory=list)
+    command_kind: str | None = None
+    result_excerpt: str | None = None
+
+    def to_json(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "evidence_id": self.evidence_id,
+            "tool_name": self.tool_name,
+            "status": self.status,
+        }
+        if self.tool_call_id:
+            data["tool_call_id"] = self.tool_call_id
+        if self.duration_ms is not None:
+            data["duration_ms"] = self.duration_ms
+        if self.exit_code is not None:
+            data["exit_code"] = self.exit_code
+        if self.arg_refs:
+            data["arg_refs"] = self.arg_refs
+        if self.command_kind is not None:
+            data["command_kind"] = self.command_kind
+        if self.result_excerpt is not None:
+            data["result_excerpt"] = self.result_excerpt
+        return data
+
+
+@dataclass
+class TurnEvidence:
+    session_id: str
+    turn_id: str
+    task_id: str | None = None
+    created_at: float = field(default_factory=time.monotonic)
+    last_seen_at: float = field(default_factory=time.monotonic)
+    evidence: list[EvidenceRef] = field(default_factory=list)
+
+    def to_refs(self) -> list[dict[str, Any]]:
+        return [item.to_json() for item in self.evidence]
+
+
+_LOCK = threading.Lock()
+_LEDGER: dict[tuple[str, str], TurnEvidence] = {}
+
+
+def redact_text(text: str) -> str:
+    """Mask common secret shapes before optional excerpts are persisted."""
+
+    text = _BEARER_SECRET_RE.sub("Bearer [REDACTED]", text)
+    text = _QUOTED_KEY_VALUE_SECRET_RE.sub(
+        lambda m: f"{m.group('prefix')}{m.group('quote')}[REDACTED]{m.group('quote')}",
+        text,
+    )
+    text = _KEY_VALUE_SECRET_RE.sub(
+        lambda m: f"{m.group('key')}{m.group('sep')}[REDACTED]", text
+    )
+    text = _OPENAI_KEY_RE.sub("sk-[REDACTED]", text)
+    return _GITHUB_TOKEN_RE.sub("gh_[REDACTED]", text)
+
+
+# Backwards-compatible private alias used by tests and older slices.
+_redact = redact_text
+
+
+def _prune_locked(
+    *,
+    now: float | None = None,
+    ttl_seconds: int = _DEFAULT_LEDGER_TTL_SECONDS,
+    max_turns: int = _DEFAULT_MAX_LEDGER_TURNS,
+) -> None:
+    """Bound ledger memory for long-running gateway processes."""
+
+    now = time.monotonic() if now is None else now
+    if ttl_seconds > 0:
+        expired = [
+            key for key, turn in _LEDGER.items() if now - turn.last_seen_at > ttl_seconds
+        ]
+        for key in expired:
+            _LEDGER.pop(key, None)
+    if max_turns > 0 and len(_LEDGER) > max_turns:
+        by_age = sorted(_LEDGER.items(), key=lambda item: item[1].last_seen_at)
+        for key, _ in by_age[: len(_LEDGER) - max_turns]:
+            _LEDGER.pop(key, None)
+
+
+def _stable_evidence_id(
+    session_id: str,
+    turn_id: str,
+    tool_name: str,
+    tool_call_id: str | None,
+    index: int,
+) -> str:
+    raw = json.dumps(
+        {
+            "session_id": session_id,
+            "turn_id": turn_id,
+            "tool_name": tool_name,
+            "tool_call_id": tool_call_id,
+            "index": index,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return "ev_" + hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+
+def _path_like(value: Any) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = value.strip()
+    if "/" in text or re.search(
+        r"\.(py|js|ts|tsx|json|ya?ml|md|txt|toml|ini|sh|bash|css|html)$", text
+    ):
+        return text[:500]
+    return None
+
+
+def _arg_refs(args: Any) -> list[str]:
+    if not isinstance(args, dict):
+        return []
+    refs: list[str] = []
+    for key in ("path", "file", "file_path", "target", "output_path"):
+        ref = _path_like(args.get(key))
+        if ref and ref not in refs:
+            refs.append(ref)
+    return refs
+
+
+def _command_kind(tool_name: str, args: Any) -> str | None:
+    if tool_name == "execute_code":
+        return "verification"
+    if tool_name != "terminal" or not isinstance(args, dict):
+        return None
+    command = args.get("command")
+    if not isinstance(command, str):
+        return None
+    return "verification" if _VERIFICATION_COMMAND_RE.search(command) else "other"
+
+
+def _result_exit_code(result: Any) -> int | None:
+    data = result
+    if isinstance(result, str):
+        try:
+            data = json.loads(result)
+        except Exception:
+            return None
+    if not isinstance(data, dict):
+        return None
+    raw = data.get("exit_code")
+    try:
+        return int(raw) if raw is not None else None
+    except Exception:
+        return None
+
+
+def _excerpt(
+    result: Any, *, include: bool, max_chars: int, redact_secrets: bool
+) -> str | None:
+    if not include:
+        return None
+    text = result if isinstance(result, str) else repr(result)
+    if redact_secrets:
+        text = redact_text(text)
+    if max_chars <= 0:
+        return ""
+    return text[:max_chars]
+
+
+def record_tool_call(
+    *,
+    session_id: str | None = None,
+    turn_id: str | None = None,
+    task_id: str | None = None,
+    tool_name: str = "",
+    tool_call_id: str | None = None,
+    status: str | None = None,
+    duration_ms: float | int | None = None,
+    args: Any = None,
+    result: Any = None,
+    include_result_excerpt: bool = False,
+    max_result_excerpt_chars: int = 800,
+    redact_secrets: bool = True,
+    **_: Any,
+) -> bool:
+    """Record one post_tool_call event.
+
+    Returns ``False`` when the hook payload cannot be correlated to a turn.
+    """
+    if not session_id or not turn_id:
+        return False
+    key = (str(session_id), str(turn_id))
+    with _LOCK:
+        _prune_locked()
+        turn = _LEDGER.get(key)
+        if turn is None:
+            turn = TurnEvidence(
+                session_id=str(session_id), turn_id=str(turn_id), task_id=task_id
+            )
+            _LEDGER[key] = turn
+        elif turn.task_id and task_id and turn.task_id != task_id:
+            return False
+        elif not turn.task_id and task_id:
+            turn.task_id = task_id
+        turn.last_seen_at = time.monotonic()
+        index = len(turn.evidence)
+        tool_name_text = str(tool_name or "unknown")
+        turn.evidence.append(
+            EvidenceRef(
+                evidence_id=_stable_evidence_id(
+                    str(session_id), str(turn_id), tool_name_text, tool_call_id, index
+                ),
+                tool_name=tool_name_text,
+                status=str(status or "unknown"),
+                tool_call_id=tool_call_id,
+                duration_ms=duration_ms,
+                exit_code=_result_exit_code(result),
+                arg_refs=_arg_refs(args),
+                command_kind=_command_kind(tool_name_text, args),
+                result_excerpt=_excerpt(
+                    result,
+                    include=include_result_excerpt,
+                    max_chars=max_result_excerpt_chars,
+                    redact_secrets=redact_secrets,
+                ),
+            )
+        )
+    return True
+
+
+def pop_turn(session_id: str | None, turn_id: str | None) -> TurnEvidence | None:
+    """Return and remove evidence for a completed turn."""
+    if not session_id or not turn_id:
+        return None
+    with _LOCK:
+        _prune_locked()
+        return _LEDGER.pop((str(session_id), str(turn_id)), None)
+
+
+def clear() -> None:
+    """Clear the in-memory ledger. Intended for tests."""
+    with _LOCK:
+        _LEDGER.clear()
+
+
+def size() -> int:
+    with _LOCK:
+        _prune_locked()
+        return len(_LEDGER)

--- a/plugins/completion-auditor/plugin.yaml
+++ b/plugins/completion-auditor/plugin.yaml
@@ -1,0 +1,8 @@
+name: completion-auditor
+version: "0.1.0"
+description: "Audit-only completion-claim observer. Records local JSONL evidence-alignment metadata from post_tool_call and post_llm_call without mutating user-visible responses. Disabled by default; enable with `hermes plugins enable completion-auditor`."
+author: NousResearch
+kind: standalone
+hooks:
+  - post_tool_call
+  - post_llm_call

--- a/plugins/completion-auditor/report.py
+++ b/plugins/completion-auditor/report.py
@@ -1,0 +1,183 @@
+"""JSONL reporting for completion-auditor."""
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from .classifier import classify_response
+from .config import SCHEMA, AuditorConfig
+from .evidence import TurnEvidence, redact_text
+from .verdict import evaluate_claim
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _profile_name() -> str:
+    return os.getenv("HERMES_PROFILE") or os.getenv("HERMES_ACTIVE_PROFILE") or "default"
+
+
+def _private_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    try:
+        path.chmod(0o700)
+    except Exception:
+        pass
+
+
+def _append_jsonl(path: Path, record: dict[str, Any]) -> None:
+    _private_dir(path.parent)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(path, flags, 0o600)
+    with os.fdopen(fd, "a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n")
+    try:
+        path.chmod(0o600)
+    except Exception:
+        pass
+
+
+def _daily_log_path(log_dir: Path) -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    return log_dir / f"completion-audit-{stamp}.jsonl"
+
+
+def _prune_old_logs(settings: AuditorConfig) -> None:
+    if settings.log_retention_days <= 0 or not settings.log_dir.exists():
+        return
+    cutoff = datetime.now(timezone.utc) - timedelta(days=settings.log_retention_days)
+    for path in settings.log_dir.glob("completion-audit-*.jsonl*"):
+        try:
+            modified = datetime.fromtimestamp(path.stat().st_mtime, timezone.utc)
+        except Exception:
+            continue
+        if modified < cutoff:
+            try:
+                path.unlink()
+            except Exception:
+                pass
+
+
+def _rotated_log_path(settings: AuditorConfig, base_path: Path) -> Path:
+    if settings.max_log_size_mb <= 0 or not base_path.exists():
+        return base_path
+    max_bytes = settings.max_log_size_mb * 1024 * 1024
+    try:
+        if base_path.stat().st_size < max_bytes:
+            return base_path
+    except Exception:
+        return base_path
+    index = 1
+    while True:
+        candidate = base_path.with_name(f"{base_path.stem}.{index}{base_path.suffix}")
+        if not candidate.exists():
+            return candidate
+        try:
+            if candidate.stat().st_size < max_bytes:
+                return candidate
+        except Exception:
+            return candidate
+        index += 1
+
+
+def _base_record(
+    *,
+    settings: AuditorConfig,
+    session_id: str | None,
+    turn_id: str | None,
+    task_id: str | None,
+    assistant_response: str | None,
+) -> dict[str, Any]:
+    return {
+        "schema": SCHEMA,
+        "timestamp": _utc_now(),
+        "profile": _profile_name(),
+        "session_id": session_id,
+        "turn_id": turn_id,
+        "task_id": task_id,
+        "plugin_enabled": True,
+        "audit_executed": True,
+        "mode": settings.mode,
+        "claim_text": None,
+        "claim_type": "other",
+        "claim_scope": None,
+        "assistant_response_chars": len(assistant_response or ""),
+        "evidence_refs": [],
+        "evidence_tier": "tier_4",
+        "verdict": "not_applicable",
+        "semantic_correctness_guaranteed": False,
+        "degraded": False,
+        "degrade_reason": None,
+        "contradictions": [],
+        "final_response_mutated": False,
+        "tool_result_excerpt_included": settings.include_tool_result_excerpt,
+    }
+
+
+def build_record(
+    *,
+    settings: AuditorConfig,
+    session_id: str | None,
+    turn_id: str | None,
+    task_id: str | None = None,
+    assistant_response: str | None = None,
+    evidence: TurnEvidence | None = None,
+) -> dict[str, Any]:
+    """Build a schema-v1 audit record for a completed turn.
+
+    This slice classifies explicit final-response completion claims and runs a
+    conservative deterministic evidence-alignment evaluator.
+    """
+    record = _base_record(
+        settings=settings,
+        session_id=session_id,
+        turn_id=turn_id,
+        task_id=task_id,
+        assistant_response=assistant_response,
+    )
+    if not session_id or not turn_id:
+        record.update(
+            {
+                "verdict": "audit_error",
+                "degraded": True,
+                "degrade_reason": "missing session_id or turn_id",
+            }
+        )
+        return record
+
+    claim = classify_response(assistant_response)
+    if claim is not None:
+        record.update(
+            {
+                "claim_text": redact_text(claim.claim_text),
+                "claim_type": claim.claim_type,
+                "claim_scope": claim.claim_scope,
+            }
+        )
+
+    if evidence is not None:
+        record["evidence_refs"] = evidence.to_refs()
+    verdict = evaluate_claim(claim, evidence)
+    record.update(
+        {
+            "verdict": verdict.verdict,
+            "evidence_tier": verdict.evidence_tier,
+            "contradictions": verdict.contradictions,
+            "degraded": verdict.degraded,
+            "degrade_reason": verdict.degrade_reason,
+        }
+    )
+    return record
+
+
+def write_record(settings: AuditorConfig, record: dict[str, Any]) -> Path:
+    _prune_old_logs(settings)
+    path = _rotated_log_path(settings, _daily_log_path(settings.log_dir))
+    _append_jsonl(path, record)
+    return path

--- a/plugins/completion-auditor/verdict.py
+++ b/plugins/completion-auditor/verdict.py
@@ -1,0 +1,172 @@
+"""Deterministic evidence evaluator for completion-auditor."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .classifier import Claim
+from .evidence import EvidenceRef, TurnEvidence
+
+_VERIFICATION_TOOLS = {"terminal", "execute_code"}
+_MUTATION_TOOLS = {"write_file", "patch", "browser_type", "browser_click"}
+_EXTERNAL_TOOLS = {"send_message", "image_generate", "text_to_speech"}
+
+
+@dataclass(frozen=True)
+class Verdict:
+    verdict: str
+    evidence_tier: str
+    contradictions: list[str] = field(default_factory=list)
+    degraded: bool = False
+    degrade_reason: str | None = None
+
+
+def _status(item: EvidenceRef) -> str:
+    return item.status.strip().lower()
+
+
+def _is_success(item: EvidenceRef) -> bool:
+    status = _status(item)
+    if status in {"error", "failed", "failure", "exception", "timeout"}:
+        return False
+    if item.exit_code is not None:
+        return item.exit_code == 0
+    return status in {"success", "ok", "completed", "unknown"}
+
+
+def _is_failure(item: EvidenceRef) -> bool:
+    status = _status(item)
+    return status in {"error", "failed", "failure", "exception", "timeout"} or (
+        item.exit_code is not None and item.exit_code != 0
+    )
+
+
+def _has_matching_scope(item: EvidenceRef, claim_scope: str | None) -> bool:
+    if not claim_scope:
+        return True
+    scope = claim_scope.rstrip("/.")
+    return any(ref.rstrip("/.").endswith(scope) or scope.endswith(ref.rstrip("/.")) for ref in item.arg_refs)
+
+
+def _tool_in(item: EvidenceRef, names: set[str]) -> bool:
+    return item.tool_name in names
+
+
+def _evaluate_verification_claim(claim: Claim, evidence: list[EvidenceRef]) -> Verdict:
+    failed = [item for item in evidence if _tool_in(item, _VERIFICATION_TOOLS) and _is_failure(item)]
+    if failed:
+        return Verdict(
+            verdict="fail",
+            evidence_tier="tier_1",
+            contradictions=[
+                f"{item.tool_name} evidence {item.evidence_id} returned exit_code={item.exit_code} status={item.status}"
+                for item in failed[:3]
+            ],
+        )
+
+    direct = [
+        item
+        for item in evidence
+        if _tool_in(item, _VERIFICATION_TOOLS)
+        and _is_success(item)
+        and item.exit_code == 0
+        and item.command_kind == "verification"
+    ]
+    if direct:
+        return Verdict(verdict="supported", evidence_tier="tier_1")
+
+    weak = [item for item in evidence if _tool_in(item, _VERIFICATION_TOOLS) and _is_success(item)]
+    if weak:
+        return Verdict(
+            verdict="weak",
+            evidence_tier="tier_3",
+            degraded=True,
+            degrade_reason="verification evidence lacks structured exit_code=0",
+        )
+    return Verdict(verdict="weak", evidence_tier="tier_4")
+
+
+def _evaluate_mutation_claim(claim: Claim, evidence: list[EvidenceRef]) -> Verdict:
+    failed = [
+        item
+        for item in evidence
+        if _tool_in(item, _MUTATION_TOOLS) and _has_matching_scope(item, claim.claim_scope) and _is_failure(item)
+    ]
+    if failed:
+        return Verdict(
+            verdict="fail",
+            evidence_tier="tier_1",
+            contradictions=[
+                f"{item.tool_name} evidence {item.evidence_id} failed for claimed scope"
+                for item in failed[:3]
+            ],
+        )
+
+    direct = [
+        item
+        for item in evidence
+        if _tool_in(item, _MUTATION_TOOLS) and _has_matching_scope(item, claim.claim_scope) and _is_success(item)
+    ]
+    if direct:
+        return Verdict(verdict="supported", evidence_tier="tier_1" if claim.claim_scope else "tier_2")
+
+    indirect = [item for item in evidence if _tool_in(item, _MUTATION_TOOLS) and _is_success(item)]
+    if indirect:
+        return Verdict(
+            verdict="weak",
+            evidence_tier="tier_3",
+            degraded=bool(claim.claim_scope),
+            degrade_reason="mutation evidence does not match claim_scope" if claim.claim_scope else None,
+        )
+    return Verdict(verdict="weak", evidence_tier="tier_4")
+
+
+def _evaluate_external_claim(claim: Claim, evidence: list[EvidenceRef]) -> Verdict:
+    failed = [item for item in evidence if _tool_in(item, _EXTERNAL_TOOLS) and _is_failure(item)]
+    if failed:
+        return Verdict(
+            verdict="fail",
+            evidence_tier="tier_1",
+            contradictions=[f"{item.tool_name} evidence {item.evidence_id} failed" for item in failed[:3]],
+        )
+    direct = [item for item in evidence if _tool_in(item, _EXTERNAL_TOOLS) and _is_success(item)]
+    if direct:
+        return Verdict(verdict="supported", evidence_tier="tier_2")
+    return Verdict(verdict="weak", evidence_tier="tier_4")
+
+
+def evaluate_claim(claim: Claim | None, evidence: TurnEvidence | None) -> Verdict:
+    """Return an evidence-alignment verdict for one classified final-response claim.
+
+    This evaluator is intentionally conservative. It only marks a claim as
+    ``supported`` when the hook ledger contains direct structured metadata for
+    the same turn; it never claims semantic task correctness.
+    """
+
+    if claim is None:
+        return Verdict(verdict="not_applicable", evidence_tier="tier_4")
+
+    refs = evidence.evidence if evidence is not None else []
+    if not refs:
+        return Verdict(verdict="weak", evidence_tier="tier_4")
+
+    if claim.claim_type in {"tested", "verified"}:
+        return _evaluate_verification_claim(claim, refs)
+    if claim.claim_type in {"modified", "created"}:
+        return _evaluate_mutation_claim(claim, refs)
+    if claim.claim_type == "deployed":
+        return _evaluate_external_claim(claim, refs)
+
+    # Broad semantic claims such as implemented/fixed/completed remain weak in
+    # the MVP unless a later slice narrows them to verifier-specific semantics.
+    if any(_is_failure(item) for item in refs):
+        failures = [item for item in refs if _is_failure(item)]
+        return Verdict(
+            verdict="fail",
+            evidence_tier="tier_3",
+            contradictions=[
+                f"{item.tool_name} evidence {item.evidence_id} failed while broad completion was claimed"
+                for item in failures[:3]
+            ],
+        )
+    return Verdict(verdict="weak", evidence_tier="tier_3")

--- a/tests/plugins/test_completion_auditor_classifier.py
+++ b/tests/plugins/test_completion_auditor_classifier.py
@@ -1,0 +1,105 @@
+"""Tests for completion-auditor's deterministic claim classifier."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _load_classifier():
+    plugin_dir = _repo_root() / "plugins" / "completion-auditor"
+    if "hermes_plugins" not in sys.modules:
+        ns = types.ModuleType("hermes_plugins")
+        ns.__path__ = []
+        sys.modules["hermes_plugins"] = ns
+    for key in list(sys.modules):
+        if key.startswith("hermes_plugins.completion_auditor_classifier_under_test"):
+            del sys.modules[key]
+    spec = importlib.util.spec_from_file_location(
+        "hermes_plugins.completion_auditor_classifier_under_test.classifier",
+        plugin_dir / "classifier.py",
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["hermes_plugins.completion_auditor_classifier_under_test.classifier"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Hermes plugins are opt-in. You can enable one from config.yaml.",
+        "Plan: add a plugin skeleton, then write tests, then run pytest.",
+        "I will run the tests next.",
+        "테스트는 다음에 실행할게.",
+        "If tests pass, we can call this done.",
+        "테스트가 통과하면 완료라고 볼 수 있어.",
+        "Blocked because credentials are missing.",
+        "Blocked because credentials are missing, but updated config.yaml.",
+        "인증 정보가 없어서 진행할 수 없어.",
+        "```\nTests passed: 21 passed.\n```",
+        "Example output: `Tests passed: 21 passed.`",
+    ],
+)
+def test_false_positive_fixtures_return_none(text):
+    mod = _load_classifier()
+    assert mod.classify_response(text) is None
+
+
+@pytest.mark.parametrize(
+    ("text", "claim_type"),
+    [
+        ("Updated config.yaml and kept the change scoped.", "modified"),
+        ("Created plugins/completion-auditor/classifier.py.", "created"),
+        ("Implemented the deterministic classifier.", "implemented"),
+        ("Tests passed: 21 passed.", "tested"),
+        ("Verification passed with pytest.", "verified"),
+        ("Deployed the worker and published the release notes.", "deployed"),
+        ("작업 완료했어.", "completed"),
+        ("테스트 통과했어.", "tested"),
+        ("設定を更新しました。", "modified"),
+        ("テスト成功しました。", "tested"),
+    ],
+)
+def test_completion_claim_fixtures_are_classified(text, claim_type):
+    mod = _load_classifier()
+    claim = mod.classify_response(text)
+    assert claim is not None
+    assert claim.claim_type == claim_type
+    assert claim.claim_text
+
+
+def test_scope_prefers_path_like_token():
+    mod = _load_classifier()
+    claim = mod.classify_response("Updated plugins/completion-auditor/report.py.")
+    assert claim is not None
+    assert claim.claim_type == "modified"
+    assert claim.claim_scope == "plugins/completion-auditor/report.py"
+
+
+def test_first_real_claim_skips_plan_sentence():
+    mod = _load_classifier()
+    claim = mod.classify_response(
+        "Plan: run pytest next. Updated plugins/completion-auditor/classifier.py."
+    )
+    assert claim is not None
+    assert claim.claim_type == "modified"
+    assert claim.claim_scope == "plugins/completion-auditor/classifier.py"
+
+
+def test_separate_blocker_sentence_does_not_hide_later_real_claim():
+    mod = _load_classifier()
+    claim = mod.classify_response(
+        "Blocked because credentials are missing. Updated config.yaml."
+    )
+    assert claim is not None
+    assert claim.claim_type == "modified"
+    assert claim.claim_scope == "config.yaml"

--- a/tests/plugins/test_completion_auditor_plugin.py
+++ b/tests/plugins/test_completion_auditor_plugin.py
@@ -1,0 +1,282 @@
+"""Tests for the bundled completion-auditor plugin."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("HERMES_COMPLETION_AUDITOR_LOG_DIR", raising=False)
+    yield hermes_home
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _load_plugin_init():
+    plugin_dir = _repo_root() / "plugins" / "completion-auditor"
+    if "hermes_plugins" not in sys.modules:
+        ns = types.ModuleType("hermes_plugins")
+        ns.__path__ = []
+        sys.modules["hermes_plugins"] = ns
+    for key in list(sys.modules):
+        if key.startswith("hermes_plugins.completion_auditor_under_test"):
+            del sys.modules[key]
+    spec = importlib.util.spec_from_file_location(
+        "hermes_plugins.completion_auditor_under_test",
+        plugin_dir / "__init__.py",
+        submodule_search_locations=[str(plugin_dir)],
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = "hermes_plugins.completion_auditor_under_test"
+    mod.__path__ = [str(plugin_dir)]
+    sys.modules["hermes_plugins.completion_auditor_under_test"] = mod
+    spec.loader.exec_module(mod)
+    mod._reset_for_tests()
+    return mod
+
+
+def _audit_records(hermes_home: Path) -> list[dict]:
+    records = []
+    for path in sorted((hermes_home / "logs" / "completion-auditor").glob("*.jsonl")):
+        for line in path.read_text(encoding="utf-8").splitlines():
+            records.append(json.loads(line))
+    return records
+
+
+class TestCompletionAuditorHooks:
+    def test_post_llm_call_writes_metadata_only_jsonl_record(self, _isolate_env):
+        mod = _load_plugin_init()
+
+        assert mod._on_post_tool_call(
+            session_id="s1",
+            turn_id="turn-1",
+            task_id="task-1",
+            tool_name="terminal",
+            tool_call_id="tc1",
+            status="success",
+            duration_ms=12,
+            result='{"output": "SECRET RAW OUTPUT SHOULD NOT BE LOGGED"}',
+        ) is None
+        assert mod._ledger_size_for_tests() == 1
+
+        original = "테스트 통과했어."
+        assert mod._on_post_llm_call(
+            session_id="s1",
+            turn_id="turn-1",
+            task_id="task-1",
+            assistant_response=original,
+        ) is None
+
+        assert mod._ledger_size_for_tests() == 0
+        records = _audit_records(_isolate_env)
+        assert len(records) == 1
+        record = records[0]
+        assert record["schema"] == "hermes-completion-audit-v1"
+        assert record["session_id"] == "s1"
+        assert record["turn_id"] == "turn-1"
+        assert record["task_id"] == "task-1"
+        assert record["plugin_enabled"] is True
+        assert record["audit_executed"] is True
+        assert record["mode"] == "audit"
+        assert record["verdict"] == "weak"
+        assert record["claim_type"] == "tested"
+        assert record["claim_text"] == original
+        assert record["semantic_correctness_guaranteed"] is False
+        assert record["final_response_mutated"] is False
+        assert record["tool_result_excerpt_included"] is False
+        assert record["assistant_response_chars"] == len(original)
+        assert len(record["evidence_refs"]) == 1
+        assert record["evidence_refs"][0]["tool_name"] == "terminal"
+        assert "result_excerpt" not in record["evidence_refs"][0]
+        assert "SECRET RAW OUTPUT" not in json.dumps(record)
+
+        log_dir = _isolate_env / "logs" / "completion-auditor"
+        log_file = next(log_dir.glob("*.jsonl"))
+        if os.name == "posix":
+            assert log_dir.stat().st_mode & 0o777 == 0o700
+            assert log_file.stat().st_mode & 0o777 == 0o600
+
+    def test_missing_turn_identity_records_audit_error(self, _isolate_env):
+        mod = _load_plugin_init()
+        mod._on_post_llm_call(session_id="s1", assistant_response="done")
+        record = _audit_records(_isolate_env)[0]
+        assert record["verdict"] == "audit_error"
+        assert record["degraded"] is True
+        assert record["degrade_reason"] == "missing session_id or turn_id"
+
+    def test_unsupported_runtime_mode_is_noop(self, _isolate_env):
+        import yaml
+
+        (_isolate_env / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"completion_auditor": {"mode": "enforce"}}}),
+            encoding="utf-8",
+        )
+        mod = _load_plugin_init()
+        mod._on_post_llm_call(session_id="s1", turn_id="t1", assistant_response="done")
+        assert _audit_records(_isolate_env) == []
+
+    def test_result_excerpt_redacts_common_secret_shapes(self, _isolate_env):
+        import yaml
+
+        (_isolate_env / "config.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "plugins": {
+                        "completion_auditor": {
+                            "include_tool_result_excerpt": True,
+                            "redact_secrets": True,
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        mod = _load_plugin_init()
+        raw_secret = "sk-1234567890abcdefghijklmnop"
+        bearer_secret = "abcdefghijklmnop1234567890"
+        mod._on_post_tool_call(
+            session_id="s1",
+            turn_id="turn-1",
+            tool_name="terminal",
+            status="success",
+            result=f"api_key={raw_secret} Authorization: Bearer {bearer_secret}",
+        )
+        mod._on_post_llm_call(
+            session_id="s1", turn_id="turn-1", assistant_response="Updated config.yaml."
+        )
+        record = _audit_records(_isolate_env)[0]
+        excerpt = record["evidence_refs"][0]["result_excerpt"]
+        assert "[REDACTED]" in excerpt
+        assert raw_secret not in excerpt
+        assert bearer_secret not in excerpt
+
+    def test_result_excerpt_redacts_quoted_dict_secret_values(self, _isolate_env):
+        import yaml
+
+        (_isolate_env / "config.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "plugins": {
+                        "completion_auditor": {
+                            "include_tool_result_excerpt": True,
+                            "redact_secrets": True,
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        mod = _load_plugin_init()
+        mod._on_post_tool_call(
+            session_id="s1",
+            turn_id="turn-1",
+            tool_name="terminal",
+            status="success",
+            result={"password": "super-secret-token", "token": "another-secret-token"},
+        )
+        mod._on_post_llm_call(
+            session_id="s1", turn_id="turn-1", assistant_response="Updated config.yaml."
+        )
+        excerpt = _audit_records(_isolate_env)[0]["evidence_refs"][0]["result_excerpt"]
+        assert "super-secret-token" not in excerpt
+        assert "another-secret-token" not in excerpt
+        assert excerpt.count("[REDACTED]") == 2
+
+    def test_hyphenated_runtime_config_alias_is_supported(self, _isolate_env):
+        import yaml
+
+        (_isolate_env / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"completion-auditor": {"log_verdicts": False}}}),
+            encoding="utf-8",
+        )
+        mod = _load_plugin_init()
+        mod._on_post_llm_call(session_id="s1", turn_id="t1", assistant_response="done")
+        assert _audit_records(_isolate_env) == []
+
+    def test_direct_config_default_log_dir_is_profile_safe(self, _isolate_env):
+        _load_plugin_init()
+        config_mod = sys.modules["hermes_plugins.completion_auditor_under_test.config"]
+        cfg = config_mod.AuditorConfig()
+        assert cfg.log_dir == _isolate_env / "logs" / "completion-auditor"
+
+    def test_ledger_prunes_stale_turns(self):
+        mod = _load_plugin_init()
+        evidence_mod = sys.modules["hermes_plugins.completion_auditor_under_test.evidence"]
+        assert mod._on_post_tool_call(
+            session_id="s1", turn_id="old", tool_name="terminal", status="success"
+        ) is None
+        assert mod._on_post_tool_call(
+            session_id="s1", turn_id="new", tool_name="terminal", status="success"
+        ) is None
+        evidence_mod._LEDGER[("s1", "old")].last_seen_at = 0
+        evidence_mod._prune_locked(now=evidence_mod._DEFAULT_LEDGER_TTL_SECONDS + 1)
+        assert ("s1", "old") not in evidence_mod._LEDGER
+        assert ("s1", "new") in evidence_mod._LEDGER
+
+
+class TestCompletionAuditorPluginRegistration:
+    def test_register_adds_observer_hooks(self):
+        mod = _load_plugin_init()
+        hooks = []
+
+        class Ctx:
+            def register_hook(self, name, callback):
+                hooks.append((name, callback))
+
+        mod.register(Ctx())
+        assert [name for name, _ in hooks] == ["post_tool_call", "post_llm_call"]
+        assert all(callback(**{}) is None for _, callback in hooks)
+
+    def test_bundled_plugin_is_disabled_by_default(self, _isolate_env):
+        import yaml
+
+        (_isolate_env / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": []}}), encoding="utf-8"
+        )
+        for key in list(sys.modules):
+            if key.startswith("hermes_plugins"):
+                del sys.modules[key]
+
+        import hermes_cli.plugins as plugins_mod
+
+        plugins_mod._plugin_manager = plugins_mod.PluginManager()
+        mgr = plugins_mod._ensure_plugins_discovered(force=True)
+        loaded = mgr._plugins["completion-auditor"]
+        assert loaded.enabled is False
+        assert loaded.error is not None
+        assert loaded.error.startswith("not enabled in config")
+        assert "post_tool_call" not in mgr._hooks
+        assert "post_llm_call" not in mgr._hooks
+
+    def test_bundled_plugin_loads_when_enabled(self, _isolate_env):
+        import yaml
+
+        (_isolate_env / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["completion-auditor"]}}),
+            encoding="utf-8",
+        )
+        for key in list(sys.modules):
+            if key.startswith("hermes_plugins"):
+                del sys.modules[key]
+
+        import hermes_cli.plugins as plugins_mod
+
+        plugins_mod._plugin_manager = plugins_mod.PluginManager()
+        mgr = plugins_mod._ensure_plugins_discovered(force=True)
+        loaded = mgr._plugins["completion-auditor"]
+        assert loaded.enabled is True
+        assert "post_tool_call" in mgr._hooks
+        assert "post_llm_call" in mgr._hooks

--- a/tests/plugins/test_completion_auditor_reporting.py
+++ b/tests/plugins/test_completion_auditor_reporting.py
@@ -1,0 +1,139 @@
+"""Reporting and hook-smoke tests for completion-auditor."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import types
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("HERMES_COMPLETION_AUDITOR_LOG_DIR", raising=False)
+    yield hermes_home
+
+
+def _load_plugin_package():
+    plugin_dir = _repo_root() / "plugins" / "completion-auditor"
+    if "hermes_plugins" not in sys.modules:
+        ns = types.ModuleType("hermes_plugins")
+        ns.__path__ = []
+        sys.modules["hermes_plugins"] = ns
+    for key in list(sys.modules):
+        if key.startswith("hermes_plugins.completion_auditor_reporting_under_test"):
+            del sys.modules[key]
+    spec = importlib.util.spec_from_file_location(
+        "hermes_plugins.completion_auditor_reporting_under_test",
+        plugin_dir / "__init__.py",
+        submodule_search_locations=[str(plugin_dir)],
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = "hermes_plugins.completion_auditor_reporting_under_test"
+    mod.__path__ = [str(plugin_dir)]
+    sys.modules["hermes_plugins.completion_auditor_reporting_under_test"] = mod
+    spec.loader.exec_module(mod)
+    mod._reset_for_tests()
+    return mod
+
+
+def _records(hermes_home: Path) -> list[dict]:
+    found = []
+    for path in sorted((hermes_home / "logs" / "completion-auditor").glob("*.jsonl*")):
+        for line in path.read_text(encoding="utf-8").splitlines():
+            found.append(json.loads(line))
+    return found
+
+
+def test_log_retention_prunes_old_completion_audit_files(_isolate_env):
+    _load_plugin_package()
+    report_mod = sys.modules["hermes_plugins.completion_auditor_reporting_under_test.report"]
+    config_mod = sys.modules["hermes_plugins.completion_auditor_reporting_under_test.config"]
+    log_dir = _isolate_env / "logs" / "completion-auditor"
+    log_dir.mkdir(parents=True)
+    old = log_dir / "completion-audit-2000-01-01.jsonl"
+    old.write_text("{}\n", encoding="utf-8")
+    old_time = (datetime.now(timezone.utc) - timedelta(days=30)).timestamp()
+    os.utime(old, (old_time, old_time))
+
+    settings = config_mod.AuditorConfig(log_dir=log_dir, log_retention_days=7)
+    report_mod.write_record(settings, {"schema": "hermes-completion-audit-v1"})
+
+    assert not old.exists()
+    assert list(log_dir.glob("completion-audit-*.jsonl"))
+
+
+def test_log_rotation_uses_numbered_jsonl_when_daily_file_is_full(_isolate_env):
+    _load_plugin_package()
+    report_mod = sys.modules["hermes_plugins.completion_auditor_reporting_under_test.report"]
+    config_mod = sys.modules["hermes_plugins.completion_auditor_reporting_under_test.config"]
+    log_dir = _isolate_env / "logs" / "completion-auditor"
+    log_dir.mkdir(parents=True)
+    settings = config_mod.AuditorConfig(log_dir=log_dir, max_log_size_mb=1)
+    base = report_mod._daily_log_path(log_dir)
+    base.write_text("x" * (1024 * 1024), encoding="utf-8")
+
+    written = report_mod.write_record(settings, {"schema": "hermes-completion-audit-v1"})
+
+    assert written != base
+    assert written.name.endswith(".1.jsonl")
+    assert written.exists()
+
+
+def test_enabled_plugin_hook_smoke_writes_audit_without_mutating_response(_isolate_env):
+    import yaml
+
+    (_isolate_env / "config.yaml").write_text(
+        yaml.safe_dump({"plugins": {"enabled": ["completion-auditor"]}}),
+        encoding="utf-8",
+    )
+    for key in list(sys.modules):
+        if key.startswith("hermes_plugins"):
+            del sys.modules[key]
+
+    import hermes_cli.plugins as plugins_mod
+
+    plugins_mod._plugin_manager = plugins_mod.PluginManager()
+    mgr = plugins_mod._ensure_plugins_discovered(force=True)
+    assert mgr.has_hook("post_tool_call")
+    assert mgr.has_hook("post_llm_call")
+
+    assert mgr.invoke_hook(
+        "post_tool_call",
+        session_id="s1",
+        turn_id="t1",
+        task_id="task-1",
+        tool_name="terminal",
+        status="success",
+        args={"command": "python -m pytest tests/plugins -q"},
+        result={"output": "54 passed", "exit_code": 0},
+    ) == []
+    response = "Tests passed: 54 passed."
+    assert mgr.invoke_hook(
+        "post_llm_call",
+        session_id="s1",
+        turn_id="t1",
+        task_id="task-1",
+        assistant_response=response,
+    ) == []
+
+    records = _records(_isolate_env)
+    assert len(records) == 1
+    record = records[0]
+    assert record["schema"] == "hermes-completion-audit-v1"
+    assert record["claim_text"] == response
+    assert record["verdict"] == "supported"
+    assert record["final_response_mutated"] is False
+    assert record["tool_result_excerpt_included"] is False

--- a/tests/plugins/test_completion_auditor_verdict.py
+++ b/tests/plugins/test_completion_auditor_verdict.py
@@ -1,0 +1,145 @@
+"""Tests for completion-auditor's deterministic evidence evaluator."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _load_plugin_package():
+    plugin_dir = _repo_root() / "plugins" / "completion-auditor"
+    if "hermes_plugins" not in sys.modules:
+        ns = types.ModuleType("hermes_plugins")
+        ns.__path__ = []
+        sys.modules["hermes_plugins"] = ns
+    for key in list(sys.modules):
+        if key.startswith("hermes_plugins.completion_auditor_verdict_under_test"):
+            del sys.modules[key]
+    spec = importlib.util.spec_from_file_location(
+        "hermes_plugins.completion_auditor_verdict_under_test",
+        plugin_dir / "__init__.py",
+        submodule_search_locations=[str(plugin_dir)],
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    mod.__package__ = "hermes_plugins.completion_auditor_verdict_under_test"
+    mod.__path__ = [str(plugin_dir)]
+    sys.modules["hermes_plugins.completion_auditor_verdict_under_test"] = mod
+    spec.loader.exec_module(mod)
+    mod._reset_for_tests()
+    return mod
+
+
+def _record_for_response(assistant_response: str, *, tool_name="terminal", args=None, result=None, status="success"):
+    mod = _load_plugin_package()
+    evidence_mod = sys.modules["hermes_plugins.completion_auditor_verdict_under_test.evidence"]
+    report_mod = sys.modules["hermes_plugins.completion_auditor_verdict_under_test.report"]
+    config_mod = sys.modules["hermes_plugins.completion_auditor_verdict_under_test.config"]
+    evidence_mod.record_tool_call(
+        session_id="s1",
+        turn_id="t1",
+        tool_name=tool_name,
+        status=status,
+        args=args or {},
+        result=result,
+    )
+    evidence = evidence_mod.pop_turn("s1", "t1")
+    return report_mod.build_record(
+        settings=config_mod.AuditorConfig(),
+        session_id="s1",
+        turn_id="t1",
+        assistant_response=assistant_response,
+        evidence=evidence,
+    )
+
+
+def test_tested_claim_supported_by_successful_structured_command_evidence():
+    record = _record_for_response(
+        "Tests passed: 21 passed.",
+        args={"command": "python -m pytest tests/plugins -q"},
+        result={"output": "21 passed", "exit_code": 0},
+    )
+    assert record["verdict"] == "supported"
+    assert record["evidence_tier"] == "tier_1"
+    assert record["evidence_refs"][0]["exit_code"] == 0
+    assert record["semantic_correctness_guaranteed"] is False
+
+
+def test_tested_claim_not_supported_by_non_verification_command_success():
+    record = _record_for_response(
+        "Tests passed: 21 passed.",
+        args={"command": "ls plugins"},
+        result={"output": "plugins", "exit_code": 0},
+    )
+    assert record["verdict"] == "weak"
+    assert record["evidence_tier"] == "tier_3"
+    assert record["evidence_refs"][0]["command_kind"] == "other"
+
+
+def test_tested_claim_not_supported_by_path_or_echo_words_that_look_like_verification():
+    for command in ("ls tests", "echo build", "cat tests/plugins/test_completion_auditor_verdict.py"):
+        record = _record_for_response(
+            "Tests passed: 21 passed.",
+            args={"command": command},
+            result={"output": "ok", "exit_code": 0},
+        )
+        assert record["verdict"] == "weak"
+        assert record["evidence_tier"] == "tier_3"
+        assert record["evidence_refs"][0]["command_kind"] == "other"
+
+
+def test_claim_text_is_redacted_before_logging():
+    record = _record_for_response("Updated password='super-secret-token'.")
+    assert "super-secret-token" not in record["claim_text"]
+    assert "[REDACTED]" in record["claim_text"]
+
+
+def test_tested_claim_fails_on_structured_nonzero_exit_code():
+    record = _record_for_response(
+        "Tests passed: 21 passed.",
+        result={"output": "1 failed", "exit_code": 1},
+    )
+    assert record["verdict"] == "fail"
+    assert record["evidence_tier"] == "tier_1"
+    assert record["contradictions"]
+
+
+def test_modified_claim_supported_by_matching_path_mutation_evidence():
+    record = _record_for_response(
+        "Updated plugins/completion-auditor/report.py.",
+        tool_name="patch",
+        args={"path": "plugins/completion-auditor/report.py"},
+        result={"success": True},
+    )
+    assert record["verdict"] == "supported"
+    assert record["evidence_tier"] == "tier_1"
+    assert record["claim_scope"] == "plugins/completion-auditor/report.py"
+    assert record["evidence_refs"][0]["arg_refs"] == ["plugins/completion-auditor/report.py"]
+
+
+def test_modified_claim_weak_when_mutation_evidence_scope_does_not_match():
+    record = _record_for_response(
+        "Updated plugins/completion-auditor/report.py.",
+        tool_name="patch",
+        args={"path": "plugins/completion-auditor/config.py"},
+        result={"success": True},
+    )
+    assert record["verdict"] == "weak"
+    assert record["evidence_tier"] == "tier_3"
+    assert record["degraded"] is True
+    assert record["degrade_reason"] == "mutation evidence does not match claim_scope"
+
+
+def test_no_completion_claim_remains_not_applicable_even_with_evidence():
+    record = _record_for_response(
+        "Hermes plugins are opt-in.",
+        result={"output": "ok", "exit_code": 0},
+    )
+    assert record["verdict"] == "not_applicable"
+    assert record["evidence_tier"] == "tier_4"
+    assert record["claim_text"] is None


### PR DESCRIPTION
## Summary
- add audit-only completion-auditor plugin for local evidence-alignment metadata
- add classifier, evidence extraction, verdict/reporting helpers, and plugin config
- add focused plugin/classifier/verdict/reporting tests

## Test plan
- python -m pytest tests/plugins/test_completion_auditor_classifier.py tests/plugins/test_completion_auditor_plugin.py tests/plugins/test_completion_auditor_verdict.py tests/plugins/test_completion_auditor_reporting.py tests/test_transform_tool_result_hook.py tests/test_transform_llm_output_hook.py -q -o 'addopts='
- python -m py_compile plugins/completion-auditor/*.py
- git diff --cached --check