### PR TITLE
Treat pristine SOUL.md template as absent so the default identity loads

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -7,6 +7,7 @@ assemble pieces, then combines them with memory and ephemeral prompts.
 import json
 import logging
 import os
+import re
 import threading
 from collections import OrderedDict
 from pathlib import Path
@@ -1466,12 +1467,40 @@ def _truncate_content(content: str, filename: str, max_chars: int = CONTEXT_FILE
     return head + marker + tail
 
 
+_HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+
+
+def _soul_has_persona_content(content: str) -> bool:
+    """True when SOUL.md contains real persona text.
+
+    The SOUL.md template seeded by the install scripts and the docker
+    image is a markdown heading plus an HTML comment of editing
+    instructions.  Neither is persona content, so a pristine template
+    must not displace ``DEFAULT_AGENT_IDENTITY``.  Heading-only lines
+    are dropped along with comments because the template's sole
+    non-comment line is its title heading; a file consisting only of
+    headings carries no persona either — the same rule ``hermes
+    doctor`` applies for its "persona configured" check.
+    """
+    without_comments = _HTML_COMMENT_RE.sub("", content)
+    return any(
+        line.strip() and not line.strip().startswith("#")
+        for line in without_comments.splitlines()
+    )
+
+
 def load_soul_md() -> Optional[str]:
     """Load SOUL.md from HERMES_HOME and return its content, or None.
 
     Used as the agent identity (slot #1 in the system prompt).  When this
     returns content, ``build_context_files_prompt`` should be called with
     ``skip_soul=True`` so SOUL.md isn't injected twice.
+
+    A pristine seeded template (heading + HTML comment, no persona text)
+    is treated as absent so the default identity loads.  When real
+    persona text exists the ORIGINAL content is returned, comments
+    included — users may keep the template comment as documentation
+    alongside their persona.
     """
     try:
         from hermes_cli.config import ensure_hermes_home
@@ -1484,7 +1513,7 @@ def load_soul_md() -> Optional[str]:
         return None
     try:
         content = soul_path.read_text(encoding="utf-8").strip()
-        if not content:
+        if not content or not _soul_has_persona_content(content):
             return None
         content = _scan_context_content(content, "SOUL.md")
         content = _truncate_content(content, "SOUL.md")

--- a/docker/SOUL.md
+++ b/docker/SOUL.md
@@ -10,6 +10,6 @@ Examples:
   - "You are a concise technical expert. No fluff, just facts."
   - "You speak like a friendly coworker who happens to know everything."
 
-This file is loaded fresh each message -- no restart needed.
+This file is loaded when a session starts -- restart the session to apply edits.
 Delete the contents (or this file) to use the default personality.
 -->

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1834,7 +1834,7 @@ Examples:
   - "You are a concise technical expert. No fluff, just facts."
   - "You speak like a friendly coworker who happens to know everything."
 
-This file is loaded fresh each message -- no restart needed.
+This file is loaded when a session starts -- restart the session to apply edits.
 Delete the contents (or this file) to use the default personality.
 -->
 "@

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1703,7 +1703,7 @@ Examples:
   - "You are a concise technical expert. No fluff, just facts."
   - "You speak like a friendly coworker who happens to know everything."
 
-This file is loaded fresh each message -- no restart needed.
+This file is loaded when a session starts -- restart the session to apply edits.
 Delete the contents (or this file) to use the default personality.
 -->
 SOUL_EOF

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -18,6 +18,7 @@ from agent.prompt_builder import (
     build_skills_system_prompt,
     build_nous_subscription_prompt,
     build_context_files_prompt,
+    load_soul_md,
     CONTEXT_FILE_MAX_CHARS,
     DEFAULT_AGENT_IDENTITY,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
@@ -739,6 +740,67 @@ class TestBuildContextFilesPrompt:
         (tmp_path / ".cursorrules").write_text("Use ESLint.")
         result = build_context_files_prompt(cwd=str(tmp_path))
         assert "ESLint" in result
+
+
+# =========================================================================
+# load_soul_md — pristine template must not displace the default identity
+# =========================================================================
+
+
+# Mirrors the SOUL.md template seeded by scripts/install.sh,
+# scripts/install.ps1 and docker/SOUL.md: a heading plus an HTML comment,
+# no persona text.
+PRISTINE_SOUL_TEMPLATE = """# Hermes Agent Persona
+
+<!--
+This file defines the agent's personality and tone.
+The agent will embody whatever you write here.
+Edit this to customize how Hermes communicates with you.
+
+Examples:
+  - "You are a warm, playful assistant who uses kaomoji occasionally."
+  - "You are a concise technical expert. No fluff, just facts."
+  - "You speak like a friendly coworker who happens to know everything."
+
+This file is loaded when a session starts -- restart the session to apply edits.
+Delete the contents (or this file) to use the default personality.
+-->
+"""
+
+
+class TestLoadSoulMd:
+    def _write_soul(self, tmp_path, monkeypatch, text):
+        hermes_home = tmp_path / "hermes_home"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        hermes_home.mkdir()
+        (hermes_home / "SOUL.md").write_text(text, encoding="utf-8")
+
+    def test_pristine_template_returns_none(self, tmp_path, monkeypatch):
+        """Heading + HTML comment only — no persona, default identity loads."""
+        self._write_soul(tmp_path, monkeypatch, PRISTINE_SOUL_TEMPLATE)
+        assert load_soul_md() is None
+
+    def test_template_plus_persona_returns_original_content(self, tmp_path, monkeypatch):
+        """Real persona text keeps the file's ORIGINAL content, comment included."""
+        content = PRISTINE_SOUL_TEMPLATE + "\nYou are a concise technical expert.\n"
+        self._write_soul(tmp_path, monkeypatch, content)
+        result = load_soul_md()
+        assert result is not None
+        assert "You are a concise technical expert." in result
+        assert "<!--" in result  # comment preserved as documentation
+
+    def test_whitespace_only_returns_none(self, tmp_path, monkeypatch):
+        self._write_soul(tmp_path, monkeypatch, "  \n\n\t\n")
+        assert load_soul_md() is None
+
+    def test_heading_only_returns_none(self, tmp_path, monkeypatch):
+        """Bare headings carry no persona (same rule as the doctor check)."""
+        self._write_soul(tmp_path, monkeypatch, "# Hermes Agent Persona\n")
+        assert load_soul_md() is None
+
+    def test_plain_persona_returned(self, tmp_path, monkeypatch):
+        self._write_soul(tmp_path, monkeypatch, "Be warm and playful.")
+        assert load_soul_md() == "Be warm and playful."
 
 
 # =========================================================================


### PR DESCRIPTION
## Bug

The SOUL.md template seeded by `scripts/install.sh`, `scripts/install.ps1` and `docker/SOUL.md` is a markdown heading plus an HTML comment of editing instructions. `load_soul_md()` (agent/prompt_builder.py) only checked the content was non-empty after `strip()`, so the pristine template was loaded as the agent persona. In `build_system_prompt_parts` (agent/system_prompt.py) that set `_soul_loaded = True` and `DEFAULT_AGENT_IDENTITY` was never appended -- default installs ran with editing instructions as their identity, defeating the template's own "Delete the contents (or this file) to use the default personality" instruction.

Note: `hermes_cli/default_soul.py::DEFAULT_SOUL_MD` (the `_ensure_default_soul_md` seed) was already reset to real identity text in 0426bb745, so it no longer carries the template comment described in the issue -- but the heading+comment template still ships via the install scripts and the docker image, where the bug bites.

## Fix

`load_soul_md()` now treats SOUL.md as absent (returns `None`, so the default identity loads) when nothing remains after dropping HTML comments (`<!-- ... -->`, multi-line included) and heading-only lines. Heading-only lines are dropped because the template's sole non-comment line is its title heading; a file consisting only of headings carries no persona -- the same rule `hermes doctor` already applies for its "persona configured" check.

When real persona text exists, the ORIGINAL content is returned verbatim, comments included -- users may keep the template comment as documentation alongside their persona.

## Doc correction

The template claimed "This file is loaded fresh each message -- no restart needed", but `build_system_prompt_parts` caches the stable tier for the agent's lifetime. All three template copies (`docker/SOUL.md`, `scripts/install.sh`, `scripts/install.ps1`) now say: "This file is loaded when a session starts -- restart the session to apply edits."

## Tests

New `TestLoadSoulMd` in `tests/agent/test_prompt_builder.py`:
- pristine template -> `None` (default identity loads)
- template + real persona text -> original content returned, comment preserved
- whitespace-only file -> `None`
- heading-only file -> `None`
- plain persona text -> returned

`tests/agent/test_prompt_builder.py` (139 passed), `tests/agent/test_system_prompt.py` + `tests/hermes_cli/test_config.py` (105 passed).

Fixes #44914

🤖 Generated with [Claude Code](https://claude.com/claude-code)
