### PR TITLE
fix(cli): accept api_key_env alias in providers entries

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3849,7 +3849,7 @@ def _normalize_custom_provider_entry(
     if isinstance(api_key, str) and api_key.strip():
         normalized["api_key"] = api_key.strip()
 
-    key_env = entry.get("key_env")
+    key_env = entry.get("key_env") or entry.get("api_key_env")
     if isinstance(key_env, str) and key_env.strip():
         normalized["key_env"] = key_env.strip()
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1780,7 +1780,7 @@ def list_authenticated_providers(
             if not raw_name or not api_url:
                 continue
             inline_api_key = (entry.get("api_key") or "").strip()
-            key_env = (entry.get("key_env") or "").strip()
+            key_env = (entry.get("key_env") or entry.get("api_key_env") or "").strip()
             api_key = inline_api_key or (
                 os.environ.get(key_env, "").strip() if key_env else ""
             )

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -539,7 +539,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             # Match exact name or normalized name
             name_norm = _normalize_custom_provider_name(ep_name)
             # Resolve the API key from the env var name stored in key_env
-            key_env = str(entry.get("key_env", "") or "").strip()
+            key_env = str(entry.get("key_env") or entry.get("api_key_env") or "").strip()
             resolved_api_key = os.getenv(key_env, "").strip() if key_env else ""
             # Fall back to inline api_key when key_env is absent or unresolvable
             if not resolved_api_key:
@@ -626,7 +626,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             "base_url": base_url.strip(),
             "api_key": str(entry.get("api_key", "") or "").strip(),
         }
-        key_env = str(entry.get("key_env", "") or "").strip()
+        key_env = str(entry.get("key_env") or entry.get("api_key_env") or "").strip()
         if key_env:
             result["key_env"] = key_env
         if provider_key:
@@ -758,7 +758,7 @@ def _resolve_named_custom_runtime(
     api_key_candidates = [
         (explicit_api_key or "").strip(),
         str(custom_provider.get("api_key", "") or "").strip(),
-        os.getenv(str(custom_provider.get("key_env", "") or "").strip(), "").strip(),
+        os.getenv(str(custom_provider.get("key_env") or custom_provider.get("api_key_env") or "").strip(), "").strip(),
         # Gate provider env keys on their authoritative hosts — sending
         # OPENAI_API_KEY to a local-llm endpoint leaks credentials (#28660).
         (os.getenv("OPENAI_API_KEY", "").strip()     if _cp_is_openai_url  else ""),


### PR DESCRIPTION
## Summary

When defining a named custom provider under `providers:` in config.yaml using the documented `api_key_env` field, the key resolution silently ignores it because only `key_env` is checked. This causes 401 errors — `"no-key-required"` is sent as the bearer token.

Fixes #44666

## Root Cause

`_get_named_custom_provider()` in `runtime_provider.py` (lines 542, 629) only checks `entry.get("key_env")`. The same gap exists in `model_switch.py` line 1783 and `config.py` line 3852.

Other code paths already handle both aliases correctly:
- `agent/auxiliary_client.py:3652` — `custom_entry.get("key_env") or custom_entry.get("api_key_env")`
- `agent/agent_init.py:833` — `_fb.get("key_env") or _fb.get("api_key_env")`
- `hermes_cli/config.py:3786` — normalizes `api_key_env` → `key_env` for camelCase keys

## Changes

| File | Change |
|------|--------|
| `hermes_cli/runtime_provider.py` | Add `api_key_env` fallback in 3 locations |
| `hermes_cli/model_switch.py` | Add `api_key_env` fallback in provider resolution |
| `hermes_cli/config.py` | Add `api_key_env` fallback in entry normalization |

## Testing

```bash
# Verify the fix pattern matches existing usage
grep -n "api_key_env" hermes_cli/runtime_provider.py
grep -n "api_key_env" hermes_cli/model_switch.py
grep -n "api_key_env" hermes_cli/config.py
```

The same class of bug was fixed for `fallback_providers:` in #25091 (commit `6ddc48b0`).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope): description`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I have considered cross-platform impact (Windows, macOS, Linux) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)

### Documentation

- [x] I have updated relevant documentation or marked as N/A
- [x] I have updated `cli-config.yaml.example` if I added/changed config keys or marked as N/A