### PR TITLE
fix(gateway): never prune sessions when active-process check fails

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1110,6 +1110,10 @@ class SessionStore:
                             "has_active_processes_fn raised during prune for %s: %s",
                             entry.session_key, exc,
                         )
+                        # Fail safe: if we can't tell whether a background
+                        # process is attached, keep the entry rather than
+                        # risk orphaning live work.
+                        continue
                 if entry.updated_at < cutoff:
                     removed_keys.append(key)
             for key in removed_keys:

--- a/tests/gateway/test_session_store_prune.py
+++ b/tests/gateway/test_session_store_prune.py
@@ -165,6 +165,37 @@ class TestPruneBasics:
         assert removed == 1
         assert "active" not in store._entries
 
+    def test_prune_keeps_entry_when_active_check_raises(self, tmp_path):
+        """A failing active-process check must fail safe, not fail open.
+
+        If has_active_processes_fn raises, we can't tell whether a live
+        background process is attached — so the entry must be kept.
+        Previously the except block logged and fell through to the age
+        check, pruning the session anyway.
+        """
+        def _broken(session_key: str) -> bool:
+            raise RuntimeError("process registry unavailable")
+
+        store = _make_store(tmp_path, has_active_processes_fn=_broken)
+        store._entries["old"] = _entry("old", age_days=1000)
+
+        removed = store.prune_old_entries(max_age_days=90)
+
+        assert removed == 0
+        assert "old" in store._entries
+
+    def test_prune_removes_old_entry_when_active_check_returns_false(self, tmp_path):
+        """Sibling guard: a callback that cleanly reports no active process
+        must still allow the old entry to be pruned.
+        """
+        store = _make_store(tmp_path, has_active_processes_fn=lambda key: False)
+        store._entries["old"] = _entry("old", age_days=1000)
+
+        removed = store.prune_old_entries(max_age_days=90)
+
+        assert removed == 1
+        assert "old" not in store._entries
+
     def test_prune_does_not_write_disk_when_no_removals(self, tmp_path):
         """If nothing is evictable, _save() should NOT be called."""
         store = _make_store(tmp_path)


### PR DESCRIPTION
## Problem

`SessionStore.prune_old_entries` (gateway/session.py) has a guard documented as: *"Never prune sessions with an active background process attached — the user may still be waiting on output."*

If `has_active_processes_fn` raises, the `except Exception` block logs at debug and **falls through** — there is no `continue` — so the entry proceeds to the age check and gets pruned anyway. A session with a live background process is deleted from memory and `sessions.json`, orphaning in-flight work.

The callback (`process_registry.has_active_for_session`) calls `_refresh_detached_session` per process, which does OS-level process polling — exactly the kind of call that can raise under shutdown races or transient OS errors. Prune runs hourly from the session-expiry watcher, so a single flaky poll is enough.

Notably, commit 6b408e131 already fixed this same guard once (the `session_id` vs `session_key` mismatch that meant "active sessions got pruned anyway") and edited this exact except block (`pass` → `logger.debug`) — but left the exception path failing open. An error in a destruction-veto check must fail safe (keep the entry), not fail open.

## Fix

Add `continue` in the except block: if we cannot determine whether the session has active processes, skip pruning it this cycle. It remains eligible on the next hourly pass.

## Tests

Extended `tests/gateway/test_session_store_prune.py`:
- raising callback → old entry survives pruning
- callback cleanly returning `False` → old entry is still pruned (guard not over-broadened)

All 20 tests in the file pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)