### PR TITLE
fix(desktop): flag sidebar sessions that finish while you're viewing another chat

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -13,7 +13,7 @@ import { triggerHaptic } from '@/lib/haptics'
 import { handoffOriginSource, sessionSourceLabel } from '@/lib/session-source'
 import { coarseElapsed } from '@/lib/time'
 import { cn } from '@/lib/utils'
-import { $attentionSessionIds } from '@/store/session'
+import { $attentionSessionIds, $unreadSessionIds } from '@/store/session'
 import { canOpenSessionWindow, openSessionInNewWindow } from '@/store/windows'
 
 import { SidebarRowBody, SidebarRowGrab, SidebarRowLabel, SidebarRowLead, SidebarRowShell } from './chrome'
@@ -78,6 +78,9 @@ export function SidebarSessionRow({
   // the atom is tiny and rarely non-empty. True when a clarify prompt in this
   // session is waiting on the user.
   const needsInput = useStore($attentionSessionIds).includes(session.id)
+  // True when this session finished a turn while the user was viewing another
+  // chat — a completed, not-yet-read reply. Cleared when the row is selected.
+  const isUnread = useStore($unreadSessionIds).includes(session.id)
 
   return (
     <SessionContextMenu
@@ -234,7 +237,7 @@ function SessionRowLeadDot({
           {branchStem}
         </span>
       ) : null}
-      <SidebarRowDot isWorking={isWorking} needsInput={needsInput} />
+      <SidebarRowDot isUnread={isUnread} isWorking={isWorking} needsInput={needsInput} />
     </span>
   )
 }
@@ -242,10 +245,12 @@ function SessionRowLeadDot({
 function SidebarRowDot({
   isWorking,
   needsInput = false,
+  isUnread = false,
   className
 }: {
   isWorking: boolean
   needsInput?: boolean
+  isUnread?: boolean
   className?: string
 }) {
   const { t } = useI18n()
@@ -266,17 +271,37 @@ function SidebarRowDot({
     )
   }
 
+  // An active turn outranks "completed" — it's still in progress. Accent + ping.
+  if (isWorking) {
+    return (
+      <span
+        aria-label={r.sessionRunning}
+        className={cn(
+          "relative size-1.5 rounded-full bg-(--ui-accent) shadow-[0_0_0.625rem_color-mix(in_srgb,var(--ui-accent)_55%,transparent)] before:absolute before:inset-0 before:animate-ping before:rounded-full before:bg-(--ui-accent) before:opacity-70 before:content-['']",
+          className
+        )}
+        role="status"
+      />
+    )
+  }
+
+  // Completed while the user was viewing another chat: a solid accent dot, NO
+  // pulse. Reads as "done, fresh, unseen" — calmer than working's ping and
+  // distinct from needs-input's amber glow, but still clearly "this row wants
+  // your attention" versus the faint gray of an already-read idle chat.
+  if (isUnread) {
+    return (
+      <span
+        aria-label={r.unreadReply}
+        className={cn('size-1.5 rounded-full bg-(--ui-accent)', className)}
+        role="status"
+        title={r.unreadReply}
+      />
+    )
+  }
+
+  // Idle: nothing pending.
   return (
-    <span
-      aria-label={isWorking ? r.sessionRunning : undefined}
-      className={cn(
-        'rounded-full',
-        isWorking
-          ? "relative size-1.5 bg-(--ui-accent) shadow-[0_0_0.625rem_color-mix(in_srgb,var(--ui-accent)_55%,transparent)] before:absolute before:inset-0 before:animate-ping before:rounded-full before:bg-(--ui-accent) before:opacity-70 before:content-['']"
-          : 'size-1 bg-(--ui-text-quaternary) opacity-80',
-        className
-      )}
-      role={isWorking ? 'status' : undefined}
-    />
+    <span className={cn('size-1 rounded-full bg-(--ui-text-quaternary) opacity-80', className)} />
   )
 }

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1617,6 +1617,7 @@ export const en: Translations = {
       sessionRunning: 'Session running',
       needsInput: 'Needs your input',
       waitingForAnswer: 'Waiting for your answer',
+      unreadReply: 'Completed — unread',
       handoffOrigin: platform => `Handed off from ${platform}`,
       renamed: 'Renamed',
       renameFailed: 'Rename failed',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1560,6 +1560,7 @@ export const ja = defineLocale({
       sessionRunning: 'セッション実行中',
       needsInput: '入力が必要です',
       waitingForAnswer: '回答を待っています',
+      unreadReply: '完了 — 未読',
       handoffOrigin: platform => `${platform} から引き継ぎ`,
       renamed: '名前を変更しました',
       renameFailed: '名前の変更に失敗しました',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1343,6 +1343,7 @@ export interface Translations {
       sessionRunning: string
       needsInput: string
       waitingForAnswer: string
+      unreadReply: string
       handoffOrigin: (platform: string) => string
       renamed: string
       renameFailed: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1510,6 +1510,7 @@ export const zhHant = defineLocale({
       sessionRunning: '工作階段執行中',
       needsInput: '需要您的輸入',
       waitingForAnswer: '等待您的回答',
+      unreadReply: '已完成 — 未讀',
       handoffOrigin: platform => `從 ${platform} 轉接`,
       renamed: '已重新命名',
       renameFailed: '重新命名失敗',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1792,6 +1792,7 @@ export const zh: Translations = {
       sessionRunning: '会话运行中',
       needsInput: '需要你输入',
       waitingForAnswer: '正在等待你的回答',
+      unreadReply: '已完成 — 未读',
       handoffOrigin: platform => `从 ${platform} 转接`,
       renamed: '已重命名',
       renameFailed: '重命名失败',

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { SessionInfo } from '@/types/hermes'
 
@@ -7,12 +7,16 @@ import {
   $attentionSessionIds,
   $connection,
   $currentCwd,
+  $selectedStoredSessionId,
+  $unreadSessionIds,
   $workingSessionIds,
   applyConfiguredDefaultProjectDir,
+  clearSessionUnread,
   getRecentlySettledSessionIds,
   mergeSessionPage,
   sessionPinId,
   setCurrentCwd,
+  setSelectedStoredSessionId,
   setSessionAttention,
   setSessionWorking,
   workspaceCwdForNewSession
@@ -295,5 +299,65 @@ describe('getRecentlySettledSessionIds', () => {
     // settled set so it's tracked as working, not recently-finished.
     setSessionWorking('s2', true)
     expect(getRecentlySettledSessionIds()).toEqual([])
+  })
+})
+
+describe('completed-while-away unread tracking', () => {
+  beforeEach(() => {
+    $unreadSessionIds.set([])
+    $workingSessionIds.set([])
+    $selectedStoredSessionId.set(null)
+  })
+
+  it('flags a session that finishes while a DIFFERENT session is selected', () => {
+    $selectedStoredSessionId.set('other')
+
+    // A background session runs a full turn while the user looks elsewhere.
+    setSessionWorking('bg', true)
+    setSessionWorking('bg', false)
+
+    expect($unreadSessionIds.get()).toEqual(['bg'])
+  })
+
+  it('does NOT flag the session the user is currently viewing', () => {
+    $selectedStoredSessionId.set('active')
+
+    setSessionWorking('active', true)
+    setSessionWorking('active', false)
+
+    // A turn that finishes in the session you're watching is read by definition.
+    expect($unreadSessionIds.get()).toEqual([])
+  })
+
+  it('does NOT flag on an idle re-assertion (session was never working)', () => {
+    $selectedStoredSessionId.set('other')
+
+    // updateSessionState re-asserts `false` every tick for idle sessions; this
+    // must not be mistaken for a working→idle completion.
+    setSessionWorking('idle', false)
+    setSessionWorking('idle', false)
+
+    expect($unreadSessionIds.get()).toEqual([])
+  })
+
+  it('clears unread when the session is later selected (read)', () => {
+    $selectedStoredSessionId.set('other')
+    setSessionWorking('bg', true)
+    setSessionWorking('bg', false)
+    expect($unreadSessionIds.get()).toEqual(['bg'])
+
+    // Opening the session is reading it — the flag drops via the selection
+    // chokepoint, with no per-call-site bookkeeping.
+    setSelectedStoredSessionId('bg')
+    expect($unreadSessionIds.get()).toEqual([])
+  })
+
+  it('clearSessionUnread no-ops on null and unknown ids', () => {
+    $unreadSessionIds.set(['a'])
+
+    clearSessionUnread(null)
+    clearSessionUnread('zzz')
+
+    expect($unreadSessionIds.get()).toEqual(['a'])
   })
 })

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -301,7 +301,15 @@ export const setSessionProfileTotals = (next: Updater<Record<string, number>>) =
 export const setSessionsLoading = (next: Updater<boolean>) => updateAtom($sessionsLoading, next)
 export const setWorkingSessionIds = (next: Updater<string[]>) => updateAtom($workingSessionIds, next)
 export const setActiveSessionId = (next: Updater<string | null>) => updateAtom($activeSessionId, next)
-export const setSelectedStoredSessionId = (next: Updater<string | null>) => updateAtom($selectedStoredSessionId, next)
+export const setSelectedStoredSessionId = (next: Updater<string | null>) => {
+  updateAtom($selectedStoredSessionId, next)
+  // Selecting a session is the user reading it — drop its "completed while you
+  // were away" unread flag. This is the single chokepoint every selection path
+  // (resume / create / branch / restore) routes through, so the flag clears no
+  // matter how the session was opened.
+  clearSessionUnread($selectedStoredSessionId.get())
+}
+
 export const setMessages = (next: Updater<ChatMessage[]>) => updateAtom($messages, next)
 export const setFreshDraftReady = (next: Updater<boolean>) => updateAtom($freshDraftReady, next)
 export const setResumeFailedSessionId = (next: Updater<string | null>) => updateAtom($resumeFailedSessionId, next)
@@ -497,6 +505,23 @@ export function setSessionAttention(sessionId: string | null | undefined, needsI
   }
 }
 
+// Stored session ids whose turn finished while the user was viewing a DIFFERENT
+// session — a completed reply they have not seen yet. Like $attentionSessionIds,
+// this powers a persistent sidebar dot that survives window blur / alt-tab, so a
+// user who steps away and returns can tell at a glance which conversations have
+// fresh, unread output waiting. In-memory only by design: an app restart counts
+// as a fresh look, so the set legitimately resets.
+export const $unreadSessionIds = atom<string[]>([])
+export const setUnreadSessionIds = (next: Updater<string[]>) => updateAtom($unreadSessionIds, next)
+
+/** Drop a session from the unread set — the user is now looking at it. No-ops on
+ *  null (new chat) and on ids not in the set, so it's safe at every call site. */
+export function clearSessionUnread(sessionId: string | null | undefined) {
+  if (sessionId) {
+    toggleMembership(setUnreadSessionIds, sessionId, false)
+  }
+}
+
 export function setSessionWorking(sessionId: string | null | undefined, working: boolean) {
   if (!sessionId) {
     return
@@ -520,6 +545,14 @@ export function setSessionWorking(sessionId: string | null | undefined, working:
     // aggregator to return its now-persisted row.
     if (wasWorking) {
       markSessionSettled(sessionId)
+
+      // A turn that ends while the user is viewing a DIFFERENT session produced a
+      // reply they haven't seen — flag it unread so the sidebar dot reads "fresh"
+      // instead of collapsing to the same gray as a long-read chat. A turn that
+      // finishes in the chat you're watching is read by definition.
+      if ($selectedStoredSessionId.get() !== sessionId) {
+        toggleMembership(setUnreadSessionIds, sessionId, true)
+      }
     }
   }
 }


### PR DESCRIPTION
## The bug

The sidebar status dot already tells you, at a glance, which conversations want your attention. It ships **three** states, each backed by its own store atom:

| State | Dot | Meaning |
|---|---|---|
| Working | accent + pulsing ring | turn is running |
| Needs input | steady amber glow | a clarify is blocking on you |
| Idle | faint gray | nothing pending |

But there's a **fourth** attention-worthy state the system silently drops: a conversation that **finishes its turn while you're looking at a different session**. That reply is brand-new and unseen — yet its dot is identical to a chat you read hours ago.

### Why this matters for the Hermes Desktop workflow

The whole point of Hermes Desktop's multi-session sidebar is running several conversations at once — kicking off work in one chat, switching to another while it runs, delegating to subagents. The moment you do that, you need to know **which conversations have finished and have a reply waiting for you**. Right now you can't: you step away, come back to a sidebar full of identical gray dots, and have to click into each one to discover which produced fresh output. The indicator that's supposed to answer \"what should I look at next?\" goes blank exactly when you have more than one thing going. That's the productivity loss this fixes — pick up right where you left off instead of re-auditing every conversation by hand.

This reads as a **gap in the existing indicator system, not a new feature**. The working→idle transition, the \"currently viewing\" signal (\`\$selectedStoredSessionId\`), and the per-row dot renderer all already exist — the completed-and-unread state just was never connected.

## The fix

Mirrors the existing \`\$attentionSessionIds\` (needs-input) pattern almost exactly:

- New in-memory \`\$unreadSessionIds\` atom + \`clearSessionUnread\` helper in \`store/session.ts\`.
- In \`setSessionWorking\`'s **existing** working→idle transition, flag the session unread **only if it isn't the one currently selected** — a turn that finishes in the chat you're watching is read by definition.
- Clear the flag in \`setSelectedStoredSessionId\`, the **single chokepoint** every selection path (resume / create / branch / restore) routes through, so opening the session clears it with **zero** per-call-site bookkeeping.
- Render a fourth dot state: a **solid accent dot, no pulse** (\"done, fresh, unseen\") — visually distinct from working's ping and needs-input's amber glow, but clearly \"this row wants you\" versus idle gray.

## Design decisions

- **In-memory only** — an app restart counts as a fresh look, so the set legitimately resets. No persistence, matching \`\$workingSessionIds\` / \`\$attentionSessionIds\`.
- **Narrow scope** — a session you *watched* finish is never flagged; only ones that completed while you were elsewhere.
- **Watchdog interaction (intentional):** the 8-minute working-watchdog clears the working flag via \`setWorkingSessionIds\` directly (not \`setSessionWorking\`), so a hung turn that never emitted completion does **not** mark unread. Correct — a stuck turn isn't a fresh reply.

## Footprint

8 files, +150/−15. No gateway, no RPC, no protocol, no new deps.

| File | Change |
|---|---|
| \`store/session.ts\` | atom + setter + \`clearSessionUnread\`; mark in \`setSessionWorking\`; clear in \`setSelectedStoredSessionId\` |
| \`app/chat/sidebar/session-row.tsx\` | subscribe \`isUnread\`; new dot branch (split the working/idle ternary into early-returns) |
| \`i18n/types.ts\` + \`en/ja/zh/zh-hant.ts\` | \`unreadReply\` label |
| \`store/session.test.ts\` | 5 new tests |

## Verification

\`\`\`
cd apps/desktop
npm run test:ui -- src/store/session.test.ts   # 25 passed (20 prior + 5 new)
eslint <touched files>                          # 0 errors, 0 warnings
tsc -b                                          # passes (also proves all 4 locales have the key)
\`\`\`

New tests cover: flags when another session is selected; does **not** flag the active session; does **not** flag on idle re-assertion (never-working); clears on select; \`clearSessionUnread\` no-ops on null/unknown ids.