### PR TITLE
Add AI Gateway provider support

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -295,6 +295,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("MINIMAX_API_KEY",),
         base_url_env_var="MINIMAX_BASE_URL",
     ),
+    "aigateway": ProviderConfig(
+        id="aigateway",
+        name="AI Gateway",
+        auth_type="api_key",
+        inference_base_url="https://api.aigateway.sh/v1",
+        api_key_env_vars=("AIGATEWAY_API_KEY",),
+        base_url_env_var="AIGATEWAY_BASE_URL",
+    ),
     "minimax-oauth": ProviderConfig(
         id="minimax-oauth",
         name="MiniMax (OAuth \u00b7 minimax.io)",
@@ -1531,6 +1539,7 @@ def resolve_provider(
         "ollama": "custom", "ollama_cloud": "ollama-cloud",
         "vllm": "custom", "llamacpp": "custom",
         "llama.cpp": "custom", "llama-cpp": "custom",
+        "aig": "aigateway", "ai-gateway": "aigateway",
     }
     # Extend with aliases declared in plugins/model-providers/<name>/ that aren't already mapped.
     # This keeps providers/ as the single source for new aliases while the

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2899,6 +2899,7 @@ def select_provider_and_model(args=None):
         "deepseek",
         "xai",
         "zai",
+        "aigateway",
         "kimi-coding-cn",
         "minimax",
         "minimax-cn",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -313,6 +313,11 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "MiniMax-M2.1",
         "MiniMax-M2",
     ],
+    "aigateway": [
+        "moonshotai/kimi-k2.6",
+        "google/gemini-3.1-pro-preview",
+        "qwen/qwen3.7-max",
+    ],
     "minimax-oauth": [
         "MiniMax-M3",
         "MiniMax-M2.7",
@@ -1024,6 +1029,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("bedrock",        "AWS Bedrock",              "AWS Bedrock (Claude, Nova, Llama, DeepSeek; IAM or API key)"),
     ProviderEntry("azure-foundry",  "Azure Foundry",            "Azure Foundry (OpenAI-style or Anthropic-style endpoint, your Azure AI deployment)"),
     ProviderEntry("qwen-oauth",     "Qwen OAuth (Portal)",      "Qwen OAuth (Reuses local Qwen CLI login)"),
+    ProviderEntry("aigateway", "AI Gateway", "AI Gateway (api.aigateway.sh)"),
 ]
 
 # Auto-extend CANONICAL_PROVIDERS with any provider registered in providers/
@@ -1230,6 +1236,8 @@ _PROVIDER_ALIASES = {
     "lm_studio": "lmstudio",
     "ollama": "custom",  # bare "ollama" = local; use "ollama-cloud" for cloud
     "ollama_cloud": "ollama-cloud",
+    "aig": "aigateway",
+    "ai-gateway": "aigateway",
 }
 
 

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -196,6 +196,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="https://api.gmi-serving.com/v1",
         base_url_env_var="GMI_BASE_URL",
     ),
+    "aigateway": HermesOverlay(
+        transport="openai_chat",
+        extra_env_vars=("AIGATEWAY_API_KEY",),
+        base_url_override="https://api.aigateway.sh/v1",
+        base_url_env_var="AIGATEWAY_BASE_URL",
+    ),
     "ollama-cloud": HermesOverlay(
         transport="openai_chat",
         base_url_override="https://ollama.com/v1",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1175,6 +1175,25 @@ def _resolve_explicit_runtime(
             explicit_api_key=explicit_api_key,
             explicit_base_url=explicit_base_url,
         )
+    if provider == "aigateway":
+        api_key = (
+            os.environ.get("AIGATEWAY_API_KEY")
+            or config.get("aigateway_api_key")
+        )
+
+        base_url = os.environ.get(
+            "AIGATEWAY_BASE_URL",
+            "https://api.aigateway.sh/v1",
+        )
+
+        return {
+            "provider": "aigateway",
+            "api_mode": "chat_completions",
+            "base_url": base_url,
+            "api_key": api_key,
+            "source": "env" if os.environ.get("AIGATEWAY_API_KEY") else "config",
+            "requested_provider": requested_provider,
+        }
 
     pconfig = PROVIDER_REGISTRY.get(provider)
     if pconfig and pconfig.auth_type == "api_key":


### PR DESCRIPTION
## What does this PR do?

Adds AI Gateway as a supported API-key provider in Hermes Agent. This allows users to configure and use AI Gateway models through the existing provider selection and runtime infrastructure.

## Related Issue

Fixes #

## Type of Change

* [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

* Added `aigateway` to `PROVIDER_REGISTRY` in `hermes_cli/auth.py`
* Added provider aliases (`aig`, `ai-gateway`)
* Added AI Gateway model entries in `hermes_cli/models.py`
* Added AI Gateway to the provider selection UI
* Added AI Gateway overlay configuration in `hermes_cli/providers.py`
* Added runtime provider resolution in `hermes_cli/runtime_provider.py`
* Added support for `AIGATEWAY_API_KEY` and `AIGATEWAY_BASE_URL`

## How to Test

1. Run `python -m hermes_cli.main model`
2. Select **AI Gateway** from the provider list
3. Enter a valid `AIGATEWAY_API_KEY`
4. Select an AI Gateway model
5. Start a chat session and verify requests are routed through `https://api.aigateway.sh/v1`
6. Run `python -m hermes_cli.main status` and verify AI Gateway is shown as the active provider

## Checklist

### Code

* [x] My PR contains only changes related to this feature
* [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

* [x] I've considered cross-platform impact (N/A – uses existing OpenAI-compatible provider flow)
* [x] No documentation changes required
