### PR TITLE
fix(cron): resume_job preserves existing next_run_at instead of recomputing from now

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1407,12 +1407,42 @@ def pause_job(job_id: str, reason: Optional[str] = None) -> Optional[Dict[str, A
 
 
 def resume_job(job_id: str) -> Optional[Dict[str, Any]]:
-    """Resume a paused job and compute the next future run from now. Accepts a job ID or name."""
+    """Resume a paused job while preserving its original schedule cadence.
+
+    If the job already has a future ``next_run_at`` (from before it was paused),
+    that value is preserved rather than recomputed from ``now``, which would
+    shift the cadence by the entire pause duration.  If ``next_run_at`` is in
+    the past, absent, or malformed, the next run is computed from
+    ``last_run_at`` so the interval anchor is maintained.
+
+    Malformed stored ``next_run_at`` values are treated as absent (same repair
+    policy as the due-scan path) so resume never raises on corrupt job state.
+
+    Accepts a job ID or name.
+    """
     job = resolve_job_ref(job_id)
     if not job:
         return None
 
-    next_run_at = compute_next_run(job["schedule"])
+    now = _hermes_now()
+    existing_next = job.get("next_run_at")
+    next_run_at = None
+
+    # Preserve a future next_run_at so pause/resume doesn't shift cadence.
+    if isinstance(existing_next, str) and existing_next:
+        try:
+            next_dt = _ensure_aware(datetime.fromisoformat(existing_next))
+            if next_dt > now:
+                next_run_at = existing_next
+        except Exception:
+            # Corrupt ISO / non-parseable value — fall through to recompute.
+            next_run_at = None
+
+    if next_run_at is None:
+        next_run_at = compute_next_run(
+            job["schedule"], last_run_at=job.get("last_run_at")
+        )
+
     if next_run_at is None and job["schedule"].get("kind") == "once":
         run_at = job["schedule"].get("run_at", "unknown")
         raise ValueError(

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -445,6 +445,104 @@ class TestPauseResumeJob:
         assert resumed["paused_at"] is None
         assert resumed["paused_reason"] is None
 
+    def test_resume_preserves_future_next_run_at(self, tmp_cron_dir, monkeypatch):
+        """Future next_run_at must survive pause/resume so cadence is not shifted."""
+        now = datetime(2026, 7, 6, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        future_next = (now + timedelta(minutes=30)).isoformat()
+        job = {
+            "id": "test-resume-preserve",
+            "name": "test-resume-preserve",
+            "prompt": "Preserve next",
+            "schedule": {"kind": "interval", "minutes": 60, "display": "every 1h"},
+            "repeat": {"times": 0, "completed": 0},
+            "enabled": False,
+            "state": "paused",
+            "paused_at": now.isoformat(),
+            "paused_reason": "test",
+            "next_run_at": future_next,
+            "last_run_at": (now - timedelta(minutes=30)).isoformat(),
+            "last_status": "ok",
+            "last_error": None,
+            "last_delivery_error": None,
+            "created_at": (now - timedelta(hours=2)).isoformat(),
+            "deliver": "local",
+        }
+        save_jobs([job])
+        resumed = resume_job("test-resume-preserve")
+        assert resumed is not None
+        assert resumed["enabled"] is True
+        assert resumed["next_run_at"] == future_next
+
+    def test_resume_stale_next_run_falls_back_to_last_run_anchor(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        """Stale next_run_at must recompute from last_run_at, not from now.
+
+        Without the fix, resume always used now+interval and shifted cadence
+        by the full pause duration even when last_run_at is a better anchor.
+        """
+        now = datetime(2026, 7, 6, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        last_run = now - timedelta(minutes=90)
+        stale_next = (now - timedelta(minutes=30)).isoformat()
+        job = {
+            "id": "test-resume-stale",
+            "name": "test-resume-stale",
+            "prompt": "Stale next",
+            "schedule": {"kind": "interval", "minutes": 60, "display": "every 1h"},
+            "repeat": {"times": 0, "completed": 0},
+            "enabled": False,
+            "state": "paused",
+            "paused_at": now.isoformat(),
+            "paused_reason": "test",
+            "next_run_at": stale_next,
+            "last_run_at": last_run.isoformat(),
+            "last_status": "ok",
+            "last_error": None,
+            "last_delivery_error": None,
+            "created_at": (now - timedelta(hours=3)).isoformat(),
+            "deliver": "local",
+        }
+        save_jobs([job])
+        resumed = resume_job("test-resume-stale")
+        assert resumed is not None
+        expected = (last_run + timedelta(minutes=60)).isoformat()
+        assert resumed["next_run_at"] == expected
+        # Must NOT be now+interval (the old bug).
+        assert resumed["next_run_at"] != (now + timedelta(minutes=60)).isoformat()
+
+    def test_resume_malformed_next_run_falls_back_without_raising(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        """Corrupt next_run_at must be treated as absent, not raise from resume."""
+        now = datetime(2026, 7, 6, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        last_run = now - timedelta(minutes=20)
+        job = {
+            "id": "test-resume-bad-next",
+            "name": "test-resume-bad-next",
+            "prompt": "Bad next",
+            "schedule": {"kind": "interval", "minutes": 60, "display": "every 1h"},
+            "repeat": {"times": 0, "completed": 0},
+            "enabled": False,
+            "state": "paused",
+            "paused_at": now.isoformat(),
+            "paused_reason": "test",
+            "next_run_at": "not-a-valid-iso-timestamp",
+            "last_run_at": last_run.isoformat(),
+            "last_status": "ok",
+            "last_error": None,
+            "last_delivery_error": None,
+            "created_at": (now - timedelta(hours=1)).isoformat(),
+            "deliver": "local",
+        }
+        save_jobs([job])
+        resumed = resume_job("test-resume-bad-next")
+        assert resumed is not None
+        expected = (last_run + timedelta(minutes=60)).isoformat()
+        assert resumed["next_run_at"] == expected
+
     def test_resume_rejects_past_oneshot(self, tmp_cron_dir, monkeypatch):
         """Resuming a paused one-shot whose time is now in the past must raise
         ValueError — the revived job would silently never fire."""


### PR DESCRIPTION
## Summary

`resume_job()` recomputes `next_run_at` as `now + interval`, so pause/resume an interval cron job shifts the cadence by the entire pause duration. A job halfway through its interval before being paused gets delayed by up to a full interval after resume.

### Fix

`resume_job()` now preserves a future `next_run_at` when one exists (the job was paused before its next scheduled run). When `next_run_at` is in the past or absent, it falls back to computing from `last_run_at` (the original anchor) instead of from `now`, keeping the schedule cadence stable.

### Reproduction

1. Create a 1h interval job that ran 30 minutes ago (`next_run_at` ≈ 30 minutes from now)
2. `hermes cron pause <id>` → `hermes cron resume <id>`
3. Observe `next_run_at` jumps from ~30 min to ~1h (the full interval from resume time)

### Root Cause

`cron/jobs.py:814` — `compute_next_run()` called without `last_run_at`, so interval jobs use `now + interval` instead of `last_run_at + interval`.

### Tests

`tests/cron/test_jobs.py` — 87 passed ✅