### PR TITLE
chore(release): map AIalliAI and plcunha contributor emails in AUTHOR_MAP

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1520,6 +1520,10 @@ AUTHOR_MAP = {
     "chanhokyim@gmail.com": "joel611",  # PR #33958 salvage (DISCORD_ALLOWED_ROLES role_authorized gateway flag)
     "desg38@gmail.com": "dschnurbusch",  # PR #42373 salvage (archive compressed conversation lineages)
     "bsmith@bramarstrategicservices.com": "bcsmith528",  # PR #20589 salvage (register_slack_action_handler plugin API)
+    "adalsteinnhelgason@users.noreply.github.com": "AIalliAI",
+    "aialli@users.noreply.github.com": "AIalliAI",
+    "adalsteinnhelgason@Aalsteinns-MacBook-Pro-3.local": "AIalliAI",
+    "jvsantos.cunha@gmail.com": "plcunha",  # PR #44460 (bound CDP reconnect loop)
 }
 
 


### PR DESCRIPTION
## What

Adds four entries to `AUTHOR_MAP` in `scripts/release.py`:

- three commit emails used by **AIalliAI** (this account's noreply, an older noreply variant, and a local-hostname email matching the existing `peterhao@Peters-MacBook-Air.local` precedent)
- `jvsantos.cunha@gmail.com` → **plcunha**, whose open PR #44460 trips the same check

## Why

The `check-attribution` job flags any PR whose commits carry author emails missing from `AUTHOR_MAP`. AIalliAI currently has ~40 open PRs, and each one fails this required check as soon as its workflows are approved — adding the same one-line mapping hunk to every PR would just create 40 copies of a merge conflict in this file.

Since the workflow reads `AUTHOR_MAP` from the PR merge ref, landing the mapping on `main` once clears the check for all open PRs on their next run, with no per-PR changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)