### PR TITLE
fix(gateway): log delivery facts when suppressing the final send

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -71,54 +71,6 @@ _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 _GATEWAY_PROXY_SSE_BUFFER_MAX_CHARS = 16 * 1024 * 1024
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 
-
-def _delivery_log_facts(final_text: Any, stream_consumer: Any) -> str:
-    """Compose the ``key=value`` facts appended to the final-send
-    suppression log line.
-
-    Diagnostic only: lengths, short sha256 prefixes, and the consumer's
-    message id let an operator prove from logs whether the suppressed send
-    matched what streaming delivered (#27942, #29200) without logging
-    message text.  Consumer values describe its current bubble; on
-    overflow splits earlier chunks are separate messages, so reset values
-    alongside ``content_delivered=True`` mean split delivery, not lost
-    content.  Never raises: composition failures degrade to ``?`` fields
-    so log formatting can never affect the suppression decision itself.
-    """
-    import hashlib
-
-    def _digest(value: str) -> str:
-        return hashlib.sha256(value.encode("utf-8", "replace")).hexdigest()[:8]
-
-    try:
-        final = final_text if isinstance(final_text, str) else str(final_text or "")
-        parts = [f"final_len={len(final)}", f"final_digest={_digest(final)}"]
-    except Exception:
-        parts = ["final_len=? final_digest=?"]
-    summary = None
-    try:
-        getter = getattr(stream_consumer, "delivery_summary", None)
-        if callable(getter):
-            summary = getter()
-    except Exception:
-        summary = None
-    if isinstance(summary, dict):
-        parts.extend(
-            [
-                f"acc_len={summary.get('accumulated_len', '?')}",
-                f"acc_digest={summary.get('accumulated_digest', '?')}",
-                f"last_sent_len={summary.get('last_sent_len', '?')}",
-                f"sc_msg_id={summary.get('message_id') or '?'}",
-                f"last_edit_overflowed={summary.get('last_edit_overflowed', '?')}",
-            ]
-        )
-    else:
-        parts.append(
-            "acc_len=? acc_digest=? last_sent_len=? sc_msg_id=? last_edit_overflowed=?"
-        )
-    return " ".join(parts)
-
-
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"("  # transient/auxiliary status that should stay in logs, not gateway chats
     r"auxiliary\s+.+\s+failed"
