### PR TITLE
fix(telegram): auto-disable topic mode when disabled externally

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6367,6 +6367,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """Disable stale Telegram topic mode before applying a lobby gate."""
         if source.platform != Platform.TELEGRAM or source.chat_type != "dm":
             return
+        thread_id = str(source.thread_id or "")
+        if thread_id not in self._TELEGRAM_GENERAL_TOPIC_IDS:
+            return
         if not await asyncio.to_thread(self._telegram_topic_mode_enabled, source):
             return
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6359,6 +6359,49 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # opt into topic mode) means topic mode is off for this chat.
         return raw is True
 
+    async def _recover_telegram_topic_mode_desync(
+        self,
+        event: MessageEvent,
+        source: SessionSource,
+    ) -> None:
+        """Disable stale Telegram topic mode before applying a lobby gate."""
+        if source.platform != Platform.TELEGRAM or source.chat_type != "dm":
+            return
+        if not await asyncio.to_thread(self._telegram_topic_mode_enabled, source):
+            return
+
+        raw_message = getattr(event, "raw_message", None)
+        raw_chat = getattr(raw_message, "chat", None) if raw_message else None
+        if getattr(raw_chat, "is_forum", None) is not False:
+            return
+
+        logger.info(
+            "Telegram topic-mode desync detected for chat %s: "
+            "chat.is_forum=False but DB has topic_mode=ON. "
+            "Auto-disabling topic mode.",
+            source.chat_id,
+        )
+        session_db = getattr(self, "_session_db", None)
+        if session_db is None:
+            return
+        try:
+            await session_db.disable_telegram_topic_mode(
+                chat_id=str(source.chat_id)
+            )
+        except Exception:
+            logger.debug("Failed to auto-disable topic mode", exc_info=True)
+            return
+
+        # Avoid stale debounce state if the root message reaches a lobby
+        # reminder again after topic mode is re-enabled.
+        for attr in (
+            "_telegram_lobby_reminder_ts",
+            "_telegram_capability_hint_ts",
+        ):
+            store = getattr(self, attr, None)
+            if isinstance(store, dict):
+                store.pop(str(source.chat_id), None)
+
     # Telegram's General (pinned top) topic in forum-enabled private chats.
     # Bot API behavior varies: some clients omit message_thread_id for
     # General, others send "1". Treat both as "root" for lobby/lane purposes.
@@ -14286,6 +14329,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     break
 
         if canonical == "new":
+            await self._recover_telegram_topic_mode_desync(event, source)
             if await asyncio.to_thread(self._is_telegram_topic_root_lobby, source):
                 return self._telegram_topic_root_new_message()
             async def _do_reset():
@@ -14854,6 +14898,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # No bare text matching — "yes" in normal conversation must not trigger
         # execution of a dangerous command.
 
