### PR TITLE
fix(gateway): honor nested DingTalk allowed_users config in gateway auth

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1209,6 +1209,20 @@ def load_gateway_config() -> GatewayConfig:
                         ac = ",".join(str(v) for v in ac)
                     os.environ["DINGTALK_ALLOWED_CHATS"] = str(ac)
                 allowed = dingtalk_cfg.get("allowed_users")
+                if allowed is None:
+                    # Fall back to the documented nested path
+                    # (gateway.platforms.dingtalk.extra.allowed_users, see
+                    # website/docs/user-guide/messaging/dingtalk.md). The
+                    # adapter reads the allowlist from PlatformConfig.extra,
+                    # but _is_user_authorized() in gateway/authz_mixin.py only
+                    # consults DINGTALK_ALLOWED_USERS — without this bridge a
+                    # nested-only allowlist passes the adapter and is then
+                    # denied at the gateway. platforms_data already merged
+                    # gateway.platforms and top-level platforms blocks.
+                    _dt_plat = platforms_data.get(Platform.DINGTALK.value)
+                    _dt_extra = _dt_plat.get("extra") if isinstance(_dt_plat, dict) else None
+                    if isinstance(_dt_extra, dict):
+                        allowed = _dt_extra.get("allowed_users")
                 if allowed is not None and not os.getenv("DINGTALK_ALLOWED_USERS"):
                     if isinstance(allowed, list):
                         allowed = ",".join(str(v) for v in allowed)

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -479,6 +479,164 @@ class TestLoadGatewayConfig:
         ]
         assert os.environ.get("DISCORD_ALLOWED_USERS") == "123456789012345678"
 
