### PR TITLE
fix: Kubernetes containers

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -701,7 +701,7 @@ def _secure_dir(path):
 
 
 def _is_container() -> bool:
-    """Detect if we're running inside a Docker/Podman/LXC container.
+    """Detect whether we're running inside a container.
 
     When Hermes runs in a container with volume-mounted config files, forcing
     0o600 permissions breaks multi-process setups where the gateway and
@@ -711,18 +711,9 @@ def _is_container() -> bool:
     # Explicit opt-out
     if os.environ.get("HERMES_CONTAINER") or os.environ.get("HERMES_SKIP_CHMOD"):
         return True
-    # Docker / Podman marker file
-    if os.path.exists("/.dockerenv"):
-        return True
-    # LXC / cgroup-based detection
-    try:
-        with open("/proc/1/cgroup", "r", encoding="utf-8") as f:
-            cgroup_content = f.read()
-        if "docker" in cgroup_content or "lxc" in cgroup_content or "kubepods" in cgroup_content:
-            return True
-    except (OSError, IOError):
-        pass
-    return False
+    from hermes_constants import is_container
+
+    return is_container()
 
 
 def _secure_file(path):

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -364,11 +364,12 @@ _container_detected: bool | None = None
 
 
 def is_container() -> bool:
-    """Return True when running inside a Docker/Podman container.
+    """Return True when running inside a container.
 
     Checks ``/.dockerenv`` (Docker), ``/run/.containerenv`` (Podman),
-    and ``/proc/1/cgroup`` for container runtime markers.  Result is
-    cached for the process lifetime.  Import-safe — no heavy deps.
+    and ``/proc/1/cgroup`` for container runtime markers, including
+    Kubernetes/containerd cgroup paths.  Result is cached for the process
+    lifetime.  Import-safe — no heavy deps.
     """
     global _container_detected
     if _container_detected is not None:
@@ -381,8 +382,19 @@ def is_container() -> bool:
         return True
     try:
         with open("/proc/1/cgroup", "r", encoding="utf-8") as f:
-            cgroup = f.read()
-            if "docker" in cgroup or "podman" in cgroup or "/lxc/" in cgroup:
+            cgroup = f.read().lower()
+            markers = (
+                "docker",
+                "podman",
+                "libpod",
+                "/lxc/",
+                "kubepods",
+                "containerd",
+                "cri-containerd",
+                "crio",
+                "cri-o",
+            )
+            if any(marker in cgroup for marker in markers):
                 _container_detected = True
                 return True
     except OSError:

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -106,7 +106,7 @@ class TestGetHermesHome:
 
 
 class TestIsContainer:
-    """Tests for is_container() — Docker/Podman detection."""
+    """Tests for is_container() — container runtime detection."""
 
     def _reset_cache(self, monkeypatch):
         """Reset the cached detection result before each test."""
@@ -135,6 +135,26 @@ class TestIsContainer:
         monkeypatch.setattr("builtins.open", lambda p, *a, **kw: _real_open(str(cgroup_file), *a, **kw) if p == "/proc/1/cgroup" else _real_open(p, *a, **kw))
         assert is_container() is True
 
+    @pytest.mark.parametrize(
+        "cgroup_line",
+        [
+            "0::/kubepods.slice/kubepods-burstable.slice/pod123/cri-containerd-abc.scope\n",
+            "0::/kubepods/besteffort/pod123/abc\n",
+            "0::/system.slice/containerd.service/kubepods/pod123/abc\n",
+            "0::/crio-abc.scope\n",
+        ],
+    )
+    def test_detects_kubernetes_container_cgroups(self, monkeypatch, tmp_path, cgroup_line):
+        """Kubernetes/containerd cgroup markers trigger container detection."""
+        import builtins
+        self._reset_cache(monkeypatch)
+        monkeypatch.setattr(os.path, "exists", lambda p: False)
+        cgroup_file = tmp_path / "cgroup"
+        cgroup_file.write_text(cgroup_line)
+        _real_open = builtins.open
+        monkeypatch.setattr("builtins.open", lambda p, *a, **kw: _real_open(str(cgroup_file), *a, **kw) if p == "/proc/1/cgroup" else _real_open(p, *a, **kw))
+        assert is_container() is True
+
     def test_negative_case(self, monkeypatch, tmp_path):
         """Returns False on a regular Linux host."""
         import builtins
@@ -153,6 +173,24 @@ class TestIsContainer:
         # Even if we make os.path.exists return False, cached value wins
         monkeypatch.setattr(os.path, "exists", lambda p: False)
         assert is_container() is True
+
+    @pytest.mark.parametrize("env_name", ["HERMES_CONTAINER", "HERMES_SKIP_CHMOD"])
+    def test_config_helper_honors_env_override(self, monkeypatch, env_name):
+        """Config permissions helper keeps its explicit container overrides."""
+        from hermes_cli import config as hermes_config
+
+        monkeypatch.setenv(env_name, "1")
+        assert hermes_config._is_container() is True
+
+    def test_config_helper_delegates_to_shared_detector(self, monkeypatch):
+        """Config permissions helper uses the shared container detector."""
+        from hermes_cli import config as hermes_config
+
+        monkeypatch.delenv("HERMES_CONTAINER", raising=False)
+        monkeypatch.delenv("HERMES_SKIP_CHMOD", raising=False)
+        monkeypatch.setattr(hermes_constants, "is_container", lambda: True)
+
+        assert hermes_config._is_container() is True
 
 
 class TestParseReasoningEffort:
@@ -297,4 +335,3 @@ class TestSecureParentDir:
         secure_parent_dir(link_target)
         assert len(called_with) == 1
         assert called_with[0] == (str(real_dir), 0o700)
-


### PR DESCRIPTION
## Summary
- recognize Kubernetes/containerd cgroup markers in shared container detection
- make the config permission helper delegate to the shared detector
- add regression coverage for Kubernetes and CRI-style cgroup paths

## Why
In Kubernetes/k3s Pods, gateway lifecycle commands can miss the container runtime and fall through to unsupported host-service handling.

Fixes #44721.

## Validation
- `git diff --check`
- `/Users/flownium/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_hermes_constants.py -q`