@@ -153,6 +105,40 @@ _GATEWAY_RAW_TEXT_PLATFORMS = frozenset(
 def _gateway_surface_passes_raw_text(platform: Any) -> bool:
     """True only for programmatic/local surfaces that must keep raw text."""
     return _gateway_platform_value(platform) in _GATEWAY_RAW_TEXT_PLATFORMS
+_NO_CONSUMER_DELIVERY_FACTS = (
+    "acc_len=? acc_digest=? last_sent_len=? sc_msg_id=? last_edit_overflowed=?"
+)
+
+
+def _delivery_log_facts(final_text: Any, stream_consumer: Any) -> str:
+    """Compose the ``key=value`` facts appended to the final-send
+    suppression log line (#27942, #29200): lengths, short digests, and the
+    consumer's message id, never message text.  Field semantics are
+    documented on ``GatewayStreamConsumer.delivery_summary``.  Never
+    raises: a missing consumer or a failing summary degrades to ``?``
+    fields so log composition cannot affect the suppression decision.
+    """
+    from gateway.stream_consumer import _short_digest
+
+    final = final_text if isinstance(final_text, str) else ""
+    parts = [f"final_len={len(final)}", f"final_digest={_short_digest(final)}"]
+    try:
+        summary = (
+            stream_consumer.delivery_summary()
+            if stream_consumer is not None
+            else None
+        )
+        consumer_parts = summary and [
+            f"acc_len={summary['accumulated_len']}",
+            f"acc_digest={summary['accumulated_digest']}",
+            f"last_sent_len={summary['last_sent_len']}",
+            f"sc_msg_id={summary['message_id'] or '?'}",
+            f"last_edit_overflowed={summary['last_edit_overflowed']}",
+        ]
+    except Exception:
+        consumer_parts = None
+    parts.extend(consumer_parts or [_NO_CONSUMER_DELIVERY_FACTS])
+    return " ".join(parts)
 
 
 _GATEWAY_PROVIDER_ERROR_RE = re.compile(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -105,8 +105,15 @@ _GATEWAY_RAW_TEXT_PLATFORMS = frozenset(
 def _gateway_surface_passes_raw_text(platform: Any) -> bool:
     """True only for programmatic/local surfaces that must keep raw text."""
     return _gateway_platform_value(platform) in _GATEWAY_RAW_TEXT_PLATFORMS
+
+
 _NO_CONSUMER_DELIVERY_FACTS = (
     "acc_len=? acc_digest=? last_sent_len=? sc_msg_id=? last_edit_overflowed=?"
+)
+
+_SUPPRESS_FINAL_SEND_LOG_FMT = (
+    "Suppressing normal final send for session %s: final delivery already "
+    "confirmed (streamed=%s previewed=%s content_delivered=%s). %s"
 )
 
 
@@ -118,10 +125,13 @@ def _delivery_log_facts(final_text: Any, stream_consumer: Any) -> str:
     raises: a missing consumer or a failing summary degrades to ``?``
     fields so log composition cannot affect the suppression decision.
     """
-    from gateway.stream_consumer import _short_digest
+    try:
+        from gateway.stream_consumer import _short_digest
 
-    final = final_text if isinstance(final_text, str) else ""
-    parts = [f"final_len={len(final)}", f"final_digest={_short_digest(final)}"]
+        final = final_text if isinstance(final_text, str) else ""
+        parts = [f"final_len={len(final)}", f"final_digest={_short_digest(final)}"]
+    except Exception:
+        parts = ["final_len=? final_digest=?"]
     try:
         summary = (
             stream_consumer.delivery_summary()
@@ -20299,7 +20309,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             if not _is_empty_sentinel and not _transformed and (_streamed or _content_delivered):
                 logger.info(
-                    "Suppressing normal final send for session %s: final delivery already confirmed (streamed=%s previewed=%s content_delivered=%s). %s",
+                    _SUPPRESS_FINAL_SEND_LOG_FMT,
                     session_key or "?",
                     _streamed,
                     _previewed,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -71,6 +71,54 @@ _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 _GATEWAY_PROXY_SSE_BUFFER_MAX_CHARS = 16 * 1024 * 1024
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 
+
+def _delivery_log_facts(final_text: Any, stream_consumer: Any) -> str:
+    """Compose the ``key=value`` facts appended to the final-send
+    suppression log line.
+
+    Diagnostic only: lengths, short sha256 prefixes, and the consumer's
+    message id let an operator prove from logs whether the suppressed send
+    matched what streaming delivered (#27942, #29200) without logging
+    message text.  Consumer values describe its current bubble; on
+    overflow splits earlier chunks are separate messages, so reset values
+    alongside ``content_delivered=True`` mean split delivery, not lost
+    content.  Never raises: composition failures degrade to ``?`` fields
+    so log formatting can never affect the suppression decision itself.
+    """
+    import hashlib
+
+    def _digest(value: str) -> str:
+        return hashlib.sha256(value.encode("utf-8", "replace")).hexdigest()[:8]
+
+    try:
+        final = final_text if isinstance(final_text, str) else str(final_text or "")
+        parts = [f"final_len={len(final)}", f"final_digest={_digest(final)}"]
+    except Exception:
+        parts = ["final_len=? final_digest=?"]
+    summary = None
+    try:
+        getter = getattr(stream_consumer, "delivery_summary", None)
+        if callable(getter):
+            summary = getter()
+    except Exception:
+        summary = None
+    if isinstance(summary, dict):
+        parts.extend(
+            [
+                f"acc_len={summary.get('accumulated_len', '?')}",
+                f"acc_digest={summary.get('accumulated_digest', '?')}",
+                f"last_sent_len={summary.get('last_sent_len', '?')}",
+                f"sc_msg_id={summary.get('message_id') or '?'}",
+                f"last_edit_overflowed={summary.get('last_edit_overflowed', '?')}",
+            ]
+        )
+    else:
+        parts.append(
+            "acc_len=? acc_digest=? last_sent_len=? sc_msg_id=? last_edit_overflowed=?"
+        )
+    return " ".join(parts)
+
+
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"("  # transient/auxiliary status that should stay in logs, not gateway chats
     r"auxiliary\s+.+\s+failed"
@@ -20265,11 +20313,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             if not _is_empty_sentinel and not _transformed and (_streamed or _content_delivered):
                 logger.info(
-                    "Suppressing normal final send for session %s: final delivery already confirmed (streamed=%s previewed=%s content_delivered=%s).",
+                    "Suppressing normal final send for session %s: final delivery already confirmed (streamed=%s previewed=%s content_delivered=%s). %s",
                     session_key or "?",
                     _streamed,
                     _previewed,
                     _content_delivered,
+                    _delivery_log_facts(_final, _sc),
                 )
                 response["already_sent"] = True
             elif not _is_empty_sentinel and _transformed and _sc is not None:

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -289,6 +289,7 @@ class GatewayStreamConsumer:
                 await result
         except Exception:
             pass
+
     def delivery_summary(self) -> dict[str, Any]:
         """Read-only delivery facts for diagnostic logging.
 

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -16,6 +16,7 @@ Credit: jobless0x (#774, #1312), OutThisLife (#798), clicksingh (#697).
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import inspect
 import logging
 import queue
@@ -280,6 +281,29 @@ class GatewayStreamConsumer:
                 await result
         except Exception:
             pass
+    def delivery_summary(self) -> dict[str, Any]:
+        """Read-only delivery facts for diagnostic logging.
+
+        Consumed by the gateway's final-send suppression log line so an
+        operator can prove from logs whether the suppressed send matched
+        what streaming delivered (#27942, #29200).  Lengths and the digest
+        describe the consumer's CURRENT bubble: overflow handling resets
+        ``_accumulated``/``_last_sent_text`` as chunks seal or a
+        continuation is adopted, so small or zero values alongside
+        ``final_content_delivered=True`` signify split delivery across
+        multiple messages, not lost content (``last_edit_overflowed`` is
+        the interpretation key).  Restricted to attribute reads, ``len()``,
+        and a sha256 prefix so it cannot raise or mutate consumer state.
+        """
+        return {
+            "message_id": self._message_id,
+            "accumulated_len": len(self._accumulated),
+            "accumulated_digest": hashlib.sha256(
+                self._accumulated.encode("utf-8", "replace")
+            ).hexdigest()[:8],
+            "last_sent_len": len(self._last_sent_text),
+            "last_edit_overflowed": self._last_edit_overflowed,
+        }
 
     async def _edit_message(
         self,

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -40,6 +40,14 @@ from gateway.response_filters import (
 
 logger = logging.getLogger("gateway.stream_consumer")
 
+
+def _short_digest(text: str) -> str:
+    """8-char sha256 prefix used to compare texts in logs without
+    exposing content.  Single owner of the algorithm: the gateway's
+    suppression log line compares the consumer-side and final-response
+    digests, so both sides must use this exact function."""
+    return hashlib.sha256(text.encode("utf-8", "replace")).hexdigest()[:8]
+
 # Sentinel to signal the stream is complete
 _DONE = object()
 
@@ -298,9 +306,7 @@ class GatewayStreamConsumer:
         return {
             "message_id": self._message_id,
             "accumulated_len": len(self._accumulated),
-            "accumulated_digest": hashlib.sha256(
-                self._accumulated.encode("utf-8", "replace")
-            ).hexdigest()[:8],
+            "accumulated_digest": _short_digest(self._accumulated),
             "last_sent_len": len(self._last_sent_text),
             "last_edit_overflowed": self._last_edit_overflowed,
         }

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -6,7 +6,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+from gateway.stream_consumer import (
+    GatewayStreamConsumer,
+    StreamConsumerConfig,
+    _short_digest,
+)
 
 
 # ── _clean_for_display unit tests ────────────────────────────────────────
@@ -2376,23 +2380,19 @@ class TestDeliverySummary:
 
     def test_fresh_consumer_reports_empty_state(self):
         """Nothing streamed yet: ids absent, lengths zero, flag False."""
-        import hashlib
-
         consumer = GatewayStreamConsumer(MagicMock(), "chat_123")
         summary = consumer.delivery_summary()
         assert summary["message_id"] is None
         assert summary["accumulated_len"] == 0
         assert summary["last_sent_len"] == 0
         assert summary["last_edit_overflowed"] is False
-        assert summary["accumulated_digest"] == hashlib.sha256(b"").hexdigest()[:8]
+        assert summary["accumulated_digest"] == _short_digest("")
 
     @pytest.mark.asyncio
     async def test_successful_finalize_reports_delivery_facts(self):
         """Happy path: after a confirmed finalize, the summary proves the
         last ACKed payload equals the accumulated text, and never exposes
         message content."""
-        import hashlib
-
         adapter = MagicMock()
         adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
         adapter.send = AsyncMock(
@@ -2412,12 +2412,9 @@ class TestDeliverySummary:
         assert consumer.final_content_delivered is True
         summary = consumer.delivery_summary()
         assert summary["message_id"] == "msg_1"
-        assert summary["accumulated_len"] > 0
+        assert summary["accumulated_len"] == len("The complete response.\n")
         assert summary["last_sent_len"] == summary["accumulated_len"]
-        expected_digest = hashlib.sha256(
-            consumer._accumulated.encode("utf-8", "replace")
-        ).hexdigest()[:8]
-        assert summary["accumulated_digest"] == expected_digest
+        assert summary["accumulated_digest"] == _short_digest("The complete response.\n")
         assert summary["last_edit_overflowed"] is False
         assert "complete response" not in str(summary)
 

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -2363,3 +2363,89 @@ class TestStripOrphanCloseTags:
             assert tag not in consumer._accumulated
         assert "trailing prose" in consumer._accumulated
         assert "more" in consumer._accumulated
+
+# ── delivery_summary diagnostics ─────────────────────────────────────────
+
+
+class TestDeliverySummary:
+    """delivery_summary() exposes read-only delivery facts consumed by the
+    gateway's final-send suppression log line (#27942, #29200).
+
+    Kept self-contained at the end of the file to minimize rebase overlap
+    with concurrently open stream-consumer PRs."""
+
+    def test_fresh_consumer_reports_empty_state(self):
+        """Nothing streamed yet: ids absent, lengths zero, flag False."""
+        import hashlib
+
+        consumer = GatewayStreamConsumer(MagicMock(), "chat_123")
+        summary = consumer.delivery_summary()
+        assert summary["message_id"] is None
+        assert summary["accumulated_len"] == 0
+        assert summary["last_sent_len"] == 0
+        assert summary["last_edit_overflowed"] is False
+        assert summary["accumulated_digest"] == hashlib.sha256(b"").hexdigest()[:8]
+
+    @pytest.mark.asyncio
+    async def test_successful_finalize_reports_delivery_facts(self):
+        """Happy path: after a confirmed finalize, the summary proves the
+        last ACKed payload equals the accumulated text, and never exposes
+        message content."""
+        import hashlib
+
+        adapter = MagicMock()
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+        adapter.send = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="msg_1"),
+        )
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5)
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        consumer.on_delta("The complete response.\n")
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.05)
+        consumer.finish()
+        await task
+
+        assert consumer.final_content_delivered is True
+        summary = consumer.delivery_summary()
+        assert summary["message_id"] == "msg_1"
+        assert summary["accumulated_len"] > 0
+        assert summary["last_sent_len"] == summary["accumulated_len"]
+        expected_digest = hashlib.sha256(
+            consumer._accumulated.encode("utf-8", "replace")
+        ).hexdigest()[:8]
+        assert summary["accumulated_digest"] == expected_digest
+        assert summary["last_edit_overflowed"] is False
+        assert "complete response" not in str(summary)
+
+    @pytest.mark.asyncio
+    async def test_overflow_adoption_reports_split_delivery_signature(self):
+        """Per-bubble semantics: continuation adoption resets the last-sent
+        tracking and flips the overflow flag.  Reset lengths alongside
+        delivered flags signify split delivery, not lost content."""
+        adapter = MagicMock()
+        adapter.edit_message = AsyncMock(
+            return_value=SimpleNamespace(
+                success=True,
+                message_id="msg_3",
+                continuation_message_ids=("msg_2", "msg_3"),
+            ),
+        )
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        config = StreamConsumerConfig(fresh_final_after_seconds=0.0)
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+        consumer._message_id = "msg_1"
+        consumer._accumulated = "long text " * 50
+
+        delivered = await consumer._send_or_edit(consumer._accumulated, finalize=True)
+
+        assert delivered is True
+        summary = consumer.delivery_summary()
+        assert summary["last_edit_overflowed"] is True
+        assert summary["message_id"] == "msg_3"
+        assert summary["last_sent_len"] == 0
+        assert summary["accumulated_len"] == len(consumer._accumulated)

--- a/tests/gateway/test_suppression_log_facts.py
+++ b/tests/gateway/test_suppression_log_facts.py
@@ -8,9 +8,15 @@ module-level helper that these tests exercise directly."""
 
 from unittest.mock import MagicMock
 
-from gateway.run import _delivery_log_facts
+from gateway.run import _SUPPRESS_FINAL_SEND_LOG_FMT, _delivery_log_facts
 from gateway.stream_consumer import GatewayStreamConsumer
 from gateway.stream_consumer import _short_digest as _digest
+
+
+def _fields(suffix: str) -> list[str]:
+    """Split the composed suffix into whole key=value tokens so length
+    assertions cannot false-pass on digit prefixes (acc_len=14 vs 140)."""
+    return suffix.split()
 
 
 class TestDeliveryLogFacts:
@@ -23,13 +29,14 @@ class TestDeliveryLogFacts:
 
         suffix = _delivery_log_facts("delivered text", consumer)
 
-        assert "final_len=14" in suffix
-        assert f"final_digest={_digest('delivered text')}" in suffix
-        assert "acc_len=14" in suffix
-        assert f"acc_digest={_digest('delivered text')}" in suffix
-        assert "last_sent_len=14" in suffix
-        assert "sc_msg_id=msg_9" in suffix
-        assert "last_edit_overflowed=False" in suffix
+        fields = _fields(suffix)
+        assert "final_len=14" in fields
+        assert f"final_digest={_digest('delivered text')}" in fields
+        assert "acc_len=14" in fields
+        assert f"acc_digest={_digest('delivered text')}" in fields
+        assert "last_sent_len=14" in fields
+        assert "sc_msg_id=msg_9" in fields
+        assert "last_edit_overflowed=False" in fields
         assert "delivered text" not in suffix
 
     def test_divergence_between_final_and_accumulated_is_visible(self):
@@ -42,20 +49,56 @@ class TestDeliveryLogFacts:
 
         suffix = _delivery_log_facts("a longer final response", consumer)
 
-        assert "final_len=23" in suffix
-        assert "acc_len=5" in suffix
+        fields = _fields(suffix)
+        assert "final_len=23" in fields
+        assert "acc_len=5" in fields
         digest_final = _digest("a longer final response")
         digest_acc = _digest("short")
-        assert f"final_digest={digest_final}" in suffix
-        assert f"acc_digest={digest_acc}" in suffix
+        assert f"final_digest={digest_final}" in fields
+        assert f"acc_digest={digest_acc}" in fields
 
     def test_no_consumer_logs_sentinels_without_raising(self):
         """previewed-only suppressions have no stream consumer; the suffix
         still composes with sentinel fields."""
         suffix = _delivery_log_facts("final text", None)
-        assert "final_len=10" in suffix
-        assert "sc_msg_id=?" in suffix
-        assert "acc_len=?" in suffix
+        fields = _fields(suffix)
+        assert "final_len=10" in fields
+        assert "sc_msg_id=?" in fields
+        assert "acc_len=?" in fields
+
+    def test_live_consumer_without_message_id_logs_sentinel_id(self):
+        """A consumer that never sent anything reports message_id=None; the
+        composed field falls back to the sentinel."""
+        consumer = GatewayStreamConsumer(MagicMock(), "chat_x")
+        suffix = _delivery_log_facts("text", consumer)
+        fields = _fields(suffix)
+        assert "sc_msg_id=?" in fields
+        assert "acc_len=0" in fields
+
+    def test_raising_digest_degrades_final_fields_to_sentinels(self, monkeypatch):
+        """No statement in the helper may raise: a failing digest (or a
+        failing lazy import) degrades the final fields to sentinels instead
+        of propagating into the suppression decision."""
+        import gateway.stream_consumer as sc_module
+
+        def _boom(text):
+            raise RuntimeError("digest unavailable")
+
+        monkeypatch.setattr(sc_module, "_short_digest", _boom)
+        suffix = _delivery_log_facts("final text", None)
+        fields = _fields(suffix)
+        assert "final_len=?" in fields
+        assert "final_digest=?" in fields
+        assert "sc_msg_id=?" in fields
+
+    def test_suppression_log_format_matches_arg_count(self):
+        """The suppression logger.info call passes exactly five arguments;
+        logging swallows placeholder mismatches silently, so the format
+        string is pinned here instead."""
+        assert _SUPPRESS_FINAL_SEND_LOG_FMT.count("%s") == 5
+        assert _SUPPRESS_FINAL_SEND_LOG_FMT.startswith(
+            "Suppressing normal final send for session %s"
+        )
 
     def test_poisoned_summary_never_raises(self):
         """Log composition must never be able to abort the suppression

--- a/tests/gateway/test_suppression_log_facts.py
+++ b/tests/gateway/test_suppression_log_facts.py
@@ -6,15 +6,11 @@ a unit test (it lives deep inside the agent-response flow with the stream
 consumer as a closure local), so the composed suffix is produced by a pure
 module-level helper that these tests exercise directly."""
 
-import hashlib
 from unittest.mock import MagicMock
 
 from gateway.run import _delivery_log_facts
 from gateway.stream_consumer import GatewayStreamConsumer
-
-
-def _digest(text: str) -> str:
-    return hashlib.sha256(text.encode("utf-8", "replace")).hexdigest()[:8]
+from gateway.stream_consumer import _short_digest as _digest
 
 
 class TestDeliveryLogFacts:
@@ -50,7 +46,6 @@ class TestDeliveryLogFacts:
         assert "acc_len=5" in suffix
         digest_final = _digest("a longer final response")
         digest_acc = _digest("short")
-        assert digest_final != digest_acc
         assert f"final_digest={digest_final}" in suffix
         assert f"acc_digest={digest_acc}" in suffix
 

--- a/tests/gateway/test_suppression_log_facts.py
+++ b/tests/gateway/test_suppression_log_facts.py
@@ -1,0 +1,79 @@
+"""Tests for the delivery facts appended to the gateway's final-send
+suppression log line (#27942, #29200).
+
+The suppression branch in gateway/run.py is not practically reachable from
+a unit test (it lives deep inside the agent-response flow with the stream
+consumer as a closure local), so the composed suffix is produced by a pure
+module-level helper that these tests exercise directly."""
+
+import hashlib
+from unittest.mock import MagicMock
+
+from gateway.run import _delivery_log_facts
+from gateway.stream_consumer import GatewayStreamConsumer
+
+
+def _digest(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8", "replace")).hexdigest()[:8]
+
+
+class TestDeliveryLogFacts:
+    def test_consumer_facts_present_and_content_free(self):
+        """All fields appear with correct values; message text never leaks."""
+        consumer = GatewayStreamConsumer(MagicMock(), "chat_123")
+        consumer._accumulated = "delivered text"
+        consumer._last_sent_text = "delivered text"
+        consumer._message_id = "msg_9"
+
+        suffix = _delivery_log_facts("delivered text", consumer)
+
+        assert "final_len=14" in suffix
+        assert f"final_digest={_digest('delivered text')}" in suffix
+        assert "acc_len=14" in suffix
+        assert f"acc_digest={_digest('delivered text')}" in suffix
+        assert "last_sent_len=14" in suffix
+        assert "sc_msg_id=msg_9" in suffix
+        assert "last_edit_overflowed=False" in suffix
+        assert "delivered text" not in suffix
+
+    def test_divergence_between_final_and_accumulated_is_visible(self):
+        """When the agent's final response differs from what the consumer
+        delivered, both lengths and both digests expose the divergence."""
+        consumer = GatewayStreamConsumer(MagicMock(), "chat_123")
+        consumer._accumulated = "short"
+        consumer._last_sent_text = "short"
+        consumer._message_id = "msg_9"
+
+        suffix = _delivery_log_facts("a longer final response", consumer)
+
+        assert "final_len=23" in suffix
+        assert "acc_len=5" in suffix
+        digest_final = _digest("a longer final response")
+        digest_acc = _digest("short")
+        assert digest_final != digest_acc
+        assert f"final_digest={digest_final}" in suffix
+        assert f"acc_digest={digest_acc}" in suffix
+
+    def test_no_consumer_logs_sentinels_without_raising(self):
+        """previewed-only suppressions have no stream consumer; the suffix
+        still composes with sentinel fields."""
+        suffix = _delivery_log_facts("final text", None)
+        assert "final_len=10" in suffix
+        assert "sc_msg_id=?" in suffix
+        assert "acc_len=?" in suffix
+
+    def test_poisoned_summary_never_raises(self):
+        """Log composition must never be able to abort the suppression
+        decision: a raising summary degrades to sentinels."""
+
+        class Poisoned:
+            def delivery_summary(self):
+                raise RuntimeError("boom")
+
+        suffix = _delivery_log_facts("final", Poisoned())
+        assert "final_len=5" in suffix
+        assert "sc_msg_id=?" in suffix
+
+    def test_non_string_final_text_degrades_to_zero(self):
+        suffix = _delivery_log_facts(None, None)
+        assert "final_len=0" in suffix


### PR DESCRIPTION
## What does this PR do?

When the gateway suppresses its normal final send because streaming already delivered the reply, the only record is three booleans:

```
Suppressing normal final send for session ...: final delivery already confirmed (streamed=True previewed=False content_delivered=True).
```

That line cannot prove what actually reached the user. Issue #29200 documented a real false positive behind this exact line, and #27942's acceptance criteria ask for logs that distinguish delivery states. Diagnosing a live incident today means pulling the session DB, because at INFO level neither the stream consumer nor the adapters record message ids or payload sizes for successful edits.

This PR makes the suppression line carry its own evidence. The same line now ends with:

```
... content_delivered=True). final_len=1758 final_digest=ab12cd34 acc_len=1758 acc_digest=ab12cd34 last_sent_len=1758 sc_msg_id=123 last_edit_overflowed=False
```

Matching digests prove the delivered text equals the final response without logging any message content. Diverging values point at the exact failure class (accumulated-vs-final divergence, split delivery, or suppression on a stale flag).

Zero behavior change. The suppression condition and every delivery flag are untouched, and the composition helper cannot raise (a failing summary degrades to `?` fields), so log formatting can never affect the suppression decision itself.

Design notes:

- `GatewayStreamConsumer.delivery_summary()` is a read-only accessor restricted to attribute reads, `len()`, and a sha256 prefix.
- `_short_digest` has a single owner in `gateway/stream_consumer.py`; both sides of the digest comparison import it, so the algorithm cannot drift.
- Lengths and digests describe the consumer's current bubble. On overflow splits, earlier chunks are separate already-sent messages, so reset values alongside `content_delivered=True` mean split delivery, not lost content. The accessor docstring documents this.
- Message content never appears in logs; a test pins that.

## Related Issue

Related: #27942, #29200

This is a step toward the logging acceptance criterion in #27942 ("Logs should distinguish: partial preview delivered; final content delivered; ...") and makes the false-positive class from #29200 provable or refutable from logs alone. It does not close either issue: per-path delivery provenance and an adapter-side success log are natural follow-ups.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/stream_consumer.py`: add module helper `_short_digest()` and read-only `GatewayStreamConsumer.delivery_summary()`.
- `gateway/run.py`: add pure helper `_delivery_log_facts()` plus `_SUPPRESS_FINAL_SEND_LOG_FMT`; the suppression `logger.info` call appends the facts. The suppression condition is byte-identical to main.
- `tests/gateway/test_stream_consumer.py`: `TestDeliverySummary` (3 tests) in a self-contained class at the end of the file.
- `tests/gateway/test_suppression_log_facts.py`: new module with 8 tests for the helper (field values, content never leaked, sentinel paths, raising summary and raising digest degrade instead of propagating, length and digest divergence visibility, format-string placeholder count).

## How to Test

1. `pytest tests/gateway/test_suppression_log_facts.py tests/gateway/test_stream_consumer.py -q`: 133 passed.
2. `pytest tests/gateway/test_telegram_final_delivery.py -q`: 10 passed. This verifies the current `_stream_confirmed_final_delivery()` path remains intact.
3. `ruff check gateway/run.py gateway/stream_consumer.py tests/gateway/test_stream_consumer.py tests/gateway/test_suppression_log_facts.py`: passed.
4. `git diff --check`: passed.

## Post-Deploy Monitoring & Validation

- Log query: `grep "Suppressing normal final send" gateway.log`
- Healthy signal on non-overflow turns: `final_digest` equals `acc_digest`, and `final_len`, `acc_len`, `last_sent_len` all match.
- Investigate signal: digests differ while `last_edit_overflowed=False`; the consumer delivered different text than the agent's final response, so pull the session transcript for that turn.
- Expected, not a failure: small or zero `acc_len`/`last_sent_len` together with `content_delivered=True` on overflow turns (split delivery resets per-bubble tracking).
- Rollback: revert is safe at any time; the change is log composition only.
- Validation window: first day of normal traffic after deploy.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the targeted stream-consumer, suppression-log, and final-delivery tests and they pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings on the new accessor and helper)
- [x] `cli-config.yaml.example`: N/A, no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A, no architecture or workflow change
- [x] Cross-platform impact: N/A, stdlib-only change (hashlib), no platform-specific paths
- [x] Tool descriptions/schemas: N/A, no tool behavior changed

