### PR TITLE
fix(desktop): sync activeGatewayProfile on reconnect so session sidebar shows correct profile scope

### DIFF
--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -104,6 +104,14 @@ export async function refreshActiveProfile(): Promise<void> {
     const res = await window.hermesDesktop.api<ActiveProfileResponse>({ path: '/api/profiles/active' })
 
     setActiveProfile(res.current || 'default')
+
+    // Sync the gateway profile so the session sidebar immediately reflects the
+    // correct profile scope on reconnect/restart, instead of defaulting to
+    // 'default' until the user manually taps a profile pill.
+    const current = normalizeProfileKey(res.current)
+    if (current !== normalizeProfileKey($activeGatewayProfile.get())) {
+      $activeGatewayProfile.set(current)
+    }
   } catch {
     // Backend may not be ready; keep the last known value.
   }


### PR DESCRIPTION
## Problem

When the desktop app reconnects to a remote backend after restart, `refreshActiveProfile()` fetches `/api/profiles/active` to learn which profile the backend is running, but only updated `$activeProfile` — never `$activeGatewayProfile`. Since the session sidebar scopes its list to `$activeGatewayProfile` (which defaulted to "default"), the user saw an empty or wrong session list until they manually tapped the profile pill.

**Reproduction (remote backend, multi-profile):**
1. Have sessions in a non-default profile (e.g. "homelab")
2. Close the desktop app
3. Reopen the desktop app — it reconnects to the remote backend
4. The session sidebar shows no sessions (or only "default" sessions)
5. The user's last session from "homelab" only appears under "All Profiles"

## Root Cause

`refreshActiveProfile()` in `store/profile.ts` reads the backend's active profile via `/api/profiles/active` and sets `$activeProfile`, but `$activeGatewayProfile` — the atom that drives the sidebar's `$profileScope` — is left at its initial value "default". The sidebar filters sessions against `$activeGatewayProfile`, so it shows the wrong slice until the user manually clicks a profile pill (which triggers `ensureGatewayProfile()` -> `$activeGatewayProfile.set()`).

## Fix

After setting `$activeProfile` from the backend response, also sync `$activeGatewayProfile` to the same value. A `normalizeProfileKey` guard prevents redundant writes that would trigger spurious query invalidation.

## Testing

- Single-profile users: unaffected — `refreshActiveProfile()` returns "default" for both `$activeProfile` and `$activeGatewayProfile`, no change in behaviour.
- Multi-profile remote: after restart, the sidebar now immediately shows sessions from the correct profile without requiring a manual profile pill click.
- Profile switch via pill: still works — `ensureGatewayProfile()` calls `$activeGatewayProfile.set()` which triggers the subscriber and invalidates queries as before.
