### PR TITLE
fix(kanban): use -z (short prompt) instead of -q in default spawn

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6809,8 +6809,7 @@ def _default_spawn(
     if task.model_override:
         cmd.extend(["-m", task.model_override])
     cmd.extend([
-        "chat",
-        "-q", prompt,
+        "-z", prompt,
     ])
     # Redirect output to a per-task log under <board-root>/logs/.
     # Anchored at the board root (not the shared kanban root), so

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -52,6 +52,18 @@ _vnc_url: Optional[str] = None  # cached from /health response
 _vnc_url_checked = False  # only probe once per process
 
 
+def _camofox_headers() -> Dict[str, str]:
+    """Return auth headers for Camofox API.
+
+    Reads the API key from the CAMOFOX_API_KEY environment variable.
+    """
+    api_key = os.getenv("CAMOFOX_API_KEY", "").strip()
+    headers: Dict[str, str] = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    return headers
+
+
 def get_camofox_url() -> str:
     """Return the configured Camofox server URL, or empty string."""
     return os.getenv("CAMOFOX_URL", "").rstrip("/")
@@ -77,7 +89,7 @@ def check_camofox_available() -> bool:
     if not url:
         return False
     try:
-        resp = requests.get(f"{url}/health", timeout=5)
+        resp = requests.get(f"{url}/health", timeout=5, headers=_camofox_headers())
         if resp.status_code == 200 and not _vnc_url_checked:
             try:
                 data = resp.json()
@@ -349,6 +361,7 @@ def _ensure_tab(task_id: Optional[str], url: str = "about:blank") -> Dict[str, A
             "url": url,
         },
         timeout=_DEFAULT_TIMEOUT,
+        headers=_camofox_headers(),
     )
     resp.raise_for_status()
     data = resp.json()
@@ -387,7 +400,7 @@ def camofox_soft_cleanup(task_id: Optional[str] = None) -> bool:
 def _post(path: str, body: dict, timeout: int = _DEFAULT_TIMEOUT) -> dict:
     """POST JSON to camofox and return parsed response."""
     url = f"{get_camofox_url()}{path}"
-    resp = requests.post(url, json=body, timeout=timeout)
+    resp = requests.post(url, json=body, timeout=timeout, headers=_camofox_headers())
     resp.raise_for_status()
     return resp.json()
 
@@ -395,7 +408,7 @@ def _post(path: str, body: dict, timeout: int = _DEFAULT_TIMEOUT) -> dict:
 def _get(path: str, params: dict = None, timeout: int = _DEFAULT_TIMEOUT) -> dict:
     """GET from camofox and return parsed response."""
     url = f"{get_camofox_url()}{path}"
-    resp = requests.get(url, params=params, timeout=timeout)
+    resp = requests.get(url, params=params, timeout=timeout, headers=_camofox_headers())
     resp.raise_for_status()
     return resp.json()
 
@@ -403,7 +416,7 @@ def _get(path: str, params: dict = None, timeout: int = _DEFAULT_TIMEOUT) -> dic
 def _get_raw(path: str, params: dict = None, timeout: int = _DEFAULT_TIMEOUT) -> requests.Response:
     """GET from camofox and return raw response (for binary data)."""
     url = f"{get_camofox_url()}{path}"
-    resp = requests.get(url, params=params, timeout=timeout)
+    resp = requests.get(url, params=params, timeout=timeout, headers=_camofox_headers())
     resp.raise_for_status()
     return resp
 
@@ -411,7 +424,7 @@ def _get_raw(path: str, params: dict = None, timeout: int = _DEFAULT_TIMEOUT) ->
 def _delete(path: str, body: dict = None, timeout: int = _DEFAULT_TIMEOUT) -> dict:
     """DELETE to camofox and return parsed response."""
     url = f"{get_camofox_url()}{path}"
