### PR TITLE
fix(agent): keep pool entries when terminal-OAuth quarantine save fails

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1012,6 +1012,7 @@ class CredentialPool:
                     logger.debug(
                         "xAI OAuth refresh token is terminally invalid; clearing local token state"
                     )
+                    cleared = False
                     try:
                         with _auth_store_lock():
                             auth_store = _load_auth_store()
@@ -1035,17 +1036,19 @@ class CredentialPool:
                                         }
                                         _save_provider_state(auth_store, "xai-oauth", state)
                                         _save_auth_store(auth_store)
+                        cleared = True
                     except Exception as clear_exc:
-                        logger.debug(
+                        logger.warning(
                             "Failed to clear terminal xAI OAuth state: %s", clear_exc
                         )
-                    self._entries = [
-                        item for item in self._entries
-                        if item.source != "loopback_pkce"
-                    ]
-                    if self._current_id == entry.id:
-                        self._current_id = None
-                    self._persist()
+                    if cleared:
+                        self._entries = [
+                            item for item in self._entries
+                            if item.source != "loopback_pkce"
+                        ]
+                        if self._current_id == entry.id:
+                            self._current_id = None
+                        self._persist()
                     return None
             # For openai-codex: same race as xAI/nous — another Hermes process
             # may have consumed the refresh token between our proactive sync
@@ -1078,6 +1081,7 @@ class CredentialPool:
                     logger.debug(
                         "Codex OAuth refresh token is terminally invalid; clearing local token state"
                     )
+                    cleared = False
                     try:
                         with _auth_store_lock():
                             auth_store = _load_auth_store()
@@ -1101,17 +1105,19 @@ class CredentialPool:
                                         }
                                         _save_provider_state(auth_store, "openai-codex", state)
                                         _save_auth_store(auth_store)
+                        cleared = True
                     except Exception as clear_exc:
-                        logger.debug(
+                        logger.warning(
                             "Failed to clear terminal Codex OAuth state: %s", clear_exc
                         )
-                    self._entries = [
-                        item for item in self._entries
-                        if item.source != "device_code"
-                    ]
-                    if self._current_id == entry.id:
-                        self._current_id = None
-                    self._persist()
+                    if cleared:
+                        self._entries = [
+                            item for item in self._entries
+                            if item.source != "device_code"
+                        ]
+                        if self._current_id == entry.id:
+                            self._current_id = None
+                        self._persist()
                     return None
             # For nous: another process may have consumed the refresh token
             # between our proactive sync and the HTTP call.  Re-sync from
@@ -1135,6 +1141,7 @@ class CredentialPool:
                     return updated
                 if auth_mod._is_terminal_nous_refresh_error(exc):
                     logger.debug("Nous refresh token is terminally invalid; clearing local token state")
+                    cleared = False
                     try:
                         with _auth_store_lock():
                             auth_store = _load_auth_store()
@@ -1161,20 +1168,22 @@ class CredentialPool:
                                 )
                                 _save_provider_state(auth_store, "nous", state)
                                 _save_auth_store(auth_store)
+                        cleared = True
                     except Exception as clear_exc:
-                        logger.debug("Failed to clear terminal Nous OAuth state: %s", clear_exc)
+                        logger.warning("Failed to clear terminal Nous OAuth state: %s", clear_exc)
 
