### PR TITLE
fix: avoid desktop image preview stack overflow

### DIFF
--- a/apps/desktop/src/lib/embedded-images.test.ts
+++ b/apps/desktop/src/lib/embedded-images.test.ts
@@ -32,4 +32,13 @@ describe('extractEmbeddedImages', () => {
     expect(result.cleanedText).toBe('first  mid  tail')
     expect(result.images).toEqual([SAMPLE_PNG_DATA_URL, second])
   })
+
+  it('handles multi-megabyte image data URLs without recursive regex overflow', () => {
+    const large = 'data:image/jpeg;base64,' + 'A'.repeat(2_500_000)
+    const result = extractEmbeddedImages(`before ${large} after`)
+
+    expect(result.cleanedText).toBe('before  after')
+    expect(result.images).toHaveLength(1)
+    expect(result.images[0]).toHaveLength(large.length)
+  })
 })

--- a/apps/desktop/src/lib/embedded-images.ts
+++ b/apps/desktop/src/lib/embedded-images.ts
@@ -1,7 +1,6 @@
-const EMBEDDED_IMAGE_RE =
-  /(\{\s*"type"\s*:\s*"image_url"\s*,\s*"image_url"\s*:\s*\{\s*"url"\s*:\s*")?(data:image\/[\w.+-]+;base64,[A-Za-z0-9+/=]{64,})("\s*\}\s*\})?/g
-
+const DATA_IMAGE_URL_PREFIX_RE = /data:image\/[\w.+-]+;base64,/iy
 const DATA_URL_RE = /^data:([\w./+-]+);base64,(.*)$/i
+const BASE64_CHAR_RE = /[A-Za-z0-9+/=]/
 
 export const DATA_IMAGE_URL_RE = /^data:image\/[\w.+-]+;base64,/i
 
@@ -31,19 +30,71 @@ export function dataUrlToBlob(dataUrl: string): Blob | null {
   }
 }
 
+function dataImageUrlEnd(text: string, start: number): number | null {
+  DATA_IMAGE_URL_PREFIX_RE.lastIndex = start
+  const prefix = DATA_IMAGE_URL_PREFIX_RE.exec(text)
+
+  if (!prefix || prefix.index !== start) {
+    return null
+  }
+
+  let end = DATA_IMAGE_URL_PREFIX_RE.lastIndex
+
+  while (end < text.length && BASE64_CHAR_RE.test(text[end])) {
+    end += 1
+  }
+
+  // Ignore tiny/partial strings so normal prose is preserved. The old regex used
+  // the same 64-character floor; keep that contract while avoiding a huge
+  // backtracking match over multi-megabyte data URLs.
+  return end - DATA_IMAGE_URL_PREFIX_RE.lastIndex >= 64 ? end : null
+}
+
 export function extractEmbeddedImages(text: string): EmbeddedImageExtraction {
   if (!text || !text.includes('data:image/')) {
     return { cleanedText: text, images: [] }
   }
 
   const images: string[] = []
+  const chunks: string[] = []
+  let cursor = 0
 
-  const cleanedText = text
-    .replace(EMBEDDED_IMAGE_RE, (_match, _open, dataUrl: string) => {
-      images.push(dataUrl)
+  while (cursor < text.length) {
+    const start = text.indexOf('data:image/', cursor)
 
-      return ''
-    })
+    if (start < 0) {
+      chunks.push(text.slice(cursor))
+
+      break
+    }
+
+    const end = dataImageUrlEnd(text, start)
+
+    if (!end) {
+      chunks.push(text.slice(cursor, start + 'data:image/'.length))
+      cursor = start + 'data:image/'.length
+
+      continue
+    }
+
+    let removeStart = start
+    let removeEnd = end
+
+    const jsonPrefix = '{"type":"image_url","image_url":{"url":"'
+    const jsonSuffix = '"}}'
+
+    if (text.slice(start - jsonPrefix.length, start) === jsonPrefix && text.slice(end, end + jsonSuffix.length) === jsonSuffix) {
+      removeStart = start - jsonPrefix.length
+      removeEnd = end + jsonSuffix.length
+    }
+
+    chunks.push(text.slice(cursor, removeStart))
+    images.push(text.slice(start, end))
+    cursor = removeEnd
+  }
+
+  const cleanedText = chunks
+    .join('')
     .replace(/[ \t]+\n/g, '\n')
     .replace(/\n{3,}/g, '\n\n')
     .trim()


### PR DESCRIPTION
## Summary

Fixes a Hermes Desktop renderer crash when uploading images with large base64 preview data URLs.

The existing embedded-image extractor used one large global regex over `data:image/...;base64,...` strings. In Desktop, image uploads can place multi-megabyte data URLs in the optimistic user message preview, and rendering that message can throw:

```text
RangeError: Maximum call stack size exceeded
[error-boundary:root]
UserMessage
```

This PR replaces the large regex extraction with an iterative scanner that:

- Finds `data:image/` with `indexOf`
- Validates the prefix with a sticky regex
- Scans base64 characters in a simple loop
- Preserves the prior 64-character minimum behavior
- Handles the compact JSON `image_url` envelope

Fixes #44785

## Validation

```text
npm run test:ui -- src/lib/embedded-images.test.ts
✓ src/lib/embedded-images.test.ts (5 tests)

npm run typecheck
passed

npx eslint src/lib/embedded-images.ts src/lib/embedded-images.test.ts
passed
```
