### PR TITLE
fix(tui): use context-reference pattern instead of bare @ check

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -29,6 +29,11 @@ import shutil
 import sys
 import json
 import re
+
+# Pre-compiled pattern matching @-context references (@file:, @diff, @folder:, etc.)
+# Used as a fast-path guard so ordinary "@" in email addresses doesn't trigger
+# the expensive preprocess_context_references pipeline (#44656).
+_CONTEXT_REF_RE = re.compile(r"(?<![\w/])@(?:diff|staged|file|folder|git|url):?")
 import concurrent.futures
 import base64
 import atexit
@@ -10025,7 +10030,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 )
 
         # Expand @ context references (e.g. @file:main.py, @diff, @folder:src/)
-        if isinstance(message, str) and "@" in message:
+        # Use the actual pattern to avoid triggering on ordinary "@" in email
+        # addresses or other text (#44656).
+        if isinstance(message, str) and _CONTEXT_REF_RE.search(message):
             try:
                 from agent.context_references import preprocess_context_references
                 from agent.model_metadata import get_model_context_length

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1,4 +1,5 @@
 import atexit
+import re
 import concurrent.futures
 import contextlib
 import contextvars
@@ -34,6 +35,11 @@ from tui_gateway.transport import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Pre-compiled pattern matching @-context references (@file:, @diff, @folder:, etc.)
+# Used as a fast-path guard so ordinary "@" in email addresses doesn't trigger
+# the expensive preprocess_context_references pipeline (#44656).
+_CONTEXT_REF_RE = re.compile(r"(?<![\w/])@(?:diff|staged|file|folder|git|url):?")
 
 _hermes_home = get_hermes_home()
 load_hermes_dotenv(
@@ -5358,7 +5364,11 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             streamer = make_stream_renderer(cols)
             prompt = text
 
-            if isinstance(prompt, str) and "@" in prompt:
+            # Use the actual context-reference pattern instead of a bare "@" check
+            # so ordinary messages containing "@" (e.g. email addresses) don't
+            # trigger the expensive preprocess_context_references pipeline
+            # which can block on HTTP calls to resolve model context length (#44656).
+            if isinstance(prompt, str) and _CONTEXT_REF_RE.search(prompt):
                 from agent.context_references import preprocess_context_references
                 from agent.model_metadata import get_model_context_length
 


### PR DESCRIPTION
## Summary

The fast-path guard `"@" in prompt` in both `tui_gateway/server.py` and `cli.py` triggers for every message containing an at-sign — including email addresses like `user@domain.com`. This invokes the full `preprocess_context_references` pipeline which calls `get_model_context_length()` (an HTTP request), blocking the handler and exceeding the 10-second WebSocket timeout.

Replace with a pre-compiled regex that only matches actual context-reference syntax (`@file:`, `@diff`, `@folder:`, `@git:`, `@url:`, `@staged`). Ordinary `@` in email addresses or other text no longer triggers the pipeline.

Fixes #44656

## Root Cause

`tui_gateway/server.py:5361` and `cli.py:10028` both use:
```python
if isinstance(prompt, str) and "@" in prompt:
```

This is overly broad. The downstream `preprocess_context_references()` calls `get_model_context_length()` which may make HTTP requests to the provider, causing the timeout.

## Fix

The actual `REFERENCE_PATTERN` in `agent/context_references.py` already only matches specific context-reference syntax. Use a simplified version of that pattern as the fast-path guard:

```python
_CONTEXT_REF_RE = re.compile(r"(?<![\w/])@(?:diff|staged|file|folder|git|url):?")
```

- `user@domain.com` → no match (preceded by word char)
- `@file:main.py` → match
- `@diff` → match
- `@staged` → match

## Changes

| File | Change |
|------|--------|
| `tui_gateway/server.py` | Add `import re`, `_CONTEXT_REF_RE` pattern, replace `"@" in prompt` |
| `cli.py` | Add `_CONTEXT_REF_RE` pattern, replace `"@" in message` |

## Testing

```python
import re
P = re.compile(r"(?<![\w/])@(?:diff|staged|file|folder|git|url):?")
assert not P.search("user@domain.com")
assert not P.search("contact us at hello@example.org")
assert P.search("@diff")
assert P.search("@file:main.py")
assert P.search("check @file:test.py and @diff")
```

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I have considered cross-platform impact per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)