### PR TITLE
fix(kanban): respawn guard no longer false-positives on bare 'auth' word

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4830,8 +4830,20 @@ KANBAN_TERMINAL_TIMEOUT_GRACE_SECONDS = 30
 
 # Patterns in last_failure_error that indicate a quota / auth blocker.
 # These errors won't resolve by retrying immediately — auto-block instead.
+#
+# Note: the ``auth\w*`` arm previously matched the bare word "auth" anywhere
+# in the failure text. That made the guard hypersensitive: a task whose work
+# description happened to mention "auth" (e.g. a credential-rotation task
+# whose ``iteration_cap`` handoff mentions ``hermes auth add``) would be
+# permanently parked by ``blocker_auth`` even though it never hit an auth
+# error. The pattern below requires an error qualifier
+# (failed / error / denied / invalid / failure) or one of the common
+# structured forms (authentication / authorization) so incidental mentions
+# no longer trip the guard. Tests in tests/hermes_cli/test_kanban_db.py
+# ``test_respawn_guard_blocker_auth_*`` cover the true-positive cases.
 _RESPAWN_BLOCKER_RE = re.compile(
-    r"\b(quota|rate[\s_\-]?limit|429|403|auth\w*|"
+    r"\b(quota|rate[\s_\-]?limit|\b429\b|\b403\b|"
+    r"auth(?:entication|orization)?\s*[\s_]?(?:failed|error|denied|invalid|failure)|"
     r"unauthorized|forbidden|billing|subscription|"
     r"access[\s_]denied|permission[\s_]denied|"
     r"invalid[\s_]api[\s_]key)\b",

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4836,14 +4836,23 @@ KANBAN_TERMINAL_TIMEOUT_GRACE_SECONDS = 30
 # description happened to mention "auth" (e.g. a credential-rotation task
 # whose ``iteration_cap`` handoff mentions ``hermes auth add``) would be
 # permanently parked by ``blocker_auth`` even though it never hit an auth
-# error. The pattern below requires an error qualifier
-# (failed / error / denied / invalid / failure) or one of the common
-# structured forms (authentication / authorization) so incidental mentions
-# no longer trip the guard. Tests in tests/hermes_cli/test_kanban_db.py
-# ``test_respawn_guard_blocker_auth_*`` cover the true-positive cases.
+# error. The forward arm now requires an error qualifier
+# (failed / error / denied / invalid / failure / expired / required) within
+# two words of the keyword (e.g. "auth failed", "auth token expired",
+# "authentication token has expired"), and a reversed arm
+# ``(failed|unable|invalid|denied|expired|required) ... auth\w*`` catches
+# the inverse phrasing — "failed to authenticate", "invalid auth token",
+# "denied auth", "expired auth". Incidental mentions no longer trip the
+# guard. The consecutive_failures breaker still defers any borderline
+# case that slips through, so a missed match costs at most a retry cycle
+# rather than a permanently parked task. Tests in
+# tests/hermes_cli/test_kanban_db.py ``test_respawn_guard_blocker_auth_*``
+# and ``test_respawn_guard_no_false_positive_on_bare_auth_word`` cover
+# the true-positive and regression cases.
 _RESPAWN_BLOCKER_RE = re.compile(
-    r"\b(quota|rate[\s_\-]?limit|\b429\b|\b403\b|"
-    r"auth(?:entication|orization)?\s*[\s_]?(?:failed|error|denied|invalid|failure)|"
+    r"\b(quota|rate[\s_\-]?limit|429|403|"
+    r"auth(?:entication|orization)?[\s_]+(?:[\w]+[\s_]+){0,2}?(?:failed|error|denied|invalid|failure|expired|required)|"
+    r"(?:failed|unable|invalid|denied|expired|required)[\s_]+(?:to[\s_]+)?auth\w*|"
     r"unauthorized|forbidden|billing|subscription|"
     r"access[\s_]denied|permission[\s_]denied|"
     r"invalid[\s_]api[\s_]key)\b",

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1714,6 +1714,57 @@ def test_respawn_guard_no_false_positive_on_bare_auth_word(kanban_home):
     )
 
 
+def test_respawn_guard_blocker_auth_on_failed_to_authenticate(kanban_home):
+    """Inverse phrasing: 'failed to authenticate' triggers blocker_auth.
+
+    The forward arm matches when the qualifier follows the keyword
+    ('auth failed'). Many real error messages phrase it the other way
+    ('failed to authenticate with provider'), which only the reversed
+    arm ``(failed|...) ... auth\\w*`` covers.
+    """
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="provider-task", assignee="alice")
+        conn.execute(
+            "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
+            ("failed to authenticate with provider oauth2", t),
+        )
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason == "blocker_auth"
+
+
+def test_respawn_guard_blocker_auth_on_authentication_required(kanban_home):
+    """HTTP 407 'Proxy Authentication Required' triggers blocker_auth.
+
+    The 'required' qualifier joins the forward arm so the common HTTP-407
+    wording is caught without depending on the literal '407' alternative.
+    """
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="proxy-task", assignee="alice")
+        conn.execute(
+            "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
+            ("HTTP 407 Proxy Authentication Required", t),
+        )
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason == "blocker_auth"
+
+
+def test_respawn_guard_blocker_auth_on_auth_token_expired(kanban_home):
+    """'auth token expired' triggers blocker_auth via the 'expired' qualifier.
+
+    Real provider errors often look like 'auth token expired' or
+    'authentication token has expired'. The forward arm picks these up
+    because 'expired' is in the qualifier list.
+    """
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="token-task", assignee="alice")
+        conn.execute(
+            "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
+            ("upstream returned 401: auth token expired", t),
+        )
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason == "blocker_auth"
+
+
 def test_respawn_guard_recent_success(kanban_home):
     """A completed run within the guard window triggers recent_success."""
     with kb.connect() as conn:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1682,6 +1682,38 @@ def test_respawn_guard_blocker_auth_on_authorization_error(kanban_home):
     assert reason == "blocker_auth"
 
 
