### PR TITLE
fix(gateway): gate quick commands with slash access policy

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8091,13 +8091,28 @@ class GatewayRunner:
                         _cmd_def = _resolve_cmd(command) if command else None
                         canonical = _cmd_def.name if _cmd_def else command
 
+        if command:
+            if isinstance(self.config, dict):
+                quick_commands = self.config.get("quick_commands", {}) or {}
+            else:
+                quick_commands = getattr(self.config, "quick_commands", {}) or {}
+            if not isinstance(quick_commands, dict):
+                quick_commands = {}
+        else:
+            quick_commands = {}
+
         # Per-platform slash command access control. Only kicks in when the
         # operator has set ``allow_admin_from`` for the source's scope (DM
         # vs group). When unset → backward-compat: every allowed user can
         # run every command. When set → non-admins can run only commands in
         # ``user_allowed_commands`` (plus the always-allowed floor: /help,
         # /whoami). Plain chat is unaffected — only slash commands gate.
-        if command and canonical and is_gateway_known_command(canonical):
+        #
+        # Config-backed quick commands are slash capabilities too. They may
+        # execute shell commands later in this handler, so gate the raw quick
+        # command name through the same policy even though it is not present
+        # in the built-in/plugin slash registry.
+        if command and canonical and (is_gateway_known_command(canonical) or command in quick_commands):
             _denied = self._check_slash_access(source, canonical)
             if _denied is not None:
                 return _denied
@@ -8340,12 +8355,6 @@ class GatewayRunner:
 
         # User-defined quick commands (bypass agent loop, no LLM call)
         if command:
-            if isinstance(self.config, dict):
-                quick_commands = self.config.get("quick_commands", {}) or {}
-            else:
-                quick_commands = getattr(self.config, "quick_commands", {}) or {}
-            if not isinstance(quick_commands, dict):
-                quick_commands = {}
             if command in quick_commands:
                 qcmd = quick_commands[command]
                 if qcmd.get("type") == "exec":

--- a/tests/gateway/test_slash_access_dispatch.py
+++ b/tests/gateway/test_slash_access_dispatch.py
@@ -186,6 +186,28 @@ async def test_non_admin_with_empty_user_commands_gets_floor_only():
     assert "Tier: user" in whoami_result
 
 
+@pytest.mark.asyncio
+async def test_non_admin_denied_for_unlisted_quick_command_exec():
+    runner = _make_runner(
+        platform_extra={
+            "allow_admin_from": ["111"],
+            "user_allowed_commands": [],
+        }
+    )
+    runner.config.quick_commands = {
+        "limits": {"type": "exec", "command": "printf quick-command-bypass-confirmed"}
+    }
+
+    result = await runner._handle_message(
+        _make_event("/limits", _make_source(user_id="999"))
+    )
+
+    assert result is not None
+    assert "⛔" in result
+    assert "/limits is admin-only here" in result
+    assert "quick-command-bypass-confirmed" not in result
+
+
 # ---------------------------------------------------------------------------
 # Gate ALLOW — admin and listed user
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Apply gateway slash access checks to config-backed quick commands before dispatch
- Reuse the resolved quick command config for the exec path
- Add a regression test covering non-admin denial for an unlisted exec quick command

Fixes #44727

## Test Plan
- scripts/run_tests.sh tests/gateway/test_slash_access_dispatch.py