### PR TITLE
fix: allow per-platform busy input modes

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -40,6 +40,10 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
     "interim_assistant_messages": True,
     "long_running_notifications": True,
     "busy_ack_detail": True,
+    # Busy follow-up handling while an agent is already running in the same
+    # session.  Platform overrides let chatty/team surfaces prefer queueing
+    # without changing CLI/DM defaults.
+    "busy_input_mode": "interrupt",
     # When true, delete tool-progress / "⏳ Working — N min" / status bubbles
     # after the final response lands on platforms that support message
     # deletion (e.g. Telegram). Off by default — progress is still shown
@@ -224,6 +228,9 @@ def _normalise(setting: str, value: Any) -> Any:
         if value is True:
             return "all"
         return str(value).lower()
+    if setting == "busy_input_mode":
+        value = str(value).strip().lower()
+        return value if value in {"interrupt", "queue", "steer"} else "interrupt"
     if setting in {
         "show_reasoning",
         "streaming",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3393,11 +3393,47 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not mode:
             cfg = _load_gateway_runtime_config()
             mode = str(cfg_get(cfg, "display", "busy_input_mode", default="") or "").strip().lower()
-        if mode == "queue":
-            return "queue"
-        if mode == "steer":
-            return "steer"
-        return "interrupt"
+        return GatewayRunner._normalize_busy_input_mode(mode)
+
+    @staticmethod
+    def _normalize_busy_input_mode(mode: Any, *, default: str = "interrupt") -> str:
+        value = str(mode or "").strip().lower()
+        if value in {"interrupt", "queue", "steer"}:
+            return value
+        return default if default in {"interrupt", "queue", "steer"} else "interrupt"
+
+    def _resolve_busy_input_mode_for_source(self, source: SessionSource) -> str:
+        """Resolve busy-input mode, honoring per-platform display overrides.
+
+        ``display.busy_input_mode`` remains the global default.  Messaging
+        surfaces can opt into safer queue/steer behavior without changing CLI
+        semantics via ``display.platforms.<platform>.busy_input_mode`` or the
+        equivalent env var ``HERMES_GATEWAY_BUSY_INPUT_MODE_<PLATFORM>``.
+        """
+        default = self._normalize_busy_input_mode(getattr(self, "_busy_input_mode", "interrupt"))
+        try:
+            platform_key = _platform_config_key(source.platform)
+        except Exception:
+            return default
+
+        env_key = f"HERMES_GATEWAY_BUSY_INPUT_MODE_{platform_key.upper().replace('-', '_')}"
+        env_mode = os.getenv(env_key, "").strip()
+        if env_mode:
+            return self._normalize_busy_input_mode(env_mode, default=default)
+
+        try:
+            cfg = _load_gateway_config()
+            display_cfg = cfg.get("display") or {}
+            platforms_cfg = display_cfg.get("platforms") or {}
+            platform_cfg = platforms_cfg.get(platform_key)
+            if isinstance(platform_cfg, dict) and platform_cfg.get("busy_input_mode") is not None:
+                return self._normalize_busy_input_mode(
+                    platform_cfg.get("busy_input_mode"),
+                    default=default,
+                )
+        except Exception:
+            return default
+        return default
 
     @staticmethod
     def _load_busy_text_mode() -> str:
@@ -3702,7 +3738,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         running_agent = self._running_agents.get(session_key)
 
-        effective_mode = self._busy_input_mode
+        effective_mode = self._resolve_busy_input_mode_for_source(event.source)
         busy_text_mode = getattr(self, "_busy_text_mode", "interrupt")
         if (
             event.message_type == MessageType.TEXT

--- a/tests/gateway/test_platform_busy_input_mode.py
+++ b/tests/gateway/test_platform_busy_input_mode.py
@@ -1,0 +1,144 @@
+"""Per-platform busy_input_mode regression tests.
+
+Slack users often work in multiple visible threads at once.  A global
+``display.busy_input_mode: interrupt`` is still useful for CLI/DM operators, but
+Slack should be able to opt into queueing follow-ups without changing every
+platform or relying on process-wide env hacks.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Minimal Telegram stubs so gateway.run imports cleanly in focused tests.
+_tg = types.ModuleType("telegram")
+_tg.constants = types.ModuleType("telegram.constants")
+_ct = MagicMock()
+_ct.SUPERGROUP = "supergroup"
+_ct.GROUP = "group"
+_ct.PRIVATE = "private"
+_tg.constants.ChatType = _ct
+sys.modules.setdefault("telegram", _tg)
+sys.modules.setdefault("telegram.constants", _tg.constants)
+sys.modules.setdefault("telegram.ext", types.ModuleType("telegram.ext"))
+
+from gateway.config import Platform  # noqa: E402
+from gateway.platforms.base import MessageEvent, MessageType, SessionSource  # noqa: E402
+from gateway.run import GatewayRunner  # noqa: E402
+
+
+def _make_runner() -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._busy_ack_ts = {}
+    runner._draining = False
+    runner._busy_input_mode = "interrupt"
+    runner._busy_text_mode = "interrupt"
+    runner.adapters = {}
+    runner.config = MagicMock()
+    runner.session_store = None
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = True
+    runner._is_user_authorized = lambda _source: True
+    return runner
+
+
+def _make_adapter() -> MagicMock:
+    adapter = MagicMock()
+    adapter._pending_messages = {}
+    adapter._send_with_retry = AsyncMock()
+    adapter.config = MagicMock()
+    adapter.config.extra = {}
+    adapter.platform = Platform.SLACK
+    return adapter
+
+
+def _make_slack_event(text: str = "follow up") -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.SLACK,
+            chat_id="C1",
+            chat_type="group",
+            user_id="U1",
+            thread_id="1000.0001",
+        ),
+        message_id="1000.0002",
+    )
+
+
+def test_platform_config_busy_input_mode_overrides_global_interrupt(monkeypatch) -> None:
+    runner = _make_runner()
+    monkeypatch.delenv("HERMES_GATEWAY_BUSY_INPUT_MODE_SLACK", raising=False)
+
+    with patch(
+        "gateway.run._load_gateway_config",
+        return_value={
+            "display": {
+                "busy_input_mode": "interrupt",
+                "platforms": {"slack": {"busy_input_mode": "queue"}},
+            }
+        },
+    ):
+        assert runner._resolve_busy_input_mode_for_source(_make_slack_event().source) == "queue"
+
+
+def test_platform_env_busy_input_mode_overrides_config(monkeypatch) -> None:
+    runner = _make_runner()
+    monkeypatch.setenv("HERMES_GATEWAY_BUSY_INPUT_MODE_SLACK", "steer")
+
+    with patch(
+        "gateway.run._load_gateway_config",
+        return_value={
+            "display": {
+                "busy_input_mode": "interrupt",
+                "platforms": {"slack": {"busy_input_mode": "queue"}},
+            }
+        },
+    ):
+        assert runner._resolve_busy_input_mode_for_source(_make_slack_event().source) == "steer"
+
+
+@pytest.mark.asyncio
+async def test_slack_platform_queue_mode_does_not_interrupt_running_agent(monkeypatch) -> None:
+    runner = _make_runner()
+    adapter = _make_adapter()
+    event = _make_slack_event("please queue this")
+    session_key = "agent:main:slack:group:C1:1000.0001"
+    parent = MagicMock()
+    parent.get_activity_summary.return_value = {
+        "api_call_count": 3,
+        "max_iterations": 60,
+        "current_tool": "terminal",
+    }
+    runner._running_agents[session_key] = parent
+    runner.adapters[Platform.SLACK] = adapter
+    monkeypatch.delenv("HERMES_GATEWAY_BUSY_INPUT_MODE_SLACK", raising=False)
+
+    with patch(
+        "gateway.run._load_gateway_config",
+        return_value={
+            "display": {
+                "busy_input_mode": "interrupt",
+                "platforms": {"slack": {"busy_input_mode": "queue"}},
+            }
+        },
+    ), patch("gateway.run.merge_pending_message_event") as merge_mock:
+        handled = await runner._handle_active_session_busy_message(event, session_key)
+
+    assert handled is True
+    parent.interrupt.assert_not_called()
+    merge_mock.assert_called_once()
+    adapter._send_with_retry.assert_called_once()
+    sent = adapter._send_with_retry.call_args.kwargs["content"]
+    assert "Queued for the next turn" in sent
+    assert "Interrupting current task" not in sent


### PR DESCRIPTION
## Summary
- add per-platform `display.platforms.<platform>.busy_input_mode` support for gateway busy follow-ups
- add `HERMES_GATEWAY_BUSY_INPUT_MODE_<PLATFORM>` env override
- keep global `display.busy_input_mode` and default `interrupt` behavior unchanged
- cover Slack queue override so chatty/threaded workspaces can queue same-session follow-ups instead of interrupting in-flight work

## Motivation
Slack users often work across multiple visible threads while long-running agent turns are active. Hermes already keys Slack sessions by `thread_ts`, so separate threads should not interrupt each other; however, a follow-up in the same active thread uses the global busy mode and can show `⚡ Interrupting current task...`. This change lets operators choose safer queue semantics for Slack only without changing CLI or other platforms.

Example config:

```yaml
display:
  busy_input_mode: interrupt
  platforms:
    slack:
      busy_input_mode: queue
```

## Tests
- `uv run --extra dev python -m pytest tests/gateway/test_platform_busy_input_mode.py tests/gateway/test_subagent_protection_30170.py tests/gateway/test_runtime_config_env_expansion.py tests/gateway/test_config_env_bridge_authority.py -q -o 'addopts='`
- `uv run --extra dev ruff check gateway/run.py gateway/display_config.py tests/gateway/test_platform_busy_input_mode.py`
- `git diff --check HEAD~1..HEAD`

## Safety
- no tokens, workspace IDs, local paths, customer data, or private automation details included
- global/default behavior remains backward-compatible (`interrupt`)
