### PR TITLE
fix(agent): prefer auto-resolved model over stale config in auxiliary auto (#44746)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3409,6 +3409,7 @@ def resolve_provider_client(
     # main_model also empty), the branches still hit their own
     # missing-credentials returns and ``_resolve_auto`` falls through to
     # the Step-2 chain as before.
+    caller_provided_model = bool(model)
     if not model:
         model = _get_aux_model_for_provider(provider) or _read_main_model() or model
 
@@ -3466,16 +3467,23 @@ def resolve_provider_client(
         client, resolved = _resolve_auto(main_runtime=main_runtime)
         if client is None:
             return None, None
-        # When auto-detection lands on a non-OpenRouter provider (e.g. a
-        # local server), an OpenRouter-formatted model override like
-        # "google/gemini-3-flash-preview" won't work.  Drop it and use
-        # the provider's own default model instead.
-        if model and "/" in model and resolved and "/" not in resolved:
-            logger.debug(
-                "Dropping OpenRouter-format model %r for non-OpenRouter "
-                "auxiliary provider (using %r instead)", model, resolved)
-            model = None
-        final_model = model or resolved
+        # When the caller didn't explicitly pass a model, prefer the
+        # auto-resolved model that matches the live runtime client.
+        # _read_main_model() may return a stale config value from a
+        # different provider, causing a cross-provider model mismatch.
+        if not caller_provided_model and resolved:
+            final_model = resolved
+        else:
+            # When auto-detection lands on a non-OpenRouter provider (e.g. a
+            # local server), an OpenRouter-formatted model override like
+            # "google/gemini-3-flash-preview" won't work.  Drop it and use
+            # the provider's own default model instead.
+            if model and "/" in model and resolved and "/" not in resolved:
+                logger.debug(
+                    "Dropping OpenRouter-format model %r for non-OpenRouter "
+                    "auxiliary provider (using %r instead)", model, resolved)
+                model = None
+            final_model = model or resolved
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                 else (client, final_model))
 

--- a/tests/agent/test_auxiliary_client_auto_model.py
+++ b/tests/agent/test_auxiliary_client_auto_model.py
@@ -1,0 +1,96 @@
+"""Tests for auxiliary auto provider using the live runtime model instead of
+stale config when the caller does not explicitly pass a model.
+
+Regression test for #44746.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from agent.auxiliary_client import resolve_provider_client
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for key in (
+        "OPENROUTER_API_KEY", "OPENAI_BASE_URL", "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    import agent.auxiliary_client as _aux_mod
+    _aux_mod._aux_unhealthy_until.clear()
+    _aux_mod._aux_unhealthy_logged_at.clear()
+    yield
+    _aux_mod._aux_unhealthy_until.clear()
+    _aux_mod._aux_unhealthy_logged_at.clear()
+
+
+class TestAutoDoesNotUseStaleModel:
+    """provider=auto should use the model returned by _resolve_auto, not a
+    stale value from _read_main_model, when the caller passes no model."""
+
+    def test_auto_uses_runtime_model_not_config_model(self):
+        fake_client = MagicMock()
+        fake_client.base_url = "https://api.z.ai/v1"
+
+        with (
+            patch(
+                "agent.auxiliary_client._resolve_auto",
+                return_value=(fake_client, "glm-5.1"),
+            ),
+            patch(
+                "agent.auxiliary_client._read_main_model",
+                return_value="gpt-5.5",
+            ),
+            patch(
+                "agent.auxiliary_client._get_aux_model_for_provider",
+                return_value="",
+            ),
+            patch(
+                "agent.auxiliary_client._validate_proxy_env_urls",
+            ),
+        ):
+            client, model = resolve_provider_client(
+                "auto",
+                model=None,
+                main_runtime={
+                    "provider": "zai",
+                    "model": "glm-5.1",
+                    "base_url": "https://api.z.ai/v1",
+                },
+            )
+
+        assert client is fake_client
+        assert model == "glm-5.1", (
+            f"Expected auto-resolved model 'glm-5.1', got stale '{model}'"
+        )
+
+    def test_explicit_model_overrides_auto_resolved(self):
+        fake_client = MagicMock()
+        fake_client.base_url = "https://api.z.ai/v1"
+
+        with (
+            patch(
+                "agent.auxiliary_client._resolve_auto",
+                return_value=(fake_client, "glm-5.1"),
+            ),
+            patch(
+                "agent.auxiliary_client._validate_proxy_env_urls",
+            ),
+        ):
+            client, model = resolve_provider_client(
+                "auto",
+                model="custom-model-override",
+                main_runtime={
+                    "provider": "zai",
+                    "model": "glm-5.1",
+                    "base_url": "https://api.z.ai/v1",
+                },
+            )
+
+        assert client is fake_client
+        assert model == "custom-model-override", (
+            f"Expected explicit model override, got '{model}'"
+        )


### PR DESCRIPTION
## Summary

When \`auxiliary.<task>.provider: auto\`, the model fallback chain reads \`_read_main_model()\` from stale config before \`_resolve_auto()\` runs. This can pair a live runtime client (e.g. Z.AI) with a stale config model (e.g. \`gpt-5.5\`), causing 400 errors like "Unknown Model".

The fix tracks whether the caller explicitly passed a model. When provider is \`auto\` and no explicit model was given, the model returned by \`_resolve_auto()\` (which matches the live runtime) takes priority over the fallback-chain model.

## Changes

- \`agent/auxiliary_client.py\`: add \`caller_provided_model\` flag; in the auto branch, prefer the auto-resolved model when no explicit model was given
- \`tests/agent/test_auxiliary_client_auto_model.py\`: 2 tests verifying auto uses runtime model (not stale config) and explicit model still overrides

## Test plan

- [x] New tests pass (\`pytest tests/agent/test_auxiliary_client_auto_model.py\`)
- [ ] Manual: switch main provider to Z.AI with \`glm-5.1\`, verify auxiliary compression uses \`glm-5.1\` (not stale \`gpt-5.5\` from config)

Fixes #44746