### PR TITLE
fix(file-tools): normalize MSYS paths in _resolve_path_for_task on Windows (#44726)

### DIFF
--- a/tests/tools/test_file_tools_msys_path.py
+++ b/tests/tools/test_file_tools_msys_path.py
@@ -1,0 +1,43 @@
+"""Tests for MSYS path normalization in file_tools._resolve_path_for_task.
+
+On Windows + Git Bash/MSYS2, the LLM may pass MSYS-style paths like
+``/d/Project/file.sh`` to file tools. Without normalization, Python's
+pathlib treats ``/d/Project`` as "root \\ on the current drive" and
+resolves it to e.g. ``D:\\d\\Project`` instead of ``D:\\Project``.
+
+Regression test for #44726.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from tools import file_tools as ft_mod
+from tools.environments import local as local_mod
+
+
+class TestResolvePathMsysNormalization:
+    """_resolve_path_for_task normalizes MSYS paths before Path construction."""
+
+    def test_msys_drive_path_normalized_on_windows(self, monkeypatch):
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        with patch.object(ft_mod, "_resolve_base_dir", return_value=Path("C:/fallback")):
+            result = ft_mod._resolve_path_for_task("/d/Project/file.sh")
+        assert result == Path("D:\\Project\\file.sh").resolve()
+
+    def test_msys_c_drive_path_normalized_on_windows(self, monkeypatch):
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        with patch.object(ft_mod, "_resolve_base_dir", return_value=Path("C:/fallback")):
+            result = ft_mod._resolve_path_for_task("/c/Users/dev/code.py")
+        assert result == Path("C:\\Users\\dev\\code.py").resolve()
+
+    def test_native_windows_path_unchanged(self, monkeypatch):
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        with patch.object(ft_mod, "_resolve_base_dir", return_value=Path("C:/fallback")):
+            result = ft_mod._resolve_path_for_task("D:\\Project\\file.sh")
+        assert result == Path("D:\\Project\\file.sh").resolve()
+
+    def test_noop_on_non_windows(self, monkeypatch):
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
+        with patch.object(ft_mod, "_resolve_base_dir", return_value=Path("/home/user")):
+            result = ft_mod._resolve_path_for_task("/d/Project/file.sh")
+        assert result == Path("/d/Project/file.sh").resolve()

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -16,6 +16,7 @@ from tools.file_operations import (
     normalize_search_pagination,
 )
 from tools import file_state
+from tools.environments.local import _msys_to_windows_path
 from agent.redact import redact_sensitive_text
 
 logger = logging.getLogger(__name__)
@@ -202,6 +203,7 @@ def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path:
     See :func:`_resolve_base_dir` for how the base is chosen. Absolute input
     paths are returned resolved-but-unanchored.
     """
+    filepath = _msys_to_windows_path(filepath)
     p = Path(filepath).expanduser()
     if p.is_absolute():
         return p.resolve()


### PR DESCRIPTION
## Summary

On Windows + Git Bash/MSYS2, file tools silently write to wrong paths when the LLM passes MSYS-style paths (`/d/Project/file.sh`). Python's `pathlib.Path` treats `/d/Project` as "root `\` on the current drive", resolving it to `D:\d\Project` instead of `D:\Project`.

The normalization already exists in the codebase (`_msys_to_windows_path` in `tools/environments/local.py`) and is used by the terminal tool, but was missing from `file_tools._resolve_path_for_task`.

## Changes

- `tools/file_tools.py`: import and call `_msys_to_windows_path` at the top of `_resolve_path_for_task` before `Path()` construction
- `tests/tools/test_file_tools_msys_path.py`: 4 tests covering MSYS drive paths on Windows, native Windows paths passthrough, and non-Windows no-op

## Test plan

- [x] New tests pass (`pytest tests/tools/test_file_tools_msys_path.py`)
- [x] Existing MSYS path tests still pass (`pytest tests/tools/test_local_env_windows_msys.py`)
- [ ] Manual: on Windows + Git Bash, verify `write_file` with `/d/Project/file` resolves to `D:\Project\file`

Fixes #44726