### PR TITLE
fix(gateway): reset stream delivery state on cached turns

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12549,6 +12549,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 pass
 
     @staticmethod
+    def _reset_cached_stream_consumer_for_turn(agent: Any) -> None:
+        """Clear stale per-turn stream-delivery bookkeeping on cached agents."""
+        # Use __dict__ instead of hasattr/getattr directly: test fixtures often
+        # use MagicMock, where hasattr(mock, "sc") fabricates a child mock.  We
+        # only want an explicitly-attached stream consumer from a previous turn.
+        agent_dict = getattr(agent, "__dict__", {}) or {}
+        stream_consumer = agent_dict.get("sc") or agent_dict.get("_stream_consumer")
+        if stream_consumer is None:
+            return
+
+        for attr, value in (
+            ("_final_response_sent", False),
+            ("_final_content_delivered", False),
+            ("_already_sent", False),
+            ("_message_id", None),
+            ("_message_created_ts", None),
+            ("_last_sent_text", ""),
+            ("_last_edit_overflowed", False),
+            ("_fallback_final_send", False),
+            ("_fallback_prefix", ""),
+            ("_fallback_preserve_partial_messages", False),
+        ):
+            if hasattr(stream_consumer, attr):
+                setattr(stream_consumer, attr, value)
+
+    @staticmethod
     def _init_cached_agent_for_turn(agent: Any, interrupt_depth: int) -> None:
         """Reset per-turn state on a cached agent before a new turn starts.
 
@@ -12565,6 +12591,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if interrupt_depth == 0:
             agent._last_activity_ts = time.time()
             agent._last_activity_desc = "starting new turn (cached)"
+            GatewayRunner._reset_cached_stream_consumer_for_turn(agent)
             # Reset the SessionDB flush cursor so the new turn's messages are
             # fully persisted — a stale value from the previous turn would
             # cause `_flush_messages_to_session_db` to skip new rows (#44327).

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -10,6 +10,7 @@ Verifies that the agent cache correctly:
 """
 
 import threading
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 
@@ -1456,6 +1457,29 @@ class TestCachedAgentInactivityReset:
 
         assert agent_fresh._api_call_count == 0
         assert agent_interrupted._api_call_count == 0
+
+    def test_fresh_turn_resets_stale_stream_delivery_state(self):
+        """Depth-0 cached-agent reuse must not inherit the previous stream final state."""
+        from gateway.run import GatewayRunner
+
+        agent = self._fake_agent()
+        agent.sc = SimpleNamespace(
+            _final_response_sent=True,
+            _final_content_delivered=True,
+            _already_sent=True,
+            _message_id="previous-message-id",
+            _last_sent_text="previous plain streaming body",
+        )
+
+        with patch("gateway.run.time") as mock_time:
+            mock_time.time.return_value = _FAKE_NOW
+            GatewayRunner._init_cached_agent_for_turn(agent, interrupt_depth=0)
+
+        assert agent.sc._final_response_sent is False
+        assert agent.sc._final_content_delivered is False
+        assert agent.sc._already_sent is False
+        assert agent.sc._message_id is None
+        assert agent.sc._last_sent_text == ""
 
     def test_watchdog_accumulation_across_recursive_turns(self):
         """Scenario: stuck turn + user interrupt → recursive turn.


### PR DESCRIPTION
## Summary
- Reset cached stream-consumer delivery bookkeeping at the start of each fresh cached-agent turn.
- Prevent stale `_final_response_sent`, `_final_content_delivered`, `_already_sent`, and message state from leaking across Telegram/gateway turns.
- Add a focused regression test for cached-agent reuse with stale streamed-delivery state.

## Why
A long Telegram/draft-streamed response can leave per-turn delivery flags on the cached agent's stream consumer. When the same cached agent is reused for a new user turn, stale delivery state can make the gateway pick the wrong final-send path — e.g. one visible plain/unfinalized streamed copy plus a later correctly formatted final copy, or incorrect suppression of the formatted final.

This is a narrow reset at the existing fresh-turn cache boundary; interrupt-recursive turns still preserve activity state as before.

Refs #36965
Refs #43835
Refs #25349

## Test plan
- `pytest tests/gateway/test_agent_cache.py::TestCachedAgentInactivityReset::test_fresh_turn_resets_stale_stream_delivery_state -q`
- `pytest tests/gateway/test_agent_cache.py::TestCachedAgentInactivityReset tests/gateway/test_stream_consumer_fresh_final.py tests/gateway/test_telegram_approval_buttons.py tests/gateway/test_telegram_model_picker.py tests/gateway/test_telegram_slash_confirm.py -q`
- `pytest tests/gateway -q` currently reports 7 failures; I reproduced the same 7 failures on a clean `origin/main` worktree, so they appear pre-existing/unrelated to this patch.
