### PR TITLE
fix(tools): skip read_file dedup for execute_code sandbox calls

### DIFF
--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -24,6 +24,7 @@ from tools.file_tools import (
     _DEFAULT_MAX_READ_CHARS,
     _read_tracker,
     notify_other_tool_call,
+    _handle_read_file,
 )
 
 
@@ -363,6 +364,68 @@ class TestFileDedup(unittest.TestCase):
 # ---------------------------------------------------------------------------
 # Dedup stub-loop guard (issue #15759)
 # ---------------------------------------------------------------------------
+
+class TestDedupSkipForSandbox(unittest.TestCase):
+    """read_file(skip_dedup=True) must always return full content, even when
+    the dedup cache has a hit for the same (path, offset, limit) key.
+
+    This covers the execute_code sandbox API contract (issue #44843):
+    sandbox code expects a consistent dict structure with ``content`` on
+    every call.
+    """
+
+    def setUp(self):
+        _read_tracker.clear()
+        self._tmpdir = _make_safe_tempdir("hermes-dedup-skip-")
+        self._tmpfile = os.path.join(self._tmpdir, "skip_test.txt")
+        with open(self._tmpfile, "w") as f:
+            f.write("sandbox content\n")
+
+    def tearDown(self):
+        _read_tracker.clear()
+        try:
+            os.unlink(self._tmpfile)
+            os.rmdir(self._tmpdir)
+        except OSError:
+            pass
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_skip_dedup_returns_content(self, mock_ops):
+        """With skip_dedup=True, second read returns full content."""
+        mock_ops.return_value = _make_fake_ops(
+            content="sandbox content\n", file_size=16,
+        )
+        # First read — populates dedup cache
+        r1 = json.loads(read_file_tool(self._tmpfile, task_id="sandbox"))
+        self.assertNotIn("dedup", r1)
+
+        # Second read with skip_dedup=True — must return content, not stub
+        r2 = json.loads(
+            read_file_tool(self._tmpfile, task_id="sandbox", skip_dedup=True)
+        )
+        self.assertNotIn("dedup", r2, "skip_dedup should bypass dedup stub")
+        self.assertIn("content", r2, "skip_dedup must return content key")
+        self.assertIn("sandbox content", r2["content"])
+
+    @patch("tools.file_tools._get_file_ops")
+    def test_skip_dedup_handler_arg(self, mock_ops):
+        """_handle_read_file passes _skip_dedup through to read_file_tool."""
+        mock_ops.return_value = _make_fake_ops(
+            content="handler content\n", file_size=16,
+        )
+        # First read — populates dedup
+        _handle_read_file({"path": self._tmpfile}, task_id="handler-test")
+
+        # Second read via handler with _skip_dedup
+        result = json.loads(
+            _handle_read_file(
+                {"path": self._tmpfile, "_skip_dedup": True},
+                task_id="handler-test",
+            )
+        )
+        self.assertIn("content", result, "_skip_dedup via handler must return content")
+        self.assertNotIn("dedup", result)
+
 
 class TestDedupStubLoopGuard(unittest.TestCase):
     """Repeated dedup stubs must escalate to a hard BLOCKED error so weak

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -541,6 +541,12 @@ def _rpc_server_loop(
                     for param in _TERMINAL_BLOCKED_PARAMS:
                         tool_args.pop(param, None)
 
+                # Skip read_file dedup for sandbox calls — the sandbox API
+                # contract requires a consistent response structure with
+                # ``content`` present on every call (issue #44843).
+                if tool_name == "read_file" and isinstance(tool_args, dict):
+                    tool_args["_skip_dedup"] = True
+
                 # Dispatch through the standard tool handler.
                 # Suppress stdout/stderr from internal tool handlers so
                 # their status prints don't leak into the CLI spinner.
@@ -815,6 +821,10 @@ def _rpc_poll_loop(
                     if tool_name == "terminal" and isinstance(tool_args, dict):
                         for param in _TERMINAL_BLOCKED_PARAMS:
                             tool_args.pop(param, None)
+
+                    # Skip read_file dedup for sandbox calls (issue #44843).
+                    if tool_name == "read_file" and isinstance(tool_args, dict):
+                        tool_args["_skip_dedup"] = True
 
                     # Dispatch through the standard tool handler
                     try:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -742,7 +742,7 @@ def clear_file_ops_cache(task_id: str = None):
             _file_ops_cache.clear()
 
 
-def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = "default") -> str:
+def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = "default", skip_dedup: bool = False) -> str:
     """Read a file with pagination and line numbers."""
     try:
         offset, limit = normalize_read_pagination(offset, limit)
@@ -803,7 +803,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                 task_data["read_timestamps"] = {}
             cached_mtime = task_data.get("dedup", {}).get(dedup_key)
 
-        if cached_mtime is not None:
+        if cached_mtime is not None and not skip_dedup:
             try:
                 current_mtime = os.path.getmtime(resolved_str)
                 if current_mtime == cached_mtime:
@@ -1530,7 +1530,7 @@ SEARCH_FILES_SCHEMA = {
 
 def _handle_read_file(args, **kw):
     tid = kw.get("task_id") or "default"
-    return read_file_tool(path=args.get("path", ""), offset=args.get("offset", 1), limit=args.get("limit", 500), task_id=tid)
+    return read_file_tool(path=args.get("path", ""), offset=args.get("offset", 1), limit=args.get("limit", 500), task_id=tid, skip_dedup=args.get("_skip_dedup", False))
 
 
 def _handle_write_file(args, **kw):


### PR DESCRIPTION
## What does this PR do?

Fixes an inconsistent response structure from `read_file()` when called inside the `execute_code()` sandbox. The dedup optimization was leaking into the sandbox API, returning `{status: "unchanged", content_returned: false}` instead of the standard `{content: ..., total_lines: ...}` structure, causing `KeyError` crashes in sandbox code.

## Related Issue

Fixes #44843
Related #44819

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/file_tools.py`: Added `skip_dedup` parameter to `read_file_tool()`. When `True`, the dedup mtime check is bypassed, ensuring a consistent response with `content` on every call. Updated `_handle_read_file()` to forward `_skip_dedup` from args.
- `tools/code_execution_tool.py`: Both RPC transport handlers (UDS local + file-based remote) now inject `_skip_dedup=True` into `read_file` tool args, ensuring sandbox calls always get full content.
- `tests/tools/test_file_read_guards.py`: Added `TestDedupSkipForSandbox` with 2 tests — one for the direct `read_file_tool(skip_dedup=True)` path, one for the `_handle_read_file({"_skip_dedup": True})` handler path.

## How to Test

1. Run the new tests: `python -m pytest tests/tools/test_file_read_guards.py::TestDedupSkipForSandbox -v`
2. Run all dedup-related tests: `python -m pytest tests/tools/test_file_read_guards.py -v` (41 tests, all pass)
3. Manual verification: in a conversation, read a file with `read_file`, then use `execute_code` with `from hermes_tools import read_file` to read the same file — it should return full content with the `content` key, not a dedup stub.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `read_file_tool` dedup path (callers: 2 RPC handlers in `code_execution_tool.py`, 1 handler in `file_tools.py`)
- Blast radius: LOW — `skip_dedup` defaults to `False`, no behavioral change for existing callers
- Related patterns: dedup optimization at `file_tools.py:806` intended for agent-facing model token savings; sandbox API contract requires stable `content` key
