### PR TITLE
feat: add per-user gateway display overrides

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -1,13 +1,15 @@
 """Per-platform display/verbosity configuration resolver.
 
-Provides ``resolve_display_setting()`` — the single entry-point for reading
-display settings with platform-specific overrides and sensible defaults.
+Provides ``resolve_display_setting()`` for platform-level display defaults and
+``resolve_display_setting_for_user()`` for sender-specific overrides.
 
 Resolution order (first non-None wins):
-    1. ``display.platforms.<platform>.<key>``  — explicit per-platform user override
-    2. ``display.<key>``                       — global user setting
-    3. ``_PLATFORM_DEFAULTS[<platform>][<key>]``  — built-in sensible default
-    4. ``_GLOBAL_DEFAULTS[<key>]``              — built-in global default
+    1. ``display.users.<platform>.<user_id>.<key>``  — per-user override
+       (``resolve_display_setting_for_user()`` only)
+    2. ``display.platforms.<platform>.<key>``        — per-platform override
+    3. ``display.<key>``                             — global user setting
+    4. ``_PLATFORM_DEFAULTS[<platform>][<key>]``     — built-in sensible default
+    5. ``_GLOBAL_DEFAULTS[<key>]``                   — built-in global default
 
 Exception: ``display.streaming`` is CLI-only.  Gateway streaming follows the
 top-level ``streaming`` config unless ``display.platforms.<platform>.streaming``
@@ -171,6 +173,59 @@ def resolve_display_setting(
     -------
     The resolved value, or *fallback* if nothing is configured.
     """
+    return _resolve_display_setting_base(
+        user_config,
+        platform_key,
+        setting,
+        fallback=fallback,
+    )
+
+
+def resolve_display_setting_for_user(
+    user_config: dict,
+    platform_key: str,
+    setting: str,
+    *,
+    user_id: str | None = None,
+    user_id_alt: str | None = None,
+    fallback: Any = None,
+) -> Any:
+    """Resolve a display setting with sender-specific overrides first.
+
+    Per-user overrides live under ``display.users.<platform>.<user_id>`` and
+    are checked before platform/global defaults.  ``user_id_alt`` is also
+    accepted for platforms with a second stable identity (for example Signal
+    UUIDs); the primary ``user_id`` wins if both are configured.
+    """
+    display_cfg = user_config.get("display") or {}
+    users_cfg = display_cfg.get("users") or {}
+    platform_users = users_cfg.get(platform_key)
+
+    if isinstance(platform_users, dict):
+        for candidate in (user_id, user_id_alt):
+            if not candidate:
+                continue
+            user_overrides = platform_users.get(str(candidate))
+            if isinstance(user_overrides, dict):
+                val = user_overrides.get(setting)
+                if val is not None:
+                    return _normalise(setting, val)
+
+    return _resolve_display_setting_base(
+        user_config,
+        platform_key,
+        setting,
+        fallback=fallback,
+    )
+
+
+def _resolve_display_setting_base(
+    user_config: dict,
+    platform_key: str,
+    setting: str,
+    fallback: Any = None,
+) -> Any:
+    """Resolve display config without sender-specific overrides."""
     display_cfg = user_config.get("display") or {}
 
     # 1. Explicit per-platform override (display.platforms.<platform>.<key>)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13092,25 +13092,58 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Per-platform display settings — resolve via display_config module
         # which checks display.platforms.<platform>.<key> first, then
         # display.<key> global, then built-in platform defaults.
-        from gateway.display_config import resolve_display_setting
+        from gateway.display_config import (
+            resolve_display_setting,
+            resolve_display_setting_for_user,
+        )
 
-        # Apply tool preview length config (0 = no limit)
+        # Apply tool preview length config (0 = no limit). User-level display
+        # overrides let operators opt themselves into deeper debug previews
+        # without making the whole platform noisy.
         try:
             from agent.display import set_tool_preview_max_len
