### PR TITLE
Improve memory Write Gate review flow

### DIFF
--- a/hermes_cli/write_approval_commands.py
+++ b/hermes_cli/write_approval_commands.py
@@ -30,10 +30,63 @@ def _fmt_state(subsystem: str) -> str:
 # Formatting helpers
 # ---------------------------------------------------------------------------
 
+def _memory_action_menu(pending_id: str) -> str:
+    return "\n".join([
+        "Choose:",
+        f"  A) Approve this memory write    /memory approve {pending_id}   (or /memory a {pending_id})",
+        f"  B) Reject this memory write     /memory reject {pending_id}    (or /memory b {pending_id})",
+        "  C) Show all pending memory writes /memory pending              (or /memory c)",
+        "  D) Reject all pending memory writes /memory reject all          (or /memory d)",
+        f"  E) Review one-by-one / edit      /memory review                (or /memory e)",
+        f"     Edit before approving: /memory edit {pending_id} <new text>",
+    ])
+
+
+def _fmt_memory_record(record) -> str:
+    payload = record.get("payload", {}) if isinstance(record, dict) else {}
+    pending_id = record.get("id", "")
+    action = payload.get("action") or record.get("action", "")
+    target = payload.get("target", "memory")
+    content = payload.get("content") or ""
+    old_text = payload.get("old_text") or ""
+
+    lines = [
+        "MEMORY WRITE APPROVAL",
+        f"Pending ID: {pending_id}",
+        f"Action: {action} to {target.upper()}",
+    ]
+    if old_text:
+        lines.extend(["Old content:", old_text])
+    if content:
+        lines.extend(["Content:", content])
+    lines.extend(["", _memory_action_menu(pending_id)])
+    return "\n".join(lines)
+
+
 def _fmt_pending_list(subsystem: str) -> str:
     records = wa.list_pending(subsystem)
     if not records:
         return f"No pending {subsystem} writes."
+    if subsystem == wa.MEMORY:
+        lines = [
+            f"MEMORY WRITE APPROVAL — pending writes ({len(records)}):",
+        ]
+        for r in records:
+            payload = r.get("payload", {})
+            target = str(payload.get("target", "memory")).upper()
+            action = payload.get("action", r.get("action", ""))
+            content = (payload.get("content") or payload.get("old_text") or r.get("summary", "")).replace("\n", " ")
+            if len(content) > 120:
+                content = content[:117] + "..."
+            lines.append(f"  {r['id']}  {action} {target}: {content}")
+        lines.append("")
+        lines.append("Review one at a time: /memory review    (or /memory e)")
+        lines.append("Approve: /memory approve <id>           (or /memory a <id>)")
+        lines.append("Reject:  /memory reject <id>            (or /memory b <id>)")
+        lines.append("Edit:    /memory edit <id> <new text>")
+        lines.append("Reject all: /memory reject all          (or /memory d)")
+        return "\n".join(lines)
+
     lines = [f"Pending {subsystem} writes ({len(records)}):"]
     for r in records:
         origin = r.get("origin", "foreground")
