### PR TITLE
fix(gateway): resolve compression chain in session.resume

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -627,20 +627,37 @@ export function usePromptActions({
       }
 
       if (!sessionId) {
-        try {
-          sessionId = await createBackendSessionForSend(visibleText)
-        } catch (err) {
-          dropOptimistic(null)
-          releaseBusy()
-          notifyError(err, copy.sessionUnavailable)
+        // Guard: if the user selected a stored session to resume, do NOT
+        // silently create a brand-new session.  Re-attempt the resume instead
+        // so the gateway can resolve the compression chain (#44640).
+        if (selectedStoredSessionIdRef.current) {
+          try {
+            const resumed = await requestGateway<{ session_id: string }>('session.resume', {
+              session_id: selectedStoredSessionIdRef.current
+            })
+            sessionId = resumed?.session_id ?? null
+          } catch (resumeErr) {
+            console.warn('[prompt-actions] resume retry failed for stored session', selectedStoredSessionIdRef.current, resumeErr)
+            // fall through to error below — do NOT silently create a new session
+          }
+        }
 
-          return false
+        if (!sessionId && !selectedStoredSessionIdRef.current) {
+          try {
+            sessionId = await createBackendSessionForSend(visibleText)
+          } catch (err) {
+            dropOptimistic(null)
+            releaseBusy()
+            notifyError(err, copy.sessionUnavailable)
+
+            return false
+          }
         }
 
         if (!sessionId) {
           dropOptimistic(null)
           releaseBusy()
-          notify({ kind: 'error', title: copy.sessionUnavailable, message: copy.createSessionFailed })
+          notify({ kind: 'error', title: copy.sessionUnavailable, message: copy.resumeFailed ?? copy.createSessionFailed })
 
           return false
         }

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1520,6 +1520,7 @@ AUTHOR_MAP = {
     "chanhokyim@gmail.com": "joel611",  # PR #33958 salvage (DISCORD_ALLOWED_ROLES role_authorized gateway flag)
     "desg38@gmail.com": "dschnurbusch",  # PR #42373 salvage (archive compressed conversation lineages)
     "bsmith@bramarstrategicservices.com": "bcsmith528",  # PR #20589 salvage (register_slack_action_handler plugin API)
+    "kagura.agent.ai@gmail.com": "kagura-agent",  # PR #44782 fix(gateway): resolve compression chain in session.resume
 }
 
 

--- a/tests/gateway/test_tui_resume_compression_chain.py
+++ b/tests/gateway/test_tui_resume_compression_chain.py
@@ -1,0 +1,78 @@
+"""Regression test for #44640 — session.resume must resolve the compression chain.
+
+When context compression forks a new child session, the TUI gateway's
+``session.resume`` handler must call ``resolve_resume_session_id()`` so
+that messages are loaded from the descendant session, not the stale parent.
+
+``web_server.py`` and ``cli_commands_mixin.py`` already do this; this test
+pins the behavior for ``tui_gateway/server.py``.
+"""
+
+import ast
+import inspect
+import textwrap
+
+
+def _get_session_resume_source():
+    """Return the source of the session.resume handler from tui_gateway/server.py."""
+    import tui_gateway.server as srv
+
+    # The handler is registered via @method("session.resume"). Walk module-level
+    # AST to find the decorated function.
+    source = inspect.getsource(srv)
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef):
+            for dec in node.decorator_list:
+                if (
+                    isinstance(dec, ast.Call)
+                    and isinstance(dec.func, ast.Name)
+                    and dec.func.id == "method"
+                    and dec.args
+                    and isinstance(dec.args[0], ast.Constant)
+                    and dec.args[0].value == "session.resume"
+                ):
+                    return ast.get_source_segment(source, node)
+    raise AssertionError("session.resume handler not found in tui_gateway/server.py")
+
+
+class TestTuiResumeResolvesCompressionChain:
+    """Ensure the TUI gateway session.resume handler resolves compressed sessions."""
+
+    def test_session_resume_calls_resolve_resume_session_id(self):
+        """The handler must call resolve_resume_session_id before reopen_session."""
+        handler_src = _get_session_resume_source()
+
+        assert "resolve_resume_session_id" in handler_src, (
+            "session.resume handler in tui_gateway/server.py must call "
+            "resolve_resume_session_id() to follow the compression chain. "
+            "See #44640 and the equivalent calls in web_server.py / cli_commands_mixin.py."
+        )
+
+    def test_resolve_before_reopen(self):
+        """resolve_resume_session_id must appear before reopen_session."""
+        handler_src = _get_session_resume_source()
+
+        resolve_pos = handler_src.find("resolve_resume_session_id")
+        reopen_pos = handler_src.find("reopen_session")
+
+        assert resolve_pos != -1, (
+            "resolve_resume_session_id() not found in session.resume handler"
+        )
+        assert reopen_pos != -1, (
+            "reopen_session() not found in session.resume handler"
+        )
+        assert resolve_pos < reopen_pos, (
+            "resolve_resume_session_id() must be called BEFORE reopen_session() "
+            "so the resolved target is used for loading messages."
+        )
+
+    def test_resolve_guards_against_none(self):
+        """The resolve call should guard against None return."""
+        handler_src = _get_session_resume_source()
+
+        # The guard should check that resolved is truthy before using it
+        assert "resolved and" in handler_src or "if resolved" in handler_src, (
+            "resolve_resume_session_id() result must be guarded against None "
+            "to handle deleted sessions / DB inconsistency."
+        )

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -876,6 +876,9 @@ def test_session_resume_uses_parent_lineage_for_display(monkeypatch):
         def get_session(self, target):
             return {"id": target}
 
+        def resolve_resume_session_id(self, sid):
+            return sid
+
         def reopen_session(self, target):
             captured["reopened"] = target
 
@@ -930,6 +933,9 @@ def test_session_resume_passes_stored_runtime_to_agent(monkeypatch):
                 "billing_provider": "openai-codex",
                 "model_config": '{"reasoning_config":{"enabled":true,"effort":"high"},"service_tier":"priority","base_url":"https://custom.example/v1","api_mode":"chat_completions"}',
             }
+
+        def resolve_resume_session_id(self, sid):
+            return sid
 
         def reopen_session(self, target):
             pass

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -301,6 +301,9 @@ def test_session_resume_returns_hydrated_messages(server, monkeypatch):
         def get_session_by_title(self, _title):
             return None
 
+        def resolve_resume_session_id(self, sid):
+            return sid
+
         def reopen_session(self, _sid):
             return None
 
@@ -359,6 +362,9 @@ def test_session_resume_handles_multimodal_list_content(server, monkeypatch):
         def get_session_by_title(self, _title):
             return None
 
+        def resolve_resume_session_id(self, sid):
+            return sid
+
         def reopen_session(self, _sid):
             return None
 
@@ -409,6 +415,9 @@ def test_session_resume_reuses_existing_live_session(server, monkeypatch):
 
         def get_session_by_title(self, _title):
             return None
+
+        def resolve_resume_session_id(self, sid):
+            return sid
 
         def reopen_session(self, _sid):
             return None
@@ -530,6 +539,9 @@ def test_session_resume_live_payload_uses_current_history_with_ancestors(server,
 
         def get_session_by_title(self, _title):
             return None
+
+        def resolve_resume_session_id(self, sid):
+            return sid
 
         def reopen_session(self, _sid):
             return None

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3839,6 +3839,14 @@ def _(rid, params: dict) -> dict:
         set_hermes_home_override(str(profile_home)) if profile_home is not None else None
     )
     try:
+        # Follow the context-compression chain so we load messages from the
+        # latest descendant session (see #15000 / #44640).  web_server.py and
+        # cli_commands_mixin.py already do this; the TUI gateway was missing it.
+        resolved = db.resolve_resume_session_id(target)
+        if resolved and resolved != target:
+            target = resolved
+            found = db.get_session(target) or found
+
         db.reopen_session(target)
         history = db.get_messages_as_conversation(target)
         display_history = db.get_messages_as_conversation(


### PR DESCRIPTION
## Summary

Fixes #44640 — Desktop resuming an old session creates a new session instead of continuing, freezing the old session.

## Root Cause

The TUI gateway's `session.resume` handler was missing a `resolve_resume_session_id()` call that `web_server.py` and `cli_commands_mixin.py` already perform. When a session has been through context compression, the Desktop loads messages via the REST API (which resolves the chain) but creates the agent on the stale parent session via the TUI gateway, causing a new session to be created instead of continuing.

## Changes

### Python (root cause fix)
- **`tui_gateway/server.py`**: Call `resolve_resume_session_id()` before `reopen_session()` to follow the compression chain. If the target changes, refresh the session row for accurate runtime overrides. Includes a None guard for DB inconsistency.

### TypeScript (defense-in-depth)
- **`use-prompt-actions.ts`**: When `selectedStoredSessionIdRef.current` is set and `activeSessionId` is null, re-attempt `session.resume` instead of silently calling `createBackendSessionForSend` (which creates a brand-new session). This prevents the Desktop from creating ghost sessions when the user intended to resume.

### Tests
- **`test_tui_resume_compression_chain.py`**: Regression tests verifying the handler calls `resolve_resume_session_id` before `reopen_session` and guards against None returns.

## Testing

- 176 related gateway tests pass (session, resume, restart-resume, compression)
- 15 CLI resume tests pass
- 3 new regression tests pass

## Related PRs

There are several existing PRs targeting similar symptoms (#13374, #15742, #40078). This PR takes a minimal approach — 2 files changed in production code, following the exact pattern already established in `web_server.py` and `cli_commands_mixin.py`.

---

🤖 **Disclosure:** This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent. Open source contribution is one of the things I do - you can see my work history [here](https://github.com/kagura-agent/github-contribution). If you'd prefer not to receive AI-authored PRs, just let me know and I'll stop - no hard feelings.