### PR TITLE
fix(cli): show sessions from all sources in /sessions command

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5736,12 +5736,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         print()
     
     def _list_recent_sessions(self, limit: int = 10) -> list[dict[str, Any]]:
-        """Return recent CLI sessions for in-chat browsing/resume affordances."""
+        """Return recent sessions for in-chat browsing/resume affordances."""
         if not self._session_db:
             return []
         try:
             sessions = self._session_db.list_sessions_rich(
-                source="cli",
                 exclude_sources=["tool"],
                 limit=limit,
             )

--- a/tests/cli/test_cli_resume_command.py
+++ b/tests/cli/test_cli_resume_command.py
@@ -287,3 +287,28 @@ class TestRestoreSessionCwdMarkup:
             assert "Working directory" in printed or "working" in printed.lower()
         finally:
             os.chdir(original_cwd)
+
+    def test_list_recent_sessions_does_not_filter_by_source(self):
+        """_list_recent_sessions should include sessions from all sources
+        (cli, tui, gateway, etc.), not just source='cli'.
+
+        Regression test for #44964: the /sessions command previously
+        filtered by source="cli", hiding TUI and gateway sessions.
+        """
+        cli_obj = _make_cli()
+        cli_obj._session_db.list_sessions_rich.return_value = [
+            {"id": "s1", "title": "CLI session", "source": "cli"},
+            {"id": "s2", "title": "TUI session", "source": "tui"},
+            {"id": "s3", "title": "WhatsApp session", "source": "whatsapp"},
+        ]
+
+        result = cli_obj._list_recent_sessions(limit=10)
+
+        # Verify the call was made WITHOUT a source filter
+        call_kwargs = cli_obj._session_db.list_sessions_rich.call_args[1]
+        assert "source" not in call_kwargs or call_kwargs.get("source") is None
+        # Should still exclude tool sessions
+        assert call_kwargs.get("exclude_sources") == ["tool"]
+        # All three sessions should be returned
+        assert len(result) == 3
+        assert {s["id"] for s in result} == {"s1", "s2", "s3"}


### PR DESCRIPTION
## What does this PR do?

Removes the `source="cli"` filter from `_list_recent_sessions()` so that the `/sessions` command shows sessions from all sources (CLI, TUI, WhatsApp, etc.), matching the Dashboard's behavior. Previously, TUI and gateway sessions were silently hidden from the CLI session browser.

## Related Issue

Fixes #44964

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py`: Remove `source="cli"` filter from `_list_recent_sessions()` and update docstring to reflect the broader scope
- `tests/cli/test_cli_resume_command.py`: Add regression test verifying the function passes no source filter and still excludes tool sessions

## How to Test

1. Start Hermes in TUI mode: `hermes` (default TUI)
2. Start a conversation and set a title: `/title Test TUI Session`
3. Exit TUI: `/exit`
4. Start Hermes in CLI prompt mode: `hermes --cli`
5. Run `/sessions`
6. **Expected:** The TUI session appears in the list alongside CLI sessions
7. **Before this fix:** Only CLI sessions were shown; TUI sessions were hidden

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `cli.py:_list_recent_sessions` (callers: `_show_recent_sessions`, `/resume`, `/sessions`)
- Blast radius: LOW — only affects session listing in CLI, no impact on session creation or gateway
- Related patterns: `web_server.py` and `tui_gateway/server.py` already use `source=None` for their session lists
