### PR TITLE
fix(file-tools): normalize MSYS/Git Bash paths on Windows

### DIFF
--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -365,7 +365,7 @@ def _path_resolution_warning(filepath: str, resolved: Path, task_id: str = "defa
                 f"OUTSIDE the active workspace ({str(root)!r}). The edit will land in "
                 f"a different directory than the terminal's cwd. If this is not "
                 f"intended (e.g. a git-worktree session writing into the main "
-                f"checkout), pass a native absolute path (e.g. D:\\Project\file "
+                f"checkout), pass a native absolute path (e.g. D:/Project/file "
                 f"on Windows) under the workspace instead."
             )
     except Exception:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -6,6 +6,8 @@ import json
 import logging
 import os
 import threading
+import platform as _platform
+import re as _re
 from pathlib import Path
 
 from agent.file_safety import get_read_block_error
@@ -282,12 +284,48 @@ def _resolve_base_dir(task_id: str = "default") -> Path:
     return base.resolve()
 
 
+_IS_WINDOWS = _platform.system() == "Windows"
+
+
+def _normalize_msys_path(filepath: str) -> str:
+    """Normalize MSYS / Git Bash style paths to native form on Windows.
+
+    On Windows, ``pathlib.Path`` treats ``/d/Project/file`` as an absolute
+    path on the *current drive* (root ``\`` with no drive letter), resolving
+    it to e.g. ``D:\d\Project\file`` instead of ``D:\Project\file``.
+
+    This function converts MSYS-style drive paths (``/c/Users/...``,
+    ``/cygdrive/d/...``, ``/mnt/c/...``) to native Windows form before
+    ``Path`` construction, matching the conversion already applied by
+    ``_msys_to_windows_path`` in ``tools/environments/local.py`` and
+    ``_normalize_git_bash_path`` in ``cli.py``.
+
+    No-op on non-Windows platforms and for paths that are not in MSYS form.
+    """
+    if not _IS_WINDOWS or not filepath:
+        return filepath
+    # /c/Users/... or /C/Users/...  (also handles bare /c/ = drive root)
+    m = _re.match(r"^/([a-zA-Z])/(.*)$", filepath)
+    if m:
+        drive = m.group(1).upper()
+        rest = m.group(2).replace("/", os.sep)
+        return f"{drive}:{os.sep}{rest}" if rest else f"{drive}:{os.sep}"
+    # /cygdrive/c/... or /mnt/c/...
+    m = _re.match(r"^/(?:cygdrive|mnt)/([a-zA-Z])/(.*)$", filepath)
+    if m:
+        drive = m.group(1).upper()
+        rest = m.group(2).replace("/", os.sep)
+        return f"{drive}:{os.sep}{rest}" if rest else f"{drive}:{os.sep}"
+    return filepath
+
+
 def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path:
     """Resolve *filepath* against the task's absolute base directory.
 
     See :func:`_resolve_base_dir` for how the base is chosen. Absolute input
     paths are returned resolved-but-unanchored.
     """
+    filepath = _normalize_msys_path(filepath)
     p = Path(_expand_tilde(filepath))
     if p.is_absolute():
         return p.resolve()

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -348,7 +348,8 @@ def _path_resolution_warning(filepath: str, resolved: Path, task_id: str = "defa
     (no ``cd`` run yet) is warned on the very first write.
     """
     try:
-        if Path(_expand_tilde(filepath)).is_absolute():
+        normalized = _normalize_msys_path(filepath)
+        if Path(_expand_tilde(normalized)).is_absolute():
             return None
         workspace_root = _authoritative_workspace_root(task_id)
         if not workspace_root:
@@ -360,11 +361,12 @@ def _path_resolution_warning(filepath: str, resolved: Path, task_id: str = "defa
             return None  # Inside the workspace — expected.
         except ValueError:
             return (
-                f"Relative path {filepath!r} resolved to {str(resolved)!r}, which is "
+                f"Path {filepath!r} resolved to {str(resolved)!r}, which is "
                 f"OUTSIDE the active workspace ({str(root)!r}). The edit will land in "
                 f"a different directory than the terminal's cwd. If this is not "
                 f"intended (e.g. a git-worktree session writing into the main "
-                f"checkout), pass an absolute path under the workspace instead."
+                f"checkout), pass a native absolute path (e.g. D:\\Project\file "
+                f"on Windows) under the workspace instead."
             )
     except Exception:
         return None


### PR DESCRIPTION
## Summary

On Windows + Git Bash/MSYS2, file tools (`write_file`, `read_file`, `patch`, `search_files`) silently resolve MSYS-style paths (`/d/Project/file.sh`) to wrong locations (`D:\d\Project\_check_pr.sh`) because `_resolve_path_for_task()` lacks MSYS path normalization.

The codebase already has MSYS→Windows path conversion in two places:
- `_msys_to_windows_path()` in `tools/environments/local.py` (for terminal cwd)
- `_normalize_git_bash_path()` in `cli.py` (for git repo root)

But `file_tools.py` was missed. Additionally, the system prompt (`prompt_builder.py:715`) tells the model that MSYS-style paths "work alongside native `C:\Users\...` paths" — which is **incorrect for file tools**.

## Changes

- Added `_normalize_msys_path()` to `tools/file_tools.py` — same conversion pattern as existing functions, handling `/c/Users/...`, `/cygdrive/d/...`, and `/mnt/c/...` variants
- Applied normalization in `_resolve_path_for_task()` before `Path()` construction
- No-op on non-Windows platforms (early return)

## Test Plan

Manual verification on Windows (this fix was developed on Linux; Windows testing needed):

```python
# Before fix (Windows, cwd = D:\Project\Hermes):
Path("/d/Project/file.sh").resolve()  # → D:\d\Project\file.sh ❌

# After fix:
_normalize_msys_path("/d/Project/file.sh")  # → "D:\Project\file.sh"
Path("D:\Project\file.sh").resolve()        # → D:\Project\file.sh ✅
```

Path patterns that should NOT be converted (verified):
- `/home/user` → unchanged (multi-char after first `/`)
- `/dev/zero` → unchanged
- `/etc/config` → unchanged
- `D:/Project/file.sh` → unchanged (already native)
- `./relative/path` → unchanged

Closes #44726

Related: #39834, #35819, #17999