-            _tpl = resolve_display_setting(user_config, platform_key, "tool_preview_length", 0)
+            _tpl = resolve_display_setting_for_user(
+                user_config,
+                platform_key,
+                "tool_preview_length",
+                user_id=getattr(source, "user_id", None),
+                user_id_alt=getattr(source, "user_id_alt", None),
+                fallback=0,
+            )
             set_tool_preview_max_len(int(_tpl) if _tpl else 0)
         except Exception:
             pass
 
-        # Tool progress mode — resolved per-platform with env var fallback
-        _resolved_tp = resolve_display_setting(user_config, platform_key, "tool_progress")
+        # Tool progress mode — resolved per-user/per-platform with env var fallback
+        _resolved_tp = resolve_display_setting_for_user(
+            user_config,
+            platform_key,
+            "tool_progress",
+            user_id=getattr(source, "user_id", None),
+            user_id_alt=getattr(source, "user_id_alt", None),
+        )
         _env_tp = os.getenv("HERMES_TOOL_PROGRESS_MODE")
         _display_cfg = display_config if isinstance(display_config, dict) else {}
         _platforms_cfg = _display_cfg.get("platforms") or {}
         _platform_cfg = _platforms_cfg.get(platform_key) or {}
+        _users_cfg = _display_cfg.get("users") or {}
+        _platform_users_cfg = _users_cfg.get(platform_key) or {}
+        _user_tp_configured = False
+        if isinstance(_platform_users_cfg, dict):
+            for _uid in (
+                getattr(source, "user_id", None),
+                getattr(source, "user_id_alt", None),
+            ):
+                if not _uid:
+                    continue
+                _user_cfg = _platform_users_cfg.get(str(_uid))
+                if isinstance(_user_cfg, dict) and "tool_progress" in _user_cfg:
+                    _user_tp_configured = True
+                    break
         _legacy_tp_overrides = _display_cfg.get("tool_progress_overrides") or {}
         _tool_progress_configured = (
             "tool_progress" in _display_cfg
+            or _user_tp_configured
             or (
                 isinstance(_platform_cfg, dict)
                 and "tool_progress" in _platform_cfg

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1505,7 +1505,7 @@ DEFAULT_CONFIG = {
         # platform user IDs (e.g. Slack `U…` IDs). These override platform/global
         # settings for presentation only, without changing the agent prompt or
         # conversation state. Useful for operator debug mode:
-        # display.users.slack.U09LYP9GT44.tool_progress: verbose
+        # display.users.slack.UDEBUGUSER.tool_progress: verbose
         "users": {},
         # Gateway runtime-metadata footer appended to the FINAL message of a turn
         # (disabled by default to keep replies minimal). When enabled, renders

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1501,6 +1501,12 @@ DEFAULT_CONFIG = {
             "telegram": {"streaming": True},
             "discord": {"streaming": False},
         },
+        # Per-user display overrides. Keys are gateway platform names, then
+        # platform user IDs (e.g. Slack `U…` IDs). These override platform/global
+        # settings for presentation only, without changing the agent prompt or
+        # conversation state. Useful for operator debug mode:
+        # display.users.slack.U09LYP9GT44.tool_progress: verbose
+        "users": {},
         # Gateway runtime-metadata footer appended to the FINAL message of a turn
         # (disabled by default to keep replies minimal). When enabled, renders
         # e.g. `model · 68% · ~/projects/hermes`. Per-platform overrides go under

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -20,7 +20,7 @@ class TestResolveDisplaySetting:
                 },
                 "users": {
                     "slack": {
-                        "U09LYP9GT44": {"tool_progress": "verbose"},
+                        "UDEBUGUSER": {"tool_progress": "verbose"},
                     },
                 },
             }
@@ -30,7 +30,7 @@ class TestResolveDisplaySetting:
                 config,
                 "slack",
                 "tool_progress",
-                user_id="U09LYP9GT44",
+                user_id="UDEBUGUSER",
             )
             == "verbose"
         )
@@ -92,7 +92,7 @@ class TestResolveDisplaySetting:
             "display": {
                 "users": {
                     "slack": {
-                        "U09LYP9GT44": {"tool_progress": True},
+                        "UDEBUGUSER": {"tool_progress": True},
                     },
                 },
             }
@@ -102,7 +102,7 @@ class TestResolveDisplaySetting:
                 config,
                 "slack",
                 "tool_progress",
