### PR TITLE
fix(credential-pool): keep OAuth refresh chain alive during exhaustion cooldown

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1312,6 +1312,83 @@ class CredentialPool:
             if entry.last_status == STATUS_EXHAUSTED:
                 exhausted_until = _exhausted_until(entry)
                 if exhausted_until is not None and now < exhausted_until:
+                    # Keep the OAuth refresh chain alive even while the entry
+                    # is sitting out a cooldown window.  Provider refresh-token
+                    # exchanges (Codex, xAI, Anthropic) do NOT count against
+                    # the same quota that put us in exhaustion — they only
+                    # rotate tokens.  But refresh_tokens themselves expire on
+                    # their own clock (and many providers are single-use).
+                    # If the cooldown (e.g. ChatGPT's ~7-day weekly window)
+                    # outlives the refresh_token's lifetime, the user is
+                    # forced to redo a device-code login as soon as the
+                    # cooldown clears.  Refreshing in place here keeps the
+                    # token chain warm without changing the exhaustion gate:
+                    # we restore the exhausted status fields after the
+                    # rotation so the entry is still NOT returned for use.
+                    if (
+                        refresh
+                        and entry.auth_type == AUTH_TYPE_OAUTH
+                        and self._entry_needs_refresh(entry)
+                    ):
+                        snapshot = (
+                            entry.last_status,
+                            entry.last_status_at,
+                            entry.last_error_code,
+                            entry.last_error_reason,
+                            entry.last_error_message,
+                            entry.last_error_reset_at,
+                        )
+                        try:
+                            refreshed = self._refresh_entry(entry, force=False)
+                        except Exception as exc:  # pragma: no cover - defensive
+                            logger.debug(
+                                "credential pool: keepalive refresh raised for "
+                                "exhausted %s entry %s: %s",
+                                self.provider,
+                                entry.label or entry.id[:8],
+                                exc,
+                            )
+                            refreshed = None
+
+                        # Whether _refresh_entry succeeded, returned None, or
+                        # raised, it may have rewritten our pool entry in place
+                        # (either with rotated tokens + STATUS_OK on success, or
+                        # with a short default-cooldown via _mark_exhausted on
+                        # non-terminal failure). Either outcome would corrupt
+                        # the original quota window. Pick the most-recent view
+                        # of the entry — preferring the rotated copy returned
+                        # by _refresh_entry (real impl swaps it in via
+                        # _replace_entry already; we still cover the case
+                        # where it didn't) — restore the original exhaustion
+                        # fields, and persist exactly once so the visible-on-
+                        # disk gap is the smallest window we can achieve
+                        # without touching _refresh_entry's signature.
+                        current = next(
+                            (e for e in self._entries if e.id == entry.id),
+                            None,
+                        )
+                        base = refreshed if refreshed is not None else current
+                        if base is not None and (
+                            base.last_status != snapshot[0]
+                            or base.last_status_at != snapshot[1]
+                            or base.last_error_code != snapshot[2]
+                            or base.last_error_reason != snapshot[3]
+                            or base.last_error_message != snapshot[4]
+                            or base.last_error_reset_at != snapshot[5]
+                            or current is not base
+                        ):
+                            restored = replace(
+                                base,
+                                last_status=snapshot[0],
+                                last_status_at=snapshot[1],
+                                last_error_code=snapshot[2],
+                                last_error_reason=snapshot[3],
+                                last_error_message=snapshot[4],
+                                last_error_reset_at=snapshot[5],
+                            )
+                            anchor = current if current is not None else base
+                            self._replace_entry(anchor, restored)
+                            cleared_any = True
                     continue
                 if clear_expired:
                     cleared = replace(

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -2998,3 +2998,322 @@ def test_codex_oauth_nonterminal_refresh_does_not_quarantine(tmp_path, monkeypat
     tokens = auth_payload["providers"]["openai-codex"].get("tokens", {})
     assert tokens.get("access_token") == "old-access-token"
     assert tokens.get("refresh_token") == "old-refresh-token"
+
+
+# ── OAuth refresh keep-alive while exhausted ─────────────────────────────
+
+def _make_exhausted_codex_pool(tmp_path, monkeypatch, *, auth_type: str = "oauth"):
+    """Build a pool with a single OAuth Codex entry sitting in cooldown."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr(
+        "hermes_cli.auth._import_codex_cli_tokens",
+        lambda: None,
+    )
+    reset_at = time.time() + 30 * 60  # 30 minutes in the future
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "cred-keepalive",
+                        "label": "weekly-cooldown",
+                        "auth_type": auth_type,
+                        "priority": 0,
+                        "source": "manual:device_code",
+                        "access_token": "old-access",
+                        "refresh_token": "old-refresh",
+                        "last_status": "exhausted",
+                        "last_status_at": time.time() - 60,
+                        "last_error_code": 429,
+                        "last_error_reason": "weekly_quota",
+                        "last_error_message": "weekly limit",
+                        "last_error_reset_at": reset_at,
+                    }
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    return load_pool("openai-codex"), reset_at
+
+
+def test_oauth_refresh_keepalive_while_exhausted(tmp_path, monkeypatch):
+    """Exhausted OAuth entries should still rotate refresh_tokens in the background.
+
+    Regression for #44799: long cooldown windows (e.g. ChatGPT weekly quota)
+    can outlive the upstream refresh_token's lifetime.  The pool must keep
+    the token chain warm without flipping the entry back to STATUS_OK.
+    """
+    from dataclasses import replace as dc_replace
+
+    from agent.credential_pool import STATUS_OK, STATUS_EXHAUSTED
+
+    pool, reset_at = _make_exhausted_codex_pool(tmp_path, monkeypatch)
+
+    refresh_calls = []
+
+    def _fake_refresh(entry, *, force):
+        refresh_calls.append((entry.id, force))
+        return dc_replace(
+            entry,
+            access_token="new-access",
+            refresh_token="new-refresh",
+            last_status=STATUS_OK,
+            last_status_at=None,
+            last_error_code=None,
+            last_error_reason=None,
+            last_error_message=None,
+            last_error_reset_at=None,
+        )
+
+    monkeypatch.setattr(pool, "_entry_needs_refresh", lambda e: True)
+    monkeypatch.setattr(pool, "_refresh_entry", _fake_refresh)
+
+    available = pool._available_entries(refresh=True)
+
+    assert available == []
+    assert refresh_calls == [("cred-keepalive", False)]
+
+    rotated = pool._entries[0]
+    assert rotated.access_token == "new-access"
+    assert rotated.refresh_token == "new-refresh"
+    # Exhaustion gating must remain intact.
+    assert rotated.last_status == STATUS_EXHAUSTED
+    assert rotated.last_error_reset_at == reset_at
+    assert rotated.last_error_code == 429
+    assert rotated.last_error_reason == "weekly_quota"
+
+
+def test_oauth_keepalive_skipped_when_no_refresh_needed(tmp_path, monkeypatch):
+    pool, _ = _make_exhausted_codex_pool(tmp_path, monkeypatch)
+
+    refresh_calls = []
+    monkeypatch.setattr(pool, "_entry_needs_refresh", lambda e: False)
+    monkeypatch.setattr(
+        pool,
+        "_refresh_entry",
+        lambda entry, *, force: refresh_calls.append(entry.id) or None,
+    )
+
+    available = pool._available_entries(refresh=True)
+
+    assert available == []
+    assert refresh_calls == []
+    untouched = pool._entries[0]
+    assert untouched.access_token == "old-access"
+    assert untouched.refresh_token == "old-refresh"
+
+
+def test_api_key_exhausted_entry_is_not_keepalive_refreshed(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "anthropic": [
+                    {
+                        "id": "cred-api",
+                        "label": "api-key",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-ant-api",
+                        "last_status": "exhausted",
+                        "last_status_at": time.time(),
+                        "last_error_code": 429,
+                        "last_error_reset_at": time.time() + 30 * 60,
+                    }
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("anthropic")
+    refresh_calls = []
+    monkeypatch.setattr(pool, "_entry_needs_refresh", lambda e: True)
+    monkeypatch.setattr(
+        pool,
+        "_refresh_entry",
+        lambda entry, *, force: refresh_calls.append(entry.id) or None,
+    )
+
+    available = pool._available_entries(refresh=True)
+
+    assert available == []
+    # API key entries have no refresh token to rotate; keep-alive must not fire.
+    assert refresh_calls == []
+
+
+def test_oauth_keepalive_swallows_refresh_failure(tmp_path, monkeypatch):
+    from agent.credential_pool import STATUS_EXHAUSTED
+
+    pool, reset_at = _make_exhausted_codex_pool(tmp_path, monkeypatch)
+
+    def _boom(entry, *, force):
+        raise RuntimeError("network is down")
+
+    monkeypatch.setattr(pool, "_entry_needs_refresh", lambda e: True)
+    monkeypatch.setattr(pool, "_refresh_entry", _boom)
+
+    available = pool._available_entries(refresh=True)
+
+    assert available == []
+    untouched = pool._entries[0]
+    assert untouched.access_token == "old-access"
+    assert untouched.refresh_token == "old-refresh"
+    assert untouched.last_status == STATUS_EXHAUSTED
+    assert untouched.last_error_reset_at == reset_at
+
+
+def test_oauth_keepalive_preserves_reset_window_on_refresh_returning_none(
+    tmp_path, monkeypatch
+):
+    """Non-terminal refresh failure must not collapse the cooldown window.
+
+    _refresh_entry() catches non-fatal errors internally and falls through to
+    _mark_exhausted(entry, None), which rewrites the entry with a freshly-
+    defaulted exhaustion window.  The keep-alive path must restore the
+    original snapshot regardless of the refresh outcome.
+    """
+    from dataclasses import replace as dc_replace
+
+    from agent.credential_pool import STATUS_EXHAUSTED
+
+    pool, reset_at = _make_exhausted_codex_pool(tmp_path, monkeypatch)
+
+    def _fake_refresh_returns_none(entry, *, force):
+        # Mimic _mark_exhausted(entry, None) damaging the entry in place.
+        current = next(e for e in pool._entries if e.id == entry.id)
+        damaged = dc_replace(
+            current,
+            last_status=STATUS_EXHAUSTED,
+            last_status_at=time.time(),
+            last_error_code=None,
+            last_error_reason=None,
+            last_error_message=None,
+            last_error_reset_at=None,
+        )
+        pool._replace_entry(current, damaged)
+        return None
+
+    monkeypatch.setattr(pool, "_entry_needs_refresh", lambda e: True)
+    monkeypatch.setattr(pool, "_refresh_entry", _fake_refresh_returns_none)
+
+    available = pool._available_entries(refresh=True)
+
+    assert available == []
+    restored = pool._entries[0]
+    assert restored.last_error_reset_at == reset_at
+    assert restored.last_error_code == 429
+    assert restored.last_error_reason == "weekly_quota"
+    assert restored.last_status == STATUS_EXHAUSTED
+
+
+def test_oauth_keepalive_persists_restored_state(tmp_path, monkeypatch):
+    """After keep-alive, on-disk pool must reflect rotated tokens + cooldown."""
+    from dataclasses import replace as dc_replace
+
+    from agent.credential_pool import STATUS_OK, STATUS_EXHAUSTED, load_pool
+
+    pool, reset_at = _make_exhausted_codex_pool(tmp_path, monkeypatch)
+
+    def _fake_refresh(entry, *, force):
+        return dc_replace(
+            entry,
+            access_token="new-access",
+            refresh_token="new-refresh",
+            last_status=STATUS_OK,
+            last_status_at=None,
+            last_error_code=None,
+            last_error_reason=None,
+            last_error_message=None,
+            last_error_reset_at=None,
+        )
+
+    monkeypatch.setattr(pool, "_entry_needs_refresh", lambda e: True)
+    monkeypatch.setattr(pool, "_refresh_entry", _fake_refresh)
+
+    pool._available_entries(refresh=True)
+
+    reloaded = load_pool("openai-codex")
+    on_disk = reloaded._entries[0]
+    assert on_disk.access_token == "new-access"
+    assert on_disk.refresh_token == "new-refresh"
+    assert on_disk.last_status == STATUS_EXHAUSTED
+    assert on_disk.last_error_reset_at == reset_at
+
+
+def test_xai_oauth_keepalive_while_exhausted(tmp_path, monkeypatch):
+    """Keep-alive isn't openai-codex-specific; xai-oauth must work the same."""
+    from dataclasses import replace as dc_replace
+
+    from agent.credential_pool import STATUS_OK, STATUS_EXHAUSTED, load_pool
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    reset_at = time.time() + 30 * 60
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "xai-oauth": [
+                    {
+                        "id": "cred-xai",
+                        "label": "xai-cooldown",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "loopback_pkce",
+                        "access_token": "old-access",
+                        "refresh_token": "old-refresh",
+                        "last_status": "exhausted",
+                        "last_status_at": time.time() - 60,
+                        "last_error_code": 429,
+                        "last_error_reason": "weekly_quota",
+                        "last_error_message": "weekly limit",
+                        "last_error_reset_at": reset_at,
+                    }
+                ]
+            },
+        },
+    )
+
+    pool = load_pool("xai-oauth")
+
+    refresh_calls = []
+
+    def _fake_refresh(entry, *, force):
+        refresh_calls.append((entry.id, force))
+        return dc_replace(
+            entry,
+            access_token="new-access",
+            refresh_token="new-refresh",
+            last_status=STATUS_OK,
+            last_status_at=None,
+            last_error_code=None,
+            last_error_reason=None,
+            last_error_message=None,
+            last_error_reset_at=None,
+        )
+
+    monkeypatch.setattr(pool, "_entry_needs_refresh", lambda e: True)
+    monkeypatch.setattr(pool, "_refresh_entry", _fake_refresh)
+
+    available = pool._available_entries(refresh=True)
+
+    assert available == []
+    assert refresh_calls == [("cred-xai", False)]
+
+    rotated = pool._entries[0]
+    assert rotated.access_token == "new-access"
+    assert rotated.refresh_token == "new-refresh"
+    assert rotated.last_status == STATUS_EXHAUSTED
+    assert rotated.last_error_reset_at == reset_at
+    assert rotated.last_error_code == 429
+    assert rotated.last_error_reason == "weekly_quota"