+        if not is_internal:
+            await self._recover_telegram_topic_mode_desync(event, source)
         if not is_internal and await asyncio.to_thread(
             self._is_telegram_topic_root_lobby, source
         ):

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -783,6 +783,22 @@ async def test_topic_mode_auto_disables_when_chat_is_forum_false(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_topic_lane_skips_desync_recovery_db_read():
+    runner = _make_runner()
+    runner._telegram_topic_mode_enabled = MagicMock(
+        side_effect=AssertionError("topic lane must skip the topic-mode DB read")
+    )
+    event = _make_event("Hello", thread_id="17585")
+    event.raw_message = SimpleNamespace(
+        chat=SimpleNamespace(id=208214988, is_forum=True)
+    )
+
+    await runner._recover_telegram_topic_mode_desync(event, event.source)
+
+    runner._telegram_topic_mode_enabled.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_new_auto_disables_topic_mode_when_chat_is_forum_false(tmp_path):
     db = SessionDB(tmp_path / "state.db")
     runner = _make_runner(session_db=db)

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -762,3 +762,73 @@ def test_get_telegram_topic_binding_by_session_returns_binding(tmp_path):
 # Test for session-split thread_id recovery (issue #27166)
 # ---------------------------------------------------------------------------
 
+@pytest.mark.asyncio
+async def test_topic_mode_auto_disables_when_chat_is_forum_false(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    runner = _make_runner(session_db=db)
+    runner._handle_message_with_agent = AsyncMock(return_value="agent response")
+    db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+
+    event = _make_event("Hello", thread_id=None)
+    event.raw_message = SimpleNamespace(
+        chat=SimpleNamespace(id=208214988, is_forum=False)
+    )
+
+    response = await runner._handle_message(event)
+
+    assert db.is_telegram_topic_mode_enabled(chat_id="208214988", user_id="208214988") is False
+    assert runner._telegram_topic_mode_enabled(event.source) is False
+    assert response == "agent response"
+    runner._handle_message_with_agent.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_new_auto_disables_topic_mode_when_chat_is_forum_false(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    runner = _make_runner(session_db=db)
+    db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+
+    event = _make_event("/new", thread_id=None)
+    event.raw_message = SimpleNamespace(
+        chat=SimpleNamespace(id=208214988, is_forum=False)
+    )
+
+    response = await runner._handle_message(event)
+
+    assert db.is_telegram_topic_mode_enabled(chat_id="208214988", user_id="208214988") is False
+    assert "create a new topic" not in str(response)
+    runner.session_store.reset_session.assert_called_once_with(
+        build_session_key(event.source)
+    )
+
+
+@pytest.mark.asyncio
+async def test_topic_mode_stays_enabled_when_chat_is_forum_true(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    runner = _make_runner(session_db=db)
+    db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+
+    event = _make_event("Hello", thread_id=None)
+    event.raw_message = SimpleNamespace(
+        chat=SimpleNamespace(id=208214988, is_forum=True)
+    )
+
+    response = await runner._handle_message(event)
+
+    assert db.is_telegram_topic_mode_enabled(chat_id="208214988", user_id="208214988") is True
+    assert "reserved for system commands" in str(response)
+
+
+@pytest.mark.asyncio
+async def test_topic_mode_no_crash_when_raw_message_missing(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    runner = _make_runner(session_db=db)
+    db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+
+    event = _make_event("Hello", thread_id=None)
+    event.raw_message = None
+
+    response = await runner._handle_message(event)
+
+    assert db.is_telegram_topic_mode_enabled(chat_id="208214988", user_id="208214988") is True
+    assert "reserved for system commands" in str(response)


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->
Fixes a design gap where Hermes's SQLite database permanently traps users in the Telegram topic "lobby" if they disable forum topics externally (e.g., via BotFather or the Telegram UI).

When a user enables `/topic`, `telegram_dm_topic_mode.enabled` is set to 1. If they later disable forum topics in Telegram, all incoming messages arrive without a `message_thread_id`. Because the topic mode check `_telegram_topic_mode_enabled()` is a pure DB lookup, Hermes continues to treat the chat as a lobby and silently drops or rejects all messages at the lobby gate. The user is entirely locked out of the bot unless they know to type `/topic off`.

This PR introduces pragmatic auto-recovery at the lobby gate: if a message is about to be blocked by the lobby gate, we first inspect the raw Telegram `Update` to check `chat.is_forum`. If `is_forum` is `False` but the DB says topic mode is ON, we auto-disable the topic mode in the DB and allow the message through.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- Added auto-detect and auto-disable recovery logic for `chat.is_forum` desyncs in `gateway/run.py` at the lobby gate.
- Added 3 new `pytest` test cases in `tests/gateway/test_telegram_topic_mode.py` for full test coverage of this specific desync scenario and edge cases.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Run `/topic` in a Telegram DM with the bot to enable topic mode.
2. Go to BotFather or Telegram Settings and disable "Topics" for the chat.
3. Send a normal message to the bot. Before this PR, the message would hit the lobby gate and lock you out. With this PR, the database auto-recovers and processes the message as a standard DM.
4. Run the automated tests: `pytest tests/gateway/test_telegram_topic_mode.py -v -k test_topic_mode`

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux Ubuntu

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->
