### PR TITLE
fix(state): log WAL checkpoint failures instead of silently swallowing

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -877,8 +877,15 @@ class SessionDB:
                         "WAL checkpoint: %d/%d pages checkpointed",
                         result[2], result[1],
                     )
-        except Exception:
-            pass  # Best effort — never fatal.
+        except Exception as exc:
+            logger.warning("WAL checkpoint failed (non-fatal): %s", exc)
+            try:
+                self._conn.execute("PRAGMA quick_check(1)")
+            except Exception:
+                logger.error(
+                    "state.db integrity check failed after checkpoint error "
+                    "— DB may be corrupted"
+                )
 
     def close(self):
         """Close the database connection.
@@ -890,8 +897,8 @@ class SessionDB:
             if self._conn:
                 try:
                     self._conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
-                except Exception:
-                    pass
+                except Exception as exc:
+                    logger.debug("WAL checkpoint on close failed: %s", exc)
                 self._conn.close()
                 self._conn = None
 
@@ -4499,8 +4506,8 @@ class SessionDB:
             # Best-effort WAL checkpoint first, then VACUUM.
             try:
                 self._conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("WAL checkpoint before VACUUM failed: %s", exc)
             self._conn.execute("VACUUM")
         return optimized
 

--- a/tests/test_wal_checkpoint_exception.py
+++ b/tests/test_wal_checkpoint_exception.py
@@ -1,0 +1,129 @@
+"""Tests for WAL checkpoint exception handling in SessionDB.
+
+Covers the fix for #44795: _try_wal_checkpoint silently swallows exceptions
+from destructive TRUNCATE checkpoint, potentially corrupting state.db.
+"""
+
+import logging
+import sqlite3
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture()
+def db(tmp_path):
+    """Create a SessionDB with a temp database file."""
+    db_path = tmp_path / "test_state.db"
+    session_db = SessionDB(db_path=db_path)
+    yield session_db
+    session_db.close()
+
+
+class TestWalCheckpointExceptionLogging:
+    """Verify that WAL checkpoint failures are logged, not silently swallowed."""
+
+    def test_try_wal_checkpoint_logs_warning_on_exception(self, db, caplog):
+        """_try_wal_checkpoint should log warning when checkpoint raises."""
+        mock_conn = MagicMock()
+        mock_conn.execute.side_effect = sqlite3.OperationalError("disk I/O error")
+        db._conn = mock_conn
+
+        with caplog.at_level(logging.WARNING):
+            db._try_wal_checkpoint()
+
+        assert any(
+            "WAL checkpoint failed" in r.message and "disk I/O error" in r.message
+            for r in caplog.records
+        ), f"Expected warning log not found in: {[r.message for r in caplog.records]}"
+
+    def test_try_wal_checkpoint_integrity_check_on_failure(self, db):
+        """_try_wal_checkpoint should run PRAGMA quick_check after failure."""
+        mock_conn = MagicMock()
+        call_sequence = []
+
+        def track_execute(sql, *args, **kwargs):
+            call_sequence.append(sql)
+            if "wal_checkpoint" in sql:
+                raise sqlite3.OperationalError("checkpoint failed")
+            if "quick_check" in sql:
+                return MagicMock(fetchone=lambda: ("ok",))
+            return MagicMock(fetchone=lambda: None)
+
+        mock_conn.execute.side_effect = track_execute
+        db._conn = mock_conn
+
+        db._try_wal_checkpoint()
+
+        assert any(
+            "quick_check" in sql for sql in call_sequence
+        ), f"Expected quick_check call, got: {call_sequence}"
+
+    def test_try_wal_checkpoint_logs_error_on_integrity_failure(self, db, caplog):
+        """_try_wal_checkpoint should log error when integrity check also fails."""
+        mock_conn = MagicMock()
+
+        def track_execute(sql, *args, **kwargs):
+            if "wal_checkpoint" in sql:
+                raise sqlite3.OperationalError("checkpoint failed")
+            if "quick_check" in sql:
+                raise sqlite3.OperationalError("corruption detected")
+            return MagicMock(fetchone=lambda: None)
+
+        mock_conn.execute.side_effect = track_execute
+        db._conn = mock_conn
+
+        with caplog.at_level(logging.ERROR):
+            db._try_wal_checkpoint()
+
+        assert any(
+            "integrity check failed" in r.message
+            for r in caplog.records
+        ), f"Expected integrity error log not found in: {[r.message for r in caplog.records]}"
+
+    def test_try_wal_checkpoint_succeeds_silently(self, db, caplog):
+        """_try_wal_checkpoint should not warn when checkpoint succeeds."""
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchone.return_value = (0, 0, 0)
+        db._conn = mock_conn
+
+        with caplog.at_level(logging.WARNING):
+            db._try_wal_checkpoint()
+
+        assert not any(
+            "WAL checkpoint failed" in r.message for r in caplog.records
+        ), "Unexpected warning on successful checkpoint"
+
+    def test_close_does_not_raise_on_checkpoint_failure(self, db):
+        """close() should not raise when final checkpoint fails."""
+        mock_conn = MagicMock()
+        mock_conn.execute.side_effect = sqlite3.OperationalError("database is closed")
+        db._conn = mock_conn
+
+        # close() should not raise even if checkpoint fails
+        db.close()
+
+        # After close, _conn is None — verify it completed
+        assert db._conn is None
+
+    def test_vacuum_continues_on_checkpoint_failure(self, db):
+        """vacuum() should continue to VACUUM even if pre-VACUUM checkpoint fails."""
+        execute_calls = []
+
+        def track_execute(sql, *args, **kwargs):
+            execute_calls.append(sql)
+            if "wal_checkpoint" in sql:
+                raise sqlite3.OperationalError("checkpoint failed")
+            return MagicMock(fetchone=lambda: None)
+
+        mock_conn = MagicMock()
+        mock_conn.execute.side_effect = track_execute
+        db._conn = mock_conn
+
+        db.vacuum()
+
+        # VACUUM should still be called even if checkpoint fails
+        assert any("VACUUM" in sql for sql in execute_calls), \
+            f"Expected VACUUM call, got: {execute_calls}"


### PR DESCRIPTION
## What does this PR do?

Replaces the bare `except Exception: pass` in `_try_wal_checkpoint()` and related methods with proper exception logging and an integrity guard. The destructive `PRAGMA wal_checkpoint(TRUNCATE)` was silently swallowing all errors — when it fails mid-operation, the WAL is already truncated to zero bytes but data was not fully written back, causing state.db corruption that cascades to TUI session store, holographic memory provider, and SessionDB.

## Related Issue

Fixes #44795

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py` (`_try_wal_checkpoint`): Replace `except Exception: pass` with `except Exception as exc: logger.warning(...)` plus `PRAGMA quick_check(1)` integrity guard that logs an error if the DB is corrupted after a failed checkpoint.
- `hermes_state.py` (`close`): Replace `except Exception: pass` with `except Exception as exc: logger.debug(...)` for the final checkpoint.
- `hermes_state.py` (`vacuum`): Replace `except Exception: pass` with `except Exception as exc: logger.debug(...)` for the pre-VACUUM checkpoint.
- `tests/test_wal_checkpoint_exception.py`: New test file with 6 tests covering warning logging, integrity check on failure, error logging on integrity failure, silent success, close resilience, and vacuum resilience.

## How to Test

1. Run `python -m pytest tests/test_wal_checkpoint_exception.py -v` — all 6 tests should pass
2. Verify the fix handles the scenario from #44795: when `_try_wal_checkpoint` encounters a checkpoint failure, it now logs a warning instead of silently continuing, and runs `PRAGMA quick_check(1)` to detect corruption
3. Existing `test_hermes_state.py` tests remain unaffected — no behavioral change in the happy path

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `_try_wal_checkpoint()`, `close()`, `vacuum()` in `hermes_state.py` (3 call sites for `PRAGMA wal_checkpoint(TRUNCATE)`)
- Blast radius: LOW — only changes exception handling from silent to logged; no control flow or behavioral changes in the happy path
- Related patterns: #33865 (FTS corruption during checkpoint), PR #31294 (WAL incompat markers), PR #31208 (synchronous=FULL hardening)
