### PR TITLE
fix(cli): drop agent-browser/@streamdown-math from root npm deps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,7 @@ cd "${HERMES_HOME:-$HOME/.hermes}/hermes-agent"
 # Add dev/test extras on top of the standard install.
 uv pip install -e ".[all,dev]"
 
-# Optional: browser tools / docs site dependencies.
+# Optional: docs site + workspace dependencies.
 npm install
 ```
 
@@ -167,7 +167,7 @@ export PATH="$VIRTUAL_ENV/bin:$PATH"
 # Install with all extras (messaging, cron, CLI menus, dev tools)
 uv pip install -e ".[all,dev]"
 
-# Optional: browser tools
+# Optional: workspace / docs dependencies
 npm install
 ```
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -83,6 +83,7 @@
     "@nanostores/react": "1.1.0",
     "@nous-research/ui": "0.18.2",
     "@streamdown/code": "1.1.1",
+    "@streamdown/math": "1.0.2",
     "@tabler/icons-react": "3.44.0",
     "@tailwindcss/typography": "0.5.20",
     "@tailwindcss/vite": "4.3.3",

--- a/hermes_cli/dep_ensure.py
+++ b/hermes_cli/dep_ensure.py
@@ -35,6 +35,7 @@ _DEP_CHECKS = {
         agent_browser_runnable(shutil.which("agent-browser"))
         or _has_system_browser()
         or _has_hermes_agent_browser()
+        or _has_npx_agent_browser()
     ),
     "ripgrep": lambda: shutil.which("rg") is not None,
     "ffmpeg": lambda: shutil.which("ffmpeg") is not None,
@@ -57,6 +58,25 @@ def _has_system_browser() -> bool:
         if shutil.which(name):
             return True
     return False
+
+
+def _has_npx_agent_browser() -> bool:
+    """agent-browser resolves lazily via npx on the default install (#43564),
+    invisible to the PATH/managed-dir probes above. Mirror
+    tools.browser_tool.check_browser_requirements's Termux carve-out so this
+    check can't diverge from what browser tools actually find."""
+    try:
+        from tools.browser_tool import (
+            _find_agent_browser,
+            _is_npx_agent_browser_sentinel,
+            _requires_real_termux_browser_install,
+        )
+        browser_cmd = _find_agent_browser(validate=False)
+    except Exception:
+        return False
+    if not _is_npx_agent_browser_sentinel(browser_cmd):
+        return False
+    return not _requires_real_termux_browser_install(browser_cmd)
 
 
 def _has_hermes_agent_browser() -> bool:

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2115,12 +2115,12 @@ def run_doctor(args):
         # existence check with no subprocess spawn or install side effects.
         agent_browser_ok = False
         try:
-            from tools.browser_tool import _find_agent_browser
+            from tools.browser_tool import _find_agent_browser, _is_npx_agent_browser_sentinel
             _resolved_ab = _find_agent_browser(validate=False)
         except Exception:
             _resolved_ab = None
 
-        if _resolved_ab == "npx agent-browser":
+        if _resolved_ab and _is_npx_agent_browser_sentinel(_resolved_ab):
             check_ok("agent-browser", "(resolves via npx on first use)")
             agent_browser_ok = True
             if should_fix:
@@ -2130,8 +2130,7 @@ def run_doctor(args):
                 # doesn't pay the registry fetch either way.
                 from tools.browser_tool import warm_agent_browser_npx_cache
                 if warm_agent_browser_npx_cache():
-                    check_ok("  Warmed npx cache for agent-browser")
-                    fixed_count += 1
+                    check_info("  Warmed npx cache for agent-browser")
                 else:
                     check_info("  Could not warm npx cache (offline or npx unavailable)")
         elif _resolved_ab and agent_browser_runnable(_resolved_ab):

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2107,49 +2107,43 @@ def run_doctor(args):
     # Node.js + agent-browser (for browser automation tools)
     if _safe_which("node"):
         check_ok("Node.js")
-        # Check if agent-browser is installed
-        agent_browser_path = PROJECT_ROOT / "node_modules" / "agent-browser"
+        # agent-browser is no longer a root package.json dependency (#43564)
+        # — it resolves lazily via npx (or a global/Hermes-managed install)
+        # at first use. Mirror tools.browser_tool._find_agent_browser's own
+        # resolution cascade here so doctor can't diverge from what browser
+        # tools will actually find; validate=False keeps this a cheap
+        # existence check with no subprocess spawn or install side effects.
         agent_browser_ok = False
-        _which_ab = shutil.which("agent-browser")
-        # `hermes acp --setup-browser` installs agent-browser into the
-        # Hermes-managed node prefix, which isn't necessarily on PATH. Mirror
-        # dep_ensure._has_hermes_agent_browser() so doctor and dep_ensure agree
-        # on what "installed" means; otherwise doctor false-negatives (#53192).
-        # Resolve with PATHEXT-aware ``shutil.which`` (not a bare is_file())
-        # so Windows picks the executable ``.cmd`` shim — the same class of
-        # miss fixed for _has_agent_browser() in #73932.
-        def _which_in(directory) -> str | None:
-            try:
-                if not directory.is_dir():
-                    return None
-                return shutil.which("agent-browser", path=str(directory))
-            except Exception:
-                return None
+        try:
+            from tools.browser_tool import _find_agent_browser
+            _resolved_ab = _find_agent_browser(validate=False)
+        except Exception:
+            _resolved_ab = None
 
-        _managed_ab = (
-            _which_in(HERMES_HOME / "node" / "bin")
-            or _which_in(HERMES_HOME / "node")
-        )
-        _legacy_ab = _which_in(HERMES_HOME / "node_modules" / ".bin")
-        if agent_browser_path.exists():
-            check_ok("agent-browser (Node.js)", "(browser automation)")
+        if _resolved_ab == "npx agent-browser":
+            check_ok("agent-browser", "(resolves via npx on first use)")
             agent_browser_ok = True
-        elif _which_ab and agent_browser_runnable(_which_ab):
+            if should_fix:
+                # Doctor can't tell from here whether npx's cache already
+                # has agent-browser warm — just fire the same warm-up
+                # `hermes update` does, so a session's first browser call
+                # doesn't pay the registry fetch either way.
+                from tools.browser_tool import warm_agent_browser_npx_cache
+                if warm_agent_browser_npx_cache():
+                    check_ok("  Warmed npx cache for agent-browser")
+                    fixed_count += 1
+                else:
+                    check_info("  Could not warm npx cache (offline or npx unavailable)")
+        elif _resolved_ab and agent_browser_runnable(_resolved_ab):
             check_ok("agent-browser", "(browser automation)")
             agent_browser_ok = True
-        elif _managed_ab and agent_browser_runnable(_managed_ab):
-            check_ok("agent-browser", "(browser automation)")
-            agent_browser_ok = True
-        elif _legacy_ab and agent_browser_runnable(_legacy_ab):
-            check_ok("agent-browser", "(browser automation)")
-            agent_browser_ok = True
-        elif _which_ab:
+        elif _resolved_ab:
             # Found on PATH but won't run — almost always a dangling global
             # symlink left behind by agent-browser's npm postinstall after a
             # `hermes update` wiped node_modules (issue #48521).
             check_warn(
                 "agent-browser found but not runnable",
-                f"(broken symlink at {_which_ab}? run: npm install)",
+                f"(broken symlink at {_resolved_ab}? run: npx agent-browser --version)",
             )
         elif _is_termux():
             check_info("agent-browser is not installed (expected in the tested Termux path)")
@@ -2158,7 +2152,7 @@ def run_doctor(args):
             for step in _termux_browser_setup_steps(node_installed=True):
                 check_info(step)
         else:
-            check_warn("agent-browser not installed", "(run: npm install)")
+            check_warn("agent-browser not installed", "(requires npm/npx on PATH)")
 
         # Chromium presence — the browser tools silently fail to register when
         # agent-browser is found but no Playwright-managed Chromium is on disk

--- a/hermes_cli/doctor_live.py
+++ b/hermes_cli/doctor_live.py
@@ -91,7 +91,14 @@ def _browser_available() -> bool:
                 return True
     except Exception:
         pass
-    return False
+    # agent-browser resolves lazily via npx on the default install (#43564),
+    # invisible to the PATH/node_modules probes above. Mirror the rung
+    # hermes_cli.doctor uses so this probe can't diverge from it.
+    try:
+        from tools.browser_tool import _find_agent_browser, _is_npx_agent_browser_sentinel
+        return _is_npx_agent_browser_sentinel(_find_agent_browser(validate=False))
+    except Exception:
+        return False
 
 
 def _launch_browser_probe(timeout: float) -> tuple:

--- a/hermes_cli/doctor_live.py
+++ b/hermes_cli/doctor_live.py
@@ -93,12 +93,21 @@ def _browser_available() -> bool:
         pass
     # agent-browser resolves lazily via npx on the default install (#43564),
     # invisible to the PATH/node_modules probes above. Mirror the rung
-    # hermes_cli.doctor uses so this probe can't diverge from it.
+    # hermes_cli.doctor uses so this probe can't diverge from it, including
+    # the Termux carve-out (bare npx is too fragile to advertise as ready
+    # there — see check_browser_requirements).
     try:
-        from tools.browser_tool import _find_agent_browser, _is_npx_agent_browser_sentinel
-        return _is_npx_agent_browser_sentinel(_find_agent_browser(validate=False))
+        from tools.browser_tool import (
+            _find_agent_browser,
+            _is_npx_agent_browser_sentinel,
+            _requires_real_termux_browser_install,
+        )
+        browser_cmd = _find_agent_browser(validate=False)
     except Exception:
         return False
+    if not _is_npx_agent_browser_sentinel(browser_cmd):
+        return False
+    return not _requires_real_termux_browser_install(browser_cmd)
 
 
 def _launch_browser_probe(timeout: float) -> tuple:

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -159,35 +159,43 @@ def _toolset_enabled(config: Dict[str, object], toolset_key: str) -> bool:
 def _has_agent_browser() -> bool:
     import shutil
 
-    from hermes_constants import agent_browser_runnable, with_hermes_node_path
+    from hermes_constants import agent_browser_runnable
 
-    # Validate the resolved binary actually runs — a dangling global symlink
-    # (issue #48521) is reported by ``which`` but fails at exec. Fall through to
-    # the local node_modules copy, which the validator also checks.
-    if agent_browser_runnable(shutil.which("agent-browser")):
-        return True
-
-    # Hermes-managed Node dirs (Windows installer / POSIX $HERMES_HOME/node)
-    # are prepended to PATH at runtime but usually absent from the *probe*
-    # process's PATH — the same rung `_find_agent_browser` searches. Without
-    # it a successful install keeps reporting "needs setup" on Windows.
-    managed_path = with_hermes_node_path().get("PATH", "")
-    if managed_path:
-        managed_hit = shutil.which("agent-browser", path=managed_path)
-        if managed_hit and agent_browser_runnable(managed_hit):
+    # agent-browser is no longer a root package.json dependency (#43564) — it
+    # resolves lazily via npx for most installs, which a bare PATH +
+    # node_modules probe can't see. Mirror the local-CLI tail of
+    # :func:`tools.browser_tool.check_browser_requirements` (same cascade, same
+    # Termux carve-out) so the setup/status surfaces can't diverge from what
+    # browser tools actually find at runtime; validate=False keeps this a cheap
+    # existence check with no subprocess spawn.
+    try:
+        from tools.browser_tool import (
+            _find_agent_browser,
+            _requires_real_termux_browser_install,
+        )
+    except Exception:
+        # If the runtime probe can't be imported, fall back to binary presence
+        # (prior behaviour) rather than crashing the setup/status surface.
+        # Validate the resolved binary actually runs — a dangling global
+        # symlink (issue #48521) is reported by ``which`` but fails at exec.
+        # Fall through to the local node_modules copy, which the validator
+        # also checks.
+        if agent_browser_runnable(shutil.which("agent-browser")):
             return True
+        local_bin = (
+            Path(__file__).parent.parent / "node_modules" / ".bin" / "agent-browser"
+        )
+        return agent_browser_runnable(str(local_bin)) if local_bin.exists() else False
 
-    # Local node_modules/.bin: resolve via PATHEXT-aware ``shutil.which`` so
-    # Windows picks the executable ``.cmd`` shim. Probing the extensionless
-    # POSIX shim directly fails exec (WinError 193) even right after a
-    # successful ``npm install`` — the bug that pinned every browser row on
-    # "Setup required" in the desktop GUI.
-    local_bin_dir = Path(__file__).parent.parent / "node_modules" / ".bin"
-    if local_bin_dir.is_dir():
-        local_which = shutil.which("agent-browser", path=str(local_bin_dir))
-        if local_which and agent_browser_runnable(local_which):
-            return True
-    return False
+    try:
+        browser_cmd = _find_agent_browser(validate=False)
+    except FileNotFoundError:
+        return False
+    # On Termux, the bare npx fallback is too fragile to advertise as ready —
+    # require a real install, matching check_browser_requirements.
+    if _requires_real_termux_browser_install(browser_cmd):
+        return False
+    return True
 
 
 def _local_browser_runnable() -> bool:

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -178,14 +178,30 @@ def _has_agent_browser() -> bool:
         # (prior behaviour) rather than crashing the setup/status surface.
         # Validate the resolved binary actually runs — a dangling global
         # symlink (issue #48521) is reported by ``which`` but fails at exec.
-        # Fall through to the local node_modules copy, which the validator
-        # also checks.
         if agent_browser_runnable(shutil.which("agent-browser")):
             return True
-        local_bin = (
-            Path(__file__).parent.parent / "node_modules" / ".bin" / "agent-browser"
-        )
-        return agent_browser_runnable(str(local_bin)) if local_bin.exists() else False
+
+        # Hermes-managed Node dirs (Windows installer / POSIX $HERMES_HOME/node)
+        # are prepended to PATH at runtime but usually absent from the *probe*
+        # process's PATH. Without this rung a successful install keeps
+        # reporting "needs setup" on Windows.
+        from hermes_constants import with_hermes_node_path
+        managed_path = with_hermes_node_path().get("PATH", "")
+        if managed_path:
+            managed_hit = shutil.which("agent-browser", path=managed_path)
+            if managed_hit and agent_browser_runnable(managed_hit):
+                return True
+
+        # Local node_modules/.bin: resolve via PATHEXT-aware ``shutil.which`` so
+        # Windows picks the executable ``.cmd`` shim — probing the
+        # extensionless POSIX shim directly fails exec (WinError 193) even
+        # right after a successful ``npm install``.
+        local_bin_dir = Path(__file__).parent.parent / "node_modules" / ".bin"
+        if local_bin_dir.is_dir():
+            local_which = shutil.which("agent-browser", path=str(local_bin_dir))
+            if local_which and agent_browser_runnable(local_which):
+                return True
+        return False
 
     try:
         browser_cmd = _find_agent_browser(validate=False)

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1659,6 +1659,8 @@ def _run_post_setup(post_setup_key: str):
                 _running_in_docker,
                 _find_agent_browser,
                 _resolve_npx_bin,
+                _is_npx_agent_browser_sentinel,
+                AGENT_BROWSER_NPX_SPEC,
             )
         except Exception as exc:  # pragma: no cover — defensive
             _print_warning(f"    Could not check Chromium status: {exc}")
@@ -1707,7 +1709,7 @@ def _run_post_setup(post_setup_key: str):
         # browser_cmd was already resolved above (same PATH -> Homebrew ->
         # Hermes-managed-node -> npx cascade _find_agent_browser uses at
         # runtime), so this can't diverge from what actually gets invoked.
-        if browser_cmd == "npx agent-browser":
+        if _is_npx_agent_browser_sentinel(browser_cmd):
             # Re-resolve via the same PATH + extended-PATH cascade
             # _find_agent_browser used, rather than a bare shutil.which("npx")
             # — Hermes-managed-Node-only setups resolve npx only through the
@@ -1719,7 +1721,7 @@ def _run_post_setup(post_setup_key: str):
                     "    npx not found - install Chromium manually: npx agent-browser install --with-deps"
                 )
                 return
-            install_cmd = [npx_bin, "-y", "agent-browser", "install", "--with-deps"]
+            install_cmd = [npx_bin, "-y", AGENT_BROWSER_NPX_SPEC, "install", "--with-deps"]
         else:
             install_cmd = [browser_cmd, "install", "--with-deps"]
 

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1644,69 +1644,50 @@ def _run_cua_driver_installer(
 
 def _run_post_setup(post_setup_key: str):
     """Run post-setup hooks for tools that need extra installation steps."""
-    import shutil
     from hermes_constants import find_node_executable
 
     if post_setup_key in {"agent_browser", "browserbase"}:
-        node_modules = PROJECT_ROOT / "node_modules" / "agent-browser"
-        # Managed Node first — $HERMES_HOME/node is not on PATH, so a bare
-        # which() reports "no npm" on installs whose only Node is the one
-        # Hermes installed for exactly this toolchain.
-        npm_bin = find_node_executable("npm")
-        npx_bin = find_node_executable("npx")
-        # Step 1: install the agent-browser npm package into node_modules/
-        if not node_modules.exists() and npm_bin:
-            _print_info("    Installing Node.js dependencies for browser tools...")
-            import subprocess
-            # Use the resolved npm_bin absolute path so subprocess.Popen can
-            # execute npm.cmd on Windows (CreateProcessW otherwise rejects
-            # batch shims).  On POSIX npm_bin is the plain path — same
-            # behaviour as before.
-            result = subprocess.run(
-                # --workspaces=false restricts the install to the repo root
-                # only, avoiding the apps/* glob which would pull in
-                # apps/desktop (Electron + node-pty) unnecessarily. See #38772.
-                [npm_bin, "install", "--silent", "--workspaces=false"],
-                capture_output=True, text=True, encoding="utf-8", errors="replace", cwd=str(PROJECT_ROOT),
-                creationflags=_post_setup_no_window_flags(),
-            )
-            if result.returncode == 0:
-                _print_success("    Node.js dependencies installed")
-            else:
-                from hermes_constants import display_hermes_home
-                _print_warning(f"    npm install failed - run manually: cd {display_hermes_home()}/hermes-agent && npm install --workspaces=false")
-                if result.stderr:
-                    _print_info(f"      {result.stderr.strip()[:200]}")
-        elif node_modules.exists():
-            # Distinct message for the re-run case so the GUI action log tells
-            # the truth ("nothing to do") instead of implying a fresh install.
-            _print_success("    agent-browser already installed, nothing to do")
-        else:
-            _print_warning("    Node.js not found - browser tools require: npm install (in hermes-agent directory)")
-            return
-
-        # Step 2: only the local browser provider actually needs Chromium on
-        # disk. Cloud providers (Browserbase, Browser Use, Firecrawl) host
-        # their own Chromium and don't need the local install.
-        if post_setup_key != "agent_browser":
-            return
-
-        # Step 3: ensure the Chromium / headless-shell build agent-browser
-        # drives is actually installed. Without it the CLI hangs on first
-        # use until the command timeout fires. Skip inside Docker — the
-        # image bakes Chromium in at build time, and runtime users usually
-        # can't write to PLAYWRIGHT_BROWSERS_PATH anyway.
+        # agent-browser is no longer a root package.json dependency (#43564)
+        # — it resolves lazily via npx (or a global/Hermes-managed install)
+        # instead of a local `npm install`, so there's no node_modules/
+        # population step here anymore.
         try:
             # Import lazily so the tools_config UI doesn't pull in the full
             # browser_tool module at import time.
             from tools.browser_tool import (
                 _chromium_installed,
                 _running_in_docker,
+                _find_agent_browser,
+                _resolve_npx_bin,
             )
         except Exception as exc:  # pragma: no cover — defensive
             _print_warning(f"    Could not check Chromium status: {exc}")
             return
 
+        # Reuse the same resolution cascade browser tools use at runtime
+        # (PATH -> Homebrew/Hermes-managed node -> npx) rather than a bare
+        # shutil.which — Hermes-managed-Node-only setups resolve agent-browser
+        # / npx only through the extended fallback path, which a bare
+        # shutil.which("npx") lookup misses.
+        try:
+            browser_cmd = _find_agent_browser(validate=False)
+        except FileNotFoundError:
+            _print_warning(
+                "    npx not found - browser tools require Node.js: https://nodejs.org"
+            )
+            return
+
+        # Step 1: only the local browser provider actually needs Chromium on
+        # disk. Cloud providers (Browserbase, Browser Use, Firecrawl) host
+        # their own Chromium and don't need the local install.
+        if post_setup_key != "agent_browser":
+            return
+
+        # Step 2: ensure the Chromium / headless-shell build agent-browser
+        # drives is actually installed. Without it the CLI hangs on first
+        # use until the command timeout fires. Skip inside Docker — the
+        # image bakes Chromium in at build time, and runtime users usually
+        # can't write to PLAYWRIGHT_BROWSERS_PATH anyway.
         if _chromium_installed():
             _print_success("    Chromium browser already installed, nothing to do")
             return
@@ -1723,27 +1704,27 @@ def _run_post_setup(post_setup_key: str):
             )
             return
 
-        if not npx_bin:
-            _print_warning(
-                "    npx not found - install Chromium manually: npx agent-browser install --with-deps"
-            )
-            return
+        # browser_cmd was already resolved above (same PATH -> Homebrew ->
+        # Hermes-managed-node -> npx cascade _find_agent_browser uses at
+        # runtime), so this can't diverge from what actually gets invoked.
+        if browser_cmd == "npx agent-browser":
+            # Re-resolve via the same PATH + extended-PATH cascade
+            # _find_agent_browser used, rather than a bare shutil.which("npx")
+            # — Hermes-managed-Node-only setups resolve npx only through the
+            # extended fallback path, and a bare lookup here would silently
+            # diverge and hand subprocess.run a None argument.
+            npx_bin = _resolve_npx_bin()
+            if not npx_bin:
+                _print_warning(
+                    "    npx not found - install Chromium manually: npx agent-browser install --with-deps"
+                )
+                return
+            install_cmd = [npx_bin, "-y", "agent-browser", "install", "--with-deps"]
+        else:
+            install_cmd = [browser_cmd, "install", "--with-deps"]
 
         _print_info("    Installing Chromium (~170MB one-time download)...")
         import subprocess
-        # Prefer the bundled agent-browser install subcommand so the
-        # version of Chromium matches the CLI. Fall back to npx shim on
-        # setups where the local bin stub isn't present.
-        local_ab = PROJECT_ROOT / "node_modules" / ".bin" / "agent-browser"
-        if sys.platform == "win32":
-            local_ab_win = local_ab.with_suffix(".cmd")
-            if local_ab_win.exists():
-                local_ab = local_ab_win
-        install_cmd = (
-            [str(local_ab), "install", "--with-deps"]
-            if local_ab.exists()
-            else [npx_bin, "-y", "agent-browser", "install", "--with-deps"]
-        )
         try:
             result = subprocess.run(
                 install_cmd,

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1721,7 +1721,7 @@ def _run_post_setup(post_setup_key: str):
                     "    npx not found - install Chromium manually: npx agent-browser install --with-deps"
                 )
                 return
-            install_cmd = [npx_bin, "-y", AGENT_BROWSER_NPX_SPEC, "install", "--with-deps"]
+            install_cmd = [npx_bin, "--ignore-scripts", "-y", AGENT_BROWSER_NPX_SPEC, "install", "--with-deps"]
         else:
             install_cmd = [browser_cmd, "install", "--with-deps"]
 

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2140,6 +2140,18 @@ def _update_node_dependencies() -> list[str]:
     # Hermes profile using this checkout. Keep one per-checkout cache under the
     # shared Hermes root rather than rerunning npm once per named profile.
     shared_hermes_root = get_default_hermes_root()
