### PR TITLE
fix(cron): add seconds support to parse_duration

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -184,22 +184,23 @@ def ensure_dirs():
 
 def parse_duration(s: str) -> int:
     """
-    Parse duration string into minutes.
-    
+    Parse duration string into minutes (fractional for sub-minute durations).
+
     Examples:
         "30m" → 30
         "2h" → 120
         "1d" → 1440
+        "10s" → 0.166...  (sub-minute, returned as fractional minutes)
     """
     s = s.strip().lower()
-    match = re.match(r'^(\d+)\s*(m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days)$', s)
+    match = re.match(r'^(\d+)\s*(s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days)$', s)
     if not match:
-        raise ValueError(f"Invalid duration: '{s}'. Use format like '30m', '2h', or '1d'")
-    
+        raise ValueError(f"Invalid duration: '{s}'. Use format like '10s', '30m', '2h', or '1d'")
+
     value = int(match.group(1))
-    unit = match.group(2)[0]  # First char: m, h, or d
-    
-    multipliers = {'m': 1, 'h': 60, 'd': 1440}
+    unit = match.group(2)[0]  # First char: s, m, h, or d
+
+    multipliers = {'s': 1/60, 'm': 1, 'h': 60, 'd': 1440}
     return value * multipliers[unit]
 
 
@@ -229,10 +230,15 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
     if schedule_lower.startswith("every "):
         duration_str = schedule[6:].strip()
         minutes = parse_duration(duration_str)
+        total_seconds = max(1, round(minutes * 60))
+        if total_seconds < 60:
+            display = f"every {total_seconds}s"
+        else:
+            display = f"every {minutes}m"
         return {
             "kind": "interval",
             "minutes": minutes,
-            "display": f"every {minutes}m"
+            "display": display
         }
     
     # Check for cron expression (5 or 6 space-separated fields)
@@ -271,10 +277,11 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
         except ValueError as e:
             raise ValueError(f"Invalid timestamp '{schedule}': {e}")
     
-    # Duration like "30m", "2h", "1d" → one-shot from now
+    # Duration like "10s", "30m", "2h", "1d" → one-shot from now
     try:
         minutes = parse_duration(schedule)
-        run_at = _hermes_now() + timedelta(minutes=minutes)
+        total_seconds = max(1, round(minutes * 60))
+        run_at = _hermes_now() + timedelta(seconds=total_seconds)
         return {
             "kind": "once",
             "run_at": run_at.isoformat(),
@@ -285,7 +292,7 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
     
     raise ValueError(
         f"Invalid schedule '{original}'. Use:\n"
-        f"  - Duration: '30m', '2h', '1d' (one-shot)\n"
+        f"  - Duration: '10s', '30m', '2h', '1d' (one-shot)\n"
         f"  - Interval: 'every 30m', 'every 2h' (recurring)\n"
         f"  - Cron: '0 9 * * *' (cron expression)\n"
         f"  - Timestamp: '2026-02-03T14:00:00' (one-shot at time)"

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -182,7 +182,7 @@ def ensure_dirs():
 # Schedule Parsing
 # =============================================================================
 
-def parse_duration(s: str) -> int:
+def parse_duration(s: str) -> float:
     """
     Parse duration string into minutes (fractional for sub-minute durations).
 
@@ -238,7 +238,7 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
         return {
             "kind": "interval",
             "minutes": minutes,
-            "display": display
+            "display": display,
         }
     
     # Check for cron expression (5 or 6 space-separated fields)
@@ -390,13 +390,14 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
 
     elif schedule["kind"] == "interval":
         minutes = schedule["minutes"]
+        total_seconds = max(1, round(minutes * 60))
         if last_run_at:
             # Next run is last_run + interval
             last = _ensure_aware(datetime.fromisoformat(last_run_at))
-            next_run = last + timedelta(minutes=minutes)
+            next_run = last + timedelta(seconds=total_seconds)
         else:
             # First run is now + interval
-            next_run = now + timedelta(minutes=minutes)
+            next_run = now + timedelta(seconds=total_seconds)
         return next_run.isoformat()
 
     elif schedule["kind"] == "cron":


### PR DESCRIPTION
## Summary

`parse_duration` only accepts `m/h/d` units. When the LLM constructs a sub-minute schedule like `"10s"` or `"30s"`, it raises `ValueError`, causing the cron job creation to fail silently or produce an incorrect timestamp.

Fixes #44749

## Changes

**`cron/jobs.py`:**

1. **`parse_duration`** — Add `s/sec/secs/second/seconds` to the regex and multiplier map (`'s': 1/60`). Return value remains in minutes (fractional for sub-minute) to preserve backward compatibility.

2. **`parse_schedule`** — Use `timedelta(seconds=total_seconds)` instead of `timedelta(minutes=minutes)` for sub-minute precision. Update display text and error message to include seconds examples.

3. **Interval display** — Show `"every 30s"` instead of `"every 0.5m"` for sub-minute recurring schedules.

## Examples

```
"10s"       → once in 10 seconds
"30s"       → once in 30 seconds
"every 30s" → recurring every 30 seconds
"30m"       → once in 30 minutes (unchanged)
"2h"        → once in 2 hours (unchanged)
```

## Testing

```bash
cd hermes-agent && python -m pytest tests/cron/test_jobs.py -v -k "parse"
```

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope): description`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I have considered cross-platform impact (Windows, macOS, Linux) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)

### Documentation

- [x] I have updated relevant documentation or marked as N/A
- [x] I have updated `cli-config.yaml.example` if I added/changed config keys or marked as N/A