### PR TITLE
feat: Ollama local fallback when all remote providers fail

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -901,7 +901,13 @@ def init_agent(
             print(f"🔄 Fallback model: {fb['model']} ({fb['provider']})")
         else:
             print(f"🔄 Fallback chain ({len(agent._fallback_chain)} providers): " +
-                  " → ".join(f"{f['model']} ({f['provider']})" for f in agent._fallback_chain))
+                  " → ".join(f"{f['model']} ({f['provider']})\n" for f in agent._fallback_chain))
+
+    # Local fallback config (Ollama) — loaded once at init
+    from hermes_cli.config import cfg_get
+
+    agent._local_fallback_config = cfg_get("local_fallback", {})
+    agent._on_local_fallback = False
 
     # Get available tools with filtering
     agent.tools = _ra().get_tool_definitions(

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1261,6 +1261,34 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         return agent._try_activate_fallback()  # try next in chain
 
 
+def try_local_fallback(agent) -> bool:
+    """Attempt local Ollama fallback after the provider chain is exhausted.
+
+    Calls :func:`agent.local_fallback.local_fallback_orchestrator` and, on
+    success, resets the agent's retry counters so the conversation loop can
+    ``continue`` with the newly-switched local model.
+
+    Returns ``True`` if the local fallback was activated, ``False`` otherwise.
+    """
+    try:
+        from agent.local_fallback import local_fallback_orchestrator
+
+        success, model_name = local_fallback_orchestrator(agent)
+        if success:
+            logger.info(
+                "Local Ollama fallback activated: %s",
+                model_name,
+            )
+            return True
+        logger.warning(
+            "Local Ollama fallback failed: %s",
+            model_name,
+        )
+        return False
+    except Exception as exc:
+        logger.error("Local Ollama fallback error: %s", exc)
+        return False
+
 
 def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
     """Request a summary when max iterations are reached. Returns the final response text."""
@@ -2451,6 +2479,7 @@ __all__ = [
     "build_api_kwargs",
     "build_assistant_message",
     "try_activate_fallback",
+    "try_local_fallback",
     "handle_max_iterations",
     "cleanup_task_resources",
     "interruptible_streaming_api_call",

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1188,6 +1188,14 @@ def run_conversation(
                             compression_attempts = 0
                             primary_recovery_attempted = False
                             continue
+                        # ── Local Ollama fallback as last resort ──
+                        agent._buffer_status("🔄 All providers exhausted — trying local Ollama...")
+                        from agent.chat_completion_helpers import try_local_fallback
+                        if try_local_fallback(agent):
+                            retry_count = 0
+                            compression_attempts = 0
+                            primary_recovery_attempted = False
+                            continue
                         # No fallback available — surface buffered context
                         # so user sees the rate-limit message that led here.
                         agent._flush_status_buffer()
@@ -1473,6 +1481,14 @@ def run_conversation(
                         compression_attempts = 0
                         primary_recovery_attempted = False
                         continue
+                    # ── Local Ollama fallback as last resort ──
+                    agent._buffer_status("🔄 All providers exhausted — trying local Ollama...")
+                    from agent.chat_completion_helpers import try_local_fallback
+                    if try_local_fallback(agent):
+                        retry_count = 0
+                        compression_attempts = 0
+                        primary_recovery_attempted = False
+                        continue
 
                     # Check for error field in response (some providers include this)
                     error_msg = "Unknown"
@@ -1540,6 +1556,14 @@ def run_conversation(
                         if agent._has_pending_fallback():
                             agent._buffer_status(f"⚠️ Max retries ({max_retries}) for invalid responses — trying fallback...")
                         if agent._try_activate_fallback():
+                            retry_count = 0
+                            compression_attempts = 0
+                            primary_recovery_attempted = False
+                            continue
+                        # ── Local Ollama fallback as last resort ──
+                        agent._buffer_status("🔄 All providers exhausted — trying local Ollama...")
+                        from agent.chat_completion_helpers import try_local_fallback
+                        if try_local_fallback(agent):
                             retry_count = 0
                             compression_attempts = 0
                             primary_recovery_attempted = False
@@ -3263,6 +3287,14 @@ def run_conversation(
                         compression_attempts = 0
                         primary_recovery_attempted = False
                         continue
+                    # ── Local Ollama fallback as last resort ──
+                    agent._buffer_status("🔄 All providers exhausted — trying local Ollama...")
+                    from agent.chat_completion_helpers import try_local_fallback
+                    if try_local_fallback(agent):
+                        retry_count = 0
+                        compression_attempts = 0
+                        primary_recovery_attempted = False
+                        continue
                     if api_kwargs is not None:
                         agent._dump_api_request_debug(
                             api_kwargs, reason="non_retryable_client_error", error=api_error,
@@ -3403,6 +3435,14 @@ def run_conversation(
                     if agent._has_pending_fallback():
                         agent._buffer_status(f"⚠️ Max retries ({max_retries}) exhausted — trying fallback...")
                     if agent._try_activate_fallback():
+                        retry_count = 0
+                        compression_attempts = 0
+                        primary_recovery_attempted = False
+                        continue
+                    # ── Local Ollama fallback as last resort ──
+                    agent._buffer_status("🔄 All providers exhausted — trying local Ollama...")
+                    from agent.chat_completion_helpers import try_local_fallback
+                    if try_local_fallback(agent):
                         retry_count = 0
                         compression_attempts = 0
                         primary_recovery_attempted = False
@@ -4340,8 +4380,13 @@ def run_conversation(
                             continue
 
                     # Exhausted retries and fallback chain (or no
-                    # fallback configured).  Fall through to the
-                    # "(empty)" terminal.
+                    # fallback configured). Try local Ollama as last resort.
+                    agent._buffer_status("🔄 All providers exhausted — trying local Ollama...")
+                    from agent.chat_completion_helpers import try_local_fallback
+                    if try_local_fallback(agent):
+                        agent._empty_content_retries = 0
+                        continue
+
                     # Surface the buffered retry/fallback trace so the
                     # user can see what was attempted before "(empty)".
                     agent._flush_status_buffer()

--- a/agent/local_fallback.py
+++ b/agent/local_fallback.py
@@ -1,0 +1,194 @@
+"""Local Ollama fallback orchestrator.
+
+When all remote providers and configured fallbacks are exhausted, this
+module attempts to find or set up a local Ollama model to keep the
+conversation going.
+
+The process:
+  1. Check local_fallback.enabled config
+  2. Find the ollama binary on the system
+  3. Check server health (start if needed)
+  4. List available models (pull the configured default if empty)
+  5. Switch the agent's active provider to Ollama
+  6. On the next turn, attempt to restore the primary provider
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional, Tuple
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+def local_fallback_orchestrator(agent: Any) -> Tuple[bool, str]:
+    """Orchestrate the full local fallback process.
+
+    Returns ``(True, model_name)`` on success, ``(False, error_message)``
+    on failure.
+
+    The agent object is modified in-place: ``agent.model``, ``agent.provider``,
+    ``agent.base_url``, and ``agent.client`` are updated to point to the local
+    Ollama instance.
+    """
+    # Step 1: Check config
+    fb_config = getattr(agent, "_local_fallback_config", {})
+    if not fb_config.get("enabled", False):
+        return False, "Local fallback is not enabled in config"
+
+    model = fb_config.get("model", "qwen3.5:0.8b")
+    host = fb_config.get("ollama_host", "http://localhost:11434")
+    ask_user = fb_config.get("ask_user", True)
+    auto_pull = fb_config.get("auto_pull", True)
+    auto_install = fb_config.get("auto_install", False)
+    serve_timeout = int(fb_config.get("serve_timeout", 10))
+    download_timeout = int(fb_config.get("download_timeout", 300))
+
+    # Step 2: Find ollama binary
+    from agent.ollama_discovery import (
+        check_ollama_health,
+        find_ollama_binary,
+        install_ollama,
+        list_available_models,
+        start_ollama_serve,
+    )
+
+    binary = find_ollama_binary()
+    if binary is None:
+        if auto_install:
+            agent._buffer_status("📦 Ollama not found — installing...")
+            if not install_ollama():
+                return False, "Failed to install Ollama automatically"
+            binary = find_ollama_binary()
+            if binary is None:
+                return False, "Ollama installed but binary not found"
+        else:
+            agent._buffer_status(
+                "💡 Ollama not found. Set local_fallback.auto_install=true "
+                "to auto-install, or install manually: brew install ollama"
+            )
+            return False, "Ollama not installed"
+
+    # Step 3: Check / start server
+    if not check_ollama_health(host=host):
+        agent._buffer_status("🚀 Starting Ollama server...")
+        if not start_ollama_serve(binary, timeout=serve_timeout):
+            return False, "Failed to start Ollama server"
+
+    # Step 4: List available models, pull if needed
+    available = list_available_models(host=host)
+    if not available:
+        if auto_pull:
+            agent._buffer_status(f"📥 No models found — pulling {model}...")
+            from agent.model_puller import pull_model
+            if not pull_model(
+                model, host=host, timeout=download_timeout,
+                status_callback=lambda msg: agent._buffer_status(msg),
+            ):
+                return False, f"Failed to pull model {model}"
+            available = list_available_models(host=host)
+
+        if not available:
+            return False, (
+                f"No models available and auto-pull is disabled. "
+                f"Run: ollama pull {model}"
+            )
+
+    # Pick the smallest available model (or the configured one)
+    target_model = model
+    if target_model not in available:
+        # Fall back to first available
+        target_model = available[0]
+
+    # Step 5: Switch agent to Ollama
+    _switch_agent_to_ollama(agent, target_model, host)
+    agent._buffer_status(
+        f"🔄 Switched to local model: {target_model} (Ollama)"
+    )
+
+    return True, target_model
+
+
+def restore_primary_provider(agent: Any) -> bool:
+    """Attempt to restore the original primary provider.
+
+    Checks whether the primary provider's config is still viable.  If so,
+    restores the agent state from ``agent._primary_runtime`` and returns
+    ``True``.
+
+    Called on every conversation turn when local fallback is active.
+    """
+    if not getattr(agent, "_on_local_fallback", False):
+        return False
+
+    # Check if primary runtime snapshot exists
+    primary = getattr(agent, "_primary_runtime", None)
+    if not primary:
+        return False
+
+    # Quick health check — try a simple models list to see if primary is back
+    try:
+        base_url = primary.get("base_url", "")
+        api_key = primary.get("api_key", "")
+        if base_url and api_key:
+            resp = httpx.get(
+                f"{base_url}/models",
+                headers={"Authorization": f"Bearer {api_key}"},
+                timeout=5,
+            )
+            if resp.status_code == 200:
+                _perform_restore(agent, primary)
+                return True
+    except Exception:
+        pass
+
+    return False
+
+
+def _switch_agent_to_ollama(agent: Any, model_name: str, host: str) -> None:
+    """Reconfigure the agent's active provider to Ollama.
+
+    Sets ``agent.model``, ``agent.provider``, ``agent.base_url``,
+    ``agent._client_kwargs``, and rebuilds the OpenAI client via
+    ``agent._create_openai_client()``.
+    """
+    agent.model = model_name
+    agent.provider = "ollama"
+    agent.base_url = host
+    agent._client_kwargs = {"base_url": host}
+    agent._on_local_fallback = True
+
+    try:
+        agent.client = agent._create_openai_client(
+            agent._client_kwargs,
+            reason="local_fallback",
+        )
+        logger.info(
+            "Switched to local Ollama model: %s (host=%s)",
+            model_name, host,
+        )
+    except Exception as exc:
+        logger.error("Failed to create Ollama client: %s", exc)
+        raise
+
+
+def _perform_restore(agent: Any, primary: Dict[str, Any]) -> None:
+    """Restore agent state from a primary runtime snapshot."""
+    agent.model = primary.get("model", agent.model)
+    agent.provider = primary.get("provider", agent.provider)
+    agent.base_url = primary.get("base_url", agent.base_url)
+    agent.api_mode = primary.get("api_mode", agent.api_mode)
+    agent.api_key = primary.get("api_key", agent.api_key)
+    agent._client_kwargs = dict(primary.get("client_kwargs", {}))
+    agent._on_local_fallback = False
+
+    try:
+        agent.client = agent._create_openai_client(
+            agent._client_kwargs,
+            reason="restore_primary",
+        )
+        logger.info("Restored primary provider: %s (%s)", agent.model, agent.provider)
+    except Exception as exc:
+        logger.error("Failed to restore primary client: %s", exc)

--- a/agent/model_puller.py
+++ b/agent/model_puller.py
@@ -1,0 +1,98 @@
+"""Ollama model puller with streaming progress feedback."""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable, Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+def pull_model(
+    model_name: str,
+    host: str = "http://localhost:11434",
+    timeout: int = 300,
+    status_callback: Optional[Callable[[str], None]] = None,
+) -> bool:
+    """Pull an Ollama model with streaming progress feedback.
+
+    Sends a ``POST /api/pull`` with ``{"name": model_name, "stream": true}``
+    and parses the NDJSON response lines for status updates.  The
+    ``status_callback`` is invoked with human-readable progress messages
+    (throttled to ~every 2 seconds to avoid flooding).
+
+    Returns ``True`` if the model was pulled successfully.
+    """
+    try:
+        if status_callback:
+            status_callback(f"⏳ Pulling model {model_name}...")
+
+        with httpx.Client(timeout=httpx.Timeout(timeout)) as client:
+            with client.stream(
+                "POST",
+                f"{host}/api/pull",
+                json={"name": model_name, "stream": True},
+            ) as response:
+                if response.status_code != 200:
+                    logger.error(
+                        "Failed to pull model %s: HTTP %s",
+                        model_name, response.status_code,
+                    )
+                    if status_callback:
+                        status_callback(
+                            f"❌ Failed to pull {model_name} "
+                            f"(HTTP {response.status_code})"
+                        )
+                    return False
+
+                _last_progress = 0.0
+                for line in response.iter_lines():
+                    if not line:
+                        continue
+                    try:
+                        import json
+                        data = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+
+                    status = data.get("status", "")
+                    if status == "success":
+                        if status_callback:
+                            status_callback(
+                                f"✅ Model {model_name} pulled successfully"
+                            )
+                        return True
+
+                    # Throttle progress updates to ~every 2s
+                    now = _now_seconds()
+                    if status_callback and (now - _last_progress) >= 2.0:
+                        _last_progress = now
+                        total = data.get("total", 0) or 0
+                        completed = data.get("completed", 0) or 0
+                        pct = (
+                            f"{completed // (1024 * 1024)}MB / "
+                            f"{total // (1024 * 1024)}MB"
+                        ) if total else status
+                        status_callback(f"⏳ {model_name}: {pct}")
+
+                logger.error(
+                    "Model pull stream ended without success for %s",
+                    model_name,
+                )
+                if status_callback:
+                    status_callback(f"❌ Pull stream ended unexpectedly for {model_name}")
+                return False
+
+    except Exception as exc:
+        logger.error("Failed to pull model %s: %s", model_name, exc)
+        if status_callback:
+            status_callback(f"❌ Error pulling {model_name}: {exc}")
+        return False
+
+
+def _now_seconds() -> float:
+    """Return monotonic time in seconds (Python 3.7+ compat)."""
+    import time
+    return time.monotonic()

--- a/agent/ollama_discovery.py
+++ b/agent/ollama_discovery.py
@@ -1,0 +1,124 @@
+"""Ollama binary and server discovery utilities."""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+import time
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+_OLLAMA_COMMON_PATHS = [
+    "/usr/local/bin/ollama",
+    "/opt/homebrew/bin/ollama",
+    "/home/linuxbrew/.linuxbrew/bin/ollama",
+    "/snap/bin/ollama",
+]
+
+
+def find_ollama_binary() -> Optional[str]:
+    """Find the ollama binary on the system.
+
+    Checks PATH first, then common install locations.
+    Returns the full path to the binary, or ``None`` if not found.
+    """
+    path = shutil.which("ollama")
+    if path:
+        return path
+    for candidate in _OLLAMA_COMMON_PATHS:
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
+def check_ollama_health(host: str = "http://localhost:11434", timeout: int = 3) -> bool:
+    """Check if the Ollama server is running and healthy.
+
+    Sends a ``GET /api/tags`` request to the Ollama API.
+    Returns ``True`` if the server responds with HTTP 200.
+    """
+    try:
+        import httpx
+        resp = httpx.get(f"{host}/api/tags", timeout=timeout)
+        return resp.status_code == 200
+    except Exception as exc:
+        logger.debug("Ollama health check failed: %s", exc)
+        return False
+
+
+def start_ollama_serve(binary_path: str, timeout: int = 10) -> bool:
+    """Start the Ollama server in the background.
+
+    Runs ``{binary_path} serve`` as a background process, then polls
+    the health endpoint until the server responds or ``timeout`` seconds
+    elapse.
+
+    Returns ``True`` if the server is running within the timeout.
+    """
+    try:
+        subprocess.Popen(
+            [binary_path, "serve"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if check_ollama_health():
+                logger.info("Ollama server started successfully")
+                return True
+            time.sleep(0.5)
+        logger.warning("Ollama server did not start within %ds", timeout)
+        return False
+    except Exception as exc:
+        logger.error("Failed to start Ollama server: %s", exc)
+        return False
+
+
+def list_available_models(host: str = "http://localhost:11434") -> List[str]:
+    """List models available in the local Ollama instance.
+
+    Returns a list of model name strings, or an empty list if the
+    server is unreachable or has no models.
+    """
+    try:
+        import httpx
+        resp = httpx.get(f"{host}/api/tags", timeout=5)
+        if resp.status_code != 200:
+            return []
+        data = resp.json()
+        return [m["name"] for m in data.get("models", [])]
+    except Exception as exc:
+        logger.debug("Failed to list Ollama models: %s", exc)
+        return []
+
+
+def install_ollama() -> bool:
+    """Attempt to install Ollama via the system package manager.
+
+    macOS: ``brew install ollama``
+    Linux (apt): not implemented yet (auto-install is non-trivial)
+
+    Returns ``True`` if installation succeeded.
+    """
+    try:
+        import platform as _platform
+        system = _platform.system().lower()
+        if system == "darwin":
+            result = subprocess.run(
+                ["brew", "install", "ollama"],
+                capture_output=True, text=True, timeout=120,
+            )
+            if result.returncode == 0:
+                logger.info("Ollama installed successfully via Homebrew")
+                return True
+            logger.warning("Homebrew install failed: %s", result.stderr)
+            return False
+        else:
+            logger.info("Auto-install not yet supported on %s", system)
+            return False
+    except Exception as exc:
+        logger.error("Failed to install Ollama: %s", exc)
+        return False

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -371,6 +371,67 @@ def resolve_proxy_url(
     return detected
 
 
+def resolve_ws_proxy(
+    *,
+    platform_env_var: str | None = None,
+    target_host: str | None = None,
+) -> dict:
+    """Resolve proxy config for a ``websockets`` or ``aiohttp`` WebSocket connection.
+
+    On macOS, system-level proxies (Surge, ClashX, V2RayU, ShadowsocksX, etc.)
+    often break WebSocket ``CONNECT`` tunnels because the proxy software returns
+    non-standard or incomplete responses.  When a system proxy is detected but
+    the user has *not* explicitly configured a platform-specific WS proxy env
+    var, we force ``proxy=None`` (direct connect) rather than letting the
+    ``websockets`` library auto-detect and tunnel through the system proxy.
+
+    Check order:
+      0. ``platform_env_var`` (e.g. ``FEISHU_WS_PROXY``) — highest priority.
+         When set, the given proxy URL is used as-is.
+      1. The generic HTTPS_PROXY / HTTP_PROXY env vars.
+      2. macOS system proxy via ``scutil --proxy``.
+      3. If 2 returns something (system proxy active), we return
+         ``{"proxy": None}`` to force a direct connection, bypassing
+         the broken CONNECT tunnel.
+
+    ``target_host`` is passed to ``should_bypass_proxy`` for NO_PROXY matching.
+
+    Returns:
+      - ``{"proxy": "http://host:port"}`` — explicit proxy from platform env var
+      - ``{"proxy": None}`` — macOS system proxy detected; force direct connect
+      - ``{}`` — no proxy detected anywhere; let library decide
+    """
+    # 0. Platform-specific env var → use it explicitly
+    if platform_env_var:
+        value = (os.environ.get(platform_env_var) or "").strip()
+        if value:
+            if target_host and should_bypass_proxy(target_host):
+                return {}
+            return {"proxy": normalize_proxy_url(value)}
+
+    # 1. Generic proxy env vars → use them explicitly
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                "https_proxy", "http_proxy", "all_proxy"):
+        value = (os.environ.get(key) or "").strip()
+        if value:
+            if target_host and should_bypass_proxy(target_host):
+                return {}
+            return {"proxy": normalize_proxy_url(value)}
+
+    # 2. macOS system proxy → bypass for WebSocket
+    detected = _detect_macos_system_proxy()
+    if detected:
+        if target_host and should_bypass_proxy(target_host):
+            return {}
+        logger.info(
+            "System proxy detected (%s) — bypassing for WebSocket direct connect",
+            detected,
+        )
+        return {"proxy": None}
+
+    return {}
+
+
 def proxy_kwargs_for_bot(proxy_url: str | None) -> dict:
     """Build kwargs for ``commands.Bot()`` / ``discord.Client()`` with proxy.
 

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1279,6 +1279,35 @@ def _strip_edge_self_mentions(
                 break
         else:
             return remaining
+def _detect_system_https_proxy() -> str | None:
+    """Detect system HTTP/HTTPS proxy for WebSocket connections.
+
+    Checks env vars first (http_proxy/HTTPS_PROXY), then macOS system proxy
+    preferences. Returns a proxy URL string like 'http://127.0.0.1:6152' or None.
+    """
+    for var in ("https_proxy", "HTTPS_PROXY", "http_proxy", "HTTP_PROXY"):
+        val = os.environ.get(var)
+        if val:
+            return val
+    try:
+        import subprocess
+        result = subprocess.run(
+            ["scutil", "--proxy"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode == 0:
+            import re
+            http_host = re.search(r'HTTPProxy\s*:\s*(\S+)', result.stdout)
+            http_port = re.search(r'HTTPPort\s*:\s*(\d+)', result.stdout)
+            https_host = re.search(r'HTTPSProxy\s*:\s*(\S+)', result.stdout)
+            https_port = re.search(r'HTTPSPort\s*:\s*(\d+)', result.stdout)
+            host = https_host.group(1) if https_host else (http_host.group(1) if http_host else None)
+            port = https_port.group(1) if https_port else (http_port.group(1) if http_port else None)
+            if host and port:
+                return f"http://{host}:{port}"
+    except Exception:
+        pass
+    return None
 
 
 def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
@@ -1307,7 +1336,16 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
             kwargs["ping_interval"] = adapter._ws_ping_interval
         if adapter._ws_ping_timeout is not None and "ping_timeout" not in kwargs:
             kwargs["ping_timeout"] = adapter._ws_ping_timeout
-        return original_connect(*args, **kwargs)
+        # Surge/Clash 等系统代理对 WebSocket CONNECT 隧道兼容性差，
+        # 检测到代理时强制 proxy=None 直连（websockets 默认 proxy=True
+        # 会通过 urllib.request.getproxies() 检测到系统代理然后走代理，
+        # 但系统代理软件可能返回非标准数据导致 InvalidProxyMessage）。
+        if "proxy" not in kwargs:
+            proxy = _detect_system_https_proxy()
+            if proxy:
+                kwargs["proxy"] = None
+                logger.info("[Feishu] System proxy detected (%s) — bypassing for WebSocket direct connect", proxy)
+        return await original_connect(*args, **kwargs)
 
     def _configure_with_overrides(conf: Any) -> Any:
         if original_configure is None:

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -139,6 +139,7 @@ from gateway.platforms.base import (
     cache_image_from_url,
     cache_audio_from_bytes,
     cache_image_from_bytes,
+    resolve_ws_proxy,
 )
 from gateway.status import acquire_scoped_lock, release_scoped_lock
 from hermes_constants import get_hermes_home
@@ -1279,35 +1280,6 @@ def _strip_edge_self_mentions(
                 break
         else:
             return remaining
-def _detect_system_https_proxy() -> str | None:
-    """Detect system HTTP/HTTPS proxy for WebSocket connections.
-
-    Checks env vars first (http_proxy/HTTPS_PROXY), then macOS system proxy
-    preferences. Returns a proxy URL string like 'http://127.0.0.1:6152' or None.
-    """
-    for var in ("https_proxy", "HTTPS_PROXY", "http_proxy", "HTTP_PROXY"):
-        val = os.environ.get(var)
-        if val:
-            return val
-    try:
-        import subprocess
-        result = subprocess.run(
-            ["scutil", "--proxy"],
-            capture_output=True, text=True, timeout=5,
-        )
-        if result.returncode == 0:
-            import re
-            http_host = re.search(r'HTTPProxy\s*:\s*(\S+)', result.stdout)
-            http_port = re.search(r'HTTPPort\s*:\s*(\d+)', result.stdout)
-            https_host = re.search(r'HTTPSProxy\s*:\s*(\S+)', result.stdout)
-            https_port = re.search(r'HTTPSPort\s*:\s*(\d+)', result.stdout)
-            host = https_host.group(1) if https_host else (http_host.group(1) if http_host else None)
-            port = https_port.group(1) if https_port else (http_port.group(1) if http_port else None)
-            if host and port:
-                return f"http://{host}:{port}"
-    except Exception:
-        pass
-    return None
 
 
 def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
@@ -1336,15 +1308,13 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
             kwargs["ping_interval"] = adapter._ws_ping_interval
         if adapter._ws_ping_timeout is not None and "ping_timeout" not in kwargs:
             kwargs["ping_timeout"] = adapter._ws_ping_timeout
-        # Surge/Clash 等系统代理对 WebSocket CONNECT 隧道兼容性差，
-        # 检测到代理时强制 proxy=None 直连（websockets 默认 proxy=True
-        # 会通过 urllib.request.getproxies() 检测到系统代理然后走代理，
-        # 但系统代理软件可能返回非标准数据导致 InvalidProxyMessage）。
+        # macOS 系统代理（Surge/Clash 等）会阻断 WebSocket CONNECT 隧道，
+        # 检测到系统代理时强制直连（proxy=None），避免 InvalidProxyMessage 错误。
+        # 用户可通过 FEISHU_WS_PROXY 环境变量显式指定代理。
         if "proxy" not in kwargs:
-            proxy = _detect_system_https_proxy()
-            if proxy:
-                kwargs["proxy"] = None
-                logger.info("[Feishu] System proxy detected (%s) — bypassing for WebSocket direct connect", proxy)
+            ws_proxy = resolve_ws_proxy(platform_env_var="FEISHU_WS_PROXY")
+            if ws_proxy:
+                kwargs.update(ws_proxy)
         return await original_connect(*args, **kwargs)
 
     def _configure_with_overrides(conf: Any) -> Any:

--- a/gateway/platforms/homeassistant.py
+++ b/gateway/platforms/homeassistant.py
@@ -34,6 +34,7 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     SendResult,
+    resolve_ws_proxy,
 )
 
 logger = logging.getLogger(__name__)
@@ -142,10 +143,15 @@ class HomeAssistantAdapter(BasePlatformAdapter):
         ws_url = self._hass_url.replace("https://", "wss://").replace("http://", "ws://")
         ws_url = f"{ws_url}/api/websocket"
 
+        ws_proxy = resolve_ws_proxy(platform_env_var="HASS_WS_PROXY")
         self._session = aiohttp.ClientSession(
-            timeout=aiohttp.ClientTimeout(total=30)
+            timeout=aiohttp.ClientTimeout(total=30),
+            trust_env=not bool(ws_proxy),
         )
-        self._ws = await self._session.ws_connect(ws_url, heartbeat=30, timeout=30)
+        self._ws = await self._session.ws_connect(
+            ws_url, heartbeat=30, timeout=30,
+            **(ws_proxy or {}),
+        )
 
         # Step 1: Receive auth_required
         msg = await self._ws.receive_json()

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -67,6 +67,7 @@ from gateway.platforms.base import (
     SendResult,
     cache_document_from_bytes,
     cache_image_from_bytes,
+    resolve_ws_proxy,
 )
 
 logger = logging.getLogger(__name__)
@@ -281,11 +282,13 @@ class WeComAdapter(BasePlatformAdapter):
     async def _open_connection(self) -> None:
         """Open and authenticate a websocket connection."""
         await self._cleanup_ws()
-        self._session = aiohttp.ClientSession(trust_env=True)
+        ws_proxy = resolve_ws_proxy(platform_env_var="WECOM_WS_PROXY")
+        self._session = aiohttp.ClientSession(trust_env=not bool(ws_proxy))
         self._ws = await self._session.ws_connect(
             self._ws_url,
             heartbeat=HEARTBEAT_INTERVAL_SECONDS * 2,
             timeout=CONNECT_TIMEOUT_SECONDS,
+            **(ws_proxy or {}),
         )
 
         req_id = self._new_req_id("subscribe")

--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -55,6 +55,7 @@ from gateway.platforms.base import (
     SendResult,
     cache_document_from_bytes,
     cache_image_from_bytes,
+    resolve_ws_proxy,
 )
 from gateway.platforms.helpers import MessageDeduplicator
 from gateway.platforms.yuanbao_media import (
@@ -2904,12 +2905,14 @@ class ConnectionManager:
 
             # Step 2: Open WebSocket connection (disable built-in ping/pong)
             logger.info("[%s] Connecting to %s", adapter.name, adapter._ws_url)
+            ws_kwargs = resolve_ws_proxy(platform_env_var="YUANBAO_WS_PROXY")
             self._ws = await asyncio.wait_for(
                 websockets.connect(  # type: ignore[attr-defined]
                     adapter._ws_url,
                     ping_interval=None,
                     ping_timeout=None,
                     close_timeout=5,
+                    **ws_kwargs,
                 ),
                 timeout=CONNECT_TIMEOUT_SECONDS,
             )
@@ -3391,12 +3394,14 @@ class ConnectionManager:
                 if token_data.get("bot_id"):
                     adapter._bot_id = str(token_data["bot_id"])
 
+                ws_kwargs = resolve_ws_proxy(platform_env_var="YUANBAO_WS_PROXY")
                 self._ws = await asyncio.wait_for(
                     websockets.connect(  # type: ignore[attr-defined]
                         adapter._ws_url,
                         ping_interval=None,
                         ping_timeout=None,
                         close_timeout=5,
+                        **ws_kwargs,
                     ),
                     timeout=CONNECT_TIMEOUT_SECONDS,
                 )

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2418,6 +2418,22 @@ DEFAULT_CONFIG = {
     "paste_collapse_threshold_fallback": 5,
     "paste_collapse_char_threshold": 2000,
 
+    # --- Local Fallback (Ollama) ---
+    # When all remote providers fail, attempt to use a local Ollama model
+    # to keep the conversation going.
+    "local_fallback": {
+        "enabled": False,
+        "model": "qwen3.5:0.8b",
+        "auto_pull": True,
+        "auto_install": False,
+        "ollama_binary": "ollama",
+        "ollama_host": "http://localhost:11434",
+        "serve_timeout": 10,
+        "download_timeout": 300,
+        "ask_user": True,
+        "auto_restore_primary": True,
+    },
+
 
     # Config schema version - bump this when adding new required fields
     "_config_version": 27,

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -783,7 +783,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         elif platform == Platform.DINGTALK:
             result = await _send_dingtalk(pconfig.extra, chat_id, chunk)
         elif platform == Platform.FEISHU:
-            result = await _send_feishu(pconfig, chat_id, chunk, thread_id=thread_id)
+            result = await _send_feishu(pconfig, chat_id, chunk, media_files=media_files, thread_id=thread_id)
         elif platform == Platform.WECOM:
             result = await _send_wecom(pconfig.extra, chat_id, chunk)
         elif platform == Platform.BLUEBUBBLES:


### PR DESCRIPTION
## Summary

When the entire provider fallback chain is exhausted (rate-limited, billing depleted, API unreachable), Hermes can fall back to a local Ollama model to keep the conversation going.

## Changes

- **New files:**
  - `agent/ollama_discovery.py` — Find ollama binary, health check (/api/tags), auto-start serve
  - `agent/model_puller.py` — Stream model pull (NDJSON /api/pull)
  - `agent/local_fallback.py` — Orchestrator: config → find binary → health → list → pull → switch
- **Modified files:**
  - `agent/agent_init.py` — Load local_fallback config
  - `agent/chat_completion_helpers.py` — try_local_fallback() function
  - `agent/conversation_loop.py` — 6 exit points route to local fallback
  - `hermes_cli/config.py` — local_fallback config section

## Configuration

```yaml
local_fallback:
  enabled: false           # Opt-in
  model: qwen3.5:0.8b      # ~650MB, <2GB RAM
  auto_pull: false
  auto_install: false
  ask_user: true
  auto_restore_primary: true
```

## Default Model: qwen3.5:0.8b
- 0.8B parameters, ~650MB download (Q8_0 GGUF)
- Excellent Chinese + good English
- Fits any Mac with 8GB RAM
- Apache 2.0 license