### PR TITLE
docs(website): redirect old automation-templates URL to automation-blueprints

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -66,6 +66,23 @@ const config: Config = {
     ],
   ],
 
+  plugins: [
+    [
+      '@docusaurus/plugin-client-redirects',
+      {
+        // Static-host redirects for renamed doc pages (GitHub Pages can't
+        // do server-side redirects). Paths are relative to baseUrl (/docs/).
+        redirects: [
+          {
+            // Renamed in #44470 (Automation Blueprints terminology rebrand)
+            from: '/guides/automation-templates',
+            to: '/guides/automation-blueprints',
+          },
+        ],
+      },
+    ],
+  ],
+
   presets: [
     [
       'classic',

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/core": "3.9.2",
+        "@docusaurus/plugin-client-redirects": "3.9.2",
         "@docusaurus/preset-classic": "3.9.2",
         "@docusaurus/theme-mermaid": "^3.9.2",
         "@easyops-cn/docusaurus-search-local": "^0.55.1",
@@ -3607,6 +3608,30 @@
       "peerDependencies": {
         "react": "*",
         "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/plugin-client-redirects": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.9.2.tgz",
+      "integrity": "sha512-lUgMArI9vyOYMzLRBUILcg9vcPTCyyI2aiuXq/4npcMVqOr6GfmwtmBYWSbNMlIUM0147smm4WhpXD0KFboffw==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.9.2",
+        "@docusaurus/logger": "3.9.2",
+        "@docusaurus/utils": "3.9.2",
+        "@docusaurus/utils-common": "3.9.2",
+        "@docusaurus/utils-validation": "3.9.2",
+        "eta": "^2.2.0",
+        "fs-extra": "^11.1.1",
+        "lodash": "^4.17.21",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {

--- a/website/package.json
+++ b/website/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "3.9.2",
+    "@docusaurus/plugin-client-redirects": "3.9.2",
     "@docusaurus/preset-classic": "3.9.2",
     "@docusaurus/theme-mermaid": "^3.9.2",
     "@easyops-cn/docusaurus-search-local": "^0.55.1",


### PR DESCRIPTION
## What

Adds a client-side redirect so the old guide URL works again:

`/docs/guides/automation-templates` → `/docs/guides/automation-blueprints`

## Why

The Automation Blueprints terminology rebrand (#44470) renamed the guide page, and the old URL now 404s for anyone holding a stale link. The docs deploy to static hosting, so a server-side redirect isn't an option — this uses `@docusaurus/plugin-client-redirects` (pinned `3.9.2`, same as the other Docusaurus packages), which emits a static HTML page at the old path that redirects to the new one (meta refresh + JS, preserves `?query` and `#hash`, sets `rel=canonical` for SEO).

The plugin wasn't installed before — this also gives us a one-line pattern for any future doc renames.

## Changes

- `website/package.json` / `package-lock.json`: add `@docusaurus/plugin-client-redirects@3.9.2`
- `website/docusaurus.config.ts`: plugin config with the one redirect entry

## Verification

Ran the docs-site-checks steps locally (`extract-skills.py`, `generate-skill-docs.py`, `npm run build`). Build succeeds and generates:

- `build/guides/automation-templates/index.html` → redirects to `/docs/guides/automation-blueprints`
- `build/zh-Hans/guides/automation-templates/index.html` → redirects to `/docs/zh-Hans/guides/automation-blueprints` (locales handled automatically)