### PR TITLE
feat(gateway): allow chat_id:thread_id in Telegram allowed_chats

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5285,9 +5285,25 @@ class TelegramAdapter(BasePlatformAdapter):
         # allowed_chats check (whitelist). When set, group messages from chats
         # outside the whitelist are ignored unless guest_mode permits this
         # exact message as an explicit direct mention. DMs are excluded above.
+        # Supports chat_id alone (legacy, matches any thread) and chat_id:thread_id
+        # (matches only that specific topic). If any entry uses :thread_id format,
+        # strict thread-level filtering is applied.
         allowed = self._telegram_allowed_chats()
-        if allowed and chat_id_str not in allowed:
-            return guest_mention
+        if allowed:
+            has_thread_entries = any(":" in a for a in allowed)
+            if has_thread_entries:
+                # Strict mode: check chat_id:thread_id first, then chat_id bare
+                if thread_id is not None:
+                    candidate = f"{chat_id_str}:{thread_id}"
+                    if candidate not in allowed and chat_id_str not in allowed:
+                        return guest_mention
+                else:
+                    if chat_id_str not in allowed:
+                        return guest_mention
+            else:
+                # Legacy mode: chat_id match only
+                if chat_id_str not in allowed:
+                    return guest_mention
 
         if guest_mention:
             return True

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -1162,3 +1162,76 @@ def test_unmentioned_unsupported_document_observed_without_caching(monkeypatch):
         assert "unsupported" in message["content"].lower()
 
     asyncio.run(_run())
+
+
+def test_allowed_chats_with_thread_id_strict_mode():
+    """When any allowed_chats entry uses chat_id:thread_id, exact match is required."""
+    adapter = _make_adapter(require_mention=False, allowed_chats=["-100:1", "-200:5"])
+
+    # Exact matches pass
+    assert adapter._should_process_message(_group_message("hello", chat_id=-100, thread_id=1)) is True
+    assert adapter._should_process_message(_group_message("hello", chat_id=-200, thread_id=5)) is True
+
+    # Wrong thread_id is blocked
+    assert adapter._should_process_message(_group_message("hello", chat_id=-100, thread_id=2)) is False
+    assert adapter._should_process_message(_group_message("hello", chat_id=-200, thread_id=1)) is False
+
+    # Chat not in list at all is blocked
+    assert adapter._should_process_message(_group_message("hello", chat_id=-300, thread_id=1)) is False
+
+
+def test_allowed_chats_strict_mode_allows_chat_id_without_thread():
+    """In strict mode, a bare chat_id entry still allows that chat in any thread."""
+    adapter = _make_adapter(require_mention=False, allowed_chats=["-100:1", "-200"])
+
+    # Exact thread match
+    assert adapter._should_process_message(_group_message("hello", chat_id=-100, thread_id=1)) is True
+    # Bare chat_id allows any thread in that chat
+    assert adapter._should_process_message(_group_message("hello", chat_id=-200, thread_id=99)) is True
+    assert adapter._should_process_message(_group_message("hello", chat_id=-200, thread_id=None)) is True
+    # Other chat blocked
+    assert adapter._should_process_message(_group_message("hello", chat_id=-300, thread_id=1)) is False
+
+
+def test_allowed_chats_legacy_mode_without_colon():
+    """When no entry uses chat_id:thread_id, legacy chat-only matching applies."""
+    adapter = _make_adapter(require_mention=False, allowed_chats=["-100", "-200"])
+
+    assert adapter._should_process_message(_group_message("hello", chat_id=-100, thread_id=1)) is True
+    assert adapter._should_process_message(_group_message("hello", chat_id=-100, thread_id=None)) is True
+    assert adapter._should_process_message(_group_message("hello", chat_id=-200, thread_id=99)) is True
+    assert adapter._should_process_message(_group_message("hello", chat_id=-300, thread_id=1)) is False
+
+
+def test_allowed_chats_strict_mode_does_not_filter_dms():
+    """DMs bypass allowed_chats regardless of strict mode."""
+    adapter = _make_adapter(require_mention=False, allowed_chats=["-100:1"])
+
+    assert adapter._should_process_message(_dm_message("hello")) is True
+
+
+def test_allowed_chats_strict_mode_with_guest_mode_mention():
+    """Guest mention outside strict allowed_chats still passes."""
+    adapter = _make_adapter(
+        require_mention=True,
+        allowed_chats=["-100:1"],
+        guest_mode=True,
+    )
+
+    # Mentioned in allowed chat+thread passes
+    mentioned = _group_message(
+        "hi @hermes_bot", chat_id=-100, thread_id=1,
+        entities=[_mention_entity("hi @hermes_bot")],
+    )
+    assert adapter._should_process_message(mentioned) is True
+
+    # Mentioned outside allowed chat+thread also passes (guest mode)
+    mentioned_outside = _group_message(
+        "hi @hermes_bot", chat_id=-100, thread_id=2,
+        entities=[_mention_entity("hi @hermes_bot")],
+    )
+    assert adapter._should_process_message(mentioned_outside) is True
+
+    # Not mentioned outside allowed chat+thread is blocked
+    not_mentioned = _group_message("hello", chat_id=-100, thread_id=2)
+    assert adapter._should_process_message(not_mentioned) is False


### PR DESCRIPTION
## What

Extends `telegram.allowed_chats` to support `chat_id:thread_id` entries for forum supergroups, while keeping backward compatibility with bare `chat_id` entries.

## Behavior

- If any entry in `allowed_chats` contains `:`, the adapter switches to **strict mode**.
- In strict mode, a message from a forum topic must match either `chat_id:thread_id` (exact topic) or `chat_id` (any topic in that chat).
- If no entry uses `:`, **legacy behavior** applies (`chat_id` match only).

Example:

```yaml
telegram:
  allowed_chats:
    - -1001234567890:1   # only topic 1 in this group
    - -1001234567890:5   # only topic 5 in this group
    - -2001234567890     # any topic in this group
```

## Tests

Added 5 new test cases in `test_telegram_group_gating.py`:
- strict mode exact match
- strict mode with bare `chat_id` wildcard
- legacy mode without colon
- DMs bypass strict mode
- `guest_mode` mentions still work outside allowed topics

## Checklist

- [x] Code follows existing style
- [x] Tests added and passing
- [x] Backward compatible (no colon = no behavior change)
- [x] No new dependencies
- [x] No new env vars
