### PR TITLE
fix(desktop): refresh session list via refreshSessions after delete/archive

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -502,7 +502,7 @@ export function DesktopController() {
 
       const storedProfile = $sessions
         .get()
-        .find(session => session.id === storedSessionId || session._lineage_root_id === storedSessionId)?.profile
+        .find(session => sessionMatchesStoredId(session, storedSessionId))?.profile
 
       for (let index = 0; index < Math.max(1, attempts); index += 1) {
         try {
@@ -619,6 +619,7 @@ export function DesktopController() {
     ensureSessionState,
     getRouteToken,
     navigate,
+    refreshSessions,
     requestGateway,
     resetViewSync,
     runtimeIdByStoredSessionIdRef,

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.test.tsx
@@ -1,0 +1,183 @@
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import type { MutableRefObject } from 'react'
+import { useEffect } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { deleteSession, setSessionArchived } from '@/hermes'
+import { $pinnedSessionIds } from '@/store/layout'
+import { $sessions, setSessions } from '@/store/session'
+
+import type { ClientSessionState } from '../../../types'
+
+import { useSessionActions } from './index'
+
+vi.mock('@/hermes', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  deleteSession: vi.fn(),
+  getSessionMessages: vi.fn(),
+  listAllProfileSessions: vi.fn(),
+  setApiRequestProfile: vi.fn(),
+  setSessionArchived: vi.fn()
+}))
+
+function ref<T>(value: T): MutableRefObject<T> {
+  return { current: value }
+}
+
+type Actions = ReturnType<typeof useSessionActions>
+
+function Harness({
+  onReady,
+  refreshSessions
+}: {
+  onReady: (actions: Actions) => void
+  refreshSessions: (profileOverride?: string) => Promise<void>
+}) {
+  const actions = useSessionActions({
+    activeSessionId: null,
+    activeSessionIdRef: ref<string | null>(null),
+    busyRef: ref(false),
+    creatingSessionRef: ref(false),
+    ensureSessionState: () => ({}) as ClientSessionState,
+    getRouteToken: () => 'token',
+    navigate: vi.fn() as never,
+    refreshSessions,
+    requestGateway: vi.fn(async () => ({})) as never,
+    resetViewSync: vi.fn(),
+    runtimeIdByStoredSessionIdRef: ref(new Map<string, string>()),
+    selectedStoredSessionId: null,
+    selectedStoredSessionIdRef: ref<string | null>(null),
+    sessionStateByRuntimeIdRef: ref(new Map<string, ClientSessionState>()),
+    syncSessionStateToView: vi.fn(),
+    updateSessionState: () => ({}) as ClientSessionState
+  })
+
+  useEffect(() => {
+    onReady(actions)
+  }, [actions, onReady])
+
+  return null
+}
+
+async function withActions(
+  refreshSessions: (profileOverride?: string) => Promise<void>
+): Promise<Actions> {
+  let actions: Actions | null = null
+  render(<Harness onReady={a => (actions = a)} refreshSessions={refreshSessions} />)
+  await waitFor(() => expect(actions).not.toBeNull())
+  return actions!
+}
+
+describe('removeSession refresh', () => {
+  afterEach(() => {
+    cleanup()
+    setSessions([])
+    $pinnedSessionIds.set([])
+    vi.restoreAllMocks()
+  })
+
+  it('calls refreshSessions with the removed session profile after deleteSession succeeds', async () => {
+    const refreshSessions = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(deleteSession).mockResolvedValue({ ok: true })
+
+    setSessions([
+      {
+        id: 'stored-1',
+        _lineage_root_id: 'root-1',
+        profile: 'aux',
+        message_count: 1
+      } as never
+    ])
+
+    const actions = await withActions(refreshSessions)
+
+    await act(async () => {
+      await actions.removeSession('stored-1')
+    })
+
+    expect(deleteSession).toHaveBeenCalledWith('stored-1', 'aux')
+    expect(refreshSessions).toHaveBeenCalledTimes(1)
+    expect(refreshSessions).toHaveBeenCalledWith('aux')
+  })
+
+  it('does not call refreshSessions if deleteSession rejects', async () => {
+    const refreshSessions = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(deleteSession).mockRejectedValue(new Error('boom'))
+
+    setSessions([
+      {
+        id: 'stored-1',
+        _lineage_root_id: 'root-1',
+        profile: 'default',
+        message_count: 1
+      } as never
+    ])
+
+    const actions = await withActions(refreshSessions)
+
+    await act(async () => {
+      await actions.removeSession('stored-1')
+    })
+
+    expect(refreshSessions).not.toHaveBeenCalled()
+    // Error path restores the session.
+    expect($sessions.get().some(s => s.id === 'stored-1')).toBe(true)
+  })
+})
+
+describe('archiveSession refresh', () => {
+  afterEach(() => {
+    cleanup()
+    setSessions([])
+    $pinnedSessionIds.set([])
+    vi.restoreAllMocks()
+  })
+
+  it('calls refreshSessions with the archived session profile after setSessionArchived succeeds', async () => {
+    const refreshSessions = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(setSessionArchived).mockResolvedValue({ ok: true })
+
+    setSessions([
+      {
+        id: 'stored-2',
+        _lineage_root_id: 'root-2',
+        profile: 'dev',
+        message_count: 1
+      } as never
+    ])
+
+    const actions = await withActions(refreshSessions)
+
+    await act(async () => {
+      await actions.archiveSession('stored-2')
+    })
+
+    expect(setSessionArchived).toHaveBeenCalledWith('stored-2', true, 'dev')
+    expect(refreshSessions).toHaveBeenCalledTimes(1)
+    expect(refreshSessions).toHaveBeenCalledWith('dev')
+  })
+
+  it('does not call refreshSessions if setSessionArchived rejects', async () => {
+    const refreshSessions = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(setSessionArchived).mockRejectedValue(new Error('boom'))
+
+    setSessions([
+      {
+        id: 'stored-2',
+        _lineage_root_id: 'root-2',
+        profile: 'default',
+        message_count: 1
+      } as never
+    ])
+
+    const actions = await withActions(refreshSessions)
+
+    await act(async () => {
+      await actions.archiveSession('stored-2')
+    })
+
+    expect(refreshSessions).not.toHaveBeenCalled()
+    // Error path restores the session.
+    expect($sessions.get().some(s => s.id === 'stored-2')).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -74,6 +74,7 @@ interface SessionActionsOptions {
   ensureSessionState: (sessionId: string, storedSessionId?: string | null) => ClientSessionState
   getRouteToken: () => string
   navigate: NavigateFunction
+  refreshSessions?: (profileOverride?: string) => Promise<void>
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
   resetViewSync: () => void
   runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>>
@@ -105,6 +106,7 @@ export function useSessionActions({
   ensureSessionState,
   getRouteToken,
   navigate,
+  refreshSessions,
   requestGateway,
   resetViewSync,
   runtimeIdByStoredSessionIdRef,
@@ -876,6 +878,11 @@ export function useSessionActions({
         if (closingRuntimeId) {
           clearQueuedPrompts(closingRuntimeId)
         }
+
+        // Reconcile with the server through the established merge + keep +
+        // race-guard path. The optimistic removal already dropped this row
+        // from $sessions, so mergeSessionPage cannot resurrect it.
+        await refreshSessions?.(removed?.profile ?? undefined)
       } catch (err) {
         if (removed) {
           setSessions(prev => [removed, ...prev])
@@ -917,6 +924,7 @@ export function useSessionActions({
       activeSessionIdRef,
       copy,
       navigate,
+      refreshSessions,
       requestGateway,
       selectedStoredSessionId,
       selectedStoredSessionIdRef,
@@ -950,12 +958,9 @@ export function useSessionActions({
 
       try {
         await setSessionArchived(storedSessionId, true, archived?.profile)
-        // A sidebar refresh can race the optimistic removal while the PATCH is
-        // in flight and briefly reinsert the still-unarchived backend row. Win
-        // that race after the mutation succeeds so right-click → Archive does
-        // not appear to do nothing until the next full refresh.
-        setSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
-        $pinnedSessionIds.set($pinnedSessionIds.get().filter(id => id !== storedSessionId && id !== archivedPinId))
+        // Reconcile with the server through the established merge + keep +
+        // race-guard path. The optimistic removal already dropped this row.
+        await refreshSessions?.(archived?.profile ?? undefined)
         notify({ durationMs: 2_000, kind: 'success', message: copy.archived })
       } catch (err) {
         if (archived) {
@@ -968,7 +973,7 @@ export function useSessionActions({
         notifyError(err, copy.archiveFailed)
       }
     },
-    [copy, selectedStoredSessionId, startFreshSessionDraft]
+    [copy, refreshSessions, selectedStoredSessionId, startFreshSessionDraft]
   )
 
   return {

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -152,7 +152,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
     }
   }, [])
 
-  const refreshSessions = useCallback(async () => {
+  const refreshSessions = useCallback(async (profileOverride?: string) => {
     const requestId = refreshSessionsRequestRef.current + 1
     refreshSessionsRequestRef.current = requestId
     setSessionsLoading(true)
@@ -171,16 +171,35 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
       // Scope the fetch to the active profile (not always 'all') so a profile
       // with few recent sessions isn't windowed out of the cross-profile
       // recency page — the empty-history-on-profile-switch bug.
-      const sessionProfile = profileScope === ALL_PROFILES ? 'all' : profileScope
+      // A profile override lets callers (e.g. delete/archive) refresh the
+      // exact profile that just mutated instead of the currently visible one.
+      const sessionProfile = profileOverride ?? (profileScope === ALL_PROFILES ? 'all' : profileScope)
 
       const result = await listAllProfileSessions(limit, 1, 'exclude', 'recent', sessionProfile, {
         excludeSources: SIDEBAR_EXCLUDED_SOURCES
       })
 
       if (refreshSessionsRequestRef.current === requestId) {
-        setSessions(prev => mergeSessionPage(prev, result.sessions, sessionsToKeep()))
-        setSessionsTotal(typeof result.total === 'number' ? result.total : result.sessions.length)
-        setSessionProfileTotals(result.profile_totals ?? {})
+        if (profileOverride && profileScope === ALL_PROFILES) {
+          // In ALL_PROFILES view, a profile-scoped refresh (e.g. after a
+          // cross-profile delete/archive) must merge only the target profile
+          // in place and preserve every other profile's rows. The fetch only
+          // returned that profile's sessions, so global totals are untouched.
+          const key = normalizeProfileKey(profileOverride)
+          const inKey = (s: SessionInfo) => normalizeProfileKey(s.profile) === key
+
+          setSessions(prev => [
+            ...prev.filter(s => !inKey(s)),
+            ...mergeSessionPage(prev.filter(inKey), result.sessions, sessionsToKeep(key))
+          ])
+
+          const total = result.profile_totals?.[key] ?? result.total ?? result.sessions.length
+          setSessionProfileTotals(prev => ({ ...prev, [key]: Math.max(total, result.sessions.length) }))
+        } else {
+          setSessions(prev => mergeSessionPage(prev, result.sessions, sessionsToKeep()))
+          setSessionsTotal(typeof result.total === 'number' ? result.total : result.sessions.length)
+          setSessionProfileTotals(result.profile_totals ?? {})
+        }
       }
     } finally {
       if (refreshSessionsRequestRef.current === requestId) {


### PR DESCRIPTION
fix(desktop): refresh session list via refreshSessions after delete/archive

Routes post-delete and post-archive reconciliation through the established
`refreshSessions` callback from `useSessionListActions`, reusing
`mergeSessionPage` / `sessionsToKeep` / the request-counter race guard instead
of hard-replacing `$sessions`.

- `removeSession` calls `refreshSessions` with the removed session's profile.
- `archiveSession` calls `refreshSessions` with the archived session's profile,
  replacing the previous post-PATCH optimistic re-filter.
- `refreshSessions` accepts an optional profile override so cross-profile
deletes/archives in the ALL_PROFILES view refresh only the mutated profile
without clobbering other profiles' rows or totals.

## Testing

- `npm run typecheck` (apps/desktop) — passed
- `npm test` (apps/desktop) — 201 files, 1698 passed, 1 skipped
- `scripts/check-windows-footguns.py --diff origin/main` — 0 footguns

Also added focused tests in `use-session-actions/index.test.tsx` verifying that
`refreshSessions` is invoked after successful delete/archive and not invoked when
the mutation fails.