### PR TITLE
fix: use LM Studio max_context_length when model is loaded at default 64K

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1261,12 +1261,25 @@ def _query_local_context_length(model: str, base_url: str, api_key: str = "") ->
                     data = resp.json()
                     for m in data.get("models", []):
                         if _model_id_matches(m.get("key", ""), model) or _model_id_matches(m.get("id", ""), model):
-                            # Prefer loaded instance context (actual runtime value)
+                            # Prefer loaded instance context (actual runtime value).
+                            # When the model is loaded at or below MINIMUM_CONTEXT_LENGTH
+                            # (the default JIT load), fall back to max_context_length so
+                            # auto-discovery reports the model's real capability instead of
+                            # the placeholder 64K.
+                            loaded_ctx = None
                             for inst in m.get("loaded_instances", []):
                                 cfg = inst.get("config", {})
                                 ctx = cfg.get("context_length")
                                 if ctx and isinstance(ctx, (int, float)):
-                                    return int(ctx)
+                                    loaded_ctx = int(ctx)
+                                    break
+                            if loaded_ctx is not None and loaded_ctx > MINIMUM_CONTEXT_LENGTH:
+                                return loaded_ctx
+                            # Fall back to the model's advertised max when the loaded
+                            # instance is at/below the Hermes minimum (i.e. the default).
+                            max_ctx = m.get("max_context_length")
+                            if max_ctx and isinstance(max_ctx, (int, float)):
+                                return int(max_ctx)
                             break
 
             # LM Studio / vLLM / llama.cpp: try /v1/models/{model}

--- a/tests/agent/test_model_metadata_local_ctx.py
+++ b/tests/agent/test_model_metadata_local_ctx.py
@@ -424,6 +424,44 @@ class TestQueryLocalContextLengthLmStudio:
             "max_context_length (1048576) must not win over loaded_instances."
         )
 
+    def test_lmstudio_fallback_max_context_length_when_loaded_at_minimum(self):
+        """When loaded context equals the minimum (64K), fall back to max_context_length.
+
+        If LM Studio loaded the model with the default 64K (e.g. JIT load without
+        explicit context), auto-discovery should still report the model's real
+        capability from max_context_length rather than the placeholder 64K.
+        """
+        from agent.model_metadata import _query_local_context_length
+
+        native_resp = self._make_resp(200, {
+            "models": [
+                {
+                    "key": "qwen/qwen3.6-35b-a3b",
+                    "id": "qwen/qwen3.6-35b-a3b",
+                    "max_context_length": 262_144,
+                    "loaded_instances": [
+                        {"config": {"context_length": 64_000}},
+                    ],
+                },
+            ]
+        })
+        client_mock = self._make_client(
+            native_resp,
+            self._make_resp(404, {}),
+            self._make_resp(404, {}),
+        )
+
+        with patch("agent.model_metadata.detect_local_server_type", return_value="lm-studio"), \
+             patch("httpx.Client", return_value=client_mock):
+            result = _query_local_context_length(
+                "qwen3.6-35b-a3b", "http://192.168.1.22:1234/v1"
+            )
+
+        assert result == 262_144, (
+            f"Expected max_context_length (262144) but got {result}. "
+            "When loaded context is at the minimum, max_context_length should be used."
+        )
+
 
 class TestDetectLocalServerTypeAuth:
     def test_passes_bearer_token_to_probe_requests(self):


### PR DESCRIPTION
## Summary
- fall back to LM Studio `max_context_length` when the loaded instance context is only Hermes' 64K minimum/default
- keep preferring the loaded instance value when it is above the minimum
- add a regression test covering the default-64K JIT-load case

## Problem
Hermes auto-discovers LM Studio context by checking `loaded_instances[].config.context_length` from `/api/v1/models`.
When Hermes JIT-loads a model without an explicit context override, LM Studio can load it at the default 64K. Hermes then reports 64K as the model context even when the model's advertised `max_context_length` is much higher.

## Fix
If the loaded instance context is only Hermes' default/minimum load size, fall back to LM Studio's advertised `max_context_length`. If the loaded instance is already above that minimum, keep using the loaded runtime value.

## Why this PR is separate from #36852
This fixes the LM Studio **JIT-loaded autodiscovery** path.
PR #36852 fixes a different layer: `custom_providers` per-model `context_length` lookup when LM Studio reports model ids as `publisher/slug`.

Related to #30178.
