### PR TITLE
perf(cli): skip large foreign binaries in profile alias scan, use libyaml loader

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -452,6 +452,14 @@ def find_alias_for_profile(profile_name: str) -> Optional[str]:
             continue
         if not is_windows and entry.suffix:
             continue
+        # Wrapper scripts are a few hundred bytes; anything large is a foreign
+        # binary (uv, language servers, …) sharing ~/.local/bin. Reading those
+        # as text costs seconds each and blocks the dashboard event loop.
+        try:
+            if entry.stat().st_size > 16 * 1024:
+                continue
+        except OSError:
+            continue
         try:
             content = entry.read_text()
         except (OSError, UnicodeDecodeError):
@@ -535,8 +543,11 @@ def _read_config_model(profile_dir: Path) -> tuple:
         return None, None
     try:
         import yaml
+        # Prefer the libyaml C loader — the pure-python parser costs ~0.3s per
+        # config and this runs once per profile on dashboard-blocking paths.
+        loader = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
         with open(config_path, "r", encoding="utf-8") as f:
-            cfg = yaml.safe_load(f) or {}
+            cfg = yaml.load(f, Loader=loader) or {}
         model_cfg = cfg.get("model", {})
         if isinstance(model_cfg, str):
             return model_cfg, None

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -756,6 +756,27 @@ class TestFindAliasForProfile:
         (wrapper_dir / "pip").write_text("#!/bin/sh\nexec python -m pip \"$@\"\n")
         assert find_alias_for_profile("steve") is None
 
+    def test_skips_large_foreign_binaries(self, profile_env, monkeypatch):
+        # ~/.local/bin is also the default install target for uv tools, so it
+        # holds multi-MB extensionless binaries. Reading them as text blocks
+        # the dashboard event loop for seconds per file per profile — the size
+        # guard must skip them without reading, even if their bytes happen to
+        # contain the wrapper needle.
+        monkeypatch.setattr("sys.platform", "darwin")
+        from hermes_cli.profiles import (
+            _get_wrapper_dir,
+            create_wrapper_script,
+            find_alias_for_profile,
+        )
+        wrapper_dir = _get_wrapper_dir()
+        wrapper_dir.mkdir(parents=True, exist_ok=True)
+        big = wrapper_dir / "fakebinary"
+        big.write_bytes(b"\x00" * (64 * 1024) + b"hermes -p steve\n")
+        assert find_alias_for_profile("steve") is None
+        # A real (small) wrapper alongside the binary still resolves.
+        create_wrapper_script("steve")
+        assert find_alias_for_profile("steve") == "steve"
+
     def test_custom_alias_on_windows(self, profile_env, monkeypatch):
         monkeypatch.setattr("sys.platform", "win32")
         from hermes_cli.profiles import create_wrapper_script, find_alias_for_profile


### PR DESCRIPTION
## What does this PR do?

`find_alias_for_profile()` reads every extensionless file in `~/.local/bin` fully into memory as UTF-8 text, once per profile, to find wrapper scripts. That directory is also the default install target for `uv tool install` and similar tools, so it commonly contains multi-MB (in my case one 145MB) extensionless binaries.

Because callers like `GET /api/cron/jobs` → `list_profiles()` run this synchronously inside an async dashboard handler, the cost lands on the backend event loop. On my machine (11 profiles, 61 files in `~/.local/bin` including uv-installed binaries), `list_profiles()` took **36.8s**, freezing every HTTP/WS response — including the gateway-ready frame, which made the desktop renderer's 15s WebSocket connect timeout fail boot with "Hermes couldn't start".

Fix: skip files larger than 16KB before reading. Wrapper scripts written by `create_wrapper_script` are a few hundred bytes (POSIX: `#!/bin/sh` + one exec line; Windows: two-line `.bat`), so the guard cannot skip a real wrapper. Also parse profile `config.yaml` with the libyaml `CSafeLoader` when available (the pure-Python parser costs ~0.3s per config on this path).

Before/after on the same machine: `list_profiles()` 36.8s → ~2s. Alias resolution output unchanged.

## Related Issue

Companion issue on the broader pattern (sync work on the dashboard event loop) filed separately.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/profiles.py`: size guard (>16KB skip, OSError-safe stat) in `find_alias_for_profile`; `CSafeLoader` fallback in `_read_config_model`
- `tests/hermes_cli/test_profiles.py`: regression test `test_skips_large_foreign_binaries` — a 64KB extensionless file containing the wrapper needle must not match, while a real wrapper alongside it still resolves

## How to Test

1. Drop a large extensionless binary in `~/.local/bin` (e.g. `uv tool install` anything, or `truncate -s 100M ~/.local/bin/fakebin`)
2. With several profiles, time `python -c "from hermes_cli.profiles import list_profiles; import time; t=time.time(); list_profiles(); print(time.time()-t)"` before/after
3. `pytest tests/hermes_cli/test_profiles.py -q` — 125 passed

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run `pytest tests/hermes_cli/test_profiles.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.x (Darwin 24.6), Python 3.11.15

### Documentation & Housekeeping

- [x] Documentation — N/A (no user-facing behavior change)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] Cross-platform impact considered: the size guard wraps `stat()` in `except OSError` (broken symlinks); Windows `.bat` wrappers are 2 lines and unaffected
- [x] Tool descriptions/schemas — N/A
