### PR TITLE
fix(security): remove mutable display-name from SimpleX allowlist check

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -336,20 +336,15 @@ class GatewayAuthorizationMixin:
             if normalized_user_id:
                 check_ids.add(normalized_user_id)
 
-        # SimpleX: SIMPLEX_ALLOWED_USERS accepts either the numeric contactId
-        # or the contact's display name. The adapter sets user_id=contactId for
-        # stability across renames, but the SimpleX UI never surfaces the
-        # numeric id — operators only see display names, so that's what they
-        # naturally put in the env var. Match both so the allowlist works
-        # regardless of which form was chosen.
+        # SimpleX: SIMPLEX_ALLOWED_USERS must match only the stable numeric
+        # contactId (held in user_id), NOT the mutable display name
+        # (user_name).  A contact's localDisplayName / profile.displayName
+        # is attacker-controlled: any SimpleX contact can set their display
+        # name to match another user's, which would bypass the allowlist if
+        # user_name were also checked.  Operators should put the numeric
+        # contactId in SIMPLEX_ALLOWED_USERS.
         # Plugin platform: compare by value since Platform.SIMPLEX is not a
         # hardcoded enum member (it's a dynamic plugin platform).
-        if (
-            source.platform is not None
-            and source.platform.value == "simplex"
-            and source.user_name
-        ):
-            check_ids.add(source.user_name)
 
         return bool(check_ids & allowed_ids)
 

--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -190,9 +190,9 @@ def _principal_matches_allowlist(source, user_id: str, allowed_ids: set) -> bool
             check_ids.add(normalized_user_id)
 
     platform_value = source.platform.value if source.platform is not None else None
-    # SimpleX: user_id is the numeric contactId but the UI only shows display names.
-    if platform_value == "simplex" and source.user_name:
-        check_ids.add(source.user_name)
+    # SimpleX: SIMPLEX_ALLOWED_USERS matches only the stable numeric contactId (user_id).
+    # The display name (user_name) is attacker-controlled — any contact can adopt another
+    # contact's display name, so matching it would bypass the allowlist (#44729).
     # Buzz: allowlist may hold npub or hex; inbound pubkeys are hex.
     if platform_value == "buzz":
         # Buzz (Nostr-based): BUZZ_ALLOWED_USERS accepts npub or hex, but inbound event pubkeys are always

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -2,7 +2,7 @@
 or ``docker run -p 5225:5225 simplexchat/simplex-chat-cli -p 5225``); JSON commands out, events in.
 
 Env: SIMPLEX_WS_URL (required; default ws://127.0.0.1:5225) · SIMPLEX_ALLOWED_USERS (numeric
-contactIds — stable across renames, see ``/contacts`` — or display names) · SIMPLEX_ALLOW_ALL_USERS ·
+contactIds — stable across renames, see ``/contacts``) · SIMPLEX_ALLOW_ALL_USERS ·
 SIMPLEX_AUTO_ACCEPT ('false' disables contact-request auto-accept; default true) ·
 SIMPLEX_GROUP_ALLOWED (group IDs or '*'; omit to ignore groups) · SIMPLEX_HOME_CHANNEL[_NAME] ·
 HERMES_SIMPLEX_TEXT_BATCH_DELAY (quiet seconds, default 0.8, merging rapid-fire inbound text).
