### PR TITLE
fix(desktop): retry initial gateway WS connect during backend cold-start

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot-initial-connect.test.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot-initial-connect.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { GatewayReauthRequiredError } from '@/lib/gateway-ws-url'
+
+import { connectInitialGateway } from './use-gateway-boot'
+
+const never = () => false
+
+describe('connectInitialGateway (initial-boot retry)', () => {
+  it('retries past transient failures and resolves once a connect succeeds', async () => {
+    const connect = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error('1006'))
+      .mockRejectedValueOnce(new Error('1006'))
+      .mockResolvedValueOnce(undefined)
+
+    await expect(
+      connectInitialGateway({ connect, delayMs: 0, isCancelled: never })
+    ).resolves.toBeUndefined()
+    expect(connect).toHaveBeenCalledTimes(3)
+  })
+
+  it('throws the last error after exhausting all attempts', async () => {
+    const connect = vi.fn<() => Promise<void>>().mockRejectedValue(new Error('backend cold'))
+
+    await expect(
+      connectInitialGateway({ attempts: 3, connect, delayMs: 0, isCancelled: never })
+    ).rejects.toThrow('backend cold')
+    expect(connect).toHaveBeenCalledTimes(3)
+  })
+
+  it('fails fast on reauth errors without retrying', async () => {
+    const connect = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValue(new GatewayReauthRequiredError('sign in again'))
+
+    await expect(
+      connectInitialGateway({ connect, delayMs: 0, isCancelled: never })
+    ).rejects.toBeInstanceOf(GatewayReauthRequiredError)
+    expect(connect).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops retrying once cancelled (component unmounted)', async () => {
+    let cancelled = false
+    const connect = vi.fn<() => Promise<void>>().mockImplementation(() => {
+      cancelled = true
+
+      return Promise.reject(new Error('1006'))
+    })
+
+    await expect(
+      connectInitialGateway({ connect, delayMs: 0, isCancelled: () => cancelled })
+    ).rejects.toThrow('1006')
+    expect(connect).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -332,8 +332,34 @@ export function useGatewayBoot({
         // conn.wsUrl is stale; resolveGatewayWsUrl() re-mints it and, on
         // failure, throws a reauth error rather than connecting with a dead
         // ticket (which would surface as an opaque "connection closed").
-        const wsUrl = await resolveGatewayWsUrl(desktop, conn)
-        await gateway.connect(wsUrl)
+        // A freshly spawned backend can block its event loop for 15-30s while
+        // it connects MCP servers and discovers plugins, so a single connect
+        // attempt (15s client timeout) races backend cold-start and loses
+        // intermittently. Retry the initial connect a few times — re-minting
+        // the WS URL each attempt (OAuth tickets are single-use) — instead of
+        // failing the whole boot on the first 1006.
+        {
+          let lastConnectError: unknown = null
+
+          for (let attempt = 0; attempt < 8 && !cancelled; attempt += 1) {
+            try {
+              const wsUrl = await resolveGatewayWsUrl(desktop, conn)
+              await gateway.connect(wsUrl)
+              lastConnectError = null
+              break
+            } catch (err) {
+              if (isGatewayReauthRequired(err)) {
+                throw err
+              }
+              lastConnectError = err
+              await new Promise(resolve => setTimeout(resolve, 3_000))
+            }
+          }
+
+          if (lastConnectError) {
+            throw lastConnectError
+          }
+        }
 
         if (cancelled) {
           return

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -40,6 +40,45 @@ import {
 } from '@/store/session'
 import type { RpcEvent } from '@/types/hermes'
 
+// A freshly spawned backend can block its event loop for 15-30s while it
+// connects MCP servers and discovers plugins, so a single connect attempt
+// (15s client timeout) races backend cold-start and loses intermittently.
+// Retry the initial connect — re-invoking `connect` each attempt so callers
+// re-mint the WS URL (OAuth tickets are single-use) — instead of failing the
+// whole boot on the first 1006. Reauth errors propagate immediately: more
+// attempts with a dead ticket can never succeed. Exported for tests.
+export async function connectInitialGateway({
+  attempts = 8,
+  connect,
+  delayMs = 3_000,
+  isCancelled
+}: {
+  attempts?: number
+  connect: () => Promise<void>
+  delayMs?: number
+  isCancelled: () => boolean
+}): Promise<void> {
+  let lastConnectError: unknown = null
+
+  for (let attempt = 0; attempt < attempts && !isCancelled(); attempt += 1) {
+    try {
+      await connect()
+      lastConnectError = null
+      break
+    } catch (err) {
+      if (isGatewayReauthRequired(err)) {
+        throw err
+      }
+      lastConnectError = err
+      await new Promise(resolve => setTimeout(resolve, delayMs))
+    }
+  }
+
+  if (lastConnectError) {
+    throw lastConnectError
+  }
+}
+
 interface GatewayBootOptions {
   handleGatewayEvent: (event: RpcEvent) => void
   onConnectionReady: (
@@ -332,34 +371,13 @@ export function useGatewayBoot({
         // conn.wsUrl is stale; resolveGatewayWsUrl() re-mints it and, on
         // failure, throws a reauth error rather than connecting with a dead
         // ticket (which would surface as an opaque "connection closed").
-        // A freshly spawned backend can block its event loop for 15-30s while
-        // it connects MCP servers and discovers plugins, so a single connect
-        // attempt (15s client timeout) races backend cold-start and loses
-        // intermittently. Retry the initial connect a few times — re-minting
-        // the WS URL each attempt (OAuth tickets are single-use) — instead of
-        // failing the whole boot on the first 1006.
-        {
-          let lastConnectError: unknown = null
-
-          for (let attempt = 0; attempt < 8 && !cancelled; attempt += 1) {
-            try {
-              const wsUrl = await resolveGatewayWsUrl(desktop, conn)
-              await gateway.connect(wsUrl)
-              lastConnectError = null
-              break
-            } catch (err) {
-              if (isGatewayReauthRequired(err)) {
-                throw err
-              }
-              lastConnectError = err
-              await new Promise(resolve => setTimeout(resolve, 3_000))
-            }
-          }
-
-          if (lastConnectError) {
-            throw lastConnectError
-          }
-        }
+        await connectInitialGateway({
+          connect: async () => {
+            const wsUrl = await resolveGatewayWsUrl(desktop, conn)
+            await gateway.connect(wsUrl)
+          },
+          isCancelled: () => cancelled
+        })
 
         if (cancelled) {
           return


### PR DESCRIPTION
## What does this PR do?

The renderer's initial boot makes exactly one `gateway.connect()` attempt with the 15s client timeout. A freshly spawned backend can block its event loop for 15–30s while it connects MCP servers and discovers plugins, so the single attempt races backend cold-start and loses intermittently — surfacing as "Hermes couldn't start … Timed out connecting to Hermes backend after 60000ms" or a permanent CONNECTING screen, even though the backend becomes healthy seconds later. Server-side signature in the gateway log: `ws accepted` followed by `ws ready frame send failed`.

Fix: retry the initial connect up to 8 times, 3s apart, re-invoking the connect callback each attempt so the WS URL is re-minted (OAuth tickets are single-use). Reauth errors still fail fast — more attempts with a dead ticket can never succeed. The post-sleep reconnect machinery is untouched; this only covers the initial-boot window, which previously had no retry at all. On exhaustion the last error is thrown, so the existing `failDesktopBoot()`/`notifyError()` UX is preserved.

The retry is extracted into an exported `connectInitialGateway()` helper so it's unit-testable without the full boot harness.

Verified by repeated cold-start launches on a machine that reproduced the failure ~50% of the time: boot now completes in ~6s consistently.

## Related Issue

Companion issue on the underlying backend behavior (sync work blocking the event loop during startup) filed separately.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts`: initial `gateway.connect` wrapped in `connectInitialGateway()` (8 attempts, 3s apart, re-minted WS URL per attempt, reauth fast-fail, cancellation-aware)
- `apps/desktop/src/app/gateway/hooks/use-gateway-boot-initial-connect.test.ts`: 4 unit tests — retries past transient failures, throws last error after exhausting attempts, reauth fails without retry, stops retrying once cancelled

## How to Test

1. `npx vitest run src/app/gateway/hooks/use-gateway-boot-initial-connect.test.ts` in `apps/desktop` — 4 passed
2. `npx tsc --noEmit -p apps/desktop/tsconfig.json` — clean
3. Manual repro: configure an MCP server with a slow connect (or any backend whose startup blocks >15s), launch the desktop cold; before this change boot intermittently fails with the 60000ms error, after it the renderer connects on a later attempt

Note: the pre-existing tests in `use-gateway-boot.test.tsx` have 2 failures on current `main` unrelated to this change (verified identical on the parent commit).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.x (Darwin 24.6)

### Documentation & Housekeeping

- [x] Documentation — N/A (no user-facing behavior change beyond fixing the failure)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (renderer TypeScript only)
- [x] Tool descriptions/schemas — N/A
