### PR TITLE
Improve Langfuse tracing reliability

### DIFF
--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -17,6 +17,9 @@ Optional env vars:
   HERMES_LANGFUSE_ENV         - environment tag (e.g. "production", "local")
   HERMES_LANGFUSE_RELEASE     - release/version tag
   HERMES_LANGFUSE_SAMPLE_RATE - sampling rate 0.0–1.0 (default: 1.0)
+  HERMES_LANGFUSE_TRACE_ID    - optional fixed trace id (EvalOps golden runs)
+  HERMES_EVALOPS_RUN_ID       - optional EvalOps verify run id (metadata)
+  HERMES_EVALOPS_CASE_ID      - optional EvalOps golden case id (metadata)
   HERMES_LANGFUSE_MAX_CHARS   - max chars per field (default: 12000)
   HERMES_LANGFUSE_DEBUG       - set to "true" for verbose logging
 """
@@ -28,6 +31,7 @@ import os
 import re
 import threading
 import time
+import atexit
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
@@ -55,6 +59,13 @@ class TraceState:
 _STATE_LOCK = threading.Lock()
 _TRACE_STATE: Dict[str, TraceState] = {}
 _LANGFUSE_CLIENT = None
+# Guards _LANGFUSE_CLIENT initialization against the TOCTOU race: two
+# concurrent first callers both pass the ``is not None`` guard, both
+# construct a Langfuse(**kwargs) client, and the loser's client leaks an
+# open HTTPS connection + background flush thread.  _STATE_LOCK is not
+# reused here because it guards _TRACE_STATE (hot path) and nesting the
+# two locks would risk deadlock with future callers.
+_LANGFUSE_CLIENT_LOCK = threading.Lock()
 _READ_FILE_LINE_RE = re.compile(r"^\s*(\d+)\|(.*)$")
 _READ_FILE_HEAD_LINES = 25
 _READ_FILE_TAIL_LINES = 15
@@ -145,78 +156,93 @@ def _get_langfuse() -> Optional[Langfuse]:
     + credentials present). The result is cached: on the first call we try
     to construct a client, and every subsequent call returns that client
     (or fast-returns ``None`` if init failed).
+
+    Thread-safe: ``_LANGFUSE_CLIENT_LOCK`` serializes the first build so
+    concurrent callers can't both pass the ``is not None`` guard, both
+    construct a ``Langfuse(**kwargs)`` client, and leak the loser's open
+    HTTP connection and background flush thread (same TOCTOU class fixed
+    for the Honcho and FAL clients in ``plugins/plugin_utils.py``).
     """
     global _LANGFUSE_CLIENT
+    # Fast path — already settled (success or _INIT_FAILED); no lock needed.
     if _LANGFUSE_CLIENT is _INIT_FAILED:
         return None
     if _LANGFUSE_CLIENT is not None:
         return _LANGFUSE_CLIENT
 
-    if Langfuse is None:
-        _LANGFUSE_CLIENT = _INIT_FAILED
-        return None
+    with _LANGFUSE_CLIENT_LOCK:
+        # Re-check inside the lock: a racing thread may have completed init
+        # while we were waiting.
+        if _LANGFUSE_CLIENT is _INIT_FAILED:
+            return None
+        if _LANGFUSE_CLIENT is not None:
+            return _LANGFUSE_CLIENT
 
-    public_key = _env("HERMES_LANGFUSE_PUBLIC_KEY") or _env("LANGFUSE_PUBLIC_KEY")
-    secret_key = _env("HERMES_LANGFUSE_SECRET_KEY") or _env("LANGFUSE_SECRET_KEY")
-    if not (public_key and secret_key):
-        _LANGFUSE_CLIENT = _INIT_FAILED
-        return None
+        if Langfuse is None:
+            _LANGFUSE_CLIENT = _INIT_FAILED
+            return None
 
