### PR TITLE
fix(skills/github): make gh-env.sh self-diagnose the .env path it checks

### DIFF
--- a/skills/github/github-auth/SKILL.md
+++ b/skills/github/github-auth/SKILL.md
@@ -245,3 +245,4 @@ fi
 | Credentials not persisting | Check `git config --global credential.helper` — must be `store` or `cache` |
 | Multiple GitHub accounts | Use SSH with different keys per host alias in `~/.ssh/config`, or per-repo credential URLs |
 | `gh: command not found` + no sudo | Use git-only Method 1 above — no installation needed |
+| Token "not set" under Docker, but it's in your `.env` | The `.env` lives at `$HERMES_HOME/.env` (e.g. `/opt/data/.env`). In the official Docker layout the subprocess `HOME` is redirected to `$HERMES_HOME/home`, so `~/.hermes/.env` points at the wrong file. Source `gh-env.sh` (it resolves via `HERMES_HOME` and prints the path it checked) rather than reading `~/.hermes/.env` directly |

--- a/skills/github/github-auth/scripts/gh-env.sh
+++ b/skills/github/github-auth/scripts/gh-env.sh
@@ -12,6 +12,18 @@
 #   GH_REPO         - repo name   (only if inside a git repo with a github remote)
 #   GH_OWNER_REPO   - owner/repo  (only if inside a git repo with a github remote)
 
+# --- Resolve the Hermes .env location ---
+#
+# HERMES_HOME is bridged into tool subprocesses. Under the official Docker
+# layout HERMES_HOME=/opt/data while the subprocess HOME is redirected to
+# /opt/data/home (profile isolation), so a bare ~/.hermes/.env expands to
+# /opt/data/home/.hermes/.env — the WRONG file — while the real secrets live
+# at /opt/data/.env. Resolve against HERMES_HOME first, and keep a home-dir
+# fallback for bare installs / unexpected HERMES_HOME-unset subprocesses.
+HERMES_ENV_FILE="${HERMES_HOME:-$HOME/.hermes}/.env"
+HERMES_ENV_FALLBACK="$HOME/.hermes/.env"
+GH_ENV_SOURCE=""
+
 # --- Auth detection ---
 
 GH_AUTH_METHOD="none"
@@ -23,15 +35,24 @@ if command -v gh &>/dev/null && gh auth status &>/dev/null 2>&1; then
     GH_USER=$(gh api user --jq '.login' 2>/dev/null)
 elif [ -n "$GITHUB_TOKEN" ]; then
     GH_AUTH_METHOD="curl"
-elif _hermes_env="${HERMES_HOME:-$HOME/.hermes}/.env"; [ -f "$_hermes_env" ] && grep -q "^GITHUB_TOKEN=" "$_hermes_env" 2>/dev/null; then
-    GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$_hermes_env" | head -1 | cut -d= -f2 | tr -d '\n\r')
+    GH_ENV_SOURCE="environment"
+elif [ -f "$HERMES_ENV_FILE" ] && grep -q "^GITHUB_TOKEN=" "$HERMES_ENV_FILE" 2>/dev/null; then
+    GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$HERMES_ENV_FILE" | head -1 | cut -d= -f2 | tr -d '\n\r')
     if [ -n "$GITHUB_TOKEN" ]; then
         GH_AUTH_METHOD="curl"
+        GH_ENV_SOURCE="$HERMES_ENV_FILE"
+    fi
+elif [ "$HERMES_ENV_FALLBACK" != "$HERMES_ENV_FILE" ] && [ -f "$HERMES_ENV_FALLBACK" ] && grep -q "^GITHUB_TOKEN=" "$HERMES_ENV_FALLBACK" 2>/dev/null; then
+    GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$HERMES_ENV_FALLBACK" | head -1 | cut -d= -f2 | tr -d '\n\r')
+    if [ -n "$GITHUB_TOKEN" ]; then
+        GH_AUTH_METHOD="curl"
+        GH_ENV_SOURCE="$HERMES_ENV_FALLBACK"
     fi
 elif [ -f "$HOME/.git-credentials" ] && grep -q "github.com" "$HOME/.git-credentials" 2>/dev/null; then
     GITHUB_TOKEN=$(grep "github.com" "$HOME/.git-credentials" | head -1 | sed 's|https://[^:]*:\([^@]*\)@.*|\1|')
     if [ -n "$GITHUB_TOKEN" ]; then
         GH_AUTH_METHOD="curl"
