### PR TITLE
fix Kubernetes container detection

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -848,28 +848,18 @@ def _secure_dir(path):
 
 
 def _is_container() -> bool:
-    """Detect if we're running inside a Docker/Podman/LXC container.
+    """Return whether config permission hardening should be container-safe.
 
     When Hermes runs in a container with volume-mounted config files, forcing
     0o600 permissions breaks multi-process setups where the gateway and
     dashboard run as different UIDs or the volume mount requires broader
     permissions.
     """
-    # Explicit opt-out
+    # Config-specific compatibility opt-outs. Keep these local: promoting them
+    # to the shared detector would change gateway, updater, and profile behavior.
     if os.environ.get("HERMES_CONTAINER") or os.environ.get("HERMES_SKIP_CHMOD"):
         return True
-    # Docker / Podman marker file
-    if os.path.exists("/.dockerenv"):
-        return True
-    # LXC / cgroup-based detection
-    try:
-        with open("/proc/1/cgroup", "r", encoding="utf-8") as f:
-            cgroup_content = f.read()
-        if "docker" in cgroup_content or "lxc" in cgroup_content or "kubepods" in cgroup_content:
-            return True
-    except (OSError, IOError):
-        pass
-    return False
+    return _running_in_container()
 
 
 def _secure_file(path):

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1,5 +1,7 @@
 """Tests for hermes_cli configuration management."""
 
+import builtins
+import io
 import os
 from pathlib import Path
 from unittest.mock import patch
@@ -7,6 +9,8 @@ from unittest.mock import patch
 import pytest
 import yaml
 
+import hermes_constants
+import hermes_cli.config as config_module
 from hermes_cli.config import (
     DEFAULT_CONFIG,
     check_config_version,
@@ -606,6 +610,80 @@ class TestSaveEnvValueSecure:
             parsed = dotenv_values(str(tmp_path / ".env"))
             assert parsed["ANTHROPIC_TOKEN"] == token
             assert load_env()["ANTHROPIC_TOKEN"] == token
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission behavior")
+class TestSecureFileContainerHandling:
+    @pytest.mark.parametrize("env_name", ["HERMES_CONTAINER", "HERMES_SKIP_CHMOD"])
+    def test_config_opt_out_preserves_existing_mode(
+        self, tmp_path, monkeypatch, env_name
+    ):
+        """Config-local opt-outs must not depend on global container detection."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("model: test\n", encoding="utf-8")
+        os.chmod(config_path, 0o640)
+
+        monkeypatch.delenv("HERMES_CONTAINER", raising=False)
+        monkeypatch.delenv("HERMES_SKIP_CHMOD", raising=False)
+        monkeypatch.setenv(env_name, "1")
+        monkeypatch.setattr(config_module, "is_managed", lambda: False)
+        monkeypatch.setattr(hermes_constants, "is_container", lambda: False)
+
+        config_module._secure_file(config_path)
+
+        assert config_path.stat().st_mode & 0o777 == 0o640
+
+    def test_shared_kubernetes_signal_preserves_existing_mode(
+        self, tmp_path, monkeypatch
+    ):
+        """Config permissions must inherit Kubernetes detection from the shared probe."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("model: test\n", encoding="utf-8")
+        os.chmod(config_path, 0o640)
+
+        monkeypatch.delenv("HERMES_CONTAINER", raising=False)
+        monkeypatch.delenv("HERMES_SKIP_CHMOD", raising=False)
+        monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.43.0.1")
+        monkeypatch.setattr(hermes_constants, "_container_detected", None)
+        monkeypatch.setattr(config_module, "is_managed", lambda: False)
+
+        real_exists = os.path.exists
+        marker_paths = {"/.dockerenv", "/run/.containerenv"}
+        monkeypatch.setattr(
+            os.path,
+            "exists",
+            lambda path: False if path in marker_paths else real_exists(path),
+        )
+
+        real_open = builtins.open
+
+        def fake_open(path, *args, **kwargs):
+            if path == "/proc/1/cgroup":
+                return io.StringIO("0::/\n")
+            if path == "/proc/self/mountinfo":
+                return io.StringIO("22 21 0:20 / /sys rw - sysfs sysfs rw\n")
+            return real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", fake_open)
+
+        config_module._secure_file(config_path)
+
+        assert config_path.stat().st_mode & 0o777 == 0o640
+
+    def test_regular_host_still_hardens_permissions(self, tmp_path, monkeypatch):
+        """Delegation must not weaken the owner-only default on regular hosts."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("model: test\n", encoding="utf-8")
+        os.chmod(config_path, 0o640)
+
+        monkeypatch.delenv("HERMES_CONTAINER", raising=False)
+        monkeypatch.delenv("HERMES_SKIP_CHMOD", raising=False)
+        monkeypatch.setattr(config_module, "is_managed", lambda: False)
+        monkeypatch.setattr(config_module, "_running_in_container", lambda: False)
+
+        config_module._secure_file(config_path)
+
+        assert config_path.stat().st_mode & 0o777 == 0o600
 
 
 class TestRemoveEnvValue:
@@ -1926,5 +2004,4 @@ class TestCodexAppServerAutoConfig:
 
             raw = yaml.safe_load((tmp_path / "config.yaml").read_text())
             assert raw["compression"]["codex_app_server_auto"] == "hermes"
-
 


### PR DESCRIPTION
## Summary

Fixes #44721.

- Extend `hermes_constants.is_container()` to detect Kubernetes/k3s pod environments via Kubernetes env/service-account signals and cgroup markers such as `kubepods`, `containerd`, and `crio`.
- Keep the existing Docker/Podman/LXC checks and honor the existing `HERMES_CONTAINER` explicit container hint.
- Make `hermes_cli.config._is_container()` delegate to the shared detector so config chmod behavior and gateway/service-manager behavior do not drift again.

## Root cause

`hermes -p coder gateway start` in a Kubernetes/k3s pod could fall through to the generic unsupported-platform path because the gateway/service-manager paths use `hermes_constants.is_container()`, which only recognized Docker/Podman/LXC markers. Kubernetes/containerd pods often lack those markers, so Hermes treated the pod like an unsupported bare Linux host.

## Validation

- Watched the new Kubernetes container-detection tests fail before the fix.
- `.\.venv\Scripts\python.exe scripts\run_tests_parallel.py tests/test_hermes_constants.py -- -q -k "IsContainer"` → 8 passed
- `.\.venv\Scripts\python.exe scripts\run_tests_parallel.py tests/hermes_cli/test_config.py -- -q -k "not default_path"` → 98 passed
- `.\.venv\Scripts\python.exe scripts\run_tests_parallel.py tests/hermes_cli/test_service_manager.py -- -q -k "detect_service_manager_returns_known_value"` → 1 passed
- `.\.venv\Scripts\ruff.exe check hermes_constants.py hermes_cli/config.py tests/test_hermes_constants.py` → passed
- `git diff --check` → passed

Note: the full `tests/test_hermes_constants.py` and `tests/hermes_cli/test_config.py` files have one pre-existing Windows-only default-path expectation failure in this local environment (`AppData/Local/hermes` vs `~/.hermes`), so I used the targeted cross-platform subsets above for this change.