### PR TITLE
fix: install scripts write default SOUL.md identity instead of empty template

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -7,6 +7,7 @@ assemble pieces, then combines them with memory and ephemeral prompts.
 import json
 import logging
 import os
+import re
 import threading
 from collections import OrderedDict
 from pathlib import Path
@@ -1466,6 +1467,20 @@ def _truncate_content(content: str, filename: str, max_chars: int = CONTEXT_FILE
     return head + marker + tail
 
 
+_LEGACY_SOUL_HEADING = "# Hermes Agent Persona"
+
+
+def _soul_md_persona_body(raw: str) -> Optional[str]:
+    """Return persona text from SOUL.md, or None when only installer scaffolding remains."""
+    body = re.sub(r"<!--.*?-->", "", raw, flags=re.DOTALL).strip()
+    if not body:
+        return None
+    # Older install scripts seeded a heading + HTML comment with no identity.
+    if body == _LEGACY_SOUL_HEADING:
+        return None
+    return body
+
+
 def load_soul_md() -> Optional[str]:
     """Load SOUL.md from HERMES_HOME and return its content, or None.
 
@@ -1483,7 +1498,8 @@ def load_soul_md() -> Optional[str]:
     if not soul_path.exists():
         return None
     try:
-        content = soul_path.read_text(encoding="utf-8").strip()
+        raw = soul_path.read_text(encoding="utf-8")
+        content = _soul_md_persona_body(raw)
         if not content:
             return None
         content = _scan_context_content(content, "SOUL.md")

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1822,19 +1822,10 @@ function Copy-ConfigTemplates {
     $soulPath = "$HermesHome\SOUL.md"
     if (-not (Test-Path $soulPath)) {
         $soulContent = @"
-# Hermes Agent Persona
+You are Hermes Agent, an intelligent AI assistant created by Nous Research. You are helpful, knowledgeable, and direct. You assist users with a wide range of tasks including answering questions, writing and editing code, analyzing information, creative work, and executing actions via your tools. You communicate clearly, admit uncertainty when appropriate, and prioritize being genuinely useful over being verbose unless otherwise directed below. Be targeted and efficient in your exploration and investigations.
 
 <!--
-This file defines the agent's personality and tone.
-The agent will embody whatever you write here.
-Edit this to customize how Hermes communicates with you.
-
-Examples:
-  - "You are a warm, playful assistant who uses kaomoji occasionally."
-  - "You are a concise technical expert. No fluff, just facts."
-  - "You speak like a friendly coworker who happens to know everything."
-
-This file is loaded fresh each message -- no restart needed.
+Edit the text above to customize how Hermes communicates with you.
 Delete the contents (or this file) to use the default personality.
 -->
 "@

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1691,19 +1691,10 @@ copy_config_templates() {
     # Create SOUL.md if it doesn't exist (global persona file)
     if [ ! -f "$HERMES_HOME/SOUL.md" ]; then
         cat > "$HERMES_HOME/SOUL.md" << 'SOUL_EOF'
-# Hermes Agent Persona
+You are Hermes Agent, an intelligent AI assistant created by Nous Research. You are helpful, knowledgeable, and direct. You assist users with a wide range of tasks including answering questions, writing and editing code, analyzing information, creative work, and executing actions via your tools. You communicate clearly, admit uncertainty when appropriate, and prioritize being genuinely useful over being verbose unless otherwise directed below. Be targeted and efficient in your exploration and investigations.
 
 <!--
-This file defines the agent's personality and tone.
-The agent will embody whatever you write here.
-Edit this to customize how Hermes communicates with you.
-
-Examples:
-  - "You are a warm, playful assistant who uses kaomoji occasionally."
-  - "You are a concise technical expert. No fluff, just facts."
-  - "You speak like a friendly coworker who happens to know everything."
-
-This file is loaded fresh each message -- no restart needed.
+Edit the text above to customize how Hermes communicates with you.
 Delete the contents (or this file) to use the default personality.
 -->
 SOUL_EOF

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -18,6 +18,7 @@ from agent.prompt_builder import (
     build_skills_system_prompt,
     build_nous_subscription_prompt,
     build_context_files_prompt,
+    load_soul_md,
     CONTEXT_FILE_MAX_CHARS,
     DEFAULT_AGENT_IDENTITY,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
@@ -590,6 +591,26 @@ class TestBuildContextFilesPrompt:
         (hermes_home / "SOUL.md").write_text("\n\n", encoding="utf-8")
         result = build_context_files_prompt(cwd=str(tmp_path))
         assert result == ""
+
+    def test_legacy_installer_template_treated_as_absent(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        (hermes_home / "SOUL.md").write_text(
+            "# Hermes Agent Persona\n\n<!--\nEdit this to customize.\n-->\n",
+            encoding="utf-8",
+        )
+        assert load_soul_md() is None
+
+    def test_installer_identity_with_html_comment_is_loaded(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        (hermes_home / "SOUL.md").write_text(
+            f"{DEFAULT_AGENT_IDENTITY}\n\n<!-- Edit the text above. -->\n",
+            encoding="utf-8",
+        )
+        assert load_soul_md() == DEFAULT_AGENT_IDENTITY
 
     def test_blocks_injection_in_agents_md(self, tmp_path):
         (tmp_path / "AGENTS.md").write_text(


### PR DESCRIPTION
## Summary

- Update `scripts/install.sh` and `scripts/install.ps1` to seed `SOUL.md` with the same default identity text as `hermes_cli/default_soul.py` (`DEFAULT_SOUL_MD`), plus a short HTML comment for customization instructions.
- Fix `load_soul_md()` to strip HTML comments and treat the legacy installer template (heading + comment only) as absent, so existing installs with the broken template fall back to the built-in default identity.

## Problem

The install scripts previously wrote a `SOUL.md` template containing only `# Hermes Agent Persona` and HTML comments with no actual persona text. Because `load_soul_md()` treated any non-empty stripped content as valid, this empty scaffolding replaced the real default identity from `DEFAULT_SOUL_MD`.

## Test plan

- [x] `scripts/run_tests.sh tests/agent/test_prompt_builder.py`
- [x] Verified install script persona text matches `DEFAULT_SOUL_MD`
- [x] New tests cover legacy comment-only templates and identity + HTML comment cases


Made with [Cursor](https://cursor.com)