### PR TITLE
fix(model-switch): preserve api_key on same-provider switch when resolver returns empty (#44490)

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -958,12 +958,13 @@ def switch_model(
                 requested=current_provider,
                 target_model=new_model,
             )
-            # If resolution fell through to "custom" (e.g. named custom provider like
-            # "ollama-launch" that resolve_runtime_provider doesn't know), keep existing
-            # credentials. Otherwise use the resolved values (picks up credential rotation,
-            # base_url adjustments for OpenCode, etc.).
-            api_key = runtime.get("api_key", "")
-            base_url = runtime.get("base_url", "")
+            # Use resolved values when available (picks up credential rotation,
+            # base_url adjustments for OpenCode, etc.), but fall back to the
+            # current session credentials when resolution returns empty values.
+            # This handles providers like opencode-go whose env-var-based key
+            # resolution can return empty during a same-provider model switch.
+            api_key = runtime.get("api_key", "") or current_api_key
+            base_url = runtime.get("base_url", "") or current_base_url
             api_mode = runtime.get("api_mode", "")
         except Exception:
             pass

--- a/tests/hermes_cli/test_model_switch_preserve_key.py
+++ b/tests/hermes_cli/test_model_switch_preserve_key.py
@@ -1,0 +1,114 @@
+"""Tests for same-provider model switch preserving api_key when resolver
+returns empty credentials.
+
+When switching models on the same provider (provider_changed=False),
+resolve_runtime_provider() may return an empty api_key for providers
+that rely on env-var-based key resolution (e.g. opencode-go). The
+switch must fall back to the current session api_key rather than
+overwriting it with an empty string.
+
+Regression test for #44490.
+"""
+
+from unittest.mock import patch
+
+from hermes_cli.model_switch import switch_model
+
+
+_MOCK_VALIDATION = {
+    "accepted": True,
+    "persist": True,
+    "recognized": True,
+    "message": None,
+}
+
+
+def _run_switch(
+    raw_input: str,
+    current_provider: str,
+    current_model: str,
+    current_base_url: str,
+    current_api_key: str,
+    runtime_api_key: str = "",
+    runtime_base_url: str = "",
+):
+    """Run switch_model with mocks that simulate empty resolver output."""
+    with (
+        patch("hermes_cli.model_switch.resolve_alias", return_value=None),
+        patch("hermes_cli.model_switch.list_provider_models", return_value=[]),
+        patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "api_key": runtime_api_key,
+                "base_url": runtime_base_url,
+                "api_mode": "chat_completions",
+            },
+        ),
+        patch(
+            "hermes_cli.models.validate_requested_model",
+            return_value=_MOCK_VALIDATION,
+        ),
+        patch("hermes_cli.model_switch.get_model_info", return_value=None),
+        patch("hermes_cli.model_switch.get_model_capabilities", return_value=None),
+        patch("hermes_cli.models.detect_provider_for_model", return_value=None),
+    ):
+        return switch_model(
+            raw_input=raw_input,
+            current_provider=current_provider,
+            current_model=current_model,
+            current_base_url=current_base_url,
+            current_api_key=current_api_key,
+        )
+
+
+class TestSameProviderPreservesKey:
+    """Same-provider model switch must keep current api_key when resolver
+    returns empty."""
+
+    def test_empty_resolved_key_falls_back_to_current(self):
+        result = _run_switch(
+            raw_input="kimi-k2.5",
+            current_provider="opencode-go",
+            current_model="mimo-v2.5",
+            current_base_url="https://opencode.ai/zen/go/v1",
+            current_api_key="sk-opencode-real-key",
+            runtime_api_key="",
+            runtime_base_url="https://opencode.ai/zen/go/v1",
+        )
+
+        assert result.success, f"switch failed: {result.error_message}"
+        assert result.api_key == "sk-opencode-real-key", (
+            f"Expected current api_key preserved; got {result.api_key!r}"
+        )
+
+    def test_empty_resolved_base_url_falls_back_to_current(self):
+        result = _run_switch(
+            raw_input="kimi-k2.5",
+            current_provider="opencode-go",
+            current_model="mimo-v2.5",
+            current_base_url="https://opencode.ai/zen/go/v1",
+            current_api_key="sk-opencode-real-key",
+            runtime_api_key="sk-opencode-real-key",
+            runtime_base_url="",
+        )
+
+        assert result.success, f"switch failed: {result.error_message}"
+        assert result.base_url == "https://opencode.ai/zen/go/v1", (
+            f"Expected current base_url preserved; got {result.base_url!r}"
+        )
+
+    def test_nonempty_resolved_key_is_used(self):
+        result = _run_switch(
+            raw_input="kimi-k2.5",
+            current_provider="opencode-go",
+            current_model="mimo-v2.5",
+            current_base_url="https://opencode.ai/zen/go/v1",
+            current_api_key="sk-old-key",
+            runtime_api_key="sk-rotated-new-key",
+            runtime_base_url="https://opencode.ai/zen/go/v1",
+        )
+
+        assert result.success, f"switch failed: {result.error_message}"
+        assert result.api_key == "sk-rotated-new-key", (
+            f"Expected resolved api_key used; got {result.api_key!r}"
+        )


### PR DESCRIPTION
## Summary

Same-provider model switches (e.g. `mimo-v2.5` to `kimi-k2.5` on `opencode-go`) overwrite `api_key` with an empty string when `resolve_runtime_provider()` returns empty credentials, causing 401 errors on every subsequent message.

The `else` branch (line 955 of `model_switch.py`) for `provider_changed=False` unconditionally assigns `api_key = runtime.get("api_key", "")` even when the resolved value is empty. The defaults at line 894 (`api_key = current_api_key`) are overwritten before reaching validation.

## Changes

- `hermes_cli/model_switch.py`: use `or current_api_key` / `or current_base_url` fallback when resolved values are empty, so the current session credentials are preserved
- `tests/hermes_cli/test_model_switch_preserve_key.py`: 3 regression tests covering empty key fallback, empty base_url fallback, and non-empty key passthrough

## Test plan

- [x] New tests pass (`pytest tests/hermes_cli/test_model_switch_preserve_key.py`)
- [x] Existing opencode model switch tests pass (`pytest tests/hermes_cli/test_model_switch_opencode_anthropic.py`)
- [ ] Manual: configure opencode-go with `OPENCODE_GO_API_KEY`, start session on `mimo-v2.5`, switch to `kimi-k2.5`, verify no 401

Fixes #44490