### PR TITLE
fix(skills): make bundled-update backup handling crash-safe and idempotent

### DIFF
--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -1,5 +1,6 @@
 """Tests for tools/skills_sync.py — manifest-based skill seeding and updating."""
 
+import shutil
 import json
 from pathlib import Path
 from unittest.mock import patch
@@ -1067,3 +1068,123 @@ class TestOptOutToggleAndRemove:
             assert "EDITED" in (skills_dir / "beta" / "SKILL.md").read_text()
             # non-bundled local skill never considered
             assert (skills_dir / "mine" / "SKILL.md").exists()
+
+
+class TestUpdateBackupRecovery:
+    """Regression tests for backup handling in the bundled-update path.
+
+    Covers three failure modes around ``dest.with_suffix(".bak")``:
+    a stale backup poisoning the next update's move/restore, an orphaned
+    backup (crash between move and copytree) being misread as a user
+    deletion, and a partially-written dest blocking restore-on-failure.
+    """
+
+    def _setup(self, tmp_path, bundled_text="# Old v2 (updated)"):
+        """Bundled dir with one flat skill, plus user dirs."""
+        bundled = tmp_path / "bundled_skills"
+        (bundled / "old-skill").mkdir(parents=True)
+        (bundled / "old-skill" / "SKILL.md").write_text(bundled_text)
+        skills_dir = tmp_path / "user_skills"
+        skills_dir.mkdir()
+        manifest_file = skills_dir / ".bundled_manifest"
+        return bundled, skills_dir, manifest_file
+
+    def _patches(self, bundled, skills_dir, manifest_file):
+        from contextlib import ExitStack
+        stack = ExitStack()
+        stack.enter_context(patch("tools.skills_sync._get_bundled_dir", return_value=bundled))
+        stack.enter_context(patch("tools.skills_sync._get_optional_dir", return_value=bundled.parent / "optional-skills"))
+        stack.enter_context(patch("tools.skills_sync.SKILLS_DIR", skills_dir))
+        stack.enter_context(patch("tools.skills_sync.MANIFEST_FILE", manifest_file))
+        return stack
+
+    def _seed_synced_copy(self, skills_dir, manifest_file, text="# Old v1"):
+        """User copy of old-skill whose hash matches the manifest origin."""
+        dest = skills_dir / "old-skill"
+        dest.mkdir(parents=True)
+        (dest / "SKILL.md").write_text(text)
+        with patch("tools.skills_sync.MANIFEST_FILE", manifest_file):
+            _write_manifest({"old-skill": _dir_hash(dest)})
+        return dest
+
+    def test_stale_backup_does_not_poison_failed_update(self, tmp_path):
+        """A leftover .bak must not nest the live copy or corrupt restore.
+
+        With a stale ``old-skill.bak`` present, ``shutil.move(dest, backup)``
+        moves the live copy *inside* the stale dir. If copytree then fails,
+        restore drags the stale junk (with the live copy nested in it) back
+        to dest — corrupting the skill and wedging it as "user-modified".
+        """
+        bundled, skills_dir, manifest_file = self._setup(tmp_path)
+        dest = self._seed_synced_copy(skills_dir, manifest_file)
+
+        stale = skills_dir / "old-skill.bak"
+        stale.mkdir()
+        (stale / "SKILL.md").write_text("# stale junk from an earlier failure")
+
+        def _boom(src, dst, **kwargs):
+            raise OSError("simulated copy failure")
+
+        with self._patches(bundled, skills_dir, manifest_file), \
+                patch("tools.skills_sync.shutil.copytree", side_effect=_boom):
+            sync_skills(quiet=True)
+
+        # The live copy must survive the failed update untouched...
+        assert (dest / "SKILL.md").read_text() == "# Old v1"
+        # ...not be nested inside recycled stale-backup content.
+        assert not (dest / "old-skill").exists()
+        # And no backup directory may linger.
+        assert not (skills_dir / "old-skill.bak").exists()
+
+    def test_orphaned_backup_is_recovered_not_treated_as_deleted(self, tmp_path):
+        """Crash between move and copytree must not lose the skill.
+
+        After such a crash, dest is gone and the user's only copy sits in
+        ``old-skill.bak``. The sync loop's "in manifest but not on disk"
+        branch reads that as a deliberate user deletion and skips — the
+        skill silently vanishes. It must instead be recovered and updated.
+        """
+        bundled, skills_dir, manifest_file = self._setup(tmp_path)
+        dest = self._seed_synced_copy(skills_dir, manifest_file)
+        # Simulate the crash: dest was moved aside, new copy never arrived.
+        shutil.move(str(dest), str(skills_dir / "old-skill.bak"))
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            result = sync_skills(quiet=True)
+
+        # Recovered and then updated to the new bundled version in one run.
+        assert (dest / "SKILL.md").exists()
+        assert (dest / "SKILL.md").read_text() == "# Old v2 (updated)"
+        assert "old-skill" in result["updated"]
+        assert not (skills_dir / "old-skill.bak").exists()
+
+    def test_partial_copy_failure_restores_original(self, tmp_path):
+        """A half-written dest must not block restore-on-failure.
+
+        If copytree dies after creating dest, the ``not dest.exists()``
+        guard skips the restore: the user keeps a broken partial skill,
+        the .bak lingers, and the partial hash wedges the skill as
+        "user-modified" on every later sync.
+        """
+        bundled, skills_dir, manifest_file = self._setup(tmp_path)
+        dest = self._seed_synced_copy(skills_dir, manifest_file)
+
+        def _partial_then_fail(src, dst, **kwargs):
+            Path(dst).mkdir(parents=True, exist_ok=True)
+            (Path(dst) / "PARTIAL").write_text("half-written")
+            raise OSError("simulated failure mid-copy")
+
+        with self._patches(bundled, skills_dir, manifest_file), \
+                patch("tools.skills_sync.shutil.copytree", side_effect=_partial_then_fail):
+            sync_skills(quiet=True)
+
+        # Original content restored, partial debris and backup gone.
+        assert (dest / "SKILL.md").read_text() == "# Old v1"
+        assert not (dest / "PARTIAL").exists()
+        assert not (skills_dir / "old-skill.bak").exists()
+
+        # And the skill is not wedged: a later normal sync updates cleanly.
+        with self._patches(bundled, skills_dir, manifest_file):
+            result2 = sync_skills(quiet=True)
+        assert "old-skill" in result2["updated"]
+        assert result2["user_modified"] == []

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -506,6 +506,24 @@ def sync_skills(quiet: bool = False) -> dict:
         dest = _compute_relative_dest(skill_src, bundled_dir)
         bundled_hash = _dir_hash(skill_src)
 
