### PR TITLE
fix(gateway): send handled pre-dispatch replies

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6359,6 +6359,73 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         await adapter.send(source.chat_id, content, metadata=metadata)
 
+    @staticmethod
+    def _pre_gateway_dispatch_reply_text(result: Dict[str, Any]) -> Optional[str]:
+        """Extract a user-facing reply from a pre_gateway_dispatch result."""
+        for key in ("text", "content"):
+            value = result.get(key)
+            if isinstance(value, str) and value.strip():
+                return value
+
+        for key in ("reply", "message"):
+            value = result.get(key)
+            if isinstance(value, str) and value.strip():
+                return value
+            if isinstance(value, dict):
+                for nested_key in ("text", "content", "message"):
+                    nested = value.get(nested_key)
+                    if isinstance(nested, str) and nested.strip():
+                        return nested
+
+        return None
+
+    async def _send_pre_gateway_dispatch_reply(
+        self,
+        event: MessageEvent,
+        content: str,
+    ) -> None:
+        source = event.source
+        adapter = self.adapters.get(source.platform)
+        if adapter is None:
+            logger.warning(
+                "pre_gateway_dispatch handled message but no adapter exists: platform=%s chat=%s",
+                source.platform.value if source.platform else "unknown",
+                source.chat_id or "unknown",
+            )
+            return
+
+        reply_anchor = self._reply_anchor_for_event(event)
+        metadata = self._thread_metadata_for_source(source, reply_anchor)
+        if metadata is not None:
+            metadata = dict(metadata)
+            metadata["notify"] = True
+        else:
+            metadata = {"notify": True}
+
+        send = getattr(adapter, "_send_with_retry", None)
+        if callable(send):
+            result = await send(
+                chat_id=source.chat_id,
+                content=content,
+                reply_to=reply_anchor,
+                metadata=metadata,
+            )
+        else:
+            result = await adapter.send(
+                chat_id=source.chat_id,
+                content=content,
+                reply_to=reply_anchor,
+                metadata=metadata,
+            )
+
+        if not getattr(result, "success", True):
+            logger.warning(
+                "pre_gateway_dispatch handled reply send failed: platform=%s chat=%s error=%s",
+                source.platform.value if source.platform else "unknown",
+                source.chat_id or "unknown",
+                getattr(result, "error", None),
+            )
+
     async def _handle_message(self, event: MessageEvent) -> Optional[str]:
         """
         Handle an incoming message from any platform.
@@ -6380,7 +6447,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Fire pre_gateway_dispatch plugin hook for user-originated messages.
         # Plugins receive the MessageEvent and may return a dict influencing flow:
-        #   {"action": "skip",    "reason": ...}    -> drop (no reply, plugin handled)
+        #   {"action": "handled", "reply": ...}     -> send reply, then stop
+        #   {"action": "skip",    "reason": ...}    -> stop (silent unless reply/text provided)
         #   {"action": "rewrite", "text":  ...}     -> replace event.text, continue
         #   {"action": "allow"}   /   None          -> normal dispatch
         # Hook runs BEFORE auth so plugins can handle unauthorized senders
@@ -6402,12 +6470,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if not isinstance(_result, dict):
                     continue
                 _action = _result.get("action")
-                if _action == "skip":
+                if _action in {"skip", "handled"} or _result.get("handled") is True:
+                    _reply_text = self._pre_gateway_dispatch_reply_text(_result)
+                    if _reply_text:
+                        await self._send_pre_gateway_dispatch_reply(event, _reply_text)
                     logger.info(
-                        "pre_gateway_dispatch skip: reason=%s platform=%s chat=%s",
+                        "pre_gateway_dispatch %s: reason=%s platform=%s chat=%s replied=%s",
+                        _action or "handled",
                         _result.get("reason"),
                         source.platform.value if source.platform else "unknown",
                         source.chat_id or "unknown",
+                        bool(_reply_text),
                     )
                     return None
                 if _action == "rewrite":

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -148,9 +148,10 @@ VALID_HOOKS: Set[str] = {
     # Gateway pre-dispatch hook. Fired once per incoming MessageEvent
     # after the internal-event guard but BEFORE auth/pairing and agent
     # dispatch. Plugins may return a dict to influence flow:
-    #   {"action": "skip",    "reason": "..."}  -> drop message (no reply)
-    #   {"action": "rewrite", "text": "..."}    -> replace event.text, continue
-    #   {"action": "allow"}  /  None             -> normal dispatch
+    #   {"action": "handled", "reply": {"text": "..."}} -> send reply and stop
+    #   {"action": "skip",    "reason": "..."}           -> stop silently unless reply/text provided
+    #   {"action": "rewrite", "text": "..."}             -> replace event.text, continue
+    #   {"action": "allow"}  /  None                      -> normal dispatch
     # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
     "pre_gateway_dispatch",
     # Approval lifecycle hooks. Fired by tools/approval.py when a dangerous

--- a/tests/gateway/test_pre_gateway_dispatch.py
+++ b/tests/gateway/test_pre_gateway_dispatch.py
@@ -2,7 +2,7 @@
 
 The hook allows plugins to intercept incoming messages before auth and
 agent dispatch. It runs in _handle_message and acts on returned action
-dicts: {"action": "skip"|"rewrite"|"allow"}.
+dicts: {"action": "handled"|"skip"|"rewrite"|"allow"}.
 """
 
 from types import SimpleNamespace