+    def test_bridges_nested_gateway_platforms_dingtalk_allowed_users_to_env(self, tmp_path, monkeypatch):
+        """gateway.platforms.dingtalk.extra.allowed_users must reach
+        DINGTALK_ALLOWED_USERS — it's the documented config.yaml alternative
+        to the env var (website/docs/user-guide/messaging/dingtalk.md), the
+        adapter reads it from PlatformConfig.extra, but gateway auth
+        (_is_user_authorized) only consults the env var.
+        """
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "gateway:\n"
+            "  platforms:\n"
+            "    dingtalk:\n"
+            "      enabled: true\n"
+            "      extra:\n"
+            "        allowed_users:\n"
+            "          - user-id-1\n"
+            "          - user-id-2\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("DINGTALK_ALLOWED_USERS", raising=False)
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.DINGTALK].extra["allowed_users"] == [
+            "user-id-1",
+            "user-id-2",
+        ]
+        assert os.environ.get("DINGTALK_ALLOWED_USERS") == "user-id-1,user-id-2"
+
+    def test_bridges_platforms_dingtalk_extra_allowed_users_to_env(self, tmp_path, monkeypatch):
+        """platforms.dingtalk.extra.allowed_users should reach DINGTALK_ALLOWED_USERS too."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "platforms:\n"
+            "  dingtalk:\n"
+            "    extra:\n"
+            "      allowed_users:\n"
+            "        - manager1234\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("DINGTALK_ALLOWED_USERS", raising=False)
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.DINGTALK].extra["allowed_users"] == [
+            "manager1234",
+        ]
+        assert os.environ.get("DINGTALK_ALLOWED_USERS") == "manager1234"
+
+    def test_dingtalk_allowed_users_env_takes_precedence_over_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "gateway:\n"
+            "  platforms:\n"
+            "    dingtalk:\n"
+            "      extra:\n"
+            "        allowed_users:\n"
+            "          - config-user\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("DINGTALK_ALLOWED_USERS", "env-user")
+
+        load_gateway_config()
+
+        assert os.environ.get("DINGTALK_ALLOWED_USERS") == "env-user"
+
+    def test_top_level_dingtalk_allowed_users_wins_over_nested_extra(self, tmp_path, monkeypatch):
+        """The legacy top-level dingtalk: block keeps precedence over the
+        nested platform extra when both define an allowlist."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "dingtalk:\n"
+            "  allowed_users:\n"
+            "    - top-level-user\n"
+            "gateway:\n"
+            "  platforms:\n"
+            "    dingtalk:\n"
+            "      extra:\n"
+            "        allowed_users:\n"
+            "          - nested-user\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("DINGTALK_ALLOWED_USERS", raising=False)
+
+        load_gateway_config()
+
+        assert os.environ.get("DINGTALK_ALLOWED_USERS") == "top-level-user"
+
+    def test_nested_dingtalk_allowlist_authorizes_listed_user_only(self, tmp_path, monkeypatch):
+        """E2E for the documented setup: a nested-only allowlist must
+        authorize the listed user at the gateway and still deny others.
+
+        Before the bridge existed, the listed user passed the adapter's
+        _is_user_allowed() but _is_user_authorized() fell through to
+        default-deny because DINGTALK_ALLOWED_USERS was never populated.
+        """
+        from types import SimpleNamespace
+
+        from gateway.run import GatewayRunner
+        from gateway.session import SessionSource
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "gateway:\n"
+            "  platforms:\n"
+            "    dingtalk:\n"
+            "      enabled: true\n"
+            "      extra:\n"
+            "        allowed_users:\n"
+            "          - user-id-1\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        for var in (
+            "DINGTALK_ALLOWED_USERS",
+            "DINGTALK_ALLOW_ALL_USERS",
+            "GATEWAY_ALLOWED_USERS",
+            "GATEWAY_ALLOW_ALL_USERS",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+        config = load_gateway_config()
+
+        runner = object.__new__(GatewayRunner)
+        runner.pairing_store = SimpleNamespace(is_approved=lambda *_a, **_kw: False)
+        runner.config = config
+
+        def _dm_source(user_id):
+            return SessionSource(
+                platform=Platform.DINGTALK,
+                chat_id="dm-1",
+                chat_type="dm",
+                user_id=user_id,
+                user_name="someone",
+            )
+
+        assert runner._is_user_authorized(_dm_source("user-id-1")) is True
+        assert runner._is_user_authorized(_dm_source("intruder")) is False
+
     def test_bridges_quoted_false_platform_enabled_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/website/docs/user-guide/messaging/dingtalk.md
+++ b/website/docs/user-guide/messaging/dingtalk.md
@@ -154,7 +154,7 @@ gateway:
 
 - `group_sessions_per_user: true` keeps each participant's context isolated inside shared group chats
 - `require_mention: true` prevents the bot from responding to every group message — it only answers when someone @-mentions it
-- `allowed_users` under `dingtalk.extra` is an alternative to `DINGTALK_ALLOWED_USERS`; if both are set, they're merged
+- `allowed_users` under `dingtalk.extra` is an alternative to `DINGTALK_ALLOWED_USERS`; set one or the other (if both are set, only users present in both lists are authorized)
 
 ### Start the Gateway
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/dingtalk.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/dingtalk.md
@@ -154,7 +154,7 @@ gateway:
 
 - `group_sessions_per_user: true` 在共享群聊中保持每个参与者的上下文隔离
 - `require_mention: true` 防止机器人响应每条群消息——仅在有人 @提及 时才回答
-- `dingtalk.extra` 下的 `allowed_users` 是 `DINGTALK_ALLOWED_USERS` 的替代方式；若两者同时设置，则合并生效
+- `dingtalk.extra` 下的 `allowed_users` 是 `DINGTALK_ALLOWED_USERS` 的替代方式；两者择一配置（若同时设置，只有同时出现在两个列表中的用户才会被授权）
 
 ### 启动 Gateway
 


### PR DESCRIPTION
## What does this PR do?

