### PR TITLE
fix(slack): resume unmentioned bot thread replies after restart

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -1533,10 +1533,10 @@ class SlackAdapter(BasePlatformAdapter):
                     chat_id, chunk, metadata, human_delay=human_delay
                 )
 
-    def _record_uploaded_file_thread(
+    def _record_bot_thread_participation(
         self, chat_id: str, thread_ts: Optional[str]
     ) -> None:
-        """Treat successful file uploads as bot participation in a thread."""
+        """Record a thread root where this bot has posted a reply."""
         if not thread_ts:
             return
         self._bot_message_ts.add(thread_ts)
@@ -1544,6 +1544,12 @@ class SlackAdapter(BasePlatformAdapter):
             excess = len(self._bot_message_ts) - self._BOT_TS_MAX // 2
             for old_ts in list(self._bot_message_ts)[:excess]:
                 self._bot_message_ts.discard(old_ts)
+
+    def _record_uploaded_file_thread(
+        self, chat_id: str, thread_ts: Optional[str]
+    ) -> None:
+        """Backward-compatible wrapper for file/video send paths."""
+        self._record_bot_thread_participation(chat_id, thread_ts)
 
     def _is_retryable_upload_error(self, exc: Exception) -> bool:
         """Best-effort detection for transient Slack upload failures."""
@@ -2400,7 +2406,8 @@ class SlackAdapter(BasePlatformAdapter):
         #   1. The bot is @mentioned in this message, OR
         #   2. The message is a reply in a thread the bot started/participated in, OR
         #   3. The message is in a thread where the bot was previously @mentioned, OR
-        #   4. There's an existing session for this thread (survives restarts)
+        #   4. There's an existing session for this thread (survives restarts), OR
+        #   5. Slack history proves this bot already participated in the thread
         bot_uid = self._team_bot_user_ids.get(team_id, self._bot_user_id)
         routing_text = original_text or ""
         is_mentioned = bot_uid and f"<@{bot_uid}>" in routing_text
@@ -2435,10 +2442,26 @@ class SlackAdapter(BasePlatformAdapter):
                     thread_ts=event_thread_ts,
                     user_id=user_id,
                 )
+                has_fetched_bot_participation = False
                 if (
                     not reply_to_bot_thread
                     and not in_mentioned_thread
                     and not has_session
+                    and is_thread_reply
+                ):
+                    has_fetched_bot_participation = (
+                        await self._thread_has_prior_bot_participation(
+                            channel_id=channel_id,
+                            thread_ts=event_thread_ts,
+                            current_ts=ts,
+                            team_id=team_id,
+                        )
+                    )
+                if (
+                    not reply_to_bot_thread
+                    and not in_mentioned_thread
+                    and not has_session
+                    and not has_fetched_bot_participation
                 ):
                     return
 
@@ -3190,6 +3213,95 @@ class SlackAdapter(BasePlatformAdapter):
         # (approval state already consumed by atomic pop above)
 
     # ----- Thread context fetching -----