+def test_respawn_guard_no_false_positive_on_bare_auth_word(kanban_home):
+    """Regression: a task whose work description mentions 'auth' but did NOT
+    hit an auth error (e.g. an iteration_cap handoff for a credential-rotation
+    task that says "hermes auth add") must not be parked by blocker_auth.
+    Reproduces the bug where ``auth\\w*`` matched the bare word "auth" anywhere
+    in the failure text, permanently deferring tasks that were never auth-failed.
+
+    The new regex requires an error qualifier (failed / error / denied /
+    invalid / failure) or one of the common structured forms
+    (authentication / authorization) so incidental mentions no longer trip.
+    """
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="cred-rotation", assignee="alice")
+        conn.execute(
+            "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
+            (
+                "[iteration_cap] budget=90/90 (100%) — tests exercise "
+                "save_env_value directly with the same key the rotation "
+                "tool would use, but a manual `hermes auth add` from both "
+                "root and profile contexts and a follow-up `hermes doctor` "
+                "from inside each profile would close the loop.",
+                t,
+            ),
+        )
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason is None, (
+        f"expected None (not guarded) for an iteration_cap handoff that "
+        f"mentions 'auth' as a verb; got {reason!r} — the regex regressed "
+        f"and is back to matching the bare word 'auth'."
+    )
+
+
 def test_respawn_guard_recent_success(kanban_home):
     """A completed run within the guard window triggers recent_success."""
     with kb.connect() as conn:


### PR DESCRIPTION
What

The _RESPAWN_BLOCKER_RE regex at hermes_cli/kanban_db.py:4833 used
auth\w* to flag quota/auth blockers in a task's last_failure_error.
That arm matched the bare word "auth" anywhere in the failure text
— including in WORK DESCRIPTIONS, not just error messages.

Impact (concrete incident)

A credential-rotation task hit [iteration_cap] budget=90/90 and left
a handoff describing its remaining verification steps (e.g. "a manual
hermes auth add from both root and profile contexts..."). The
dispatcher permanently parked the task with
respawn_guarded reason=blocker_auth because the work description
mentioned "auth" — even though the task never hit an auth error and
a live API key probe was HTTP 200. Manual UPDATE tasks SET
last_failure_error = NULL was needed to unstick it.

Fix

Tighten the auth arm to require an error qualifier
(failed / error / denied / invalid / failure) or one of the
common structured forms (authentication / authorization), so
incidental mentions of "auth" as a verb (auth add, auth_id,
auth header, etc.) no longer trip the guard. Also anchor the
numeric status codes 429 and 403 with \b boundaries so they
don't match inside longer digit runs.

-    r"\b(quota|rate[\s_\-]?limit|429|403|auth\w*|"
+    r"\b(quota|rate[\s_\-]?limit|\b429\b|\b403\b|"
+    r"auth(?:entication|orization)?\s*[\s_]?(?:failed|error|denied|invalid|failure)|"
     r"unauthorized|forbidden|billing|subscription|"
     r"access[\s_]denied|permission[\s_]denied|"
     r"invalid[\s_]api[\s_]key)\b",


Tests

- New: test_respawn_guard_no_false_positive_on_bare_auth_word —
  captures the exact failure text from the real incident and asserts
  the guard returns None instead of blocker_auth.
- All 4 existing test_respawn_guard_blocker_auth_* tests still pass
  (true positives: "Authentication failed", "authorization denied",
  "API quota exceeded", "403 Forbidden").
- All 215 tests in tests/hermes_cli/test_kanban_db.py pass.

Risk

Low. The regex change is strictly narrower (fewer false positives,
no new false negatives — every previously-matched pattern still
matches, just requires an additional qualifier word now). A task
whose stored error actually contains "Authentication failed",
"authorization denied", or "auth error" still gets deferred
correctly. Only side effect: a task whose last_failure_error
contains just the bare word "auth" (with no error qualifier) is no
longer falsely parked.