### PR TITLE
fix(tui): exit notification poller when session removed from _sessions

### DIFF
--- a/tests/test_notification_poller_session_exit.py
+++ b/tests/test_notification_poller_session_exit.py
@@ -1,0 +1,94 @@
+"""Regression test: notification poller exits when session removed from _sessions.
+
+Issue #44789 — leaked poller threads from earlier tests race on the shared
+completion_queue because the loop only checked stop_event and _finalized.
+Adding `sid in _sessions` makes _sessions.pop(sid) sufficient to reap the
+poller in both test cleanup and production (dead-session reaping).
+"""
+import threading
+import time
+
+import pytest
+
+
+def test_poller_exits_when_session_removed_from_sessions(monkeypatch):
+    """Removing the session from _sessions causes the poller loop to exit."""
+    from tools.process_registry import process_registry
+    import tui_gateway.server as server
+
+    # Drain the queue first
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+
+    sess = {
+        "running": False,
+        "history_lock": threading.Lock(),
+        "_finalized": False,
+    }
+    sid = "sid_poller_exit_test"
+    server._sessions[sid] = sess
+
+    emitted = []
+    monkeypatch.setattr(server, "_emit", lambda *a, **kw: emitted.append(a))
+    monkeypatch.setattr(server, "_run_prompt_submit", lambda *a, **kw: None)
+
+    stop = threading.Event()
+    t = threading.Thread(
+        target=server._notification_poller_loop,
+        args=(stop, sid, sess),
+        daemon=True,
+    )
+    t.start()
+
+    # Let the poller start and settle into the get(timeout=0.5) wait
+    time.sleep(0.3)
+
+    # Remove the session — this should cause the loop to exit
+    server._sessions.pop(sid, None)
+
+    # Wait for the thread to finish (it should exit within one iteration)
+    t.join(timeout=2.0)
+    assert not t.is_alive(), "poller thread should exit when session removed from _sessions"
+
+    # Cleanup
+    stop.set()
+
+
+def test_poller_stays_alive_when_session_present(monkeypatch):
+    """Poller keeps running while session is still in _sessions and not stopped."""
+    from tools.process_registry import process_registry
+    import tui_gateway.server as server
+
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+
+    sess = {
+        "running": False,
+        "history_lock": threading.Lock(),
+        "_finalized": False,
+    }
+    sid = "sid_poller_alive_test"
+    server._sessions[sid] = sess
+
+    emitted = []
+    monkeypatch.setattr(server, "_emit", lambda *a, **kw: emitted.append(a))
+    monkeypatch.setattr(server, "_run_prompt_submit", lambda *a, **kw: None)
+
+    stop = threading.Event()
+    t = threading.Thread(
+        target=server._notification_poller_loop,
+        args=(stop, sid, sess),
+        daemon=True,
+    )
+    t.start()
+
+    # Let it settle
+    time.sleep(0.3)
+
+    # Session is still present — thread should be alive
+    assert t.is_alive(), "poller thread should keep running while session is in _sessions"
+
+    # Cleanup
+    stop.set()
+    server._sessions.pop(sid, None)
+    t.join(timeout=2.0)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5206,7 +5206,7 @@ def _notification_poller_loop(
     from tools.process_registry import process_registry, format_process_notification
 
     _emitted = set()  # dedup re-queued events so same completion isn't emitted 50 times while session is busy
-    while not stop_event.is_set() and not session.get("_finalized"):
+    while not stop_event.is_set() and not session.get("_finalized") and sid in _sessions:
         try:
             evt = process_registry.completion_queue.get(timeout=0.5)
         except Exception:


### PR DESCRIPTION
## What does this PR do?

Adds a `sid in _sessions` check to the notification poller loop in `_notification_poller_loop`, so the poller thread automatically exits when its session is removed from the global `_sessions` dict. This fixes a flaky test caused by leaked poller threads from earlier tests racing on the shared `completion_queue`.

## Related Issue

Fixes #44789

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py`: Added `sid in _sessions` to the `while` condition in `_notification_poller_loop` (+1/-1 line). The poller now exits when the session is removed, making `_sessions.pop(sid)` sufficient for cleanup — no explicit thread join needed.
- `tests/test_notification_poller_session_exit.py`: Added 2 regression tests — one verifying the poller exits when the session is removed, and one verifying it stays alive while the session is present.

## How to Test

1. Run `pytest tests/test_notification_poller_session_exit.py -v` — both tests should pass
2. Run `pytest tests/test_tui_gateway_server.py -k "notification_poller" -v` — all 4 existing tests should still pass
3. To reproduce the original flake, run `pytest tests/test_tui_gateway_server.py::test_notification_poller_emits_distinct_watch_matches_once` multiple times in sequence (without this fix, occasional `assert 3 == 2` failures occur)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `_notification_poller_loop` in `tui_gateway/server.py` (callers: `_start_notification_poller`, tests)
- Blast radius: LOW — single while-condition change in TUI notification poller; no gateway/CLI code affected
- Related patterns: Issue reporter identified the server-side approach as one of two valid fixes (the other being test-side cleanup, which is #34455). Our fix also reaps dead-session pollers in production, not just in tests.
