### PR TITLE
fix(model-metadata): _extract_pricing crashes on nested pricing objects in /models

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -605,8 +605,19 @@ def _extract_pricing(payload: Dict[str, Any]) -> Dict[str, Any]:
         pricing: Dict[str, Any] = {}
         for target, aliases in alias_map.items():
             for alias in aliases:
-                if alias in normalized and normalized[alias] not in {None, ""}:
-                    pricing[target] = normalized[alias]
+                if alias not in normalized:
+                    continue
+                value = normalized[alias]
+                # Skip nested shapes — some OpenAI-compatible /models endpoints
+                # nest rates under an alias key (e.g. a ``price`` field mapping
+                # ``input``/``output`` to ``{...}`` sub-objects); only scalar
+                # per-token/per-request rates belong here. The tuple (not set)
+                # membership check below also avoids hashing unhashable values
+                # (a dict value would raise ``TypeError: unhashable type``).
+                if isinstance(value, (dict, list)):
+                    continue
+                if value not in (None, ""):
+                    pricing[target] = value
                     break
         if pricing:
             return pricing

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1422,3 +1422,41 @@ class TestGrok43StaleCacheGuard:
                 slug, base_url=base, api_key="", provider="xai"
             )
             assert ctx == 256_000, f"{slug} should stay 256000, got {ctx}"
+
+
+class TestExtractPricing:
+    """Robustness of _extract_pricing against /models pricing shapes."""
+
+    def test_nested_price_objects_do_not_crash(self):
+        """Some OpenAI-compatible /models endpoints return a nested ``price``
+        field that maps ``input``/``output`` to ``{...}`` sub-objects, often
+        alongside a flat ``pricing`` field of scalar rates.
+
+        Regression: the alias loop used set membership
+        (``value not in {None, ""}``), which hashes the value and raised
+        ``TypeError: unhashable type: 'dict'`` on the nested sub-objects. The
+        exception propagated out of ``fetch_endpoint_model_metadata`` and
+        silently emptied the entire endpoint-metadata cache for that endpoint.
+        """
+        from agent.model_metadata import _extract_pricing
+        payload = {
+            "id": "vendor/model",
+            "price": {
+                "input": {"unit_a": 0.0004, "usd": 0.104},
+                "output": {"unit_a": 0.0019, "usd": 0.416},
+            },
+            "pricing": {"prompt": 0.104, "completion": 0.416, "input_cache_read": 0.052},
+        }
+        result = _extract_pricing(payload)  # must not raise
+        assert result.get("prompt") == 0.104
+        assert result.get("completion") == 0.416
+
+    def test_flat_scalar_pricing_still_extracted(self):
+        from agent.model_metadata import _extract_pricing
+        result = _extract_pricing({"pricing": {"prompt": 1.0, "completion": 2.0}})
+        assert result.get("prompt") == 1.0
+        assert result.get("completion") == 2.0
+
+    def test_no_pricing_returns_empty(self):
+        from agent.model_metadata import _extract_pricing
+        assert _extract_pricing({"id": "vendor/model"}) == {}


### PR DESCRIPTION
## Summary

`_extract_pricing` (in `agent/model_metadata.py`) crashes with
`TypeError: unhashable type: 'dict'` when an OpenAI-compatible `/models`
response nests pricing rates under a recognized alias key.

## Root cause

`_extract_pricing` walks the nested dicts of a model entry and, for each alias
it recognizes (`input`, `output`, `prompt`, …), keeps the value unless it is
`None`/`""`. The emptiness check used **set membership**:

```python
if alias in normalized and normalized[alias] not in {None, ""}:
```

`x not in {None, ""}` hashes `x`. When an endpoint nests rates — e.g. a
`price` field mapping `input`/`output` to `{...}` sub-objects — the value is a
`dict`, and hashing it raises `TypeError: unhashable type: 'dict'`.

The exception propagates out of `fetch_endpoint_model_metadata`, which catches
it per-candidate URL and falls through to returning `{}` — **silently emptying
the entire endpoint-metadata cache** for that endpoint. As a result,
context-length and pricing resolution break for *every* model served by it.

## Fix

Skip non-scalar (`dict`/`list`) alias values, and use tuple membership
(`value not in (None, "")`, which compares by equality and never hashes the
value) for the emptiness check. Only scalar per-token/per-request rates are
collected, so a nested `price` object is ignored and a sibling flat `pricing`
field is still picked up.

## Tests

`tests/agent/test_model_metadata.py::TestExtractPricing`:
- nested `price` sub-objects no longer raise and the flat scalar rates are used;
- flat scalar pricing is still extracted;
- a no-pricing entry returns `{}`.
