### PR TITLE
feat(slack): add per-channel no_agent script handlers (channel_handlers)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -729,6 +729,18 @@ platform_toolsets:
 #   reactions: true                  # Show processing reactions (default: true)
 #   history_backfill: true           # Recover missed channel messages on mention (default: true)
 #   history_backfill_limit: 50       # Max messages to scan backwards (default: 50)
+#
+# Slack-specific settings (config.yaml top-level, not under platforms:):
+#
+# slack:
+#   # Per-channel no_agent script handlers — run a script on every plain user
+#   # message in a channel (the Slack analogue of webhook deliver_only). The
+#   # raw Slack event JSON is piped to the script on stdin; failures/timeouts
+#   # never affect normal message handling. @mentions still reach the agent.
+#   channel_handlers:
+#     C0123456789:                   # channel ID
+#       script: contact_spam_cleanup.py  # under ~/.hermes/scripts/ (or absolute path inside it)
+#       timeout: 120                 # seconds (default 60)
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Available toolsets (use these names in platform_toolsets or the toolsets list)

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -975,6 +975,14 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["group_user_allowed_commands"] = platform_cfg["group_user_allowed_commands"]
                 if plat in {Platform.DISCORD, Platform.SLACK} and "channel_skill_bindings" in platform_cfg:
                     bridged["channel_skill_bindings"] = platform_cfg["channel_skill_bindings"]
+                if plat == Platform.SLACK and "channel_handlers" in platform_cfg:
+                    channel_handlers = platform_cfg["channel_handlers"]
+                    if isinstance(channel_handlers, dict):
+                        bridged["channel_handlers"] = {
+                            str(k): v for k, v in channel_handlers.items()
+                        }
+                    else:
+                        bridged["channel_handlers"] = channel_handlers
                 if "channel_prompts" in platform_cfg:
                     channel_prompts = platform_cfg["channel_prompts"]
                     if isinstance(channel_prompts, dict):

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -338,6 +338,10 @@ class SlackAdapter(BasePlatformAdapter):
         # Dedup cache: prevents duplicate bot responses when Socket Mode
         # reconnects redeliver events.
         self._dedup = MessageDeduplicator()
+        # Live references to in-flight per-channel no_agent handler subprocess
+        # tasks (slack.channel_handlers).  Held so fire-and-forget tasks aren't
+        # garbage-collected before they finish.
+        self._channel_handler_tasks: set = set()
         # Track pending approval message_ts → resolved flag to prevent
         # double-clicks on approval buttons.
         self._approval_resolved: Dict[str, bool] = {}
@@ -2349,6 +2353,39 @@ class SlackAdapter(BasePlatformAdapter):
             channel_type = "im"
         is_dm = channel_type in {"im", "mpim"}  # Both 1:1 and group DMs
 
+        # ── Per-channel no_agent script handlers (channel_handlers) ─────────
+        # If this channel is mapped to a handler script, dispatch the raw
+        # Slack event to it as a fire-and-forget subprocess.  This is the
+        # Slack analogue of the webhook ``deliver_only`` contract: real-time
+        # deterministic channel automation (e.g. spam triage) without spawning
+        # an agent session and without a sidecar Socket Mode app.
+        #
+        # Important: the handler runs IN ADDITION to normal processing.  We do
+        # NOT return here — execution falls through to the existing mention /
+        # allowed-channel gates, so @mentions in a mapped channel still reach
+        # the agent.  Handler-only channels are achieved with the existing
+        # ``strict_mention`` behaviour; agent-path behaviour is unchanged.
+        #
+        # The bot/self, ``bot_message``, ``message_changed``/``message_deleted``
+        # skips above have already returned for non-plain-user events.  Guard
+        # the remaining thread-broadcast-of-our-own-send case explicitly: a
+        # ``thread_broadcast`` subtype authored by us must not feed the handler.
+        handler_cfg = self._slack_channel_handler_for(channel_id)
+        if handler_cfg is not None:
+            _msg_user = event.get("user", "")
+            _is_self = bool(
+                _msg_user and self._bot_user_id and _msg_user == self._bot_user_id
+            )
+            _is_broadcast = event.get("subtype") == "thread_broadcast"
+            if not _is_self and not (_is_broadcast and _is_self):
+                try:
+                    self._dispatch_channel_handler(channel_id, handler_cfg, event)
+                except Exception:  # pragma: no cover - defensive
+                    logger.exception(
+                        "[Slack] channel_handler dispatch failed channel=%s",
+                        channel_id,
+                    )
+
         # Build thread_ts for session keying.
         # In channels: fall back to ts so each top-level @mention starts a
         #   new thread/session (the bot always replies in a thread).
