### PR TITLE
feat(skills): add version history and rollback for user skills

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -24,6 +24,7 @@ from rich.table import Table
 # tools.skills_hub and tools.skills_guard are imported inside functions.
 from hermes_constants import display_hermes_home
 from agent.skill_utils import is_excluded_skill_path
+from tools.skill_versioning import do_skills_log, do_skills_revert
 
 _console = Console()
 
@@ -1653,8 +1654,15 @@ def skills_command(args) -> None:
             _console.print("Usage: hermes skills tap [list|add|remove]\n")
             return
         do_tap(tap_action, repo=repo)
+    elif action == "log":
+        do_skills_log(name=getattr(args, "name", ""))
+    elif action == "revert":
+        do_skills_revert(
+            name=getattr(args, "name", ""),
+            to_version=getattr(args, "to", None),
+        )
     else:
-        _console.print("Usage: hermes skills [browse|search|install|inspect|list|check|update|audit|uninstall|reset|opt-out|opt-in|publish|snapshot|tap]\n")
+        _console.print("Usage: hermes skills [browse|search|install|inspect|list|check|update|audit|uninstall|reset|opt-out|opt-in|publish|snapshot|tap|log|revert]\n")
         _console.print("Run 'hermes skills <command> --help' for details.\n")
 
 

--- a/hermes_cli/subcommands/skills.py
+++ b/hermes_cli/subcommands/skills.py
@@ -261,6 +261,23 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
     tap_rm = tap_subparsers.add_parser("remove", help="Remove a tap")
     tap_rm.add_argument("name", help="Tap name to remove")
 
