### PR TITLE
fix(gateway): only rewrite transcript when session rotation happened (#44794)

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2494,8 +2494,12 @@ class GatewaySlashCommandsMixin:
                     self._sync_telegram_topic_binding(
                         source, session_entry, reason="compress-command",
                     )
-
-                self.session_store.rewrite_transcript(new_session_id, compressed)
+                    # Only rewrite transcript when rotation actually happened.
+                    # When _session_db is None or rotation failed, no new session
+                    # was created — calling rewrite_transcript() would unconditionally
+                    # overwrite the original session with compressed content, destroying
+                    # the full conversation history (#44794).
+                    self.session_store.rewrite_transcript(new_session_id, compressed)
                 # Reset stored token count — transcript changed, old value is stale
                 self.session_store.update_session(
                     session_entry.session_key, last_prompt_tokens=0


### PR DESCRIPTION
Fixes #44794. When _session_db is None or session rotation fails, rewrite_transcript() was called unconditionally on the original session, overwriting the full conversation history with only the compressed summary. This fix moves rewrite_transcript() inside the rotation check so it only executes when a new session was actually created.