+
+    # Best-effort: warm npx's cache for agent-browser (#43564). Runs before
+    # the lockfile-unchanged early return below since that's the common
+    # `hermes update` case. Synchronous and can block ~11s on a true cold
+    # cache (~0.4s once warm) — print first so that doesn't look like a hang.
+    print("→ Warming npx cache for agent-browser...")
+    try:
+        from tools.browser_tool import warm_agent_browser_npx_cache
+        warm_agent_browser_npx_cache()
+    except Exception:
+        pass
+
     if not _m()._npm_lockfile_changed(shared_hermes_root):
         logger.info("npm lockfile unchanged, skipping npm install")
         return []
@@ -2194,17 +2206,6 @@ def _update_node_dependencies() -> list[str]:
         if stderr:
             print(f"    {stderr.splitlines()[-1]}")
         failures = _partial_update_failure("ui-tui, web workspaces")
-
-    # Fire-and-forget: warm npx's cache for agent-browser so the first
-    # browser-tool call in a session doesn't pay a registry fetch that used
-    # to happen here for free back when agent-browser was an eager root
-    # dependency (see #43564). Independent of the workspace install result
-    # above — never blocks or fails `hermes update`.
-    try:
-        from tools.browser_tool import warm_agent_browser_npx_cache
-        warm_agent_browser_npx_cache()
-    except Exception:
-        pass
 
     return failures
 

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2023,12 +2023,13 @@ def _npm_manifest_paths() -> tuple[Path, ...]:
 
     The workspace list is pulled from the root package.json's `workspaces`
     globs (npm's own source of truth) rather than hardcoded, so adding a
-    workspace can never silently escape the skip key. The root install
-    (step 1, --workspaces=false) still hoists shared deps for EVERY
-    workspace — desktop included — so all of them belong in the key, not
-    just the ones step 2 installs. Falls back to hashing just root
-    manifests if package.json is unreadable (never skips more than main
-    would have installed).
+    workspace can never silently escape the skip key. Every workspace
+    manifest belongs in the key — desktop included, even though the
+    install only names ui-tui and web — because the single lockfile spans
+    the whole workspace graph, so any manifest edit can put the lockfile
+    out of sync and change what the install must do. Falls back to hashing
+    just root manifests if package.json is unreadable (never skips more
+    than main would have installed).
     """
     root_pkg = _m().PROJECT_ROOT / "package.json"
     paths = [_m().PROJECT_ROOT / "package-lock.json", root_pkg]
@@ -2102,7 +2103,7 @@ def _record_npm_lockfile_hash(hermes_root: Path) -> None:
         logger.debug("Could not write npm lockfile hash cache")
 
 def _update_node_dependencies() -> list[str]:
-    """Refresh Node deps in the repo root and update workspaces.
+    """Refresh Node deps for the ui-tui and web workspaces.
 
     Returns the list of labels whose npm install failed (empty on success),
     so the caller can treat a Node refresh failure as a partial update rather
@@ -2124,7 +2125,7 @@ def _update_node_dependencies() -> list[str]:
             print("  ⚠ Skipped: only a Windows npm is reachable from this WSL shell.")
             print("    Install Node.js inside the WSL distro (nvm, or your distro's")
             print("    package manager), then re-run `hermes update`.")
-            failed = ["repo root"]
+            failed = []
             if any(
                 (_m().PROJECT_ROOT / workspace / "package.json").exists()
                 for workspace in ("ui-tui", "web")
@@ -2143,12 +2144,15 @@ def _update_node_dependencies() -> list[str]:
         logger.info("npm lockfile unchanged, skipping npm install")
         return []
 
-    # With a single workspace lockfile the root install would cover ALL
-    # workspaces — but apps/desktop pulls in Electron as a devDependency,
-    # and its postinstall downloads a ~200MB binary.  Most users don't
-    # need desktop during `hermes update`, so we install root-only first
-    # then add just the workspaces the CLI/TUI/web build actually requires.
-    # Desktop deps are installed on demand by the desktop launcher
+    # Root package.json has no dependencies of its own (agent-browser and
+    # @streamdown/math were moved out — see #43564): agent-browser resolves
+    # at runtime via `npx agent-browser` (tools/browser_tool.py), and
+    # @streamdown/math is a desktop-only import now declared in
+    # apps/desktop/package.json. That means a plain workspace-scoped install
+    # can never prune anything root-only, so we only need to name the
+    # workspaces the CLI/TUI/web build actually requires. apps/desktop pulls
+    # in Electron as a devDependency with a ~200MB postinstall download, so
+    # it's deliberately never named here — desktop deps install on demand
     # (see _desktop_build_needed).
     print("→ Updating Node.js dependencies...")
 
@@ -2159,53 +2163,50 @@ def _update_node_dependencies() -> list[str]:
         print("    deps). Fix npm and re-run `hermes update`.")
         return list(labels)
 
-    extra_args = ["--no-fund", "--no-audit", "--prefer-offline", "--progress=false"]
+    install_args = [
+        "--no-fund", "--no-audit", "--prefer-offline", "--progress=false",
+        "--workspace", "ui-tui", "--workspace", "web",
+    ]
 
     from hermes_constants import with_hermes_node_path
 
     nixos_env = with_hermes_node_path(_m()._nixos_build_env())
 
-    # Step 1: root install (no workspace recursion).
     # NOTE: capture_output=False here is deliberate (#18840) — optional
-    # postinstall scripts (e.g. @askjo/camofox-browser's browser-binary fetch)
-    # print download progress, and capturing it makes a long download look
-    # hung. The chatty npm-deprecation noise during `hermes update` comes from
-    # the *desktop* build, not this step; that one is captured to update.log.
-    root_args = [*extra_args, "--workspaces=false"]
-    root_result = _m()._run_npm_install_deterministic(
+    # postinstall scripts print download progress, and capturing it makes a
+    # long download look hung. The chatty npm-deprecation noise during
+    # `hermes update` comes from the *desktop* build, not this step; that
+    # one is captured to update.log.
+    result = _m()._run_npm_install_deterministic(
         npm,
         _m().PROJECT_ROOT,
-        extra_args=tuple(root_args),
+        extra_args=tuple(install_args),
         capture_output=False,
         env=nixos_env,
     )
-    if root_result.returncode != 0:
-        print("  ⚠ npm install failed in repo root")
-        stderr = (root_result.stderr or "").strip() if root_result.stderr else ""
+    if result.returncode == 0:
+        _record_npm_lockfile_hash(shared_hermes_root)
+        print("  ✓ ui-tui, web workspaces installed (desktop skipped)")
+        failures: list[str] = []
+    else:
+        print("  ⚠ npm install failed")
+        stderr = (result.stderr or "").strip() if result.stderr else ""
         if stderr:
             print(f"    {stderr.splitlines()[-1]}")
-        return _partial_update_failure("repo root")
+        failures = _partial_update_failure("ui-tui, web workspaces")
 
-    # Step 2: install only the workspaces update needs (ui-tui, web).
-    # --workspace selects specific workspaces; the rest (desktop) are skipped.
-    ws_args = [*extra_args, "--workspace", "ui-tui", "--workspace", "web"]
-    ws_result = _m()._run_npm_install_deterministic(
-        npm,
-        _m().PROJECT_ROOT,
-        extra_args=tuple(ws_args),
-        capture_output=False,
-        env=nixos_env,
-    )
-    if ws_result.returncode == 0:
-        _record_npm_lockfile_hash(shared_hermes_root)
-        print("  ✓ repo root + ui-tui, web workspaces (desktop skipped)")
-        return []
+    # Fire-and-forget: warm npx's cache for agent-browser so the first
+    # browser-tool call in a session doesn't pay a registry fetch that used
+    # to happen here for free back when agent-browser was an eager root
+    # dependency (see #43564). Independent of the workspace install result
+    # above — never blocks or fails `hermes update`.
+    try:
+        from tools.browser_tool import warm_agent_browser_npx_cache
+        warm_agent_browser_npx_cache()
+    except Exception:
+        pass
 
-    print("  ⚠ npm workspace install failed")
-    stderr = (ws_result.stderr or "").strip() if ws_result.stderr else ""
-    if stderr:
-        print(f"    {stderr.splitlines()[-1]}")
-    return _partial_update_failure("ui-tui, web workspaces")
+    return failures
 
 def _log_only_write(text: str) -> None:
     """Write ``text`` to ``~/.hermes/logs/update.log`` only, never the terminal.

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2178,6 +2178,13 @@ def _update_node_dependencies() -> list[str]:
     install_args = [
         "--no-fund", "--no-audit", "--prefer-offline", "--progress=false",
         "--workspace", "ui-tui", "--workspace", "web",
+        # Root package.json's own devDependencies (the shared ESLint flat
+        # config every workspace's eslint.config.mjs imports) are otherwise
+        # pruned by this scoped install, same as agent-browser/@streamdown
+        # math used to be before they moved out of root entirely (#43564).
+        # Unlike those, root's devDependencies have nowhere else to live —
+        # this flag still excludes apps/desktop, which is never named above.
+        "--include-workspace-root",
     ]
 
     from hermes_constants import with_hermes_node_path

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,10 +16,6 @@
         "web",
         "tests-js"
       ],
-      "dependencies": {
-        "@streamdown/math": "1.0.2",
-        "agent-browser": "0.26.0"
-      },
       "devDependencies": {
         "@eslint/js": "9.39.5",
         "eslint-plugin-perfectionist": "5.10.0",
@@ -90,6 +86,7 @@
         "@nanostores/react": "1.1.0",
         "@nous-research/ui": "0.18.2",
         "@streamdown/code": "1.1.1",
+        "@streamdown/math": "1.0.2",
         "@tabler/icons-react": "3.44.0",
         "@tailwindcss/typography": "0.5.20",
         "@tailwindcss/vite": "4.3.3",
@@ -7051,16 +7048,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/agent-browser": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/agent-browser/-/agent-browser-0.26.0.tgz",
-      "integrity": "sha512-pdqSfjwbFSp+qnwlb2g23e9wXveIOfMi19xpPA9xZUbzEAUp6W4YBZj6Ybj8z4M7WkcbGDDYc+oDIHDt9R3EDQ==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "agent-browser": "bin/agent-browser.js"
       }
     },
     "node_modules/aggregate-error": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "tests-js"
   ],
   "scripts": {
-    "postinstall": "echo '\u2705 Browser tools ready. Run: python run_agent.py --help'",
+    "postinstall": "echo '\u2705 Node dependencies installed. Run: python run_agent.py --help'",
     "install:root": "npm install --workspaces=false",
     "install:web": "npm install --workspace web",
     "install:tui": "npm install --workspace ui-tui",
@@ -34,10 +34,6 @@
     "url": "https://github.com/NousResearch/Hermes-Agent/issues"
   },
   "homepage": "https://github.com/NousResearch/Hermes-Agent#readme",
