### PR TITLE
fix(logging): alias stdlib RotatingFileHandler to concurrent-log-handler (#44873)

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -32,9 +32,23 @@ import logging
 import os
 import sys
 import threading
-from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Optional, Sequence
+
+# On Windows, stdlib ``RotatingFileHandler`` calls ``os.rename()`` in
+# ``doRollover()`` and fails with ``PermissionError [WinError 32]`` whenever
+# another process holds an append-mode handle on ``agent.log`` — which is
+# essentially always in Hermes (TUI, gateway, ``hy_memory`` server, MCP
+# servers, and on-demand CLI commands all log from separate processes),
+# pinning ``agent.log`` at the 5 MiB threshold and spamming stderr with
+# a traceback on every emit. ``concurrent-log-handler`` wraps the
+# rename in a cross-process file lock (msvcrt on Windows, fcntl on POSIX)
+# so only one process rotates at a time and the others wait their turn.
+# Drop-in API compatibility — aliasing lets every existing
+# ``RotatingFileHandler`` reference in this module (the class declaration,
+# the ``isinstance`` checks, the docstring) keep working unchanged.
+# See #44873.
+from concurrent_log_handler import ConcurrentRotatingFileHandler as RotatingFileHandler  # noqa: E402
 
 from hermes_constants import get_config_path, get_hermes_home
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,19 @@ dependencies = [
   # install rather than gating it behind an extra + a mid-session lazy install
   # (which deadlocked the CLI under prompt_toolkit — see #40490).
   "Pillow==12.2.0",
+  # Windows log rotation. Stdlib ``RotatingFileHandler.doRollover()`` uses
+  # ``os.rename()`` which fails with ``PermissionError [WinError 32]`` on
+  # Windows whenever any other process holds an append-mode handle on
+  # ``agent.log`` (always the case in Hermes — TUI, gateway, ``hy_memory``
+  # server, MCP servers, and on-demand CLI commands all log from separate
+  # processes), pinning ``agent.log`` at the 5 MiB threshold and spamming
+  # stderr on every emit (see #44873). ``concurrent-log-handler`` wraps
+  # the rename in a cross-process file lock (msvcrt on Windows, fcntl on
+  # POSIX) so only one process rotates at a time and the others wait
+  # their turn. Aliasing the import in ``hermes_logging.py`` makes the
+  # swap transparent to every existing ``isinstance`` / class-declaration
+  # check. Pure-Python, no compiled deps.
+  "concurrent-log-handler==0.9.29",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -1,11 +1,14 @@
 """Tests for hermes_logging — centralized logging setup."""
-
+import io
 import logging
 import os
 import stat
 import sys
 import threading
-from logging.handlers import RotatingFileHandler
+# Same alias as hermes_logging.py so the autouse fixture's isinstance
+# checks (which strip rotating handlers between tests) match the new
+# CLH-backed handler class on installs that pulled in #44873's fix.
+from concurrent_log_handler import ConcurrentRotatingFileHandler as RotatingFileHandler
 from pathlib import Path
 from unittest.mock import patch
 

--- a/uv.lock
+++ b/uv.lock
@@ -676,6 +676,18 @@ wheels = [
 ]
 
 [[package]]
+name = "concurrent-log-handler"
+version = "0.9.29"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "portalocker" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/2c/ba185acc438cff6b58cd8f8dec27e7f4fcabf6968a1facbb6d0cacbde7fe/concurrent_log_handler-0.9.29.tar.gz", hash = "sha256:bc37a76d3f384cbf4a98f693ebd770543edc0f4cd5c6ab6bc70e9e1d7d582265", size = 42114, upload-time = "2026-02-22T18:18:25.758Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/f3/3e3188fdb3e53c6343fd1c7de41c55d4db626f07db3877eae77b28d58bd2/concurrent_log_handler-0.9.29-py3-none-any.whl", hash = "sha256:0d6c077fbaef2dae49a25975dcf72a602fe0a6a4ce80a3b7c37696d37e10459a", size = 32052, upload-time = "2026-02-22T18:18:24.558Z" },
+]
+
+[[package]]
 name = "croniter"
 version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1394,6 +1406,7 @@ version = "0.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },
+    { name = "concurrent-log-handler" },
     { name = "croniter" },
     { name = "fastapi" },
     { name = "fire" },
@@ -1599,6 +1612,7 @@ requires-dist = [
     { name = "boto3", marker = "extra == 'bedrock'", specifier = "==1.42.89" },
     { name = "brotlicffi", marker = "extra == 'messaging'", specifier = "==1.2.0.1" },
     { name = "certifi", specifier = "==2026.5.20" },
+    { name = "concurrent-log-handler", specifier = "==0.9.29" },
     { name = "croniter", specifier = "==6.0.0" },
     { name = "daytona", marker = "extra == 'daytona'", specifier = "==0.155.0" },
     { name = "debugpy", marker = "extra == 'dev'", specifier = "==1.8.20" },
@@ -2783,6 +2797,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "portalocker"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/77/65b857a69ed876e1951e88aaba60f5ce6120c33703f7cb61a3c894b8c1b6/portalocker-3.2.0.tar.gz", hash = "sha256:1f3002956a54a8c3730586c5c77bf18fae4149e07eaf1c29fc3faf4d5a3f89ac", size = 95644, upload-time = "2025-06-14T13:20:40.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/a6/38c8e2f318bf67d338f4d629e93b0b4b9af331f455f0390ea8ce4a099b26/portalocker-3.2.0-py3-none-any.whl", hash = "sha256:3cdc5f565312224bc570c49337bd21428bba0ef363bbcf58b9ef4a9f11779968", size = 22424, upload-time = "2025-06-14T13:20:38.083Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Replaces the overengineered #44904 with a much smaller version.

## Summary

On Windows, stdlib `RotatingFileHandler.doRollover()` fails with `PermissionError [WinError 32]` whenever another process holds an append-mode handle on `agent.log` (always the case in Hermes — TUI, gateway, `hy_memory` server, MCP servers, and on-demand CLI commands all log from separate processes). Aliasing the import to `concurrent_log_handler.ConcurrentRotatingFileHandler` wraps the rename in a cross-process file lock (`msvcrt` on Windows, `fcntl` on POSIX) so only one process rotates at a time and the others wait their turn.

## Changes (3 source files, 1 auto-generated lock)

- `hermes_logging.py` — alias the import to CLH. The `as RotatingFileHandler` alias keeps every existing `isinstance(h, RotatingFileHandler)` check in this module working unchanged.
- `pyproject.toml` — exact-pinned `concurrent-log-handler==0.9.29` dep
- `uv.lock` — lock entry (auto-generated)
- `tests/test_hermes_logging.py` — same alias in the test file so the autouse fixture's `isinstance(h, RotatingFileHandler)` checks strip the new CLH-backed handlers between tests

## Verification

**Multi-process repro** (the actual failure mode on Windows — separate processes each with their own FD on the file):

20 interleaved emits across 2 independent `_ManagedRotatingFileHandler` instances on the same file → 0 exceptions, 0 stderr, clean rotation producing `.1` / `.2` / `.3` backups + `.__agent.lock` sidecar.

**Multi-thread repro** (8-thread variant — also passes, validates the same fix from a single-process angle):

8 threads × 80 emits (640 records) at `maxBytes=256`: 3 backup files created, 0 errors, 0 stderr tracebacks.

## Test suite

60/62 pass on Windows. The 2 `test_managed_mode_*` failures are pre-existing and unrelated: `_chmod_if_managed` in `hermes_logging.py` doesn't actually `os.chmod` (the function body only creates the file if it doesn't exist; the class docstring claims it applies `chmod 0660` but no such call exists in the file). On Windows this fails because `os.chmod` doesn't set Unix permission bits; on Linux it would fail because the umask-corrected default mode is `0o644`, not `0o660`. Happy to file a follow-up that adds the missing `os.chmod(path, 0o660)` to `_chmod_if_managed` and adjusts the test.