+        # Recover an orphaned backup before classifying. If a previous
+        # update was interrupted between moving dest aside and copying the
+        # new version in, the user's only copy sits in ``dest.bak`` while
+        # dest is gone — without this, the "in manifest but not on disk"
+        # branch below misreads the skill as user-deleted and it silently
+        # vanishes from discovery.
+        _orphan = dest.with_suffix(".bak")
+        if _orphan.exists() and not dest.exists():
+            try:
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.move(str(_orphan), str(dest))
+                logger.info("Recovered orphaned skill backup: %s", _orphan)
+            except (OSError, IOError):
+                logger.warning(
+                    "Could not recover orphaned skill backup %s", _orphan,
+                    exc_info=True,
+                )
+
         if skill_name not in manifest:
             # ── New skill — never offered before ──
             try:
@@ -569,6 +587,12 @@ def sync_skills(quiet: bool = False) -> dict:
                 try:
                     # Move old copy to a backup so we can restore on failure
                     backup = dest.with_suffix(".bak")
+                    # A stale backup left by an earlier failure would make
+                    # shutil.move() nest dest *inside* it (or fail outright)
+                    # and would poison the restore path below. The current
+                    # dest is the authoritative copy — clear the leftover.
+                    if backup.exists():
+                        _rmtree_writable(backup)
                     shutil.move(str(dest), str(backup))
                     try:
                         shutil.copytree(skill_src, dest)
@@ -582,9 +606,20 @@ def sync_skills(quiet: bool = False) -> dict:
                         except (OSError, IOError):
                             logger.debug("Could not remove backup %s", backup, exc_info=True)
                     except (OSError, IOError):
