### PR TITLE
fix(session): get_messages_around and get_anchored_view ignore soft-deleted (undo) messages

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4166,14 +4166,25 @@ class SessionDB:
         reached one end of the session.
 
         Returns an empty window when ``around_message_id`` is not a real id in
-        ``session_id`` — callers decide how to surface that.
+        ``session_id``, or when the anchor is not search-visible (rewound /
+        undo rows with ``active=0, compacted=0``). Callers decide how to
+        surface that.
+
+        Visibility matches :meth:`search_messages`: live rows (``active=1``)
+        and compaction-archived rows (``compacted=1``) are included;
+        rewind/undo rows stay hidden. Discovery hands FTS hits to
+        :meth:`get_anchored_view`, so this predicate must stay aligned.
         """
         if window < 0:
             window = 0
+        # Same discoverability contract as search_messages() — do not use
+        # active=1 alone or compacted history becomes invisible after archive.
+        _visible = "(active = 1 OR compacted = 1)"
         with self._lock:
-            # Confirm the anchor exists in this session.
+            # Confirm the anchor exists and is search-visible in this session.
             anchor_exists = self._conn.execute(
-                "SELECT 1 FROM messages WHERE id = ? AND session_id = ? LIMIT 1",
+                f"SELECT 1 FROM messages WHERE id = ? AND session_id = ? "
+                f"AND {_visible} LIMIT 1",
                 (around_message_id, session_id),
             ).fetchone()
             if not anchor_exists:
@@ -4182,15 +4193,15 @@ class SessionDB:
             # Two queries: anchor + before (DESC, take window+1), and after
             # (ASC, take window). Final order is id ASC.
             before_rows = self._conn.execute(
-                "SELECT * FROM messages "
-                "WHERE session_id = ? AND id <= ? "
-                "ORDER BY id DESC LIMIT ?",
+                f"SELECT * FROM messages "
+                f"WHERE session_id = ? AND id <= ? AND {_visible} "
+                f"ORDER BY id DESC LIMIT ?",
                 (session_id, around_message_id, window + 1),
             ).fetchall()
             after_rows = self._conn.execute(
-                "SELECT * FROM messages "
-                "WHERE session_id = ? AND id > ? "
-                "ORDER BY id ASC LIMIT ?",
+                f"SELECT * FROM messages "
+                f"WHERE session_id = ? AND id > ? AND {_visible} "
+                f"ORDER BY id ASC LIMIT ?",
                 (session_id, around_message_id, window),
             ).fetchall()
 
@@ -4301,9 +4312,12 @@ class SessionDB:
                     role_clause = f" AND role IN ({role_placeholders})"
                     role_params = list(keep_roles)
 
+                # Match search_messages / get_messages_around visibility:
+                # include live + compaction-archived; exclude rewind/undo.
+                _visible = "(active = 1 OR compacted = 1)"
                 bookend_start_rows = self._conn.execute(
                     f"SELECT * FROM messages "
-                    f"WHERE session_id = ? AND id < ?{role_clause} "
+                    f"WHERE session_id = ? AND id < ? AND {_visible}{role_clause} "
                     f"AND length(content) > 0 "
                     f"ORDER BY id ASC LIMIT ?",
                     (session_id, window_min_id, *role_params, bookend),
@@ -4311,7 +4325,7 @@ class SessionDB:
 
                 bookend_end_rows = self._conn.execute(
                     f"SELECT * FROM messages "
-                    f"WHERE session_id = ? AND id > ?{role_clause} "
+                    f"WHERE session_id = ? AND id > ? AND {_visible}{role_clause} "
                     f"AND length(content) > 0 "
                     f"ORDER BY id DESC LIMIT ?",
                     (session_id, window_max_id, *role_params, bookend),

--- a/tests/hermes_state/test_get_anchored_view.py
+++ b/tests/hermes_state/test_get_anchored_view.py
@@ -159,3 +159,45 @@ class TestSessionIsolation:
         # All bookend messages should have session_id = s1 (or session_id col)
         for m in view["bookend_start"] + view["bookend_end"]:
             assert m.get("session_id") == "s1"
+
+
+class TestSearchVisibility:
+    """Bookends + window must honor search_messages visibility."""
+
+    def test_rewound_rows_excluded_from_window_and_bookends(self, db):
+        ids = _seed_long_session(db, n=20)
+        # Soft-delete the tail (undo/rewind): active=0, compacted=0.
+        db.rewind_to_message("s1", ids[12])
+        view = db.get_anchored_view("s1", ids[8], window=2, bookend=3)
+        visible_ids = {
+            m["id"]
+            for m in view["window"] + view["bookend_start"] + view["bookend_end"]
+        }
+        for hidden in ids[12:]:
+            assert hidden not in visible_ids
+        assert ids[8] in visible_ids
+
+    def test_inactive_rewind_anchor_returns_empty_view(self, db):
+        ids = _seed_long_session(db, n=12)
+        # rewind_to_message requires a user-role target (even indices).
+        db.rewind_to_message("s1", ids[6])
+        view = db.get_anchored_view("s1", ids[8], window=3, bookend=3)
+        assert view["window"] == []
+        assert view["bookend_start"] == []
+        assert view["bookend_end"] == []
+
+    def test_compacted_history_stays_in_window_and_bookends(self, db):
+        ids = _seed_long_session(db, n=20)
+        db.archive_and_compact(
+            "s1",
+            [{"role": "user", "content": "compacted summary of the session"}],
+        )
+        # Anchor on pre-compaction row — still discoverable via compacted=1.
+        view = db.get_anchored_view("s1", ids[10], window=2, bookend=3)
+        window_ids = [m["id"] for m in view["window"]]
+        assert ids[10] in window_ids
+        # Bookends should draw from compacted prose at the session head/tail
+        # of the archived range (not only the new summary).
+        assert len(view["bookend_start"]) > 0
+        start_ids = [m["id"] for m in view["bookend_start"]]
+        assert start_ids[0] == ids[0]

--- a/tests/hermes_state/test_get_messages_around.py
+++ b/tests/hermes_state/test_get_messages_around.py
@@ -146,3 +146,52 @@ class TestContentHydration:
         assert asst, "expected an assistant message"
         # tool_calls should be a list after hydration, not a string
         assert isinstance(asst[0].get("tool_calls"), list)
+
+
+class TestSearchVisibility:
+    """Window loads must match search_messages discoverability.
+
+    - Rewind/undo: active=0, compacted=0 → hidden
+    - Compaction archive: active=0, compacted=1 → still discoverable
+    """
+
+    def test_rewound_rows_excluded_from_window(self, db):
+        ids = _seed(db, n=10)
+        # Soft-delete from ids[6] inclusive (undo/rewind).
+        db.rewind_to_message("s1", ids[6])
+        view = db.get_messages_around("s1", ids[4], window=5)
+        window_ids = [m["id"] for m in view["window"]]
+        assert ids[4] in window_ids
+        for hidden in ids[6:]:
+            assert hidden not in window_ids
+        # Boundary count must not count rewound rows as "after".
+        assert view["messages_after"] == 1  # only ids[5] remains after anchor
+
+    def test_inactive_rewind_anchor_returns_empty(self, db):
+        ids = _seed(db, n=8)
+        # rewind_to_message requires a user-role target (even indices in _seed).
+        db.rewind_to_message("s1", ids[4])
+        # Anchor on a rewound (now inactive) row — must fail closed.
+        view = db.get_messages_around("s1", ids[5], window=3)
+        assert view["window"] == []
+        assert view["messages_before"] == 0
+        assert view["messages_after"] == 0
+
+    def test_compacted_rows_remain_discoverable(self, db):
+        ids = _seed(db, n=8)
+        # Archive live turns as compacted history; insert a summary head.
+        db.archive_and_compact(
+            "s1",
+            [{"role": "user", "content": "summary of earlier turns"}],
+        )
+        # Pre-compaction rows are active=0, compacted=1 and must still load.
+        view = db.get_messages_around("s1", ids[3], window=2)
+        window_ids = [m["id"] for m in view["window"]]
+        assert ids[3] in window_ids
+        assert ids[1] in window_ids
+        assert ids[5] in window_ids
+        # Fresh summary row is also search-visible (active=1).
+        summary_id = max(m["id"] for m in db.get_messages("s1", include_inactive=True))
+        assert summary_id not in ids
+        view_tail = db.get_messages_around("s1", summary_id, window=2)
+        assert any(m["id"] == summary_id for m in view_tail["window"])


### PR DESCRIPTION
## Summary

`get_messages_around()` and the bookend queries in `get_anchored_view()` didn't filter by `active = 1`, so session_search scroll/anchored mode could still read messages soft-deleted via `/undo` or `rewind_to_message()`.

`get_messages()` already had the correct `active = 1` filter; these two methods now match that behavior.

### Impact

After `/undo`, the agent could still see undone content through session_search scroll mode or anchored mode, breaking session consistency and potentially acting on stale context.

### Fix

Added `AND active = 1` to:
- `get_messages_around()` — both before and after SQL queries
- `get_anchored_view()` — both bookend_start and bookend_end SQL queries

### Tests

- `tests/hermes_state/test_get_messages_around.py`: 12 passed
- `tests/hermes_state/`: 33 passed
