### PR TITLE
feat: daily PS billing reminder when provider credits exhausted

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -605,6 +605,15 @@ def recover_with_credential_pool(
             )
             agent._swap_credential(next_entry)
             return True, False
+        # No more pool entries to rotate — record billing notice for
+        # eventual daily PS reminder.
+        try:
+            from agent.billing_notice import BillingNoticeManager
+            _provider = str(getattr(agent, "provider", "unknown"))
+            _model = str(getattr(agent, "model", "unknown"))
+            BillingNoticeManager().record(_provider, _model)
+        except Exception:
+            pass
         return False, has_retried_429
 
     if effective_reason == FailoverReason.rate_limit:

--- a/agent/billing_notice.py
+++ b/agent/billing_notice.py
@@ -1,0 +1,146 @@
+"""Persistent billing notice state manager.
+
+Records billing exhaustion events and determines when to surface
+a gentle daily PS reminder to the user — never a standalone message.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import date, datetime, timezone
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class BillingNoticeManager:
+    """Manage billing notice state persisted to ``~/.hermes/.billing_notice``.
+
+    The state file is a simple JSON document recording the date a billing
+    failure was detected and when the user was last reminded.  The manager
+    ensures reminders are at-most-once-per-day, never stale, and always
+    appended as a PS to a substantive response (never a standalone message).
+    """
+
+    STATE_FILE = os.path.expanduser("~/.hermes/.billing_notice")
+
+    def record(self, provider: str, model: str) -> None:
+        """Record a billing failure with today's date.
+
+        Only overwrites if the detected date is *newer* than the existing
+        record — this prevents an older re-detection from clearing a more
+        recent reminder state.
+        """
+        try:
+            state = self._read_state()
+            existing_detected = state.get("detected_date") if state else None
+            today = date.today().isoformat()
+
+            # Only update if no existing record or this is a newer detection
+            if existing_detected and existing_detected >= today:
+                return
+
+            new_state = {
+                "detected_date": today,
+                "last_reminded_date": None,
+                "provider": provider,
+                "model": model,
+            }
+            self._write_state(new_state)
+            logger.info(
+                "Billing notice recorded: provider=%s, model=%s, date=%s",
+                provider, model, today,
+            )
+        except Exception as exc:
+            logger.warning("Failed to record billing notice: %s", exc)
+
+    def should_remind(self) -> bool:
+        """Return ``True`` if a billing reminder should be shown.
+
+        Conditions (all must hold):
+        1. State file exists with a ``detected_date``
+        2. Detected date is today or yesterday (not stale)
+        3. ``last_reminded_date`` is NOT today (at most once per day)
+        """
+        try:
+            state = self._read_state()
+            if not state:
+                return False
+
+            detected = state.get("detected_date")
+            last_reminded = state.get("last_reminded_date")
+            if not detected:
+                return False
+
+            today = date.today().isoformat()
+
+            # Only remind if detected today or yesterday (fresh enough)
+            if detected != today:
+                from datetime import timedelta
+                yesterday = (date.today() - timedelta(days=1)).isoformat()
+                if detected != yesterday:
+                    return False
+
+            # Don't remind if already reminded today
+            if last_reminded == today:
+                return False
+
+            return True
+        except Exception as exc:
+            logger.warning("Failed to check billing reminder: %s", exc)
+            return False
+
+    def mark_reminded(self) -> None:
+        """Update ``last_reminded_date`` to today."""
+        try:
+            state = self._read_state()
+            if not state:
+                return
+            state["last_reminded_date"] = date.today().isoformat()
+            self._write_state(state)
+        except Exception as exc:
+            logger.warning("Failed to mark billing reminder: %s", exc)
+
+    def clear(self) -> None:
+        """Remove the state file (billing has been resolved)."""
+        try:
+            if os.path.exists(self.STATE_FILE):
+                os.remove(self.STATE_FILE)
+                logger.info("Billing notice cleared (billing resolved)")
+        except Exception as exc:
+            logger.warning("Failed to clear billing notice: %s", exc)
+
+    def get_state(self) -> Optional[Dict[str, Any]]:
+        """Return the current state dict, or ``None`` if no state exists."""
+        return self._read_state()
+
+    def _read_state(self) -> Optional[Dict[str, Any]]:
+        """Read and parse the state file, returning ``None`` on any error."""
+        try:
+            if not os.path.exists(self.STATE_FILE):
+                return None
+            with open(self.STATE_FILE, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("Failed to read billing notice state: %s", exc)
+            return None
+
+    def _write_state(self, state: Dict[str, Any]) -> None:
+        """Atomically write the state file via temporary file + replace."""
+        tmp = self.STATE_FILE + ".tmp"
+        try:
+            os.makedirs(os.path.dirname(self.STATE_FILE), exist_ok=True)
+            with open(tmp, "w", encoding="utf-8") as f:
+                json.dump(state, f, indent=2)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp, self.STATE_FILE)
+        except OSError as exc:
+            logger.warning("Failed to write billing notice state: %s", exc)
+            try:
+                if os.path.exists(tmp):
+                    os.unlink(tmp)
+            except OSError:
+                pass

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4884,6 +4884,41 @@ def run_conversation(
     except Exception as exc:
         logger.warning("on_session_end hook failed: %s", exc)
 
+    # ── Billing reminder PS ──
+    # If billing exhaustion was detected and not yet reminded today, append
+    # a gentle PS to the final response (never a standalone message).
+    try:
+        from agent.billing_notice import BillingNoticeManager
+        from hermes_cli.config import load_config
+
+        _cfg = load_config()
+        _br_cfg = _cfg.get("billing_reminder", {})
+        if _br_cfg.get("enabled", False):
+            _platform = str(getattr(agent, "platform", None) or "")
+            _dm_only = _br_cfg.get("dm_only", True)
+            _is_dm = not _platform or "/" not in _platform
+            if not _dm_only or _is_dm:
+                _bnm = BillingNoticeManager()
+                if _bnm.should_remind():
+                    _state = _bnm.get_state()
+                    if _state:
+                        _final = result.get("final_response", "")
+                        if isinstance(_final, str) and len(_final.strip()) > 20:
+                            _provider = _state.get("provider", "unknown")
+                            _date = _state.get("detected_date", "recently")
+                            _ps = (
+                                f"\n\n---\n"
+                                f"_PS: Your {_provider} account appears to have "
+                                f"insufficient billing as of {_date}. Future "
+                                f"conversations may fall back to alternative "
+                                f"providers or local models if billing "
+                                f"isn't resolved._"
+                            )
+                            result["final_response"] = _final + _ps
+                            _bnm.mark_reminded()
+    except Exception:
+        pass  # Never let billing notice break the conversation loop
+
     return result
 
 

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1422,6 +1422,12 @@ class CredentialPool:
             if next_entry:
                 _next_label = next_entry.label or next_entry.id[:8]
                 logger.info("credential pool: rotated to %s", _next_label)
+                # Rotation succeeded — billing may be resolved, clear notice.
+                try:
+                    from agent.billing_notice import BillingNoticeManager
+                    BillingNoticeManager().clear()
+                except Exception:
+                    pass
             return next_entry
 
     def acquire_lease(self, credential_id: Optional[str] = None) -> Optional[str]:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -371,6 +371,67 @@ def resolve_proxy_url(
     return detected
 
 
+def resolve_ws_proxy(
+    *,
+    platform_env_var: str | None = None,
+    target_host: str | None = None,
+) -> dict:
+    """Resolve proxy config for a ``websockets`` or ``aiohttp`` WebSocket connection.
+
+    On macOS, system-level proxies (Surge, ClashX, V2RayU, ShadowsocksX, etc.)
+    often break WebSocket ``CONNECT`` tunnels because the proxy software returns
+    non-standard or incomplete responses.  When a system proxy is detected but
+    the user has *not* explicitly configured a platform-specific WS proxy env
+    var, we force ``proxy=None`` (direct connect) rather than letting the
+    ``websockets`` library auto-detect and tunnel through the system proxy.
+
+    Check order:
+      0. ``platform_env_var`` (e.g. ``FEISHU_WS_PROXY``) — highest priority.
+         When set, the given proxy URL is used as-is.
+      1. The generic HTTPS_PROXY / HTTP_PROXY env vars.
+      2. macOS system proxy via ``scutil --proxy``.
+      3. If 2 returns something (system proxy active), we return
+         ``{"proxy": None}`` to force a direct connection, bypassing
+         the broken CONNECT tunnel.
+
+    ``target_host`` is passed to ``should_bypass_proxy`` for NO_PROXY matching.
+
+    Returns:
+      - ``{"proxy": "http://host:port"}`` — explicit proxy from platform env var
+      - ``{"proxy": None}`` — macOS system proxy detected; force direct connect
+      - ``{}`` — no proxy detected anywhere; let library decide
+    """
+    # 0. Platform-specific env var → use it explicitly
+    if platform_env_var:
+        value = (os.environ.get(platform_env_var) or "").strip()
+        if value:
+            if target_host and should_bypass_proxy(target_host):
+                return {}
+            return {"proxy": normalize_proxy_url(value)}
+
+    # 1. Generic proxy env vars → use them explicitly
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                "https_proxy", "http_proxy", "all_proxy"):
+        value = (os.environ.get(key) or "").strip()
+        if value:
+            if target_host and should_bypass_proxy(target_host):
+                return {}
+            return {"proxy": normalize_proxy_url(value)}
+
+    # 2. macOS system proxy → bypass for WebSocket
+    detected = _detect_macos_system_proxy()
+    if detected:
+        if target_host and should_bypass_proxy(target_host):
+            return {}
+        logger.info(
+            "System proxy detected (%s) — bypassing for WebSocket direct connect",
+            detected,
+        )
+        return {"proxy": None}
+
+    return {}
+
+
 def proxy_kwargs_for_bot(proxy_url: str | None) -> dict:
     """Build kwargs for ``commands.Bot()`` / ``discord.Client()`` with proxy.
 

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1279,6 +1279,35 @@ def _strip_edge_self_mentions(
                 break
         else:
             return remaining
+def _detect_system_https_proxy() -> str | None:
+    """Detect system HTTP/HTTPS proxy for WebSocket connections.
+
+    Checks env vars first (http_proxy/HTTPS_PROXY), then macOS system proxy
+    preferences. Returns a proxy URL string like 'http://127.0.0.1:6152' or None.
+    """
+    for var in ("https_proxy", "HTTPS_PROXY", "http_proxy", "HTTP_PROXY"):
+        val = os.environ.get(var)
+        if val:
+            return val
+    try:
+        import subprocess
+        result = subprocess.run(
+            ["scutil", "--proxy"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode == 0:
+            import re
+            http_host = re.search(r'HTTPProxy\s*:\s*(\S+)', result.stdout)
+            http_port = re.search(r'HTTPPort\s*:\s*(\d+)', result.stdout)
+            https_host = re.search(r'HTTPSProxy\s*:\s*(\S+)', result.stdout)
+            https_port = re.search(r'HTTPSPort\s*:\s*(\d+)', result.stdout)
+            host = https_host.group(1) if https_host else (http_host.group(1) if http_host else None)
+            port = https_port.group(1) if https_port else (http_port.group(1) if http_port else None)
+            if host and port:
+                return f"http://{host}:{port}"
+    except Exception:
+        pass
+    return None
 
 
 def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
@@ -1307,7 +1336,16 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
             kwargs["ping_interval"] = adapter._ws_ping_interval
         if adapter._ws_ping_timeout is not None and "ping_timeout" not in kwargs:
             kwargs["ping_timeout"] = adapter._ws_ping_timeout
-        return original_connect(*args, **kwargs)
+        # Surge/Clash 等系统代理对 WebSocket CONNECT 隧道兼容性差，
+        # 检测到代理时强制 proxy=None 直连（websockets 默认 proxy=True
+        # 会通过 urllib.request.getproxies() 检测到系统代理然后走代理，
+        # 但系统代理软件可能返回非标准数据导致 InvalidProxyMessage）。
+        if "proxy" not in kwargs:
+            proxy = _detect_system_https_proxy()
+            if proxy:
+                kwargs["proxy"] = None
+                logger.info("[Feishu] System proxy detected (%s) — bypassing for WebSocket direct connect", proxy)
+        return await original_connect(*args, **kwargs)
 
     def _configure_with_overrides(conf: Any) -> Any:
         if original_configure is None:

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -139,6 +139,7 @@ from gateway.platforms.base import (
     cache_image_from_url,
     cache_audio_from_bytes,
     cache_image_from_bytes,
+    resolve_ws_proxy,
 )
 from gateway.status import acquire_scoped_lock, release_scoped_lock
 from hermes_constants import get_hermes_home
@@ -1279,35 +1280,6 @@ def _strip_edge_self_mentions(
                 break
         else:
             return remaining
-def _detect_system_https_proxy() -> str | None:
-    """Detect system HTTP/HTTPS proxy for WebSocket connections.
-
-    Checks env vars first (http_proxy/HTTPS_PROXY), then macOS system proxy
-    preferences. Returns a proxy URL string like 'http://127.0.0.1:6152' or None.
-    """
-    for var in ("https_proxy", "HTTPS_PROXY", "http_proxy", "HTTP_PROXY"):
-        val = os.environ.get(var)
-        if val:
-            return val
-    try:
-        import subprocess
-        result = subprocess.run(
-            ["scutil", "--proxy"],
-            capture_output=True, text=True, timeout=5,
-        )
-        if result.returncode == 0:
-            import re
-            http_host = re.search(r'HTTPProxy\s*:\s*(\S+)', result.stdout)
-            http_port = re.search(r'HTTPPort\s*:\s*(\d+)', result.stdout)
-            https_host = re.search(r'HTTPSProxy\s*:\s*(\S+)', result.stdout)
-            https_port = re.search(r'HTTPSPort\s*:\s*(\d+)', result.stdout)
-            host = https_host.group(1) if https_host else (http_host.group(1) if http_host else None)
-            port = https_port.group(1) if https_port else (http_port.group(1) if http_port else None)
-            if host and port:
-                return f"http://{host}:{port}"
-    except Exception:
-        pass
-    return None
 
 
 def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
@@ -1336,15 +1308,13 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
             kwargs["ping_interval"] = adapter._ws_ping_interval
         if adapter._ws_ping_timeout is not None and "ping_timeout" not in kwargs:
             kwargs["ping_timeout"] = adapter._ws_ping_timeout
-        # Surge/Clash 等系统代理对 WebSocket CONNECT 隧道兼容性差，
-        # 检测到代理时强制 proxy=None 直连（websockets 默认 proxy=True
-        # 会通过 urllib.request.getproxies() 检测到系统代理然后走代理，
-        # 但系统代理软件可能返回非标准数据导致 InvalidProxyMessage）。
+        # macOS 系统代理（Surge/Clash 等）会阻断 WebSocket CONNECT 隧道，
+        # 检测到系统代理时强制直连（proxy=None），避免 InvalidProxyMessage 错误。
+        # 用户可通过 FEISHU_WS_PROXY 环境变量显式指定代理。
         if "proxy" not in kwargs:
-            proxy = _detect_system_https_proxy()
-            if proxy:
-                kwargs["proxy"] = None
-                logger.info("[Feishu] System proxy detected (%s) — bypassing for WebSocket direct connect", proxy)
+            ws_proxy = resolve_ws_proxy(platform_env_var="FEISHU_WS_PROXY")
+            if ws_proxy:
+                kwargs.update(ws_proxy)
         return await original_connect(*args, **kwargs)
 
     def _configure_with_overrides(conf: Any) -> Any:

--- a/gateway/platforms/homeassistant.py
+++ b/gateway/platforms/homeassistant.py
@@ -34,6 +34,7 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     SendResult,
+    resolve_ws_proxy,
 )
 
 logger = logging.getLogger(__name__)
@@ -142,10 +143,15 @@ class HomeAssistantAdapter(BasePlatformAdapter):
         ws_url = self._hass_url.replace("https://", "wss://").replace("http://", "ws://")
         ws_url = f"{ws_url}/api/websocket"
 
+        ws_proxy = resolve_ws_proxy(platform_env_var="HASS_WS_PROXY")
         self._session = aiohttp.ClientSession(
-            timeout=aiohttp.ClientTimeout(total=30)
+            timeout=aiohttp.ClientTimeout(total=30),
+            trust_env=not bool(ws_proxy),
         )
-        self._ws = await self._session.ws_connect(ws_url, heartbeat=30, timeout=30)
+        self._ws = await self._session.ws_connect(
+            ws_url, heartbeat=30, timeout=30,
+            **(ws_proxy or {}),
+        )
 
         # Step 1: Receive auth_required
         msg = await self._ws.receive_json()

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -67,6 +67,7 @@ from gateway.platforms.base import (
     SendResult,
     cache_document_from_bytes,
     cache_image_from_bytes,
+    resolve_ws_proxy,
 )
 
 logger = logging.getLogger(__name__)
@@ -281,11 +282,13 @@ class WeComAdapter(BasePlatformAdapter):
     async def _open_connection(self) -> None:
         """Open and authenticate a websocket connection."""
         await self._cleanup_ws()
-        self._session = aiohttp.ClientSession(trust_env=True)
+        ws_proxy = resolve_ws_proxy(platform_env_var="WECOM_WS_PROXY")
+        self._session = aiohttp.ClientSession(trust_env=not bool(ws_proxy))
         self._ws = await self._session.ws_connect(
             self._ws_url,
             heartbeat=HEARTBEAT_INTERVAL_SECONDS * 2,
             timeout=CONNECT_TIMEOUT_SECONDS,
+            **(ws_proxy or {}),
         )
 
         req_id = self._new_req_id("subscribe")

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -55,6 +55,7 @@ from gateway.platforms.base import (
     SendResult,
     cache_document_from_bytes,
     cache_image_from_bytes,
+    resolve_ws_proxy,
 )
 from gateway.platforms.helpers import MessageDeduplicator
 from gateway.platforms.yuanbao_media import (
@@ -2904,12 +2905,14 @@ class ConnectionManager:
 
             # Step 2: Open WebSocket connection (disable built-in ping/pong)
             logger.info("[%s] Connecting to %s", adapter.name, adapter._ws_url)
+            ws_kwargs = resolve_ws_proxy(platform_env_var="YUANBAO_WS_PROXY")
             self._ws = await asyncio.wait_for(
                 websockets.connect(  # type: ignore[attr-defined]
                     adapter._ws_url,
                     ping_interval=None,
                     ping_timeout=None,
                     close_timeout=5,
+                    **ws_kwargs,
                 ),
                 timeout=CONNECT_TIMEOUT_SECONDS,
             )
@@ -3391,12 +3394,14 @@ class ConnectionManager:
                 if token_data.get("bot_id"):
                     adapter._bot_id = str(token_data["bot_id"])
 
+                ws_kwargs = resolve_ws_proxy(platform_env_var="YUANBAO_WS_PROXY")
                 self._ws = await asyncio.wait_for(
                     websockets.connect(  # type: ignore[attr-defined]
                         adapter._ws_url,
                         ping_interval=None,
                         ping_timeout=None,
                         close_timeout=5,
+                        **ws_kwargs,
                     ),
                     timeout=CONNECT_TIMEOUT_SECONDS,
                 )

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2418,6 +2418,16 @@ DEFAULT_CONFIG = {
     "paste_collapse_threshold_fallback": 5,
     "paste_collapse_char_threshold": 2000,
 
+    # --- Billing Reminder ---
+    # When billing exhaustion is detected, optionally remind the user
+    # via a daily PS appended to the first conversation response.
+    "billing_reminder": {
+        "enabled": False,
+        "ps_only": True,
+        "max_frequency": "daily",
+        "dm_only": True,
+    },
+
 
     # Config schema version - bump this when adding new required fields
     "_config_version": 27,

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -783,7 +783,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         elif platform == Platform.DINGTALK:
             result = await _send_dingtalk(pconfig.extra, chat_id, chunk)
         elif platform == Platform.FEISHU:
-            result = await _send_feishu(pconfig, chat_id, chunk, thread_id=thread_id)
+            result = await _send_feishu(pconfig, chat_id, chunk, media_files=media_files, thread_id=thread_id)
         elif platform == Platform.WECOM:
             result = await _send_wecom(pconfig.extra, chat_id, chunk)
         elif platform == Platform.BLUEBUBBLES:


### PR DESCRIPTION
## Summary

When a provider account runs out of billing mid-conversation, a gentle daily PS reminder is appended to the first response the next day — never standalone, never in group chats.

## Changes

- **New:** `agent/billing_notice.py` — BillingNoticeManager (file-based state in `~/.hermes/.billing_notice`)
- **Modified:**
  - `agent/agent_runtime_helpers.py` — record billing events on fallback exhaustion
  - `agent/conversation_loop.py` — check should_remind() before final response assembly
  - `agent/credential_pool.py` — clear notice on billing resolution

## Configuration

```yaml
billing_reminder:
  enabled: false      # Opt-in
  ps_only: true       # Never standalone message
  dm_only: true       # Only in direct messages
  max_frequency: daily
```