### PR TITLE
fix(telegram): omit thread id for direct DM topic sends

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -664,7 +664,6 @@ class TelegramAdapter(BasePlatformAdapter):
                 direct_topic_id = cls._metadata_direct_messages_topic_id(metadata)
                 if direct_topic_id is not None:
                     return {
-                        "message_thread_id": None,
                         "direct_messages_topic_id": int(direct_topic_id),
                     }
                 return {}
@@ -672,7 +671,6 @@ class TelegramAdapter(BasePlatformAdapter):
         direct_topic_id = cls._metadata_direct_messages_topic_id(metadata)
         if direct_topic_id is not None:
             return {
-                "message_thread_id": None,
                 "direct_messages_topic_id": int(direct_topic_id),
             }
         return {"message_thread_id": cls._message_thread_id_for_send(thread_id)}

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -453,7 +453,7 @@ async def test_send_private_dm_topic_uses_direct_messages_topic_id():
     )
 
     assert result.success is True
-    assert call_log[0]["message_thread_id"] is None
+    assert "message_thread_id" not in call_log[0]
     assert call_log[0]["direct_messages_topic_id"] == 99999
 
 
@@ -794,7 +794,7 @@ async def test_send_dm_topic_fallback_without_anchor_does_not_crash():
 
     assert result.success is True
     assert call_log[0]["reply_to_message_id"] is None
-    assert call_log[0]["message_thread_id"] is None
+    assert "message_thread_id" not in call_log[0]
     assert call_log[0]["direct_messages_topic_id"] == 20197
 
 


### PR DESCRIPTION
## Summary

Telegram DM topic sends that route via `direct_messages_topic_id` should not include `message_thread_id` at all. Current `main` returns `message_thread_id: None` next to `direct_messages_topic_id`, which can serialize as `message_thread_id: null` and make Telegram route the message outside the intended DM topic.

This PR removes `message_thread_id` from the two direct-topic branches in `_thread_kwargs_for_send()` and updates the existing expectations to assert the key is omitted rather than set to `None`.

## Related

- Adjacent to #35739 and #35759, but covers the direct `direct_messages_topic_id` payload path rather than the reply-anchor/media retry path.
- Also relates to the broader Telegram DM topic routing reports such as #27139.

## Testing

Not run locally; this is a narrow payload-shape fix and the changed assertions document the expected behavior.
