### PR TITLE
fix: allow PR governance review cards through active_pr guard

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4859,6 +4859,25 @@ _RESPAWN_GUARD_PR_URL_RE = re.compile(
     re.IGNORECASE,
 )
 
+_PR_REVIEW_WATCHDOG_AUTHOR = "pr-review-watchdog"
+_PR_GOVERNANCE_TITLE_PREFIXES = (
+    "review-required:",
+    "needs_dev_fixes:",
+    "waiting_author_ready:",
+    "orion_approved_waiting_merge:",
+    "stale_requires_decision:",
+    "merged_needs_deploy_verify:",
+)
+
+
+def _is_pr_governance_task(row: sqlite3.Row) -> bool:
+    """Return True for watchdog-created PR governance/escalation tasks."""
+    created_by = (row["created_by"] or "").strip().casefold()
+    if created_by == _PR_REVIEW_WATCHDOG_AUTHOR:
+        return True
+    title = (row["title"] or "").strip().casefold()
+    return title.startswith(_PR_GOVERNANCE_TITLE_PREFIXES)
+
 
 @dataclass
 class DispatchResult:
@@ -5886,8 +5905,11 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
 
     ``"active_pr"``
         A GitHub PR URL appears in a recent task comment (within
-        ``_RESPAWN_GUARD_PR_WINDOW`` seconds).  A prior worker already
-        opened a PR; re-spawning risks a duplicate PR on the same task.
+        ``_RESPAWN_GUARD_PR_WINDOW`` seconds) on a normal implementation
+        task.  A prior worker already opened a PR; re-spawning risks a
+        duplicate PR on the same task.  PR-governance/watchdog tasks are
+        exempt because their comments can legitimately cite existing PRs
+        as evidence.
 
     Stale / dead claim locks are NOT a guard reason — they are handled
     by ``release_stale_claims`` and ``detect_crashed_workers`` which
