### PR TITLE
fix(tools): share execute_code RPC dispatch policy

### DIFF
--- a/tests/tools/test_execute_code_rpc_dispatch.py
+++ b/tests/tools/test_execute_code_rpc_dispatch.py
@@ -1,0 +1,119 @@
+"""Focused tests for execute_code sandbox RPC dispatch policy."""
+
+from __future__ import annotations
+
+import json
+
+from tools.code_execution_tool import _dispatch_sandbox_tool_request
+
+
+def _dispatch_request(
+    request: dict,
+    *,
+    allowed_tools=frozenset({"terminal", "read_file"}),
+    counter=None,
+    log=None,
+    max_tool_calls=3,
+    dispatch_fn=None,
+):
+    if counter is None:
+        counter = [0]
+    if log is None:
+        log = []
+    if dispatch_fn is None:
+        dispatch_fn = lambda name, args, task_id=None: json.dumps({"ok": name})
+
+    result = _dispatch_sandbox_tool_request(
+        request,
+        task_id="rpc-test-task",
+        tool_call_log=log,
+        tool_call_counter=counter,
+        max_tool_calls=max_tool_calls,
+        allowed_tools=allowed_tools,
+        call_start=1.0,
+        dispatch_fn=dispatch_fn,
+    )
+    return json.loads(result), counter, log
+
+
+def test_dispatch_rejects_tools_outside_execute_code_allowlist():
+    payload, counter, log = _dispatch_request({"tool": "send_message", "args": {}})
+
+    assert payload == {
+        "error": "Tool 'send_message' is not available in execute_code. Available: read_file, terminal"
+    }
+    assert counter == [0]
+    assert log == []
+
+
+def test_dispatch_rejects_requests_after_tool_call_limit():
+    payload, counter, log = _dispatch_request(
+        {"tool": "read_file", "args": {"path": "README.md"}},
+        counter=[3],
+        max_tool_calls=3,
+    )
+
+    assert payload == {
+        "error": "Tool call limit reached (3). No more tool calls allowed in this execution."
+    }
+    assert counter == [3]
+    assert log == []
+
+
+def test_dispatch_strips_blocked_terminal_parameters_before_calling_tool():
+    seen = {}
+
+    def dispatch_fn(name, args, task_id=None):
+        seen.update({"name": name, "args": dict(args), "task_id": task_id})
+        return json.dumps({"success": True})
+
+    payload, counter, log = _dispatch_request(
+        {
+            "tool": "terminal",
+            "args": {
+                "command": "printf safe",
+                "background": True,
+                "pty": True,
+                "notify_on_complete": True,
+                "watch_patterns": ["DONE"],
+            },
+        },
+        dispatch_fn=dispatch_fn,
+    )
+
+    assert payload == {"success": True}
+    assert seen == {
+        "name": "terminal",
+        "args": {"command": "printf safe"},
+        "task_id": "rpc-test-task",
+    }
+    assert counter == [1]
+    assert log == [{"tool": "terminal", "args_preview": "{'command': 'printf safe'}", "duration": log[0]["duration"]}]
+
+
+def test_dispatch_logs_successful_tool_calls():
+    payload, counter, log = _dispatch_request(
+        {"tool": "read_file", "args": {"path": "README.md"}},
+        dispatch_fn=lambda name, args, task_id=None: json.dumps({"content": "hello"}),
+    )
+
+    assert payload == {"content": "hello"}
+    assert counter == [1]
+    assert len(log) == 1
+    assert log[0]["tool"] == "read_file"
+    assert log[0]["args_preview"] == "{'path': 'README.md'}"
+    assert isinstance(log[0]["duration"], float)
+
+
+def test_dispatch_converts_tool_exceptions_to_tool_error():
+    def dispatch_fn(name, args, task_id=None):
+        raise RuntimeError("boom")
+
+    payload, counter, log = _dispatch_request(
+        {"tool": "read_file", "args": {"path": "README.md"}},
+        dispatch_fn=dispatch_fn,
+    )
+
+    assert payload == {"error": "boom"}
+    assert counter == [1]
+    assert log[0]["tool"] == "read_file"

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -465,6 +465,80 @@ def _call(tool_name, args):
 _TERMINAL_BLOCKED_PARAMS = {"background", "pty", "notify_on_complete", "watch_patterns"}
 
 
