### PR TITLE
fix(tools): recurse into nested objects in coerce_tool_args for array repair

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -697,7 +697,48 @@ def coerce_tool_args(tool_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
         if coerced is not value:
             args[key] = coerced
 
+    # Recurse into nested objects and array items so that deeply nested
+    # array properties are also repaired (e.g. MiniMax native XML parsing
+    # collapses single-element nested arrays to {"item": element}).
+    _coerce_nested_args(properties, args)
+
     return args
+
+
+def _coerce_nested_args(properties: Dict[str, Any], args: Dict[str, Any]) -> None:
+    """Recursively coerce nested argument values to match JSON Schema types.
+
+    Walks into nested objects and array items, applying the same bare-scalar-
+    to-list wrapping and xmltodict ``{"item": element}`` unwrapping that
+    ``coerce_tool_args`` performs at the top level.
+    """
+    for key, value in list(args.items()):
+        prop_schema = properties.get(key)
+        if not prop_schema:
+            continue
+        expected = prop_schema.get("type")
+
+        if expected == "array" and value is not None and not isinstance(value, (list, tuple)):
+            # xmltodict collapses single-element arrays to {"item": element}
+            if isinstance(value, dict) and len(value) == 1 and "item" in value:
+                args[key] = [value["item"]]
+                continue
+            args[key] = [value]
+            continue
+
+        if expected == "object" and isinstance(value, dict):
+            nested_props = prop_schema.get("properties")
+            if nested_props:
+                _coerce_nested_args(nested_props, value)
+
+        if expected == "array" and isinstance(value, list):
+            items_schema = prop_schema.get("items")
+            if isinstance(items_schema, dict) and items_schema.get("type") == "object":
+                item_props = items_schema.get("properties")
+                if item_props:
+                    for item in value:
+                        if isinstance(item, dict):
+                            _coerce_nested_args(item_props, item)
 
 
 def _coerce_value(value: str, expected_type, schema: dict | None = None):

--- a/tests/run_agent/test_tool_arg_coercion.py
+++ b/tests/run_agent/test_tool_arg_coercion.py
@@ -408,3 +408,81 @@ class TestCoerceToolArgs:
         assert isinstance(result["offset"], int)
         assert result["limit"] == 100
         assert isinstance(result["limit"], int)
+
+    def test_nested_array_xmltodict_collapse_unwrapped(self):
+        """xmltodict single-element collapse {"item": X} is unwrapped to [X]."""
+        schema = self._mock_schema({
+            "children": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "paragraph": {
+                            "type": "object",
+                            "properties": {
+                                "rich_text": {"type": "array"},
+                            },
+                        },
+                    },
+                },
+            },
+        })
+        with patch("model_tools.registry.get_schema", return_value=schema):
+            args = {
+                "children": [
+                    {
+                        "paragraph": {
+                            "rich_text": {"item": {"text": {"content": "test"}, "type": "text"}},
+                        },
+                    },
+                ],
+            }
+            result = coerce_tool_args("test_tool", args)
+            # rich_text should be unwrapped from {"item": ...} to [...]
+            assert isinstance(result["children"][0]["paragraph"]["rich_text"], list)
+            assert result["children"][0]["paragraph"]["rich_text"] == [
+                {"text": {"content": "test"}, "type": "text"},
+            ]
+
+    def test_nested_bare_scalar_wrapped_as_array(self):
+        """Bare scalar in nested object is wrapped in single-element list."""
+        schema = self._mock_schema({
+            "block": {
+                "type": "object",
+                "properties": {
+                    "tags": {"type": "array"},
+                },
+            },
+        })
+        with patch("model_tools.registry.get_schema", return_value=schema):
+            args = {"block": {"tags": "important"}}
+            result = coerce_tool_args("test_tool", args)
+            assert result["block"]["tags"] == ["important"]
+
+    def test_nested_array_already_list_untouched(self):
+        """Nested array that is already a list is left unchanged."""
+        schema = self._mock_schema({
+            "children": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "text": {"type": "string"},
+                    },
+                },
+            },
+        })
+        with patch("model_tools.registry.get_schema", return_value=schema):
+            args = {"children": [{"text": "hello"}, {"text": "world"}]}
+            result = coerce_tool_args("test_tool", args)
+            assert result["children"] == [{"text": "hello"}, {"text": "world"}]
+
+    def test_nested_object_without_properties_not_recurse(self):
+        """Nested object without properties schema is left unchanged."""
+        schema = self._mock_schema({
+            "metadata": {"type": "object"},
+        })
+        with patch("model_tools.registry.get_schema", return_value=schema):
+            args = {"metadata": {"arbitrary": "data"}}
+            result = coerce_tool_args("test_tool", args)
+            assert result["metadata"] == {"arbitrary": "data"}


### PR DESCRIPTION
## What does this PR do?

Fixes `coerce_tool_args()` to recurse into nested objects and array items when repairing tool call arguments. Previously, bare-scalar-to-list wrapping only worked at the top level — deeply nested array properties (e.g. `rich_text` inside `paragraph` inside `children[0]`) were left uncoerced. This also handles the xmltodict single-element collapse pattern (`{"item": element}` → `[element]`).

## Related Issue

Fixes #44976

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `model_tools.py`: Added `_coerce_nested_args()` recursive helper that walks nested objects and array items using the tool's JSON Schema, applying the same array coercion logic as the top-level `coerce_tool_args()`. Detects xmltodict `{"item": X}` collapse and unwraps to `[X]`.
- `tests/run_agent/test_tool_arg_coercion.py`: Added 4 tests covering nested xmltodict collapse unwrapping, nested bare scalar wrapping, already-correct nested arrays, and loosely-typed nested objects.

## How to Test

1. `python -m pytest tests/run_agent/test_tool_arg_coercion.py -q` — all 65 tests pass
2. The key test `test_nested_array_xmltodict_collapse_unwrapped` verifies the exact reproduction from the issue: a Notion-style nested `rich_text` array collapsed to `{"item": {...}}` is unwrapped back to `[{...}]`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `coerce_tool_args` (callers: 1 in `model_tools.py:917`, flows: tool dispatch → coercion → MCP dispatch)
- Blast radius: LOW — `_coerce_nested_args` only activates when schema declares nested `properties`; loosely-typed objects are untouched
- Related patterns: bare-scalar-to-list wrapping (existing), xmltodict single-element collapse (`force_list` workaround)
