### PR TITLE
fix(cli): show all session sources in /sessions list

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5736,12 +5736,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         print()
     
     def _list_recent_sessions(self, limit: int = 10) -> list[dict[str, Any]]:
-        """Return recent CLI sessions for in-chat browsing/resume affordances."""
+        """Return recent sessions for in-chat browsing/resume affordances."""
         if not self._session_db:
             return []
         try:
             sessions = self._session_db.list_sessions_rich(
-                source="cli",
                 exclude_sources=["tool"],
                 limit=limit,
             )

--- a/tests/cli/test_cli_resume_command.py
+++ b/tests/cli/test_cli_resume_command.py
@@ -222,6 +222,22 @@ class TestPendingResumeNumberedSelection:
         # A non-resume command disarms the one-shot prompt (#34584).
         assert cli_obj._pending_resume_sessions is None
 
+    def test_list_recent_sessions_does_not_filter_by_cli_source(self):
+        cli_obj = _make_cli()
+        cli_obj._session_db = MagicMock()
+        cli_obj._session_db.list_sessions_rich.return_value = []
+        cli_obj.session_id = "current_session"
+
+        cli_obj._list_recent_sessions(limit=5)
+
+        # Assert list_sessions_rich was called, and source was NOT passed (or was not "cli")
+        cli_obj._session_db.list_sessions_rich.assert_called_once()
+        kwargs = cli_obj._session_db.list_sessions_rich.call_args[1]
+        assert "source" not in kwargs
+        assert kwargs.get("exclude_sources") == ["tool"]
+        assert kwargs.get("limit") == 5
+
+
 
 class TestRestoreSessionCwdMarkup:
     """Regression: _restore_session_cwd must not crash with Rich MarkupError.


### PR DESCRIPTION
Resolves #44964. Remove the restrictive source='cli' filter in _list_recent_sessions to show all session types (TUI, WhatsApp, telegram, discord, etc.) rather than only CLI sessions.