### PR TITLE
fix(send_message): reuse gateway Telegram HTTP config

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -108,6 +108,81 @@ _TELEGRAM_IMAGE_EXT_TO_MIME = {
 MAX_COMMANDS_PER_SCOPE = 30
 
 
+def _telegram_env_int(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _telegram_env_float(name: str, default: float) -> float:
+    try:
+        return float(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+async def build_telegram_httpx_requests(logger_name: str = "telegram"):
+    """Build Telegram HTTPXRequest objects with shared timeout/proxy settings.
+
+    Reused by both the live gateway adapter and standalone send paths so cron
+    delivery matches the gateway's network behavior.
+    """
+    request_kwargs = {
+        "connection_pool_size": _telegram_env_int("HERMES_TELEGRAM_HTTP_POOL_SIZE", 512),
+        "pool_timeout": _telegram_env_float("HERMES_TELEGRAM_HTTP_POOL_TIMEOUT", 8.0),
+        "connect_timeout": _telegram_env_float("HERMES_TELEGRAM_HTTP_CONNECT_TIMEOUT", 10.0),
+        "read_timeout": _telegram_env_float("HERMES_TELEGRAM_HTTP_READ_TIMEOUT", 20.0),
+        "write_timeout": _telegram_env_float("HERMES_TELEGRAM_HTTP_WRITE_TIMEOUT", 20.0),
+    }
+
+    disable_fallback = (
+        os.getenv("HERMES_TELEGRAM_DISABLE_FALLBACK_IPS", "").strip().lower()
+        in {"1", "true", "yes", "on"}
+    )
+    fallback_ips = parse_fallback_ip_env(os.getenv("HERMES_TELEGRAM_FALLBACK_IPS", ""))
+    if not fallback_ips:
+        fallback_ips = await discover_fallback_ips()
+        if fallback_ips:
+            logger.info(
+                "[%s] Auto-discovered Telegram fallback IPs: %s",
+                logger_name,
+                ", ".join(fallback_ips),
+            )
+
+    proxy_targets = ["api.telegram.org", *fallback_ips]
+    proxy_url = resolve_proxy_url("TELEGRAM_PROXY", target_hosts=proxy_targets)
+    if fallback_ips and not proxy_url and not disable_fallback:
+        logger.info(
+            "[%s] Telegram fallback IPs active: %s",
+            logger_name,
+            ", ".join(fallback_ips),
+        )
+        request = HTTPXRequest(
+            **request_kwargs,
+            httpx_kwargs={"transport": TelegramFallbackTransport(fallback_ips)},
+        )
+        get_updates_request = HTTPXRequest(
+            **request_kwargs,
+            httpx_kwargs={"transport": TelegramFallbackTransport(fallback_ips)},
+        )
+    elif proxy_url:
+        logger.info(
+            "[%s] Proxy detected; passing explicitly to HTTPXRequest: %s",
+            logger_name,
+            proxy_url,
+        )
+        request = HTTPXRequest(**request_kwargs, proxy=proxy_url)
+        get_updates_request = HTTPXRequest(**request_kwargs, proxy=proxy_url)
+    else:
+        if disable_fallback:
+            logger.info("[%s] Telegram fallback-IP transport disabled via env", logger_name)
+        request = HTTPXRequest(**request_kwargs)
+        get_updates_request = HTTPXRequest(**request_kwargs)
+
+    return request, get_updates_request
+
+
 def check_telegram_requirements() -> bool:
     """Check if Telegram dependencies are available.
 
@@ -1545,66 +1620,10 @@ class TelegramAdapter(BasePlatformAdapter):
                 builder = builder.local_mode(True)
                 logger.info("[%s] Using Telegram local_mode (read files from disk)", self.name)
 
-            # PTB defaults (pool_timeout=1s) are too aggressive on flaky networks and
-            # can trigger "Pool timeout: All connections in the connection pool are occupied"
-            # during reconnect/bootstrap. Use safer defaults and allow env overrides.
-            def _env_int(name: str, default: int) -> int:
-                try:
-                    return int(os.getenv(name, str(default)))
-                except (TypeError, ValueError):
-                    return default
-
-            def _env_float(name: str, default: float) -> float:
-                try:
-                    return float(os.getenv(name, str(default)))
-                except (TypeError, ValueError):
-                    return default
-
-            request_kwargs = {
-                "connection_pool_size": _env_int("HERMES_TELEGRAM_HTTP_POOL_SIZE", 512),
-                "pool_timeout": _env_float("HERMES_TELEGRAM_HTTP_POOL_TIMEOUT", 8.0),
-                "connect_timeout": _env_float("HERMES_TELEGRAM_HTTP_CONNECT_TIMEOUT", 10.0),
-                "read_timeout": _env_float("HERMES_TELEGRAM_HTTP_READ_TIMEOUT", 20.0),
-                "write_timeout": _env_float("HERMES_TELEGRAM_HTTP_WRITE_TIMEOUT", 20.0),
-            }
-
-            disable_fallback = (os.getenv("HERMES_TELEGRAM_DISABLE_FALLBACK_IPS", "").strip().lower() in {"1", "true", "yes", "on"})
-            fallback_ips = self._fallback_ips()
-            if not fallback_ips:
-                fallback_ips = await discover_fallback_ips()
-                logger.info(
-                    "[%s] Auto-discovered Telegram fallback IPs: %s",
-                    self.name,
-                    ", ".join(fallback_ips),
-                )
-
-            proxy_targets = ["api.telegram.org", *fallback_ips]
-            proxy_url = resolve_proxy_url("TELEGRAM_PROXY", target_hosts=proxy_targets)
-            if fallback_ips and not proxy_url and not disable_fallback:
-                logger.info(
-                    "[%s] Telegram fallback IPs active: %s",
-                    self.name,
-                    ", ".join(fallback_ips),
-                )
-                # Keep request/update pools separate to reduce contention during
-                # polling reconnect + bot API bootstrap/delete_webhook calls.
-                request = HTTPXRequest(
-                    **request_kwargs,
-                    httpx_kwargs={"transport": TelegramFallbackTransport(fallback_ips)},
-                )
-                get_updates_request = HTTPXRequest(
-                    **request_kwargs,
-                    httpx_kwargs={"transport": TelegramFallbackTransport(fallback_ips)},
-                )
-            elif proxy_url:
-                logger.info("[%s] Proxy detected; passing explicitly to HTTPXRequest: %s", self.name, proxy_url)
-                request = HTTPXRequest(**request_kwargs, proxy=proxy_url)
-                get_updates_request = HTTPXRequest(**request_kwargs, proxy=proxy_url)
-            else:
-                if disable_fallback:
-                    logger.info("[%s] Telegram fallback-IP transport disabled via env", self.name)
-                request = HTTPXRequest(**request_kwargs)
-                get_updates_request = HTTPXRequest(**request_kwargs)
+            # PTB defaults are too aggressive on flaky networks; share the
+            # hardened request construction with standalone send paths so cron
+            # delivery behaves the same way as the live adapter.
+            request, get_updates_request = await build_telegram_httpx_requests(self.name)
 
             builder = builder.request(request).get_updates_request(get_updates_request)
             self._app = builder.build()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -973,29 +973,19 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                 formatted = message
             send_parse_mode = ParseMode.MARKDOWN_V2
 
-        # Honour a configured proxy (telegram.proxy_url in config.yaml, exported
-        # as TELEGRAM_PROXY env var by load_gateway_config). Without this, the
-        # standalone send path bypasses the proxy and times out in regions
-        # where api.telegram.org is blocked. The in-gateway adapter does the
-        # same thing in gateway/platforms/telegram.py.
         try:
-            from gateway.platforms.base import resolve_proxy_url
-            _tg_proxy = resolve_proxy_url("TELEGRAM_PROXY", target_hosts=["api.telegram.org"])
-        except Exception:
-            _tg_proxy = None
-        if _tg_proxy:
-            try:
-                from telegram.request import HTTPXRequest
-                logger.info("send_message: standalone Telegram send routed through proxy %s", _tg_proxy)
-                bot = Bot(
-                    token=token,
-                    request=HTTPXRequest(proxy=_tg_proxy),
-                    get_updates_request=HTTPXRequest(proxy=_tg_proxy),
-                )
-            except Exception as _proxy_err:
-                logger.warning("send_message: failed to attach Telegram proxy (%s), falling back to direct connection", _proxy_err)
-                bot = Bot(token=token)
-        else:
+            from gateway.platforms.telegram import build_telegram_httpx_requests
+            request, get_updates_request = await build_telegram_httpx_requests("send_message")
+            bot = Bot(
+                token=token,
+                request=request,
+                get_updates_request=get_updates_request,
+            )
+        except Exception as request_err:
+            logger.warning(
+                "send_message: failed to build shared Telegram HTTP config (%s), falling back to Bot defaults",
+                _sanitize_error_text(request_err),
+            )
             bot = Bot(token=token)
         int_chat_id = int(chat_id)
         media_files = media_files or []


### PR DESCRIPTION
## Summary

This reuses the gateway adapter's Telegram `HTTPXRequest` construction for standalone sends.

The standalone cron-delivery path in `tools/send_message_tool.py` was still creating its own `Bot(...)` request path, so it could miss:
- `TELEGRAM_PROXY` routing
- fallback-IP transport
- tuned `HERMES_TELEGRAM_HTTP_*` timeout/pool settings

As a result, live Telegram usage could work while cron final delivery still failed with `Telegram send failed: Timed out`.

## What changed

- extracted a shared `build_telegram_httpx_requests(...)` helper in `gateway/platforms/telegram.py`
- switched the live adapter to use that helper instead of duplicating request setup inline
- switched standalone Telegram sends to use the same helper, with a safe fallback to default `Bot(...)` behavior if helper construction itself fails

## Validation

- `python3 -m py_compile gateway/platforms/telegram.py tools/send_message_tool.py`

## Context

Closes #44995.

This extends the parity principle already pursued in:
- #20924
- #21777

It is not the same root cause as closed #38780.