@@ -81,8 +134,27 @@ def handle_pending_subcommand(
     sub = args[0].lower()
     rest = args[1:]
 
+    if subsystem == wa.MEMORY:
+        alias_map = {
+            "a": "approve",
+            "b": "reject",
+            "c": "pending",
+            "d": "reject_all",
+            "e": "review",
+        }
+        sub = alias_map.get(sub, sub)
+
     if sub == "pending":
         return _fmt_pending_list(subsystem)
+
+    if sub in {"review", "show"} and subsystem == wa.MEMORY:
+        return _review_memory(rest)
+
+    if sub == "edit" and subsystem == wa.MEMORY:
+        return _edit_memory(rest)
+
+    if sub == "reject_all" and subsystem == wa.MEMORY:
+        return _reject(subsystem, ["all"])
 
     if sub in {"approve", "apply"}:
         return _approve(subsystem, rest, memory_store)
@@ -168,6 +240,42 @@ def _reject(subsystem: str, rest: List[str]) -> str:
     if wa.discard_pending(subsystem, target):
         return f"Rejected pending {subsystem} write '{target}'."
     return f"No pending {subsystem} write with id '{target}'."
+
+
+def _review_memory(rest: List[str]) -> str:
+    if rest:
+        rec = wa.get_pending(wa.MEMORY, rest[0])
+        if not rec:
+            return f"No pending memory write with id '{rest[0]}'."
+    else:
+        records = wa.list_pending(wa.MEMORY)
+        if not records:
+            return "No pending memory writes."
+        rec = records[0]
+    return _fmt_memory_record(rec)
+
+
+def _edit_memory(rest: List[str]) -> str:
+    if len(rest) < 2:
+        return "Usage: /memory edit <id> <new text>"
+    pending_id = rest[0]
+    rec = wa.get_pending(wa.MEMORY, pending_id)
+    if not rec:
+        return f"No pending memory write with id '{pending_id}'."
+    payload = dict(rec.get("payload", {}))
+    action = payload.get("action")
+    if action not in {"add", "replace"}:
+        return f"Pending memory write '{pending_id}' is action '{action}' and cannot be edited. Reject it instead."
+    new_text = " ".join(rest[1:]).strip()
+    if not new_text:
+        return "Usage: /memory edit <id> <new text>"
+    payload["content"] = new_text
+    target = payload.get("target", "memory")
+    summary = f"{action} to {target}: {new_text[:120]}"
+    updated = wa.update_pending(wa.MEMORY, pending_id, payload, summary=summary)
+    if updated is None:
+        return f"Failed to edit pending memory write '{pending_id}'."
+    return "Updated pending memory write.\n\n" + _fmt_memory_record(updated)
 
 
 def _diff(rest: List[str]) -> str:

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -216,6 +216,70 @@ def test_handle_reject(hermes_home):
     assert wa.pending_count("skills") == 0
 
 
+def test_memory_pending_list_is_labeled_and_has_abcde(hermes_home):
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+    wa.stage_write("memory", {"action": "add", "target": "memory", "content": "remember carefully"},
+                   summary="remember carefully", origin="foreground")
+    out = handle_pending_subcommand(wa.MEMORY, ["pending"])
+    assert out is not None
+    assert "MEMORY WRITE APPROVAL" in out
+    assert "Review one at a time" in out
+    assert "/memory a <id>" in out
+    assert "/memory d" in out
+
+
+def test_memory_review_shows_one_record_and_abcde_menu(hermes_home):
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+    rec = wa.stage_write("memory", {"action": "add", "target": "user", "content": "specific fact"},
+                         summary="specific fact", origin="foreground")
+    out = handle_pending_subcommand(wa.MEMORY, ["review"])
+    assert out is not None
+    assert "MEMORY WRITE APPROVAL" in out
+    assert f"Pending ID: {rec['id']}" in out
+    assert "Action: add to USER" in out
+    assert "A) Approve" in out
+    assert "E) Review one-by-one" in out
+
+
+def test_memory_edit_updates_pending_content(hermes_home):
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+    rec = wa.stage_write("memory", {"action": "add", "target": "memory", "content": "old fact"},
+                         summary="old fact", origin="foreground")
+    out = handle_pending_subcommand(wa.MEMORY, ["edit", rec["id"], "new", "fact"])
+    assert out is not None
+    assert "Updated pending memory write" in out
+    updated = wa.get_pending(wa.MEMORY, rec["id"])
+    assert updated is not None
+    assert updated["payload"]["content"] == "new fact"
+    assert "new fact" in updated["summary"]
+
+
+def test_memory_abcde_aliases(hermes_home):
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools.memory_tool import MemoryStore
+    from tools import write_approval as wa
+    store = MemoryStore(); store.load_from_disk()
+    rec = wa.stage_write("memory", {"action": "add", "target": "memory", "content": "alias fact"},
+                         summary="alias fact", origin="foreground")
+    e_out = handle_pending_subcommand(wa.MEMORY, ["e"])
+    c_out = handle_pending_subcommand(wa.MEMORY, ["c"])
+    a_out = handle_pending_subcommand(wa.MEMORY, ["a", rec["id"]], memory_store=store)
+    assert e_out is not None and "MEMORY WRITE APPROVAL" in e_out
+    assert c_out is not None and "pending writes" in c_out
+    assert a_out is not None and "Approved 1" in a_out
+    rec2 = wa.stage_write("memory", {"action": "add", "target": "memory", "content": "reject me"},
+                          summary="reject me", origin="foreground")
+    b_out = handle_pending_subcommand(wa.MEMORY, ["b", rec2["id"]])
+    assert b_out is not None and "Rejected" in b_out
+    wa.stage_write("memory", {"action": "add", "target": "memory", "content": "reject all"},
+                   summary="reject all", origin="foreground")
+    d_out = handle_pending_subcommand(wa.MEMORY, ["d"])
+    assert d_out is not None and "Rejected 1" in d_out
+
+
 def test_handle_approval_on(hermes_home):
     from hermes_cli.write_approval_commands import handle_pending_subcommand
     from tools import write_approval as wa
@@ -283,58 +347,24 @@ def approval_callback_cleanup():
     set_approval_callback(None)
 
 
-def test_memory_inline_approve_writes(hermes_home, approval_callback_cleanup):
+def test_memory_gate_on_stages_even_with_approval_callback(hermes_home, approval_callback_cleanup):
+    # Memory writes use the pending-review flow, not the generic timed approval
+    # box. A registered CLI approval callback must not be invoked.
     from tools.memory_tool import memory_tool, MemoryStore
     from tools.terminal_tool import set_approval_callback
     from tools import write_approval as wa
     _set_approval("memory", True)
 
     calls = []
-    def approve_cb(command, description, **kw):
-        calls.append((command, description))
-        return "once"
-    set_approval_callback(approve_cb)
+    set_approval_callback(lambda command, description, **kw: calls.append((command, description)) or "once")
 
     store = MemoryStore(); store.load_from_disk()
     r = json.loads(memory_tool("add", "memory", "approved fact", store=store))
     assert r["success"] is True
-    assert r.get("staged") is None  # real write, not staged
-    assert store.memory_entries == ["approved fact"]
-    assert wa.pending_count("memory") == 0
-    # The registered callback must actually be invoked (not the input() path).
-    assert len(calls) == 1
-    assert "approved fact" in calls[0][0]
-
-
-def test_memory_inline_deny_blocks(hermes_home, approval_callback_cleanup):
-    from tools.memory_tool import memory_tool, MemoryStore
-    from tools.terminal_tool import set_approval_callback
-    from tools import write_approval as wa
-    _set_approval("memory", True)
-    set_approval_callback(lambda command, description, **kw: "deny")
-
-    store = MemoryStore(); store.load_from_disk()
-    r = json.loads(memory_tool("add", "memory", "denied fact", store=store))
-    assert r["success"] is False
-    assert "denied" in r["error"].lower()
-    assert store.memory_entries == []
-    assert wa.pending_count("memory") == 0  # denied, not staged
-
-
-def test_memory_inline_callback_error_stages(hermes_home, approval_callback_cleanup):
-    # If the prompt machinery fails, fall back to staging — never drop silently.
-    from tools.memory_tool import memory_tool, MemoryStore
-    from tools.terminal_tool import set_approval_callback
-    from tools import write_approval as wa
-    _set_approval("memory", True)
-    def broken_cb(command, description, **kw):
-        raise RuntimeError("boom")
-    set_approval_callback(broken_cb)
-
-    store = MemoryStore(); store.load_from_disk()
-    r = json.loads(memory_tool("add", "memory", "fallback fact", store=store))
     assert r.get("staged") is True
+    assert store.memory_entries == []
     assert wa.pending_count("memory") == 1
+    assert calls == []
 
 
 def test_gateway_context_stages_not_prompts(hermes_home, monkeypatch):

--- a/tools/write_approval.py
+++ b/tools/write_approval.py
@@ -189,6 +189,31 @@ def discard_pending(subsystem: str, pending_id: str) -> bool:
     return False
 
 
+def update_pending(subsystem: str, pending_id: str, payload: Dict[str, Any],
+                   *, summary: Optional[str] = None) -> Optional[Dict[str, Any]]:
+    """Update a pending record in place and return the updated record.
+
+    Used by the memory review flow so a user can correct staged memory text
+    before approving it. Returns None when the record does not exist or cannot
+    be read/written.
+    """
+    path = _pending_dir(subsystem) / f"{pending_id}.json"
+    if not path.exists():
+        return None
+    try:
+        record = json.loads(path.read_text(encoding="utf-8"))
+        record["payload"] = payload
+        if summary is not None:
+            record["summary"] = (summary or "").strip()
+        tmp = path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(record, ensure_ascii=False, indent=2), encoding="utf-8")
+        os.replace(tmp, path)
+        return record
+    except Exception as e:  # pragma: no cover
+        logger.error("Failed to update pending %s/%s: %s", subsystem, pending_id, e)
+        return None
+
+
 def pending_count(subsystem: str) -> int:
     """Cheap count of pending records (for notification badges)."""
     d = _pending_dir(subsystem)