### PR DESCRIPTION
## What does this PR do?

Keeps the OAuth refresh chain alive for credential-pool entries that are sitting out a STATUS_EXHAUSTED cooldown window, so the upstream refresh_token does not silently expire while we wait for the quota to reset.

### The bug

Provider OAuth refresh exchanges (Codex, xAI, Anthropic) do **not** count against the same quota that triggers STATUS_EXHAUSTED — they only rotate access_token + refresh_token. But refresh_tokens have their own lifetime, and on Codex/xAI they are **single-use**. When a long cooldown window (e.g. ChatGPT weekly quota, ~7 days) outlives the refresh_token lifetime, the token chain dies in place:

1. Entry hits 429 weekly → STATUS_EXHAUSTED, last_error_reset_at = ~7 days.
2. Inside the cooldown branch of `_available_entries()` we `continue` before ever touching the OAuth refresh path — the refresh keep-alive below is unreachable while exhausted.
3. The underlying ChatGPT session expires while we sit idle.
4. Cooldown elapses → `clear_expired` flips the entry back to STATUS_OK.
5. The very next `_refresh_entry()` call fails with `token_invalidated` / `refresh_token_reused` → entry transitions to STATUS_DEAD.
6. The user must redo a device-code login on **every** weekly quota reset.

For multi-credential pools the loss is progressive — every credential that hits the weekly window dies.

