### PR TITLE
fix(dashboard): correct approvals.mode dropdown options

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -482,7 +482,12 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     "approvals.mode": {
         "type": "select",
         "description": "Dangerous command approval mode",
-        "options": ["ask", "yolo", "deny"],
+        "options": ["manual", "smart", "off"],
+        "option_descriptions": {
+            "manual": "Prompt for every dangerous command",
+            "smart": "LLM auto-approves low-risk commands",
+            "off": "Skip all approval prompts (--yolo equivalent)",
+        },
     },
     "context.engine": {
         "type": "select",


### PR DESCRIPTION
## Summary

The web dashboard Settings page rendered `approvals.mode` as a `<select>` dropdown with options `["ask", "yolo", "deny"]`, but the approval engine only recognizes `["manual", "smart", "off"]` (defined in `tools/approval.py:963-966`, documented in `hermes_cli/config.py:1971-1982`).

Selecting "yolo" or "deny" wrote an unrecognized string to `config.yaml` that silently degraded to `manual` behavior. On messaging platforms (QQ, Telegram, WeChat) with no interactive approval UI, this caused **all dangerous commands to time out** — the user had no way to approve or bypass them.

## Changes

- Replace dropdown options with actual config values: `["manual", "smart", "off"]`
- Add `option_descriptions` for clarity

## Before

```python
"approvals.mode": {
    "type": "select",
    "description": "Dangerous command approval mode",
    "options": ["ask", "yolo", "deny"],
}
```

## After

```python
"approvals.mode": {
    "type": "select",
    "description": "Dangerous command approval mode",
    "options": ["manual", "smart", "off"],
    "option_descriptions": {
        "manual": "Prompt for every dangerous command",
        "smart": "LLM auto-approves low-risk commands",
        "off": "Skip all approval prompts (--yolo equivalent)",
    },
}
```

Closes #44821

## Test Plan

- [ ] Open web dashboard → Settings → Security
- [ ] Verify dropdown now shows `manual`, `smart`, `off`
- [ ] Select `off`, save, verify `approvals.mode: off` in config.yaml
- [ ] Run a dangerous command and confirm it bypasses approval
- [ ] Select `smart`, save, verify `approvals.mode: smart` in config.yaml
- [ ] Select `manual`, save, verify `approvals.mode: manual` in config.yaml