### PR TITLE
feat(kanban): add structured key naming helpers for swarm blackboard

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE_FILLED.md
+++ b/.github/PULL_REQUEST_TEMPLATE_FILLED.md
@@ -1,0 +1,61 @@
+## What does this PR do?
+
+Add structured key naming to the Kanban swarm blackboard.
+
+The blackboard already lets workers write `post_blackboard_update(conn, root, key="anything", value=...)`. But currently keys are ad-hoc strings — `"worker3_status"`, `"w3-result"`, `"sources"`. A coordinator scanning the merged blackboard can't tell which worker owns which key, or even whether a key IS a worker key.
+
+This PR adds `kv_helpers.py` — **builders and parsers that enforce a naming convention without changing the storage layer**. If callers write `worker_key(3, "status")` instead of `"worker3_status"`, the coordinator can later `parse_worker_key(k)` → `(3, "status")` and machine-read the board. No schema changes, no new tables, no new protocol — it's a convention library, not a persistence layer.
+
+The same naming convention was independently arrived at in CC_Pure's blackboard (`src/blackboard/kvHelpers.ts`) — an existence proof in another codebase that it works well for multi-worker blackboards.
+
+## Related Issue
+
+N/A — new capability, not a bug fix. Happy to open an issue first if preferred.
+
+Fixes #
+
+## Type of Change
+
+- [x] ✨ New feature (non-breaking change that adds functionality)
+- [x] ✅ Tests (adding or improving test coverage)
+
+## Changes Made
+
+- **New**: `hermes_cli/kv_helpers.py` — key builders (`worker_key`, `team_key`, `coordinator_key`), parsers (`parse_worker_key`, `parse_namespaced_key`), read-back utilities (`worker_fields`, `get_worker_field`, `worker_prefix`), and well-known constants (`TOPOLOGY_KEY`, `GOAL_KEY`, field names like `FIELD_STATUS`)
+- **Modified**: `hermes_cli/kanban_swarm.py` — imports and re-exports all helpers; replaces bare `"topology"` string with `TOPOLOGY_KEY` constant
+- **Modified**: `tests/hermes_cli/test_kanban_swarm.py` — 10 new tests (builder, parser, namespace, integration with real blackboard)
+
+## How to Test
+
+1. Run the swarm-specific tests:
+   ```
+   pytest tests/hermes_cli/test_kanban_swarm.py -v
+   ```
+2. Verify no regressions in the broader kanban suite:
+   ```
+   pytest tests/hermes_cli/test_kanban_*.py tests/tools/test_kanban_tools.py -q
+   ```
+3. (Optional) Exercise the helpers manually:
+   ```python
+   from hermes_cli.kv_helpers import worker_key, parse_worker_key, worker_fields
+   assert worker_key(3, "status") == "worker:3:status"
+   assert parse_worker_key("worker:3:status") == (3, "status")
+   ```
+
+## Checklist
+
+### Code
+- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
+- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
+- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
+- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
+- [x] I've run `pytest tests/ -q` and all tests pass
+- [x] I've added tests for my changes (10 new tests, 13 total including existing)
+- [x] I've tested on my platform: Ubuntu 24.04 (Linux arm64, DGX Spark)
+
+### Documentation & Housekeeping
+- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings in `kv_helpers.py` serve as API reference; module docstring explains the convention
+- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
+- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
+- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure Python, no platform-specific code)
+- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no new tools; these are library functions)

--- a/hermes_cli/kanban_swarm.py
+++ b/hermes_cli/kanban_swarm.py
@@ -23,6 +23,26 @@ from typing import Any, Iterable, Optional
 
 from hermes_cli import kanban_db as kb
 
+# Re-export structured key helpers for callers that want namespaced keys.
+# The blackboard itself stays string-keyed — these are naming convention
+# helpers, not a schema change.
+from hermes_cli.kv_helpers import (  # noqa: F401  — public re-export
+    worker_key,
+    worker_result_key,
+    worker_status_key,
+    worker_handoff_key,
+    team_key,
+    coordinator_key,
+    parse_worker_key,
+    parse_namespaced_key,
+    worker_prefix,
+    worker_fields,
+    get_worker_field,
+    TOPOLOGY_KEY,
+    GOAL_KEY,
+    AUTHORS_KEY,
+)
+
 BLACKBOARD_PREFIX = "[swarm:blackboard] "
 
 
