### PR TITLE
feat(agent): make MINIMUM_CONTEXT_LENGTH configurable via HERMES_MIN_CONTEXT_LENGTH

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -129,8 +129,15 @@ DEFAULT_FALLBACK_CONTEXT = CONTEXT_PROBE_TIERS[0]
 
 # Minimum context length required to run Hermes Agent.  Models with fewer
 # tokens cannot maintain enough working memory for tool-calling workflows.
-# Sessions, model switches, and cron jobs should reject models below this.
-MINIMUM_CONTEXT_LENGTH = 64_000
+# Configurable via HERMES_MIN_CONTEXT_LENGTH so operators on small local GPU
+# slots (where effective ctx = -c / --parallel can fall below 64k) can lower
+# the floor instead of being hard-rejected at init.  Default unchanged.
+MINIMUM_CONTEXT_LENGTH = int(os.environ.get("HERMES_MIN_CONTEXT_LENGTH", "64000"))
+if MINIMUM_CONTEXT_LENGTH <= 0:
+    raise ValueError(
+        "HERMES_MIN_CONTEXT_LENGTH must be a positive integer, got "
+        f"{MINIMUM_CONTEXT_LENGTH!r}"
+    )
 
 # Thin fallback defaults — only broad model family patterns.
 # These fire only when provider is unknown AND models.dev/OpenRouter/Anthropic


### PR DESCRIPTION
## Problem

`agent/agent_init.py` hard-rejects any model whose context window is below `MINIMUM_CONTEXT_LENGTH = 64_000`:

```
Model X has a context window of 40,000 tokens, which is below the minimum
64,000 required by Hermes Agent. ... or set model.context_length in config.yaml to override.
```

But the advertised override does not work: an explicit `model.context_length` below 64K is still rejected (the same constant is also the `context_compressor` floor). So there is **no** real escape hatch.

## Who this hurts

Operators running local GGUF backends (llama.cpp / llama-swap / ik_llama) where the **effective per-request context = `-c / --parallel`**. A 256K model split into 6 slots is a 43K slot; that is a perfectly usable agent context, but it is hard-rejected at init, bricking the whole deployment.

## Change

Read the floor from `HERMES_MIN_CONTEXT_LENGTH` (default `64000` — **behaviour unchanged** for everyone who doesn't set it). One line, backward-compatible. Lets small-slot operators lower the floor to match their real slot size.

## Test

Local llama-swap fleet (35B/9B/4B split across two GPUs, slots 8-43K). Before: every cell dies at init with the 64K refusal. After (`HERMES_MIN_CONTEXT_LENGTH=8000`): 35B and 9B cells initialize and complete tool-calling turns normally.