### PR TITLE
fix(tui): prevent prompt indicator (❯) from ghosting on status bar re-render (#44936)

### DIFF
--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -640,7 +640,7 @@ export function StatusRule({
       {rightWidth > 0 ? (
         <>
           <Text color={t.color.border}>{separatorWidth >= 3 ? ' ─ ' : ' '}</Text>
-          <Box flexShrink={0} width={rightWidth}>
+          <Box flexShrink={0} overflow="hidden" width={rightWidth}>
             <Text color={t.color.label} wrap="truncate-end">
               {cwdLabel}
             </Text>

--- a/ui-tui/src/lib/prompt.ts
+++ b/ui-tui/src/lib/prompt.ts
@@ -1,4 +1,21 @@
+import { stringWidth } from '@hermes/ink'
+
 const TERMUX_SAFE_PROMPT = '>'
+
+/**
+ * Ensure the prompt string fills its display width so re-renders don't leave
+ * ghost artifacts from ambiguous-width glyphs (e.g. ❯ U+276F which some
+ * terminals render at 2 cells while stringWidth reports 1).  Pad with spaces
+ * so Ink properly clears all previously-occupied cells on the next render.
+ */
+const widthSafePrompt = (text: string): string => {
+  const w = stringWidth(text)
+
+  // If the measured width is below the raw char length, we have an
+  // ambiguous-width situation — pad by one space to give the terminal
+  // room to clear the prior render's cells.
+  return text.length > w ? text.padEnd(text.length + 1) : text
+}
 
 export function composerPromptText(
   prompt: string,
@@ -21,15 +38,15 @@ export function composerPromptText(
     // panes this burns precious columns and increases wrap/clipping risk.
     const wideEnoughForProfile = typeof totalCols === 'number' ? totalCols >= 90 : false
     if (wideEnoughForProfile && profileName && !['default', 'custom'].includes(profileName)) {
-      return `${profileName} ${basePrompt}`
+      return widthSafePrompt(`${profileName} ${basePrompt}`)
     }
 
-    return basePrompt
+    return widthSafePrompt(basePrompt)
   }
 
   if (profileName && !['default', 'custom'].includes(profileName)) {
-    return `${profileName} ${prompt}`
+    return widthSafePrompt(`${profileName} ${prompt}`)
   }
 
-  return prompt
+  return widthSafePrompt(prompt)
 }


### PR DESCRIPTION
## What does this PR do?

fix(tui): prevent prompt indicator (❯) from ghosting on status bar re-render (#44936).

## Related Issue

Closes #44936

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

See commit for details.

## How to Test

1. Reproduce the symptom described in #44936
2. Apply the fix
3. Verify symptom is resolved