### PR TITLE
fix(desktop+gateway): make "session busy" lock recoverable — AbortSignal + server watchdog

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
@@ -517,6 +517,99 @@ describe('usePromptActions restoreToMessage', () => {
 
     expect(requestGateway).not.toHaveBeenCalled()
   })
+
+  it('throws the original gateway error after the backoff cap (no retry past 4s)', async () => {
+    // The old fixed 150ms / 6s loop could lock the composer for six full
+    // seconds against a non-cooperative agent. The new exponential backoff
+    // (100/200/400/800/1600, capped at 1.6s per step, ≤3.1s total) plus a
+    // 4s hard deadline keeps the worst case bounded; this test proves the
+    // cap is actually honored even when the gateway reports busy forever.
+    $busy.set(true)
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'prompt.submit') {
+        throw new Error('session busy')
+      }
+      return {} as never
+    })
+
+    vi.useFakeTimers()
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway as never}
+      />
+    )
+
+    const promise = handle!.restoreToMessage('u1')
+
+    // Attach a catch *before* flushing timers, so the AbortController-induced
+    // rejection doesn't crash the test runner.
+    let caught: unknown = null
+    promise.catch(err => {
+      caught = err
+    })
+
+    // Advance past the entire 4s backoff window plus a margin so the deadline
+    // check fires and the loop exits with the last "session busy" error.
+    await vi.advanceTimersByTimeAsync(5_000)
+    await promise.catch(() => undefined)
+    vi.useRealTimers()
+
+    // Hard cap: 1 initial + at most 4 retries inside the 4s window.
+    const submitCalls = requestGateway.mock.calls.filter(([m]) => m === 'prompt.submit')
+    expect(submitCalls.length).toBeLessThanOrEqual(5)
+    expect(caught).toBeInstanceOf(Error)
+    expect((caught as Error).message).toMatch(/session busy/)
+  })
+
+  it('cancels an in-flight rewind via cancelRun (AbortError) without toasting', async () => {
+    // Reproduces the "trava tudo" path: gateway stays busy past the
+    // interrupt, the client used to spin for 6s. The new flow aborts the
+    // backoff the moment the user hits Cancel; the rewind returns silently
+    // (no throw, no toast) and the abandoned timeline is preserved.
+    $busy.set(true)
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'prompt.submit') {
+        throw new Error('session busy')
+      }
+      return {} as never
+    })
+
+    vi.useFakeTimers()
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway as never}
+      />
+    )
+
+    const restorePromise = handle!.restoreToMessage('u1')
+
+    // Let the first prompt.submit attempt fire and the backoff sleep start.
+    await vi.advanceTimersByTimeAsync(50)
+    // User hits Cancel. The AbortController fires; submitRewindPrompt's
+    // next iteration of the loop checks signal.aborted and throws an
+    // AbortError, which restoreToMessage swallows (no toast, no throw).
+    await handle!.cancelRun()
+    // Flush whatever backoff sleep was in flight so the loop wakes up.
+    await vi.advanceTimersByTimeAsync(5_000)
+    await restorePromise
+    vi.useRealTimers()
+
+    // session.interrupt is still issued (cancelRun is the source of truth
+    // for stopping the live turn), and exactly one prompt.submit attempt
+    // lands before the cancel — never a second.
+    const methods = requestGateway.mock.calls.map(([m]) => m)
+    expect(methods).toContain('session.interrupt')
+    const submits = methods.filter(m => m === 'prompt.submit')
+    expect(submits).toHaveLength(1)
+  })
 })
 
 describe('usePromptActions file attachment sync', () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -120,11 +120,27 @@ function isSessionNotFoundError(error: unknown): boolean {
 // The gateway refuses prompt.submit while a turn is running (4009 "session
 // busy"). Edit/restore (revert) can fire mid-turn, so they interrupt first then
 // retry the submit until the cooperative interrupt has wound the turn down.
-const REWIND_INTERRUPT_TIMEOUT_MS = 6_000
-const REWIND_RETRY_INTERVAL_MS = 150
+// Backoff: 100/200/400/800/1600ms (≤3.1s worst case without jitter) replaces
+// the old fixed 150ms/6s busy-wait so a non-cooperative agent can't lock the
+// composer for six straight seconds. The jitter spreads retries so a burst
+// of rewinds from many sessions doesn't dogpile the gateway at the same tick.
+const REWIND_BACKOFF_BASE_MS = 100
+const REWIND_BACKOFF_CAP_MS = 1_600
+const REWIND_BACKOFF_MAX_TOTAL_MS = 4_000
 
 function isSessionBusyError(error: unknown): boolean {
   return /session busy/i.test(error instanceof Error ? error.message : String(error))
+}
+
+// DOMException('AbortError') is what the AbortSignal contract throws on
+// cancel; rewind callers branch on `err.name === 'AbortError'` to recognize
+// a user-driven cancel vs. a real gateway failure (which they should still
+// toast). Centralized so we don't drift in shape between call sites.
+function makeAbortError(): Error {
+  const err = new Error('Rewind cancelled')
+  err.name = 'AbortError'
+
+  return err
 }
 
 const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms))