@@ -130,7 +150,7 @@ def create_swarm(
     # If idempotency returned an existing non-archived root, do not duplicate the
     # swarm graph. Recover the topology from the root's latest blackboard, if it
     # was created by this helper previously.
-    existing = latest_blackboard(conn, root).get("topology")
+    existing = latest_blackboard(conn, root).get(TOPOLOGY_KEY)
     if isinstance(existing, dict):
         worker_ids = [str(x) for x in existing.get("worker_ids", []) if x]
         verifier_id = existing.get("verifier_id")
@@ -217,7 +237,7 @@ def create_swarm(
         conn,
         root,
         author=created_by,
-        key="topology",
+        key=TOPOLOGY_KEY,
         value=created.as_dict() | {"goal": goal},
     )
     return created

--- a/hermes_cli/kv_helpers.py
+++ b/hermes_cli/kv_helpers.py
@@ -1,0 +1,221 @@
+"""Structured key naming helpers for the Kanban swarm blackboard.
+
+These helpers enforce a namespaced key convention on top of the existing
+`post_blackboard_update` / `latest_blackboard` surface.  No new storage
+or schema is introduced — the blackboard remains a flat string-keyed
+dictionary backed by Kanban task comments.  The convention is:
+
+    worker:{index}:{field}
+    team:{field}
+    coordinator:{field}
+
+Adopting structured keys gives the blackboard **machine-parseable structure**
+without any code changes to the core board.  It is a naming convention,
+not a new persistence layer.
+
+Usage::
+
+    from hermes_cli.kv_helpers import worker_key, parse_worker_key
+
+    post_blackboard_update(conn, root, author="worker-3",
+                           key=worker_key(3, "status"), value="running")
+
+    board = latest_blackboard(conn, root)
+    for key in board:
+        if key.startswith("worker:"):
+            parsed = parse_worker_key(key)
+            # → (3, "status")
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+# ---------------------------------------------------------------------------
+# Key namespace prefixes
+# ---------------------------------------------------------------------------
+
+WORKER_NS = "worker"
+TEAM_NS = "team"
+COORDINATOR_NS = "coordinator"
+
+# ---------------------------------------------------------------------------
+# Reserved top-level blackboard keys (non-namespaced)
+# ---------------------------------------------------------------------------
+
+TOPOLOGY_KEY = "topology"
+GOAL_KEY = "goal"
+AUTHORS_KEY = "_authors"
+
+# ---------------------------------------------------------------------------
+# Well-known per-worker field names
+# ---------------------------------------------------------------------------
+
+FIELD_STATUS = "status"
+FIELD_RESULT = "result"
+FIELD_HANDOFF = "handoff"
+FIELD_HEARTBEAT = "heartbeat"
+FIELD_AGENT_TYPE = "agent_type"
+FIELD_DIRECTIVE = "directive"
+FIELD_TASK = "task"
+FIELD_UPDATED_AT = "updated_at"
+
+
+# ===========================================================================
+# Builders
+# ===========================================================================
+
+
+def worker_key(worker_index: int, field: str) -> str:
+    """Build a namespaced key for a worker's blackboard entry.
+
+    >>> worker_key(3, "status")
+    'worker:3:status'
+    """
+    return f"{WORKER_NS}:{worker_index}:{field}"
+
+
+def worker_result_key(worker_index: int) -> str:
+    """Shortcut for the worker's result field."""
+    return worker_key(worker_index, FIELD_RESULT)
+
+
+def worker_status_key(worker_index: int) -> str:
+    """Shortcut for the worker's status field."""
+    return worker_key(worker_index, FIELD_STATUS)
+
+
+def worker_handoff_key(worker_index: int) -> str:
+    """Shortcut for the worker's handoff (cross-worker note) field."""
+    return worker_key(worker_index, FIELD_HANDOFF)
+
+
+def team_key(field: str) -> str:
+    """Build a team-level blackboard key.
+
+    >>> team_key("sources")
+    'team:sources'
+    """
+    return f"{TEAM_NS}:{field}"
+
+
+def coordinator_key(field: str) -> str:
+    """Build a coordinator-level blackboard key.
+
+    >>> coordinator_key("decision")
+    'coordinator:decision'
+    """
+    return f"{COORDINATOR_NS}:{field}"
+
+
+# ===========================================================================
+# Parsers
+# ===========================================================================
+
+
+def parse_worker_key(key: str) -> Optional[tuple[int, str]]:
+    """Parse a ``worker:N:field`` key into its components.
+
+    Returns ``(worker_index, field)`` if the key matches the worker namespace,
+    otherwise ``None``.
+
+    >>> parse_worker_key("worker:3:status")
+    (3, 'status')
+    >>> parse_worker_key("worker:0:result")
+    (0, 'result')
+    >>> parse_worker_key("topology") is None
+    True
+    >>> parse_worker_key("worker:abc:status") is None
+    True
+    """
+    if not key.startswith(f"{WORKER_NS}:"):
+        return None
+
+    rest = key[len(WORKER_NS) + 1:]
+    separator = rest.rfind(":")
+    if separator <= 0 or separator == len(rest) - 1:
+        return None
+
+    index_str = rest[:separator]
+    field = rest[separator + 1:]
+    if not index_str or not field:
+        return None
+
+    try:
+        worker_index = int(index_str)
+    except ValueError:
+        return None
+
+    return (worker_index, field)
+
+
+def parse_namespaced_key(key: str) -> Optional[tuple[str, str]]:
+    """Parse any namespaced key into ``(namespace, field``).
+
+    Returns ``None`` for non-namespaced keys (e.g. ``"topology"``).
+
+    >>> parse_namespaced_key("worker:3:status")
+    ('worker', 'status')
+    >>> parse_namespaced_key("team:sources")
+    ('team', 'sources')
+    >>> parse_namespaced_key("topology") is None
+    True
+    """
+    if ":" not in key:
+        return None
+    # For worker keys the namespace is the first segment before the first ":"
+    ns_end = key.index(":")
+    ns = key[:ns_end]
+    # The "field" is everything after the last ":"
+    field_start = key.rfind(":") + 1
+    field = key[field_start:]
+    if not field:
+        return None
+    return (ns, field)
+
+
+# ===========================================================================
+# Utilities
+# ===========================================================================
+
+
+def worker_prefix(worker_index: int) -> str:
+    """Return the key prefix for all entries belonging to a worker.
+
+    >>> worker_prefix(3)
+    'worker:3:'
+    """
+    return f"{WORKER_NS}:{worker_index}:"
+
+
+def worker_fields(
+    blackboard: dict[str, Any],
+    worker_index: int,
+) -> dict[str, Any]:
+    """Extract all blackboard fields for a given worker.
+
+    Returns a dict with the per-worker field names (without the
+    ``worker:N:`` prefix) as keys.
+
+    >>> board = {"worker:3:status": "running", "topology": {...}}
+    >>> worker_fields(board, 3)
+    {'status': 'running'}
+    """
+    prefix = worker_prefix(worker_index)
+    return {
+        key.removeprefix(prefix): value
+        for key, value in blackboard.items()
+        if key.startswith(prefix)
+    }
+
+
+def get_worker_field(
+    blackboard: dict[str, Any],
+    worker_index: int,
+    field: str,
+) -> Any:
+    """Read a single field from a worker's blackboard slice.
+
+    Returns ``None`` if the key has never been written.
+    """
+    return blackboard.get(worker_key(worker_index, field))

--- a/tests/hermes_cli/test_kanban_swarm.py
+++ b/tests/hermes_cli/test_kanban_swarm.py
@@ -5,6 +5,18 @@ from hermes_cli.kanban_swarm import (
     create_swarm,
     latest_blackboard,
     post_blackboard_update,
+    TOPOLOGY_KEY,
+    worker_key,
+    worker_result_key,
+    worker_status_key,
+    worker_handoff_key,
+    team_key,
+    coordinator_key,
+    parse_worker_key,
+    parse_namespaced_key,
+    worker_prefix,
+    worker_fields,
+    get_worker_field,
 )
 
 
@@ -113,5 +125,133 @@ def test_swarm_verifier_and_synthesis_are_dependency_gated(tmp_path):
         )
         kb.recompute_ready(conn)
         assert kb.get_task(conn, created.synthesizer_id).status == "ready"
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Structured key helpers
+# ---------------------------------------------------------------------------
+
+
+def test_worker_key_builds_namespaced_string():
+    assert worker_key(0, "status") == "worker:0:status"
+    assert worker_key(3, "result") == "worker:3:result"
+    assert worker_key(7, "handoff") == "worker:7:handoff"
+
+
+def test_worker_result_and_status_and_handoff_shortcuts():
+    assert worker_result_key(2) == "worker:2:result"
+    assert worker_status_key(2) == "worker:2:status"
+    assert worker_handoff_key(5) == "worker:5:handoff"
+
+
+def test_parse_worker_key_returns_index_and_field():
+    assert parse_worker_key("worker:3:status") == (3, "status")
+    assert parse_worker_key("worker:0:result") == (0, "result")
+    assert parse_worker_key("worker:12:handoff") == (12, "handoff")
+
+
+def test_parse_worker_key_rejects_non_worker_keys():
+    assert parse_worker_key("topology") is None
+    assert parse_worker_key("team:sources") is None
+    assert parse_worker_key("coordinator:decision") is None
+    assert parse_worker_key("worker:abc:status") is None  # non-int index
+    assert parse_worker_key("worker:3") is None           # no field
+    assert parse_worker_key("worker:3:") is None          # empty field
+    assert parse_worker_key("worker::status") is None     # empty index
+
+
+def test_parse_namespaced_key_detects_namespace():
+    assert parse_namespaced_key("worker:3:status") == ("worker", "status")
+    assert parse_namespaced_key("team:sources") == ("team", "sources")
+    assert parse_namespaced_key("coordinator:decision") == ("coordinator", "decision")
+    assert parse_namespaced_key("topology") is None
+    assert parse_namespaced_key("bareword") is None
+
+
+def test_team_and_coordinator_key_builders():
+    assert team_key("sources") == "team:sources"
+    assert team_key("risks") == "team:risks"
+    assert coordinator_key("decision") == "coordinator:decision"
+
+
+def test_worker_prefix():
+    assert worker_prefix(3) == "worker:3:"
+    assert worker_prefix(0) == "worker:0:"
+
+
+def test_worker_fields_extracts_all_fields_for_worker():
+    board = {
+        "worker:3:status": "running",
+        "worker:3:result": "passed",
+        "worker:5:status": "done",
+        "topology": {"worker_ids": ["id-3", "id-5"]},
+    }
+    fields = worker_fields(board, 3)
+    assert fields == {"status": "running", "result": "passed"}
+    # worker 5 has no overlapping keys
+    assert worker_fields(board, 5) == {"status": "done"}
+    # worker that never wrote is empty
+    assert worker_fields(board, 99) == {}
+
+
+def test_get_worker_field_reads_single_value():
+    board = {"worker:3:status": "running", "worker:3:result": "passed"}
+    assert get_worker_field(board, 3, "status") == "running"
+    assert get_worker_field(board, 3, "result") == "passed"
+    assert get_worker_field(board, 3, "heartbeat") is None
+    assert get_worker_field(board, 99, "status") is None
+
+
+# ---------------------------------------------------------------------------
+# Structured keys wired into the swarm blackboard
+# ---------------------------------------------------------------------------
+
+
+def test_swarm_blackboard_uses_structured_worker_keys(tmp_path):
+    """Workers can write status/result via structured keys and read them back."""
+    conn = kb.connect(tmp_path / "kanban.db")
+    try:
+        created = create_swarm(
+            conn,
+            goal="Write structured status.",
+            workers=[SwarmWorkerSpec(profile="worker-a", title="Task A", body="Do A")],
+            verifier_assignee="reviewer",
+            synthesizer_assignee="writer",
+        )
+
+        # Worker 0 writes its status
+        post_blackboard_update(
+            conn,
+            created.root_id,
+            author="worker-a",
+            key=worker_status_key(0),
+            value="running",
+        )
+        post_blackboard_update(
+            conn,
+            created.root_id,
+            author="worker-a",
+            key=worker_result_key(0),
+            value={"ok": True, "output": "done"},
+        )
+
+        board = latest_blackboard(conn, created.root_id)
+
+        # Non-worker keys ("topology") still present
+        assert TOPOLOGY_KEY in board
+        topology = board[TOPOLOGY_KEY]
+        assert isinstance(topology, dict)
+        assert topology.get("goal") == "Write structured status."
+
+        # Worker keys readable via structured access
+        assert get_worker_field(board, 0, "status") == "running"
+        assert get_worker_field(board, 0, "result") == {"ok": True, "output": "done"}
+
+        # Parse the keys from the merged board
+        parsed = {k: parse_worker_key(k) for k in board if k.startswith("worker:")}
+        assert parsed[worker_status_key(0)] == (0, "status")
+        assert parsed[worker_result_key(0)] == (0, "result")
     finally:
         conn.close()