-    # Reject placeholder credentials with a one-shot warning so the
-    # operator sees the misconfiguration instead of silently shipping a
-    # broken observability stack (#23823).  The SDK does not validate
-    # keys at construction time — it queues traces in memory and only
-    # discovers the auth failure when the background flush thread tries
-    # to post them, by which point the warning is buried under whatever
-    # else the process is logging.  Catch it here, surface it once, and
-    # short-circuit via the same _INIT_FAILED path as the empty case.
-    placeholder_issues = [
-        msg
-        for msg in (
-            _validate_langfuse_key("HERMES_LANGFUSE_PUBLIC_KEY", public_key),
-            _validate_langfuse_key("HERMES_LANGFUSE_SECRET_KEY", secret_key),
-        )
-        if msg
-    ]
-    if placeholder_issues:
-        logger.warning(
-            "Langfuse plugin: credentials look like placeholders, traces will "
-            "NOT be emitted (%s). Set real Langfuse keys (pk-lf-... / sk-lf-...) "
-            "or unset HERMES_LANGFUSE_PUBLIC_KEY / HERMES_LANGFUSE_SECRET_KEY to "
-            "silence this warning.",
-            "; ".join(placeholder_issues),
-        )
-        _LANGFUSE_CLIENT = _INIT_FAILED
-        return None
+        public_key = _env("HERMES_LANGFUSE_PUBLIC_KEY") or _env("LANGFUSE_PUBLIC_KEY")
+        secret_key = _env("HERMES_LANGFUSE_SECRET_KEY") or _env("LANGFUSE_SECRET_KEY")
+        if not (public_key and secret_key):
+            _LANGFUSE_CLIENT = _INIT_FAILED
+            return None
 
-    base_url = _env("HERMES_LANGFUSE_BASE_URL") or _env("LANGFUSE_BASE_URL") or "https://cloud.langfuse.com"
-    environment = _env("HERMES_LANGFUSE_ENV") or _env("LANGFUSE_ENV")
-    release = _env("HERMES_LANGFUSE_RELEASE") or _env("LANGFUSE_RELEASE")
-    sample_rate = _env("HERMES_LANGFUSE_SAMPLE_RATE")
+        # Reject placeholder credentials with a one-shot warning so the
+        # operator sees the misconfiguration instead of silently shipping a
+        # broken observability stack (#23823).  The SDK does not validate
+        # keys at construction time — it queues traces in memory and only
+        # discovers the auth failure when the background flush thread tries
+        # to post them, by which point the warning is buried under whatever
+        # else the process is logging.  Catch it here, surface it once, and
+        # short-circuit via the same _INIT_FAILED path as the empty case.
+        placeholder_issues = [
+            msg
+            for msg in (
+                _validate_langfuse_key("HERMES_LANGFUSE_PUBLIC_KEY", public_key),
+                _validate_langfuse_key("HERMES_LANGFUSE_SECRET_KEY", secret_key),
+            )
+            if msg
+        ]
+        if placeholder_issues:
+            logger.warning(
+                "Langfuse plugin: credentials look like placeholders, traces will "
+                "NOT be emitted (%s). Set real Langfuse keys (pk-lf-... / sk-lf-...) "
+                "or unset HERMES_LANGFUSE_PUBLIC_KEY / HERMES_LANGFUSE_SECRET_KEY to "
+                "silence this warning.",
+                "; ".join(placeholder_issues),
+            )
+            _LANGFUSE_CLIENT = _INIT_FAILED
+            return None
 
-    kwargs: Dict[str, Any] = {
-        "public_key": public_key,
-        "secret_key": secret_key,
-        "base_url": base_url,
-    }
-    if environment:
-        kwargs["environment"] = environment
-    if release:
-        kwargs["release"] = release
-    if sample_rate:
+        base_url = _env("HERMES_LANGFUSE_BASE_URL") or _env("LANGFUSE_BASE_URL") or "https://cloud.langfuse.com"
+        environment = _env("HERMES_LANGFUSE_ENV") or _env("LANGFUSE_ENV")
+        release = _env("HERMES_LANGFUSE_RELEASE") or _env("LANGFUSE_RELEASE")
+        sample_rate = _env("HERMES_LANGFUSE_SAMPLE_RATE")
+
+        kwargs: Dict[str, Any] = {
+            "public_key": public_key,
+            "secret_key": secret_key,
+            "base_url": base_url,
+        }
+        if environment:
+            kwargs["environment"] = environment
+        if release:
+            kwargs["release"] = release
+        if sample_rate:
+            try:
+                kwargs["sample_rate"] = float(sample_rate)
+            except ValueError:
+                logger.warning("Invalid HERMES_LANGFUSE_SAMPLE_RATE=%r", sample_rate)
+
         try:
