### PR TITLE
fix(whatsapp): lower default text batch delay from 5s to 0.5s (#44883)

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -296,16 +296,16 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         # WhatsApp often delivers multiple messages in rapid succession
         # (e.g. forwarded batches, paste-splits) — without debounce each
         # message triggers a separate agent invocation, wasting tokens and
-        # flooding the user with reply fragments.  Default 5s delay /
-        # 10s split delay are conservative for WhatsApp's delivery cadence.
+        # flooding the user with reply fragments.  Default 0.5s delay /
+        # 2.0s split delay balance responsiveness with batching efficiency.
         # Tunable via config.yaml under
         # ``gateway.platforms.whatsapp.extra.text_batch_delay_seconds`` /
         # ``text_batch_split_delay_seconds``.
         self._text_batch_delay_seconds = self._coerce_float_extra(
-            "text_batch_delay_seconds", 5.0
+            "text_batch_delay_seconds", 0.5
         )
         self._text_batch_split_delay_seconds = self._coerce_float_extra(
-            "text_batch_split_delay_seconds", 10.0
+            "text_batch_split_delay_seconds", 2.0
         )
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}

--- a/tests/gateway/test_whatsapp_text_batching.py
+++ b/tests/gateway/test_whatsapp_text_batching.py
@@ -35,8 +35,8 @@ def _event(text):
 
 def test_batch_delays_default_from_config():
     adapter = _make_adapter()
-    assert adapter._text_batch_delay_seconds == 5.0
-    assert adapter._text_batch_split_delay_seconds == 10.0
+    assert adapter._text_batch_delay_seconds == 0.5
+    assert adapter._text_batch_split_delay_seconds == 2.0
 
 
 def test_batch_delays_overridden_via_config_extra():
@@ -53,15 +53,15 @@ def test_invalid_config_value_falls_back_to_default():
         text_batch_delay_seconds="garbage",
         text_batch_split_delay_seconds=-3,
     )
-    assert adapter._text_batch_delay_seconds == 5.0
-    assert adapter._text_batch_split_delay_seconds == 10.0
+    assert adapter._text_batch_delay_seconds == 0.5
+    assert adapter._text_batch_split_delay_seconds == 2.0
 
 
 def test_env_var_is_ignored(monkeypatch):
     # Config-only path: the legacy HERMES_* env var must NOT influence delays.
     monkeypatch.setenv("HERMES_WHATSAPP_TEXT_BATCH_DELAY_SECONDS", "99")
     adapter = _make_adapter()
-    assert adapter._text_batch_delay_seconds == 5.0
+    assert adapter._text_batch_delay_seconds == 0.5
 
 
 def test_rapid_texts_collapse_into_single_dispatch():


### PR DESCRIPTION
Fixes #44883. PR #35391 introduced text-debounce batching for WhatsApp with defaults of 5.0s / 10.0s for text_batch_delay_seconds and text_batch_split_delay_seconds. These are far too long compared to Telegram (0.3s / 1.0s), adding 5s dead silence to every response. Lowered defaults to 0.5s / 2.0s which balance responsiveness with batching efficiency while remaining configurable via config.yaml.