### PR TITLE
fix(cron): add seconds support and honor sub-minute schedules

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -831,6 +831,62 @@ def get_ticker_success_age() -> Optional[float]:
     return _epoch_file_age(TICKER_SUCCESS_FILE)
 
 
+def seconds_until_next_job() -> Optional[float]:
+    """Seconds until the soonest enabled, non-paused job is due.
+
+    Returns:
+        ``0.0`` if a job is already due/overdue, a positive float for a future
+        job, or ``None`` when no scheduled jobs are waiting.
+    """
+    now = _hermes_now()
+    soonest: Optional[float] = None
+    try:
+        jobs = load_jobs()
+    except Exception:
+        return None
+
+    for job in jobs:
+        if not job.get("enabled", True):
+            continue
+        if job.get("state") == "paused":
+            continue
+        next_run = job.get("next_run_at")
+        if not next_run or not isinstance(next_run, str):
+            continue
+        try:
+            next_run_dt = _ensure_aware(datetime.fromisoformat(next_run))
+        except Exception:
+            continue
+        delta = (next_run_dt - now).total_seconds()
+        if soonest is None or delta < soonest:
+            soonest = delta
+    return soonest
+
+
+def compute_ticker_wait_seconds(max_interval: float = TICKER_INTERVAL_SECONDS) -> float:
+    """How long the built-in ticker should sleep before the next tick.
+
+    Aligns sleep with the next scheduled job so sub-minute durations
+    (``10s``, ``30s``) can fire without permanently lowering the default
+    60s cadence. When no near-term job exists, returns ``max_interval``.
+    """
+    try:
+        max_interval = float(max_interval)
+    except (TypeError, ValueError):
+        max_interval = float(TICKER_INTERVAL_SECONDS)
+    if max_interval <= 0:
+        return 0.0
+
+    until = seconds_until_next_job()
+    if until is None:
+        return max_interval
+    # Already due → tick ASAP. Tiny floor avoids a busy-spin if a job stays
+    # "due" across a failed tick (e.g. dispatch paused during drain).
+    if until <= 0:
+        return min(max_interval, 0.05)
+    return min(max_interval, until)
+
+
 # =============================================================================
 # Job CRUD Operations
 # =============================================================================

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -458,24 +458,34 @@ def ensure_dirs():
 # Schedule Parsing
 # =============================================================================
 
-def parse_duration(s: str) -> int:
+def parse_duration(s: str) -> float:
     """
-    Parse duration string into minutes.
+    Parse duration string into minutes (float, to support sub-minute durations).
     
     Examples:
         "30m" → 30
         "2h" → 120
         "1d" → 1440
+        "30s" → 0.5
+        "10sec" → 0.1667
     """
     s = s.strip().lower()
-    match = re.match(r'^(\d+)\s*(m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days)$', s)
+    match = re.match(
+        r'^(\d+(?:\.\d+)?)\s*'
+        r'(s|sec|secs|second|seconds'
+        r'|m|min|mins|minute|minutes'
+        r'|h|hr|hrs|hour|hours'
+        r'|d|day|days)$', s
+    )
     if not match:
-        raise ValueError(f"Invalid duration: '{s}'. Use format like '30m', '2h', or '1d'")
+        raise ValueError(
+            f"Invalid duration: '{s}'. Use format like '30s', '30m', '2h', or '1d'"
+        )
     
-    value = int(match.group(1))
-    unit = match.group(2)[0]  # First char: m, h, or d
+    value = float(match.group(1))
+    unit = match.group(2)[0]  # First char: s, m, h, or d
     
-    multipliers = {'m': 1, 'h': 60, 'd': 1440}
+    multipliers = {'s': 1 / 60, 'm': 1, 'h': 60, 'd': 1440}
     return value * multipliers[unit]
 
 

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -467,7 +467,7 @@ def parse_duration(s: str) -> float:
         "2h" → 120
         "1d" → 1440
         "30s" → 0.5
