### PR TITLE
feat: add fallback move command

### DIFF
--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -55,6 +55,7 @@ Examples:
     hermes model                  Select default model
     hermes fallback [list]        Show fallback provider chain
     hermes fallback add           Add a fallback provider (same picker as `hermes model`)
+    hermes fallback move FROM TO  Reorder fallback providers by displayed position
     hermes fallback remove        Remove a fallback provider from the chain
     hermes config                 View configuration
     hermes config edit            Edit config in $EDITOR

--- a/hermes_cli/fallback_cmd.py
+++ b/hermes_cli/fallback_cmd.py
@@ -9,6 +9,7 @@ Subcommands:
   hermes fallback [list]   Show the current fallback chain (default when no subcommand)
   hermes fallback add      Pick provider + model via the same picker as `hermes model`,
                            then append the selection to the chain
+  hermes fallback move     Reorder an existing fallback entry by position
   hermes fallback remove   Pick an entry to delete from the chain
   hermes fallback clear    Remove all fallback entries
 
@@ -276,6 +277,53 @@ def cmd_fallback_remove(args) -> None:  # noqa: ARG001
     print()
 
 
+def cmd_fallback_move(args) -> None:
+    """Move a fallback entry from one 1-based position to another."""
+    from hermes_cli.config import load_config, save_config
+
+    config = load_config()
+    chain = _read_chain(config)
+
+    if not chain:
+        print()
+        print("  No fallback providers configured — nothing to move.")
+        print()
+        return
+
+    from_position = getattr(args, "from_position", None)
+    to_position = getattr(args, "to_position", None)
+    try:
+        from_index = int(from_position) - 1
+        to_index = int(to_position) - 1
+    except (TypeError, ValueError):
+        print("FROM and TO must be numeric positions from `hermes fallback list`.")
+        raise SystemExit(2)
+
+    max_position = len(chain)
+    if not 0 <= from_index < max_position:
+        print(f"FROM must be between 1 and {max_position}.")
+        raise SystemExit(2)
+    if not 0 <= to_index < max_position:
+        print(f"TO must be between 1 and {max_position}.")
+        raise SystemExit(2)
+
+    moved = chain.pop(from_index)
+    chain.insert(to_index, moved)
+    _write_chain(config, chain)
+    save_config(config)
+
+    print()
+    if from_index == to_index:
+        print(f"  Fallback already at position {to_position}: {_format_entry(moved)}")
+    else:
+        print(f"  Moved fallback from position {from_position} to {to_position}: {_format_entry(moved)}")
+    print()
+    print(f"  Fallback chain ({len(chain)} {'entry' if len(chain) == 1 else 'entries'}):")
+    for i, entry in enumerate(chain, 1):
+        print(f"    {i}. {_format_entry(entry)}")
+    print()
+
+
 def cmd_fallback_clear(args) -> None:  # noqa: ARG001
     """Remove all fallback entries (with confirmation)."""
     from hermes_cli.config import load_config, save_config
@@ -344,11 +392,13 @@ def cmd_fallback(args) -> None:
         cmd_fallback_list(args)
     elif sub == "add":
         cmd_fallback_add(args)
+    elif sub == "move":
+        cmd_fallback_move(args)
     elif sub in {"remove", "rm"}:
         cmd_fallback_remove(args)
     elif sub == "clear":
         cmd_fallback_clear(args)
     else:
         print(f"Unknown fallback subcommand: {sub}")
-        print("Use one of: list, add, remove, clear")
+        print("Use one of: list, add, move, remove, clear")
         raise SystemExit(2)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12098,6 +12098,13 @@ def main():
         "add",
         help="Pick a provider + model (same picker as `hermes model`) and append to the chain",
     )
