### PR TITLE
fix(agent): only bypass compression lock on version-skew errors

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -375,10 +375,12 @@ def compress_context(
             _lock_acquired = _lock_db.try_acquire_compression_lock(
                 _lock_sid, _lock_holder
             )
-        except Exception as _lock_err:
-            # Broken/absent lock subsystem (version skew, etc.).  Log once
-            # per session and proceed WITHOUT the lock rather than letting
-            # the exception spin the outer loop.
+        except AttributeError as _lock_err:
+            # Structurally absent lock subsystem (version skew: stale
+            # in-memory ``SessionDB`` without the method).  No competing
+            # compressor can exist, so log once per session and proceed
+            # WITHOUT the lock rather than letting the exception spin the
+            # outer loop (the #34475 fix).
             _lock_holder = None  # we don't own anything to release
             if getattr(agent, "_last_compression_lock_error_sid", None) != _lock_sid:
                 agent._last_compression_lock_error_sid = _lock_sid
@@ -390,6 +392,24 @@ def compress_context(
                     _lock_sid, type(_lock_err).__name__, _lock_err,
                 )
             _lock_acquired = True  # treat as acquired-but-unlocked; proceed
+        except Exception as _lock_err:
+            # Transient/ambiguous lock-acquire failure (lock DB busy,
+            # RuntimeError, ...).  Unlike the AttributeError case above,
+            # the lock subsystem exists, so another compressor MAY be
+            # mid-flight on this session.  Fail CLOSED: treat the lock as
+            # not acquired and skip compression this cycle (the abort path
+            # below returns the messages unchanged; we retry next cycle).
+            _lock_holder = None  # we don't own anything to release
+            if getattr(agent, "_last_compression_lock_error_sid", None) != _lock_sid:
+                agent._last_compression_lock_error_sid = _lock_sid
+                logger.warning(
+                    "compression lock acquire failed for session=%s "
+                    "(%s: %s) — skipping compression this cycle to avoid a "
+                    "possible concurrent-compression session fork; will "
+                    "retry next cycle.",
+                    _lock_sid, type(_lock_err).__name__, _lock_err,
+                )
+            _lock_acquired = False  # fail closed; abort path below
         if not _lock_acquired:
             try:
                 existing = _lock_db.get_compression_lock_holder(_lock_sid)

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -240,6 +240,64 @@ def test_missing_lock_subsystem_fails_open_not_infinite_loop(tmp_path: Path) -> 
     assert agent.session_id != parent_sid
 
 
+class _TransientLockErrorDB:
+    """Wraps a real SessionDB whose lock-acquire raises a transient error.
+
+    Unlike ``_NoLockSubsystemDB`` (structural AttributeError — no lock
+    subsystem exists at all), here the lock subsystem is present but the
+    acquire fails for an ambiguous, non-sqlite reason (RuntimeError).
+    Another compressor MAY be mid-flight, so ``_compress_context`` must
+    fail CLOSED: skip compression this cycle rather than risk the
+    concurrent double-compression / session-id fork the lock prevents.
+    """
+
+    def __init__(self, real_db: SessionDB) -> None:
+        self._real = real_db
+
+    def try_acquire_compression_lock(self, *_a, **_k):
+        raise RuntimeError("lock backend temporarily unavailable")
+
+    def get_compression_lock_holder(self, *_a, **_k):
+        # The holder probe in the not-acquired abort path must tolerate
+        # the lock subsystem still being broken.
+        raise RuntimeError("lock backend temporarily unavailable")
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+
+def test_transient_lock_error_fails_closed_and_skips_compression(tmp_path: Path) -> None:
+    """A non-AttributeError lock-acquire failure must SKIP compression.
+
+    Regression for the over-broad #34475 fail-open: it treated ALL
+    lock-acquire exceptions as "no lock subsystem" and proceeded, letting
+    transient errors bypass the concurrency veto. Only version-skew
+    AttributeError may proceed; anything else aborts the cycle (messages
+    returned unchanged, compress() never called, no rotation) and retries
+    next cycle.
+    """
+    db = SessionDB(db_path=tmp_path / "state.db")
+    parent_sid = "TRANSIENT_LOCK_ERR_TEST"
+    db.create_session(parent_sid, source="discord")
+
+    agent = _build_agent_with_db(db, parent_sid)
+    agent._session_db = _TransientLockErrorDB(db)
+
+    messages = [{"role": "user", "content": f"m{i}"} for i in range(20)]
+
+    # MUST NOT raise — and MUST NOT compress.
+    compressed, _sp = agent._compress_context(messages, "sys", approx_tokens=120_000)
+
+    assert compressed is messages or compressed == messages, (
+        "Fail-closed path must return the input messages verbatim so the "
+        "caller's no-op detection (len(returned) == len(input)) holds."
+    )
+    agent.context_compressor.compress.assert_not_called()
+    # No rotation, no child sessions — the session is untouched.
+    assert agent.session_id == parent_sid
+    assert _count_children(db, parent_sid) == 0
+
+
 def test_review_fork_disables_compression_to_prevent_stale_parent_fork() -> None:
     """The background-review fork must set ``compression_enabled = False``
     so it can never compress the parent it shares a session_id with


### PR DESCRIPTION
## Problem

When `try_acquire_compression_lock` raises in `agent/conversation_compression.py`, the handler sets `_lock_acquired = True` and proceeds to the irreversible `compress()` call. This fail-open was introduced by #34475 to stop an infinite compaction spin from version-skew `AttributeError` (stale in-memory module after `hermes update`) — and for that case it is correct: if the lock subsystem is structurally absent, no competing compressor can exist either.

But the handler catches `Exception`, conflating that case with transient/ambiguous failures (`RuntimeError`, lock-DB anomalies — note `hermes_state.py` already converts `sqlite3.Error` to a fail-safe `False` internally, so what escapes here is precisely the non-sqlite surprises). Under a transient error, another compressor may be mid-flight on the same session — proceeding risks exactly the concurrent double-compression / session-id fork the lock exists to prevent (the comment above the lock block describes the orphaned-sibling-session shape).

## Fix

Split the handler:
- `except AttributeError` — behavior from #34475 preserved exactly: warn once per session, proceed without the lock.
- `except Exception` — new fail-closed branch: warn once per session (same dedup key), treat the lock as **not acquired**, so control flows into the existing not-acquired abort path and compression is skipped this cycle (retried next cycle). That abort path's lock-holder probe already tolerates a still-raising lock subsystem.

## Tests

Extended `tests/agent/test_compression_concurrent_fork.py` with a transient-error lock DB (raises `RuntimeError` from both acquire and holder-probe): asserts messages are returned verbatim, `compress()` is never called, no session rotation, zero child sessions. The existing tests for AttributeError-proceeds (#34475 regression) and returns-False-skips pass unchanged — 19 tests across the relevant files; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)