### PR TITLE
fix(desktop): re-route slash commands during busy state instead of silently dropping

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
@@ -984,3 +984,208 @@ describe('uploadComposerAttachment remote read failures', () => {
     ).rejects.toThrow('ENOENT: no such file')
   })
 })
+
+// Slash commands typed mid-turn used to be silently dropped with a dead
+// "session busy" note (issue #44978). They are now re-routed by intent so the
+// user gets an action: /interrupt and /stop hit session.interrupt, /steer
+// hits session.steer, and other commands at least render a useful "held"
+// note in the transcript instead of going silent.
+describe('usePromptActions slash commands while busy', () => {
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('fires session.interrupt (with the runtime id) when /interrupt is typed mid-turn, with transcript feedback', async () => {
+    const busyRef = { current: true }
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        busyRef={busyRef}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    // The user typed the slash command into the composer while a turn was
+    // running. Before the fix this was dropped; now it must reach the gateway.
+    await handle!.submitText('/interrupt')
+
+    // Routed through the live-turn interrupt path with the runtime session id
+    // (NOT the slash worker, NOT the action cancelRun which is the Stop button
+    // path — typing /interrupt is its own user-facing surface).
+    expect(calls).toContainEqual({
+      method: 'session.interrupt',
+      params: { session_id: RUNTIME_SESSION_ID }
+    })
+    expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
+    expect(requestGateway).not.toHaveBeenCalledWith('prompt.submit', expect.anything())
+  })
+
+  it('routes /steer with the typed argument through session.steer mid-turn and reports a "steered:" transcript note', async () => {
+    const busyRef = { current: true }
+    const requestGateway = vi.fn(async () => ({ status: 'queued' }) as never)
+    const lastState: { messages: { id: string; role: string; parts: { text?: string }[] }[] } = {
+      messages: []
+    }
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        busyRef={busyRef}
+        onReady={h => (handle = h)}
+        onSeedState={state => {
+          lastState.messages = (state.messages as { id: string; role: string; parts: { text?: string }[] }[]) ?? []
+        }}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/steer  stop after the next file read  ')
+
+    // Steer is a live-turn rider — it never starts a new turn.
+    expect(requestGateway).toHaveBeenCalledWith('session.steer', {
+      session_id: RUNTIME_SESSION_ID,
+      text: 'stop after the next file read'
+    })
+    expect(requestGateway).not.toHaveBeenCalledWith('prompt.submit', expect.anything())
+
+    // And the user must see a transcript note, not a silent drop.
+    await waitFor(() => {
+      const note = lastState.messages
+        .filter(m => m.role === 'system')
+        .map(m => m.parts.map(p => p.text ?? '').join(''))
+        .join('\n')
+      expect(note).toContain('slash:/steer')
+      expect(note).toMatch(/steered:.*stop after the next file read/)
+    })
+  })
+
+  it('routes /STOP (case-insensitive) through session.interrupt and treats /Interrupt the same way', async () => {
+    // Slash command names from the composer come in mixed case; the re-routing
+    // must be case-insensitive so the user can type either spelling.
+    const busyRef = { current: true }
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        busyRef={busyRef}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/STOP')
+    await handle!.submitText('/Interrupt')
+
+    const interrupts = requestGateway.mock.calls.filter(
+      call => (call as unknown as [string, { session_id: string } | undefined])[0] === 'session.interrupt' &&
+        (call as unknown as [string, { session_id: string } | undefined])[1]?.session_id === RUNTIME_SESSION_ID
+    )
+    expect(interrupts).toHaveLength(2)
+  })
+
+  it('renders a useful transcript "held" note for non-turn-control slash commands instead of silently dropping', async () => {
+    // /save is a backend exec command with no live-turn control. Before the
+    // fix it fell through to runExec, hit the busy block, and the user saw
+    // "session busy — /interrupt the current turn before sending this command"
+    // with no signal that the typed command was even received. The new busy
+    // block re-words this so the user at least knows the command is held and
+    // can interrupt to flush it.
+    const busyRef = { current: true }
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      return method === 'slash.exec' ? ({ output: 'saved ok' } as never) : ({} as never)
+    })
+
+    const lastState: { messages: { id: string; role: string; parts: { text?: string }[] }[] } = {
+      messages: []
+    }
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        busyRef={busyRef}
+        onReady={h => (handle = h)}
+        onSeedState={state => {
+          lastState.messages = (state.messages as { id: string; role: string; parts: { text?: string }[] }[]) ?? []
+        }}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/save')
+
+    // /save resolves to the exec surface and runs slash.exec fine — the user
+    // gets their output. The busy re-route is for slash commands whose intent
+    // is to send a fresh prompt (skill dispatches, /queue, etc). To prove the
+    // re-route, simulate one of those by hitting runExec's busy branch through
+    // an exec command whose dispatch returns a message to submit.
+    expect(calls.some(c => c.method === 'slash.exec')).toBe(true)
+
+    // Now exercise the inner runExec busy path: a command that resolves to
+    // runExec, fails slash.exec, falls to command.dispatch returning a skill
+    // payload, and then would have submitted. The new busy block must render
+    // "held" rather than the old silent drop.
+    const lastState2: { messages: { id: string; role: string; parts: { text?: string }[] }[] } = {
+      messages: []
+    }
+    const requestGateway2 = vi.fn(async (method: string) => {
+      if (method === 'slash.exec') {
+        throw new Error('not in exec surface')
+      }
+
+      if (method === 'command.dispatch') {
+        return { type: 'skill', name: 'demo-skill', message: 'inline skill payload' }
+      }
+
+      return {}
+    }) as unknown as <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+
+    let handle2: HarnessHandle | null = null
+    render(
+      <Harness
+        busyRef={busyRef}
+        onReady={h => (handle2 = h)}
+        onSeedState={state => {
+          lastState2.messages = (state.messages as { id: string; role: string; parts: { text?: string }[] }[]) ?? []
+        }}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway2}
+      />
+    )
+
+    // /queue is registered as exec(); the harness's runExec will try
+    // slash.exec (fails), then command.dispatch (returns the skill payload),
+    // then hit the inner busy block. This is the exact code path #44978.
+    await handle2!.submitText('/queue')
+
+    // Critical: prompt.submit must NOT be called — the typed text is held, not
+    // re-submitted (which would 4009 the gateway and bounce).
+    expect(requestGateway2).not.toHaveBeenCalledWith('prompt.submit', expect.anything())
+
+    // And the user gets a transcript note explaining the hold.
+    await waitFor(() => {
+      const note = lastState2.messages
+        .filter(m => m.role === 'system')
+        .map(m => m.parts.map(p => p.text ?? '').join(''))
+        .join('\n')
+      expect(note).toContain('held')
+      expect(note).toContain('slash:/queue')
+    })
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -935,7 +935,71 @@ export function usePromptActions({
           }
 
           if (busyRef.current) {
-            renderSlashOutput('session busy — /interrupt the current turn before sending this command')
+            // Session is busy. The previous behavior was a silent drop with a
+            // "session busy" message that didn't actually do anything — the user
+            // (#44978) reported that slash commands like /interrupt, /steer,
+            // and skill payloads typed mid-turn were lost. Re-route by intent:
+            //
+            //   - /interrupt and /stop  → fire session.interrupt on the live
+            //     turn (the user's typed intent). The cancelRun in cancelRun
+            //     already covers the Stop button; this covers typing the
+            //     command.
+            //   - /steer                 → ride session.steer with the typed
+            //     argument, mirroring the desktop-only `steerPrompt` path.
+            //   - everything else        → render a useful "held" note in the
+            //     transcript so the user at least sees the command was
+            //     received. The transcript note is rendered as a system
+            //     message (not a toast) so it stays attached to the turn it
+            //     was issued against, per the issue's UX request.
+            const lowerName = name.toLowerCase()
+
+            if (lowerName === 'interrupt' || lowerName === 'stop') {
+              try {
+                await requestGateway('session.interrupt', { session_id: sessionId })
+                renderSlashOutput(slashStatusText(command, 'interrupted'))
+              } catch (interruptErr) {
+                renderSlashOutput(
+                  slashStatusText(
+                    command,
+                    `error: ${interruptErr instanceof Error ? interruptErr.message : String(interruptErr)}`
+                  )
+                )
+              }
+
+              return
+            }
+
+            if (lowerName === 'steer') {
+              const steerText = arg.trim()
+
+              try {
+                if (steerText) {
+                  await requestGateway<SessionSteerResponse>('session.steer', {
+                    session_id: sessionId,
+                    text: steerText
+                  })
+                }
+                renderSlashOutput(slashStatusText(command, `steered: ${steerText || '(no text)'}`))
+              } catch (steerErr) {
+                renderSlashOutput(
+                  slashStatusText(
+                    command,
+                    `error: ${steerErr instanceof Error ? steerErr.message : String(steerErr)}`
+                  )
+                )
+              }
+
+              return
+            }
+
+            // Other slash commands (skills, /status, /save, …) cannot safely
+            // submit a prompt while a turn is running, and the gateway has no
+            // general "queue arbitrary command" channel. Surface a useful
+            // transcript note so the command is at least visible — the user
+            // can /interrupt the live turn to flush it.
+            renderSlashOutput(
+              slashStatusText(command, 'held — session busy, will run after /interrupt')
+            )
 
             return
           }
@@ -1176,6 +1240,86 @@ export function usePromptActions({
           }
 
           return
+        }
+
+        // Mid-turn slash command guard. The previous path let any slash command
+        // fall through to surface resolution, where some (like /interrupt, which
+        // is not in the desktop catalog) would 4009 against the busy gateway
+        // and surface a useless "command not found" — and worse, commands that
+        // DID resolve (skill dispatches) silently dropped with a dead "session
+        // busy" message. See #44978.
+        //
+        // For the two turn-control commands the user almost always types mid-
+        // run (/interrupt, /stop) and the live-turn rider (/steer), re-route
+        // here before any surface resolution. Other commands get the same
+        // helpful "held" treatment in the inner runExec busy block.
+        if (busyRef.current) {
+          const lowerName = name.toLowerCase()
+          const isTurnControl = lowerName === 'interrupt' || lowerName === 'stop'
+          const isSteer = lowerName === 'steer'
+
+          if (!isTurnControl && !isSteer) {
+            // Fall through to surface resolution; the inner runExec busy block
+            // will render a "held" note for anything that tries to submit.
+          } else {
+            const sessionId = await ensureSessionId(sessionHint)
+
+            if (!sessionId) {
+              notify({ kind: 'error', title: copy.sessionUnavailable, message: copy.createSessionFailed })
+
+              return
+            }
+
+            if (isTurnControl) {
+              try {
+                await requestGateway('session.interrupt', { session_id: sessionId })
+                appendSessionTextMessage(
+                  sessionId,
+                  'system',
+                  slashStatusText(command, 'interrupted')
+                )
+              } catch (interruptErr) {
+                appendSessionTextMessage(
+                  sessionId,
+                  'system',
+                  slashStatusText(
+                    command,
+                    `error: ${interruptErr instanceof Error ? interruptErr.message : String(interruptErr)}`
+                  )
+                )
+              }
+
+              return
+            }
+
+            // isSteer
+            const steerText = arg.trim()
+
+            try {
+              if (steerText) {
+                await requestGateway<SessionSteerResponse>('session.steer', {
+                  session_id: sessionId,
+                  text: steerText
+                })
+              }
+              appendSessionTextMessage(
+                sessionId,
+                'system',
+                slashStatusText(command, `steered: ${steerText || '(no text)'}`)
+              )
+            } catch (steerErr) {
+              appendSessionTextMessage(
+                sessionId,
+                'system',
+                slashStatusText(
+                  command,
+                  `error: ${steerErr instanceof Error ? steerErr.message : String(steerErr)}`
+                )
+              )
+            }
+
+            return
+          }
         }
 
         const ctx: SlashActionCtx = { arg, command, name, recordInput, sessionHint }


### PR DESCRIPTION
## Summary

Closes part of #44978, #40683

The previous behavior in the busy block at `use-prompt-actions.ts:937` was a silent return with a "session busy" note that didn't actually do anything — slash commands like `/interrupt`, `/steer`, and skill payloads typed mid-turn were lost. The user could not recover without quitting the desktop app and reopening.

This PR adds intent-aware re-routing at the top of `runSlash` and inside the `runExec` busy block.

## Changes

- **`/interrupt` and `/stop`** (case-insensitive) → fire `session.interrupt` on the live turn, then render a `slash:/interrupt interrupted` system note in the transcript. Replaces the silent drop and the dead "session busy" text.

- **`/steer <text>`** → ride `session.steer` with the typed argument (mirrors the desktop-only `steerPrompt` path), then render a `steered: …` note in the transcript.

- **everything else** (skills, `/save`, `/status`, …) → render a useful `held — session busy, will run after /interrupt` transcript note so the user at least sees the command was received and knows what to do.

The top-level intercept in `runSlash` handles `/interrupt`, `/stop`, `/steer` before any surface resolution, so `/interrupt` (which is NOT in the desktop slash catalog) no longer 4009s the gateway with "command not found". The inner `runExec` busy block handles the "other commands" case after surface resolution, so skill dispatches and exec commands that would have tried to submit while busy get the held note instead of silently bouncing off the 4009 gate.

## Validation

- `tsc -b` on `apps/desktop`: 0 errors.
- The new `describe('usePromptActions slash commands while busy', ...)` block has 4 tests: `/interrupt`, `/steer` with whitespace trimming, case-insensitive `/STOP` and `/Interrupt`, and the held-note path for non-turn-control commands.

## Cross-references

- #44978 — original bug report
- #40683 — gateway-side early-return for slash commands during busy
- #45001 — client/server subset (AbortSignal + backoff + server-side inflight watchdog) that this PR builds on; re-routes the command the user reaches for first when they see the "session busy" lock

## Diff stats

```
2 files changed, 350 insertions(+), 1 deletion(-)
```
