### PR TITLE
fix(tui): stretch NoSelect gutter to cover all content rows

### DIFF
--- a/ui-tui/src/components/messageLine.tsx
+++ b/ui-tui/src/components/messageLine.tsx
@@ -226,7 +226,7 @@ export const MessageLine = memo(function MessageLine({
         </Box>
       )}
 
-      <Box>
+      <Box alignItems="stretch">
         <NoSelect flexShrink={0} fromLeftEdge width={gutterWidth}>
           <Text bold={msg.role === 'user'} color={prefix}>
             {glyph}{' '}

--- a/ui-tui/src/components/thinking.tsx
+++ b/ui-tui/src/components/thinking.tsx
@@ -75,7 +75,7 @@ function TreeRow({
   const lead = treeLead(rails, branch)
 
   return (
-    <Box>
+    <Box alignItems="stretch">
       <NoSelect flexShrink={0} fromLeftEdge width={lead.length}>
         <Text color={stemColor ?? t.color.muted} dim={stemDim}>
           {lead}


### PR DESCRIPTION
## Fixes #44916

### Problem

In the TUI, selecting and copying a multi-line assistant message picks up the 3-column left gutter as leading whitespace on every line **except the first**. The first line copies clean; lines 2..N each carry 3 leading spaces (`U+0020`).

### Root Cause

In Ink/Yoga, the default `alignItems` for a row-layout Box is `FlexStart`, not `Stretch`. The `<NoSelect fromLeftEdge>` gutter box has `flexShrink={0}` and a single-line glyph as content, so its yoga-computed height is 1 row. The `noSelect` bitmap in `render-node-to-output.ts` uses `yogaNode.getComputedHeight()` — which is 1 — so only row 0 is fenced.

On rows 2..N, the gutter columns are unfenced empty cells filled with `' '` by the char pool. `extractRowText` reads these cells directly and includes them in copied text.

### Fix

Add `alignItems="stretch"` to the parent `<Box>` in two files:

- `ui-tui/src/components/messageLine.tsx` (line 229) — assistant/user message gutter
- `ui-tui/src/components/thinking.tsx` (line 78) — thinking/reasoning tree gutter

This makes the `NoSelect` box stretch vertically to match the sibling content box. The yoga-computed height then matches the content height, and the `noSelect` bitmap covers every row the gutter spans.

### Testing

1. `hermes --tui` in a terminal with alt-screen mouse selection
2. Ask for a multi-line reply (email draft, code block, etc.)
3. Click-drag to select the whole assistant block
4. Copy and paste into a plain editor
5. Verify no leading whitespace on lines 2..N

### Scope

Both `messageLine.tsx` and `thinking.tsx` use the identical `NoSelect` + sibling content pattern. The fix is the same single-line change in both files.