-            kwargs["sample_rate"] = float(sample_rate)
-        except ValueError:
-            logger.warning("Invalid HERMES_LANGFUSE_SAMPLE_RATE=%r", sample_rate)
+            _LANGFUSE_CLIENT = Langfuse(**kwargs)
+        except Exception as exc:  # pragma: no cover - fail-open
+            logger.warning("Could not initialize Langfuse client: %s", exc)
+            _LANGFUSE_CLIENT = _INIT_FAILED
+            return None
 
-    try:
-        _LANGFUSE_CLIENT = Langfuse(**kwargs)
-    except Exception as exc:  # pragma: no cover - fail-open
-        logger.warning("Could not initialize Langfuse client: %s", exc)
-        _LANGFUSE_CLIENT = _INIT_FAILED
-        return None
-
-    return _LANGFUSE_CLIENT
+        return _LANGFUSE_CLIENT
 
 
 def _trace_key(task_id: str, session_id: str) -> str:
@@ -564,7 +590,20 @@ def _usage_and_cost(response: Any, *, provider: str, api_mode: str, model: str, 
 
 def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform: str, provider: str, model: str,
                       api_mode: str, messages: Any, client: Langfuse) -> TraceState:
-    trace_id = client.create_trace_id(seed=f"{session_id or 'sessionless'}::{task_id or task_key}")
+    evalops_run_id = _env("HERMES_EVALOPS_RUN_ID")
+    evalops_case_id = _env("HERMES_EVALOPS_CASE_ID")
+    external_trace_id = _env("HERMES_LANGFUSE_TRACE_ID")
+    if external_trace_id and not (evalops_run_id or evalops_case_id):
+        logger.warning(
+            "Langfuse plugin: ignoring HERMES_LANGFUSE_TRACE_ID outside EvalOps "
+            "context. Set HERMES_EVALOPS_RUN_ID or HERMES_EVALOPS_CASE_ID when "
+            "using a fixed trace id."
+        )
+        external_trace_id = ""
+    if external_trace_id:
+        trace_id = external_trace_id
+    else:
+        trace_id = client.create_trace_id(seed=f"{session_id or 'sessionless'}::{task_id or task_key}")
     trace_input = _extract_last_user_message(messages)
     metadata = {
         "source": "hermes",
@@ -574,6 +613,10 @@ def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform:
         "model": model,
         "api_mode": api_mode,
     }
+    if evalops_run_id:
+        metadata["evalops_run_id"] = evalops_run_id
+    if evalops_case_id:
+        metadata["evalops_case_id"] = evalops_case_id
 
     # session_id must be passed in trace_context for Langfuse session grouping.
     trace_ctx: Dict[str, Any] = {"trace_id": trace_id}
