### PR TITLE
feat(providers): add Chutes provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,15 @@
 # NOVITA_BASE_URL=https://api.novita.ai/openai/v1  # Override default base URL
 
 # =============================================================================
+# LLM PROVIDER (Chutes)
+# =============================================================================
+# Chutes — decentralized, OpenAI-compatible inference with TEE confidential
+# compute (models run in Intel TDX enclaves; prompts/responses stay private).
+# Get your key at: https://chutes.ai/app/api  (keys are prefixed cpk_)
+# CHUTES_API_KEY=
+# CHUTES_BASE_URL=https://llm.chutes.ai/v1  # Override default base URL
+
+# =============================================================================
 # LLM PROVIDER (Google AI Studio / Gemini)
 # =============================================================================
 # Native Gemini API via Google's OpenAI-compatible endpoint.

--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,8 @@
 # LLM PROVIDER (Chutes)
 # =============================================================================
 # Chutes — decentralized, OpenAI-compatible inference with TEE confidential
-# compute (models run in Intel TDX enclaves; prompts/responses stay private).
+# compute (Intel TDX Trust Domains + NVIDIA PPCIE; privacy verifiable via
+# remote attestation, so prompts/responses stay private).
 # Get your key at: https://chutes.ai/app/api  (keys are prefixed cpk_)
 # CHUTES_API_KEY=
 # CHUTES_BASE_URL=https://llm.chutes.ai/v1  # Override default base URL

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -823,8 +823,18 @@ def _extract_pricing(payload: Dict[str, Any]) -> Dict[str, Any]:
         pricing: Dict[str, Any] = {}
         for target, aliases in alias_map.items():
             for alias in aliases:
-                if alias in normalized and normalized[alias] not in {None, ""}:
-                    pricing[target] = normalized[alias]
+                if alias not in normalized:
+                    continue
+                value = normalized[alias]
+                # Skip nested shapes — e.g. Chutes' ``price`` field maps
+                # input/output to ``{tao, usd}`` sub-objects; only scalar
+                # per-token/per-request rates belong here. The tuple (not set)
+                # membership check below also avoids hashing unhashable values
+                # (a dict would raise ``TypeError: unhashable type``).
+                if isinstance(value, (dict, list)):
+                    continue
+                if value not in (None, ""):
+                    pricing[target] = value
                     break
         if pricing:
             return pricing
@@ -2201,6 +2211,16 @@ def get_model_context_length(
 
     if provider == "novita" or (base_url and base_url_host_matches(base_url, "api.novita.ai")):
         ctx = _resolve_endpoint_context_length(model, base_url or "https://api.novita.ai/openai/v1", api_key=api_key)
+        if ctx is not None:
+            if base_url:
+                save_context_length(model, base_url, ctx)
+            return ctx
+
+    if provider == "chutes" or (base_url and base_url_host_matches(base_url, "llm.chutes.ai")):
+        # Chutes exposes authoritative per-model context_length via /v1/models
+        # (e.g. Qwen3-32B = 40960, Kimi K2.6 = 262144) but is not in models.dev,
+        # so prefer that live value over the hardcoded family defaults.
+        ctx = _resolve_endpoint_context_length(model, base_url or "https://llm.chutes.ai/v1", api_key=api_key)
         if ctx is not None:
             if base_url:
                 save_context_length(model, base_url, ctx)

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -48,7 +48,7 @@ def _resolve_requests_verify() -> bool | str:
 _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
     "gemini", "ollama-cloud", "zai", "kimi-coding", "kimi-coding-cn", "stepfun", "minimax", "minimax-oauth", "minimax-cn", "anthropic", "deepseek",
-    "opencode-zen", "opencode-go", "kilocode", "alibaba", "novita",
+    "opencode-zen", "opencode-go", "kilocode", "alibaba", "novita", "chutes",
     "qwen-oauth",
     "xiaomi",
     "arcee",
@@ -68,6 +68,7 @@ _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "xai", "x-ai", "x.ai", "grok",
     "nvidia", "nim", "nvidia-nim", "nemotron",
     "qwen-portal", "novita-ai", "novitaai",
+    "chutes-ai", "chutesai",
 })
 
 
@@ -481,6 +482,7 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "xiaomimimo.com": "xiaomi",
     "api.gmi-serving.com": "gmi",
     "api.novita.ai": "novita",
+    "llm.chutes.ai": "chutes",
     "tokenhub.tencentmaas.com": "tencent-tokenhub",
     "ollama.com": "ollama-cloud",
 }

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1585,7 +1585,7 @@ def _resolve_nous_pricing_credentials() -> tuple[str, str]:
 
 
 def get_pricing_for_provider(provider: str, *, force_refresh: bool = False) -> dict[str, dict[str, str]]:
-    """Return live pricing for providers that support it (openrouter, nous, novita)."""
+    """Return live pricing for providers that support it (openrouter, nous, novita, chutes)."""
     normalized = normalize_provider(provider)
     if normalized == "openrouter":
         return fetch_models_with_pricing(
@@ -1595,6 +1595,8 @@ def get_pricing_for_provider(provider: str, *, force_refresh: bool = False) -> d
         )
     if normalized == "novita":
         return _fetch_novita_pricing(force_refresh=force_refresh)
+    if normalized == "chutes":
+        return _fetch_chutes_pricing(force_refresh=force_refresh)
     if normalized == "nous":
         api_key, base_url = _resolve_nous_pricing_credentials()
         if base_url:
