### PR TITLE
fix(desktop): new chat honours the active profile instead of rubberbanding to default

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -1,0 +1,119 @@
+import { cleanup, render, waitFor } from '@testing-library/react'
+import type { MutableRefObject } from 'react'
+import { useEffect } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { $activeGatewayProfile, $newChatProfile } from '@/store/profile'
+import { $currentCwd } from '@/store/session'
+
+import type { ClientSessionState } from '../../types'
+
+import { useSessionActions } from './use-session-actions'
+
+vi.mock('@/hermes', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  deleteSession: vi.fn(),
+  getSessionMessages: vi.fn(),
+  listAllProfileSessions: vi.fn(),
+  setApiRequestProfile: vi.fn(),
+  setSessionArchived: vi.fn()
+}))
+
+const RUNTIME_SESSION_ID = 'rt-new-001'
+
+function Harness({
+  onReady,
+  requestGateway
+}: {
+  onReady: (create: (preview?: string | null) => Promise<string | null>) => void
+  requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
+}) {
+  const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value })
+
+  const actions = useSessionActions({
+    activeSessionId: null,
+    activeSessionIdRef: ref<string | null>(null),
+    busyRef: ref(false),
+    creatingSessionRef: ref(false),
+    ensureSessionState: () => ({}) as ClientSessionState,
+    getRouteToken: () => 'token',
+    navigate: vi.fn() as never,
+    requestGateway,
+    runtimeIdByStoredSessionIdRef: ref(new Map<string, string>()),
+    selectedStoredSessionId: null,
+    selectedStoredSessionIdRef: ref<string | null>(null),
+    sessionStateByRuntimeIdRef: ref(new Map<string, ClientSessionState>()),
+    syncSessionStateToView: vi.fn(),
+    updateSessionState: () => ({}) as ClientSessionState
+  })
+
+  useEffect(() => {
+    onReady(actions.createBackendSessionForSend)
+  }, [actions.createBackendSessionForSend, onReady])
+
+  return null
+}
+
+async function createWith(profileSetup: () => void): Promise<Record<string, unknown> | undefined> {
+  let createParams: Record<string, unknown> | undefined
+
+  const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+    if (method === 'session.create') {
+      createParams = params
+
+      return { session_id: RUNTIME_SESSION_ID, stored_session_id: null } as never
+    }
+
+    return {} as never
+  })
+
+  $currentCwd.set('')
+  profileSetup()
+
+  let create: ((preview?: string | null) => Promise<string | null>) | null = null
+  render(<Harness onReady={c => (create = c)} requestGateway={requestGateway} />)
+  await waitFor(() => expect(create).not.toBeNull())
+  await create!()
+
+  return createParams
+}
+
+describe('createBackendSessionForSend profile routing', () => {
+  afterEach(() => {
+    cleanup()
+    $newChatProfile.set(null)
+    $activeGatewayProfile.set('default')
+    vi.restoreAllMocks()
+  })
+
+  it('routes a plain new chat (no explicit profile) to the live gateway profile', async () => {
+    // The "rubberband to default" bug: the top New Session button clears
+    // $newChatProfile to null. In global-remote mode one backend serves every
+    // profile, so an omitted `profile` lands the chat on the launch (default)
+    // profile. The session must instead carry the active gateway profile.
+    const params = await createWith(() => {
+      $activeGatewayProfile.set('coder')
+      $newChatProfile.set(null)
+    })
+
+    expect(params).toMatchObject({ profile: 'coder' })
+  })
+
+  it('honours an explicit per-profile "+" selection', async () => {
+    const params = await createWith(() => {
+      $activeGatewayProfile.set('coder')
+      $newChatProfile.set('analyst')
+    })
+
+    expect(params).toMatchObject({ profile: 'analyst' })
+  })
+
+  it('passes the default profile for single-profile users (backend resolves it to launch)', async () => {
+    const params = await createWith(() => {
+      $activeGatewayProfile.set('default')
+      $newChatProfile.set(null)
+    })
+
+    expect(params).toMatchObject({ profile: 'default' })
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -407,13 +407,17 @@ export function useSessionActions({
       creatingSessionRef.current = true
 
       try {
-        // Route the new chat to the chosen profile's backend (null = primary,
-        // so single-profile users are unaffected).
-        await ensureGatewayProfile($newChatProfile.get())
+        // A plain new session (top "New Session", /new, keybind) leaves
+        // $newChatProfile null to mean "use the live context"; the per-profile
+        // "+" sets it explicitly. Resolve null to the active gateway profile so
+        // session.create always carries it: in global-remote mode one backend
+        // serves every profile, so an omitted profile param silently lands the
+        // chat on the launch (default) profile — the "rubberbands back to
+        // default" bug. This is a no-op for single-profile/local-pooled users:
+        // a backend resolves its own launch profile to None (_profile_home).
+        const newChatProfile = $newChatProfile.get() ?? normalizeProfileKey($activeGatewayProfile.get())
+        await ensureGatewayProfile(newChatProfile)
         const cwd = $currentCwd.get().trim() || workspaceCwdForNewSession()
-        // Pass the owning profile so a new chat under a non-launch profile (global
-        // remote mode) builds its agent + persists against THAT profile's home/db.
-        const newChatProfile = $newChatProfile.get()
 
         const created = await requestGateway<SessionCreateResponse>('session.create', {
           cols: 96,


### PR DESCRIPTION
## Summary

Fixes the reported desktop bug: with a non-default profile selected, clicking the top **New Session** button (or `/new`, or the keyboard shortcut) creates the new chat under the **default** profile — it "rubberbands back to default" even though the profile rail still shows the selected profile. Starting a chat via the per-profile **+** worked fine.

## Root cause

The two entry points diverge before any backend call:

- **Per-profile "+"** → `newSessionInProfile()` sets `$newChatProfile` to the target profile.
- **Top "New Session" / `/new` / keybind** → explicitly set `$newChatProfile` to `null`, meaning "use the live gateway context".

But `createBackendSessionForSend()` turned a `null` `$newChatProfile` into an **omitted `profile` param** on `session.create`. In **global-remote mode** a single backend serves every profile, and the backend binds an omitted `profile` to its **launch (default) profile's** `HERMES_HOME` / `state.db` (`_profile_home` → `None`). So the new chat silently lands on default — exactly the symptom the user reported (and why it only showed up on a remote gateway).

## Fix

Resolve a `null` `$newChatProfile` to the **active gateway profile** at the single session-creation chokepoint (`createBackendSessionForSend`), so `session.create` always carries the live profile. This covers every "plain new session" path (top button, `/new`, keyboard shortcut) at once.

Safe for single-profile and local-pooled users: a backend resolves *its own* launch profile name to `None` in `_profile_home`, so passing `profile: "default"` (or the pooled profile's own name) changes nothing.

## Test plan

- [x] New `use-session-actions.test.tsx` asserts the invariant: a plain new chat carries the active gateway profile on `session.create`; an explicit per-profile selection is honoured; single-profile users pass `"default"` (backend resolves to launch).
- [x] `vitest run --environment jsdom src/app/session/hooks/` — 48 passed.
- [x] `tsc --noEmit` clean.
- [x] eslint clean on changed files.