### PR TITLE
fix(backup): exclude Git for Windows dir from backups (#44852)

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
 # are not accidentally excluded.
 _EXCLUDED_DIRS = {
     "hermes-agent",     # the codebase repo — re-clone instead
+    "git",              # Git for Windows installation (~9,500 files, 390 MB)
     "__pycache__",      # bytecode caches — regenerated on import
     ".git",             # nested git dirs (profiles shouldn't have these, but safety)
     "node_modules",     # js deps if website/ somehow leaks in


### PR DESCRIPTION
Fixes #44852. Adds 'git' to _EXCLUDED_DIRS in hermes_cli/backup.py to prevent bundling the entire Git for Windows installation (~9,500 files, 390 MB) into backups on Windows.