@@ -49,7 +49,7 @@ def _make_runner(platform: Platform):
     )
     runner = object.__new__(GatewayRunner)
     runner.config = config
-    adapter = SimpleNamespace(send=AsyncMock())
+    adapter = SimpleNamespace(send=AsyncMock(), _send_with_retry=AsyncMock())
     runner.adapters = {platform: adapter}
     runner.pairing_store = MagicMock()
     runner.pairing_store.is_approved.return_value = False
@@ -77,6 +77,40 @@ async def test_hook_skip_short_circuits_dispatch(monkeypatch):
     result = await runner._handle_message(_make_event("hi"))
 
     assert result is None
+    adapter._send_with_retry.assert_not_awaited()
+    adapter.send.assert_not_awaited()
+    runner.pairing_store.generate_code.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_hook_handled_reply_sends_canned_response_before_auth(monkeypatch):
+    """A handled hook result sends its reply and never reaches auth or agent dispatch."""
+    _clear_auth_env(monkeypatch)
+
+    def _fake_hook(name, **kwargs):
+        if name == "pre_gateway_dispatch":
+            return [
+                {
+                    "action": "handled",
+                    "reason": "nora_consent_gate",
+                    "reply": {"text": "OpenClaw is locked until explicit informed consent is recorded."},
+                }
+            ]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    runner, adapter = _make_runner(Platform.TELEGRAM)
+
+    result = await runner._handle_message(_make_event("hey, how's my day looking?", Platform.TELEGRAM))
+
+    assert result is None
+    adapter._send_with_retry.assert_awaited_once()
+    call = adapter._send_with_retry.await_args.kwargs
+    assert call["chat_id"] == "15551234567@s.whatsapp.net"
+    assert call["content"] == "OpenClaw is locked until explicit informed consent is recorded."
+    assert call["reply_to"] == "m1"
+    assert call["metadata"] == {"notify": True}
     adapter.send.assert_not_awaited()
     runner.pairing_store.generate_code.assert_not_called()
 


### PR DESCRIPTION
## Root cause

`pre_gateway_dispatch` hooks could return handled decisions with a canned reply payload, but `GatewayRunner._handle_message` only treated hook results as silent skips unless they were rewrites. The OpenClaw consent gate therefore blocked model dispatch correctly while Telegram/Signal received no immediate consent prompt.

## Fix

- Extract reply text from handled pre-dispatch hook results (`text`, `reply.text`, `message.content`, etc.).
- Send the canned response through the platform adapter before short-circuiting dispatch.
- Preserve silent `skip` behavior when no reply payload is provided.
- Document the `handled` pre-dispatch contract and add regression coverage for the `nora_consent_gate` shape.

## Tests

- `/tmp/hermes-gateway-test-venv/bin/python -m pytest -s -q tests/gateway/test_pre_gateway_dispatch.py tests/hermes_cli/test_plugins.py`
- Result: `92 passed`

## Deployment

Not synced to live yet from this PR. Local incident workaround/sync can be applied after merge or by explicit emergency hotfix.