### PR TITLE
feat(cli): add Manifest as an inference provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,15 @@
 # ARCEE_BASE_URL=                                 # Override default base URL
 
 # =============================================================================
+# LLM PROVIDER (Manifest)
+# =============================================================================
+# Manifest is a smart model router that scores requests and routes them to the
+# cheapest model that can handle them. OpenAI-compatible endpoint.
+# Get your key at: https://app.manifest.build (create an agent, copy its mnfst_* key)
+# MANIFEST_API_KEY=
+# MANIFEST_BASE_URL=                              # Override default base URL
+
+# =============================================================================
 # LLM PROVIDER (MiniMax)
 # =============================================================================
 # MiniMax provides access to MiniMax models (global endpoint)

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -27,6 +27,7 @@ model:
   #   "nvidia"       - NVIDIA NIM / build.nvidia.com (requires: NVIDIA_API_KEY)
   #   "xiaomi"       - Xiaomi MiMo (requires: XIAOMI_API_KEY)
   #   "arcee"        - Arcee AI Trinity models (requires: ARCEEAI_API_KEY)
+  #   "manifest"     - Manifest smart model router (requires: MANIFEST_API_KEY — https://app.manifest.build)
   #   "ollama-cloud" - Ollama Cloud (requires: OLLAMA_API_KEY — https://ollama.com/settings)
   #   "kilocode"     - KiloCode gateway (requires: KILOCODE_API_KEY)
   #   "ai-gateway"   - Vercel AI Gateway (requires: AI_GATEWAY_API_KEY)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -414,6 +414,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("AZURE_FOUNDRY_API_KEY",),
         base_url_env_var="AZURE_FOUNDRY_BASE_URL",
     ),
+    "manifest": ProviderConfig(
+        id="manifest",
+        name="Manifest",
+        auth_type="api_key",
+        inference_base_url="https://app.manifest.build/v1",
+        api_key_env_vars=("MANIFEST_API_KEY",),
+        base_url_env_var="MANIFEST_BASE_URL",
+    ),
 }
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1859,6 +1859,7 @@ def select_provider_and_model(args=None):
         "ollama-cloud",
         "tencent-tokenhub",
         "lmstudio",
+        "manifest",
     ):
         _model_flow_api_key_provider(config, selected_provider, current_model)
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -804,6 +804,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("opencode-go",    "OpenCode Go",              "OpenCode Go (open models, $10/month subscription)"),
     ProviderEntry("bedrock",        "AWS Bedrock",              "AWS Bedrock (Claude, Nova, Llama, DeepSeek — IAM or API key)"),
     ProviderEntry("azure-foundry",  "Azure Foundry",            "Azure Foundry (OpenAI-style or Anthropic-style endpoint — your Azure AI deployment)"),
+    ProviderEntry("manifest",       "Manifest",                 "Manifest (smart model router — routes to cheapest capable model)"),
 ]
 
 # Derived dicts — used throughout the codebase
@@ -885,6 +886,8 @@ _PROVIDER_ALIASES = {
     "lm_studio": "lmstudio",
     "ollama": "custom",  # bare "ollama" = local; use "ollama-cloud" for cloud
     "ollama_cloud": "ollama-cloud",
+    "manifest-build": "manifest",
+    "mnfst": "manifest",
 }
 
 

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -199,6 +199,13 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         transport="bedrock_converse",
         auth_type="aws_sdk",
     ),
+    "manifest": HermesOverlay(
+        transport="openai_chat",
+        is_aggregator=True,
+        extra_env_vars=("MANIFEST_API_KEY",),
+        base_url_override="https://app.manifest.build/v1",
+        base_url_env_var="MANIFEST_BASE_URL",
+    ),
 }
 
 
@@ -333,6 +340,10 @@ ALIASES: Dict[str, str] = {
     "gmi-cloud": "gmi",
     "gmicloud": "gmi",
 
+    # manifest
+    "manifest-build": "manifest",
+    "mnfst": "manifest",
+
     # Local server aliases → virtual "local" concept (resolved via user config)
     "lmstudio": "lmstudio",
     "lm-studio": "lmstudio",
@@ -361,6 +372,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "local": "Local endpoint",
     "bedrock": "AWS Bedrock",
     "ollama-cloud": "Ollama Cloud",
+    "manifest": "Manifest",
 }
 
 

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -40,6 +40,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **Google / Gemini** | `GOOGLE_API_KEY` (or `GEMINI_API_KEY`) in `~/.hermes/.env` (provider: `gemini`) |
 | **Google Gemini (OAuth)** | `hermes model` → "Google Gemini (OAuth)" (provider: `google-gemini-cli`, free tier supported, browser PKCE login) |
 | **LM Studio** | `hermes model` → "LM Studio" (provider: `lmstudio`, optional `LM_API_KEY`) |
