### PR TITLE
Allow pre_api_request hooks to inject context via the steer queue

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -923,7 +923,7 @@ def run_conversation(
                         # provider client.  New consumers should read the
                         # sanitised view from ``request["body"]["messages"]``.
                         _request_payload = agent._api_request_payload_for_hook(api_kwargs)
-                        _invoke_hook(
+                        _pre_api_hook_results = _invoke_hook(
                             "pre_api_request",
                             task_id=effective_task_id,
                             turn_id=turn_id,
@@ -949,6 +949,23 @@ def run_conversation(
                             middleware_trace=list(_llm_middleware_trace),
                             request=_request_payload,
                         )
+                        # Hooks may return {"context": "..."} (see
+                        # agent/shell_hooks.py wire protocol).  Route that
+                        # text into the pending-steer queue: agent.steer()
+                        # is thread-safe and the steer drains onto the LAST
+                        # tool result as soon as the current tool batch
+                        # finishes (apply_pending_steer_to_tool_results /
+                        # the pre-API-call steer drain above), so the
+                        # context lands immediately before the model's next
+                        # reply — unlike pre_llm_call context, which sits in
+                        # the user message before the whole tool-call loop.
+                        for _pre_api_hook_result in _pre_api_hook_results or []:
+                            if not isinstance(_pre_api_hook_result, dict):
+                                continue
+                            _pre_api_hook_context = _pre_api_hook_result.get("context")
+                            if (isinstance(_pre_api_hook_context, str)
+                                    and _pre_api_hook_context.strip()):
+                                agent.steer(_pre_api_hook_context)
                 except Exception:
                     pass
 

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -44,7 +44,10 @@ Wire protocol
     {"decision": "block", "reason":  "Forbidden command"}   # Claude-Code-style
     {"action":   "block", "message": "Forbidden command"}   # Hermes-canonical
 
-    # Inject context for pre_llm_call:
+    # Inject context for pre_llm_call (appended to this turn's user
+    # message) or pre_api_request (routed into the agent's pending-steer
+    # queue and appended to the last tool result, so it lands immediately
+    # before the model's next reply):
     {"context": "Today is Friday"}
 
     # Silent no-op:
@@ -505,7 +508,11 @@ def _parse_response(event: str, stdout: str) -> Optional[Dict[str, Any]]:
     block directive.
 
     For ``pre_llm_call``, ``{"context": "..."}`` is passed through
-    unchanged to match the existing plugin-hook contract.
+    unchanged to match the existing plugin-hook contract.  The same
+    shape is honoured for ``pre_api_request``: the conversation loop
+    routes that context into the agent's pending-steer queue, so it is
+    appended to the last tool result right before the model's next
+    reply (useful for late-iteration nudges in long agentic runs).
 
     Anything else returns ``None``.
     """

--- a/tests/agent/test_shell_hooks.py
+++ b/tests/agent/test_shell_hooks.py
@@ -84,6 +84,12 @@ class TestParseResponse:
         )
         assert r == {"context": "today is Friday"}
 
+    def test_pre_api_request_context_passthrough(self):
+        r = shell_hooks._parse_response(
+            "pre_api_request", '{"context": "wrap up; budget is low"}',
+        )
+        assert r == {"context": "wrap up; budget is low"}
+
     def test_subagent_stop_context_passthrough(self):
         r = shell_hooks._parse_response(
             "subagent_stop", '{"context": "child role=leaf"}',

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3473,6 +3473,74 @@ class TestRunConversation:
         assert all("usage" in c and "response" in c for c in post_request_calls)
         assert all("assistant_message" in c["response"] for c in post_request_calls)
 
+    def test_pre_api_request_hook_context_feeds_steer_queue(self, agent):
+        self._setup_agent(agent)
+        tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")
+        resp1 = _mock_response(content="", finish_reason="tool_calls", tool_calls=[tc])
+        resp2 = _mock_response(content="Done searching", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [resp1, resp2]
+
+        def _hook(name, **kwargs):
+            if name == "pre_api_request":
+                return [{"context": "focus on summarising"}, {"note": "no context here"}]
+            return []
+
+        with (
+            patch("run_agent.handle_function_call", return_value="search result"),
+            patch(
+                "hermes_cli.plugins.has_hook",
+                side_effect=lambda name: name == "pre_api_request",
+            ),
+            patch("hermes_cli.plugins.invoke_hook", side_effect=_hook),
+            patch.object(agent, "steer", wraps=agent.steer) as steer_spy,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("search something")
+
+        assert result["final_response"] == "Done searching"
+        # The hook fired before each of the two API calls; only the dict
+        # carrying a non-empty "context" was enqueued each time.
+        assert steer_spy.call_count == 2
+        steer_spy.assert_any_call("focus on summarising")
+        # The steer enqueued before API call 1 drained onto the tool result
+        # after the batch ran, so the model saw it right before its reply.
+        tool_msgs = [
+            m for m in result["messages"]
+            if isinstance(m, dict) and m.get("role") == "tool"
+        ]
+        assert tool_msgs
+        assert any(
+            "focus on summarising" in str(m.get("content", "")) for m in tool_msgs
+        )
+        # The steer enqueued before the final (stop) call had no tool batch
+        # left to drain into; the finalizer hands it back to the caller.
+        assert result.get("pending_steer") == "focus on summarising"
+
+    def test_pre_api_request_hook_without_context_is_steer_noop(self, agent):
+        self._setup_agent(agent)
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="Done", finish_reason="stop",
+        )
+        with (
+            patch(
+                "hermes_cli.plugins.has_hook",
+                side_effect=lambda name: name == "pre_api_request",
+            ),
+            patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+            patch.object(agent, "steer", wraps=agent.steer) as steer_spy,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["final_response"] == "Done"
+        steer_spy.assert_not_called()
+        assert getattr(agent, "_pending_steer", None) is None
+        assert "pending_steer" not in result
+
     def test_api_request_error_hook_skips_payload_work_without_listener(self, agent, monkeypatch):
         payload_built = False
         hook_called = False


### PR DESCRIPTION
## Motivation

Shell hooks can currently inject context only on `pre_llm_call`, whose output is appended to the turn's **user message**. In agentic runs that message sits before the entire tool-call loop — often thousands of tokens away from where the final reply is generated, where injected context has the least leverage.

The agent already has a mechanism with true reply-time recency: the pending-steer queue (`AIAgent.steer()`). Steered text is appended to the **last tool result** as soon as the current tool batch finishes (`apply_pending_steer_to_tool_results`, plus the pre-API-call drain in `agent/conversation_loop.py`), so the model sees it immediately before producing its next reply. But nothing external could feed that queue programmatically.

This PR wires the two together: `pre_api_request` hooks can now return `{"context": "..."}` and the conversation loop routes that text into the steer queue via the thread-safe `agent.steer()`.

## Wire-protocol addition

```json
{"context": "wrap up; budget is low"}
```

returned on stdout by a `pre_api_request` shell hook is enqueued as a steer and delivered at the end of the last tool result, right before the model's next reply. (`_parse_response` already passed `{"context": ...}` through for non-`pre_tool_call` events; the docstrings now document the `pre_api_request` contract explicitly, and the conversation loop now consumes it.) Empty/missing context, non-dict results, and hook errors are all no-ops — the hook block keeps its existing fail-open behavior.

Since the `pre_api_request` payload already includes `api_call_count` (plus `approx_input_tokens`, `message_count`, etc.), hooks can target late iterations specifically — e.g. nudge the agent to wrap up once the loop passes N calls or the request grows past a token budget.

## Test coverage

- `tests/agent/test_shell_hooks.py`: `{"context": ...}` passthrough for `pre_api_request` in `_parse_response`.
- `tests/run_agent/test_run_agent.py::TestRunConversation`:
  - hook-returned context is enqueued via `agent.steer()` and lands on the tool result before the next reply (and surfaces as `pending_steer` when no tool batch remains);
  - hooks returning nothing leave the steer queue untouched.

`tests/agent/test_shell_hooks.py` (54 passed) and `tests/run_agent/test_run_agent.py` (378 passed; `TestInit::test_model_max_tokens_from_config` deselected — it requires network access and fails on a clean checkout in the sandbox) run green with the repo venv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
