### PR TITLE
feat(update): add --light flag to skip npm/web/desktop rebuilds (2-5x faster updates)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9562,13 +9562,14 @@ def cmd_update(args):
         return
 
     gateway_mode = getattr(args, "gateway", False)
+    light_mode = getattr(args, "light", False) or gateway_mode
 
     # Protect against mid-update terminal disconnects (SIGHUP) and tolerate
     # writes to a closed stdout.  No-op in gateway mode.  See
     # _install_hangup_protection for rationale.
     _update_io_state = _install_hangup_protection(gateway_mode=gateway_mode)
     try:
-        _cmd_update_impl(args, gateway_mode=gateway_mode)
+        _cmd_update_impl(args, gateway_mode=gateway_mode, light=light_mode)
     finally:
         _finalize_update_output(_update_io_state)
 
@@ -9634,7 +9635,7 @@ def _cmd_update_pip(args):
     print("✓ Update complete! Restart hermes to use the new version.")
 
 
-def _cmd_update_impl(args, gateway_mode: bool):
+def _cmd_update_impl(args, gateway_mode: bool, light: bool = False):
     """Body of ``cmd_update`` — kept separate so the wrapper can always
     restore stdio even on ``sys.exit``."""
     # In gateway mode, use file-based IPC for prompts instead of stdin
@@ -10180,30 +10181,53 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
         _refresh_active_lazy_features()
 
-        node_failures = _update_node_dependencies()
-        _build_web_ui(PROJECT_ROOT / "web")
+        node_failures = []
+        if light:
+            print("  ✓ Light mode: skipped npm install, web UI, and desktop rebuild")
+            print("    (run 'cd web && npm install && npm run build' if you need the dashboard)")
+            # If the user actually has a built dashboard/desktop app, light mode
+            # leaves it on the previously-built version.  Surface that so they
+            # aren't surprised when the UI doesn't reflect the update they just
+            # pulled (esp. after a web/ or apps/desktop source change).
+            desktop_dir = PROJECT_ROOT / "apps" / "desktop"
+            has_desktop_app = (
+                _desktop_packaged_executable(desktop_dir) is not None
+                or _desktop_dist_exists(desktop_dir)
+            )
+            has_web_dashboard = not _web_ui_build_needed(PROJECT_ROOT / "web")
+            if has_desktop_app or has_web_dashboard:
+                print(
+                    "  ⚠ You have a built dashboard/desktop app — light mode left it on the"
+                )
+                print("    previous version. Rebuild when needed:")
+                print("      cd web && npm install && npm run build")
+                if has_desktop_app:
+                    print("      hermes desktop --build-only")
+        else:
+            node_failures = _update_node_dependencies()
+            _build_web_ui(PROJECT_ROOT / "web")
 
