### PR TITLE
fix(logging): catch PermissionError in doRollover (#44873)

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -467,7 +467,28 @@ class _ManagedRotatingFileHandler(RotatingFileHandler):
         return stream
 
     def doRollover(self):
-        super().doRollover()
+        try:
+            super().doRollover()
+        except (PermissionError, OSError) as exc:
+            # On Windows, PermissionError [WinError 32] fires when the log
+            # file is locked by another process (antivirus, backup agent, etc).
+            # The stdlib logging module's default handler would then print a
+            # full traceback to stderr on *every* subsequent emit — flooding
+            # both stderr and the log file itself.  Swallow the exception and
+            # force the handler to reopen its stream so it keeps writing to
+            # the current file instead of the rotated-away inode.
+            try:
+                if self.stream is not None:
+                    self.stream.close()
+            except Exception:
+                pass
+            self.stream = None  # type: ignore[assignment]
+            try:
+                self.stream = self._open()
+                self._record_stream_stat()
+            except Exception:
+                pass
+            return
         self._chmod_if_managed()
         # Our own rollover writes a new baseFilename; refresh the snapshot
         # so the next emit doesn't mistake it for external rotation.

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -1069,3 +1069,93 @@ class TestSafeStderr:
             logger.info("Session hygiene: 400 messages — auto-compressing")
         finally:
             logger.removeHandler(handler)
+
+
+class TestDoRolloverPermissionError:
+    """Tests for _ManagedRotatingFileHandler.doRollover() PermissionError handling."""
+
+    def test_doRollover_permission_error_reopens_stream(self, hermes_home):
+        """When doRollover hits PermissionError, the handler reopens the
+        current file and keeps logging (Windows WinError 32 scenario)."""
+        hermes_logging.setup_logging(hermes_home=hermes_home)
+        root = logging.getLogger()
+        agent_handlers = [
+            h for h in root.handlers
+            if isinstance(h, hermes_logging._ManagedRotatingFileHandler)
+            and "agent.log" in getattr(h, "baseFilename", "")
+        ]
+        assert len(agent_handlers) == 1
+        handler = agent_handlers[0]
+
+        # Force the file to exceed maxBytes so next emit triggers rollover
+        original_max = handler.maxBytes
+        handler.maxBytes = 1
+
+        # Write something to make the file non-empty
+        logging.getLogger("test.rollover").info("before rollover trigger")
+        for h in root.handlers:
+            try:
+                h.flush()
+            except Exception:
+                pass
+
+        # Patch super().doRollover to raise PermissionError
+        from unittest.mock import patch
+
+        def _raise_permission_error(self_handler):
+            raise PermissionError("[WinError 32] The process cannot access the file")
+
+        with patch.object(RotatingFileHandler, 'doRollover', _raise_permission_error):
+            # This should NOT raise -- it should catch the error
+            handler.doRollover()
+
+        # Restore maxBytes and verify the handler still works
+        handler.maxBytes = original_max
+        logging.getLogger("test.rollover").info("after rollover failure")
+        for h in root.handlers:
+            try:
+                h.flush()
+            except Exception:
+                pass
+
+        agent_log = hermes_home / "logs" / "agent.log"
+        content = agent_log.read_text()
+        assert "after rollover failure" in content
+
+    def test_doRollover_os_error_reopens_stream(self, hermes_home):
+        """When doRollover hits a generic OSError, the handler reopens."""
+        hermes_logging.setup_logging(hermes_home=hermes_home)
+        root = logging.getLogger()
+        agent_handlers = [
+            h for h in root.handlers
+            if isinstance(h, hermes_logging._ManagedRotatingFileHandler)
+            and "agent.log" in getattr(h, "baseFilename", "")
+        ]
+        handler = agent_handlers[0]
+        original_max = handler.maxBytes
+        handler.maxBytes = 1
+
+        logging.getLogger("test.rollover2").info("before")
+        for h in root.handlers:
+            try:
+                h.flush()
+            except Exception:
+                pass
+
+        def _raise_os_error(self_handler):
+            raise OSError("Device or resource busy")
+
+        from unittest.mock import patch
+        with patch.object(RotatingFileHandler, 'doRollover', _raise_os_error):
+            handler.doRollover()
+
+        handler.maxBytes = original_max
+        logging.getLogger("test.rollover2").info("after os error")
+        for h in root.handlers:
+            try:
+                h.flush()
+            except Exception:
+                pass
+
+        agent_log = hermes_home / "logs" / "agent.log"
+        assert "after os error" in agent_log.read_text()


### PR DESCRIPTION
Fixes #44873. On Windows, RotatingFileHandler.doRollover() raises PermissionError [WinError 32] when the log file is locked by another process. The exception was uncaught, causing the stdlib logging error handler to print a full traceback to stderr on every subsequent emit. The fix wraps super().doRollover() in a try/except for PermissionError and OSError, closing and reopening the stream on failure so logging continues writing to the current file.