### PR TITLE
[codex] Add Simplified Chinese desktop copy

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -3285,32 +3285,49 @@ function sendWindowStateChanged(nextIsFullscreen) {
   webContents.send('hermes:window-state-changed', state)
 }
 
+function isSimplifiedChineseDesktopLocale() {
+  const locale = String(app.getLocale?.() || app.getSystemLocale?.() || '').toLowerCase().replace(/_/g, '-')
+  return locale === 'zh' || locale.startsWith('zh-cn') || locale.startsWith('zh-hans')
+}
+
+function desktopLabel(english, simplifiedChinese) {
+  return isSimplifiedChineseDesktopLocale() ? simplifiedChinese : english
+}
+
+function desktopRole(role, simplifiedChinese, options = {}) {
+  const item = { role, ...options }
+  if (isSimplifiedChineseDesktopLocale()) {
+    item.label = simplifiedChinese
+  }
+  return item
+}
+
 function buildApplicationMenu() {
   const template = []
   const checkForUpdatesItem = {
-    label: 'Check for Updates…',
+    label: desktopLabel('Check for Updates…', '检查更新…'),
     click: () => sendOpenUpdatesRequested()
   }
   if (IS_MAC) {
     template.push({
       label: APP_NAME,
       submenu: [
-        { label: `About ${APP_NAME}`, click: () => showAboutPanelFresh() },
+        { label: desktopLabel(`About ${APP_NAME}`, `关于 ${APP_NAME}`), click: () => showAboutPanelFresh() },
         checkForUpdatesItem,
         { type: 'separator' },
-        { role: 'services' },
+        desktopRole('services', '服务'),
         { type: 'separator' },
-        { role: 'hide' },
-        { role: 'hideOthers' },
-        { role: 'unhide' },
+        desktopRole('hide', `隐藏 ${APP_NAME}`),
+        desktopRole('hideOthers', '隐藏其他'),
+        desktopRole('unhide', '全部显示'),
         { type: 'separator' },
-        { role: 'quit' }
+        desktopRole('quit', `退出 ${APP_NAME}`)
       ]
     })
   }
 
   template.push({
-    label: 'File',
+    label: desktopLabel('File', '文件'),
     submenu: [
       IS_MAC
         ? {
@@ -3322,40 +3339,40 @@ function buildApplicationMenu() {
                 mainWindow?.close()
               }
             },
-            label: 'Close'
+            label: desktopLabel('Close', '关闭窗口')
           }
-        : { role: 'quit' }
+        : desktopRole('quit', '退出')
     ]
   })
   template.push({
-    label: 'Edit',
+    label: desktopLabel('Edit', '编辑'),
     submenu: [
-      { role: 'undo' },
-      { role: 'redo' },
+      desktopRole('undo', '撤销'),
+      desktopRole('redo', '重做'),
       { type: 'separator' },
-      { role: 'cut' },
-      { role: 'copy' },
-      { role: 'paste' },
-      { role: 'delete' },
-      { role: 'selectAll' }
+      desktopRole('cut', '剪切'),
+      desktopRole('copy', '复制'),
+      desktopRole('paste', '粘贴'),
+      desktopRole('delete', '删除'),
+      desktopRole('selectAll', '全选')
     ]
   })
   template.push({
-    label: 'View',
+    label: desktopLabel('View', '视图'),
     submenu: [
-      { role: 'reload' },
-      { role: 'forceReload' },
-      { role: 'toggleDevTools' },
+      desktopRole('reload', '重新加载'),
+      desktopRole('forceReload', '强制重新加载'),
+      desktopRole('toggleDevTools', '切换开发者工具'),
       { type: 'separator' },
       {
-        label: 'Actual Size',
+        label: desktopLabel('Actual Size', '实际大小'),
         accelerator: 'CommandOrControl+0',
         click: () => {
           setAndPersistZoomLevel(mainWindow, 0)
         }
       },
       {
-        label: 'Zoom In',
+        label: desktopLabel('Zoom In', '放大'),
         accelerator: 'CommandOrControl+Plus',
         click: () => {
           if (mainWindow && !mainWindow.isDestroyed()) {
@@ -3364,7 +3381,7 @@ function buildApplicationMenu() {
         }
       },
       {
-        label: 'Zoom Out',
+        label: desktopLabel('Zoom Out', '缩小'),
         accelerator: 'CommandOrControl+-',
         click: () => {
           if (mainWindow && !mainWindow.isDestroyed()) {
@@ -3373,17 +3390,17 @@ function buildApplicationMenu() {
         }
       },
       { type: 'separator' },
-      { role: 'togglefullscreen' }
+      desktopRole('togglefullscreen', '切换全屏')
     ]
   })
   template.push({
-    label: 'Window',
+    label: desktopLabel('Window', '窗口'),
     submenu: IS_MAC
-      ? [{ role: 'minimize' }, { role: 'zoom' }, { role: 'front' }]
-      : [{ role: 'minimize' }, { role: 'close' }]
+      ? [desktopRole('minimize', '最小化'), desktopRole('zoom', '缩放'), desktopRole('front', '前置全部窗口')]
+      : [desktopRole('minimize', '最小化'), desktopRole('close', '关闭')]
   })
   template.push({
-    label: 'Help',
+    label: desktopLabel('Help', '帮助'),
     role: 'help',
     submenu: [checkForUpdatesItem]
   })
@@ -3501,7 +3518,7 @@ function installContextMenu(window) {
     if (hasImage) {
       template.push(
         {
-          label: 'Open Image',
+          label: desktopLabel('Open Image', '打开图片'),
           click: () => {
             if (params.srcURL && !params.srcURL.startsWith('data:')) {
               openExternalUrl(params.srcURL)
@@ -3510,17 +3527,17 @@ function installContextMenu(window) {
           enabled: !params.srcURL.startsWith('data:')
         },
         {
-          label: 'Copy Image',
+          label: desktopLabel('Copy Image', '复制图片'),
           click: () => {
             void copyImageFromUrl(params.srcURL).catch(error => rememberLog(`Copy image failed: ${error.message}`))
           }
         },
         {
-          label: 'Copy Image Address',
+          label: desktopLabel('Copy Image Address', '复制图片地址'),
           click: () => clipboard.writeText(params.srcURL)
         },
         {
-          label: 'Save Image As...',
+          label: desktopLabel('Save Image As...', '图片另存为…'),
           click: () => {
             void saveImageFromUrl(params.srcURL).catch(error => rememberLog(`Save image failed: ${error.message}`))
           }
@@ -3532,11 +3549,11 @@ function installContextMenu(window) {
       if (template.length) template.push({ type: 'separator' })
       template.push(
         {
-          label: 'Open Link',
+          label: desktopLabel('Open Link', '打开链接'),
           click: () => openExternalUrl(params.linkURL)
         },
         {
-          label: 'Copy Link',
+          label: desktopLabel('Copy Link', '复制链接'),
           click: () => clipboard.writeText(params.linkURL)
         }
       )
@@ -3559,7 +3576,7 @@ function installContextMenu(window) {
 
       template.push({ type: 'separator' })
       template.push({
-        label: 'Add to dictionary',
+        label: desktopLabel('Add to dictionary', '添加到词典'),
         click: () => window.webContents.session.addWordToSpellCheckerDictionary(params.misspelledWord)
       })
     }
@@ -3568,19 +3585,19 @@ function installContextMenu(window) {
       if (template.length) template.push({ type: 'separator' })
       if (isEditable) {
         template.push(
-          { role: 'cut', enabled: params.editFlags.canCut },
-          { role: 'copy', enabled: params.editFlags.canCopy },
-          { role: 'paste', enabled: params.editFlags.canPaste },
+          desktopRole('cut', '剪切', { enabled: params.editFlags.canCut }),
+          desktopRole('copy', '复制', { enabled: params.editFlags.canCopy }),
+          desktopRole('paste', '粘贴', { enabled: params.editFlags.canPaste }),
           { type: 'separator' },
-          { role: 'selectAll', enabled: params.editFlags.canSelectAll }
+          desktopRole('selectAll', '全选', { enabled: params.editFlags.canSelectAll })
         )
       } else {
-        template.push({ role: 'copy', enabled: params.editFlags.canCopy })
+        template.push(desktopRole('copy', '复制', { enabled: params.editFlags.canCopy }))
       }
     }
 
     if (!template.length) {
-      template.push({ role: 'selectAll' })
+      template.push(desktopRole('selectAll', '全选'))
     }
 
     Menu.buildFromTemplate(template).popup({ window })

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -259,6 +259,8 @@ export function ChatBar({
     prevSessionIdRef.current = sessionId
 
     if (prev === sessionId) {
+      setRestingPlaceholder(pickPlaceholder(sessionId ? followUpPlaceholders : newSessionPlaceholders))
+
       return
     }
 

--- a/apps/desktop/src/components/chat/intro.tsx
+++ b/apps/desktop/src/components/chat/intro.tsx
@@ -1,5 +1,7 @@
 import { type CSSProperties, useState } from 'react'
 
+import { useI18n } from '@/i18n'
+
 import introCopyJsonl from './intro-copy.jsonl?raw'
 
 type IntroCopy = {
@@ -38,6 +40,29 @@ const FALLBACK_COPY: IntroCopy[] = [
   {
     headline: 'What needs attention?',
     body: "Send the context you have. I'll help sort it into a plan or a fix."
+  }
+]
+
+const ZH_COPY: IntroCopy[] = [
+  {
+    headline: '准备好了',
+    body: '告诉我目标、贴一段报错，或给我一个文件路径。我会先看清上下文，再把事情推进到可验证的结果。'
+  },
+  {
+    headline: '今天从哪里开始？',
+    body: '可以让我看代码、跑测试、修 bug、整理方案或写文档。把任务说出来就行。'
+  },
+  {
+    headline: 'Hermes Agent 已就绪',
+    body: '描述你想做什么，我会读取相关文件、调用工具，并在需要你确认时停下来。'
+  },
+  {
+    headline: '把问题发给我',
+    body: '一个想法、一个路径、一段错误信息都可以。我会拆解步骤、执行操作，并检查结果。'
+  },
+  {
+    headline: '开始一个任务',
+    body: '说出目标即可：调研、编码、排查、测试、总结都可以从这里开始。'
   }
 ]
 
@@ -144,7 +169,11 @@ function pickCopy(copies: IntroCopy[], seed = 0): IntroCopy {
 
 const WORDMARK = 'HERMES AGENT'
 
-function resolveCopy(personality?: string, seed?: number): IntroCopy {
+function resolveCopy(personality?: string, seed?: number, locale?: string): IntroCopy {
+  if (locale === 'zh') {
+    return pickCopy(ZH_COPY, seed)
+  }
+
   const personalityKey = normalizeKey(personality)
 
   const copies = NEUTRAL_PERSONALITIES.has(personalityKey)
@@ -155,8 +184,9 @@ function resolveCopy(personality?: string, seed?: number): IntroCopy {
 }
 
 export function Intro({ personality, seed }: IntroProps) {
+  const { locale } = useI18n()
   const [mountSeed] = useState(() => Math.floor(Math.random() * 100000))
-  const copy = resolveCopy(personality, mountSeed + (seed ?? 0))
+  const copy = resolveCopy(personality, mountSeed + (seed ?? 0), locale)
 
   return (
     <div


### PR DESCRIPTION
## Summary

Adds Simplified Chinese copy for desktop-only surfaces that were still English when the app is running under a Simplified Chinese locale.

- Localizes the Electron application menu and context menu labels when `app.getLocale()` resolves to Simplified Chinese.
- Adds Simplified Chinese intro screen copy via the existing renderer i18n context, without changing the default English locale.
- Refreshes the chat composer resting placeholder when localized placeholder arrays change while staying in the same session.

## Why

The renderer already has Chinese UI translations, but several desktop shell surfaces were still English or kept stale placeholder copy after a language change. This keeps English and other locales unchanged while improving the Simplified Chinese desktop experience.

## Validation

- `npm --prefix apps/desktop run typecheck`
- `cd apps/desktop && npx eslint electron/main.cjs src/components/chat/intro.tsx src/app/chat/composer/index.tsx`
- `cd apps/desktop && node --test electron/backend-env.test.cjs electron/backend-probes.test.cjs electron/connection-config.test.cjs`
- `git diff --check`

Note: full `npm --prefix apps/desktop run lint` still reports existing unrelated lint errors in files outside this PR's diff.