### PR TITLE
fix(tools): report environment failures instead of 'File not found' in read_file/search

### DIFF
--- a/tests/tools/test_file_ops_env_not_ready.py
+++ b/tests/tools/test_file_ops_env_not_ready.py
@@ -1,0 +1,96 @@
+"""Tests for environment-failure disambiguation in tools/file_operations.py.
+
+When the terminal environment cannot execute commands at all (docker container
+still starting, container removed out-of-band, transport error), file
+existence probes exit non-zero exactly like a missing file would. These tests
+guard the disambiguation added for that case:
+
+- ``read_file`` / ``read_file_raw`` must report an environment error, not
+  "File not found", when the environment is down.
+- ``search`` must report an environment error when its existence probe
+  returns neither the ``exists`` nor the ``not_found`` marker.
+- Genuinely missing files must still produce "File not found" when the
+  environment is healthy.
+
+Regression context: with ``terminal.backend: docker`` and non-persistent
+containers, the first ``read_file`` of a session raced container startup and
+returned a false "File not found", which the model then trusted for the rest
+of the session.
+"""
+
+import pytest
+
+from tools.file_operations import ShellFileOperations
+
+
+class _DeadEnv:
+    """Environment whose execute() always fails (e.g. container starting)."""
+
+    cwd = "/workspace"
+
+    def execute(self, command: str, cwd: str = None, **kwargs) -> dict:
+        return {"output": "Error: container is not running", "returncode": 125}
+
+
+class _HealthyEnvWithoutFile:
+    """Environment that runs commands fine but has no files in it."""
+
+    cwd = "/workspace"
+
+    def execute(self, command: str, cwd: str = None, **kwargs) -> dict:
+        if command.startswith("echo "):
+            return {"output": command[len("echo "):].strip() + "\n", "returncode": 0}
+        if command.startswith("test -e"):
+            return {"output": "not_found\n", "returncode": 0}
+        if command.startswith("test -d"):
+            return {"output": "no\n", "returncode": 0}
+        # wc -c, ls, head, ... — behave like an empty filesystem
+        return {"output": "", "returncode": 1}
+
+
+@pytest.fixture()
+def dead_ops():
+    return ShellFileOperations(_DeadEnv())
+
+
+@pytest.fixture()
+def healthy_ops():
+    return ShellFileOperations(_HealthyEnvWithoutFile())
+
+
+class TestReadFileEnvNotReady:
+    def test_read_file_reports_env_failure_not_missing_file(self, dead_ops):
+        result = dead_ops.read_file("state/notes.md")
+        assert result.error
+        assert "File not found" not in result.error
+        assert "environment unavailable" in result.error.lower()
+
+    def test_read_file_raw_reports_env_failure_not_missing_file(self, dead_ops):
+        result = dead_ops.read_file_raw("state/notes.md")
+        assert result.error
+        assert "File not found" not in result.error
+        assert "environment unavailable" in result.error.lower()
+
+    def test_read_file_still_reports_missing_file_when_env_healthy(self, healthy_ops):
+        result = healthy_ops.read_file("state/notes.md")
+        assert result.error
+        assert "File not found" in result.error
+
+    def test_env_ready_true_on_healthy_env(self, healthy_ops):
+        assert healthy_ops._env_ready() is True
+
+    def test_env_ready_false_on_dead_env(self, dead_ops):
+        assert dead_ops._env_ready() is False
+
+
+class TestSearchEnvNotReady:
+    def test_search_reports_env_failure_when_probe_returns_no_marker(self, dead_ops):
+        result = dead_ops.search("pattern", path="/workspace")
+        assert result.error
+        assert "environment unavailable" in result.error.lower()
+        assert "Path not found" not in (result.error or "")
+
+    def test_search_still_reports_missing_path_when_env_healthy(self, healthy_ops):
+        result = healthy_ops.search("pattern", path="/workspace/nope")
+        assert result.error
+        assert "Path not found" in result.error

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1040,8 +1040,43 @@ class ShellFileOperations(FileOperations):
             hint=hint
         )
     
