### PR TITLE
fix(auth): refresh OAuth tokens during exhaustion cooldown (#44799)

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1312,6 +1312,19 @@ class CredentialPool:
             if entry.last_status == STATUS_EXHAUSTED:
                 exhausted_until = _exhausted_until(entry)
                 if exhausted_until is not None and now < exhausted_until:
+                    # For OAuth providers (esp. openai-codex), still refresh
+                    # the token during cooldown to prevent the refresh chain
+                    # from expiring.  A long cooldown (e.g. weekly ChatGPT
+                    # quota) can outlive the OAuth session; if the refresh
+                    # token isn't rotated, the credential is permanently
+                    # dead when the cooldown finally expires.
+                    if (refresh
+                            and self._entry_needs_refresh(entry)
+                            and entry.auth_type == AUTH_TYPE_OAUTH
+                            and entry.refresh_token):
+                        refreshed = self._refresh_entry(entry, force=False)
+                        if refreshed is not None:
+                            entry = refreshed
                     continue
                 if clear_expired:
                     cleared = replace(


### PR DESCRIPTION
Fixes #44799. During a long exhaustion cooldown (e.g. weekly ChatGPT quota), the pool entry was completely skipped, so the OAuth refresh chain was never maintained. By the time the cooldown expired, the refresh token had naturally expired and the credential was permanently dead. Now refreshes OAuth tokens for exhausted entries during cooldown to keep the chain alive.