### PR TITLE
fix(bluebubbles): stabilize iMessage webhook and bubble delivery

### DIFF
--- a/docs/plans/2026-06-14-hermes-bluebubbles-auto-update.md
+++ b/docs/plans/2026-06-14-hermes-bluebubbles-auto-update.md
@@ -1,0 +1,67 @@
+# Hermes BlueBubbles Auto-Update Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Keep the local running Hermes checkout automatically updated to upstream `main` while preserving the BlueBubbles/iMessage fixes.
+
+**Architecture:** Maintain a dedicated fork branch, `fix/bluebubbles-canonical-chat-id`, that rebases onto official `NousResearch/hermes-agent/main`. A local updater script validates the rebased branch in a staging worktree, pushes the branch to the user's fork, deploys it into the runtime checkout at `~/.hermes/hermes-agent`, and restarts the Hermes gateway only after validation succeeds. Failures stop before deployment whenever possible; restart failures roll the runtime checkout back to the previous commit.
+
+**Tech Stack:** Python stdlib, Git worktrees, pytest, uv, Hermes gateway CLI, Codex cron automation.
+
+---
+
+### Task 1: Add updater unit tests
+
+**Files:**
+- Create: `tests/scripts/test_auto_update_bluebubbles_fix.py`
+
+**Steps:**
+1. Test remote resolution for the current local layout: official remote plus user fork remote.
+2. Test that untracked local config/skills do not count as blocking tracked changes.
+3. Test that dependency sync only runs for environment files such as `pyproject.toml` and `uv.lock`.
+4. Test that BlueBubbles validation runs only `py_compile` and `tests/gateway/test_bluebubbles.py`.
+
+### Task 2: Implement the updater script
+
+**Files:**
+- Create: `scripts/auto_update_bluebubbles_fix.py`
+
+**Steps:**
+1. Detect official and fork remotes, adding the fork remote when absent.
+2. Fetch both remotes.
+3. Create a staging worktree from `fix/bluebubbles-canonical-chat-id`.
+4. Rebase the staging branch onto official `main`.
+5. Sync dependencies into the runtime venv when dependency files changed or pytest is missing.
+6. Run BlueBubbles validation.
+7. Push the rebased branch to the fork.
+8. Deploy the validated branch to `~/.hermes/hermes-agent`.
+9. Restart Hermes gateway and report status.
+
+### Task 3: Initial branch migration
+
+**Files:**
+- Modify: `gateway/platforms/bluebubbles.py`
+- Modify: `tests/gateway/test_bluebubbles.py`
+- Add updater files from Tasks 1-2.
+
+**Steps:**
+1. Add the user's fork remote to the runtime checkout.
+2. Create `fix/bluebubbles-canonical-chat-id` from current upstream `main`.
+3. Reapply the two BlueBubbles fixes from the earlier fork branch.
+4. Commit the updater and tests.
+5. Push the branch to the fork.
+
+### Task 4: Install recurring automation
+
+**Steps:**
+1. Create a Codex cron automation that runs the updater from `~/.hermes/hermes-agent`.
+2. Keep the automation active.
+3. Log every run to `~/.hermes/logs/bluebubbles-auto-update.log`.
+
+### Task 5: Verify deployment
+
+**Steps:**
+1. Run updater dry-run or equivalent validation.
+2. Run BlueBubbles tests.
+3. Verify `hermes --version` points at `~/.hermes/hermes-agent`.
+4. Verify `hermes gateway status` no longer reports a stale service definition after restart.

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -62,10 +62,15 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) 
     synthetic/resumed sends that have no reply anchor fall back to Telegram's
     ``direct_messages_topic_id`` when the Bot API supports it.
     """
+    metadata = {}
+    chat_id_alt = getattr(source, "chat_id_alt", None)
+    if chat_id_alt:
+        metadata["chat_id_alt"] = str(chat_id_alt)
+
     thread_id = getattr(source, "thread_id", None)
     if thread_id is None:
-        return None
-    metadata = {"thread_id": thread_id}
+        return metadata or None
+    metadata["thread_id"] = thread_id
     if _platform_name(getattr(source, "platform", None)) == "telegram" and getattr(source, "chat_type", None) == "dm":
         metadata["telegram_dm_topic_reply_fallback"] = True
         tid = str(thread_id)

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -581,16 +581,12 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         text = self.format_message(content)
         if not text:
             return SendResult(success=False, error="BlueBubbles send requires text")
-        # Split on paragraph breaks first (double newlines) so each thought
-        # becomes its own iMessage bubble, then truncate any that are still
-        # too long.
-        paragraphs = [p.strip() for p in re.split(r'\n\s*\n', text) if p.strip()]
-        chunks: List[str] = []
-        for para in (paragraphs or [text]):
-            if len(para) <= self.MAX_MESSAGE_LENGTH:
-                chunks.append(para)
-            else:
-                chunks.extend(self.truncate_message(para, max_length=self.MAX_MESSAGE_LENGTH))
+        # Keep paragraph breaks inside one iMessage bubble. Each BlueBubbles
+        # text API call renders as a separate bubble, so only chunk by length.
+        if len(text) <= self.MAX_MESSAGE_LENGTH:
+            chunks = [text]
+        else:
+            chunks = self.truncate_message(text, max_length=self.MAX_MESSAGE_LENGTH)
         last = SendResult(success=True)
         for chunk in chunks:
             guid = await self._resolve_chat_guid(chat_id)

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -557,8 +557,19 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             data = res.get("data") or {}
             msg_id = data.get("guid") or data.get("messageGuid") or "ok"
             return SendResult(success=True, message_id=str(msg_id), raw_response=res)
+        except (httpx.ReadTimeout, httpx.WriteTimeout) as exc:
+            return self._assume_delivered_after_send_timeout("create-chat send", exc)
         except Exception as exc:
             return SendResult(success=False, error=str(exc))
+
+    @staticmethod
+    def _assume_delivered_after_send_timeout(action: str, exc: Exception) -> SendResult:
+        logger.warning(
+            "[bluebubbles] %s timed out; assuming delivered to avoid duplicate fallback: %s",
+            action,
+            type(exc).__name__,
+        )
+        return SendResult(success=True, message_id="timeout-assumed-delivered")
 
     # ------------------------------------------------------------------
     # Text sending
@@ -616,6 +627,8 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 last = SendResult(
                     success=True, message_id=str(msg_id), raw_response=res
                 )
+            except (httpx.ReadTimeout, httpx.WriteTimeout) as exc:
+                return self._assume_delivered_after_send_timeout("text send", exc)
             except Exception as exc:
                 return SendResult(success=False, error=str(exc))
         return last

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -598,9 +598,22 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             chunks = [text]
         else:
             chunks = self.truncate_message(text, max_length=self.MAX_MESSAGE_LENGTH)
+        chat_id_alt = None
+        if isinstance(metadata, dict):
+            raw_alt = metadata.get("chat_id_alt")
+            if isinstance(raw_alt, str):
+                raw_alt = raw_alt.strip()
+                if raw_alt and raw_alt != chat_id:
+                    chat_id_alt = raw_alt
         last = SendResult(success=True)
         for chunk in chunks:
-            guid = await self._resolve_chat_guid(chat_id)
+            guid = None
+            for target in (chat_id_alt, chat_id):
+                if not target:
+                    continue
+                guid = await self._resolve_chat_guid(target)
+                if guid:
+                    break
             if not guid:
                 # If the target looks like an address, try creating a new chat
                 if self._private_api_enabled and (

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -63,7 +63,8 @@ _TAPBACK_REMOVED = {
     3003: "laugh", 3004: "emphasize", 3005: "question",
 }
 
-# Webhook event types that carry user messages
+# Webhook event types that may carry user messages. The adapter only subscribes
+# to new-message by default; this broader set filters out non-message webhooks.
 _MESSAGE_EVENTS = {"new-message", "message", "updated-message"}
 
 # Log redaction patterns
@@ -135,6 +136,24 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         )
         if not str(self.webhook_path).startswith("/"):
             self.webhook_path = f"/{self.webhook_path}"
+        webhook_events = (
+            extra.get("webhook_events")
+            or os.getenv("BLUEBUBBLES_WEBHOOK_EVENTS")
+            or ["new-message"]
+        )
+        if isinstance(webhook_events, str):
+            webhook_events = [
+                event.strip()
+                for event in webhook_events.split(",")
+                if event.strip()
+            ]
+        elif not isinstance(webhook_events, (list, tuple, set)):
+            webhook_events = ["new-message"]
+        self.webhook_events = tuple(
+            event.strip()
+            for event in webhook_events
+            if isinstance(event, str) and event.strip()
+        ) or ("new-message",)
         self.send_read_receipts = bool(extra.get("send_read_receipts", True))
         _require_mention = extra.get("require_mention")
         if _require_mention is None:
@@ -352,19 +371,53 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             return False
 
         webhook_url = self._webhook_register_url
+        desired_events = list(self.webhook_events)
 
         # Crash resilience — reuse an existing registration if present
         existing = await self._find_registered_webhooks(webhook_url)
         if existing:
-            logger.info(
-                "[bluebubbles] webhook already registered: %s",
-                self._webhook_register_url_for_log,
-            )
-            return True
+            reusable = []
+            stale = []
+            for wh in existing:
+                events = wh.get("events") or []
+                if (
+                    set(events) == set(desired_events)
+                    and len(events) == len(desired_events)
+                ):
+                    reusable.append(wh)
+                else:
+                    stale.append(wh)
+
+            for wh in stale:
+                wh_id = wh.get("id")
+                if not wh_id:
+                    continue
+                try:
+                    res = await self.client.delete(
+                        self._api_url(f"/api/v1/webhook/{wh_id}")
+                    )
+                    res.raise_for_status()
+                    logger.info(
+                        "[bluebubbles] removed stale webhook registration: %s",
+                        self._webhook_register_url_for_log,
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "[bluebubbles] failed to remove stale webhook registration: %s",
+                        exc,
+                    )
+                    return False
+
+            if reusable:
+                logger.info(
+                    "[bluebubbles] webhook already registered: %s",
+                    self._webhook_register_url_for_log,
+                )
+                return True
 
         payload = {
             "url": webhook_url,
-            "events": ["new-message", "updated-message"],
+            "events": desired_events,
         }
 
         try:
@@ -389,6 +442,28 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 exc,
             )
             return False
+
+    @staticmethod
+    def _canonical_inbound_chat_id(
+        chat_guid: Optional[str],
+        chat_identifier: Optional[str],
+        sender: Optional[str],
+        is_group: bool,
+    ) -> Optional[str]:
+        """Return the stable Hermes session key for an inbound BlueBubbles chat."""
+        if is_group:
+            return chat_guid or chat_identifier or sender
+
+        for candidate in (chat_identifier, sender):
+            if candidate and ";" not in candidate:
+                return candidate
+
+        if chat_guid and ";-;" in chat_guid:
+            identifier = chat_guid.rsplit(";-;", 1)[-1].strip()
+            if identifier:
+                return identifier
+
+        return chat_guid or chat_identifier or sender
 
     async def _unregister_webhook(self) -> bool:
         """Unregister this webhook URL from the BlueBubbles server.