@@ -585,7 +628,7 @@ def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform:
             with propagate_attributes(
                 session_id=session_id or task_key,
                 trace_name="Hermes turn",
-                tags=["hermes", "langfuse"],
+                tags=(["hermes", "langfuse", "evalops"] if evalops_case_id or _env("HERMES_LANGFUSE_ENV") == "evalops" else ["hermes", "langfuse"]),
             ):
                 root_ctx = client.start_as_current_observation(
                     trace_context=trace_ctx,
@@ -660,6 +703,17 @@ def _end_observation(observation: Any, *, output: Any = None, metadata: Optional
         _debug(f"end observation failed: {exc}")
 
 
+def _close_root_context(state: TraceState) -> None:
+    root_ctx = state.root_ctx
+    state.root_ctx = None
+    if root_ctx is None:
+        return
+    try:
+        root_ctx.__exit__(None, None, None)
+    except Exception as exc:  # pragma: no cover - fail-open
+        _debug(f"close root context failed: {exc}")
+
+
 def _merge_trace_output(output: Any, state: TraceState) -> Any:
     if not state.turn_tool_calls:
         return output
@@ -695,10 +749,45 @@ def _finish_trace(task_key: str, *, output: Any = None) -> None:
     except Exception as exc:  # pragma: no cover - fail-open
         _debug(f"finish trace failed: {exc}")
     finally:
+        _close_root_context(state)
         try:
             client.flush()
         except Exception:
             pass
+
+
+def _shutdown_active_traces() -> None:
+    client = _LANGFUSE_CLIENT
+    if client is None or client is _INIT_FAILED:
+        return
+
+    with _STATE_LOCK:
+        states = list(_TRACE_STATE.values())
+        _TRACE_STATE.clear()
+
+    for state in states:
+        try:
+            for observation in state.generations.values():
+                _end_observation(observation)
+            for observation in state.tools.values():
+                _end_observation(observation)
+            for queue in state.pending_tools_by_name.values():
+                for observation in queue:
+                    _end_observation(observation)
+            try:
+                state.root_span.end()
+            except Exception:
+                pass
+        finally:
+            _close_root_context(state)
+
+    try:
+        client.flush()
+    except Exception:
+        pass
+
+
+atexit.register(_shutdown_active_traces)
 
 
 def _assistant_has_tool_calls(message: Any) -> bool:

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import importlib
 import logging
 import sys
+import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -234,6 +236,65 @@ class _FakeLangfuse:
     def __init__(self, **kwargs):
         self.kwargs = kwargs
         _FakeLangfuse.instances.append(self)
+
+
+class _FakeRootSpan:
+    def __init__(self):
+        self.ended = 0
+        self.trace_io = {}
+        self.updated = {}
+
+    def set_trace_io(self, **kwargs):
+        self.trace_io.update(kwargs)
+
+    def update(self, **kwargs):
+        self.updated.update(kwargs)
+
+    def end(self):
+        self.ended += 1
+
+
+class _FakeRootCtx:
+    def __init__(self, span=None):
+        self.span = span or _FakeRootSpan()
+        self.entered = 0
+        self.exited = 0
+
+    def __enter__(self):
+        self.entered += 1
+        return self.span
+
+    def __exit__(self, exc_type, exc, tb):
+        self.exited += 1
+
+
+class _FakeObservation:
+    def __init__(self):
+        self.ended = 0
+        self.updated = []
+
+    def update(self, **kwargs):
+        self.updated.append(kwargs)
+
+    def end(self):
+        self.ended += 1
+
+
+class _FakeTraceClient:
+    def __init__(self, root_ctx=None):
+        self.root_ctx = root_ctx or _FakeRootCtx()
+        self.flush_count = 0
+        self.created_seeds = []
+
+    def create_trace_id(self, *, seed):
+        self.created_seeds.append(seed)
+        return f"generated::{seed}"
+
+    def start_as_current_observation(self, **_kwargs):
+        return self.root_ctx
+
+    def flush(self):
+        self.flush_count += 1
 
 
 class TestPlaceholderKeyDetection:
@@ -477,6 +538,135 @@ class TestPlaceholderKeyDetection:
         assert "placeholders" not in caplog.text.lower(), (
             f"Valid Langfuse keys tripped the placeholder guard: {caplog.text!r}"
         )
+
+    def test_get_langfuse_initializes_once_under_concurrency(self, monkeypatch):
+        self._clear_env(monkeypatch)
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "pk-lf-real-public-xyz")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "sk-lf-real-secret-xyz")
+        plugin = self._fresh_plugin()
+
+        class _SlowLangfuse:
+            instances = []
+
+            def __init__(self, **kwargs):
+                time.sleep(0.02)
+                self.kwargs = kwargs
+                _SlowLangfuse.instances.append(self)
+
+        monkeypatch.setattr(plugin, "Langfuse", _SlowLangfuse, raising=False)
+
+        clients = []
+        start = threading.Barrier(8)
+
+        def worker():
+            start.wait()
+            clients.append(plugin._get_langfuse())
+
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert len(_SlowLangfuse.instances) == 1
+        assert clients == [_SlowLangfuse.instances[0]] * 8
+
+
+class TestTraceLifecycle:
+    def _fresh_plugin(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        return importlib.import_module("plugins.observability.langfuse")
+
+    def test_fixed_trace_id_requires_evalops_context(self, monkeypatch, caplog):
+        mod = self._fresh_plugin()
+        monkeypatch.setattr(mod, "propagate_attributes", None, raising=False)
+        monkeypatch.setenv("HERMES_LANGFUSE_TRACE_ID", "fixed-trace")
+        monkeypatch.delenv("HERMES_EVALOPS_RUN_ID", raising=False)
+        monkeypatch.delenv("HERMES_EVALOPS_CASE_ID", raising=False)
+        client = _FakeTraceClient()
+
+        with caplog.at_level(logging.WARNING, logger="plugins.observability.langfuse"):
+            state = mod._start_root_trace(
+                "task-key",
+                task_id="task-1",
+                session_id="session-1",
+                platform="cli",
+                provider="openai",
+                model="gpt-test",
+                api_mode="chat",
+                messages=[{"role": "user", "content": "hi"}],
+                client=client,
+            )
+
+        assert state.trace_id == "generated::session-1::task-1"
+        assert client.created_seeds == ["session-1::task-1"]
+        assert "ignoring HERMES_LANGFUSE_TRACE_ID outside EvalOps" in caplog.text
+
+    def test_fixed_trace_id_is_used_with_evalops_context(self, monkeypatch):
+        mod = self._fresh_plugin()
+        monkeypatch.setattr(mod, "propagate_attributes", None, raising=False)
+        monkeypatch.setenv("HERMES_LANGFUSE_TRACE_ID", "fixed-trace")
+        monkeypatch.setenv("HERMES_EVALOPS_CASE_ID", "case-1")
+        client = _FakeTraceClient()
+
+        state = mod._start_root_trace(
+            "task-key",
+            task_id="task-1",
+            session_id="session-1",
+            platform="cli",
+            provider="openai",
+            model="gpt-test",
+            api_mode="chat",
+            messages=[{"role": "user", "content": "hi"}],
+            client=client,
+        )
+
+        assert state.trace_id == "fixed-trace"
+        assert client.created_seeds == []
+
+    def test_finish_trace_closes_root_context_once_and_flushes(self, monkeypatch):
+        mod = self._fresh_plugin()
+        root_ctx = _FakeRootCtx()
+        client = _FakeTraceClient(root_ctx=root_ctx)
+        state = mod.TraceState(trace_id="trace-1", root_ctx=root_ctx, root_span=root_ctx.span)
+        state.generations["1"] = _FakeObservation()
+        task_key = mod._trace_key("task-1", "session-1")
+        monkeypatch.setitem(mod._TRACE_STATE, task_key, state)
+        monkeypatch.setattr(mod, "_get_langfuse", lambda: client)
+
+        mod._finish_trace(task_key, output={"content": "done"})
+        mod._close_root_context(state)
+
+        assert task_key not in mod._TRACE_STATE
+        assert state.generations["1"].ended == 1
+        assert root_ctx.span.ended == 1
+        assert root_ctx.exited == 1
+        assert client.flush_count == 1
+
+    def test_shutdown_active_traces_ends_pending_observations_and_flushes(self, monkeypatch):
+        mod = self._fresh_plugin()
+        root_ctx = _FakeRootCtx()
+        client = _FakeTraceClient(root_ctx=root_ctx)
+        generation = _FakeObservation()
+        tool = _FakeObservation()
+        pending = _FakeObservation()
+        state = mod.TraceState(trace_id="trace-1", root_ctx=root_ctx, root_span=root_ctx.span)
+        state.generations["1"] = generation
+        state.tools["tool-1"] = tool
+        state.pending_tools_by_name["read_file"] = [pending]
+        monkeypatch.setattr(mod, "_LANGFUSE_CLIENT", client)
+        monkeypatch.setitem(mod._TRACE_STATE, mod._trace_key("task-1", "session-1"), state)
+
+        mod._shutdown_active_traces()
+        mod._shutdown_active_traces()
+
+        assert mod._TRACE_STATE == {}
+        assert generation.ended == 1
+        assert tool.ended == 1
+        assert pending.ended == 1
+        assert root_ctx.span.ended == 1
+        assert root_ctx.exited == 1
+        assert client.flush_count == 2
 
 
 class TestRequestMessageCoercion:


### PR DESCRIPTION
## Summary
- serialize Langfuse client initialization so concurrent first calls construct only one client
- close root trace contexts and flush active traces on normal finish and process exit
- support fixed trace IDs only in explicit EvalOps context, preventing accidental trace-id reuse if the env var leaks
- add tests for client init concurrency, fixed trace-id guard, root context close, and active-trace shutdown

## Why
The Langfuse plugin can lose child observations when a process exits before active traces are finalized. Concurrent first-use initialization can also construct multiple clients and leak the losing client's background resources. These changes keep tracing fail-open while making trace finalization and client lifecycle more deterministic.

## Tests
- /Users/zhuxun/.hermes/hermes-agent/venv/bin/python -m pytest tests/plugins/test_langfuse_plugin.py -q