@@ -3667,6 +3704,229 @@ class SlackAdapter(BasePlatformAdapter):
             "yes",
             "on",
         }
+
+    def _slack_channel_handler_for(self, channel_id: str) -> Optional[dict]:
+        """Return the channel_handlers config for ``channel_id``, or None.
+
+        Config shape (under the ``slack`` platform's ``extra`` block)::
+
+            channel_handlers:
+              C4R0C7FPZ:
+                script: ab_contact_spam_cleanup.py
+                timeout: 120
+
+        Each entry maps a Slack channel ID to a no_agent handler script that
+        runs on every plain user message in that channel (see
+        ``_handle_slack_message``).  ``script`` is resolved the same way cron
+        no_agent scripts are — relative to ``HERMES_HOME/scripts/`` or an
+        absolute path inside that directory.  ``timeout`` is in seconds and
+        defaults to 60.  Returns a normalised ``{"script", "timeout"}`` dict.
+        """
+        if not channel_id:
+            return None
+        raw = self.config.extra.get("channel_handlers")
+        if not isinstance(raw, dict):
+            return None
+        entry = raw.get(channel_id)
+        if entry is None:
+            return None
+        # Accept either a bare string (script name) or a dict.
+        if isinstance(entry, str):
+            script = entry.strip()
+            timeout = 60
+        elif isinstance(entry, dict):
+            script = str(entry.get("script", "")).strip()
+            try:
+                timeout = int(float(entry.get("timeout", 60)))
+            except (TypeError, ValueError):
+                timeout = 60
+        else:
+            return None
+        if not script:
+            logger.warning(
+                "[Slack] channel_handlers entry for %s has no script — ignoring",
+                channel_id,
+            )
+            return None
+        if timeout <= 0:
+            timeout = 60
+        return {"script": script, "timeout": timeout}
+
+    def _resolve_handler_script_path(self, script: str) -> _Path:
+        """Resolve a channel_handler script path, mirroring cron's contract.
+
+        Relative names resolve under ``HERMES_HOME/scripts/``; absolute and
+        ``~``-prefixed paths are allowed but MUST stay inside that directory.
+        Raises ``ValueError`` on path-traversal / out-of-tree paths so the
+        caller can log and bail without executing anything.
+        """
+        from hermes_constants import get_hermes_home
+
+        scripts_dir = get_hermes_home() / "scripts"
+        scripts_dir_resolved = scripts_dir.resolve()
+
+        raw = _Path(script).expanduser()
+        if raw.is_absolute():
+            path = raw.resolve()
+        else:
+            path = (scripts_dir / raw).resolve()
+
+        try:
+            path.relative_to(scripts_dir_resolved)
+        except ValueError:
+            raise ValueError(
+                f"channel_handler script resolves outside the scripts "
+                f"directory ({scripts_dir_resolved}): {script!r}"
+            )
+        return path
+
+    def _dispatch_channel_handler(
+        self, channel_id: str, handler_cfg: dict, event: dict
+    ) -> None:
+        """Fire-and-forget the channel handler subprocess.
+
+        Schedules ``_run_channel_handler`` as a background task so handler
+        execution never blocks or delays the Slack adapter's event loop.
+        Exceptions inside the task are logged, never raised — a misbehaving
+        handler must not crash the gateway.
+        """
+        task = asyncio.create_task(
+            self._run_channel_handler(channel_id, handler_cfg, event)
+        )
+        # Keep a reference so the task isn't garbage-collected mid-flight, and
+        # surface any unexpected error via the done-callback.
+        self._channel_handler_tasks.add(task)
+        task.add_done_callback(self._channel_handler_tasks.discard)
+        task.add_done_callback(self._on_channel_handler_done)
+
+    def _on_channel_handler_done(self, task: "asyncio.Task") -> None:
+        """Log unexpected exceptions from a channel-handler task."""
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.error("[Slack] channel_handler task crashed: %r", exc)
+
+    async def _run_channel_handler(
+        self, channel_id: str, handler_cfg: dict, event: dict
+    ) -> None:
+        """Run a channel handler script with the Slack event JSON on stdin.
+
+        Mirrors the cron no_agent / webhook deliver_only subprocess contract:
+        the raw event JSON is piped on stdin, stdout/stderr are captured to
+        the gateway log at DEBUG, an INFO one-liner records channel/script/
+        exit-code/duration, and a timeout is enforced.  All failures are
+        swallowed (logged) so the adapter is never impacted.
+        """
+        script = handler_cfg["script"]
+        timeout = handler_cfg["timeout"]
+        try:
+            path = self._resolve_handler_script_path(script)
+        except ValueError as exc:
+            logger.error("[Slack] channel_handler %s", exc)
+            return
+        if not path.exists() or not path.is_file():
+            logger.error(
+                "[Slack] channel_handler script not found: %s (channel=%s)",
+                path,
+                channel_id,
+            )
+            return
+
+        # Pick an interpreter by extension — bash for .sh/.bash, the current
+        # Python for everything else — exactly as cron's _run_job_script does.
+        suffix = path.suffix.lower()
+        if suffix in {".sh", ".bash"}:
+            import shutil
+
+            _bash = shutil.which("bash") or (
+                "/bin/bash" if os.path.isfile("/bin/bash") else None
+            )
+            if _bash is None:
+                logger.error(
+                    "[Slack] channel_handler cannot run %s: bash not found",
+                    path.name,
+                )
+                return
+            argv = [_bash, str(path)]
+        else:
+            argv = [sys.executable, str(path)]
+
+        try:
+            payload = json.dumps(event).encode("utf-8")
+        except (TypeError, ValueError):
+            payload = b"{}"
+
+        start = time.monotonic()
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *argv,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=str(path.parent),
+            )
+        except Exception:
+            logger.exception(
+                "[Slack] channel_handler failed to spawn %s (channel=%s)",
+                path.name,
+                channel_id,
+            )
+            return
+
+        try:
+            stdout_b, stderr_b = await asyncio.wait_for(
+                proc.communicate(input=payload), timeout=timeout
+            )
+        except asyncio.TimeoutError:
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+            # Reap the killed process so it doesn't linger as a zombie.
+            try:
+                await proc.communicate()
+            except Exception:
+                pass
+            logger.warning(
+                "[Slack] channel_handler timed out after %ss channel=%s script=%s",
+                timeout,
+                channel_id,
+                path.name,
+            )
+            return
+        except Exception:
+            logger.exception(
+                "[Slack] channel_handler errored channel=%s script=%s",
+                channel_id,
+                path.name,
+            )
+            return
+
+        duration = time.monotonic() - start
+        stdout = (stdout_b or b"").decode("utf-8", "replace").strip()
+        stderr = (stderr_b or b"").decode("utf-8", "replace").strip()
+
+        # Redact secrets before logging captured output.
+        try:
+            from agent.redact import redact_sensitive_text
+
+            stdout = redact_sensitive_text(stdout)
+            stderr = redact_sensitive_text(stderr)
+        except Exception:
+            pass
+
+        logger.info(
+            "[Slack] channel_handler channel=%s script=%s exit=%s duration=%.2fs",
+            channel_id,
+            path.name,
+            proc.returncode,
+            duration,
+        )
+        if stdout:
+            logger.debug("[Slack] channel_handler stdout (%s): %s", path.name, stdout)
+        if stderr:
+            logger.debug("[Slack] channel_handler stderr (%s): %s", path.name, stderr)
 
     def _slack_free_response_channels(self) -> set:
         """Return channel IDs where no @mention is required."""

