### PR TITLE
fix(prompt_builder): treat pristine seeded SOUL.md as absent so DEFAULT_AGENT_IDENTITY is used (#44914)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1486,6 +1486,17 @@ def load_soul_md() -> Optional[str]:
         content = soul_path.read_text(encoding="utf-8").strip()
         if not content:
             return None
+
+        # If the file is byte-identical to the pristine seed template, treat it
+        # as absent so DEFAULT_AGENT_IDENTITY takes effect.  A user who wants a
+        # custom identity must actually edit the file to something different.
+        try:
+            from hermes_cli.default_soul import DEFAULT_SOUL_MD
+            if content.strip() == DEFAULT_SOUL_MD.strip():
+                return None
+        except Exception:
+            pass  # import or comparison failure — fall through safely
+
         content = _scan_context_content(content, "SOUL.md")
         content = _truncate_content(content, "SOUL.md")
         return content


### PR DESCRIPTION
## What does this PR do?

The seeded default `~/.hermes/SOUL.md` (written by `_ensure_default_soul_md` on first run) contains the identity text — the same string as `DEFAULT_AGENT_IDENTITY`. Because `load_soul_md()` only checks for `strip()` non-emptiness, the pristine template is returned as persona content and `DEFAULT_AGENT_IDENTITY` is never appended to the system prompt.

This means the agent opens with the seeded content instead of the canonical identity, and future updates to `DEFAULT_AGENT_IDENTITY` won't take effect for existing installs where the file already exists.

## Related Issue

Closes #44914

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

1. **agent/prompt_builder.py** — In `load_soul_md()`, compare the file content against `DEFAULT_SOUL_MD` (the pristine seed template) and return `None` when they match. A user who wants a custom identity must actually edit the file to something different.

## How to Test

1. Fresh install → SOUL.md seeded → `load_soul_md()` returns identity text → `DEFAULT_AGENT_IDENTITY` skipped (bug on main)
2. After fix → fresh install → SOUL.md seeded → `load_soul_md()` returns `None` → `DEFAULT_AGENT_IDENTITY` used correctly