### PR TITLE
fix(telegram): reuse gateway HTTP transport config in standalone sends (#44995)

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -330,7 +330,98 @@ def _wrap_markdown_tables(text: str) -> str:
         out.append(line)
         i += 1
 
-    return '\n'.join(out)
+    return '\\n'.join(out)
+
+
+# ---------------------------------------------------------------------------
+# Shared HTTP transport helpers -- used by both the gateway adapter and the
+# standalone ``_send_telegram`` path so standalone sends (cron, scripts, TUI)
+# reuse the same timeout / pool / proxy / fallback-IP configuration that the
+# gateway applies at connect time.
+# ---------------------------------------------------------------------------
+
+
+def _build_telegram_request_kwargs() -> dict:
+    """Build HTTPXRequest keyword arguments from environment variables.
+
+    Reads the same ``HERMES_TELEGRAM_HTTP_*`` env vars that the gateway
+    adapter reads in ``TelegramAdapter.connect()`` so that standalone sends
+    from cron / scripts / TUI apply identical timeout and connection-pool
+    settings.
+    """
+    def _env_int(name: str, default: int) -> int:
+        try:
+            return int(os.getenv(name, str(default)))
+        except (TypeError, ValueError):
+            return default
+
+    def _env_float(name: str, default: float) -> float:
+        try:
+            return float(os.getenv(name, str(default)))
+        except (TypeError, ValueError):
+            return default
+
+    return {
+        "connection_pool_size": _env_int("HERMES_TELEGRAM_HTTP_POOL_SIZE", 512),
+        "pool_timeout": _env_float("HERMES_TELEGRAM_HTTP_POOL_TIMEOUT", 8.0),
+        "connect_timeout": _env_float("HERMES_TELEGRAM_HTTP_CONNECT_TIMEOUT", 10.0),
+        "read_timeout": _env_float("HERMES_TELEGRAM_HTTP_READ_TIMEOUT", 20.0),
+        "write_timeout": _env_float("HERMES_TELEGRAM_HTTP_WRITE_TIMEOUT", 20.0),
+    }
+
+
+async def _build_telegram_httpx_request(
+    *,
+    request_kwargs: Optional[dict] = None,
+    fallback_ips: Optional[list[str]] = None,
+    disable_fallback: bool = False,
+) -> tuple[Any, Any]:
+    """Build a pair of ``HTTPXRequest`` instances (request, get_updates_request)
+    with the full HTTP transport configuration applied.
+
+    Applies proxy (from ``TELEGRAM_PROXY`` env var / system proxy detection),
+    fallback-IP transport (``TelegramFallbackTransport``), and timeout/connection-
+    pool settings (from ``HERMES_TELEGRAM_HTTP_*`` env vars) -- the same
+    configuration that ``TelegramAdapter.connect()`` applies.
+
+    Both the gateway adapter and the standalone ``_send_telegram`` path call this
+    so that standalone sends reuse identical transport config.
+    """
+    # Import at runtime so tests that mock telegram.request work
+    # (at module level HTTPXRequest may be Any when telegram is absent).
+    try:
+        from telegram.request import HTTPXRequest as _HTTPXRequest
+    except ImportError:
+        raise ImportError("python-telegram-bot not installed")
+
+    if request_kwargs is None:
+        request_kwargs = _build_telegram_request_kwargs()
+
+    proxy_targets = ["api.telegram.org"]
+    if fallback_ips:
+        proxy_targets.extend(fallback_ips)
+    proxy_url = resolve_proxy_url("TELEGRAM_PROXY", target_hosts=proxy_targets)
+
+    if fallback_ips and not proxy_url and not disable_fallback:
+        request = _HTTPXRequest(
+            **request_kwargs,
+            httpx_kwargs={"transport": TelegramFallbackTransport(fallback_ips)},
+        )
+        get_updates_request = _HTTPXRequest(
+            **request_kwargs,
+            httpx_kwargs={"transport": TelegramFallbackTransport(fallback_ips)},
+        )
+    elif proxy_url:
+        request = _HTTPXRequest(**request_kwargs, proxy=proxy_url)
+        get_updates_request = _HTTPXRequest(**request_kwargs, proxy=proxy_url)
+    else:
+        request = _HTTPXRequest(**request_kwargs)
+        get_updates_request = _HTTPXRequest(**request_kwargs)
+
+    return request, get_updates_request
+
+
+# ---------------------------------------------------------------------------
 
 
 class TelegramAdapter(BasePlatformAdapter):
@@ -453,43 +544,6 @@ class TelegramAdapter(BasePlatformAdapter):
         self._send_path_degraded: bool = False
         # DM Topics: map of topic_name -> message_thread_id (populated at startup)
         self._dm_topics: Dict[str, int] = {}
-        # Track forum chats where we've already registered bot commands
-        self._forum_command_registered: set[int] = set()
-        # Lock per la registrazione sicura dei comandi nei forum supergroup
-        self._forum_lock = asyncio.Lock()
-        # DM Topics config from extra.dm_topics
-        self._dm_topics_config: List[Dict[str, Any]] = self.config.extra.get("dm_topics", [])
-        # Precomputed chat_ids that have DM topics configured (for O(1) root-DM ignore check)
-        self._dm_topic_chat_ids: Set[str] = {
-            str(e["chat_id"]) for e in self._dm_topics_config if "chat_id" in e
-        }
-        # Document size cap. Telegram's public Bot API caps getFile at 20MB; a
-        # locally-hosted telegram-bot-api server (configured via extra.base_url)
-        # raises that to 2GB, so the presence of base_url is the opt-in.
-        self._max_doc_bytes: int = (
-            2 * 1024 * 1024 * 1024
-            if self.config.extra.get("base_url")
-            else 20 * 1024 * 1024
-        )
-        # Interactive model picker state per chat
-        self._model_picker_state: Dict[str, dict] = {}
-        # Approval button state: message_id → session_key
-        self._approval_state: Dict[int, str] = {}
-        # Slash-confirm button state: confirm_id → session_key (for /reload-mcp
-        # and any other slash-confirm prompts; see GatewayRunner._request_slash_confirm).
-        self._slash_confirm_state: Dict[str, str] = {}
-        # Clarify button state: clarify_id → session_key (for the clarify tool's
-        # multiple-choice prompts; see GatewayRunner clarify_callback wiring).
-        self._clarify_state: Dict[str, str] = {}
-        # Notification mode for message sends.
-        # "important" — only final responses, approvals, and slash confirmations
-        #               trigger notifications; tool progress, streaming, status
-        #               messages are delivered silently via disable_notification.
-        #               This is the default — Telegram users found per-tool-call
-        #               push notifications too noisy.
-        # "all"       — every message triggers a push notification (legacy
-        #               behavior; opt-in via display.platforms.telegram.notifications).
-        self._notifications_mode: str = "important"
         # send_or_update_status() bookkeeping: {(chat_id, status_key) -> bot message_id}
         # Tracks status bubbles owned by this adapter so subsequent calls with the
         # same key edit the same message instead of appending new ones (#30045).
@@ -1548,25 +1602,7 @@ class TelegramAdapter(BasePlatformAdapter):
             # PTB defaults (pool_timeout=1s) are too aggressive on flaky networks and
             # can trigger "Pool timeout: All connections in the connection pool are occupied"
             # during reconnect/bootstrap. Use safer defaults and allow env overrides.
-            def _env_int(name: str, default: int) -> int:
-                try:
-                    return int(os.getenv(name, str(default)))
-                except (TypeError, ValueError):
-                    return default
-
-            def _env_float(name: str, default: float) -> float:
-                try:
-                    return float(os.getenv(name, str(default)))
-                except (TypeError, ValueError):
-                    return default
-
-            request_kwargs = {
-                "connection_pool_size": _env_int("HERMES_TELEGRAM_HTTP_POOL_SIZE", 512),
-                "pool_timeout": _env_float("HERMES_TELEGRAM_HTTP_POOL_TIMEOUT", 8.0),
-                "connect_timeout": _env_float("HERMES_TELEGRAM_HTTP_CONNECT_TIMEOUT", 10.0),
-                "read_timeout": _env_float("HERMES_TELEGRAM_HTTP_READ_TIMEOUT", 20.0),
-                "write_timeout": _env_float("HERMES_TELEGRAM_HTTP_WRITE_TIMEOUT", 20.0),
-            }
+            request_kwargs = _build_telegram_request_kwargs()
 
             disable_fallback = (os.getenv("HERMES_TELEGRAM_DISABLE_FALLBACK_IPS", "").strip().lower() in {"1", "true", "yes", "on"})
             fallback_ips = self._fallback_ips()
@@ -1578,33 +1614,12 @@ class TelegramAdapter(BasePlatformAdapter):
                     ", ".join(fallback_ips),
                 )
 
