### PR TITLE
fix(kanban): anchor worktree root to assignee profile + availability-guard per-task skills

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3092,6 +3092,9 @@ def claim_review_task(
 ) -> Optional[Task]:
     """Atomically transition ``review -> running``.
 
+    Currently unreachable: the only caller is the dead review-column dispatch in
+    :func:`dispatch_once`; retained but marked for removal.
+
     Returns the claimed ``Task`` on success, ``None`` if the task was
     already claimed (or is not in ``review`` status).
 
@@ -6018,6 +6021,10 @@ def has_spawnable_review(conn: sqlite3.Connection) -> bool:
     Mirror of :func:`has_spawnable_ready` for the review column —
     used by the health telemetry to decide whether the dispatcher
     should have spawned a review agent.
+
+    Currently unreachable: the review-column dispatch never fires (nothing
+    transitions a task into status='review'), so this helper has no live
+    callers; retained but marked for removal.
     """
     rows = conn.execute(
         "SELECT DISTINCT assignee FROM tasks "
@@ -6350,6 +6357,14 @@ def dispatch_once(
                 result.auto_blocked.append(claimed.id)
 
     # ---- review column dispatch ----
+    #
+    # NOTE: this lane is currently unreachable and is marked for removal. No
+    # tool, CLI verb, MCP surface, or API transitions a task INTO
+    # status='review', so this loop never runs on any supported path, and the
+    # ``sdlc-review`` skill it force-loads below does not exist. Retained (not
+    # deleted) for now so the removal can be reviewed on its own — do not build
+    # on it.
+    #
     # Review tasks are tasks that a worker moved to 'review' after
     # creating a PR.  The dispatcher spawns a review agent (loading
     # sdlc-review skill) that verifies the PR and either merges (→ done)
@@ -6395,11 +6410,11 @@ def dispatch_once(
         # Persist the resolved workspace path so the worker can cd there.
         set_workspace_path(conn, claimed.id, str(workspace))
         _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
-        # Force-load sdlc-review skill for review agents.  The
-        # _default_spawn function already auto-loads kanban-worker, and
-        # appends task.skills via --skills.  Setting task.skills here
-        # means the review agent gets both kanban-worker (lifecycle)
-        # and sdlc-review (review logic: AC verification, merge, etc.).
+        # Unreachable (see note above): ``sdlc-review`` is a non-existent skill.
+        # This force-load previously crashed the review worker at CLI startup
+        # (Unknown skill(s): sdlc-review); _default_spawn now availability-guards
+        # per-task skills, so it is dropped-with-warning instead — but the whole
+        # review lane is unreachable and marked for removal regardless.
         claimed.skills = ["sdlc-review"]
         _spawn = spawn_fn if spawn_fn is not None else _default_spawn
         try:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4736,7 +4736,21 @@ def resolve_workspace(task: Task, *, board: Optional[str] = None) -> Path:
         return p
     if kind == "worktree":
         if not task.workspace_path:
-            # Default: .worktrees/<id>/ under CWD.  Worker skill creates it.
+            # Default worktree root: ``<assignee-profile-home>/.worktrees/<id>``.
+            # Anchor to the ASSIGNEE's profile home, NOT ``Path.cwd()``: the
+            # dispatcher runs inside whichever profile owns the gateway, so a
+            # CWD-relative root silently rooted every executor's worktree under
+            # the gateway profile's dir, mixing unrelated profiles' checkouts
+            # under one shared ``.git/worktrees`` registry. Resolving the
+            # assignee's home keeps each executor's worktrees under its own
+            # profile. Falls back to the legacy CWD-relative path only when no
+            # assignee is set or the profile cannot be resolved.
+            if task.assignee:
+                try:
+                    from hermes_cli.profiles import get_profile_dir
+                    return get_profile_dir(task.assignee) / ".worktrees" / task.id
+                except Exception:
+                    pass
             return Path.cwd() / ".worktrees" / task.id
         p = Path(task.workspace_path).expanduser()
         if not p.is_absolute():
@@ -6610,6 +6624,33 @@ def _resolve_hermes_argv() -> list[str]:
     return _module_hermes_argv()
 
 
+def _kanban_skill_available(hermes_home: Optional[str], skill_name: str) -> bool:
+    """True if a force-loadable skill ``skill_name`` resolves for the home the
+    spawned worker will run under.
+
+    Generalizes :func:`_kanban_worker_skill_available` to ANY per-task skill so
+    an unresolved name is dropped-with-warning at spawn time instead of crashing
+    the worker at CLI startup (``ValueError: Unknown skill(s): <name>``) before
+    the agent loop runs. An unset ``hermes_home`` means the worker falls back to
+    the default root home (``~/.hermes``).
+    """
+    from pathlib import Path as _Path
+
+    if not skill_name:
+        return False
+    base = _Path(hermes_home) if hermes_home else (_Path.home() / ".hermes")
+    skills_root = base / "skills"
+    if not skills_root.is_dir():
+        return False
+    try:
+        for skill_md in skills_root.rglob(f"{skill_name}/SKILL.md"):
+            if skill_md.is_file():
+                return True
+    except OSError:
+        pass
+    return False
+
+
 def _kanban_worker_skill_available(hermes_home: Optional[str]) -> bool:
     """True if the bundled ``kanban-worker`` skill resolves for the home the
     spawned worker will run under.
@@ -6626,23 +6667,12 @@ def _kanban_worker_skill_available(hermes_home: Optional[str]) -> bool:
     """
     from pathlib import Path as _Path
 
-    # An unset HERMES_HOME means the worker falls back to the default root
-    # home (``~/.hermes``), which ships the bundled skill.
-    base = _Path(hermes_home) if hermes_home else (_Path.home() / ".hermes")
-    skills_root = base / "skills"
-    if not skills_root.is_dir():
-        return False
-    # Canonical bundled location first (cheap), then a bounded scan for
+    # Canonical bundled location first (cheap), then the general resolver for
     # profiles that have it nested elsewhere.
-    if (skills_root / "devops" / "kanban-worker" / "SKILL.md").is_file():
+    base = _Path(hermes_home) if hermes_home else (_Path.home() / ".hermes")
+    if (base / "skills" / "devops" / "kanban-worker" / "SKILL.md").is_file():
         return True
-    try:
-        for skill_md in skills_root.rglob("kanban-worker/SKILL.md"):
-            if skill_md.is_file():
-                return True
-    except OSError:
-        pass
-    return False
+    return _kanban_skill_available(hermes_home, "kanban-worker")
 
 
 def _worker_terminal_timeout_env(
@@ -6803,9 +6833,23 @@ def _default_spawn(
     # Dedupe against the built-in so we don't double-load kanban-worker
     # if a task author asks for it explicitly.
     if task.skills:
+        worker_home = env.get("HERMES_HOME")
         for sk in task.skills:
-            if sk and sk != "kanban-worker":
+            if not sk or sk == "kanban-worker":
+                continue
+            # Availability-guard EVERY per-task force-loaded skill: an
+            # unresolved name is fatal at the worker's CLI startup
+            # (``Unknown skill(s): <name>``), crashing it before the agent loop
+            # runs. Drop-with-warning degrades gracefully — the task still runs,
+            # just without that skill's pattern library.
+            if _kanban_skill_available(worker_home, sk):
                 cmd.extend(["--skills", sk])
+            else:
+                _log.warning(
+                    "kanban task %s: dropping unresolved force-loaded skill %r "
+                    "(not found under %s/skills) to avoid worker startup crash",
+                    task.id, sk, worker_home or "~/.hermes",
+                )
     if task.model_override:
         cmd.extend(["-m", task.model_override])
     cmd.extend([

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -2985,8 +2985,14 @@ def test_create_task_skills_lists_all_toolset_typos(kanban_home):
 
 def test_default_spawn_appends_per_task_skills(kanban_home, monkeypatch):
     """Dispatcher argv must carry one `--skills X` pair per task skill,
-    in addition to the built-in kanban-worker."""
+    in addition to the built-in kanban-worker.
+
+    Resolution is mocked True here so the test stays focused on argv *shaping*;
+    the per-skill availability guard is exercised separately in
+    ``test_default_spawn_drops_unresolved_per_task_skills``.
+    """
     monkeypatch.setattr(kb, "_kanban_worker_skill_available", lambda _h: True)
+    monkeypatch.setattr(kb, "_kanban_skill_available", lambda _h, _s: True)
     captured = {}
 
     class FakeProc:
@@ -3032,6 +3038,50 @@ def test_default_spawn_appends_per_task_skills(kanban_home, monkeypatch):
     assert last_skills_idx < chat_idx, (
         f"--skills must come before 'chat' in argv: {cmd}"
     )
+
+
+def test_default_spawn_drops_unresolved_per_task_skills(kanban_home, monkeypatch):
+    """A per-task skill that does not resolve under the worker's skills dir is
+    dropped from the spawn argv (with a warning) instead of being appended —
+    force-loading an unknown skill crashes the worker at CLI startup before the
+    agent loop runs."""
+    monkeypatch.setattr(kb, "_kanban_worker_skill_available", lambda _h: True)
+    # Use the REAL _kanban_skill_available: nothing exists under the isolated
+    # test skills dir, so any per-task skill is unresolved and must be dropped.
+    captured = {}
+
+    class FakeProc:
+        def __init__(self):
+            self.pid = 42
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return FakeProc()
+
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="ghost-skill worker",
+            assignee="linguist",
+            skills=["does-not-exist"],
+        )
+        task = kb.get_task(conn, tid)
+        workspace = kb.resolve_workspace(task)
+        kb._default_spawn(task, str(workspace))
+    finally:
+        conn.close()
+
+    cmd = captured["cmd"]
+    skill_names = [
+        cmd[i + 1] for i, tok in enumerate(cmd)
+        if tok == "--skills" and i + 1 < len(cmd)
+    ]
+    assert "does-not-exist" not in skill_names
+    # The built-in worker skill (mocked available) is still passed.
+    assert "kanban-worker" in skill_names
 
 
 def test_default_spawn_dedupes_kanban_worker_from_task_skills(kanban_home, monkeypatch):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1929,6 +1929,44 @@ def test_worktree_workspace_returns_intended_path(kanban_home, tmp_path):
     assert str(ws) == target
 
 
+def test_worktree_default_anchors_under_assignee_profile(kanban_home):
+    """A worktree task with no explicit path roots its worktree under the
+    ASSIGNEE's profile home (``<profiles>/<assignee>/.worktrees/<id>``), NOT the
+    dispatcher's CWD — so executors never share a ``.git/worktrees`` registry
+    with whichever profile happens to own the gateway."""
+    from hermes_cli.profiles import get_profile_dir
+    with kb.connect() as conn:
+        t = kb.create_task(
+            conn, title="code slice", workspace_kind="worktree", assignee="alice"
+        )
+        task = kb.get_task(conn, t)
+        ws = kb.resolve_workspace(task)
+    assert ws == get_profile_dir("alice") / ".worktrees" / t
+
+
+def test_worktree_default_falls_back_to_cwd_without_assignee(kanban_home):
+    """Fallback: with no assignee the legacy CWD-relative root is used."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="orphan slice", workspace_kind="worktree")
+        task = kb.get_task(conn, t)
+        ws = kb.resolve_workspace(task)
+    assert ws.name == t
+    assert ws.parent.name == ".worktrees"
+
+
+def test_kanban_skill_available_resolves_and_rejects(tmp_path):
+    """The per-task skill availability guard resolves a present skill and
+    rejects an absent one, so an unresolved force-loaded skill is dropped at
+    spawn time rather than crashing the worker at CLI startup."""
+    skill_dir = tmp_path / "skills" / "devops" / "my-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# my-skill\n")
+    home = str(tmp_path)
+    assert kb._kanban_skill_available(home, "my-skill") is True
+    assert kb._kanban_skill_available(home, "absent-skill") is False
+    assert kb._kanban_skill_available(home, "") is False
+
+
 # ---------------------------------------------------------------------------
 # Scratch cleanup containment (#28818)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Two small, self-contained robustness fixes to the kanban dispatcher, plus one dead-code annotation (separate commit).

### 1. Anchor the default worktree root to the assignee profile (not the dispatcher CWD)

`resolve_workspace()` resolved a `worktree`-kind task with no explicit `workspace_path` to `Path.cwd() / ".worktrees" / <id>`. The dispatcher runs inside whichever profile owns the gateway, so this CWD-relative default rooted **every** executor's worktree under that single profile's directory — mixing unrelated profiles' checkouts under one shared `.git/worktrees` registry.

This anchors the default worktree root under the **assignee** profile's home (`<profiles>/<assignee>/.worktrees/<id>`), and falls back to the legacy CWD-relative path when no assignee is set or the profile can't be resolved.

### 2. Availability-guard every per-task force-loaded skill

`_default_spawn()` appended each `task.skills` entry to the worker argv as `--skills <name>` **without checking the skill resolves** for the profile-scoped home the worker runs under. An unresolved name is fatal at the worker's CLI startup (`ValueError: Unknown skill(s): <name>`), crashing the worker before the agent loop runs. The built-in `kanban-worker` skill was already guarded by `_kanban_worker_skill_available`; this generalizes that into `_kanban_skill_available(home, name)` and applies it to every per-task skill — dropping unresolved names with a warning instead of crashing.

### 3. (separate commit) Mark the dead `status='review'` dispatch lane

No tool, CLI verb, MCP surface, or API transitions a task into `status='review'`, so the review-column dispatch in `dispatch_once()` (and `claim_review_task` / `has_spawnable_review`) never runs, and the `sdlc-review` skill it force-loads does not exist. This commit only **annotates** them as unreachable / for-removal (comments, no behavior change). Happy to drop this commit if you'd prefer to keep the PR to the two fixes.

## Tests

- New: worktree anchoring (assignee + no-assignee fallback), skill availability-guard resolution, and a drop-unresolved-skill spawn test.
- The existing argv-shaping test is updated to mock resolution (it tests `--skills` ordering, not resolution).
- Full kanban suite green locally: `tests/hermes_cli/test_kanban_db.py`, `test_kanban_core_functionality.py`, `test_kanban_cli.py`, `tests/tools/test_kanban_tools.py`, `tests/hermes_cli/test_kanban_goal_mode.py`, `tests/plugins/test_kanban_worker_runs.py`.
