### PR TITLE
fix(discord): prevent operator lockout when all username allowlist entries fail to resolve

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3232,7 +3232,10 @@ class DiscordAdapter(BasePlatformAdapter):
         if not to_resolve:
             return
 
-        print(f"[{self.name}] Resolving {len(to_resolve)} username(s): {', '.join(to_resolve)}")
+        logger.info(
+            "[%s] Resolving %d username(s): %s",
+            self.name, len(to_resolve), ", ".join(sorted(to_resolve)),
+        )
         resolved_count = 0
 
         for guild in self._client.guilds:
@@ -3259,19 +3262,40 @@ class DiscordAdapter(BasePlatformAdapter):
                         display_lower if display_lower in to_resolve else global_lower
                     )
                     to_resolve.discard(matched_name)
-                    print(f"[{self.name}] Resolved '{matched_name}' -> {uid} ({member.name}#{member.discriminator})")
+                    logger.debug(
+                        "[%s] Resolved '%s' -> %s (%s#%s)",
+                        self.name, matched_name, uid, member.name, member.discriminator,
+                    )
 
             if not to_resolve:
                 break
 
         if to_resolve:
-            print(f"[{self.name}] Could not resolve usernames: {', '.join(to_resolve)}")
+            # If ALL entries were non-numeric and none resolved, rewriting
+            # the allowlist to empty would cause operator lockout (gateway
+            # default-denies on empty Discord allowlist).  Keep the raw
+            # entries so the operator can diagnose the issue.
+            if not numeric_ids:
+                logger.warning(
+                    "[%s] None of %d configured username(s) resolved: %s. "
+                    "Keeping raw entries in DISCORD_ALLOWED_USERS to avoid "
+                    "operator lockout. Verify usernames and Server Members intent.",
+                    self.name, len(to_resolve), ", ".join(sorted(to_resolve)),
+                )
+                return
+            logger.warning(
+                "[%s] Could not resolve %d username(s): %s",
+                self.name, len(to_resolve), ", ".join(sorted(to_resolve)),
+            )
 
         # Update internal set and env var so gateway auth checks use IDs
         self._allowed_user_ids = numeric_ids
         os.environ["DISCORD_ALLOWED_USERS"] = ",".join(sorted(numeric_ids))
         if resolved_count:
