### PR TITLE
fix(constants): detect Kubernetes/k3s pods in is_container() (#44721)

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -364,25 +364,32 @@ _container_detected: bool | None = None
 
 
 def is_container() -> bool:
-    """Return True when running inside a Docker/Podman container.
+    """Return True when running inside a container (Docker/Podman/k8s/LXC).
 
-    Checks ``/.dockerenv`` (Docker), ``/run/.containerenv`` (Podman),
-    and ``/proc/1/cgroup`` for container runtime markers.  Result is
-    cached for the process lifetime.  Import-safe — no heavy deps.
+    Checks marker files, environment variables, and ``/proc/1/cgroup``
+    for container runtime markers.  Result is cached for the process
+    lifetime.  Import-safe — no heavy deps.
     """
     global _container_detected
     if _container_detected is not None:
         return _container_detected
+    if os.environ.get("HERMES_CONTAINER") or os.environ.get("HERMES_SKIP_CHMOD"):
+        _container_detected = True
+        return True
     if os.path.exists("/.dockerenv"):
         _container_detected = True
         return True
     if os.path.exists("/run/.containerenv"):
         _container_detected = True
         return True
+    if os.environ.get("KUBERNETES_SERVICE_HOST"):
+        _container_detected = True
+        return True
     try:
         with open("/proc/1/cgroup", "r", encoding="utf-8") as f:
             cgroup = f.read()
-            if "docker" in cgroup or "podman" in cgroup or "/lxc/" in cgroup:
+            if ("docker" in cgroup or "podman" in cgroup
+                    or "/lxc/" in cgroup or "kubepods" in cgroup):
                 _container_detected = True
                 return True
     except OSError:

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -146,6 +146,37 @@ class TestIsContainer:
         monkeypatch.setattr("builtins.open", lambda p, *a, **kw: _real_open(str(cgroup_file), *a, **kw) if p == "/proc/1/cgroup" else _real_open(p, *a, **kw))
         assert is_container() is False
 
+    def test_detects_kubernetes_service_host(self, monkeypatch):
+        """KUBERNETES_SERVICE_HOST env var triggers detection (k8s pods)."""
+        self._reset_cache(monkeypatch)
+        monkeypatch.setattr(os.path, "exists", lambda p: False)
+        monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.96.0.1")
+        monkeypatch.delenv("HERMES_CONTAINER", raising=False)
+        monkeypatch.delenv("HERMES_SKIP_CHMOD", raising=False)
+        assert is_container() is True
+
+    def test_detects_cgroup_kubepods(self, monkeypatch, tmp_path):
+        """/proc/1/cgroup containing 'kubepods' triggers detection."""
+        import builtins
+        self._reset_cache(monkeypatch)
+        monkeypatch.setattr(os.path, "exists", lambda p: False)
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+        monkeypatch.delenv("HERMES_CONTAINER", raising=False)
+        monkeypatch.delenv("HERMES_SKIP_CHMOD", raising=False)
+        cgroup_file = tmp_path / "cgroup"
+        cgroup_file.write_text("12:memory:/kubepods/burstable/pod-abc123\n")
+        _real_open = builtins.open
+        monkeypatch.setattr("builtins.open", lambda p, *a, **kw: _real_open(str(cgroup_file), *a, **kw) if p == "/proc/1/cgroup" else _real_open(p, *a, **kw))
+        assert is_container() is True
+
+    def test_detects_hermes_container_env(self, monkeypatch):
+        """HERMES_CONTAINER env var triggers detection."""
+        self._reset_cache(monkeypatch)
+        monkeypatch.setattr(os.path, "exists", lambda p: False)
+        monkeypatch.setenv("HERMES_CONTAINER", "1")
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+        assert is_container() is True
+
     def test_caches_result(self, monkeypatch):
         """Second call uses cached value without re-probing."""
         monkeypatch.setattr(hermes_constants, "_container_detected", True)


### PR DESCRIPTION
## Summary

\`hermes_constants.is_container()\` does not detect Kubernetes/k3s/containerd environments, causing \`hermes gateway start\` to report "Not supported on this platform" inside k8s pods.

The function only checks Docker/Podman/LXC markers. Meanwhile, \`hermes_cli.config._is_container()\` already checks \`kubepods\` and \`HERMES_CONTAINER\` env var, so the two detectors are inconsistent.

## Changes

- \`hermes_constants.py\`: add \`kubepods\` to the \`/proc/1/cgroup\` check, add \`KUBERNETES_SERVICE_HOST\` env var check (set in all k8s pods), add \`HERMES_CONTAINER\`/\`HERMES_SKIP_CHMOD\` env var check (parity with \`hermes_cli.config._is_container()\`)
- \`tests/test_hermes_constants.py\`: 3 new tests for kubepods cgroup, KUBERNETES_SERVICE_HOST env, and HERMES_CONTAINER env

## Test plan

- [x] All 8 \`TestIsContainer\` tests pass (5 existing + 3 new)
- [ ] Manual: inside a k8s pod, verify \`is_container()\` returns True

Fixes #44721