### PR TITLE
fix(curator): cap review iterations and exclude external symlinked skills (#44771)

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -62,6 +62,7 @@ DEFAULT_ARCHIVE_AFTER_DAYS = 90
 # whenever the curator is enabled; only the opinionated, aux-model-cost
 # consolidation pass is opt-in.
 DEFAULT_CONSOLIDATE = False
+DEFAULT_MAX_ITERATIONS = 200
 
 
 # ---------------------------------------------------------------------------
@@ -173,6 +174,14 @@ def get_archive_after_days() -> int:
         return int(cfg.get("archive_after_days", DEFAULT_ARCHIVE_AFTER_DAYS))
     except (TypeError, ValueError):
         return DEFAULT_ARCHIVE_AFTER_DAYS
+
+
+def get_max_iterations() -> int:
+    cfg = _load_config()
+    try:
+        return int(cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS))
+    except (TypeError, ValueError):
+        return DEFAULT_MAX_ITERATIONS
 
 
 def get_prune_builtins() -> bool:
@@ -1881,12 +1890,7 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
             api_key=_api_key,
             base_url=_base_url,
             api_mode=_api_mode,
-            # Umbrella-building over a large skill collection is worth a
-            # high iteration ceiling — the pass typically takes 50-100
-            # API calls against hundreds of candidate skills. The
-            # single-session review path caps itself at a much smaller
-            # number because it's not doing a curation sweep.
-            max_iterations=9999,
+            max_iterations=get_max_iterations(),
             quiet_mode=True,
             platform="curator",
             skip_context_files=True,

--- a/tests/agent/test_curator_iteration_cap.py
+++ b/tests/agent/test_curator_iteration_cap.py
@@ -1,0 +1,139 @@
+"""Tests for curator iteration cap and external-symlink exclusion.
+
+Regression tests for #44771: curator entered a multi-hour loop making 811
+API calls because max_iterations was 9999 and 26 external symlinked skills
+inflated the candidate list.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_symlinks_available = True
+try:
+    os.symlink
+except AttributeError:
+    _symlinks_available = False
+else:
+    if sys.platform == "win32":
+        _tmp = Path(os.environ.get("TEMP", ".")) / "_symlink_test"
+        try:
+            _tmp.symlink_to(".")
+            _tmp.unlink()
+        except OSError:
+            _symlinks_available = False
+
+skip_no_symlinks = pytest.mark.skipif(
+    not _symlinks_available,
+    reason="symlinks not available (Windows without developer mode)",
+)
+
+
+@pytest.fixture
+def curator_env(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME + freshly reloaded curator + skill_usage modules."""
+    home = tmp_path / ".hermes"
+    (home / "skills").mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import tools.skill_usage as usage
+    importlib.reload(usage)
+    import agent.curator as curator
+    importlib.reload(curator)
+
+    monkeypatch.setattr(curator, "_run_llm_review", lambda prompt: "llm-stub")
+    monkeypatch.setattr(curator, "_load_config", lambda: {})
+    monkeypatch.setattr(usage, "_prune_builtins_enabled", lambda: False)
+
+    return {"home": home, "curator": curator, "usage": usage}
+
+
+def _write_skill(skills_dir: Path, name: str):
+    d = skills_dir / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: x\n---\n", encoding="utf-8",
+    )
+    return d
+
+
+def _mark_agent_created(usage_mod, name: str):
+    data = usage_mod.load_usage()
+    data[name] = usage_mod._empty_record()
+    data[name]["created_by"] = "agent"
+    usage_mod.save_usage(data)
+
+
+class TestMaxIterationsCap:
+    """curator.get_max_iterations() must return a sane default and honor config."""
+
+    def test_default_is_200(self, curator_env):
+        c = curator_env["curator"]
+        assert c.get_max_iterations() == 200
+
+    def test_config_override(self, curator_env, monkeypatch):
+        c = curator_env["curator"]
+        monkeypatch.setattr(c, "_load_config", lambda: {"max_iterations": 500})
+        assert c.get_max_iterations() == 500
+
+    def test_invalid_config_falls_back(self, curator_env, monkeypatch):
+        c = curator_env["curator"]
+        monkeypatch.setattr(c, "_load_config", lambda: {"max_iterations": "not-a-number"})
+        assert c.get_max_iterations() == 200
+
+
+@skip_no_symlinks
+class TestExternalSymlinksExcluded:
+    """Symlinked skills pointing outside ~/.hermes/skills/ must be skipped."""
+
+    def test_external_symlink_excluded(self, curator_env):
+        u = curator_env["usage"]
+        skills_dir = curator_env["home"] / "skills"
+
+        external_dir = curator_env["home"].parent / "agents" / "skills" / "lark-im"
+        external_dir.mkdir(parents=True)
+        (external_dir / "SKILL.md").write_text(
+            "---\nname: lark-im\ndescription: x\n---\n", encoding="utf-8",
+        )
+
+        link = skills_dir / "lark-im"
+        link.symlink_to(external_dir)
+
+        _mark_agent_created(u, "lark-im")
+
+        names = u.list_agent_created_skill_names()
+        assert "lark-im" not in names
+
+    def test_internal_symlink_included(self, curator_env):
+        u = curator_env["usage"]
+        skills_dir = curator_env["home"] / "skills"
+
+        real_dir = skills_dir / ".internal" / "my-skill"
+        real_dir.mkdir(parents=True)
+        (real_dir / "SKILL.md").write_text(
+            "---\nname: my-skill\ndescription: x\n---\n", encoding="utf-8",
+        )
+
+        link = skills_dir / "my-skill"
+        link.symlink_to(real_dir)
+
+        _mark_agent_created(u, "my-skill")
+
+        names = u.list_agent_created_skill_names()
+        assert "my-skill" in names
+
+    def test_non_symlink_still_included(self, curator_env):
+        u = curator_env["usage"]
+        skills_dir = curator_env["home"] / "skills"
+
+        _write_skill(skills_dir, "normal-skill")
+        _mark_agent_created(u, "normal-skill")
+
+        names = u.list_agent_created_skill_names()
+        assert "normal-skill" in names

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -346,6 +346,8 @@ def list_agent_created_skill_names() -> List[str]:
     prune_builtins = _prune_builtins_enabled()
     usage = load_usage()
 
