### PR TITLE
fix(feishu): read group_policy from config extra + add WS fallback for group messages

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1284,6 +1284,7 @@ def _strip_edge_self_mentions(
 def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     """Run the official Lark WS client in its own thread-local event loop."""
     import lark_oapi.ws.client as ws_client_module
+    from gateway.platforms.feishu_group_fallback import patch_ws_client_for_group_messages
 
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
@@ -1320,6 +1321,7 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
     if original_configure is not None:
         setattr(ws_client, "_configure", _configure_with_overrides)
     _apply_runtime_ws_overrides()
+    patch_ws_client_for_group_messages(ws_client, adapter)
     try:
         ws_client.start()
     except Exception:
@@ -1524,7 +1526,7 @@ class FeishuAdapter(BasePlatformAdapter):
             verification_token=str(
                 extra.get("verification_token") or os.getenv("FEISHU_VERIFICATION_TOKEN", "")
             ).strip(),
-            group_policy=os.getenv("FEISHU_GROUP_POLICY", "allowlist").strip().lower(),
+            group_policy=str(extra.get("group_policy", os.getenv("FEISHU_GROUP_POLICY", "allowlist"))).strip().lower(),
             allowed_group_users=frozenset(
                 item.strip()
                 for item in os.getenv("FEISHU_ALLOWED_USERS", "").split(",")

--- a/gateway/platforms/feishu_group_fallback.py
+++ b/gateway/platforms/feishu_group_fallback.py
@@ -1,0 +1,87 @@
+"""WebSocket fallback for Feishu group messages.
+
+The lark-oapi SDK's EventDispatcherHandler dispatches events by event_key
+(``{schema}.{event_type}``).  Both p2p and group messages arrive as
+``im.message.receive_v1`` so the registered processor *should* handle both.
+
+However, in some SDK versions or edge cases the dispatcher may fail to route
+group messages (e.g. EventException, silent drop).  This module provides a
+monkey-patch for the SDK's ``_handle_data_frame`` that catches dispatch
+failures and manually routes group messages to the adapter's
+``_on_message_event`` handler.
+
+The fallback is a safety-net — under normal operation the SDK handles both
+p2p and group messages through the same processor.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from types import SimpleNamespace
+from typing import Any
+
+logger = logging.getLogger("gateway.platforms.feishu")
+
+
+def patch_ws_client_for_group_messages(ws_client: Any, adapter: Any) -> None:
+    """Monkey-patch the SDK WS client to catch dropped group messages.
+
+    Wraps ``ws_client._handle_data_frame`` so that when the SDK's
+    ``EventDispatcherHandler`` fails to process an ``im.message.receive_v1``
+    event, we parse the raw payload and manually route group messages to
+    ``adapter._on_message_event``.
+    """
+    original = getattr(ws_client, "_handle_data_frame", None)
+    if original is None:
+        # WS client doesn't have _handle_data_frame (e.g. test mock) — nothing to patch.
+        return
+
+    async def _handle_data_frame_with_fallback(frame: Any) -> Any:
+        try:
+            return await original(frame)
+        except Exception as dispatch_err:
+            # Dispatcher failed — attempt to extract and route group messages.
+            try:
+                pl = frame.payload
+                payload_str = pl.decode("utf-8") if isinstance(pl, bytes) else str(pl)
+                payload = json.loads(payload_str)
+
+                header = payload.get("header", {})
+                event_type = header.get("event_type", "")
+
+                if event_type == "im.message.receive_v1":
+                    event_data = payload.get("event", {})
+                    message = event_data.get("message", {})
+                    chat_type = message.get("chat_type", "p2p")
+
+                    if chat_type == "group":
+                        logger.info(
+                            "[Feishu] Fallback captured group message: "
+                            "chat_id=%s message_id=%s",
+                            message.get("chat_id", ""),
+                            message.get("message_id", ""),
+                        )
+                        data = _dict_to_namespace(payload)
+                        adapter._on_message_event(data)
+                        return
+
+                # Not a group message — re-raise original error
+                raise dispatch_err
+
+            except Exception:
+                # Fallback also failed — re-raise the original dispatcher error
+                raise dispatch_err from None
+
+    ws_client._handle_data_frame = _handle_data_frame_with_fallback
+    logger.debug("[Feishu] Group message fallback patch applied")
+
+
+def _dict_to_namespace(d: Any) -> Any:
+    """Recursively convert a dict to SimpleNamespace for SDK compatibility."""
+    if isinstance(d, dict):
+        return SimpleNamespace(**{k: _dict_to_namespace(v) for k, v in d.items()})
+    elif isinstance(d, list):
+        return [_dict_to_namespace(item) for item in d]
+    else:
+        return d

--- a/tests/gateway/test_feishu_group_fix.py
+++ b/tests/gateway/test_feishu_group_fix.py
@@ -1,0 +1,239 @@
+"""Tests for Feishu group message fixes:
+
+1. ``group_policy`` readable from config ``extra`` dict (not only env var)
+2. WebSocket fallback captures dropped group messages
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+from tests.gateway.feishu_helpers import (
+    install_dedup_state,
+    make_adapter_skeleton,
+    make_message,
+    make_sender,
+    stub_mention,
+)
+
+
+# ---------------------------------------------------------------------------
+# group_policy config reading
+# ---------------------------------------------------------------------------
+
+
+class TestGroupPolicyConfigReading:
+    """Verify that group_policy is read from config ``extra`` dict,
+    falling back to the env var, then to ``'allowlist'``."""
+
+    @patch.dict("os.environ", {"FEISHU_APP_ID": "cli_t", "FEISHU_APP_SECRET": "s"}, clear=False)
+    def test_reads_from_extra(self, monkeypatch):
+        monkeypatch.delenv("FEISHU_GROUP_POLICY", raising=False)
+        from gateway.platforms.feishu import FeishuAdapter
+
+        settings = FeishuAdapter._load_settings(extra={"group_policy": "open"})
+        assert settings.group_policy == "open"
+
+    @patch.dict("os.environ", {"FEISHU_APP_ID": "cli_t", "FEISHU_APP_SECRET": "s"}, clear=False)
+    def test_falls_back_to_env(self, monkeypatch):
+        monkeypatch.setenv("FEISHU_GROUP_POLICY", "blacklist")
+        from gateway.platforms.feishu import FeishuAdapter
+
+        settings = FeishuAdapter._load_settings(extra={})
+        assert settings.group_policy == "blacklist"
+
+    @patch.dict("os.environ", {"FEISHU_APP_ID": "cli_t", "FEISHU_APP_SECRET": "s"}, clear=False)
+    def test_defaults_to_allowlist(self, monkeypatch):
+        monkeypatch.delenv("FEISHU_GROUP_POLICY", raising=False)
+        from gateway.platforms.feishu import FeishuAdapter
+
+        settings = FeishuAdapter._load_settings(extra={})
+        assert settings.group_policy == "allowlist"
+
+    @patch.dict("os.environ", {"FEISHU_APP_ID": "cli_t", "FEISHU_APP_SECRET": "s"}, clear=False)
+    def test_extra_overrides_env(self, monkeypatch):
+        monkeypatch.setenv("FEISHU_GROUP_POLICY", "allowlist")
+        from gateway.platforms.feishu import FeishuAdapter
+
+        settings = FeishuAdapter._load_settings(extra={"group_policy": "open"})
+        assert settings.group_policy == "open"
+
+
+# ---------------------------------------------------------------------------
+# Group message admission with group_policy=open
+# ---------------------------------------------------------------------------
+
+
+class TestGroupPolicyOpen:
+    """When group_policy is 'open', all group messages should pass admission."""
+
+    def test_group_message_admitted_when_open(self):
+        adapter = make_adapter_skeleton(group_policy="open")
+        install_dedup_state(adapter)
+        stub_mention(adapter, mentions_self=True)
+
+        sender = make_sender(open_id="ou_user1")
+        message = make_message(chat_type="group", chat_id="oc_group1")
+
+        result = adapter._admit(sender, message)
+        assert result is None  # None = admitted
+
+    def test_group_message_rejected_when_allowlist_empty(self):
+        adapter = make_adapter_skeleton(group_policy="allowlist")
+        install_dedup_state(adapter)
+        stub_mention(adapter, mentions_self=True)
+
+        sender = make_sender(open_id="ou_user1")
+        message = make_message(chat_type="group", chat_id="oc_group1")
+
+        result = adapter._admit(sender, message)
+        assert result == "group_policy_rejected"
+
+
+# ---------------------------------------------------------------------------
+# WebSocket fallback
+# ---------------------------------------------------------------------------
+
+
+class TestWebSocketFallback:
+    """Verify the fallback captures group messages when the SDK dispatcher fails."""
+
+    def test_fallback_captures_group_message_on_dispatch_error(self):
+        from gateway.platforms.feishu_group_fallback import (
+            patch_ws_client_for_group_messages,
+        )
+
+        # Create a mock adapter
+        adapter = MagicMock()
+        adapter._on_message_event = MagicMock()
+
+        # Create a mock WS client whose _handle_data_frame raises
+        ws_client = MagicMock()
+
+        group_payload = {
+            "header": {"event_type": "im.message.receive_v1"},
+            "event": {
+                "message": {
+                    "chat_type": "group",
+                    "chat_id": "oc_group1",
+                    "message_id": "om_test123",
+                },
+                "sender": {"sender_id": {"open_id": "ou_user1"}},
+            },
+        }
+
+        frame = MagicMock()
+        frame.payload = json.dumps(group_payload).encode("utf-8")
+
+        original_error = Exception("dispatcher failed")
+
+        async def failing_handle_data_frame(f):
+            raise original_error
+
+        ws_client._handle_data_frame = failing_handle_data_frame
+
+        # Apply the patch
+        patch_ws_client_for_group_messages(ws_client, adapter)
+
+        # Run the patched handler
+        import asyncio
+
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(ws_client._handle_data_frame(frame))
+        finally:
+            loop.close()
+
+        # Verify the fallback captured the group message
+        adapter._on_message_event.assert_called_once()
+        call_args = adapter._on_message_event.call_args[0][0]
+        assert call_args.event.message.chat_type == "group"
+        assert call_args.event.message.chat_id == "oc_group1"
+
+    def test_fallback_does_not_capture_p2p_message(self):
+        from gateway.platforms.feishu_group_fallback import (
+            patch_ws_client_for_group_messages,
+        )
+
+        adapter = MagicMock()
+        adapter._on_message_event = MagicMock()
+
+        ws_client = MagicMock()
+
+        p2p_payload = {
+            "header": {"event_type": "im.message.receive_v1"},
+            "event": {
+                "message": {
+                    "chat_type": "p2p",
+                    "chat_id": "oc_dm1",
+                    "message_id": "om_dm123",
+                },
+            },
+        }
+
+        frame = MagicMock()
+        frame.payload = json.dumps(p2p_payload).encode("utf-8")
+
+        async def failing_handle_data_frame(f):
+            raise Exception("dispatcher failed")
+
+        ws_client._handle_data_frame = failing_handle_data_frame
+
+        patch_ws_client_for_group_messages(ws_client, adapter)
+
+        import asyncio
+
+        loop = asyncio.new_event_loop()
+        try:
+            with pytest.raises(Exception, match="dispatcher failed"):
+                loop.run_until_complete(ws_client._handle_data_frame(frame))
+        finally:
+            loop.close()
+
+        # P2P messages should NOT be captured by the fallback
+        adapter._on_message_event.assert_not_called()
+
+    def test_fallback_passes_through_when_dispatcher_succeeds(self):
+        from gateway.platforms.feishu_group_fallback import (
+            patch_ws_client_for_group_messages,
+        )
+
+        adapter = MagicMock()
+        ws_client = MagicMock()
+
+        frame = MagicMock()
+        frame.payload = b'{"header": {"event_type": "im.message.receive_v1"}}'
+
+        async def successful_handle_data_frame(f):
+            return "ok"
+
+        ws_client._handle_data_frame = successful_handle_data_frame
+
+        patch_ws_client_for_group_messages(ws_client, adapter)
+
+        import asyncio
+
+        loop = asyncio.new_event_loop()
+        try:
+            result = loop.run_until_complete(ws_client._handle_data_frame(frame))
+        finally:
+            loop.close()
+
+        assert result == "ok"
+
+    def test_dict_to_namespace_recursive(self):
+        from gateway.platforms.feishu_group_fallback import _dict_to_namespace
+
+        data = {"a": 1, "b": {"c": "hello", "d": [1, {"e": 2}]}}
+        ns = _dict_to_namespace(data)
+
+        assert ns.a == 1
+        assert ns.b.c == "hello"
+        assert ns.b.d[0] == 1
+        assert ns.b.d[1].e == 2


### PR DESCRIPTION
## Problem

Feishu group chat messages (@bot) were silently dropped in WebSocket mode.
Two independent issues contributed:

1. **group_policy config ignored**: The adapter only read group_policy from
   the FEISHU_GROUP_POLICY env var (defaulting to allowlist). Setting
   group_policy in config.yaml platforms.feishu.extra had no effect.
   With an empty allowlist ALL group messages were rejected by _admit()
   before reaching _on_message_event.

2. **No WS fallback**: If the lark-oapi SDKs EventDispatcherHandler
   failed to route an event the error was caught internally and the
   message was lost.

## Fix

1. Read group_policy from config extra dict first falling back to env var
   then to allowlist.

2. Add feishu_group_fallback.py a monkey-patch for the SDKs WS client
   _handle_data_frame that catches dispatch failures and manually routes
   group messages to _on_message_event.

## Config usage

platforms.feishu.extra.group_policy: open
platforms.feishu.extra.require_mention: false

## Tests

10 new tests covering config reading admission logic and WS fallback.
All 275 Feishu tests pass.