+| **Manifest** | `MANIFEST_API_KEY` in `~/.hermes/.env` (provider: `manifest`; aliases: `manifest-build`, `mnfst`) |
 | **Custom Endpoint** | `hermes model` → choose "Custom endpoint" (saved in `config.yaml`) |
 
 :::tip Model key alias
@@ -305,6 +306,11 @@ hermes chat --provider arcee --model trinity-large-thinking
 # Use the exact model ID returned by GMI's /v1/models endpoint.
 hermes chat --provider gmi --model zai-org/GLM-5.1-FP8
 # Requires: GMI_API_KEY in ~/.hermes/.env
+
+# Manifest (smart model router)
+hermes chat --provider manifest --model manifest/auto
+# Requires: MANIFEST_API_KEY in ~/.hermes/.env
+# Get your key at https://app.manifest.build (create an agent, copy its mnfst_* key)
 ```
 
 Or set the provider permanently in `config.yaml`:
@@ -314,7 +320,7 @@ model:
   default: "zai-org/GLM-5.1-FP8"
 ```
 
-Base URLs can be overridden with `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, `DASHSCOPE_BASE_URL`, `XIAOMI_BASE_URL`, `GMI_BASE_URL`, or `TOKENHUB_BASE_URL` environment variables.
+Base URLs can be overridden with `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, `DASHSCOPE_BASE_URL`, `XIAOMI_BASE_URL`, `GMI_BASE_URL`, `TOKENHUB_BASE_URL`, or `MANIFEST_BASE_URL` environment variables.
 
 :::note Z.AI Endpoint Auto-Detection
 When using the Z.AI / GLM provider, Hermes automatically probes multiple endpoints (global, China, coding variants) to find one that accepts your API key. You don't need to set `GLM_BASE_URL` manually — the working endpoint is detected and cached automatically.
@@ -1161,7 +1167,7 @@ You can also select named custom providers from the interactive `hermes model` m
 | **Production GPU serving** | vLLM or SGLang |
 | **Mac / no GPU** | Ollama or llama.cpp |
 | **Multi-provider routing** | LiteLLM Proxy or OpenRouter |
-| **Cost optimization** | ClawRouter or OpenRouter with `sort: "price"` |
+| **Cost optimization** | Manifest, ClawRouter, or OpenRouter with `sort: "price"` |
 | **Maximum privacy** | Ollama, vLLM, or llama.cpp (fully local) |
 | **Enterprise / Azure** | Azure OpenAI with custom endpoint |
 | **Chinese AI models** | z.ai (GLM), Kimi/Moonshot (`kimi-coding` or `kimi-coding-cn`), MiniMax, Xiaomi MiMo, or Tencent TokenHub (first-class providers) |
@@ -1239,7 +1245,7 @@ fallback_model:
 
 When activated, the fallback swaps the model and provider mid-session without losing your conversation. It fires **at most once** per session.
 
