### PR TITLE
fix(send_message): resolve Signal group targets in _parse_target_ref (#44967)

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -515,6 +515,17 @@ def _parse_target_ref(platform_name: str, target_ref: str):
             # Preserve the leading '+' — signal-cli and sms/whatsapp adapters
             # expect E.164 format for direct recipients.
             return target_ref.strip(), None, True
+    if platform_name == "signal":
+        ref = target_ref.strip()
+        # Accept "group.<id>" as a common alias for "group:<id>"
+        if ref.startswith("group."):
+            ref = "group:" + ref[len("group.") :]
+        # Explicit group target: "group:<base64GroupId>" or bare base64 group id
+        if ref.startswith("group:"):
+            return ref, None, True
+        # Base64-encoded Signal group IDs (~44 chars ending in '=' or '==')
+        if re.fullmatch(r"[A-Za-z0-9+/]{40,}={0,2}", ref):
+            return "group:" + ref, None, True
     if target_ref.lstrip("-").isdigit():
         return target_ref, None, True
     # Matrix room IDs (start with !) and user IDs (start with @) are explicit


### PR DESCRIPTION
## What does this PR do?

`_parse_target_ref()` in `send_message_tool.py` had no branch for Signal group IDs. The function only checked for E.164 phone numbers, so base64-encoded Signal group IDs fell through to the fallback return of None. Meanwhile, `_send_signal()` already supports groups via `chat_id.startswith('group:')` — the delivery path was ready, but the parser never let an explicit group ID through.

## Related Issue

Closes #44967

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `tools/send_message_tool.py`: Added Signal group recognition to `_parse_target_ref()` — handles `group:<base64GroupId>`, `group.<base64GroupId>`, and bare base64 encoded group IDs

## How to Test

1. Call send_message with target=\group:A1b2C3d4E5...=\ on Signal
2. Verify the message is delivered to the group chat