-    resp = requests.delete(url, json=body, timeout=timeout)
+    resp = requests.delete(url, json=body, timeout=timeout, headers=_camofox_headers())
     resp.raise_for_status()
     return resp.json()
 

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -52,18 +52,6 @@ _vnc_url: Optional[str] = None  # cached from /health response
 _vnc_url_checked = False  # only probe once per process
 
 
-def _camofox_headers() -> Dict[str, str]:
-    """Return auth headers for Camofox API.
-
-    Reads the API key from the CAMOFOX_API_KEY environment variable.
-    """
-    api_key = os.getenv("CAMOFOX_API_KEY", "").strip()
-    headers: Dict[str, str] = {"Content-Type": "application/json"}
-    if api_key:
-        headers["Authorization"] = f"Bearer {api_key}"
-    return headers
-
-
 def get_camofox_url() -> str:
     """Return the configured Camofox server URL, or empty string."""
     return os.getenv("CAMOFOX_URL", "").rstrip("/")
@@ -89,7 +77,7 @@ def check_camofox_available() -> bool:
     if not url:
         return False
     try:
-        resp = requests.get(f"{url}/health", timeout=5, headers=_camofox_headers())
+        resp = requests.get(f"{url}/health", timeout=5)
         if resp.status_code == 200 and not _vnc_url_checked:
             try:
                 data = resp.json()
@@ -361,7 +349,6 @@ def _ensure_tab(task_id: Optional[str], url: str = "about:blank") -> Dict[str, A
             "url": url,
         },
         timeout=_DEFAULT_TIMEOUT,
-        headers=_camofox_headers(),
     )
     resp.raise_for_status()
     data = resp.json()
@@ -400,7 +387,7 @@ def camofox_soft_cleanup(task_id: Optional[str] = None) -> bool:
 def _post(path: str, body: dict, timeout: int = _DEFAULT_TIMEOUT) -> dict:
     """POST JSON to camofox and return parsed response."""
     url = f"{get_camofox_url()}{path}"
-    resp = requests.post(url, json=body, timeout=timeout, headers=_camofox_headers())
+    resp = requests.post(url, json=body, timeout=timeout)
     resp.raise_for_status()
     return resp.json()
 
@@ -408,7 +395,7 @@ def _post(path: str, body: dict, timeout: int = _DEFAULT_TIMEOUT) -> dict:
 def _get(path: str, params: dict = None, timeout: int = _DEFAULT_TIMEOUT) -> dict:
     """GET from camofox and return parsed response."""
     url = f"{get_camofox_url()}{path}"
-    resp = requests.get(url, params=params, timeout=timeout, headers=_camofox_headers())
+    resp = requests.get(url, params=params, timeout=timeout)
     resp.raise_for_status()
     return resp.json()
 
@@ -416,7 +403,7 @@ def _get(path: str, params: dict = None, timeout: int = _DEFAULT_TIMEOUT) -> dic
 def _get_raw(path: str, params: dict = None, timeout: int = _DEFAULT_TIMEOUT) -> requests.Response:
     """GET from camofox and return raw response (for binary data)."""
     url = f"{get_camofox_url()}{path}"
-    resp = requests.get(url, params=params, timeout=timeout, headers=_camofox_headers())
+    resp = requests.get(url, params=params, timeout=timeout)
     resp.raise_for_status()
     return resp
 
@@ -424,7 +411,7 @@ def _get_raw(path: str, params: dict = None, timeout: int = _DEFAULT_TIMEOUT) ->
 def _delete(path: str, body: dict = None, timeout: int = _DEFAULT_TIMEOUT) -> dict:
     """DELETE to camofox and return parsed response."""
     url = f"{get_camofox_url()}{path}"
-    resp = requests.delete(url, json=body, timeout=timeout, headers=_camofox_headers())
+    resp = requests.delete(url, json=body, timeout=timeout)
     resp.raise_for_status()
     return resp.json()
 


### PR DESCRIPTION
The kanban `_default_spawn` was passing `chat -q <prompt>` when invoking the subagent. `-q` expects a quoted single-query string but the prompt can contain spaces and special characters. Switch to `-z` which correctly handles short-form prompts passed through the shell.