### PR TITLE
fix(matrix): preserve table HTML in sanitizer

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -209,7 +209,7 @@ class _MatrixHtmlSanitizer(HTMLParser):
     _ALLOWED_TAGS = {
         "a", "b", "blockquote", "br", "code", "del", "em", "h1", "h2", "h3",
         "h4", "h5", "h6", "hr", "i", "li", "ol", "p", "pre", "s", "strike",
-        "strong", "ul",
+        "strong", "table", "tbody", "td", "tfoot", "th", "thead", "tr", "ul",
     }
     _VOID_TAGS = {"br", "hr"}
 

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1090,6 +1090,39 @@ class TestMatrixMarkdownToHtml:
         assert "<code" in result
         assert "print" in result
 
+    def test_matrix_sanitizer_preserves_tables(self):
+        from gateway.platforms.matrix import _sanitize_matrix_html
+
+        result = _sanitize_matrix_html(
+            '<table onclick="alert(1)"><thead><tr><th>Name</th><th>Value</th></tr>'
+            '</thead><tbody><tr><td style="color:red">Alpha</td><td>1</td></tr>'
+            "</tbody></table>"
+        )
+        assert "<table>" in result
+        assert "<thead>" in result
+        assert "<tbody>" in result
+        assert "<tr>" in result
+        assert "<th>" in result
+        assert "<td>" in result
+        assert "onclick" not in result
+        assert "style=" not in result
+        assert "Alpha" in result
+
+    def test_matrix_markdown_preserves_tables_when_markdown_library_available(self):
+        pytest.importorskip("markdown")
+        result = self.adapter._markdown_to_html(
+            "| Name | Value |\n"
+            "| --- | --- |\n"
+            "| Alpha | 1 |\n"
+        )
+        assert "<table>" in result
+        assert "<thead>" in result
+        assert "<tbody>" in result
+        assert "<tr>" in result
+        assert "<th>" in result
+        assert "<td>" in result
+        assert "Alpha" in result
+
 
 # ---------------------------------------------------------------------------
 # Helper: display name extraction


### PR DESCRIPTION
## Summary

Fixes a Matrix rendering regression introduced by #18505: the new Matrix HTML sanitizer stripped table structure emitted by the existing Markdown `tables` extension.

## Changes

- Add Matrix-compatible table structure tags to `_MatrixHtmlSanitizer`:
  - `table`
  - `thead`
  - `tbody`
  - `tfoot`
  - `tr`
  - `th`
  - `td`
- Preserve the existing sanitizer posture by continuing to strip unsafe attributes such as event handlers and inline styles.
- Add regression coverage for sanitized table HTML and optional Markdown-table output when the `markdown` package is installed.

## Validation

```bash
.venv/bin/python -m pytest tests/gateway/test_matrix.py::TestMatrixMarkdownToHtml -q
.venv/bin/python -m pytest tests/gateway/test_matrix.py -q
.venv/bin/python -m py_compile gateway/platforms/matrix.py
git diff --check
```

Results:

- `13 passed, 1 skipped`
- `230 passed, 1 skipped`
- `py_compile` passed
- `git diff --check` passed
