### PR TITLE
fix(telegram): make command menu configurable

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -105,7 +105,7 @@ _TELEGRAM_IMAGE_EXT_TO_MIME = {
 }
 
 
-MAX_COMMANDS_PER_SCOPE = 30
+DEFAULT_MAX_COMMANDS_PER_SCOPE = 30
 
 
 def check_telegram_requirements() -> bool:
@@ -1739,11 +1739,12 @@ class TelegramAdapter(BasePlatformAdapter):
                     BotCommandScopeAllGroupChats,
                     BotCommandScopeDefault,
                 )
-                from hermes_cli.commands import telegram_menu_commands
-                # Telegram allows up to 100 commands but has an undocumented
-                # payload size limit (~4KB total).  Limit to 30 core commands
-                # to stay well under the threshold while covering all categories.
-                menu_commands, hidden_count = telegram_menu_commands(max_commands=MAX_COMMANDS_PER_SCOPE)
+                from hermes_cli.commands import telegram_max_commands_per_scope, telegram_menu_commands
+                # Telegram supports up to 100 commands per scope.  The default
+                # stays conservative, but operators can raise/lower it with
+                # gateway.telegram.max_commands_per_scope.
+                max_commands = telegram_max_commands_per_scope(DEFAULT_MAX_COMMANDS_PER_SCOPE)
+                menu_commands, hidden_count = telegram_menu_commands(max_commands=max_commands)
                 bot_commands = [BotCommand(name, desc) for name, desc in menu_commands]
                 # Register for all scopes independently — Telegram picks the
                 # narrowest matching scope per chat type (forum topics fall
