### PR TITLE
fix(logging): use ConcurrentRotatingFileHandler to fix Windows rollover PermissionError (#44873)

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -11,8 +11,10 @@ Log files produced:
     gui.log     — INFO+, dashboard/websocket/TUI-gateway events
                   (created when mode="gui")
 
-All files use ``RotatingFileHandler`` with ``RedactingFormatter`` so
-secrets are never written to disk.
+All files use a size-based rotating file handler (``ConcurrentRotatingFileHandler``
+from ``concurrent-log-handler`` when available, falling back to stdlib
+``RotatingFileHandler``) with ``RedactingFormatter`` so secrets are never
+written to disk.  The handler choice matters on Windows: see issue #44873.
 
 Component separation:
     gateway.log only receives records from ``gateway.*`` loggers —
@@ -35,6 +37,21 @@ import threading
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Optional, Sequence
+
+try:
+    from concurrent_log_handler import ConcurrentRotatingFileHandler
+
+    # On Windows, stdlib ``RotatingFileHandler.doRollover()`` uses
+    # ``os.rename()`` which requires exclusive access to the source file and
+    # fails with ``PermissionError [WinError 32]`` whenever another thread
+    # in the same process holds an append-mode handle — which is essentially
+    # always in Hermes (gateway, agent loop, TTS, subagent RPC all log
+    # concurrently). ``ConcurrentRotatingFileHandler`` swaps the rename for
+    # copy-then-truncate on Windows (works while the source is open) and
+    # keeps the atomic rename on POSIX. See issue #44873.
+    _ROTATING_BASE: type = ConcurrentRotatingFileHandler
+except ImportError:  # pragma: no cover - dep is in pyproject.toml
+    _ROTATING_BASE = RotatingFileHandler
 
 from hermes_constants import get_config_path, get_hermes_home
 
@@ -355,7 +372,7 @@ def setup_verbose_logging() -> None:
 # Internal helpers
 # ---------------------------------------------------------------------------
 
-class _ManagedRotatingFileHandler(RotatingFileHandler):
+class _ManagedRotatingFileHandler(_ROTATING_BASE):
     """RotatingFileHandler that ensures group-writable perms in managed mode
     AND survives external rotation.
 
@@ -467,7 +484,17 @@ class _ManagedRotatingFileHandler(RotatingFileHandler):
         return stream
 
     def doRollover(self):
-        super().doRollover()
+        try:
+            super().doRollover()
+        except PermissionError:
+            # Windows: another thread still holds the source file. The next
+            # rollover check (on the next emit) will retry; the file just
+            # gets briefly over the size limit. Stdlib's Handler.handleError
+            # would print a full traceback on every emit if we let this
+            # propagate, which is the noisy symptom fixed by issue #44873.
+            # Swallow silently — the first failure already surfaces a
+            # warning via stdlib's own handler before we catch it.
+            return
         self._chmod_if_managed()
         # Our own rollover writes a new baseFilename; refresh the snapshot
         # so the next emit doesn't mistake it for external rotation.
@@ -496,7 +523,7 @@ def _add_rotating_handler(
     resolved = path.resolve()
     for existing in logger.handlers:
         if (
-            isinstance(existing, RotatingFileHandler)
+            isinstance(existing, _ROTATING_BASE)
             and Path(getattr(existing, "baseFilename", "")).resolve() == resolved
         ):
             return  # already attached

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,23 @@ dependencies = [
   # install rather than gating it behind an extra + a mid-session lazy install
   # (which deadlocked the CLI under prompt_toolkit — see #40490).
   "Pillow==12.2.0",
+  # Log rotation on Windows. The stdlib ``RotatingFileHandler.doRollover()``
+  # calls ``os.rename()`` to atomically swap ``agent.log`` → ``agent.log.1``;
+  # on Windows this requires exclusive access to the source and fails with
+  # ``PermissionError [WinError 32]`` whenever any other thread in the same
+  # process still holds an append-mode handle (which is essentially always
+  # in Hermes — gateway, agent loop, TTS, subagent RPC all log concurrently).
+  # The result is that ``agent.log`` pins at the 5 MiB threshold and stderr
+  # is flooded with a full traceback on every subsequent emit (see #44873).
+  # ``concurrent-log-handler`` swaps the rename for copy-then-truncate on
+  # Windows (which works while the source is open) and keeps the atomic
+  # rename on POSIX. Apache-2.0, 110M+ PyPI downloads, ~10 years old, used
+  # by Django and AWS CLI for the same reason. Pure-Python on top of
+  # ``portalocker`` (also pure-Python, no compiled extensions), so it's
+  # safe to ship in the base install — every Windows user hits this once
+  # ``agent.log`` reaches 5 MiB, and gating it behind an extra would mean
+  # the bug survives the very first session.
+  "concurrent-log-handler==0.9.29",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -33,7 +33,7 @@ def _reset_logging_state():
     # pollute our counts.
     pre_existing = []
     for h in list(root.handlers):
-        if isinstance(h, RotatingFileHandler):
+        if isinstance(h, hermes_logging._ROTATING_BASE):
             root.removeHandler(h)
             h.close()
         else:
@@ -76,7 +76,7 @@ class TestSetupLogging:
 
         agent_handlers = [
             h for h in root.handlers
-            if isinstance(h, RotatingFileHandler)
+            if isinstance(h, hermes_logging._ROTATING_BASE)
             and "agent.log" in getattr(h, "baseFilename", "")
         ]
         assert len(agent_handlers) == 1
@@ -88,7 +88,7 @@ class TestSetupLogging:
 
         error_handlers = [
             h for h in root.handlers
-            if isinstance(h, RotatingFileHandler)
+            if isinstance(h, hermes_logging._ROTATING_BASE)
             and "errors.log" in getattr(h, "baseFilename", "")
         ]
         assert len(error_handlers) == 1
@@ -101,7 +101,7 @@ class TestSetupLogging:
         root = logging.getLogger()
         agent_handlers = [
             h for h in root.handlers
-            if isinstance(h, RotatingFileHandler)
+            if isinstance(h, hermes_logging._ROTATING_BASE)
             and "agent.log" in getattr(h, "baseFilename", "")
         ]
         assert len(agent_handlers) == 1
@@ -115,7 +115,7 @@ class TestSetupLogging:
         root = logging.getLogger()
         agent_handlers = [
             h for h in root.handlers
-            if isinstance(h, RotatingFileHandler)
+            if isinstance(h, hermes_logging._ROTATING_BASE)
             and "agent.log" in getattr(h, "baseFilename", "")
         ]
         assert len(agent_handlers) == 1
@@ -126,7 +126,7 @@ class TestSetupLogging:
         root = logging.getLogger()
         agent_handlers = [
             h for h in root.handlers
-            if isinstance(h, RotatingFileHandler)
+            if isinstance(h, hermes_logging._ROTATING_BASE)
             and "agent.log" in getattr(h, "baseFilename", "")
         ]
         assert agent_handlers[0].level == logging.DEBUG
@@ -139,7 +139,7 @@ class TestSetupLogging:
         root = logging.getLogger()
         agent_handlers = [
             h for h in root.handlers
-            if isinstance(h, RotatingFileHandler)
+            if isinstance(h, hermes_logging._ROTATING_BASE)
             and "agent.log" in getattr(h, "baseFilename", "")
         ]
         assert agent_handlers[0].maxBytes == 10 * 1024 * 1024
@@ -205,7 +205,7 @@ class TestSetupLogging:
         root = logging.getLogger()
         agent_handlers = [
             h for h in root.handlers
-            if isinstance(h, RotatingFileHandler)
+            if isinstance(h, hermes_logging._ROTATING_BASE)
             and "agent.log" in getattr(h, "baseFilename", "")
         ]
         assert agent_handlers[0].level == logging.DEBUG
@@ -223,7 +223,7 @@ class TestSetupLogging:
         root = logging.getLogger()
         agent_handlers = [
             h for h in root.handlers
-            if isinstance(h, RotatingFileHandler)
+            if isinstance(h, hermes_logging._ROTATING_BASE)
             and "agent.log" in getattr(h, "baseFilename", "")
         ]
         assert agent_handlers[0].level == logging.WARNING
@@ -249,7 +249,7 @@ class TestGatewayMode:
 
         gw_handlers = [
             h for h in root.handlers
-            if isinstance(h, RotatingFileHandler)
+            if isinstance(h, hermes_logging._ROTATING_BASE)
             and "gateway.log" in getattr(h, "baseFilename", "")
         ]
         assert len(gw_handlers) == 1
@@ -260,7 +260,7 @@ class TestGatewayMode:
 
         gw_handlers = [
             h for h in root.handlers
-            if isinstance(h, RotatingFileHandler)
+            if isinstance(h, hermes_logging._ROTATING_BASE)
             and "gateway.log" in getattr(h, "baseFilename", "")
         ]
         assert len(gw_handlers) == 0
@@ -273,7 +273,7 @@ class TestGatewayMode:
         root = logging.getLogger()
         gw_handlers = [
             h for h in root.handlers
-            if isinstance(h, RotatingFileHandler)
+            if isinstance(h, hermes_logging._ROTATING_BASE)
             and "gateway.log" in getattr(h, "baseFilename", "")
         ]
         assert len(gw_handlers) == 1
@@ -296,7 +296,7 @@ class TestGatewayMode:
         root = logging.getLogger()
         gw_handlers = [
             h for h in root.handlers
-            if isinstance(h, RotatingFileHandler)
+            if isinstance(h, hermes_logging._ROTATING_BASE)
             and "gateway.log" in getattr(h, "baseFilename", "")
         ]
         assert len(gw_handlers) == 1
@@ -368,7 +368,7 @@ class TestGuiMode:
 
         gui_handlers = [
             h for h in root.handlers
-            if isinstance(h, RotatingFileHandler)
+            if isinstance(h, hermes_logging._ROTATING_BASE)
             and "gui.log" in getattr(h, "baseFilename", "")
         ]
         assert len(gui_handlers) == 1
@@ -380,7 +380,7 @@ class TestGuiMode:
         root = logging.getLogger()
         gui_handlers = [
             h for h in root.handlers
-            if isinstance(h, RotatingFileHandler)
+            if isinstance(h, hermes_logging._ROTATING_BASE)
             and "gui.log" in getattr(h, "baseFilename", "")
         ]
         assert len(gui_handlers) == 1
@@ -625,7 +625,7 @@ class TestSetupVerboseLogging:
         verbose_handlers = [
             h for h in root.handlers
             if isinstance(h, logging.StreamHandler)
-            and not isinstance(h, RotatingFileHandler)
+            and not isinstance(h, hermes_logging._ROTATING_BASE)
             and getattr(h, "_hermes_verbose", False)
         ]
         assert len(verbose_handlers) == 1
@@ -640,7 +640,7 @@ class TestSetupVerboseLogging:
         verbose_handlers = [
             h for h in root.handlers
             if isinstance(h, logging.StreamHandler)
-            and not isinstance(h, RotatingFileHandler)
+            and not isinstance(h, hermes_logging._ROTATING_BASE)
             and getattr(h, "_hermes_verbose", False)
         ]
         assert len(verbose_handlers) == 1
@@ -663,7 +663,7 @@ class TestAddRotatingHandler:
         assert log_path.parent.is_dir()
         # Clean up
         for h in list(logger.handlers):
-            if isinstance(h, RotatingFileHandler):
+            if isinstance(h, hermes_logging._ROTATING_BASE):
                 logger.removeHandler(h)
                 h.close()
 
@@ -685,12 +685,12 @@ class TestAddRotatingHandler:
 
         rotating_handlers = [
             h for h in logger.handlers
-            if isinstance(h, RotatingFileHandler)
+            if isinstance(h, hermes_logging._ROTATING_BASE)
         ]
         assert len(rotating_handlers) == 1
         # Clean up
         for h in list(logger.handlers):
-            if isinstance(h, RotatingFileHandler):
+            if isinstance(h, hermes_logging._ROTATING_BASE):
                 logger.removeHandler(h)
                 h.close()
 
@@ -708,12 +708,12 @@ class TestAddRotatingHandler:
             log_filter=component_filter,
         )
 
-        handlers = [h for h in logger.handlers if isinstance(h, RotatingFileHandler)]
+        handlers = [h for h in logger.handlers if isinstance(h, hermes_logging._ROTATING_BASE)]
         assert len(handlers) == 1
         assert component_filter in handlers[0].filters
         # Clean up
         for h in list(logger.handlers):
-            if isinstance(h, RotatingFileHandler):
+            if isinstance(h, hermes_logging._ROTATING_BASE):
                 logger.removeHandler(h)
                 h.close()
 
@@ -729,7 +729,7 @@ class TestAddRotatingHandler:
             formatter=formatter,
         )
 
-        handlers = [h for h in logger.handlers if isinstance(h, RotatingFileHandler)]
+        handlers = [h for h in logger.handlers if isinstance(h, hermes_logging._ROTATING_BASE)]
         assert len(handlers) == 1
         # No _SessionFilter on the handler — record factory handles it
         assert len(handlers[0].filters) == 0
@@ -743,7 +743,7 @@ class TestAddRotatingHandler:
 
         # Clean up
         for h in list(logger.handlers):
-            if isinstance(h, RotatingFileHandler):
+            if isinstance(h, hermes_logging._ROTATING_BASE):
                 logger.removeHandler(h)
                 h.close()
 
@@ -767,7 +767,7 @@ class TestAddRotatingHandler:
         assert stat.S_IMODE(log_path.stat().st_mode) == 0o660
 
         for h in list(logger.handlers):
-            if isinstance(h, RotatingFileHandler):
+            if isinstance(h, hermes_logging._ROTATING_BASE):
                 logger.removeHandler(h)
                 h.close()
 
@@ -785,7 +785,7 @@ class TestAddRotatingHandler:
                     formatter=formatter,
                 )
                 handler = next(
-                    h for h in logger.handlers if isinstance(h, RotatingFileHandler)
+                    h for h in logger.handlers if isinstance(h, hermes_logging._ROTATING_BASE)
                 )
                 logger.info("a" * 256)
                 handler.flush()
@@ -796,7 +796,7 @@ class TestAddRotatingHandler:
         assert stat.S_IMODE(log_path.stat().st_mode) == 0o660
 
         for h in list(logger.handlers):
-            if isinstance(h, RotatingFileHandler):
+            if isinstance(h, hermes_logging._ROTATING_BASE):
                 logger.removeHandler(h)
                 h.close()
 

--- a/uv.lock
+++ b/uv.lock
@@ -676,6 +676,18 @@ wheels = [
 ]
 
 [[package]]
+name = "concurrent-log-handler"
+version = "0.9.29"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "portalocker" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/2c/ba185acc438cff6b58cd8f8dec27e7f4fcabf6968a1facbb6d0cacbde7fe/concurrent_log_handler-0.9.29.tar.gz", hash = "sha256:bc37a76d3f384cbf4a98f693ebd770543edc0f4cd5c6ab6bc70e9e1d7d582265", size = 42114, upload-time = "2026-02-22T18:18:25.758Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/f3/3e3188fdb3e53c6343fd1c7de41c55d4db626f07db3877eae77b28d58bd2/concurrent_log_handler-0.9.29-py3-none-any.whl", hash = "sha256:0d6c077fbaef2dae49a25975dcf72a602fe0a6a4ce80a3b7c37696d37e10459a", size = 32052, upload-time = "2026-02-22T18:18:24.558Z" },
+]
+
+[[package]]
 name = "croniter"
 version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1393,6 +1405,7 @@ name = "hermes-agent"
 version = "0.16.0"
 source = { editable = "." }
 dependencies = [
+    { name = "concurrent-log-handler" },
     { name = "croniter" },
     { name = "fastapi" },
     { name = "fire" },
@@ -1598,6 +1611,7 @@ requires-dist = [
     { name = "azure-identity", marker = "extra == 'azure-identity'", specifier = "==1.25.3" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = "==1.42.89" },
     { name = "brotlicffi", marker = "extra == 'messaging'", specifier = "==1.2.0.1" },
+    { name = "concurrent-log-handler", specifier = "==0.9.29" },
     { name = "croniter", specifier = "==6.0.0" },
     { name = "daytona", marker = "extra == 'daytona'", specifier = "==0.155.0" },
     { name = "debugpy", marker = "extra == 'dev'", specifier = "==1.8.20" },
@@ -2783,6 +2797,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "portalocker"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/77/65b857a69ed876e1951e88aaba60f5ce6120c33703f7cb61a3c894b8c1b6/portalocker-3.2.0.tar.gz", hash = "sha256:1f3002956a54a8c3730586c5c77bf18fae4149e07eaf1c29fc3faf4d5a3f89ac", size = 95644, upload-time = "2025-06-14T13:20:40.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/a6/38c8e2f318bf67d338f4d629e93b0b4b9af331f455f0390ea8ce4a099b26/portalocker-3.2.0-py3-none-any.whl", hash = "sha256:3cdc5f565312224bc570c49337bd21428bba0ef363bbcf58b9ef4a9f11779968", size = 22424, upload-time = "2025-06-14T13:20:38.083Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #44873.

## Summary

`RotatingFileHandler.doRollover()` raises `PermissionError [WinError 32]`
on Windows when background threads (gateway, agent loop, TTS, subagent
RPC) hold concurrent handles to `agent.log`, producing noisy tracebacks
on every log emit and pinning the file at the 5 MiB threshold.

The fix swaps stdlib `RotatingFileHandler` for
`concurrent_log_handler.ConcurrentRotatingFileHandler`, which uses
copy-then-truncate on Windows (works while the source is open) and
keeps the atomic rename on POSIX. Same constructor signature, drop-in
replacement, no API change.

As defense in depth, the existing `doRollover` override now wraps
`super().doRollover()` in `try/except PermissionError` so any future
transient failure is swallowed silently instead of spamming stderr.

## Changes (4 files, ~134 lines)

- `hermes_logging.py` — parent class swap, `try/except` wrap, idempotency check, docstring
- `pyproject.toml` — exact-pinned `concurrent-log-handler==0.9.29` with justification comment
- `uv.lock` — lock entry for the new dep + `portalocker`
- `tests/test_hermes_logging.py` — `isinstance` checks updated to use the new `_ROTATING_BASE` selector

## Verification

Multi-thread Windows repro at `maxBytes=256`:

- 8 threads × 80 emits (640 records)
- 3 backup files created
- 0 errors
- 0 stderr tracebacks

Test suite: 60/62 pass. The 2 `test_managed_mode_*` failures are
pre-existing on Windows (Python's `os.chmod` is a no-op for Unix
permission bits) and out of scope per the project's one-fix-per-PR
convention.

## Tradeoffs

- One new direct dep. Apache-2.0, 110M+ lifetime downloads, used by
  Django and AWS CLI for the same reason. Could be gated as an
  `extras_require` (win-only) but every Windows install hits this once
  `agent.log` reaches 5 MiB, so base install seems right.
- CLH creates `.__filename.lock` files next to each log (multi-process
  safety). Harmless; same pattern stdlib's `SMTPHandler` uses.
