### PR TITLE
fix(tools): search_files breaks when the pattern starts with "-"

### DIFF
--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2085,7 +2085,9 @@ class ShellFileOperations(FileOperations):
         elif output_mode == "count":
             cmd_parts.append("-c")  # Count per file
         
-        # Add pattern and path
+        # Add pattern and path ("--" stops flag parsing so patterns
+        # beginning with "-" are not misread as options)
+        cmd_parts.append("--")
         cmd_parts.append(self._escape_shell_arg(pattern))
         cmd_parts.append(self._escape_shell_arg(path))
         
@@ -2203,7 +2205,9 @@ class ShellFileOperations(FileOperations):
         elif output_mode == "count":
             cmd_parts.append("-c")
         
-        # Add pattern and path
+        # Add pattern and path ("--" stops flag parsing so patterns
+        # beginning with "-" are not misread as options)
+        cmd_parts.append("--")
         cmd_parts.append(self._escape_shell_arg(pattern))
         cmd_parts.append(self._escape_shell_arg(path))
         


### PR DESCRIPTION
## Problem

`search_files` builds `rg`/`grep` commands as `rg <flags> <pattern> <path>`. When a model passes a pattern that begins with `-` (observed live: `--account|contacts`), ripgrep parses it as a flag and the tool fails:

```
Search failed: rg: unrecognized flag --account|contacts
```

## Fix

Insert `--` (end-of-options marker) before the pattern in both the ripgrep and grep code paths of `tools/file_operations.py`, so user patterns are never interpreted as options.

## Tests

Reproduced live on v0.16.x before the fix; after the fix `rg -- '--account|contacts'` matches correctly. Full `tests/tools/test_file_operations*.py` suite green (112 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)