### PR TITLE
[codex] Include Discord reply attachments

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -4525,7 +4525,17 @@ class DiscordAdapter(BasePlatformAdapter):
                     auto_threaded_channel = thread
                     self._threads.mark(thread_id)
 
-        all_attachments = list(message.attachments) + snapshot_attachments
+        referenced_attachments = []
+        if message.reference and message.reference.resolved:
+            referenced_attachments.extend(
+                getattr(message.reference.resolved, "attachments", []) or []
+            )
+
+        all_attachments = (
+            list(message.attachments)
+            + snapshot_attachments
+            + referenced_attachments
+        )
 
         # Determine message type
         msg_type = MessageType.TEXT

--- a/tests/gateway/test_discord_attachment_download.py
+++ b/tests/gateway/test_discord_attachment_download.py
@@ -358,3 +358,54 @@ class TestHandleMessageUsesAuthenticatedRead:
         event = adapter.handle_message.call_args[0][0]
         assert event.media_urls == ["/tmp/img_from_read.png"]
         assert event.media_types == ["image/png"]
+
+    @pytest.mark.asyncio
+    async def test_referenced_image_attachment_is_forwarded_to_media(self, monkeypatch):
+        """Replying to an image message forwards the referenced attachment."""
+        adapter = _make_adapter()
+        adapter._client = SimpleNamespace(user=SimpleNamespace(id=999))
+        adapter.handle_message = AsyncMock()
+
+        with patch(
+            "gateway.platforms.discord.cache_image_from_bytes",
+            return_value="/tmp/referenced_img.png",
+        ), patch(
+            "gateway.platforms.discord.cache_image_from_url",
+            new_callable=AsyncMock,
+        ) as mock_url_download:
+            att = SimpleNamespace(
+                url="https://cdn.discordapp.com/attachments/fake/referenced.png",
+                filename="referenced.png",
+                content_type="image/png",
+                size=len(_PNG_BYTES),
+                read=AsyncMock(return_value=_PNG_BYTES),
+            )
+            from datetime import datetime, timezone
+
+            class _FakeDMChannel:
+                id = 100
+                name = "dm"
+
+            monkeypatch.setattr(
+                "gateway.platforms.discord.discord.DMChannel",
+                _FakeDMChannel,
+            )
+            chan = _FakeDMChannel()
+            referenced = SimpleNamespace(content="", attachments=[att])
+            msg = SimpleNamespace(
+                id=2,
+                content="what is this?",
+                attachments=[],
+                mentions=[],
+                reference=SimpleNamespace(message_id=1, resolved=referenced),
+                created_at=datetime.now(timezone.utc),
+                channel=chan,
+                author=SimpleNamespace(id=42, display_name="U", name="U"),
+            )
+            await adapter._handle_message(msg)
+
+        mock_url_download.assert_not_called()
+        event = adapter.handle_message.call_args[0][0]
+        assert event.media_urls == ["/tmp/referenced_img.png"]
+        assert event.media_types == ["image/png"]
+        assert event.reply_to_message_id == "1"


### PR DESCRIPTION
## Summary

- include attachments from a resolved Discord reply target when building incoming media
- let Hermes analyze images when a user replies to an earlier image and mentions the bot
- add a regression test for reply-target image attachments

## Root cause

The Discord adapter already forwarded direct message attachments and forwarded message snapshot attachments into `all_attachments`, but it dropped attachments from `message.reference.resolved`. In Discord, replying to an earlier image and mentioning the bot is a common way to ask about that specific image. Since the referenced message attachment was not forwarded to the vision pipeline, Hermes could fall back to unrelated recent channel history instead of the image the user explicitly replied to.

## Impact

This uses data already present on the Discord message object and does not add a Discord API call. Direct attachments keep priority, followed by snapshot attachments, then attachments from the resolved referenced message.

## Validation

- `venv/bin/python -m pytest -o addopts='' tests/gateway/test_discord_attachment_download.py`
- `venv/bin/python -m pytest -o addopts='' tests/tools/test_discord_tool.py`
- `/opt/homebrew/bin/python3.11 -m py_compile gateway/platforms/discord.py`