+def _dispatch_sandbox_tool_request(
+    request: dict,
+    *,
+    task_id: str,
+    tool_call_log: list,
+    tool_call_counter: list,
+    max_tool_calls: int,
+    allowed_tools: frozenset,
+    call_start: float | None = None,
+    error_context: str = "sandbox",
+    dispatch_fn=None,
+) -> str:
+    """Apply execute_code sandbox policy and dispatch one tool request.
+
+    The local socket listener and remote file-poll listener are transport
+    adapters.  This helper is the policy seam they share: allow-listing,
+    call-limit enforcement, terminal argument sanitisation, stdout/stderr
+    suppression, error coercion, and observability logging all live here so
+    local and remote execute_code transports cannot drift.
+    """
+    if dispatch_fn is None:
+        from model_tools import handle_function_call as dispatch_fn
+
+    tool_name = request.get("tool", "")
+    tool_args = request.get("args", {})
+
+    if tool_name not in allowed_tools:
+        available = ", ".join(sorted(allowed_tools))
+        return json.dumps({
+            "error": (
+                f"Tool '{tool_name}' is not available in execute_code. "
+                f"Available: {available}"
+            )
+        })
+
+    if tool_call_counter[0] >= max_tool_calls:
+        return json.dumps({
+            "error": (
+                f"Tool call limit reached ({max_tool_calls}). "
+                "No more tool calls allowed in this execution."
+            )
+        })
+
+    if call_start is None:
+        call_start = time.monotonic()
+
+    if tool_name == "terminal" and isinstance(tool_args, dict):
+        for param in _TERMINAL_BLOCKED_PARAMS:
+            tool_args.pop(param, None)
+
+    try:
+        _real_stdout, _real_stderr = sys.stdout, sys.stderr
+        devnull = open(os.devnull, "w", encoding="utf-8")
+        try:
+            sys.stdout = devnull
+            sys.stderr = devnull
+            result = dispatch_fn(tool_name, tool_args, task_id=task_id)
+        finally:
+            sys.stdout, sys.stderr = _real_stdout, _real_stderr
+            devnull.close()
+    except Exception as exc:
+        logger.error("Tool call failed in %s: %s", error_context, exc, exc_info=True)
+        result = tool_error(str(exc))
+
+    tool_call_counter[0] += 1
+    call_duration = time.monotonic() - call_start
+    tool_call_log.append({
+        "tool": tool_name,
+        "args_preview": str(tool_args)[:80],
+        "duration": round(call_duration, 2),
+    })
+    return result
+
+
 def _rpc_server_loop(
     server_sock: socket.socket,
     task_id: str,
@@ -477,8 +551,6 @@ def _rpc_server_loop(
     Accept one client connection and dispatch tool-call requests until
     the client disconnects or the call limit is reached.
     """
-    from model_tools import handle_function_call
-
     conn = None
     try:
         server_sock.settimeout(5)
@@ -510,68 +582,17 @@ def _rpc_server_loop(
                     conn.sendall((resp + "\n").encode())
                     continue
 
-                tool_name = request.get("tool", "")
-                tool_args = request.get("args", {})
-
-                # Enforce the allow-list
-                if tool_name not in allowed_tools:
-                    available = ", ".join(sorted(allowed_tools))
-                    resp = json.dumps({
-                        "error": (
-                            f"Tool '{tool_name}' is not available in execute_code. "
-                            f"Available: {available}"
-                        )
-                    })
-                    conn.sendall((resp + "\n").encode())
-                    continue
-
-                # Enforce tool call limit
-                if tool_call_counter[0] >= max_tool_calls:
-                    resp = json.dumps({
-                        "error": (
-                            f"Tool call limit reached ({max_tool_calls}). "
-                            "No more tool calls allowed in this execution."
-                        )
-                    })
-                    conn.sendall((resp + "\n").encode())
-                    continue
-
-                # Strip forbidden terminal parameters
-                if tool_name == "terminal" and isinstance(tool_args, dict):
-                    for param in _TERMINAL_BLOCKED_PARAMS:
-                        tool_args.pop(param, None)
-
-                # Dispatch through the standard tool handler.
-                # Suppress stdout/stderr from internal tool handlers so
-                # their status prints don't leak into the CLI spinner.
-                try:
-                    _real_stdout, _real_stderr = sys.stdout, sys.stderr
-                    devnull = open(os.devnull, "w", encoding="utf-8")
-                    try:
-                        sys.stdout = devnull
-                        sys.stderr = devnull
-                        result = handle_function_call(
-                            tool_name, tool_args, task_id=task_id
-                        )
-                    finally:
-                        sys.stdout, sys.stderr = _real_stdout, _real_stderr
-                        devnull.close()
-                except Exception as exc:
-                    logger.error("Tool call failed in sandbox: %s", exc, exc_info=True)
-                    result = tool_error(str(exc))
-
-                tool_call_counter[0] += 1
-                call_duration = time.monotonic() - call_start
-
-                # Log for observability
-                args_preview = str(tool_args)[:80]
-                tool_call_log.append({
-                    "tool": tool_name,
-                    "args_preview": args_preview,
-                    "duration": round(call_duration, 2),
-                })
-
-                conn.sendall((result + "\n").encode())
+                resp = _dispatch_sandbox_tool_request(
+                    request,
+                    task_id=task_id,
+                    tool_call_log=tool_call_log,
+                    tool_call_counter=tool_call_counter,
+                    max_tool_calls=max_tool_calls,
+                    allowed_tools=allowed_tools,
+                    call_start=call_start,
+                    error_context="sandbox",
+                )
+                conn.sendall((resp + "\n").encode())
 
     except socket.timeout:
         logger.debug("RPC listener socket timeout")
@@ -740,8 +761,6 @@ def _rpc_poll_loop(
     independent process, so these calls run safely concurrent with the
     script-execution thread.
     """
-    from model_tools import handle_function_call
-
     poll_interval = 0.1  # 100 ms
 
     quoted_rpc_dir = shlex.quote(rpc_dir)
@@ -786,61 +805,21 @@ def _rpc_poll_loop(
                     env.execute(f"rm -f {quoted_req_file}", cwd="/", timeout=5)
                     continue
 
-                tool_name = request.get("tool", "")
-                tool_args = request.get("args", {})
                 seq = request.get("seq", 0)
                 seq_str = f"{seq:06d}"
                 res_file = f"{rpc_dir}/res_{seq_str}"
                 quoted_res_file = shlex.quote(res_file)
 
-                # Enforce allow-list
-                if tool_name not in allowed_tools:
-                    available = ", ".join(sorted(allowed_tools))
-                    tool_result = json.dumps({
-                        "error": (
-                            f"Tool '{tool_name}' is not available in execute_code. "
-                            f"Available: {available}"
-                        )
-                    })
-                # Enforce tool call limit
-                elif tool_call_counter[0] >= max_tool_calls:
-                    tool_result = json.dumps({
-                        "error": (
-                            f"Tool call limit reached ({max_tool_calls}). "
-                            "No more tool calls allowed in this execution."
-                        )
-                    })
-                else:
-                    # Strip forbidden terminal parameters
-                    if tool_name == "terminal" and isinstance(tool_args, dict):
-                        for param in _TERMINAL_BLOCKED_PARAMS:
-                            tool_args.pop(param, None)
-
-                    # Dispatch through the standard tool handler
-                    try:
-                        _real_stdout, _real_stderr = sys.stdout, sys.stderr
-                        devnull = open(os.devnull, "w", encoding="utf-8")
-                        try:
-                            sys.stdout = devnull
-                            sys.stderr = devnull
-                            tool_result = handle_function_call(
-                                tool_name, tool_args, task_id=task_id
-                            )
-                        finally:
-                            sys.stdout, sys.stderr = _real_stdout, _real_stderr
-                            devnull.close()
-                    except Exception as exc:
-                        logger.error("Tool call failed in remote sandbox: %s",
-                                     exc, exc_info=True)
-                        tool_result = tool_error(str(exc))
-
-                    tool_call_counter[0] += 1
-                    call_duration = time.monotonic() - call_start
-                    tool_call_log.append({
-                        "tool": tool_name,
-                        "args_preview": str(tool_args)[:80],
-                        "duration": round(call_duration, 2),
-                    })
+                tool_result = _dispatch_sandbox_tool_request(
+                    request,
+                    task_id=task_id,
+                    tool_call_log=tool_call_log,
+                    tool_call_counter=tool_call_counter,
+                    max_tool_calls=max_tool_calls,
+                    allowed_tools=allowed_tools,
+                    call_start=call_start,
+                    error_context="remote sandbox",
+                )
 
                 # Write response atomically (tmp + rename).
                 # Use echo piping (not stdin_data) because Modal doesn't


### PR DESCRIPTION
## Summary
- Extract shared execute_code sandbox tool-dispatch policy into `_dispatch_sandbox_tool_request`.
- Reuse the same allow-list, call-limit, terminal-argument sanitization, exception handling, and logging path for both local socket RPC and remote file-poll RPC transports.
- Add focused unit coverage for the dispatch policy seam.

## Verification
- `uv run --extra dev pytest tests/tools/test_execute_code_rpc_dispatch.py` — 5 passed
- `uv run --extra dev pytest tests/tools/test_execute_code_rpc_dispatch.py tests/tools/test_execute_code_approval_cluster.py` — 25 passed
- `git diff --check` — passed

## Risk / rollback
- Low-risk refactor of duplicate policy logic; rollback is reverting this commit.
