### PR TITLE
fix(curator): verify reference files exist on disk after consolidation

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -1005,6 +1005,118 @@ def _build_rename_summary(
     return "\n".join(lines)
 
 
+_REF_LINK_RE = re.compile(r"references/[\w\-./]+\.md")
+_REF_MIN_BYTES = 200
+
+
+def _verify_consolidation_integrity(
+    consolidated: List[Dict[str, Any]],
+    pruned: List[Dict[str, Any]],
+    skills_root: Path,
+    archive_root: Path,
+) -> Dict[str, Any]:
+    """Post-pass on-disk verification for the curator's consolidation claims.
+
+    The curator's LLM consolidation pass directs a subagent to copy each
+    sibling's content into ``<umbrella>/references/<topic>.md`` and then
+    archive the source. We trust the model's textual summary, but the
+    subagent occasionally drops the copy step while still listing the
+    reference in the new umbrella SKILL.md — silent dead links.
+
+    This helper independently checks each consolidation/pruning claim
+    against the filesystem and returns a structured report. It NEVER
+    raises: any error reading a SKILL.md is logged and that entry is
+    skipped, so verification failures cannot break the run report.
+    """
+    result: Dict[str, Any] = {
+        "consolidations_checked": 0,
+        "prunings_checked": 0,
+        "missing_refs": [],
+        "missing_archives": [],
+        "prunings_without_archive": [],
+        "prunings_with_empty_refs": [],
+        "ok": True,
+    }
+
+    for entry in consolidated or []:
+        if not isinstance(entry, dict):
+            continue
+        src = entry.get("name")
+        dst = entry.get("into")
+        if not src or not dst:
+            continue
+        result["consolidations_checked"] += 1
+
+        archived_skill = archive_root / src / "SKILL.md"
+        if not archived_skill.exists():
+            result["missing_archives"].append({"from": src, "into": dst})
+            continue
+
+        try:
+            body = archived_skill.read_text(encoding="utf-8", errors="replace")
+        except Exception as e:
+            logger.debug("Verifier could not read %s: %s", archived_skill, e)
+            continue
+
+        declared_refs = sorted(set(_REF_LINK_RE.findall(body)))
+        for ref in declared_refs:
+            target = skills_root / dst / ref
+            if not target.exists():
+                result["missing_refs"].append(
+                    {"from": src, "into": dst, "ref": ref, "reason": "absent"}
+                )
+            else:
+                try:
+                    if target.stat().st_size <= _REF_MIN_BYTES:
+                        result["missing_refs"].append(
+                            {"from": src, "into": dst, "ref": ref, "reason": "too_small"}
+                        )
+                except Exception as e:
+                    logger.debug("Verifier stat failed on %s: %s", target, e)
+
+    for entry in pruned or []:
+        if isinstance(entry, dict):
+            name = entry.get("name")
+        else:
+            name = entry
+        if not name:
+            continue
+        result["prunings_checked"] += 1
+
+        archived_skill = archive_root / name / "SKILL.md"
+        if not archived_skill.exists():
+            result["prunings_without_archive"].append(
+                {"name": name, "archive_missing": True}
+            )
+            continue
+
+        refs_dir = archive_root / name / "references"
+        if refs_dir.is_dir():
+            try:
+                if not any(refs_dir.iterdir()):
+                    result["prunings_with_empty_refs"].append({"name": name})
+            except Exception as e:
+                logger.debug("Verifier could not list %s: %s", refs_dir, e)
+
+    if (
+        result["missing_refs"]
+        or result["missing_archives"]
+        or result["prunings_without_archive"]
+        or result["prunings_with_empty_refs"]
+    ):
+        result["ok"] = False
+        logger.warning(
+            "Curator verification found issues: %d missing refs, %d missing archives, "
+            "%d prunings without archive, %d prunings with empty refs",
+            len(result["missing_refs"]),
+            len(result["missing_archives"]),
+            len(result["prunings_without_archive"]),
+            len(result["prunings_with_empty_refs"]),
+        )
+
+    return result
+
+
 def _write_run_report(
     *,
     started_at: datetime,
@@ -1135,6 +1247,30 @@ def _write_run_report(
             "error": str(e),
         }
 
+    # On-disk verification of the curator's consolidation/pruning claims.
+    # See _verify_consolidation_integrity for rationale (issue #44760).
+    skills_root = get_hermes_home() / "skills"
+    archive_root = skills_root / ".archive"
+    try:
+        verification = _verify_consolidation_integrity(
+            consolidated=consolidated,
+            pruned=pruned,
+            skills_root=skills_root,
+            archive_root=archive_root,
+        )
+    except Exception as e:
+        logger.debug("Curator verification helper failed: %s", e, exc_info=True)
+        verification = {
+            "consolidations_checked": 0,
+            "prunings_checked": 0,
+            "missing_refs": [],
+            "missing_archives": [],
+            "prunings_without_archive": [],
+            "prunings_with_empty_refs": [],
+            "ok": True,
+            "error": str(e),
+        }
+
     payload = {
         "started_at": started_at.isoformat(),
         "duration_seconds": round(elapsed_seconds, 2),
@@ -1152,6 +1288,11 @@ def _write_run_report(
             "state_transitions": len(transitions),
             "cron_jobs_rewritten": int(cron_rewrites.get("jobs_updated", 0)),
             "tool_calls_total": sum(tc_counts.values()),
+            "verification_missing_refs": len(verification.get("missing_refs", [])),
+            "verification_missing_archives": (
+                len(verification.get("missing_archives", []))
+                + len(verification.get("prunings_without_archive", []))
+            ),
         },
         "tool_call_counts": tc_counts,
         "archived": removed,
@@ -1161,6 +1302,7 @@ def _write_run_report(
         "added": added,
         "state_transitions": transitions,
         "cron_rewrites": cron_rewrites,
+        "verification": verification,
         "llm_final": llm_meta.get("final", ""),
         "llm_summary": llm_meta.get("summary", ""),
         "llm_error": llm_meta.get("error"),
@@ -1356,6 +1498,58 @@ def _render_report_markdown(p: Dict[str, Any]) -> str:
                 "(see `cron_rewrites.json`)"
             )
         lines.append("")
+
+    # Verification — on-disk audit of consolidation/pruning claims.
+    # Rendered only when there's at least one finding so normal runs
+    # stay quiet (issue #44760).
+    verification = p.get("verification") or {}
+    missing_refs = verification.get("missing_refs") or []
+    missing_archives = verification.get("missing_archives") or []
+    prunings_without_archive = verification.get("prunings_without_archive") or []
+    prunings_with_empty_refs = verification.get("prunings_with_empty_refs") or []
+    if (
+        missing_refs
+        or missing_archives
+        or prunings_without_archive
+        or prunings_with_empty_refs
+    ):
+        lines.append("## Verification\n")
+        archive_issues = (
+            len(missing_archives)
+            + len(prunings_without_archive)
+            + len(prunings_with_empty_refs)
+        )
+        lines.append(
+            f"⚠ Found {len(missing_refs)} dead reference link(s) and "
+            f"{archive_issues} archive-integrity issue(s).\n"
+        )
+        if missing_refs:
+            lines.append("### Missing references (declared by umbrella but not on disk)\n")
+            for entry in missing_refs:
+                lines.append(
+                    f"- `{entry.get('from','?')}` → `{entry.get('into','?')}` — "
+                    f"`{entry.get('ref','?')}` (reason: {entry.get('reason','?')})"
+                )
+            lines.append("")
+        if missing_archives:
+            lines.append("### Consolidations missing archived source\n")
+            for entry in missing_archives:
+                lines.append(
+                    f"- `{entry.get('from','?')}` → `{entry.get('into','?')}` — "
+                    "no archived SKILL.md at expected location"
+                )
+            lines.append("")
+        if prunings_without_archive or prunings_with_empty_refs:
+            lines.append("### Prunings without recoverable archive\n")
+            for entry in prunings_without_archive:
+                lines.append(
+                    f"- `{entry.get('name','?')}` — archive missing"
+                )
+            for entry in prunings_with_empty_refs:
+                lines.append(
+                    f"- `{entry.get('name','?')}` — archived references/ left empty"
+                )
+            lines.append("")
 
     # Full LLM final response
     final = (p.get("llm_final") or "").strip()

--- a/tests/agent/test_curator_verification.py
+++ b/tests/agent/test_curator_verification.py
@@ -1,0 +1,211 @@
+"""Tests for the curator's on-disk verification helper.
+
+The curator's LLM consolidation pass directs a subagent to copy each
+sibling skill's content into ``<umbrella>/references/<topic>.md``.
+The model's textual report sometimes claims success even when the
+subagent dropped one or more copy steps, leaving silent dead links in
+the new umbrella SKILL.md. ``_verify_consolidation_integrity`` audits
+these claims against the filesystem after the fact (issue #44760).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def curator_env(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "skills").mkdir()
+    (home / "skills" / ".archive").mkdir()
+    (home / "logs").mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    import importlib
+    import hermes_constants
+    importlib.reload(hermes_constants)
+    from agent import curator
+    importlib.reload(curator)
+    from tools import skill_usage
+    importlib.reload(skill_usage)
+    yield {"home": home, "curator": curator}
+
+
+def _seed_archived_skill(home: Path, name: str, refs: list[str]) -> None:
+    """Write an archived SKILL.md that declares the given references/."""
+    arch = home / "skills" / ".archive" / name
+    arch.mkdir(parents=True, exist_ok=True)
+    body = f"# {name}\n\nSee:\n"
+    for ref in refs:
+        body += f"- [{ref}]({ref})\n"
+    (arch / "SKILL.md").write_text(body, encoding="utf-8")
+    (arch / "references").mkdir(exist_ok=True)
+    for ref in refs:
+        target = arch / ref
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("x" * 400, encoding="utf-8")
+
+
+def _seed_umbrella_ref(home: Path, umbrella: str, ref: str, size: int = 400) -> None:
+    target = home / "skills" / umbrella / ref
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("x" * size, encoding="utf-8")
+
+
+def test_verification_clean_run(curator_env):
+    home = curator_env["home"]
+    curator = curator_env["curator"]
+
+    _seed_archived_skill(home, "alpha", ["references/a.md", "references/b.md"])
+    (home / "skills" / "umbrella").mkdir()
+    _seed_umbrella_ref(home, "umbrella", "references/a.md")
+    _seed_umbrella_ref(home, "umbrella", "references/b.md")
+
+    result = curator._verify_consolidation_integrity(
+        consolidated=[{"name": "alpha", "into": "umbrella"}],
+        pruned=[],
+        skills_root=home / "skills",
+        archive_root=home / "skills" / ".archive",
+    )
+    assert result["ok"] is True
+    assert result["consolidations_checked"] == 1
+    assert result["missing_refs"] == []
+    assert result["missing_archives"] == []
+    assert result["prunings_without_archive"] == []
+
+
+def test_verification_detects_missing_ref_file(curator_env):
+    home = curator_env["home"]
+    curator = curator_env["curator"]
+
+    _seed_archived_skill(
+        home,
+        "alpha",
+        ["references/a.md", "references/b.md", "references/c.md"],
+    )
+    (home / "skills" / "umbrella").mkdir()
+    _seed_umbrella_ref(home, "umbrella", "references/a.md")
+    _seed_umbrella_ref(home, "umbrella", "references/b.md")
+    # references/c.md was never copied — silent dead link
+
+    result = curator._verify_consolidation_integrity(
+        consolidated=[{"name": "alpha", "into": "umbrella"}],
+        pruned=[],
+        skills_root=home / "skills",
+        archive_root=home / "skills" / ".archive",
+    )
+    assert result["ok"] is False
+    assert len(result["missing_refs"]) == 1
+    miss = result["missing_refs"][0]
+    assert miss["from"] == "alpha"
+    assert miss["into"] == "umbrella"
+    assert miss["ref"] == "references/c.md"
+    assert miss["reason"] == "absent"
+
+
+def test_verification_detects_too_small_ref_file(curator_env):
+    home = curator_env["home"]
+    curator = curator_env["curator"]
+
+    _seed_archived_skill(home, "alpha", ["references/a.md"])
+    (home / "skills" / "umbrella").mkdir()
+    _seed_umbrella_ref(home, "umbrella", "references/a.md", size=50)
+
+    result = curator._verify_consolidation_integrity(
+        consolidated=[{"name": "alpha", "into": "umbrella"}],
+        pruned=[],
+        skills_root=home / "skills",
+        archive_root=home / "skills" / ".archive",
+    )
+    assert result["ok"] is False
+    assert len(result["missing_refs"]) == 1
+    assert result["missing_refs"][0]["reason"] == "too_small"
+
+
+def test_verification_detects_missing_archive_for_consolidation(curator_env):
+    home = curator_env["home"]
+    curator = curator_env["curator"]
+
+    result = curator._verify_consolidation_integrity(
+        consolidated=[{"name": "ghost", "into": "umbrella"}],
+        pruned=[],
+        skills_root=home / "skills",
+        archive_root=home / "skills" / ".archive",
+    )
+    assert result["ok"] is False
+    assert result["missing_archives"] == [{"from": "ghost", "into": "umbrella"}]
+
+
+def test_verification_detects_pruning_without_archive(curator_env):
+    home = curator_env["home"]
+    curator = curator_env["curator"]
+
+    result = curator._verify_consolidation_integrity(
+        consolidated=[],
+        pruned=[{"name": "ghost-pruned"}],
+        skills_root=home / "skills",
+        archive_root=home / "skills" / ".archive",
+    )
+    assert result["ok"] is False
+    assert result["prunings_without_archive"] == [
+        {"name": "ghost-pruned", "archive_missing": True}
+    ]
+
+
+def test_verification_renders_section_when_findings(curator_env):
+    curator = curator_env["curator"]
+    payload = {
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "duration_seconds": 1.0,
+        "counts": {},
+        "auto_transitions": {},
+        "verification": {
+            "consolidations_checked": 1,
+            "prunings_checked": 1,
+            "missing_refs": [
+                {"from": "alpha", "into": "umbrella",
+                 "ref": "references/c.md", "reason": "absent"},
+            ],
+            "missing_archives": [],
+            "prunings_without_archive": [
+                {"name": "ghost", "archive_missing": True},
+            ],
+            "prunings_with_empty_refs": [],
+            "ok": False,
+        },
+    }
+    md = curator._render_report_markdown(payload)
+    assert "## Verification" in md
+    assert "Missing references" in md
+    assert "`alpha`" in md
+    assert "`umbrella`" in md
+    assert "references/c.md" in md
+    assert "absent" in md
+    assert "Prunings without recoverable archive" in md
+    assert "`ghost`" in md
+
+
+def test_verification_skips_section_when_clean(curator_env):
+    curator = curator_env["curator"]
+    payload = {
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "duration_seconds": 1.0,
+        "counts": {},
+        "auto_transitions": {},
+        "verification": {
+            "consolidations_checked": 0,
+            "prunings_checked": 0,
+            "missing_refs": [],
+            "missing_archives": [],
+            "prunings_without_archive": [],
+            "prunings_with_empty_refs": [],
+            "ok": True,
+        },
+    }
+    md = curator._render_report_markdown(payload)
+    assert "## Verification" not in md


### PR DESCRIPTION
## Summary
Fixes #44760 — Curator silently loses reference subfiles during umbrella consolidation.

When the curator's LLM consolidation pass merges sibling skills into an umbrella, it
tells the subagent to copy each sibling's content into `<umbrella>/references/<topic>.md`
and then archive the source. The curator trusted the subagent's textual summary — there
was **no on-disk check** that the declared `references/<file>.md` files were actually
written. When the subagent ran out of context, got rate-limited, or simply forgot the
copy step, the new umbrella `SKILL.md` kept linking to references that never made it
to disk, and `run.json` reported success.

The reporter (issue #44760) saw `research/SKILL.md` declare 18 references while
`research/references/` held only 12 — 6 silent dead links, with the curator's success
message actively misleading.

## What changed

**`agent/curator.py`**

Added `_verify_consolidation_integrity()` (and wired it into `_write_run_report()`).
After the LLM finishes and the run report is being assembled, it independently audits
the filesystem against the model's claims:

- For every `consolidations[]` entry `{from: X, into: Y}`:
  - Read the archived source `~/.hermes/skills/.archive/X/SKILL.md`.
  - Parse every `references/<file>.md` link with a single regex.
  - For each link, confirm `~/.hermes/skills/Y/<link>` exists and is `> 200` bytes.
- For every `pruned[]` entry `{name: X}`:
  - Confirm `~/.hermes/skills/.archive/X/SKILL.md` exists (recoverable archive).
  - If the archived `references/` subdirectory is present, confirm it is non-empty.

Output:
- A new `verification` block in `run.json` listing `missing_refs`, `missing_archives`,
  `prunings_without_archive`, `prunings_with_empty_refs`, plus an `ok` flag.
- Two new summary counters in `payload["counts"]`: `verification_missing_refs` and
  `verification_missing_archives`.
- A `## Verification` section in `REPORT.md` that **only renders when there are
  findings** — normal runs stay quiet, matching the reporter's request to "ping the
  user only when something is off".

Conservative scoping (deliberate, per the AGENTS.md "smallest mitigation" rubric):

- The verifier **never raises**: any I/O error reading a SKILL.md is logged at debug
  and the entry is skipped. A buggy verifier can't break the run report.
- The run-status text (`auto: success`) is **left alone**. The issue's suggested
  rename to `auto: partial` is a separate UX concern; surfacing the warnings under
  `verification` + `## Verification` is enough to unblock the reporter, and lets a
  follow-up decide the status taxonomy without coupling.

**`tests/agent/test_curator_verification.py`** (new, 7 tests)

- `test_verification_clean_run` — declared refs present, status `ok=True`.
- `test_verification_detects_missing_ref_file` — declared but absent → `missing_refs`.
- `test_verification_detects_too_small_ref_file` — present but `<= 200B` → `missing_refs` with `reason: too_small`.
- `test_verification_detects_missing_archive_for_consolidation` — archive vanished → `missing_archives`.
- `test_verification_detects_pruning_without_archive` — pruning lost its archive → `prunings_without_archive`.
- `test_verification_renders_section_when_findings` — REPORT.md grows a `## Verification` section.
- `test_verification_skips_section_when_clean` — clean runs stay quiet in REPORT.md.

## Testing

```
$ pytest tests/agent/test_curator_verification.py -v
============================== 7 passed in 0.12s ==============================

$ pytest tests/agent/ -k curator
============================== 146 passed ==============================
```

Full curator suite stays green (no regressions in the existing 139 tests).

## Notes for reviewers

- The regex `references/[\w\-./]+\.md` matches the same link form the LLM prompt at
  `agent/curator.py:407-491` instructs the subagent to write. It's intentionally
  permissive on path chars to handle subdirectories like `references/sources/foo.md`.
- The 200-byte floor for `too_small` flags the "wrote an empty stub" failure mode the
  reporter saw; tune if real refs ever legitimately fall below.
- All paths go through `get_hermes_home() / "skills"`, so profile-aware HERMES_HOME
  remains correct.
