### PR TITLE
fix(tui): watchdog for keepBusy interrupt that never settles

### DIFF
--- a/ui-tui/src/__tests__/turnControllerKeepBusyWatchdog.test.ts
+++ b/ui-tui/src/__tests__/turnControllerKeepBusyWatchdog.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { turnController } from '../app/turnController.js'
+import { resetTurnState } from '../app/turnStore.js'
+import { getUiState, patchUiState, resetUiState } from '../app/uiStore.js'
+import type { Msg } from '../types.js'
+
+// Cross-fork follow-up to the desktop+gateway fix in #45001: the TUI has
+// the same recoverability hole when `interruptTurn({ keepBusy: true })`
+// re-asserts busy and waits for the gateway's real settle edge
+// (`message.complete`). If that edge never arrives — orphaned session,
+// transport dropped, agent thread crash — the user is stranded in a
+// permanent busy state with no recovery path.
+//
+// The watchdog arms in `interruptTurn`, cancels in the natural settle
+// sites (`recordMessageComplete`, `recordError`, `startMessage`,
+// `reset`/`fullReset`), and fires after KEEP_BUSY_WATCHDOG_MS otherwise
+// to force `idle()` and surface a ttl notice.
+const buildDeps = () => ({
+  appendMessage: vi.fn((_msg: Msg) => {}),
+  // `interruptTurn` chains `.catch(() => {})` on the request — the mock
+  // must return a thenable so the chained catch doesn't blow up. The
+  // resolved value type is irrelevant; the call is fire-and-forget.
+  gw: { request: vi.fn(async () => null) },
+  sid: 'sess-watchdog',
+  sys: vi.fn()
+})
+
+const startTurn = () => {
+  patchUiState({ sid: 'sess-watchdog' })
+  turnController.startMessage()
+  // Simulate the first delta to mirror a real turn (revs bufRef etc.).
+  turnController.recordMessageDelta({ text: 'thinking…' })
+}
+
+describe('turnController.interruptTurn — keepBusy settle watchdog', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    resetUiState()
+    resetTurnState()
+    turnController.fullReset()
+  })
+
+  afterEach(() => {
+    // Always drain any pending fake timers and restore real timers so a
+    // mid-test failure can't leak the watchdog across test files (the
+    // same cross-file flake concern already covered for
+    // interrupt-cooldown in createGatewayEventHandler.test.ts).
+    try {
+      vi.runOnlyPendingTimers()
+    } catch {
+      // ignore
+    }
+
+    vi.useRealTimers()
+  })
+
+  it('cancels the watchdog when the gateway settles naturally via recordMessageComplete', () => {
+    // The natural settle path: message.complete lands well within the
+    // watchdog window. The watchdog must NOT fire, busy must flip false,
+    // and no ttl notice should be surfaced.
+    startTurn()
+    const deps = buildDeps()
+
+    turnController.interruptTurn(deps, { keepBusy: true })
+    expect(getUiState().busy).toBe(true)
+
+    // Settle well before the watchdog (10s) fires.
+    turnController.recordMessageComplete({ text: 'Operation interrupted' })
+
+    expect(getUiState().busy).toBe(false)
+    expect(getUiState().notice?.key).not.toBe('tui.busy_watchdog')
+
+    // Advance past the watchdog — nothing should happen, it's already
+    // cancelled. (We use `runOnlyPendingTimers` after advancing to prove
+    // no scheduled timer is still alive.)
+    vi.advanceTimersByTime(20_000)
+    expect(getUiState().busy).toBe(false)
+    expect(getUiState().notice?.key).not.toBe('tui.busy_watchdog')
+  })
+
+  it('forces idle() and emits a ttl notice when the watchdog fires with no settle', () => {
+    // The orphan path: the interrupt was sent, keepBusy re-asserted, but
+    // the gateway never delivers message.complete (session died, transport
+    // dropped, agent thread crashed). After KEEP_BUSY_WATCHDOG_MS the
+    // watchdog must force busy:false, surface a ttl notice, and the user
+    // is no longer stranded.
+    startTurn()
+    const deps = buildDeps()
+
+    turnController.interruptTurn(deps, { keepBusy: true })
+    expect(getUiState().busy).toBe(true)
+    expect(getUiState().notice).toBeNull()
+
+    vi.advanceTimersByTime(10_000)
+
+    // Watchdog fired: busy cleared, ttl notice surfaced, status ready.
+    expect(getUiState().busy).toBe(false)
+    expect(getUiState().status).toBe('ready')
+    expect(getUiState().notice).toMatchObject({
+      key: 'tui.busy_watchdog',
+      kind: 'ttl',
+      level: 'warn',
+      text: '⚠ Live turn lost — UI settled automatically'
+    })
+    // Stream state was force-cleared by idle().
+    expect(turnController.bufRef).toBe('')
+  })
+
+  it('does not fire the watchdog if a new genuine turn has already started (startMessage cancels it)', () => {
+    // The "queued message drained a new turn" path: the interrupted turn
+    // never settles (no message.complete), but the gateway sends
+    // message.start for the next turn. The watchdog must be cancelled by
+    // startMessage() — otherwise it would clobber the new, healthy turn.
+    startTurn()
+    const deps = buildDeps()
+
+    turnController.interruptTurn(deps, { keepBusy: true })
+    expect(getUiState().busy).toBe(true)
+
+    // A new turn starts (e.g. queued message drain, or a fresh user
+    // submit landed and the gateway's session.interrupt has resolved
+    // into a new turn). startMessage() is the signal.
+    turnController.startMessage()
+    expect(getUiState().busy).toBe(true)
+
+    vi.advanceTimersByTime(20_000)
+
+    // Watchdog never fired: no ttl notice, busy still true (the new turn
+    // is in flight, that's correct).
+    expect(getUiState().notice?.key).not.toBe('tui.busy_watchdog')
+    expect(getUiState().busy).toBe(true)
+  })
+
+  it('does not arm a watchdog when keepBusy is not requested', () => {
+    // Plain interrupt (Esc, ctrl-c with no queue): the cooldown handles
+    // status decay, no keepBusy hold. Advancing well past the watchdog
+    // window must be a no-op.
+    startTurn()
+    const deps = buildDeps()
+
+    turnController.interruptTurn(deps) // no keepBusy
+    expect(getUiState().busy).toBe(false)
+
+    vi.advanceTimersByTime(20_000)
+
+    expect(getUiState().notice).toBeNull()
+    expect(getUiState().busy).toBe(false)
+  })
+
+  it('cancels the watchdog on recordError (defensive settle for keepBusy hold)', () => {
+    // message.error from the gateway also means the interrupted turn is
+    // over. The watchdog must cancel here too so it can't fire later
+    // and clobber an already-idle UI.
+    startTurn()
+    const deps = buildDeps()
+
+    turnController.interruptTurn(deps, { keepBusy: true })
+    expect(getUiState().busy).toBe(true)
+
+    turnController.recordError()
+
+    expect(getUiState().busy).toBe(false)
+    vi.advanceTimersByTime(20_000)
+    expect(getUiState().notice?.key).not.toBe('tui.busy_watchdog')
+  })
+
+  it('cancels the watchdog on reset()/fullReset() (session boundary)', () => {
+    // Session boundary: a pending watchdog from session A must not fire
+    // into session B (or after fullReset teardown).
+    startTurn()
+    const deps = buildDeps()
+
+    turnController.interruptTurn(deps, { keepBusy: true })
+    expect(getUiState().busy).toBe(true)
+
+    turnController.reset()
+    vi.advanceTimersByTime(20_000)
+    expect(getUiState().notice?.key).not.toBe('tui.busy_watchdog')
+
+    // Re-arm + fullReset path.
+    startTurn()
+    turnController.interruptTurn(buildDeps(), { keepBusy: true })
+    turnController.fullReset()
+    vi.advanceTimersByTime(20_000)
+    expect(getUiState().notice?.key).not.toBe('tui.busy_watchdog')
+  })
+
+  it('re-arms cleanly across two back-to-back keepBusy interrupts (no leaked timer)', () => {
+    // Re-arming must cancel the prior handle, otherwise the first
+    // watchdog fires during the second keepBusy hold and clobbers a
+    // turn we didn't mean to settle. Two interleaved interrupts:
+    //   t=0:    1st interruptTurn({ keepBusy: true })  → wd#1 fires t=10s
+    //   t=2s:   2nd interruptTurn({ keepBusy: true })  → wd#2 fires t=12s
+    //                                                  (wd#1 cancelled)
+    //   t=11s:  advance — wd#1 has NOT fired (cancelled),
+    //           wd#2 has NOT yet fired (1s to go), busy=true, no notice
+    //   t=13s:  advance — wd#2 fires, busy=false, notice set
+    startTurn()
+    turnController.interruptTurn(buildDeps(), { keepBusy: true })
+    expect(getUiState().busy).toBe(true)
+
+    // Re-arm at t=2s. The first watchdog is cancelled; the second is
+    // scheduled for t=2s + 10s = 12s.
+    vi.advanceTimersByTime(2_000)
+    startTurn()
+    turnController.interruptTurn(buildDeps(), { keepBusy: true })
+
+    // At t=11s: wd#1 would have fired at t=10s, but the re-arm at t=2s
+    // cancelled it. wd#2 fires at t=12s, so we should still be busy.
+    vi.advanceTimersByTime(9_000)
+    expect(getUiState().busy).toBe(true)
+    expect(getUiState().notice?.key).not.toBe('tui.busy_watchdog')
+
+    // At t=13s: wd#2 has fired (1s past its 12s deadline).
+    vi.advanceTimersByTime(2_000)
+    expect(getUiState().busy).toBe(false)
+    expect(getUiState().notice?.key).toBe('tui.busy_watchdog')
+  })
+})

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -29,6 +29,16 @@ const INTERRUPT_COOLDOWN_MS = 1500
 const ACTIVITY_LIMIT = 8
 const TRAIL_LIMIT = 8
 