-            print(f"[{self.name}] Updated DISCORD_ALLOWED_USERS with {resolved_count} resolved ID(s)")
+            logger.info(
+                "[%s] Updated DISCORD_ALLOWED_USERS with %d resolved ID(s)",
+                self.name, resolved_count,
+            )
 
     def format_message(self, content: str) -> str:
         """

--- a/tests/gateway/test_discord_username_allowlist.py
+++ b/tests/gateway/test_discord_username_allowlist.py
@@ -1,0 +1,118 @@
+"""Tests for Discord username allowlist resolution guard.
+
+Covers the fix for #44802: _resolve_allowed_usernames rewrites the allowlist
+to empty when all configured usernames fail to resolve, causing operator lockout.
+"""
+
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+@pytest.fixture()
+def adapter(tmp_path, monkeypatch):
+    """Create a DiscordAdapter with minimal setup for testing."""
+    monkeypatch.setenv("DISCORD_TOKEN", "test-token")
+    monkeypatch.setenv("DISCORD_ALLOWED_USERS", "alice,bob")
+
+    from plugins.platforms.discord.adapter import DiscordAdapter
+
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._client = MagicMock()
+    adapter._client.guilds = []
+    return adapter
+
+
+class TestResolveAllowedUsernamesGuard:
+    """Verify that unresolved usernames don't cause operator lockout."""
+
+    @pytest.mark.asyncio
+    async def test_all_unresolved_keeps_original_entries(self, adapter, caplog):
+        """When ALL usernames fail to resolve, keep original entries."""
+        import logging
+        adapter._allowed_user_ids = {"alice", "bob"}
+
+        # No guilds → nothing resolves
+        adapter._client.guilds = []
+
+        with caplog.at_level(logging.WARNING):
+            await adapter._resolve_allowed_usernames()
+
+        # Original entries should be preserved (not overwritten to empty)
+        assert "alice" in adapter._allowed_user_ids or "bob" in adapter._allowed_user_ids
+        # Warning should be logged about unresolved usernames
+        assert any("None of" in r.message and "resolved" in r.message
+                    for r in caplog.records), \
+            f"Expected warning not found: {[r.message for r in caplog.records]}"
+
+    @pytest.mark.asyncio
+    async def test_partial_resolution_updates_with_resolved_ids(self, adapter):
+        """When some usernames resolve, update with resolved IDs."""
+        adapter._allowed_user_ids = {"alice", "12345"}
+
+        # Mock a guild with alice as a member
+        member = MagicMock()
+        member.name = "alice"
+        member.display_name = "Alice Display"
+        member.global_name = None
+        member.id = 99999
+        member.discriminator = "0"
+
+        guild = MagicMock()
+        guild.members = [member]
+        guild.member_count = 1
+        adapter._client.guilds = [guild]
+
+        await adapter._resolve_allowed_usernames()
+
+        # Should have both the pre-existing numeric ID and the resolved one
+        assert "12345" in adapter._allowed_user_ids
+        assert "99999" in adapter._allowed_user_ids
+
+    @pytest.mark.asyncio
+    async def test_all_numeric_no_resolution_needed(self, adapter):
+        """When all entries are numeric, no resolution happens."""
+        adapter._allowed_user_ids = {"12345", "67890"}
+
+        await adapter._resolve_allowed_usernames()
+
+        # Unchanged
+        assert adapter._allowed_user_ids == {"12345", "67890"}
+
+    @pytest.mark.asyncio
+    async def test_empty_allowlist_returns_early(self, adapter):
+        """Empty allowlist should return immediately."""
+        adapter._allowed_user_ids = set()
+
+        await adapter._resolve_allowed_usernames()
+        # No error raised
+
+    @pytest.mark.asyncio
+    async def test_mixed_resolution_with_partial_failure(self, adapter, caplog):
+        """When some resolve and some don't (but IDs exist), update normally."""
+        import logging
+        adapter._allowed_user_ids = {"alice", "charlie", "12345"}
+
+        member = MagicMock()
+        member.name = "alice"
+        member.display_name = "Alice"
+        member.global_name = None
+        member.id = 11111
+        member.discriminator = "0"
+
+        guild = MagicMock()
+        guild.members = [member]
+        guild.member_count = 1
+        adapter._client.guilds = [guild]
+
+        with caplog.at_level(logging.WARNING):
+            await adapter._resolve_allowed_usernames()
+
+        # Should have resolved IDs + original numeric
+        assert "12345" in adapter._allowed_user_ids
+        assert "11111" in adapter._allowed_user_ids
+        # charlie should not be in the set (unresolved, but IDs exist)
+        assert "charlie" not in adapter._allowed_user_ids


### PR DESCRIPTION
## What does this PR do?

Prevents operator lockout in the Discord adapter when all configured username allowlist entries fail to resolve. `_resolve_allowed_usernames()` was unconditionally rewriting the internal allowlist and `os.environ["DISCORD_ALLOWED_USERS"]` to only the resolved numeric IDs — when all entries are non-numeric and none resolve, the allowlist becomes empty, causing the gateway to default-deny all Discord senders including the operator.

## Related Issue

Fixes #44802

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/discord/adapter.py` (`_resolve_allowed_usernames`): When all entries were non-numeric and none resolved, early return without mutating the allowlist. Log a warning with actionable diagnostics (unresolved names, Server Members intent hint).
- `plugins/platforms/discord/adapter.py`: Replace all `print()` calls in this method with structured `logger.info()` / `logger.warning()` / `logger.debug()`.
- `tests/gateway/test_discord_username_allowlist.py`: New test file with 5 tests covering all-unresolved guard, partial resolution, all-numeric passthrough, empty allowlist, and mixed resolution with partial failure.

## How to Test

1. Run `python -m pytest tests/gateway/test_discord_username_allowlist.py -v` — all 5 tests should pass
2. Simulate the lockout scenario: set `DISCORD_ALLOWED_USERS=nonexistent_user` (no numeric IDs), start Discord adapter. Before this fix, the allowlist would be silently rewritten to empty. After the fix, a warning is logged and the original entries are preserved.
3. Verify partial resolution still works: `DISCORD_ALLOWED_USERS=alice,12345` where "alice" is a real guild member → allowlist updated to `{"12345", "<alice_id>"}`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `_resolve_allowed_usernames()` in `plugins/platforms/discord/adapter.py` (callers: Discord ready handler at L858)
- Blast radius: LOW — only affects Discord username resolution path; fallback (numeric IDs) unchanged
- Related patterns: #42368 (actionable auth hint for empty allowlist config)