@@ -1762,7 +1763,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 if hidden_count:
                     logger.info(
                         "[%s] Telegram menu: %d commands registered, %d hidden (over %d limit). Use /commands for full list.",
-                        self.name, len(menu_commands), hidden_count, 30,
+                        self.name, len(menu_commands), hidden_count, max_commands,
                     )
             except Exception as e:
                 logger.warning(
@@ -5319,8 +5320,9 @@ class TelegramAdapter(BasePlatformAdapter):
                 if chat_id in self._forum_command_registered:
                     return
                 from telegram import BotCommand, BotCommandScopeChat
-                from hermes_cli.commands import telegram_menu_commands
-                menu_commands, _ = telegram_menu_commands(max_commands=MAX_COMMANDS_PER_SCOPE)
+                from hermes_cli.commands import telegram_max_commands_per_scope, telegram_menu_commands
+                max_commands = telegram_max_commands_per_scope(DEFAULT_MAX_COMMANDS_PER_SCOPE)
+                menu_commands, _ = telegram_menu_commands(max_commands=max_commands)
                 bot_commands = [BotCommand(name, desc) for name, desc in menu_commands]
                 await self._bot.set_my_commands(bot_commands, scope=BotCommandScopeChat(chat_id=chat_id))
                 self._forum_command_registered.add(chat_id)

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -522,7 +522,69 @@ def telegram_bot_commands() -> list[tuple[str, str]]:
         tg_name = _sanitize_telegram_name(name)
         if tg_name:
             result.append((tg_name, description))
-    return result
+    return _dedupe_command_names(result)
+
+
+def _dedupe_command_names(
+    commands: list[tuple[str, str]],
+) -> list[tuple[str, str]]:
+    """Drop duplicate command names while preserving first-seen order."""
+    seen: set[str] = set()
+    deduped: list[tuple[str, str]] = []
+    for name, description in commands:
+        if name in seen:
+            continue
+        seen.add(name)
+        deduped.append((name, description))
+    return deduped
+
+
+def _telegram_config() -> dict[str, Any]:
+    """Return the optional ``gateway.telegram`` config block."""
+    try:
+        from hermes_cli.config import read_raw_config
+
+        cfg = read_raw_config() or {}
+    except Exception:
+        return {}
+    gateway_cfg = cfg.get("gateway")
+    if not isinstance(gateway_cfg, dict):
+        return {}
+    telegram_cfg = gateway_cfg.get("telegram")
+    return telegram_cfg if isinstance(telegram_cfg, dict) else {}
+
+
+def telegram_max_commands_per_scope(default: int = 30) -> int:
+    """Return the configured Telegram BotCommand cap, clamped to API bounds."""
+    value = _telegram_config().get("max_commands_per_scope", default)
+    try:
+        max_commands = int(value)
+    except (TypeError, ValueError):
+        max_commands = default
+    return max(1, min(100, max_commands))
+
+
+def _configured_telegram_menu_priority() -> tuple[str, ...]:
+    """Return user-configured command names to pin before defaults."""
+    value = _telegram_config().get("menu_priority", ())
+    if isinstance(value, str):
+        raw_items = [value]
+    elif isinstance(value, (list, tuple)):
+        raw_items = list(value)
+    else:
+        raw_items = []
+
+    priority: list[str] = []
+    seen: set[str] = set()
+    for raw in raw_items:
+        if not isinstance(raw, str):
+            continue
+        name = _sanitize_telegram_name(raw.lstrip("/"))
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        priority.append(name)
+    return tuple(priority)
 
 
 _TELEGRAM_MENU_PRIORITY = (
@@ -565,10 +627,15 @@ need to survive the visible menu cap ahead of lower-priority built-ins.
 def _prioritize_telegram_menu_commands(
     commands: list[tuple[str, str]],
 ) -> list[tuple[str, str]]:
-    priority = {
-        _sanitize_telegram_name(name): index
-        for index, name in enumerate(_TELEGRAM_MENU_PRIORITY)
-    }
+    priority_names = (
+        _configured_telegram_menu_priority()
+        + tuple(
+            name
+            for name in (_sanitize_telegram_name(n) for n in _TELEGRAM_MENU_PRIORITY)
+            if name
+        )
+    )
+    priority = {name: index for index, name in enumerate(dict.fromkeys(priority_names))}
     return [
         command
         for _index, command in sorted(

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2278,6 +2278,19 @@ DEFAULT_CONFIG = {
         # multi-tool agent turn. Bridged to HERMES_MEDIA_TRUST_RECENT_SECONDS.
         # Only consulted when ``strict`` is true.
         "trust_recent_files_seconds": 600,
+        # Telegram BotCommand menu controls. Telegram supports up to 100
+        # commands per scope, but Hermes keeps the historical 30-command
+        # default to avoid overwhelming small installs. Raise this when
+        # install-specific commands or many skills should be visible in
+        # Telegram slash autocomplete.
+        "telegram": {
+            "max_commands_per_scope": 30,
+            # Command names to pin before the built-in menu priority list.
+            # Names may be written with or without the leading slash, and
+            # hyphenated commands are normalized to Telegram underscores.
+            # Example: ["foo", "bar-baz"]
+            "menu_priority": [],
+        },
     },
 
     # Real-time token streaming to messaging platforms (Telegram, Discord,

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -26,6 +26,7 @@ from hermes_cli.commands import (
     slack_native_slashes,
     slack_subcommand_map,
     telegram_bot_commands,
+    telegram_max_commands_per_scope,
     telegram_menu_commands,
 )
 
@@ -1153,6 +1154,66 @@ class TestTelegramMenuCommands:
             "status",
         ):
             assert name in names
+
+
+    def test_telegram_menu_limit_reads_gateway_config(self, tmp_path, monkeypatch):
+        (tmp_path / "config.yaml").write_text(
+            "gateway:\n"
+            "  telegram:\n"
+            "    max_commands_per_scope: 42\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        assert telegram_max_commands_per_scope() == 42
+
+    def test_telegram_menu_limit_clamps_to_bot_api_cap(self, tmp_path, monkeypatch):
+        (tmp_path / "config.yaml").write_text(
+            "gateway:\n"
+            "  telegram:\n"
+            "    max_commands_per_scope: 500\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        assert telegram_max_commands_per_scope() == 100
+
+    def test_configured_telegram_menu_priority_pins_commands(self, tmp_path, monkeypatch):
+        (tmp_path / "config.yaml").write_text(
+            "gateway:\n"
+            "  telegram:\n"
+            "    menu_priority:\n"
+            "      - whoami\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        menu, _ = telegram_menu_commands(max_commands=5)
+
+        assert [name for name, _desc in menu][0] == "whoami"
+
+    def test_dedupes_sanitized_plugin_command_names(self, tmp_path, monkeypatch):
+        """Hyphen/underscore plugin aliases should not waste Telegram menu slots."""
+        from unittest.mock import patch
+        import hermes_cli.plugins as plugins_mod
+
+        plugin_dir = tmp_path / "plugins" / "dupe-plugin"
+        plugin_dir.mkdir(parents=True, exist_ok=True)
+        (plugin_dir / "plugin.yaml").write_text(
+            "name: dupe-plugin\nversion: 0.1.0\ndescription: Test plugin\n"
+        )
+        (plugin_dir / "__init__.py").write_text(
+            "def register(ctx):\n"
+            "    ctx.register_command('ops-check', lambda args: 'ok', description='Ops check')\n"
+            "    ctx.register_command('ops_check', lambda args: 'ok', description='Ops check alias')\n"
+        )
+        (tmp_path / "config.yaml").write_text(
+            "plugins:\n  enabled:\n    - dupe-plugin\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        with patch.object(plugins_mod, "_plugin_manager", None):
+            menu, _ = telegram_menu_commands(max_commands=100)
+
+        names = [name for name, _desc in menu]
+        assert names.count("ops_check") == 1
 
     def test_includes_plugin_commands_via_lazy_discovery(self, tmp_path, monkeypatch):
         """Telegram menu generation should discover plugin slash commands on first access."""


### PR DESCRIPTION
## Summary
- Add `gateway.telegram.max_commands_per_scope` so Telegram BotCommand menu size can be configured per install/profile, clamped to Telegram's 100-command limit.
- Add `gateway.telegram.menu_priority` so operators can pin important commands ahead of the built-in menu priority list.
- Dedupe sanitized Telegram command names so hyphen/underscore aliases do not waste visible menu slots.

## Why
Telegram command menus can overflow once an install has many commands and skills enabled. Until now the adapter used a hardcoded 30-command cap and hardcoded priority list, which made install-specific command visibility require source edits. These knobs move that policy into config while preserving the existing default behavior.

## Test Plan
- `python3 -m py_compile hermes_cli/commands.py gateway/platforms/telegram.py tests/hermes_cli/test_commands.py`
- `python3 -m pytest tests/hermes_cli/test_commands.py -q`
- `python3 -m pytest tests/gateway/test_telegram_forum_commands.py -q`
- `python3 -m ruff check --no-fix gateway/platforms/telegram.py hermes_cli/commands.py hermes_cli/config.py tests/hermes_cli/test_commands.py`
