### PR TITLE
feat(desktop): expand the full command inline from the approval bar

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool-approval.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool-approval.test.tsx
@@ -84,6 +84,19 @@ describe('PendingToolApproval', () => {
     expect($approvalRequest.get()).toBeNull()
   })
 
+  it('reveals the full command inline when the Command toggle is clicked', () => {
+    const longCommand = 'python -c "' + 'x'.repeat(400) + '"'
+    setRequest(longCommand)
+    render(<PendingToolApproval part={part('terminal')} />)
+
+    // Collapsed by default: the full command is not in the DOM yet.
+    expect(screen.queryByText(longCommand)).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: /Command/ }))
+
+    expect(screen.getByText(longCommand)).toBeTruthy()
+  })
+
   it('sends choice "deny" on Reject', async () => {
     const request = mockGateway()
     setRequest()

--- a/apps/desktop/src/components/assistant-ui/tool-approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool-approval.tsx
@@ -16,6 +16,7 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { ChevronDown, Loader2 } from '@/lib/icons'
+import { cn } from '@/lib/utils'
 import { $gateway } from '@/store/gateway'
 import { notifyError } from '@/store/notifications'
 import { $approvalRequest, type ApprovalRequest, clearApprovalRequest } from '@/store/prompts'
@@ -60,9 +61,15 @@ const ApprovalBar: FC<{ request: ApprovalRequest }> = ({ request }) => {
   // "Always allow" persists the pattern to ~/.hermes/config.yaml permanently, so
   // it goes through a confirm step rather than firing straight from the menu.
   const [confirmAlways, setConfirmAlways] = useState(false)
+  // The pending tool row only shows a single truncated line of the command, and
+  // a pending row can't be expanded (no result yet), so the full command was
+  // previously only reachable via the "Always allow" modal. Let the user reveal
+  // it inline instead — "expand, Run" (2 clicks) rather than the modal dance.
+  const [showCommand, setShowCommand] = useState(false)
   const busy = submitting !== null
   // false when the backend won't honor a permanent allow (tirith warning) → hide "Always allow".
   const allowPermanent = request.allowPermanent !== false
+  const hasCommand = request.command.trim().length > 0
 
   const respond = useCallback(
     async (choice: ApprovalChoice) => {
@@ -119,70 +126,89 @@ const ApprovalBar: FC<{ request: ApprovalRequest }> = ({ request }) => {
   }, [confirmAlways, respond])
 
   return (
-    <div className="mt-1 flex items-center gap-2.5 ps-5" data-slot="tool-approval-inline">
-      <div className="inline-flex h-6 items-stretch overflow-hidden rounded-md border border-primary/25 bg-primary/10 text-primary">
+    <div className="mt-1 ps-5" data-slot="tool-approval-inline">
+      <div className="flex items-center gap-2.5">
+        <div className="inline-flex h-6 items-stretch overflow-hidden rounded-md border border-primary/25 bg-primary/10 text-primary">
+          <Button
+            className="h-full gap-1 rounded-none px-2 text-xs font-medium text-primary hover:bg-primary/15 hover:text-primary"
+            disabled={busy}
+            onClick={() => void respond('once')}
+            size="xs"
+            variant="ghost"
+          >
+            {submitting === 'once' ? <Loader2 className="size-3 animate-spin" /> : copy.run}
+            {submitting !== 'once' && <span className="text-[0.625rem] text-primary/60">{isMac ? '⌘⏎' : 'Ctrl⏎'}</span>}
+          </Button>
+          <span aria-hidden className="w-px self-stretch bg-primary/20" />
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                aria-label={copy.moreOptions}
+                className="h-full w-5 rounded-none px-0 text-primary hover:bg-primary/15 hover:text-primary"
+                disabled={busy}
+                size="xs"
+                variant="ghost"
+              >
+                <ChevronDown className="size-3" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="min-w-44">
+              <DropdownMenuItem onSelect={() => void respond('session')}>{copy.allowSession}</DropdownMenuItem>
+              {allowPermanent && (
+                <DropdownMenuItem
+                  onSelect={() => {
+                    // Defer one tick so the menu fully unmounts before the dialog
+                    // mounts — otherwise Radix's focus-return races the dialog and
+                    // dismisses it via onInteractOutside.
+                    setTimeout(() => setConfirmAlways(true), 0)
+                  }}
+                >
+                  {copy.alwaysAllowMenu}
+                </DropdownMenuItem>
+              )}
+              <DropdownMenuItem onSelect={() => void respond('deny')} variant="destructive">
+                {copy.reject}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+
         <Button
-          className="h-full gap-1 rounded-none px-2 text-xs font-medium text-primary hover:bg-primary/15 hover:text-primary"
+          className="h-6 gap-1.5 rounded-md px-1.5 text-xs font-normal text-(--ui-text-tertiary) hover:text-foreground"
           disabled={busy}
-          onClick={() => void respond('once')}
+          onClick={() => void respond('deny')}
           size="xs"
           variant="ghost"
         >
-          {submitting === 'once' ? <Loader2 className="size-3 animate-spin" /> : copy.run}
-          {submitting !== 'once' && <span className="text-[0.625rem] text-primary/60">{isMac ? '⌘⏎' : 'Ctrl⏎'}</span>}
+          {submitting === 'deny' ? <Loader2 className="size-3 animate-spin" /> : copy.reject}
+          {submitting !== 'deny' && <span className="text-[0.625rem] opacity-55">Esc</span>}
         </Button>
-        <span aria-hidden className="w-px self-stretch bg-primary/20" />
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              aria-label={copy.moreOptions}
-              className="h-full w-5 rounded-none px-0 text-primary hover:bg-primary/15 hover:text-primary"
-              disabled={busy}
-              size="xs"
-              variant="ghost"
-            >
-              <ChevronDown className="size-3" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="start" className="min-w-44">
-            <DropdownMenuItem onSelect={() => void respond('session')}>{copy.allowSession}</DropdownMenuItem>
-            {allowPermanent && (
-              <DropdownMenuItem
-                onSelect={() => {
-                  // Defer one tick so the menu fully unmounts before the dialog
-                  // mounts — otherwise Radix's focus-return races the dialog and
-                  // dismisses it via onInteractOutside.
-                  setTimeout(() => setConfirmAlways(true), 0)
-                }}
-              >
-                {copy.alwaysAllowMenu}
-              </DropdownMenuItem>
-            )}
-            <DropdownMenuItem onSelect={() => void respond('deny')} variant="destructive">
-              {copy.reject}
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+
+        {hasCommand && (
+          <Button
+            aria-expanded={showCommand}
+            className="h-6 gap-1 rounded-md px-1.5 text-xs font-normal text-(--ui-text-tertiary) hover:text-foreground"
+            onClick={() => setShowCommand(value => !value)}
+            size="xs"
+            variant="ghost"
+          >
+            {copy.command}
+            <ChevronDown className={cn('size-3 transition-transform', showCommand && 'rotate-180')} />
+          </Button>
+        )}
       </div>
 
-      <Button
-        className="h-6 gap-1.5 rounded-md px-1.5 text-xs font-normal text-(--ui-text-tertiary) hover:text-foreground"
-        disabled={busy}
-        onClick={() => void respond('deny')}
-        size="xs"
-        variant="ghost"
-      >
-        {submitting === 'deny' ? <Loader2 className="size-3 animate-spin" /> : copy.reject}
-        {submitting !== 'deny' && <span className="text-[0.625rem] opacity-55">Esc</span>}
-      </Button>
+      {showCommand && hasCommand && (
+        <pre className="mt-1.5 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-chat-surface-background) px-2.5 py-1.5 font-mono text-xs leading-snug text-foreground">
+          {request.command.trim()}
+        </pre>
+      )}
 
       <Dialog onOpenChange={setConfirmAlways} open={confirmAlways}>
         <DialogContent className="max-w-md">
           <DialogHeader>
             <DialogTitle>{copy.alwaysTitle}</DialogTitle>
-            <DialogDescription>
-              {copy.alwaysDescription(request.description)}
-            </DialogDescription>
+            <DialogDescription>{copy.alwaysDescription(request.description)}</DialogDescription>
           </DialogHeader>
 
           {request.command.trim() && (

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1665,6 +1665,7 @@ export const en: Translations = {
       gatewayDisconnected: 'Hermes gateway is not connected',
       sendFailed: 'Could not send approval response',
       run: 'Run',
+      command: 'Command',
       moreOptions: 'More approval options',
       allowSession: 'Allow this session',
       alwaysAllowMenu: 'Always allow…',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1798,6 +1798,7 @@ export const ja = defineLocale({
       gatewayDisconnected: 'Hermes ゲートウェイが接続されていません',
       sendFailed: '承認応答を送信できませんでした',
       run: '実行',
+      command: 'コマンド',
       moreOptions: 'その他の承認オプション',
       allowSession: 'このセッションで許可',
       alwaysAllowMenu: '常に許可…',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1325,6 +1325,7 @@ export interface Translations {
       gatewayDisconnected: string
       sendFailed: string
       run: string
+      command: string
       moreOptions: string
       allowSession: string
       alwaysAllowMenu: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1759,6 +1759,7 @@ export const zhHant = defineLocale({
       gatewayDisconnected: 'Hermes 閘道未連線',
       sendFailed: '無法傳送核准回應',
       run: '執行',
+      command: '指令',
       moreOptions: '更多核准選項',
       allowSession: '允許本工作階段',
       alwaysAllowMenu: '一律允許…',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1844,6 +1844,7 @@ export const zh: Translations = {
       gatewayDisconnected: 'Hermes 网关未连接',
       sendFailed: '无法发送审批响应',
       run: '运行',
+      command: '命令',
       moreOptions: '更多审批选项',
       allowSession: '允许本会话',
       alwaysAllowMenu: '始终允许…',


### PR DESCRIPTION
## Summary

Follow-up to the Ink/TUI fix that wrapped long approval commands — the **native desktop** approval bar (`apps/desktop/src/components/assistant-ui/tool-approval.tsx`) was untouched and still hides the command.

The bar deliberately omits the command (comment: "the row already shows the command, so the strip deliberately doesn't repeat it"), but:
- the pending tool row only renders **one truncated line** of `view.title`, and
- a pending row **can't be expanded** (no result yet → no expandable content),

so the full command was only reachable by opening the "Always allow…" dropdown → reading the modal → cancelling → clicking Run. As a reporter put it, "4-5 clicks every time an approval shows."

This adds a **"Command" toggle** to the approval bar that reveals the full `request.command` inline (reusing the Always-allow dialog's `<pre>` styling), default-collapsed. Approving a long command becomes "expand, Run" (2 clicks). The toggle is gated on a non-empty command, so approvals without a command string are visually unchanged.

- Commit 1: the inline expander + one i18n key (`command`) across en/zh/zh-hant/ja + types.
- Commit 2: a test asserting the command is hidden until toggled, then shown in full.

## Test plan

- [x] `npx vitest run --environment jsdom src/components/assistant-ui/tool-approval.test.tsx` (6 passed)
- [x] `npm run typecheck` (clean)
- [x] `eslint` on touched files (no new warnings; the one warning is pre-existing on the `respond` callback)
- Manual: long terminal command shows truncated in the row; click **Command** → full text in a scrollable block; click **Run**.

## Infographic

![Desktop approval command expander](https://v3b.fal.media/files/b/0a9e20d7/AibEOcWX2fMcH3hsmjwMm_XSbJs1sf.png)