### The fix

Inside the exhausted-cooldown branch of `CredentialPool._available_entries()` (and only there), optionally call `_refresh_entry(entry, force=False)` for OAuth entries that report `_entry_needs_refresh()` True, then **restore** the snapshotted exhaustion-gate fields (`last_status`, `last_status_at`, `last_error_code`, `last_error_reason`, `last_error_message`, `last_error_reset_at`) so the cooldown window is unchanged and the entry is still **not** returned for use. Rotated tokens land on disk along with the original cooldown via the existing `cleared_any` persist at the end of the loop.

The restore runs **unconditionally** — on success, on `_refresh_entry` returning `None` (which internally calls `_mark_exhausted(entry, None)` and would otherwise collapse a 7-day weekly reset into the default short cooldown), and on exception.

Important non-changes:
- `_entry_needs_refresh()` and `_refresh_entry()` signatures are untouched.
- The post-cooldown `clear_expired` branch and the non-exhausted `refresh` branch are untouched — they keep flipping status back to STATUS_OK exactly as before when the cooldown actually elapses.
- No new env var, no new public API, no new core tool.

### Known limitation

`_refresh_entry()` persists STATUS_OK plus rotated tokens mid-call before control returns to the keep-alive branch. The cross-process visible window cannot be fully closed without changing `_refresh_entry` signature (broadening the diff into a shared helper used by many call sites). This PR shrinks the window to one intermediate persist before the gate is restored.