--- a/tests/gateway/test_slack_channel_handlers.py
+++ b/tests/gateway/test_slack_channel_handlers.py
@@ -1,0 +1,311 @@
+"""Tests for Slack per-channel no_agent script handlers (``channel_handlers``).
+
+These exercise the real ``SlackAdapter._handle_slack_message`` dispatch seam
+plus the ``_run_channel_handler`` subprocess runner.  The handler is the Slack
+analogue of the webhook ``deliver_only`` contract: on every plain user message
+in a mapped channel, a script is run as a fire-and-forget subprocess with the
+raw event JSON on stdin, and a handler failure/timeout must never break normal
+message handling.  @mentions in a mapped channel must still reach the agent.
+
+Conventions mirror ``test_slack_channel_session_scope.py``: ``handle_message``
+is the agent path (an ``AsyncMock``); driving the real
+``_handle_slack_message`` keeps the seam tight against production behaviour.
+"""
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig, load_gateway_config
+from gateway.platforms.slack import SlackAdapter
+
+
+MAPPED_CHANNEL = "C_MAPPED"
+UNMAPPED_CHANNEL = "C_OTHER"
+
+
+@pytest.fixture
+def adapter():
+    config = PlatformConfig(enabled=True, token="xoxb-fake-token")
+    a = SlackAdapter(config)
+    a._app = MagicMock()
+    a._app.client = AsyncMock()
+    a._bot_user_id = "U_BOT"
+    a._running = True
+    a.handle_message = AsyncMock()
+    # Map a channel to a handler. The script path is irrelevant for the
+    # dispatch-decision tests because we patch the runner; the runner tests
+    # below use a real tmp script via _run_channel_handler directly.
+    a.config.extra["channel_handlers"] = {
+        MAPPED_CHANNEL: {"script": "handler.py", "timeout": 30}
+    }
+    return a
+
+
+@pytest.fixture(autouse=True)
+def _redirect_cache(tmp_path, monkeypatch):
+    """Point document cache to tmp_path so tests don't touch ~/.hermes."""
+    monkeypatch.setattr(
+        "gateway.platforms.base.DOCUMENT_CACHE_DIR", tmp_path / "doc_cache"
+    )
+
+
+def _event(channel: str, text: str = "hello", **extra) -> dict:
+    event = {
+        "channel": channel,
+        "channel_type": "channel",
+        "user": "U_USER",
+        "text": text,
+        "ts": "1700000000.000001",
+    }
+    event.update(extra)
+    return event
+
+
+async def _drive(adapter, event):
+    """Run _handle_slack_message with user-resolution stubbed."""
+    with patch.object(
+        adapter, "_resolve_user_name", new=AsyncMock(return_value="testuser")
+    ):
+        await adapter._handle_slack_message(event)
+
+
+class TestDispatchDecision:
+    """Which messages get dispatched to the channel handler."""
+
+    @pytest.mark.asyncio
+    async def test_mapped_channel_dispatches(self, adapter):
+        with patch.object(adapter, "_dispatch_channel_handler") as disp:
+            await _drive(adapter, _event(MAPPED_CHANNEL))
+        assert disp.call_count == 1, "mapped channel must dispatch the handler"
+        args = disp.call_args.args
+        assert args[0] == MAPPED_CHANNEL
+        assert args[1] == {"script": "handler.py", "timeout": 30}
+        assert args[2]["channel"] == MAPPED_CHANNEL  # raw event passed through
+
+    @pytest.mark.asyncio
+    async def test_unmapped_channel_untouched(self, adapter):
+        with patch.object(adapter, "_dispatch_channel_handler") as disp:
+            await _drive(adapter, _event(UNMAPPED_CHANNEL))
+        assert disp.call_count == 0, "unmapped channel must not dispatch"
+
+    @pytest.mark.asyncio
+    async def test_self_message_skipped(self, adapter):
+        # A message authored by our own bot user must not feed the handler.
+        ev = _event(MAPPED_CHANNEL, user="U_BOT")
+        with patch.object(adapter, "_dispatch_channel_handler") as disp:
+            await _drive(adapter, ev)
+        assert disp.call_count == 0, "self-authored message must be skipped"
+
+    @pytest.mark.asyncio
+    async def test_bot_message_subtype_skipped(self, adapter):
+        # bot_message subtype is dropped before dispatch (default allow_bots).
+        ev = _event(MAPPED_CHANNEL, subtype="bot_message", bot_id="B123")
+        with patch.object(adapter, "_dispatch_channel_handler") as disp:
+            await _drive(adapter, ev)
+        assert disp.call_count == 0, "bot_message subtype must be skipped"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("subtype", ["message_changed", "message_deleted"])
+    async def test_edit_delete_subtypes_skipped(self, adapter, subtype):
+        ev = _event(MAPPED_CHANNEL, subtype=subtype)
+        with patch.object(adapter, "_dispatch_channel_handler") as disp:
+            await _drive(adapter, ev)
+        assert disp.call_count == 0, f"{subtype} must be skipped"
+
+    @pytest.mark.asyncio
+    async def test_self_thread_broadcast_skipped(self, adapter):
+        ev = _event(MAPPED_CHANNEL, subtype="thread_broadcast", user="U_BOT")
+        with patch.object(adapter, "_dispatch_channel_handler") as disp:
+            await _drive(adapter, ev)
+        assert disp.call_count == 0, "self thread-broadcast must be skipped"
+
+
+class TestRunsInAdditionToAgent:
+    """Handler runs in addition to normal processing — @mentions in a mapped
+    channel must still reach the agent path."""
+
+    @pytest.mark.asyncio
+    async def test_mention_in_mapped_channel_still_reaches_agent(self, adapter):
+        captured = []
+        adapter.handle_message = AsyncMock(side_effect=lambda e: captured.append(e))
+        with patch.object(adapter, "_dispatch_channel_handler") as disp:
+            await _drive(adapter, _event(MAPPED_CHANNEL, text="<@U_BOT> ping"))
+        assert disp.call_count == 1, "handler still fires on the mention"
+        assert len(captured) == 1, (
+            "an @mention in a mapped channel must still reach the agent path "
+            "— channel_handlers must not short-circuit agent processing"
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_mention_in_mapped_channel_does_not_reach_agent(self, adapter):
+        # Default gating: a non-mention channel message is dropped from the
+        # agent path, but the handler still fires. This is the spam-triage
+        # case: deterministic handling without an agent session.
+        captured = []
+        adapter.handle_message = AsyncMock(side_effect=lambda e: captured.append(e))
+        with patch.object(adapter, "_dispatch_channel_handler") as disp:
+            await _drive(adapter, _event(MAPPED_CHANNEL, text="buy cheap stuff"))
+        assert disp.call_count == 1, "handler fires on the non-mention message"
+        assert len(captured) == 0, (
+            "a plain non-mention message must not reach the agent under "
+            "default mention gating — only the handler runs"
+        )
+
+
+class TestConfigResolution:
+    """``_slack_channel_handler_for`` normalisation."""
+
+    def test_dict_entry(self, adapter):
+        cfg = adapter._slack_channel_handler_for(MAPPED_CHANNEL)
+        assert cfg == {"script": "handler.py", "timeout": 30}
+
+    def test_bare_string_entry_uses_default_timeout(self, adapter):
+        adapter.config.extra["channel_handlers"] = {MAPPED_CHANNEL: "s.py"}
+        assert adapter._slack_channel_handler_for(MAPPED_CHANNEL) == {
+            "script": "s.py",
+            "timeout": 60,
+        }
+
+    def test_unmapped_returns_none(self, adapter):
+        assert adapter._slack_channel_handler_for(UNMAPPED_CHANNEL) is None
+
+    def test_no_channel_handlers_config_returns_none(self, adapter):
+        adapter.config.extra.pop("channel_handlers", None)
+        assert adapter._slack_channel_handler_for(MAPPED_CHANNEL) is None
+
+    def test_empty_script_ignored(self, adapter):
+        adapter.config.extra["channel_handlers"] = {MAPPED_CHANNEL: {"script": "  "}}
+        assert adapter._slack_channel_handler_for(MAPPED_CHANNEL) is None
+
+    def test_nonpositive_timeout_falls_back_to_default(self, adapter):
+        adapter.config.extra["channel_handlers"] = {
+            MAPPED_CHANNEL: {"script": "s.py", "timeout": 0}
+        }
+        assert adapter._slack_channel_handler_for(MAPPED_CHANNEL)["timeout"] == 60
+
+
+class TestScriptPathResolution:
+    """Path resolution mirrors cron's contract: relative under
+    HERMES_HOME/scripts, traversal blocked."""
+
+    def test_relative_resolves_under_scripts_dir(self, adapter, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_constants.get_hermes_home", lambda: tmp_path
+        )
+        path = adapter._resolve_handler_script_path("handler.py")
+        assert path == (tmp_path / "scripts" / "handler.py").resolve()
+
+    def test_traversal_is_blocked(self, adapter, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_constants.get_hermes_home", lambda: tmp_path
+        )
+        with pytest.raises(ValueError):
+            adapter._resolve_handler_script_path("../../etc/passwd")
+
+
+class TestRunChannelHandlerSubprocess:
+    """The real subprocess runner: stdin payload, timeout, and failure
+    isolation."""
+
+    @pytest.mark.asyncio
+    async def test_runs_script_and_passes_event_on_stdin(
+        self, adapter, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir(parents=True, exist_ok=True)
+        out_file = tmp_path / "received.json"
+        script = scripts_dir / "handler.py"
+        script.write_text(
+            "import sys, json, pathlib\n"
+            "data = sys.stdin.read()\n"
+            f"pathlib.Path(r'{out_file}').write_text(data)\n"
+        )
+
+        event = _event(MAPPED_CHANNEL, text="spam?")
+        await adapter._run_channel_handler(
+            MAPPED_CHANNEL, {"script": "handler.py", "timeout": 30}, event
+        )
+
+        assert out_file.exists(), "handler did not run / did not read stdin"
+        received = json.loads(out_file.read_text())
+        assert received["channel"] == MAPPED_CHANNEL
+        assert received["text"] == "spam?"
+
+    @pytest.mark.asyncio
+    async def test_timeout_does_not_raise(self, adapter, tmp_path, monkeypatch):
+        monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir(parents=True, exist_ok=True)
+        script = scripts_dir / "slow.py"
+        script.write_text("import time\ntime.sleep(5)\n")
+
+        # timeout=1 < sleep 5 → must time out, kill the proc, and return
+        # cleanly without raising.
+        await adapter._run_channel_handler(
+            MAPPED_CHANNEL, {"script": "slow.py", "timeout": 1}, _event(MAPPED_CHANNEL)
+        )
+
+    @pytest.mark.asyncio
+    async def test_missing_script_does_not_raise(self, adapter, tmp_path, monkeypatch):
+        monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+        (tmp_path / "scripts").mkdir(parents=True, exist_ok=True)
+        await adapter._run_channel_handler(
+            MAPPED_CHANNEL, {"script": "nope.py", "timeout": 5}, _event(MAPPED_CHANNEL)
+        )
+
+    @pytest.mark.asyncio
+    async def test_nonzero_exit_does_not_raise(self, adapter, tmp_path, monkeypatch):
+        monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir(parents=True, exist_ok=True)
+        script = scripts_dir / "boom.py"
+        script.write_text("import sys\nsys.exit(3)\n")
+        await adapter._run_channel_handler(
+            MAPPED_CHANNEL, {"script": "boom.py", "timeout": 5}, _event(MAPPED_CHANNEL)
+        )
+
+
+class TestConfigBridging:
+    """``slack.channel_handlers`` from config.yaml must reach the adapter's
+    ``config.extra`` — otherwise the dispatch never sees the mapping."""
+
+    def test_channel_handlers_bridged_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "slack:\n"
+            "  channel_handlers:\n"
+            "    C4R0C7FPZ:\n"
+            "      script: ab_contact_spam_cleanup.py\n"
+            "      timeout: 120\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+        slack_cfg = config.platforms.get(Platform.SLACK)
+        assert slack_cfg is not None
+        assert slack_cfg.extra.get("channel_handlers") == {
+            "C4R0C7FPZ": {"script": "ab_contact_spam_cleanup.py", "timeout": 120}
+        }
+
+
+class TestDispatchFailureIsolation:
+    """A handler dispatch error must never break message handling."""
+
+    @pytest.mark.asyncio
+    async def test_dispatch_exception_does_not_break_handling(self, adapter):
+        # Make dispatch raise; the message handler must still complete and the
+        # agent path must still be reached for an @mention.
+        captured = []
+        adapter.handle_message = AsyncMock(side_effect=lambda e: captured.append(e))
+        with patch.object(
+            adapter, "_dispatch_channel_handler", side_effect=RuntimeError("boom")
+        ):
+            await _drive(adapter, _event(MAPPED_CHANNEL, text="<@U_BOT> hi"))
+        assert len(captured) == 1, (
+            "a channel_handler dispatch error must be swallowed and must not "
+            "prevent the agent path from running"
+        )

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -421,6 +421,52 @@ Behavior:
 
 See also: [admin/user slash command split](../../reference/slash-commands.md#permissions-and-adminuser-split).
 
+### Per-channel script handlers (`channel_handlers`)
+
+Run a deterministic **no_agent** script on every plain user message in a
+specific channel — the Slack analogue of the webhook adapter's `deliver_only`
+mode. This gives you real-time, zero-LLM-cost channel automation (e.g. spam
+triage, intake routing, logging) **without** standing up a separate Socket
+Mode sidecar app or polling on a cron.
+
+```yaml
+slack:
+  channel_handlers:
+    C4R0C7FPZ:                       # channel ID → handler
+      script: contact_spam_cleanup.py  # under ~/.hermes/scripts/ (or an absolute path inside it)
+      timeout: 120                     # seconds; default 60
+```
+
+A bare string is also accepted as shorthand for `{script: <name>}` with the
+default timeout:
+
+```yaml
+slack:
+  channel_handlers:
+    C4R0C7FPZ: contact_spam_cleanup.py
+```
+
+How it works:
+
+- On each incoming message in a mapped channel, the **raw Slack event JSON** is
+  piped to the script on **stdin**, and the script runs as a subprocess. The
+  script is resolved exactly like cron no_agent scripts — a bare name resolves
+  under `~/.hermes/scripts/`; absolute / `~`-prefixed paths are allowed but must
+  stay inside that directory (path traversal is blocked).
+- `.sh`/`.bash` scripts run under `bash`; everything else runs under the active
+  Python interpreter.
+- The handler is **fire-and-forget**: it runs on a background task with a
+  bounded timeout, and a handler crash, non-zero exit, or timeout **never**
+  delays or breaks normal message handling. stdout/stderr are captured to the
+  gateway log at DEBUG, with an INFO one-liner recording channel, script, exit
+  code, and duration.
+- The handler runs **in addition to** normal processing. Bot/self messages,
+  `bot_message`, `message_changed`/`message_deleted`, and thread broadcasts of
+  the bot's own sends are skipped. After dispatch, execution falls through to
+  the usual gating, so `@mentions` in a mapped channel still reach the agent.
+  For a handler-only channel (no agent path), combine this with
+  [`strict_mention`](#mention--trigger-behavior).
+
 ### Unauthorized User Handling
 
 ```yaml


### PR DESCRIPTION
## What does this PR do?

Adds **`slack.channel_handlers`** — a config map from Slack channel ID to a `no_agent` handler script. On every plain user message in a mapped channel, the raw Slack event JSON is piped to the script on stdin and run as a fire-and-forget subprocess. It is the **Slack analogue of the webhook adapter's `deliver_only`** contract.

**Why:** Today every reacted-to Slack message necessarily spawns a full agent session, and `strict_mention` simply drops non-mention messages — there is no non-agent hook point for a channel. Deterministic, real-time per-channel handling (e.g. spam triage in a #contact channel, intake routing, logging) is therefore only possible via a polling cron or a separate sidecar Socket Mode app (token duplication + event load-balancing hazard). This adds the missing dispatch point so the gateway, which already receives these messages in real time over Socket Mode, can run a deterministic handler with zero LLM cost.

Motivating case: a deployment currently runs an every-2h cron poll purely to triage #contact spam, only because the gateway has no non-agent dispatch for inbound channel messages.

## Related Issue

No existing issue/PR — searched issues and PRs for "channel handler", "slack script", "deliver_only slack", "no_agent slack", "channel automation", and `channel_handlers`. The nearest neighbors are different concerns: #22262 routes channels to different agent *profiles* (still the agent path), #26474 is cron structured payloads, #22714 is a Matrix per-request LLM-dispatcher hook, and #10572 is a webhook script param. None provide a Slack-channel no_agent subprocess dispatch.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/platforms/slack.py`:
  - Dispatch in `_handle_slack_message` **before** the mention/allowed-channel gate, after the existing bot/self, `bot_message`, `message_changed`/`message_deleted`, and self `thread_broadcast` skips. The handler runs **in addition to** normal processing — execution falls through to the existing gates, so `@mentions` in a mapped channel still reach the agent. Handler-only channels are achieved via the existing `strict_mention` behavior (agent-path behavior is unchanged).
  - `_slack_channel_handler_for()` (config normalization; accepts a dict `{script, timeout}` or a bare script-name string), `_resolve_handler_script_path()` (mirrors cron's contract: relative under `HERMES_HOME/scripts/`, traversal blocked), `_dispatch_channel_handler()` (fire-and-forget task with reference-holding + done-callback), and `_run_channel_handler()` (async subprocess; raw event JSON on stdin; `.sh`/`.bash` via bash else the active Python; bounded timeout default 60s; stdout/stderr captured to the gateway log at DEBUG with an INFO one-liner: channel/script/exit/duration; secrets redacted; **all failures/timeouts swallowed** so the adapter is never delayed or crashed).
- `website/docs/user-guide/messaging/slack.md`: new "Per-channel script handlers (`channel_handlers`)" section.
- `cli-config.yaml.example`: documented `slack.channel_handlers` block.
- `tests/gateway/test_slack_channel_handlers.py`: 22 tests.

## How to Test

```bash
scripts/run_tests.sh tests/gateway/test_slack_channel_handlers.py
```

Manual: add to `config.yaml`
```yaml
slack:
  channel_handlers:
    C0123456789:
      script: my_handler.py   # ~/.hermes/scripts/my_handler.py, reads event JSON on stdin
      timeout: 120
```
Post a non-mention message in that channel → the script runs (gateway log shows `[Slack] channel_handler channel=... script=... exit=0 duration=...`). `@mention` the bot in the same channel → the agent still responds.

Coverage added:
- mapped channel dispatches; unmapped channel untouched
- bot/self messages skipped; `bot_message` / `message_changed` / `message_deleted` / self `thread_broadcast` skipped
- handler missing-script / non-zero-exit / timeout do not raise and do not break message handling
- a dispatch exception is swallowed and the agent path still runs
- `@mention` in a mapped channel still reaches the agent; a plain non-mention message reaches only the handler (not the agent) under default mention gating
- config normalization (dict + bare-string forms, defaults) and script-path traversal blocking

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run the tests and all pass (22 new + 307 existing slack tests green via `scripts/run_tests.sh`)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux / WSL2 (Ubuntu, Python 3)

### Documentation & Housekeeping
- [x] I've updated relevant documentation (`docs/`, docstrings)
- [x] I've updated `cli-config.yaml.example` for the new config key
- [x] N/A — no architecture/workflow change
- [x] I've considered cross-platform impact: interpreter resolution mirrors cron (`shutil.which("bash")` fallback), `pathlib` throughout, async subprocess — no Unix-only assumptions
- [x] N/A — no tool behavior change