+    # skill history subcommands
+    skills_log = skills_subparsers.add_parser(
+        "log", help="Show version history of a skill"
+    )
+    skills_log.add_argument("name", help="Skill name to inspect")
+
+    skills_revert = skills_subparsers.add_parser(
+        "revert", help="Revert a skill to a previous version"
+    )
+    skills_revert.add_argument("name", help="Skill name to revert")
+    skills_revert.add_argument(
+        "--to",
+        type=int,
+        required=True,
+        help="Target version number (use `hermes skills log <name>` to see available versions)",
+    )
+
     # config sub-action: interactive enable/disable
     skills_subparsers.add_parser(
         "config",

--- a/tests/tools/test_skill_versioning.py
+++ b/tests/tools/test_skill_versioning.py
@@ -1,0 +1,290 @@
+"""Tests for tools/skill_versioning.py — skill version history and rollback."""
+
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tools.skill_versioning import (
+    get_version,
+    list_versions,
+    revert_skill,
+    save_version,
+)
+
+_VALID_SKILL_V1 = """\
+---
+name: test-skill
+description: A test skill.
+---
+
+# Test Skill v1
+
+Step 1: Do the thing.
+"""
+
+_VALID_SKILL_V2 = """\
+---
+name: test-skill
+description: Updated description.
+---
+
+# Test Skill v2
+
+Step 1: Do the new thing.
+"""
+
+
+@contextmanager
+def _skill_env(tmp_path):
+    """Isolate skills directory and wire up _find_skill to look inside it."""
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    with patch("tools.skill_manager_tool.SKILLS_DIR", skills_dir), \
+         patch("agent.skill_utils.get_all_skills_dirs", return_value=[skills_dir]), \
+         patch("tools.skill_versioning.save_version.MAX_VERSIONS_DEFAULT", 5):
+        yield skills_dir
+
+
+def _create_skill_on_disk(skills_dir: Path, name: str = "test-skill",
+                          content: str = _VALID_SKILL_V1,
+                          category: str = "") -> Path:
+    """Create a skill directory and SKILL.md for testing."""
+    if category:
+        skill_dir = skills_dir / category / name
+    else:
+        skill_dir = skills_dir / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+    return skill_dir
+
+
+# ── save_version ──────────────────────────────────────────────────────────
+
+
+class TestSaveVersion:
+    """Test version snapshot creation."""
+
+    def test_save_initial_version(self, tmp_path):
+        with _skill_env(tmp_path) as skills_dir:
+            _create_skill_on_disk(skills_dir)
+            assert save_version("test-skill") is True
+
+            # Verify version directory
+            vdir = skills_dir / ".history" / "test-skill" / "1"
+            assert (vdir / "SKILL.md").exists()
+            assert (vdir / "SKILL.md").read_text(encoding="utf-8") == _VALID_SKILL_V1
+
+            # Verify meta.json
+            meta = json.loads((skills_dir / ".history" / "test-skill" / "meta.json").read_text())
+            assert len(meta["versions"]) == 1
+            assert meta["versions"][0]["v"] == 1
+            assert meta["versions"][0]["action"] == "create"
+
+    def test_save_multiple_versions(self, tmp_path):
+        with _skill_env(tmp_path) as skills_dir:
+            _create_skill_on_disk(skills_dir)
+            save_version("test-skill")  # v1
+
+            # Update content and save again
+            skill_md = skills_dir / "test-skill" / "SKILL.md"
+            skill_md.write_text(_VALID_SKILL_V2, encoding="utf-8")
+            assert save_version("test-skill") is True  # v2
+
+            meta = json.loads((skills_dir / ".history" / "test-skill" / "meta.json").read_text())
+            assert len(meta["versions"]) == 2
+            assert meta["versions"][0]["v"] == 1
+            assert meta["versions"][1]["v"] == 2
+            assert meta["versions"][1]["action"] == "edit"
+
+    def test_save_missing_skill_returns_false(self, tmp_path):
+        with _skill_env(tmp_path):
+            assert save_version("nonexistent") is False
+
+    def test_save_skill_without_skilLmd_returns_false(self, tmp_path):
+        with _skill_env(tmp_path) as skills_dir:
+            # Create directory but no SKILL.md
+            (skills_dir / "empty-skill").mkdir()
+            assert save_version("empty-skill") is False
+
+    def test_prune_old_versions(self, tmp_path):
+        with _skill_env(tmp_path) as skills_dir:
+            _create_skill_on_disk(skills_dir)
+            for i in range(7):  # max is 5, so we push past it
+                save_version("test-skill")
+                # Rotate content slightly each time so each version is unique
+                skill_md = skills_dir / "test-skill" / "SKILL.md"
+                current = skill_md.read_text(encoding="utf-8")
+                skill_md.write_text(current.replace(f"v1", f"v{i+2}"), encoding="utf-8")
+
+            meta = json.loads((skills_dir / ".history" / "test-skill" / "meta.json").read_text())
+            # Should only have 5 versions (the newest ones)
+            assert len(meta["versions"]) == 5
+            # Oldest version should be v3 (since v1 and v2 were pruned)
+            assert meta["versions"][0]["v"] == 3
+            assert meta["versions"][-1]["v"] == 7
+
+
+# ── list_versions ─────────────────────────────────────────────────────────
+
+
+class TestListVersions:
+    """Test listing version history."""
+
+    def test_list_versions(self, tmp_path):
+        with _skill_env(tmp_path) as skills_dir:
+            _create_skill_on_disk(skills_dir)
+            save_version("test-skill")
+            # Second version
+            skill_md = skills_dir / "test-skill" / "SKILL.md"
+            skill_md.write_text(_VALID_SKILL_V2, encoding="utf-8")
+            save_version("test-skill")
+
+            versions = list_versions("test-skill")
+            assert len(versions) == 2
+            # Newest first
+            assert versions[0]["v"] == 2
+            assert versions[1]["v"] == 1
+
+    def test_list_versions_empty(self, tmp_path):
+        with _skill_env(tmp_path):
+            assert list_versions("nonexistent") == []
+
+
+# ── get_version ───────────────────────────────────────────────────────────
+
+
+class TestGetVersion:
+    """Test retrieving a specific version's content."""
+
+    def test_get_version(self, tmp_path):
+        with _skill_env(tmp_path) as skills_dir:
+            _create_skill_on_disk(skills_dir)
+            save_version("test-skill")
+
+            content = get_version("test-skill", 1)
+            assert content == _VALID_SKILL_V1
+
+    def test_get_nonexistent_version(self, tmp_path):
+        with _skill_env(tmp_path):
+            assert get_version("test-skill", 99) is None
+
+
+# ── revert_skill ──────────────────────────────────────────────────────────
+
+
+class TestRevertSkill:
+    """Test reverting a skill to a previous version."""
+
+    def test_revert_to_version(self, tmp_path):
+        with _skill_env(tmp_path) as skills_dir:
+            _create_skill_on_disk(skills_dir)
+            save_version("test-skill")  # v1
+
+            skill_md = skills_dir / "test-skill" / "SKILL.md"
+            skill_md.write_text(_VALID_SKILL_V2, encoding="utf-8")
+            save_version("test-skill")  # v2
+
+            # Mock security scan to pass
+            with patch("tools.skill_versioning.save_version._security_scan_skill",
+                       return_value=None if False else None):
+                with patch("tools.skill_manager_tool._security_scan_skill",
+                           return_value=None):
+                    result = revert_skill("test-skill", 1)
+
+            assert result.get("success") is True
+            assert result.get("to_version") == 1
+
+            # Live SKILL.md should now contain v1 content
+            live = skill_md.read_text(encoding="utf-8")
+            assert live == _VALID_SKILL_V1
+
+    def test_revert_to_nonexistent_version(self, tmp_path):
+        with _skill_env(tmp_path) as skills_dir:
+            _create_skill_on_disk(skills_dir)
+            save_version("test-skill")
+
+            result = revert_skill("test-skill", 99)
+            assert result.get("success") is False
+            assert "not found" in result.get("error", "")
+
+    def test_revert_nonexistent_skill(self, tmp_path):
+        with _skill_env(tmp_path):
+            result = revert_skill("ghost", 1)
+            assert result.get("success") is False
+            assert "not found" in result.get("error", "")
+
+
+# ── Integration: save on create/edit/patch via skill_manager hooks ────────
+
+
+class TestManagerToolHooks:
+    """Verify that skill_manager_tool hooks create version history."""
+
+    @contextmanager
+    def _manager_env(self, tmp_path):
+        """Patches all the paths skill_manager_tool and skill_versioning need."""
+        from tools import skill_manager_tool as smt
+        from tools import skill_versioning as sv
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        with patch.object(smt, "SKILLS_DIR", skills_dir), \
+             patch.object(sv, "save_version._history_dir",
+                          lambda n: skills_dir / ".history" / n) if False else \
+             patch("agent.skill_utils.get_all_skills_dirs", return_value=[skills_dir]), \
+             patch("tools.skill_manager_tool._security_scan_skill", return_value=None), \
+             patch("tools.skill_versioning.save_version._max_versions",
+                   return_value=10):
+            yield skills_dir
+
+    def _create_skill_via_manager(self, skills_dir: Path):
+        """Use skill_manage to create a skill (triggers save_version hook)."""
+        from tools.skill_manager_tool import _create_skill
+        return _create_skill("test-skill", _VALID_SKILL_V1)
+
+    def _edit_skill_via_manager(self, skills_dir: Path):
+        from tools.skill_manager_tool import _edit_skill
+        return _edit_skill("test-skill", _VALID_SKILL_V2)
+
+    def test_create_triggers_version(self, tmp_path):
+        with self._manager_env(tmp_path) as skills_dir:
+            result = self._create_skill_via_manager(skills_dir)
+            assert result.get("success") is True
+
+            # Version history should exist
+            meta_path = skills_dir / ".history" / "test-skill" / "meta.json"
+            assert meta_path.exists(), f"meta.json not found at {meta_path}"
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+            assert len(meta["versions"]) == 1
+            assert meta["versions"][0]["v"] == 1
+
+    def test_edit_triggers_new_version(self, tmp_path):
+        with self._manager_env(tmp_path) as skills_dir:
+            self._create_skill_via_manager(skills_dir)
+            result = self._edit_skill_via_manager(skills_dir)
+            assert result.get("success") is True
+
+            meta_path = skills_dir / ".history" / "test-skill" / "meta.json"
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+            assert len(meta["versions"]) == 2
+            # v1 = create, v2 = edit
+            assert meta["versions"][0]["action"] == "create"
+            assert meta["versions"][1]["action"] == "edit"
+
+    def test_edit_saves_old_content(self, tmp_path):
+        """Edit should save the OLD content as a version before overwriting."""
+        with self._manager_env(tmp_path) as skills_dir:
+            self._create_skill_via_manager(skills_dir)
+            self._edit_skill_via_manager(skills_dir)
+
+            # Version 1 should contain the original V1 content
+            v1 = get_version("test-skill", 1)
+            assert v1 == _VALID_SKILL_V1
+
+            # Live file should be V2
+            live = (skills_dir / "test-skill" / "SKILL.md").read_text(encoding="utf-8")
+            assert live == _VALID_SKILL_V2

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -44,6 +44,7 @@ from typing import Dict, Any, List, Optional, Tuple
 
 from utils import atomic_replace, is_truthy_value
 from hermes_cli.config import cfg_get
+from tools.skill_versioning import save_version
 
 logger = logging.getLogger(__name__)
 
@@ -518,6 +519,9 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
     skill_md = skill_dir / "SKILL.md"
     _atomic_write_text(skill_md, content)
 
+    # Save initial version in history
+    save_version(name, skill_dir=skill_dir)
+
     # Security scan — roll back on block
     scan_error = _security_scan_skill(skill_dir)
     if scan_error:
@@ -556,6 +560,9 @@ def _edit_skill(name: str, content: str) -> Dict[str, Any]:
     skill_md = existing["path"] / "SKILL.md"
     # Back up original content for rollback
     original_content = skill_md.read_text(encoding="utf-8") if skill_md.exists() else None
+    # Save current state as a new version before overwriting
+    save_version(name, skill_dir=existing["path"])
+
     _atomic_write_text(skill_md, content)
 
     # Security scan — roll back on block
@@ -653,6 +660,9 @@ def _patch_skill(
 
     original_content = content  # for rollback
     _atomic_write_text(target, new_content)
+    # Save old state as a new version before applying patch
+    if not file_path:
+        save_version(name, skill_dir=skill_dir)
 
     # Security scan — roll back on block
     scan_error = _security_scan_skill(skill_dir)

--- a/tools/skill_versioning.py
+++ b/tools/skill_versioning.py
@@ -1,0 +1,347 @@
+"""Skill version history — track changes to user skills and enable rollback.
+
+Stores version snapshots under ``~/.hermes/skills/.history/<skill-name>/``.
+Each version is a numbered subdirectory containing the full ``SKILL.md``
+content.  A ``meta.json`` manifest tracks version metadata (timestamp,
+origin, action).
+
+Designed to be called from ``skill_manager_tool``'s create/edit/patch hooks
+and from the CLI via ``hermes skills log`` / ``hermes skills revert``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from hermes_cli.config import cfg_get, load_config
+
+logger = logging.getLogger(__name__)
+
+# ── History directory ─────────────────────────────────────────────────────
+
+HISTORY_DIR_NAME = ".history"
+MAX_VERSIONS_DEFAULT = 10
+
+
+def _history_dir(name: str) -> Path:
+    """Return the history directory for a named skill.
+
+    Lives under ``SKILLS_DIR / ".history" / <name>``, making it invisible
+    to normal skill scanning and tooling.
+    """
+    from tools.skill_manager_tool import SKILLS_DIR
+    return SKILLS_DIR / HISTORY_DIR_NAME / name
+
+
+def _meta_path(name: str) -> Path:
+    """Path to the version manifest."""
+    return _history_dir(name) / "meta.json"
+
+
+def _version_dir(name: str, version_num: int) -> Path:
+    """Path to a specific version's snapshot directory."""
+    return _history_dir(name) / str(version_num)
+
+
+def _current_ts() -> str:
+    """ISO-8601 timestamp for version metadata."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _max_versions() -> int:
+    """Read ``skills.max_versions`` from config, fall back to default."""
+    try:
+        cfg = load_config()
+        val = cfg_get(cfg, "skills", "max_versions")
+        if val is not None:
+            return max(1, int(val))
+    except Exception:
+        pass
+    return MAX_VERSIONS_DEFAULT
+
+
+# ── Version manifest helpers ──────────────────────────────────────────────
+
+
+def _read_meta(name: str) -> list:
+    """Read the version manifest, returning list of version dicts (oldest first).
+
+    Returns an empty list when the manifest is missing or corrupt.
+    """
+    path = _meta_path(name)
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data.get("versions", [])
+    except Exception:
+        logger.warning("Corrupt meta.json for skill '%s'; resetting history.", name)
+        path.unlink(missing_ok=True)
+        return []
+
+
+def _write_meta(name: str, versions: list) -> None:
+    """Persist the version manifest to disk."""
+    path = _meta_path(name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"versions": versions}, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+# ── Write origin helper ───────────────────────────────────────────────────
+
+
+def _current_origin() -> str:
+    """Return the active write origin (foreground vs background_review).
+
+    Falls back to ``"foreground"`` when the provenance module is unavailable
+    or the ContextVar hasn't been set.
+    """
+    try:
+        from tools.skill_provenance import get_current_write_origin
+        return get_current_write_origin() or "foreground"
+    except Exception:
+        return "foreground"
+
+
+# ── Core API ──────────────────────────────────────────────────────────────
+
+
+def save_version(name: str, skill_dir: Path | None = None) -> bool:
+    """Snapshot the current SKILL.md as a new version.
+
+    Parameters
+    ----------
+    name : str
+        Skill name (used for the history directory path).
+    skill_dir : Path or None
+        The skill's directory on disk.  When ``None`` (e.g. from CLI),
+        the function looks up the skill via ``_find_skill``.
+
+    Returns
+    -------
+    bool
+        ``True`` when a snapshot was saved, ``False`` when the skill
+        doesn't exist or has no SKILL.md on disk.
+
+    Notes
+    -----
+    Call this *before* making any change you want to preserve the old
+    state — the snapshot is taken from the live file.
+
+    Oldest versions are pruned when the total exceeds ``skills.max_versions``
+    (default 10), configurable in ``~/.hermes/config.yaml``.
+    """
+    if skill_dir is None:
+        from tools.skill_manager_tool import _find_skill
+
+        existing = _find_skill(name)
+        if not existing:
+            logger.debug("save_version: skill '%s' not found, skipping.", name)
+            return False
+        skill_dir = existing["path"]
+
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.exists():
+        logger.debug("save_version: no SKILL.md at %s, skipping.", skill_md)
+        return False
+
+    content = skill_md.read_text(encoding="utf-8")
+    if not content.strip():
+        return False
+
+    # Determine the next version number
+    versions = _read_meta(name)
+    next_v = (versions[-1]["v"] + 1) if versions else 1
+
+    # Write the full SKILL.md snapshot
+    vdir = _version_dir(name, next_v)
+    vdir.mkdir(parents=True, exist_ok=True)
+    (vdir / "SKILL.md").write_text(content, encoding="utf-8")
+
+    # Update the version manifest
+    origin = _current_origin()
+    entry = {
+        "v": next_v,
+        "ts": _current_ts(),
+        "action": "create" if next_v == 1 else "edit",
+        "origin": origin,
+    }
+    versions.append(entry)
+    _write_meta(name, versions)
+
+    # Prune old versions when exceeding the configured limit
+    _prune_old(name, versions)
+
+    logger.debug("Saved version %d for skill '%s' (%s)", next_v, name, origin)
+    return True
+
+
+def list_versions(name: str) -> List[Dict[str, Any]]:
+    """Return version history for a skill, newest first.
+
+    Each entry has the shape::
+
+        {"v": int, "ts": str, "action": str, "origin": str}
+
+    Returns an empty list when the skill has no history.
+    """
+    return list(reversed(_read_meta(name)))
+
+
+def get_version(name: str, version_num: int) -> Optional[str]:
+    """Return the SKILL.md content of a specific version, or ``None``."""
+    vdir = _version_dir(name, version_num)
+    skill_md = vdir / "SKILL.md"
+    if not skill_md.exists():
+        return None
+    return skill_md.read_text(encoding="utf-8")
+
+
+def revert_skill(name: str, version_num: int) -> Dict[str, Any]:
+    """Revert a skill to a previous version.
+
+    The workflow is:
+
+    1. Save the **current** live state as a new version (so the revert
+       itself is reversible).
+    2. Validate the target version's frontmatter.
+    3. Copy the target version's ``SKILL.md`` back to the live skill
+       directory.
+    4. Run the security scan on the restored content.
+
+    Returns
+    -------
+    dict
+        ``{"success": True, "message": "...", "to_version": N}`` on
+        success, or ``{"success": False, "error": "..."}`` on failure.
+    """
+    from tools.skill_manager_tool import (
+        _atomic_write_text,
+        _find_skill,
+        _security_scan_skill,
+        _skill_not_found_error,
+        _validate_content_size,
+        _validate_frontmatter,
+    )
+
+    # 1. Verify the target version exists
+    content = get_version(name, version_num)
+    if content is None:
+        return {
+            "success": False,
+            "error": f"Version {version_num} not found for skill '{name}'.",
+        }
+
+    # 2. Find the skill on disk
+    existing = _find_skill(name)
+    if not existing:
+        return {"success": False, "error": _skill_not_found_error(name)}
+
+    # 3. Validate the old content (it should still be valid)
+    err = _validate_frontmatter(content)
+    if err:
+        return {
+            "success": False,
+            "error": f"Cannot revert: version {version_num} has invalid frontmatter: {err}",
+        }
+    err = _validate_content_size(content)
+    if err:
+        return {
+            "success": False,
+            "error": f"Cannot revert: version {version_num} exceeds size limit: {err}",
+        }
+
+    # 4. Save the current live state as a new version (revert is reversible)
+    save_version(name, skill_dir=existing["path"])
+
+    # 5. Write the old content back
+    skill_md = existing["path"] / "SKILL.md"
+    _atomic_write_text(skill_md, content)
+
+    # 6. Run the security scan on the restored content
+    scan_error = _security_scan_skill(existing["path"])
+    if scan_error:
+        return {
+            "success": False,
+            "error": f"Revert applied but security scan blocked the result: {scan_error}",
+        }
+
+    logger.info("Skill '%s' reverted to version %d", name, version_num)
+    return {
+        "success": True,
+        "message": f"Skill '{name}' reverted to version {version_num}.",
+        "to_version": version_num,
+    }
+
+
+# ── Pruning ───────────────────────────────────────────────────────────────
+
+
+def _prune_old(name: str, versions: list) -> None:
+    """Remove the oldest on-disk versions when exceeding ``max_versions``.
+
+    Mutates ``versions`` in place and persists the updated manifest.
+    """
+    max_v = _max_versions()
+    while len(versions) > max_v:
+        oldest = versions.pop(0)
+        vdir = _version_dir(name, oldest["v"])
+        if vdir.exists():
+            shutil.rmtree(vdir, ignore_errors=True)
+        logger.debug("Pruned version %d for skill '%s'", oldest["v"], name)
+    _write_meta(name, versions)
+
+
+# ── CLI helpers ───────────────────────────────────────────────────────────
+
+
+def do_skills_log(name: str) -> None:
+    """Print version history for a skill to stdout (CLI handler)."""
+    from rich.console import Console
+    from rich.table import Table
+    console = Console()
+
+    versions = list_versions(name)
+    if not versions:
+        console.print(f"[yellow]No version history found for skill '{name}'.[/yellow]")
+        console.print("Version history is created automatically when you edit a skill.")
+        return
+
+    table = Table(title=f"Version History: {name}")
+    table.add_column("Version", style="cyan", no_wrap=True)
+    table.add_column("Timestamp", style="dim")
+    table.add_column("Action", style="green")
+    table.add_column("Origin")
+
+    for v in versions:
+        origin_label = v.get("origin", "foreground")
+        origin_style = "yellow" if origin_label == "background_review" else "white"
+        table.add_row(
+            str(v["v"]),
+            v.get("ts", "?"),
+            v.get("action", "?"),
+            f"[{origin_style}]{origin_label}[/{origin_style}]",
+        )
+
+    console.print(table)
+    console.print(f"\nUse [bold]hermes skills revert {name} --to <N>[/bold] to restore a version.")
+
+
+def do_skills_revert(name: str, to_version: int) -> None:
+    """Revert a skill to a specific version (CLI handler)."""
+    from rich.console import Console
+    console = Console()
+
+    result = revert_skill(name, to_version)
+    if result.get("success"):
+        console.print(f"[green]{result['message']}[/green]")
+    else:
+        console.print(f"[red]{result['error']}[/red]")


### PR DESCRIPTION
Adds `hermes skills log <name>` and `hermes skills revert <name> --to <N>` CLI commands, plus automatic version snapshots on create/edit/patch.

Key changes:
- New module `tools/skill_versioning.py` - save/list/get/revert version history
- `_create_skill`, `_edit_skill`, `_patch_skill` hooks save versions automatically
- `hermes skills log <name>` - table output of version history
- `hermes skills revert <name> --to <N>` - restore a previous version
- Configurable `skills.max_versions` (default 10) with automatic pruning
- Full test suite in `tests/tools/test_skill_versioning.py`