+
+    async def _thread_has_prior_bot_participation(
+        self,
+        channel_id: str,
+        thread_ts: str,
+        current_ts: str,
+        team_id: str = "",
+        limit: int = 30,
+    ) -> bool:
+        """Return True if Slack history shows this bot already participated.
+
+        This is the restart-safe fallback for mention-gated channel threads:
+        in-memory ``_bot_message_ts`` / ``_mentioned_threads`` are empty after a
+        gateway restart, but Slack's thread history still contains our prior
+        bot message.  Fail closed on API errors so channel traffic does not
+        become broadly ungated.
+        """
+        if not channel_id or not thread_ts or not current_ts:
+            return False
+
+        bot_uid = self._team_bot_user_ids.get(team_id, self._bot_user_id)
+        if not bot_uid:
+            return False
+
+        try:
+            client = self._get_client(channel_id)
+            result = await client.conversations_replies(
+                channel=channel_id,
+                ts=thread_ts,
+                latest=current_ts,
+                limit=limit,
+                inclusive=False,
+            )
+            if result and result.get("ok") is False:
+                logger.debug(
+                    "[Slack] Failed to check thread bot participation; failing closed: channel=%s thread_ts=%s error=%s",
+                    channel_id,
+                    thread_ts,
+                    result.get("error", "unknown"),
+                )
+                return False
+            messages = result.get("messages", []) if result else []
+            if not messages:
+                return False
+
+            current_value = self._parse_slack_ts(current_ts)
+            for msg in messages:
+                msg_ts = str(msg.get("ts", "") or "")
+                if msg_ts == current_ts:
+                    continue
+                msg_value = self._parse_slack_ts(msg_ts)
+                if (
+                    current_value is not None
+                    and msg_value is not None
+                    and msg_value >= current_value
+                ):
+                    continue
+
+                msg_user = str(msg.get("user", "") or "")
+                if msg_user == bot_uid:
+                    self._record_bot_thread_participation(channel_id, thread_ts)
+                    logger.debug(
+                        "[Slack] Allowing unmentioned thread reply after history confirmed bot participation: channel=%s thread_ts=%s",
+                        channel_id,
+                        thread_ts,
+                    )
+                    return True
+
+            logger.debug(
+                "[Slack] Ignoring unmentioned thread reply: no prior bot participation found in Slack history (channel=%s thread_ts=%s)",
+                channel_id,
+                thread_ts,
+            )
+            return False
+        except Exception as exc:
+            logger.debug(
+                "[Slack] Failed to check thread bot participation; failing closed: channel=%s thread_ts=%s error=%s",
+                channel_id,
+                thread_ts,
+                exc,
+            )
+            return False
+
+    @staticmethod
+    def _parse_slack_ts(ts: str) -> Optional[float]:
+        try:
+            return float(ts)
+        except (TypeError, ValueError):
+            return None
 
     async def _fetch_thread_context(
         self,

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -107,6 +107,12 @@ def adapter():
     # Mock the Slack app client
     a._app = MagicMock()
     a._app.client = AsyncMock()
+    a._app.client.users_info = AsyncMock(
+        return_value={"user": {"profile": {"display_name": "Test User"}}}
+    )
+    a._app.client.conversations_replies = AsyncMock(
+        return_value={"ok": True, "messages": []}
+    )
     a._bot_user_id = "U_BOT"
     a._running = True
     # Capture events instead of processing them
@@ -1678,6 +1684,196 @@ class TestIncomingDocumentHandling:
 
 
 class TestMessageRouting:
+    def _channel_thread_reply_event(self, text="thread follow-up"):
+        return {
+            "text": text,
+            "user": "U_USER",
+            "channel": "C123",
+            "channel_type": "channel",
+            "ts": "1234567890.000002",
+            "thread_ts": "1234567890.000001",
+            "team": "T123",
+        }
+
+    async def _handle_with_thread_fetches_stubbed(self, adapter, event):
+        with (
+            patch.object(
+                adapter, "_fetch_thread_context", new_callable=AsyncMock
+            ) as fetch_context,
+            patch.object(
+                adapter, "_fetch_thread_parent_text", new_callable=AsyncMock
+            ) as fetch_parent,
+        ):
+            fetch_context.return_value = ""
+            fetch_parent.return_value = ""
+            await adapter._handle_slack_message(event)
+
+    @pytest.mark.asyncio
+    async def test_unmentioned_thread_reply_processed_when_replies_show_prior_bot_participation(
+        self, adapter
+    ):
+        """Unmentioned channel thread replies continue after restart when Slack history shows this bot already participated."""
+        adapter._team_bot_user_ids["T123"] = "U_BOT"
+        adapter._app.client.conversations_replies = AsyncMock(
+            return_value={
+                "ok": True,
+                "messages": [
+                    {"ts": "1234567890.000001", "user": "U_USER", "text": "parent"},
+                    {
+                        "ts": "1234567890.0000015",
+                        "user": "U_BOT",
+                        "bot_id": "B_BOT",
+                        "subtype": "bot_message",
+                        "text": "bob reply",
+                    },
+                    {
+                        "ts": "1234567890.000002",
+                        "user": "U_USER",
+                        "text": "thread follow-up",
+                    },
+                ],
+            }
+        )
+
+        await self._handle_with_thread_fetches_stubbed(
+            adapter, self._channel_thread_reply_event()
+        )
+
+        adapter.handle_message.assert_called_once()
+        msg_event = adapter.handle_message.call_args.args[0]
+        assert msg_event.text == "thread follow-up"
+        assert msg_event.source.thread_id == "1234567890.000001"
+        assert "1234567890.000001" in adapter._bot_message_ts
+        adapter._app.client.conversations_replies.assert_awaited_once_with(
+            channel="C123",
+            ts="1234567890.000001",
+            latest="1234567890.000002",
+            limit=30,
+            inclusive=False,
+        )
+
+    @pytest.mark.asyncio
+    async def test_unmentioned_thread_reply_checks_recent_prior_window_not_thread_start(
+        self, adapter
+    ):
+        """Long threads should check the bounded window immediately before the triggering reply."""
+        adapter._team_bot_user_ids["T123"] = "U_BOT"
+        adapter._app.client.conversations_replies = AsyncMock(
+            return_value={
+                "ok": True,
+                "messages": [
+                    {
+                        "ts": "1234567890.0000015",
+                        "user": "U_BOT",
+                        "bot_id": "B_BOT",
+                        "subtype": "bot_message",
+                        "text": "recent bob reply",
+                    }
+                ],
+            }
+        )
+
+        await self._handle_with_thread_fetches_stubbed(
+            adapter, self._channel_thread_reply_event()
+        )
+
+        adapter.handle_message.assert_called_once()
+        adapter._app.client.conversations_replies.assert_awaited_once_with(
+            channel="C123",
+            ts="1234567890.000001",
+            latest="1234567890.000002",
+            limit=30,
+            inclusive=False,
+        )
+
+    @pytest.mark.asyncio
+    async def test_unmentioned_thread_reply_ignored_when_replies_show_no_bot_participation(
+        self, adapter
+    ):
+        adapter._team_bot_user_ids["T123"] = "U_BOT"
+        adapter._app.client.conversations_replies = AsyncMock(
+            return_value={
+                "ok": True,
+                "messages": [
+                    {"ts": "1234567890.000001", "user": "U_USER", "text": "parent"},
+                    {"ts": "1234567890.000002", "user": "U_USER", "text": "follow-up"},
+                ],
+            }
+        )
+
+        await self._handle_with_thread_fetches_stubbed(
+            adapter, self._channel_thread_reply_event()
+        )
+
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_strict_mention_ignores_unmentioned_thread_even_with_prior_bot_participation(
+        self,
+    ):
+        config = PlatformConfig(
+            enabled=True,
+            token="***",
+            extra={"strict_mention": True, "require_mention": True},
+        )
+        adapter = SlackAdapter(config)
+        adapter._app = MagicMock()
+        adapter._app.client = AsyncMock()
+        adapter._app.client.users_info = AsyncMock(
+            return_value={"user": {"profile": {"display_name": "Test User"}}}
+        )
+        adapter._bot_user_id = "U_BOT"
+        adapter._running = True
+        adapter.handle_message = AsyncMock()
+        adapter._app.client.conversations_replies = AsyncMock(
+            return_value={
+                "ok": True,
+                "messages": [
+                    {"ts": "1234567890.000001", "user": "U_USER", "text": "parent"},
+                    {
+                        "ts": "1234567890.0000015",
+                        "user": "U_BOT",
+                        "bot_id": "B_BOT",
+                        "subtype": "bot_message",
+                        "text": "bob reply",
+                    },
+                ],
+            }
+        )
+
+        await self._handle_with_thread_fetches_stubbed(
+            adapter, self._channel_thread_reply_event()
+        )
+
+        adapter.handle_message.assert_not_called()
+        adapter._app.client.conversations_replies.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_thread_participation_api_failure_fails_closed(self, adapter):
+        adapter._team_bot_user_ids["T123"] = "U_BOT"
+        adapter._app.client.conversations_replies = AsyncMock(
+            side_effect=RuntimeError("slack unavailable")
+        )
+
+        await self._handle_with_thread_fetches_stubbed(
+            adapter, self._channel_thread_reply_event()
+        )
+
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_thread_participation_not_ok_response_fails_closed(self, adapter):
+        adapter._team_bot_user_ids["T123"] = "U_BOT"
+        adapter._app.client.conversations_replies = AsyncMock(
+            return_value={"ok": False, "error": "missing_scope", "messages": []}
+        )
+
+        await self._handle_with_thread_fetches_stubbed(
+            adapter, self._channel_thread_reply_event()
+        )
+
+        adapter.handle_message.assert_not_called()
+
     @pytest.mark.asyncio
     async def test_dm_processed_without_mention(self, adapter):
         """DM messages should be processed without requiring a bot mention."""
@@ -1703,6 +1899,7 @@ class TestMessageRouting:
         }
         await adapter._handle_slack_message(event)
         adapter.handle_message.assert_not_called()