@@ -896,6 +971,9 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         # Only process message events; silently acknowledge everything else
         if event_type and event_type not in _MESSAGE_EVENTS:
             return web.Response(text="ok")
+        allowed_events = set(self.webhook_events) | {"message"}
+        if event_type and event_type not in allowed_events:
+            return web.Response(text="ok")
 
         record = self._extract_payload_record(payload) or {}
         is_from_me = bool(
@@ -993,7 +1071,6 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         if not sender or not (chat_guid or chat_identifier) or not text:
             return web.json_response({"error": "missing message fields"}, status=400)
 
-        session_chat_id = chat_guid or chat_identifier
         is_group = bool(record.get("isGroup")) or (";+;" in (chat_guid or ""))
         if is_group and self.require_mention:
             if not self._message_matches_mention_patterns(text):
@@ -1002,13 +1079,19 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 )
                 return web.Response(text="ok")
             text = self._clean_mention_text(text)
+        session_chat_id = self._canonical_inbound_chat_id(
+            chat_guid=chat_guid,
+            chat_identifier=chat_identifier,
+            sender=sender,
+            is_group=is_group,
+        )
         source = self.build_source(
             chat_id=session_chat_id,
             chat_name=chat_identifier or sender,
             chat_type="group" if is_group else "dm",
             user_id=sender,
             user_name=sender,
-            chat_id_alt=chat_identifier,
+            chat_id_alt=chat_guid if session_chat_id != chat_guid else chat_identifier,
         )
         event = MessageEvent(
             text=text,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11272,6 +11272,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             getattr(source, "chat_id", None),
             getattr(source, "thread_id", None),
             chat_type=getattr(source, "chat_type", None),
+            chat_id_alt=getattr(source, "chat_id_alt", None),
             reply_to_message_id=reply_to_message_id or getattr(source, "message_id", None),
         )
 