+    fallback_move = fallback_subparsers.add_parser(
+        "move",
+        help="Move a fallback entry from one position to another",
+        description="Reorder fallback providers using the 1-based positions shown by `hermes fallback list`.",
+    )
+    fallback_move.add_argument("from_position", metavar="FROM", type=int)
+    fallback_move.add_argument("to_position", metavar="TO", type=int)
     fallback_subparsers.add_parser(
         "remove",
         aliases=["rm"],

--- a/tests/hermes_cli/test_fallback_cmd.py
+++ b/tests/hermes_cli/test_fallback_cmd.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import types
+import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -591,8 +593,6 @@ class TestArgparseWiring:
     """
 
     def test_fallback_help_lists_subcommands(self):
-        import subprocess
-        import sys
         result = subprocess.run(
             [sys.executable, "-m", "hermes_cli.main", "fallback", "--help"],
             capture_output=True,
@@ -608,3 +608,28 @@ class TestArgparseWiring:
         assert "move" in out
         assert "remove" in out
         assert "clear" in out
+
+    def test_fallback_move_cli_reorders_temp_config(self, isolated_home):
+        _write_config(isolated_home, {
+            "fallback_providers": [
+                {"provider": "a", "model": "a-model"},
+                {"provider": "b", "model": "b-model", "base_url": "http://localhost:11434/v1"},
+                {"provider": "c", "model": "c-model"},
+            ],
+        })
+
+        result = subprocess.run(
+            [sys.executable, "-m", "hermes_cli.main", "fallback", "move", "2", "1"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        assert "Moved fallback from position 2 to 1" in result.stdout
+        cfg = _read_config(isolated_home)
+        assert cfg["fallback_providers"] == [
+            {"provider": "b", "model": "b-model", "base_url": "http://localhost:11434/v1"},
+            {"provider": "a", "model": "a-model"},
+            {"provider": "c", "model": "c-model"},
+        ]

--- a/tests/hermes_cli/test_fallback_cmd.py
+++ b/tests/hermes_cli/test_fallback_cmd.py
@@ -407,6 +407,93 @@ class TestRemoveCommand:
         assert len(cfg["fallback_providers"]) == 1
 
 
+
+# ---------------------------------------------------------------------------
+# cmd_fallback_move
+# ---------------------------------------------------------------------------
+
+class TestMoveCommand:
+    def test_move_empty_chain(self, isolated_home, capsys):
+        _write_config(isolated_home, {})
+        from hermes_cli.fallback_cmd import cmd_fallback_move
+        cmd_fallback_move(types.SimpleNamespace(from_position=1, to_position=1))
+        out = capsys.readouterr().out
+        assert "nothing to move" in out
+
+    def test_move_first_to_last(self, isolated_home, capsys):
+        _write_config(isolated_home, {
+            "fallback_providers": [
+                {"provider": "openrouter", "model": "gpt-5.4"},
+                {"provider": "nous", "model": "Hermes-4"},
+                {"provider": "anthropic", "model": "claude-sonnet-4-6"},
+            ],
+        })
+        from hermes_cli.fallback_cmd import cmd_fallback_move
+        cmd_fallback_move(types.SimpleNamespace(from_position=1, to_position=3))
+
+        cfg = _read_config(isolated_home)
+        assert cfg["fallback_providers"] == [
+            {"provider": "nous", "model": "Hermes-4"},
+            {"provider": "anthropic", "model": "claude-sonnet-4-6"},
+            {"provider": "openrouter", "model": "gpt-5.4"},
+        ]
+        out = capsys.readouterr().out
+        assert "Moved fallback from position 1 to 3" in out
+
+    def test_move_last_to_first_preserves_custom_fields(self, isolated_home):
+        custom = {
+            "provider": "custom:local",
+            "model": "qwen2.5-coder:3b",
+            "base_url": "http://localhost:11434/v1",
+            "api_mode": "chat_completions",
+        }
+        _write_config(isolated_home, {
+            "fallback_providers": [
+                {"provider": "openrouter", "model": "gpt-5.4"},
+                {"provider": "nous", "model": "Hermes-4"},
+                custom,
+            ],
+        })
+        from hermes_cli.fallback_cmd import cmd_fallback_move
+        cmd_fallback_move(types.SimpleNamespace(from_position="3", to_position="1"))
+
+        cfg = _read_config(isolated_home)
+        assert cfg["fallback_providers"] == [
+            custom,
+            {"provider": "openrouter", "model": "gpt-5.4"},
+            {"provider": "nous", "model": "Hermes-4"},
+        ]
+
+    def test_move_middle_to_front(self, isolated_home):
+        _write_config(isolated_home, {
+            "fallback_providers": [
+                {"provider": "a", "model": "a-model"},
+                {"provider": "b", "model": "b-model"},
+                {"provider": "c", "model": "c-model"},
+            ],
+        })
+        from hermes_cli.fallback_cmd import cmd_fallback_move
+        cmd_fallback_move(types.SimpleNamespace(from_position=2, to_position=1))
+
+        cfg = _read_config(isolated_home)
+        assert [entry["provider"] for entry in cfg["fallback_providers"]] == ["b", "a", "c"]
+
+    @pytest.mark.parametrize("from_position,to_position", [(0, 1), (4, 1), (1, 0), (1, 4), ("x", 1), (1, "x")])
+    def test_move_rejects_invalid_positions(self, isolated_home, from_position, to_position):
+        _write_config(isolated_home, {
+            "fallback_providers": [
+                {"provider": "a", "model": "a-model"},
+                {"provider": "b", "model": "b-model"},
+                {"provider": "c", "model": "c-model"},
+            ],
+        })
+        from hermes_cli.fallback_cmd import cmd_fallback_move
+        with pytest.raises(SystemExit):
+            cmd_fallback_move(types.SimpleNamespace(from_position=from_position, to_position=to_position))
+
+        cfg = _read_config(isolated_home)
+        assert [entry["provider"] for entry in cfg["fallback_providers"]] == ["a", "b", "c"]
+
 # ---------------------------------------------------------------------------
 # cmd_fallback_clear
 # ---------------------------------------------------------------------------
@@ -473,6 +560,18 @@ class TestDispatcher:
         out = capsys.readouterr().out
         assert "nothing to remove" in out
 
+    def test_move_dispatches(self, isolated_home):
+        _write_config(isolated_home, {
+            "fallback_providers": [
+                {"provider": "a", "model": "a-model"},
+                {"provider": "b", "model": "b-model"},
+            ],
+        })
+        from hermes_cli.fallback_cmd import cmd_fallback
+        cmd_fallback(types.SimpleNamespace(fallback_command="move", from_position=2, to_position=1))
+        cfg = _read_config(isolated_home)
+        assert [entry["provider"] for entry in cfg["fallback_providers"]] == ["b", "a"]
+
     def test_unknown_subcommand_exits(self, isolated_home):
         _write_config(isolated_home, {})
         from hermes_cli.fallback_cmd import cmd_fallback
@@ -503,8 +602,9 @@ class TestArgparseWiring:
         # --help exits 0
         assert result.returncode == 0, f"stderr: {result.stderr}"
         out = result.stdout + result.stderr
-        # All four subcommands should appear in help
+        # All five subcommands should appear in help
         assert "list" in out
         assert "add" in out
+        assert "move" in out
         assert "remove" in out
         assert "clear" in out

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1131,6 +1131,7 @@ Manage the fallback provider chain. Fallback providers are tried in order when t
 |------------|-------------|
 | `list` (alias: `ls`) | Show the current fallback chain (default when no subcommand) |
 | `add` | Pick a provider + model (same picker as `hermes model`) and append to the chain |
+| `move FROM TO` | Reorder entries using the 1-based positions shown by `hermes fallback list` |
 | `remove` (alias: `rm`) | Pick an entry to delete from the chain |
 | `clear` | Remove all fallback entries |
 

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -27,7 +27,7 @@ The easiest path is the interactive manager:
 hermes fallback
 ```
 
-`hermes fallback` reuses the provider picker from `hermes model` — same provider list, same credential prompts, same validation. Use the subcommands `add`, `list` (alias `ls`), `remove` (alias `rm`), and `clear` to manage the chain. Changes persist under the top-level `fallback_providers:` list in `config.yaml`.
+`hermes fallback` reuses the provider picker from `hermes model` — same provider list, same credential prompts, same validation. Use the subcommands `add`, `list` (alias `ls`), `move FROM TO`, `remove` (alias `rm`), and `clear` to manage the chain. `move` reorders entries using the 1-based positions shown by `hermes fallback list`. Changes persist under the top-level `fallback_providers:` list in `config.yaml`.
 
 If you'd rather edit the YAML directly, add a top-level `fallback_providers` list to `~/.hermes/config.yaml`:
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/cli-commands.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/cli-commands.md
@@ -914,6 +914,7 @@ hermes fallback <subcommand>
 |------------|-------------|
 | `list`（别名：`ls`） | 显示当前 fallback 链（不带子命令时的默认行为） |
 | `add` | 选择 provider + 模型（与 `hermes model` 相同的选择器）并追加到链末尾 |
+| `move FROM TO` | 使用 `hermes fallback list` 显示的 1-based 位置重新排序条目 |
 | `remove`（别名：`rm`） | 选择要从链中删除的条目 |
 | `clear` | 删除所有 fallback 条目 |
 


### PR DESCRIPTION
## Summary
- add `hermes fallback move FROM TO` for 1-based fallback provider reordering
- preserve full fallback entry dictionaries while moving entries
- wire the command into argparse/help and dispatcher

## Tests
- `python -m pytest tests/hermes_cli/test_fallback_cmd.py -q`
- manual temp config: `HERMES_HOME=$tmp python -m hermes_cli.main fallback move 3 1`