### PR TITLE
fix: support oneshot inference env overrides

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -17,6 +17,8 @@ Model / provider selection mirrors `hermes chat`:
 
 Env var fallbacks (used when the corresponding arg is not passed):
     - HERMES_INFERENCE_MODEL
+    - HERMES_INFERENCE_REASONING_EFFORT (none|minimal|low|medium|high|xhigh)
+    - HERMES_INFERENCE_SERVICE_TIER (fast|priority|normal|off)
 """
 
 from __future__ import annotations
@@ -120,6 +122,45 @@ def _validate_explicit_toolsets(toolsets: object = None) -> tuple[list[str] | No
         return None, "hermes -z: --toolsets did not contain any valid toolsets.\n"
 
     return valid, None
+
+
+def _parse_env_reasoning_config() -> dict | None:
+    """Return a oneshot reasoning override from env, or None for default."""
+    effort = os.getenv("HERMES_INFERENCE_REASONING_EFFORT", "").strip()
+    if not effort:
+        return None
+    try:
+        parse_reasoning_effort = __import__("hermes_constants").parse_reasoning_effort
+    except Exception:
+        return None
+    result = parse_reasoning_effort(effort)
+    if result is None:
+        logging.warning("Unknown HERMES_INFERENCE_REASONING_EFFORT '%s', using provider default", effort)
+    return result
+
+
+def _parse_env_service_tier() -> str | None:
+    """Parse env fast/priority toggle into the API service tier value."""
+    value = os.getenv("HERMES_INFERENCE_SERVICE_TIER", "").strip().lower()
+    if not value or value in {"normal", "default", "standard", "off", "none"}:
+        return None
+    if value in {"fast", "priority", "on"}:
+        return "priority"
+    logging.warning("Unknown HERMES_INFERENCE_SERVICE_TIER '%s', ignoring", value)
+    return None
+
+
+def _fast_mode_request_overrides(model_id: str, service_tier: str | None) -> dict | None:
+    if not service_tier:
+        return None
+    try:
+        resolve_fast_mode_overrides = __import__(
+            "hermes_cli.models", fromlist=["resolve_fast_mode_overrides"]
+        ).resolve_fast_mode_overrides
+
+        return resolve_fast_mode_overrides(model_id)
+    except Exception:
+        return {"service_tier": service_tier}
 
 
 def run_oneshot(
@@ -332,6 +373,10 @@ def _run_agent(
     # honour the same merge semantics as interactive CLI and gateway sessions.
     _fb = get_fallback_chain(cfg)
 
+    reasoning_config = _parse_env_reasoning_config()
+    service_tier = _parse_env_service_tier()
+    request_overrides = _fast_mode_request_overrides(effective_model, service_tier)
+
     agent = AIAgent(
         api_key=runtime.get("api_key"),
         base_url=runtime.get("base_url"),
@@ -344,6 +389,9 @@ def _run_agent(
         session_db=session_db,
         credential_pool=runtime.get("credential_pool"),
         fallback_model=_fb or None,
+        reasoning_config=reasoning_config,
+        service_tier=service_tier,
+        request_overrides=request_overrides,
         # Interactive callbacks are intentionally NOT wired beyond this
         # one.  In oneshot mode there's no user sitting at a terminal:
         #   - clarify  → returns a synthetic "pick a default" instruction

--- a/tests/hermes_cli/test_oneshot_env_overrides.py
+++ b/tests/hermes_cli/test_oneshot_env_overrides.py
@@ -1,0 +1,25 @@
+from hermes_cli.oneshot import (
+    _fast_mode_request_overrides,
+    _parse_env_reasoning_config,
+    _parse_env_service_tier,
+)
+
+
+def test_oneshot_reads_reasoning_effort_from_env(monkeypatch):
+    monkeypatch.setenv("HERMES_INFERENCE_REASONING_EFFORT", "minimal")
+
+    assert _parse_env_reasoning_config() == {"enabled": True, "effort": "minimal"}
+
+
+def test_oneshot_reads_service_tier_from_env(monkeypatch):
+    monkeypatch.setenv("HERMES_INFERENCE_SERVICE_TIER", "fast")
+    assert _parse_env_service_tier() == "priority"
+
+    monkeypatch.setenv("HERMES_INFERENCE_SERVICE_TIER", "off")
+    assert _parse_env_service_tier() is None
+
+
+def test_oneshot_builds_fast_mode_overrides_for_openai_model():
+    assert _fast_mode_request_overrides("gpt-5.4-mini", "priority") == {
+        "service_tier": "priority"
+    }


### PR DESCRIPTION
## Summary
- Add `HERMES_INFERENCE_REASONING_EFFORT` support to `hermes -z` / oneshot mode
- Add `HERMES_INFERENCE_SERVICE_TIER` support so subprocess callers can request fast/priority mode without changing global config
- Cover the new env parsing helpers with focused tests

## Why
One-shot callers such as lightweight translation bots need to tune reasoning effort and fast mode per subprocess without mutating the user's default Hermes profile.

## Test Plan
- `/Users/baedabin/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/hermes_cli/test_oneshot_env_overrides.py`
- `/Users/baedabin/.hermes/hermes-agent/venv/bin/python -m py_compile hermes_cli/oneshot.py tests/hermes_cli/test_oneshot_env_overrides.py`
- `git diff --check`