@@ -11282,13 +11283,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         thread_id: Optional[str],
         *,
         chat_type: Optional[str] = None,
+        chat_id_alt: Optional[str] = None,
         reply_to_message_id: Optional[str] = None,
         adapter: Optional[Any] = None,
     ) -> Optional[Dict[str, Any]]:
         """Build thread metadata for synthetic sends that only have routing state."""
+        metadata: Dict[str, Any] = {}
+        if chat_id_alt:
+            metadata["chat_id_alt"] = str(chat_id_alt)
+
         if thread_id is None:
-            return None
-        metadata: Dict[str, Any] = {"thread_id": thread_id}
+            return metadata or None
+        metadata["thread_id"] = thread_id
         if self._is_telegram_dm_topic_target(
             platform,
             chat_id,

--- a/scripts/auto_update_bluebubbles_fix.py
+++ b/scripts/auto_update_bluebubbles_fix.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import fcntl
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, NamedTuple
+
+
+OFFICIAL_URL = "https://github.com/NousResearch/hermes-agent.git"
+FORK_URL = "https://github.com/1960697431/hermes-agent.git"
+OFFICIAL_SLUG = "nousresearch/hermes-agent"
+FORK_SLUG = "1960697431/hermes-agent"
+DEFAULT_BRANCH = "fix/bluebubbles-canonical-chat-id"
+AUTO_BRANCH = "auto/bluebubbles-update"
+DEFAULT_REPO = Path.home() / ".hermes" / "hermes-agent"
+DEFAULT_STATE_DIR = Path.home() / ".hermes" / "auto-update" / "bluebubbles-fix"
+DEFAULT_LOG_FILE = Path.home() / ".hermes" / "logs" / "bluebubbles-auto-update.log"
+DEPENDENCY_FILES = {
+    "pyproject.toml",
+    "uv.lock",
+    "setup-hermes.sh",
+    "constraints-termux.txt",
+}
+
+
+class CommandError(RuntimeError):
+    def __init__(self, cmd: list[str], cwd: Path, returncode: int):
+        super().__init__(
+            f"command failed with exit code {returncode}: {shlex.join(cmd)}"
+        )
+        self.cmd = cmd
+        self.cwd = cwd
+        self.returncode = returncode
+
+
+class RemoteLayout(NamedTuple):
+    upstream: str
+    fork: str
+
+
+class Logger:
+    def __init__(self, path: Path):
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def __call__(self, message: str) -> None:
+        timestamp = dt.datetime.now().astimezone().isoformat(timespec="seconds")
+        line = f"[{timestamp}] {message}"
+        print(line, flush=True)
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write(line + "\n")
+
+
+class FileLock:
+    def __init__(self, path: Path):
+        self.path = path
+        self.handle = None
+
+    def __enter__(self) -> FileLock:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.handle = self.path.open("w", encoding="utf-8")
+        try:
+            fcntl.flock(self.handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            raise SystemExit("another BlueBubbles auto-update run is active") from exc
+        self.handle.write(str(os.getpid()))
+        self.handle.flush()
+        return self
+
+    def __exit__(self, *args) -> None:
+        assert self.handle is not None
+        fcntl.flock(self.handle, fcntl.LOCK_UN)
+        self.handle.close()
+
+
+def normalize_remote_url(url: str) -> str:
+    return url.lower().removesuffix(".git").replace(":", "/")
+
+
+def remote_matches(url: str, slug: str) -> bool:
+    return slug.lower().removesuffix(".git") in normalize_remote_url(url)
+
+
+def parse_remote_rows(output: str) -> list[tuple[str, str, str]]:
+    rows: list[tuple[str, str, str]] = []
+    for line in output.splitlines():
+        parts = line.split()
+        if len(parts) >= 3:
+            rows.append((parts[0], parts[1], parts[2].strip("()")))
+    return rows
+
+
+def resolve_remote_layout(rows: Iterable[tuple[str, str, str]]) -> RemoteLayout:
+    upstream = None
+    fork = None
+    for name, url, direction in rows:
+        if direction != "fetch":
+            continue
+        if upstream is None and remote_matches(url, OFFICIAL_SLUG):
+            upstream = name
+        if fork is None and remote_matches(url, FORK_SLUG):
+            fork = name
+    if upstream is None:
+        raise ValueError("official NousResearch/hermes-agent remote is missing")
+    if fork is None:
+        raise ValueError("1960697431/hermes-agent fork remote is missing")
+    return RemoteLayout(upstream=upstream, fork=fork)
+
+
+def tracked_status_paths(status_lines: Iterable[str]) -> list[str]:
+    paths: list[str] = []
+    for line in status_lines:
+        if not line or line.startswith("??") or line.startswith("!!"):
+            continue
+        path = line[3:].strip()
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1]
+        if path:
+            paths.append(path)
+    return paths
+
+
+def needs_dependency_sync(changed_paths: Iterable[str]) -> bool:
+    return any(path in DEPENDENCY_FILES for path in changed_paths)
+
+
+def build_bluebubbles_validation_commands(python: str) -> list[list[str]]:
+    return [
+        [
+            python,
+            "-m",
+            "py_compile",
+            "gateway/platforms/bluebubbles.py",
+        ],
+        ["scripts/run_tests.sh", "tests/gateway/test_bluebubbles.py"],
+    ]
+
+
+def run_command(
+    cmd: list[str | Path],
+    cwd: Path,
+    logger: Logger,
+    *,
+    check: bool = True,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    rendered = [str(part) for part in cmd]
+    logger(f"$ ({cwd}) {shlex.join(rendered)}")
+    completed = subprocess.run(
+        rendered,
+        cwd=str(cwd),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    for line in completed.stdout.splitlines():
+        logger(f"  {line}")
+    if check and completed.returncode != 0:
+        raise CommandError(rendered, cwd, completed.returncode)
+    return completed
+
+
+def git_stdout(repo: Path, args: list[str]) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=str(repo),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+    return completed.stdout.strip()
+
+
+def ref_exists(repo: Path, ref: str) -> bool:
+    completed = subprocess.run(
+        ["git", "rev-parse", "--verify", f"{ref}^{{commit}}"],
+        cwd=str(repo),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    return completed.returncode == 0
+
+
+def find_uv() -> str | None:
+    for candidate in (
+        shutil.which("uv"),
+        str(Path.home() / ".local" / "bin" / "uv"),
+        str(Path.home() / ".cargo" / "bin" / "uv"),
+    ):
+        if candidate and Path(candidate).exists():
+            return candidate
+    return None
+
+
+def python_can_import(python: Path, module: str) -> bool:
+    completed = subprocess.run(
+        [str(python), "-c", f"import {module}"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    return completed.returncode == 0
+
+
+def ensure_remote_layout(repo: Path, logger: Logger) -> RemoteLayout:
+    rows = parse_remote_rows(git_stdout(repo, ["remote", "-v"]))
+    names = {name for name, _, _ in rows}
+
+    if not any(remote_matches(url, OFFICIAL_SLUG) for _, url, d in rows if d == "fetch"):
+        name = "upstream" if "upstream" not in names else "official"
+        run_command(["git", "remote", "add", name, OFFICIAL_URL], repo, logger)
+
+    rows = parse_remote_rows(git_stdout(repo, ["remote", "-v"]))
+    names = {name for name, _, _ in rows}
+    if not any(remote_matches(url, FORK_SLUG) for _, url, d in rows if d == "fetch"):
+        name = "cherry" if "cherry" not in names else "fork"
+        run_command(["git", "remote", "add", name, FORK_URL], repo, logger)
+
+    rows = parse_remote_rows(git_stdout(repo, ["remote", "-v"]))
+    return resolve_remote_layout(rows)
+
+
+def remove_staging_worktree(repo: Path, staging: Path, logger: Logger) -> None:
+    if staging.exists():
+        run_command(
+            ["git", "worktree", "remove", "--force", staging],
+            repo,
+            logger,
+            check=False,
+        )
+    if staging.exists():
+        shutil.rmtree(staging)
+    run_command(["git", "worktree", "prune"], repo, logger, check=False)
+    run_command(["git", "branch", "-D", AUTO_BRANCH], repo, logger, check=False)
+
+
+def ensure_staging_venv_link(repo: Path, staging: Path, logger: Logger) -> None:
+    source = repo / "venv"
+    target = staging / "venv"
+    if target.exists() or target.is_symlink():
+        return
+    if source.exists():
+        target.symlink_to(source, target_is_directory=True)
+        logger(f"linked staging venv to {source}")
+
+
+def sync_dependencies(project_dir: Path, repo: Path, logger: Logger) -> None:
+    uv = find_uv()
+    env = os.environ.copy()
+    env["UV_NO_CONFIG"] = "1"
+    env["UV_PROJECT_ENVIRONMENT"] = str(repo / "venv")
+    if uv is not None:
+        run_command(
+            [uv, "sync", "--extra", "all", "--extra", "dev", "--locked"],
+            project_dir,
+            logger,
+            env=env,
+        )
+        return
+
+    python = repo / "venv" / "bin" / "python"
+    run_command([python, "-m", "pip", "install", "-e", ".[all,dev]"], project_dir, logger)
+
+
+def validate_bluebubbles(staging: Path, logger: Logger) -> None:
+    python = staging / "venv" / "bin" / "python"
+    for cmd in build_bluebubbles_validation_commands(str(python)):
+        run_command(cmd, staging, logger)
+
+
+def prepare_staging(
+    repo: Path,
+    staging: Path,
+    source_ref: str,
+    upstream_ref: str,
+    logger: Logger,
+) -> str:
+    remove_staging_worktree(repo, staging, logger)
+    run_command(["git", "worktree", "add", "--detach", staging, source_ref], repo, logger)
+    ensure_staging_venv_link(repo, staging, logger)
+    run_command(["git", "checkout", "-B", AUTO_BRANCH], staging, logger)
+    try:
+        run_command(["git", "rebase", upstream_ref], staging, logger)
+    except CommandError:
+        run_command(["git", "rebase", "--abort"], staging, logger, check=False)
+        raise
+    return git_stdout(staging, ["rev-parse", "HEAD"])
+
+
+def deploy_to_runtime_repo(
+    repo: Path,
+    branch: str,
+    fork_remote: str,
+    old_rev: str,
+    new_ref: str,
+    logger: Logger,
+    *,
+    sync_runtime_dependencies: bool,
+    restart_gateway: bool,
+) -> None:
+    status_lines = git_stdout(repo, ["status", "--porcelain=v1"]).splitlines()
+    tracked_paths = tracked_status_paths(status_lines)
+    if tracked_paths:
+        stamp = dt.datetime.now().strftime("%Y%m%d-%H%M%S")
+        run_command(
+            ["git", "stash", "push", "-m", f"auto-update tracked backup {stamp}"],
+            repo,
+            logger,
+        )
+
+    run_command(["git", "fetch", fork_remote, branch], repo, logger)
+    if ref_exists(repo, branch):
+        run_command(["git", "switch", branch], repo, logger)
+    else:
+        run_command(["git", "switch", "-c", branch], repo, logger)
+    run_command(["git", "reset", "--hard", new_ref], repo, logger)
+
+    if sync_runtime_dependencies:
+        sync_dependencies(repo, repo, logger)
+
+    python = repo / "venv" / "bin" / "python"
+    run_command(
+        [python, "-m", "py_compile", "gateway/platforms/bluebubbles.py"],
+        repo,
+        logger,
+    )
+    run_command([repo / "venv" / "bin" / "hermes", "--version"], repo, logger)
+
+    if restart_gateway:
+        try:
+            run_command([repo / "venv" / "bin" / "hermes", "gateway", "restart"], repo, logger)
+        except CommandError:
+            logger("gateway restart failed; rolling back runtime checkout")
+            run_command(["git", "reset", "--hard", old_rev], repo, logger, check=False)
+            run_command(
+                [repo / "venv" / "bin" / "hermes", "gateway", "restart"],
+                repo,
+                logger,
+                check=False,
+            )
+            raise
+        run_command([repo / "venv" / "bin" / "hermes", "gateway", "status"], repo, logger)
+
+
+def changed_paths_between(repo: Path, old_rev: str, new_rev: str) -> list[str]:
+    output = git_stdout(repo, ["diff", "--name-only", old_rev, new_rev])
+    return [line for line in output.splitlines() if line]
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Keep the local Hermes BlueBubbles fix branch rebased and deployed."
+    )
+    parser.add_argument("--repo", type=Path, default=DEFAULT_REPO)
+    parser.add_argument("--branch", default=DEFAULT_BRANCH)
+    parser.add_argument("--state-dir", type=Path, default=DEFAULT_STATE_DIR)
+    parser.add_argument("--log-file", type=Path, default=DEFAULT_LOG_FILE)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--no-restart-gateway", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    repo = args.repo.expanduser().resolve()
+    state_dir = args.state_dir.expanduser().resolve()
+    staging = state_dir / "staging"
+    logger = Logger(args.log_file.expanduser())
+    lock_path = state_dir / "update.lock"
+
+    try:
+        with FileLock(lock_path):
+            logger("starting Hermes BlueBubbles auto-update")
+            logger(f"runtime repo: {repo}")
+            layout = ensure_remote_layout(repo, logger)
+            logger(f"upstream remote: {layout.upstream}; fork remote: {layout.fork}")
+
+            run_command(["git", "fetch", "--prune", layout.upstream], repo, logger)
+            run_command(["git", "fetch", "--prune", layout.fork], repo, logger)
+
+            upstream_ref = f"{layout.upstream}/main"
+            fork_ref = f"{layout.fork}/{args.branch}"
+            source_ref = fork_ref if ref_exists(repo, fork_ref) else args.branch
+            if not ref_exists(repo, source_ref):
+                raise SystemExit(f"source branch not found: {source_ref}")
+
+            old_rev = git_stdout(repo, ["rev-parse", "HEAD"])
+            new_rev = prepare_staging(repo, staging, source_ref, upstream_ref, logger)
+            changed_paths = changed_paths_between(repo, old_rev, new_rev)
+            pytest_missing = not python_can_import(repo / "venv" / "bin" / "python", "pytest")
+            if needs_dependency_sync(changed_paths) or pytest_missing:
+                sync_dependencies(repo, repo, logger)
+            validate_bluebubbles(staging, logger)
+
+            if args.dry_run:
+                logger(f"dry run complete; validated candidate {new_rev}")
+                return 0
+
+            run_command(
+                ["git", "push", "--force-with-lease", layout.fork, f"HEAD:{args.branch}"],
+                staging,
+                logger,
+            )
+            deploy_to_runtime_repo(
+                repo,
+                args.branch,
+                layout.fork,
+                old_rev,
+                f"{layout.fork}/{args.branch}",
+                logger,
+                sync_runtime_dependencies=needs_dependency_sync(changed_paths),
+                restart_gateway=not args.no_restart_gateway,
+            )
+            logger(f"completed Hermes BlueBubbles auto-update at {new_rev}")
+            return 0
+    except Exception as exc:
+        logger(f"FAILED: {exc}")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -85,7 +85,7 @@ class TestBlueBubblesHelpers:
         assert all("(" not in chunk for chunk in chunks)
 
     @pytest.mark.asyncio
-    async def test_send_splits_paragraphs_into_multiple_bubbles(self, monkeypatch):
+    async def test_send_preserves_paragraphs_in_one_bubble(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
         sent = []
 
@@ -102,7 +102,7 @@ class TestBlueBubblesHelpers:
         result = await adapter.send("user@example.com", "first thought\n\nsecond thought")
 
         assert result.success is True
-        assert sent == ["first thought", "second thought"]
+        assert sent == ["first thought\n\nsecond thought"]
 
     def test_format_message_strips_markdown(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -2,6 +2,7 @@
 import asyncio
 import json
 
+import httpx
 import pytest
 
 from gateway.config import Platform, PlatformConfig
@@ -103,6 +104,44 @@ class TestBlueBubblesHelpers:
 
         assert result.success is True
         assert sent == ["first thought\n\nsecond thought"]
+
+    @pytest.mark.asyncio
+    async def test_text_send_read_timeout_assumes_delivered_to_avoid_fallback_duplicate(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        calls = []
+
+        async def fake_resolve_chat_guid(chat_id):
+            return "iMessage;-;user@example.com"
+
+        async def fake_api_post(path, payload):
+            calls.append(payload["message"])
+            raise httpx.ReadTimeout("")
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve_chat_guid)
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+
+        result = await adapter._send_with_retry("user@example.com", "hello")
+
+        assert result.success is True
+        assert result.message_id == "timeout-assumed-delivered"
+        assert calls == ["hello"]
+
+    @pytest.mark.asyncio
+    async def test_create_chat_read_timeout_assumes_delivered(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        calls = []
+
+        async def fake_api_post(path, payload):
+            calls.append((path, payload["message"]))
+            raise httpx.ReadTimeout("")
+
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+
+        result = await adapter._create_chat_for_handle("user@example.com", "hello")
+
+        assert result.success is True
+        assert result.message_id == "timeout-assumed-delivered"
+        assert calls == [("/api/v1/chat/new", "hello")]
 
     def test_format_message_strips_markdown(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -6,6 +6,8 @@ import httpx
 import pytest
 
 from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import _thread_metadata_for_source
+from gateway.session import SessionSource
 
 
 def _make_adapter(monkeypatch, **extra):
@@ -142,6 +144,59 @@ class TestBlueBubblesHelpers:
         assert result.success is True
         assert result.message_id == "timeout-assumed-delivered"
         assert calls == [("/api/v1/chat/new", "hello")]
+
+    @pytest.mark.asyncio
+    async def test_send_uses_metadata_chat_id_alt_when_canonical_chat_id_does_not_resolve(
+        self, monkeypatch
+    ):
+        adapter = _make_adapter(monkeypatch)
+        adapter._private_api_enabled = True
+        raw_guid = "any;-;+15551234567"
+        sent = []
+
+        async def fake_api_post(path, payload):
+            sent.append((path, payload))
+            return {"data": {"guid": "msg-1"}}
+
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+
+        result = await adapter.send(
+            "+15551234567",
+            "hello",
+            metadata={"chat_id_alt": raw_guid},
+        )
+
+        assert result.success is True
+        assert result.message_id == "msg-1"
+        assert len(sent) == 1
+        assert sent[0][0] == "/api/v1/message/text"
+        assert sent[0][1]["chatGuid"] == raw_guid
+        assert sent[0][1]["message"] == "hello"
+
+    def test_thread_metadata_carries_chat_id_alt_without_thread(self):
+        source = SessionSource(
+            platform=Platform.BLUEBUBBLES,
+            chat_id="+15551234567",
+            chat_id_alt="any;-;+15551234567",
+        )
+
+        assert _thread_metadata_for_source(source) == {
+            "chat_id_alt": "any;-;+15551234567"
+        }
+
+    def test_runner_thread_metadata_carries_chat_id_alt_without_thread(self):
+        from gateway.run import GatewayRunner
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        source = SessionSource(
+            platform=Platform.BLUEBUBBLES,
+            chat_id="+15551234567",
+            chat_id_alt="any;-;+15551234567",
+        )
+
+        assert runner._thread_metadata_for_source(source) == {
+            "chat_id_alt": "any;-;+15551234567"
+        }
 
     def test_format_message_strips_markdown(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -378,6 +378,41 @@ class TestBlueBubblesWebhookParsing:
                 chat_guid = _chats[0].get("guid") or _chats[0].get("chatGuid")
         assert chat_guid == "any;+;chat-uuid-abc123"
 
+    def test_dm_session_chat_id_prefers_stable_chat_identifier(self, monkeypatch):
+        """DM GUID variants must collapse to one Hermes session key."""
+        adapter = _make_adapter(monkeypatch)
+        assert (
+            adapter._canonical_inbound_chat_id(
+                chat_guid="any;-;+15551234567",
+                chat_identifier="+15551234567",
+                sender="+15551234567",
+                is_group=False,
+            )
+            == "+15551234567"
+        )
+        assert (
+            adapter._canonical_inbound_chat_id(
+                chat_guid="iMessage;-;+15551234567",
+                chat_identifier="+15551234567",
+                sender="+15551234567",
+                is_group=False,
+            )
+            == "+15551234567"
+        )
+
+    def test_group_session_chat_id_keeps_bluebubbles_guid(self, monkeypatch):
+        """Group GUIDs are the stable BlueBubbles routing key and must not collapse."""
+        adapter = _make_adapter(monkeypatch)
+        assert (
+            adapter._canonical_inbound_chat_id(
+                chat_guid="any;+;chat-uuid-abc123",
+                chat_identifier="+15551234567",
+                sender="+15551234567",
+                is_group=True,
+            )
+            == "any;+;chat-uuid-abc123"
+        )
+
     def test_extract_payload_record_accepts_list_data(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
         payload = {
@@ -738,6 +773,45 @@ class TestBlueBubblesWebhookRegistration:
         )
         assert ok is True
         assert not post_called, "Should reuse existing, not POST again"
+
+    def test_register_replaces_existing_when_events_drift(self, monkeypatch):
+        """Existing registrations with updated-message must be replaced."""
+        import asyncio
+        adapter = _make_adapter(monkeypatch)
+        url = adapter._webhook_register_url
+        deleted_urls = []
+        posted_payloads = []
+
+        async def mock_delete(*args, **kwargs):
+            deleted_urls.append(args[0] if args else "")
+
+            class R:
+                status_code = 200
+
+                def raise_for_status(self):
+                    pass
+
+            return R()
+
+        async def tracking_post(path, payload):
+            posted_payloads.append(payload)
+            return {"status": 200, "data": {"id": 8}}
+
+        adapter.client = self._mock_client(
+            get_response={"status": 200, "data": [
+                {"id": 7, "url": url, "events": ["new-message", "updated-message"]},
+            ]},
+        )
+        adapter.client.delete = mock_delete
+        adapter._api_post = tracking_post
+
+        ok = asyncio.get_event_loop().run_until_complete(
+            adapter._register_webhook()
+        )
+
+        assert ok is True
+        assert posted_payloads == [{"url": url, "events": ["new-message"]}]
+        assert any("/api/v1/webhook/7" in deleted_url for deleted_url in deleted_urls)
 
     def test_register_returns_false_without_client(self, monkeypatch):
         import asyncio

--- a/tests/scripts/test_auto_update_bluebubbles_fix.py
+++ b/tests/scripts/test_auto_update_bluebubbles_fix.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "auto_update_bluebubbles_fix.py"
+
+
+def load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "auto_update_bluebubbles_fix", SCRIPT_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_resolve_remote_layout_supports_current_local_names():
+    module = load_script_module()
+
+    layout = module.resolve_remote_layout(
+        [
+            ("cherry", "https://github.com/1960697431/hermes-agent.git", "fetch"),
+            ("cherry", "https://github.com/1960697431/hermes-agent.git", "push"),
+            ("origin", "https://github.com/NousResearch/hermes-agent.git", "fetch"),
+            ("origin", "https://github.com/NousResearch/hermes-agent.git", "push"),
+        ]
+    )
+
+    assert layout.upstream == "origin"
+    assert layout.fork == "cherry"
+
+
+def test_tracked_status_paths_ignore_untracked_local_config_and_skills():
+    module = load_script_module()
+
+    paths = module.tracked_status_paths(
+        [
+            " M gateway/platforms/bluebubbles.py",
+            "M  pyproject.toml",
+            "?? config.yaml",
+            "?? skills/devops/hermes-update-fix-cn/",
+        ]
+    )
+
+    assert paths == ["gateway/platforms/bluebubbles.py", "pyproject.toml"]
+
+
+def test_needs_dependency_sync_only_for_environment_files():
+    module = load_script_module()
+
+    assert module.needs_dependency_sync(["gateway/platforms/bluebubbles.py"]) is False
+    assert module.needs_dependency_sync(["uv.lock"]) is True
+    assert module.needs_dependency_sync(["pyproject.toml"]) is True
+
+
+def test_build_bluebubbles_validation_commands_are_narrow_and_deterministic():
+    module = load_script_module()
+
+    commands = module.build_bluebubbles_validation_commands(
+        python="/repo/venv/bin/python"
+    )
+
+    assert commands == [
+        [
+            "/repo/venv/bin/python",
+            "-m",
+            "py_compile",
+            "gateway/platforms/bluebubbles.py",
+        ],
+        ["scripts/run_tests.sh", "tests/gateway/test_bluebubbles.py"],
+    ]
+
+
+def test_sync_dependencies_installs_dev_extra_for_pytest(monkeypatch, tmp_path):
+    module = load_script_module()
+    calls = []
+
+    monkeypatch.setattr(module, "find_uv", lambda: "/bin/uv")
+
+    def fake_run_command(cmd, cwd, logger, *, check=True, env=None):
+        calls.append((cmd, cwd, env))
+
+    monkeypatch.setattr(module, "run_command", fake_run_command)
+
+    module.sync_dependencies(tmp_path / "project", tmp_path / "repo", lambda msg: None)
+
+    assert calls[0][0] == [
+        "/bin/uv",
+        "sync",
+        "--extra",
+        "all",
+        "--extra",
+        "dev",
+        "--locked",
+    ]


### PR DESCRIPTION
## Summary
- default BlueBubbles webhook registration to new-message only, while allowing explicit webhook_events overrides
- replace existing webhook registrations whose event set drifted, such as new-message + updated-message
- canonicalize inbound one-to-one chat GUID variants to the stable chat identifier so the same iMessage DM does not split across sessions
- keep paragraph breaks inside a single iMessage bubble by chunking BlueBubbles text sends only by message length

## Tests
- /Users/yuhanglin/hermes-agent/venv/bin/python -m pytest tests/gateway/test_bluebubbles.py tests/gateway/test_session.py tests/gateway/test_channel_directory.py tests/gateway/test_duplicate_reply_suppression.py -q
- /Users/yuhanglin/hermes-agent/venv/bin/python -m py_compile gateway/platforms/bluebubbles.py
- git diff --check -- gateway/platforms/bluebubbles.py tests/gateway/test_bluebubbles.py