### PR TITLE
fix(gateway): migrate active /goal to new session on context compression

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8333,12 +8333,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                     # and searchable via session_search.
                                     _hyg_new_sid = _hyg_agent.session_id
                                     if _hyg_new_sid != session_entry.session_id:
+                                        _hyg_old_sid = session_entry.session_id
                                         session_entry.session_id = _hyg_new_sid
                                         self.session_store._save()
                                         self._sync_telegram_topic_binding(
                                             source, session_entry,
                                             reason="hygiene-compression",
                                         )
+                                        # Migrate active /goal to the new session
+                                        # (same fix as agent-result path).
+                                        try:
+                                            from hermes_cli.goals import load_goal, save_goal
+                                            _old_goal = load_goal(_hyg_old_sid)
+                                            if _old_goal and _old_goal.status == "active":
+                                                save_goal(_hyg_new_sid, _old_goal)
+                                        except Exception:
+                                            pass
 
                                     self.session_store.rewrite_transcript(
                                         session_entry.session_id, _compressed
@@ -8636,11 +8646,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # If the agent's session_id changed during compression, update
             # session_entry so transcript writes below go to the right session.
             if agent_result.get("session_id") and agent_result["session_id"] != session_entry.session_id:
+                _old_sid_for_goal = session_entry.session_id
                 session_entry.session_id = agent_result["session_id"]
                 self.session_store._save()
                 self._sync_telegram_topic_binding(
                     source, session_entry, reason="agent-result-compression",
                 )
+                # Migrate active /goal to the new session so the goal loop
+                # continues after compression.  Without this, state_meta
+                # goal:<old_sid> is orphaned and is_active() returns False.
+                try:
+                    from hermes_cli.goals import load_goal, save_goal
+                    _old_goal = load_goal(_old_sid_for_goal)
+                    if _old_goal and _old_goal.status == "active":
+                        save_goal(session_entry.session_id, _old_goal)
+                except Exception:
+                    pass
 
             # Prepend reasoning/thinking if display is enabled (per-platform)
             try:

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -737,3 +737,77 @@ class TestStatusLineSubgoalCount:
         mgr.add_subgoal("b")
         line = mgr.status_line()
         assert "2 subgoals" in line
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Goal migration on session_id rotation (compression)
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestGoalMigrationOnCompression:
+    """Verify that an active /goal survives session_id rotation.
+
+    When context compression creates a child session (rotating session_id),
+    the active goal must be copied to the new session so the goal loop
+    continues without interruption.
+    """
+
+    def test_active_goal_migrates_to_new_session(self, hermes_home):
+        """load_goal(new_sid) returns the goal after save_goal migration."""
+        from hermes_cli.goals import GoalManager, load_goal, save_goal
+
+        old_sid = "compress-old-001"
+        new_sid = "compress-child-002"
+
+        # Set an active goal on the old session
+        mgr = GoalManager(session_id=old_sid)
+        mgr.set("Build and ship the widget")
+
+        # Simulate the migration that happens in gateway/run.py
+        old_goal = load_goal(old_sid)
+        assert old_goal is not None
+        assert old_goal.status == "active"
+        save_goal(new_sid, old_goal)
+
+        # Verify the goal is accessible from the new session
+        new_goal = load_goal(new_sid)
+        assert new_goal is not None
+        assert new_goal.status == "active"
+        assert "widget" in new_goal.goal
+
+    def test_cleared_goal_is_not_migrated(self, hermes_home):
+        """Only active goals are migrated — cleared goals stay behind."""
+        from hermes_cli.goals import GoalManager, load_goal, save_goal
+
+        old_sid = "compress-old-003"
+        new_sid = "compress-child-004"
+
+        mgr = GoalManager(session_id=old_sid)
+        mgr.set("Do the thing")
+        mgr.clear()  # mark as cleared
+
+        # Migration only copies active goals
+        old_goal = load_goal(old_sid)
+        assert old_goal.status == "cleared"
+        if old_goal and old_goal.status == "active":
+            save_goal(new_sid, old_goal)
+
+        new_goal = load_goal(new_sid)
+        assert new_goal is None  # should NOT be migrated
+
+    def test_no_goal_on_old_session_is_safe(self, hermes_home):
+        """Migration is a no-op when old session has no goal."""
+        from hermes_cli.goals import load_goal, save_goal
+
+        old_sid = "compress-old-005"
+        new_sid = "compress-child-006"
+
+        old_goal = load_goal(old_sid)
+        assert old_goal is None
+        # The migration guard: only save if goal exists and is active
+        if old_goal and old_goal.status == "active":
+            save_goal(new_sid, old_goal)
+
+        # No crash, no stale data
+        new_goal = load_goal(new_sid)
+        assert new_goal is None


### PR DESCRIPTION
## What does this PR do?

Migrates the active `/goal` to the new session when context compression rotates `session_id`. Without this fix, the goal continuation loop silently stops after compression because `state_meta` key `goal:<old_session_id>` is orphaned.

## Related Issue

Fixes #45059

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: Added goal migration in both compression paths — agent-result compression (line ~8638) and hygiene compression (line ~8335). After session_id rotation, the active goal is copied from the old session to the new one via `load_goal`/`save_goal`.
- `tests/hermes_cli/test_goals.py`: Added `TestGoalMigrationOnCompression` with 3 tests — active goal migration, cleared goal non-migration, and no-goal safety.

## How to Test

1. Start a gateway session (Discord/Telegram/etc.)
2. Set a `/goal` (e.g., `/goal Research and summarize Q4 earnings`)
3. Have a long enough conversation to trigger context compression
4. After compression, verify the goal loop continues (agent still works toward the goal)

```bash
python -m pytest tests/hermes_cli/test_goals.py::TestGoalMigrationOnCompression -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/run.py` session_id rotation in compression (2 call sites: agent-result path + hygiene path)
- Blast radius: LOW — adds a try/except block at each compression point; no existing code paths changed
- Related patterns: mirrors `_sync_telegram_topic_binding` pattern already present at both sites
