### PR TITLE
fix(auxiliary): skip stale main model fallback for auto provider

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3410,7 +3410,15 @@ def resolve_provider_client(
     # missing-credentials returns and ``_resolve_auto`` falls through to
     # the Step-2 chain as before.
     if not model:
-        model = _get_aux_model_for_provider(provider) or _read_main_model() or model
+        # For provider == "auto", skip the _read_main_model() fallback.
+        # The auto branch resolves the model from the live runtime via
+        # _resolve_auto(main_runtime=...), and a stale model from config
+        # would override the correctly resolved one (issue #44746).
+        _aux_default = _get_aux_model_for_provider(provider)
+        if _aux_default:
+            model = _aux_default
+        elif provider != "auto":
+            model = _read_main_model() or model
 
     def _needs_codex_wrap(client_obj, base_url_str: str, model_str: str) -> bool:
         """Decide if a plain OpenAI client should be wrapped for Responses API.

--- a/tests/agent/test_auxiliary_auto_model_mismatch.py
+++ b/tests/agent/test_auxiliary_auto_model_mismatch.py
@@ -1,0 +1,130 @@
+"""Tests for auxiliary auto provider model mismatch fix (issue #44746).
+
+When provider == "auto", the model resolution should use the live runtime's
+resolved model, not a stale model from _read_main_model().
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent import auxiliary_client as ac
+
+
+class TestAuxiliaryAutoModelMismatch:
+    """provider == "auto" must not use stale _read_main_model()."""
+
+    def test_auto_uses_resolved_model_not_stale_main(self, monkeypatch):
+        """Auto provider should use resolved model from _resolve_auto, not _read_main_model."""
+        # Mock _resolve_auto to return a live runtime model
+        mock_client = MagicMock()
+        monkeypatch.setattr(
+            ac, "_resolve_auto",
+            lambda main_runtime=None: (mock_client, "glm-5.1"),
+        )
+        # Mock _read_main_model to return a stale model
+        monkeypatch.setattr(ac, "_read_main_model", lambda: "gpt-5.5")
+        # Mock _get_aux_model_for_provider to return empty for "auto"
+        monkeypatch.setattr(ac, "_get_aux_model_for_provider", lambda p: "")
+
+        client, model = ac.resolve_provider_client(
+            "auto",
+            model=None,
+            main_runtime={
+                "provider": "zai",
+                "model": "glm-5.1",
+                "base_url": "https://api.z.ai/api/coding/paas/v4",
+            },
+        )
+
+        assert client is mock_client
+        assert model == "glm-5.1"  # Should be resolved, not stale "gpt-5.5"
+
+    def test_auto_with_explicit_model_keeps_explicit(self, monkeypatch):
+        """When caller provides explicit model, auto should keep it."""
+        mock_client = MagicMock()
+        monkeypatch.setattr(
+            ac, "_resolve_auto",
+            lambda main_runtime=None: (mock_client, "glm-5.1"),
+        )
+        monkeypatch.setattr(ac, "_read_main_model", lambda: "gpt-5.5")
+        monkeypatch.setattr(ac, "_get_aux_model_for_provider", lambda p: "")
+
+        client, model = ac.resolve_provider_client(
+            "auto",
+            model="custom-model",
+            main_runtime={
+                "provider": "zai",
+                "model": "glm-5.1",
+                "base_url": "https://api.z.ai/api/coding/paas/v4",
+            },
+        )
+
+        assert client is mock_client
+        assert model == "custom-model"  # Explicit model should be preserved
+
+    def test_non_auto_still_uses_main_model_fallback(self, monkeypatch):
+        """Non-auto providers should still fall back to _read_main_model."""
+        mock_client = MagicMock()
+        monkeypatch.setattr(
+            ac, "_try_openrouter",
+            lambda **kw: (mock_client, "openrouter-default"),
+        )
+        monkeypatch.setattr(ac, "_read_main_model", lambda: "gpt-5.5")
+        monkeypatch.setattr(ac, "_get_aux_model_for_provider", lambda p: "")
+        monkeypatch.setattr(ac, "_normalize_resolved_model", lambda m, p: m)
+
+        client, model = ac.resolve_provider_client(
+            "openrouter",
+            model=None,
+        )
+
+        assert client is mock_client
+        assert model == "gpt-5.5"  # Should use _read_main_model for non-auto
+
+    def test_auto_with_aux_model_default(self, monkeypatch):
+        """When _get_aux_model_for_provider returns a value, auto should use it."""
+        mock_client = MagicMock()
+        monkeypatch.setattr(
+            ac, "_resolve_auto",
+            lambda main_runtime=None: (mock_client, "glm-5.1"),
+        )
+        monkeypatch.setattr(ac, "_read_main_model", lambda: "gpt-5.5")
+        monkeypatch.setattr(ac, "_get_aux_model_for_provider", lambda p: "aux-default" if p == "auto" else "")
+
+        client, model = ac.resolve_provider_client(
+            "auto",
+            model=None,
+            main_runtime={
+                "provider": "zai",
+                "model": "glm-5.1",
+                "base_url": "https://api.z.ai/api/coding/paas/v4",
+            },
+        )
+
+        assert client is mock_client
+        # _get_aux_model_for_provider returns "aux-default", which should be used
+        # But the auto branch's resolved model should take precedence
+        # Actually, looking at the code: model = _get_aux_model_for_provider("auto") or None or model
+        # So model = "aux-default", then in auto branch: final_model = "aux-default" or "glm-5.1"
+        # So it should be "aux-default"
+        assert model == "aux-default"
+
+    def test_auto_resolves_to_none_when_no_runtime(self, monkeypatch):
+        """Auto provider with no runtime should return None."""
+        monkeypatch.setattr(
+            ac, "_resolve_auto",
+            lambda main_runtime=None: (None, None),
+        )
+        monkeypatch.setattr(ac, "_read_main_model", lambda: "gpt-5.5")
+        monkeypatch.setattr(ac, "_get_aux_model_for_provider", lambda p: "")
+
+        client, model = ac.resolve_provider_client(
+            "auto",
+            model=None,
+            main_runtime=None,
+        )
+
+        assert client is None
+        assert model is None


### PR DESCRIPTION
## What does this PR do?

Fixes auxiliary auto provider using a stale model from `_read_main_model()` instead of the correctly resolved model from the live runtime.

## Related Issue

Fixes #44746

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py`: Skip `_read_main_model()` fallback when `provider == "auto"` to prevent stale model from overriding the live runtime's resolved model (9 lines)
- `tests/agent/test_auxiliary_auto_model_mismatch.py`: Added 5 tests covering the auto provider model resolution fix (130 lines)

## How to Test

1. Run the new tests: `pytest tests/agent/test_auxiliary_auto_model_mismatch.py -v`
2. Run existing auxiliary client tests: `pytest tests/agent/test_auxiliary_client.py -v`
3. Verify all 223 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation and Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/auxiliary_client.py::resolve_provider_client` (callers: multiple auxiliary tasks)
- Blast radius: LOW — only affects `provider == "auto"` path, no changes to explicit provider routing
- Related patterns: Uses existing `_resolve_auto()`, `_get_aux_model_for_provider()`, `_read_main_model()` infrastructure
