### PR TITLE
fix(tools): make read_file dedup response consistent (#44843)

### DIFF
--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -833,6 +833,10 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                         }, ensure_ascii=False)
 
                     return json.dumps({
+                        "content": "",
+                        "total_lines": 0,
+                        "file_size": 0,
+                        "truncated": False,
                         "status": "unchanged",
                         "message": _READ_DEDUP_STATUS_MESSAGE,
                         "path": path,


### PR DESCRIPTION
Fixes #44843. Adds content, total_lines, file_size, and truncated fields to the read_file dedup response so it matches the standard response structure. This prevents KeyError crashes in execute_code() sandbox code that reads a file twice.