### PR TITLE
fix(code-exec): make RPC stub timeout configurable via code_execution.rpc_timeout

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1035,6 +1035,7 @@ stt:
 # Intermediate tool results stay out of the LLM's context window.
 code_execution:
   timeout: 300         # Max seconds per script before kill (default: 300 = 5 min)
+  rpc_timeout: 300     # Max seconds per tool-call RPC round-trip (default: 300)
   max_tool_calls: 50   # Max RPC tool calls per execution (default: 50)
 
 # =============================================================================

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2694,6 +2694,14 @@ DEFAULT_CONFIG = {
         # Env scrubbing (strips *_API_KEY, *_TOKEN, *_SECRET, ...) and the
         # tool whitelist apply identically in both modes.
         "mode": "project",
+        # Max seconds for the script process itself.
+        "timeout": 300,
+        # Max seconds for one sandbox tool-call round-trip (child stub ↔ parent).
+        # Raise this alongside ``timeout`` when long-lived execute_code tasks
+        # make slow or blocking tool calls.
+        "rpc_timeout": 300,
+        # Max number of Hermes tool calls the script may make.
+        "max_tool_calls": 50,
     },
 
     # Tool Search (progressive disclosure for large tool surfaces).

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -105,6 +105,7 @@ class TestHermesToolsGeneration(unittest.TestCase):
     def test_rpc_infrastructure_present(self):
         src = generate_hermes_tools_module(["terminal"])
         self.assertIn("HERMES_RPC_SOCKET", src)
+        self.assertIn("HERMES_CODE_EXEC_RPC_TIMEOUT", src)
         self.assertIn("AF_UNIX", src)
         self.assertIn("def _connect(", src)
         self.assertIn("def _call(", src)
@@ -160,7 +161,7 @@ class TestExecuteCodeRemoteTempDir(unittest.TestCase):
         env = FakeEnv()
         fake_thread = MagicMock()
 
-        with patch("tools.code_execution_tool._load_config", return_value={"timeout": 30, "max_tool_calls": 5}), \
+        with patch("tools.code_execution_tool._load_config", return_value={"timeout": 30, "rpc_timeout": 45, "max_tool_calls": 5}), \
              patch("tools.code_execution_tool._get_or_create_env", return_value=(env, "ssh")), \
              patch("tools.code_execution_tool._ship_file_to_remote"), \
              patch("tools.code_execution_tool.threading.Thread", return_value=fake_thread):
@@ -172,6 +173,7 @@ class TestExecuteCodeRemoteTempDir(unittest.TestCase):
         cleanup_cmd = env.commands[-1][0]
         self.assertIn("mkdir -p /data/data/com.termux/files/usr/tmp/hermes_exec_", mkdir_cmd)
         self.assertIn("HERMES_RPC_DIR=/data/data/com.termux/files/usr/tmp/hermes_exec_", run_cmd)
+        self.assertIn("HERMES_CODE_EXEC_RPC_TIMEOUT=45", run_cmd)
         self.assertIn("rm -rf /data/data/com.termux/files/usr/tmp/hermes_exec_", cleanup_cmd)
         self.assertNotIn("mkdir -p /tmp/hermes_exec_", mkdir_cmd)
 