@@ -5895,7 +5917,7 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
     genuinely dead (no live PID on this host).
     """
     row = conn.execute(
-        "SELECT last_failure_error FROM tasks WHERE id = ?",
+        "SELECT title, created_by, last_failure_error FROM tasks WHERE id = ?",
         (task_id,),
     ).fetchone()
     if row is None:
@@ -5954,13 +5976,26 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
         return "recent_success"
 
     # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
+    #    Do not apply this guard to PR governance/watchdog tasks; those tasks
+    #    cite existing pull requests as evidence and must still dispatch.
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
+    pr_comments = []
     for c in conn.execute(
-        "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
+        "SELECT author, body FROM task_comments "
+        "WHERE task_id = ? AND created_at >= ?",
         (task_id, pr_cutoff),
     ).fetchall():
         if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
-            return "active_pr"
+            pr_comments.append(c)
+    if pr_comments:
+        if _is_pr_governance_task(row):
+            return None
+        if all(
+            (c["author"] or "").strip().casefold() == _PR_REVIEW_WATCHDOG_AUTHOR
+            for c in pr_comments
+        ):
+            return None
+        return "active_pr"
 
     return None
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4868,15 +4868,23 @@ _PR_GOVERNANCE_TITLE_PREFIXES = (
     "stale_requires_decision:",
     "merged_needs_deploy_verify:",
 )
+_PR_GOVERNANCE_ASSIGNEES = ("orion",)
+_PR_GOVERNANCE_TITLE_HINT_RE = re.compile(r"\bPR\s*#\d+\b", re.IGNORECASE)
 
 
 def _is_pr_governance_task(row: sqlite3.Row) -> bool:
-    """Return True for watchdog-created PR governance/escalation tasks."""
+    """Return True for PR governance/review/merge handoff tasks."""
     created_by = (row["created_by"] or "").strip().casefold()
     if created_by == _PR_REVIEW_WATCHDOG_AUTHOR:
         return True
     title = (row["title"] or "").strip().casefold()
-    return title.startswith(_PR_GOVERNANCE_TITLE_PREFIXES)
+    if title.startswith(_PR_GOVERNANCE_TITLE_PREFIXES):
+        return True
+    assignee = (row["assignee"] or "").strip().casefold()
+    return (
+        assignee in _PR_GOVERNANCE_ASSIGNEES
+        and bool(_PR_GOVERNANCE_TITLE_HINT_RE.search(title))
+    )
 
 
 @dataclass
@@ -5917,7 +5925,8 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
     genuinely dead (no live PID on this host).
     """
     row = conn.execute(
-        "SELECT title, created_by, last_failure_error FROM tasks WHERE id = ?",
+        "SELECT title, assignee, created_by, last_failure_error "
+        "FROM tasks WHERE id = ?",
         (task_id,),
     ).fetchone()
     if row is None:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1764,6 +1764,51 @@ def test_respawn_guard_allows_pr_governance_title_prefixes(
     assert reason is None
 
 
+def test_respawn_guard_allows_orion_pr_review_handoff_title(
+    kanban_home,
+):
+    """Ready Orion PR handoff cards must dispatch even with PR evidence comments."""
+    with kb.connect() as conn:
+        t = kb.create_task(
+            conn,
+            title="Fix PR #197 duplicate Rust test definitions",
+            assignee="orion",
+            created_by="orion",
+        )
+        kb.add_comment(
+            conn, t, "dev",
+            "Review-ready handoff: https://github.com/org/repo/pull/197",
+        )
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason is None
+
+
+def test_dispatch_spawns_orion_pr_review_handoff_despite_active_pr_comment(
+    kanban_home, all_assignees_spawnable
+):
+    """Regression: active_pr must not strand Orion review cards in ready."""
+    spawned_ids = []
+
+    def fake_spawn(task, workspace):
+        spawned_ids.append(task.id)
+
+    with kb.connect() as conn:
+        t = kb.create_task(
+            conn,
+            title="Fix PR #197 duplicate Rust test definitions",
+            assignee="orion",
+            created_by="orion",
+        )
+        kb.add_comment(
+            conn, t, "dev",
+            "Review-ready handoff: https://github.com/org/repo/pull/197",
+        )
+        res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+
+    assert t in spawned_ids
+    assert (t, "active_pr") not in res.respawn_guarded
+
+
 def test_respawn_guard_allows_only_watchdog_authored_recent_pr_comments(
     kanban_home,
 ):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1722,6 +1722,81 @@ def test_respawn_guard_active_pr_in_comment(kanban_home):
     assert reason == "active_pr"
 
 
+def test_respawn_guard_allows_watchdog_created_governance_pr_comment(kanban_home):
+    """Watchdog-created PR governance tasks cite existing PRs as evidence."""
+    with kb.connect() as conn:
+        t = kb.create_task(
+            conn,
+            title="needs_dev_fixes: org/repo PR #42",
+            assignee="alice",
+            created_by="pr-review-watchdog",
+        )
+        kb.add_comment(
+            conn, t, "pr-review-watchdog",
+            "Existing PR evidence: https://github.com/org/repo/pull/42",
+        )
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason is None
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "review-required: org/repo PR #42",
+        "needs_dev_fixes: org/repo PR #42",
+        "waiting_author_ready: org/repo PR #42",
+        "orion_approved_waiting_merge: org/repo PR #42",
+        "stale_requires_decision: org/repo PR #42",
+        "merged_needs_deploy_verify: org/repo PR #42",
+    ],
+)
+def test_respawn_guard_allows_pr_governance_title_prefixes(
+    kanban_home, title
+):
+    """PR governance title prefixes bypass active_pr even with PR evidence."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title=title, assignee="alice")
+        kb.add_comment(
+            conn, t, "orion",
+            "Governance evidence: https://github.com/org/repo/pull/42",
+        )
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason is None
+
+
+def test_respawn_guard_allows_only_watchdog_authored_recent_pr_comments(
+    kanban_home,
+):
+    """A normal task is not guarded when every recent PR URL is watchdog evidence."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="implementation task", assignee="alice")
+        kb.add_comment(
+            conn, t, "pr-review-watchdog",
+            "Existing PR evidence: https://github.com/org/repo/pull/42",
+        )
+        kb.add_comment(conn, t, "worker", "No PR URL in this comment")
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason is None
+
+
+def test_respawn_guard_keeps_active_pr_for_normal_worker_pr_comment(
+    kanban_home,
+):
+    """Normal implementation tasks with worker-created PR URLs stay guarded."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="implementation task", assignee="alice")
+        kb.add_comment(
+            conn, t, "pr-review-watchdog",
+            "Related PR evidence: https://github.com/org/repo/pull/41",
+        )
+        kb.add_comment(
+            conn, t, "worker",
+            "Opened fix PR: https://github.com/org/repo/pull/42",
+        )
+        reason = kb.check_respawn_guard(conn, t)
+    assert reason == "active_pr"
+
+
 def test_respawn_guard_old_pr_comment_not_guarded(kanban_home):
     """A GitHub PR URL in a comment older than the PR window does not block."""
     with kb.connect() as conn:


### PR DESCRIPTION
## Summary
- Exempt PR governance/watchdog tasks from the Kanban active_pr respawn guard.
- Treat Orion-assigned PR-number handoff cards as review/merge governance, so existing PR evidence comments do not strand them in ready.
- Add regression coverage for the PR #197-style Orion review handoff and existing active_pr behavior.

## Test Plan
- python -m pytest tests/hermes_cli/test_kanban_db.py -k 'respawn_guard or active_pr or pr_review_handoff' -q
- python -m pytest tests/hermes_cli/test_kanban_db.py -q

## Live verification
- On the current Kanban DB, kb.check_respawn_guard(conn, 't_9184cd2c') returns None with this branch loaded.

Fixes Kanban dispatcher stall for t_9184cd2c / PR #197 review handoff.