### PR TITLE
Dockerfile: retry transient apt fetch failures in playwright deps layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -129,6 +129,13 @@ COPY ui-tui/packages/hermes-ink/ ui-tui/packages/hermes-ink/
 # guards against a future regression if the source npm version changes.
 ENV npm_config_install_links=false
 
+# Retry transient apt fetch failures instead of failing the whole layer on a
+# single 5xx.  `playwright install --with-deps` pulls in dozens of packages,
+# so without retries one flaky mirror/CDN response kills the entire build —
+# and this layer is expensive to redo (full npm install + Chromium download).
+RUN printf 'Acquire::Retries "10";\nAcquire::Retries::Delay::Maximum "15";\n' \
+    > /etc/apt/apt.conf.d/80-retries
+
 RUN npm install --prefer-offline --no-audit && \
     npx playwright install --with-deps chromium --only-shell && \
     npm cache clean --force


### PR DESCRIPTION
## What

Add an apt retry policy (`Acquire::Retries 10`, capped backoff) via `/etc/apt/apt.conf.d/80-retries` just before the npm + Playwright install layer.

## Why

`npx playwright install --with-deps` fetches dozens of Debian packages in one `RUN`. A single transient 5xx from the mirror/CDN currently fails the entire layer, which is expensive to redo — it re-runs the full `npm install` and re-downloads Chromium. Hit this twice in a row on a fresh arm64 build where exactly one random .deb 502'd each time while everything else succeeded.

With retries configured, apt rides out one-off flaky responses instead of aborting the build.

## Notes for review

- Scoped to a tiny separate `RUN` so it caches independently and adds no meaningful layer weight.
- `Acquire::Retries::Delay::Maximum 15` caps the exponential backoff so worst-case stall stays bounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)