### PR TITLE
fix(backup): exclude Git for Windows installation from hermes backup

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -38,6 +38,7 @@ _EXCLUDED_DIRS = {
     "hermes-agent",     # the codebase repo — re-clone instead
     "__pycache__",      # bytecode caches — regenerated on import
     ".git",             # nested git dirs (profiles shouldn't have these, but safety)
+    "git",              # Git for Windows installation on Windows (~9,500 files, 390 MB)
     "node_modules",     # js deps if website/ somehow leaks in
     "backups",          # prior auto-backups — don't nest backups exponentially
     "checkpoints",      # session-local trajectory caches — regenerated per-session,

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -110,6 +110,13 @@ class TestShouldExclude:
         from hermes_cli.backup import _should_exclude
         assert _should_exclude(Path("backups/pre-update-2026-04-27-063400.zip"))
 
+    def test_excludes_git_for_windows(self):
+        """git/ (Git for Windows installation) must be excluded — ~9,500 files, 390 MB."""
+        from hermes_cli.backup import _should_exclude
+        assert _should_exclude(Path("git/usr/bin/git.exe"))
+        assert _should_exclude(Path("git/mingw64/bin/git.exe"))
+        assert _should_exclude(Path("git/usr/share/vim/vim92/syntax/c.vim"))
+
     def test_excludes_sqlite_sidecars(self):
         """SQLite WAL/SHM/journal sidecars must not ship alongside the
         safe-copied .db — pairing a fresh snapshot with stale sidecar state
@@ -271,6 +278,36 @@ class TestBackup:
             names = zf.namelist()
             agent_files = [n for n in names if "hermes-agent" in n]
             assert agent_files == [], f"hermes-agent files leaked into backup: {agent_files}"
+
+    def test_excludes_git_for_windows(self, tmp_path, monkeypatch):
+        """Backup does NOT include git/ (Git for Windows installation)."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        _make_hermes_tree(hermes_home)
+
+        # Simulate Git for Windows installation
+        git_dir = hermes_home / "git"
+        git_dir.mkdir()
+        (git_dir / "usr").mkdir()
+        (git_dir / "usr" / "bin").mkdir()
+        (git_dir / "usr" / "bin" / "git.exe").write_text("fake")
+        (git_dir / "mingw64").mkdir()
+        (git_dir / "mingw64" / "bin").mkdir()
+        (git_dir / "mingw64" / "bin" / "git.exe").write_text("fake")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        out_zip = tmp_path / "backup.zip"
+        args = Namespace(output=str(out_zip))
+
+        from hermes_cli.backup import run_backup
+        run_backup(args)
+
+        with zipfile.ZipFile(out_zip, "r") as zf:
+            names = zf.namelist()
+            git_files = [n for n in names if n.startswith("git/")]
+            assert git_files == [], f"git/ files leaked into backup: {git_files}"
 
     def test_includes_nested_hermes_agent_in_skills(self, tmp_path, monkeypatch):
         """Backup includes skills/.../hermes-agent/ but NOT root hermes-agent/."""


### PR DESCRIPTION
## What does this PR do?

Excludes the `git/` directory (Git for Windows installation) from `hermes backup`. On Windows, Hermes installs Git for Windows under `~/.hermes/git/`, which contains ~9,500 files and ~390 MB. Without this exclusion, backups are 91% waste (10,466 files / 242 MB vs expected ~960 files / ~60 MB).

## Related Issue

Fixes #44852

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/backup.py`: Added `"git"` to `_EXCLUDED_DIRS` to skip the Git for Windows installation directory during backup
- `tests/hermes_cli/test_backup.py`: Added `test_excludes_git_for_windows` unit test (verifies `_should_exclude` matches `git/` paths) and integration test (verifies `git/` files don't appear in backup zip)

## How to Test

1. Run `python -m pytest tests/hermes_cli/test_backup.py::TestShouldExclude::test_excludes_git_for_windows -v`
2. Run `python -m pytest tests/hermes_cli/test_backup.py::TestBackup::test_excludes_git_for_windows -v`
3. Run `python -m pytest tests/hermes_cli/test_backup.py -q` (all 111 tests pass)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `_EXCLUDED_DIRS` in `hermes_cli/backup.py` (callers: `_should_exclude`, `os.walk` filter)
- Blast radius: LOW — single exclusion list entry, no control flow changes
- Related patterns: follows existing `.git` and `__pycache__` exclusion pattern
