### PR TITLE
Tag LiteLLM requests with source attribution metadata

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -29,6 +29,7 @@ from hermes_cli.timeouts import get_provider_request_timeout, get_provider_stale
 from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
 from agent.error_classifier import FailoverReason
 from agent.model_metadata import is_local_endpoint
+from agent.litellm_metadata import build_litellm_request_metadata
 from agent.message_sanitization import (
     _sanitize_surrogates,
     _repair_tool_call_arguments,
@@ -650,6 +651,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             max_tokens=agent.max_tokens,
             timeout=agent._resolved_api_call_timeout(),
             request_overrides=agent.request_overrides,
+            request_metadata=build_litellm_request_metadata(agent, caller="main"),
             is_github_responses=is_github_responses,
             is_codex_backend=is_codex_backend,
             is_xai_responses=is_xai_responses,
@@ -752,6 +754,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             max_tokens_param_fn=agent._max_tokens_param,
             reasoning_config=agent.reasoning_config,
             request_overrides=agent.request_overrides,
+            request_metadata=build_litellm_request_metadata(agent, caller="main"),
             session_id=getattr(agent, "session_id", None),
             provider_profile=_profile,
             ollama_num_ctx=agent._ollama_num_ctx,
@@ -784,6 +787,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         max_tokens_param_fn=agent._max_tokens_param,
         reasoning_config=agent.reasoning_config,
         request_overrides=agent.request_overrides,
+        request_metadata=build_litellm_request_metadata(agent, caller="main"),
         session_id=getattr(agent, "session_id", None),
         model_lower=(agent.model or "").lower(),
         is_openrouter=_is_or,

--- a/agent/litellm_metadata.py
+++ b/agent/litellm_metadata.py
@@ -1,0 +1,125 @@
+"""LiteLLM request metadata helpers for source-level spend attribution."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from typing import Any
+from urllib.parse import urlparse
+
+
+def _truthy(value: str | None) -> bool:
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _clean(value: Any, *, limit: int = 160) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    # Metadata is for aggregation keys only; keep it compact and printable.
+    text = "".join(ch if 32 <= ord(ch) < 127 else "_" for ch in text)
+    return text[:limit]
+
+
+def _digest(value: Any) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
+def is_litellm_proxy(base_url: Any) -> bool:
+    """Return True when the target endpoint is a LiteLLM proxy.
+
+    The explicit env override is useful for private hostnames that do not include
+    ``litellm`` but still expose LiteLLM's metadata-aware OpenAI-compatible API.
+    """
+    if _truthy(os.getenv("HERMES_LITELLM_METADATA")):
+        return True
+    try:
+        host = urlparse(str(base_url or "")).hostname or ""
+    except Exception:
+        host = ""
+    return "litellm" in host.lower()
+
+
+def _session_env(name: str, default: str = "") -> str:
+    try:
+        from gateway.session_context import get_session_env
+
+        return get_session_env(name, default)
+    except Exception:
+        return os.getenv(name, default)
+
+
+def _context_env(name: str, default: str = "") -> str:
+    """Read only task-local contextvars, avoiding stale process env fallback."""
+    try:
+        from gateway.session_context import get_context_env
+
+        return get_context_env(name, default)
+    except Exception:
+        return default
+
+
+def build_litellm_request_metadata(
+    agent: Any, *, caller: str = "main"
+) -> dict[str, str] | None:
+    """Build safe LiteLLM metadata tags for request/spend attribution.
+
+    Returns ``None`` for non-LiteLLM endpoints so strict direct providers do not
+    receive extra request fields they might reject.
+    """
+    if not is_litellm_proxy(getattr(agent, "base_url", "")):
+        return None
+
+    platform = _clean(
+        getattr(agent, "platform", "") or _session_env("HERMES_SESSION_PLATFORM")
+    )
+    cron_job_id = _context_env("HERMES_CRON_JOB_ID")
+    cron_job_hash = _digest(cron_job_id)
+    parent_session_hash = _digest(getattr(agent, "_parent_session_id", ""))
+    cron_active = bool(cron_job_hash)
+
+    if cron_active:
+        source = "cron"
+        source_tag = f"cron:{cron_job_hash}" if cron_job_hash else "cron"
+    else:
+        source = platform or _clean(os.getenv("HERMES_SESSION_SOURCE")) or "cli"
+        if parent_session_hash:
+            source_tag = f"delegate:{source}"
+        elif source in {
+            "slack",
+            "discord",
+            "telegram",
+            "matrix",
+            "signal",
+            "whatsapp",
+            "yuanbao",
+        }:
+            source_tag = f"interactive:{source}"
+        else:
+            source_tag = source
+
+    metadata: dict[str, str] = {
+        "hermes_app": "hermes-agent",
+        "hermes_caller": _clean(caller, limit=80) or "main",
+        "hermes_source": source,
+        "hermes_source_tag": source_tag,
+    }
+
+    for key, value in {
+        "hermes_session_hash": _digest(getattr(agent, "session_id", "")),
+        "hermes_parent_session_hash": parent_session_hash,
+        "hermes_provider": getattr(agent, "provider", ""),
+        "hermes_profile": os.getenv("HERMES_PROFILE", ""),
+        "hermes_cron_job_hash": cron_job_hash,
+        "hermes_gateway_session_hash": _digest(
+            getattr(agent, "_gateway_session_key", "")
+        ),
+    }.items():
+        cleaned = _clean(value)
+        if cleaned:
+            metadata[key] = cleaned
+
+    return metadata

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -99,6 +99,41 @@ def _is_gemini_openai_compat_base_url(base_url: Any) -> bool:
     return normalized.endswith("/openai")
 
 
+def _merge_extra_body(base: dict[str, Any], additions: dict[str, Any] | None) -> None:
+    """Merge extra_body dictionaries, preserving nested metadata keys."""
+    if not additions:
+        return
+    for key, value in additions.items():
+        if key == "metadata" and isinstance(value, dict):
+            existing = base.get("metadata")
+            merged: dict[str, Any] = {}
+            if isinstance(existing, dict):
+                merged.update(existing)
+            merged.update(value)
+            base["metadata"] = merged
+        else:
+            base[key] = value
+
+
+def _apply_request_overrides(
+    api_kwargs: dict[str, Any], extra_body: dict[str, Any], overrides: dict[str, Any] | None
+) -> bool:
+    """Apply caller overrides; return True when extra_body was replaced."""
+    replaced_extra_body = False
+    if not overrides:
+        return replaced_extra_body
+    for key, value in overrides.items():
+        if key == "extra_body" and isinstance(value, dict):
+            _merge_extra_body(extra_body, value)
+        elif key == "extra_body":
+            api_kwargs[key] = value
+            replaced_extra_body = True
+            extra_body.clear()
+        else:
+            api_kwargs[key] = value
+    return replaced_extra_body
+
+
 def _model_consumes_thought_signature(model: Any) -> bool:
     """True when the outgoing model is a Gemini family model that requires
     ``extra_content`` (thought_signature) to be replayed on tool calls.
@@ -440,16 +475,26 @@ class ChatCompletionsTransport(ProviderTransport):
 
         # Merge any pre-built extra_body additions
         additions = params.get("extra_body_additions")
-        if additions:
-            extra_body.update(additions)
+        _merge_extra_body(extra_body, additions)
+
+        request_metadata = params.get("request_metadata")
+        if request_metadata:
+            _merge_extra_body(extra_body, {"metadata": request_metadata})
 
         if extra_body:
             api_kwargs["extra_body"] = extra_body
 
         # Request overrides last (service_tier etc.)
-        overrides = params.get("request_overrides")
-        if overrides:
-            api_kwargs.update(overrides)
+        replaced_extra_body = _apply_request_overrides(
+            api_kwargs, extra_body, params.get("request_overrides")
+        )
+
+        if replaced_extra_body:
+            pass
+        elif extra_body:
+            api_kwargs["extra_body"] = extra_body
+        else:
+            api_kwargs.pop("extra_body", None)
 
         return api_kwargs
 
@@ -557,19 +602,20 @@ class ChatCompletionsTransport(ProviderTransport):
 
         # Merge any pre-built extra_body additions from the caller
         additions = params.get("extra_body_additions")
-        if additions:
-            extra_body.update(additions)
+        _merge_extra_body(extra_body, additions)
+
+        request_metadata = params.get("request_metadata")
+        if request_metadata:
+            _merge_extra_body(extra_body, {"metadata": request_metadata})
 
         # Request overrides (user config)
-        overrides = params.get("request_overrides")
-        if overrides:
-            for k, v in overrides.items():
-                if k == "extra_body" and isinstance(v, dict):
-                    extra_body.update(v)
-                else:
-                    api_kwargs[k] = v
+        replaced_extra_body = _apply_request_overrides(
+            api_kwargs, extra_body, params.get("request_overrides")
+        )
 
-        if extra_body:
+        if replaced_extra_body:
+            pass
+        elif extra_body:
             # Native Gemini (generativelanguage.googleapis.com, non-/openai)
             # speaks Google's REST schema, not OpenAI's. OpenAI-style extra_body
             # keys (tags, reasoning, provider, plugins, …) are unknown fields

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -247,25 +247,41 @@ class ResponsesApiTransport(ProviderTransport):
         elif not is_github_responses and not is_xai_responses:
             kwargs["include"] = []
 
-        request_metadata = params.get("request_metadata")
-        if request_metadata:
-            existing_metadata = kwargs.get("metadata")
+        def _merge_metadata_into_extra_body(metadata: Dict[str, Any]) -> None:
+            existing_extra_body = kwargs.get("extra_body")
+            merged_extra_body: Dict[str, Any] = {}
+            if isinstance(existing_extra_body, dict):
+                merged_extra_body.update(existing_extra_body)
+            existing_metadata = merged_extra_body.get("metadata")
             merged_metadata: Dict[str, Any] = {}
             if isinstance(existing_metadata, dict):
                 merged_metadata.update(existing_metadata)
-            merged_metadata.update(request_metadata)
-            kwargs["metadata"] = merged_metadata
+            merged_metadata.update(metadata)
+            merged_extra_body["metadata"] = merged_metadata
+            kwargs["extra_body"] = merged_extra_body
+
+        request_metadata = params.get("request_metadata")
+        if isinstance(request_metadata, dict) and request_metadata:
+            _merge_metadata_into_extra_body(request_metadata)
 
         request_overrides = params.get("request_overrides")
         if request_overrides:
             for key, value in request_overrides.items():
                 if key == "metadata" and isinstance(value, dict):
-                    existing_metadata = kwargs.get("metadata")
-                    merged_metadata = {}
-                    if isinstance(existing_metadata, dict):
-                        merged_metadata.update(existing_metadata)
-                    merged_metadata.update(value)
-                    kwargs["metadata"] = merged_metadata
+                    _merge_metadata_into_extra_body(value)
+                elif key == "extra_body" and isinstance(value, dict):
+                    existing_extra_body = kwargs.get("extra_body")
+                    merged_extra_body: Dict[str, Any] = {}
+                    if isinstance(existing_extra_body, dict):
+                        merged_extra_body.update(existing_extra_body)
+                    existing_metadata = merged_extra_body.get("metadata")
+                    merged_extra_body.update(value)
+                    override_metadata = value.get("metadata")
+                    if isinstance(existing_metadata, dict) and isinstance(override_metadata, dict):
+                        merged_metadata: Dict[str, Any] = dict(existing_metadata)
+                        merged_metadata.update(override_metadata)
+                        merged_extra_body["metadata"] = merged_metadata
+                    kwargs["extra_body"] = merged_extra_body
                 else:
                     kwargs[key] = value
 

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -247,9 +247,27 @@ class ResponsesApiTransport(ProviderTransport):
         elif not is_github_responses and not is_xai_responses:
             kwargs["include"] = []
 
+        request_metadata = params.get("request_metadata")
+        if request_metadata:
+            existing_metadata = kwargs.get("metadata")
+            merged_metadata: Dict[str, Any] = {}
+            if isinstance(existing_metadata, dict):
+                merged_metadata.update(existing_metadata)
+            merged_metadata.update(request_metadata)
+            kwargs["metadata"] = merged_metadata
+
         request_overrides = params.get("request_overrides")
         if request_overrides:
-            kwargs.update(request_overrides)
+            for key, value in request_overrides.items():
+                if key == "metadata" and isinstance(value, dict):
+                    existing_metadata = kwargs.get("metadata")
+                    merged_metadata = {}
+                    if isinstance(existing_metadata, dict):
+                        merged_metadata.update(existing_metadata)
+                    merged_metadata.update(value)
+                    kwargs["metadata"] = merged_metadata
+                else:
+                    kwargs[key] = value
 
         # xAI Responses API rejects ``service_tier`` (HTTP 400 "Argument not
         # supported: service_tier") — hit when ``/fast`` priority-processing

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1821,9 +1821,13 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         "HERMES_CRON_AUTO_DELIVER_PLATFORM",
         "HERMES_CRON_AUTO_DELIVER_CHAT_ID",
         "HERMES_CRON_AUTO_DELIVER_THREAD_ID",
+        "HERMES_CRON_JOB_ID",
+        "HERMES_CRON_JOB_NAME",
     )
     for _var_name in _cron_delivery_vars:
         _VAR_MAP[_var_name].set("")
