### PR TITLE
feat(discord): add emoji reaction tags to channel context

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -67,6 +67,26 @@ from gateway.platforms.base import (
 )
 from tools.url_safety import is_safe_url
 
+try:
+    import emoji as _emoji_lib
+except ImportError:
+    _emoji_lib = None
+
+
+def _emoji_to_name(emoji_obj) -> str:
+    """Convert a discord.py emoji to :colon_name: format."""
+    if hasattr(emoji_obj, "name") and emoji_obj.name:
+        return f":{emoji_obj.name}:"
+    s = str(emoji_obj)
+    if _emoji_lib is not None:
+        try:
+            name = _emoji_lib.demojize(s)
+            if name != s:
+                return name
+        except Exception:
+            pass
+    return s
+
 
 def _clean_discord_id(entry: str) -> str:
     """Strip common prefixes from a Discord user ID or username entry.
@@ -3691,6 +3711,30 @@ class DiscordAdapter(BasePlatformAdapter):
         except (ValueError, TypeError):
             return 50
 
+    async def _format_reactions(self, msg: Any) -> str:
+        """Format message reactions as an [EMOJI, ...] tag string."""
+        reactions = getattr(msg, "reactions", None)
+        if not reactions:
+            return ""
+
+        user_emojis: Dict[str, List[str]] = {}
+        for reaction in reactions:
+            emoji_name = _emoji_to_name(reaction.emoji)
+            try:
+                async for user in reaction.users():
+                    name = getattr(user, "display_name", None) or getattr(user, "name", str(user))
+                    user_emojis.setdefault(name, []).append(emoji_name)
+            except Exception:
+                return " [EMOJI, ERROR]"
+
+        if not user_emojis:
+            return ""
+
+        parts = []
+        for name, emojis in user_emojis.items():
+            parts.append(f"{name}: {', '.join(emojis)}")
+        return " [EMOJI, " + "; ".join(parts) + "]"
+
     async def _fetch_channel_context(
         self,
         channel: Any,
@@ -3708,11 +3752,22 @@ class DiscordAdapter(BasePlatformAdapter):
             [Alice] some message
             [Bob [bot]] another message
 
+        When ``history_backfill_reactions`` is enabled, messages with
+        reactions include an ``[EMOJI, ...]`` tag::
+
+            [Alice] some message [EMOJI, Bob: :thumbsup:; Alice: :heart:]
+
         Returns an empty string if no context is available.
         """
         limit = self._discord_history_backfill_limit()
         if limit <= 0:
             return ""
+
+        # Determine whether to fetch per-user reaction data
+        fetch_reactions = self.config.extra.get("history_backfill_reactions", False)
+        if not fetch_reactions:
+            raw = os.getenv("DISCORD_HISTORY_BACKFILL_REACTIONS", "").lower().strip()
+            fetch_reactions = raw in {"true", "1", "yes", "on"}
 
         # Determine which bot messages to include in context
         allow_bots_raw = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
@@ -3774,7 +3829,10 @@ class DiscordAdapter(BasePlatformAdapter):
                 name = msg.author.display_name
                 if getattr(msg.author, "bot", False):
                     name = f"{name} [bot]"
-                collected.append(f"[{name}] {content}")
+                line = f"[{name}] {content}"
+                if fetch_reactions:
+                    line += await self._format_reactions(msg)
+                collected.append(line)
 
             if not collected:
                 return ""

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -113,6 +113,7 @@ def adapter(monkeypatch):
         "DISCORD_IGNORED_CHANNELS",
         "DISCORD_HISTORY_BACKFILL",
         "DISCORD_HISTORY_BACKFILL_LIMIT",
+        "DISCORD_HISTORY_BACKFILL_REACTIONS",
         "DISCORD_ALLOW_BOTS",
     ):
         monkeypatch.delenv(_var, raising=False)
