### PR TITLE
fix(plugins): cmd_enable and cmd_disable now sync platform_toolsets

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -864,6 +864,11 @@ def cmd_enable(name: str, allow_tool_override: Optional[bool] = None) -> None:
     else:
         console.print(f"[dim]Plugin '{key}' is already enabled.[/dim]")
 
+    # Always reconcile platform_toolsets — including the already-enabled path —
+    # so a stale config can be repaired by re-running enable (dashboard path
+    # already toggles toolsets; CLI must match).
+    _toggle_plugin_toolset(key, enable=True)
+
     # Built-in tool override is a privileged grant. Bundled plugins ship with
     # Hermes core and are trusted; every other source needs operator opt-in.
     if source == "bundled":
@@ -927,6 +932,9 @@ def cmd_disable(name: str) -> None:
 
     if key not in enabled and key in disabled:
         console.print(f"[dim]Plugin '{key}' is already disabled.[/dim]")
+        # Still reconcile platform_toolsets so re-running disable repairs
+        # stale toolset entries left from a prior partial state.
+        _toggle_plugin_toolset(key, enable=False)
         return
 
     enabled.discard(key)
@@ -938,6 +946,8 @@ def cmd_disable(name: str) -> None:
     disabled.add(key)
     _save_enabled_set(enabled)
     _save_disabled_set(disabled)