@@ -1663,6 +1665,66 @@ def _fetch_novita_pricing(
         result[str(mid)] = {
             "prompt": str(float(inp or 0) / 10_000 / 1_000_000),
             "completion": str(float(out or 0) / 10_000 / 1_000_000),
+        }
+
+    _pricing_cache[cache_key] = result
+    return result
+
+
+def _fetch_chutes_pricing(
+    timeout: float = 8.0,
+    *,
+    force_refresh: bool = False,
+) -> dict[str, dict[str, str]]:
+    """Fetch pricing from the Chutes /v1/models catalog.
+
+    Chutes returns OpenAI-style per-model pricing under ``pricing`` with
+    ``prompt``/``completion`` expressed in USD per million tokens. Convert to
+    the per-token strings used by the shared pricing formatter.
+
+    Results are cached in ``_pricing_cache`` keyed on the resolved base URL.
+    """
+    api_key = os.getenv("CHUTES_API_KEY", "").strip()
+    if not api_key:
+        return {}
+
+    base_url = os.getenv("CHUTES_BASE_URL", "").strip() or "https://llm.chutes.ai/v1"
+    cache_key = base_url.rstrip("/")
+    if not force_refresh and cache_key in _pricing_cache:
+        return _pricing_cache[cache_key]
+
+    url = cache_key + "/models"
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Accept": "application/json",
+        "User-Agent": _HERMES_USER_AGENT,
+    }
+
+    try:
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            payload = json.loads(resp.read().decode())
+    except Exception:
+        _pricing_cache[cache_key] = {}
+        return {}
+
+    result: dict[str, dict[str, str]] = {}
+    for item in payload.get("data", []):
+        if not isinstance(item, dict):
+            continue
+        mid = item.get("id")
+        if not mid:
+            continue
+        pricing = item.get("pricing")
+        if not isinstance(pricing, dict):
+            continue
+        inp = pricing.get("prompt")
+        out = pricing.get("completion")
+        if inp is None and out is None:
+            continue
+        result[str(mid)] = {
+            "prompt": str(float(inp or 0) / 1_000_000),
+            "completion": str(float(out or 0) / 1_000_000),
         }
 
     _pricing_cache[cache_key] = result

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -556,6 +556,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "zai-org/GLM-5.1-TEE",
         "moonshotai/Kimi-K2.6-TEE",
         "MiniMaxAI/MiniMax-M2.5-TEE",
+        "google/gemma-4-31B-turbo-TEE",
     ],
 }
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -550,6 +550,13 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "deepseek/deepseek-r1-0528",
         "qwen/qwen3-235b-a22b-fp8",
     ],
+    "chutes": [
+        "deepseek-ai/DeepSeek-V3.2-TEE",
+        "Qwen/Qwen3.5-397B-A17B-TEE",
+        "zai-org/GLM-5.1-TEE",
+        "moonshotai/Kimi-K2.6-TEE",
+        "MiniMaxAI/MiniMax-M2.5-TEE",
+    ],
 }
 
 # ---------------------------------------------------------------------------
@@ -1049,6 +1056,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("openrouter",     "OpenRouter",               "OpenRouter (Pay-per-use API aggregator)"),
     ProviderEntry("moa",            "Mixture of Agents",        "Mixture of Agents (named presets; aggregator acts after reference models)"),
     ProviderEntry("novita",         "NovitaAI",                 "NovitaAI (Cloud: Model API, Agent Sandbox, GPU Cloud)"),
+    ProviderEntry("chutes",         "Chutes",                   "Chutes (Decentralized inference, OpenAI-compatible, TEE confidential compute)"),
     ProviderEntry("lmstudio",       "LM Studio",                "LM Studio (Local desktop app with built-in model server)"),
     ProviderEntry("anthropic",      "Anthropic",                "Anthropic (Claude models via API key or Claude Code)"),
     ProviderEntry("openai-codex",   "OpenAI Codex",             "OpenAI Codex (Codex CLI via ChatGPT subscription or API key)"),
