### PR TITLE
fix(gateway): honor config-backed DingTalk credentials during adapter creation

### DIFF
--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -7,7 +7,8 @@ Supports: text, images, audio, video, rich text, files, and group @mentions.
 
 Requires:
     pip install "dingtalk-stream>=0.20" httpx
-    DINGTALK_CLIENT_ID and DINGTALK_CLIENT_SECRET env vars
+    Credentials: DINGTALK_CLIENT_ID and DINGTALK_CLIENT_SECRET env vars,
+    or client_id/client_secret under the platform's ``extra`` config (below)
 
 Configuration in config.yaml:
     platforms:
@@ -110,8 +111,13 @@ DINGTALK_TYPE_MAPPING = {
 }
 
 
-def check_dingtalk_requirements() -> bool:
+def check_dingtalk_requirements(config: Optional[PlatformConfig] = None) -> bool:
     """Check if DingTalk dependencies are available and configured.
+
+    Credentials may come from ``config.extra`` (``client_id``/``client_secret``)
+    or the ``DINGTALK_CLIENT_ID``/``DINGTALK_CLIENT_SECRET`` env vars — the same
+    resolution order as ``DingTalkAdapter.__init__`` and the connected-platform
+    checker in ``gateway.config``.
 
     Lazy-installs dingtalk-stream via ``tools.lazy_deps.ensure("platform.dingtalk")``
     on first call if not present.
@@ -138,7 +144,10 @@ def check_dingtalk_requirements() -> bool:
         httpx = _httpx
         DINGTALK_STREAM_AVAILABLE = True
         HTTPX_AVAILABLE = True
-    if not os.getenv("DINGTALK_CLIENT_ID") or not os.getenv("DINGTALK_CLIENT_SECRET"):
+    extra = getattr(config, "extra", None) or {}
+    client_id = extra.get("client_id") or os.getenv("DINGTALK_CLIENT_ID")
+    client_secret = extra.get("client_secret") or os.getenv("DINGTALK_CLIENT_SECRET")
+    if not client_id or not client_secret:
         return False
     return True
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6232,8 +6232,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         elif platform == Platform.DINGTALK:
             from gateway.platforms.dingtalk import DingTalkAdapter, check_dingtalk_requirements
-            if not check_dingtalk_requirements():
-                logger.warning("DingTalk: dingtalk-stream not installed or DINGTALK_CLIENT_ID/SECRET not set")
+            if not check_dingtalk_requirements(config):
+                logger.warning(
+                    "DingTalk: dingtalk-stream not installed or client_id/client_secret "
+                    "not configured (config extra or DINGTALK_CLIENT_ID/SECRET env vars)"
+                )
                 return None
             return DingTalkAdapter(config)
 

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -119,6 +119,62 @@ class TestDingTalkRequirements:
         from gateway.platforms.dingtalk import check_dingtalk_requirements
         assert check_dingtalk_requirements() is True
 
+    def test_returns_true_with_config_credentials(self, monkeypatch):
+        """config.yaml extra credentials must satisfy the gate without env vars.
+
+        Regression test: the runner used to reject config-backed DingTalk
+        credentials that GatewayConfig already recognised as connected and
+        DingTalkAdapter.__init__ already accepted.
+        """
+        monkeypatch.setattr(
+            "gateway.platforms.dingtalk.DINGTALK_STREAM_AVAILABLE", True
+        )
+        monkeypatch.setattr("gateway.platforms.dingtalk.HTTPX_AVAILABLE", True)
+        monkeypatch.delenv("DINGTALK_CLIENT_ID", raising=False)
+        monkeypatch.delenv("DINGTALK_CLIENT_SECRET", raising=False)
+        from gateway.platforms.dingtalk import check_dingtalk_requirements
+        config = PlatformConfig(
+            enabled=True,
+            extra={"client_id": "cfg-id", "client_secret": "cfg-secret"},
+        )
+        assert check_dingtalk_requirements(config) is True
+
+    def test_returns_false_when_config_lacks_credentials(self, monkeypatch):
+        monkeypatch.setattr(
+            "gateway.platforms.dingtalk.DINGTALK_STREAM_AVAILABLE", True
+        )
+        monkeypatch.setattr("gateway.platforms.dingtalk.HTTPX_AVAILABLE", True)
+        monkeypatch.delenv("DINGTALK_CLIENT_ID", raising=False)
+        monkeypatch.delenv("DINGTALK_CLIENT_SECRET", raising=False)
+        from gateway.platforms.dingtalk import check_dingtalk_requirements
+        assert check_dingtalk_requirements(PlatformConfig(enabled=True)) is False
+
+    def test_mixed_config_and_env_credentials(self, monkeypatch):
+        """Each credential resolves independently (extra first, then env),
+        mirroring DingTalkAdapter.__init__."""
+        monkeypatch.setattr(
+            "gateway.platforms.dingtalk.DINGTALK_STREAM_AVAILABLE", True
+        )
+        monkeypatch.setattr("gateway.platforms.dingtalk.HTTPX_AVAILABLE", True)
+        monkeypatch.delenv("DINGTALK_CLIENT_ID", raising=False)
+        monkeypatch.setenv("DINGTALK_CLIENT_SECRET", "env-secret")
+        from gateway.platforms.dingtalk import check_dingtalk_requirements
+        config = PlatformConfig(enabled=True, extra={"client_id": "cfg-id"})
+        assert check_dingtalk_requirements(config) is True
+
+    def test_config_credentials_do_not_bypass_dependency_check(self, monkeypatch):
+        with patch.dict("sys.modules", {"dingtalk_stream": None}), \
+             patch("tools.lazy_deps.ensure", side_effect=ImportError("dingtalk_stream unavailable")):
+            monkeypatch.setattr(
+                "gateway.platforms.dingtalk.DINGTALK_STREAM_AVAILABLE", False
+            )
+            from gateway.platforms.dingtalk import check_dingtalk_requirements
+            config = PlatformConfig(
+                enabled=True,
+                extra={"client_id": "cfg-id", "client_secret": "cfg-secret"},
+            )
+            assert check_dingtalk_requirements(config) is False
+
 
 # ---------------------------------------------------------------------------
 # Adapter construction
@@ -146,6 +202,53 @@ class TestDingTalkAdapterInit:
         adapter = DingTalkAdapter(config)
         assert adapter._client_id == "env-id"
         assert adapter._client_secret == "env-secret"
+
+
+# ---------------------------------------------------------------------------
+# Runner integration — _create_adapter preflight
+# ---------------------------------------------------------------------------
+
+
+class TestRunnerCreateAdapter:
+    """The runner's DingTalk preflight must accept the same credential
+    sources the adapter and GatewayConfig connected-checker accept."""
+
+    def _create_dingtalk_adapter(self, config):
+        from gateway.config import GatewayConfig
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(platforms={Platform.DINGTALK: config})
+        return runner._create_adapter(Platform.DINGTALK, config)
+
+    def test_config_only_credentials_create_adapter(self, monkeypatch):
+        """config.yaml-only credentials must produce a working adapter —
+        previously the env-only preflight returned None here even though
+        GatewayConfig reported the platform as connected."""
+        monkeypatch.delenv("DINGTALK_CLIENT_ID", raising=False)
+        monkeypatch.delenv("DINGTALK_CLIENT_SECRET", raising=False)
+        monkeypatch.setattr(
+            "gateway.platforms.dingtalk.DINGTALK_STREAM_AVAILABLE", True
+        )
+        monkeypatch.setattr("gateway.platforms.dingtalk.HTTPX_AVAILABLE", True)
+        config = PlatformConfig(
+            enabled=True,
+            extra={"client_id": "cfg-id", "client_secret": "cfg-secret"},
+        )
+        adapter = self._create_dingtalk_adapter(config)
+        assert adapter is not None
+        assert adapter._client_id == "cfg-id"
+        assert adapter._client_secret == "cfg-secret"
+
+    def test_missing_credentials_still_blocked(self, monkeypatch):
+        monkeypatch.delenv("DINGTALK_CLIENT_ID", raising=False)
+        monkeypatch.delenv("DINGTALK_CLIENT_SECRET", raising=False)
+        monkeypatch.setattr(
+            "gateway.platforms.dingtalk.DINGTALK_STREAM_AVAILABLE", True
+        )
+        monkeypatch.setattr("gateway.platforms.dingtalk.HTTPX_AVAILABLE", True)
+        adapter = self._create_dingtalk_adapter(PlatformConfig(enabled=True))
+        assert adapter is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes a gateway startup bug: DingTalk never starts when credentials are provided via `config.yaml` instead of env vars.

`check_dingtalk_requirements()` only checked the `DINGTALK_CLIENT_ID`/`DINGTALK_CLIENT_SECRET` env vars, while the rest of the integration already treats `platforms.dingtalk.extra.client_id`/`client_secret` as first-class: `DingTalkAdapter.__init__` resolves `config.extra` first, `GatewayConfig` reports such a platform as connected (`tests/gateway/test_config.py::test_dingtalk_recognised_via_extras`), and the adapter docstring documents the `extra:` form. Result: the platform was reported connected, but `_create_adapter()` returned `None` with a misleading warning and DingTalk never started.

The preflight now accepts an optional `PlatformConfig` and resolves each credential from `config.extra` first, then the env var — the same order as the adapter and the connected-platform checker. The dependency check (lazy install of dingtalk-stream/httpx) is unchanged, and calling the function without a config behaves exactly as before.

## Related Issue

No existing issue; searched open PRs for DingTalk credential/config handling — not a duplicate.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/dingtalk.py` — `check_dingtalk_requirements(config=None)` accepts config-backed credentials; docstrings updated
- `gateway/run.py` — `_create_adapter()` passes the platform config to the preflight; warning now names both credential sources
- `tests/gateway/test_dingtalk.py` — 6 new tests covering the requirements gate and the runner path

## How to Test

1. Unset `DINGTALK_CLIENT_ID` / `DINGTALK_CLIENT_SECRET`
2. `config = PlatformConfig(enabled=True, extra={"client_id": "cid", "client_secret": "sec"})`
3. `GatewayRunner._create_adapter(Platform.DINGTALK, config)` — before: `None` + warning; after: a `DingTalkAdapter` carrying the config credentials

Or run the tests: `scripts/run_tests.sh tests/gateway/test_dingtalk.py tests/gateway/test_config.py`

New tests:
- config-only credentials pass the requirements gate (regression test for this bug)
- missing credentials still fail, with and without a config object
- mixed sources (config `client_id` + env `client_secret`) accepted — mirrors adapter resolution
- config credentials cannot bypass the dependency check
- runner-level `_create_adapter()`: config-only credentials → adapter created; no credentials → `None`

Test results:
- `tests/gateway/test_dingtalk.py`: **74 passed** (68 existing + 6 new)
- `tests/gateway/test_config.py`: **62 passed**
- Full `tests/gateway/` run compared file-by-file against a clean `main` baseline: **no new failures introduced by this change**

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(gateway): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (single focused commit)
- [x] I've run the test suite — all DingTalk/gateway tests pass with no regressions against `main`
- [x] I've added tests for my changes

### Documentation & Housekeeping

- [x] Docstrings updated in `gateway/platforms/dingtalk.py` — no user-facing docs affected
- [x] No new/changed config keys — N/A
- [x] No architecture or workflow changes — N/A
- [x] Cross-platform impact considered — change is pure config/env resolution, platform-independent
- [x] No tool behavior changes — N/A