### PR TITLE
fix(dingtalk): merge config and env allowed_users as documented

### DIFF
--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -455,19 +455,28 @@ class DingTalkAdapter(BasePlatformAdapter):
         return compiled
 
     def _load_allowed_users(self) -> Set[str]:
-        """Load allowed-users list from config.extra or env var.
+        """Load allowed-users list from config.extra and env var.
 
-        IDs are matched case-insensitively against the sender's ``staff_id`` and
-        ``sender_id``. A wildcard ``*`` disables the check.
+        ``allowed_users`` in config.extra and ``DINGTALK_ALLOWED_USERS`` are
+        merged when both are set — the documented contract — so neither source
+        silently drops the other's entries. IDs are matched case-insensitively
+        against the sender's ``staff_id`` and ``sender_id``. A wildcard ``*``
+        in either source disables the check.
         """
-        raw = self.config.extra.get("allowed_users") if self.config.extra else None
-        if raw is None:
-            raw = os.getenv("DINGTALK_ALLOWED_USERS", "")
-        if isinstance(raw, list):
-            items = [str(part).strip() for part in raw if str(part).strip()]
-        else:
-            items = [part.strip() for part in str(raw).split(",") if part.strip()]
-        return {item.lower() for item in items}
+        allowed: Set[str] = set()
+        sources = (
+            self.config.extra.get("allowed_users") if self.config.extra else None,
+            os.getenv("DINGTALK_ALLOWED_USERS", ""),
+        )
+        for raw in sources:
+            if raw is None:
+                continue
+            if isinstance(raw, list):
+                items = [str(part).strip() for part in raw if str(part).strip()]
+            else:
+                items = [part.strip() for part in str(raw).split(",") if part.strip()]
+            allowed.update(item.lower() for item in items)
+        return allowed
 
     def _is_user_allowed(self, sender_id: str, sender_staff_id: str) -> bool:
         if not self._allowed_users or "*" in self._allowed_users:

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -682,6 +682,47 @@ class TestAllowedUsersGate:
         assert adapter._is_user_allowed("alice", "") is True
         assert adapter._is_user_allowed("dave", "") is False
 
+    def test_config_and_env_allowlists_are_merged(self, monkeypatch):
+        """Documented contract: when both extra.allowed_users and
+        DINGTALK_ALLOWED_USERS are set, the union is enforced — config must
+        not silently drop the env entries."""
+        adapter = _make_gating_adapter(
+            monkeypatch,
+            extra={"allowed_users": ["alice"]},
+            env={"DINGTALK_ALLOWED_USERS": "bob"},
+        )
+        assert adapter._allowed_users == {"alice", "bob"}
+        assert adapter._is_user_allowed("alice", "") is True
+        assert adapter._is_user_allowed("bob", "") is True
+        assert adapter._is_user_allowed("mallory", "") is False
+
+    def test_merged_allowlist_dedupes_case_insensitively(self, monkeypatch):
+        adapter = _make_gating_adapter(
+            monkeypatch,
+            extra={"allowed_users": ["Alice", "carol"]},
+            env={"DINGTALK_ALLOWED_USERS": "alice,BOB"},
+        )
+        assert adapter._allowed_users == {"alice", "bob", "carol"}
+
+    def test_env_wildcard_disables_check_alongside_config_list(self, monkeypatch):
+        adapter = _make_gating_adapter(
+            monkeypatch,
+            extra={"allowed_users": ["alice"]},
+            env={"DINGTALK_ALLOWED_USERS": "*"},
+        )
+        assert adapter._is_user_allowed("anyone", "any-staff") is True
+
+    def test_empty_config_list_does_not_mask_env_allowlist(self, monkeypatch):
+        """An explicit empty extra.allowed_users used to discard the env
+        allowlist entirely, silently allowing everyone."""
+        adapter = _make_gating_adapter(
+            monkeypatch,
+            extra={"allowed_users": []},
+            env={"DINGTALK_ALLOWED_USERS": "alice"},
+        )
+        assert adapter._is_user_allowed("alice", "") is True
+        assert adapter._is_user_allowed("dave", "") is False
+
 
 class TestMentionPatterns:
 


### PR DESCRIPTION
## What does this PR do?

Fixes the DingTalk allowlist so `allowed_users` under `gateway.platforms.dingtalk.extra` and `DINGTALK_ALLOWED_USERS` are **merged**, as documented ("if both are set, they're merged" — `website/docs/user-guide/messaging/dingtalk.md`). Previously `_load_allowed_users()` treated the config key as an override: when it was present, the env var was never read.

With both sources set, env-listed users were silently dropped at adapter intake even though gateway-level authorization (`gateway/authz_mixin.py`) independently honors the env var — so neither source's users could get all the way through. An explicit empty `allowed_users: []` in config was worse: it discarded the env allowlist entirely at the adapter gate.

The fix reads both sources and enforces the union, preserving each source's parsing (YAML list or comma-separated string), case-insensitive matching, and `*` wildcard semantics. Config-only and env-only behavior is unchanged.

Security note: the union can only widen the adapter gate to IDs the operator explicitly listed in their own env var, which gateway-level authorization already honors independently.

## Related Issue

No existing issue — contradiction between the documented contract and the code, found while auditing the adapter's allowlist handling.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/dingtalk.py` — `_load_allowed_users()` now merges `config.extra["allowed_users"]` with `DINGTALK_ALLOWED_USERS` instead of letting the config key shadow the env var
- `tests/gateway/test_dingtalk.py` — 4 new regression tests in `TestAllowedUsersGate`

## How to Test

1. Set `gateway.platforms.dingtalk.extra.allowed_users: [alice]` in `config.yaml` and `DINGTALK_ALLOWED_USERS=bob` in `.env`, then start the gateway. Before: only `alice` passes the adapter gate (`bob` is silently dropped). After: both users are allowed, matching the docs.
2. Run the adapter tests: `scripts/run_tests.sh tests/gateway/test_dingtalk.py`

Test results:

- `tests/gateway/test_dingtalk.py`: **72 passed** — includes the 4 new tests (config+env union, case-insensitive dedupe across sources, env wildcard alongside a config list, empty config list no longer masking the env allowlist). All 4 new tests fail on the previous implementation.
- Neighboring allowlist suites (`test_unauthorized_dm_behavior.py`, `test_allowlist_startup_check.py`): **37 passed**
- Full `tests/gateway/` run: **no new failures** vs. base.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform

### Documentation & Housekeeping

- [x] Documentation already describes the merged behavior — the code now matches it, no doc change needed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure-Python set union)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A