-  "dependencies": {
-    "@streamdown/math": "1.0.2",
-    "agent-browser": "0.26.0"
-  },
   "devDependencies": {
     "@eslint/js": "9.39.5",
     "typescript-eslint": "8.64.0",
@@ -71,7 +67,6 @@
     "esbuild@0.28.1": true,
     "node-pty@1.1.0": true,
     "electron-winstaller@5.4.0": true,
-    "agent-browser@0.26.0": true,
     "electron@40.10.2": true,
     "fsevents@2.3.2": true,
     "fsevents@2.3.3": true,

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -653,14 +653,21 @@ function Write-BrowserEnv {
 }
 
 function Install-AgentBrowser {
-    param([switch]$SkipChromium)
     $npm = Resolve-NpmCmd
     if (-not $npm) {
         Write-Err "npm not found -- install Node.js first"
         throw "npm not found"
     }
 
-    Write-Info "Installing agent-browser via npm -g --prefix..."
+    # agent-browser itself is intentionally NOT installed here (#43564 /
+    # PR #44772 review): it resolves lazily via `npx agent-browser` instead,
+    # which every consumer (tools/browser_tool.py, `hermes update`'s npx
+    # cache warm) already goes through. Eagerly npm-installing a second,
+    # separately version-pinned copy here -- only reachable via this
+    # explicit -Ensure browser fallback in the first place -- was redundant
+    # complexity and an extra credential/supply-chain surface for a path
+    # npx already covers.
+    Write-Info "Installing camofox browser server..."
     $prefixDir = Join-Path $HermesHome "node"
     if (-not (Test-Path $prefixDir)) {
         New-Item -ItemType Directory -Path $prefixDir -Force | Out-Null
@@ -668,7 +675,7 @@ function Install-AgentBrowser {
     $npmLog = [System.IO.Path]::GetTempFileName()
     $prevEAP = $ErrorActionPreference
     $ErrorActionPreference = "Continue"
-    & $npm install -g --prefix $prefixDir --silent --ignore-scripts "agent-browser@^0.26.0" "@askjo/camofox-browser@^1.5.2" 2>&1 | Tee-Object -FilePath $npmLog | Out-Null
+    & $npm install -g --prefix $prefixDir --silent --ignore-scripts "@askjo/camofox-browser@^1.5.2" 2>&1 | Tee-Object -FilePath $npmLog | Out-Null
     $npmExit = $LASTEXITCODE
     $ErrorActionPreference = $prevEAP
     if ($npmExit -ne 0) {
@@ -683,30 +690,10 @@ function Install-AgentBrowser {
     }
     Remove-Item $npmLog -Force -ErrorAction SilentlyContinue
 
-    if (-not $SkipChromium) {
-        $sysBrowser = Find-SystemBrowser
-        if ($sysBrowser) {
-            Write-BrowserEnv -BrowserPath $sysBrowser
-            Write-Info "Explicit browser override set -- skipping bundled Chromium download"
-        } else {
-            $abExe = Join-Path $prefixDir "agent-browser.cmd"
-            if (Test-Path $abExe) {
-                Write-Info "Installing Chromium via agent-browser install..."
-                $abLog = [System.IO.Path]::GetTempFileName()
-                $prevEAP = $ErrorActionPreference
-                $ErrorActionPreference = "Continue"
-                & $abExe install 2>&1 | Tee-Object -FilePath $abLog | Out-Null
-                $abExit = $LASTEXITCODE
-                $ErrorActionPreference = $prevEAP
-                if ($abExit -ne 0) {
-                    $abDetail = Get-Content $abLog -Raw -ErrorAction SilentlyContinue
-                    Write-Warn "Chromium install failed (exit $abExit): $abDetail"
-                }
-                Remove-Item $abLog -Force -ErrorAction SilentlyContinue
-            } else {
-                Write-Warn "agent-browser.cmd not found at $abExe"
-            }
-        }
+    $sysBrowser = Find-SystemBrowser
+    if ($sysBrowser) {
+        Write-BrowserEnv -BrowserPath $sysBrowser
+        Write-Info "Explicit browser override set -- Chromium download will be skipped when agent-browser installs on demand"
     }
     Write-Success "Agent-browser ready"
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2672,13 +2672,20 @@ ensure_browser() {
         return 1
     fi
 
-    log_info "Installing agent-browser..."
+    # agent-browser itself is intentionally NOT installed here (#43564 /
+    # PR #44772 review): it resolves lazily via `npx agent-browser` instead,
+    # which every consumer (tools/browser_tool.py, `hermes update`'s npx
+    # cache warm) already goes through. Eagerly npm-installing a second,
+    # separately version-pinned copy here -- only reachable via this
+    # explicit --ensure browser fallback in the first place -- was redundant
+    # complexity and an extra credential/supply-chain surface for a path
+    # npx already covers.
+    log_info "Installing camofox browser server..."
     local log_file
     log_file="$(mktemp)"
     # Time-boxed (#39219): a stalled npm registry fetch here would otherwise
     # hang the installer with no progress, same class as the desktop build.
     if ! run_with_timeout "$NODE_DEPS_TIMEOUT" "$npm_bin" install -g --prefix "$HERMES_HOME/node" --silent --ignore-scripts \
-        "agent-browser@^0.26.0" \
         "@askjo/camofox-browser@^1.5.2" \
         >"$log_file" 2>&1; then
         log_error "npm install failed or timed out:"
@@ -2694,31 +2701,7 @@ ensure_browser() {
     sys_browser="$(find_system_browser 2>/dev/null || true)"
     if [ -n "$sys_browser" ]; then
         configure_browser_env_from_system_browser "$sys_browser"
-        log_info "Explicit browser override set -- skipping bundled Chromium download"
-        return 0
-    fi
-
-    log_info "Installing Chromium via agent-browser install..."
-    local ab_bin="$HERMES_HOME/node/bin/agent-browser"
-    if [ -x "$ab_bin" ]; then
-        "$ab_bin" install 2>/dev/null || {
-            log_warn "Chromium install failed. Browser tools may not work without a system browser."
-
-            # OS-specific hints (detect_os sets $DISTRO)
-            case "${DISTRO:-unknown}" in
-                ubuntu|debian)
-                    log_info "Try: sudo apt-get install -y chromium-browser"
-                    ;;
-                arch)
-                    log_info "Try: sudo pacman -S chromium"
-                    ;;
-                fedora|rhel|centos)
-                    log_info "Try: sudo dnf install -y chromium"
-                    ;;
-            esac
-        }
-    else
-        log_warn "agent-browser not found at $ab_bin"
+        log_info "Explicit browser override set -- Chromium download will be skipped when agent-browser installs on demand"
     fi
 
     return 0

--- a/tests-js/package-json-lazy-deps.test.ts
+++ b/tests-js/package-json-lazy-deps.test.ts
@@ -4,14 +4,29 @@
  * The root ``package.json`` is installed by ``hermes update`` on every user,
  * including users who never opted into a given browser backend. Anything
  * listed in ``dependencies`` therefore runs its npm postinstall script for
- * everyone — including binary-fetching backends, on every update.
+ * everyone, and — per #43564 — is also part of the npm workspace install
+ * graph, where a workspace-scoped ``npm ci`` (``--workspace ui-tui
+ * --workspace web``) can silently prune it right back out on the next
+ * ``hermes update``.
  *
  * The contract:
  *
- * - ``agent-browser`` IS eager. It is the default Chromium-driving backend
- *   used whenever the agent makes a browser call without a cloud provider
- *   configured, so it must already be installed before any session starts.
- *   Its postinstall is also small.
+ * - ``agent-browser`` is NOT a root dependency. It used to be eager (see
+ *   #27055, which reasoned its postinstall was small enough to keep eager
+ *   unlike Camofox's) but #43564 found that keeping ANY dependency in root
+ *   ``package.json`` — however small its postinstall — entangles it with
+ *   the ui-tui/web workspace install and risks it being pruned. It now
+ *   resolves at runtime via ``npx agent-browser`` (see
+ *   ``tools/browser_tool.py::_find_agent_browser``), which sidesteps the
+ *   workspace graph entirely. ``hermes update`` and ``hermes doctor --fix``
+ *   both fire-and-forget ``warm_agent_browser_npx_cache()`` to keep npx's
+ *   own cache warm, preserving the "available before any session starts"
+ *   property #27055 cared about without re-entangling the dependency.
+ *
+ * - ``@streamdown/math`` is NOT a root dependency either. It's imported only
+ *   by desktop's own TS code (``apps/desktop/src/...``), so it belongs in
+ *   ``apps/desktop/package.json`` (alongside its sibling ``@streamdown/code``)
+ *   — not root, where it was subject to the exact same pruning risk.
  *
  * - ``@askjo/camofox-browser`` is NOT eager. It is an explicit opt-in
  *   alternative browser backend, selected by the user via
@@ -23,10 +38,9 @@
  *   installed on demand by ``tools_config.py`` ``post_setup_key ==
  *   "camofox"`` when the user actually selects Camofox.
  *
- * If a future PR re-adds Camofox (or any other binary-postinstall package)
- * to root ``dependencies``, this test fails — read the lazy-install
- * guidance in the ``hermes-agent-dev`` skill before changing the
- * expectations.
+ * If a future PR re-adds any of these to root ``dependencies``, this test
+ * fails — read the lazy-install guidance in the ``hermes-agent-dev`` skill
+ * before changing the expectations.
  */
 
 import assert from 'node:assert/strict'
@@ -38,6 +52,7 @@ import { test } from 'vitest'
 const REPO_ROOT = path.resolve(__dirname, '..')
 const ROOT_PKG = path.join(REPO_ROOT, 'package.json')
 const ROOT_LOCK = path.join(REPO_ROOT, 'package-lock.json')
+const DESKTOP_PKG = path.join(REPO_ROOT, 'apps', 'desktop', 'package.json')
 
 function rootPackageJson(): Record<string, unknown> {
   return JSON.parse(fs.readFileSync(ROOT_PKG, 'utf-8'))
@@ -55,15 +70,41 @@ test('camofox is not in root dependencies (must stay opt-in)', () => {
   )
 })
 
-test('agent-browser stays eager (default backend)', () => {
+test('agent-browser is not in root dependencies (resolves via npx, #43564)', () => {
   const deps = (rootPackageJson().dependencies ?? {}) as Record<string, string>
   assert.ok(
-    'agent-browser' in deps,
-    'agent-browser is the default browser-tool backend used by every ' +
-      'session that doesn\'t have a cloud browser provider configured. ' +
-      'It must stay in root package.json dependencies so it is present ' +
-      'after `hermes setup` / `hermes update` without an explicit ' +
-      'post_setup step.'
+    !('agent-browser' in deps),
+    'agent-browser must not be a root package.json dependency — it ' +
+      'resolves lazily via `npx agent-browser` instead (see ' +
+      'tools/browser_tool.py::_find_agent_browser and ' +
+      'warm_agent_browser_npx_cache). Putting it back in root ' +
+      'dependencies re-entangles it with the ui-tui/web workspace ' +
+      'install graph and reintroduces #43564.'
+  )
+})
+
+test('@streamdown/math is not in root dependencies (desktop-only import)', () => {
+  const deps = (rootPackageJson().dependencies ?? {}) as Record<string, string>
+  assert.ok(
+    !('@streamdown/math' in deps),
+    '@streamdown/math is only imported by apps/desktop\'s own TS code ' +
+      '(markdown-text.tsx, katex-memo.ts) — it belongs in ' +
+      'apps/desktop/package.json alongside its sibling @streamdown/code, ' +
+      'not root, where it\'s subject to the same workspace-pruning risk ' +
+      'agent-browser had (#43564).'
+  )
+})
+
+test('@streamdown/math is in desktop dependencies', () => {
+  const deps = (JSON.parse(fs.readFileSync(DESKTOP_PKG, 'utf-8')).dependencies ??
+    {}) as Record<string, string>
+
+  assert.ok(
+    '@streamdown/math' in deps,
+    '@streamdown/math is imported by apps/desktop\'s own TS code ' +
+      '(markdown-text.tsx, katex-memo.ts) and must be declared in ' +
+      'apps/desktop/package.json now that it is no longer a root ' +
+      'dependency.'
   )
 })
 
@@ -85,5 +126,22 @@ test('root lockfile has no camofox entries', () => {
     !text.includes('camoufox-js'),
     'package-lock.json still references camoufox-js (transitive of ' +
       '@askjo/camofox-browser). Regenerate the lockfile.'
+  )
+})
+
+test('root lockfile has no agent-browser entry (#43564)', () => {
+  if (!fs.existsSync(ROOT_LOCK)) {
+    // Some CI matrix shards skip lockfile materialization.
+    return
+  }
+
+  const text = fs.readFileSync(ROOT_LOCK, 'utf-8')
+  assert.ok(
+    !text.includes('"node_modules/agent-browser"'),
+    'package-lock.json still has a node_modules/agent-browser entry. ' +
+      'It must resolve lazily via `npx agent-browser` instead — ' +
+      'regenerate the lockfile after removing the dep: ' +
+      '`rm package-lock.json && npm install --package-lock-only ' +
+      '--ignore-scripts --no-fund --no-audit`.'
   )
 })

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -234,7 +234,6 @@ class TestCmdUpdateBranchFallback:
         captured = capsys.readouterr()
         assert "Already up to date!" in captured.out
 
-
     def test_update_non_interactive_runs_safe_config_migrations(self, mock_args, capsys):
         """Dashboard/web updates apply non-interactive migrations before restart."""
         with patch("shutil.which", return_value=None), patch(
@@ -744,12 +743,13 @@ class TestNodeRuntimeNpmResolution:
             lambda *a, **k: subprocess.CompletedProcess([], 1, stdout="", stderr=""),
         )
 
-        failed = hm._update_node_dependencies()
-        assert failed == ["repo root"]
+        with patch(
+            "tools.browser_tool.warm_agent_browser_npx_cache", return_value=True
+        ):
+            failed = hm._update_node_dependencies()
+        assert failed == ["ui-tui, web workspaces"]
         out = capsys.readouterr().out
         assert "mixed state" in out
-
-
 
     def test_wsl_update_skips_windows_npm_build_paths(self, mock_args, monkeypatch):
         """A Windows-only npm on WSL must not reach web or desktop builds."""
@@ -790,3 +790,212 @@ class TestNodeRuntimeNpmResolution:
             not call.args or not call.args[0] or call.args[0][0] != windows_npm
             for call in mock_run.call_args_list
         )
+
+
+class TestUpdateNodeDependencies:
+    """Unit tests for _update_node_dependencies — issue #43564.
+
+    Root package.json has no dependencies of its own: agent-browser
+    resolves at runtime via npx (tools/browser_tool.py), and @streamdown/math
+    moved to apps/desktop/package.json since it's a desktop-only import.
+    With nothing root-only left to protect, a single workspace-scoped
+    install (ui-tui, web) is safe — apps/desktop is simply never named, so
+    its ~200 MB Electron devDependency is never resolved. Skipping is
+    governed by _npm_lockfile_changed (content hash over the lockfile +
+    every workspace package.json), tested separately in
+    TestNpmLockfileChanged.
+    Uses a tmp_path root so tests never touch real node_modules.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _stub_npx_warmup(self):
+        """The npx cache warm-up is covered by its own dedicated test below;
+        stub it out everywhere else so it doesn't add a spurious npm/npx
+        call to the workspace-install assertions in this class."""
+        with patch("tools.browser_tool.warm_agent_browser_npx_cache", return_value=True):
+            yield
+
+    def _npm_calls(self, mock_run):
+        return [
+            call.args[0]
+            for call in mock_run.call_args_list
+            if call.args and "npm" in str(call.args[0][0])
+        ]
+
+    @patch("subprocess.run")
+    @patch("shutil.which", return_value="/usr/bin/npm")
+    def test_install_names_ui_tui_and_web_workspaces(self, _which, mock_run, tmp_path, monkeypatch):
+        """Regression for #43564: install ui-tui + web directly. apps/desktop
+        must never appear, so its Electron postinstall is never triggered.
+        """
+        from hermes_cli import main as hm
+
+        (tmp_path / "package.json").write_text("{}")
+        (tmp_path / "package-lock.json").write_text("{}")
+        monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+        monkeypatch.setattr(hm, "_npm_lockfile_changed", lambda root: True)
+        mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+
+        hm._update_node_dependencies()
+
+        calls = self._npm_calls(mock_run)
+        assert len(calls) == 1, f"expected exactly 1 npm call, got: {calls}"
+        joined = " ".join(str(a) for a in calls[0])
+        assert "--workspace ui-tui" in joined and "--workspace web" in joined, (
+            f"expected ui-tui + web workspace selectors; actual: {calls[0]}"
+        )
+        assert "desktop" not in joined, (
+            f"apps/desktop must not appear (avoids ~200 MB Electron download); actual: {calls[0]}"
+        )
+        assert "--workspaces=false" not in joined, (
+            f"no root-only deps remain to protect; --workspaces=false is unnecessary now; actual: {calls[0]}"
+        )
+
+    @patch("subprocess.run")
+    @patch("shutil.which", return_value="/usr/bin/npm")
+    def test_install_preserves_standard_flags(self, _which, mock_run, tmp_path, monkeypatch):
+        """--no-fund, --no-audit, --progress=false must survive."""
+        from hermes_cli import main as hm
+
+        (tmp_path / "package.json").write_text("{}")
+        (tmp_path / "package-lock.json").write_text("{}")
+        monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+        monkeypatch.setattr(hm, "_npm_lockfile_changed", lambda root: True)
+        mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+
+        hm._update_node_dependencies()
+
+        calls = self._npm_calls(mock_run)
+        assert len(calls) == 1
+        joined = " ".join(str(a) for a in calls[0])
+        for flag in ("--no-fund", "--no-audit", "--progress=false"):
+            assert flag in joined, f"{flag} missing from npm call; actual: {calls[0]}"
+
+    @patch("subprocess.run")
+    @patch("shutil.which", return_value="/usr/bin/npm")
+    def test_skips_install_when_deps_up_to_date(self, _which, mock_run, tmp_path, monkeypatch):
+        """When _npm_lockfile_changed reports no change, npm must not be called."""
+        from hermes_cli import main as hm
+
+        (tmp_path / "package.json").write_text("{}")
+        (tmp_path / "package-lock.json").write_text("{}")
+        monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+        monkeypatch.setattr(hm, "_npm_lockfile_changed", lambda root: False)
+
+        hm._update_node_dependencies()
+
+        assert not self._npm_calls(mock_run), (
+            "npm must not run when _npm_lockfile_changed reports no change"
+        )
+
+    @patch("subprocess.run")
+    @patch("shutil.which", return_value="/usr/bin/npm")
+    def test_runs_install_when_lockfile_changed(self, _which, mock_run, tmp_path, monkeypatch):
+        """When _npm_lockfile_changed reports a change, npm must run."""
+        from hermes_cli import main as hm
+
+        (tmp_path / "package.json").write_text("{}")
+        (tmp_path / "package-lock.json").write_text("{}")
+        monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+        monkeypatch.setattr(hm, "_npm_lockfile_changed", lambda root: True)
+        mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+
+        hm._update_node_dependencies()
+
+        calls = self._npm_calls(mock_run)
+        assert len(calls) == 1, f"expected npm to run when lockfile changed; got: {calls}"
+
+    @patch("subprocess.run")
+    @patch("shutil.which", return_value="/usr/bin/npm")
+    def test_records_lockfile_hash_only_on_success(self, _which, mock_run, tmp_path, monkeypatch):
+        """A failed install must not record the lockfile hash (so the next
+        run retries instead of wrongly believing deps are up to date)."""
+        from hermes_cli import main as hm
+
+        (tmp_path / "package.json").write_text("{}")
+        (tmp_path / "package-lock.json").write_text("{}")
+        monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+        monkeypatch.setattr(hm, "_npm_lockfile_changed", lambda root: True)
+        recorded = []
+        monkeypatch.setattr(hm, "_record_npm_lockfile_hash", lambda root: recorded.append(root))
+        mock_run.return_value = subprocess.CompletedProcess(
+            [], 1, stdout="", stderr="npm ERR!"
+        )
+
+        hm._update_node_dependencies()
+
+        assert not recorded, "lockfile hash must not be recorded when npm install fails"
+
+    @patch("subprocess.run")
+    @patch("shutil.which", return_value="/usr/bin/npm")
+    def test_warms_npx_agent_browser_cache_regardless_of_install_result(
+        self, _which, mock_run, tmp_path, monkeypatch
+    ):
+        """The npx warm-up must fire even when the workspace install fails —
+        it's independent of ui-tui/web dependency state (#43564)."""
+        from hermes_cli import main as hm
+
+        (tmp_path / "package.json").write_text("{}")
+        (tmp_path / "package-lock.json").write_text("{}")
+        monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+        monkeypatch.setattr(hm, "_npm_lockfile_changed", lambda root: True)
+        mock_run.return_value = subprocess.CompletedProcess(
+            [], 1, stdout="", stderr="npm ERR!"
+        )
+
+        with patch(
+            "tools.browser_tool.warm_agent_browser_npx_cache", return_value=True
+        ) as mock_warm:
+            hm._update_node_dependencies()
+
+        mock_warm.assert_called_once()
+
+    @patch("subprocess.run")
+    @patch("shutil.which", return_value=None)
+    def test_returns_silently_when_npm_not_found(self, _which, mock_run, tmp_path, monkeypatch):
+        """No npm on PATH → return without calling subprocess."""
+        from hermes_cli import main as hm
+
+        (tmp_path / "package.json").write_text("{}")
+        monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+
+        hm._update_node_dependencies()
+
+        mock_run.assert_not_called()
+
+    @patch("subprocess.run")
+    @patch("shutil.which", return_value="/usr/bin/npm")
+    def test_returns_silently_when_package_json_absent(self, _which, mock_run, tmp_path, monkeypatch):
+        """No package.json → return without calling npm."""
+        from hermes_cli import main as hm
+
+        monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+
+        hm._update_node_dependencies()
+
+        mock_run.assert_not_called()
+
+    @patch("subprocess.run")
+    @patch("shutil.which", return_value="/usr/bin/npm")
+    def test_install_runs_from_project_root(self, _which, mock_run, tmp_path, monkeypatch):
+        """npm install must execute from PROJECT_ROOT, not a workspace subdir."""
+        from hermes_cli import main as hm
+
+        (tmp_path / "package.json").write_text("{}")
+        (tmp_path / "package-lock.json").write_text("{}")
+        monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+
+        cwd_calls = []
+
+        def capture(cmd, **kwargs):
+            if "npm" in str(cmd[0]):
+                cwd_calls.append(kwargs.get("cwd"))
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        mock_run.side_effect = capture
+
+        hm._update_node_dependencies()
+
+        assert cwd_calls, "expected at least one npm call"
+        for cwd in cwd_calls:
+            assert cwd == tmp_path, f"npm must run from PROJECT_ROOT; got cwd={cwd}"

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -822,9 +822,36 @@ class TestUpdateNodeDependencies:
             if call.args and "npm" in str(call.args[0][0])
         ]
 
-    @patch("subprocess.run")
+    def _make_popen(self, calls, returncode=0, stderr_lines=()):
+        """Fake subprocess.Popen recording each invocation's cmd/kwargs.
+
+        _update_node_dependencies always runs npm with capture_output=False,
+        which routes through the Popen-based stderr-teeing path in
+        _run_npm_watching_for_engine_failure rather than subprocess.run.
+        """
+
+        class _FakeProc:
+            def __init__(self, cmd, **kwargs):
+                calls.append({"cmd": cmd, "kwargs": kwargs})
+                self.stderr = iter(stderr_lines)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc_info):
+                return False
+
+            def wait(self):
+                return returncode
+
+        return _FakeProc
+
+    def _popen_npm_calls(self, calls):
+        return [c["cmd"] for c in calls if c["cmd"] and "npm" in str(c["cmd"][0])]
+
+    @patch("subprocess.Popen")
     @patch("shutil.which", return_value="/usr/bin/npm")
-    def test_install_names_ui_tui_and_web_workspaces(self, _which, mock_run, tmp_path, monkeypatch):
+    def test_install_names_ui_tui_and_web_workspaces(self, _which, mock_popen, tmp_path, monkeypatch):
         """Regression for #43564: install ui-tui + web directly. apps/desktop
         must never appear, so its Electron postinstall is never triggered.
         """
@@ -834,11 +861,12 @@ class TestUpdateNodeDependencies:
         (tmp_path / "package-lock.json").write_text("{}")
         monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
         monkeypatch.setattr(hm, "_npm_lockfile_changed", lambda root: True)
-        mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        popen_calls = []
+        mock_popen.side_effect = self._make_popen(popen_calls)
 
         hm._update_node_dependencies()
 
-        calls = self._npm_calls(mock_run)
+        calls = self._popen_npm_calls(popen_calls)
         assert len(calls) == 1, f"expected exactly 1 npm call, got: {calls}"
         joined = " ".join(str(a) for a in calls[0])
         assert "--workspace ui-tui" in joined and "--workspace web" in joined, (
@@ -851,9 +879,9 @@ class TestUpdateNodeDependencies:
             f"no root-only deps remain to protect; --workspaces=false is unnecessary now; actual: {calls[0]}"
         )
 
-    @patch("subprocess.run")
+    @patch("subprocess.Popen")
     @patch("shutil.which", return_value="/usr/bin/npm")
-    def test_install_preserves_standard_flags(self, _which, mock_run, tmp_path, monkeypatch):
+    def test_install_preserves_standard_flags(self, _which, mock_popen, tmp_path, monkeypatch):
         """--no-fund, --no-audit, --progress=false must survive."""
         from hermes_cli import main as hm
 
@@ -861,11 +889,12 @@ class TestUpdateNodeDependencies:
         (tmp_path / "package-lock.json").write_text("{}")
         monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
         monkeypatch.setattr(hm, "_npm_lockfile_changed", lambda root: True)
-        mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        popen_calls = []
+        mock_popen.side_effect = self._make_popen(popen_calls)
 
         hm._update_node_dependencies()
 
-        calls = self._npm_calls(mock_run)
+        calls = self._popen_npm_calls(popen_calls)
         assert len(calls) == 1
         joined = " ".join(str(a) for a in calls[0])
         for flag in ("--no-fund", "--no-audit", "--progress=false"):
@@ -888,9 +917,9 @@ class TestUpdateNodeDependencies:
             "npm must not run when _npm_lockfile_changed reports no change"
         )
 
-    @patch("subprocess.run")
+    @patch("subprocess.Popen")
     @patch("shutil.which", return_value="/usr/bin/npm")
-    def test_runs_install_when_lockfile_changed(self, _which, mock_run, tmp_path, monkeypatch):
+    def test_runs_install_when_lockfile_changed(self, _which, mock_popen, tmp_path, monkeypatch):
         """When _npm_lockfile_changed reports a change, npm must run."""
         from hermes_cli import main as hm
 
@@ -898,16 +927,17 @@ class TestUpdateNodeDependencies:
         (tmp_path / "package-lock.json").write_text("{}")
         monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
         monkeypatch.setattr(hm, "_npm_lockfile_changed", lambda root: True)
-        mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        popen_calls = []
+        mock_popen.side_effect = self._make_popen(popen_calls)
 
         hm._update_node_dependencies()
 
-        calls = self._npm_calls(mock_run)
+        calls = self._popen_npm_calls(popen_calls)
         assert len(calls) == 1, f"expected npm to run when lockfile changed; got: {calls}"
 
-    @patch("subprocess.run")
+    @patch("subprocess.Popen")
     @patch("shutil.which", return_value="/usr/bin/npm")
-    def test_records_lockfile_hash_only_on_success(self, _which, mock_run, tmp_path, monkeypatch):
+    def test_records_lockfile_hash_only_on_success(self, _which, mock_popen, tmp_path, monkeypatch):
         """A failed install must not record the lockfile hash (so the next
         run retries instead of wrongly believing deps are up to date)."""
         from hermes_cli import main as hm
@@ -918,18 +948,16 @@ class TestUpdateNodeDependencies:
         monkeypatch.setattr(hm, "_npm_lockfile_changed", lambda root: True)
         recorded = []
         monkeypatch.setattr(hm, "_record_npm_lockfile_hash", lambda root: recorded.append(root))
-        mock_run.return_value = subprocess.CompletedProcess(
-            [], 1, stdout="", stderr="npm ERR!"
-        )
+        mock_popen.side_effect = self._make_popen([], returncode=1, stderr_lines=["npm ERR!\n"])
 
         hm._update_node_dependencies()
 
         assert not recorded, "lockfile hash must not be recorded when npm install fails"
 
-    @patch("subprocess.run")
+    @patch("subprocess.Popen")
     @patch("shutil.which", return_value="/usr/bin/npm")
     def test_warms_npx_agent_browser_cache_regardless_of_install_result(
-        self, _which, mock_run, tmp_path, monkeypatch
+        self, _which, mock_popen, tmp_path, monkeypatch
     ):
         """The npx warm-up must fire even when the workspace install fails —
         it's independent of ui-tui/web dependency state (#43564)."""
@@ -939,9 +967,7 @@ class TestUpdateNodeDependencies:
         (tmp_path / "package-lock.json").write_text("{}")
         monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
         monkeypatch.setattr(hm, "_npm_lockfile_changed", lambda root: True)
-        mock_run.return_value = subprocess.CompletedProcess(
-            [], 1, stdout="", stderr="npm ERR!"
-        )
+        mock_popen.side_effect = self._make_popen([], returncode=1, stderr_lines=["npm ERR!\n"])
 
         with patch(
             "tools.browser_tool.warm_agent_browser_npx_cache", return_value=True
@@ -975,9 +1001,9 @@ class TestUpdateNodeDependencies:
 
         mock_run.assert_not_called()
 
-    @patch("subprocess.run")
+    @patch("subprocess.Popen")
     @patch("shutil.which", return_value="/usr/bin/npm")
-    def test_install_runs_from_project_root(self, _which, mock_run, tmp_path, monkeypatch):
+    def test_install_runs_from_project_root(self, _which, mock_popen, tmp_path, monkeypatch):
         """npm install must execute from PROJECT_ROOT, not a workspace subdir."""
         from hermes_cli import main as hm
 
@@ -985,17 +1011,16 @@ class TestUpdateNodeDependencies:
         (tmp_path / "package-lock.json").write_text("{}")
         monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
 
-        cwd_calls = []
-
-        def capture(cmd, **kwargs):
-            if "npm" in str(cmd[0]):
-                cwd_calls.append(kwargs.get("cwd"))
-            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
-
-        mock_run.side_effect = capture
+        popen_calls = []
+        mock_popen.side_effect = self._make_popen(popen_calls)
 
         hm._update_node_dependencies()
 
+        cwd_calls = [
+            c["kwargs"].get("cwd")
+            for c in popen_calls
+            if c["cmd"] and "npm" in str(c["cmd"][0])
+        ]
         assert cwd_calls, "expected at least one npm call"
         for cwd in cwd_calls:
             assert cwd == tmp_path, f"npm must run from PROJECT_ROOT; got cwd={cwd}"

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -881,6 +881,36 @@ class TestUpdateNodeDependencies:
 
     @patch("subprocess.Popen")
     @patch("shutil.which", return_value="/usr/bin/npm")
+    def test_install_includes_workspace_root_to_protect_root_devdependencies(
+        self, _which, mock_popen, tmp_path, monkeypatch
+    ):
+        """Root package.json still owns devDependencies (the shared ESLint
+        flat config every workspace's own eslint.config.mjs imports) even
+        though agent-browser and @streamdown/math were removed from root
+        `dependencies` (#43564). --include-workspace-root keeps them from
+        being pruned by this scoped install, while --workspace ui-tui
+        --workspace web still excludes the unnamed apps/desktop workspace
+        (confirmed empirically against npm 10.9.8 and 11.9.0 in PR #44772
+        review)."""
+        from hermes_cli import main as hm
+
+        (tmp_path / "package.json").write_text("{}")
+        (tmp_path / "package-lock.json").write_text("{}")
+        monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+        monkeypatch.setattr(hm, "_npm_lockfile_changed", lambda root: True)
+        popen_calls = []
+        mock_popen.side_effect = self._make_popen(popen_calls)
+
+        hm._update_node_dependencies()
+
+        calls = self._popen_npm_calls(popen_calls)
+        assert len(calls) == 1
+        joined = " ".join(str(a) for a in calls[0])
+        assert "--include-workspace-root" in joined
+        assert "desktop" not in joined
+
+    @patch("subprocess.Popen")
+    @patch("shutil.which", return_value="/usr/bin/npm")
     def test_install_preserves_standard_flags(self, _which, mock_popen, tmp_path, monkeypatch):
         """--no-fund, --no-audit, --progress=false must survive."""
         from hermes_cli import main as hm

--- a/tests/hermes_cli/test_dep_ensure.py
+++ b/tests/hermes_cli/test_dep_ensure.py
@@ -58,6 +58,46 @@ def test_has_npx_agent_browser_false_when_nothing_resolves():
         assert _has_npx_agent_browser() is False
 
 
+def test_find_agent_browser_lazy_install_cycle_terminates(monkeypatch):
+    """tools.browser_tool._find_agent_browser's "nothing found" branch calls
+    ensure_dependency("browser"), whose "browser" check now includes
+    _has_npx_agent_browser() -> _find_agent_browser(validate=False) again.
+    That nested call must NOT be able to trigger another ensure_dependency
+    call (only validate=True does that) — verifying the cycle is bounded to
+    one extra rescan, not unbounded recursion, using the real functions on
+    both sides rather than mocking the cycle away."""
+    import shutil
+    import tools.browser_tool as bt
+    from hermes_cli import dep_ensure
+
+    monkeypatch.setattr(bt, "_cached_agent_browser", None)
+    monkeypatch.setattr(bt, "_agent_browser_resolved", False)
+    monkeypatch.setattr(shutil, "which", lambda *a, **k: None)
+    monkeypatch.setattr(bt, "_resolve_npx_bin", lambda: None)
+    monkeypatch.setattr(dep_ensure, "_has_system_browser", lambda: False)
+    monkeypatch.setattr(dep_ensure, "_has_hermes_agent_browser", lambda: False)
+    monkeypatch.setattr(dep_ensure, "_find_install_script", lambda *a, **k: (None, None))
+
+    real_find_agent_browser = bt._find_agent_browser
+    validate_calls = []
+
+    def counting_find_agent_browser(*, validate=True):
+        validate_calls.append(validate)
+        return real_find_agent_browser(validate=validate)
+
+    monkeypatch.setattr(bt, "_find_agent_browser", counting_find_agent_browser)
+
+    with pytest.raises(FileNotFoundError):
+        bt._find_agent_browser(validate=True)
+
+    # One outer validate=True call, plus exactly one bounded nested
+    # validate=False rescan from _has_npx_agent_browser inside
+    # ensure_dependency's "browser" check — not unbounded recursion, and not
+    # a second ensure_dependency("browser") call (which would show up as a
+    # second `True` in this list).
+    assert validate_calls == [True, False]
+
+
 @pytest.mark.windows_only
 def test_ensure_dependency_uses_powershell_on_windows(tmp_path):
     """``windows_only``: the assertion is that we shell out to a real

--- a/tests/hermes_cli/test_dep_ensure.py
+++ b/tests/hermes_cli/test_dep_ensure.py
@@ -26,6 +26,38 @@ def test_find_install_script_from_checkout(tmp_path):
 
 
 
+def test_has_npx_agent_browser_true_when_npx_resolves():
+    """agent-browser resolves lazily via npx on the default install (#43564)
+    — _has_npx_agent_browser mirrors the runtime cascade so the "browser" dep
+    check doesn't wrongly report it missing."""
+    from hermes_cli.dep_ensure import _has_npx_agent_browser
+    import tools.browser_tool as bt
+
+    with patch.object(bt, "_find_agent_browser", return_value="npx agent-browser"), \
+         patch.object(bt, "_requires_real_termux_browser_install", return_value=False):
+        assert _has_npx_agent_browser() is True
+
+
+def test_has_npx_agent_browser_false_on_termux_local_bare_npx():
+    from hermes_cli.dep_ensure import _has_npx_agent_browser
+    import tools.browser_tool as bt
+
+    with patch.object(bt, "_find_agent_browser", return_value="npx agent-browser"), \
+         patch.object(bt, "_requires_real_termux_browser_install", return_value=True):
+        assert _has_npx_agent_browser() is False
+
+
+def test_has_npx_agent_browser_false_when_nothing_resolves():
+    from hermes_cli.dep_ensure import _has_npx_agent_browser
+    import tools.browser_tool as bt
+
+    def _raise(**_kw):
+        raise FileNotFoundError("agent-browser CLI not found")
+
+    with patch.object(bt, "_find_agent_browser", _raise):
+        assert _has_npx_agent_browser() is False
+
+
 @pytest.mark.windows_only
 def test_ensure_dependency_uses_powershell_on_windows(tmp_path):
     """``windows_only``: the assertion is that we shell out to a real

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -680,41 +680,24 @@ def test_run_doctor_termux_does_not_mark_browser_available_without_agent_browser
     assert "npm install -g agent-browser && agent-browser install" in out
 
 
-def _run_doctor_with_managed_agent_browser(monkeypatch, tmp_path, runnable):
-    """Set up run_doctor with node present, agent-browser only in the
-    Hermes-managed node bin (~/.hermes/node/bin), not on PATH or in
-    PROJECT_ROOT/node_modules. Returns the captured stdout."""
+def _doctor_env_for_agent_browser(monkeypatch, tmp_path):
+    """Shared non-Termux fixture setup for the agent-browser npx-resolution
+    branch in run_doctor (hermes_cli/doctor.py ~1557-1605)."""
     home = tmp_path / ".hermes"
-    (home / "node" / "bin").mkdir(parents=True, exist_ok=True)
+    home.mkdir(parents=True, exist_ok=True)
     (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
-    managed_ab = home / "node" / "bin" / "agent-browser"
-    managed_ab.write_text("#!/bin/sh\n", encoding="utf-8")
-    managed_ab.chmod(0o755)
     project = tmp_path / "project"
-    project.mkdir(exist_ok=True)  # no node_modules/agent-browser here
+    project.mkdir(exist_ok=True)
 
     monkeypatch.delenv("TERMUX_VERSION", raising=False)
-    monkeypatch.delenv("PREFIX", raising=False)
+    monkeypatch.setenv("PREFIX", "/usr")
     monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
     monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
     monkeypatch.setattr(doctor_mod, "_DHH", str(home))
-
-    # node on PATH, agent-browser is NOT on PATH (only in the managed bin).
-    # The managed-dir rung resolves via shutil.which(..., path=<dir>) so
-    # Windows picks the .cmd shim — mirror that shape here.
-    def _fake_which(cmd, path=None):
-        if path is not None:
-            if cmd == "agent-browser" and str(managed_ab.parent) == str(path):
-                return str(managed_ab)
-            return None
-        return "/usr/bin/node" if cmd in {"node", "npm"} else None
-
-    monkeypatch.setattr(doctor_mod.shutil, "which", _fake_which)
-    # agent_browser_runnable is imported into doctor's namespace
     monkeypatch.setattr(
-        doctor_mod,
-        "agent_browser_runnable",
-        lambda path: runnable and str(path) == str(managed_ab),
+        doctor_mod.shutil,
+        "which",
+        lambda cmd: "/usr/bin/node" if cmd in {"node", "npm"} else None,
     )
 
     fake_model_tools = types.SimpleNamespace(
@@ -731,10 +714,74 @@ def _run_doctor_with_managed_agent_browser(monkeypatch, tmp_path, runnable):
     except Exception:
         pass
 
+
+def test_run_doctor_reports_agent_browser_resolves_via_npx(monkeypatch, tmp_path):
+    """When agent-browser has no local/global install, _find_agent_browser
+    falls through to 'npx agent-browser' — doctor must report that as OK
+    (#43564: agent-browser is no longer a root package.json dependency, so
+    this is the expected common case now, not a warning)."""
+    _doctor_env_for_agent_browser(monkeypatch, tmp_path)
+
+    import tools.browser_tool as bt
+    monkeypatch.setattr(bt, "_find_agent_browser", lambda **_kw: "npx agent-browser")
+    warm_calls = []
+    monkeypatch.setattr(
+        bt, "warm_agent_browser_npx_cache", lambda *a, **kw: warm_calls.append(1) or True
+    )
+
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
         doctor_mod.run_doctor(Namespace(fix=False))
-    return buf.getvalue()
+    out = buf.getvalue()
+
+    assert "agent-browser" in out
+    assert "resolves via npx on first use" in out
+    assert "agent-browser not installed" not in out
+    # --fix was not requested: the warm-up must not fire on a plain check.
+    assert not warm_calls
+
+
+def test_run_doctor_fix_warms_npx_cache_when_agent_browser_resolves_via_npx(
+    monkeypatch, tmp_path
+):
+    """`hermes doctor --fix` must actually call warm_agent_browser_npx_cache()
+    when agent-browser resolves via npx, and report success."""
+    _doctor_env_for_agent_browser(monkeypatch, tmp_path)
+
+    import tools.browser_tool as bt
+    monkeypatch.setattr(bt, "_find_agent_browser", lambda **_kw: "npx agent-browser")
+    warm_calls = []
+    monkeypatch.setattr(
+        bt, "warm_agent_browser_npx_cache", lambda *a, **kw: warm_calls.append(1) or True
+    )
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=True))
+    out = buf.getvalue()
+
+    assert warm_calls, "warm_agent_browser_npx_cache() must be called under --fix"
+    assert "Warmed npx cache for agent-browser" in out
+    assert "Could not warm npx cache" not in out
+
+
+def test_run_doctor_fix_reports_when_npx_warmup_fails(monkeypatch, tmp_path):
+    """If warm_agent_browser_npx_cache() fails (offline, npx missing from
+    PATH at call time, etc.), doctor must say so instead of silently
+    claiming success — and must not count it as a fix."""
+    _doctor_env_for_agent_browser(monkeypatch, tmp_path)
+
+    import tools.browser_tool as bt
+    monkeypatch.setattr(bt, "_find_agent_browser", lambda **_kw: "npx agent-browser")
+    monkeypatch.setattr(bt, "warm_agent_browser_npx_cache", lambda *a, **kw: False)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=True))
+    out = buf.getvalue()
+
+    assert "Could not warm npx cache (offline or npx unavailable)" in out
+    assert "Warmed npx cache for agent-browser" not in out
 
 
 def test_run_doctor_kimi_cn_env_is_detected_and_probe_is_null_safe(monkeypatch, tmp_path):

--- a/tests/hermes_cli/test_doctor_live.py
+++ b/tests/hermes_cli/test_doctor_live.py
@@ -17,6 +17,10 @@ from hermes_cli.doctor_live import (
     run_live_checks,
 )
 
+# Captured before the autouse fixture below stubs doctor_live._browser_available
+# to a constant, so TestBrowserAvailableNpxRung can exercise the real function.
+_real_browser_available = doctor_live._browser_available
+
 
 def _args(live: bool = True) -> argparse.Namespace:
     return argparse.Namespace(live=live)
@@ -184,6 +188,36 @@ class TestConfiguredOnlySelection:
             lambda timeout: (True, "about:blank ok"))
         results = {r.name: r for r in run_live_checks([])}
         assert results["Browser"].status == "pass"
+
+
+class TestBrowserAvailableNpxRung:
+    """agent-browser resolves lazily via npx on the default install (#43564),
+    invisible to the bare PATH/node_modules probes _browser_available starts
+    with. It must fall through to the same cascade `hermes doctor` uses."""
+
+    def _block_path_and_node_modules_checks(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("shutil.which", lambda *a, **k: None)
+        monkeypatch.setattr("hermes_cli.doctor.HERMES_HOME", tmp_path / "home")
+        monkeypatch.setattr("hermes_cli.doctor.PROJECT_ROOT", tmp_path / "root")
+
+    def test_true_when_npx_resolves_agent_browser(self, monkeypatch, tmp_path):
+        self._block_path_and_node_modules_checks(monkeypatch, tmp_path)
+        import tools.browser_tool as bt
+
+        monkeypatch.setattr(bt, "_find_agent_browser", lambda **_kw: "npx agent-browser")
+
+        assert _real_browser_available() is True
+
+    def test_false_when_nothing_resolves(self, monkeypatch, tmp_path):
+        self._block_path_and_node_modules_checks(monkeypatch, tmp_path)
+        import tools.browser_tool as bt
+
+        def _raise(**_kw):
+            raise FileNotFoundError("agent-browser CLI not found")
+
+        monkeypatch.setattr(bt, "_find_agent_browser", _raise)
+
+        assert _real_browser_available() is False
 
 
 class TestFailureIsolation:

--- a/tests/hermes_cli/test_doctor_live.py
+++ b/tests/hermes_cli/test_doctor_live.py
@@ -219,6 +219,18 @@ class TestBrowserAvailableNpxRung:
 
         assert _real_browser_available() is False
 
+    def test_false_on_termux_local_bare_npx(self, monkeypatch, tmp_path):
+        """On Termux in local mode the bare npx fallback is too fragile to
+        advertise as ready — must not diverge from dep_ensure/nous_subscription's
+        same carve-out."""
+        self._block_path_and_node_modules_checks(monkeypatch, tmp_path)
+        import tools.browser_tool as bt
+
+        monkeypatch.setattr(bt, "_find_agent_browser", lambda **_kw: "npx agent-browser")
+        monkeypatch.setattr(bt, "_requires_real_termux_browser_install", lambda cmd: True)
+
+        assert _real_browser_available() is False
+
 
 class TestFailureIsolation:
     def test_one_probe_raising_does_not_stop_others(self, monkeypatch):

--- a/tests/hermes_cli/test_nous_subscription.py
+++ b/tests/hermes_cli/test_nous_subscription.py
@@ -298,6 +298,41 @@ def test_has_agent_browser_import_failure_falls_back_to_path_check(monkeypatch):
     assert ns._has_agent_browser() is True
 
 
+def test_has_agent_browser_import_failure_falls_back_to_hermes_managed_node_path(
+    monkeypatch, tmp_path
+):
+    """If tools.browser_tool cannot be imported, the managed-Node rung must
+    still find a runnable agent-browser under the Hermes Node dir even when
+    it's absent from the probe process's PATH — the Windows installer shape
+    where install succeeded but the GUI still said needs setup."""
+    monkeypatch.setitem(sys.modules, "tools.browser_tool", None)
+    managed_dir = tmp_path / "node"
+    managed_dir.mkdir()
+    managed_bin = managed_dir / "agent-browser"
+    managed_bin.write_text("#!/bin/sh\nexit 0\n")
+    managed_bin.chmod(0o755)
+
+    real_which = shutil.which
+    monkeypatch.setattr(
+        shutil,
+        "which",
+        lambda cmd, *args, **kwargs: (
+            None
+            if cmd == "agent-browser" and not kwargs.get("path")
+            else real_which(cmd, *args, **kwargs)
+        ),
+    )
+    monkeypatch.setattr(
+        "hermes_constants.with_hermes_node_path", lambda: {"PATH": str(managed_dir)}
+    )
+    monkeypatch.setattr(
+        "hermes_constants.agent_browser_runnable",
+        lambda p: bool(p) and str(p) == str(managed_bin),
+    )
+
+    assert ns._has_agent_browser() is True
+
+
 def test_has_agent_browser_import_failure_and_no_binary_is_false(monkeypatch):
     monkeypatch.setitem(sys.modules, "tools.browser_tool", None)
     _block_legacy_agent_browser_checks(monkeypatch)

--- a/tests/hermes_cli/test_nous_subscription.py
+++ b/tests/hermes_cli/test_nous_subscription.py
@@ -1,5 +1,8 @@
 """Tests for Nous subscription feature detection."""
 
+import shutil
+import sys
+
 from hermes_cli.nous_account import NousPortalAccountInfo, NousToolAccessInfo
 from hermes_cli import nous_subscription as ns
 
@@ -207,27 +210,96 @@ def _stt_features_stub(*, account_info):
 
 
 
-def test_has_agent_browser_resolves_via_hermes_managed_node_path(monkeypatch, tmp_path):
-    """The managed-Node rung: a runnable agent-browser under the Hermes Node
-    dir must count even when it's absent from the probe process's PATH (the
-    Windows installer shape — install succeeded, GUI still said needs setup)."""
-    import shutil as _shutil
-
-    managed_dir = tmp_path / "node"
-    managed_dir.mkdir()
-    managed_bin = managed_dir / "agent-browser"
-    managed_bin.write_text("#!/bin/sh\nexit 0\n")
-    managed_bin.chmod(0o755)
-
-    monkeypatch.setattr(_shutil, "which", lambda cmd, path=None: str(managed_bin) if path else None)
+def _block_legacy_agent_browser_checks(monkeypatch):
+    """Make the legacy checks (PATH lookup + local node_modules/.bin) find nothing."""
+    real_which = shutil.which
     monkeypatch.setattr(
-        "hermes_constants.with_hermes_node_path", lambda: {"PATH": str(managed_dir)}
+        shutil,
+        "which",
+        lambda cmd, *args, **kwargs: (
+            None if cmd == "agent-browser" else real_which(cmd, *args, **kwargs)
+        ),
+    )
+    monkeypatch.setattr("hermes_constants.agent_browser_runnable", lambda path: False)
+
+
+def test_has_agent_browser_true_for_npx_only_resolution(monkeypatch):
+    """No PATH binary and no runnable node_modules copy, but the browser_tool
+    cascade resolves the npx fallback: browser capability is available."""
+    _block_legacy_agent_browser_checks(monkeypatch)
+    import tools.browser_tool as browser_tool
+
+    calls = []
+
+    def fake_find_agent_browser(*, validate=True):
+        calls.append({"validate": validate})
+        return "npx agent-browser"
+
+    monkeypatch.setattr(browser_tool, "_find_agent_browser", fake_find_agent_browser)
+    monkeypatch.setattr(
+        browser_tool, "_requires_real_termux_browser_install", lambda cmd: False
+    )
+
+    assert ns._has_agent_browser() is True
+    # A readiness probe must resolve without spawning the daemon.
+    assert calls and all(call["validate"] is False for call in calls)
+
+
+def test_has_agent_browser_false_for_termux_local_bare_npx(monkeypatch):
+    """On Termux in local mode the bare npx fallback is not a usable install."""
+    _block_legacy_agent_browser_checks(monkeypatch)
+    import tools.browser_tool as browser_tool
+
+    monkeypatch.setattr(
+        browser_tool,
+        "_find_agent_browser",
+        lambda *, validate=True: "npx agent-browser",
+    )
+    monkeypatch.setattr(
+        browser_tool,
+        "_requires_real_termux_browser_install",
+        lambda cmd: cmd.strip() == "npx agent-browser",
+    )
+
+    assert ns._has_agent_browser() is False
+
+
+def test_has_agent_browser_false_when_nothing_resolvable(monkeypatch):
+    _block_legacy_agent_browser_checks(monkeypatch)
+    import tools.browser_tool as browser_tool
+
+    def raise_not_found(*, validate=True):
+        raise FileNotFoundError("agent-browser CLI not found")
+
+    monkeypatch.setattr(browser_tool, "_find_agent_browser", raise_not_found)
+
+    assert ns._has_agent_browser() is False
+
+
+def test_has_agent_browser_import_failure_falls_back_to_path_check(monkeypatch):
+    """If tools.browser_tool cannot be imported, the old PATH + node_modules
+    check must still answer (prior behaviour), not crash."""
+    monkeypatch.setitem(sys.modules, "tools.browser_tool", None)
+    real_which = shutil.which
+    monkeypatch.setattr(
+        shutil,
+        "which",
+        lambda cmd, *args, **kwargs: (
+            "/fake/bin/agent-browser"
+            if cmd == "agent-browser"
+            else real_which(cmd, *args, **kwargs)
+        ),
     )
     monkeypatch.setattr(
         "hermes_constants.agent_browser_runnable",
-        lambda p: bool(p) and str(p) == str(managed_bin),
+        lambda path: path == "/fake/bin/agent-browser",
     )
 
     assert ns._has_agent_browser() is True
 
 
+def test_has_agent_browser_import_failure_and_no_binary_is_false(monkeypatch):
+    monkeypatch.setitem(sys.modules, "tools.browser_tool", None)
+    _block_legacy_agent_browser_checks(monkeypatch)
+
+    assert ns._has_agent_browser() is False

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -1,6 +1,7 @@
 """Tests for hermes_cli.tools_config platform tool persistence."""
 
 import logging
+import subprocess
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -343,6 +344,261 @@ def test_numeric_mcp_server_name_does_not_crash_sorted():
 
 
 
+
+
+class TestAgentBrowserPostSetup:
+    """_run_post_setup('agent_browser'/'browserbase') — #43564.
+
+    agent-browser is no longer a root package.json dependency (there's no
+    local `npm install` step anymore); it resolves at runtime via
+    tools.browser_tool._find_agent_browser (PATH -> Homebrew/Hermes-managed
+    node -> local .bin -> npx). This class exercises the Chromium-install
+    branch of _run_post_setup, which now delegates to that same resolution
+    cascade instead of hand-rolling its own node_modules/.bin/agent-browser
+    (and Windows .cmd-shim) lookup.
+    """
+
+    def test_warns_when_neither_npx_nor_agent_browser_on_path(self):
+        with patch("shutil.which", return_value=None), patch(
+            "subprocess.run"
+        ) as run, patch("hermes_cli.tools_config._print_warning") as warn:
+            _run_post_setup("agent_browser")
+
+        run.assert_not_called()
+        warn.assert_called_once()
+        assert "npx not found" in warn.call_args.args[0]
+
+    def test_browserbase_returns_before_any_chromium_check(self):
+        """browserbase hosts its own Chromium; it must never reach the
+        agent-browser-only Chromium-install branch."""
+        with patch("shutil.which", return_value="/usr/bin/npx"), patch(
+            "subprocess.run"
+        ) as run, patch(
+            "tools.browser_tool._chromium_installed"
+        ) as chromium_check:
+            _run_post_setup("browserbase")
+
+        run.assert_not_called()
+        chromium_check.assert_not_called()
+
+    def test_chromium_already_installed_skips_subprocess(self):
+        with patch("shutil.which", return_value="/usr/bin/npx"), patch(
+            "subprocess.run"
+        ) as run, patch(
+            "tools.browser_tool._chromium_installed", return_value=True
+        ), patch(
+            "hermes_cli.tools_config._print_success"
+        ) as success:
+            _run_post_setup("agent_browser")
+
+        run.assert_not_called()
+        success.assert_called_once()
+        assert "already installed" in success.call_args.args[0]
+
+    def test_docker_with_missing_chromium_warns_instead_of_installing(self):
+        with patch("shutil.which", return_value="/usr/bin/npx"), patch(
+            "subprocess.run"
+        ) as run, patch(
+            "tools.browser_tool._chromium_installed", return_value=False
+        ), patch(
+            "tools.browser_tool._running_in_docker", return_value=True
+        ), patch(
+            "hermes_cli.tools_config._print_warning"
+        ) as warn:
+            _run_post_setup("agent_browser")
+
+        run.assert_not_called()
+        assert any("Docker" in c.args[0] for c in warn.call_args_list)
+
+    def test_find_agent_browser_not_found_warns_before_any_chromium_check(self):
+        """_find_agent_browser is resolved up front now (shared with the
+        browserbase early-return gate), so a FileNotFoundError here must
+        short-circuit before even checking Chromium/Docker status."""
+        with patch("shutil.which", return_value="/usr/bin/npx"), patch(
+            "subprocess.run"
+        ) as run, patch(
+            "tools.browser_tool._chromium_installed"
+        ) as chromium_check, patch(
+            "tools.browser_tool._running_in_docker"
+        ) as docker_check, patch(
+            "tools.browser_tool._find_agent_browser",
+            side_effect=FileNotFoundError("agent-browser CLI not found"),
+        ), patch(
+            "hermes_cli.tools_config._print_warning"
+        ) as warn:
+            _run_post_setup("agent_browser")
+
+        run.assert_not_called()
+        chromium_check.assert_not_called()
+        docker_check.assert_not_called()
+        assert any("browser tools require Node.js" in c.args[0] for c in warn.call_args_list)
+
+    def test_installs_chromium_via_npx_when_no_local_binary_resolved(self):
+        """When _find_agent_browser falls through to npx, the install command
+        must shell out to npx directly (not the unresolved 'npx agent-browser'
+        string as a single argv element)."""
+        with patch(
+            "shutil.which",
+            side_effect=lambda name: "/usr/bin/npx" if name == "npx" else None,
+        ), patch("subprocess.run") as run, patch(
+            "tools.browser_tool._chromium_installed", return_value=False
+        ), patch(
+            "tools.browser_tool._running_in_docker", return_value=False
+        ), patch(
+            "tools.browser_tool._find_agent_browser", return_value="npx agent-browser"
+        ), patch(
+            "hermes_cli.tools_config._print_success"
+        ):
+            run.return_value = SimpleNamespace(returncode=0, stdout="", stderr="")
+            _run_post_setup("agent_browser")
+
+        run.assert_called_once()
+        assert run.call_args.args[0] == [
+            "/usr/bin/npx", "-y", "agent-browser", "install", "--with-deps",
+        ]
+
+    def test_installs_chromium_via_npx_resolved_only_through_extended_path(self):
+        """Hermes-managed-Node-only setups: npx resolves via
+        _find_agent_browser's extended-PATH fallback, not a bare PATH lookup.
+        The install command must use that same resolved npx, not silently
+        hand subprocess.run a None argument from a bare shutil.which('npx')
+        re-derivation (#43564 regression — Copilot review, task #9)."""
+        hermes_npx = "/home/user/.hermes/node/bin/npx"
+        with patch("shutil.which", return_value=None), patch(
+            "subprocess.run"
+        ) as run, patch(
+            "tools.browser_tool._chromium_installed", return_value=False
+        ), patch(
+            "tools.browser_tool._running_in_docker", return_value=False
+        ), patch(
+            "tools.browser_tool._find_agent_browser", return_value="npx agent-browser"
+        ), patch(
+            "tools.browser_tool._resolve_npx_bin", return_value=hermes_npx
+        ), patch(
+            "hermes_cli.tools_config._print_success"
+        ):
+            run.return_value = SimpleNamespace(returncode=0, stdout="", stderr="")
+            _run_post_setup("agent_browser")
+
+        run.assert_called_once()
+        assert run.call_args.args[0] == [
+            hermes_npx, "-y", "agent-browser", "install", "--with-deps",
+        ]
+
+    def test_warns_instead_of_crashing_when_npx_unresolvable_after_all(self):
+        """Defensive: if _resolve_npx_bin somehow returns None even though
+        _find_agent_browser resolved "npx agent-browser" (e.g. a race where
+        npx disappears between the two calls), warn and return instead of
+        building a command with a None argv element."""
+        with patch("shutil.which", return_value=None), patch(
+            "subprocess.run"
+        ) as run, patch(
+            "tools.browser_tool._chromium_installed", return_value=False
+        ), patch(
+            "tools.browser_tool._running_in_docker", return_value=False
+        ), patch(
+            "tools.browser_tool._find_agent_browser", return_value="npx agent-browser"
+        ), patch(
+            "tools.browser_tool._resolve_npx_bin", return_value=None
+        ), patch(
+            "hermes_cli.tools_config._print_warning"
+        ) as warn:
+            _run_post_setup("agent_browser")  # must not raise
+
+        run.assert_not_called()
+        assert any("npx not found" in c.args[0] for c in warn.call_args_list)
+
+    def test_installs_chromium_via_resolved_local_binary_path(self):
+        """When _find_agent_browser resolves a concrete executable (global
+        install, Homebrew, or the Windows .cmd shim it already knows how to
+        pick), that path must be invoked directly — not re-wrapped in npx."""
+        with patch("shutil.which", return_value="/usr/bin/npx"), patch(
+            "subprocess.run"
+        ) as run, patch(
+            "tools.browser_tool._chromium_installed", return_value=False
+        ), patch(
+            "tools.browser_tool._running_in_docker", return_value=False
+        ), patch(
+            "tools.browser_tool._find_agent_browser",
+            return_value="/usr/local/bin/agent-browser",
+        ), patch(
+            "hermes_cli.tools_config._print_success"
+        ):
+            run.return_value = SimpleNamespace(returncode=0, stdout="", stderr="")
+            _run_post_setup("agent_browser")
+
+        run.assert_called_once()
+        assert run.call_args.args[0] == [
+            "/usr/local/bin/agent-browser", "install", "--with-deps",
+        ]
+
+    def test_install_success_invalidates_chromium_cache(self):
+        import tools.browser_tool as _bt
+
+        with patch("shutil.which", return_value="/usr/bin/npx"), patch(
+            "subprocess.run",
+            return_value=SimpleNamespace(returncode=0, stdout="", stderr=""),
+        ), patch(
+            "tools.browser_tool._chromium_installed", return_value=False
+        ), patch(
+            "tools.browser_tool._running_in_docker", return_value=False
+        ), patch(
+            "tools.browser_tool._find_agent_browser", return_value="npx agent-browser"
+        ), patch(
+            "hermes_cli.tools_config._print_success"
+        ):
+            _bt._cached_chromium_installed = True
+            _run_post_setup("agent_browser")
+
+        assert _bt._cached_chromium_installed is None, (
+            "a successful install must invalidate the cached chromium-missing "
+            "result so the next check_browser_requirements() call re-probes"
+        )
+
+    def test_install_failure_prints_stderr_tail_and_does_not_invalidate_cache(self):
+        import tools.browser_tool as _bt
+
+        with patch("shutil.which", return_value="/usr/bin/npx"), patch(
+            "subprocess.run",
+            return_value=SimpleNamespace(
+                returncode=1, stdout="", stderr="line1\nline2\nfatal: network error"
+            ),
+        ), patch(
+            "tools.browser_tool._chromium_installed", return_value=False
+        ), patch(
+            "tools.browser_tool._running_in_docker", return_value=False
+        ), patch(
+            "tools.browser_tool._find_agent_browser", return_value="npx agent-browser"
+        ), patch(
+            "hermes_cli.tools_config._print_warning"
+        ) as warn, patch(
+            "hermes_cli.tools_config._print_info"
+        ) as info:
+            _bt._cached_chromium_installed = "sentinel"
+            _run_post_setup("agent_browser")
+
+        assert any("Chromium install failed" in c.args[0] for c in warn.call_args_list)
+        assert any("fatal: network error" in c.args[0] for c in info.call_args_list)
+        assert _bt._cached_chromium_installed == "sentinel", (
+            "a failed install must not invalidate the chromium cache"
+        )
+
+    def test_install_timeout_warns_without_raising(self):
+        with patch("shutil.which", return_value="/usr/bin/npx"), patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd=["npx"], timeout=600),
+        ), patch(
+            "tools.browser_tool._chromium_installed", return_value=False
+        ), patch(
+            "tools.browser_tool._running_in_docker", return_value=False
+        ), patch(
+            "tools.browser_tool._find_agent_browser", return_value="npx agent-browser"
+        ), patch(
+            "hermes_cli.tools_config._print_warning"
+        ) as warn:
+            _run_post_setup("agent_browser")  # must not raise
+
+        assert any("timed out" in c.args[0] for c in warn.call_args_list)
 
 
 class TestImagegenBackendRegistry:

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 import pytest
 
+from tools.browser_tool import AGENT_BROWSER_NPX_SPEC
 from hermes_cli.nous_account import NousPortalAccountInfo, NousToolAccessInfo
 from hermes_cli.nous_subscription import NousSubscriptionFeatures
 from hermes_cli.tools_config import (
@@ -454,7 +455,7 @@ class TestAgentBrowserPostSetup:
 
         run.assert_called_once()
         assert run.call_args.args[0] == [
-            "/usr/bin/npx", "-y", "agent-browser", "install", "--with-deps",
+            "/usr/bin/npx", "-y", AGENT_BROWSER_NPX_SPEC, "install", "--with-deps",
         ]
 
     def test_installs_chromium_via_npx_resolved_only_through_extended_path(self):
@@ -482,7 +483,7 @@ class TestAgentBrowserPostSetup:
 
         run.assert_called_once()
         assert run.call_args.args[0] == [
-            hermes_npx, "-y", "agent-browser", "install", "--with-deps",
+            hermes_npx, "-y", AGENT_BROWSER_NPX_SPEC, "install", "--with-deps",
         ]
 
     def test_warns_instead_of_crashing_when_npx_unresolvable_after_all(self):

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -384,6 +384,8 @@ class TestAgentBrowserPostSetup:
 
     def test_chromium_already_installed_skips_subprocess(self):
         with patch("shutil.which", return_value="/usr/bin/npx"), patch(
+            "tools.browser_tool.node_tool_runnable", return_value=True
+        ), patch(
             "subprocess.run"
         ) as run, patch(
             "tools.browser_tool._chromium_installed", return_value=True
@@ -398,6 +400,8 @@ class TestAgentBrowserPostSetup:
 
     def test_docker_with_missing_chromium_warns_instead_of_installing(self):
         with patch("shutil.which", return_value="/usr/bin/npx"), patch(
+            "tools.browser_tool.node_tool_runnable", return_value=True
+        ), patch(
             "subprocess.run"
         ) as run, patch(
             "tools.browser_tool._chromium_installed", return_value=False
@@ -440,7 +444,11 @@ class TestAgentBrowserPostSetup:
         string as a single argv element)."""
         with patch(
             "shutil.which",
-            side_effect=lambda name: "/usr/bin/npx" if name == "npx" else None,
+            # accepts the `path=` kwarg _resolve_npx_bin's extended-path rung
+            # calls shutil.which with, not just the bare-PATH positional form.
+            side_effect=lambda name, path=None: "/usr/bin/npx" if name == "npx" else None,
+        ), patch(
+            "tools.browser_tool.node_tool_runnable", return_value=True
         ), patch("subprocess.run") as run, patch(
             "tools.browser_tool._chromium_installed", return_value=False
         ), patch(
@@ -455,7 +463,7 @@ class TestAgentBrowserPostSetup:
 
         run.assert_called_once()
         assert run.call_args.args[0] == [
-            "/usr/bin/npx", "-y", AGENT_BROWSER_NPX_SPEC, "install", "--with-deps",
+            "/usr/bin/npx", "--ignore-scripts", "-y", AGENT_BROWSER_NPX_SPEC, "install", "--with-deps",
         ]
 
     def test_installs_chromium_via_npx_resolved_only_through_extended_path(self):
@@ -483,7 +491,7 @@ class TestAgentBrowserPostSetup:
 
         run.assert_called_once()
         assert run.call_args.args[0] == [
-            hermes_npx, "-y", AGENT_BROWSER_NPX_SPEC, "install", "--with-deps",
+            hermes_npx, "--ignore-scripts", "-y", AGENT_BROWSER_NPX_SPEC, "install", "--with-deps",
         ]
 
     def test_warns_instead_of_crashing_when_npx_unresolvable_after_all(self):
@@ -537,6 +545,8 @@ class TestAgentBrowserPostSetup:
         import tools.browser_tool as _bt
 
         with patch("shutil.which", return_value="/usr/bin/npx"), patch(
+            "tools.browser_tool.node_tool_runnable", return_value=True
+        ), patch(
             "subprocess.run",
             return_value=SimpleNamespace(returncode=0, stdout="", stderr=""),
         ), patch(
@@ -560,6 +570,8 @@ class TestAgentBrowserPostSetup:
         import tools.browser_tool as _bt
 
         with patch("shutil.which", return_value="/usr/bin/npx"), patch(
+            "tools.browser_tool.node_tool_runnable", return_value=True
+        ), patch(
             "subprocess.run",
             return_value=SimpleNamespace(
                 returncode=1, stdout="", stderr="line1\nline2\nfatal: network error"
@@ -586,6 +598,8 @@ class TestAgentBrowserPostSetup:
 
     def test_install_timeout_warns_without_raising(self):
         with patch("shutil.which", return_value="/usr/bin/npx"), patch(
+            "tools.browser_tool.node_tool_runnable", return_value=True
+        ), patch(
             "subprocess.run",
             side_effect=subprocess.TimeoutExpired(cmd=["npx"], timeout=600),
         ), patch(

--- a/tests/scripts/test_windows_footguns_full_repo_scan.py
+++ b/tests/scripts/test_windows_footguns_full_repo_scan.py
@@ -1,0 +1,41 @@
+"""Full-repo self-scan wrapper for scripts/check-windows-footguns.py.
+
+scripts/check_subprocess_stdin.py has had a pytest wrapper (see
+tests/tools/test_subprocess_stdin_guard.py's test_all_tui_subprocess_calls_
+have_stdin) that runs the checker with its default full-scan behavior and
+asserts a clean exit — so a normal pytest run of that file catches
+regressions even when no one remembers to run the standalone script by hand.
+check-windows-footguns.py had no equivalent: only a narrow rule-level test
+(tests/scripts/test_footgun_subprocess_encoding.py, scoped to the
+text=True/encoding= rule) existed, so a bare ``os.killpg``/``signal.SIGKILL``
+regression (caught by CI running the real script with --all, not by any
+local pytest run) shipped in the T1-T3 npx-agent-browser hardening commit
+before anyone ran the script directly. This closes that gap the same way
+the stdin guard already closes its equivalent one.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "check-windows-footguns.py"
+
+
+def test_full_repo_scan_has_no_unsuppressed_windows_footguns():
+    """Mirrors check_subprocess_stdin.py's wrapper: run the real checker
+    against the whole repo (--all) and require a clean exit, so this test
+    file — not just institutional memory — is what catches the next
+    bare os.killpg/signal.SIGKILL-style regression."""
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--all"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        stdin=subprocess.DEVNULL,
+    )
+    assert result.returncode == 0, (
+        f"Windows footgun check failed:\n{result.stdout}\n{result.stderr}"
+    )

--- a/tests/test_install_ps1_browser_install.py
+++ b/tests/test_install_ps1_browser_install.py
@@ -1,0 +1,72 @@
+"""Regression test for install.ps1 browser setup (PR #44772 review).
+
+agent-browser resolves lazily via npx everywhere else in the system
+(tools/browser_tool.py::_find_agent_browser); Install-AgentBrowser was the
+last place that still eagerly npm-installed a second, separately
+version-pinned copy of it. Removed: agent-browser acquisition now happens
+only via `hermes update`'s npx cache warm or an actual browser-tool call's
+lazy npx resolution.
+
+Linux CI cannot execute the PowerShell installer, so verification here is
+source-text-level only, matching tests/test_install_sh_browser_install.py
+and tests/test_install_ps1_ascii_only.py.
+"""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+
+
+def _extract_function_body(source: str, name: str) -> str:
+    m = re.search(
+        rf"^function {re.escape(name)} \{{.*?^\}}", source, re.MULTILINE | re.DOTALL
+    )
+    assert m, f"could not extract function {name} from install.ps1"
+    return m.group(0)
+
+
+def test_install_agent_browser_no_longer_npm_installs_agent_browser() -> None:
+    body = _extract_function_body(INSTALL_PS1.read_text(), "Install-AgentBrowser")
+
+    assert "agent-browser@" not in body
+    assert "Installing Chromium via agent-browser install" not in body
+    # camofox is unrelated to this change and must still be installed here.
+    assert "@askjo/camofox-browser@^1.5.2" in body
+    # System-browser detection is still cheap/valuable without agent-browser.
+    assert "Find-SystemBrowser" in body
+    assert "Write-BrowserEnv" in body
+
+
+def test_install_agent_browser_drops_unused_skip_chromium_param() -> None:
+    """$SkipChromium only existed to gate the now-removed Chromium-download
+    branch; grep confirms it's never passed at the one real call site, so a
+    lingering param would be dead code implying a control path that no
+    longer exists."""
+    body = _extract_function_body(INSTALL_PS1.read_text(), "Install-AgentBrowser")
+
+    assert "SkipChromium" not in body
+
+    # And the one real call site must not pass it either.
+    text = INSTALL_PS1.read_text()
+    call_site = re.search(r"^\s*Install-AgentBrowser.*$", text, re.MULTILINE)
+    assert call_site, "could not find Install-AgentBrowser call site"
+    assert "SkipChromium" not in call_site.group(0)
+
+
+def test_install_agent_browser_still_ignore_scripts_hardened() -> None:
+    """The removal of agent-browser must not have also dropped the
+    supply-chain hardening that still applies to the remaining camofox
+    install."""
+    body = _extract_function_body(INSTALL_PS1.read_text(), "Install-AgentBrowser")
+
+    assert "--ignore-scripts" in body
+
+
+def test_install_agent_browser_no_longer_references_agent_browser_cmd_shim() -> None:
+    """No dangling reference to the agent-browser.cmd shim should remain
+    now that this function never installs it."""
+    body = _extract_function_body(INSTALL_PS1.read_text(), "Install-AgentBrowser")
+
+    assert "agent-browser.cmd" not in body

--- a/tests/test_install_sh_browser_install.py
+++ b/tests/test_install_sh_browser_install.py
@@ -197,6 +197,53 @@ def test_no_retry_when_native_succeeds_on_ubuntu_26() -> None:
     assert r["final_rc"] == 0
 
 
+import re
+
+
+def _extract_function_body(source: str, name: str) -> str:
+    m = re.search(rf"^{re.escape(name)}\(\) \{{.*?^\}}", source, re.MULTILINE | re.DOTALL)
+    assert m, f"could not extract {name}() from install.sh"
+    return m.group(0)
+
+
+def test_ensure_browser_no_longer_npm_installs_agent_browser() -> None:
+    """agent-browser resolves lazily via npx everywhere else in the system
+    (tools/browser_tool.py::_find_agent_browser); this was the last place
+    that still eagerly npm-installed a second, separately version-pinned
+    copy of it. Removed: agent-browser acquisition now happens only via
+    `hermes update`'s npx cache warm or an actual browser-tool call's lazy
+    npx resolution (PR #44772 review)."""
+    body = _extract_function_body(INSTALL_SH.read_text(), "ensure_browser")
+
+    assert "agent-browser@" not in body
+    assert "Installing Chromium via agent-browser install" not in body
+    # camofox is unrelated to this change and must still be installed here.
+    assert "@askjo/camofox-browser@^1.5.2" in body
+    # System-browser detection is still cheap/valuable without agent-browser.
+    assert "find_system_browser" in body
+    assert "configure_browser_env_from_system_browser" in body
+
+
+def test_ensure_browser_still_ignore_scripts_and_timeout_guarded() -> None:
+    """The removal of agent-browser must not have also dropped the
+    supply-chain and hang-protection hardening that still applies to the
+    remaining camofox install."""
+    body = _extract_function_body(INSTALL_SH.read_text(), "ensure_browser")
+
+    assert "--ignore-scripts" in body
+    assert "run_with_timeout" in body
+
+
+def test_ensure_browser_no_longer_references_agent_browser_binary_path() -> None:
+    """No dangling reference to a local agent-browser binary path should
+    remain now that this function never installs it — a leftover reference
+    would be dead code pointing at a binary that no longer gets placed
+    there by this function."""
+    body = _extract_function_body(INSTALL_SH.read_text(), "ensure_browser")
+
+    assert "$HERMES_HOME/node/bin/agent-browser" not in body
+
+
 
 
 

--- a/tests/test_windows_subprocess_no_window_flags.py
+++ b/tests/test_windows_subprocess_no_window_flags.py
@@ -181,13 +181,22 @@ def test_shell_hooks_hide_hook_command_windows(monkeypatch):
     assert captured[0][1]["creationflags"] == _CREATE_NO_WINDOW
 
 
+def test_agent_browser_npx_warmup_hides_npx_window(monkeypatch):
+    from tools import browser_tool
 
+    captured = []
 
+    def fake_run(cmd, **kwargs):
+        captured.append((cmd, kwargs))
+        return _Completed(stdout="1.2.3\n")
 
+    monkeypatch.setattr(browser_tool.shutil, "which", lambda name: "/usr/bin/npx")
+    monkeypatch.setattr(browser_tool, "windows_hide_flags", lambda: _CREATE_NO_WINDOW)
+    monkeypatch.setattr(browser_tool.subprocess, "run", fake_run)
 
-
-
-
+    assert browser_tool.warm_agent_browser_npx_cache() is True
+    assert captured[0][0][0] == "/usr/bin/npx"
+    assert captured[0][1]["creationflags"] == _CREATE_NO_WINDOW
 
 
 

--- a/tests/test_windows_subprocess_no_window_flags.py
+++ b/tests/test_windows_subprocess_no_window_flags.py
@@ -182,21 +182,37 @@ def test_shell_hooks_hide_hook_command_windows(monkeypatch):
 
 
 def test_agent_browser_npx_warmup_hides_npx_window(monkeypatch):
+    """warm_agent_browser_npx_cache spawns via subprocess.Popen (not .run,
+    since the T3 security-hardening rewrite added process-tree containment
+    via Popen + communicate()) — the console-hiding flag must still survive
+    that rewrite. On Windows the real implementation now ORs in
+    CREATE_NEW_PROCESS_GROUP alongside windows_hide_flags()'s bits (for
+    _kill_process_tree's taskkill /T to have a coherent tree to kill), so
+    this checks the CREATE_NO_WINDOW bit is present rather than exact
+    equality with the whole creationflags value."""
     from tools import browser_tool
 
     captured = []
 
-    def fake_run(cmd, **kwargs):
-        captured.append((cmd, kwargs))
-        return _Completed(stdout="1.2.3\n")
+    class _FakePopen:
+        def __init__(self, cmd, **kwargs):
+            captured.append((cmd, kwargs))
+            self.returncode = 0
 
-    monkeypatch.setattr(browser_tool.shutil, "which", lambda name: "/usr/bin/npx")
+        def communicate(self, timeout=None):
+            return ("1.2.3\n", "")
+
+    monkeypatch.setattr(
+        browser_tool.shutil, "which",
+        lambda name, path=None: "/usr/bin/npx",
+    )
+    monkeypatch.setattr(browser_tool, "node_tool_runnable", lambda p: True)
     monkeypatch.setattr(browser_tool, "windows_hide_flags", lambda: _CREATE_NO_WINDOW)
-    monkeypatch.setattr(browser_tool.subprocess, "run", fake_run)
+    monkeypatch.setattr(browser_tool.subprocess, "Popen", _FakePopen)
 
     assert browser_tool.warm_agent_browser_npx_cache() is True
     assert captured[0][0][0] == "/usr/bin/npx"
-    assert captured[0][1]["creationflags"] == _CREATE_NO_WINDOW
+    assert captured[0][1]["creationflags"] & _CREATE_NO_WINDOW == _CREATE_NO_WINDOW
 
 
 

--- a/tests/tools/test_browser_chromium_autoinstall.py
+++ b/tests/tools/test_browser_chromium_autoinstall.py
@@ -64,6 +64,7 @@ class TestInstall:
         monkeypatch.setattr(bt, "_build_browser_env", lambda: {})
         monkeypatch.setattr(bt, "_chromium_installed", lambda: True)
         monkeypatch.setattr(bt.shutil, "which", lambda _, path=None: "/usr/bin/npx")
+        monkeypatch.setattr(bt, "node_tool_runnable", lambda p: True)
 
         captured = {}
         monkeypatch.setattr(
@@ -72,7 +73,9 @@ class TestInstall:
         )
 
         assert bt._maybe_autoinstall_chromium() is True
-        assert captured["cmd"] == ["/usr/bin/npx", "-y", bt.AGENT_BROWSER_NPX_SPEC, "install"]
+        assert captured["cmd"] == [
+            "/usr/bin/npx", "--ignore-scripts", "-y", bt.AGENT_BROWSER_NPX_SPEC, "install",
+        ]
         assert "--with-deps" not in captured["cmd"]
 
     def test_nonzero_exit_returns_false(self, monkeypatch):

--- a/tests/tools/test_browser_chromium_autoinstall.py
+++ b/tests/tools/test_browser_chromium_autoinstall.py
@@ -57,6 +57,23 @@ class TestInstall:
         assert captured["cmd"] == ["/x/agent-browser", "install"]
         assert "--with-deps" not in captured["cmd"]
 
+    def test_npx_form_is_binary_only(self, monkeypatch):
+        monkeypatch.setattr(bt, "_running_in_docker", lambda: False)
+        monkeypatch.setattr("tools.lazy_deps._allow_lazy_installs", lambda: True)
+        monkeypatch.setattr(bt, "_find_agent_browser", lambda: "npx agent-browser")
+        monkeypatch.setattr(bt, "_build_browser_env", lambda: {})
+        monkeypatch.setattr(bt, "_chromium_installed", lambda: True)
+        monkeypatch.setattr(bt.shutil, "which", lambda _, path=None: "/usr/bin/npx")
+
+        captured = {}
+        monkeypatch.setattr(
+            bt.subprocess, "run",
+            lambda cmd, **kw: captured.update(cmd=cmd) or SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+
+        assert bt._maybe_autoinstall_chromium() is True
+        assert captured["cmd"] == ["/usr/bin/npx", "-y", "agent-browser", "install"]
+        assert "--with-deps" not in captured["cmd"]
 
     def test_nonzero_exit_returns_false(self, monkeypatch):
         monkeypatch.setattr(bt, "_running_in_docker", lambda: False)

--- a/tests/tools/test_browser_chromium_autoinstall.py
+++ b/tests/tools/test_browser_chromium_autoinstall.py
@@ -72,7 +72,7 @@ class TestInstall:
         )
 
         assert bt._maybe_autoinstall_chromium() is True
-        assert captured["cmd"] == ["/usr/bin/npx", "-y", "agent-browser", "install"]
+        assert captured["cmd"] == ["/usr/bin/npx", "-y", bt.AGENT_BROWSER_NPX_SPEC, "install"]
         assert "--with-deps" not in captured["cmd"]
 
     def test_nonzero_exit_returns_false(self, monkeypatch):

--- a/tests/tools/test_browser_chromium_check.py
+++ b/tests/tools/test_browser_chromium_check.py
@@ -40,7 +40,7 @@ class TestChromiumInstalled:
         monkeypatch.setattr(
             bt.shutil,
             "which",
-            lambda name: "/usr/bin/chromium" if name == "chromium" else None,
+            lambda name, path=None: "/usr/bin/chromium" if name == "chromium" else None,
         )
 
         assert bt._chromium_installed() is True

--- a/tests/tools/test_browser_homebrew_paths.py
+++ b/tests/tools/test_browser_homebrew_paths.py
@@ -220,6 +220,7 @@ class TestFindAgentBrowser:
         with patch("shutil.which", side_effect=mock_which), \
              patch("os.path.isdir", return_value=False), \
              patch.object(Path, "exists", mock_path_exists), \
+             patch("tools.browser_tool.node_tool_runnable", return_value=True), \
              patch(
                  "tools.browser_tool._discover_homebrew_node_dirs",
                  return_value=[],
@@ -399,10 +400,11 @@ class TestRunBrowserCommandPathConstruction:
                 _run_browser_command("test-task", "navigate", ["https://example.com"])
 
         assert captured_cmd is not None
-        assert captured_cmd[:4] == [
-            "/opt/hermes/node/bin/npx", "--prefer-offline", "-y", AGENT_BROWSER_NPX_SPEC,
+        assert captured_cmd[:5] == [
+            "/opt/hermes/node/bin/npx", "--ignore-scripts", "--prefer-offline", "-y",
+            AGENT_BROWSER_NPX_SPEC,
         ]
-        assert captured_cmd[4:8] == ["--session", "test-session", "--json", "navigate"]
+        assert captured_cmd[5:9] == ["--session", "test-session", "--json", "navigate"]
 
     def test_subprocess_path_includes_termux_fallback_dirs(self, tmp_path):
         """Termux fallback dirs should survive browser PATH rebuilding."""
@@ -484,9 +486,95 @@ class TestRunChromeFallbackCommandNpxResolution:
 
         assert captured_cmds, "expected at least one Popen call for the chrome-fallback session"
         first_cmd = captured_cmds[0]
-        assert first_cmd[:4] == [
-            "/opt/hermes/node/bin/npx", "--prefer-offline", "-y", AGENT_BROWSER_NPX_SPEC,
+        assert first_cmd[:5] == [
+            "/opt/hermes/node/bin/npx", "--ignore-scripts", "--prefer-offline", "-y",
+            AGENT_BROWSER_NPX_SPEC,
         ]
-        assert first_cmd[4] == "--engine" and first_cmd[5] == "chrome"
-        assert first_cmd[6] == "--session" and first_cmd[7].startswith("h_cfb_")
-        assert first_cmd[8] == "--json"
+        assert first_cmd[5] == "--engine" and first_cmd[6] == "chrome"
+        assert first_cmd[7] == "--session" and first_cmd[8].startswith("h_cfb_")
+        assert first_cmd[9] == "--json"
+
+
+class TestResolveNpxBinPriority:
+    """The extended/managed search must be checked before a bare ambient
+    PATH lookup, so a broken/unexpected system npx can't shadow a healthy
+    Hermes-managed one — and each candidate must be validated (actually
+    runs) before being trusted, mirroring _find_agent_browser's own
+    validation discipline for agent-browser itself."""
+
+    def test_prefers_managed_extended_path_over_bare_path(self, monkeypatch):
+        import tools.browser_tool as bt
+
+        monkeypatch.setattr(bt, "_merge_browser_path", lambda _p: "/hermes/node/bin")
+        monkeypatch.setattr(
+            bt.shutil, "which",
+            lambda cmd, path=None: (
+                "/hermes/node/bin/npx" if path == "/hermes/node/bin"
+                else "/usr/local/bin/npx"
+            ),
+        )
+        monkeypatch.setattr(bt, "node_tool_runnable", lambda p: True)
+
+        assert bt._resolve_npx_bin() == "/hermes/node/bin/npx"
+
+    def test_falls_back_to_bare_path_when_managed_candidate_is_broken(self, monkeypatch):
+        import tools.browser_tool as bt
+
+        monkeypatch.setattr(bt, "_merge_browser_path", lambda _p: "/hermes/node/bin")
+        monkeypatch.setattr(
+            bt.shutil, "which",
+            lambda cmd, path=None: (
+                "/hermes/node/bin/npx" if path == "/hermes/node/bin"
+                else "/usr/local/bin/npx"
+            ),
+        )
+        monkeypatch.setattr(bt, "node_tool_runnable", lambda p: p == "/usr/local/bin/npx")
+
+        assert bt._resolve_npx_bin() == "/usr/local/bin/npx"
+
+    def test_returns_none_when_nothing_runnable(self, monkeypatch):
+        import tools.browser_tool as bt
+
+        monkeypatch.setattr(bt, "_merge_browser_path", lambda _p: "")
+        monkeypatch.setattr(bt.shutil, "which", lambda cmd, path=None: "/usr/local/bin/npx")
+        monkeypatch.setattr(bt, "node_tool_runnable", lambda p: False)
+
+        assert bt._resolve_npx_bin() is None
+
+    def test_skips_extended_lookup_when_merge_browser_path_returns_empty(self, monkeypatch):
+        """_merge_browser_path("") returning a falsy string (no extended
+        candidate dirs found on disk) must short-circuit straight to the
+        bare-PATH rung — shutil.which must not be called with a path=""
+        kwarg (which would silently mean "search cwd only" on some
+        platforms rather than "no extended search"), and node_tool_runnable
+        must only be asked about the one real candidate."""
+        import tools.browser_tool as bt
+
+        which_calls = []
+
+        def fake_which(cmd, path=None):
+            which_calls.append((cmd, path))
+            return "/usr/bin/npx" if path is None else None
+
+        monkeypatch.setattr(bt, "_merge_browser_path", lambda _p: "")
+        monkeypatch.setattr(bt.shutil, "which", fake_which)
+        monkeypatch.setattr(bt, "node_tool_runnable", lambda p: p == "/usr/bin/npx")
+
+        assert bt._resolve_npx_bin() == "/usr/bin/npx"
+        assert which_calls == [("npx", None)]
+
+    def test_falls_back_to_bare_path_when_extended_dir_has_no_npx(self, monkeypatch):
+        """A non-empty extended search PATH that simply doesn't contain an
+        npx binary (shutil.which returns None there) must fall through to
+        the bare-PATH rung rather than treating "no extended npx" the same
+        as "extended npx found but broken"."""
+        import tools.browser_tool as bt
+
+        monkeypatch.setattr(bt, "_merge_browser_path", lambda _p: "/hermes/node/bin")
+        monkeypatch.setattr(
+            bt.shutil, "which",
+            lambda cmd, path=None: None if path == "/hermes/node/bin" else "/usr/bin/npx",
+        )
+        monkeypatch.setattr(bt, "node_tool_runnable", lambda p: True)
+
+        assert bt._resolve_npx_bin() == "/usr/bin/npx"

--- a/tests/tools/test_browser_homebrew_paths.py
+++ b/tests/tools/test_browser_homebrew_paths.py
@@ -13,6 +13,8 @@ from tools.browser_tool import (
     _discover_homebrew_node_dirs,
     _find_agent_browser,
     _run_browser_command,
+    _run_chrome_fallback_command,
+    AGENT_BROWSER_NPX_SPEC,
     _SANE_PATH,
     check_browser_requirements,
 )
@@ -349,6 +351,59 @@ class TestRunBrowserCommandPathConstruction:
         ]
 
 
+    def test_npx_sentinel_resolves_via_resolve_npx_bin_with_pinned_spec(self, tmp_path):
+        """When _find_agent_browser resolves the npx sentinel, the cmd prefix
+        must come from _resolve_npx_bin() (not a bare shutil.which("npx"), which
+        could let a broken system npx shadow a healthy Hermes-managed one) and
+        use the pinned agent-browser npx spec, not a bare "agent-browser"."""
+        captured_cmd = None
+
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.wait.return_value = 0
+
+        def capture_popen(cmd, **kwargs):
+            nonlocal captured_cmd
+            captured_cmd = cmd
+            return mock_proc
+
+        fake_session = {
+            "session_name": "test-session",
+            "session_id": "test-id",
+            "cdp_url": None,
+        }
+        fake_json = json.dumps({"success": True})
+        hermes_home = str(tmp_path / "hermes-home")
+
+        with patch("tools.browser_tool._find_agent_browser", return_value="npx agent-browser"), \
+             patch("tools.browser_tool._resolve_npx_bin", return_value="/opt/hermes/node/bin/npx"), \
+             patch("tools.browser_tool._chromium_installed", return_value=True), \
+             patch("tools.browser_tool._get_session_info", return_value=fake_session), \
+             patch("tools.browser_tool._socket_safe_tmpdir", return_value=str(tmp_path)), \
+             patch("tools.browser_tool._discover_homebrew_node_dirs", return_value=[]), \
+             patch("hermes_constants.Path.home", return_value=tmp_path), \
+             patch("subprocess.Popen", side_effect=capture_popen), \
+             patch("os.open", return_value=99), \
+             patch("os.close"), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.dict(
+                 os.environ,
+                 {
+                     "PATH": "/usr/bin:/bin",
+                     "HOME": "/home/test",
+                     "HERMES_HOME": hermes_home,
+                 },
+                 clear=True,
+             ):
+            with patch("builtins.open", mock_open(read_data=fake_json)):
+                _run_browser_command("test-task", "navigate", ["https://example.com"])
+
+        assert captured_cmd is not None
+        assert captured_cmd[:4] == [
+            "/opt/hermes/node/bin/npx", "--prefer-offline", "-y", AGENT_BROWSER_NPX_SPEC,
+        ]
+        assert captured_cmd[4:8] == ["--session", "test-session", "--json", "navigate"]
+
     def test_subprocess_path_includes_termux_fallback_dirs(self, tmp_path):
         """Termux fallback dirs should survive browser PATH rebuilding."""
         captured_env = {}
@@ -397,3 +452,41 @@ class TestRunBrowserCommandPathConstruction:
         result_path = captured_env.get("PATH", "")
         assert "/data/data/com.termux/files/usr/bin" in result_path
         assert "/data/data/com.termux/files/usr/sbin" in result_path
+
+
+class TestRunChromeFallbackCommandNpxResolution:
+    """_run_chrome_fallback_command builds its own npx cmd prefix independently
+    of _run_browser_command's — it must resolve npx the same way (via
+    _resolve_npx_bin(), not a bare shutil.which("npx")) and use the pinned
+    agent-browser npx spec."""
+
+    def test_npx_sentinel_resolves_via_resolve_npx_bin_with_pinned_spec(self, tmp_path):
+        captured_cmds = []
+
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.wait.return_value = 0
+
+        def capture_popen(cmd, **kwargs):
+            captured_cmds.append(cmd)
+            return mock_proc
+
+        url_result = {"success": True, "data": {"result": "https://example.com"}}
+
+        with patch("tools.browser_tool._run_browser_command", return_value=url_result), \
+             patch("tools.browser_tool._find_agent_browser", return_value="npx agent-browser"), \
+             patch("tools.browser_tool._resolve_npx_bin", return_value="/opt/hermes/node/bin/npx"), \
+             patch("tools.browser_tool._chromium_installed", return_value=True), \
+             patch("tools.browser_tool._running_in_docker", return_value=False), \
+             patch("tools.browser_tool._socket_safe_tmpdir", return_value=str(tmp_path)), \
+             patch("subprocess.Popen", side_effect=capture_popen):
+            _run_chrome_fallback_command("test-task", "navigate", ["https://example.com"], timeout=10)
+
+        assert captured_cmds, "expected at least one Popen call for the chrome-fallback session"
+        first_cmd = captured_cmds[0]
+        assert first_cmd[:4] == [
+            "/opt/hermes/node/bin/npx", "--prefer-offline", "-y", AGENT_BROWSER_NPX_SPEC,
+        ]
+        assert first_cmd[4] == "--engine" and first_cmd[5] == "chrome"
+        assert first_cmd[6] == "--session" and first_cmd[7].startswith("h_cfb_")
+        assert first_cmd[8] == "--json"

--- a/tests/tools/test_browser_homebrew_paths.py
+++ b/tests/tools/test_browser_homebrew_paths.py
@@ -2,12 +2,14 @@
 
 import json
 import os
+import sys
 from pathlib import Path
 from unittest.mock import patch, MagicMock, mock_open
 
 import pytest
 
 from tools.browser_tool import (
+    _agent_browser_candidate_present,
     _discover_homebrew_node_dirs,
     _find_agent_browser,
     _run_browser_command,
@@ -94,6 +96,168 @@ class TestFindAgentBrowser:
              ):
             with pytest.raises(FileNotFoundError, match="agent-browser CLI not found"):
                 _find_agent_browser()
+
+    def test_finds_in_local_node_modules_bin(self):
+        """Should fall through to the repo's node_modules/.bin when both the
+        bare PATH and the extended (Homebrew/fallback) PATH miss."""
+        repo_root = Path(_bt.__file__).parent.parent
+        local_bin_dir = repo_root / "node_modules" / ".bin"
+        local_bin_path = str(local_bin_dir / "agent-browser")
+
+        def mock_which(cmd, path=None):
+            if cmd == "agent-browser" and path and str(local_bin_dir) in path:
+                return local_bin_path
+            return None
+
+        original_is_dir = Path.is_dir
+
+        def mock_is_dir(self):
+            if self == local_bin_dir:
+                return True
+            return original_is_dir(self)
+
+        with patch("shutil.which", side_effect=mock_which), \
+             patch("os.path.isdir", return_value=False), \
+             patch.object(Path, "is_dir", mock_is_dir), \
+             patch("tools.browser_tool.agent_browser_runnable", return_value=True), \
+             patch(
+                 "tools.browser_tool._discover_homebrew_node_dirs",
+                 return_value=[],
+             ):
+            result = _find_agent_browser()
+
+        assert result == local_bin_path
+
+    def test_extended_path_hit_validate_false_skips_runnable_check(self, tmp_path):
+        """Readiness probes (validate=False, used by _has_agent_browser) must
+        resolve a candidate found via the extended PATH's path= kwarg lookup
+        without calling agent_browser_runnable — that keeps the probe a cheap
+        existence check with no subprocess spawn."""
+        fake_binary = tmp_path / "agent-browser"
+        fake_binary.write_text("#!/bin/sh\n")
+        fake_binary.chmod(0o755)
+
+        def mock_which(cmd, path=None):
+            if cmd == "agent-browser" and path:
+                return str(fake_binary)
+            return None  # bare (path=None) PATH lookup misses
+
+        with patch("shutil.which", side_effect=mock_which), \
+             patch("os.path.isdir", return_value=True), \
+             patch(
+                 "tools.browser_tool.agent_browser_runnable",
+                 side_effect=AssertionError(
+                     "validate=False must not call agent_browser_runnable"
+                 ),
+             ), \
+             patch(
+                 "tools.browser_tool._discover_homebrew_node_dirs",
+                 return_value=["/opt/homebrew/bin"],
+             ):
+            result = _find_agent_browser(validate=False)
+
+        assert result == str(fake_binary)
+
+    def test_local_bin_hit_validate_false_skips_runnable_check(self, tmp_path):
+        """Same no-subprocess-spawn contract for the node_modules/.bin
+        candidate: validate=False relies on _agent_browser_candidate_present's
+        existence+exec-bit check instead of shelling out to --version."""
+        repo_root = Path(_bt.__file__).parent.parent
+        local_bin_dir = repo_root / "node_modules" / ".bin"
+
+        fake_binary = tmp_path / "agent-browser"
+        fake_binary.write_text("#!/bin/sh\n")
+        fake_binary.chmod(0o755)
+
+        def mock_which(cmd, path=None):
+            if cmd == "agent-browser" and path and str(local_bin_dir) in path:
+                return str(fake_binary)
+            return None
+
+        original_is_dir = Path.is_dir
+
+        def mock_is_dir(self):
+            if self == local_bin_dir:
+                return True
+            return original_is_dir(self)
+
+        with patch("shutil.which", side_effect=mock_which), \
+             patch("os.path.isdir", return_value=False), \
+             patch.object(Path, "is_dir", mock_is_dir), \
+             patch(
+                 "tools.browser_tool.agent_browser_runnable",
+                 side_effect=AssertionError(
+                     "validate=False must not call agent_browser_runnable"
+                 ),
+             ), \
+             patch(
+                 "tools.browser_tool._discover_homebrew_node_dirs",
+                 return_value=[],
+             ):
+            result = _find_agent_browser(validate=False)
+
+        assert result == str(fake_binary)
+
+    def test_npx_fallback_validate_false(self):
+        """The npx sentinel must resolve through the validate=False path too,
+        independent of the fully-mocked coverage in test_nous_subscription.py."""
+        def mock_which(cmd, path=None):
+            if cmd == "agent-browser":
+                return None
+            if cmd == "npx":
+                return "/usr/bin/npx"
+            return None
+
+        original_path_exists = Path.exists
+
+        def mock_path_exists(self):
+            if "node_modules" in str(self) and "agent-browser" in str(self):
+                return False
+            return original_path_exists(self)
+
+        with patch("shutil.which", side_effect=mock_which), \
+             patch("os.path.isdir", return_value=False), \
+             patch.object(Path, "exists", mock_path_exists), \
+             patch(
+                 "tools.browser_tool._discover_homebrew_node_dirs",
+                 return_value=[],
+             ):
+            result = _find_agent_browser(validate=False)
+
+        assert result == "npx agent-browser"
+
+
+class TestAgentBrowserCandidatePresent:
+    """Direct unit tests for the validate=False candidate check used by every
+    branch of _find_agent_browser's readiness-probe (no-subprocess) mode."""
+
+    def test_none_is_false(self):
+        assert _agent_browser_candidate_present(None) is False
+
+    def test_empty_string_is_false(self):
+        assert _agent_browser_candidate_present("") is False
+
+    def test_npx_sentinel_is_true_without_touching_filesystem(self):
+        assert _agent_browser_candidate_present("npx agent-browser") is True
+
+    def test_executable_file_is_true(self, tmp_path):
+        binary = tmp_path / "agent-browser"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        assert _agent_browser_candidate_present(str(binary)) is True
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="exec-bit is not meaningful on Windows; os.name == 'nt' short-circuits",
+    )
+    def test_nonexecutable_file_is_false(self, tmp_path):
+        binary = tmp_path / "agent-browser"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o644)
+        assert _agent_browser_candidate_present(str(binary)) is False
+
+    def test_nonexistent_path_is_false(self, tmp_path):
+        assert _agent_browser_candidate_present(str(tmp_path / "missing")) is False
 
 
 class TestBrowserRequirements:

--- a/tests/tools/test_browser_npx_warmup.py
+++ b/tests/tools/test_browser_npx_warmup.py
@@ -58,6 +58,23 @@ def test_invokes_npx_with_ignore_scripts_prefer_offline_and_pinned_spec():
     ]
 
 
+def test_stdin_is_explicitly_devnull_not_inherited():
+    """Every subprocess call in tools/ must set stdin= explicitly
+    (scripts/check_subprocess_stdin.py) — in the TUI gateway, an inherited
+    stdin fd can be consumed by a child and cause the gateway's own
+    JSON-RPC stdin read to see a premature EOF (issue #14036). This call
+    has no reason to read from stdin at all, so it must be DEVNULL, not
+    merely "present in kwargs somewhere" (the checker is a literal-argument
+    textual scan, so stdin= folded into a shared kwargs dict wouldn't
+    satisfy it either — it must appear as a literal keyword on the call)."""
+    with patch("tools.browser_tool._resolve_npx_bin", return_value="/usr/bin/npx"), \
+         patch("subprocess.Popen", return_value=_mock_proc()) as mock_popen:
+        warm_agent_browser_npx_cache()
+
+    _args, kwargs = mock_popen.call_args
+    assert kwargs.get("stdin") == subprocess.DEVNULL
+
+
 def test_captures_stdout_and_stderr_instead_of_inheriting_parent_fds():
     """The npx registry fetch runs on every `hermes update` — its stdout/
     stderr must not bleed into the caller's own output (and, on POSIX, an
@@ -225,6 +242,36 @@ class TestKillProcessTree:
             raise ProcessLookupError()
 
         monkeypatch.setattr("os.getpgid", _raise)
+
+        _kill_process_tree(proc)  # must not raise
+
+    def test_posix_missing_killpg_attribute_falls_back_to_proc_kill(self, monkeypatch):
+        """Some POSIX-like environments may lack os.killpg entirely (the
+        implementation resolves it defensively via
+        ``getattr(os, "killpg", None)`` — flagged by
+        scripts/check-windows-footguns.py against a bare ``os.killpg``
+        reference). When that resolution comes back None, the fallback must
+        be a plain ``proc.kill()`` of just the top-level PID, not an
+        AttributeError."""
+        import os as os_module
+
+        proc = MagicMock()
+        proc.pid = 999
+        monkeypatch.setattr("os.name", "posix")
+        monkeypatch.delattr(os_module, "killpg", raising=False)
+
+        _kill_process_tree(proc)
+
+        proc.kill.assert_called_once()
+
+    def test_posix_missing_killpg_fallback_proc_kill_failure_does_not_raise(self, monkeypatch):
+        import os as os_module
+
+        proc = MagicMock()
+        proc.pid = 999
+        proc.kill.side_effect = OSError("already reaped")
+        monkeypatch.setattr("os.name", "posix")
+        monkeypatch.delattr(os_module, "killpg", raising=False)
 
         _kill_process_tree(proc)  # must not raise
 

--- a/tests/tools/test_browser_npx_warmup.py
+++ b/tests/tools/test_browser_npx_warmup.py
@@ -1,0 +1,75 @@
+"""Tests for tools.browser_tool.warm_agent_browser_npx_cache (#43564).
+
+agent-browser was moved out of root package.json dependencies and now
+resolves lazily via `npx agent-browser`. warm_agent_browser_npx_cache() is
+the fire-and-forget helper `hermes update` / `hermes doctor --fix` call to
+pre-fetch it so the first real browser-tool invocation in a session doesn't
+pay npx's registry-lookup cost. It must never raise and must accurately
+report success/failure via its return value — hermes_cli/doctor.py's
+`--fix` path branches on that return value; hermes_cli/update_cmd.py calls
+it fire-and-forget inside its own try/except and ignores the result.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+from tools.browser_tool import warm_agent_browser_npx_cache
+
+
+def test_returns_false_without_calling_subprocess_when_npx_missing():
+    with patch("shutil.which", return_value=None), patch(
+        "subprocess.run"
+    ) as mock_run:
+        assert warm_agent_browser_npx_cache() is False
+    mock_run.assert_not_called()
+
+
+def test_invokes_npx_with_prefer_offline_version_check():
+    with patch("shutil.which", return_value="/usr/bin/npx"), patch(
+        "subprocess.run",
+        return_value=subprocess.CompletedProcess([], 0, stdout="1.2.3\n", stderr=""),
+    ) as mock_run:
+        assert warm_agent_browser_npx_cache() is True
+
+    mock_run.assert_called_once()
+    args, kwargs = mock_run.call_args
+    assert args[0] == ["/usr/bin/npx", "--prefer-offline", "-y", "agent-browser", "--version"]
+    assert kwargs.get("check") is False
+
+
+def test_custom_timeout_is_forwarded_to_subprocess_run():
+    with patch("shutil.which", return_value="/usr/bin/npx"), patch(
+        "subprocess.run",
+        return_value=subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+    ) as mock_run:
+        warm_agent_browser_npx_cache(timeout=5.0)
+
+    assert mock_run.call_args.kwargs.get("timeout") == 5.0
+
+
+def test_returns_false_on_nonzero_exit():
+    with patch("shutil.which", return_value="/usr/bin/npx"), patch(
+        "subprocess.run",
+        return_value=subprocess.CompletedProcess([], 1, stdout="", stderr="registry unreachable"),
+    ):
+        assert warm_agent_browser_npx_cache() is False
+
+
+def test_returns_false_instead_of_raising_on_timeout():
+    with patch("shutil.which", return_value="/usr/bin/npx"), patch(
+        "subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd=["npx"], timeout=60.0),
+    ):
+        assert warm_agent_browser_npx_cache() is False
+
+
+def test_returns_false_instead_of_raising_on_unexpected_exception():
+    """Fire-and-forget contract: hermes_cli/doctor.py calls this bare (no
+    try/except of its own), so any exception inside the subprocess call
+    must be swallowed here, not propagated."""
+    with patch("shutil.which", return_value="/usr/bin/npx"), patch(
+        "subprocess.run", side_effect=OSError("fork failed")
+    ):
+        assert warm_agent_browser_npx_cache() is False

--- a/tests/tools/test_browser_npx_warmup.py
+++ b/tests/tools/test_browser_npx_warmup.py
@@ -1,75 +1,269 @@
-"""Tests for tools.browser_tool.warm_agent_browser_npx_cache (#43564).
+"""Tests for tools.browser_tool.warm_agent_browser_npx_cache (#43564, security
+hardening follow-up on PR #44772 review).
 
-agent-browser was moved out of root package.json dependencies and now
-resolves lazily via `npx agent-browser`. warm_agent_browser_npx_cache() is
-the fire-and-forget helper `hermes update` / `hermes doctor --fix` call to
-pre-fetch it so the first real browser-tool invocation in a session doesn't
-pay npx's registry-lookup cost. It must never raise and must accurately
-report success/failure via its return value — hermes_cli/doctor.py's
-`--fix` path branches on that return value; hermes_cli/update_cmd.py calls
-it fire-and-forget inside its own try/except and ignores the result.
+warm_agent_browser_npx_cache() is the fire-and-forget helper `hermes update` /
+`hermes doctor --fix` call to pre-fetch agent-browser via npx so the first real
+browser-tool invocation in a session doesn't pay npx's registry-lookup cost.
+It must never raise, must accurately report success/failure via its return
+value, must use a credential-scrubbed and PATH-propagated environment (it
+runs registry-fetched, potentially install-scripted npm code on every
+`hermes update` — not only when a browser tool is actually used), must pass
+--ignore-scripts (AGENT_BROWSER_NPX_SPEC is a floating ^0.26.0 range, not an
+exact pin), and must kill the whole process tree — not just the top-level
+npx PID — on timeout.
 """
 
 from __future__ import annotations
 
 import subprocess
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
-from tools.browser_tool import AGENT_BROWSER_NPX_SPEC, warm_agent_browser_npx_cache
+from tools.browser_tool import (
+    AGENT_BROWSER_NPX_SPEC,
+    _kill_process_tree,
+    warm_agent_browser_npx_cache,
+)
 
 
-def test_returns_false_without_calling_subprocess_when_npx_missing():
-    with patch("shutil.which", return_value=None), patch(
-        "subprocess.run"
-    ) as mock_run:
+def _mock_proc(returncode=0, communicate_side_effect=None, pid=4242):
+    proc = MagicMock()
+    proc.pid = pid
+    if communicate_side_effect is not None:
+        proc.communicate.side_effect = communicate_side_effect
+    else:
+        proc.communicate.return_value = ("", "")
+    proc.returncode = returncode
+    return proc
+
+
+def test_returns_false_without_spawning_when_npx_unresolvable():
+    with patch("tools.browser_tool._resolve_npx_bin", return_value=None), patch(
+        "subprocess.Popen"
+    ) as mock_popen:
         assert warm_agent_browser_npx_cache() is False
-    mock_run.assert_not_called()
+    mock_popen.assert_not_called()
 
 
-def test_invokes_npx_with_prefer_offline_version_check():
-    with patch("shutil.which", return_value="/usr/bin/npx"), patch(
-        "subprocess.run",
-        return_value=subprocess.CompletedProcess([], 0, stdout="1.2.3\n", stderr=""),
-    ) as mock_run:
+def test_invokes_npx_with_ignore_scripts_prefer_offline_and_pinned_spec():
+    with patch("tools.browser_tool._resolve_npx_bin", return_value="/usr/bin/npx"), patch(
+        "subprocess.Popen", return_value=_mock_proc()
+    ) as mock_popen:
         assert warm_agent_browser_npx_cache() is True
 
-    mock_run.assert_called_once()
-    args, kwargs = mock_run.call_args
-    assert args[0] == ["/usr/bin/npx", "--prefer-offline", "-y", AGENT_BROWSER_NPX_SPEC, "--version"]
-    assert kwargs.get("check") is False
+    mock_popen.assert_called_once()
+    args, _kwargs = mock_popen.call_args
+    assert args[0] == [
+        "/usr/bin/npx", "--ignore-scripts", "--prefer-offline", "-y",
+        AGENT_BROWSER_NPX_SPEC, "--version",
+    ]
 
 
-def test_custom_timeout_is_forwarded_to_subprocess_run():
-    with patch("shutil.which", return_value="/usr/bin/npx"), patch(
-        "subprocess.run",
-        return_value=subprocess.CompletedProcess([], 0, stdout="", stderr=""),
-    ) as mock_run:
-        warm_agent_browser_npx_cache(timeout=5.0)
+def test_captures_stdout_and_stderr_instead_of_inheriting_parent_fds():
+    """The npx registry fetch runs on every `hermes update` — its stdout/
+    stderr must not bleed into the caller's own output (and, on POSIX, an
+    inherited fd is one more handle a runaway grandchild could hold open)."""
+    with patch("tools.browser_tool._resolve_npx_bin", return_value="/usr/bin/npx"), \
+         patch("subprocess.Popen", return_value=_mock_proc()) as mock_popen:
+        warm_agent_browser_npx_cache()
 
-    assert mock_run.call_args.kwargs.get("timeout") == 5.0
+    _args, kwargs = mock_popen.call_args
+    assert kwargs.get("stdout") == subprocess.PIPE
+    assert kwargs.get("stderr") == subprocess.PIPE
+
+
+def test_uses_credential_scrubbed_environment():
+    """Must not inherit the full parent environment — matching every other
+    agent-browser subprocess spawn (_build_browser_env), not the ambient
+    os.environ with every provider/gateway credential Hermes holds."""
+    scrubbed_env = {"PATH": "/scrubbed/bin", "SCRUBBED": "1"}
+    with patch("tools.browser_tool._resolve_npx_bin", return_value="/usr/bin/npx"), \
+         patch("tools.browser_tool._build_browser_env", return_value=dict(scrubbed_env)), \
+         patch("tools.browser_tool._merge_browser_path", side_effect=lambda p: p), \
+         patch("subprocess.Popen", return_value=_mock_proc()) as mock_popen:
+        warm_agent_browser_npx_cache()
+
+    _args, kwargs = mock_popen.call_args
+    assert kwargs["env"]["SCRUBBED"] == "1"
+    assert "OPENAI_API_KEY" not in kwargs["env"]
+
+
+def test_merges_extended_path_so_managed_only_npx_can_find_sibling_node():
+    """If npx was resolved via the Hermes-managed/extended search (not the
+    ambient PATH), the child's own PATH must include that same directory —
+    npx's #!/usr/bin/env node shebang resolves `node` via the child's PATH
+    at exec time, not the resolving process's PATH."""
+    with patch("tools.browser_tool._resolve_npx_bin", return_value="/opt/hermes/node/bin/npx"), \
+         patch("tools.browser_tool._build_browser_env", return_value={"PATH": "/usr/bin"}), \
+         patch(
+             "tools.browser_tool._merge_browser_path",
+             return_value="/opt/hermes/node/bin:/usr/bin",
+         ) as mock_merge, \
+         patch("subprocess.Popen", return_value=_mock_proc()) as mock_popen:
+        warm_agent_browser_npx_cache()
+
+    mock_merge.assert_called_once_with("/usr/bin")
+    _args, kwargs = mock_popen.call_args
+    assert kwargs["env"]["PATH"] == "/opt/hermes/node/bin:/usr/bin"
+
+
+def test_runs_in_its_own_process_group_on_posix(monkeypatch):
+    monkeypatch.setattr("os.name", "posix")
+    with patch("tools.browser_tool._resolve_npx_bin", return_value="/usr/bin/npx"), \
+         patch("subprocess.Popen", return_value=_mock_proc()) as mock_popen:
+        warm_agent_browser_npx_cache()
+
+    _args, kwargs = mock_popen.call_args
+    assert kwargs.get("start_new_session") is True
+
+
+def test_uses_new_process_group_creationflag_on_windows_instead_of_start_new_session():
+    """start_new_session is a POSIX-only Popen kwarg (raises on Windows).
+    The Windows equivalent for _kill_process_tree's taskkill /T to have a
+    coherent tree to kill is CREATE_NEW_PROCESS_GROUP via creationflags."""
+    with patch("os.name", "nt"), \
+         patch("tools.browser_tool._resolve_npx_bin", return_value="C:\\npx.cmd"), \
+         patch("tools.browser_tool._build_browser_env", return_value={"PATH": "C:\\Windows"}), \
+         patch("tools.browser_tool._merge_browser_path", side_effect=lambda p: p), \
+         patch("subprocess.Popen", return_value=_mock_proc()) as mock_popen:
+        warm_agent_browser_npx_cache()
+
+    _args, kwargs = mock_popen.call_args
+    assert "start_new_session" not in kwargs
+    create_new_pgroup = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+    assert kwargs["creationflags"] & create_new_pgroup == create_new_pgroup
+
+
+def test_timeout_kills_the_whole_process_tree_not_just_the_pid():
+    """subprocess.Popen.kill() only signals the direct child; npm/npx can
+    fork descendants that survive it and hold a capture pipe open past the
+    nominal timeout. On timeout, the whole process group/tree must be
+    killed, not just the top-level PID."""
+    proc = _mock_proc(
+        communicate_side_effect=[
+            subprocess.TimeoutExpired(cmd=["npx"], timeout=60.0), ("", ""),
+        ]
+    )
+    with patch("tools.browser_tool._resolve_npx_bin", return_value="/usr/bin/npx"), \
+         patch("subprocess.Popen", return_value=proc), \
+         patch("tools.browser_tool._kill_process_tree") as mock_kill:
+        assert warm_agent_browser_npx_cache(timeout=60.0) is False
+
+    mock_kill.assert_called_once_with(proc)
+    assert proc.communicate.call_count == 2, (
+        "must attempt a second, bounded communicate() after the kill to reap "
+        "the now-dead process and drain its pipes, not just abandon it"
+    )
+
+
+def test_timeout_cleanup_communicate_itself_raising_does_not_propagate():
+    """The post-kill drain call is itself best-effort — if the process is
+    stuck badly enough that even the 5s cleanup communicate() times out (or
+    raises for any other reason), that must not escape and crash the
+    fire-and-forget caller (hermes_cli/doctor.py calls this bare)."""
+    proc = _mock_proc(
+        communicate_side_effect=[
+            subprocess.TimeoutExpired(cmd=["npx"], timeout=60.0),
+            subprocess.TimeoutExpired(cmd=["npx"], timeout=5),
+        ]
+    )
+    with patch("tools.browser_tool._resolve_npx_bin", return_value="/usr/bin/npx"), \
+         patch("subprocess.Popen", return_value=proc), \
+         patch("tools.browser_tool._kill_process_tree") as mock_kill:
+        assert warm_agent_browser_npx_cache(timeout=60.0) is False
+
+    mock_kill.assert_called_once_with(proc)
 
 
 def test_returns_false_on_nonzero_exit():
-    with patch("shutil.which", return_value="/usr/bin/npx"), patch(
-        "subprocess.run",
-        return_value=subprocess.CompletedProcess([], 1, stdout="", stderr="registry unreachable"),
+    with patch("tools.browser_tool._resolve_npx_bin", return_value="/usr/bin/npx"), patch(
+        "subprocess.Popen", return_value=_mock_proc(returncode=1)
     ):
         assert warm_agent_browser_npx_cache() is False
 
 
-def test_returns_false_instead_of_raising_on_timeout():
-    with patch("shutil.which", return_value="/usr/bin/npx"), patch(
-        "subprocess.run",
-        side_effect=subprocess.TimeoutExpired(cmd=["npx"], timeout=60.0),
+def test_returns_false_instead_of_raising_on_popen_failure():
+    with patch("tools.browser_tool._resolve_npx_bin", return_value="/usr/bin/npx"), patch(
+        "subprocess.Popen", side_effect=OSError("fork failed")
     ):
         assert warm_agent_browser_npx_cache() is False
 
 
-def test_returns_false_instead_of_raising_on_unexpected_exception():
+def test_returns_false_instead_of_raising_on_unexpected_communicate_exception():
     """Fire-and-forget contract: hermes_cli/doctor.py calls this bare (no
-    try/except of its own), so any exception inside the subprocess call
-    must be swallowed here, not propagated."""
-    with patch("shutil.which", return_value="/usr/bin/npx"), patch(
-        "subprocess.run", side_effect=OSError("fork failed")
-    ):
+    try/except of its own), so any exception must be swallowed here."""
+    proc = _mock_proc(communicate_side_effect=OSError("broken pipe"))
+    with patch("tools.browser_tool._resolve_npx_bin", return_value="/usr/bin/npx"), \
+         patch("subprocess.Popen", return_value=proc), \
+         patch("tools.browser_tool._kill_process_tree") as mock_kill:
         assert warm_agent_browser_npx_cache() is False
+    mock_kill.assert_called_once_with(proc)
+
+
+class TestKillProcessTree:
+    def test_posix_kills_process_group_term_then_kill(self, monkeypatch):
+        import signal
+
+        proc = MagicMock()
+        proc.pid = 999
+        monkeypatch.setattr("os.name", "posix")
+        monkeypatch.setattr("os.getpgid", lambda pid: 999)
+        killpg_calls = []
+        monkeypatch.setattr(
+            "os.killpg", lambda pgid, sig: killpg_calls.append((pgid, sig))
+        )
+
+        _kill_process_tree(proc)
+
+        assert killpg_calls == [(999, signal.SIGTERM), (999, signal.SIGKILL)]
+
+    def test_posix_missing_process_returns_silently(self, monkeypatch):
+        proc = MagicMock()
+        proc.pid = 999
+        monkeypatch.setattr("os.name", "posix")
+
+        def _raise(pid):
+            raise ProcessLookupError()
+
+        monkeypatch.setattr("os.getpgid", _raise)
+
+        _kill_process_tree(proc)  # must not raise
+
+    def test_posix_sigterm_permission_denied_does_not_attempt_sigkill(self, monkeypatch):
+        """If SIGTERM itself is rejected (e.g. a stale pgid reused by an
+        unrelated, unkillable process), the loop must bail out rather than
+        plow ahead into a second signal against the wrong target."""
+        import signal
+
+        proc = MagicMock()
+        proc.pid = 999
+        monkeypatch.setattr("os.name", "posix")
+        monkeypatch.setattr("os.getpgid", lambda pid: 999)
+        killpg_calls = []
+
+        def fake_killpg(pgid, sig):
+            killpg_calls.append((pgid, sig))
+            raise PermissionError()
+
+        monkeypatch.setattr("os.killpg", fake_killpg)
+
+        _kill_process_tree(proc)  # must not raise
+
+        assert killpg_calls == [(999, signal.SIGTERM)]
+
+    def test_windows_uses_taskkill_with_tree_and_force_flags(self, monkeypatch):
+        proc = MagicMock()
+        proc.pid = 4321
+        monkeypatch.setattr("os.name", "nt")
+        with patch("subprocess.run") as mock_run:
+            _kill_process_tree(proc)
+
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args.args[0]
+        assert cmd == ["taskkill", "/PID", "4321", "/T", "/F"]
+
+    def test_windows_taskkill_failure_does_not_raise(self, monkeypatch):
+        proc = MagicMock()
+        proc.pid = 4321
+        monkeypatch.setattr("os.name", "nt")
+        with patch("subprocess.run", side_effect=OSError("taskkill missing")):
+            _kill_process_tree(proc)  # must not raise

--- a/tests/tools/test_browser_npx_warmup.py
+++ b/tests/tools/test_browser_npx_warmup.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import subprocess
 from unittest.mock import patch
 
-from tools.browser_tool import warm_agent_browser_npx_cache
+from tools.browser_tool import AGENT_BROWSER_NPX_SPEC, warm_agent_browser_npx_cache
 
 
 def test_returns_false_without_calling_subprocess_when_npx_missing():
@@ -35,7 +35,7 @@ def test_invokes_npx_with_prefer_offline_version_check():
 
     mock_run.assert_called_once()
     args, kwargs = mock_run.call_args
-    assert args[0] == ["/usr/bin/npx", "--prefer-offline", "-y", "agent-browser", "--version"]
+    assert args[0] == ["/usr/bin/npx", "--prefer-offline", "-y", AGENT_BROWSER_NPX_SPEC, "--version"]
     assert kwargs.get("check") is False
 
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2296,6 +2296,23 @@ def _agent_browser_candidate_present(path: str | None) -> bool:
     return os.path.exists(path) and (os.name == "nt" or os.access(path, os.X_OK))
 
 
+def _resolve_npx_bin() -> Optional[str]:
+    """Resolve the npx binary via the same PATH + extended-PATH cascade
+    _find_agent_browser uses, so callers that need npx's actual path
+    (rather than the "npx agent-browser" sentinel) can't diverge from what
+    _find_agent_browser itself would have found. A bare ``shutil.which("npx")``
+    misses Hermes-managed-Node-only setups where npx only resolves via the
+    extended fallback PATH (Homebrew, $HERMES_HOME/node, etc.).
+    """
+    npx_path = shutil.which("npx")
+    if npx_path:
+        return npx_path
+    extended_path = _merge_browser_path("")
+    if extended_path:
+        return shutil.which("npx", path=extended_path)
+    return None
+
+
 def _find_agent_browser(*, validate: bool = True) -> str:
     """
     Find the agent-browser CLI executable.
@@ -2315,7 +2332,6 @@ def _find_agent_browser(*, validate: bool = True) -> str:
             raise FileNotFoundError(
                 "agent-browser CLI not found (cached). Install it with: "
                 f"{_browser_install_hint()}\n"
-                "Or run 'npm install' in the repo root to install locally.\n"
                 "Or ensure npx is available in your PATH."
             )
         return _cached_agent_browser
@@ -2380,9 +2396,7 @@ def _find_agent_browser(*, validate: bool = True) -> str:
             return _cached_agent_browser
 
     # Check common npx locations (also search the extended fallback PATH)
-    npx_path = shutil.which("npx")
-    if not npx_path and extended_path:
-        npx_path = shutil.which("npx", path=extended_path)
+    npx_path = _resolve_npx_bin()
     if npx_path:
         if not validate:
             return "npx agent-browser"
@@ -2416,9 +2430,45 @@ def _find_agent_browser(*, validate: bool = True) -> str:
     raise FileNotFoundError(
         "agent-browser CLI not found. Install it with: "
         f"{_browser_install_hint()}\n"
-        "Or run 'npm install' in the repo root to install locally.\n"
         "Or ensure npx is available in your PATH."
     )
+
+
+def warm_agent_browser_npx_cache(timeout: float = 60.0) -> bool:
+    """Best-effort pre-fetch of the agent-browser npm package via npx.
+
+    agent-browser is no longer a root package.json dependency (#43564) —
+    it resolves lazily via ``npx agent-browser`` instead, which keeps it
+    out of the npm workspace install graph entirely (nothing to prune it
+    anymore) but means the first real invocation in a session would
+    otherwise pay npx's registry-lookup/fetch cost. Calling this during
+    ``hermes update`` (or ``hermes doctor --fix``) warms npx's own cache
+    ahead of time, restoring the "available before any session starts"
+    property agent-browser had while it was an eager root dependency —
+    without re-entangling it with the workspace graph.
+
+    Fire-and-forget: never raises, always safe to call opportunistically.
+    Returns True only if npx actually ran successfully (npx unavailable,
+    a timeout, or a nonzero exit all return False silently).
+    """
+    npx_bin = _resolve_npx_bin()
+    if not npx_bin:
+        return False
+    try:
+        result = subprocess.run(
+            # --prefer-offline: once cached, repeat `hermes update`/`doctor
+            # --fix` runs shouldn't hit the registry just to re-confirm
+            # "latest" is still latest — that would defeat the point of
+            # warming the cache in the first place.
+            [npx_bin, "--prefer-offline", "-y", "agent-browser", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+        return result.returncode == 0
+    except Exception:
+        return False
 
 
 def _extract_screenshot_path_from_text(text: str) -> Optional[str]:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -851,8 +851,26 @@ def _browser_install_hint() -> str:
     return "npm install -g agent-browser && agent-browser install --with-deps"
 
 
+# Sentinel _find_agent_browser returns/caches to mean "resolve via npx" rather
+# than a concrete executable path. A named constant + predicate keep the six
+# comparison sites (four here, plus hermes_cli/tools_config.py and
+# hermes_cli/doctor.py) from drifting if the sentinel's exact spelling ever
+# changes.
+NPX_AGENT_BROWSER_SENTINEL = "npx agent-browser"
+
+# Pinned to match scripts/install.sh / scripts/install.ps1's
+# "agent-browser@^0.26.0" managed install so a git-clone install resolving
+# agent-browser via bare npx gets the same version as a managed install,
+# instead of floating latest with no integrity check. Update both together.
+AGENT_BROWSER_NPX_SPEC = "agent-browser@^0.26.0"
+
+
+def _is_npx_agent_browser_sentinel(browser_cmd: str) -> bool:
+    return browser_cmd.strip() == NPX_AGENT_BROWSER_SENTINEL
+
+
 def _requires_real_termux_browser_install(browser_cmd: str) -> bool:
-    return _is_termux_environment() and _is_local_mode() and browser_cmd.strip() == "npx agent-browser"
+    return _is_termux_environment() and _is_local_mode() and _is_npx_agent_browser_sentinel(browser_cmd)
 
 
 def _termux_browser_install_error() -> str:
@@ -1156,14 +1174,16 @@ def _run_chrome_fallback_command(
             )
         return {"success": False, "error": hint}
 
-    # On Windows npx is npx.cmd — use shutil.which so CreateProcessW can
-    # execute the batch shim.  shutil.which honours PATHEXT on Windows and
-    # returns the plain executable on POSIX.  If npx isn't on PATH (Termux,
-    # bare container), fall back to the bare name and let Popen raise with
-    # a readable "FileNotFoundError: 'npx'" rather than WinError 193.
-    if browser_cmd == "npx agent-browser":
-        _npx_bin = shutil.which("npx") or "npx"
-        cmd_prefix = [_npx_bin, "agent-browser"]
+    # Resolve npx via the same PATH + extended-PATH cascade _find_agent_browser
+    # uses, not a bare shutil.which("npx") — Hermes-managed-Node-only setups
+    # resolve npx only through the extended fallback path, and a bare lookup
+    # would let a broken system npx shadow a healthy managed one. If npx isn't
+    # found at all (Termux, bare container), fall back to the bare name and
+    # let Popen raise with a readable "FileNotFoundError: 'npx'" rather than
+    # WinError 193.
+    if _is_npx_agent_browser_sentinel(browser_cmd):
+        _npx_bin = _resolve_npx_bin() or "npx"
+        cmd_prefix = [_npx_bin, "--prefer-offline", "-y", AGENT_BROWSER_NPX_SPEC]
     else:
         cmd_prefix = [browser_cmd]
     base_args = cmd_prefix + ["--engine", "chrome", "--session", tmp_session, "--json"]
@@ -2399,8 +2419,8 @@ def _find_agent_browser(*, validate: bool = True) -> str:
     npx_path = _resolve_npx_bin()
     if npx_path:
         if not validate:
-            return "npx agent-browser"
-        _cached_agent_browser = "npx agent-browser"
+            return NPX_AGENT_BROWSER_SENTINEL
+        _cached_agent_browser = NPX_AGENT_BROWSER_SENTINEL
         _agent_browser_resolved = True
         return _cached_agent_browser
 
@@ -2460,7 +2480,7 @@ def warm_agent_browser_npx_cache(timeout: float = 60.0) -> bool:
             # --fix` runs shouldn't hit the registry just to re-confirm
             # "latest" is still latest — that would defeat the point of
             # warming the cache in the first place.
-            [npx_bin, "--prefer-offline", "-y", "agent-browser", "--version"],
+            [npx_bin, "--prefer-offline", "-y", AGENT_BROWSER_NPX_SPEC, "--version"],
             capture_output=True,
             text=True,
             timeout=timeout,
@@ -2592,10 +2612,12 @@ def _run_browser_command(
 
     # Keep concrete executable paths intact, even when they contain spaces.
     # Only the synthetic npx fallback needs to expand into multiple argv items.
-    # shutil.which resolves npx → npx.cmd on Windows; bare "npx" stays on POSIX.
-    if browser_cmd == "npx agent-browser":
-        _npx_bin = shutil.which("npx") or "npx"
-        cmd_prefix = [_npx_bin, "agent-browser"]
+    # Resolve via the same PATH + extended-PATH cascade _find_agent_browser
+    # uses (see the chrome-fallback call site above for why a bare
+    # shutil.which("npx") is wrong here).
+    if _is_npx_agent_browser_sentinel(browser_cmd):
+        _npx_bin = _resolve_npx_bin() or "npx"
+        cmd_prefix = [_npx_bin, "--prefer-offline", "-y", AGENT_BROWSER_NPX_SPEC]
     else:
         cmd_prefix = [browser_cmd]
 
@@ -4912,8 +4934,8 @@ def _maybe_autoinstall_chromium() -> bool:
     except FileNotFoundError:
         return False
 
-    if browser_cmd == "npx agent-browser":
-        install_cmd = [shutil.which("npx") or "npx", "-y", "agent-browser", "install"]
+    if _is_npx_agent_browser_sentinel(browser_cmd):
+        install_cmd = [_resolve_npx_bin() or "npx", "-y", AGENT_BROWSER_NPX_SPEC, "install"]
     else:
         install_cmd = [browser_cmd, "install"]
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2465,6 +2465,7 @@ def warm_agent_browser_npx_cache(timeout: float = 60.0) -> bool:
             text=True,
             timeout=timeout,
             check=False,
+            creationflags=windows_hide_flags(),
         )
         return result.returncode == 0
     except Exception:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -54,6 +54,7 @@ import functools
 import json
 import logging
 import os
+import signal
 import re
 import subprocess
 import shutil
@@ -69,6 +70,7 @@ from hermes_constants import (
     agent_browser_runnable,
     get_hermes_home,
     get_hermes_home_override,
+    node_tool_runnable,
 )
 from utils import env_int, is_truthy_value
 from hermes_cli.config import DEFAULT_CONFIG, cfg_get
@@ -1183,7 +1185,10 @@ def _run_chrome_fallback_command(
     # WinError 193.
     if _is_npx_agent_browser_sentinel(browser_cmd):
         _npx_bin = _resolve_npx_bin() or "npx"
-        cmd_prefix = [_npx_bin, "--prefer-offline", "-y", AGENT_BROWSER_NPX_SPEC]
+        # --ignore-scripts: AGENT_BROWSER_NPX_SPEC is a floating ^0.26.0 range,
+        # not an exact pin — a compromised future 0.26.x patch must not get to
+        # run its own install-time lifecycle scripts on this machine.
+        cmd_prefix = [_npx_bin, "--ignore-scripts", "--prefer-offline", "-y", AGENT_BROWSER_NPX_SPEC]
     else:
         cmd_prefix = [browser_cmd]
     base_args = cmd_prefix + ["--engine", "chrome", "--session", tmp_session, "--json"]
@@ -2317,19 +2322,23 @@ def _agent_browser_candidate_present(path: str | None) -> bool:
 
 
 def _resolve_npx_bin() -> Optional[str]:
-    """Resolve the npx binary via the same PATH + extended-PATH cascade
-    _find_agent_browser uses, so callers that need npx's actual path
-    (rather than the "npx agent-browser" sentinel) can't diverge from what
-    _find_agent_browser itself would have found. A bare ``shutil.which("npx")``
-    misses Hermes-managed-Node-only setups where npx only resolves via the
-    extended fallback PATH (Homebrew, $HERMES_HOME/node, etc.).
+    """Resolve a runnable npx binary, preferring the Hermes-managed/Homebrew
+    extended search over a bare ambient PATH lookup.
+
+    Checking bare PATH first would let a broken or unrelated system npx
+    shadow a healthy Hermes-managed one with no recovery — every candidate
+    is therefore validated with ``node_tool_runnable`` (the same check
+    ``find_hermes_node_executable`` uses to self-heal a managed Node tree)
+    before being trusted, falling through to the next candidate otherwise.
     """
-    npx_path = shutil.which("npx")
-    if npx_path:
-        return npx_path
     extended_path = _merge_browser_path("")
     if extended_path:
-        return shutil.which("npx", path=extended_path)
+        extended_npx = shutil.which("npx", path=extended_path)
+        if extended_npx and node_tool_runnable(extended_npx):
+            return extended_npx
+    npx_path = shutil.which("npx")
+    if npx_path and node_tool_runnable(npx_path):
+        return npx_path
     return None
 
 
@@ -2454,6 +2463,68 @@ def _find_agent_browser(*, validate: bool = True) -> str:
     )
 
 
+def _kill_process_tree(proc: "subprocess.Popen") -> None:
+    """Best-effort kill of *proc* and any descendants it spawned.
+
+    ``Popen.kill()`` only signals the direct child PID. npm/npx routinely
+    fork further processes (registry-fetch helpers, npm's own lifecycle
+    runner, agent-browser's own detached daemon grandchild) that can survive
+    a plain ``kill()`` of the top-level PID and keep a ``capture_output``-style
+    pipe open, hanging the caller's ``communicate()`` past the nominal
+    timeout — the same orphaned-pipe hazard already hit in production on
+    POSIX (see ``tools/process_registry.py``'s ``_reader_loop``, issue
+    #68915: a backgrounded grandchild inheriting a pipe's write end kept it
+    from ever reaching EOF). That hazard is cross-platform, not
+    Windows-specific; what *is* Windows-specific is the lack of a remedy
+    other than killing the tree — anonymous pipes there don't support
+    overlapped I/O, so there's no ``select()``-style non-blocking read to
+    poll around a stuck grandchild the way POSIX can. Killing the whole
+    process group/tree the child was launched into reaches those
+    descendants on both platforms.
+
+    Fires SIGTERM then SIGKILL back-to-back with no grace period between
+    them (unlike ``tools/mcp_stdio_watchdog.py``'s ``_terminate_process_group``,
+    which waits between signals because it's reacting to a live daemon being
+    orphaned). By the time this is called, the caller has already burned its
+    full timeout budget waiting for a graceful exit — there's nothing to gain
+    from waiting again here, only more delay on an already-timed-out call.
+    """
+    if os.name == "nt":
+        try:
+            subprocess.run(
+                ["taskkill", "/PID", str(proc.pid), "/T", "/F"],
+                check=False,
+                capture_output=True,
+                stdin=subprocess.DEVNULL,
+            )
+        except Exception:
+            pass
+        return
+    # os.killpg/signal.SIGKILL don't exist on Windows; this branch is
+    # POSIX-only (the `os.name == "nt"` check above already returns first
+    # on Windows), but resolve them defensively via getattr anyway so an
+    # accidental future refactor that drops that guard degrades to a plain
+    # kill() instead of AttributeError — same discipline as
+    # tools/mcp_stdio_watchdog.py's _terminate_process_group.
+    killpg = getattr(os, "killpg", None)
+    if killpg is None:  # windows-footgun: ok - non-POSIX fallback
+        try:
+            proc.kill()
+        except Exception:
+            pass
+        return
+    try:
+        pgid = os.getpgid(proc.pid)
+    except (ProcessLookupError, OSError):
+        return
+    sigkill = getattr(signal, "SIGKILL", signal.SIGTERM)
+    for sig in (signal.SIGTERM, sigkill):
+        try:
+            killpg(pgid, sig)
+        except (ProcessLookupError, PermissionError, OSError):
+            return
+
+
 def warm_agent_browser_npx_cache(timeout: float = 60.0) -> bool:
     """Best-effort pre-fetch of the agent-browser npm package via npx.
 
@@ -2467,6 +2538,16 @@ def warm_agent_browser_npx_cache(timeout: float = 60.0) -> bool:
     property agent-browser had while it was an eager root dependency —
     without re-entangling it with the workspace graph.
 
+    Runs a credential-scrubbed, PATH-propagated environment matching every
+    other agent-browser subprocess spawn (see ``_build_browser_env``) —
+    this used to inherit the full parent environment, including every
+    provider/gateway credential Hermes holds, while running registry-fetched
+    npm code on every ``hermes update`` (the GHSA-m4m8-xjp4-5rmm class of
+    risk ``_build_browser_env`` exists specifically to prevent). Runs in its
+    own process group and kills the *whole* group — not just the top-level
+    npx PID — on timeout, since a surviving descendant can otherwise hold a
+    capture pipe open past the nominal deadline (see ``_kill_process_tree``).
+
     Fire-and-forget: never raises, always safe to call opportunistically.
     Returns True only if npx actually ran successfully (npx unavailable,
     a timeout, or a nonzero exit all return False silently).
@@ -2474,21 +2555,53 @@ def warm_agent_browser_npx_cache(timeout: float = 60.0) -> bool:
     npx_bin = _resolve_npx_bin()
     if not npx_bin:
         return False
+
+    env = _build_browser_env()
+    env["PATH"] = _merge_browser_path(env.get("PATH", ""))
+
+    popen_kwargs: dict = {
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "text": True,
+        "env": env,
+        "creationflags": windows_hide_flags(),
+    }
+    if os.name == "posix":
+        popen_kwargs["start_new_session"] = True
+    else:
+        popen_kwargs["creationflags"] |= getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+
+    cmd = [
+        npx_bin,
+        # --ignore-scripts: AGENT_BROWSER_NPX_SPEC is a floating ^0.26.0
+        # range, not an exact pin — a compromised future 0.26.x patch must
+        # not get to run its own install-time lifecycle scripts here.
+        "--ignore-scripts",
+        # --prefer-offline: once cached, repeat `hermes update`/`doctor
+        # --fix` runs shouldn't hit the registry just to re-confirm
+        # "latest" is still latest — that would defeat the point of
+        # warming the cache in the first place.
+        "--prefer-offline",
+        "-y",
+        AGENT_BROWSER_NPX_SPEC,
+        "--version",
+    ]
     try:
-        result = subprocess.run(
-            # --prefer-offline: once cached, repeat `hermes update`/`doctor
-            # --fix` runs shouldn't hit the registry just to re-confirm
-            # "latest" is still latest — that would defeat the point of
-            # warming the cache in the first place.
-            [npx_bin, "--prefer-offline", "-y", AGENT_BROWSER_NPX_SPEC, "--version"],
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-            check=False,
-            creationflags=windows_hide_flags(),
-        )
-        return result.returncode == 0
+        proc = subprocess.Popen(cmd, stdin=subprocess.DEVNULL, **popen_kwargs)
     except Exception:
+        return False
+    try:
+        proc.communicate(timeout=timeout)
+        return proc.returncode == 0
+    except subprocess.TimeoutExpired:
+        _kill_process_tree(proc)
+        try:
+            proc.communicate(timeout=5)
+        except Exception:
+            pass
+        return False
+    except Exception:
+        _kill_process_tree(proc)
         return False
 
 
@@ -2617,7 +2730,8 @@ def _run_browser_command(
     # shutil.which("npx") is wrong here).
     if _is_npx_agent_browser_sentinel(browser_cmd):
         _npx_bin = _resolve_npx_bin() or "npx"
-        cmd_prefix = [_npx_bin, "--prefer-offline", "-y", AGENT_BROWSER_NPX_SPEC]
+        # --ignore-scripts: see _run_chrome_fallback_command's identical comment.
+        cmd_prefix = [_npx_bin, "--ignore-scripts", "--prefer-offline", "-y", AGENT_BROWSER_NPX_SPEC]
     else:
         cmd_prefix = [browser_cmd]
 
@@ -4935,7 +5049,9 @@ def _maybe_autoinstall_chromium() -> bool:
         return False
 
     if _is_npx_agent_browser_sentinel(browser_cmd):
-        install_cmd = [_resolve_npx_bin() or "npx", "-y", AGENT_BROWSER_NPX_SPEC, "install"]
+        install_cmd = [
+            _resolve_npx_bin() or "npx", "--ignore-scripts", "-y", AGENT_BROWSER_NPX_SPEC, "install",
+        ]
     else:
         install_cmd = [browser_cmd, "install"]
 

--- a/website/docs/developer-guide/browser-provider-plugin.md
+++ b/website/docs/developer-guide/browser-provider-plugin.md
@@ -126,7 +126,7 @@ def get_setup_schema(self) -> dict:
              "prompt": "My Backend API key",
              "url": "https://mybackend.example"},
         ],
-        "post_setup": "agent_browser",   # auto-installs the agent-browser npm dep
+        "post_setup": "agent_browser",   # ensures local Chromium is installed (agent-browser itself resolves via npx)
     }
 ```
 

--- a/website/docs/getting-started/termux.md
+++ b/website/docs/getting-started/termux.md
@@ -155,11 +155,10 @@ hermes setup
 
 ### Install optional Node dependencies manually
 
-The tested Termux path skips Node/browser bootstrap on purpose. If you want to experiment with browser tooling later:
+The tested Termux path skips Node/browser bootstrap on purpose. If you want to experiment with browser tooling later, the only prerequisite is Node.js — `agent-browser` itself resolves lazily via `npx agent-browser` on first browser-tool use, so there's no separate install step:
 
 ```bash
 pkg install nodejs-lts
-npm install
 ```
 
 The browser tool automatically includes Termux directories (`/data/data/com.termux/files/usr/bin`) in its PATH search, so `agent-browser` and `npx` are discovered without any extra PATH configuration.

--- a/website/docs/getting-started/termux.md
+++ b/website/docs/getting-started/termux.md
@@ -155,11 +155,20 @@ hermes setup
 
 ### Install optional Node dependencies manually
 
-The tested Termux path skips Node/browser bootstrap on purpose. If you want to experiment with browser tooling later, the only prerequisite is Node.js — `agent-browser` itself resolves lazily via `npx agent-browser` on first browser-tool use, so there's no separate install step:
+The tested Termux path skips Node/browser bootstrap on purpose. If you want to experiment with browser tooling later, what you need depends on which backend you use:
 
-```bash
-pkg install nodejs-lts
-```
+- **Cloud browser providers** (Browserbase, Browser Use, Firecrawl) host their own Chromium, so Node.js alone is enough — `agent-browser` resolves lazily via `npx agent-browser` on first use:
+
+  ```bash
+  pkg install nodejs-lts
+  ```
+
+- **Local browser automation** on Termux needs a real `agent-browser` install — the bare npx fallback is deliberately rejected in local mode as too fragile to advertise as ready:
+
+  ```bash
+  pkg install nodejs-lts
+  npm install -g agent-browser && agent-browser install
+  ```
 
 The browser tool automatically includes Termux directories (`/data/data/com.termux/files/usr/bin`) in its PATH search, so `agent-browser` and `npx` are discovered without any extra PATH configuration.
 

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -442,10 +442,12 @@ AGENT_BROWSER_ARGS=--no-sandbox
 
 ### Install agent-browser CLI
 
+You don't need to install anything — `agent-browser` resolves automatically via
+`npx agent-browser` on first browser-tool use. To avoid the one-time npx fetch,
+you can install it globally ahead of time (optional):
+
 ```bash
 npm install -g agent-browser
-# Or install locally in the repo:
-npm install
 ```
 
 :::info


### PR DESCRIPTION
## What does this PR do?

`hermes update` was pruning root-level Node dependencies (e.g. `agent-browser`) on every run. This PR originally tried to fix that by juggling install order between the root and ui-tui/web workspace installs; that approach didn't hold up under review. The old two-pass shape (`npm ci --workspaces=false` then `npm ci --workspace ui-tui --workspace web`) reliably prunes a root-only dependency on its second pass, confirmed empirically and via npm/cli source.

A single-pass `npm ci --workspace ui-tui --workspace web --include-workspace-root` does keep a root-only dependency (`--include-workspace-root` is consumed via `flatOptions` into Arborist's `includeWorkspaceRoot`, independent of the two-pass shape's problem), so a flag-only fix was possible. This PR takes a different approach anyway, removing the root-only dependencies entirely, because it also eliminates the manifests-digest skip-marker problem a flag-only fix would still have to handle explicitly, and it doesn't depend on one flag's semantics staying stable across future npm versions:

1. **agent-browser is no longer a root `package.json` dependency.** It resolves lazily via `npx agent-browser` (`tools/browser_tool.py` already had npx as a fallback in its resolution cascade: PATH, then Homebrew/Hermes-managed node, then local `.bin`, then npx); it's now the primary path, identified via a shared `NPX_AGENT_BROWSER_SENTINEL` constant + `_is_npx_agent_browser_sentinel()` predicate used at every comparison site instead of ad-hoc string literals. The npx version spec (`AGENT_BROWSER_NPX_SPEC = "agent-browser@^0.26.0"`) matches the same `^0.26.0` range `install.sh`/`install.ps1` use; it is a version range, not an exact pin, and npx resolution has no lockfile-equivalent integrity check, so every real npx invocation of agent-browser passes `--ignore-scripts` so a future compromised patch release can't run install-time lifecycle scripts. A `warm_agent_browser_npx_cache()` helper runs early in both `hermes update` (before the lockfile-unchanged early return, so it actually fires on a plain run) and `hermes doctor --fix`, keeping npx's own cache warm ahead of time with a credential-scrubbed, PATH-propagated environment (matching every other agent-browser subprocess spawn) and killing its whole process tree, not just the top-level npx PID, if it hangs past its timeout. This preserves the "available before any session starts" property agent-browser had as an eager dependency (per #27055's original reasoning) without re-entangling it with the npm workspace graph or exposing Hermes's own credentials to a registry-fetched package.
2. **`@streamdown/math` moves to `apps/desktop/package.json`.** It's only ever imported by desktop's own TS code (`markdown-text.tsx`, `katex-memo.ts`); it was misplaced at root and subject to the exact same pruning risk agent-browser had.
3. **`_update_node_dependencies()` runs a single `npm ci --workspace ui-tui --workspace web --include-workspace-root` call.** `apps/desktop` is never named, so its Electron devDependency (and ~200MB postinstall) is still never resolved by default. `--include-workspace-root` protects root's own remaining `devDependencies` (the shared ESLint flat config every workspace's `eslint.config.mjs` imports) from the same scoped-install pruning; it has nothing to do with agent-browser/`@streamdown/math`, which aren't root dependencies anymore.
4. **Every surface that probes for agent-browser resolves through the same cascade**, so none of them can diverge from what browser tools actually invoke at runtime: `hermes_cli/tools_config.py`'s post-setup Chromium-install path, `hermes_cli/doctor.py`'s agent-browser check, `hermes_cli/doctor_live.py`'s `--live` browser probe, `hermes_cli/dep_ensure.py`'s `ensure_dependency("browser")`, and `hermes_cli/nous_subscription.py`'s desktop-Capabilities-panel check all resolve via `_find_agent_browser`/`_resolve_npx_bin` (honoring the same Termux bare-npx carve-out) instead of hand-rolling their own PATH/`node_modules/.bin` lookups. `_resolve_npx_bin()` checks the Hermes-managed/extended search before a bare ambient PATH lookup, validating each candidate actually runs before trusting it, so a broken system npx can't shadow a healthy managed one.
5. **`install.sh`/`install.ps1` no longer npm-install agent-browser at all**, eager or on-demand. Both scripts' browser-setup functions were only ever reached through their explicit `--ensure browser`/`-Ensure browser` fallback mode, itself only triggered by an actual browser-tool call's lazy-install path, which already resolves agent-browser via npx before ever reaching these scripts. Eagerly npm-installing a second, separately version-pinned copy there was redundant and an extra supply-chain surface for a path npx already covers. Chromium acquisition for that on-demand path now defers entirely to `_maybe_autoinstall_chromium`'s existing lazy fallback. `@askjo/camofox-browser`'s install and system-browser detection/configuration are unaffected.

## Related Issue

Fixes #43564

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `package.json`: drop `agent-browser` and `@streamdown/math` from root `dependencies` (root now has no runtime dependencies of its own; a shared ESLint `devDependencies` block remains, protected separately, see below); also drop the now-stale `"agent-browser@0.26.0": true` `allowScripts` entry, since nothing in the lockfile resolves that pin anymore
- `apps/desktop/package.json`: add `@streamdown/math` alongside its sibling `@streamdown/code`
- `package-lock.json`: regenerated to match
- `hermes_cli/update_cmd.py`: `_update_node_dependencies()` runs `npm ci --workspace ui-tui --workspace web --include-workspace-root` (the last flag protects root's own devDependencies only). `warm_agent_browser_npx_cache()` runs before the `_npm_lockfile_changed` early return (with a status line) so it fires on the common no-op `hermes update` path too, not just when npm actually reinstalls
- `tools/browser_tool.py`:
  - `_resolve_npx_bin()`: checks the Hermes-managed/Homebrew extended PATH search before a bare ambient lookup, validating each candidate with `node_tool_runnable` before trusting it
  - `warm_agent_browser_npx_cache()`: rewritten around `subprocess.Popen` instead of `subprocess.run`; runs a credential-scrubbed (`_build_browser_env()`), PATH-propagated environment instead of inheriting the full parent environment, runs in its own process group, and kills the whole tree (new `_kill_process_tree` helper: POSIX `killpg`, Windows recursive `taskkill /T /F`) if it hangs past its timeout, since a surviving descendant can otherwise hold a capture pipe open indefinitely
  - `NPX_AGENT_BROWSER_SENTINEL`/`_is_npx_agent_browser_sentinel()` and `AGENT_BROWSER_NPX_SPEC` (`agent-browser@^0.26.0`, matching `install.sh`/`install.ps1`'s range, not an exact pin)
  - every real npx-agent-browser invocation (the two real launch sites, the Chromium auto-install site, and the warm-up) resolves npx via `_resolve_npx_bin()` instead of a bare `shutil.which("npx")`, and passes `--ignore-scripts --prefer-offline -y`
- `hermes_cli/doctor.py`: agent-browser check mirrors `_find_agent_browser`'s resolution cascade instead of checking `node_modules/agent-browser` directly; `hermes doctor --fix` warms the npx cache, reported info-only (doesn't count toward "Fixed N issue(s)" since agent-browser was already healthy)
- `hermes_cli/doctor_live.py`: `--live`'s `_browser_available()` probe falls through to the same npx cascade (with the Termux carve-out) when PATH/node_modules checks miss
- `hermes_cli/dep_ensure.py`: the `"browser"` dependency check gains the same npx rung, so `ensure_dependency("browser")` (used by `hermes acp --setup-browser` and browser_tool's lazy-install path) can't shell out to `install.sh` on an install `hermes doctor` already reports healthy
- `hermes_cli/nous_subscription.py`: `_has_agent_browser`'s `tools.browser_tool` import-failure fallback restores the Hermes-managed-Node-path probe (Windows installer) and the PATHEXT-aware `shutil.which` lookup for the local `node_modules/.bin` copy (Windows `.cmd`-shim resolution)
- `hermes_cli/tools_config.py`: `_run_post_setup`'s Chromium-install path resolves via the same cascade and passes `--ignore-scripts`, dropping the now-dead `npm install --workspaces=false` step; dropped a dead `import shutil` left over once it stopped calling `shutil.which` directly
- `scripts/install.sh` / `scripts/install.ps1`: `ensure_browser()` / `Install-AgentBrowser` no longer npm-install `agent-browser` (camofox's install and system-browser detection are unaffected); `install.ps1` also drops the now-dead `-SkipChromium` switch
- Tests: `tests/hermes_cli/test_cmd_update.py`, `test_doctor.py`, `test_doctor_live.py`, `test_dep_ensure.py`, `test_nous_subscription.py`, `test_tools_config.py`, `test_windows_subprocess_no_window_flags.py`, `tests/tools/test_browser_npx_warmup.py` (full rewrite for the `Popen`-based rework), `tests/tools/test_browser_homebrew_paths.py`, `tests/tools/test_browser_chromium_autoinstall.py`, `tests/test_install_sh_browser_install.py`, and new `tests/test_install_ps1_browser_install.py`: updated/extended throughout for the above
- `tests-js/package-json-lazy-deps.test.ts`: contract updated for the new behavior (agent-browser and `@streamdown/math` must NOT be root dependencies; `@streamdown/math` must be in `apps/desktop`). This test lived at `tests/test_package_json_lazy_deps.py` until upstream ported it to vitest so it runs in the correct CI lane. Also adds a lockfile-level check (mirroring the existing camofox one) so a future regression that reintroduces `agent-browser` into `package-lock.json` fails this test directly.
- Docs updated for the npx-based resolution (root `npm install` no longer installs agent-browser):
  - `website/docs/user-guide/features/browser.md`: agent-browser install instructions now npx-first
  - `website/docs/developer-guide/browser-provider-plugin.md`: fixed a stale comment claiming `post_setup: agent_browser` installs the npm dep
  - `CONTRIBUTING.md`: relabeled the two optional `npm install` steps (no longer "browser tools")
  - `website/docs/getting-started/termux.md`: split the manual Node-deps guidance by backend: cloud browser providers only need Node.js (npx resolves agent-browser lazily), but local browser automation on Termux needs a real `agent-browser` install since local mode rejects the bare npx fallback as too fragile

## How to Test

1. Run the targeted test suite:
   ```
   scripts/run_tests.sh tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_doctor.py tests/hermes_cli/test_doctor_live.py tests/hermes_cli/test_dep_ensure.py tests/hermes_cli/test_nous_subscription.py tests/hermes_cli/test_tools_config.py tests/tools/test_browser_npx_warmup.py tests/tools/test_browser_homebrew_paths.py tests/tools/test_browser_chromium_autoinstall.py tests/test_windows_subprocess_no_window_flags.py tests/test_install_sh_browser_install.py tests/test_install_ps1_browser_install.py
   ```
   All tests should pass. The package.json invariant tests are now vitest (they were ported upstream to run in the JS CI lane): `npm run --prefix tests-js check`.
2. To verify the regression fix manually: run `hermes update`, then confirm `hermes doctor` no longer reports `agent-browser` missing (it now reports "resolves via npx on first use").
3. To verify the npx warm-up: run `hermes doctor --fix` and confirm it reports warming the npx cache for agent-browser.
4. To verify root devDependencies survive: run `hermes update`, then confirm `node_modules/@eslint`/`node_modules/typescript-eslint` etc. are still present at repo root.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` and all targeted tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) (or N/A)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys (or N/A)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows (or N/A)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) (or N/A)
- [x] I've updated tool descriptions/schemas if I changed tool behavior (or N/A)
