### PR TITLE
Expose request tools to API request hooks

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -940,6 +940,18 @@ def run_conversation(
                             request_messages=list(request_messages)
                             if isinstance(request_messages, list)
                             else [],
+                            # Full-fidelity per-call tools array — same raw
+                            # passthrough posture as request_messages above
+                            # (api_kwargs is the object sent to the provider;
+                            # secrets are not expected). Lets observability
+                            # plugins attribute per-schema token cost exactly
+                            # instead of estimating: agent.tools is assembled
+                            # post-registry and providers mutate schemas before
+                            # send, so the sanitized payload + tool_count alone
+                            # can't reconstruct what was actually sent.
+                            request_tools=list(api_kwargs.get("tools") or [])
+                            if isinstance(api_kwargs, dict)
+                            else [],
                             message_count=len(api_messages),
                             tool_count=len(agent.tools or []),
                             approx_input_tokens=approx_tokens,

--- a/hermes_cli/hooks.py
+++ b/hermes_cli/hooks.py
@@ -154,6 +154,9 @@ _DEFAULT_PAYLOADS = {
         "api_call_count": 1,
         "message_count": 4,
         "tool_count": 12,
+        # Full-fidelity per-call tools array (raw passthrough, like
+        # request_messages). Empty here; populated at runtime from api_kwargs.
+        "request_tools": [],
         "approx_input_tokens": 2048,
         "request_char_count": 8192,
         "max_tokens": 4096,

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -444,6 +444,32 @@ def _coerce_request_messages(
     return [{"role": "user", "content": user_message}]
 
 
+def _tool_schema_name(tool: Any) -> Optional[str]:
+    if not isinstance(tool, dict):
+        return None
+    function = tool.get("function")
+    if isinstance(function, dict) and function.get("name"):
+        return str(function.get("name"))
+    if tool.get("name"):
+        return str(tool.get("name"))
+    return None
+
+
+def _request_tools_metadata(request_tools: Any) -> dict[str, Any]:
+    if not isinstance(request_tools, list):
+        return {}
+
+    names = [
+        name for name in (_tool_schema_name(tool) for tool in request_tools)
+        if name
+    ]
+    return {
+        "request_tool_count": len(request_tools),
+        "request_tool_names": names[:50],
+        "request_tools": _safe_value(request_tools),
+    }
+
+
 def _serialize_messages(messages: Any) -> list[dict[str, Any]]:
     if not isinstance(messages, list):
         return []
@@ -767,6 +793,7 @@ def on_pre_llm_request(
     approx_input_tokens: int = 0,
     request_char_count: int = 0,
     max_tokens: Any = None,
+    request_tools: Any = None,
     conversation_history: Any = None,
     user_message: Any = None,
     **_: Any,
@@ -804,18 +831,20 @@ def on_pre_llm_request(
         previous = state.generations.pop(req_key, None)
         if previous is not None:
             _end_observation(previous)
+        metadata = {
+            "provider": provider,
+            "platform": platform,
+            "api_mode": api_mode,
+            "base_url": base_url,
+        }
+        metadata.update(_request_tools_metadata(request_tools))
         state.generations[req_key] = _start_child_observation(
             state,
             client=client,
             name=f"LLM call {api_call_count}",
             as_type="generation",
             input_value=_serialize_messages(input_messages),
-            metadata={
-                "provider": provider,
-                "platform": platform,
-                "api_mode": api_mode,
-                "base_url": base_url,
-            },
+            metadata=metadata,
             model=model,
             model_parameters={"api_mode": api_mode, "provider": provider},
         )

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -502,6 +502,80 @@ class TestRequestMessageCoercion:
         assert mod._coerce_request_messages(user_message="u") == [{"role": "user", "content": "u"}]
 
 
+class TestRequestToolsMetadata:
+    def test_request_tools_metadata_extracts_count_names_and_safe_schema(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        mod = importlib.import_module("plugins.observability.langfuse")
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "web_search",
+                    "description": "Search the web",
+                    "parameters": {"type": "object"},
+                },
+            },
+            {
+                "name": "legacy_tool",
+                "description": "Legacy schema shape",
+            },
+        ]
+
+        metadata = mod._request_tools_metadata(tools)
+
+        assert metadata["request_tool_count"] == 2
+        assert metadata["request_tool_names"] == ["web_search", "legacy_tool"]
+        assert metadata["request_tools"][0]["function"]["name"] == "web_search"
+
+    def test_pre_llm_request_writes_request_tools_to_generation_metadata(self, monkeypatch):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        mod = importlib.import_module("plugins.observability.langfuse")
+
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: object())
+        monkeypatch.setattr(
+            mod,
+            "_start_root_trace",
+            lambda *args, **kwargs: mod.TraceState(
+                trace_id="trace-1",
+                root_ctx=None,
+                root_span=object(),
+            ),
+        )
+
+        captured = {}
+
+        def fake_start_child_observation(state, **kwargs):
+            captured.update(kwargs)
+            return object()
+
+        monkeypatch.setattr(mod, "_start_child_observation", fake_start_child_observation)
+
+        mod.on_pre_llm_request(
+            task_id="task-1",
+            session_id="session-1",
+            api_call_count=1,
+            provider="openai",
+            platform="cli",
+            api_mode="responses",
+            base_url="https://api.example.com",
+            request_messages=[{"role": "user", "content": "hi"}],
+            request_tools=[{
+                "type": "function",
+                "function": {
+                    "name": "read_file",
+                    "parameters": {"type": "object"},
+                },
+            }],
+        )
+
+        metadata = captured["metadata"]
+        assert metadata["provider"] == "openai"
+        assert metadata["request_tool_count"] == 1
+        assert metadata["request_tool_names"] == ["read_file"]
+        assert metadata["request_tools"][0]["function"]["name"] == "read_file"
+
+
 class TestToolCallOutputBackfill:
     def test_post_tool_call_backfills_matching_turn_tool_call_output(self, monkeypatch):
         sys.modules.pop("plugins.observability.langfuse", None)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3468,6 +3468,7 @@ class TestRunConversation:
             call["api_request_id"] for call in post_request_calls
         ]
         assert all("message_count" in c and isinstance(c.get("request_messages"), list) for c in pre_request_calls)
+        assert all(isinstance(c.get("request_tools"), list) for c in pre_request_calls)
         assert all("request" in c and "messages" in c["request"]["body"] for c in pre_request_calls)
         assert any(msg.get("role") == "user" and msg.get("content") == "search something" for msg in pre_request_calls[0]["request_messages"])
         assert all("usage" in c and "response" in c for c in post_request_calls)


### PR DESCRIPTION
## Summary
- pass the provider-bound tools array through pre_api_request as request_tools
- add request_tools to the default hook payload schema
- cover the field in the run_conversation API request hook test

## Why
Observability plugins can currently see request_messages and tool_count, but not the actual per-call tool schemas sent to the provider. Exposing request_tools lets tracing/evaluation integrations attribute tool schema cost and inspect the exact request shape without reconstructing it from registry state.

## Tests
- /Users/zhuxun/.hermes/hermes-agent/venv/bin/python -m pytest tests/run_agent/test_run_agent.py -k api_request -q