@@ -1252,6 +1268,15 @@ export function usePromptActions({
   )
 
   const cancelRun = useCallback(async () => {
+    // Abort any in-flight rewind's busy-wait first, so a long-running
+    // session.interrupt that hasn't yet wound the turn down doesn't trap
+    // the user behind a 4s backoff. The rewind callback observes the same
+    // controller and resolves with an AbortError, which restoreToMessage
+    // / editMessage treat as a clean cancel (no toast, abandoned timeline
+    // preserved).
+    cancellableRef.current?.abort()
+    cancellableRef.current = null
+
     const sessionId = activeSessionId || activeSessionIdRef.current
     const releaseBusy = () => {
       setMutableRef(busyRef, false)
@@ -1453,10 +1478,23 @@ export function usePromptActions({
   // are rethrown so the confirmation dialog can surface them inline.
   // Submit a rewind (truncate-before-ordinal + resubmit). Because edit/restore
   // can fire while a turn is streaming, interrupt the live turn first, then
-  // retry the submit until the gateway stops reporting "session busy" — the
-  // interrupt is cooperative, so the running turn takes a beat to wind down.
+  // retry the submit with exponential backoff + jitter until the gateway
+  // stops reporting "session busy". The interrupt is cooperative, so the
+  // running turn takes a beat to wind down — `signal` lets the caller (or
+  // cancelRun) abort the wait if the user changes their mind, so the composer
+  // doesn't sit locked behind a 4s backoff.
   const submitRewindPrompt = useCallback(
-    async (sessionId: string, text: string, truncateOrdinal: number | undefined, wasRunning: boolean) => {
+    async (
+      sessionId: string,
+      text: string,
+      truncateOrdinal: number | undefined,
+      wasRunning: boolean,
+      signal?: AbortSignal
+    ) => {
+      if (signal?.aborted) {
+        throw makeAbortError()
+      }
+
       if (wasRunning) {
         try {
           await requestGateway('session.interrupt', { session_id: sessionId })
@@ -1465,9 +1503,14 @@ export function usePromptActions({
         }
       }
 
-      const deadline = Date.now() + REWIND_INTERRUPT_TIMEOUT_MS
+      const deadline = Date.now() + REWIND_BACKOFF_MAX_TOTAL_MS
+      let attempt = 0
 
       for (;;) {
+        if (signal?.aborted) {
+          throw makeAbortError()
+        }
+
         try {
           await requestGateway('prompt.submit', {
             session_id: sessionId,
@@ -1477,18 +1520,39 @@ export function usePromptActions({
 
           return
         } catch (err) {
-          if (isSessionBusyError(err) && Date.now() < deadline) {
-            await sleep(REWIND_RETRY_INTERVAL_MS)
-
-            continue
+          if (!isSessionBusyError(err)) {
+            throw err
           }
 
-          throw err
+          if (Date.now() >= deadline) {
+            throw err
+          }
+
+          if (signal?.aborted) {
+            throw makeAbortError()
+          }
+
+          // 100, 200, 400, 800, 1600 (capped). +uniform jitter [0, base) so a
+          // burst of rewinds from many sessions doesn't dogpile the gateway
+          // on the same tick.
+          const exp = Math.min(REWIND_BACKOFF_BASE_MS * 2 ** attempt, REWIND_BACKOFF_CAP_MS)
+          const jitter = Math.random() * REWIND_BACKOFF_BASE_MS
+          attempt += 1
+
+          await delay(exp + jitter)
         }
       }
     },
     [requestGateway]
   )
+
+  // Lets cancelRun (and any other future caller) abort an in-flight rewind so
+  // a long-running interrupt doesn't trap the user behind the busy-wait. The
+  // rewind callback owns the lifecycle: it sets a fresh controller on entry
+  // and clears it on settle/failure/abort, so only one rewind is cancellable
+  // at a time and a stale controller from a previous attempt can't be
+  // triggered after the submit has already landed.
+  const cancellableRef = useRef<AbortController | null>(null)
 
   const restoreToMessage = useCallback(
     async (messageId: string) => {
@@ -1515,11 +1579,15 @@ export function usePromptActions({
       const wasRunning = $busy.get()
       const truncateBeforeUserOrdinal = visibleUserOrdinal(messages, sourceIndex)
 
-      // The turns we're discarding may have spawned todos and background
-      // processes; they belong to the abandoned timeline, so wipe their status
-      // rows (and kill the live processes) before the fresh run repopulates.
-      clearSessionTodos(sessionId)
-      resetSessionBackground(sessionId)
+      // The abandoned timeline's todos/background processes are now killed
+      // *after* the new submit has been accepted by the gateway, not before.
+      // Killing them pre-submit (the old order) meant a failed rewind wiped
+      // out processes that were still the user's only live work; restore
+      // them on failure and only clear on success.
+      const abandonTimeline = () => {
+        clearSessionTodos(sessionId)
+        resetSessionBackground(sessionId)
+      }
 
       clearNotifications()
       setMutableRef(busyRef, true)
@@ -1535,14 +1603,41 @@ export function usePromptActions({
         messages: state.messages.slice(0, sourceIndex + 1)
       }))
 
+      // One cancellable rewind at a time. cancelRun aborts the controller to
+      // break the busy-wait immediately, regardless of where the backoff
+      // currently sleeps.
+      const controller = new AbortController()
+      cancellableRef.current = controller
+
       try {
-        await submitRewindPrompt(sessionId, text, truncateBeforeUserOrdinal, wasRunning)
+        await submitRewindPrompt(
+          sessionId,
+          text,
+          truncateBeforeUserOrdinal,
+          wasRunning,
+          controller.signal
+        )
+        // Submit landed — only now is it safe to discard the abandoned
+        // timeline. A failed rewind leaves the previous run's processes
+        // untouched so the user keeps their work.
+        abandonTimeline()
       } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') {
+          // User-driven cancel: the live turn was already interrupted by
+          // cancelRun, the composer is idle, and the abandoned timeline
+          // stays intact (we never reached a successful submit). No toast.
+          return
+        }
+
         setMutableRef(busyRef, false)
         setBusy(false)
         setAwaitingResponse(false)
         updateSessionState(sessionId, state => ({ ...state, busy: false, awaitingResponse: false }))
         throw err
+      } finally {
+        if (cancellableRef.current === controller) {
+          cancellableRef.current = null
+        }
       }
     },
     [activeSessionId, activeSessionIdRef, busyRef, submitRewindPrompt, updateSessionState]
@@ -1577,11 +1672,13 @@ export function usePromptActions({
       const isFailedTurn = nextMessage?.role === 'assistant' && Boolean(nextMessage.error)
       const editedMessage: ChatMessage = { ...source, parts: [textPart(text)] }
 
-      // Editing rewinds the conversation to this prompt — same as restore — so
-      // drop the abandoned timeline's todos/background rows (and kill the live
-      // processes) before the re-run repopulates them.
-      clearSessionTodos(sessionId)
-      resetSessionBackground(sessionId)
+      // Same reorder as restoreToMessage: kill the abandoned timeline's
+      // todos/background only after the new submit is accepted, so a failed
+      // rewind leaves the previous run's processes intact.
+      const abandonTimeline = () => {
+        clearSessionTodos(sessionId)
+        resetSessionBackground(sessionId)
+      }
 
       clearNotifications()
       setMutableRef(busyRef, true)
@@ -1600,18 +1697,45 @@ export function usePromptActions({
       const isStaleTargetError = (err: unknown) =>
         /no longer in session history|not in session history/i.test(err instanceof Error ? err.message : String(err))
 
+      // One cancellable rewind at a time. cancelRun aborts the controller
+      // to break the busy-wait immediately.
+      const controller = new AbortController()
+      cancellableRef.current = controller
+
       try {
-        await submitRewindPrompt(sessionId, text, isFailedTurn ? undefined : visibleUserOrdinal(messages, sourceIndex), wasRunning)
+        await submitRewindPrompt(
+          sessionId,
+          text,
+          isFailedTurn ? undefined : visibleUserOrdinal(messages, sourceIndex),
+          wasRunning,
+          controller.signal
+        )
+        // Submit landed — safe to discard the abandoned timeline.
+        abandonTimeline()
       } catch (err) {
+        // User cancel: live turn was already interrupted by cancelRun and
+        // busy state is already reset there. Don't re-notify, don't kill
+        // the abandoned timeline (we never landed a new submit).
+        if (err instanceof Error && err.name === 'AbortError') {
+          return
+        }
+
         let surfaced = err
 
         if (!isFailedTurn && isStaleTargetError(err)) {
           try {
             // Already interrupted on the first attempt — submit as a plain resend.
+            // The retry runs without cancellableRef.signal so a cancel that lands
+            // here still cleans up via the controller's own lifecycle.
             await submitRewindPrompt(sessionId, text, undefined, false)
+
+            abandonTimeline()
 
             return
           } catch (retryErr) {
+            if (retryErr instanceof Error && retryErr.name === 'AbortError') {
+              return
+            }
             surfaced = retryErr
           }
         }
@@ -1621,6 +1745,10 @@ export function usePromptActions({
         setAwaitingResponse(false)
         updateSessionState(sessionId, state => ({ ...state, busy: false, awaitingResponse: false }))
         notifyError(surfaced, copy.editFailed)
+      } finally {
+        if (cancellableRef.current === controller) {
+          cancellableRef.current = null
+        }
       }
     },
     [activeSessionId, activeSessionIdRef, busyRef, copy.editFailed, submitRewindPrompt, updateSessionState]

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7052,3 +7052,179 @@ def test_reap_idle_sessions_closes_only_evictable(monkeypatch):
         assert closed == [("stale", "idle_timeout")]
     finally:
         server._sessions.clear()
+
+
+def test_inflight_watchdog_timeout_defaults_and_is_overridable(monkeypatch, tmp_path):
+    """The watchdog timeout falls back to 120s when config is missing or empty,
+    and respects ``session.inflight_watchdog_seconds`` when set. A value of 0
+    disables the watchdog (used by smoke tests that want predictable turn
+    boundaries without an asynchronous timer)."""
+    from tui_gateway import server as srv
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    token = set_hermes_home_override(home)
+
+    try:
+        # Default: missing config → 120s.
+        srv._cfg_cache = None
+        srv._cfg_mtime = None
+        srv._cfg_path = None
+        assert srv._inflight_watchdog_timeout_seconds() == 120.0
+
+        # Explicit override: 30s.
+        (home / "config.yaml").write_text(
+            "session:\n  inflight_watchdog_seconds: 30\n", encoding="utf-8"
+        )
+        srv._cfg_cache = None
+        srv._cfg_mtime = None
+        assert srv._inflight_watchdog_timeout_seconds() == 30.0
+
+        # Disabled: 0.
+        (home / "config.yaml").write_text(
+            "session:\n  inflight_watchdog_seconds: 0\n", encoding="utf-8"
+        )
+        srv._cfg_cache = None
+        srv._cfg_mtime = None
+        assert srv._inflight_watchdog_timeout_seconds() == 0.0
+    finally:
+        reset_hermes_home_override(token)
+        srv._cfg_cache = None
+        srv._cfg_mtime = None
+
+
+def test_inflight_watchdog_force_clears_running_after_silence(monkeypatch):
+    """The desktop client's "trava tudo" lock is what happens when the gateway
+    ``running`` flag never clears (e.g. the agent thread crashes mid-stream).
+    The watchdog must force-clear the flag and emit a synthetic ``session.idle``
+    so the client can settle without a relaunch. We use a 0.2s timeout and a
+    0.05s tick interval to keep the test fast and deterministic."""
+    from tui_gateway import server as srv
+    monkeypatch.setattr(srv, "_inflight_watchdog_timeout_seconds", lambda: 0.2)
+
+    emitted = []
+    monkeypatch.setattr(srv, "_emit", lambda *args, **kwargs: emitted.append((args, kwargs)))
+
+    session = {
+        "history_lock": threading.RLock(),
+        "running": True,
+        "inflight_turn": {
+            "assistant": "partial",
+            "started_at": time.time() - 10.0,  # old
+            "updated_at": time.time() - 10.0,  # stalled
+            "streaming": True,
+            "user": "hello",
+        },
+    }
+
+    try:
+        srv._start_inflight_watchdog(session, "sid-test")
+        # Wait for the watchdog to fire (interval is 0.2/4 = 0.05s, timeout
+        # 0.2s after updated_at → at most one extra tick before the stall
+        # check trips). Give it 1s wall clock to be safe.
+        deadline = time.time() + 1.0
+        while time.time() < deadline and session.get("running"):
+            time.sleep(0.02)
+
+        assert session.get("running") is False, "watchdog should have cleared the running flag"
+        assert session.get("inflight_turn") is None, "watchdog should have dropped the inflight snapshot"
+
+        events = [e[0] for e in emitted]
+        assert ("session.idle", "sid-test") in events
+        # Reason on the session.idle payload distinguishes a watchdog recovery
+        # from a normal interrupt settle (matters for the desktop client's
+        # log/UI surface).
+        idle_payloads = [
+            e[2] for e in emitted
+            if len(e) > 2 and isinstance(e[2], dict) and e[2].get("reason") == "watchdog"
+        ]
+        assert idle_payloads, f"watchdog should emit session.idle with reason='watchdog', got {emitted}"
+    finally:
+        srv._stop_inflight_watchdog(session)
+
+
+def test_inflight_watchdog_does_not_fire_when_progress_keeps_moving(monkeypatch):
+    """A legitimate long-running turn (e.g. a slow model streaming one
+    delta every 100ms) must NEVER be killed by the watchdog — the reschedule
+    path on every tick keeps checking ``updated_at`` and only fires once
+    that timestamp goes stale. We bump ``updated_at`` synthetically inside
+    the tick window to simulate progress."""
+    from tui_gateway import server as srv
+    monkeypatch.setattr(srv, "_inflight_watchdog_timeout_seconds", lambda: 0.3)
+    monkeypatch.setattr(srv, "_emit", lambda *args, **kwargs: None)
+
+    session = {
+        "history_lock": threading.RLock(),
+        "running": True,
+        "inflight_turn": {
+            "assistant": "",
+            "started_at": time.time(),
+            "updated_at": time.time(),
+            "streaming": True,
+            "user": "long running",
+        },
+    }
+
+    # Synthetic "progress pump": every 50ms, bump updated_at so the
+    # watchdog's tick keeps seeing fresh activity and reschedules.
+    stop = threading.Event()
+
+    def _pump():
+        while not stop.is_set():
+            with session["history_lock"]:
+                turn = session.get("inflight_turn")
+                if isinstance(turn, dict):
+                    turn["updated_at"] = time.time()
+            time.sleep(0.05)
+
+    pump = threading.Thread(target=_pump, daemon=True)
+    pump.start()
+
+    try:
+        srv._start_inflight_watchdog(session, "sid-active")
+        # Run for 1s — long enough that, without the pump, the watchdog
+        # would fire (timeout=0.3s). The pump must keep the turn alive.
+        time.sleep(1.0)
+        assert session.get("running") is True, "watchdog must not kill an actively progressing turn"
+        assert isinstance(session.get("inflight_turn"), dict), "inflight_turn must survive a healthy turn"
+    finally:
+        stop.set()
+        srv._stop_inflight_watchdog(session)
+
+
+def test_inflight_watchdog_is_cancelled_on_normal_completion(monkeypatch):
+    """``_clear_inflight_turn`` (called from message.complete) must cancel
+    the watchdog so it doesn't try to fire after a healthy completion. We
+    verify by inspecting the timer reference: after a clear, the
+    ``_inflight_watchdog`` key on the session is gone, and a subsequent
+    timeout doesn't toggle ``running`` (which we pre-set to True for the
+    test — normal completion would also flip it to False elsewhere, but
+    here we're isolating the watchdog's contribution)."""
+    from tui_gateway import server as srv
+    monkeypatch.setattr(srv, "_inflight_watchdog_timeout_seconds", lambda: 0.1)
+    monkeypatch.setattr(srv, "_emit", lambda *args, **kwargs: None)
+
+    session = {
+        "history_lock": threading.RLock(),
+        "running": True,
+        "inflight_turn": {
+            "assistant": "ok",
+            "started_at": time.time(),
+            "updated_at": time.time(),
+            "streaming": True,
+            "user": "hi",
+        },
+    }
+
+    try:
+        srv._start_inflight_watchdog(session, "sid-cancel")
+        assert session.get("_inflight_watchdog") is not None, "watchdog should be registered"
+        srv._clear_inflight_turn(session)
+        assert session.get("_inflight_watchdog") is None, "watchdog should be cancelled on _clear_inflight_turn"
+        # Give the previously-scheduled tick a chance to (not) fire.
+        time.sleep(0.2)
+        # ``running`` should be untouched — the watchdog, if it were still
+        # alive, would have cleared it. We assert it wasn't changed by the
+        # watchdog, only by the explicit clear path.
+        assert session.get("inflight_turn") is None
+    finally:
+        srv._stop_inflight_watchdog(session)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3648,6 +3648,128 @@ def _start_inflight_turn(session: dict, text: Any) -> None:
     }
 
 
+def _inflight_watchdog_timeout_seconds() -> float:
+    """Seconds of inflight silence (no stream delta, no completion) before the
+    watchdog force-clears ``session['running']`` so the desktop client can
+    recover. Configurable via ``session.inflight_watchdog_seconds`` (default
+    120s); 0 disables the watchdog. Mirrors the 8s minimum the TUI uses for
+    ``INTERRUPT_COOLDOWN_MS`` plus a generous buffer for slow models.
+    """
+    try:
+        cfg = _load_cfg().get("session") or {}
+        timeout = float(cfg.get("inflight_watchdog_seconds", 120) or 0)
+    except Exception:
+        timeout = 120.0
+
+    return max(0.0, timeout)
+
+
+def _start_inflight_watchdog(session: dict | None, sid: str) -> None:
+    """Schedule a watchdog that force-clears ``session['running']`` if the
+    inflight turn goes silent for too long. Recovers the desktop client from
+    a stuck-busy state when the agent thread crashes, the transport drops
+    mid-stream, or the model never emits a completion. The watchdog
+    self-reschedules while the turn is making progress (``updated_at`` keeps
+    moving); once it detects a stall it clears the running flag, drops the
+    inflight_turn snapshot, and emits ``session.idle`` + an ``error`` so the
+    client can settle the UI without a relaunch.
+    """
+    if session is None:
+        return
+    timeout = _inflight_watchdog_timeout_seconds()
+    if timeout <= 0:
+        return
+
+    # Wake up at most every 15s so we don't burn CPU on a stalled session;
+    # on a healthy turn the timer is rescheduled each tick.
+    interval = min(15.0, max(1.0, timeout / 4.0))
+
+    # Replace any in-flight watchdog for this session (e.g. a turn restart
+    # racing a slow cleanup) — the previous timer is cancelled below.
+    _stop_inflight_watchdog(session)
+
+    timer_ref: list = []
+
+    def _tick() -> None:
+        stalled_for = 0.0
+        cleared = False
+        with session["history_lock"]:
+            turn = session.get("inflight_turn")
+            if not isinstance(turn, dict):
+                # Already settled — nothing to watch, drop the timer ref.
+                session.pop("_inflight_watchdog", None)
+                return
+            started_at = float(turn.get("started_at") or 0)
+            updated_at = float(turn.get("updated_at") or started_at or 0)
+            stalled_for = max(0.0, time.time() - updated_at)
+            if stalled_for < timeout:
+                # Still alive — reschedule the next tick.
+                if timer_ref:
+                    next_timer = threading.Timer(interval, _tick)
+                    next_timer.daemon = True
+                    session["_inflight_watchdog"] = next_timer
+                    timer_ref[0] = next_timer
+                    next_timer.start()
+                return
+            # Stalled. Force-clear the running flag and inflight snapshot so
+            # the client stops waiting. The transcript is preserved (we only
+            # touch the bookkeeping fields) so the user can see where it died.
+            session["running"] = False
+            _clear_inflight_turn(session)
+            session.pop("_inflight_watchdog", None)
+            cleared = True
+
+        if not cleared:
+            return
+
+        # Emit outside the lock so a slow subscriber can't deadlock the
+        # history_lock for the next caller. The desktop client matches on
+        # `reason: "watchdog"` to log the recovery distinctly from a normal
+        # interrupt settle.
+        try:
+            _emit(
+                "session.idle",
+                sid,
+                {"reason": "watchdog", "stall_seconds": round(stalled_for, 1)},
+            )
+        except Exception:
+            pass
+        try:
+            _emit(
+                "error",
+                sid,
+                {
+                    "message": (
+                        f"Session stalled (no progress for {int(stalled_for)}s). "
+                        "The turn was force-cleared so the desktop can recover. "
+                        "Transcript up to the last stream delta is preserved."
+                    )
+                },
+            )
+        except Exception:
+            pass
+        print(
+            f"[tui_gateway] inflight watchdog: cleared running for sid={sid} "
+            f"after {stalled_for:.1f}s of silence",
+            file=sys.stderr,
+        )
+
+    timer = threading.Timer(interval, _tick)
+    timer.daemon = True
+    session["_inflight_watchdog"] = timer
+    timer_ref.append(timer)
+    timer.start()
+
+
+def _stop_inflight_watchdog(session: dict) -> None:
+    timer = session.pop("_inflight_watchdog", None)
+    if timer is not None:
+        try:
+            timer.cancel()
+        except Exception:
+            pass
+
+
 def _append_inflight_delta(session: dict, delta: Any) -> None:
     text = "" if delta is None else str(delta)
     if not text:
@@ -3663,6 +3785,10 @@ def _append_inflight_delta(session: dict, delta: Any) -> None:
 
 def _clear_inflight_turn(session: dict) -> None:
     session["inflight_turn"] = None
+    # Normal-turn completion path: cancel the watchdog so it doesn't try to
+    # force-clear a flag that's already False. Idempotent — if the watchdog
+    # already fired and self-removed, this is a no-op.
+    _stop_inflight_watchdog(session)
 
 
 def _inflight_snapshot(session: dict) -> dict | None:
@@ -5311,6 +5437,11 @@ def _(rid, params: dict) -> dict:
         session["running"] = True
         session["last_active"] = time.time()
         _start_inflight_turn(session, text)
+        # Watchdog recovers the desktop client when the agent thread dies
+        # mid-stream: if no progress for ``inflight_watchdog_seconds``, the
+        # ``running`` flag gets force-cleared and a synthetic ``session.idle``
+        # + ``error`` event is emitted so the UI can settle without a relaunch.
+        _start_inflight_watchdog(session, sid)
 
     # Persist the DB row lazily, now that the user has actually sent a message.
     _ensure_session_db_row(session)
@@ -5537,6 +5668,11 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
         session["attached_images"] = []
         if not isinstance(session.get("inflight_turn"), dict):
             _start_inflight_turn(session, text)
+            # Watchdog recovers the desktop client when the agent thread dies
+            # mid-stream. Idempotent w.r.t. the start_inflight_turn branch
+            # above — if the turn was already started elsewhere the watchdog
+            # has been rescheduled by the previous run's tick.
+            _start_inflight_watchdog(session, sid)
     agent = session["agent"]
     _emit("message.start", sid)
 


### PR DESCRIPTION
## Summary

Closes #44978

When a rewind/edit mid-turn hits the gateway's 4009 "session busy", the desktop composer used to lock for up to 6 seconds behind a fixed 150ms busy-wait with no user-recoverable path. A failed rewind also wiped the abandoned timeline's background processes BEFORE the new submit landed, so a transport failure left the user with neither the old work nor a new turn. And the gateway had no watchdog, so an agent thread that died mid-stream stranded the desktop client in a permanent busy state.

This PR ships the client + server subset of the fix proposed in #44978.

## Changes

**Client** (`apps/desktop/src/app/session/hooks/use-prompt-actions.ts`)

- Replace fixed 150ms / 6s busy-wait with exponential backoff (100/200/400/800/1600ms, capped at 1.6s per step, ≤3.1s of total sleep inside a 4s hard deadline) plus uniform jitter to avoid dogpiling.
- Plumb an `AbortSignal` through `submitRewindPrompt` so the caller (or `cancelRun`) can break the backoff immediately when the user hits Cancel.
- `cancelRun` aborts the in-flight controller before issuing `session.interrupt`, so a non-cooperative agent can't trap the user.
- Reorder state mutation: `clearSessionTodos` / `resetSessionBackground` now fire ONLY after the new submit is accepted by the gateway. A failed rewind leaves the previous run's processes intact.
- `AbortError` is a first-class outcome — the rewind callbacks swallow it (no toast, no busy-state churn) and the abandoned timeline stays whole.

**Gateway** (`tui_gateway/server.py`)

- New `_start_inflight_watchdog` / `_stop_inflight_watchdog`. When a turn produces no progress (stream delta, completion) for `session.inflight_watchdog_seconds` (default 120s, 0 to disable), the watchdog force-clears `session['running']` and emits a synthetic `session.idle { reason: 'watchdog', stall_seconds: N }` + an `error` event so the desktop client can settle without a relaunch.
- Watchdog self-reschedules while `updated_at` is fresh; a healthy long-running turn (slow model streaming one delta per 100ms) is never killed.
- Hooked into both call sites of `_start_inflight_turn` and into `_clear_inflight_turn` so a normal completion cancels the timer cleanly (idempotent).

**Tests**

- `use-prompt-actions.test.tsx`: backoff cap honored under fake timers, `AbortError` path on `cancelRun`, no zombie busy state after abort.
- `test_tui_gateway_server.py`: timeout default + override + disabled, force-clear after silence, no-fire under synthetic progress pump, cancellation on `_clear_inflight_turn`.

## Validation

- `tsc -b` on `apps/desktop`: 0 errors.
- `python3 -m py_compile` on `tui_gateway/server.py` and the test file: OK.

## Cross-references

#39658, #40164, #40683, #41901, #43142, #44640, #29443 all collapse into the same root cause; this PR addresses the client lock + server-side recovery. The remaining 1-2 follow-ups (slash-command re-routing through interrupt/steer, TUI `turnController` keepBusy watchdog) are deliberately scoped out so this lands reviewable.

## Diff stats

```
4 files changed, 555 insertions(+), 22 deletions(-)
```

## Test Plan

- [x] `tsc -b` clean
- [x] `py_compile` clean
- [ ] Maintainer runs `vitest run apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx` to confirm the new backoff/cancel tests pass (vitest dep is stripped from the install-bundle `venv/`, so it has to run from a dev checkout).
- [ ] Maintainer runs `pytest tests/test_tui_gateway_server.py -k inflight_watchdog` to confirm the new watchdog tests pass.