+    resolved_base = base.resolve()
+
     names: List[str] = []
     # Top-level SKILL.md files (flat layout) AND nested category/skill/SKILL.md
     for skill_md in base.rglob("SKILL.md"):
@@ -360,6 +362,14 @@ def list_agent_created_skill_names() -> List[str]:
             skill_md.relative_to(base)
         except ValueError:
             continue
+        # Skip symlinked skills whose real content lives outside the skills
+        # directory. These are externally managed and should not be curated.
+        skill_dir = skill_md.parent
+        if skill_dir.is_symlink():
+            try:
+                skill_dir.resolve().relative_to(resolved_base)
+            except ValueError:
+                continue
         name = _read_skill_name(skill_md, fallback=skill_md.parent.name)
         # Hub-installed skills are always off-limits.
         if name in hub:


### PR DESCRIPTION
## Summary

Fixes #44771: curator entered a 4-hour loop making 811 API calls and consuming 91M input tokens when reviewing 26 symlinked `lark-*` skills.

Two root causes addressed:

- **Unbounded iteration ceiling**: `max_iterations=9999` allowed the LLM review to run indefinitely. Replaced with a configurable `curator.max_iterations` (default 200). Typical runs take 50-100 calls; 200 is generous while preventing runaway loops.
- **External symlinks treated as candidates**: Symlinked skill directories pointing outside `~/.hermes/skills/` (e.g. `~/.agents/skills/lark-*`) were included in the candidate list. These are externally managed and should not be curated. Now skipped via `resolve()` + `relative_to()` check.

### Changes

- `agent/curator.py`: Add `DEFAULT_MAX_ITERATIONS = 200`, `get_max_iterations()` config accessor, replace hardcoded 9999
- `tools/skill_usage.py`: Skip symlinked skill dirs resolving outside the skills base in `list_agent_created_skill_names()`
- `tests/agent/test_curator_iteration_cap.py`: Tests for default cap, config override, invalid config fallback, external/internal symlink handling

Users can override via `config.yaml`:

```yaml
curator:
  max_iterations: 500
```

## Test plan

- [x] 3 tests for `get_max_iterations()`: default (200), config override, invalid config fallback
- [x] 3 tests for symlink exclusion: external symlink excluded, internal symlink included, non-symlink included (skip on Windows without developer mode)
- [x] All 57 existing curator tests pass