### PR DESCRIPTION
## What does this PR do?

Add structured key naming to the Kanban swarm blackboard.

The blackboard already lets workers write `post_blackboard_update(conn, root, key="anything", value=...)`. But currently keys are ad-hoc strings — `"worker3_status"`, `"w3-result"`, `"sources"`. A coordinator scanning the merged blackboard can't tell which worker owns which key, or even whether a key IS a worker key.

This PR adds `kv_helpers.py` — **builders and parsers that enforce a naming convention without changing the storage layer**. If callers write `worker_key(3, "status")` instead of `"worker3_status"`, the coordinator can later `parse_worker_key(k)` → `(3, "status")` and machine-read the board. No schema changes, no new tables, no new protocol — it's a convention library, not a persistence layer.

The same naming convention was independently arrived at in CC_Pure's blackboard (`src/blackboard/kvHelpers.ts`) — an existence proof in another codebase that it works well for multi-worker blackboards.

## Related Issue

N/A — new capability, not a bug fix. Happy to open an issue first if preferred.

Fixes #

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- **New**: `hermes_cli/kv_helpers.py` — key builders (`worker_key`, `team_key`, `coordinator_key`), parsers (`parse_worker_key`, `parse_namespaced_key`), read-back utilities (`worker_fields`, `get_worker_field`, `worker_prefix`), and well-known constants (`TOPOLOGY_KEY`, `GOAL_KEY`, field names like `FIELD_STATUS`)
- **Modified**: `hermes_cli/kanban_swarm.py` — imports and re-exports all helpers; replaces bare `"topology"` string with `TOPOLOGY_KEY` constant
- **Modified**: `tests/hermes_cli/test_kanban_swarm.py` — 10 new tests (builder, parser, namespace, integration with real blackboard)

## How to Test

1. Run the swarm-specific tests:
   ```
   pytest tests/hermes_cli/test_kanban_swarm.py -v
   ```
2. Verify no regressions in the broader kanban suite:
   ```
   pytest tests/hermes_cli/test_kanban_*.py tests/tools/test_kanban_tools.py -q
   ```
3. (Optional) Exercise the helpers manually:
   ```python
   from hermes_cli.kv_helpers import worker_key, parse_worker_key, worker_fields
   assert worker_key(3, "status") == "worker:3:status"
   assert parse_worker_key("worker:3:status") == (3, "status")
   ```

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (10 new tests, 13 total including existing)
- [x] I've tested on my platform: Ubuntu 24.04 (Linux arm64, DGX Spark)

### Documentation & Housekeeping
- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings in `kv_helpers.py` serve as API reference; module docstring explains the convention
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure Python, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no new tools; these are library functions)