-        # Rebuild the desktop app if the source tree changed since the last
-        # build.  ``hermes desktop --build-only`` uses the content-hash stamp
-        # internally, so this is effectively a no-op when nothing changed.
-        # Only bother if the user has a desktop app installed (indicated by
-        # an existing packaged executable or desktop dist); people who have
-        # never run ``hermes desktop`` shouldn't be forced into a full
-        # Electron build by ``hermes update``.
-        desktop_dir = PROJECT_ROOT / "apps" / "desktop"
-        has_desktop_app = _desktop_packaged_executable(desktop_dir) is not None or _desktop_dist_exists(desktop_dir)
-        if (desktop_dir / "package.json").exists() and _resolve_node_runtime_npm() and has_desktop_app:
-            print("→ Checking if desktop app needs rebuilding...")
-            _desktop_build_cmd = [sys.executable, "-m", "hermes_cli.main", "desktop", "--build-only"]
-            # Capture the (very loud) Electron/vite build output into
-            # update.log instead of streaming it to the terminal. On the rare
-            # nonzero exit, retry once after waiting again for the venv — this
-            # covers a still-settling rebuild window the first wait didn't fully
-            # catch — then surface the captured tail so the failure is
-            # debuggable.
-            build_result = _run_logged_subprocess(_desktop_build_cmd, cwd=PROJECT_ROOT)
-            if build_result.returncode != 0:
+            # Rebuild the desktop app if the source tree changed since the last
+            # build.  ``hermes desktop --build-only`` uses the content-hash stamp
+            # internally, so this is effectively a no-op when nothing changed.
+            # Only bother if the user has a desktop app installed (indicated by
+            # an existing packaged executable or desktop dist); people who have
+            # never run ``hermes desktop`` shouldn't be forced into a full
+            # Electron build by ``hermes update``.
+            desktop_dir = PROJECT_ROOT / "apps" / "desktop"
+            has_desktop_app = _desktop_packaged_executable(desktop_dir) is not None or _desktop_dist_exists(desktop_dir)
+            if (desktop_dir / "package.json").exists() and _resolve_node_runtime_npm() and has_desktop_app:
+                print("→ Checking if desktop app needs rebuilding...")
+                _desktop_build_cmd = [sys.executable, "-m", "hermes_cli.main", "desktop", "--build-only"]
+                # Capture the (very loud) Electron/vite build output into
+                # update.log instead of streaming it to the terminal. On the rare
+                # nonzero exit, retry once after waiting again for the venv — this
+                # covers a still-settling rebuild window the first wait didn't fully
+                # catch — then surface the captured tail so the failure is
+                # debuggable.
                 build_result = _run_logged_subprocess(_desktop_build_cmd, cwd=PROJECT_ROOT)
+                if build_result.returncode != 0:
+                    build_result = _run_logged_subprocess(_desktop_build_cmd, cwd=PROJECT_ROOT)
             if build_result.returncode != 0:
                 print("  ⚠ Desktop build failed (non-fatal; run `hermes desktop` to retry)")
                 tail = "\n".join((build_result.stdout or "").strip().splitlines()[-15:])

--- a/hermes_cli/subcommands/update.py
+++ b/hermes_cli/subcommands/update.py
@@ -73,4 +73,11 @@ def build_update_parser(subparsers, *, cmd_update: Callable) -> None:
         default=False,
         help="Windows: mutate the venv even while other processes are running from its interpreter (desktop backend, gateway, terminals). Those processes keep native .pyd files locked, so the dependency sync will likely fail partway and strand the install half-updated. Use only if you know the detected holders are false positives.",
     )
+    update_parser.add_argument(
+        "--light",
+        "-L",
+        action="store_true",
+        default=False,
+        help="Lightweight update: skip npm install, web UI build, and desktop rebuild. Core Python update only — much faster on Windows. Run 'cd web && npm install && npm run build' separately if you need the dashboard/TUI.",
+    )
     update_parser.set_defaults(func=cmd_update)

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -1240,3 +1240,124 @@ class TestNodeRuntimeNpmResolution:
             not call.args or not call.args[0] or call.args[0][0] != windows_npm
             for call in mock_run.call_args_list
         )