-                    singleton_sources = {
-                        auth_mod.NOUS_DEVICE_CODE_SOURCE,
-                        f"manual:{auth_mod.NOUS_DEVICE_CODE_SOURCE}",
-                    }
-                    self._entries = [
-                        item for item in self._entries
-                        if item.source not in singleton_sources
-                    ]
-                    if self._current_id == entry.id:
-                        self._current_id = None
-                    self._persist()
+                    if cleared:
+                        singleton_sources = {
+                            auth_mod.NOUS_DEVICE_CODE_SOURCE,
+                            f"manual:{auth_mod.NOUS_DEVICE_CODE_SOURCE}",
+                        }
+                        self._entries = [
+                            item for item in self._entries
+                            if item.source not in singleton_sources
+                        ]
+                        if self._current_id == entry.id:
+                            self._current_id = None
+                        self._persist()
                     return None
             self._mark_exhausted(entry, None)
             return None

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -1393,6 +1393,69 @@ def test_nous_pool_terminal_refresh_removes_device_code_entry(tmp_path, monkeypa
     assert refresh_calls["count"] == 1
 
 
+def test_nous_pool_terminal_refresh_keeps_entries_when_auth_store_save_fails(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(tmp_path / "shared"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "active_provider": "nous",
+            "providers": {
+                "nous": {
+                    "portal_base_url": "https://portal.example.com",
+                    "inference_base_url": "https://inference.example.com/v1",
+                    "client_id": "hermes-cli",
+                    "token_type": "Bearer",
+                    "scope": "inference:invoke",
+                    "access_token": "access-token",
+                    "refresh_token": "refresh-token",
+                    "expires_at": "2026-03-24T12:00:00+00:00",
+                    "agent_key": "agent-key",
+                    "agent_key_expires_at": "2026-03-24T13:30:00+00:00",
+                }
+            },
+        },
+    )
+
+    import agent.credential_pool as credential_pool_mod
+    from agent.credential_pool import load_pool
+    from hermes_cli import auth as auth_mod
+    from hermes_cli.auth import AuthError
+
+    def _terminal_refresh_failure(*_args, **_kwargs):
+        raise AuthError(
+            "Refresh session has been revoked",
+            provider="nous",
+            code="invalid_grant",
+            relogin_required=True,
+        )
+
+    pool = load_pool("nous")
+    selected = pool.select()
+    assert selected is not None
+    assert selected.source == "device_code"
+
+    monkeypatch.setattr(auth_mod, "resolve_nous_runtime_credentials", _terminal_refresh_failure)
+
+    def _save_failure(*_args, **_kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(credential_pool_mod, "_save_auth_store", _save_failure)
+
+    assert pool.try_refresh_current() is None
+
+    # Quarantine save failed: the entry must stay in the pool so that auth.json
+    # and the pool remain consistent (both still hold the revoked token).
+    assert [entry.source for entry in pool.entries()] == ["device_code"]
+
+    # auth.json tokens must be untouched.
+    auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    nous_state = auth_payload["providers"]["nous"]
+    assert nous_state.get("refresh_token") == "refresh-token"
+    assert nous_state.get("access_token") == "access-token"
+
+
 def test_load_pool_removes_nous_device_code_when_singleton_quarantined(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     _write_auth_store(
@@ -2826,6 +2889,53 @@ def test_xai_oauth_terminal_refresh_clears_auth_json_and_removes_pool_entries(
     assert refresh_calls["count"] == 1
 
 
+def test_xai_oauth_terminal_refresh_keeps_entries_when_auth_store_save_fails(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    monkeypatch.delenv("XAI_OAUTH_ACCESS_TOKEN", raising=False)
+
+    _write_auth_store(tmp_path, _xai_auth_store("old-access-token", "old-refresh-token"))
+
+    import agent.credential_pool as credential_pool_mod
+    from agent.credential_pool import load_pool
+    import hermes_cli.auth as auth_mod
+    from hermes_cli.auth import AuthError
+
+    pool = load_pool("xai-oauth")
+    selected = pool.select()
+    assert selected is not None
+    assert selected.source == "loopback_pkce"
+
+    def _terminal_refresh_failure(*_args, **_kwargs):
+        raise AuthError(
+            "Refresh session has been revoked",
+            provider="xai-oauth",
+            code="xai_refresh_failed",
+            relogin_required=True,
+        )
+
+    monkeypatch.setattr(auth_mod, "refresh_xai_oauth_pure", _terminal_refresh_failure)
+
+    def _save_failure(*_args, **_kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(credential_pool_mod, "_save_auth_store", _save_failure)
+
+    assert pool.try_refresh_current() is None
+
+    # Quarantine save failed: the entry must stay in the pool so that auth.json
+    # and the pool remain consistent (both still hold the revoked token).
+    assert [entry.source for entry in pool.entries()] == ["loopback_pkce"]
+
+    # auth.json tokens must be untouched.
+    auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    tokens = auth_payload["providers"]["xai-oauth"].get("tokens", {})
+    assert tokens.get("access_token") == "old-access-token"
+    assert tokens.get("refresh_token") == "old-refresh-token"
+
+
 def test_xai_oauth_nonterminal_refresh_does_not_quarantine(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     monkeypatch.delenv("XAI_API_KEY", raising=False)
@@ -2965,6 +3075,53 @@ def test_codex_oauth_terminal_refresh_clears_auth_json_and_removes_pool_entries(
     # A second try_refresh_current must not call refresh_codex_oauth_pure again.
     assert pool.try_refresh_current() is None
     assert refresh_calls["count"] == 1
+
+
+def test_codex_oauth_terminal_refresh_keeps_entries_when_auth_store_save_fails(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("CODEX_OAUTH_ACCESS_TOKEN", raising=False)
+
+    _write_auth_store(tmp_path, _codex_auth_store("old-access-token", "old-refresh-token"))
+
+    import agent.credential_pool as credential_pool_mod
+    from agent.credential_pool import load_pool
+    import hermes_cli.auth as auth_mod
+    from hermes_cli.auth import AuthError
+
+    pool = load_pool("openai-codex")
+    selected = pool.select()
+    assert selected is not None
+    assert selected.source == "device_code"
+
+    def _terminal_refresh_failure(*_args, **_kwargs):
+        raise AuthError(
+            "Refresh session has been revoked",
+            provider="openai-codex",
+            code="codex_refresh_failed",
+            relogin_required=True,
+        )
+
+    monkeypatch.setattr(auth_mod, "refresh_codex_oauth_pure", _terminal_refresh_failure)
+
+    def _save_failure(*_args, **_kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(credential_pool_mod, "_save_auth_store", _save_failure)
+
+    assert pool.try_refresh_current() is None
+
+    # Quarantine save failed: the entry must stay in the pool so that auth.json
+    # and the pool remain consistent (both still hold the revoked token).
+    assert [entry.source for entry in pool.entries()] == ["device_code"]
+
+    # auth.json tokens must be untouched.
+    auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    tokens = auth_payload["providers"]["openai-codex"].get("tokens", {})
+    assert tokens.get("access_token") == "old-access-token"
+    assert tokens.get("refresh_token") == "old-refresh-token"
 
 
 def test_codex_oauth_nonterminal_refresh_does_not_quarantine(tmp_path, monkeypatch):


### PR DESCRIPTION
## Problem

The three terminal-OAuth-error handlers in `agent/credential_pool.py` — xAI, Codex, and Nous — share an identical structure: when a refresh token is terminally revoked, they (a) clear/quarantine the token in `auth.json` inside a `try/except` that only logs at debug, then (b) **unconditionally** remove the matching entries from the in-memory pool and persist.

If step (a) fails — the auth-store flock has a 15s timeout and is contended by the refresh path itself; the save path does `O_EXCL` open + `fsync` + atomic replace, all of which can raise — the pool is wiped while `auth.json` still holds the revoked token. On the next `load_pool()`, `_seed_from_singletons` re-seeds the dead credential and the agent loops on terminal auth failures with no path to the clean "re-login required" state.

This is exactly the re-seeding loop the quarantine logic (#27911, #28118, #28116) was added to prevent — it fails back into it when its own I/O fails.

## Fix

Gate the pool-entry removal on the quarantine actually completing: a `cleared` flag is set when the try block finishes without exception (including the no-op case where the store's refresh token doesn't match the entry's), and on exception the handler now logs at **warning** and leaves the pool entry in place. Pool and `auth.json` stay consistent either way, and the next refresh attempt retries the quarantine. Same minimal change applied to all three provider handlers.

## Tests

Added to `tests/agent/test_credential_pool.py`, one per provider: monkeypatch `_save_auth_store` to raise `OSError`, trigger a terminal refresh error, assert the pool entry survives and `auth.json` is untouched. All three new tests fail against pre-fix code (verified via stash round-trip) and pass with the fix. Existing success-path quarantine tests pass unchanged — 89 total in the touched files; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)