@@ -1263,6 +1271,8 @@ _PROVIDER_ALIASES = {
     "huggingface-hub": "huggingface",
     "novita-ai": "novita",
     "novitaai": "novita",
+    "chutes-ai": "chutes",
+    "chutesai": "chutes",
     "mimo": "xiaomi",
     "xiaomi-mimo": "xiaomi",
     "tencent": "tencent-tokenhub",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1680,8 +1680,9 @@ def _fetch_chutes_pricing(
     """Fetch pricing from the Chutes /v1/models catalog.
 
     Chutes returns OpenAI-style per-model pricing under ``pricing`` with
-    ``prompt``/``completion`` expressed in USD per million tokens. Convert to
-    the per-token strings used by the shared pricing formatter.
+    ``prompt``/``completion`` (and an optional ``input_cache_read`` rate)
+    expressed in USD per million tokens. Convert to the per-token strings used
+    by the shared pricing formatter.
 
     Results are cached in ``_pricing_cache`` keyed on the resolved base URL.
     """
@@ -1723,10 +1724,14 @@ def _fetch_chutes_pricing(
         out = pricing.get("completion")
         if inp is None and out is None:
             continue
-        result[str(mid)] = {
+        entry = {
             "prompt": str(float(inp or 0) / 1_000_000),
             "completion": str(float(out or 0) / 1_000_000),
         }
+        cache_read = pricing.get("input_cache_read")
+        if cache_read:
+            entry["input_cache_read"] = str(float(cache_read) / 1_000_000)
+        result[str(mid)] = entry
 
     _pricing_cache[cache_key] = result
     return result

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -167,6 +167,11 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         is_aggregator=True,
         base_url_env_var="NOVITA_BASE_URL",
     ),
+    "chutes": HermesOverlay(
+        transport="openai_chat",
+        is_aggregator=True,
+        base_url_env_var="CHUTES_BASE_URL",
+    ),
     "xai": HermesOverlay(
         transport="codex_responses",
         base_url_override="https://api.x.ai/v1",
@@ -318,6 +323,10 @@ ALIASES: Dict[str, str] = {
     # novita
     "novita-ai": "novita",
     "novitaai": "novita",
+
+    # chutes
+    "chutes-ai": "chutes",
+    "chutesai": "chutes",
 
     # xiaomi
     "mimo": "xiaomi",

--- a/plugins/model-providers/chutes/__init__.py
+++ b/plugins/model-providers/chutes/__init__.py
@@ -1,0 +1,24 @@
+"""Chutes provider profile."""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+chutes = ProviderProfile(
+    name="chutes",
+    aliases=("chutes-ai", "chutesai"),
+    env_vars=("CHUTES_API_KEY", "CHUTES_BASE_URL"),
+    display_name="Chutes",
+    description="Chutes — decentralized, OpenAI-compatible inference (TEE confidential compute)",
+    signup_url="https://chutes.ai/app/api",
+    base_url="https://llm.chutes.ai/v1",
+    default_aux_model="Qwen/Qwen3-32B-TEE",
+    fallback_models=(
+        "deepseek-ai/DeepSeek-V3.2-TEE",
+        "Qwen/Qwen3.5-397B-A17B-TEE",
+        "zai-org/GLM-5.1-TEE",
+        "moonshotai/Kimi-K2.6-TEE",
+        "MiniMaxAI/MiniMax-M2.5-TEE",
+    ),
+)
+
+register_provider(chutes)

--- a/plugins/model-providers/chutes/__init__.py
+++ b/plugins/model-providers/chutes/__init__.py
@@ -11,7 +11,10 @@ chutes = ProviderProfile(
     description="Chutes — decentralized, OpenAI-compatible inference (TEE confidential compute)",
     signup_url="https://chutes.ai/app/api",
     base_url="https://llm.chutes.ai/v1",
-    default_aux_model="Qwen/Qwen3-32B-TEE",
+    # Cheap auxiliary model (compression, titles, vision). Must clear Hermes'
+    # 64K MINIMUM_CONTEXT_LENGTH — so not the 40K Qwen3-32B; gemma-4-31B-turbo
+    # is the cheapest tool-capable catalog model above that floor.
+    default_aux_model="google/gemma-4-31B-turbo-TEE",
     fallback_models=(
         "deepseek-ai/DeepSeek-V3.2-TEE",
         "Qwen/Qwen3.5-397B-A17B-TEE",

--- a/plugins/model-providers/chutes/__init__.py
+++ b/plugins/model-providers/chutes/__init__.py
@@ -21,6 +21,7 @@ chutes = ProviderProfile(
         "zai-org/GLM-5.1-TEE",
         "moonshotai/Kimi-K2.6-TEE",
         "MiniMaxAI/MiniMax-M2.5-TEE",
+        "google/gemma-4-31B-turbo-TEE",
     ),
 )
 

--- a/plugins/model-providers/chutes/plugin.yaml
+++ b/plugins/model-providers/chutes/plugin.yaml
@@ -1,0 +1,5 @@
+name: chutes-provider
+kind: model-provider
+version: 1.0.0
+description: Chutes — decentralized, OpenAI-compatible inference with TEE confidential compute
+author: Nous Research

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -958,6 +958,47 @@ class TestGetModelContextLength:
         assert result == 131072
 
     @patch("agent.model_metadata.fetch_model_metadata")
+    @patch("agent.model_metadata.fetch_endpoint_model_metadata")
+    def test_chutes_uses_live_catalog_context(self, mock_endpoint_fetch, mock_fetch):
+        """Chutes is a recognized provider, so it skips the generic
+        custom-endpoint branch — but its /v1/models catalog carries the
+        authoritative per-model context_length (not in models.dev). The
+        dedicated chutes branch must prefer that live value over the
+        hardcoded family default (Qwen3-32B is 40960, not the 131072 the
+        ``qwen3`` catch-all would return)."""
+        mock_fetch.return_value = {}
+        mock_endpoint_fetch.return_value = {
+            "Qwen/Qwen3-32B-TEE": {"context_length": 40960}
+        }
+        result = get_model_context_length(
+            "Qwen/Qwen3-32B-TEE",
+            base_url="https://llm.chutes.ai/v1",
+            api_key="cpk_test",
+            provider="chutes",
+        )
+        assert result == 40960
+
+    def test_extract_pricing_handles_nested_price_objects(self):
+        """Chutes' /v1/models returns a nested ``price`` field that maps
+        input/output to ``{tao, usd}`` sub-objects, alongside a flat
+        ``pricing`` field of scalar rates. _extract_pricing must not crash on
+        the nested dicts (regression: ``TypeError: unhashable type: 'dict'``
+        from set-membership hashing of a dict value) and should use the flat
+        scalar rates."""
+        from agent.model_metadata import _extract_pricing
+        payload = {
+            "id": "Qwen/Qwen3-32B-TEE",
+            "price": {
+                "input": {"tao": 0.0004, "usd": 0.104},
+                "output": {"tao": 0.0019, "usd": 0.416},
+            },
+            "pricing": {"prompt": 0.104, "completion": 0.416, "input_cache_read": 0.052},
+        }
+        result = _extract_pricing(payload)  # must not raise
+        assert result.get("prompt") == 0.104
+        assert result.get("completion") == 0.416
+
+    @patch("agent.model_metadata.fetch_model_metadata")
     def test_config_context_length_overrides_all(self, mock_fetch):
         """Explicit config_context_length takes priority over everything."""
         mock_fetch.return_value = {

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -978,6 +978,23 @@ class TestGetModelContextLength:
         )
         assert result == 40960
 
+    @patch("agent.model_metadata.fetch_endpoint_model_metadata")
+    def test_chutes_null_catalog_context_falls_through(self, mock_endpoint_fetch):
+        """A few Chutes catalog entries report ``context_length: null`` (e.g.
+        Mistral-Nemo, Nemotron). The live-probe must return ``None`` for those
+        so resolution falls through to the family defaults, rather than
+        crashing or caching a bogus value."""
+        from agent.model_metadata import _resolve_endpoint_context_length
+        mock_endpoint_fetch.return_value = {
+            "unsloth/Mistral-Nemo-Instruct-2407-TEE": {"context_length": None}
+        }
+        result = _resolve_endpoint_context_length(
+            "unsloth/Mistral-Nemo-Instruct-2407-TEE",
+            "https://llm.chutes.ai/v1",
+            api_key="cpk_test",
+        )
+        assert result is None
+
     def test_extract_pricing_handles_nested_price_objects(self):
         """Chutes' /v1/models returns a nested ``price`` field that maps
         input/output to ``{tao, usd}`` sub-objects, alongside a flat

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -895,7 +895,7 @@ class TestGetModelContextLength:
 
         result = get_model_context_length(
             "zai-org/GLM-5-TEE",
-            base_url="https://llm.chutes.ai/v1",
+            base_url="https://custom-llm.example/v1",
             api_key="test-key",
         )
 
@@ -917,7 +917,7 @@ class TestGetModelContextLength:
         # GLM-5-TEE matches the "glm" entry in DEFAULT_CONTEXT_LENGTHS
         result = get_model_context_length(
             "zai-org/GLM-5-TEE",
-            base_url="https://llm.chutes.ai/v1",
+            base_url="https://custom-llm.example/v1",
             api_key="test-key",
         )
         assert result == 202752  # "glm" entry in DEFAULT_CONTEXT_LENGTHS

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -1234,6 +1234,119 @@ class TestNovitaProvider:
 
 
 # =============================================================================
+# Chutes provider tests (added by feat/chutes-provider)
+# =============================================================================
+
+class TestChutesProvider:
+    """Tests for Chutes — a decentralized, OpenAI-compatible aggregator."""
+
+    def test_chutes_profile_loads(self):
+        from providers import get_provider_profile
+        profile = get_provider_profile("chutes")
+        assert profile is not None
+        assert profile.name == "chutes"
+        assert profile.display_name == "Chutes"
+        assert profile.base_url == "https://llm.chutes.ai/v1"
+        assert "CHUTES_API_KEY" in profile.env_vars
+
+    def test_chutes_aliases(self):
+        from providers import get_provider_profile
+        profile = get_provider_profile("chutes")
+        assert "chutes-ai" in profile.aliases
+        assert "chutesai" in profile.aliases
+
+    def test_chutes_alias_resolves(self):
+        assert resolve_provider("chutes-ai") == "chutes"
+        assert resolve_provider("chutesai") == "chutes"
+
+    def test_chutes_in_provider_registry(self):
+        """Auto-registration from ProviderProfile should expose Chutes."""
+        assert "chutes" in PROVIDER_REGISTRY
+        pconfig = PROVIDER_REGISTRY["chutes"]
+        assert pconfig.auth_type == "api_key"
+        assert pconfig.id == "chutes"
+        assert pconfig.inference_base_url == "https://llm.chutes.ai/v1"
+        assert pconfig.api_key_env_vars == ("CHUTES_API_KEY",)
+        assert pconfig.base_url_env_var == "CHUTES_BASE_URL"
+
+    def test_chutes_aliases_in_registry(self):
+        assert "chutes-ai" in PROVIDER_REGISTRY
+        assert "chutesai" in PROVIDER_REGISTRY
+
+    def test_resolve_chutes_with_key(self, monkeypatch):
+        monkeypatch.setenv("CHUTES_API_KEY", "cpk_test-secret-key")
+        creds = resolve_api_key_provider_credentials("chutes")
+        assert creds["provider"] == "chutes"
+        assert creds["api_key"] == "cpk_test-secret-key"
+        assert creds["base_url"] == "https://llm.chutes.ai/v1"
+
+    def test_resolve_chutes_custom_base_url(self, monkeypatch):
+        monkeypatch.setenv("CHUTES_API_KEY", "cpk_key")
+        monkeypatch.setenv("CHUTES_BASE_URL", "https://custom.chutes.example/v1")
+        creds = resolve_api_key_provider_credentials("chutes")
+        assert creds["base_url"] == "https://custom.chutes.example/v1"
+
+    def test_runtime_chutes(self, monkeypatch):
+        monkeypatch.setenv("CHUTES_API_KEY", "cpk_key")
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+        result = resolve_runtime_provider(requested="chutes")
+        assert result["provider"] == "chutes"
+        assert result["api_mode"] == "chat_completions"
+        assert result["api_key"] == "cpk_key"
+        assert result["base_url"] == "https://llm.chutes.ai/v1"
+
+    def test_main_provider_models_has_chutes(self):
+        from hermes_cli.main import _PROVIDER_MODELS
+        assert "chutes" in _PROVIDER_MODELS
+        assert len(_PROVIDER_MODELS["chutes"]) >= 1
+
+    def test_models_py_has_chutes(self):
+        from hermes_cli.models import _PROVIDER_MODELS
+        assert "chutes" in _PROVIDER_MODELS
+        assert len(_PROVIDER_MODELS["chutes"]) >= 1
+
+    def test_chutes_model_lists_match(self):
+        """Model lists in main.py and models.py should be identical."""
+        from hermes_cli.main import _PROVIDER_MODELS as main_models
+        from hermes_cli.models import _PROVIDER_MODELS as models_models
+        assert main_models["chutes"] == models_models["chutes"]
+
+    def test_chutes_models_use_org_name_format(self):
+        """Chutes models should use org/name format."""
+        from hermes_cli.models import _PROVIDER_MODELS
+        for model in _PROVIDER_MODELS["chutes"]:
+            assert "/" in model, f"Chutes model {model!r} missing org/ prefix"
+
+    def test_chutes_aliases_in_models_py(self):
+        from hermes_cli.models import _PROVIDER_ALIASES
+        assert _PROVIDER_ALIASES.get("chutes-ai") == "chutes"
+        assert _PROVIDER_ALIASES.get("chutesai") == "chutes"
+
+    def test_chutes_label(self):
+        from hermes_cli.models import _PROVIDER_LABELS
+        assert "chutes" in _PROVIDER_LABELS
+        assert _PROVIDER_LABELS["chutes"] == "Chutes"
+
+    def test_chutes_in_provider_prefixes(self):
+        from agent.model_metadata import _PROVIDER_PREFIXES
+        assert "chutes" in _PROVIDER_PREFIXES
+
+    def test_chutes_url_to_provider(self):
+        from agent.model_metadata import _URL_TO_PROVIDER
+        assert _URL_TO_PROVIDER.get("llm.chutes.ai") == "chutes"
+
+    def test_chutes_aux_model_registered(self):
+        # The auxiliary model lives on the ProviderProfile
+        # (plugins/model-providers/chutes/__init__.py); the auxiliary client
+        # reads it from there so compression / vision / session-search don't
+        # warn "No auxiliary LLM provider configured" for chutes sessions.
+        import providers
+        profile = providers.get_provider_profile("chutes")
+        assert profile is not None
+        assert profile.default_aux_model
+
+
+# =============================================================================
 # MiniMax OAuth provider tests (added by feat/minimax-oauth-provider)
 # =============================================================================
 

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -1335,6 +1335,19 @@ class TestChutesProvider:
         from agent.model_metadata import _URL_TO_PROVIDER
         assert _URL_TO_PROVIDER.get("llm.chutes.ai") == "chutes"
 
+    def test_chutes_in_doctor_probe_table(self):
+        """`hermes doctor` auto-discovers api-key providers from the plugin
+        registry, so Chutes gets a `/v1/models` health-check probe without any
+        edit to doctor.py."""
+        from hermes_cli.doctor import _build_apikey_providers_list
+        rows = _build_apikey_providers_list()
+        chutes = [r for r in rows if r[0] == "Chutes"]
+        assert chutes, "Chutes missing from the doctor api-key provider probe table"
+        _label, key_vars, models_url, base_var, _hc = chutes[0]
+        assert key_vars == ("CHUTES_API_KEY",)
+        assert models_url == "https://llm.chutes.ai/v1/models"
+        assert base_var == "CHUTES_BASE_URL"
+
     def test_chutes_aux_model_registered(self):
         # The auxiliary model lives on the ProviderProfile
         # (plugins/model-providers/chutes/__init__.py); the auxiliary client

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -1344,6 +1344,12 @@ class TestChutesProvider:
         profile = providers.get_provider_profile("chutes")
         assert profile is not None
         assert profile.default_aux_model
+        # Anchor the aux model to the curated catalog so it can't silently
+        # drift to a non-existent id, and so it stays above Hermes' 64K
+        # MINIMUM_CONTEXT_LENGTH (the 40K Qwen3-32B would be rejected).
+        assert profile.default_aux_model in profile.fallback_models
+        from hermes_cli.models import _PROVIDER_MODELS
+        assert profile.default_aux_model in _PROVIDER_MODELS["chutes"]
 
     def test_chutes_pricing_from_catalog(self, monkeypatch):
         """_fetch_chutes_pricing reads OpenAI-style per-model ``pricing``

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -1345,6 +1345,47 @@ class TestChutesProvider:
         assert profile is not None
         assert profile.default_aux_model
 
+    def test_chutes_pricing_from_catalog(self, monkeypatch):
+        """_fetch_chutes_pricing reads OpenAI-style per-model ``pricing``
+        (USD per million tokens) from /v1/models and converts to per-token
+        strings. The nested ``price`` field (dict values) must not interfere."""
+        from hermes_cli import models as models_mod
+        monkeypatch.setenv("CHUTES_API_KEY", "cpk_test-key")
+        monkeypatch.setenv("CHUTES_BASE_URL", "https://llm.chutes.ai/v1")
+        models_mod._pricing_cache.pop("https://llm.chutes.ai/v1", None)
+
+        fake_payload = {
+            "data": [
+                {
+                    "id": "deepseek-ai/DeepSeek-V3.2-TEE",
+                    "pricing": {"prompt": 0.25, "completion": 1.0},
+                    "price": {"input": {"usd": 0.25}, "output": {"usd": 1.0}},
+                }
+            ]
+        }
+
+        class _FakeResp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def read(self):
+                import json as _json
+                return _json.dumps(fake_payload).encode()
+
+        def fake_urlopen(req, timeout=None):
+            return _FakeResp()
+
+        monkeypatch.setattr(models_mod.urllib.request, "urlopen", fake_urlopen)
+
+        result = models_mod._fetch_chutes_pricing(force_refresh=True)
+        assert "deepseek-ai/DeepSeek-V3.2-TEE" in result
+        entry = result["deepseek-ai/DeepSeek-V3.2-TEE"]
+        assert float(entry["prompt"]) == 0.25 / 1_000_000
+        assert float(entry["completion"]) == 1.0 / 1_000_000
+
 
 # =============================================================================
 # MiniMax OAuth provider tests (added by feat/minimax-oauth-provider)

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -1377,7 +1377,7 @@ class TestChutesProvider:
             "data": [
                 {
                     "id": "deepseek-ai/DeepSeek-V3.2-TEE",
-                    "pricing": {"prompt": 0.25, "completion": 1.0},
+                    "pricing": {"prompt": 0.25, "completion": 1.0, "input_cache_read": 0.125},
                     "price": {"input": {"usd": 0.25}, "output": {"usd": 1.0}},
                 }
             ]
@@ -1404,6 +1404,8 @@ class TestChutesProvider:
         entry = result["deepseek-ai/DeepSeek-V3.2-TEE"]
         assert float(entry["prompt"]) == 0.25 / 1_000_000
         assert float(entry["completion"]) == 1.0 / 1_000_000
+        # Cache-read rate is surfaced (inventory renders it as the "cache" column).
+        assert float(entry["input_cache_read"]) == 0.125 / 1_000_000
 
 
 # =============================================================================

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -129,6 +129,7 @@ Good defaults:
 | **xAI** | Grok models via direct API | Set `XAI_API_KEY` |
 | **xAI Grok OAuth** | SuperGrok / Premium+ subscription, no API key needed | `hermes model` → xAI Grok OAuth |
 | **NovitaAI** | Multi-model API gateway | Set `NOVITA_API_KEY` |
+| **Chutes** | Decentralized, OpenAI-compatible, TEE confidential compute | Set `CHUTES_API_KEY` |
 | **StepFun** | Step Plan models | Set `STEPFUN_API_KEY` |
 | **Xiaomi MiMo** | Xiaomi-hosted models | Set `XIAOMI_API_KEY` |
 | **Tencent TokenHub** | Tencent-hosted models | Set `TOKENHUB_API_KEY` |

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -324,7 +324,7 @@ Get your API key at [novita.ai/settings/key-management](https://novita.ai/settin
 
 ### Chutes — Decentralized, TEE Confidential Compute
 
-[Chutes](https://chutes.ai) is a decentralized, OpenAI-compatible inference network. Every model runs inside a TEE (Intel TDX) confidential-compute enclave, so prompts and responses stay encrypted end to end — including GPU VRAM — and no provider sees them. The shared endpoint is `https://llm.chutes.ai/v1` and API keys are prefixed `cpk_`.
+[Chutes](https://chutes.ai) is a decentralized, OpenAI-compatible inference network. Every model runs inside a Trusted Execution Environment: Intel TDX Trust Domains keep model memory encrypted with CPU-held keys (the hypervisor stays outside the trust boundary), and NVIDIA Protected PCIe (PPCIE) encrypts the CPU↔GPU channel. Privacy is verifiable via remote attestation (signed TD Quotes plus GPU attestation) — "don't trust, verify" — so neither the host nor Chutes can read your prompts or responses. The shared endpoint is `https://llm.chutes.ai/v1` and API keys are prefixed `cpk_`.
 
 ```bash
 # Use any available model

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -21,6 +21,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **Anthropic** | `hermes model` (Claude Max + extra usage credits via OAuth; also supports Anthropic API key or manual setup-token — see note below) |
 | **OpenRouter** | `OPENROUTER_API_KEY` in `~/.hermes/.env` |
 | **NovitaAI** | `NOVITA_API_KEY` in `~/.hermes/.env` (provider: `novita`, 200+ models, Model API, Agent Sandbox, GPU Cloud) |
+| **Chutes** | `CHUTES_API_KEY` in `~/.hermes/.env` (provider: `chutes`; aliases: `chutes-ai`, `chutesai`; decentralized, OpenAI-compatible, TEE confidential compute) |
 | **z.ai / GLM** | `GLM_API_KEY` in `~/.hermes/.env` (provider: `zai`) |
 | **Kimi / Moonshot** | `KIMI_API_KEY` in `~/.hermes/.env` (provider: `kimi-coding`) |
 | **Kimi / Moonshot (China)** | `KIMI_CN_API_KEY` in `~/.hermes/.env` (provider: `kimi-coding-cn`; aliases: `kimi-cn`, `moonshot-cn`) |
@@ -218,6 +219,10 @@ These providers have built-in support with dedicated provider IDs. Set the API k
 hermes chat --provider novita --model moonshotai/kimi-k2.5
 # Requires: NOVITA_API_KEY in ~/.hermes/.env
 
+# Chutes (decentralized, TEE confidential compute)
+hermes chat --provider chutes --model deepseek-ai/DeepSeek-V3.2-TEE
+# Requires: CHUTES_API_KEY in ~/.hermes/.env
+
 # z.ai / ZhipuAI GLM
 hermes chat --provider zai --model glm-5
 # Requires: GLM_API_KEY in ~/.hermes/.env
@@ -267,7 +272,7 @@ model:
   default: "zai-org/GLM-5.1-FP8"
 ```
 
-Base URLs can be overridden with `NOVITA_BASE_URL`, `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, `DASHSCOPE_BASE_URL`, `XIAOMI_BASE_URL`, `GMI_BASE_URL`, or `TOKENHUB_BASE_URL` environment variables.
+Base URLs can be overridden with `NOVITA_BASE_URL`, `CHUTES_BASE_URL`, `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, `DASHSCOPE_BASE_URL`, `XIAOMI_BASE_URL`, `GMI_BASE_URL`, or `TOKENHUB_BASE_URL` environment variables.
 
 :::note Z.AI Endpoint Auto-Detection
 When using the Z.AI / GLM provider, Hermes automatically probes multiple endpoints (global, China, coding variants) to find one that accepts your API key. You don't need to set `GLM_BASE_URL` manually — the working endpoint is detected and cached automatically.
@@ -316,6 +321,29 @@ model:
 ```
 
 Get your API key at [novita.ai/settings/key-management](https://novita.ai/settings/key-management). The base URL can be overridden with `NOVITA_BASE_URL`.
+
+### Chutes — Decentralized, TEE Confidential Compute
+
+[Chutes](https://chutes.ai) is a decentralized, OpenAI-compatible inference network. Every model runs inside a TEE (Intel TDX) confidential-compute enclave, so prompts and responses stay encrypted end to end — including GPU VRAM — and no provider sees them. The shared endpoint is `https://llm.chutes.ai/v1` and API keys are prefixed `cpk_`.
+
+```bash
+# Use any available model
+hermes chat --provider chutes --model deepseek-ai/DeepSeek-V3.2-TEE
+# Requires: CHUTES_API_KEY in ~/.hermes/.env
+
+# Short alias
+hermes chat --provider chutes-ai --model zai-org/GLM-5.1-TEE
+```
+
+Or set it permanently in `config.yaml`:
+```yaml
+model:
+  provider: "chutes"
+  default: "deepseek-ai/DeepSeek-V3.2-TEE"
+  base_url: "https://llm.chutes.ai/v1"
+```
+
+Hermes fetches the live model catalog, per-model context length, and pricing from Chutes' `/v1/models` endpoint, so new models appear automatically. Get your API key at [chutes.ai/app/api](https://chutes.ai/app/api). The base URL can be overridden with `CHUTES_BASE_URL`.
 
 ### Ollama Cloud — Managed Ollama Models, OAuth + API Key
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -105,7 +105,7 @@ Common options:
 | `-q`, `--query "..."` | One-shot, non-interactive prompt. |
 | `-m`, `--model <model>` | Override the model for this run. |
 | `-t`, `--toolsets <csv>` | Enable a comma-separated set of toolsets. |
-| `--provider <provider>` | Force a provider: `auto`, `openrouter`, `nous`, `openai-codex`, `copilot-acp`, `copilot`, `anthropic`, `gemini`, `huggingface`, `novita` (aliases `novita-ai`, `novitaai`), `openai-api`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `kilocode`, `xiaomi`, `arcee`, `gmi`, `alibaba`, `alibaba-coding-plan` (alias `alibaba_coding`), `deepseek`, `nvidia`, `ollama-cloud`, `xai` (alias `grok`), `xai-oauth` (alias `grok-oauth`), `qwen-oauth`, `bedrock`, `opencode-zen`, `opencode-go`, `azure-foundry`, `lmstudio`, `stepfun`, `tencent-tokenhub` (alias `tencent`, `tokenhub`). |
+| `--provider <provider>` | Force a provider: `auto`, `openrouter`, `nous`, `openai-codex`, `copilot-acp`, `copilot`, `anthropic`, `gemini`, `huggingface`, `novita` (aliases `novita-ai`, `novitaai`), `chutes` (aliases `chutes-ai`, `chutesai`), `openai-api`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `kilocode`, `xiaomi`, `arcee`, `gmi`, `alibaba`, `alibaba-coding-plan` (alias `alibaba_coding`), `deepseek`, `nvidia`, `ollama-cloud`, `xai` (alias `grok`), `xai-oauth` (alias `grok-oauth`), `qwen-oauth`, `bedrock`, `opencode-zen`, `opencode-go`, `azure-foundry`, `lmstudio`, `stepfun`, `tencent-tokenhub` (alias `tencent`, `tokenhub`). |
 | `-s`, `--skills <name>` | Preload one or more skills for the session (can be repeated or comma-separated). |
 | `-v`, `--verbose` | Verbose output. |
 | `-Q`, `--quiet` | Programmatic mode: suppress banner/spinner/tool previews. |

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -78,6 +78,8 @@ Hermes reads environment variables from the process environment and, for user-ma
 | `DEEPSEEK_BASE_URL` | Custom DeepSeek API base URL |
 | `NOVITA_API_KEY` | NovitaAI API key — AI-native cloud for Model API, Agent Sandbox, and GPU Cloud ([novita.ai/settings/key-management](https://novita.ai/settings/key-management)) |
 | `NOVITA_BASE_URL` | Override NovitaAI base URL (default: `https://api.novita.ai/openai/v1`) |
+| `CHUTES_API_KEY` | Chutes API key — decentralized, OpenAI-compatible inference with TEE confidential compute ([chutes.ai/app/api](https://chutes.ai/app/api)) |
+| `CHUTES_BASE_URL` | Override Chutes base URL (default: `https://llm.chutes.ai/v1`) |
 | `NVIDIA_API_KEY` | NVIDIA NIM API key — Nemotron and open models ([build.nvidia.com](https://build.nvidia.com)) |
 | `NVIDIA_BASE_URL` | Override NVIDIA base URL (default: `https://integrate.api.nvidia.com/v1`; set to `http://localhost:8000/v1` for a local NIM endpoint) |
 | `STEPFUN_API_KEY` | StepFun API key — Step-series models ([platform.stepfun.com](https://platform.stepfun.com)) |


### PR DESCRIPTION
## Summary

Adds [Chutes](https://chutes.ai) as a built-in model provider.

Chutes is a **decentralized, OpenAI-compatible** inference network. Its models
run inside a **Trusted Execution Environment**: Intel TDX Trust Domains keep
model memory encrypted with CPU-held keys (the hypervisor sits outside the
trust boundary), and NVIDIA Protected PCIe (PPCIE) encrypts the CPU↔GPU
channel. Privacy is **verifiable via remote attestation** (signed TD Quotes
plus GPU attestation), so neither the host nor Chutes can read your prompts or
responses. The public endpoint is `https://llm.chutes.ai/v1` and keys are
prefixed `cpk_`.

This follows the existing OpenAI-compatible aggregator pattern (NovitaAI), so
auth, the provider registry, and runtime resolution auto-wire from the
`ProviderProfile` — no edits to `auth.py` / `runtime_provider.py` needed.

## Changes

**Provider plugin & wiring**
- **`plugins/model-providers/chutes/`** — new plugin: `ProviderProfile`
  (`base_url` `https://llm.chutes.ai/v1`, `CHUTES_API_KEY` / `CHUTES_BASE_URL`,
  aliases `chutes-ai` / `chutesai`, curated fallback models, and a default aux
  model — see "Valid auxiliary model" below) + `plugin.yaml` manifest.
- **`hermes_cli/models.py`** — curated fallback model list, provider aliases,
  `CANONICAL_PROVIDERS` entry (drives the picker label).
- **`agent/model_metadata.py`** — provider prefix + `llm.chutes.ai -> chutes`
  URL mapping.
- **`hermes_cli/providers.py`** — `openai_chat` `HermesOverlay` (aggregator) +
  aliases.
- **`.env.example`** — Chutes credentials block.

**Accurate per-model context length**
- **`agent/model_metadata.py`** — `get_model_context_length` gains a `chutes`
  branch that reads the authoritative per-model `context_length` from the live
  `/v1/models` catalog (e.g. `Qwen/Qwen3-32B-TEE` = 40960, `Kimi-K2.6` =
  262144), since Chutes models are not in models.dev and the hardcoded family
  default would otherwise mis-size them.

**Live pricing**
- **`hermes_cli/models.py`** — `_fetch_chutes_pricing` reads OpenAI-style
  per-model `pricing` (USD per million tokens) from `/v1/models` and converts
  to per-token, wired into `get_pricing_for_provider`.

**Valid auxiliary model**
- **`plugins/model-providers/chutes/`** — `default_aux_model` is
  `google/gemma-4-31B-turbo-TEE` (131072 context), not the 40,960-context
  `Qwen3-32B-TEE`, which falls below Hermes' 64K `MINIMUM_CONTEXT_LENGTH` once
  the live context probe reports its real limit.

**Bug fix (general)**
- **`agent/model_metadata.py`** — `_extract_pricing` raised
  `TypeError: unhashable type: 'dict'` for any `/models` response whose pricing
  fields contain nested objects (Chutes maps `price.input`/`price.output` to
  `{tao, usd}` sub-objects). The set-membership empty-check hashed the value;
  switched to tuple membership and skip non-scalar values. This exception was
  silently emptying the entire endpoint-metadata cache, which also broke the
  context probe above.

## Docs

- **`website/docs/integrations/providers.md`** — provider table row, a quick
  example, a dedicated "Chutes — Decentralized, TEE Confidential Compute"
  section, and the base-URL override list.
- **`website/docs/getting-started/quickstart.md`**, **`reference/cli-commands.md`**,
  **`reference/environment-variables.md`** — provider tables, the `--provider`
  list, and the `CHUTES_API_KEY` / `CHUTES_BASE_URL` env vars.

## Model list

The curated `fallback_models` only contains tool-calling-capable text models
(vision input allowed); the live `/v1/models` catalog stays authoritative at
runtime and the curated list is just the offline fallback.

## Tests

- New `TestChutesProvider` in `tests/hermes_cli/test_api_key_providers.py`:
  profile, registry auto-registration, alias / runtime / credential resolution,
  model lists, label, provider prefix, URL mapping, and live-pricing parsing.
- `tests/agent/test_model_metadata.py`: chutes live-catalog context resolution
  and an `_extract_pricing` regression test for nested price objects.
- Two custom-endpoint context-length tests that used `llm.chutes.ai` as a
  stand-in for an *unknown* endpoint now use a synthetic URL, since Chutes is a
  recognized provider.