--- a/tests/tools/test_code_execution_modes.py
+++ b/tests/tools/test_code_execution_modes.py
@@ -33,8 +33,10 @@ def _force_local_terminal(monkeypatch):
 from tools.code_execution_tool import (
     SANDBOX_ALLOWED_TOOLS,
     DEFAULT_EXECUTION_MODE,
+    DEFAULT_RPC_TIMEOUT,
     EXECUTION_MODES,
     _get_execution_mode,
+    _get_rpc_timeout,
     _is_usable_python,
     _resolve_child_cwd,
     _resolve_child_python,
@@ -108,6 +110,30 @@ class TestGetExecutionMode(unittest.TestCase):
     def test_execution_modes_tuple(self):
         """Canonical set of modes — tests + config layer rely on this shape."""
         self.assertEqual(set(EXECUTION_MODES), {"project", "strict"})
+
+
+class TestGetRpcTimeout(unittest.TestCase):
+    """code_execution.rpc_timeout is config-only and defaults to 300s."""
+
+    def test_default_is_300_seconds(self):
+        self.assertEqual(DEFAULT_RPC_TIMEOUT, 300)
+
+    def test_absent_config_falls_back_to_default(self):
+        with patch("tools.code_execution_tool._load_config", return_value={}):
+            self.assertEqual(_get_rpc_timeout(), DEFAULT_RPC_TIMEOUT)
+
+    def test_explicit_rpc_timeout_is_used(self):
+        with patch("tools.code_execution_tool._load_config", return_value={"rpc_timeout": 1800}):
+            self.assertEqual(_get_rpc_timeout(), 1800)
+
+    def test_string_rpc_timeout_is_accepted(self):
+        with patch("tools.code_execution_tool._load_config", return_value={"rpc_timeout": "45"}):
+            self.assertEqual(_get_rpc_timeout(), 45)
+
+    def test_invalid_rpc_timeout_falls_back_to_default(self):
+        for bad in (0, -1, float("inf"), float("nan"), True, False, "banana", None):
+            with patch("tools.code_execution_tool._load_config", return_value={"rpc_timeout": bad}):
+                self.assertEqual(_get_rpc_timeout(), DEFAULT_RPC_TIMEOUT)
 
 
 # ---------------------------------------------------------------------------

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -71,6 +71,7 @@ SANDBOX_ALLOWED_TOOLS = frozenset([
 
 # Resource limit defaults (overridable via config.yaml → code_execution.*)
 DEFAULT_TIMEOUT = 300        # 5 minutes
+DEFAULT_RPC_TIMEOUT = 300    # 5 minutes per sandbox tool call round-trip
 DEFAULT_MAX_TOOL_CALLS = 50
 MAX_STDOUT_BYTES = 50_000    # 50 KB
 MAX_STDERR_BYTES = 10_000    # 10 KB
@@ -353,6 +354,7 @@ _sock = None
 # threads (e.g. ThreadPoolExecutor) would race on the shared socket and get
 # each other's responses. Serialize the entire send+recv round-trip.
 _call_lock = threading.Lock()
+_RPC_TIMEOUT = float(os.environ.get("HERMES_CODE_EXEC_RPC_TIMEOUT", "300"))
 ''' + _COMMON_HELPERS + '''\
 
 def _connect():
@@ -377,7 +379,7 @@ def _connect():
         else:
             _sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             _sock.connect(endpoint)
-        _sock.settimeout(300)
+        _sock.settimeout(_RPC_TIMEOUT)
     return _sock
 
 def _call(tool_name, args):
@@ -421,6 +423,7 @@ _seq = 0
 # invocations from multiple threads could allocate the same sequence number
 # and clobber each other's request files. Guard seq allocation with a lock.
 _seq_lock = threading.Lock()
+_RPC_TIMEOUT = float(os.environ.get("HERMES_CODE_EXEC_RPC_TIMEOUT", "300"))
 ''' + _COMMON_HELPERS + '''\
 
 def _call(tool_name, args):
@@ -448,11 +451,13 @@ def _call(tool_name, args):
     os.rename(tmp, req_file)
 
     # Wait for response with adaptive polling
-    deadline = time.monotonic() + 300  # 5-minute timeout per tool call
+    deadline = time.monotonic() + _RPC_TIMEOUT
     poll_interval = 0.05  # Start at 50ms
     while not os.path.exists(res_file):
         if time.monotonic() > deadline:
-            raise RuntimeError(f"RPC timeout: no response for {tool_name} after 300s")
+            raise RuntimeError(
+                f"RPC timeout: no response for {tool_name} after {_RPC_TIMEOUT:g}s"
+            )
         time.sleep(poll_interval)
         poll_interval = min(poll_interval * 1.2, 0.25)  # Back off to 250ms
 
@@ -924,6 +929,7 @@ def _execute_remote(
 
     _cfg = _load_config()
     timeout = _cfg.get("timeout", DEFAULT_TIMEOUT)
+    rpc_timeout = _get_rpc_timeout(_cfg)
     max_tool_calls = _cfg.get("max_tool_calls", DEFAULT_MAX_TOOL_CALLS)
 
     session_tools = set(enabled_tools) if enabled_tools else set()
@@ -996,6 +1002,7 @@ def _execute_remote(
         env_prefix = (
             f"HERMES_RPC_DIR={shlex.quote(f'{sandbox_dir}/rpc')} "
             f"HERMES_RPC_TOKEN={shlex.quote(rpc_token)} "
+            f"HERMES_CODE_EXEC_RPC_TIMEOUT={shlex.quote(str(rpc_timeout))} "
             f"PYTHONDONTWRITEBYTECODE=1"
         )
         tz = os.getenv("HERMES_TIMEZONE", "").strip()
@@ -1187,6 +1194,7 @@ def execute_code(
     # Resolve config
     _cfg = _load_config()
     timeout = _cfg.get("timeout", DEFAULT_TIMEOUT)
+    rpc_timeout = _get_rpc_timeout(_cfg)
     max_tool_calls = _cfg.get("max_tool_calls", DEFAULT_MAX_TOOL_CALLS)
 
     # Determine which tools the sandbox can call
@@ -1290,6 +1298,7 @@ def execute_code(
         child_env = _scrub_child_env(os.environ)
         child_env["HERMES_RPC_SOCKET"] = rpc_endpoint
         child_env["HERMES_RPC_TOKEN"] = rpc_token
+        child_env["HERMES_CODE_EXEC_RPC_TIMEOUT"] = str(rpc_timeout)
         child_env["PYTHONDONTWRITEBYTECODE"] = "1"
         # Force UTF-8 for the child's stdio and default file encoding.
         #
@@ -1642,6 +1651,42 @@ def _load_config() -> dict:
         return cfg if isinstance(cfg, dict) else {}
     except Exception:
         return {}
+
+
+def _get_rpc_timeout(cfg: Optional[dict] = None) -> float:
+    """Return the per-tool-call RPC timeout for execute_code.
+
+    User-facing configuration lives at ``code_execution.rpc_timeout`` in
+    ``config.yaml``. The internal ``HERMES_CODE_EXEC_RPC_TIMEOUT`` env var is
+    only a transport bridge into the generated child stub.
+    """
+    cfg = _load_config() if cfg is None else cfg
+    raw_value = cfg.get("rpc_timeout", DEFAULT_RPC_TIMEOUT) if isinstance(cfg, dict) else DEFAULT_RPC_TIMEOUT
+
+    if isinstance(raw_value, bool):
+        logger.warning(
+            "Ignoring code_execution.rpc_timeout=%r (expected a positive number), falling back to %ss",
+            raw_value,
+            DEFAULT_RPC_TIMEOUT,
+        )
+        return float(DEFAULT_RPC_TIMEOUT)
+    try:
+        value = float(raw_value)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Ignoring code_execution.rpc_timeout=%r (expected a positive number), falling back to %ss",
+            raw_value,
+            DEFAULT_RPC_TIMEOUT,
+        )
+        return float(DEFAULT_RPC_TIMEOUT)
+    if value <= 0 or not value < float("inf"):
+        logger.warning(
+            "Ignoring code_execution.rpc_timeout=%r (expected a positive finite number), falling back to %ss",
+            raw_value,
+            DEFAULT_RPC_TIMEOUT,
+        )
+        return float(DEFAULT_RPC_TIMEOUT)
+    return value
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1723,6 +1723,7 @@ Configure the `execute_code` tool:
 code_execution:
   mode: project                # project (default) | strict
   timeout: 300                 # Max execution time in seconds
+  rpc_timeout: 300             # Max seconds per sandbox tool-call round-trip
   max_tool_calls: 50           # Max tool calls within code execution
 ```
 
@@ -1732,6 +1733,8 @@ code_execution:
 - **`strict`** — scripts run in a temp staging directory with `sys.executable` (Hermes's own python). Maximum reproducibility, but project deps and relative paths won't resolve.
 
 Environment scrubbing (strips `*_API_KEY`, `*_TOKEN`, `*_SECRET`, `*_PASSWORD`, `*_CREDENTIAL`, `*_PASSWD`, `*_AUTH`) and the tool whitelist apply identically in both modes — switching mode does not change the security posture.
+
+`rpc_timeout` controls how long one `execute_code` tool call may wait for a Hermes tool response over the internal RPC bridge. Leave it at `300` for normal usage. If you raise `code_execution.timeout` for long-lived workflows that make slow tool calls, raise `rpc_timeout` too.
 
 ## Web Search Backends
 

--- a/website/docs/user-guide/features/code-execution.md
+++ b/website/docs/user-guide/features/code-execution.md
@@ -171,8 +171,11 @@ All limits are configurable via `config.yaml`:
 code_execution:
   mode: project      # project (default) | strict
   timeout: 300       # Max seconds per script (default: 300)
+  rpc_timeout: 300   # Max seconds per tool-call RPC round-trip (default: 300)
   max_tool_calls: 50 # Max tool calls per execution (default: 50)
 ```
+
+`timeout` and `rpc_timeout` protect different layers. `timeout` caps the whole script runtime. `rpc_timeout` caps a single Hermes tool-call round-trip inside the script. If you raise `timeout` for long-lived workflows that call tools slowly, raise `rpc_timeout` too.
 
 ## How Tool Calls Work Inside Scripts
 


### PR DESCRIPTION
## Problem

The generated RPC stubs in both `execute_code` transports (socket and file) use a hardcoded 300s timeout. Any single tool call inside an executed script that takes longer than 300s fails, even when `code_execution.timeout` is raised — the script-level timeout is configurable, but the RPC layer underneath it is not. This caps long-running use cases (e.g. web app builds and test suites driven through execute_code).

## Solution

- New config key `code_execution.rpc_timeout` (default **300**, fully backward compatible — behavior is unchanged unless explicitly raised).
- Plumbed through both the socket transport (`settimeout`) and the file transport (poll deadline), and propagated to child process environments so nested executions inherit it.
- Error messages now report the actual configured timeout instead of a literal "300s".

## Testing

- Extended `tests/tools/test_code_execution.py` and `tests/tools/test_code_execution_modes.py`; full code-execution suite passes (108 passed).
- Full suite run via `scripts/run_tests.sh` (per-file isolation, CI parity): no regressions — the only failing files are environment-dependent and fail identically on a clean `origin/main` baseline worktree on the same machine.
- `scripts/check-windows-footguns.py` clean on all changed files.
- Live verification: with `rpc_timeout: 1800`, an execute_code run sleeping 301s completes successfully (previously failed at 300s); with defaults untouched, behavior is identical to current main.

## Platforms tested

- macOS (Apple Silicon, Darwin 25.x). Change is pure-Python config plumbing (socket timeout value, poll deadline, env var propagation) with no platform-specific syscalls; Linux/Windows covered by the existing cross-platform CI matrix.

## Docs

- `website/docs/user-guide/configuration.md` and `website/docs/user-guide/features/code-execution.md` updated with the new key.
- `cli-config.yaml.example` updated alongside (the `code_execution:` block documents sibling keys there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)