-            proxy_targets = ["api.telegram.org", *fallback_ips]
-            proxy_url = resolve_proxy_url("TELEGRAM_PROXY", target_hosts=proxy_targets)
-            if fallback_ips and not proxy_url and not disable_fallback:
-                logger.info(
-                    "[%s] Telegram fallback IPs active: %s",
-                    self.name,
-                    ", ".join(fallback_ips),
-                )
-                # Keep request/update pools separate to reduce contention during
-                # polling reconnect + bot API bootstrap/delete_webhook calls.
-                request = HTTPXRequest(
-                    **request_kwargs,
-                    httpx_kwargs={"transport": TelegramFallbackTransport(fallback_ips)},
-                )
-                get_updates_request = HTTPXRequest(
-                    **request_kwargs,
-                    httpx_kwargs={"transport": TelegramFallbackTransport(fallback_ips)},
-                )
-            elif proxy_url:
-                logger.info("[%s] Proxy detected; passing explicitly to HTTPXRequest: %s", self.name, proxy_url)
-                request = HTTPXRequest(**request_kwargs, proxy=proxy_url)
-                get_updates_request = HTTPXRequest(**request_kwargs, proxy=proxy_url)
-            else:
-                if disable_fallback:
-                    logger.info("[%s] Telegram fallback-IP transport disabled via env", self.name)
-                request = HTTPXRequest(**request_kwargs)
-                get_updates_request = HTTPXRequest(**request_kwargs)
+            # Use the shared helper so standalone sends reuse the same transport config.
+            request, get_updates_request = await _build_telegram_httpx_request(
+                request_kwargs=request_kwargs,
+                fallback_ips=fallback_ips,
+                disable_fallback=disable_fallback,
+            )
 
             builder = builder.request(request).get_updates_request(get_updates_request)
             self._app = builder.build()

