### PR TITLE
Stamp outbound email with Auto-Submitted: auto-replied (RFC 3834)

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -545,6 +545,8 @@ class EmailAdapter(BasePlatformAdapter):
         msg["Date"] = formatdate(localtime=True)
         msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._address.split('@')[1]}>"
         msg["Message-ID"] = msg_id
+        # RFC 3834: mark replies as automatic so autoresponders don't answer back
+        msg["Auto-Submitted"] = "auto-replied"
 
         msg.attach(MIMEText(body, "plain", "utf-8"))
 
@@ -654,6 +656,8 @@ class EmailAdapter(BasePlatformAdapter):
         msg["Date"] = formatdate(localtime=True)
         msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._address.split('@')[1]}>"
         msg["Message-ID"] = msg_id
+        # RFC 3834: mark replies as automatic so autoresponders don't answer back
+        msg["Auto-Submitted"] = "auto-replied"
 
         if body:
             msg.attach(MIMEText(body, "plain", "utf-8"))
@@ -735,6 +739,8 @@ class EmailAdapter(BasePlatformAdapter):
         msg["Date"] = formatdate(localtime=True)
         msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._address.split('@')[1]}>"
         msg["Message-ID"] = msg_id
+        # RFC 3834: mark replies as automatic so autoresponders don't answer back
+        msg["Auto-Submitted"] = "auto-replied"
 
         if body:
             msg.attach(MIMEText(body, "plain", "utf-8"))

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -1203,5 +1203,84 @@ class TestImapIdExtensionForNetEase(unittest.TestCase):
         mock_imap.xatom.assert_called_once()
 
 
+class TestAutoSubmittedHeader(unittest.TestCase):
+    """Every outbound email must carry Auto-Submitted: auto-replied (RFC 3834).
+
+    Without it, autoresponders (vacation replies, ticketing systems) cannot
+    tell Hermes replies are automatic and may answer back, creating mail loops.
+    """
+
+    def _make_adapter(self):
+        from gateway.config import PlatformConfig
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+        }):
+            from gateway.platforms.email import EmailAdapter
+            adapter = EmailAdapter(PlatformConfig(enabled=True))
+        return adapter
+
+    def test_send_email_stamps_auto_submitted(self):
+        """Plain reply path stamps Auto-Submitted: auto-replied."""
+        adapter = self._make_adapter()
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+
+            adapter._send_email("user@test.com", "Hello!", None)
+
+            sent_msg = mock_server.send_message.call_args[0][0]
+            self.assertEqual(sent_msg["Auto-Submitted"], "auto-replied")
+
+    def test_send_email_with_attachment_stamps_auto_submitted(self):
+        """Single-attachment path stamps Auto-Submitted: auto-replied."""
+        import tempfile
+        adapter = self._make_adapter()
+
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+            f.write(b"Test document content")
+            tmp_path = f.name
+
+        try:
+            with patch("smtplib.SMTP") as mock_smtp:
+                mock_server = MagicMock()
+                mock_smtp.return_value = mock_server
+
+                adapter._send_email_with_attachment(
+                    "user@test.com", "Here is the file", tmp_path
+                )
+
+                sent_msg = mock_server.send_message.call_args[0][0]
+                self.assertEqual(sent_msg["Auto-Submitted"], "auto-replied")
+        finally:
+            os.unlink(tmp_path)
+
+    def test_send_email_with_attachments_stamps_auto_submitted(self):
+        """Multi-attachment path stamps Auto-Submitted: auto-replied."""
+        import tempfile
+        adapter = self._make_adapter()
+
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+            f.write(b"Attachment one")
+            tmp_path = f.name
+
+        try:
+            with patch("smtplib.SMTP") as mock_smtp:
+                mock_server = MagicMock()
+                mock_smtp.return_value = mock_server
+
+                adapter._send_email_with_attachments(
+                    "user@test.com", "Files attached", [tmp_path]
+                )
+
+                sent_msg = mock_server.send_message.call_args[0][0]
+                self.assertEqual(sent_msg["Auto-Submitted"], "auto-replied")
+        finally:
+            os.unlink(tmp_path)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

The email adapter already checks **inbound** mail for `Auto-Submitted` (along with `Precedence`, `X-Auto-Response-Suppress`, `List-Unsubscribe`, and noreply patterns — `gateway/platforms/email.py:48-60`) so it won't reply to autoresponders. But it never stamps its own **outbound** mail.

That means an RFC-compliant autoresponder (vacation reply, ticketing system) — or a second Hermes instance pointed at another mailbox — has no way to tell a Hermes reply is automatic, and can answer back indefinitely: a classic mail loop. RFC 3834 §3.1 says automatic responses MUST carry `Auto-Submitted: auto-replied`.

## Fix

Stamp `Auto-Submitted: auto-replied` on all three SMTP send paths in `EmailAdapter`:

- `_send_email` (plain reply)
- `_send_email_with_attachment` (single attachment)
- `_send_email_with_attachments` (multiple attachments)

## Tests

One test per send path (`TestAutoSubmittedHeader` in `tests/gateway/test_email.py`), asserting the header on the message handed to `smtplib`. Full email suite passes: 63/63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