-                        # Restore from backup
-                        if backup.exists() and not dest.exists():
-                            shutil.move(str(backup), str(dest))
+                        # Restore from backup. A partially-written dest must
+                        # not shadow the user's copy or block the restore —
+                        # clear it first, then move the backup home.
+                        if backup.exists():
+                            if dest.exists():
+                                try:
+                                    _rmtree_writable(dest)
+                                except (OSError, IOError):
+                                    logger.warning(
+                                        "Could not clear partial copy %s during restore",
+                                        dest, exc_info=True,
+                                    )
+                            if not dest.exists():
+                                shutil.move(str(backup), str(dest))
                         raise
                 except (OSError, IOError) as e:
                     if not quiet:


### PR DESCRIPTION
## What does this PR do?

The bundled-update path in `tools/skills_sync.py` mishandles `.bak` directories in three ways. A stale backup makes `shutil.move()` nest the live copy inside it and corrupts restore-on-failure. An orphaned backup (crash between move and copytree) is misread as a user deletion and the skill is silently lost. And a partially written `dest` defeats the `not dest.exists()` restore guard, leaving a broken skill wedged as "user-modified" forever.

This PR makes the update transaction tolerate a pre-existing backup and a partial copy, with three ordering-only changes. It follows up on #34860, which fixed the backup cleanup (`_rmtree_writable`); this one fixes how the update transaction interacts with a backup that exists anyway. It's distinct from #35131 (reset and cleanup paths). The happy path is unchanged: no new state, no new result keys, and recovery and cleanup are logged via the module logger.

## Related Issue

Fixes #44942

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skills_sync.py`:
  - recover an orphaned `dest.bak` before classification, so an interrupted update self-heals instead of hitting the branch that treats it as user-deleted;
  - clear a stale `dest.bak` (using the existing `_rmtree_writable`) before `shutil.move(dest, backup)`, so the move replaces instead of nesting;
  - on `copytree` failure, clear a partially written `dest` before restoring the backup, so the restore actually runs and no `.bak` lingers.
- `tests/tools/test_skills_sync.py`: `TestUpdateBackupRecovery`, 3 regression tests, each failing on current `main`.

## How to Test

1. On clean `main`, apply only the tests (`git apply --include='tests/*'`) and run `pytest tests/tools/test_skills_sync.py::TestUpdateBackupRecovery -q`. All 3 fail, which proves the bugs. The issue also has a standalone deterministic repro script.
2. With the full change, `pytest tests/tools/test_skills_sync.py -q` gives 59 passed (56 pre-existing plus 3 new).
3. `ruff check tools/skills_sync.py tests/tools/test_skills_sync.py` comes back clean.

|                                                  | Before                                          | After                                  |
| ------------------------------------------------ | ----------------------------------------------- | -------------------------------------- |
| stale `.bak` plus update failure                  | live copy nested into junk, skill wedged        | pristine copy restored, no `.bak`      |
| crash between move and copytree                   | skill silently lost ("user deleted")            | recovered, then updated in same run    |
| `copytree` dies after creating `dest`             | partial skill kept, no restore, wedged          | original restored, no `.bak`, no wedge |

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate. Closest are #34577 (read-only mode bits on copies) and #35131 (`reset_bundled_skill` ordering). Neither touches the update transaction's move and restore ordering or orphan recovery.
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass. (Honest note: I ran the affected suite, `tests/tools/test_skills_sync.py`, 59 passed, plus `ruff` on both changed files, from a source checkout. I'm leaving this box unchecked for transparency and relying on CI for the full matrix. Happy to run anything else that's needed.)
- [x] I've added tests for my changes (3 regression tests; each fails on current `main` without the fix)
- [x] I've tested on my platform: Ubuntu 22.04 (source checkout, Python 3.10.12)

### Documentation & Housekeeping

- [x] I've updated relevant documentation. N/A, no user-facing behavior change on the happy path.
- [x] I've updated `cli-config.yaml.example`. N/A, no config keys.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md`. N/A, no architecture or workflow change.
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide. These are pure `pathlib` and `shutil` ordering changes with no platform-specific calls, and they reuse the existing `_rmtree_writable`, which exists precisely for trees carrying read-only bits.