### PR TITLE
fix(memory): honor configured retain_async in hindsight_retain tool call

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1432,6 +1432,8 @@ class HindsightMemoryProvider(MemoryProvider):
             kwargs["document_id"] = document_id
         if retain_async is not None:
             kwargs["retain_async"] = retain_async
+        else:
+            kwargs["retain_async"] = self._retain_async
         merged_tags = _normalize_retain_tags(self._retain_tags)
         for tag in _normalize_retain_tags(tags):
             if tag not in merged_tags:


### PR DESCRIPTION
## Bug

`handle_tool_call` for `hindsight_retain` calls `_build_retain_kwargs` without passing `retain_async`. Since `_build_retain_kwargs` only adds the key when the value is not `None`, the parameter is omitted entirely from the kwargs dict. The `Hindsight.aretain()` client method then falls back to its default `retain_async=False`, which blocks synchronously on the LLM backend (entity resolution, knowledge graph update) — this can exceed the tool timeout and cause opaque empty-string errors.

The auto-retain path (`sync_turn` → `_do_retain`) correctly reads `self._retain_async` (default `True`) and passes it explicitly to `aretain_batch`, but the manual tool-call path never does.

## Fix

Add an `else` branch in `_build_retain_kwargs` so that when `retain_async` is not explicitly provided, `self._retain_async` (the configured default, defaulting to `True`) is used instead of the client library default `False`.

This is consistent with how `sync_turn` already handles the same parameter, and the `else` branch preserves the ability to explicitly override the per-call value.

## Reproduction

Call `hindsight_retain` tool with a cloud Hindsight backend. If the LLM backend takes >30s to process, the tool call times out with an empty error message because `retain_async=False` makes the client wait for completion.

## Impact

Only affects the `hindsight_retain` tool call path. The `sync_turn` (auto-retain) path explicitly pops `retain_async` from kwargs and passes `self._retain_async` separately (lines 1524/1534), so it is unaffected. Session-switch flush (line 1698) similarly pops and re-passes explicitly (line 1710).