## Related Issue

Fixes #44799

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/credential_pool.py` — keep-alive refresh plus unconditional exhaustion-gate restore in `_available_entries()` (only inside the exhausted-cooldown branch; everything else is untouched).
- `tests/agent/test_credential_pool.py` — 7 new tests covering:
  - happy path (Codex): tokens rotate, exhausted gate stays intact, `_refresh_entry` called exactly once
  - no-refresh-needed: keep-alive skipped, entry untouched
  - API-key entry: keep-alive does not fire (`AUTH_TYPE_API_KEY` is short-circuited)
  - `_refresh_entry` raises: no crash, entry stays exhausted, original tokens preserved
  - `_refresh_entry` returns `None` after mutating the in-pool entry via `_mark_exhausted` (the non-terminal failure shape): original `last_error_reset_at` / `last_error_code` / `last_error_reason` are restored
  - on-disk persistence: re-load via `load_pool()` and verify the persisted entry is "rotated tokens + exhausted gate"
  - xai-oauth provider variant: keep-alive is not openai-codex-specific

## How to Test

```
git checkout fix/codex-oauth-refresh-while-exhausted
python -m pytest tests/agent/test_credential_pool.py -x -q
# 85 passed
```

## Checklist

### Code

- [x] I read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Searched for existing PRs to make sure this is not a duplicate
- [x] PR contains **only** changes related to this fix
- [x] Ran pytest tests/agent/test_credential_pool.py -q — all 85 tests pass
- [x] Added tests for my changes (7 new tests)
- [x] Tested on my platform: macOS 14.x, Python 3.11

### Documentation and Housekeeping

- [x] N/A — no docs changes (only inline WHY comments added)
- [x] N/A — no config surface
- [x] N/A — no architecture change
- [x] N/A — cross-platform (pure in-memory + JSON persistence)
- [x] N/A — no tool descriptions/schemas changed