-        "10sec" → 0.1667
+        "10sec" → 10/60
     """
     s = s.strip().lower()
     match = re.match(
@@ -496,7 +496,7 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
     Returns dict with:
         - kind: "once" | "interval" | "cron"
         - For "once": "run_at" (ISO timestamp)
-        - For "interval": "minutes" (int)
+        - For "interval": "minutes" (float)
         - For "cron": "expr" (cron expression)
     
     Examples:
@@ -518,7 +518,7 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
         return {
             "kind": "interval",
             "minutes": minutes,
-            "display": f"every {minutes}m"
+            "display": f"every {duration_str}"
         }
     
     # Check for cron expression (5 or 6 space-separated fields)

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -152,14 +152,21 @@ def resolve_cron_scheduler() -> "CronScheduler":
 
 
 class InProcessCronScheduler(CronScheduler):
-    """Default provider: the historical in-process 60s ticker.
+    """Default provider: in-process ticker with adaptive wait.
 
-    ``start()`` blocks in the tick loop until ``stop_event`` is set, identical
-    to the pre-refactor ``_start_cron_ticker`` core loop. The caller runs it in
-    a daemon thread. ``can_dispatch`` is an optional synchronous gate supplied
-    by GatewayRunner during external drain; skipped ticks leave due jobs intact
-    for the next allowed tick.
+    Default cadence is 60s when nothing is due soon. When a job is scheduled
+    sooner (e.g. ``10s`` / ``30s`` relative durations), the wait shortens so
+    the promised resolution can be honored without permanently spinning at
+    sub-minute frequency. ``start()`` blocks until ``stop_event`` is set; the
+    caller runs it in a daemon thread. ``can_dispatch`` is an optional
+    synchronous gate supplied by GatewayRunner during external drain; skipped
+    ticks leave due jobs intact for the next allowed tick.
     """
+
+    # How often to re-evaluate wait while sleeping so a job created mid-cycle
+    # (e.g. "in 10 seconds") can pull the next tick earlier than the original
+    # 60s deadline. Cheap: one jobs.json read via compute_ticker_wait_seconds.
+    _WAIT_RECHECK_SECONDS = 1.0
 
     @property
     def name(self) -> str:
@@ -167,11 +174,13 @@ class InProcessCronScheduler(CronScheduler):
 
     def start(self, stop_event, *, adapters=None, loop=None, interval=60, can_dispatch=None):
         import logging
+        import time
+
         from cron.scheduler import tick as cron_tick
-        from cron.jobs import record_ticker_heartbeat
+        from cron.jobs import compute_ticker_wait_seconds, record_ticker_heartbeat
 
         logger = logging.getLogger("cron.scheduler_provider")
-        logger.info("In-process cron scheduler started (interval=%ds)", interval)
+        logger.info("In-process cron scheduler started (interval=%ds, adaptive)", interval)
         # Heartbeat once before the first sleep so `hermes cron status` sees a
         # live ticker immediately after startup, not only after the first tick.
         record_ticker_heartbeat()
@@ -202,4 +211,20 @@ class InProcessCronScheduler(CronScheduler):
             # clean tick, so status can tell "alive but failing every tick" from
             # "actually firing jobs" (#32612, #32895).
             record_ticker_heartbeat(success=ok)
-            stop_event.wait(interval)
+
+            # Adaptive wait: sleep until the next job is due (capped at
+            # ``interval``). Recheck every second so a newly-created sub-minute
+            # job shortens the remaining wait without busy-spinning.
+            wait = compute_ticker_wait_seconds(interval)
+            deadline = time.monotonic() + wait
+            while not stop_event.is_set():
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                # A job scheduled while we were sleeping can pull the wait down.
+                recomputed = compute_ticker_wait_seconds(interval)
+                if recomputed < remaining:
+                    remaining = recomputed
+                    deadline = time.monotonic() + remaining
+                if stop_event.wait(min(self._WAIT_RECHECK_SECONDS, remaining)):
+                    break

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -54,6 +54,20 @@ class TestParseDuration:
         assert parse_duration("  30m  ") == 30
         assert parse_duration("2 h") == 120
 
+    def test_seconds(self):
+        assert parse_duration("30s") == 0.5
+        assert parse_duration("10sec") == pytest.approx(10 / 60)
+        assert parse_duration("45secs") == 0.75
+        assert parse_duration("1second") == pytest.approx(1 / 60)
+        assert parse_duration("90seconds") == 1.5
+        assert parse_duration("0.5s") == pytest.approx(0.5 / 60)
+        assert parse_duration("  15s  ") == 0.25
+
+    def test_decimal_values(self):
+        assert parse_duration("1.5m") == 1.5
+        assert parse_duration("0.5h") == 30
+        assert parse_duration("0.25d") == 360
+
     def test_invalid_raises(self):
         with pytest.raises(ValueError):
             parse_duration("abc")

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -106,6 +106,32 @@ class TestParseSchedule:
         assert result["kind"] == "interval"
         assert result["minutes"] == 30
 
