### PR TITLE
fix(dashboard-auth): stop hardcoding ~/.hermes for audit log path

### DIFF
--- a/hermes_cli/dashboard_auth/audit.py
+++ b/hermes_cli/dashboard_auth/audit.py
@@ -5,9 +5,11 @@ Format: one JSON object per line. Token-like fields are stripped before
 serialisation to avoid leaking refresh tokens or JWTs to disk.
 
 This module deliberately keeps a minimal dependency surface — no imports
-from ``hermes_constants`` or other hermes_cli modules — so it can be
-imported safely from middleware code that loads early in the startup
-sequence.
+from other hermes_cli modules — so it can be imported safely from
+middleware code that loads early in the startup sequence.
+``hermes_constants`` is the one exception: it is stdlib-only and
+import-safe from anywhere, and it owns the canonical Hermes home
+resolution (env var, profile override, platform-native fallback).
 """
 from __future__ import annotations
 
@@ -15,10 +17,11 @@ import datetime as _dt
 import enum
 import json
 import logging
-import os
 import threading
 from pathlib import Path
 from typing import Any
+
+from hermes_constants import get_hermes_home
 
 _log = logging.getLogger(__name__)
 _write_lock = threading.Lock()
@@ -50,14 +53,13 @@ class AuditEvent(enum.Enum):
 
 
 def _resolve_log_path() -> Path:
-    """``$HERMES_HOME/logs/dashboard-auth.log`` with the standard fallback.
+    """``$HERMES_HOME/logs/dashboard-auth.log``, profile and platform aware.
 
-    Mirrors ``hermes_constants.get_hermes_home`` semantics: env var wins,
-    else ``~/.hermes``. A local copy avoids an import cycle with the
-    middleware which lives below ``hermes_cli``.
+    Delegates to ``hermes_constants.get_hermes_home`` (the single source
+    of truth) so the fallback matches the platform-native default —
+    ``%LOCALAPPDATA%\\hermes`` on native Windows, ``~/.hermes`` elsewhere.
     """
-    home = os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes")
-    return Path(home) / "logs" / "dashboard-auth.log"
+    return get_hermes_home() / "logs" / "dashboard-auth.log"
 
 
 def audit_log(event: AuditEvent, **fields: Any) -> None:

--- a/tests/hermes_cli/test_dashboard_auth_audit.py
+++ b/tests/hermes_cli/test_dashboard_auth_audit.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import pytest
 
+import hermes_constants
 from hermes_cli.dashboard_auth.audit import audit_log, AuditEvent
 
 
@@ -79,3 +80,29 @@ def test_audit_creates_logs_dir_if_missing(tmp_path, monkeypatch):
     audit_log(AuditEvent.LOGIN_START, provider="nous")
     assert (home / "logs").is_dir()
     assert (home / "logs" / "dashboard-auth.log").exists()
+
+
+def test_audit_fallback_uses_platform_native_home_on_windows(tmp_path, monkeypatch):
+    """HERMES_HOME unset on native Windows → %LOCALAPPDATA%\\hermes, not ~/.hermes."""
+    local_appdata = tmp_path / "LocalAppData"
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setenv("LOCALAPPDATA", str(local_appdata))
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "Home")
+    monkeypatch.setattr(hermes_constants.sys, "platform", "win32")
+
+    audit_log(AuditEvent.LOGIN_START, provider="nous")
+
+    log_path = local_appdata / "hermes" / "logs" / "dashboard-auth.log"
+    assert log_path.exists(), f"audit log not created at platform-native path: {log_path}"
+    assert not (tmp_path / "Home" / ".hermes").exists(), "audit log leaked into ~/.hermes"
+
+
+def test_audit_fallback_uses_posix_home_off_windows(tmp_path, monkeypatch):
+    """HERMES_HOME unset on POSIX → the documented ~/.hermes fallback still applies."""
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    monkeypatch.setattr(hermes_constants.sys, "platform", "linux")
+
+    audit_log(AuditEvent.LOGIN_START, provider="nous")
+
+    assert (tmp_path / ".hermes" / "logs" / "dashboard-auth.log").exists()


### PR DESCRIPTION
## What

`_resolve_log_path()` in `hermes_cli/dashboard_auth/audit.py` hardcoded
`~/.hermes` as the `HERMES_HOME` fallback, while the canonical
`hermes_constants.get_hermes_home()` resolves the platform-native default
(`%LOCALAPPDATA%\hermes`). Audit logs could land in a different tree than
every other Hermes state file, and the local copy also ignored the
context-local profile override.

## Fix

Delegate to `get_hermes_home()` — the documented single source of truth.
`hermes_constants` is stdlib-only and import-safe from anywhere, so the
import-cycle concern that motivated the local copy does not apply.

## Tests

Added 2 regression tests in `tests/hermes_cli/test_dashboard_auth_audit.py`:
platform-native fallback (`%LOCALAPPDATA%\hermes\logs\dashboard-auth.log`)
and the `~/.hermes` fallback. Existing `HERMES_HOME`-set tests unchanged.

Results:
- `tests/hermes_cli/test_dashboard_auth_audit.py` — **7 passed**
- All dashboard_auth suites (13 files) — **248 passed**