+    # Sentinel echoed through the terminal backend to verify the execution
+    # environment itself is healthy before trusting a failed file probe.
+    _ENV_PROBE_MARKER = "__HERMES_FILEOPS_ENV_OK__"
+
+    def _env_ready(self) -> bool:
+        """Check the terminal environment can execute commands at all.
+
+        A failed existence probe (``wc -c`` etc.) has two very different
+        causes: the file is genuinely missing, or ``env.execute()`` itself
+        failed — container still starting, container gone, transport error.
+        Reporting the latter as "File not found" poisons the model's beliefs
+        about its own filesystem, so callers use this probe to disambiguate.
+        """
+        try:
+            probe = self._exec(f"echo {self._ENV_PROBE_MARKER}")
+        except Exception:
+            return False
+        return probe.exit_code == 0 and self._ENV_PROBE_MARKER in probe.stdout
+
+    def _env_unavailable_result(self, path: str) -> ReadResult:
+        """ReadResult for 'the sandbox failed', as opposed to 'file missing'."""
+        return ReadResult(
+            error=(
+                f"Terminal environment unavailable while accessing {path}: "
+                "command execution failed (the sandbox may still be starting). "
+                "This is NOT evidence the file is missing — retry shortly."
+            )
+        )
+
     def _suggest_similar_files(self, path: str) -> ReadResult:
         """Suggest similar files when the requested file is not found."""
+        # The existence probe that sent us here exits non-zero for missing
+        # files AND for execution-environment failures. Only report
+        # "File not found" when the environment can actually run commands.
+        if not self._env_ready():
+            return self._env_unavailable_result(path)
+
         dir_path = os.path.dirname(path) or "."
         filename = os.path.basename(path)
         basename_no_ext = os.path.splitext(filename)[0]
@@ -1917,7 +1952,21 @@ class ShellFileOperations(FileOperations):
                 error=". ".join(hint_parts),
                 total_count=0
             )
-        
+        if "exists" not in check.stdout:
+            # Neither marker came back: the existence probe itself failed to
+            # execute (sandbox still starting, container gone, transport
+            # error). Don't proceed to a search that would return a
+            # misleading empty result.
+            return SearchResult(
+                error=(
+                    f"Terminal environment unavailable while searching {path}: "
+                    "command execution failed (the sandbox may still be "
+                    "starting). This is NOT evidence the path is missing — "
+                    "retry shortly."
+                ),
+                total_count=0,
+            )
+
         if target == "files":
             return self._search_files(pattern, path, limit, offset)
         else:


### PR DESCRIPTION
Fixes #44750.

## Problem

`read_file`/`read_file_raw` probe existence with `wc -c < path` and treat **any** non-zero exit as a missing file. When the terminal environment itself can't execute commands — docker container still starting, container removed out-of-band, transport error — the probe fails identically, and the model is told `File not found: <path>` for a file that exists.

With `terminal.backend: docker` + `container_persistent: false` this reproduces near-deterministically when `read_file` is the first tool call of a cold session (the file-ops path creates the environment and probes immediately, without the terminal tool's readiness handling). A false "missing file" then poisons the model's beliefs for the rest of the session — in our deployment the agent repeatedly concluded its own operator instructions didn't exist while a terminal `cat` of the same path succeeded seconds later.

`search()` has the equivalent hole in a different shape: its `test -e … && echo exists || echo not_found` probe yields *neither* marker when execution fails, and the search proceeds to a misleading empty result.

## Fix

- `_suggest_similar_files()` (the shared not-found path for `read_file` and `read_file_raw`) now first verifies the environment can run a trivial `echo` sentinel. If it can't, an explicit **environment-unavailable** error is returned instead of "File not found", telling the model this is not evidence the file is missing and to retry.
- `search()` returns the same explicit error when its existence probe returns neither marker, instead of proceeding.

Deliberately minimal: no retry loops or readiness waits added; the goal is correct error semantics so the model (or a wrapping retry policy) can act on them. A readiness wait in `file_tools`' environment creation path could be a follow-up.

## Tests

`tests/tools/test_file_ops_env_not_ready.py` — a dead env (every `execute()` fails) must produce environment errors, never "File not found"; a healthy env without the file must still produce "File not found"; same split for `search()` ("Path not found" preserved). All existing `tests/tools/test_file_operations_edge_cases.py` pass.
