### PR TITLE
feat(web_extract): expose use_llm_processing in tool schema

### DIFF
--- a/tests/tools/test_web_providers.py
+++ b/tests/tools/test_web_providers.py
@@ -539,3 +539,56 @@ class TestDispatchersTriggerPluginDiscovery:
         finally:
             restore()
 
+    def test_web_extract_schema_exposes_use_llm_processing(self):
+        """WEB_EXTRACT_SCHEMA must include use_llm_processing (boolean, default True)."""
+        from tools.web_tools import WEB_EXTRACT_SCHEMA
+
+        params = WEB_EXTRACT_SCHEMA["parameters"]["properties"]
+        assert "use_llm_processing" in params, (
+            "WEB_EXTRACT_SCHEMA must expose use_llm_processing "
+            "so agents can opt out of LLM summarization"
+        )
+        assert params["use_llm_processing"]["type"] == "boolean"
+        assert params["use_llm_processing"]["default"] is True, (
+            "Default must be True — backward compatible, non-breaking"
+        )
+
+    def test_web_extract_handler_forwards_use_llm_processing(self, monkeypatch):
+        """Handler lambda must pass use_llm_processing through to web_extract_tool."""
+        import asyncio
+        from tools.registry import registry
+        from tools import web_tools
+
+        tool_def = registry.get_entry("web_extract")
+        assert tool_def is not None, "web_extract must be registered"
+        handler = tool_def.handler
+
+        calls = []
+
+        async def fake_extract(urls, format=None, use_llm_processing=True,
+                               model=None, min_length=5000):
+            calls.append({
+                "format": format,
+                "use_llm_processing": use_llm_processing,
+            })
+            return '{"results": []}'
+
+        monkeypatch.setattr(web_tools, "web_extract_tool", fake_extract)
+
+        # Explicit false
+        asyncio.run(handler({
+            "urls": ["https://example.com"],
+            "use_llm_processing": False,
+        }))
+        assert calls[0]["format"] == "markdown"
+        assert calls[0]["use_llm_processing"] is False, (
+            "Handler must forward use_llm_processing=False"
+        )
+
+        # Default (absent param) → True
+        calls.clear()
+        asyncio.run(handler({"urls": ["https://example.com"]}))
+        assert calls[0]["use_llm_processing"] is True, (
+            "Default must be True when param is absent"
+        )
+

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1530,7 +1530,7 @@ WEB_SEARCH_SCHEMA = {
 
 WEB_EXTRACT_SCHEMA = {
     "name": "web_extract",
-    "description": "Extract content from web page URLs. Returns page content in markdown format. Also works with PDF URLs (arxiv papers, documents, etc.) — pass the PDF link directly and it converts to markdown text. Pages under 5000 chars return full markdown; larger pages are LLM-summarized and capped at ~5000 chars per page. Pages over 2M chars are refused. If a URL fails or times out, use the browser tool to access it instead.",
+    "description": "Extract content from web page URLs. Returns page content in markdown format. Also works with PDF URLs (arxiv papers, documents, etc.) — pass the PDF link directly and it converts to markdown text. Pages under 5000 chars return full markdown; larger pages are LLM-summarized and capped at ~5000 chars per page. Set use_llm_processing=false to skip summarization and return raw markdown instead (useful when every detail matters — docs, papers, specs). Pages over 2M chars are refused. If a URL fails or times out, use the browser tool to access it instead.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -1539,6 +1539,11 @@ WEB_EXTRACT_SCHEMA = {
                 "items": {"type": "string"},
                 "description": "List of URLs to extract content from (max 5 URLs per call)",
                 "maxItems": 5
+            },
+            "use_llm_processing": {
+                "type": "boolean",
+                "description": "Whether to process content with LLM for summarization. Defaults to true (summary mode, ~5K chars). Set false for raw full-content extraction — the agent gets the complete page.",
+                "default": True
             }
         },
         "required": ["urls"]
@@ -1560,7 +1565,9 @@ registry.register(
     toolset="web",
     schema=WEB_EXTRACT_SCHEMA,
     handler=lambda args, **kw: web_extract_tool(
-        args.get("urls", [])[:5] if isinstance(args.get("urls"), list) else [], "markdown"),
+        args.get("urls", [])[:5] if isinstance(args.get("urls"), list) else [],
+        format="markdown",
+        use_llm_processing=args.get("use_llm_processing", True)),
     check_fn=web_tools_registered,
     requires_env=_web_requires_env(),
     is_async=True,


### PR DESCRIPTION
## What
Expose the `use_llm_processing` parameter in the `web_extract` tool schema so agents can opt out of LLM summarization and get raw page content.

## Why
The `web_extract_tool()` function already supports `use_llm_processing=False` — it skips LLM summarization entirely and returns raw markdown. But the parameter is NOT exposed in the tool schema (`WEB_EXTRACT_SCHEMA`), so agents can never set it. The handler lambda hardcodes `"markdown"` as a positional arg and doesn't forward `use_llm_processing`.

This means agents ALWAYS get LLM-summarized content for pages >5000 chars, capped at ~5K. For tasks where the agent needs the FULL original content (code parsing, exact data extraction, document analysis), this is information-destroying.

## Changes

### `tools/web_tools.py` (+9/-2)

1. **Schema**: Add `use_llm_processing` parameter (boolean, default `true`)
2. **Handler**: Forward `use_llm_processing` as keyword arg with `format="markdown"`
3. **Description**: Mention the parameter

### `tests/tools/test_web_providers.py` (+53/-0)

Two new tests in `TestDispatchersTriggerPluginDiscovery`:

- `test_web_extract_schema_exposes_use_llm_processing` — schema includes the param with correct type/default
- `test_web_extract_handler_forwards_use_llm_processing` — handler passes `use_llm_processing=False` through, defaults to `True` when absent

## Non-breaking
- Default is `true` — existing behavior unchanged
- Backward compatible
- No new dependencies, no API changes