@@ -147,12 +148,14 @@ def make_history_message(
     msg_id: int,
     msg_type=None,
     attachments=None,
+    reactions=None,
 ):
     return SimpleNamespace(
         id=msg_id,
         author=author,
         content=content,
         attachments=list(attachments or []),
+        reactions=list(reactions or []),
         type=msg_type if msg_type is not None else discord_platform.discord.MessageType.default,
     )
 
@@ -882,5 +885,146 @@ async def test_discord_dm_does_not_backfill(adapter, monkeypatch):
     if adapter.handle_message.await_args is not None:
         event = adapter.handle_message.await_args.args[0]
         assert event.channel_context is None
+
+
+# ---------------------------------------------------------------------------
+# Reaction emoji tags in channel context
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_reaction(emoji_name, users):
+    """Build a fake Reaction-like object with an async users() iterator."""
+    async def _users_iter(**_kwargs):
+        for u in users:
+            yield u
+
+    return SimpleNamespace(
+        emoji=SimpleNamespace(name=emoji_name),
+        count=len(users),
+        users=lambda **kw: _users_iter(**kw),
+    )
+
+
+def _make_failing_reaction(emoji_name):
+    """Build a fake Reaction whose users() raises."""
+    async def _users_iter(**_kwargs):
+        raise RuntimeError("API error")
+        yield  # noqa: unreachable — makes this an async generator
+
+    return SimpleNamespace(
+        emoji=SimpleNamespace(name=emoji_name),
+        count=1,
+        users=lambda **kw: _users_iter(**kw),
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_channel_context_includes_reactions_when_enabled(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_HISTORY_BACKFILL_REACTIONS", "true")
+    adapter.config.extra["history_backfill_limit"] = 10
+
+    alice = SimpleNamespace(id=56, display_name="Alice", name="Alice", bot=False)
+    bob = SimpleNamespace(id=57, display_name="Bob", name="Bob", bot=False)
+
+    reactions = [
+        _make_fake_reaction("white_check_mark", [bob]),
+        _make_fake_reaction("thumbsup", [alice, bob]),
+    ]
+
+    channel = FakeHistoryChannel(
+        [make_history_message(author=alice, content="hello", msg_id=2, reactions=reactions)],
+        channel_id=123,
+    )
+
+    result = await adapter._fetch_channel_context(channel, before=make_message(channel=channel, content="trigger"))
+
+    assert "[EMOJI, " in result
+    assert "Bob: :white_check_mark:, :thumbsup:" in result
+    assert "Alice: :thumbsup:" in result
+
+
+@pytest.mark.asyncio
+async def test_fetch_channel_context_no_reactions_by_default(adapter, monkeypatch):
+    monkeypatch.delenv("DISCORD_HISTORY_BACKFILL_REACTIONS", raising=False)
+    adapter.config.extra["history_backfill_limit"] = 10
+
+    alice = SimpleNamespace(id=56, display_name="Alice", name="Alice", bot=False)
+    bob = SimpleNamespace(id=57, display_name="Bob", name="Bob", bot=False)
+
+    reactions = [_make_fake_reaction("thumbsup", [bob])]
+
+    channel = FakeHistoryChannel(
+        [make_history_message(author=alice, content="hello", msg_id=2, reactions=reactions)],
+        channel_id=123,
+    )
+
+    result = await adapter._fetch_channel_context(channel, before=make_message(channel=channel, content="trigger"))
+
+    assert "[EMOJI" not in result
+    assert result == "[Recent channel messages]\n[Alice] hello"
+
+
+@pytest.mark.asyncio
+async def test_fetch_channel_context_reaction_api_error_shows_error_tag(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_HISTORY_BACKFILL_REACTIONS", "true")
+    adapter.config.extra["history_backfill_limit"] = 10
+
+    alice = SimpleNamespace(id=56, display_name="Alice", name="Alice", bot=False)
+
+    reactions = [_make_failing_reaction("thumbsup")]
+
+    channel = FakeHistoryChannel(
+        [make_history_message(author=alice, content="hello", msg_id=2, reactions=reactions)],
+        channel_id=123,
+    )
+
+    result = await adapter._fetch_channel_context(channel, before=make_message(channel=channel, content="trigger"))
+
+    assert "[EMOJI, ERROR]" in result
+    assert result == "[Recent channel messages]\n[Alice] hello [EMOJI, ERROR]"
+
+
+@pytest.mark.asyncio
+async def test_fetch_channel_context_no_emoji_tag_when_no_reactions(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_HISTORY_BACKFILL_REACTIONS", "true")
+    adapter.config.extra["history_backfill_limit"] = 10
+
+    alice = SimpleNamespace(id=56, display_name="Alice", name="Alice", bot=False)
+
+    channel = FakeHistoryChannel(
+        [make_history_message(author=alice, content="hello", msg_id=2)],
+        channel_id=123,
+    )
+
+    result = await adapter._fetch_channel_context(channel, before=make_message(channel=channel, content="trigger"))
+
+    assert "[EMOJI" not in result
+    assert result == "[Recent channel messages]\n[Alice] hello"
+
+
+def test_emoji_to_name_custom_emoji():
+    from gateway.platforms.discord import _emoji_to_name
+
+    custom = SimpleNamespace(name="pepethink")
+    assert _emoji_to_name(custom) == ":pepethink:"
+
+
+def test_emoji_to_name_unicode_fallback():
+    from gateway.platforms.discord import _emoji_to_name
+
+    result = _emoji_to_name("✅")
+    # With emoji lib: ":white_check_mark:" or similar; without: "✅"
+    assert isinstance(result, str)
+    assert len(result) > 0
+
+
+def test_emoji_to_name_empty_name_attr():
+    from gateway.platforms.discord import _emoji_to_name
+
+    obj = SimpleNamespace(name="")
+    result = _emoji_to_name(obj)
+    # Empty name falls through to str() — verifies it doesn't produce "::"
+    assert result != "::"
+    assert isinstance(result, str)
 
 


### PR DESCRIPTION
## Summary

- Adds per-user emoji reaction annotations to the `[Recent channel messages]` context block in the Discord gateway adapter
- Format: `[Username] message [EMOJI, User1: :emoji1:; User2: :emoji2:]`
- Opt-in via `discord.history_backfill_reactions: true` in config or `DISCORD_HISTORY_BACKFILL_REACTIONS=true` env var — default off, zero overhead when disabled
- On API failure, shows `[EMOJI, ERROR]` instead of partial/misleading data — never approximates
- Uses optional `emoji` library for unicode→colon-name conversion; falls back to raw unicode if not installed

## Motivation

When the agent receives recent channel messages as context, it currently has no visibility into emoji reactions. This means it can't tell if a message was already acknowledged (e.g. a ✅ reaction from the bot) or gauge user sentiment. This feature gives the agent that signal.

The real-world situation involved me asking Hermes "Status?" after restarting and it saw a few "recent" messages (In the dashboard, this showed as a Discord session with "[Recent channel messages]" at the top and the messages, but with no other context.)

The issue arises because Hermes has already responded and followed up on all of those messages using threads and also marked the messages with a green/white checkmark box reaction emoji. However, those extra details were not included in the "recent messages". So Hermes assumed the previous messages were outstanding/open messages that still needed to be addressed. It then immediately went on to answer all of them again without any prompt.

## Test plan

- [x] Reactions included in context when config enabled
- [x] No reactions by default (opt-in, no behavior change for existing users)
- [x] `[EMOJI, ERROR]` shown on API failure — no partial data
- [x] No `[EMOJI]` tag when message has zero reactions
- [x] `_emoji_to_name` handles custom emoji, unicode, and edge cases
- [x] All 41 tests in `test_discord_free_response.py` pass