+    def test_every_seconds_interval(self):
+        result = parse_schedule("every 30s")
+        assert result["kind"] == "interval"
+        assert result["minutes"] == pytest.approx(0.5)
+        assert result["display"] == "every 30s"
+
+    def test_seconds_one_shot(self):
+        result = parse_schedule("30s")
+        assert result["kind"] == "once"
+        assert "run_at" in result
+        run_at_str = result["run_at"]
+        assert isinstance(run_at_str, str)
+        run_at = datetime.fromisoformat(run_at_str)
+        now = datetime.now().astimezone()
+        assert run_at > now
+        assert run_at < now + timedelta(minutes=1)
+        assert "once in 30s" in result["display"]
+
+    def test_decimal_duration(self):
+        result = parse_schedule("1.5m")
+        assert result["kind"] == "once"
+        run_at = datetime.fromisoformat(result["run_at"])
+        now = datetime.now().astimezone()
+        assert run_at > now
+        assert run_at < now + timedelta(minutes=2)
+
     def test_cron_expression(self):
         pytest.importorskip("croniter")
         result = parse_schedule("0 9 * * *")

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -8,6 +8,7 @@ from cron.jobs import (
     parse_duration,
     parse_schedule,
     compute_next_run,
+    compute_ticker_wait_seconds,
     create_job,
     load_jobs,
     save_jobs,
@@ -23,6 +24,7 @@ from cron.jobs import (
     heartbeat_run_claim,
     get_due_jobs,
     save_job_output,
+    seconds_until_next_job,
 )
 
 
@@ -277,6 +279,69 @@ def tmp_cron_dir(tmp_path, monkeypatch):
     monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
     monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
     return tmp_path
+
+
+# =========================================================================
+# Adaptive ticker wait (sub-minute schedules)
+# =========================================================================
+
+class TestTickerWait:
+    def test_no_jobs_uses_max_interval(self, tmp_cron_dir):
+        assert seconds_until_next_job() is None
+        assert compute_ticker_wait_seconds(60) == 60
+        assert compute_ticker_wait_seconds(0) == 0.0
+
+    def test_near_term_job_shortens_wait(self, tmp_cron_dir):
+        create_job(prompt="soon", schedule="10s", name="near-term")
+        until = seconds_until_next_job()
+        assert until is not None
+        assert 0 < until <= 10.5
+        wait = compute_ticker_wait_seconds(60)
+        assert 0 < wait <= 10.5
+
+    def test_overdue_job_returns_near_zero_wait(self, tmp_cron_dir):
+        past = (datetime.now(timezone.utc) - timedelta(seconds=5)).isoformat()
+        save_jobs([
+            {
+                "id": "overdue1",
+                "name": "overdue",
+                "prompt": "x",
+                "enabled": True,
+                "state": "scheduled",
+                "schedule": {"kind": "once", "run_at": past},
+                "next_run_at": past,
+            }
+        ])
+        until = seconds_until_next_job()
+        assert until is not None
+        assert until <= 0
+        wait = compute_ticker_wait_seconds(60)
+        assert wait == pytest.approx(0.05)
+
+    def test_paused_and_disabled_jobs_ignored(self, tmp_cron_dir):
+        future = (datetime.now(timezone.utc) + timedelta(seconds=30)).isoformat()
+        save_jobs([
+            {
+                "id": "paused1",
+                "name": "paused",
+                "prompt": "x",
+                "enabled": True,
+                "state": "paused",
+                "schedule": {"kind": "once", "run_at": future},
+                "next_run_at": future,
+            },
+            {
+                "id": "disabled1",
+                "name": "disabled",
+                "prompt": "x",
+                "enabled": False,
+                "state": "scheduled",
+                "schedule": {"kind": "once", "run_at": future},
+                "next_run_at": future,
+            },
+        ])
+        assert seconds_until_next_job() is None
+        assert compute_ticker_wait_seconds(60) == 60
 
 
 class TestJobCRUD:

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -207,6 +207,58 @@ def test_inprocess_provider_stop_is_noop():
     assert InProcessCronScheduler().stop() is None
 
 
+def test_inprocess_provider_honors_subminute_schedule(tmp_path, monkeypatch):
+    """End-to-end: a 2s one-shot fires within a few seconds even with interval=60.
+
+    Review requirement for seconds support: the built-in trigger must be able
+    to honor sub-minute schedules, not only parse them. Adaptive wait shortens
+    the 60s default cadence when a near-term job exists.
+    """
+    from cron.jobs import create_job, get_due_jobs, mark_job_run
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    cron_dir = tmp_path / "cron"
+    monkeypatch.setattr("cron.jobs.CRON_DIR", cron_dir)
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", cron_dir / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", cron_dir / "output")
+    monkeypatch.setattr("cron.jobs.TICKER_HEARTBEAT_FILE", cron_dir / "ticker_heartbeat")
+    monkeypatch.setattr("cron.jobs.TICKER_SUCCESS_FILE", cron_dir / "ticker_last_success")
+
+    job = create_job(prompt="drink water", schedule="2s", name="submin-e2e")
+    fired = []
+
+    def fake_tick(*args, **kwargs):
+        due = get_due_jobs()
+        for j in due:
+            fired.append(j["id"])
+            mark_job_run(j["id"], True)
+        return len(due)
+
+    stop = threading.Event()
+    provider = InProcessCronScheduler()
+    started = time.monotonic()
+    with patch("cron.scheduler.tick", side_effect=fake_tick):
+        thread = threading.Thread(
+            target=provider.start,
+            args=(stop,),
+            kwargs={"interval": 60},
+            daemon=True,
+        )
+        thread.start()
+        assert _wait_until(lambda: job["id"] in fired, timeout=8.0), (
+            f"sub-minute job did not fire within 8s; fired={fired}"
+        )
+        elapsed = time.monotonic() - started
+        stop.set()
+        thread.join(timeout=5)
+
+    assert not thread.is_alive(), "provider did not exit after stop_event was set"
+    # Fixed 60s sleep would miss this window; adaptive wait must land well under it.
+    assert elapsed < 6.0, (
+        f"job took {elapsed:.1f}s; adaptive ticker should honor ~2s schedule"
+    )
+
+
 # ── Phase 2: config key, discovery, resolver ─────────────────────────────────
 
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1003,7 +1003,7 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             },
             "schedule": {
                 "type": "string",
-                "description": "REQUIRED for action=create. For create/update: '30m', 'every 2h', '0 9 * * *', or ISO timestamp. Examples: '30m' (every 30 minutes), 'every 2h' (every 2 hours), '0 9 * * *' (daily at 9am), '2026-06-01T09:00:00' (one-shot). You MUST include this field when action=create."
+                "description": "REQUIRED for action=create. For create/update: '30s', '30m', 'every 2h', '0 9 * * *', or ISO timestamp. Examples: '30s' (every 30 seconds), '30m' (every 30 minutes), 'every 2h' (every 2 hours), '0 9 * * *' (daily at 9am), '2026-06-01T09:00:00' (one-shot). You MUST include this field when action=create. IMPORTANT: For relative times like 'in 10 seconds' or 'after 5 minutes', use duration format like '10s' or '5m' — do NOT construct ISO timestamps yourself because you don't know the current time."
             },
             "name": {
                 "type": "string",

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1003,7 +1003,7 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             },
             "schedule": {
                 "type": "string",
-                "description": "REQUIRED for action=create. Supported formats: duration ('30s', '30m', 'every 2h'), cron ('0 9 * * *'), or ISO timestamp ('2026-06-01T09:00:00'). Examples: '30s' (in 30 seconds), '30m' (in 30 minutes), 'every 2h' (every 2 hours), '0 9 * * *' (daily at 9am). You MUST include this field when action=create. IMPORTANT: The system prompt only tells you the current date, not the current time — do NOT attempt to construct ISO timestamps for relative times like 'in 10 seconds'. Use the duration format ('10s', '5m', '2h') instead."
+                "description": "REQUIRED for action=create. Supported formats: duration ('10s', '30s', '30m', 'every 2h'), cron ('0 9 * * *'), or ISO timestamp ('2026-06-01T09:00:00'). Examples: '10s' (in 10 seconds), '30s' (in 30 seconds), '30m' (in 30 minutes), 'every 2h' (every 2 hours), '0 9 * * *' (daily at 9am). Sub-minute durations are supported — the built-in scheduler wakes early for near-term jobs. You MUST include this field when action=create. IMPORTANT: The system prompt only tells you the current date, not the current time — do NOT attempt to construct ISO timestamps for relative times like 'in 10 seconds'. Use the duration format ('10s', '5m', '2h') instead."
             },
             "name": {
                 "type": "string",

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1003,7 +1003,7 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             },
             "schedule": {
                 "type": "string",
-                "description": "REQUIRED for action=create. For create/update: '30s', '30m', 'every 2h', '0 9 * * *', or ISO timestamp. Examples: '30s' (every 30 seconds), '30m' (every 30 minutes), 'every 2h' (every 2 hours), '0 9 * * *' (daily at 9am), '2026-06-01T09:00:00' (one-shot). You MUST include this field when action=create. IMPORTANT: For relative times like 'in 10 seconds' or 'after 5 minutes', use duration format like '10s' or '5m' — do NOT construct ISO timestamps yourself because you don't know the current time."
+                "description": "REQUIRED for action=create. Supported formats: duration ('30s', '30m', 'every 2h'), cron ('0 9 * * *'), or ISO timestamp ('2026-06-01T09:00:00'). Examples: '30s' (in 30 seconds), '30m' (in 30 minutes), 'every 2h' (every 2 hours), '0 9 * * *' (daily at 9am). You MUST include this field when action=create. IMPORTANT: The system prompt only tells you the current date, not the current time — do NOT attempt to construct ISO timestamps for relative times like 'in 10 seconds'. Use the duration format ('10s', '5m', '2h') instead."
             },
             "name": {
                 "type": "string",

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -526,14 +526,21 @@ The agent's final response is automatically delivered to the job's `deliver:` ta
 ### Relative delays (one-shot)
 
 ```text
+10s     → Run once in 10 seconds
+30s     → Run once in 30 seconds
 30m     → Run once in 30 minutes
 2h      → Run once in 2 hours
 1d      → Run once in 1 day
 ```
 
+Sub-minute delays (`10s`, `30s`, …) are supported. The built-in in-process
+scheduler normally ticks about once per minute, but shortens its wait when a
+job is due sooner so these fire near the requested time.
+
 ### Intervals (recurring)
 
 ```text
+every 30s    → Every 30 seconds
 every 30m    → Every 30 minutes
 every 2h     → Every 2 hours
 every 1d     → Every day


### PR DESCRIPTION
## Summary

Fixes #44749. Relative schedules like "in 10 seconds" were broken in two places:

1. **LLM fabricates absolute timestamps.** The system prompt only injects the date (for caching), so models invent something like `12:35` for "now + 10s" and the job never fires.
2. **`parse_duration` rejected seconds.** Even a correct `"10s"` schedule raised `ValueError`.

This PR adds seconds support and makes the built-in ticker actually honor those schedules.

## Changes

**`cron/jobs.py`**
- `parse_duration` accepts `s` / `sec` / `secs` / `second` / `seconds`
- Allows decimal values (`1.5s`, `0.5m`)
- Returns `float` minutes so sub-minute precision is preserved
- `seconds_until_next_job` / `compute_ticker_wait_seconds` for adaptive sleep

**`cron/scheduler_provider.py`**
- Built-in ticker still defaults to a 60s cadence when nothing is due soon
- When a job is due sooner, wait shortens to that job's `next_run_at`
- Rechecks every second so a job created mid-cycle (e.g. "remind me in 10s") still fires on time

**`tools/cronjob_tools.py`**
- Schema examples include `10s` / `30s`
- Explicit warning: do not invent ISO timestamps for relative times; use duration format instead

**Docs**
- `website/docs/user-guide/features/cron.md` documents seconds formats and adaptive wake

## Review follow-up

Earlier feedback correctly pointed out that advertising `10s` while the ticker slept a fixed 60s could not honor the promised resolution. This update keeps the seconds parser and adds the trigger path plus an end-to-end test that a `2s` one-shot fires in under ~6s with `interval=60`.

## Test plan

- [x] `parse_duration("30s") == 0.5`
- [x] `parse_duration("90seconds") == 1.5`
- [x] `parse_schedule("every 30s")` / `"30s"` / `"1.5m"`
- [x] `TestTickerWait` (no jobs, near-term shortens wait, overdue near-zero, paused/disabled ignored)
- [x] `test_inprocess_provider_honors_subminute_schedule` (e2e dispatch path)
- [x] Existing scheduler-provider suite green (61 tests)

```bash
.venv/bin/python -m pytest tests/cron/test_scheduler_provider.py \
  tests/cron/test_jobs.py::TestTickerWait \
  tests/cron/test_jobs.py::TestParseDuration \
  tests/cron/test_jobs.py::TestParseSchedule -q
```