The DingTalk docs offer `gateway.platforms.dingtalk.extra.allowed_users` as the config.yaml
alternative to `DINGTALK_ALLOWED_USERS`. The adapter honors it (`_load_allowed_users()` reads
`PlatformConfig.extra`), but gateway authorization (`_is_user_authorized()` in
`gateway/authz_mixin.py`) only consults the env var, and `load_gateway_config()` bridged the
allowlist to the env var only from a top-level `dingtalk:` block. A nested-only allowlist
therefore passed the adapter and was then denied at the gateway — listed users fell through
to pairing/default-deny in DMs.

This extends the DingTalk YAML→env bridge to fall back to the merged nested platform config
(`gateway.platforms` / `platforms`), mirroring the existing `platforms.discord.extra.allow_from`
bridge. Precedence is unchanged: explicit `DINGTALK_ALLOWED_USERS` env var > top-level
`dingtalk:` block > nested extra.

Access-control note: this makes the documented allowlist effective; default-deny for unlisted
users is preserved and covered by a test.

## Related Issue

No existing issue — found by verifying the documented config path against the gateway auth
code. Searched open issues/PRs for duplicates; none found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/config.py` — DingTalk env bridge falls back to `extra.allowed_users` from the
  merged nested platform config when the top-level block doesn't set it and the env var is unset
- `tests/gateway/test_config.py` — 5 regression tests (bridge for both nested paths, env-var
  precedence, top-level block precedence, and an e2e auth test)
- `website/docs/user-guide/messaging/dingtalk.md` (+ zh-Hans counterpart) — corrected the
  "if both are set, they're merged" claim (merge semantics never existed in code); docs now
  recommend configuring one or the other

## How to Test

1. In `~/.hermes/config.yaml` set only the nested allowlist (no `DINGTALK_ALLOWED_USERS` in `.env`):

   ```yaml
   gateway:
     platforms:
       dingtalk:
         enabled: true
         extra:
           allowed_users:
             - user-id-1
   ```

2. Before this fix: `load_gateway_config()` left `DINGTALK_ALLOWED_USERS` unset, so the
   adapter's `_is_user_allowed("user-id-1")` returned `True` while the gateway's
   `_is_user_authorized()` returned `False` (DM fell into pairing/default-deny).
   After: the listed user is authorized end to end; unlisted users are still denied.

3. Run the tests:

   ```bash
   pytest tests/gateway/test_config.py tests/gateway/test_dingtalk.py \
     tests/gateway/test_allowlist_startup_check.py \
     tests/gateway/test_unauthorized_dm_behavior.py \
     tests/gateway/test_config_driven_access_policy.py -q
   ```

**Test results:**

- New regression tests in `tests/gateway/test_config.py`:
  - `test_bridges_nested_gateway_platforms_dingtalk_allowed_users_to_env`
  - `test_bridges_platforms_dingtalk_extra_allowed_users_to_env`
  - `test_dingtalk_allowed_users_env_takes_precedence_over_config_yaml`
  - `test_top_level_dingtalk_allowed_users_wins_over_nested_extra`
  - `test_nested_dingtalk_allowlist_authorizes_listed_user_only` (e2e: real
    `GatewayRunner._is_user_authorized`; listed user passes, unlisted user denied)
- Command above: **200 passed**
- Full `tests/gateway/` via `scripts/run_tests_parallel.py`: failure set identical to a clean
  `main` baseline run — **no new failures introduced**

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the test suite (`tests/gateway/` in full plus all auth/config suites) — no new failures vs a clean `main` baseline
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure config parsing, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Repro script output (documented nested-only config, no env var):

```text
Before fix:
  config.extra.allowed_users : ['user-id-1']
  env DINGTALK_ALLOWED_USERS : None
  adapter _is_user_allowed('user-id-1')   : True
  gateway _is_user_authorized('user-id-1'): False   <-- listed user denied

After fix:
  config.extra.allowed_users : ['user-id-1']
  env DINGTALK_ALLOWED_USERS : user-id-1
  adapter _is_user_allowed('user-id-1')   : True
  gateway _is_user_authorized('user-id-1'): True
```