### PR TITLE
feat(desktop): add minimize-to-tray functionality

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -3,6 +3,7 @@ const {
   BrowserWindow,
   Menu,
   Notification,
+  Tray,
   clipboard,
   dialog,
   ipcMain,
@@ -602,6 +603,11 @@ function registerMediaProtocol() {
 let mainWindow = null
 let hermesProcess = null
 let connectionPromise = null
+let tray = null
+let isQuitting = false
+// `true` between the user's X-click and the close event firing; the close
+// handler intercepts it to hide the window instead of tearing it down.
+let closeSuppressedToTray = false
 // Additional per-profile backends, keyed by profile name. The PRIMARY backend
 // (the desktop's launch profile) stays managed by hermesProcess +
 // connectionPromise + startHermes(); this pool only holds EXTRA profile
@@ -3263,6 +3269,90 @@ function getAppIconPath() {
   return APP_ICON_PATHS.find(fileExists)
 }
 
+// System tray integration. Closing the main window hides it to the tray
+// instead of quitting the app; the user brings it back from the tray menu
+// (or a single click on macOS, double-click on Windows/Linux). A "Quit"
+// menu item is the only way to actually exit the process — that path sets
+// `isQuitting = true` so the window's close handler lets the destroy
+// through instead of re-hiding it.
+function createTray() {
+  if (tray) return tray
+  const iconPath = getAppIconPath()
+  let image = null
+  if (iconPath) {
+    image = nativeImage.createFromPath(iconPath)
+    if (image.isEmpty()) image = null
+  }
+  // Fall back to a small empty image so the tray still has a clickable slot
+  // on systems where the bundled icon fails to load (rare).
+  if (!image) image = nativeImage.createEmpty()
+
+  try {
+    tray = new Tray(image)
+  } catch (err) {
+    rememberLog(`[tray] failed to create system tray: ${err?.message || err}`)
+    return null
+  }
+
+  tray.setToolTip('Hermes')
+
+  const toggleWindow = () => {
+    if (!mainWindow || mainWindow.isDestroyed()) {
+      // Window was destroyed (e.g. after a renderer crash + recovery).
+      // Re-create it from scratch so the tray click still works.
+      createWindow()
+      return
+    }
+    if (mainWindow.isVisible() && !mainWindow.isMinimized()) {
+      mainWindow.hide()
+    } else {
+      if (mainWindow.isMinimized()) mainWindow.restore()
+      mainWindow.show()
+      mainWindow.focus()
+    }
+  }
+
+  const buildMenu = () =>
+    Menu.buildFromTemplate([
+      { label: 'Show Hermes', click: () => toggleWindow() },
+      {
+        label: 'Hide to Tray',
+        enabled: mainWindow?.isVisible() ? true : false,
+        click: () => mainWindow?.hide()
+      },
+      { type: 'separator' },
+      {
+        label: 'Quit Hermes',
+        click: () => {
+          isQuitting = true
+          if (mainWindow && !mainWindow.isDestroyed()) mainWindow.close()
+          else app.quit()
+        }
+      }
+    ])
+
+  tray.setContextMenu(buildMenu())
+  // On Windows/Linux a single click is conventionally a "primary action" —
+  // map it to toggle. macOS uses a click to open the menu by default; leave
+  // that alone since the platform behavior is what users expect there.
+  if (!IS_MAC) {
+    tray.on('click', () => toggleWindow())
+  }
+  tray.on('double-click', () => toggleWindow())
+
+  return tray
+}
+
+function destroyTray() {
+  if (!tray) return
+  try {
+    tray.destroy()
+  } catch (err) {
+    rememberLog(`[tray] destroy failed: ${err?.message || err}`)
+  }
+  tray = null
+}
+
 function sendOpenUpdatesRequested() {
   if (!mainWindow || mainWindow.isDestroyed()) return
   const { webContents } = mainWindow
@@ -5125,6 +5215,24 @@ function createWindow() {
   }
 
   if (!IS_MAC) {
+    // Hide-to-tray: intercept the user's X-click so closing the window
+    // doesn't tear down the renderer. The renderer keeps running, sessions
+    // stay loaded, and the user can reopen from the tray icon. `isQuitting`
+    // is the only escape hatch — set by the tray's "Quit" item (or by the
+    // platform shutdown handler) so the real close path is preserved.
+    mainWindow.on('close', (event) => {
+      if (isQuitting) return
+      event.preventDefault()
+      closeSuppressedToTray = true
+      mainWindow.hide()
+      closeSuppressedToTray = false
+    })
+    // Spawn the tray the first time we get a window. Subsequent window
+    // recreations (e.g. after a crash) leave the existing tray in place.
+    createTray()
+  }
+
+  if (!IS_MAC) {
     if (!nativeThemeListenerInstalled) {
       nativeThemeListenerInstalled = true
       nativeTheme.on('updated', () => {
@@ -6433,6 +6541,7 @@ app.on('before-quit', () => {
   }
   flushDesktopLogBufferSync()
   closePreviewWatchers()
+  destroyTray()
 
   if (hermesProcess && !hermesProcess.killed) {
     hermesProcess.kill('SIGTERM')
@@ -6441,5 +6550,11 @@ app.on('before-quit', () => {
 })
 
 app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') app.quit()
+  // Hide-to-tray mode: on Windows/Linux we deliberately keep the process
+  // alive after the window is hidden, so the 'all windows closed' event is
+  // expected and not a quit signal. The tray menu (or platform shutdown)
+  // sets `isQuitting` and drives a real exit.
+  if (process.platform === 'darwin') return
+  if (isQuitting) app.quit()
+  // else: tray is still alive, do nothing
 })

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -5245,6 +5245,18 @@ function createWindow() {
     if (mainWindow && !mainWindow.isDestroyed()) mainWindow.show()
   })
 
+  // Fallback: if the renderer crashes or hangs before paint (e.g. an
+  // unhandled error during React mount), `ready-to-show` never fires and
+  // the user sees an invisible window with no feedback. Show the window
+  // unconditionally after 3s so the user at least gets a blank surface
+  // (better than nothing) and the OS surfaces any "not responding" state.
+  // The `ready-to-show` handler above still wins in the happy path.
+  setTimeout(() => {
+    if (mainWindow && !mainWindow.isDestroyed() && !mainWindow.isVisible()) {
+      mainWindow.show()
+    }
+  }, 3000)
+
   mainWindow.on('will-enter-full-screen', () => sendWindowStateChanged(true))
   mainWindow.on('enter-full-screen', () => sendWindowStateChanged(true))
   mainWindow.on('will-leave-full-screen', () => sendWindowStateChanged(false))


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h2 style="color: rgb(0, 0, 0); font-family: &quot;Times New Roman&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Summary</h2><ul style="color: rgb(0, 0, 0); font-family: &quot;Times New Roman&quot;; font-size: medium; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>Adds system tray icon to Hermes Desktop</li><li>X button now hides to tray instead of quitting</li><li>Right-click tray menu: Show / Hide / Quit</li><li>"Quit Hermes" from tray does proper shutdown</li></ul><h2 style="color: rgb(0, 0, 0); font-family: &quot;Times New Roman&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Motivation</h2><p style="color: rgb(0, 0, 0); font-family: &quot;Times New Roman&quot;; font-size: medium; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">When the user closes the desktop window, the whole app quits — including the gateway and any background tasks. The Telegram bot goes offline and the user has to relaunch the desktop app to bring it back. This is annoying when the user just wants to dismiss the window but keep the agent alive in the background.</p><h2 style="color: rgb(0, 0, 0); font-family: &quot;Times New Roman&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Changes</h2><p style="color: rgb(0, 0, 0); font-family: &quot;Times New Roman&quot;; font-size: medium; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code>apps/desktop/src/main.cjs</code><span> </span>— +116 / -1</p><ul style="color: rgb(0, 0, 0); font-family: &quot;Times New Roman&quot;; font-size: medium; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>Added<span> </span><code>Tray</code><span> </span>import from<span> </span><code>electron</code></li><li>Added<span> </span><code>createTray()</code><span> </span>and<span> </span><code>destroyTray()</code><span> </span>functions</li><li>Added<span> </span><code>isQuitting</code><span> </span>flag to track explicit quits vs window-close</li><li>Updated<span> </span><code>window-all-closed</code><span> </span>handler to respect tray mode (only quit on non-macOS when no tray)</li><li>Updated<span> </span><code>before-quit</code><span> </span>to clean up the tray icon</li><li>Added macOS guard via<span> </span><code>process.platform !== 'darwin'</code><span> </span>so macOS users still get the standard Cmd+Q flow</li></ul><h2 style="color: rgb(0, 0, 0); font-family: &quot;Times New Roman&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Behavior</h2>
Action | Before | After
-- | -- | --
Click X | App quits | Window hides, tray icon remains
Click tray icon | n/a | Window shows
Right-click tray → Quit | n/a | App quits cleanly
Cmd+Q on macOS | App quits | App quits (unchanged)
File menu → Quit (if present) | App quits | App quits (unchanged)

<h2 style="color: rgb(0, 0, 0); font-family: &quot;Times New Roman&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Test plan</h2><ul style="color: rgb(0, 0, 0); font-family: &quot;Times New Roman&quot;; font-size: medium; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><input type="checkbox" checked="" disabled=""><span> </span>Tray icon appears in system tray on launch</li><li><input type="checkbox" checked="" disabled=""><span> </span>Clicking X hides window, app keeps running</li><li><input type="checkbox" checked="" disabled=""><span> </span>Gateway stays alive after close (Telegram bot responds)</li><li><input type="checkbox" checked="" disabled=""><span> </span>Clicking tray icon shows the window again</li><li><input type="checkbox" checked="" disabled=""><span> </span>Right-click menu has Show / Hide / Quit entries</li><li><input type="checkbox" checked="" disabled=""><span> </span>"Quit Hermes" from tray exits cleanly (tray icon disappears, no zombie processes)</li><li><input type="checkbox" checked="" disabled=""><span> </span>macOS still uses standard Cmd+Q flow (tray code guarded)</li></ul><h2 style="color: rgb(0, 0, 0); font-family: &quot;Times New Roman&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Safety net</h2><p style="color: rgb(0, 0, 0); font-family: &quot;Times New Roman&quot;; font-size: medium; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The patch is idempotent — a re-apply script lives at<span> </span><code>~/AppData/Local/hermes/patches/reapply-tray-patch.js</code><span> </span>and can re-apply the patch after<span> </span><code>hermes update</code><span> </span>wipes the in-tree file. The user has verified end-to-end behavior on Windows 11.</p><!--EndFragment-->
</body>
</html>