### PR TITLE
fix(config): only call _secure_file when original permissions were not preserved

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5702,13 +5702,14 @@ def save_env_value(key: str, value: str):
                 os.chmod(env_path, original_mode)
             except OSError:
                 pass
+        else:
+            _secure_file(env_path)
     except BaseException:
         try:
             os.unlink(tmp_path)
         except OSError:
             pass
         raise
-    _secure_file(env_path)
 
     os.environ[key] = value
     invalidate_env_cache()
@@ -5758,13 +5759,14 @@ def remove_env_value(key: str) -> bool:
                     os.chmod(env_path, original_mode)
                 except OSError:
                     pass
+            else:
+                _secure_file(env_path)
         except BaseException:
             try:
                 os.unlink(tmp_path)
             except OSError:
                 pass
             raise
-        _secure_file(env_path)
 
     os.environ.pop(key, None)
     invalidate_env_cache()


### PR DESCRIPTION
## Problem

In `save_env_value` and `remove_env_value`, `_secure_file()` was called unconditionally after `os.chmod()` restored original file permissions. This defeats the permission preservation intended for Docker volume mounts and other non-standard file modes.

### The Bug Pattern



### The Fix

Move `_secure_file` into the `else` branch so it only tightens permissions on new files (where no original mode exists), not when the original mode was successfully restored.



## Files Changed

- `hermes_cli/config.py` — `save_env_value()` and `remove_env_value()`

## Impact

- Fixes the `_secure_file` permission bug pattern documented in `references/secure-file-perm-undo-pattern.md`
- Preserves Docker volume mount permissions (e.g., non-0600 .env files)
- No functional change for the common case (new files still get 0600)