### PR TITLE
fix(prompt-size): resolve per-platform toolsets for accurate diagnostics

### DIFF
--- a/hermes_cli/prompt_size.py
+++ b/hermes_cli/prompt_size.py
@@ -31,13 +31,23 @@ def _build_inspection_agent(platform: str) -> Any:
     Dummy ``api_key`` + ``base_url`` force the direct-construction path in
     ``run_agent.py`` (no provider auto-detection, no network). Toolsets and
     platform come from the caller so the breakdown matches a real session.
+
+    When ``enabled_toolsets`` is omitted, ``init_agent`` loads *every*
+    toolset minus ``agent.disabled_toolsets`` — which over-counts tools for
+    platforms like ``api_server`` that have an explicit ``platform_toolsets``
+    entry in config.yaml.  Mirror Gateway: resolve per-platform toolsets here.
     """
     from run_agent import AIAgent
     from hermes_cli.config import load_config
+    from hermes_cli.tools_config import _get_platform_tools
 
     cfg = load_config()
     model_cfg = cfg.get("model", {}) if isinstance(cfg.get("model"), dict) else {}
     model = model_cfg.get("default") or model_cfg.get("model") or ""
+
+    agent_cfg = cfg.get("agent", {}) if isinstance(cfg.get("agent"), dict) else {}
+    disabled_toolsets = agent_cfg.get("disabled_toolsets") or []
+    enabled_toolsets = sorted(_get_platform_tools(cfg, platform))
 
     return AIAgent(
         model=model,
@@ -46,6 +56,8 @@ def _build_inspection_agent(platform: str) -> Any:
         quiet_mode=True,
         save_trajectories=False,
         platform=platform,
+        enabled_toolsets=enabled_toolsets,
+        disabled_toolsets=disabled_toolsets,
     )
 
 


### PR DESCRIPTION
## Summary

Fixes `hermes prompt-size` to report tool counts that match what the Gateway actually ships for each platform, by resolving per-platform toolset configuration instead of loading every installed toolset.

## Problem

When `_build_inspection_agent()` constructs the offline AIAgent, it omitted `enabled_toolsets` and `disabled_toolsets`. This caused `init_agent` to load **every installed toolset**, inflating the reported tool-schema size — especially for platforms like `api_server` that declare a restricted `platform_toolsets` list.

Example: `hermes prompt-size --platform api_server` showed 50+ tools when the api_server default is 26.

## Fix

Three-line logic change in `_build_inspection_agent()`:

```python
agent_cfg = cfg.get("agent", {}) if isinstance(cfg.get("agent"), dict) else {}
disabled_toolsets = agent_cfg.get("disabled_toolsets") or []
enabled_toolsets = sorted(_get_platform_tools(cfg, platform))
```

Now passes both `enabled_toolsets` and `disabled_toolsets` to `AIAgent.__init__()`, mirroring the Gateway platform adapter's own toolset resolution.

## Why this matters for the Hermes ecosystem

1. **Debugging accuracy** — the diagnostic tool exists so users can understand their prompt budget (issue #34667). Inaccurate tool counts undermine that purpose. Platform operators debugging "why is my api_server prompt 8K tokens?" should see the real toolset, not the union of everything installed.

2. **Config validation** — `platform_toolsets` in config.yaml defines the actual API surface. When `prompt-size` overcounts, operators cannot validate whether their platform config is correctly scoped. This fix makes the diagnostic a reliable config-validation aid.

3. **Provider compatibility** — Mismatched tool counts between what `prompt-size` reports and what the Gateway actually sends leads to wasted debugging cycles. A user tweaking toolset size based on inflated numbers may accidentally ship a trimmed toolset that breaks API clients.

4. **Ecosystem consistency** — Every gateway adapter (api_server, telegram, discord, whatsapp, etc.) resolves toolsets via `_get_platform_tools()`. The inspection agent should follow the same code path, not a different one. Single source of truth.

## Tests

All 7 existing `test_prompt_size.py` tests pass unchanged.