+        adapter._app.client.conversations_replies.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_channel_mention_strips_bot_id(self, adapter):
@@ -2525,6 +2722,12 @@ class TestThreadReplyHandling:
         a = SlackAdapter(config)
         a._app = MagicMock()
         a._app.client = AsyncMock()
+        a._app.client.users_info = AsyncMock(
+            return_value={"user": {"profile": {"display_name": "Test User"}}}
+        )
+        a._app.client.conversations_replies = AsyncMock(
+            return_value={"ok": True, "messages": []}
+        )
         a._bot_user_id = "U_BOT"
         a._team_bot_user_ids = {"T_TEAM": "U_BOT"}
         a._running = True
@@ -2621,6 +2824,7 @@ class TestThreadReplyHandling:
         }
         await adapter_with_session_store._handle_slack_message(event)
         adapter_with_session_store.handle_message.assert_not_called()
+        adapter_with_session_store._app.client.conversations_replies.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_no_session_store_ignores_thread_replies(self, adapter):
@@ -2663,6 +2867,12 @@ class TestAssistantThreadLifecycle:
         a = SlackAdapter(config)
         a._app = MagicMock()
         a._app.client = AsyncMock()
+        a._app.client.users_info = AsyncMock(
+            return_value={"user": {"profile": {"display_name": "Test User"}}}
+        )
+        a._app.client.conversations_replies = AsyncMock(
+            return_value={"ok": True, "messages": []}
+        )
         a._bot_user_id = "U_BOT"
         a._team_bot_user_ids = {"T_TEAM": "U_BOT"}
         a._running = True


