### PR TITLE
fix(metadata): clear model metadata caches on /new session reset

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -111,6 +111,23 @@ _endpoint_model_metadata_cache: Dict[str, Dict[str, Dict[str, Any]]] = {}
 _endpoint_model_metadata_cache_time: Dict[str, float] = {}
 _ENDPOINT_MODEL_CACHE_TTL = 300
 
+
+def clear_model_metadata_caches() -> None:
+    """Clear all cached model metadata.
+
+    Called on ``/new`` (session reset) so that provider-side changes
+    (e.g. LM Studio KV-cache resize) are reflected immediately.
+    """
+    global _model_metadata_cache, _model_metadata_cache_time
+    global _novita_metadata_cache, _novita_metadata_cache_time
+    _model_metadata_cache = {}
+    _model_metadata_cache_time = 0
+    _novita_metadata_cache = {}
+    _novita_metadata_cache_time = 0
+    _endpoint_model_metadata_cache.clear()
+    _endpoint_model_metadata_cache_time.clear()
+
+
 # Descending tiers for context length probing when the model is unknown.
 # We start at 256K (covers GPT-5.x, many current large-context models) and
 # step down on context-length errors until one works.  Tier[0] is also the

--- a/cli.py
+++ b/cli.py
@@ -5936,6 +5936,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             if hasattr(self.agent, "_invalidate_system_prompt"):
                 self.agent._invalidate_system_prompt()
 
+            # Clear cached model metadata so provider-side changes (e.g.
+            # LM Studio KV-cache resize) are reflected in the new session.
+            try:
+                from agent.model_metadata import clear_model_metadata_caches
+                clear_model_metadata_caches()
+            except Exception:
+                pass
+
             if self._session_db:
                 try:
                     self.agent._session_db_created = False

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -110,6 +110,14 @@ class GatewaySlashCommandsMixin:
         except Exception:
             pass
 
+        # Clear cached model metadata so provider-side changes (e.g.
+        # LM Studio KV-cache resize) are reflected in the new session.
+        try:
+            from agent.model_metadata import clear_model_metadata_caches
+            clear_model_metadata_caches()
+        except Exception:
+            pass
+
         # Reset the session
         new_entry = self.session_store.reset_session(session_key)
 

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -28,6 +28,7 @@ from agent.model_metadata import (
     parse_context_limit_from_error,
     save_context_length,
     fetch_model_metadata,
+    clear_model_metadata_caches,
     _MODEL_CACHE_TTL,
 )
 
@@ -1422,3 +1423,59 @@ class TestGrok43StaleCacheGuard:
                 slug, base_url=base, api_key="", provider="xai"
             )
             assert ctx == 256_000, f"{slug} should stay 256000, got {ctx}"
+
+
+# =========================================================================
+# clear_model_metadata_caches — /new session reset
+# =========================================================================
+
+class TestClearModelMetadataCaches:
+    """Verify that clear_model_metadata_caches() resets all metadata caches."""
+
+    def test_clears_openrouter_cache(self):
+        """OpenRouter model metadata cache is emptied."""
+        import agent.model_metadata as mm
+        # Populate the cache
+        mm._model_metadata_cache = {"gpt-5": {"context_length": 128000}}
+        mm._model_metadata_cache_time = time.time()
+        assert mm._model_metadata_cache  # not empty
+        clear_model_metadata_caches()
+        assert mm._model_metadata_cache == {}
+        assert mm._model_metadata_cache_time == 0
+
+    def test_clears_endpoint_cache(self):
+        """Per-endpoint model metadata cache is emptied."""
+        import agent.model_metadata as mm
+        mm._endpoint_model_metadata_cache["http://localhost:1234/v1"] = {
+            "my-model": {"context_length": 8192}
+        }
+        mm._endpoint_model_metadata_cache_time["http://localhost:1234/v1"] = time.time()
+        assert mm._endpoint_model_metadata_cache
+        clear_model_metadata_caches()
+        assert mm._endpoint_model_metadata_cache == {}
+        assert mm._endpoint_model_metadata_cache_time == {}
+
+    def test_clears_novita_cache(self):
+        """Novita metadata cache is emptied."""
+        import agent.model_metadata as mm
+        mm._novita_metadata_cache = {"model-a": {"context_length": 32768}}
+        mm._novita_metadata_cache_time = time.time()
+        assert mm._novita_metadata_cache
+        clear_model_metadata_caches()
+        assert mm._novita_metadata_cache == {}
+        assert mm._novita_metadata_cache_time == 0
+
+    def test_forces_refetch_after_clear(self):
+        """After clearing, fetch_model_metadata(force_refresh=True) re-fetches."""
+        import agent.model_metadata as mm
+        # Populate cache
+        mm._model_metadata_cache = {"old-model": {"context_length": 4096}}
+        mm._model_metadata_cache_time = time.time()
+
+        clear_model_metadata_caches()
+
+        # The cache is empty, so the next call with force_refresh=True
+        # would hit the network. We verify the cache was cleared,
+        # which means fetch_model_metadata will attempt a fresh fetch.
+        assert not mm._model_metadata_cache
+        assert mm._model_metadata_cache_time == 0


### PR DESCRIPTION
## What does this PR do?

Clears cached model metadata (context length, KV cache size) when `/new` is invoked, so provider-side changes (e.g. LM Studio KV-cache resize) are reflected immediately in the new session instead of requiring a full Hermes restart.

## Related Issue

Fixes #45029

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/model_metadata.py`: Added `clear_model_metadata_caches()` function that resets all in-memory model metadata caches (OpenRouter, Novita, per-endpoint)
- `cli.py`: Call `clear_model_metadata_caches()` in `new_session()` after system prompt invalidation
- `gateway/slash_commands.py`: Call `clear_model_metadata_caches()` in the `/new` handler alongside existing cache clears
- `tests/agent/test_model_metadata.py`: Added `TestClearModelMetadataCaches` with 4 tests covering all cache types

## How to Test

1. Start a Hermes session with LM Studio as provider
2. Note the displayed context length in the status bar
3. Change the KV cache size in LM Studio and reload the model
4. Run `/new` in the Hermes session
5. Verify the updated context length is reflected without restarting Hermes

```bash
python -m pytest tests/agent/test_model_metadata.py::TestClearModelMetadataCaches -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/model_metadata.py` (module-level caches: `_model_metadata_cache`, `_endpoint_model_metadata_cache`, `_novita_metadata_cache`)
- Blast radius: LOW — adds a new public function and two call sites; no existing code paths changed
- Related patterns: mirrors `clear_env_passthrough()` and `clear_credential_files()` in the gateway `/new` handler