+
+class TestCmdUpdateLightMode:
+    """`--light` skips the Node/Web/Desktop rebuild steps.
+
+    Regression guard for PR #45012: light mode must run the core Python
+    update (git pull + pip) but NOT shell out to npm for the web UI build or
+    trigger the Electron desktop rebuild.
+    """
+
+    @patch("shutil.which")
+    @patch("subprocess.run")
+    def test_light_mode_skips_node_and_web_build(
+        self, mock_run, mock_which, mock_args, capsys
+    ):
+        from hermes_cli import main as hm
+
+        # Keep uv and npm distinct so the uv pip install doesn't masquerade
+        # as an npm call in assertions.
+        mock_which.side_effect = {"uv": "/usr/bin/uv", "npm": "/usr/bin/npm"}.get
+        mock_args.light = True
+        mock_args.gateway = False
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="1"
+        )
+
+        cmd_update(mock_args)
+
+        npm_calls = [
+            c for c in mock_run.call_args_list
+            if c.args and c.args[0][0] == "/usr/bin/npm"
+        ]
+        # No npm install / web UI build in light mode.
+        assert npm_calls == []
+
+        out = capsys.readouterr().out
+        assert "Light mode" in out
+        assert "npm install" in out
+
+    @patch("shutil.which")
+    @patch("subprocess.run")
+    def test_gateway_mode_implies_light(
+        self, mock_run, mock_which, mock_args, capsys
+    ):
+        from hermes_cli import main as hm
+
+        # Gateway chat-based updates must NOT rebuild the dashboard/desktop.
+        mock_which.side_effect = {"uv": "/usr/bin/uv", "npm": "/usr/bin/npm"}.get
+        mock_args.light = False
+        mock_args.gateway = True
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="1"
+        )
+
+        cmd_update(mock_args)
+
+        npm_calls = [
+            c for c in mock_run.call_args_list
+            if c.args and c.args[0][0] == "/usr/bin/npm"
+        ]
+        assert npm_calls == [], "gateway mode must imply --light"
+
+        out = capsys.readouterr().out
+        assert "Light mode" in out
+
+    @patch("shutil.which")
+    @patch("subprocess.run")
+    def test_light_mode_without_desktop_app_does_not_crash(
+        self, mock_run, mock_which, mock_args, capsys
+    ):
+        """Light mode must not reference the desktop build_result variable.
+
+        Regression guard for PR #45012: the non-light desktop-build block
+        assigned `build_result` only inside an `if has_desktop_app:` guard; a
+        later unguarded `if build_result.returncode` would raise
+        UnboundLocalError on machines without a packaged desktop app. Light
+        mode sidesteps the block entirely.
+        """
+        from hermes_cli import main as hm
+
+        mock_which.side_effect = {"uv": "/usr/bin/uv", "npm": "/usr/bin/npm"}.get
+        mock_args.light = True
+        mock_args.gateway = False
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="1"
+        )
+
+        # Should complete without raising UnboundLocalError.
+        cmd_update(mock_args)
+
+    @patch("shutil.which")
+    @patch("subprocess.run")
+    def test_light_mode_warns_when_built_app_present(
+        self, mock_run, mock_which, mock_args, capsys
+    ):
+        """Light mode must warn that a built dashboard/desktop is left stale.
+
+        Regression guard for PR #45012: skipping the rebuilds silently leaves
+        an installed dashboard/desktop on its previous version. Light mode must
+        tell the user so the UI reflects the update they just pulled.
+        """
+        from hermes_cli import main as hm
+
+        mock_which.side_effect = {"uv": "/usr/bin/uv", "npm": "/usr/bin/npm"}.get
+        mock_args.light = True
+        mock_args.gateway = False
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="1"
+        )
+
+        # Simulate a built desktop app + existing web dashboard dist.
+        with patch.object(hm, "_desktop_packaged_executable", return_value=None), \
+             patch.object(hm, "_desktop_dist_exists", return_value=True), \
+             patch.object(hm, "_web_ui_build_needed", return_value=False):
+            cmd_update(mock_args)
+
+        out = capsys.readouterr().out
+        assert "Light mode" in out
+        assert "built dashboard/desktop app" in out
+        assert "left it on the" in out
+        # Includes the desktop rebuild command since a desktop app exists.
+        assert "hermes desktop --build-only" in out

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1542,16 +1542,21 @@ hermes completion fish > ~/.config/fish/completions/hermes.fish
 ## `hermes update`
 
 ```bash
-hermes update [--gateway] [--check] [--no-backup] [--backup] [--yes]
+hermes update [--gateway] [--light] [--check] [--no-backup] [--backup] [--yes]
 ```
 
 Pulls the latest `hermes-agent` code and reinstalls dependencies in the managed venv, then re-runs the post-install hooks (MCP servers, skills sync, completion install). Safe to run on a live install. Use `--check` to see whether your checkout is behind `origin/main` without installing.
 
 `hermes update` pulls the configured update branch (default: `main`). If your checkout is on another branch, Hermes may check out the update branch before pulling. Commit branch work before updating when you want to keep it outside the update autostash flow.
 
