### PR TITLE
fix: install scripts write default SOUL.md identity instead of empty template

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1822,19 +1822,10 @@ function Copy-ConfigTemplates {
     $soulPath = "$HermesHome\SOUL.md"
     if (-not (Test-Path $soulPath)) {
         $soulContent = @"
-# Hermes Agent Persona
+You are Hermes Agent, an intelligent AI assistant created by Nous Research. You are helpful, knowledgeable, and direct. You assist users with a wide range of tasks including answering questions, writing and editing code, analyzing information, creative work, and executing actions via your tools. You communicate clearly, admit uncertainty when appropriate, and prioritize being genuinely useful over being verbose unless otherwise directed below. Be targeted and efficient in your exploration and investigations.
 
 <!--
-This file defines the agent's personality and tone.
-The agent will embody whatever you write here.
-Edit this to customize how Hermes communicates with you.
-
-Examples:
-  - "You are a warm, playful assistant who uses kaomoji occasionally."
-  - "You are a concise technical expert. No fluff, just facts."
-  - "You speak like a friendly coworker who happens to know everything."
-
-This file is loaded fresh each message -- no restart needed.
+Edit the text above to customize how Hermes communicates with you.
 Delete the contents (or this file) to use the default personality.
 -->
 "@

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1691,19 +1691,10 @@ copy_config_templates() {
     # Create SOUL.md if it doesn't exist (global persona file)
     if [ ! -f "$HERMES_HOME/SOUL.md" ]; then
         cat > "$HERMES_HOME/SOUL.md" << 'SOUL_EOF'
-# Hermes Agent Persona
+You are Hermes Agent, an intelligent AI assistant created by Nous Research. You are helpful, knowledgeable, and direct. You assist users with a wide range of tasks including answering questions, writing and editing code, analyzing information, creative work, and executing actions via your tools. You communicate clearly, admit uncertainty when appropriate, and prioritize being genuinely useful over being verbose unless otherwise directed below. Be targeted and efficient in your exploration and investigations.
 
 <!--
-This file defines the agent's personality and tone.
-The agent will embody whatever you write here.
-Edit this to customize how Hermes communicates with you.
-
-Examples:
-  - "You are a warm, playful assistant who uses kaomoji occasionally."
-  - "You are a concise technical expert. No fluff, just facts."
-  - "You speak like a friendly coworker who happens to know everything."
-
-This file is loaded fresh each message -- no restart needed.
+Edit the text above to customize how Hermes communicates with you.
 Delete the contents (or this file) to use the default personality.
 -->
 SOUL_EOF

--- a/ui-tui/packages/hermes-ink/src/ink/gutter-noSelect.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/gutter-noSelect.test.ts
@@ -1,0 +1,229 @@
+import { EventEmitter } from 'events'
+
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+
+import Box from './components/Box.js'
+import { NoSelect } from './components/NoSelect.js'
+import Text from './components/Text.js'
+import Ink from './ink.js'
+import { cellAt, type Screen } from './screen.js'
+
+class FakeTty extends EventEmitter {
+  chunks: string[] = []
+  columns = 40
+  rows = 10
+  isTTY = true
+
+  write(chunk: string | Uint8Array, cb?: (err?: Error | null) => void): boolean {
+    this.chunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'))
+    cb?.()
+
+    return true
+  }
+}
+
+function makeInk(cols = 40, rows = 10) {
+  const stdout = new FakeTty()
+  stdout.columns = cols
+  stdout.rows = rows
+  const stdin = new FakeTty()
+  const stderr = new FakeTty()
+
+  const ink = new Ink({
+    exitOnCtrlC: false,
+    patchConsole: false,
+    stderr: stderr as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream
+  })
+
+  return { ink, stdout, stdin, stderr }
+}
+
+type InkPrivate = { frontFrame: { screen: Screen } }
+const screenOf = (ink: Ink): Screen => (ink as unknown as InkPrivate).frontFrame.screen
+
+function gutterNoSelectOnRow(screen: Screen, row: number, gutterCols: number): boolean {
+  for (let col = 0; col < gutterCols; col++) {
+    if (screen.noSelect[row * screen.width + col] !== 1) {
+      return false
+    }
+  }
+
+  return true
+}
+
+function MessageRow({ alignItems, lines }: { alignItems?: 'flex-start' | 'stretch'; lines: string[] }) {
+  const gutterWidth = 3
+  const rowProps = alignItems ? { alignItems, flexDirection: 'row' as const } : {}
+
+  return React.createElement(
+    Box,
+    { flexDirection: 'column' },
+    React.createElement(
+      Box,
+      rowProps,
+      React.createElement(
+        NoSelect,
+        { flexShrink: 0, fromLeftEdge: true, width: gutterWidth },
+        React.createElement(Text, null, '> ')
+      ),
+      React.createElement(
+        Box,
+        { width: 30 },
+        React.createElement(
+          Box,
+          { flexDirection: 'column' },
+          ...lines.map((line, i) => React.createElement(Text, { key: i }, line))
+        )
+      )
+    )
+  )
+}
+
+describe('gutter noSelect stretch', () => {
+  it('lays out gutter beside content on the same row with default Box props', () => {
+    const { ink } = makeInk()
+    const gutterWidth = 3
+
+    ink.render(
+      React.createElement(MessageRow, {
+        lines: ['Hello']
+      })
+    )
+    ink.onRender()
+
+    const screen = screenOf(ink)
+    expect(cellAt(screen, 0, 0)?.char).toBe('>')
+    expect(cellAt(screen, gutterWidth, 0)?.char).toBe('H')
+
+    ink.unmount()
+  })
+
+  it('marks from-left-edge gutter on every content row with default row layout', () => {
+    const { ink } = makeInk()
+    const gutterWidth = 3
+
+    ink.render(
+      React.createElement(MessageRow, {
+        lines: ['Line one', 'Line two', 'Line three']
+      })
+    )
+    ink.onRender()
+
+    const screen = screenOf(ink)
+
+    expect(gutterNoSelectOnRow(screen, 0, gutterWidth)).toBe(true)
+    expect(gutterNoSelectOnRow(screen, 1, gutterWidth)).toBe(true)
+    expect(gutterNoSelectOnRow(screen, 2, gutterWidth)).toBe(true)
+
+    ink.unmount()
+  })
+
+  it('marks from-left-edge gutter on every content row with explicit stretch', () => {
+    const { ink } = makeInk()
+    const gutterWidth = 3
+
+    ink.render(
+      React.createElement(MessageRow, {
+        alignItems: 'stretch',
+        lines: ['Line one', 'Line two', 'Line three']
+      })
+    )
+    ink.onRender()
+
+    const screen = screenOf(ink)
+
+    expect(gutterNoSelectOnRow(screen, 0, gutterWidth)).toBe(true)
+    expect(gutterNoSelectOnRow(screen, 1, gutterWidth)).toBe(true)
+    expect(gutterNoSelectOnRow(screen, 2, gutterWidth)).toBe(true)
+
+    ink.unmount()
+  })
+
+  it('fails to fence continuation rows when the row disables cross-axis stretch', () => {
+    const { ink } = makeInk()
+    const gutterWidth = 3
+
+    ink.render(
+      React.createElement(MessageRow, {
+        alignItems: 'flex-start',
+        lines: ['Line one', 'Line two', 'Line three']
+      })
+    )
+    ink.onRender()
+
+    const screen = screenOf(ink)
+
+    expect(gutterNoSelectOnRow(screen, 0, gutterWidth)).toBe(true)
+    expect(gutterNoSelectOnRow(screen, 1, gutterWidth)).toBe(false)
+
+    ink.unmount()
+  })
+
+  it('fences continuation rows when gutter uses height 100% in a stretch row', () => {
+    const { ink } = makeInk()
+    const gutterWidth = 3
+
+    ink.render(
+      React.createElement(
+        Box,
+        { flexDirection: 'column' },
+        React.createElement(
+          Box,
+          { alignItems: 'stretch', flexDirection: 'row' },
+          React.createElement(
+            NoSelect,
+            { flexShrink: 0, fromLeftEdge: true, height: '100%', width: gutterWidth },
+            React.createElement(Text, null, '> ')
+          ),
+          React.createElement(
+            Box,
+            { width: 30 },
+            React.createElement(
+              Box,
+              { flexDirection: 'column' },
+              React.createElement(Text, null, 'Line one'),
+              React.createElement(Text, null, 'Line two'),
+              React.createElement(Text, null, 'Line three')
+            )
+          )
+        )
+      )
+    )
+    ink.onRender()
+
+    const screen = screenOf(ink)
+
+    expect(gutterNoSelectOnRow(screen, 0, gutterWidth)).toBe(true)
+    expect(gutterNoSelectOnRow(screen, 1, gutterWidth)).toBe(true)
+    expect(gutterNoSelectOnRow(screen, 2, gutterWidth)).toBe(true)
+
+    ink.unmount()
+  })
+
+  it('extends gutter noSelect when content grows but the gutter node stays clean', () => {
+    const { ink } = makeInk()
+    const gutterWidth = 3
+
+    ink.render(React.createElement(MessageRow, { alignItems: 'stretch', lines: ['Short'] }))
+    ink.onRender()
+
+    ink.render(
+      React.createElement(MessageRow, {
+        alignItems: 'stretch',
+        lines: ['Line one', 'Line two', 'Line three']
+      })
+    )
+    ink.onRender()
+
+    const screen = screenOf(ink)
+
+    expect(gutterNoSelectOnRow(screen, 0, gutterWidth)).toBe(true)
+    expect(gutterNoSelectOnRow(screen, 1, gutterWidth)).toBe(true)
+    expect(gutterNoSelectOnRow(screen, 2, gutterWidth)).toBe(true)
+
+    ink.unmount()
+  })
+})

--- a/ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts
@@ -475,6 +475,21 @@ function renderNodeToOutput(
       const fy = Math.floor(y)
       const fw = Math.floor(width)
       const fh = Math.floor(height)
+
+      // Re-emit noSelect before blitting so gutter exclusion tracks the
+      // current Yoga rect even when this subtree is React-clean. Blit copies
+      // cells from prevScreen but the noSelect op must reflect layout now.
+      if (node.style.noSelect) {
+        const boxX = fx
+        const fromEdge = node.style.noSelect === 'from-left-edge'
+        output.noSelect({
+          x: fromEdge ? 0 : boxX,
+          y: fy,
+          width: fromEdge ? boxX + fw : fw,
+          height: fh
+        })
+      }
+
       output.blit(prevScreen, fx, fy, fw, fh)
 
       if (node.style.position === 'absolute') {
@@ -644,9 +659,8 @@ function renderNodeToOutput(
       // selection). noSelect ops are applied AFTER blits/writes in
       // output.get(), so this wins regardless of what's rendered into
       // the region — including blits from prevScreen when the box is
-      // clean (the op is emitted on both the dirty-render path here
-      // AND on the blit fast-path at line ~235 since blitRegion copies
-      // the noSelect bitmap alongside cells).
+      // clean (the op is emitted on both the dirty-render path below
+      // AND on the blit fast-path above, before blitRegion copies cells).
       //
       // 'from-left-edge' extends the exclusion from col 0 so any
       // upstream indentation (tool prefix, tree lines) is covered too

--- a/ui-tui/packages/hermes-ink/src/ink/selection.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/selection.test.ts
@@ -65,6 +65,45 @@ describe('selection whitespace handling', () => {
     expect(getSelectedText(selection, screen)).toBe('hi')
   })
 
+  it('skips from-left-edge gutter on continuation rows when noSelect spans full block height', () => {
+    const styles = new StylePool()
+    const screen = createScreen(20, 3, styles, new CharPool(), new HyperlinkPool())
+    const selection = createSelectionState()
+
+    // Gutter cols 0-2 marked noSelect on every row (stretch row layout).
+    for (let row = 0; row < 3; row++) {
+      for (let col = 0; col < 3; col++) {
+        screen.noSelect[row * screen.width + col] = 1
+      }
+    }
+
+    const line1 = 'Hi'
+    const line2 = 'There'
+
+    for (let i = 0; i < line1.length; i++) {
+      setCellAt(screen, 3 + i, 0, {
+        char: line1[i]!,
+        hyperlink: undefined,
+        styleId: screen.emptyStyleId,
+        width: CellWidth.Narrow
+      })
+    }
+
+    for (let i = 0; i < line2.length; i++) {
+      setCellAt(screen, 3 + i, 1, {
+        char: line2[i]!,
+        hyperlink: undefined,
+        styleId: screen.emptyStyleId,
+        width: CellWidth.Narrow
+      })
+    }
+
+    startSelection(selection, 0, 0)
+    updateSelection(selection, 19, 1)
+
+    expect(getSelectedText(selection, screen)).toBe('Hi\nThere')
+  })
+
   it('does not paint selection background on leading/trailing empty cells or empty rows', () => {
     const { screen, styles } = screenWithText()
     const selection = createSelectionState()

--- a/ui-tui/src/components/messageLine.tsx
+++ b/ui-tui/src/components/messageLine.tsx
@@ -216,7 +216,7 @@ export const MessageLine = memo(function MessageLine({
       )}
 
       {showResponseSeparator && (
-        <Box marginBottom={1}>
+        <Box flexDirection="row" marginBottom={1}>
           <NoSelect flexShrink={0} fromLeftEdge width={gutterWidth}>
             <Text color={t.color.border}>└─ </Text>
           </NoSelect>
@@ -226,7 +226,7 @@ export const MessageLine = memo(function MessageLine({
         </Box>
       )}
 
-      <Box>
+      <Box flexDirection="row">
         <NoSelect flexShrink={0} fromLeftEdge width={gutterWidth}>
           <Text bold={msg.role === 'user'} color={prefix}>
             {glyph}{' '}

--- a/ui-tui/src/components/messageLine.tsx
+++ b/ui-tui/src/components/messageLine.tsx
@@ -216,7 +216,7 @@ export const MessageLine = memo(function MessageLine({
       )}
 
       {showResponseSeparator && (
-        <Box flexDirection="row" marginBottom={1}>
+        <Box alignItems="stretch" flexDirection="row" marginBottom={1}>
           <NoSelect flexShrink={0} fromLeftEdge width={gutterWidth}>
             <Text color={t.color.border}>└─ </Text>
           </NoSelect>
@@ -226,7 +226,7 @@ export const MessageLine = memo(function MessageLine({
         </Box>
       )}
 
-      <Box flexDirection="row">
+      <Box alignItems="stretch" flexDirection="row">
         <NoSelect flexShrink={0} fromLeftEdge width={gutterWidth}>
           <Text bold={msg.role === 'user'} color={prefix}>
             {glyph}{' '}

--- a/ui-tui/src/components/streamingMarkdown.tsx
+++ b/ui-tui/src/components/streamingMarkdown.tsx
@@ -20,9 +20,9 @@
 // the ref resets naturally.
 //
 // Layout: the two <Md> subtrees MUST render stacked (column). The parent
-// container in messageLine.tsx is a default `flexDirection: 'row'` Box
-// (Ink's default), so returning a bare Fragment of two <Md> siblings
-// laid them out side-by-side — producing the "two jumbled columns while
+// container in messageLine.tsx is a `flexDirection: 'row'` Box (glyph
+// gutter + body), so returning a bare Fragment of two <Md> siblings laid
+// them out side-by-side — producing the "two jumbled columns while
 // streaming" rendering bug. Wrapping in a flexDirection="column" Box
 // here localizes the fix to the streaming path; the non-streaming <Md>
 // already returns its own column Box, so its single-child case was never

--- a/ui-tui/src/components/thinking.tsx
+++ b/ui-tui/src/components/thinking.tsx
@@ -75,7 +75,7 @@ function TreeRow({
   const lead = treeLead(rails, branch)
 
   return (
-    <Box>
+    <Box flexDirection="row">
       <NoSelect flexShrink={0} fromLeftEdge width={lead.length}>
         <Text color={stemColor ?? t.color.muted} dim={stemDim}>
           {lead}

--- a/ui-tui/src/components/thinking.tsx
+++ b/ui-tui/src/components/thinking.tsx
@@ -75,7 +75,7 @@ function TreeRow({
   const lead = treeLead(rails, branch)
 
   return (
-    <Box flexDirection="row">
+    <Box alignItems="stretch" flexDirection="row">
       <NoSelect flexShrink={0} fromLeftEdge width={lead.length}>
         <Text color={stemColor ?? t.color.muted} dim={stemDim}>
           {lead}


### PR DESCRIPTION
## Summary

Installation scripts (`install.sh` and `install.ps1`) write a SOUL.md template containing only a heading and HTML comments. `load_soul_md()` considers this file as a valid identity (non-empty after strip), causing it to replace the default agent identity (`DEFAULT_AGENT_IDENTITY`) with an empty/comment-only persona.

The Python-side `_ensure_default_soul_md` already writes the correct content via `hermes_cli/default_soul.py`, but the install scripts run first and produce a different, incompatible template.

**Fix:** Replace the empty template in both install scripts with the actual default SOUL.md content from `hermes_cli/default_soul.py`, keeping a shortened HTML comment for user customization instructions.

## Type of Change
- [x] Bug fix

## Affected Areas
- [x] Build / packaging / release

## Testing
- [x] `pnpm typecheck` (not applicable — shell/PowerShell scripts, no typecheck)

## Security and Privacy Checklist
- [x] No credentials, private keys, passphrases, tokens, API keys, or real production host details are included.