### PR TITLE
fix(desktop): auto-scroll to last message when response completes (#44935)

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
@@ -453,17 +453,22 @@ function useThreadScrollAnchor({
     prevGroupCountForLayoutRef.current = groupCount
   }, [enabled, groupCount, pinToBottom, stickyBottomRef])
 
-  // Intentionally NO post-run bottom lock. Earlier builds kept pinning to
-  // the bottom for POST_RUN_BOTTOM_LOCK_MS after `isRunning` flipped false to
-  // chase final Shiki re-highlight measurement. With streaming follow gone,
-  // re-pinning at completion would yank the viewport back to the bottom even
-  // though the user is reading earlier content — the opposite of what's
-  // wanted. The one-time submit / new-turn jump already covers landing a
-  // fresh message in view.
+  // Post-run pin: when the run completes (isRunning → false) while the user
+  // is still at the bottom, pin the viewport one final time so the complete
+  // response is in view. This catches content that arrived within the same
+  // turn group (which doesn't increment groupCount) and ensures the tail of
+  // a non-streaming response isn't left below the fold.
+  //
+  // We guard with stickyBottomRef so a user who scrolled up during the run
+  // is not yanked back to the bottom on completion.
   const prevIsRunningForLayoutRef = useRef(isRunning)
   useLayoutEffect(() => {
+    if (prevIsRunningForLayoutRef.current && !isRunning && enabled && stickyBottomRef.current) {
+      pinToBottom()
+    }
+
     prevIsRunningForLayoutRef.current = isRunning
-  }, [isRunning])
+  }, [enabled, isRunning, pinToBottom, stickyBottomRef])
 
   useAuiEvent('thread.runStart', jumpToBottom)
 }


### PR DESCRIPTION
## What does this PR do?

When a streaming or non-streaming response completes (`isRunning` → `false`), the viewport is now re-pinned to the bottom so the tail of the response is visible — provided the user hasn't scrolled up during the run.

## Related Issue

Closes #44935

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

1. **`apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx`** — Replaced the inert `prevIsRunningForLayoutRef` tracker with a `useLayoutEffect` that calls `pinToBottom()` when `isRunning` transitions from `true` → `false` while `stickyBottomRef` is still true. The pin is skipped if the user scrolled up during the run.

## How to Test

1. Start a streaming response in the desktop app
2. Let it complete — viewport should re-pin to bottom
3. Scroll up during streaming — viewport should NOT yank back to bottom on completion