### PR TITLE
[codex] fix desktop compressed session identity

### DIFF
--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -38,6 +38,7 @@ import {
   $messages,
   $selectedStoredSessionId,
   $sessions,
+  sessionMatchesAnyId,
   sessionPinId
 } from '@/store/session'
 import type { ModelOptionsResponse } from '@/types/hermes'
@@ -89,6 +90,7 @@ interface ChatHeaderProps {
   isRoutedSessionView: boolean
   onDeleteSelectedSession: () => void
   onToggleSelectedPin: () => void
+  routedSessionId: null | string
   selectedSessionId: null | string
 }
 
@@ -97,13 +99,14 @@ function ChatHeader({
   isRoutedSessionView,
   onDeleteSelectedSession,
   onToggleSelectedPin,
+  routedSessionId,
   selectedSessionId
 }: ChatHeaderProps) {
   const sessions = useStore($sessions)
   const pinnedSessionIds = useStore($pinnedSessionIds)
 
   const activeStoredSession =
-    sessions.find(session => session.id === selectedSessionId || session._lineage_root_id === selectedSessionId) || null
+    sessions.find(session => sessionMatchesAnyId(session, [selectedSessionId, routedSessionId, activeSessionId])) || null
 
   const title = activeStoredSession ? sessionTitle(activeStoredSession) : 'New session'
 
@@ -123,6 +126,8 @@ function ChatHeader({
     return null
   }
 
+  const actionSessionId = selectedSessionId || activeStoredSession?.id || routedSessionId || activeSessionId || ''
+
   return (
     <header className={cn(titlebarHeaderBaseClass, isRoutedSessionView && titlebarHeaderShadowClass)}>
       <div className={titlebarHeaderTitleClass}>
@@ -131,7 +136,7 @@ function ChatHeader({
           onDelete={selectedSessionId ? onDeleteSelectedSession : undefined}
           onPin={selectedSessionId ? onToggleSelectedPin : undefined}
           pinned={selectedIsPinned}
-          sessionId={selectedSessionId || activeSessionId || ''}
+          sessionId={actionSessionId}
           sideOffset={8}
           title={title}
         >
@@ -191,7 +196,8 @@ export function ChatView({
   const messages = useStore($messages)
   const selectedSessionId = useStore($selectedStoredSessionId)
   const runtimeMessageCacheRef = useRef(new WeakMap<ChatMessage, ThreadMessage>())
-  const isRoutedSessionView = Boolean(routeSessionId(location.pathname))
+  const routedSessionId = routeSessionId(location.pathname)
+  const isRoutedSessionView = Boolean(routedSessionId)
 
   const showIntro =
     freshDraftReady && !isRoutedSessionView && !selectedSessionId && !activeSessionId && messages.length === 0
@@ -340,6 +346,7 @@ export function ChatView({
         isRoutedSessionView={isRoutedSessionView}
         onDeleteSelectedSession={onDeleteSelectedSession}
         onToggleSelectedPin={onToggleSelectedPin}
+        routedSessionId={routedSessionId}
         selectedSessionId={selectedSessionId}
       />
 

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -38,8 +38,8 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { Tip } from '@/components/ui/tooltip'
 import { searchSessions, type SessionInfo, type SessionSearchResult } from '@/hermes'
 import { useI18n } from '@/i18n'
-import { profileColor } from '@/lib/profile-color'
 import { comboTokens } from '@/lib/keybinds/combo'
+import { profileColor } from '@/lib/profile-color'
 import { sessionMatchesSearch } from '@/lib/session-search'
 import { normalizeSessionSource, sessionSourceLabel } from '@/lib/session-source'
 import { cn } from '@/lib/utils'
@@ -88,6 +88,8 @@ import {
   $sessionsLoading,
   $sessionsTotal,
   $workingSessionIds,
+  sessionMatchesAnyId,
+  sessionMatchesId,
   sessionPinId
 } from '@/store/session'
 
@@ -423,6 +425,12 @@ export function ChatSidebar({
 
       if (s._lineage_root_id && !map.has(s._lineage_root_id)) {
         map.set(s._lineage_root_id, s)
+      }
+
+      for (const lineageId of s._lineage_ids ?? []) {
+        if (!map.has(lineageId)) {
+          map.set(lineageId, s)
+        }
       }
     }
 
@@ -1205,8 +1213,8 @@ function SidebarSessionsSection({
   const renderRow = (session: SessionInfo) => {
     const rowProps = {
       isPinned: pinned,
-      isSelected: session.id === activeSessionId,
-      isWorking: workingSessionIdSet.has(session.id),
+      isSelected: sessionMatchesId(session, activeSessionId),
+      isWorking: sessionMatchesAnyId(session, workingSessionIdSet),
       onArchive: () => onArchiveSession(session.id),
       onDelete: () => onDeleteSession(session.id),
       onPin: () => onTogglePin(sessionPinId(session)),

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
@@ -5,7 +5,7 @@ import { type FC, useCallback, useMemo, useRef } from 'react'
 
 import type { SessionInfo } from '@/hermes'
 import { cn } from '@/lib/utils'
-import { sessionPinId } from '@/store/session'
+import { sessionMatchesAnyId, sessionMatchesId, sessionPinId } from '@/store/session'
 
 import { SidebarSessionRow } from './session-row'
 
@@ -74,8 +74,8 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
 
     const commonProps: SessionRowCommonProps = {
       isPinned: pinned,
-      isSelected: session.id === activeSessionId,
-      isWorking: workingSessionIdSet.has(session.id),
+      isSelected: sessionMatchesId(session, activeSessionId),
+      isWorking: sessionMatchesAnyId(session, workingSessionIdSet),
       onArchive: () => onArchiveSession(session.id),
       onDelete: () => onDeleteSession(session.id),
       onPin: () => onTogglePin(sessionPinId(session)),

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -59,6 +59,7 @@ import {
   getRecentlySettledSessionIds,
   mergeSessionPage,
   MESSAGING_SECTION_LIMIT,
+  sessionMatchesId,
   sessionPinId,
   setAwaitingResponse,
   setBusy,
@@ -473,7 +474,7 @@ export function DesktopController() {
     }
 
     // Pin on the durable lineage-root id so the pin survives auto-compression.
-    const session = $sessions.get().find(s => s.id === sessionId || s._lineage_root_id === sessionId)
+    const session = $sessions.get().find(s => sessionMatchesId(s, sessionId))
     const pinId = session ? sessionPinId(session) : sessionId
 
     if ($pinnedSessionIds.get().includes(pinId)) {
@@ -556,7 +557,7 @@ export function DesktopController() {
 
       const storedProfile = $sessions
         .get()
-        .find(session => session.id === storedSessionId || session._lineage_root_id === storedSessionId)?.profile
+        .find(session => sessionMatchesId(session, storedSessionId))?.profile
 
       for (let index = 0; index < Math.max(1, attempts); index += 1) {
         try {

--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -18,6 +18,7 @@ import {
   $messages,
   $sessions,
   $yoloActive,
+  sessionMatchesId,
   sessionPinId,
   setActiveSessionId,
   setAwaitingResponse,
@@ -210,9 +211,8 @@ function patchSessionWorkspace(sessionId: string, cwd: string | undefined) {
   setSessions(prev => prev.map(session => (session.id === sessionId ? { ...session, cwd } : session)))
 }
 
-function sessionMatchesStoredId(session: SessionInfo, storedSessionId: string): boolean {
-  return session.id === storedSessionId || session._lineage_root_id === storedSessionId
-}
+const sessionMatchesStoredId = (session: SessionInfo, storedSessionId: string): boolean =>
+  sessionMatchesId(session, storedSessionId)
 
 function upsertResolvedSession(session: SessionInfo, storedSessionId: string) {
   const lineage = session._lineage_root_id ?? session.id
@@ -648,6 +648,7 @@ export function useSessionActions({
           reconcileResumeMessages(toChatMessages(resumed.messages), currentMessages),
           currentMessages
         )
+
         // Keep the local snapshot when resume would only reshuffle runtime projection.
         const preferredMessages =
           localSnapshot.length > 0

--- a/apps/desktop/src/lib/session-search.ts
+++ b/apps/desktop/src/lib/session-search.ts
@@ -13,6 +13,7 @@ export function sessionMatchesSearch(session: SessionInfo, query: string): boole
   return [
     session.id,
     session._lineage_root_id ?? '',
+    ...(session._lineage_ids ?? []),
     sessionTitle(session),
     session.preview ?? '',
     session.cwd ?? '',

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -11,6 +11,7 @@ import {
   applyConfiguredDefaultProjectDir,
   getRecentlySettledSessionIds,
   mergeSessionPage,
+  sessionMatchesId,
   sessionPinId,
   setCurrentCwd,
   setSessionAttention,
@@ -74,6 +75,22 @@ describe('sessionPinId', () => {
     // After auto-compression the entry surfaces under a fresh tip id but keeps
     // the original root — pinning on the root keeps the pin stable.
     expect(sessionPinId(session({ id: 'tip', _lineage_root_id: 'root' }))).toBe('root')
+  })
+})
+
+describe('sessionMatchesId', () => {
+  it('matches live, root, and intermediate compression ids', () => {
+    const projected = session({
+      id: 'tip',
+      _lineage_ids: ['root', 'middle', 'tip'],
+      _lineage_root_id: 'root'
+    })
+
+    expect(sessionMatchesId(projected, 'tip')).toBe(true)
+    expect(sessionMatchesId(projected, 'root')).toBe(true)
+    expect(sessionMatchesId(projected, 'middle')).toBe(true)
+    expect(sessionMatchesId(projected, 'other')).toBe(false)
+    expect(sessionMatchesId(projected, null)).toBe(false)
   })
 })
 
@@ -143,6 +160,18 @@ describe('mergeSessionPage', () => {
     expect(merged.map(s => s.id)).toEqual(['tip', 'other'])
   })
 
+  it('keeps a working session matched by an intermediate compression id', () => {
+    const previous = [
+      session({ id: 'tip', _lineage_ids: ['root', 'middle', 'tip'], _lineage_root_id: 'root' })
+    ] as SessionInfo[]
+
+    const incoming = [session({ id: 'other' })] as SessionInfo[]
+
+    const merged = mergeSessionPage(previous, incoming, ['middle'])
+
+    expect(merged.map(s => s.id)).toEqual(['tip', 'other'])
+  })
+
   it('evicts an old compression tip when the incoming page has the new tip from the same lineage', () => {
     // Repro of #43483: after auto-compression rotates the tip (#4 → #5),
     // the sidebar showed both the old tip and the new tip as separate rows.
@@ -152,6 +181,7 @@ describe('mergeSessionPage', () => {
       session({ id: 'tip-4', _lineage_root_id: 'root' }),
       session({ id: 'other' }),
     ] as SessionInfo[]
+
     const incoming = [
       session({ id: 'tip-5', _lineage_root_id: 'root' }),
     ] as SessionInfo[]
@@ -173,6 +203,7 @@ describe('mergeSessionPage', () => {
       session({ id: 'a-old', _lineage_root_id: 'lineage-a' }),
       session({ id: 'b', _lineage_root_id: 'lineage-b' }),
     ] as SessionInfo[]
+
     const incoming = [
       session({ id: 'a-new', _lineage_root_id: 'lineage-a' }),
     ] as SessionInfo[]

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -19,6 +19,7 @@ function workspaceCwdKey(connection: HermesConnection | null = $connection.get()
 
   const base = encodeURIComponent(connection.baseUrl || 'remote')
   const profile = encodeURIComponent(connection.profile || 'default')
+
   return `${WORKSPACE_CWD_KEY}.remote.${base}.${profile}`
 }
 
@@ -64,6 +65,7 @@ export async function ensureDefaultWorkspaceCwd(): Promise<void> {
 
   if ($connection.get()?.mode === 'remote') {
     seedLiveCwd(remembered)
+
     return
   }
 
@@ -105,6 +107,32 @@ function updateAtom<T>(store: AppAtom<T>, next: Updater<T>) {
 export const sessionPinId = (session: Pick<SessionInfo, '_lineage_root_id' | 'id'>): string =>
   session._lineage_root_id ?? session.id
 
+type SessionIdentity = Pick<SessionInfo, '_lineage_ids' | '_lineage_root_id' | 'id'>
+
+/** True when an id refers to this logical conversation.
+ *
+ *  Auto-compression can leave the route or transient running-state store
+ *  pointing at an older segment while the sidebar row has already projected to
+ *  the current tip. Match all known lineage ids so header titles, selection,
+ *  and running indicators survive that rotation. */
+export function sessionMatchesId(session: SessionIdentity, id: null | string | undefined): boolean {
+  if (!id) {
+    return false
+  }
+
+  return session.id === id || session._lineage_root_id === id || Boolean(session._lineage_ids?.includes(id))
+}
+
+export function sessionMatchesAnyId(session: SessionIdentity, ids: Iterable<null | string | undefined>): boolean {
+  for (const id of ids) {
+    if (sessionMatchesId(session, id)) {
+      return true
+    }
+  }
+
+  return false
+}
+
 /** Merge a fresh server session page into the in-memory list, keeping any
  *  row the server omitted that we still want visible — both still-"working"
  *  sessions and pinned sessions.
@@ -140,6 +168,7 @@ export function mergeSessionPage(
   }
 
   const incomingIds = new Set(incoming.map(session => session.id))
+
   // Deduplicate by compression lineage: when auto-compression rotates the tip
   // id (old #4 → new #5), the incoming page carries the new tip but the
   // previous list still holds the old one.  Without lineage-level dedup both
@@ -152,7 +181,9 @@ export function mergeSessionPage(
     session =>
       !incomingIds.has(session.id) &&
       !incomingLineageKeys.has(session._lineage_root_id ?? session.id) &&
-      (keep.has(session.id) || (session._lineage_root_id != null && keep.has(session._lineage_root_id)))
+      (keep.has(session.id) ||
+        (session._lineage_root_id != null && keep.has(session._lineage_root_id)) ||
+        Boolean(session._lineage_ids?.some(id => keep.has(id))))
   )
 
   return survivors.length ? [...survivors, ...incoming] : incoming

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -286,6 +286,9 @@ export interface SessionInfo {
    *  continuation tip. Stable across compressions — used as the durable id for
    *  pins so a pinned conversation survives auto-compression. */
   _lineage_root_id?: null | string
+  /** Full root-to-tip compression chain for a projected continuation. Lets
+   *  clients match stale route/runtime ids to the current visible row. */
+  _lineage_ids?: string[]
   input_tokens: number
   is_active: boolean
   last_active: number

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1972,6 +1972,48 @@ class SessionDB:
             current = row["id"]
         return current
 
+    def get_compression_lineage(self, session_id: str) -> List[str]:
+        """Return the compression-continuation ids from root to tip.
+
+        Unlike ``get_compression_tip()``, callers that surface a projected tip
+        to UI clients also need the intermediate ids. A user can still be routed
+        to an older segment after context compaction, so exposing the full chain
+        lets clients treat root, intermediate ids, and current tip as the same
+        logical conversation.
+        """
+        if not session_id:
+            return []
+
+        chain = [session_id]
+        seen = {session_id}
+        current = session_id
+
+        for _ in range(100):
+            with self._lock:
+                cursor = self._conn.execute(
+                    "SELECT id FROM sessions "
+                    "WHERE parent_session_id = ? "
+                    "  AND started_at >= ("
+                    "      SELECT ended_at FROM sessions "
+                    "      WHERE id = ? AND end_reason = 'compression'"
+                    "  ) "
+                    "ORDER BY started_at DESC LIMIT 1",
+                    (current, current),
+                )
+                row = cursor.fetchone()
+            if row is None:
+                return chain
+
+            next_id = row["id"]
+            if next_id in seen:
+                return chain
+
+            chain.append(next_id)
+            seen.add(next_id)
+            current = next_id
+
+        return chain
+
     def list_sessions_rich(
         self,
         source: str = None,
@@ -2186,7 +2228,8 @@ class SessionDB:
                 if s.get("end_reason") != "compression":
                     projected.append(s)
                     continue
-                tip_id = self.get_compression_tip(s["id"])
+                lineage_ids = self.get_compression_lineage(s["id"])
+                tip_id = lineage_ids[-1] if lineage_ids else s["id"]
                 if tip_id == s["id"]:
                     projected.append(s)
                     continue
@@ -2205,6 +2248,7 @@ class SessionDB:
                     if key in tip_row:
                         merged[key] = tip_row[key]
                 merged["_lineage_root_id"] = s["id"]
+                merged["_lineage_ids"] = lineage_ids
                 projected.append(merged)
             sessions = projected
 

--- a/tests/hermes_state/test_session_archiving.py
+++ b/tests/hermes_state/test_session_archiving.py
@@ -49,3 +49,30 @@ def test_unarchiving_compression_tip_unarchives_projected_root(db):
     assert db.get_session("root")["archived"] == 0
     assert db.get_session("tip")["archived"] == 0
     assert [s["id"] for s in db.list_sessions_rich(order_by_last_active=True)] == ["tip"]
+
+
+def test_projected_compression_tip_includes_full_lineage_ids(db):
+    base = time.time() - 100
+    db.create_session("root", source="cli")
+    db.create_session("middle", source="cli", parent_session_id="root")
+    db.create_session("tip", source="cli", parent_session_id="middle")
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, ended_at = ?, end_reason = 'compression', message_count = 1 WHERE id = 'root'",
+        (base, base + 10),
+    )
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, ended_at = ?, end_reason = 'compression', message_count = 1 WHERE id = 'middle'",
+        (base + 20, base + 30),
+    )
+    db._conn.execute(
+        "UPDATE sessions SET started_at = ?, message_count = 1 WHERE id = 'tip'",
+        (base + 40,),
+    )
+    db._conn.commit()
+
+    rows = db.list_sessions_rich(order_by_last_active=True)
+
+    assert len(rows) == 1
+    assert rows[0]["id"] == "tip"
+    assert rows[0]["_lineage_root_id"] == "root"
+    assert rows[0]["_lineage_ids"] == ["root", "middle", "tip"]


### PR DESCRIPTION
## Summary

This fixes Desktop session identity after context compression rotates a conversation from an older session id to a new continuation tip.

The backend already projects compression roots to their live tips for session lists, but clients only received the root id alias. If the route or transient runtime/working state still pointed at an intermediate compressed segment, Desktop could fail to resolve the projected row and fall back to `New session`, drop sidebar selection, or hide the running indicator.

## Changes

- expose `_lineage_ids` for projected compression-tip session rows
- match Desktop session rows by live id, root id, or any compression lineage id
- apply that matching to header title resolution, sidebar selection/running state, pin/profile lookups, cached resume handling, and local session search
- add backend and Desktop regression coverage for intermediate lineage ids

## Validation

- `PYTHONPATH=$PWD /Users/yt/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_state/test_resolve_resume_session_id.py tests/hermes_state/test_session_archiving.py` — 11 passed
- `npm --workspace apps/desktop run test:ui -- src/store/session.test.ts src/lib/session-search.test.ts src/app/session/hooks/use-prompt-actions.test.tsx src/app/session/hooks/use-session-state-cache.test.tsx` — 4 files / 62 tests passed
- `npm --workspace apps/desktop run typecheck` — passed
- `cd apps/desktop && npx eslint src/store/session.ts src/store/session.test.ts src/app/chat/index.tsx src/app/chat/sidebar/index.tsx src/app/chat/sidebar/virtual-session-list.tsx src/app/desktop-controller.tsx src/app/session/hooks/use-session-actions.ts src/lib/session-search.ts` — passed
- `git diff --check` — passed
