### PR TITLE
fix(tui): clean error for CLI-only installs instead of FileNotFoundError

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1640,6 +1640,25 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
             node = _node_bin("node")
             return [node, "--expose-gc", str(bundled)], bundled.parent
 
+    # CLI-only install (e.g. pip / Homebrew that ships the Python package but
+    # not the Node/Ink TUI tree): the ui-tui directory simply isn't on disk.
+    # Fail with an actionable message instead of letting the npm-install / node
+    # spawn below raise a bare FileNotFoundError on the missing cwd — the exact
+    # symptom users report ("FileNotFoundError: .../site-packages/ui-tui").
+    if not tui_dir.is_dir():
+        print(
+            "The TUI is not available in this installation.\n"
+            f"  Expected the TUI at: {tui_dir}\n"
+            "This Hermes was installed in a CLI-only layout (e.g. a pip / Homebrew\n"
+            "package that doesn't ship the Node/Ink TUI). To use the TUI either:\n"
+            "  • reinstall with the official installer or a git checkout, or\n"
+            "  • set HERMES_TUI_DIR to a prebuilt TUI bundle (a directory containing\n"
+            "    dist/entry.js).\n"
+            "The CLI (`hermes`) and the gateway work normally without the TUI.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     # 2. Normal flow: npm install if needed, always esbuild, then node dist/entry.js.
     #    --dev flow: npm install if needed, then tsx src/entry.tsx.
     #    Existing desktop behaviour runs npm from the workspace root.  Termux

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -465,6 +465,34 @@ def test_tui_launch_install_uses_workspace_scope(
     assert "--workspace" in install_cmd
     assert "ui-tui" in install_cmd
 
+def test_make_tui_argv_errors_cleanly_when_tui_dir_missing(
+    tmp_path: Path, main_mod, monkeypatch, capsys
+) -> None:
+    """CLI-only install (no ui-tui tree, no prebuilt bundle): a clean error +
+    exit(1), NOT a bare FileNotFoundError from npm/node on a nonexistent cwd.
+
+    Regression for the Homebrew/pip report: `hermes --tui` crashed with
+    `FileNotFoundError: .../site-packages/ui-tui` because the launcher fell
+    through to `npm install` with `cwd=<missing>/ui-tui`.
+    """
+    missing = tmp_path / "site-packages" / "ui-tui"  # never created
+    monkeypatch.delenv("HERMES_TUI_DIR", raising=False)
+    monkeypatch.setattr(main_mod, "_ensure_tui_node", lambda: None)
+    monkeypatch.setattr(main_mod, "_find_bundled_tui", lambda *_a, **_k: None)
+
+    def fail_run(*_args, **_kwargs):
+        raise AssertionError("must not spawn npm/node when the TUI dir is missing")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fail_run)
+    monkeypatch.setattr(main_mod.subprocess, "call", fail_run)
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod._make_tui_argv(missing, tui_dev=False)
+
+    assert exc.value.code == 1
+    assert "TUI is not available" in capsys.readouterr().err
+
+
 def test_make_tui_argv_omits_workspace_when_tui_has_own_lockfile(
     tmp_path: Path, main_mod, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Summary

`hermes --tui` on a CLI-only install (e.g. **Homebrew / pip** that ships the
Python package but not the Node/Ink `ui-tui` tree) crashes with a bare
traceback:

```
FileNotFoundError: [Errno 2] No such file or directory: '.../site-packages/ui-tui'
```

Root cause: in `_make_tui_argv` (`hermes_cli/main.py`), after the
`HERMES_TUI_DIR` and bundled-wheel (`_find_bundled_tui`) lookups come up empty,
the launcher falls through to the source-checkout flow and runs `npm install`
with `cwd = <install-root>/ui-tui`. On these installs that directory doesn't
exist, so `subprocess` raises `FileNotFoundError` on the missing cwd.

This PR adds a guard: if the `ui-tui` directory is absent at that point, print
an **actionable message** and `sys.exit(1)` instead of crashing — pointing the
user at the official installer / git checkout or `HERMES_TUI_DIR`. The CLI and
gateway are unaffected and keep working without the TUI.

The guard checks `tui_dir.is_dir()` (not `package.json`) so the prebuilt-bundle
layout (`dist/entry.js`, no `package.json`) and all existing source/Termux
paths are untouched.

## Test plan

- [x] `scripts/run_tests.sh tests/hermes_cli/test_tui_npm_install.py` (28 passed)
- [x] New test `test_make_tui_argv_errors_cleanly_when_tui_dir_missing` asserts
      exit(1) + actionable message + no npm/node spawn on a missing dir.
- [x] Existing prebuilt-bundle / source / Termux tests still pass (dir exists).

Two commits: fix, then test.