+// Maximum time the controller will hold `busy: true` after a
+// `interruptTurn({ keepBusy: true })` waiting for the gateway's real settle
+// edge (message.complete, message.error). If the settle never arrives —
+// orphaned session, transport dropped, agent thread crash — the watchdog
+// fires, forces `idle()`, and surfaces a ttl notice so the user is not
+// trapped in a permanent busy state. Sits well below the gateway's own
+// 120s inflight watchdog (server-side; tui_gateway/server.py) so we
+// recover UI-side first.
+const KEEP_BUSY_WATCHDOG_MS = 10_000
+
 // Extracts the raw patch from a diff-only segment produced by
 // pushInlineDiffSegment. Used at message.complete to dedupe against final
 // assistant text that narrates the same patch. Returns null for anything
@@ -132,6 +142,15 @@ class TurnController {
   private streamTimer: Timer = null
   private streamDelay = STREAM_IDLE_BATCH_MS
   private toolProgressTimer: Timer = null
+  // ── keepBusy settle watchdog ──────────────────────────────────────────
+  // Armed by `interruptTurn({ keepBusy: true })` after re-asserting busy.
+  // The natural settle path is `recordMessageComplete()` (and
+  // `recordError()` as a defensive sibling); a fresh `startMessage()` is the
+  // signal that a queued-message drain is in flight and the interrupted
+  // turn is no longer the one we're waiting on. `reset()`/`fullReset()`
+  // tear it down on session boundary. Fires after KEEP_BUSY_WATCHDOG_MS,
+  // forces `idle()`, and emits a ttl notice.
+  private settleWatchdog: Timer = null
 
   // ── Credits notice machinery (Strategy B) ───────────────────────────
   //
@@ -167,6 +186,13 @@ class TurnController {
 
   clearStatusTimer() {
     this.statusTimer = clear(this.statusTimer)
+  }
+
+  // Cancel the keepBusy settle watchdog. Idempotent — safe to call from
+  // recordMessageComplete, recordError, startMessage, reset, fullReset,
+  // and from interruptTurn itself when re-arming.
+  private clearSettleWatchdog() {
+    this.settleWatchdog = clear(this.settleWatchdog)
   }
 
   // ── Notice: arrival ──────────────────────────────────────────────────
@@ -334,6 +360,43 @@ class TurnController {
     if (opts.keepBusy) {
       // `idle()` already cleared busy; re-assert it so the drain waits for settle.
       patchUiState({ busy: true, status: 'interrupting…' })
+
+      // Arm a settle watchdog. If `message.complete` (or `message.error`,
+      // see recordError) never arrives — orphaned session, transport drop,
+      // agent thread crash — the watchdog force-clears busy and surfaces a
+      // ttl notice so the user is not stranded. The natural cancellation
+      // path is `recordMessageComplete()`; `startMessage()` cancels when a
+      // queued-message drain kicks off a new turn. `reset()`/`fullReset()`
+      // tear it down on session boundary.
+      this.clearSettleWatchdog()
+
+      this.settleWatchdog = setTimeout(() => {
+        this.settleWatchdog = null
+
+        // Defensive: only force-settle if we're still in the kept-busy
+        // hold. A natural settle that landed between timer fire and
+        // callback (microtask race) already cleared busy — skip.
+        if (!getUiState().busy) {
+          return
+        }
+
+        this.idle()
+        this.clearReasoning()
+        this.turnTools = []
+        this.persistedToolLabels.clear()
+        patchTurnState({ activity: [], outcome: '' })
+        this.showNotice({
+          key: 'tui.busy_watchdog',
+          kind: 'ttl',
+          level: 'warn',
+          text: '⚠ Live turn lost — UI settled automatically',
+          ttl_ms: 6_000
+        })
+        // Real turn end: surface any held notice, then settle status.
+        this.flushPendingNotice()
+        patchUiState({ status: 'ready' })
+        this.clearStatusTimer()
+      }, KEEP_BUSY_WATCHDOG_MS)
 
       return
     }
@@ -542,6 +605,10 @@ class TurnController {
   }
 
   recordError() {
+    // Defensive settle for the keepBusy hold — message.error from the
+    // gateway also means the interrupted turn is over, so the watchdog
+    // must not fire later and clobber a (possibly already-idle) UI.
+    this.clearSettleWatchdog()
     this.idle()
     this.clearReasoning()
     this.clearStatusTimer()
@@ -555,6 +622,10 @@ class TurnController {
   }
 
   recordMessageComplete(payload: { rendered?: string; reasoning?: string; text?: string }) {
+    // Natural settle for any in-flight keepBusy hold. Always cancel the
+    // watchdog before doing any other work so an `idle()` re-entry from a
+    // racing timer can't double-settle the UI.
+    this.clearSettleWatchdog()
     this.closeReasoningSegment()
 
     // Ink renders markdown via <Md>; the gateway's Rich-rendered ANSI
@@ -839,6 +910,9 @@ class TurnController {
   reset() {
     this.clearReasoning()
     this.clearStatusTimer()
+    // Session boundary: drop any pending keepBusy watchdog so a session-A
+    // timer can't fire into session B (or after a fullReset teardown).
+    this.clearSettleWatchdog()
     this.idle()
     this.bufRef = ''
     this.interrupted = false
@@ -898,6 +972,10 @@ class TurnController {
   }
 
   startMessage() {
+    // A genuine new turn is starting. Cancel any keepBusy watchdog — the
+    // turn it's waiting on is no longer the turn we're working on. Safe
+    // to call even if no watchdog is armed (idempotent).
+    this.clearSettleWatchdog()
     this.endReasoningPhase()
     this.clearReasoning()
     this.activeTools = []


### PR DESCRIPTION
## Summary

Closes part of #44978

When the TUI calls `interruptTurn({ keepBusy: true })` the controller re-asserts `busy: true` after `idle()` and waits for the gateway's real settle edge (`message.complete`, `message.error`). If that settle never arrives — orphaned session, transport dropped, agent thread crash — there was no watchdog: the controller sat in `busy: true` forever and the user could not recover without quitting the TUI.

This PR adds a 10s settle watchdog (`KEEP_BUSY_WATCHDOG_MS`) that force-clears busy and surfaces a ttl notice on fire. Sits well below the gateway's 120s server-side inflight watchdog so the UI recovers first.

## Changes

- New constant `KEEP_BUSY_WATCHDOG_MS = 10_000` (well below the 120s server watchdog).
- New private field `settleWatchdog: Timer = null` on `TurnController`.
- New helper `clearSettleWatchdog()` (idempotent, parallels `clearStatusTimer`).
- Armed in `interruptTurn({ keepBusy: true })` after re-asserting busy; cancelled in:
  - `recordMessageComplete()` — at the very top, before any work
  - `recordError()` — defensive sibling for `message.error` settle
  - `startMessage()` — a queued-message drain is in flight
  - `reset()` / `fullReset()` — session boundary
  - `interruptTurn()` itself when re-arming (idempotent)
- Fire callback is defensive: if `busy` has already cleared (microtask race between settle and timer fire), the watchdog returns without touching UI state.

## Validation

- `tsc -b` on `ui-tui`: 0 errors.
- 7 new tests in `ui-tui/src/__tests__/turnControllerKeepBusyWatchdog.test.ts`:
  1. `recordMessageComplete` cancels the watchdog — no fire, no notice
  2. Watchdog fires with no settle — `idle()` forced, ttl notice surfaced
  3. `startMessage` cancels the watchdog — advance past deadline, no fire
  4. Plain interrupt (no `keepBusy`) never arms a watchdog
  5. `recordError` cancels the watchdog
  6. `reset()` / `fullReset()` cancel the watchdog (session boundary)
  7. Re-arm across two back-to-back `keepBusy` interrupts — no leaked timer

## Cross-references

- #44978 — original bug report
- #45001 — client/server subset (AbortSignal + backoff + server-side inflight watchdog)
- #45030 — desktop-side slash command re-routing
- Builds on the server subset by adding the TUI-side equivalent: the UI no longer waits forever for a settle that may never come.

## Diff stats

```
2 files changed, 298 insertions(+)
```
