### PR TITLE
fix(security): add SSRF guard to save_url_image for provider-returned URLs

### DIFF
--- a/agent/image_gen_provider.py
+++ b/agent/image_gen_provider.py
@@ -225,6 +225,17 @@ def save_url_image(
     """
     import requests
 
+    # SSRF guard: validate the provider-returned URL against the same
+    # private-network policy used for user-supplied URLs.  A compromised
+    # or malicious provider could return a URL targeting internal hosts,
+    # loopback addresses, or cloud metadata endpoints.
+    from tools.url_safety import is_safe_url
+
+    if not is_safe_url(url):
+        raise ValueError(
+            f"Blocked: provider-returned URL targets a private or internal address: {url}"
+        )
+
     response = requests.get(url, timeout=timeout, stream=True)
     response.raise_for_status()
 

--- a/agent/image_gen_provider.py
+++ b/agent/image_gen_provider.py
@@ -229,23 +229,40 @@ def save_url_image(
     # private-network policy used for user-supplied URLs.  A compromised
     # or malicious provider could return a URL targeting internal hosts,
     # loopback addresses, or cloud metadata endpoints.
+    #
+    # We must intercept redirects *before* the HTTP library follows them,
+    # otherwise the request to the private address has already been made
+    # by the time we inspect ``response.url``.  Using
+    # ``allow_redirects=False`` gives us control over each hop.
     from tools.url_safety import is_safe_url
 
-    if not is_safe_url(url):
+    _current_url = url
+    if not is_safe_url(_current_url):
         raise ValueError(
-            f"Blocked: provider-returned URL targets a private or internal address: {url}"
+            f"Blocked: provider-returned URL targets a private or internal address: {_current_url}"
         )
 
-    response = requests.get(url, timeout=timeout, stream=True)
+    _MAX_REDIRECTS = 10
+    response = None
+    for _hop in range(_MAX_REDIRECTS + 1):
+        response = requests.get(
+            _current_url, timeout=timeout, stream=True, allow_redirects=False
+        )
+        # 3xx with Location → validate before following
+        if response.is_redirect and response.headers.get("Location"):
+            from urllib.parse import urljoin
+
+            next_url = urljoin(_current_url, response.headers["Location"])
+            if not is_safe_url(next_url):
+                raise ValueError(
+                    f"Blocked: redirect target is a private or internal address: {next_url}"
+                )
+            _current_url = next_url
+            response.close()
+            continue
+        # Final response (non-redirect) — break out
+        break
     response.raise_for_status()
-
-    # Re-validate after redirects: a safe initial URL may redirect to a
-    # private/internal address via a compromised CDN or provider.
-    final_url = getattr(response, "url", url) or url
-    if final_url != url and not is_safe_url(final_url):
-        raise ValueError(
-            f"Blocked: redirect target is a private or internal address: {final_url}"
-        )
 
     # Infer extension from the response content-type, falling back to the
     # URL suffix when xAI / OpenAI omit a precise type (some CDNs return

--- a/agent/image_gen_provider.py
+++ b/agent/image_gen_provider.py
@@ -262,6 +262,13 @@ def save_url_image(
             continue
         # Final response (non-redirect) — break out
         break
+    else:
+        # Loop exhausted — too many safe redirects without a final response
+        if response is not None:
+            response.close()
+        raise ValueError(
+            f"Blocked: too many redirects (>{_MAX_REDIRECTS}) fetching provider-returned URL"
+        )
     response.raise_for_status()
 
     # Infer extension from the response content-type, falling back to the

--- a/agent/image_gen_provider.py
+++ b/agent/image_gen_provider.py
@@ -239,6 +239,14 @@ def save_url_image(
     response = requests.get(url, timeout=timeout, stream=True)
     response.raise_for_status()
 
+    # Re-validate after redirects: a safe initial URL may redirect to a
+    # private/internal address via a compromised CDN or provider.
+    final_url = getattr(response, "url", url) or url
+    if final_url != url and not is_safe_url(final_url):
+        raise ValueError(
+            f"Blocked: redirect target is a private or internal address: {final_url}"
+        )
+
     # Infer extension from the response content-type, falling back to the
     # URL suffix when xAI / OpenAI omit a precise type (some CDNs return
     # ``application/octet-stream``).  Defaults to ``png``.

--- a/tests/agent/test_image_gen_ssrf_guard.py
+++ b/tests/agent/test_image_gen_ssrf_guard.py
@@ -1,0 +1,49 @@
+"""Tests for save_url_image SSRF guard in agent.image_gen_provider."""
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(tmp_path, monkeypatch):
+    """Point HERMES_HOME at a temp dir so cache writes land safely."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+
+
+def test_save_url_image_blocks_private_loopback():
+    """SSRF guard: save_url_image must reject loopback URLs."""
+    from agent.image_gen_provider import save_url_image
+
+    with pytest.raises(ValueError, match="private or internal"):
+        save_url_image("http://127.0.0.1:8080/secret")
+
+
+def test_save_url_image_blocks_cloud_metadata():
+    """SSRF guard: save_url_image must reject cloud metadata endpoints."""
+    from agent.image_gen_provider import save_url_image
+
+    with pytest.raises(ValueError, match="private or internal"):
+        save_url_image("http://169.254.169.254/latest/meta-data/")
+
+
+def test_save_url_image_blocks_internal_host():
+    """SSRF guard: save_url_image must reject internal network addresses."""
+    from agent.image_gen_provider import save_url_image
+
+    with pytest.raises(ValueError, match="private or internal"):
+        save_url_image("http://10.0.0.1/admin")
+
+
+def test_save_url_image_allows_public_url():
+    """SSRF guard: save_url_image should proceed with valid public URLs."""
+    from agent.image_gen_provider import save_url_image
+
+    mock_response = MagicMock()
+    mock_response.headers = {"Content-Type": "image/png"}
+    mock_response.raise_for_status = MagicMock()
+    mock_response.iter_content = MagicMock(return_value=[b"\x89PNG\r\n"])
+
+    with patch("requests.get", return_value=mock_response),          patch("tools.url_safety.is_safe_url", return_value=True):
+        path = save_url_image("https://api.x.ai/v1/images/abc.png")
+        assert path.exists()
+        assert path.name.endswith(".png")

--- a/tests/agent/test_image_gen_ssrf_guard.py
+++ b/tests/agent/test_image_gen_ssrf_guard.py
@@ -109,7 +109,6 @@ def test_save_url_image_multi_hop_redirect_validates_each_hop():
 
     hop1 = _mock_redirect_response("https://cdn2.example.com/step2")
     hop2 = _mock_redirect_response("http://10.0.0.1/internal")
-    final = _mock_final_response()
 
     def _is_safe(url: str) -> bool:
         return "10.0.0.1" not in url
@@ -123,3 +122,23 @@ def test_save_url_image_multi_hop_redirect_validates_each_hop():
         # (only 2 requests: initial + safe redirect)
         from unittest.mock import _CallList
         # Verify the private URL was never fetched
+
+
+def test_save_url_image_too_many_redirects_raises():
+    """SSRF guard: redirect loop exceeding budget must raise ValueError."""
+    from agent.image_gen_provider import save_url_image
+
+    # 11 safe redirects (exceeds _MAX_REDIRECTS=10) — loop exhausts
+    redirects = [
+        _mock_redirect_response(f"https://cdn{i}.example.com/next")
+        for i in range(11)
+    ]
+
+    with patch("requests.get", side_effect=redirects), \
+         patch("tools.url_safety.is_safe_url", return_value=True):
+        with pytest.raises(ValueError, match="too many redirects"):
+            save_url_image("https://cdn.example.com/image.png")
+
+    # All 11 redirect responses should have been closed
+    for r in redirects:
+        r.close.assert_called()

--- a/tests/agent/test_image_gen_ssrf_guard.py
+++ b/tests/agent/test_image_gen_ssrf_guard.py
@@ -1,6 +1,6 @@
 """Tests for save_url_image SSRF guard in agent.image_gen_provider."""
 import pytest
-from unittest.mock import patch, MagicMock, call
+from unittest.mock import patch, MagicMock
 
 
 @pytest.fixture(autouse=True)
@@ -113,15 +113,17 @@ def test_save_url_image_multi_hop_redirect_validates_each_hop():
     def _is_safe(url: str) -> bool:
         return "10.0.0.1" not in url
 
-    with patch("requests.get", side_effect=[hop1, hop2]), \
+    with patch("requests.get", side_effect=[hop1, hop2]) as mock_get, \
          patch("tools.url_safety.is_safe_url", side_effect=_is_safe):
         with pytest.raises(ValueError, match="redirect target.*10\\.0\\.0\\.1"):
             save_url_image("https://cdn.example.com/image.png")
 
         # hop2's Location was private → third request must NOT happen
         # (only 2 requests: initial + safe redirect)
-        from unittest.mock import _CallList
-        # Verify the private URL was never fetched
+        assert mock_get.call_count == 2
+        # The private URL (10.0.0.1) must never appear in any request
+        for c in mock_get.call_args_list:
+            assert "10.0.0.1" not in c.args[0]
 
 
 def test_save_url_image_too_many_redirects_raises():

--- a/tests/agent/test_image_gen_ssrf_guard.py
+++ b/tests/agent/test_image_gen_ssrf_guard.py
@@ -1,6 +1,6 @@
 """Tests for save_url_image SSRF guard in agent.image_gen_provider."""
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, call
 
 
 @pytest.fixture(autouse=True)
@@ -8,6 +8,27 @@ def _isolate_home(tmp_path, monkeypatch):
     """Point HERMES_HOME at a temp dir so cache writes land safely."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     monkeypatch.delenv("HERMES_PROFILE", raising=False)
+
+
+def _mock_final_response(content_type="image/png"):
+    """Create a mock non-redirect response."""
+    resp = MagicMock()
+    resp.headers = {"Content-Type": content_type}
+    resp.raise_for_status = MagicMock()
+    resp.iter_content = MagicMock(return_value=[b"\x89PNG\r\n"])
+    resp.is_redirect = False
+    resp.close = MagicMock()
+    return resp
+
+
+def _mock_redirect_response(location, content_type="image/png"):
+    """Create a mock redirect response with a Location header."""
+    resp = MagicMock()
+    resp.headers = {"Content-Type": content_type, "Location": location}
+    resp.raise_for_status = MagicMock()
+    resp.is_redirect = True
+    resp.close = MagicMock()
+    return resp
 
 
 def test_save_url_image_blocks_private_loopback():
@@ -38,62 +59,67 @@ def test_save_url_image_allows_public_url():
     """SSRF guard: save_url_image should proceed with valid public URLs."""
     from agent.image_gen_provider import save_url_image
 
-    mock_response = MagicMock()
-    mock_response.headers = {"Content-Type": "image/png"}
-    mock_response.raise_for_status = MagicMock()
-    mock_response.iter_content = MagicMock(return_value=[b"\x89PNG\r\n"])
-
-    with patch("requests.get", return_value=mock_response),          patch("tools.url_safety.is_safe_url", return_value=True):
+    with patch("requests.get", return_value=_mock_final_response()), \
+         patch("tools.url_safety.is_safe_url", return_value=True):
         path = save_url_image("https://api.x.ai/v1/images/abc.png")
         assert path.exists()
         assert path.name.endswith(".png")
 
 
 def test_save_url_image_blocks_redirect_to_private():
-    """SSRF guard: redirect from public URL to private must be blocked."""
+    """SSRF guard: redirect from public URL to private must be blocked
+    BEFORE the request to the private address is made."""
     from agent.image_gen_provider import save_url_image
 
-    mock_response = MagicMock()
-    mock_response.headers = {"Content-Type": "image/png"}
-    mock_response.raise_for_status = MagicMock()
-    mock_response.url = "http://127.0.0.1:8080/exfil"  # redirect target
+    redirect_resp = _mock_redirect_response("http://127.0.0.1:8080/exfil")
 
     def _is_safe(url: str) -> bool:
         return "127.0.0.1" not in url
 
-    with patch("requests.get", return_value=mock_response),          patch("tools.url_safety.is_safe_url", side_effect=_is_safe):
+    with patch("requests.get", return_value=redirect_resp) as mock_get, \
+         patch("tools.url_safety.is_safe_url", side_effect=_is_safe):
         with pytest.raises(ValueError, match="redirect target"):
             save_url_image("https://cdn.example.com/image.png")
+
+        # Only ONE request should have been made (the initial one).
+        # The private redirect target must NOT be fetched.
+        assert mock_get.call_count == 1
+        mock_get.assert_called_with(
+            "https://cdn.example.com/image.png",
+            timeout=60.0, stream=True, allow_redirects=False,
+        )
 
 
 def test_save_url_image_allows_redirect_to_public():
     """SSRF guard: redirect to another public URL should proceed."""
     from agent.image_gen_provider import save_url_image
 
-    mock_response = MagicMock()
-    mock_response.headers = {"Content-Type": "image/png"}
-    mock_response.raise_for_status = MagicMock()
-    mock_response.iter_content = MagicMock(return_value=[b"\x89PNG\r\n"])
-    mock_response.url = "https://cdn2.example.com/final.png"  # redirect
+    redirect_resp = _mock_redirect_response("https://cdn2.example.com/final.png")
+    final_resp = _mock_final_response()
 
-    with patch("requests.get", return_value=mock_response),          patch("tools.url_safety.is_safe_url", return_value=True):
+    with patch("requests.get", side_effect=[redirect_resp, final_resp]), \
+         patch("tools.url_safety.is_safe_url", return_value=True):
         path = save_url_image("https://cdn1.example.com/image.png")
         assert path.exists()
 
 
-def test_save_url_image_no_redirect_skips_revalidation():
-    """SSRF guard: when response.url matches original, skip re-check."""
+def test_save_url_image_multi_hop_redirect_validates_each_hop():
+    """SSRF guard: each hop in a redirect chain must be validated."""
     from agent.image_gen_provider import save_url_image
 
-    url = "https://api.x.ai/v1/images/abc.png"
-    mock_response = MagicMock()
-    mock_response.headers = {"Content-Type": "image/png"}
-    mock_response.raise_for_status = MagicMock()
-    mock_response.iter_content = MagicMock(return_value=[b"\x89PNG\r\n"])
-    mock_response.url = url  # same URL — no redirect
+    hop1 = _mock_redirect_response("https://cdn2.example.com/step2")
+    hop2 = _mock_redirect_response("http://10.0.0.1/internal")
+    final = _mock_final_response()
 
-    with patch("requests.get", return_value=mock_response),          patch("tools.url_safety.is_safe_url", return_value=True) as mock_safe:
-        path = save_url_image(url)
-        assert path.exists()
-        # is_safe_url should be called once (initial check), not twice
-        assert mock_safe.call_count == 1
+    def _is_safe(url: str) -> bool:
+        return "10.0.0.1" not in url
+
+    with patch("requests.get", side_effect=[hop1, hop2]), \
+         patch("tools.url_safety.is_safe_url", side_effect=_is_safe):
+        with pytest.raises(ValueError, match="redirect target.*10\\.0\\.0\\.1"):
+            save_url_image("https://cdn.example.com/image.png")
+
+        # hop2's Location was private → third request must NOT happen
+        # (only 2 requests: initial + safe redirect)
+        from unittest.mock import _CallList
+        # Verify the private URL was never fetched

--- a/tests/agent/test_image_gen_ssrf_guard.py
+++ b/tests/agent/test_image_gen_ssrf_guard.py
@@ -47,3 +47,53 @@ def test_save_url_image_allows_public_url():
         path = save_url_image("https://api.x.ai/v1/images/abc.png")
         assert path.exists()
         assert path.name.endswith(".png")
+
+
+def test_save_url_image_blocks_redirect_to_private():
+    """SSRF guard: redirect from public URL to private must be blocked."""
+    from agent.image_gen_provider import save_url_image
+
+    mock_response = MagicMock()
+    mock_response.headers = {"Content-Type": "image/png"}
+    mock_response.raise_for_status = MagicMock()
+    mock_response.url = "http://127.0.0.1:8080/exfil"  # redirect target
+
+    def _is_safe(url: str) -> bool:
+        return "127.0.0.1" not in url
+
+    with patch("requests.get", return_value=mock_response),          patch("tools.url_safety.is_safe_url", side_effect=_is_safe):
+        with pytest.raises(ValueError, match="redirect target"):
+            save_url_image("https://cdn.example.com/image.png")
+
+
+def test_save_url_image_allows_redirect_to_public():
+    """SSRF guard: redirect to another public URL should proceed."""
+    from agent.image_gen_provider import save_url_image
+
+    mock_response = MagicMock()
+    mock_response.headers = {"Content-Type": "image/png"}
+    mock_response.raise_for_status = MagicMock()
+    mock_response.iter_content = MagicMock(return_value=[b"\x89PNG\r\n"])
+    mock_response.url = "https://cdn2.example.com/final.png"  # redirect
+
+    with patch("requests.get", return_value=mock_response),          patch("tools.url_safety.is_safe_url", return_value=True):
+        path = save_url_image("https://cdn1.example.com/image.png")
+        assert path.exists()
+
+
+def test_save_url_image_no_redirect_skips_revalidation():
+    """SSRF guard: when response.url matches original, skip re-check."""
+    from agent.image_gen_provider import save_url_image
+
+    url = "https://api.x.ai/v1/images/abc.png"
+    mock_response = MagicMock()
+    mock_response.headers = {"Content-Type": "image/png"}
+    mock_response.raise_for_status = MagicMock()
+    mock_response.iter_content = MagicMock(return_value=[b"\x89PNG\r\n"])
+    mock_response.url = url  # same URL — no redirect
+
+    with patch("requests.get", return_value=mock_response),          patch("tools.url_safety.is_safe_url", return_value=True) as mock_safe:
+        path = save_url_image(url)
+        assert path.exists()
+        # is_safe_url should be called once (initial check), not twice
+        assert mock_safe.call_count == 1

--- a/tests/agent/test_save_url_image.py
+++ b/tests/agent/test_save_url_image.py
@@ -73,6 +73,21 @@ class _TinyImageHandler(http.server.BaseHTTPRequestHandler):
         return
 
 
+@pytest.fixture(autouse=True)
+def _allow_localhost_urls(monkeypatch):
+    """The SSRF guard in save_url_image blocks 127.0.0.1 by default.
+
+    These tests exercise the *download* logic against a local HTTP server,
+    not the SSRF guard (that is tested separately in
+    test_image_gen_ssrf_guard.py).  Bypass the guard so the existing tests
+    keep working.
+    """
+    from unittest.mock import patch as _patch
+
+    with _patch("tools.url_safety.is_safe_url", return_value=True):
+        yield
+
+
 @pytest.fixture
 def http_server(tmp_path, monkeypatch):
     """Spin up a localhost HTTP server and isolate HERMES_HOME under tmp_path."""


### PR DESCRIPTION
## What does this PR do?

Adds an SSRF guard to `save_url_image()` in `agent/image_gen_provider.py`. Before downloading a provider-returned URL, the function now checks it against the existing `is_safe_url()` private-network policy. This prevents a compromised or malicious image generation provider (xAI, OpenAI, Krea) from causing the Hermes host to fetch internal resources such as loopback services, cloud metadata endpoints, or private network hosts.

## Related Issue

Fixes #44728

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/image_gen_provider.py`: Added `is_safe_url()` check before `requests.get()` in `save_url_image()`. Raises `ValueError` with descriptive message if the URL targets a private/internal address.
- `tests/agent/test_image_gen_ssrf_guard.py`: Added 4 tests — blocks loopback (127.0.0.1), cloud metadata (169.254.169.254), internal network (10.0.0.1), and allows valid public URLs.

## How to Test

1. Run `pytest tests/agent/test_image_gen_ssrf_guard.py -v` — all 4 tests pass
2. Verify `test_save_url_image_blocks_cloud_metadata` passes (the key SSRF regression test)
3. Verify `test_save_url_image_allows_public_url` passes (public URLs still work)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/image_gen_provider.py::save_url_image()` — shared by xAI, OpenAI, and Krea providers
- Blast radius: LOW — single function change, all 3 providers benefit from the guard
- Related patterns: Same `is_safe_url` check used in `tools/vision_tools.py` and `tools/web_tools.py`
