### PR TITLE
fix(cli): show all session sources in /sessions command (#44964)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5741,7 +5741,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             return []
         try:
             sessions = self._session_db.list_sessions_rich(
-                source="cli",
                 exclude_sources=["tool"],
                 limit=limit,
             )


### PR DESCRIPTION
## What does this PR do?

The `/sessions` CLI command was hiding sessions created from the TUI, web dashboard, and gateway platforms (Telegram, WhatsApp) because it filtered by `source="cli"`.

## Related Issue

Closes #44964

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

1. **cli.py** — Removed the `source="cli"` filter from `_list_recent_sessions()`, keeping only `exclude_sources=["tool"]` (internal subagent sessions).

## How to Test

1. Create a session via TUI or gateway
2. Run `/sessions` in CLI — the session should appear
3. Before fix: only CLI-created sessions were shown