### PR TITLE
feat: propagate title_callback in TUI gateway for real-time title updates

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5587,12 +5587,29 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 try:
                     from agent.title_generator import maybe_auto_title
 
+                    _effective_sid = session.get("session_key") or sid
+
+                    def _title_generated(title: str, _sid=_effective_sid) -> None:
+                        """Notify connected clients when title is auto-generated."""
+                        try:
+                            _emit("session.info", _sid, _session_info(agent, session))
+                        except Exception:
+                            pass
+
                     maybe_auto_title(
                         _get_db(),
-                        session.get("session_key") or sid,
+                        _effective_sid,
                         text,
                         raw,
                         session.get("history", []),
+                        title_callback=_title_generated,
+                        main_runtime={
+                            "model": getattr(agent, "model", None),
+                            "provider": getattr(agent, "provider", None),
+                            "base_url": getattr(agent, "base_url", None),
+                            "api_key": getattr(agent, "api_key", None),
+                            "api_mode": getattr(agent, "api_mode", None),
+                        } if agent else None,
                     )
                 except Exception:
                     pass


### PR DESCRIPTION
## Summary

When a conversation title is auto-generated after the first assistant response, the TUI gateway now emits a `session.info` event to notify connected clients (WebUI, Desktop app) of the new title in real time.

## Problem

Previously, the TUI gateway called `maybe_auto_title()` without a `title_callback` or `main_runtime`, so:
- Connected clients never saw the title update until a page refresh
- The title generator could not use the session's model/provider for generation, falling back to defaults

## Solution

- Added a `_title_generated` callback that emits `session.info` via `_emit()` when a title is generated
- Passed `main_runtime` with the agent's model/provider/base_url/api_key/api_mode so the title generator can use the same provider as the session
- Aligns the TUI gateway with the main gateway behavior (which already propagates title callbacks for Telegram topic renames)

## Testing

- Verified the patch applies cleanly and passes existing linting
- The change is minimal and defensive (wrapped in try/except like the existing gateway pattern)