### PR TITLE
fix(gateway): gate [[audio_as_voice]] to audio files so images aren't sent as documents

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2938,8 +2938,17 @@ class BasePlatformAdapter(ABC):
                 path = path[1:-1].strip()
             path = path.lstrip("`\"'").rstrip("`\"',.;:)}]")
             if path:
+                # ``[[audio_as_voice]]`` is message-global, but it must only
+                # affect audio files. Tagging a non-audio file (image, video,
+                # document) as is_voice taints it: an image flagged is_voice is
+                # excluded from the embedded-photo batch and falls through to
+                # send_document, arriving as a file attachment instead of an
+                # inline photo. Gating on the extension lets one message carry
+                # an embedded image AND a voice bubble together.
+                ext = os.path.splitext(path)[1].lower()
+                is_voice = has_voice_tag and ext in _AUDIO_EXTS
                 try:
-                    media.append((os.path.expanduser(path), has_voice_tag))
+                    media.append((os.path.expanduser(path), is_voice))
                 except (OSError, RuntimeError, ValueError):
                     # Skip a crafted ~\x00 path rather than aborting extraction
                     # and dropping every other attachment in the response.


### PR DESCRIPTION
`[[audio_as_voice]]` is a message-global directive but was applied to **every** media file in a message. A non-audio file flagged `is_voice` is excluded from the embedded-photo batch and falls through to `send_document` — so an image in a message that *also* carries a voice note arrives as a **file attachment instead of an inline photo**.

This gates the voice flag on the file extension (`ext in _AUDIO_EXTS`), letting one message carry an inline image **and** a voice bubble. Also wraps the path append in a defensive try/except so a crafted `~\x00` path is skipped rather than aborting extraction of all other attachments.

Low risk: narrows an over-broad flag; no behavior change for audio-only or image-only messages.