### PR TITLE
fix(desktop): show full command in approval dialog instead of truncating (#44888)

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool-fallback-model.ts
+++ b/apps/desktop/src/components/assistant-ui/tool-fallback-model.ts
@@ -1044,7 +1044,7 @@ function toolSubtitle(
 
     const command = firstStringField(argsRecord, ['command', 'code']) || contextValue(argsRecord)
 
-    return command ? compactPreview(command, 120) : 'Executed command'
+    return command ? compactPreview(command, 2000) : 'Executed command'
   }
 
   if (toolName === 'read_file' || toolName === 'write_file' || toolName === 'edit_file') {


### PR DESCRIPTION
## What does this PR do?

fix(desktop): show full command in approval dialog instead of truncating (#44888).

## Related Issue

Closes #44888

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

See commit for details.

## How to Test

1. Reproduce the symptom described in #44888
2. Apply the fix
3. Verify symptom is resolved