### PR TITLE
fix(auxiliary): use empty default for OpenRouter auxiliary model (#44894)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -483,7 +483,7 @@ NOUS_EXTRA_BODY = _nous_extra_body()
 auxiliary_is_nous: bool = False
 
 # Default auxiliary models per provider
-_OPENROUTER_MODEL = "google/gemini-3-flash-preview"
+_OPENROUTER_MODEL = ""
 _NOUS_MODEL = "google/gemini-3-flash-preview"
 _NOUS_DEFAULT_BASE_URL = "https://inference-api.nousresearch.com/v1"
 _ANTHROPIC_DEFAULT_BASE_URL = "https://api.anthropic.com"


### PR DESCRIPTION
## What does this PR do?

fix(auxiliary): use empty default for OpenRouter auxiliary model (#44894).

## Related Issue

Closes #44894

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

See commit for details.

## How to Test

1. Reproduce the symptom described in #44894
2. Apply the fix
3. Verify symptom is resolved