@@ -652,7 +652,7 @@ async def _standalone_send(
 
 _SETUP_PROMPTS = (
     ("SIMPLEX_WS_URL", "Daemon WebSocket URL (default ws://127.0.0.1:5225)"),
-    ("SIMPLEX_ALLOWED_USERS", "Allowed contactIds or display names (comma-separated; blank=skip)"),
+    ("SIMPLEX_ALLOWED_USERS", "Allowed contactIds (comma-separated; blank=skip)"),
     ("SIMPLEX_GROUP_ALLOWED", "Allowed group IDs (comma-separated, or '*' for any; blank=disable groups)"),
     ("SIMPLEX_AUTO_ACCEPT", "Auto-accept incoming contact requests? (true/false, default true)"),
     ("SIMPLEX_HOME_CHANNEL", "Home channel contact/group ID (or empty)"))

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -449,3 +449,11 @@ def test_multiplex_scope_reads_profile_own_env_not_default(
     seeded = _env_enablement()
     assert seeded == {"ws_url": "ws://profile:5225", "group_allowed": "g1"}
     assert check_requirements() is True
+
+
+def test_setup_prompts_no_longer_offer_display_names():
+    """The setup wizard must not suggest display names as SIMPLEX_ALLOWED_USERS
+    values: authorization only matches the stable numeric contactId, and a
+    display-name entry would silently fail closed (#44729)."""
+    prompts = dict(_simplex._SETUP_PROMPTS)
+    assert "display name" not in prompts["SIMPLEX_ALLOWED_USERS"].lower()

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -100,11 +100,11 @@ def test_whatsapp_lid_user_matches_phone_allowlist_via_session_mapping(monkeypat
     assert runner._is_user_authorized(source) is True
 
 
-def test_simplex_allowlist_accepts_display_name(monkeypatch):
-    """SIMPLEX_ALLOWED_USERS should match the contact's display name as well
-    as the numeric contactId. The SimpleX UI surfaces only display names, so
-    operators naturally put those in the env var — and the adapter sets
-    user_id=contactId for stability. Both forms must work. (#TBD)"""
+def test_simplex_allowlist_rejects_display_name_only(monkeypatch):
+    """SIMPLEX_ALLOWED_USERS must NOT match the mutable display name — only
+    the stable numeric contactId.  A different contact can set their display
+    name to the same value, so matching on user_name would be an auth bypass.
+    See security advisory: display name collision bypass."""
     _clear_auth_env(monkeypatch)
     monkeypatch.delenv("SIMPLEX_ALLOWED_USERS", raising=False)
     monkeypatch.setenv("SIMPLEX_ALLOWED_USERS", "hujikuji")
@@ -126,8 +126,9 @@ def test_simplex_allowlist_accepts_display_name(monkeypatch):
         GatewayConfig(platforms={simplex: PlatformConfig(enabled=True)}),
     )
 
-    # contactId in the allowlist would still work — but the operator chose
-    # the display name. Verify the gateway honors it.
+    # The operator put the display name in the allowlist, but user_id is the
+    # stable contactId which differs. This must be rejected because display
+    # names are attacker-controlled.
     source = SessionSource(
         platform=simplex,
         user_id="4",            # adapter sets this to the numeric contactId
@@ -135,7 +136,7 @@ def test_simplex_allowlist_accepts_display_name(monkeypatch):
         user_name="hujikuji",   # adapter sets this to displayName
         chat_type="dm",
     )
-    assert runner._is_user_authorized(source) is True
+    assert runner._is_user_authorized(source) is False  # display name must NOT match
 
 
 def test_simplex_allowlist_accepts_numeric_contact_id(monkeypatch):
@@ -198,6 +199,42 @@ def test_simplex_allowlist_denies_unlisted(monkeypatch):
         user_id="7",
         chat_id="stranger",
         user_name="stranger",
+        chat_type="dm",
+    )
+    assert runner._is_user_authorized(source) is False
+
+
+def test_simplex_allowlist_rejects_colliding_display_name(monkeypatch):
+    """Security: a different contact who sets the same display name as an
+    allowed user must NOT pass the allowlist check.  The allowlist must only
+    match on the stable contactId (user_id), not the mutable user_name."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.delenv("SIMPLEX_ALLOWED_USERS", raising=False)
+    # Operator allowed contactId "4" (who happens to use display name "hujikuji")
+    monkeypatch.setenv("SIMPLEX_ALLOWED_USERS", "4")
+
+    from gateway.platform_registry import platform_registry, PlatformEntry
+    platform_registry.register(PlatformEntry(
+        name="simplex",
+        label="SimpleX Chat",
+        adapter_factory=lambda cfg: None,
+        check_fn=lambda: True,
+        allowed_users_env="SIMPLEX_ALLOWED_USERS",
+        allow_all_env="SIMPLEX_ALLOW_ALL_USERS",
+    ))
+
+    simplex = Platform("simplex")
+    runner, _adapter = _make_runner(
+        simplex,
+        GatewayConfig(platforms={simplex: PlatformConfig(enabled=True)}),
+    )
+
+    # Attacker: different contactId ("7") but same display name as the allowed user
+    source = SessionSource(
+        platform=simplex,
+        user_id="7",              # different contactId — NOT in allowlist
+        chat_id="attacker",
+        user_name="hujikuji",     # same display name as allowed user
         chat_type="dm",
     )
     assert runner._is_user_authorized(source) is False

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -119,11 +119,11 @@ def test_whatsapp_lid_user_matches_phone_allowlist_via_modern_session_mapping(
     assert runner._is_user_authorized(source) is True
 
 
-def test_simplex_allowlist_accepts_display_name(monkeypatch):
-    """SIMPLEX_ALLOWED_USERS should match the contact's display name as well
-    as the numeric contactId. The SimpleX UI surfaces only display names, so
-    operators naturally put those in the env var — and the adapter sets
-    user_id=contactId for stability. Both forms must work. (#TBD)"""
+def test_simplex_allowlist_rejects_display_name_only(monkeypatch):
+    """SIMPLEX_ALLOWED_USERS must NOT match the contact's display name — only
+    the stable numeric contactId. A different contact can set their display
+    name to the same value, so matching user_name would bypass the allowlist
+    (security: display-name collision bypass, #44729)."""
     _clear_auth_env(monkeypatch)
     monkeypatch.delenv("SIMPLEX_ALLOWED_USERS", raising=False)
     monkeypatch.setenv("SIMPLEX_ALLOWED_USERS", "hujikuji")
@@ -145,13 +145,83 @@ def test_simplex_allowlist_accepts_display_name(monkeypatch):
         GatewayConfig(platforms={simplex: PlatformConfig(enabled=True)}),
     )
 
-    # contactId in the allowlist would still work — but the operator chose
-    # the display name. Verify the gateway honors it.
+    # The operator put the display name in the allowlist, but user_id is the
+    # stable contactId which differs. Display names are attacker-controlled,
+    # so this must be rejected.
     source = SessionSource(
         platform=simplex,
         user_id="4",            # adapter sets this to the numeric contactId
         chat_id="hujikuji",
         user_name="hujikuji",   # adapter sets this to displayName
+        chat_type="dm",
+    )
+    assert runner._is_user_authorized(source) is False
+
+
+def test_simplex_allowlist_rejects_colliding_display_name(monkeypatch):
+    """Security regression guard: a contact whose contactId is NOT in the
+    allowlist must stay unauthorized even when they adopt the display name of
+    an allowed contact (#44729)."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.delenv("SIMPLEX_ALLOWED_USERS", raising=False)
+    # Operator allowed contactId "4" (who happens to use display name "hujikuji")
+    monkeypatch.setenv("SIMPLEX_ALLOWED_USERS", "4")
+
+    from gateway.platform_registry import platform_registry, PlatformEntry
+    platform_registry.register(PlatformEntry(
+        name="simplex",
+        label="SimpleX Chat",
+        adapter_factory=lambda cfg: None,
+        check_fn=lambda: True,
+        allowed_users_env="SIMPLEX_ALLOWED_USERS",
+        allow_all_env="SIMPLEX_ALLOW_ALL_USERS",
+    ))
+
+    simplex = Platform("simplex")
+    runner, _adapter = _make_runner(
+        simplex,
+        GatewayConfig(platforms={simplex: PlatformConfig(enabled=True)}),
+    )
+
+    # Attacker: different contactId ("7") but same display name as the allowed user
+    source = SessionSource(
+        platform=simplex,
+        user_id="7",              # different contactId — NOT in allowlist
+        chat_id="attacker",
+        user_name="hujikuji",     # same display name as allowed user
+        chat_type="dm",
+    )
+    assert runner._is_user_authorized(source) is False
+
+
+def test_simplex_allowlist_accepts_numeric_contact_id(monkeypatch):
+    """SIMPLEX_ALLOWED_USERS continues to match the stable numeric contactId
+    (user_id) — the one identity form a SimpleX contact cannot forge."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.delenv("SIMPLEX_ALLOWED_USERS", raising=False)
+    monkeypatch.setenv("SIMPLEX_ALLOWED_USERS", "4")
+
+    from gateway.platform_registry import platform_registry, PlatformEntry
+    platform_registry.register(PlatformEntry(
+        name="simplex",
+        label="SimpleX Chat",
+        adapter_factory=lambda cfg: None,
+        check_fn=lambda: True,
+        allowed_users_env="SIMPLEX_ALLOWED_USERS",
+        allow_all_env="SIMPLEX_ALLOW_ALL_USERS",
+    ))
+
+    simplex = Platform("simplex")
+    runner, _adapter = _make_runner(
+        simplex,
+        GatewayConfig(platforms={simplex: PlatformConfig(enabled=True)}),
+    )
+
+    source = SessionSource(
+        platform=simplex,
+        user_id="4",              # numeric contactId in the allowlist
+        chat_id="hujikuji",
+        user_name="whatever",     # display name is irrelevant to the verdict
         chat_type="dm",
     )
     assert runner._is_user_authorized(source) is True


### PR DESCRIPTION
## What does this PR do?

Removes the mutable display name (`user_name`) from the SimpleX sender allowlist check in `gateway/authz_mixin.py`. The allowlist now matches only on the stable numeric `contactId` (held in `user_id`), closing an authorization bypass where any SimpleX contact could set a colliding display name to gain unauthorized access.

**Why fail-closed is the right trade-off — the `alice` / `alice_1` late-arrival case.** SimpleX display names are not exclusive: when a second contact presenting the same name connects, the client suffixes it (`alice` → `alice_1`), so which contact "owns" the bare name is decided by connection order, not identity. An attacker who connects first and presents `alice` holds the bare display name, while the legitimate Alice — arriving later — is rendered as `alice_1`. Under display-name matching, the allowlist entry the operator added for Alice authorizes the attacker, and no re-checking of the contact list can fix it, because the mapping the operator relies on ("`alice` = my friend") is exactly what the ordering attack corrupted. Matching only the immutable numeric `contactId` removes this ordering dependence entirely; a display-name-only entry failing closed is strictly safer than authorizing whoever connected first.

Rebased onto latest `main`: the SimpleX check has moved into the module-level `_principal_matches_allowlist()` helper during an upstream refactor; the fix is applied at the new location with identical semantics. Also stops the setup wizard and module docstring from advertising display names as `SIMPLEX_ALLOWED_USERS` values (they would now fail closed).

## Related Issue

Fixes #44729

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/authz_mixin.py`: Removed the `check_ids.add(source.user_name)` block for SimpleX in `_principal_matches_allowlist()` (new home of the check after the upstream authz refactor). Updated the comment to explain that only the immutable `contactId` authorizes, since display names are attacker-controlled.
- `plugins/platforms/simplex/adapter.py`: Setup-wizard prompt and module docstring no longer offer display names as `SIMPLEX_ALLOWED_USERS` values — a display-name entry would now silently fail closed, so the copy points operators at numeric contactIds (visible via `/contacts`).
- `tests/gateway/test_unauthorized_dm_behavior.py`: Renamed `test_simplex_allowlist_accepts_display_name` → `test_simplex_allowlist_rejects_display_name_only` and flipped its assertion from `True` to `False`. Added `test_simplex_allowlist_rejects_colliding_display_name` — a fail-closed test verifying that a different contact with a matching display name is rejected. Added `test_simplex_allowlist_accepts_numeric_contact_id` — positive anchor that stable contactId auth keeps working.
- `tests/gateway/test_simplex_plugin.py`: Added `test_setup_prompts_no_longer_offer_display_names` so the wizard copy cannot regress back to suggesting display names.

## How to Test

1. Run `pytest tests/gateway/test_unauthorized_dm_behavior.py tests/gateway/test_simplex_plugin.py -q` — all 34 tests pass (Observed result: 34 passed).
2. Specifically verify `test_simplex_allowlist_rejects_colliding_display_name` passes (the new security regression test).
3. Red/green check: reverting only the `authz_mixin.py` hunk makes `test_simplex_allowlist_rejects_display_name_only` fail (display name gets authorized), confirming the tests pin the vulnerability.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/authz_mixin.py::_principal_matches_allowlist()` — the single SimpleX-specific auth check path (moved out of `_is_user_authorized()` by the upstream authz refactor)
- Blast radius: LOW — only affects SimpleX platform allowlist behavior; no other platforms touched
- Related patterns: Same `check_ids` pattern is used by WhatsApp (LID alias expansion) and Buzz (npub→hex); those are unaffected