### PR DESCRIPTION
## Summary

- Allows unmentioned replies inside Slack channel threads to continue being processed after a gateway restart when `require_mention=true` and `strict_mention=false`, if Slack thread history proves this bot already participated earlier in the thread.
- Keeps top-level channel messages mention-gated.
- Records confirmed bot thread participation back into the bounded in-memory thread participation cache.

## Safety

- Mention gate preserved: the new Slack history fallback only runs for channel thread replies; top-level channel messages remain gated by mention/session rules.
- Strict mention preserved: `strict_mention=true` returns before any history lookup and does not call `conversations.replies` for unmentioned thread replies.
- Fail-closed Slack history lookup: Slack API exceptions and `ok: false` responses return `False` and do not route the message.
- Bounded lookup: uses `conversations.replies` with `latest=<current message ts>`, `inclusive=false`, and `limit=30`; no unbounded scans.

## Verification

- `uv run pytest -q tests/gateway/test_slack.py::TestMessageRouting -o 'addopts='` -> 11 passed
- `uv run pytest -q tests/gateway/test_slack.py -o 'addopts='` -> 200 passed, 2 warnings
- `uv run python -m compileall -q gateway/platforms/slack.py tests/gateway/test_slack.py` -> passed
- `uv run ruff check gateway/platforms/slack.py tests/gateway/test_slack.py` -> All checks passed

## Caveat

No intentional live Slack channel write in this PR; runtime already restarted from local checkout by Bob.