@@ -276,9 +301,13 @@ def evaluate_gate(subsystem: str, *, inline_summary: str = "",
 
     background = is_background()
 
-    # Skills always stage — a SKILL.md is too large to review inline, and a
-    # background skill write happens in a daemon thread with no user present.
-    if subsystem == SKILLS or background:
+    # Memory and skills both stage while their write gate is on. Earlier builds
+    # used the generic timed dangerous-command approval box for foreground CLI
+    # memory writes, but that made permanent memory writes too easy to approve
+    # accidentally. Staging gives memory writes a clearly labelled review flow
+    # (/memory pending, /memory review, /memory approve|reject|edit) and keeps
+    # the generic timed approval UI for command execution only.
+    if subsystem in {MEMORY, SKILLS} or background:
         where = "/skills pending" if subsystem == SKILLS else "/memory pending"
         return GateDecision(
             stage=True,
@@ -288,6 +317,8 @@ def evaluate_gate(subsystem: str, *, inline_summary: str = "",
             ),
         )
 
+    # This branch is intentionally unreachable for the built-in subsystems, but
+    # kept as a defensive fallback if a future subsystem reuses evaluate_gate().
     # Memory + foreground: if an interactive approval channel exists (a CLI
     # approval callback registered on this thread), prompt inline — entries
     # are small enough to show in full. Otherwise (gateway, script, batch,


### PR DESCRIPTION
## Summary

This PR proposes one implementation for #44963: make memory Write Gate approvals explicit and staged instead of using the generic timed approval prompt for foreground memory writes.

When `memory.write_approval` is enabled, memory writes now stage for review. Users can then review, approve, reject, reject all, or edit pending memory writes through memory-specific commands.

## Why

Persistent memory writes are more sensitive than ordinary command/tool approvals. A generic timed approval prompt can be easy to misread as approving a command or test action, while actually allowing a durable memory change. Staging memory writes creates a distinct review flow and makes the permanent-write decision explicit.

## Changes

- Stage memory writes whenever `memory.write_approval` is enabled.
- Keep the generic timed approval prompt out of the memory-write path.
- Add pending-record update support for editing staged memory writes.
- Add memory-specific `MEMORY WRITE APPROVAL` formatting.
- Add one-at-a-time review:
  - `/memory review`
  - `/memory review <id>`
  - `/memory e`
- Add A/B/C/D/E aliases:
  - `/memory a <id>` approve
  - `/memory b <id>` reject
  - `/memory c` show pending
  - `/memory d` reject all
  - `/memory e` review one-by-one
- Add edit-before-approval:
  - `/memory edit <id> <new text>`
- Update regression tests around memory Write Gate behavior and review commands.

## Testing

Ran focused tests:

```bash
/usr/local/lib/hermes-agent/venv/bin/python3 -m pytest tests/tools/test_write_approval.py -q -o 'addopts='
```

Result:

```text
27 passed in 0.89s
```

## Notes

This is intended as a concrete implementation proposal. If maintainers prefer different command names, wording, or a different UX shape, the underlying safety behavior can be adjusted while preserving the main principle: memory writes should have a memory-specific explicit review flow rather than sharing the generic timed approval box.