-Supported providers: `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `gemini`, `google-gemini-cli`, `qwen-oauth`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `deepseek`, `nvidia`, `xai`, `ollama-cloud`, `bedrock`, `ai-gateway`, `opencode-zen`, `opencode-go`, `kilocode`, `xiaomi`, `arcee`, `gmi`, `alibaba`, `tencent-tokenhub`, `custom`.
+Supported providers: `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `gemini`, `google-gemini-cli`, `qwen-oauth`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `deepseek`, `nvidia`, `xai`, `ollama-cloud`, `bedrock`, `ai-gateway`, `opencode-zen`, `opencode-go`, `kilocode`, `xiaomi`, `arcee`, `gmi`, `alibaba`, `tencent-tokenhub`, `manifest`, `custom`.
 
 :::tip
 Fallback is configured exclusively through `config.yaml` — there are no environment variables for it. For full details on when it triggers, supported providers, and how it interacts with auxiliary tasks and delegation, see [Fallback Providers](/docs/user-guide/features/fallback-providers).

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -48,6 +48,8 @@ All variables go in `~/.hermes/.env`. You can also set them with `hermes config 
 | `XIAOMI_BASE_URL` | Override Xiaomi MiMo base URL (default: `https://api.xiaomimimo.com/v1`) |
 | `TOKENHUB_API_KEY` | Tencent TokenHub API key ([tokenhub.tencentmaas.com](https://tokenhub.tencentmaas.com)) |
 | `TOKENHUB_BASE_URL` | Override Tencent TokenHub base URL (default: `https://tokenhub.tencentmaas.com/v1`) |
+| `MANIFEST_API_KEY` | Manifest API key — `mnfst_*` format ([app.manifest.build](https://app.manifest.build)) |
+| `MANIFEST_BASE_URL` | Override Manifest base URL (default: `https://app.manifest.build/v1`) |
 | `AZURE_FOUNDRY_API_KEY` | Azure AI Foundry / Azure OpenAI API key ([ai.azure.com](https://ai.azure.com/)) |
 | `AZURE_FOUNDRY_BASE_URL` | Azure AI Foundry endpoint URL (e.g. `https://<resource>.openai.azure.com/openai/v1` for OpenAI-style, or `https://<resource>.services.ai.azure.com/anthropic` for Anthropic-style) |
 | `AZURE_ANTHROPIC_KEY` | Azure Anthropic API key for `provider: anthropic` + `base_url` pointing at an Azure Foundry Claude deployment (alternative to `ANTHROPIC_API_KEY` when both Anthropic and Azure Anthropic are configured) |

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -78,6 +78,7 @@ Both `provider` and `model` are **required**. If either is missing, the fallback
 | Kimi / Moonshot (China) | `kimi-coding-cn` | `KIMI_CN_API_KEY` |
 | StepFun | `stepfun` | `STEPFUN_API_KEY` |
 | Tencent TokenHub | `tencent-tokenhub` | `TOKENHUB_API_KEY` |
+| Manifest | `manifest` | `MANIFEST_API_KEY` (optional: `MANIFEST_BASE_URL`) |
 | Azure AI Foundry | `azure-foundry` | `AZURE_FOUNDRY_API_KEY` + `AZURE_FOUNDRY_BASE_URL` |
 | LM Studio (local) | `lmstudio` | `LM_API_KEY` (or none for local) + `LM_BASE_URL` |
 | Hugging Face | `huggingface` | `HF_TOKEN` |


### PR DESCRIPTION
## What does this PR do?

Adds [Manifest](https://manifest.build) as a built-in inference provider. Manifest is an open-source LLM router for AI agents -- it scores each request across 23 dimensions and routes it to the cheapest model that can handle it, exposing a standard OpenAI-compatible endpoint at `https://app.manifest.build/v1`.

Since Manifest is OpenAI-compatible and acts as an aggregator (like OpenRouter), it requires no custom setup flow -- the generic API-key flow handles everything. Auth uses Bearer tokens with `mnfst_*`-prefixed keys generated per-agent from the dashboard.

## Related Issue

N/A -- new provider addition.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

**Code (4 files):**
- `hermes_cli/providers.py`: `HermesOverlay` entry (`openai_chat`, `is_aggregator=True`, `MANIFEST_API_KEY`, base URL `https://app.manifest.build/v1`), aliases (`manifest-build`, `mnfst`), display label
- `hermes_cli/auth.py`: `ProviderConfig` in `PROVIDER_REGISTRY` for credential resolution
- `hermes_cli/models.py`: `ProviderEntry` in `CANONICAL_PROVIDERS` (TUI picker) + aliases in `_PROVIDER_ALIASES`
- `hermes_cli/main.py`: `"manifest"` added to `_model_flow_api_key_provider` dispatch tuple

**Config examples (2 files):**
- `.env.example`: `MANIFEST_API_KEY` / `MANIFEST_BASE_URL` section
- `cli-config.yaml.example`: provider comment entry

**Documentation (3 files):**
- `website/docs/integrations/providers.md`: provider table row, usage example in First-Class API-Key Providers, base URL override, fallback providers list, "Choosing the Right Setup" table
- `website/docs/reference/environment-variables.md`: `MANIFEST_API_KEY` and `MANIFEST_BASE_URL` entries
- `website/docs/user-guide/features/fallback-providers.md`: provider table row

## How to Test

1. Sign up at `https://app.manifest.build`, create an agent, copy its `mnfst_*` API key
2. Set `MANIFEST_API_KEY=mnfst_...` in `~/.hermes/.env`
3. Run `hermes setup` -- Manifest appears in the provider picker
4. Or set `provider: "manifest"` in `~/.hermes/config.yaml`
5. Run `hermes chat -q "Hello"` -- request routes through Manifest's `/v1/chat/completions`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(cli): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 14.5 (Sonoma)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (providers page, env vars reference, fallback providers)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows -- or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) -- or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior -- or N/A
