### PR TITLE
fix(kanban): recompute_ready promotes children of cancelled parents

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2932,7 +2932,7 @@ def recompute_ready(
                 "WHERE l.child_id = ?",
                 (task_id,),
             ).fetchall()
-            if all(p["status"] in ("done", "archived") for p in parents):
+            if all(p["status"] in ("done", "archived", "cancelled") for p in parents):
                 if cur_status == "blocked":
                     # Don't auto-recover tasks that have hit the
                     # circuit-breaker failure limit.  Without this


### PR DESCRIPTION
## Summary

When a parent task is **cancelled**, its children should be eligible for promotion to `ready`. Currently `recompute_ready` only accepts `done` and `archived` as "unblocking" parent statuses, leaving cancelled parents to block their children forever — children sit in `todo` indefinitely even when the parent is explicitly abandoned.

This is a 1-line fix to the parent-status allowlist at `hermes_cli/kanban_db.py:2935`.

## Root cause

```python
# hermes_cli/kanban_db.py:2935
if all(p["status"] in ("done", "archived") for p in parents):
```

When a parent is `cancelled`, this check fails and the child is never promoted. There is no separate code path that recognizes `cancelled` as a terminal parent state. `cancelled` is a legitimate terminal status (set by `kanban_cancel`, user-driven) and means "this work is explicitly abandoned, don't block downstream on it."

## Repro

**Setup** (synthetic):
```python
conn.execute("INSERT INTO tasks VALUES ('p1','cancelled',0,NULL)")
conn.execute("INSERT INTO tasks VALUES ('p2','done',0,NULL)")
conn.execute("INSERT INTO tasks VALUES ('c1','todo',0,NULL)")
conn.execute("INSERT INTO tasks VALUES ('c2','todo',0,NULL)")
conn.execute("INSERT INTO task_links VALUES ('p1','c1')")  # child of cancelled
conn.execute("INSERT INTO task_links VALUES ('p2','c2')")  # child of done
conn.commit()
```

**Before this PR:**
```
Promoted: 1
  c1: todo        ← stuck indefinitely
  c2: ready
```

**After this PR:**
```
Promoted: 2
  c1: ready
  c2: ready
```

## Fix

```diff
-            if all(p["status"] in ("done", "archived") for p in parents):
+            if all(p["status"] in ("done", "archived", "cancelled") for p in parents):
```

Mirrors the existing `done`/`archived` handling. `cancelled` joins them as a terminal parent state that releases children for promotion.

## Production evidence

This bug has been observed and worked around in production via the WSL2 consolidation hook at `~/.hermes/hooks/wsl2-kanban-monkeypatches/handler.py:127-141`. The hook's monkey-patch SQL implements the same fix:

```python
"AND p.status NOT IN ('done', 'archived', 'cancelled')"
```

That hook has been live in the user's `hermes-agent` deployment since **2026-06-12**, with the system running 5 active workers and 0 failed dispatcher ticks. Filing this PR retires the hook dependency for this specific fix.

## Risk

- **Minimal.** 1-line allowlist change. Adds a status to an existing `in (...)` check. No new code paths, no new dependencies, no behavior changes for any status not in the set.
- All 4 other parent statuses (`ready`, `running`, `blocked`, `todo`) still correctly block their children — only the terminal `cancelled` status is added.
- Compatible with the existing `_has_sticky_block` / circuit-breaker logic further down in the same function (those operate on `task_id` not parent status).

## Test plan

- [x] Synthetic test: child of `cancelled` parent + child of `done` parent → both promoted (was 1 of 2 before)
- [ ] Run existing `tests/hermes_cli/test_kanban_db.py` recompute_ready tests
- [ ] Verify no existing test asserts the (now-changed) `cancelled` blocking behavior

## Bead

- `prod-audit-0a5pa` (parent epic for upstream PRs in this batch)