### PR TITLE
fix(desktop): bind new-session profile to active gateway profile

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -71,6 +71,7 @@ import {
 } from '@/store/layout'
 import {
   $newChatProfile,
+  $activeGatewayProfile,
   $profiles,
   $profileScope,
   ALL_PROFILES,
@@ -816,7 +817,7 @@ export function ChatSidebar({
                         // no swap. The switcher header is the single place to
                         // change which profile that is.
                         if (isNewSession) {
-                          $newChatProfile.set(null)
+                          $newChatProfile.set($activeGatewayProfile.get())
                         }
 
                         onNavigate(item)

--- a/apps/desktop/src/app/hooks/use-keybinds.ts
+++ b/apps/desktop/src/app/hooks/use-keybinds.ts
@@ -19,6 +19,7 @@ import {
 } from '@/store/layout'
 import {
   $newChatProfile,
+  $activeGatewayProfile,
   cycleProfile,
   requestProfileCreate,
   switchProfileToSlot,
@@ -128,7 +129,7 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
       // Match the sidebar New Session button. A plain keyboard new chat should
       // target the current live profile, not a stale per-profile quick-create
       // selection from a prior action.
-      $newChatProfile.set(null)
+      $newChatProfile.set($activeGatewayProfile.get())
       deps.startFreshSession()
       window.dispatchEvent(new CustomEvent('hermes:new-session-shortcut'))
     },


### PR DESCRIPTION
## What does this PR do?

Fixes new sessions being created in the launch profile (typically `default`) instead of the user's actively selected profile when using the Desktop sidebar "New Session" button or Ctrl/Cmd+N shortcut in app-global remote mode.

## Related Issue

Fixes #45000

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/chat/sidebar/index.tsx`: Set `$newChatProfile` to `$activeGatewayProfile.get()` instead of `null` when creating a plain new session. Added `$activeGatewayProfile` to the import from `@/store/profile`.
- `apps/desktop/src/app/hooks/use-keybinds.ts`: Same fix for the Ctrl/Cmd+N keyboard shortcut handler. Added `$activeGatewayProfile` to the import from `@/store/profile`.

## How to Test

1. Connect the Desktop to a remote backend that has at least 2 profiles (e.g., `default` and `lab`).
2. Click the `lab` profile in the profile rail — the sidebar should show `lab`'s sessions.
3. Click the sidebar "New Session" button (or press Ctrl/Cmd+N).
4. Send a message and verify the session appears under `lab`, not `default`.
5. Check `state.db` in the `lab` profile's HERMES_HOME to confirm the session persisted there.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `apps/desktop/src/store/profile.ts` ($activeGatewayProfile atom, exported as `atom<string>('default')`)
- Analyzed: `tui_gateway/server.py` (session.create handler, line ~3605: "None/own profile → launch")
- Blast radius: LOW — only affects new-session creation in app-global remote mode
- Related patterns: `$newChatProfile` atom stores the profile for the next new chat session; `null` was intended to mean "use current live profile" but the server interpreted it as the launch profile.