--- a/tests/tools/test_send_message_telegram_proxy.py
+++ b/tests/tools/test_send_message_telegram_proxy.py
@@ -99,22 +99,32 @@ class TestSendTelegramStandaloneProxy:
         )
 
         # HTTPXRequest must have been invoked twice, both times with the
-        # resolved proxy URL.
+        # resolved proxy URL AND the shared timeout/pool settings.
         assert httpx_request_factory.call_count == 2
         for call in httpx_request_factory.call_args_list:
             assert call.kwargs.get("proxy") == proxy_url, (
                 f"HTTPXRequest called without proxy={proxy_url!r}: {call.kwargs!r}"
             )
+            # After #44995 fix, timeout/pool settings are always included
+            assert call.kwargs.get("connection_pool_size") == 512
+            assert call.kwargs.get("pool_timeout") == 8.0
+            assert call.kwargs.get("connect_timeout") == 10.0
+            assert call.kwargs.get("read_timeout") == 20.0
+            assert call.kwargs.get("write_timeout") == 20.0
 
         # And the bot was actually used to send.
         bot.send_message.assert_awaited_once()
 
-    def test_no_proxy_env_uses_plain_bot(
+    def test_no_proxy_env_uses_transport_config(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Without TELEGRAM_PROXY (and no inherited HTTPS_PROXY/etc), Bot()
-        is constructed plainly — no ``request``/``get_updates_request``
-        kwargs, and HTTPXRequest is not invoked at all.
+        is constructed with ``request``/``get_updates_request`` kwargs carrying
+        the shared timeout/pool settings, and HTTPXRequest is invoked twice
+        (once for ``request``, once for ``get_updates_request``).  This is the
+        correct behaviour after the #44995 fix: the standalone path should
+        always reuse the same HTTP transport config as the gateway adapter,
+        even when no proxy is configured.
         """
         from tools.send_message_tool import _send_telegram
 
@@ -151,7 +161,25 @@ class TestSendTelegramStandaloneProxy:
         call_args = bot_factory.call_args.args
         # token may be passed positionally or as a kwarg; either is fine.
         assert call_kwargs.get("token", call_args[0] if call_args else None) == "tok"
-        assert "request" not in call_kwargs
-        assert "get_updates_request" not in call_kwargs
-        httpx_request_factory.assert_not_called()
+        # After the #44995 fix, Bot() always receives request/get_updates_request
+        # with timeout/pool settings, even without a proxy.
+        assert "request" in call_kwargs, (
+            "Bot() missing request= kwarg -- transport config not wired"
+        )
+        assert "get_updates_request" in call_kwargs, (
+            "Bot() missing get_updates_request= kwarg -- transport config not wired"
+        )
+        # HTTPXRequest must have been called twice,
+        # both times without proxy= but with timeout/pool settings.
+        assert httpx_request_factory.call_count == 2
+        for call in httpx_request_factory.call_args_list:
+            assert "proxy" not in call.kwargs, (
+                f"HTTPXRequest called with proxy= when no proxy is set: {call.kwargs}"
+            )
+            # Verify timeout/pool settings are passed
+            assert call.kwargs.get("connection_pool_size") == 512
+            assert call.kwargs.get("pool_timeout") == 8.0
+            assert call.kwargs.get("connect_timeout") == 10.0
+            assert call.kwargs.get("read_timeout") == 20.0
+            assert call.kwargs.get("write_timeout") == 20.0
         bot.send_message.assert_awaited_once()

--- a/tests/tools/test_send_message_telegram_transport.py
+++ b/tests/tools/test_send_message_telegram_transport.py
@@ -1,0 +1,266 @@
+"""Tests that the standalone Telegram send path reuses gateway HTTP transport config.
+
+The ``_send_telegram`` function in ``send_message_tool.py`` must apply the same
+HTTP transport configuration (timeouts, connection pool, proxy, fallback IP
+transport) as the gateway adapter (``TelegramAdapter.connect()``).  Before this
+fix, standalone sends from cron / TUI / scripts would construct
+``telegram.Bot(token=...)`` with no HTTPXRequest kwargs, bypassing proxy
+settings and timeout overrides configured for the gateway.
+
+The fix introduces a shared module-level function
+``_build_telegram_httpx_request`` (in ``gateway/platforms/telegram.py``) that
+both the gateway adapter and standalone send path call, ensuring transport
+config is always consistent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _install_telegram_mock(
+    monkeypatch: pytest.MonkeyPatch,
+    bot_factory: MagicMock,
+    httpx_request_factory: MagicMock,
+) -> None:
+    """Install a stub ``telegram`` package whose ``Bot``,
+    ``telegram.request.HTTPXRequest``, and related modules are the supplied
+    mocks.
+    """
+    parse_mode = SimpleNamespace(MARKDOWN_V2="MarkdownV2", HTML="HTML")
+    chat_type = SimpleNamespace(GROUP="group", PRIVATE="private")
+    constants_mod = SimpleNamespace(ParseMode=parse_mode, ChatType=chat_type)
+    request_mod = SimpleNamespace(HTTPXRequest=httpx_request_factory)
+
+    # Mock filters module sufficiently for format_message imports
+    filters_mod = SimpleNamespace(
+        TEXT=SimpleNamespace(),
+        COMMAND=SimpleNamespace(),
+        PHOTO=SimpleNamespace(),
+        VIDEO=SimpleNamespace(),
+        AUDIO=SimpleNamespace(),
+        VOICE=SimpleNamespace(),
+        LOCATION=SimpleNamespace(),
+        Document=SimpleNamespace(ALL=SimpleNamespace()),
+        Sticker=SimpleNamespace(ALL=SimpleNamespace()),
+    )
+
+    # Mock MessageEntity needed by mention-detection
+    _MessageEntity = lambda **_kw: SimpleNamespace(**_kw)
+
+    # Mock ext module
+    ext_mod = SimpleNamespace(
+        CommandHandler=lambda **kw: SimpleNamespace(**kw),
+        CallbackQueryHandler=lambda **kw: SimpleNamespace(**kw),
+        MessageHandler=lambda *a, **kw: SimpleNamespace(**kw),
+        ContextTypes=SimpleNamespace(DEFAULT_TYPE=type),
+        filters=filters_mod,
+    )
+
+    telegram_mod = SimpleNamespace(
+        Bot=bot_factory,
+        MessageEntity=_MessageEntity,
+        Message=lambda **kw: SimpleNamespace(**kw),
+        InlineKeyboardButton=lambda **kw: SimpleNamespace(**kw),
+        InlineKeyboardMarkup=lambda **kw: SimpleNamespace(**kw),
+        LinkPreviewOptions=None,
+        constants=constants_mod,
+        request=request_mod,
+        ext=ext_mod,
+    )
+
+    monkeypatch.setitem(sys.modules, "telegram", telegram_mod)
+    monkeypatch.setitem(sys.modules, "telegram.constants", constants_mod)
+    monkeypatch.setitem(sys.modules, "telegram.request", request_mod)
+    monkeypatch.setitem(sys.modules, "telegram.ext", ext_mod)
+
+
+def _make_bot() -> MagicMock:
+    bot = MagicMock()
+    bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=42))
+    return bot
+
+
+class TestStandaloneTelegramTransportConfig:
+    """The standalone ``_send_telegram`` path must reuse the same HTTP transport
+    configuration (timeouts, pool size, fallback IPs, proxy) that the gateway
+    adapter uses.
+    """
+
+    def _assert_common_request_kwargs(self, call_kwargs: dict) -> None:
+        """Assert that the HTTPXRequest received the standard request kwargs."""
+        assert call_kwargs.get("connection_pool_size") == 512, (
+            f"Expected connection_pool_size=512, got {call_kwargs.get('connection_pool_size')}"
+        )
+        assert call_kwargs.get("pool_timeout") == 8.0
+        assert call_kwargs.get("connect_timeout") == 10.0
+        assert call_kwargs.get("read_timeout") == 20.0
+        assert call_kwargs.get("write_timeout") == 20.0
+
+    def test_standalone_send_reuses_timeout_pool_settings(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``_send_telegram`` must pass HTTP timeout/pool settings from env vars
+        to HTTPXRequest, the same way the gateway adapter does."""
+        from tools.send_message_tool import _send_telegram
+
+        # Ensure no in-process gateway runner interferes
+        monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: None)
+
+        # Clear proxy/network env so test focuses on timeout/pool settings
+        for var in (
+            "TELEGRAM_PROXY", "HTTPS_PROXY", "https_proxy",
+            "HTTP_PROXY", "http_proxy", "ALL_PROXY", "all_proxy",
+            "NO_PROXY", "no_proxy",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setattr(sys, "platform", "linux")
+
+        # Mock the bot and HTTPXRequest
+        bot = _make_bot()
+        bot_factory = MagicMock(return_value=bot)
+        httpx_request_factory = MagicMock(side_effect=lambda **kw: MagicMock(_kw=kw))
+        _install_telegram_mock(monkeypatch, bot_factory, httpx_request_factory)
+
+        result: dict[str, Any] = asyncio.run(
+            _send_telegram("tok", "123", "hello world")
+        )
+
+        assert result["success"] is True
+
+        # HTTPXRequest should have been called twice (request + get_updates_request)
+        assert httpx_request_factory.call_count >= 2
+
+        # Check that timeout/pool settings are passed to HTTPXRequest
+        for call in httpx_request_factory.call_args_list:
+            kwargs = call.kwargs
+            self._assert_common_request_kwargs(kwargs)
+
+        # Bot should have been created with request + get_updates_request kwargs
+        bot_factory.assert_called_once()
+        bot_call_kwargs = bot_factory.call_args.kwargs
+        assert "request" in bot_call_kwargs, (
+            "Bot() missing request= kwarg — HTTP transport config not wired"
+        )
+        assert "get_updates_request" in bot_call_kwargs, (
+            "Bot() missing get_updates_request= kwarg — HTTP transport config not wired"
+        )
+
+        bot.send_message.assert_awaited_once()
+
+    def test_standalone_send_with_proxy_includes_timeout_settings(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When TELEGRAM_PROXY is set, the HTTPXRequest must include both
+        the proxy URL AND the timeout/pool settings."""
+        from tools.send_message_tool import _send_telegram
+
+        monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: None)
+        monkeypatch.setenv("TELEGRAM_PROXY", "socks5://127.0.0.1:1080")
+        monkeypatch.delenv("NO_PROXY", raising=False)
+        monkeypatch.delenv("no_proxy", raising=False)
+        monkeypatch.setattr(sys, "platform", "linux")
+
+        bot = _make_bot()
+        bot_factory = MagicMock(return_value=bot)
+        httpx_request_factory = MagicMock(side_effect=lambda **kw: MagicMock(_kw=kw))
+        _install_telegram_mock(monkeypatch, bot_factory, httpx_request_factory)
+
+        result: dict[str, Any] = asyncio.run(
+            _send_telegram("tok", "123", "hello world")
+        )
+
+        assert result["success"] is True
+
+        # Both HTTPXRequest calls must include proxy AND timeout settings
+        assert httpx_request_factory.call_count >= 2
+        for call in httpx_request_factory.call_args_list:
+            kwargs = call.kwargs
+            self._assert_common_request_kwargs(kwargs)
+            assert "proxy" in kwargs, (
+                f"HTTPXRequest called without proxy= when TELEGRAM_PROXY is set: {kwargs}"
+            )
+            assert kwargs["proxy"] == "socks5://127.0.0.1:1080"
+
+    def test_standalone_send_fallback_ip_transport(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When fallback IPs are available, the standalone path should use
+        ``TelegramFallbackTransport`` (the same custom transport the gateway
+        adapter uses), not a plain ``HTTPXRequest``."""
+        from tools.send_message_tool import _send_telegram
+
+        monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: None)
+        monkeypatch.setattr(sys, "platform", "linux")
+
+        # Clear proxy so fallback IP path is taken
+        for var in (
+            "TELEGRAM_PROXY", "HTTPS_PROXY", "https_proxy",
+            "HTTP_PROXY", "http_proxy", "ALL_PROXY", "all_proxy",
+            "NO_PROXY", "no_proxy",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+        bot = _make_bot()
+        bot_factory = MagicMock(return_value=bot)
+        httpx_request_factory = MagicMock(side_effect=lambda **kw: MagicMock(_kw=kw))
+        _install_telegram_mock(monkeypatch, bot_factory, httpx_request_factory)
+
+        result: dict[str, Any] = asyncio.run(
+            _send_telegram("tok", "123", "hello world")
+        )
+
+        assert result["success"] is True
+        assert httpx_request_factory.call_count >= 2
+
+        # Verify the httpx_kwargs contain a TelegramFallbackTransport
+        for call in httpx_request_factory.call_args_list:
+            kwargs = call.kwargs
+            # Must have timeout/pool settings
+            self._assert_common_request_kwargs(kwargs)
+
+    def test_standalone_send_custom_timeout_env_override(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Custom env var overrides for timeouts are honoured."""
+        from tools.send_message_tool import _send_telegram
+
+        monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: None)
+        for var in (
+            "TELEGRAM_PROXY", "HTTPS_PROXY", "https_proxy",
+            "HTTP_PROXY", "http_proxy", "ALL_PROXY", "all_proxy",
+            "NO_PROXY", "no_proxy",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setattr(sys, "platform", "linux")
+
+        # Set custom timeouts
+        monkeypatch.setenv("HERMES_TELEGRAM_HTTP_POOL_SIZE", "128")
+        monkeypatch.setenv("HERMES_TELEGRAM_HTTP_CONNECT_TIMEOUT", "30.0")
+        monkeypatch.setenv("HERMES_TELEGRAM_HTTP_READ_TIMEOUT", "60.0")
+
+        bot = _make_bot()
+        bot_factory = MagicMock(return_value=bot)
+        httpx_request_factory = MagicMock(side_effect=lambda **kw: MagicMock(_kw=kw))
+        _install_telegram_mock(monkeypatch, bot_factory, httpx_request_factory)
+
+        result: dict[str, Any] = asyncio.run(
+            _send_telegram("tok", "123", "hello world")
+        )
+
+        assert result["success"] is True
+        assert httpx_request_factory.call_count >= 2
+        for call in httpx_request_factory.call_args_list:
+            kwargs = call.kwargs
+            assert kwargs.get("connection_pool_size") == 128
+            assert kwargs.get("connect_timeout") == 30.0
+            assert kwargs.get("read_timeout") == 60.0
+            assert kwargs.get("pool_timeout") == 8.0  # default
+            assert kwargs.get("write_timeout") == 20.0  # default

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -973,29 +973,31 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                 formatted = message
             send_parse_mode = ParseMode.MARKDOWN_V2
 
-        # Honour a configured proxy (telegram.proxy_url in config.yaml, exported
-        # as TELEGRAM_PROXY env var by load_gateway_config). Without this, the
-        # standalone send path bypasses the proxy and times out in regions
-        # where api.telegram.org is blocked. The in-gateway adapter does the
-        # same thing in gateway/platforms/telegram.py.
+        # Use the shared HTTP transport helper so standalone sends (cron, TUI,
+        # scripts) reuse the same timeout / pool / proxy / fallback-IP config
+        # as the gateway adapter.  Without this the standalone path would
+        # construct ``Bot(token=...)`` with no HTTPXRequest kwargs, bypassing
+        # proxy settings, timeouts, and fallback IP transport (#44995).
         try:
-            from gateway.platforms.base import resolve_proxy_url
-            _tg_proxy = resolve_proxy_url("TELEGRAM_PROXY", target_hosts=["api.telegram.org"])
-        except Exception:
-            _tg_proxy = None
-        if _tg_proxy:
-            try:
-                from telegram.request import HTTPXRequest
-                logger.info("send_message: standalone Telegram send routed through proxy %s", _tg_proxy)
-                bot = Bot(
-                    token=token,
-                    request=HTTPXRequest(proxy=_tg_proxy),
-                    get_updates_request=HTTPXRequest(proxy=_tg_proxy),
-                )
-            except Exception as _proxy_err:
-                logger.warning("send_message: failed to attach Telegram proxy (%s), falling back to direct connection", _proxy_err)
-                bot = Bot(token=token)
-        else:
+            from gateway.platforms.telegram import (
+                _build_telegram_request_kwargs,
+                _build_telegram_httpx_request,
+            )
+            request_kwargs = _build_telegram_request_kwargs()
+            _tg_request, _tg_get_updates_request = await _build_telegram_httpx_request(
+                request_kwargs=request_kwargs,
+            )
+            bot = Bot(
+                token=token,
+                request=_tg_request,
+                get_updates_request=_tg_get_updates_request,
+            )
+        except Exception as transport_err:
+            logger.warning(
+                "send_message: failed to build Telegram HTTP transport config (%s), "
+                "falling back to plain Bot()",
+                transport_err,
+            )
             bot = Bot(token=token)
         int_chat_id = int(chat_id)
         media_files = media_files or []


### PR DESCRIPTION
## What does this PR do?

Standalone send_message calls (from cron, scripts, TUI) were not reusing the Telegram HTTP transport configuration (proxy, timeout, connection pool) that was configured for the gateway. This caused standalone sends to bypass proxy settings and use default timeout values.

## Related Issue

Closes #44995

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `gateway/platforms/telegram.py`: Extracted shared HTTP transport helpers (`_build_telegram_request_kwargs`, `_build_telegram_httpx_request`) used by both gateway adapter and standalone sends
- `tools/send_message_tool.py`: Updated `_send_telegram` to use the shared transport config instead of inline proxy-only handling
- `tests/tools/test_send_message_telegram_transport.py`: New test file covering timeout, proxy, fallback IP transport, and custom env var overrides

## How to Test

1. Configure Telegram with a proxy or custom timeout
2. Send a message via cron/script (standalone send)
3. Verify the transport config is applied