-                user_id="U09LYP9GT44",
+                user_id="UDEBUGUSER",
             )
             == "all"
         )
@@ -116,7 +116,7 @@ class TestResolveDisplaySetting:
                 "platforms": {"slack": {"tool_progress": "new"}},
                 "users": {
                     "slack": {
-                        "U09LYP9GT44": {"tool_progress": "verbose"},
+                        "UDEBUGUSER": {"tool_progress": "verbose"},
                     },
                 },
             }

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -8,6 +8,129 @@
 class TestResolveDisplaySetting:
     """resolve_display_setting() resolves with correct priority."""
 
+    def test_user_override_wins_over_platform_and_global(self):
+        """display.users.<plat>.<user_id>.<key> takes top priority."""
+        from gateway.display_config import resolve_display_setting_for_user
+
+        config = {
+            "display": {
+                "tool_progress": "all",
+                "platforms": {
+                    "slack": {"tool_progress": "off"},
+                },
+                "users": {
+                    "slack": {
+                        "U09LYP9GT44": {"tool_progress": "verbose"},
+                    },
+                },
+            }
+        }
+        assert (
+            resolve_display_setting_for_user(
+                config,
+                "slack",
+                "tool_progress",
+                user_id="U09LYP9GT44",
+            )
+            == "verbose"
+        )
+
+    def test_user_override_falls_back_to_alt_id(self):
+        """Platforms with alternate stable IDs can configure either identity."""
+        from gateway.display_config import resolve_display_setting_for_user
+
+        config = {
+            "display": {
+                "users": {
+                    "signal": {
+                        "uuid-123": {"tool_progress": "new"},
+                    },
+                },
+            }
+        }
+        assert (
+            resolve_display_setting_for_user(
+                config,
+                "signal",
+                "tool_progress",
+                user_id="phone-redacted",
+                user_id_alt="uuid-123",
+            )
+            == "new"
+        )
+
+    def test_user_override_primary_id_wins_over_alt_id(self):
+        """Primary user IDs win when both primary and alternate IDs are configured."""
+        from gateway.display_config import resolve_display_setting_for_user
+
+        config = {
+            "display": {
+                "users": {
+                    "signal": {
+                        "phone-redacted": {"tool_progress": "off"},
+                        "uuid-123": {"tool_progress": "verbose"},
+                    },
+                },
+            }
+        }
+        assert (
+            resolve_display_setting_for_user(
+                config,
+                "signal",
+                "tool_progress",
+                user_id="phone-redacted",
+                user_id_alt="uuid-123",
+            )
+            == "off"
+        )
+
+    def test_user_override_normalises_yaml_values(self):
+        """Per-user bare YAML bools are normalised like platform settings."""
+        from gateway.display_config import resolve_display_setting_for_user
+
+        config = {
+            "display": {
+                "users": {
+                    "slack": {
+                        "U09LYP9GT44": {"tool_progress": True},
+                    },
+                },
+            }
+        }
+        assert (
+            resolve_display_setting_for_user(
+                config,
+                "slack",
+                "tool_progress",
+                user_id="U09LYP9GT44",
+            )
+            == "all"
+        )
+
+    def test_missing_user_override_falls_back_to_platform(self):
+        """Users without an override still get normal platform resolution."""
+        from gateway.display_config import resolve_display_setting_for_user
+
+        config = {
+            "display": {
+                "platforms": {"slack": {"tool_progress": "new"}},
+                "users": {
+                    "slack": {
+                        "U09LYP9GT44": {"tool_progress": "verbose"},
+                    },
+                },
+            }
+        }
+        assert (
+            resolve_display_setting_for_user(
+                config,
+                "slack",
+                "tool_progress",
+                user_id="U07HX9FQ10W",
+            )
+            == "new"
+        )
+
     def test_explicit_platform_override_wins(self):
         """display.platforms.<plat>.<key> takes top priority."""
         from gateway.display_config import resolve_display_setting


### PR DESCRIPTION
Closing this PR because this was intended as a local deployment patch, not an upstream contribution. I also sanitized the example user IDs before closing.
