### PR TITLE
fix(desktop): stabilize sidebar

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/cron-jobs-section.tsx
@@ -160,7 +160,7 @@ export function SidebarCronJobsSection({
           type="button"
         >
           <SidebarPanelLabel>{label}</SidebarPanelLabel>
-          <span className="text-[0.6875rem] font-medium text-(--ui-text-quaternary)">{countLabel}</span>
+          <span className="text-[11px] font-medium text-(--ui-text-quaternary)">{countLabel}</span>
           <DisclosureCaret
             className="text-(--ui-text-tertiary) opacity-0 transition group-hover/section-label:opacity-100"
             open={open}
@@ -243,7 +243,7 @@ function CronJobSidebarRow({
               )}
             />
           </span>
-          <span className="min-w-0 truncate text-[0.8125rem] text-(--ui-text-secondary) group-hover/cron:text-foreground">
+          <span className="min-w-0 truncate text-[13px] text-(--ui-text-secondary) group-hover/cron:text-foreground">
             {label}
           </span>
           <DisclosureCaret
@@ -256,7 +256,7 @@ function CronJobSidebarRow({
         </button>
         {/* Trailing cluster: countdown by default, quick actions on hover. */}
         <div className="flex items-center gap-0.5 justify-self-end pr-1">
-          <span className="text-[0.6875rem] text-(--ui-text-tertiary) tabular-nums group-hover/cron:hidden">
+          <span className="text-[11px] text-(--ui-text-tertiary) tabular-nums group-hover/cron:hidden">
             {meta}
           </span>
           <div className="hidden items-center gap-0.5 group-hover/cron:flex">
@@ -327,17 +327,17 @@ function CronJobSidebarRuns({ jobId, onOpenRun }: { jobId: string; onOpenRun: (s
   return (
     <div className="mb-1 ml-[1.375rem] flex flex-col gap-px">
       {runs === null ? (
-        <div className="flex items-center gap-1.5 py-1 pl-1 text-[0.6875rem] text-(--ui-text-tertiary)">
+        <div className="flex items-center gap-1.5 py-1 pl-1 text-[11px] text-(--ui-text-tertiary)">
           <Codicon name="loading" size="0.75rem" spinning />
         </div>
       ) : runs.length === 0 ? (
-        <div className="py-1 pl-1 text-[0.6875rem] text-(--ui-text-tertiary)">{c.noRuns}</div>
+        <div className="py-1 pl-1 text-[11px] text-(--ui-text-tertiary)">{c.noRuns}</div>
       ) : (
         <>
           {runs.map(run => (
             <button
               className={cn(
-                'truncate rounded-md px-1.5 py-0.5 text-left text-[0.6875rem] tabular-nums focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40',
+                'truncate rounded-md px-1.5 py-0.5 text-left text-[11px] tabular-nums focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40',
                 run.id === selectedSessionId
                   ? 'bg-(--ui-row-active-background) text-foreground'
                   : 'text-(--ui-text-secondary) hover:bg-(--chrome-action-hover) hover:text-foreground'

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -815,7 +815,7 @@ export function ChatSidebar({
                         // resolved region has been observed to swallow clicks on the
                         // top rows. Same carve-out as USER_BUBBLE_BASE_CLASS in
                         // thread.tsx.
-                        'flex h-7 w-full justify-start gap-2 rounded-md border border-transparent px-2 text-left text-[0.8125rem] font-medium text-(--ui-text-secondary) transition-colors duration-100 ease-out [-webkit-app-region:no-drag] hover:bg-(--ui-control-hover-background) hover:text-foreground hover:transition-none',
+                        'flex h-7 w-full justify-start gap-2 rounded-md border border-transparent px-2 text-left text-[13px] font-medium text-(--ui-text-secondary) transition-colors duration-100 ease-out [-webkit-app-region:no-drag] hover:bg-(--ui-control-hover-background) hover:text-foreground hover:transition-none',
                         active &&
                           'border-(--ui-stroke-tertiary) bg-(--ui-control-active-background) text-foreground shadow-none hover:border-(--ui-stroke-tertiary)!',
                         !isInteractive &&
@@ -860,6 +860,7 @@ export function ChatSidebar({
           <div className="shrink-0 px-2 pb-1 pt-1">
             <SearchField
               aria-label={s.searchAria}
+              inputClassName="text-[13px]"
               inputRef={searchInputRef}
               onChange={setSearchQuery}
               placeholder={s.searchPlaceholder}
@@ -875,7 +876,7 @@ export function ChatSidebar({
                 activeSessionId={activeSidebarSessionId}
                 contentClassName={cn('flex min-h-0 flex-1 flex-col gap-px pb-1.75', SCROLL_Y)}
                 emptyState={
-                  <div className="grid min-h-24 place-items-center rounded-lg px-2 text-center text-xs text-(--ui-text-tertiary)">
+                  <div className="grid min-h-24 place-items-center rounded-lg px-2 text-center text-[12px] text-(--ui-text-tertiary)">
                     {s.noMatch(trimmedQuery)}
                   </div>
                 }
@@ -1025,7 +1026,7 @@ export function ChatSidebar({
                     label={group.label}
                     labelIcon={
                       <PlatformAvatar
-                        className="size-4 rounded-[4px] text-[0.5625rem] [&_svg]:size-3"
+                        className="size-4 rounded-[4px] text-[9px] [&_svg]:size-3"
                         platformId={group.sourceId}
                         platformName={group.label}
                       />
@@ -1118,7 +1119,7 @@ function SidebarAllPinnedState() {
   const { t } = useI18n()
 
   return (
-    <div className="grid min-h-24 place-items-center rounded-lg text-center text-xs text-(--ui-text-tertiary)">
+    <div className="grid min-h-24 place-items-center rounded-lg text-center text-[12px] text-(--ui-text-tertiary)">
       {t.sidebar.allPinned}
     </div>
   )
@@ -1128,7 +1129,7 @@ function SidebarPinnedEmptyState() {
   const { t } = useI18n()
 
   return (
-    <div className="flex min-h-7 items-center gap-1.5 rounded-lg pl-2 text-[0.75rem] text-(--ui-text-tertiary)">
+    <div className="flex min-h-7 items-center gap-1.5 rounded-lg pl-2 text-[12px] text-(--ui-text-tertiary)">
       <span className="grid w-3.5 shrink-0 place-items-center text-(--ui-text-quaternary)">
         <Codicon name="pin" size="0.75rem" />
       </span>
@@ -1594,7 +1595,7 @@ function SortableSidebarWorkspaceParent(props: SortableWorkspaceParentProps) {
 }
 
 function SidebarCount({ children }: { children: React.ReactNode }) {
-  return <span className="text-[0.6875rem] font-medium text-(--ui-text-quaternary)">{children}</span>
+  return <span className="text-[11px] font-medium text-(--ui-text-quaternary)">{children}</span>
 }
 
 // Reveals the next page of already-loaded rows within a workspace/worktree.

--- a/apps/desktop/src/app/chat/sidebar/load-more-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/load-more-row.tsx
@@ -16,7 +16,7 @@ export function SidebarLoadMoreRow({ step, onClick, loading = false }: SidebarLo
 
   return (
     <button
-      className="flex min-h-5 items-center gap-1.5 self-start bg-transparent pl-2 text-left text-[0.6875rem] text-(--ui-text-tertiary) transition-colors duration-100 ease-out hover:text-foreground hover:transition-none disabled:cursor-default disabled:opacity-60 disabled:hover:text-(--ui-text-tertiary)"
+      className="flex min-h-5 items-center gap-1.5 self-start bg-transparent pl-2 text-left text-[11px] text-(--ui-text-tertiary) transition-colors duration-100 ease-out hover:text-foreground hover:transition-none disabled:cursor-default disabled:opacity-60 disabled:hover:text-(--ui-text-tertiary)"
       disabled={loading}
       onClick={onClick}
       type="button"

--- a/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
@@ -402,7 +402,7 @@ function ProfileSquare({ active, color, label, onDelete, onRecolor, onRename, on
                 <TooltipTrigger asChild>
                   <button
                     className={cn(
-                      'grid size-5 shrink-0 cursor-grab touch-none select-none place-items-center rounded-[3px] text-[0.5625rem] font-semibold uppercase leading-none transition-opacity hover:opacity-100',
+                      'grid size-5 shrink-0 cursor-grab touch-none select-none place-items-center rounded-[3px] text-[9px] font-semibold uppercase leading-none transition-opacity hover:opacity-100',
                       active ? 'opacity-100' : 'opacity-55',
                       isDragging && 'z-10 cursor-grabbing opacity-100'
                     )}
@@ -506,7 +506,7 @@ function ProfileSquare({ active, color, label, onDelete, onRecolor, onRename, on
           ))}
         </div>
         <button
-          className="mt-2 flex w-full items-center justify-center gap-1.5 rounded-md py-1 text-xs text-(--ui-text-tertiary) transition hover:bg-(--ui-control-hover-background) hover:text-foreground"
+          className="mt-2 flex w-full items-center justify-center gap-1.5 rounded-md py-1 text-[12px] text-(--ui-text-tertiary) transition hover:bg-(--ui-control-hover-background) hover:text-foreground"
           onClick={() => pickColor(null)}
           type="button"
         >

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -197,19 +197,19 @@ export function SidebarSessionRow({
           {handoffSource && handoffLabel ? (
             <Tip label={r.handoffOrigin(handoffLabel)}>
               <PlatformAvatar
-                className="size-4 rounded-[4px] text-[0.5rem] [&_svg]:size-2.5"
+                className="size-4 rounded-[4px] text-[8px] [&_svg]:size-2.5"
                 platformId={handoffSource}
                 platformName={handoffLabel}
               />
             </Tip>
           ) : null}
-          <span className="min-w-0 flex-1 truncate text-[0.8125rem] font-normal text-(--ui-text-secondary) group-hover:text-foreground group-data-[working=true]:text-foreground/90">
+          <span className="min-w-0 flex-1 truncate text-[13px] font-normal text-(--ui-text-secondary) group-hover:text-foreground group-data-[working=true]:text-foreground/90">
             {title}
           </span>
         </button>
         <div className="relative z-2 grid w-[1.375rem] place-items-center">
           {!isWorking && (
-            <span className="pointer-events-none absolute right-6 top-1/2 min-w-6 -translate-y-1/2 text-right text-[0.625rem] leading-none text-(--ui-text-tertiary) opacity-0 transition-opacity group-hover:opacity-100">
+            <span className="pointer-events-none absolute right-6 top-1/2 min-w-6 -translate-y-1/2 text-right text-[10px] leading-none text-(--ui-text-tertiary) opacity-0 transition-opacity group-hover:opacity-100">
               {age}
             </span>
           )}

--- a/apps/desktop/src/app/shell/sidebar-label.tsx
+++ b/apps/desktop/src/app/shell/sidebar-label.tsx
@@ -10,7 +10,7 @@ export function SidebarPanelLabel({ children, className, dotClassName, ...props 
   return (
     <span
       className={cn(
-        'flex min-w-0 items-center gap-2 pl-2 text-[0.64rem] font-semibold uppercase tracking-[0.16em] text-(--theme-primary)',
+        'flex min-w-0 items-center gap-2 pl-2 text-[10.25px] font-semibold uppercase tracking-[0.16em] text-(--theme-primary)',
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- Stabilize desktop sidebar with fixed pixel text sizes for navigation, section labels, session rows, counters, cron rows, and profile controls.
- Keep the visual scale consistent when the empty chat intro is visible and the window is tiled or resized.

## Root Cause
Sidebar typography used rem-based Tailwind sizes, so it could drift with the document root sizing path while the empty intro view was mounted. The sidebar should keep its own stable text scale independent of whether a session is selected.

## Validation
- npm run typecheck --workspace apps/desktop
- npx eslint src/app/chat/sidebar/cron-jobs-section.tsx src/app/chat/sidebar/index.tsx src/app/chat/sidebar/load-more-row.tsx src/app/chat/sidebar/profile-switcher.tsx src/app/chat/sidebar/session-row.tsx src/app/shell/sidebar-label.tsx

Fixes #44744
