### PR TITLE
fix(tools): bypass read dedup in execute_code

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -888,6 +888,7 @@ def handle_function_call(
     tool_request_middleware_trace: Optional[List[Dict[str, Any]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     disabled_toolsets: Optional[List[str]] = None,
+    suppress_read_dedup: bool = False,
 ) -> str:
     """
     Main function call dispatcher that routes calls to the tool registry.
@@ -909,6 +910,9 @@ def handle_function_call(
                        matching ``get_tool_definitions`` semantics.
         disabled_toolsets: The session's disabled toolsets, applied as a
                        subtraction when scoping the bridge catalog.
+        suppress_read_dedup: Internal execute_code path flag.  Programmatic
+                       sandbox reads should return actual content on repeated
+                       calls instead of the model-facing dedup status stub.
 
     Returns:
         Function result as a JSON string.
@@ -1119,6 +1123,13 @@ def handle_function_call(
                     )
             else:
                 def _dispatch(next_args: Dict[str, Any]) -> Any:
+                    if function_name == "read_file" and suppress_read_dedup:
+                        return registry.dispatch(
+                            function_name, next_args,
+                            task_id=task_id,
+                            user_task=user_task,
+                            suppress_dedup=True,
+                        )
                     return registry.dispatch(
                         function_name, next_args,
                         task_id=task_id,

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -47,7 +47,7 @@ from tools.code_execution_tool import (
 )
 
 
-def _mock_handle_function_call(function_name, function_args, task_id=None, user_task=None):
+def _mock_handle_function_call(function_name, function_args, task_id=None, user_task=None, **kwargs):
     """Mock dispatcher that returns canned responses for each tool."""
     if function_name == "terminal":
         cmd = function_args.get("command", "")
@@ -229,6 +229,36 @@ print(f"file lines: {r2['total_lines']}")
         result = self._run(code)
         self.assertEqual(result["status"], "success")
         self.assertEqual(result["tool_calls_made"], 2)
+
+    def test_read_file_calls_suppress_parent_dedup(self):
+        """Sandbox read_file calls must not receive the model-facing dedup stub."""
+        calls = []
+
+        def mock_dispatch(function_name, function_args, **kwargs):
+            calls.append((function_name, kwargs))
+            if function_name == "read_file":
+                return json.dumps({"content": "line 1\n", "total_lines": 1})
+            return json.dumps({"error": f"unexpected tool: {function_name}"})
+
+        code = """
+from hermes_tools import read_file
+first = read_file("notes.txt")
+second = read_file("notes.txt")
+print(first["content"].strip())
+print(second["content"].strip())
+"""
+        with patch("model_tools.handle_function_call", side_effect=mock_dispatch):
+            result = json.loads(execute_code(
+                code=code,
+                task_id="test-task",
+                enabled_tools=["read_file"],
+            ))
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["tool_calls_made"], 2)
+        read_kwargs = [kwargs for name, kwargs in calls if name == "read_file"]
+        self.assertEqual(len(read_kwargs), 2)
+        self.assertTrue(all(kwargs.get("suppress_read_dedup") is True for kwargs in read_kwargs))
 
     def test_syntax_error(self):
         """Script with a syntax error returns error status."""

--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -247,6 +247,29 @@ class TestFileDedup(unittest.TestCase):
         self.assertNotIn("content", r2)
 
     @patch("tools.file_tools._get_file_ops")
+    def test_suppress_dedup_returns_content_on_repeated_reads(self, mock_ops):
+        """Programmatic callers can opt out of model-facing read dedup stubs."""
+        mock_ops.return_value = _make_fake_ops(
+            content="line one\nline two\n", file_size=20,
+        )
+
+        r1 = json.loads(read_file_tool(
+            self._tmpfile,
+            task_id="sandbox",
+            suppress_dedup=True,
+        ))
+        r2 = json.loads(read_file_tool(
+            self._tmpfile,
+            task_id="sandbox",
+            suppress_dedup=True,
+        ))
+
+        self.assertEqual(r1.get("content"), "line one\nline two\n")
+        self.assertEqual(r2.get("content"), "line one\nline two\n")
+        self.assertNotIn("dedup", r1)
+        self.assertNotIn("dedup", r2)
+
+    @patch("tools.file_tools._get_file_ops")
     def test_write_rejects_internal_read_status_text(self, mock_ops):
         """write_file must not persist internal read_file status text."""
         fake = MagicMock()

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -550,8 +550,12 @@ def _rpc_server_loop(
                     try:
                         sys.stdout = devnull
                         sys.stderr = devnull
+                        dispatch_kwargs = {"task_id": task_id}
+                        if tool_name == "read_file":
+                            dispatch_kwargs["suppress_read_dedup"] = True
                         result = handle_function_call(
-                            tool_name, tool_args, task_id=task_id
+                            tool_name, tool_args,
+                            **dispatch_kwargs,
                         )
                     finally:
                         sys.stdout, sys.stderr = _real_stdout, _real_stderr
@@ -823,8 +827,12 @@ def _rpc_poll_loop(
                         try:
                             sys.stdout = devnull
                             sys.stderr = devnull
+                            dispatch_kwargs = {"task_id": task_id}
+                            if tool_name == "read_file":
+                                dispatch_kwargs["suppress_read_dedup"] = True
                             tool_result = handle_function_call(
-                                tool_name, tool_args, task_id=task_id
+                                tool_name, tool_args,
+                                **dispatch_kwargs,
                             )
                         finally:
                             sys.stdout, sys.stderr = _real_stdout, _real_stderr

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -742,7 +742,13 @@ def clear_file_ops_cache(task_id: str = None):
             _file_ops_cache.clear()
 
 
-def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = "default") -> str:
+def read_file_tool(
+    path: str,
+    offset: int = 1,
+    limit: int = 500,
+    task_id: str = "default",
+    suppress_dedup: bool = False,
+) -> str:
     """Read a file with pagination and line numbers."""
     try:
         offset, limit = normalize_read_pagination(offset, limit)
@@ -803,7 +809,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                 task_data["read_timestamps"] = {}
             cached_mtime = task_data.get("dedup", {}).get(dedup_key)
 
-        if cached_mtime is not None:
+        if cached_mtime is not None and not suppress_dedup:
             try:
                 current_mtime = os.path.getmtime(resolved_str)
                 if current_mtime == cached_mtime:
@@ -901,12 +907,15 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
             # earlier and we fell through.)
             task_data["dedup_hits"].pop(dedup_key, None)
             task_data["read_history"].add((path, offset, limit))
-            if task_data["last_key"] == read_key:
+            if suppress_dedup:
+                count = 1
+            elif task_data["last_key"] == read_key:
                 task_data["consecutive"] += 1
+                count = task_data["consecutive"]
             else:
                 task_data["last_key"] = read_key
                 task_data["consecutive"] = 1
-            count = task_data["consecutive"]
+                count = task_data["consecutive"]
 
             # Store mtime at read time for two purposes:
             # 1. Dedup: skip identical re-reads of unchanged files.
@@ -914,7 +923,8 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
             #    the agent last read it (external edit, concurrent agent, etc.).
             try:
                 _mtime_now = os.path.getmtime(resolved_str)
-                task_data["dedup"][dedup_key] = _mtime_now
+                if not suppress_dedup:
+                    task_data["dedup"][dedup_key] = _mtime_now
                 task_data.setdefault("read_timestamps", {})[resolved_str] = _mtime_now
             except OSError:
                 pass  # Can't stat — skip tracking for this entry
@@ -1530,7 +1540,13 @@ SEARCH_FILES_SCHEMA = {
 
 def _handle_read_file(args, **kw):
     tid = kw.get("task_id") or "default"
-    return read_file_tool(path=args.get("path", ""), offset=args.get("offset", 1), limit=args.get("limit", 500), task_id=tid)
+    return read_file_tool(
+        path=args.get("path", ""),
+        offset=args.get("offset", 1),
+        limit=args.get("limit", 500),
+        task_id=tid,
+        suppress_dedup=bool(kw.get("suppress_dedup", False)),
+    )
 
 
 def _handle_write_file(args, **kw):


### PR DESCRIPTION
## What does this PR do?

Fixes `execute_code` sandbox `read_file()` calls leaking the model-facing read dedup response into programmatic code.

The normal `read_file` tool intentionally returns a lightweight `status: "unchanged"` response on repeated same-range reads to save model context. Inside `execute_code`, that optimization breaks the documented `hermes_tools.read_file()` API shape: a second read can omit `content`, causing sandbox scripts to hit `KeyError` even though the file is readable.

This adds an internal dedup-suppression path for execute_code RPC calls to `read_file` only. Normal model-facing `read_file` calls keep the existing dedup behavior, while sandbox reads consistently return the actual content payload.

## Related Issue

Fixes #44843

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/code_execution_tool.py`: pass an internal dedup-suppression flag for sandbox `read_file` RPC calls in both local and remote execute_code paths.
- `model_tools.py` and `tools/file_tools.py`: route the internal flag to `read_file_tool` without exposing it in the public tool schema.
- `tests/tools/test_code_execution.py`: cover execute_code forwarding the dedup-suppression flag for repeated sandbox reads.
- `tests/tools/test_file_read_guards.py`: cover repeated programmatic reads returning content while normal dedup remains unchanged.

## How to Test

1. Reproduce the issue from #44843: call `hermes_tools.read_file()` twice for the same file/range inside `execute_code`; before this patch the second call can return the `content_returned: false` dedup stub instead of `content`.
2. Run focused validation:

```text
$ .venv/bin/python -m pytest tests/tools/test_file_read_guards.py tests/tools/test_code_execution.py -q
108 passed, 1 warning in 99.57s (0:01:39)
```

3. Check whitespace:

```text
$ git diff --check
# no output
```

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3.1 arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Focused test output:

```text
108 passed, 1 warning in 99.57s (0:01:39)
```