+    _VAR_MAP["HERMES_CRON_JOB_ID"].set(str(job_id or ""))
+    _VAR_MAP["HERMES_CRON_JOB_NAME"].set(str(job_name or ""))
 
     # Per-job working directory.  When set (and validated at create/update
     # time), we point TERMINAL_CWD at it so:

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -88,6 +88,8 @@ _SESSION_ASYNC_DELIVERY: ContextVar = ContextVar("HERMES_SESSION_ASYNC_DELIVERY"
 _CRON_AUTO_DELIVER_PLATFORM: ContextVar = ContextVar("HERMES_CRON_AUTO_DELIVER_PLATFORM", default=_UNSET)
 _CRON_AUTO_DELIVER_CHAT_ID: ContextVar = ContextVar("HERMES_CRON_AUTO_DELIVER_CHAT_ID", default=_UNSET)
 _CRON_AUTO_DELIVER_THREAD_ID: ContextVar = ContextVar("HERMES_CRON_AUTO_DELIVER_THREAD_ID", default=_UNSET)
+_CRON_JOB_ID: ContextVar = ContextVar("HERMES_CRON_JOB_ID", default=_UNSET)
+_CRON_JOB_NAME: ContextVar = ContextVar("HERMES_CRON_JOB_NAME", default=_UNSET)
 
 _VAR_MAP = {
     "HERMES_SESSION_PLATFORM": _SESSION_PLATFORM,
@@ -103,6 +105,8 @@ _VAR_MAP = {
     "HERMES_CRON_AUTO_DELIVER_PLATFORM": _CRON_AUTO_DELIVER_PLATFORM,
     "HERMES_CRON_AUTO_DELIVER_CHAT_ID": _CRON_AUTO_DELIVER_CHAT_ID,
     "HERMES_CRON_AUTO_DELIVER_THREAD_ID": _CRON_AUTO_DELIVER_THREAD_ID,
+    "HERMES_CRON_JOB_ID": _CRON_JOB_ID,
+    "HERMES_CRON_JOB_NAME": _CRON_JOB_NAME,
 }
 
 
@@ -207,6 +211,16 @@ def clear_session_vars(tokens: list) -> None:
         clear_session_cwd()
     except Exception:
         pass
+
+
+def get_context_env(name: str, default: str = "") -> str:
+    """Read only the task-local context variable without os.environ fallback."""
+    var = _VAR_MAP.get(name)
+    if var is not None:
+        value = var.get()
+        if value is not _UNSET:
+            return value
+    return default
 
 
 def get_session_env(name: str, default: str = "") -> str:

--- a/tests/agent/test_litellm_metadata.py
+++ b/tests/agent/test_litellm_metadata.py
@@ -1,0 +1,122 @@
+"""Tests for LiteLLM request metadata attribution."""
+
+from types import SimpleNamespace
+
+from agent.litellm_metadata import build_litellm_request_metadata
+from gateway import session_context
+
+
+def _set_cron_context(job_id: str = "", job_name: str = ""):
+    session_context._VAR_MAP["HERMES_CRON_JOB_ID"].set(job_id)
+    session_context._VAR_MAP["HERMES_CRON_JOB_NAME"].set(job_name)
+
+
+def _agent(**kwargs):
+    values = {
+        "base_url": "https://litellm.example.com/v1",
+        "platform": "slack",
+        "session_id": "sess-123",
+        "provider": "custom",
+        "_parent_session_id": None,
+        "_gateway_session_key": "agent:main:slack:C123:T456",
+    }
+    values.update(kwargs)
+    return SimpleNamespace(**values)
+
+
+def test_litellm_metadata_tags_interactive_source(monkeypatch):
+    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+    _set_cron_context()
+
+    metadata = build_litellm_request_metadata(_agent(), caller="main")
+
+    assert metadata is not None
+    assert metadata["hermes_app"] == "hermes-agent"
+    assert metadata["hermes_source"] == "slack"
+    assert metadata["hermes_source_tag"] == "interactive:slack"
+    assert metadata["hermes_caller"] == "main"
+    assert metadata["hermes_session_hash"]
+    assert metadata["hermes_session_hash"] != "sess-123"
+    assert metadata["hermes_provider"] == "custom"
+    assert "hermes_gateway_session_key" not in metadata
+
+
+def test_litellm_metadata_tags_cron_job(monkeypatch):
+    monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+    monkeypatch.setenv("HERMES_CRON_JOB_ID", "stale-env-job")
+    monkeypatch.setenv("HERMES_CRON_JOB_NAME", "Daily report")
+    _set_cron_context("abc123", "Daily report")
+
+    metadata = build_litellm_request_metadata(_agent(platform=""), caller="main")
+
+    assert metadata is not None
+    assert metadata["hermes_source"] == "cron"
+    assert metadata["hermes_source_tag"].startswith("cron:")
+    assert metadata["hermes_source_tag"] != "cron:abc123"
+    assert metadata["hermes_cron_job_hash"]
+    assert "hermes_cron_job_id" not in metadata
+    assert "hermes_cron_job_name" not in metadata
+
+
+def test_litellm_metadata_ignores_process_cron_flag_without_job_context(monkeypatch):
+    monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+    monkeypatch.setenv("HERMES_CRON_JOB_ID", "stale-env-job")
+    monkeypatch.delenv("HERMES_CRON_JOB_NAME", raising=False)
+    _set_cron_context()
+
+    metadata = build_litellm_request_metadata(_agent(platform="slack"), caller="main")
+
+    assert metadata is not None
+    assert metadata["hermes_source"] == "slack"
+    assert metadata["hermes_source_tag"] == "interactive:slack"
+
+
+def test_litellm_metadata_marks_delegate(monkeypatch):
+    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+    _set_cron_context()
+
+    metadata = build_litellm_request_metadata(
+        _agent(platform="slack", _parent_session_id="parent-1"), caller="main"
+    )
+
+    assert metadata is not None
+    assert metadata["hermes_source_tag"] == "delegate:slack"
+    assert metadata["hermes_parent_session_hash"]
+    assert metadata["hermes_parent_session_hash"] != "parent-1"
+
+
+def test_litellm_metadata_skips_non_litellm_proxy(monkeypatch):
+    monkeypatch.delenv("HERMES_LITELLM_METADATA", raising=False)
+    _set_cron_context()
+
+    metadata = build_litellm_request_metadata(
+        _agent(base_url="https://api.openai.com/v1")
+    )
+
+    assert metadata is None
+
+
+def test_litellm_metadata_does_not_emit_raw_context_identifiers(monkeypatch):
+    monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+    monkeypatch.setenv("HERMES_CRON_JOB_ID", "stale-env-job")
+    monkeypatch.setenv("HERMES_CRON_JOB_NAME", "Customer revenue report")
+    _set_cron_context("private-job-id", "Customer revenue report")
+
+    metadata = build_litellm_request_metadata(
+        _agent(
+            session_id="session-secret",
+            _parent_session_id="parent-secret",
+            _gateway_session_key="agent:main:slack:CSECRET:TSECRET",
+        ),
+        caller="main",
+    )
+
+    assert metadata is not None
+    serialized_values = " ".join(metadata.values())
+    assert "session-secret" not in serialized_values
+    assert "parent-secret" not in serialized_values
+    assert "CSECRET" not in serialized_values
+    assert "TSECRET" not in serialized_values
+    assert "private-job-id" not in serialized_values
+    assert "stale-env-job" not in serialized_values
+    assert "Customer revenue report" not in serialized_values

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -171,6 +171,46 @@ class TestChatCompletionsBuildKwargs:
         assert kw["messages"][0]["content"] == "Hello"
         assert kw["timeout"] == 30.0
 
+    def test_request_metadata_is_added_to_extra_body(self, transport):
+        msgs = [{"role": "user", "content": "Hello"}]
+        kw = transport.build_kwargs(
+            model="gpt-4o",
+            messages=msgs,
+            request_metadata={"hermes_source_tag": "cron:abc123"},
+        )
+        assert kw["extra_body"]["metadata"]["hermes_source_tag"] == "cron:abc123"
+
+    def test_request_metadata_merges_with_override_metadata(self, transport):
+        msgs = [{"role": "user", "content": "Hello"}]
+        kw = transport.build_kwargs(
+            model="gpt-4o",
+            messages=msgs,
+            request_metadata={"hermes_source_tag": "cron:abc123"},
+            request_overrides={
+                "extra_body": {
+                    "metadata": {
+                        "existing": "kept",
+                        "hermes_source_tag": "override",
+                    }
+                }
+            },
+        )
+        assert kw["extra_body"]["metadata"] == {
+            "hermes_source_tag": "override",
+            "existing": "kept",
+        }
+
+    def test_request_override_can_replace_extra_body_with_none(self, transport):
+        msgs = [{"role": "user", "content": "Hello"}]
+        kw = transport.build_kwargs(
+            model="gpt-4o",
+            messages=msgs,
+            request_metadata={"hermes_source_tag": "cron:abc123"},
+            request_overrides={"extra_body": None},
+        )
+        assert "extra_body" in kw
+        assert kw["extra_body"] is None
+
     def test_developer_role_swap(self, transport):
         msgs = [{"role": "system", "content": "You are helpful"}, {"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(model="gpt-5.4", messages=msgs, model_lower="gpt-5.4")

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -669,6 +669,14 @@ class TestCodexTransportTimeout:
         )
         assert kw.get("timeout") == 450.0
 
+    def test_request_metadata_is_forwarded(self, transport):
+        kw = transport.build_kwargs(
+            model="gpt-5.5",
+            messages=[{"role": "user", "content": "hello"}],
+            request_metadata={"hermes_source_tag": "interactive:slack"},
+        )
+        assert kw["metadata"]["hermes_source_tag"] == "interactive:slack"
+
 
 class TestCodexTransportXaiServiceTierStrip:
     """xAI Responses API rejects ``service_tier`` (#28490).

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -138,6 +138,60 @@ class TestCodexBuildKwargs:
         assert eb.get("prompt_cache_key") == "caller-override"
         assert eb.get("other_field") == 42
 
+    def test_request_metadata_sent_via_extra_body(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=messages,
+            tools=[],
+            request_metadata={"source": "gateway", "feature": "litellm"},
+        )
+        assert "metadata" not in kw
+        assert kw.get("extra_body", {}).get("metadata") == {
+            "source": "gateway",
+            "feature": "litellm",
+        }
+
+    def test_request_override_metadata_merges_into_extra_body(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=messages,
+            tools=[],
+            request_metadata={"source": "gateway", "feature": "litellm"},
+            request_overrides={"metadata": {"feature": "override", "job": "cron"}},
+        )
+        assert "metadata" not in kw
+        assert kw.get("extra_body", {}).get("metadata") == {
+            "source": "gateway",
+            "feature": "override",
+            "job": "cron",
+        }
+
+    def test_request_override_extra_body_preserves_metadata(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=messages,
+            tools=[],
+            request_metadata={"source": "gateway", "feature": "litellm"},
+            request_overrides={
+                "extra_body": {
+                    "metadata": {"feature": "override", "job": "cron"},
+                    "custom": True,
+                }
+            },
+        )
+        assert "metadata" not in kw
+        assert kw.get("extra_body") == {
+            "metadata": {
+                "source": "gateway",
+                "feature": "override",
+                "job": "cron",
+            },
+            "custom": True,
+        }
+
     def test_max_tokens(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(
@@ -669,13 +723,14 @@ class TestCodexTransportTimeout:
         )
         assert kw.get("timeout") == 450.0
 
-    def test_request_metadata_is_forwarded(self, transport):
+    def test_request_metadata_is_forwarded_via_extra_body(self, transport):
         kw = transport.build_kwargs(
             model="gpt-5.5",
             messages=[{"role": "user", "content": "hello"}],
             request_metadata={"hermes_source_tag": "interactive:slack"},
         )
-        assert kw["metadata"]["hermes_source_tag"] == "interactive:slack"
+        assert "metadata" not in kw
+        assert kw["extra_body"]["metadata"]["hermes_source_tag"] == "interactive:slack"
 
 
 class TestCodexTransportXaiServiceTierStrip:


### PR DESCRIPTION
## What does this PR do?

Adds compact source attribution metadata to Hermes LiteLLM/OpenAI-compatible requests so operators can break down model pressure and spend by the surface that initiated a request.

The metadata is attached at the transport boundary and keeps raw identifiers out of LiteLLM logs by hashing session, parent-session, gateway, and cron identifiers. Explicit caller-provided `extra_body` overrides are preserved, including non-dict overrides, so existing custom request behavior stays intact.

## Related Issue

N/A - this is operator observability work for LiteLLM-backed Hermes deployments.

Duplicate/overlap search performed:
- `LiteLLM source attribution metadata OR spend attribution OR request metadata repo:NousResearch/hermes-agent` returned only this PR.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/litellm_metadata.py`: adds low-cardinality metadata construction and hashing for source identifiers.
- `agent/transports/chat_completions.py`: injects metadata into OpenAI-compatible request `extra_body` while preserving explicit override semantics.
- `agent/transports/codex.py`: applies the same attribution metadata for Codex transport requests.
- `cron/scheduler.py`: tags cron-spawned requests with job attribution context.
- `gateway/session_context.py`: carries gateway/session source context for attribution.
- `tests/agent/test_litellm_metadata.py`: covers metadata shape, hashing, redaction, and cron/gateway/session context combinations.
- `tests/agent/transports/test_chat_completions.py` and `tests/agent/transports/test_codex_transport.py`: cover request-body merge behavior and transport integration.

## How to Test

1. Run `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m py_compile agent/litellm_metadata.py agent/transports/chat_completions.py agent/transports/codex.py cron/scheduler.py gateway/session_context.py`.
2. Run `./scripts/run_tests.sh tests/agent/test_litellm_metadata.py tests/agent/transports/test_chat_completions.py tests/agent/transports/test_codex_transport.py`.
3. Run `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python scripts/check-windows-footguns.py --diff upstream/main`.

Verification already performed for this PR:

- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m py_compile agent/litellm_metadata.py agent/transports/chat_completions.py agent/transports/codex.py cron/scheduler.py gateway/session_context.py` -> passed.
- `./scripts/run_tests.sh tests/agent/test_litellm_metadata.py tests/agent/transports/test_chat_completions.py tests/agent/transports/test_codex_transport.py` -> `136 passed`.
- `PYTHONDONTWRITEBYTECODE=1 /workspace/repos/hermes-agent/.venv/bin/python scripts/check-windows-footguns.py --diff upstream/main` -> no Windows footguns found in 9 scanned files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate - no duplicate found; only this PR matched the LiteLLM attribution search.
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass - not run; focused transport/metadata regression bundle passed.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 5.15 / Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A: no user-facing command, config key, or documented workflow changed.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A: no config keys added or changed.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A: no contributor workflow changes.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — metadata/context logic is platform-agnostic Python; Windows footgun check passed.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A: no LLM-facing tool schema changed.

## Screenshots / Logs

No UI screenshots. Focused validation summary:

```text
./scripts/run_tests.sh tests/agent/test_litellm_metadata.py tests/agent/transports/test_chat_completions.py tests/agent/transports/test_codex_transport.py

=== Summary: 3 files, 136 tests passed, 0 failed (100% complete) ===
```

```text
PYTHONDONTWRITEBYTECODE=1 /workspace/repos/hermes-agent/.venv/bin/python scripts/check-windows-footguns.py --diff upstream/main
✓ No Windows footguns found (9 file(s) scanned).
```
