### PR TITLE
fix(desktop): keep message component types stable across Thread re-renders

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread-remount.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-remount.test.tsx
@@ -1,0 +1,125 @@
+import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { Thread } from './thread'
+
+class NoopResizeObserver {
+  observe() {}
+
+  unobserve() {}
+
+  disconnect() {}
+}
+
+vi.stubGlobal('ResizeObserver', NoopResizeObserver)
+vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
+  window.setTimeout(() => callback(performance.now()), 0)
+)
+vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id))
+
+Element.prototype.scrollTo = function scrollTo() {}
+
+Element.prototype.animate = function animate() {
+  return {
+    cancel: () => {},
+    finished: Promise.resolve()
+  } as unknown as Animation
+}
+
+// jsdom returns 0 for offset*; the virtualizer reads those to size its
+// viewport. Fall through to client* or a sane default so virtualized
+// items render (same stub as streaming.test.tsx).
+function stubOffsetDimension(
+  prop: 'offsetHeight' | 'offsetWidth',
+  clientProp: 'clientHeight' | 'clientWidth',
+  fallback: number
+) {
+  const previous = Object.getOwnPropertyDescriptor(HTMLElement.prototype, prop)
+
+  Object.defineProperty(HTMLElement.prototype, prop, {
+    configurable: true,
+    get() {
+      return previous?.get?.call(this) || (this as HTMLElement)[clientProp] || fallback
+    }
+  })
+}
+
+stubOffsetDimension('offsetWidth', 'clientWidth', 800)
+stubOffsetDimension('offsetHeight', 'clientHeight', 600)
+
+const createdAt = new Date('2026-05-01T00:00:00.000Z')
+
+const MESSAGES: ThreadMessage[] = [
+  {
+    id: 'user-1',
+    role: 'user',
+    content: [{ type: 'text', text: 'hello from the user' }],
+    attachments: [],
+    createdAt,
+    metadata: { custom: {} }
+  } as ThreadMessage,
+  {
+    id: 'assistant-1',
+    role: 'assistant',
+    content: [{ type: 'text', text: 'stable assistant reply' }],
+    status: { type: 'complete', reason: 'stop' },
+    createdAt,
+    metadata: {
+      unstable_state: null,
+      unstable_annotations: [],
+      unstable_data: [],
+      steps: [],
+      custom: {}
+    }
+  } as ThreadMessage
+]
+
+function Harness({
+  onBranchInNewChat,
+  onCancel
+}: {
+  onBranchInNewChat: (messageId: string) => void
+  onCancel: () => void
+}) {
+  const runtime = useExternalStoreRuntime<ThreadMessage>({
+    messages: MESSAGES,
+    isRunning: false,
+    onNew: async () => {}
+  })
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread onBranchInNewChat={onBranchInNewChat} onCancel={onCancel} />
+    </AssistantRuntimeProvider>
+  )
+}
+
+describe('thread message mount stability', () => {
+  // Regression: the desktop controller re-renders every 15s (status
+  // snapshot poll) and used to pass freshly-created callbacks down to
+  // <Thread/>. Those callbacks were deps of the `messageComponents`
+  // useMemo, so new component *types* were created each poll and React
+  // unmounted/remounted every visible message — shiki re-highlighted
+  // code blocks and the whole thread visibly jumped.
+  it('keeps message DOM nodes mounted when callback props get new identities', async () => {
+    const { rerender } = render(<Harness onBranchInNewChat={() => {}} onCancel={() => {}} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('stable assistant reply')).toBeTruthy()
+      expect(screen.getByText('hello from the user')).toBeTruthy()
+    })
+
+    const assistantBefore = screen.getByText('stable assistant reply')
+    const userBefore = screen.getByText('hello from the user')
+
+    // Same data, new callback identities — exactly what a parent
+    // re-render driven by an unrelated state update produces.
+    await act(async () => {
+      rerender(<Harness onBranchInNewChat={() => {}} onCancel={() => {}} />)
+    })
+
+    expect(screen.getByText('stable assistant reply')).toBe(assistantBefore)
+    expect(screen.getByText('hello from the user')).toBe(userBefore)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread.tsx
@@ -149,14 +149,38 @@ export const Thread: FC<{
   sessionId = null,
   sessionKey
 }) => {
+  // The values in this map are component *types*: when their identity
+  // changes, React unmounts and remounts every visible message — async
+  // re-rendered parts (shiki code blocks) collapse and re-expand, so the
+  // whole thread visibly jumps. Parents re-render on unrelated state
+  // (e.g. the 15s status-snapshot poll in the desktop controller) and
+  // can't be trusted to keep callback identities stable (see #38333), so
+  // route the callbacks through a ref instead of listing them as memo
+  // deps. Only their definedness stays a dep — it gates UI (the user
+  // Stop button).
+  const callbacksRef = useRef({ onBranchInNewChat, onCancel })
+
+  useEffect(() => {
+    callbacksRef.current = { onBranchInNewChat, onCancel }
+  })
+
+  const hasBranchInNewChat = Boolean(onBranchInNewChat)
+  const hasCancel = Boolean(onCancel)
+
   const messageComponents = useMemo(
     () => ({
-      AssistantMessage: () => <AssistantMessage onBranchInNewChat={onBranchInNewChat} />,
+      AssistantMessage: () => (
+        <AssistantMessage
+          onBranchInNewChat={
+            hasBranchInNewChat ? messageId => callbacksRef.current.onBranchInNewChat?.(messageId) : undefined
+          }
+        />
+      ),
       SystemMessage,
       UserEditComposer: () => <UserEditComposer cwd={cwd} gateway={gateway} sessionId={sessionId} />,
-      UserMessage: () => <UserMessage onCancel={onCancel} />
+      UserMessage: () => <UserMessage onCancel={hasCancel ? () => callbacksRef.current.onCancel?.() : undefined} />
     }),
-    [cwd, gateway, onBranchInNewChat, onCancel, sessionId]
+    [cwd, gateway, hasBranchInNewChat, hasCancel, sessionId]
   )
 
   const emptyPlaceholder = intro ? (


### PR DESCRIPTION
## What

`Thread` builds the component map it hands to the virtualizer inside a `useMemo` whose deps included the `onBranchInNewChat` / `onCancel` callbacks. Whenever a parent re-render handed down a fresh callback identity, the memo rebuilt the map and produced new component **types**, so React unmounted and remounted every visible message. Async-rendered parts (shiki code blocks) collapsed and re-expanded on each remount, making the whole thread visibly jump.

This PR routes the callbacks through a ref so the component types survive any parent re-render. Only the callbacks' *definedness* stays a memo dep, because it gates UI (the user-message Stop button renders only when `onCancel` is provided). A regression test asserts message DOM nodes keep their identity when callback props change identity — it fails on current `main`.

## Why

This is the structural half of a bug that shipped in v0.15.1: the desktop controller passed an inline arrow for `onBranchInNewChat`, and the 15-second status-snapshot poll (`use-status-snapshot.ts`) re-rendered the controller — so any session containing code blocks visibly jumped every 15 seconds. Instrumenting the packaged app over CDP showed two layout shifts per poll cycle (scores 0.39 + 0.47, each preceded by a ~65 ms long task), and a MutationObserver confirmed the message subtrees were being removed and re-inserted with `pre.shiki` blocks re-highlighting from scratch.

#38333 already fixed that one call site by passing the `useCallback`'d function directly, but `Thread` itself was still one inline arrow away from regressing — nothing pinned the behavior. With this change, callback identity churn in any parent can no longer remount messages, and the new test pins it.

## How to test

- `cd apps/desktop && npx vitest run --environment jsdom src/components/assistant-ui/thread-remount.test.tsx`
  - fails on `main` (message `<p>` nodes are replaced across a callback-identity-only re-render), passes with this patch
- `npx vitest run --environment jsdom src/components/assistant-ui/streaming.test.tsx` — 16/17 pass; the one failure (`renders an incomplete streaming reasoning fenced code block as a code card`) also fails on unpatched `main` in my environment, so it's unrelated
- Manual repro of the original symptom on v0.15.1: open a session whose history contains fenced code blocks and wait ~15 s — the thread jumps as code blocks collapse/re-expand. With the rebuilt patched app, a 35 s CDP `layout-shift` observation over multiple poll cycles records zero entries.

## Platforms tested

macOS 15 (arm64), Electron 40 — vitest suite plus the rebuilt packaged app with CDP layout-shift instrumentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)