### PR TITLE
fix: harden kanban sqlite integrity guards

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1300,6 +1300,21 @@ class KanbanDbCorruptError(RuntimeError):
         )
 
 
+class KanbanDbUnsafeAutoVacuumError(RuntimeError):
+    """Raised when a healthy kanban DB still uses pointer-map auto-vacuum."""
+
+    def __init__(self, db_path: Path, mode: int):
+        self.db_path = db_path
+        self.mode = mode
+        mode_name = {1: "FULL", 2: "INCREMENTAL"}.get(mode, str(mode))
+        super().__init__(
+            f"Refusing to open kanban DB at {db_path}: auto_vacuum={mode_name} "
+            "uses SQLite pointer-map pages, which are unsafe for active Kanban "
+            "boards after the observed corruption pattern. Run the offline repair "
+            "workflow to rebuild the DB with PRAGMA auto_vacuum=NONE + VACUUM."
+        )
+
+
 def _backup_corrupt_db(path: Path) -> Optional[Path]:
     """Copy a corrupt DB (and its WAL/SHM sidecars) to a content-addressed backup.
 
@@ -1473,6 +1488,14 @@ def connect(
                 # Surface corrupt cells as read errors instead of silent
                 # wrong-data returns.
                 conn.execute("PRAGMA cell_size_check=ON")
+                # New boards should not use FULL auto-vacuum; pointer-map pages are a
+                # recurring corruption locus for active Kanban DBs. Existing DBs are
+                # converted by the offline repair script with VACUUM.
+                conn.execute("PRAGMA auto_vacuum=NONE")
+                auto_vacuum_row = conn.execute("PRAGMA auto_vacuum").fetchone()
+                auto_vacuum_mode = int(auto_vacuum_row[0]) if auto_vacuum_row else 0
+                if auto_vacuum_mode != 0:
+                    raise KanbanDbUnsafeAutoVacuumError(path, auto_vacuum_mode)
                 needs_init = resolved not in _INITIALIZED_PATHS
                 if needs_init:
                     # Idempotent: runs CREATE TABLE IF NOT EXISTS + the additive

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2702,6 +2702,51 @@ def test_connect_falls_back_to_delete_on_locking_protocol(tmp_path, monkeypatch,
     conn.close()
 
 
+def test_connect_configures_durable_sqlite_pragmas_for_new_boards(tmp_path):
+    """Kanban boards should default to conservative SQLite durability settings."""
+    db_path = tmp_path / "kanban.db"
+
+    with kb.connect(db_path=db_path) as conn:
+        pragmas = {
+            "synchronous": conn.execute("PRAGMA synchronous").fetchone()[0],
+            "secure_delete": conn.execute("PRAGMA secure_delete").fetchone()[0],
+            "cell_size_check": conn.execute("PRAGMA cell_size_check").fetchone()[0],
+            "auto_vacuum": conn.execute("PRAGMA auto_vacuum").fetchone()[0],
+        }
+
+    assert pragmas == {
+        "synchronous": 2,  # FULL
+        "secure_delete": 1,
+        "cell_size_check": 1,
+        "auto_vacuum": 0,  # NONE; avoids pointer-map pages on fresh boards
+    }
+
+
+def test_connect_refuses_existing_full_auto_vacuum_board(tmp_path):
+    """Healthy legacy boards with FULL auto-vacuum need offline VACUUM repair first."""
+    db_path = tmp_path / "legacy-full-autovac.db"
+    raw = sqlite3.connect(str(db_path))
+    try:
+        raw.execute("PRAGMA auto_vacuum=FULL")
+        raw.execute("VACUUM")
+        raw.execute("CREATE TABLE marker (id INTEGER PRIMARY KEY)")
+        raw.commit()
+        assert raw.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+        assert raw.execute("PRAGMA auto_vacuum").fetchone()[0] == 1
+    finally:
+        raw.close()
+
+    kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+    with pytest.raises(kb.KanbanDbUnsafeAutoVacuumError) as excinfo:
+        kb.connect(db_path=db_path)
+
+    msg = str(excinfo.value)
+    assert str(db_path) in msg
+    assert "auto_vacuum=FULL" in msg
+    assert "offline repair" in msg
+
+
 def test_unlink_tasks_triggers_recompute_ready(kanban_home):
     """Regression test for issue #22459.
 


### PR DESCRIPTION
## Summary
- fail closed when a healthy Kanban DB still uses SQLite FULL/INCREMENTAL auto-vacuum pointer-map pages
- keep new Kanban DB connections on auto_vacuum=NONE after the offline repair path
- add regression coverage for durable SQLite pragmas and unsafe auto-vacuum refusal

## Test Plan
- /Users/choesihyeon/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_kanban_db.py -q -o 'addopts='