### PR TITLE
fix(hindsight): re-read on-disk config when recreating the embedded client

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -294,13 +294,13 @@ REFLECT_SCHEMA = {
 # Config
 # ---------------------------------------------------------------------------
 
-def _load_config() -> dict:
-    """Load config from profile-scoped path, legacy path, or env vars.
+def _load_file_config() -> dict | None:
+    """Load config from disk only (no env fallback); None when no file parses.
 
-    Resolution order:
-      1. $HERMES_HOME/hindsight/config.json  (profile-scoped)
-      2. ~/.hindsight/config.json             (legacy, shared)
-      3. Environment variables
+    Used at the daemon (re)spawn boundary, where the question is "what does
+    the on-disk config say *now*" — distinct from :func:`_load_config`, whose
+    env fallback always returns a dict and would clobber explicitly-set
+    config in env-only setups.
     """
     from pathlib import Path
 
@@ -319,6 +319,20 @@ def _load_config() -> dict:
             return json.loads(legacy_path.read_text(encoding="utf-8"))
         except Exception:
             pass
+    return None
+
+
+def _load_config() -> dict:
+    """Load config from profile-scoped path, legacy path, or env vars.
+
+    Resolution order:
+      1. $HERMES_HOME/hindsight/config.json  (profile-scoped)
+      2. ~/.hindsight/config.json             (legacy, shared)
+      3. Environment variables
+    """
+    file_config = _load_file_config()
+    if file_config is not None:
+        return file_config
 
     return {
         "mode": os.environ.get("HINDSIGHT_MODE", "cloud"),
@@ -902,6 +916,21 @@ class HindsightMemoryProvider(MemoryProvider):
                     raise ImportError(str(_e))
                 from hindsight import HindsightEmbedded
                 HindsightEmbedded.__del__ = lambda self: None
+                # Client creation is the daemon (re)spawn boundary: the
+                # embedded manager materializes ~/.hindsight/profiles/<p>.env
+                # from these kwargs. Re-read config.json here so a
+                # long-running gateway that recreates the client (idle
+                # shutdown / stale-connection retry) uses current on-disk
+                # settings instead of its initialize()-time snapshot —
+                # otherwise an edit like an llm_model bump is silently
+                # reverted at the next respawn. File-gated on purpose:
+                # env-only setups keep their existing config, and
+                # session-shaping fields (banks, recall tuning) keep their
+                # initialize()-time values for in-session stability.
+                fresh_config = _load_file_config()
+                if fresh_config is not None:
+                    self._config = fresh_config
+                    self._llm_base_url = fresh_config.get("llm_base_url", "")
                 llm_provider = self._config.get("llm_provider", "")
                 if llm_provider in {"openai_compatible", "openrouter"}:
                     llm_provider = "openai"

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -297,7 +297,7 @@ class TestConfig:
 
         assert env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] == "42"
 
-    def test_get_client_passes_idle_timeout_to_hindsight_embedded(self, monkeypatch):
+    def test_get_client_passes_idle_timeout_to_hindsight_embedded(self, tmp_path, monkeypatch):
         captured = {}
 
         class FakeHindsightEmbedded:
@@ -306,6 +306,10 @@ class TestConfig:
 
         monkeypatch.setitem(sys.modules, "hindsight", SimpleNamespace(HindsightEmbedded=FakeHindsightEmbedded))
         monkeypatch.setattr("plugins.memory.hindsight._check_local_runtime", lambda: (True, ""))
+        # Hermetic against a real host config: client creation re-reads the
+        # on-disk config when one exists, so point the lookup at an empty tmp.
+        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))  # legacy ~/.hindsight fallback
 
         p = HindsightMemoryProvider()
         p._mode = "local_embedded"
@@ -322,6 +326,60 @@ class TestConfig:
 
         assert captured["idle_timeout"] == 0
         assert captured["llm_provider"] == "openai"
+
+    def test_get_client_rereads_disk_config_at_respawn(self, tmp_path, monkeypatch):
+        """Client recreation must pick up config.json edits made after init.
+
+        A long-running gateway recreates the embedded client after daemon
+        idle-shutdown or stale-connection retries; the embedded manager then
+        re-materializes the profile .env from the client kwargs. Before the
+        fix it used the initialize()-time snapshot, silently reverting
+        on-disk edits (e.g. an llm_model bump) at the next respawn.
+        """
+        captured = {}
+
+        class FakeHindsightEmbedded:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        monkeypatch.setitem(sys.modules, "hindsight", SimpleNamespace(HindsightEmbedded=FakeHindsightEmbedded))
+        monkeypatch.setattr("plugins.memory.hindsight._check_local_runtime", lambda: (True, ""))
+        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps({
+            "mode": "local_embedded",
+            "profile": "hermes",
+            "llm_provider": "openai",
+            "llm_api_key": "test-key",
+            "llm_model": "old-model",
+            "idle_timeout": 0,
+        }))
+
+        p = HindsightMemoryProvider()
+        p._mode = "local_embedded"
+        p._config = json.loads(config_path.read_text())  # initialize()-time snapshot
+        p._llm_base_url = ""
+
+        # Operator edits config.json while the gateway keeps running.
+        config_path.write_text(json.dumps({
+            "mode": "local_embedded",
+            "profile": "hermes",
+            "llm_provider": "openai",
+            "llm_api_key": "test-key",
+            "llm_model": "new-model",
+            "llm_base_url": "http://localhost:9001/v1",
+            "idle_timeout": 0,
+        }))
+
+        # Respawn boundary: stale-connection retry recreates the client.
+        p._client = None
+        p._get_client()
+
+        assert captured["llm_model"] == "new-model"
+        assert captured["llm_base_url"] == "http://localhost:9001/v1"
+        assert p._config["llm_model"] == "new-model"
 
 
 class TestPostSetup:


### PR DESCRIPTION
Fixes #44804.

## Problem

The provider caches `config.json` at `initialize()` and never re-reads it. When a long-running gateway recreates the embedded client (idle shutdown / stale-connection retry in `_call_with_idle_retry`), the embedded manager re-materializes `~/.hindsight/profiles/<p>.env` from that initialize()-time snapshot — silently reverting any `config.json` edits made while the gateway was running (observed: an `llm_model` bump undone by a respawn; details in the issue).

## Fix

Client creation is the daemon (re)spawn boundary, so re-read the on-disk config exactly there (`_get_client`, local_embedded branch). Two deliberate scope choices:

- **File-gated**: a new `_load_file_config()` helper (= `_load_config` minus the env fallback, now reused by it) returns `None` when no config file exists, so env-only setups keep their explicitly-set config instead of being clobbered by the always-non-empty env-fallback dict.
- **Daemon-facing only**: `self._config` and `_llm_base_url` refresh; session-shaping derived fields (banks, recall tuning) keep their initialize()-time values for in-session stability.

Cost: one small JSON file read per client creation (rare — only on daemon respawn), nothing on the per-request path.

## Tests

- New `test_get_client_rereads_disk_config_at_respawn`: init snapshot with model A → edit config.json to model B + new base_url → simulate the retry path (`_client = None` → `_get_client()`) → asserts the fake `HindsightEmbedded` received the fresh values.
- Hardened the existing `test_get_client_passes_idle_timeout_to_hindsight_embedded` to be hermetic against a real host config (it previously depended on no config.json existing at the real `HERMES_HOME`; with the re-read it would have absorbed the host's file).
- `tests/plugins/memory/test_hindsight_provider.py`: **103 passed** locally (macOS, Python 3.11, repo venv).

## Notes for review

- No behavior change for cloud / local_external modes (the re-read sits inside the local_embedded branch).
- The startup `_start_daemon` thread already handled the config-changed-at-boot case by comparing the materialized `.env`; this PR extends the same freshness guarantee to mid-life respawns.