### PR TITLE
fix(auth): refresh Codex OAuth tokens earlier

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -95,7 +95,12 @@ STEPFUN_STEP_PLAN_INTL_BASE_URL = "https://api.stepfun.ai/step_plan/v1"
 STEPFUN_STEP_PLAN_CN_BASE_URL = "https://api.stepfun.com/step_plan/v1"
 CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
-CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
+# Refresh Codex OAuth access tokens well before expiry.  Two minutes is too
+# close for long gateway/agent turns: a request can begin with a token that is
+# technically valid and then cross expiry while streaming/tool-calling. Refresh
+# about a day and a half early so long-lived setups do not wait until the last
+# few minutes before rotating a 10-day ChatGPT token.
+CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 36 * 60 * 60
 XAI_OAUTH_ISSUER = "https://auth.x.ai"
 XAI_OAUTH_DISCOVERY_URL = f"{XAI_OAUTH_ISSUER}/.well-known/openid-configuration"
 XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828"

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -11,6 +11,7 @@ import pytest
 from hermes_cli.auth import (
     AuthError,
     DEFAULT_CODEX_BASE_URL,
+    CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
     PROVIDER_REGISTRY,
     _read_codex_tokens,
     _save_codex_tokens,
@@ -48,6 +49,13 @@ def _jwt_with_exp(exp_epoch: int) -> str:
     payload = {"exp": exp_epoch}
     encoded = base64.urlsafe_b64encode(json.dumps(payload).encode("utf-8")).rstrip(b"=").decode("utf-8")
     return f"h.{encoded}.s"
+
+
+def test_codex_oauth_refresh_skew_is_large_enough_for_long_gateway_turns():
+    # Codex/ChatGPT tokens are long-lived, while gateway turns can stream and
+    # tool-call for many minutes.  Keep a generous skew so a request does not
+    # begin near expiry and cross the boundary mid-turn.
+    assert CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS == 36 * 60 * 60
 
 
 def test_read_codex_tokens_success(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Refresh Codex OAuth access tokens 36 hours before expiry instead of waiting until the final two minutes.
- Add regression coverage for the larger refresh skew constant.

## Problem
Gateway and long-running agent turns can start while a token is still technically valid, then cross token expiry while streaming or tool-calling. Refreshing only in the last two minutes leaves too little margin for those turns.

## Tests
- `uv run --extra dev ruff check hermes_cli/auth.py tests/hermes_cli/test_auth_codex_provider.py`
- `uv run --extra dev python -m pytest tests/hermes_cli/test_auth_codex_provider.py -q -o 'addopts='`
- `python -m py_compile hermes_cli/auth.py tests/hermes_cli/test_auth_codex_provider.py`
- `gitleaks git --log-opts='HEAD~1..HEAD' --no-banner --redact`
