### PR TITLE
fix(tui): prevent message gutter from leaking indent into copied text (#44916)

### DIFF
--- a/ui-tui/src/components/messageLine.tsx
+++ b/ui-tui/src/components/messageLine.tsx
@@ -226,15 +226,17 @@ export const MessageLine = memo(function MessageLine({
         </Box>
       )}
 
-      <Box>
-        <NoSelect flexShrink={0} fromLeftEdge width={gutterWidth}>
-          <Text bold={msg.role === 'user'} color={prefix}>
-            {glyph}{' '}
-          </Text>
-        </NoSelect>
+      <NoSelect fromLeftEdge width={cols}>
+        <Box>
+          <NoSelect flexShrink={0} fromLeftEdge width={gutterWidth}>
+            <Text bold={msg.role === 'user'} color={prefix}>
+              {glyph}{' '}
+            </Text>
+          </NoSelect>
 
-        <Box width={transcriptBodyWidth(cols, msg.role, t.brand.prompt, TERMUX_TUI_MODE)}>{content}</Box>
-      </Box>
+          <Box width={transcriptBodyWidth(cols, msg.role, t.brand.prompt, TERMUX_TUI_MODE)}>{content}</Box>
+        </Box>
+      </NoSelect>
     </Box>
   )
 })


### PR DESCRIPTION
## What does this PR do?

fix(tui): prevent message gutter from leaking indent into copied text (#44916).

## Related Issue

Closes #44916

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

See commit for details.

## How to Test

1. Reproduce the symptom described in #44916
2. Apply the fix
3. Verify symptom is resolved