+        GH_ENV_SOURCE="$HOME/.git-credentials"
     fi
 fi
 
@@ -61,6 +82,19 @@ unset _remote_url
 echo "GitHub Auth: $GH_AUTH_METHOD"
 [ -n "$GH_USER" ]       && echo "User: $GH_USER"
 [ -n "$GH_OWNER_REPO" ] && echo "Repo: $GH_OWNER_REPO"
-[ "$GH_AUTH_METHOD" = "none" ] && echo "⚠ Not authenticated — see github-auth skill"
+[ -n "$GH_ENV_SOURCE" ] && echo "Token source: $GH_ENV_SOURCE"
+if [ "$GH_AUTH_METHOD" = "none" ]; then
+    # Make a "none" result self-diagnosing: show the exact path checked plus
+    # HERMES_HOME/HOME so the common Docker mismatch (.env at $HERMES_HOME/.env,
+    # but HOME redirected so ~/.hermes/.env points elsewhere) is obvious instead
+    # of silent. Reported on Discord/GitHub against the docker-compose setup.
+    echo "⚠ Not authenticated — see github-auth skill"
+    echo "  Checked: $HERMES_ENV_FILE ($([ -f "$HERMES_ENV_FILE" ] && echo present || echo missing))"
+    if [ "$HERMES_ENV_FALLBACK" != "$HERMES_ENV_FILE" ]; then
+        echo "  Checked: $HERMES_ENV_FALLBACK ($([ -f "$HERMES_ENV_FALLBACK" ] && echo present || echo missing))"
+    fi
+    echo "  HERMES_HOME=${HERMES_HOME:-<unset>}  HOME=$HOME"
+    echo "  (In Docker the .env lives at \$HERMES_HOME/.env, e.g. /opt/data/.env — not ~/.hermes/.env)"
+fi
 
 export GH_AUTH_METHOD GITHUB_TOKEN GH_USER GH_OWNER GH_REPO GH_OWNER_REPO

