### PR TITLE
fix: preserve configured context length on model changes

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1433,10 +1433,27 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
     _snapshot["_client_kwargs"] = dict(getattr(agent, "_client_kwargs", {}) or {})
 
     try:
-        # Clear the per-config context_length override so the new model's
-        # actual context window is resolved via get_model_context_length()
-        # instead of inheriting the stale value from the previous model.
-        agent._config_context_length = None
+        # Re-read the active global context_length override.  A live model
+        # switch must not blindly inherit a stale per-model value from the
+        # previous agent, but it also must not drop an explicit
+        # ``model.context_length`` cap that is still present in config.yaml.
+        # Without this, switching from one GPT-5.x model to another resets the
+        # compressor to the model's native context window instead of the user's
+        # configured cap.
+        _config_context_length = None
+        try:
+            from hermes_cli.config import load_config
+
+            _ctx_cfg = load_config()
+            _model_cfg = _ctx_cfg.get("model", {}) if isinstance(_ctx_cfg, dict) else {}
+            _raw_ctx = _model_cfg.get("context_length") if isinstance(_model_cfg, dict) else None
+            if _raw_ctx is not None:
+                _parsed_ctx = int(_raw_ctx)
+                if _parsed_ctx > 0:
+                    _config_context_length = _parsed_ctx
+        except Exception:
+            _config_context_length = None
+        agent._config_context_length = _config_context_length
 
         # ── Swap core runtime fields ──
         agent.model = new_model

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3440,9 +3440,13 @@ def _denormalize_config_from_web(config: Dict[str, Any]) -> Dict[str, Any]:
     # with the stripped GET response, but be defensive)
     config.pop("_model_meta", None)
 
-    # Extract and remove model_context_length before processing model
+    # Extract and remove model_context_length before processing model.  Absence
+    # means "older/partial client did not send this virtual field" and should
+    # preserve the on-disk model.context_length.  An explicit 0 means the user
+    # chose auto-detect and should clear the override.
+    ctx_override_present = "model_context_length" in config
     ctx_override = config.pop("model_context_length", 0)
-    if not isinstance(ctx_override, int):
+    if ctx_override_present and not isinstance(ctx_override, int):
         try:
             ctx_override = int(ctx_override)
         except (TypeError, ValueError):
@@ -3457,11 +3461,15 @@ def _denormalize_config_from_web(config: Dict[str, Any]) -> Dict[str, Any]:
             if isinstance(disk_model, dict):
                 # Preserve all subkeys, update default with the new value
                 disk_model["default"] = model_val
-                # Write context_length into the model dict (0 = remove/auto)
-                if ctx_override > 0:
-                    disk_model["context_length"] = ctx_override
-                else:
-                    disk_model.pop("context_length", None)
+                # Write context_length into the model dict when the web payload
+                # explicitly includes the virtual field.  If it is absent,
+                # preserve the existing disk value; otherwise stale/cached
+                # clients can erase the user's configured cap.
+                if ctx_override_present:
+                    if ctx_override > 0:
+                        disk_model["context_length"] = ctx_override
+                    else:
+                        disk_model.pop("context_length", None)
                 config["model"] = disk_model
             # Model was previously a bare string — upgrade to dict if
             # user is setting a context_length override

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1032,6 +1032,36 @@ class TestWebServerEndpoints:
         defaults = resp.json()
         assert "model" in defaults
 
+    def test_update_config_preserves_model_context_length_when_field_omitted(self):
+        """A stale/partial Desktop config payload must not erase model.context_length."""
+        from hermes_cli.config import load_config, save_config
+
+        cfg = load_config()
+        cfg["model"] = {
+            "default": "gpt-5.5",
+            "provider": "novacode",
+            "base_url": "https://api.example.test/v1",
+            "context_length": 256_000,
+        }
+        save_config(cfg)
+
+        resp = self.client.put(
+            "/api/config",
+            json={
+                "config": {
+                    "model": "gpt-5.4",
+                    # Deliberately omit model_context_length to mimic an older
+                    # cached Desktop settings form or partial save payload.
+                }
+            },
+        )
+
+        assert resp.status_code == 200
+        model_cfg = load_config()["model"]
+        assert model_cfg["default"] == "gpt-5.4"
+        assert model_cfg["provider"] == "novacode"
+        assert model_cfg["context_length"] == 256_000
+
     def test_get_env_vars(self):
         resp = self.client.get("/api/env")
         assert resp.status_code == 200

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -40,13 +40,38 @@ def _make_agent_with_compressor(config_context_length=None) -> AIAgent:
     return agent
 
 
-@patch("agent.model_metadata.get_model_context_length", return_value=131_072)
-def test_switch_model_clears_previous_config_context_length(mock_ctx_len):
-    """Switching models must not reuse the previous model.context_length override."""
-    agent = _make_agent_with_compressor(config_context_length=32_768)
+def _fake_context_length(*args, **kwargs):
+    return kwargs.get("config_context_length") or 131_072
+
+
+@patch("hermes_cli.config.load_config", return_value={"model": {"context_length": 256_000}})
+@patch("agent.model_metadata.get_model_context_length", side_effect=_fake_context_length)
+def test_switch_model_preserves_active_config_context_length(mock_ctx_len, mock_load_config):
+    """Switching models should keep an explicit model.context_length override."""
+    agent = _make_agent_with_compressor(config_context_length=256_000)
 
     assert agent.context_compressor.model == "primary-model"
-    assert agent.context_compressor.context_length == 32_768  # From config override
+    assert agent.context_compressor.context_length == 256_000  # From config override
+
+    # Switch model
+    agent.switch_model("new-model", "openrouter", api_key="sk-new", base_url="https://openrouter.ai/api/v1")
+
+    # Verify the active config override is passed to the new model.
+    mock_ctx_len.assert_called_once()
+    call_kwargs = mock_ctx_len.call_args.kwargs
+    assert call_kwargs.get("config_context_length") == 256_000
+
+    # Verify compressor stayed on the configured cap, not the raw model metadata.
+    assert agent._config_context_length == 256_000
+    assert agent.context_compressor.model == "new-model"
+    assert agent.context_compressor.context_length == 256_000
+
+
+@patch("hermes_cli.config.load_config", return_value={"model": {}})
+@patch("agent.model_metadata.get_model_context_length", return_value=131_072)
+def test_switch_model_clears_stale_context_length_when_config_override_removed(mock_ctx_len, mock_load_config):
+    """Switching models should not inherit an override that is no longer in config."""
+    agent = _make_agent_with_compressor(config_context_length=32_768)
 
     # Switch model
     agent.switch_model("new-model", "openrouter", api_key="sk-new", base_url="https://openrouter.ai/api/v1")
@@ -57,6 +82,7 @@ def test_switch_model_clears_previous_config_context_length(mock_ctx_len):
     assert call_kwargs.get("config_context_length") is None
 
     # Verify compressor was updated from the newly resolved model metadata.
+    assert agent._config_context_length is None
     assert agent.context_compressor.model == "new-model"
     assert agent.context_compressor.context_length == 131_072
 


### PR DESCRIPTION
## Summary
- Preserve `model.context_length` when switching models at runtime instead of falling back to model metadata.
- Preserve the existing override when Desktop/API config saves omit the virtual `model_context_length` field.
- Add regression tests for runtime switching and config-save behavior.

## Test Plan
- `python -m pytest tests/run_agent/test_switch_model_context.py tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_update_config_preserves_model_context_length_when_field_omitted -q -o 'addopts='`
