### PR TITLE
fix: stop Discord typing after replies

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3163,6 +3163,38 @@ class BasePlatformAdapter(ABC):
                     pass
             self._typing_paused.discard(chat_id)
 
+    async def _stop_typing_refresh(
+        self,
+        chat_id: str,
+        typing_task: asyncio.Task | None = None,
+        *,
+        timeout: float = 0.5,
+        stop_attempts: int = 2,
+    ) -> None:
+        """Stop the refresh task and platform typing state as one operation."""
+        self._typing_paused.add(chat_id)
+        try:
+            if typing_task is not None and not typing_task.done():
+                typing_task.cancel()
+                try:
+                    await asyncio.wait_for(asyncio.shield(typing_task), timeout=timeout)
+                except (asyncio.CancelledError, asyncio.TimeoutError):
+                    # The task is cancelled; don't let a slow adapter-specific
+                    # cleanup block response delivery or shutdown.
+                    pass
+            if not hasattr(self, "stop_typing"):
+                return
+            attempts = max(1, stop_attempts)
+            for attempt in range(attempts):
+                try:
+                    await self.stop_typing(chat_id)
+                except Exception:
+                    pass
+                if attempt < attempts - 1:
+                    await asyncio.sleep(0)
+        finally:
+            self._typing_paused.discard(chat_id)
+
     def pause_typing_for_chat(self, chat_id: str) -> None:
         """Pause typing indicator for a chat (e.g. during approval waits).
 
@@ -4092,14 +4124,10 @@ class BasePlatformAdapter(ABC):
         )
 
         async def _stop_typing_task() -> None:
-            typing_task.cancel()
-            try:
-                await asyncio.wait_for(asyncio.shield(typing_task), timeout=0.5)
-            except (asyncio.CancelledError, asyncio.TimeoutError):
-                # Cancellation cleanup must not block adapter shutdown.  The
-                # typing task is already cancelled; if the parent task is also
-                # cancelling, let this message-processing task unwind now.
-                pass
+            await self._stop_typing_refresh(
+                event.source.chat_id,
+                typing_task,
+            )
         
         try:
             await self._run_processing_hook("on_processing_start", event)
@@ -4486,11 +4514,6 @@ class BasePlatformAdapter(ABC):
             # callbacks may perform platform I/O; a stuck callback must not
             # leave the typing refresh task running indefinitely.
             await _stop_typing_task()
-            try:
-                if hasattr(self, "stop_typing"):
-                    await self.stop_typing(event.source.chat_id)
-            except Exception:
-                pass
             # Fire any one-shot post-delivery callback registered for this
             # session (e.g. deferred background-review notifications).
             #
@@ -4524,13 +4547,14 @@ class BasePlatformAdapter(ABC):
                         )
                 except (asyncio.TimeoutError, Exception):
                     pass
-            # Also cancel any platform-level persistent typing tasks (e.g. Discord)
-            # that may have been recreated by _keep_typing after the last stop_typing()
-            try:
-                if hasattr(self, "stop_typing"):
-                    await self.stop_typing(event.source.chat_id)
-            except Exception:
-                pass
+            # Some adapters keep platform-level typing tasks.  If callback
+            # work or a late refresh recreated one, make one final bounded stop
+            # before releasing the session guard.
+            await self._stop_typing_refresh(
+                event.source.chat_id,
+                None,
+                stop_attempts=1,
+            )
             # Final drain/release boundary: force-flush any timer that missed
             # the in-band drain before deciding whether the guard can clear.
             await self._flush_text_debounce_now(session_key)

--- a/tests/gateway/test_keep_typing_timeout.py
+++ b/tests/gateway/test_keep_typing_timeout.py
@@ -198,3 +198,39 @@ class TestKeepTypingTimeoutPerTick:
         assert calls == [], (
             f"send_typing was called on a paused chat: {calls}"
         )
+
+    @pytest.mark.asyncio
+    async def test_stop_typing_refresh_blocks_late_cancel_tick(self, monkeypatch):
+        """Final cleanup must not let a cancelled refresh loop send typing again."""
+        adapter = _StubAdapter()
+        late_sends = []
+        stop_calls = []
+
+        async def send_typing(chat_id, metadata=None):
+            late_sends.append(chat_id)
+
+        async def stop_typing(chat_id):
+            stop_calls.append((chat_id, chat_id in adapter._typing_paused))
+
+        monkeypatch.setattr(adapter, "send_typing", send_typing)
+        monkeypatch.setattr(adapter, "stop_typing", stop_typing)
+
+        async def late_refresh_after_cancel():
+            try:
+                await asyncio.sleep(10)
+            except asyncio.CancelledError:
+                if "discord-chat" not in adapter._typing_paused:
+                    await adapter.send_typing("discord-chat")
+                raise
+
+        task = asyncio.create_task(late_refresh_after_cancel())
+        await asyncio.sleep(0)
+
+        await adapter._stop_typing_refresh("discord-chat", task, timeout=1.0)
+
+        assert late_sends == []
+        assert stop_calls == [
+            ("discord-chat", True),
+            ("discord-chat", True),
+        ]
+        assert "discord-chat" not in adapter._typing_paused


### PR DESCRIPTION
## Summary
- stop the typing refresh loop and platform typing state through one shared cleanup path
- pause typing refreshes while cleanup is cancelling the stale refresh task
- add a regression test for a cancelled refresh loop trying to send one last typing event

## Why
Discord keeps its typing indicator alive through a platform-level task. A final-response cleanup could cancel the shared refresh task while a late refresh still recreated that platform typing task, leaving users thinking the agent was still working after the reply was delivered.

Fixes #44677.

## Validation
- `git diff --check`
- `/Users/flownium/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_keep_typing_timeout.py tests/gateway/test_discord_send.py -q`
- `/Users/flownium/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_pending_drain_race.py tests/gateway/test_pending_drain_no_recursion.py tests/gateway/test_base_topic_sessions.py -q`