--- a/tests/skills/test_github_auth_env_resolution.py
+++ b/tests/skills/test_github_auth_env_resolution.py
@@ -1,0 +1,114 @@
+"""E2E tests for skills/github/github-auth/scripts/gh-env.sh.
+
+Reported on Discord/GitHub (henning, hng) against the official Docker layout:
+the GitHub skills' auth detection reads the Hermes ``.env``. PR #43785 made the
+script resolve it via ``${HERMES_HOME:-$HOME/.hermes}/.env`` so it works when
+``HERMES_HOME=/opt/data`` and the subprocess ``HOME`` is redirected to
+``/opt/data/home``. These tests exercise the *real* bash script (not a mock)
+against temp homes to lock in:
+
+  * token found via ``$HERMES_HOME/.env`` even when ``HOME`` has no ``.env``
+    (the Docker case),
+  * a ``none`` result self-reports the exact path(s) it checked plus
+    HERMES_HOME/HOME, so the common Docker mismatch is diagnosable instead of
+    silent.
+"""
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / "skills"
+    / "github"
+    / "github-auth"
+    / "scripts"
+    / "gh-env.sh"
+)
+
+
+def _run(env_overrides: dict, cwd: Path) -> str:
+    """Source gh-env.sh in a clean bash and return its combined output.
+
+    A clean ``PATH`` (no ``gh``) keeps the gh-CLI branch from being taken on
+    developer machines / CI runners that happen to have ``gh`` installed and
+    authenticated, so the env-file resolution under test is what runs.
+    """
+    bash = shutil.which("bash") or "/bin/bash"
+    env = {
+        "PATH": "/usr/bin:/bin",
+        "GITHUB_TOKEN": "",
+    }
+    env.update(env_overrides)
+    proc = subprocess.run(
+        [bash, "-c", f'source "{SCRIPT}"'],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(cwd),
+        timeout=20,
+    )
+    return proc.stdout + proc.stderr
+
+
+@pytest.mark.skipif(not SCRIPT.exists(), reason="gh-env.sh not present")
+def test_token_resolved_from_hermes_home_under_docker_layout(tmp_path):
+    """Docker layout: HERMES_HOME=/data, HOME=/data/home (no .env there).
+    The token lives at $HERMES_HOME/.env and must still be found."""
+    hermes_home = tmp_path / "data"
+    sub_home = hermes_home / "home"
+    sub_home.mkdir(parents=True)
+    (hermes_home / ".env").write_text("GITHUB_TOKEN=ghp_dockertoken\n")
+
+    out = _run(
+        {"HERMES_HOME": str(hermes_home), "HOME": str(sub_home)},
+        cwd=tmp_path,
+    )
+
+    assert "GitHub Auth: curl" in out
+    # It reports the real resolved path, not a hardcoded ~/.hermes literal.
+    assert f"Token source: {hermes_home / '.env'}" in out
+    assert "Not authenticated" not in out
+
+
+@pytest.mark.skipif(not SCRIPT.exists(), reason="gh-env.sh not present")
+def test_token_resolved_from_home_fallback_when_hermes_home_unset(tmp_path):
+    """Bare install: no HERMES_HOME, token in ~/.hermes/.env still works."""
+    home = tmp_path / "home"
+    (home / ".hermes").mkdir(parents=True)
+    (home / ".hermes" / ".env").write_text("GITHUB_TOKEN=ghp_baretoken\n")
+
+    env = {"HOME": str(home)}
+    env.pop("HERMES_HOME", None)
+    out = _run(env, cwd=tmp_path)
+
+    assert "GitHub Auth: curl" in out
+    assert f"Token source: {home / '.hermes' / '.env'}" in out
+
+
+@pytest.mark.skipif(not SCRIPT.exists(), reason="gh-env.sh not present")
+def test_none_result_reports_checked_paths(tmp_path):
+    """No token anywhere → the failure self-reports the exact path checked plus
+    HERMES_HOME/HOME, so the Docker `.env` mismatch is obvious (regression for
+    the 'still does not work, insists on ~/.hermes/.env' report)."""
+    hermes_home = tmp_path / "data"
+    sub_home = hermes_home / "home"
+    sub_home.mkdir(parents=True)
+    # Deliberately no .env anywhere.
+
+    out = _run(
+        {"HERMES_HOME": str(hermes_home), "HOME": str(sub_home)},
+        cwd=tmp_path,
+    )
+
+    assert "GitHub Auth: none" in out
+    assert "Not authenticated" in out
+    # The exact path it checked is surfaced (resolved via HERMES_HOME), and the
+    # HERMES_HOME/HOME values so a user can see the redirect.
+    assert f"Checked: {hermes_home / '.env'}" in out
+    assert f"HERMES_HOME={hermes_home}" in out
+    assert "/opt/data/.env" in out  # the Docker hint


### PR DESCRIPTION
## Summary

Follow-up to #43785 (which resolved the GitHub skills' `.env` via
`${HERMES_HOME:-$HOME/.hermes}/.env`). A user reported on that PR that it still
fails under their docker-compose setup — Hermes "insists on looking in
`~/.hermes/.env` instead of `/opt/data/.env`", yet when they explicitly tell
the agent to check `HERMES_HOME` it finds `GITHUB_TOKEN`.

That last clue is the giveaway: `HERMES_HOME` **is** reachable in the subprocess,
so the resolution logic is fine — but when `gh-env.sh` returns `none` it said
nothing about *which* path it checked. Under the official Docker layout the
subprocess `HOME` is redirected to `$HERMES_HOME/home`, so `~/.hermes/.env`
expands to `/opt/data/home/.hermes/.env` (wrong) while the real file is
`/opt/data/.env`. The silent failure made this impossible to diagnose.

## Changes

- `gh-env.sh`: resolve the env path once (`HERMES_ENV_FILE`); add a home-dir
  fallback (`$HOME/.hermes/.env`) for bare installs / HERMES_HOME-unset
  subprocesses; print `Token source: <path>` on success; on a `none` result
  print the exact path(s) checked plus `HERMES_HOME`/`HOME` and the Docker hint.
- `github-auth/SKILL.md`: Troubleshooting row for the Docker HOME-redirect gotcha.
- Test: E2E-runs the real bash script across the Docker layout, the bare-install
  fallback, and the self-diagnosing `none` case.

Happy path unchanged — this turns a silent "not set" into a self-explaining one.

## Test plan

- [x] `scripts/run_tests.sh tests/skills/test_github_auth_env_resolution.py` (3 passed)
- [x] `bash -n skills/github/github-auth/scripts/gh-env.sh`