+**`--light` / `-L`:** Skip the Node/Web/Desktop rebuild — npm install, the web UI Vite build, and the Electron desktop rebuild are all skipped. The core Python update (git pull, pip reinstall, skills sync, model catalog refresh) still runs. Much faster on Windows, where npm and the Electron binary download dominate update time. Gateway mode (`--gateway`) implies `--light` automatically — chat-based updates don't need the dashboard or desktop app rebuilt. If you need the dashboard afterward, run it separately: `cd web && npm install && npm run build`.
+
+**pip installs:** `hermes update` detects pip-based installations automatically — it queries PyPI for the latest release and runs `pip install --upgrade hermes-agent` instead of `git pull`. PyPI releases track tagged versions (major/minor releases), not every commit on `main`. Use `--check` to see if a newer PyPI release is available without installing.
+
 | Option | Description |
 |--------|-------------|
-| `--gateway` | Internal mode used by the messaging `/update` command. Uses file-based IPC for prompts and progress streaming instead of reading from terminal stdin. Not a gateway restart flag. |
+| `--gateway` | Internal mode used by the messaging `/update` command. Uses file-based IPC for prompts and progress streaming instead of reading from terminal stdin. Not a gateway restart flag. Implies `--light` (skips the Node/Web/Desktop rebuild). |
+| `--light`, `-L` | Skip the npm install, web UI Vite build, and Electron desktop rebuild. Core Python update only — much faster on Windows. Gateway mode implies this automatically. Run `cd web && npm install && npm run build` separately if you need the dashboard/TUI afterward. |
 | `--check` | Check whether an update is available without pulling, installing dependencies, or restarting anything. |
 | `--no-backup` | Skip the pre-update backup for this run, even if `updates.pre_update_backup` is enabled in `config.yaml`. |
 | `--backup` | Create a labeled pre-update snapshot of `HERMES_HOME` (config, auth, sessions, skills, pairing data) before pulling. Default is **off** — the previous always-backup behavior was adding minutes to every update on large homes. Flip it on permanently via `updates.pre_update_backup: true` in `config.yaml`. |


### PR DESCRIPTION
## Problem

On Windows, `hermes update` runs **npm install** (root + workspaces), **web UI build** (Vite), and **desktop Electron rebuild** sequentially after every git pull. These steps are the slowest part of the pipeline:

- npm on Windows is 2-3x slower than Linux (no native symlinks, Defender scans every extracted file)
- npm workspace install runs twice (root + workspaces)
- Web UI Vite build adds another 2-5 minutes
- Desktop Electron rebuild pulls a ~200MB binary

Combined, these steps add **15-25 minutes** to every update on Windows.

## Solution

Add a `--light` / `-L` flag that skips the three non-core steps:

1. **npm install** (repo root + ui-tui + web workspaces)
2. **Web UI Vite build**
3. **Desktop Electron rebuild**

The core update still runs: git fetch/pull, Python dependency reinstall, skills sync, and model catalog refresh.

## Gateway auto-light

Gateway mode (`--gateway`, used by `/update` in Telegram/Discord/etc.) automatically implies `--light` — chat-based updates don't need the dashboard or desktop app rebuilt.

Users who need the dashboard can run separately:
```bash
cd web && npm install && npm run build
```

## Changes

| File | Change |
|---|---|
| `hermes_cli/subcommands/update.py` | Added `--light` / `-L` argparse argument |
| `hermes_cli/main.py` — `cmd_update` | Read `args.light` and auto-set `True` in gateway mode |
| `hermes_cli/main.py` — `_cmd_update_impl` | Accept `light: bool = False`, guard npm/web/desktop behind `if not light:` |

## Testing

- `python -c \"import py_compile; py_compile.compile('hermes_cli/main.py', doraise=True)\"` — syntax OK
- `hermes update --help` shows the new flag
- Light mode prints a clear message showing what was skipped
- Gateway mode (`--gateway`) auto-sets light without requiring an explicit flag

## Future

The `--light` flag only skips the Node.js steps. The Python dependency install (`pip install -e .[all]`) is still the other time-consuming step, but that's the actual code update — harder to skip. The install is already cached by uv, and `.[all]` is much smaller now that many optional extras have moved to lazy-install.