+    # Keep platform_toolsets in sync so the agent stops seeing the plugin's tools.
+    _toggle_plugin_toolset(key, enable=False)
     console.print(
         f"[yellow]\u2298[/yellow] Plugin [bold]{key}[/bold] disabled. "
         "Takes effect on next session."

--- a/tests/hermes_cli/test_plugins_cmd_enable_disable_toolset.py
+++ b/tests/hermes_cli/test_plugins_cmd_enable_disable_toolset.py
@@ -1,0 +1,200 @@
+"""CLI enable/disable must keep platform_toolsets in sync.
+
+The dashboard path already calls ``_toggle_plugin_toolset``; the CLI
+``cmd_enable`` / ``cmd_disable`` used to only flip the allow/deny lists,
+leaving stale toolset entries after partial configs or dashboard/CLI drift.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+
+def _make_plugin_dir(parent: Path, name: str, manifest: dict) -> Path:
+    d = parent / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "plugin.yaml").write_text(yaml.dump(manifest), encoding="utf-8")
+    (d / "__init__.py").write_text("def register(ctx): pass\n", encoding="utf-8")
+    return d
+
+
+@pytest.fixture
+def tool_plugin_env(tmp_path):
+    """A flat user plugin that reports tools (via mocked toolset key)."""
+    _make_plugin_dir(
+        tmp_path,
+        "tooly",
+        {
+            "name": "tooly",
+            "version": "1.0.0",
+            "description": "provides tools",
+            "provides_tools": ["tooly_do"],
+        },
+    )
+    return tmp_path
+
+
+def _patch_env(mock_user, mock_bundled, env):
+    mock_user.return_value = env
+    mock_bundled.return_value = env / "nonexistent"
+
+
+class TestEnableDisableSyncsPlatformToolsets:
+    @patch("hermes_cli.plugins_cmd._get_plugin_toolset_key", return_value="plugin:tooly")
+    @patch("hermes_cli.plugins.get_bundled_plugins_dir")
+    @patch("hermes_cli.plugins_cmd._plugins_dir")
+    @patch("hermes_cli.plugins_cmd._save_disabled_set")
+    @patch("hermes_cli.plugins_cmd._save_enabled_set")
+    @patch("hermes_cli.plugins_cmd._get_disabled_set", return_value=set())
+    @patch("hermes_cli.plugins_cmd._get_enabled_set", return_value=set())
+    def test_enable_adds_toolset_to_platform_toolsets(
+        self,
+        mock_en,
+        mock_dis,
+        mock_save_en,
+        mock_save_dis,
+        mock_user,
+        mock_bundled,
+        mock_ts_key,
+        tool_plugin_env,
+        tmp_path,
+        monkeypatch,
+    ):
+        from hermes_cli import plugins_cmd
+
+        _patch_env(mock_user, mock_bundled, tool_plugin_env)
+
+        cfg = {
+            "platform_toolsets": {
+                "cli": ["hermes-cli"],
+                "telegram": ["hermes-telegram"],
+            }
+        }
+        saved = {}
+
+        def _load():
+            return cfg
+
+        def _save(c):
+            saved["config"] = c
+
+        monkeypatch.setattr("hermes_cli.config.load_config", _load)
+        monkeypatch.setattr("hermes_cli.config.save_config", _save)
+
+        plugins_cmd.cmd_enable("tooly", allow_tool_override=False)
+
+        assert "plugin:tooly" in saved["config"]["platform_toolsets"]["cli"]
+        assert "plugin:tooly" in saved["config"]["platform_toolsets"]["telegram"]
+        mock_save_en.assert_called_once()
+
+    @patch("hermes_cli.plugins_cmd._get_plugin_toolset_key", return_value="plugin:tooly")
+    @patch("hermes_cli.plugins.get_bundled_plugins_dir")
+    @patch("hermes_cli.plugins_cmd._plugins_dir")
+    @patch("hermes_cli.plugins_cmd._save_disabled_set")
+    @patch("hermes_cli.plugins_cmd._save_enabled_set")
+    @patch("hermes_cli.plugins_cmd._get_disabled_set", return_value=set())
+    @patch("hermes_cli.plugins_cmd._get_enabled_set")
+    def test_already_enabled_still_reconciles_stale_toolset(
+        self,
+        mock_en,
+        mock_dis,
+        mock_save_en,
+        mock_save_dis,
+        mock_user,
+        mock_bundled,
+        mock_ts_key,
+        tool_plugin_env,
+        monkeypatch,
+    ):
+        """Re-running enable must repair platform_toolsets even when already enabled."""
+        from hermes_cli import plugins_cmd
+
+        _patch_env(mock_user, mock_bundled, tool_plugin_env)
+        mock_en.return_value = {"tooly"}  # already enabled
+        mock_dis.return_value = set()
+
+        cfg = {"platform_toolsets": {"cli": ["hermes-cli"]}}  # missing plugin toolset
+        saved = {}
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+        monkeypatch.setattr("hermes_cli.config.save_config", lambda c: saved.update(config=c))
+
+        plugins_cmd.cmd_enable("tooly", allow_tool_override=False)
+
+        assert "plugin:tooly" in saved["config"]["platform_toolsets"]["cli"]
+        # Enable set already had the key — no need to rewrite allow-list.
+        mock_save_en.assert_not_called()
+
+    @patch("hermes_cli.plugins_cmd._get_plugin_toolset_key", return_value="plugin:tooly")
+    @patch("hermes_cli.plugins.get_bundled_plugins_dir")
+    @patch("hermes_cli.plugins_cmd._plugins_dir")
+    @patch("hermes_cli.plugins_cmd._save_disabled_set")
+    @patch("hermes_cli.plugins_cmd._save_enabled_set")
+    @patch("hermes_cli.plugins_cmd._get_disabled_set", return_value=set())
+    @patch("hermes_cli.plugins_cmd._get_enabled_set", return_value={"tooly"})
+    def test_disable_removes_toolset_from_platform_toolsets(
+        self,
+        mock_en,
+        mock_dis,
+        mock_save_en,
+        mock_save_dis,
+        mock_user,
+        mock_bundled,
+        mock_ts_key,
+        tool_plugin_env,
+        monkeypatch,
+    ):
+        from hermes_cli import plugins_cmd
+
+        _patch_env(mock_user, mock_bundled, tool_plugin_env)
+
+        cfg = {
+            "platform_toolsets": {
+                "cli": ["hermes-cli", "plugin:tooly"],
+                "telegram": ["plugin:tooly"],
+            }
+        }
+        saved = {}
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+        monkeypatch.setattr("hermes_cli.config.save_config", lambda c: saved.update(config=c))
+
+        plugins_cmd.cmd_disable("tooly")
+
+        assert "plugin:tooly" not in saved["config"]["platform_toolsets"]["cli"]
+        assert "plugin:tooly" not in saved["config"]["platform_toolsets"]["telegram"]
+        mock_save_dis.assert_called_once()
+
+    @patch("hermes_cli.plugins_cmd._get_plugin_toolset_key", return_value="plugin:tooly")
+    @patch("hermes_cli.plugins.get_bundled_plugins_dir")
+    @patch("hermes_cli.plugins_cmd._plugins_dir")
+    @patch("hermes_cli.plugins_cmd._save_disabled_set")
+    @patch("hermes_cli.plugins_cmd._save_enabled_set")
+    @patch("hermes_cli.plugins_cmd._get_disabled_set", return_value={"tooly"})
+    @patch("hermes_cli.plugins_cmd._get_enabled_set", return_value=set())
+    def test_already_disabled_still_reconciles_stale_toolset(
+        self,
+        mock_en,
+        mock_dis,
+        mock_save_en,
+        mock_save_dis,
+        mock_user,
+        mock_bundled,
+        mock_ts_key,
+        tool_plugin_env,
+        monkeypatch,
+    ):
+        """Re-running disable must strip stale toolset entries."""
+        from hermes_cli import plugins_cmd
+
+        _patch_env(mock_user, mock_bundled, tool_plugin_env)
+
+        cfg = {"platform_toolsets": {"cli": ["hermes-cli", "plugin:tooly"]}}
+        saved = {}
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+        monkeypatch.setattr("hermes_cli.config.save_config", lambda c: saved.update(config=c))
+
+        plugins_cmd.cmd_disable("tooly")
+
+        assert "plugin:tooly" not in saved["config"]["platform_toolsets"]["cli"]
+        mock_save_dis.assert_not_called()


### PR DESCRIPTION
## Summary

CLI `cmd_enable` and `cmd_disable` only updated `plugins.enabled`/`disabled` sets but never synced `platform_toolsets`. This meant a plugin enabled via CLI appeared as enabled in config but its tools were invisible to the agent if the toolset had been previously disabled via `hermes tools`.

`dashboard_set_agent_plugin_enabled` already called `_toggle_plugin_toolset`; now `cmd_enable` and `cmd_disable` do the same for consistency.

### Impact

- Enable a plugin via CLI -> plugin shows as enabled, but tools don't appear in sessions
- Disable a plugin via CLI -> plugin disabled, but toolset lingers in `platform_toolsets`
- Inconsistent behavior between CLI and Dashboard enable/disable

### Fix

Added `_toggle_plugin_toolset(key, enable=True)` to `cmd_enable()` and `_toggle_plugin_toolset(key, enable=False)` to `cmd_disable()` in `hermes_cli/plugins_cmd.py`, matching the dashboard path.

### Tests

- `tests/hermes_cli/test_plugins_cmd.py`: 81 passed
- `tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py`: 10 passed
