### PR TITLE
fix(gateway): preserve document type for mixed BlueBubbles attachments

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -947,10 +947,14 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 else:
                     msg_type = MessageType.DOCUMENT
 
-        # With multiple attachments, prefer PHOTO if any images present
+        # Document must win over PHOTO for mixed attachments: image delivery
+        # still keys off each per-path image/* mime type, but document-context
+        # injection only runs for MessageType.DOCUMENT.
         if len(media_urls) > 1:
             mime_prefixes = {(m or "").split("/")[0] for m in media_types}
-            if "image" in mime_prefixes:
+            if "application" in mime_prefixes or "text" in mime_prefixes:
+                msg_type = MessageType.DOCUMENT
+            elif "image" in mime_prefixes:
                 msg_type = MessageType.PHOTO
 
         if not text and media_urls:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -79,6 +79,7 @@ AUTHOR_MAP = {
     "kdunn926@gmail.com": "kdunn926",
     "mvanhorn@MacBook-Pro.local": "mvanhorn",
     "470766206@qq.com": "youjunxiaji",
+    "3483421977@qq.com": "xy200303",
     "mharris@parallel.ai": "NormallyGaussian",
     "roger@roger.local": "mollusk",
     "ted.malone@outlook.com": "temalo",

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -405,6 +405,59 @@ class TestBlueBubblesWebhookParsing:
         record = adapter._extract_payload_record(payload)
         assert record["text"] == "hello"
 
+    @pytest.mark.asyncio
+    async def test_mixed_image_and_document_prefers_document(self, monkeypatch):
+        """Mixed image+document attachments must stay DOCUMENT so file-context
+        injection still runs for the document sibling."""
+        from gateway.platforms.base import MessageType
+
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_download(att_guid, att_meta):
+            if att_guid == "img-1":
+                return "/tmp/photo.png"
+            if att_guid == "doc-1":
+                return "/tmp/report.pdf"
+            return None
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "_download_attachment", fake_download)
+
+        response = await adapter._handle_webhook(_FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {
+                "guid": "msg-mixed-1",
+                "text": "",
+                "handle": {"address": "user@example.com"},
+                "isFromMe": False,
+                "chatGuid": "iMessage;-;user@example.com",
+                "chatIdentifier": "user@example.com",
+                "attachments": [
+                    {
+                        "guid": "img-1",
+                        "mimeType": "image/png",
+                        "transferName": "photo.png",
+                    },
+                    {
+                        "guid": "doc-1",
+                        "mimeType": "application/pdf",
+                        "transferName": "report.pdf",
+                    },
+                ],
+            },
+        }))
+        await asyncio.sleep(0)
+
+        assert response.status == 200
+        assert len(handled) == 1
+        assert handled[0].message_type == MessageType.DOCUMENT
+        assert handled[0].media_urls == ["/tmp/photo.png", "/tmp/report.pdf"]
+        assert handled[0].media_types == ["image/png", "application/pdf"]
+
 
 class TestBlueBubblesGuidResolution:
     def test_raw_guid_returned_as_is(self, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Fixes a BlueBubbles inbound message-type regression for mixed attachments.

When a BlueBubbles webhook includes both an image attachment and a document attachment, the gateway currently overwrites the message type to `PHOTO` if any image is present. That drops the document sibling out of the document-context injection path, even though the cached PDF/text file is still present in `media_urls`.

This change keeps mixed image+document BlueBubbles messages classified as `MessageType.DOCUMENT`, matching the recent gateway fixes for similar attachment-classification bugs on other platforms. Image delivery still keys off each attachment's own `image/*` MIME type, so preserving `DOCUMENT` does not break image handling.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Update BlueBubbles inbound multi-attachment classification in `gateway/platforms/bluebubbles.py`
- Preserve `MessageType.DOCUMENT` when a BlueBubbles message mixes image and document/text attachments
- Add a regression test in `tests/gateway/test_bluebubbles.py` covering an inbound image+PDF webhook payload

## How to Test

1. Run `python -m pytest tests/gateway/test_bluebubbles.py -k mixed_image_and_document_prefers_document -q`
2. Confirm the new regression test fails on current `main` before the fix and passes with this patch
3. Run `python -m pytest tests/gateway/test_bluebubbles.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `python -m pytest tests/gateway/test_bluebubbles.py -q` → `57 passed`