### PR TITLE
fix(deps): relax setuptools pin to 81.0.0 for torch compat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,7 @@ edge-tts = ["edge-tts==7.2.7"]
 modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 hindsight = ["hindsight-client==0.6.1"]
-dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "pytest-timeout==2.4.0", "mcp==1.26.0", "starlette==1.0.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==82.0.1"]  # starlette: CVE-2026-48710
+dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "pytest-timeout==2.4.0", "mcp==1.26.0", "starlette==1.0.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==81.0.0"]  # starlette: CVE-2026-48710
 messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", "aiohttp==3.13.4", "brotlicffi==1.2.0.1", "slack-bolt==1.27.0", "slack-sdk==3.40.1", "qrcode==7.4.2"]  # aiohttp: CVE-2026-34513/34518/34519/34520/34525
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt==1.27.0", "slack-sdk==3.40.1", "aiohttp==3.13.4"]


### PR DESCRIPTION
## Summary

The `dev` extra exact-pins `setuptools==82.0.1`, but torch >= 2.11 declares `Requires-Dist: setuptools<82`. Any environment resolving `dev` together with torch is unsatisfiable.

Fixes #44692

## Fix

Relax the pin from `setuptools==82.0.1` to `setuptools==81.0.0` — the latest release below torch's `<82` cap, and still inside the build-system support window (`setuptools>=77.0,<83` declared in `[build-system]`).

## Verification

```bash
uv pip install --dry-run ".[dev]" "torch==2.12.0"  # should resolve successfully
```

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope): description`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I have considered cross-platform impact (Windows, macOS, Linux) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)

### Documentation

- [x] I have updated relevant documentation or marked as N/A
- [x] I have updated `cli-config.yaml.example` if I added/changed config keys or marked as N/A