### PR TITLE
feat(desktop): render html and mermaid code fences as live artifacts

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -59,6 +59,7 @@
     "@nous-research/ui": "^0.13.0",
     "@radix-ui/react-slot": "^1.2.4",
     "@streamdown/code": "^1.1.1",
+    "@streamdown/mermaid": "^1.0.2",
     "@tabler/icons-react": "^3.41.1",
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.2.4",

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -9,6 +9,8 @@ import {
 import { code } from '@streamdown/code'
 import { type ComponentProps, memo, type ReactNode, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
 
+import { HtmlPreview } from '@/components/chat/html-preview'
+import { MermaidDiagram } from '@/components/chat/mermaid-diagram'
 import { PreviewAttachment } from '@/components/chat/preview-attachment'
 import { SyntaxHighlighter } from '@/components/chat/shiki-highlighter'
 import { ZoomableImage } from '@/components/chat/zoomable-image'
@@ -379,8 +381,23 @@ function MarkdownTextSurface({ containerClassName, containerProps }: MarkdownTex
 
   // Keep code parsing enabled while streaming so incomplete fenced blocks still
   // render as code cards. The expensive Shiki pass is deferred by
-  // `SyntaxHighlighter` below when `isStreaming` is true.
+  // `SyntaxHighlighter` below when `isStreaming` is true. Note: streamdown's
+  // mermaid *plugin* would be dead code here — our `SyntaxHighlighter`
+  // override replaces the built-in code dispatcher that consults it — so
+  // ```mermaid is handled via `componentsByLanguage` below instead.
   const plugins = useMemo(() => ({ math: mathPlugin, code }), [])
+
+  const componentsByLanguage = useMemo(
+    () => ({
+      mermaid: {
+        SyntaxHighlighter: (props: SyntaxHighlighterProps) => <MermaidDiagram {...props} defer={isStreaming} />
+      },
+      html: {
+        SyntaxHighlighter: (props: SyntaxHighlighterProps) => <HtmlPreview {...props} defer={isStreaming} />
+      }
+    }),
+    [isStreaming]
+  )
 
   const components = useMemo(
     () =>
@@ -456,6 +473,7 @@ function MarkdownTextSurface({ containerClassName, containerProps }: MarkdownTex
   return (
     <StreamdownTextPrimitive
       components={components}
+      componentsByLanguage={componentsByLanguage}
       containerClassName={cn(MARKDOWN_CONTAINER_CLASS_NAME, containerClassName)}
       containerProps={containerProps}
       lineNumbers={false}

--- a/apps/desktop/src/components/chat/html-preview.test.tsx
+++ b/apps/desktop/src/components/chat/html-preview.test.tsx
@@ -1,9 +1,13 @@
 import type { SyntaxHighlighterProps } from '@assistant-ui/react-streamdown'
-import { fireEvent, render, within } from '@testing-library/react'
+import { cleanup, fireEvent, render, within } from '@testing-library/react'
 import type { ComponentProps } from 'react'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 
 import { HtmlPreview } from './html-preview'
+
+// The expand dialog portals into document.body, so some tests query `document`
+// rather than the render container — clean up between tests to avoid leakage.
+afterEach(cleanup)
 
 // The component falls back to the shared SyntaxHighlighter, which destructures
 // `components.Pre`, so every render path needs a minimal Pre supplied.
@@ -58,5 +62,33 @@ describe('HtmlPreview', () => {
     const iframe = container.querySelector('iframe')
     expect(iframe).toBeTruthy()
     expect(iframe?.getAttribute('srcdoc')).toBe(HTML)
+  })
+
+  it('re-mounts the preview frame on Refresh so scripts re-run from scratch', () => {
+    const { container, getByLabelText } = render(<HtmlPreview {...highlighterProps(HTML)} />)
+    const before = container.querySelector('iframe')
+
+    fireEvent.click(getByLabelText('Refresh'))
+
+    const after = container.querySelector('iframe')
+    expect(after).toBeTruthy()
+    expect(after?.getAttribute('srcdoc')).toBe(HTML)
+    // Bumping the key forces a fresh DOM node — that remount is what re-runs scripts.
+    expect(after).not.toBe(before)
+  })
+
+  it('opens a full-size dialog with its own sandboxed frame on Expand', () => {
+    const { container, getByLabelText } = render(<HtmlPreview {...highlighterProps(HTML)} />)
+    expect(container.querySelectorAll('iframe')).toHaveLength(1)
+
+    fireEvent.click(getByLabelText('Expand preview'))
+
+    // Dialog renders through a portal on document.body, so query the document.
+    const frames = document.querySelectorAll('iframe')
+    expect(frames.length).toBeGreaterThanOrEqual(2)
+    frames.forEach(frame => {
+      expect(frame.getAttribute('sandbox')).toBe('allow-scripts')
+      expect(frame.getAttribute('sandbox')).not.toContain('allow-same-origin')
+    })
   })
 })

--- a/apps/desktop/src/components/chat/html-preview.test.tsx
+++ b/apps/desktop/src/components/chat/html-preview.test.tsx
@@ -1,0 +1,62 @@
+import type { SyntaxHighlighterProps } from '@assistant-ui/react-streamdown'
+import { fireEvent, render, within } from '@testing-library/react'
+import type { ComponentProps } from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { HtmlPreview } from './html-preview'
+
+// The component falls back to the shared SyntaxHighlighter, which destructures
+// `components.Pre`, so every render path needs a minimal Pre supplied.
+function highlighterProps(code: string): SyntaxHighlighterProps {
+  return {
+    code,
+    language: 'html',
+    components: { Pre: (props: ComponentProps<'pre'>) => <pre {...props} /> }
+  } as unknown as SyntaxHighlighterProps
+}
+
+const HTML = '<div id="x">hi there</div>'
+
+describe('HtmlPreview', () => {
+  it('renders a sandboxed iframe when the fence is complete', () => {
+    const { container } = render(<HtmlPreview {...highlighterProps(HTML)} />)
+    const iframe = container.querySelector('iframe')
+
+    expect(iframe).toBeTruthy()
+    // SECURITY: scripts allowed, but allow-same-origin must NEVER be present —
+    // an opaque origin denies untrusted LLM HTML access to app cookies/storage/DOM.
+    expect(iframe?.getAttribute('sandbox')).toBe('allow-scripts')
+    expect(iframe?.getAttribute('sandbox')).not.toContain('allow-same-origin')
+    expect(iframe?.getAttribute('srcdoc')).toBe(HTML)
+  })
+
+  it('falls back to the code card (no iframe) while streaming', () => {
+    const { container } = render(<HtmlPreview {...highlighterProps(HTML)} defer />)
+
+    expect(container.querySelector('iframe')).toBeNull()
+    expect(container.textContent).toContain('hi there')
+  })
+
+  it('falls back (no iframe) for an empty or whitespace-only fence', () => {
+    const { container } = render(<HtmlPreview {...highlighterProps('   \n  ')} />)
+
+    expect(container.querySelector('iframe')).toBeNull()
+  })
+
+  it('toggles the iframe off for the source view and back on', () => {
+    const { container } = render(<HtmlPreview {...highlighterProps(HTML)} />)
+    const ui = within(container)
+    expect(container.querySelector('iframe')).toBeTruthy()
+
+    // Exact name match avoids colliding with the "Copy code" button. The source
+    // view is highlighted asynchronously by Shiki, so we assert on the iframe
+    // presence (synchronous) rather than the rendered source text.
+    fireEvent.click(ui.getByRole('button', { name: 'Code' }))
+    expect(container.querySelector('iframe')).toBeNull()
+
+    fireEvent.click(ui.getByRole('button', { name: 'PREVIEW' }))
+    const iframe = container.querySelector('iframe')
+    expect(iframe).toBeTruthy()
+    expect(iframe?.getAttribute('srcdoc')).toBe(HTML)
+  })
+})

--- a/apps/desktop/src/components/chat/html-preview.tsx
+++ b/apps/desktop/src/components/chat/html-preview.tsx
@@ -13,7 +13,9 @@ import {
   CodeCardTitle
 } from '@/components/chat/code-card'
 import { SyntaxHighlighter } from '@/components/chat/shiki-highlighter'
+import { Codicon } from '@/components/ui/codicon'
 import { CopyButton } from '@/components/ui/copy-button'
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
 
@@ -35,14 +37,39 @@ interface HtmlPreviewProps extends SyntaxHighlighterProps {
 // Mirror shiki-highlighter.tsx so the inline "Code" view matches the rest of
 // the app (full react-shiki bundle, light-dark() theme follows color-scheme).
 const SHIKI_THEME = { dark: 'github-dark-default', light: 'github-light-default' } as const
+
 const SHIKI_COLOR_REPLACEMENTS: Record<string, Record<string, string>> = {
   'github-light-default': { '#6e7781': '#57606a' }
 }
+
+// SECURITY: `allow-scripts` only — never `allow-same-origin`. The HTML is
+// untrusted LLM output running inside an Electron renderer; keeping the frame in
+// an opaque origin denies it access to app cookies, storage, and the parent DOM.
+// White background since HTML pages assume a white canvas. `reloadKey` re-mounts
+// the frame so Refresh re-runs the document's scripts from a clean state.
+const PreviewFrame: FC<{ className: string; reloadKey: number; source: string }> = ({
+  className,
+  reloadKey,
+  source
+}) => (
+  <iframe
+    className={className}
+    key={reloadKey}
+    sandbox="allow-scripts"
+    srcDoc={source}
+    title="html-preview"
+  />
+)
+
+const HEADER_ICON_BUTTON =
+  'flex size-5 items-center justify-center rounded-md text-muted-foreground opacity-55 transition-colors hover:bg-muted hover:text-foreground hover:opacity-100'
 
 export const HtmlPreview: FC<HtmlPreviewProps> = props => {
   const { code, defer = false } = props
   const { t } = useI18n()
   const [showCode, setShowCode] = useState(false)
+  const [expanded, setExpanded] = useState(false)
+  const [reloadKey, setReloadKey] = useState(0)
   const source = (code ?? '').trim()
 
   // Streaming or empty fence: keep the plain code card so the user watches the
@@ -52,78 +79,104 @@ export const HtmlPreview: FC<HtmlPreviewProps> = props => {
   }
 
   return (
-    <CodeCard>
-      <CodeCardHeader>
-        <CodeCardTitle>
-          <CodeCardIcon name="code" />
-          {t.assistant.tool.code}
-          <CodeCardSubtitle> · html</CodeCardSubtitle>
-        </CodeCardTitle>
-        <div className="flex items-center gap-1">
-          <div className="flex items-center rounded-md border border-border p-0.5">
-            <button
-              aria-pressed={!showCode}
-              className={cn(
-                'rounded-[0.25rem] px-1.5 py-0.5 text-[0.65rem] font-medium leading-none transition-colors',
-                showCode ? 'text-muted-foreground hover:text-foreground' : 'bg-muted text-foreground'
-              )}
-              onClick={() => setShowCode(false)}
-              type="button"
-            >
-              {t.preview.renderedPreview}
-            </button>
-            <button
-              aria-pressed={showCode}
-              className={cn(
-                'rounded-[0.25rem] px-1.5 py-0.5 text-[0.65rem] font-medium leading-none transition-colors',
-                showCode ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground'
-              )}
-              onClick={() => setShowCode(true)}
-              type="button"
-            >
-              {t.assistant.tool.code}
-            </button>
+    <>
+      <CodeCard>
+        <CodeCardHeader>
+          <CodeCardTitle>
+            <CodeCardIcon name="code" />
+            {t.assistant.tool.code}
+            <CodeCardSubtitle> · html</CodeCardSubtitle>
+          </CodeCardTitle>
+          <div className="flex items-center gap-1">
+            <div className="flex items-center rounded-md border border-border p-0.5">
+              <button
+                aria-pressed={!showCode}
+                className={cn(
+                  'rounded-[0.25rem] px-1.5 py-0.5 text-[0.65rem] font-medium leading-none transition-colors',
+                  showCode ? 'text-muted-foreground hover:text-foreground' : 'bg-muted text-foreground'
+                )}
+                onClick={() => setShowCode(false)}
+                type="button"
+              >
+                {t.preview.renderedPreview}
+              </button>
+              <button
+                aria-pressed={showCode}
+                className={cn(
+                  'rounded-[0.25rem] px-1.5 py-0.5 text-[0.65rem] font-medium leading-none transition-colors',
+                  showCode ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground'
+                )}
+                onClick={() => setShowCode(true)}
+                type="button"
+              >
+                {t.assistant.tool.code}
+              </button>
+            </div>
+            {!showCode && (
+              <>
+                <button
+                  aria-label={t.common.refresh}
+                  className={HEADER_ICON_BUTTON}
+                  onClick={() => setReloadKey(key => key + 1)}
+                  title={t.common.refresh}
+                  type="button"
+                >
+                  <Codicon name="refresh" size={12} />
+                </button>
+                <button
+                  aria-label={t.preview.expand}
+                  className={HEADER_ICON_BUTTON}
+                  onClick={() => setExpanded(true)}
+                  title={t.preview.expand}
+                  type="button"
+                >
+                  <Codicon name="screen-full" size={12} />
+                </button>
+              </>
+            )}
+            <CopyButton
+              appearance="inline"
+              className="-my-1 -mr-1 h-5 px-1 opacity-55 hover:opacity-100"
+              iconClassName="size-2.5"
+              label={t.assistant.tool.copyCode}
+              showLabel={false}
+              text={source}
+            />
           </div>
-          <CopyButton
-            appearance="inline"
-            className="-my-1 -mr-1 h-5 px-1 opacity-55 hover:opacity-100"
-            iconClassName="size-2.5"
-            label={t.assistant.tool.copyCode}
-            showLabel={false}
-            text={source}
+        </CodeCardHeader>
+        {showCode ? (
+          <CodeCardBody>
+            <pre className="aui-shiki m-0 overflow-hidden bg-transparent p-0">
+              <ShikiHighlighter
+                addDefaultStyles={false}
+                as="div"
+                colorReplacements={SHIKI_COLOR_REPLACEMENTS}
+                defaultColor="light-dark()"
+                delay={120}
+                language="html"
+                showLanguage={false}
+                theme={SHIKI_THEME}
+              >
+                {source}
+              </ShikiHighlighter>
+            </pre>
+          </CodeCardBody>
+        ) : (
+          <PreviewFrame
+            className="block h-[22.5rem] w-full border-0 bg-white"
+            reloadKey={reloadKey}
+            source={source}
           />
-        </div>
-      </CodeCardHeader>
-      {showCode ? (
-        <CodeCardBody>
-          <pre className="aui-shiki m-0 overflow-hidden bg-transparent p-0">
-            <ShikiHighlighter
-              addDefaultStyles={false}
-              as="div"
-              colorReplacements={SHIKI_COLOR_REPLACEMENTS}
-              defaultColor="light-dark()"
-              delay={120}
-              language="html"
-              showLanguage={false}
-              theme={SHIKI_THEME}
-            >
-              {source}
-            </ShikiHighlighter>
-          </pre>
-        </CodeCardBody>
-      ) : (
-        // SECURITY: `allow-scripts` only — never `allow-same-origin`. The HTML
-        // is untrusted LLM output running inside an Electron renderer; keeping
-        // the frame in an opaque origin denies it access to app cookies,
-        // storage, and the parent DOM. White background since HTML pages
-        // assume a white canvas.
-        <iframe
-          className="block h-[22.5rem] w-full border-0 bg-white"
-          sandbox="allow-scripts"
-          srcDoc={source}
-          title="html-preview"
-        />
-      )}
-    </CodeCard>
+        )}
+      </CodeCard>
+
+      <Dialog onOpenChange={setExpanded} open={expanded}>
+        <DialogContent className="h-[90vh] w-[92vw] max-w-[92vw] overflow-hidden p-0">
+          {/* Title is required for a11y but the frame is the content. */}
+          <DialogTitle className="sr-only">{t.preview.tab}</DialogTitle>
+          <PreviewFrame className="block size-full border-0 bg-white" reloadKey={reloadKey} source={source} />
+        </DialogContent>
+      </Dialog>
+    </>
   )
 }

--- a/apps/desktop/src/components/chat/html-preview.tsx
+++ b/apps/desktop/src/components/chat/html-preview.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import type { SyntaxHighlighterProps } from '@assistant-ui/react-streamdown'
-import { type FC, useState } from 'react'
+import { type FC, memo, useState } from 'react'
 import ShikiHighlighter from 'react-shiki'
 
 import {
@@ -64,7 +64,7 @@ const PreviewFrame: FC<{ className: string; reloadKey: number; source: string }>
 const HEADER_ICON_BUTTON =
   'flex size-5 items-center justify-center rounded-md text-muted-foreground opacity-55 transition-colors hover:bg-muted hover:text-foreground hover:opacity-100'
 
-export const HtmlPreview: FC<HtmlPreviewProps> = props => {
+const HtmlPreviewImpl: FC<HtmlPreviewProps> = props => {
   const { code, defer = false } = props
   const { t } = useI18n()
   const [showCode, setShowCode] = useState(false)
@@ -180,3 +180,5 @@ export const HtmlPreview: FC<HtmlPreviewProps> = props => {
     </>
   )
 }
+
+export const HtmlPreview = memo(HtmlPreviewImpl)

--- a/apps/desktop/src/components/chat/html-preview.tsx
+++ b/apps/desktop/src/components/chat/html-preview.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+import type { SyntaxHighlighterProps } from '@assistant-ui/react-streamdown'
+import { type FC, useState } from 'react'
+import ShikiHighlighter from 'react-shiki'
+
+import {
+  CodeCard,
+  CodeCardBody,
+  CodeCardHeader,
+  CodeCardIcon,
+  CodeCardSubtitle,
+  CodeCardTitle
+} from '@/components/chat/code-card'
+import { SyntaxHighlighter } from '@/components/chat/shiki-highlighter'
+import { CopyButton } from '@/components/ui/copy-button'
+import { useI18n } from '@/i18n'
+import { cn } from '@/lib/utils'
+
+/**
+ * Renders ```html fences as a live, Claude-artifacts-style preview. Registered
+ * per-language via `componentsByLanguage` on StreamdownTextPrimitive — the
+ * global `SyntaxHighlighter` override replaces streamdown's built-in code
+ * dispatcher (the only place its plugins are consulted), so a plugins-only
+ * setup never runs; this component is the supported escape hatch (same wiring
+ * as MermaidDiagram).
+ *
+ * While streaming (`defer`) or when the fence is empty we fall back to the
+ * regular code card, so the user always at least sees the source build up.
+ */
+interface HtmlPreviewProps extends SyntaxHighlighterProps {
+  defer?: boolean
+}
+
+// Mirror shiki-highlighter.tsx so the inline "Code" view matches the rest of
+// the app (full react-shiki bundle, light-dark() theme follows color-scheme).
+const SHIKI_THEME = { dark: 'github-dark-default', light: 'github-light-default' } as const
+const SHIKI_COLOR_REPLACEMENTS: Record<string, Record<string, string>> = {
+  'github-light-default': { '#6e7781': '#57606a' }
+}
+
+export const HtmlPreview: FC<HtmlPreviewProps> = props => {
+  const { code, defer = false } = props
+  const { t } = useI18n()
+  const [showCode, setShowCode] = useState(false)
+  const source = (code ?? '').trim()
+
+  // Streaming or empty fence: keep the plain code card so the user watches the
+  // markup arrive. We never preview a half-written document.
+  if (defer || !source) {
+    return <SyntaxHighlighter {...props} defer={defer} />
+  }
+
+  return (
+    <CodeCard>
+      <CodeCardHeader>
+        <CodeCardTitle>
+          <CodeCardIcon name="code" />
+          {t.assistant.tool.code}
+          <CodeCardSubtitle> · html</CodeCardSubtitle>
+        </CodeCardTitle>
+        <div className="flex items-center gap-1">
+          <div className="flex items-center rounded-md border border-border p-0.5">
+            <button
+              aria-pressed={!showCode}
+              className={cn(
+                'rounded-[0.25rem] px-1.5 py-0.5 text-[0.65rem] font-medium leading-none transition-colors',
+                showCode ? 'text-muted-foreground hover:text-foreground' : 'bg-muted text-foreground'
+              )}
+              onClick={() => setShowCode(false)}
+              type="button"
+            >
+              {t.preview.renderedPreview}
+            </button>
+            <button
+              aria-pressed={showCode}
+              className={cn(
+                'rounded-[0.25rem] px-1.5 py-0.5 text-[0.65rem] font-medium leading-none transition-colors',
+                showCode ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground'
+              )}
+              onClick={() => setShowCode(true)}
+              type="button"
+            >
+              {t.assistant.tool.code}
+            </button>
+          </div>
+          <CopyButton
+            appearance="inline"
+            className="-my-1 -mr-1 h-5 px-1 opacity-55 hover:opacity-100"
+            iconClassName="size-2.5"
+            label={t.assistant.tool.copyCode}
+            showLabel={false}
+            text={source}
+          />
+        </div>
+      </CodeCardHeader>
+      {showCode ? (
+        <CodeCardBody>
+          <pre className="aui-shiki m-0 overflow-hidden bg-transparent p-0">
+            <ShikiHighlighter
+              addDefaultStyles={false}
+              as="div"
+              colorReplacements={SHIKI_COLOR_REPLACEMENTS}
+              defaultColor="light-dark()"
+              delay={120}
+              language="html"
+              showLanguage={false}
+              theme={SHIKI_THEME}
+            >
+              {source}
+            </ShikiHighlighter>
+          </pre>
+        </CodeCardBody>
+      ) : (
+        // SECURITY: `allow-scripts` only — never `allow-same-origin`. The HTML
+        // is untrusted LLM output running inside an Electron renderer; keeping
+        // the frame in an opaque origin denies it access to app cookies,
+        // storage, and the parent DOM. White background since HTML pages
+        // assume a white canvas.
+        <iframe
+          className="block h-[22.5rem] w-full border-0 bg-white"
+          sandbox="allow-scripts"
+          srcDoc={source}
+          title="html-preview"
+        />
+      )}
+    </CodeCard>
+  )
+}

--- a/apps/desktop/src/components/chat/mermaid-diagram.test.tsx
+++ b/apps/desktop/src/components/chat/mermaid-diagram.test.tsx
@@ -1,0 +1,76 @@
+import type { SyntaxHighlighterProps } from '@assistant-ui/react-streamdown'
+import { render, waitFor, within } from '@testing-library/react'
+import type { ComponentProps } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock the heavy mermaid plugin so tests drive render success/failure directly
+// and never touch the real (DOM-measuring) mermaid library.
+const { mockRender } = vi.hoisted(() => ({ mockRender: vi.fn() }))
+
+vi.mock('@streamdown/mermaid', () => ({
+  mermaid: { getMermaid: () => ({ render: mockRender }) }
+}))
+
+import { MermaidDiagram } from './mermaid-diagram'
+
+function highlighterProps(code: string): SyntaxHighlighterProps {
+  return {
+    code,
+    language: 'mermaid',
+    components: { Pre: (props: ComponentProps<'pre'>) => <pre {...props} /> }
+  } as unknown as SyntaxHighlighterProps
+}
+
+const SOURCE = 'graph TD; A-->B'
+
+describe('MermaidDiagram', () => {
+  beforeEach(() => {
+    mockRender.mockReset()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the diagram once the source parses', async () => {
+    mockRender.mockResolvedValue({ svg: '<svg data-testid="diagram">DIAGRAM</svg>' })
+
+    const { container } = render(<MermaidDiagram {...highlighterProps(SOURCE)} />)
+
+    await waitFor(() => {
+      expect(container.querySelector('[role="img"]')).toBeTruthy()
+    })
+    expect(container.querySelector('[data-testid="diagram"]')).toBeTruthy()
+    expect(container.textContent).toContain('DIAGRAM')
+  })
+
+  it('falls back to the source (no diagram) while streaming', async () => {
+    const { container } = render(<MermaidDiagram {...highlighterProps(SOURCE)} defer />)
+
+    // Defer short-circuits before any render call.
+    expect(mockRender).not.toHaveBeenCalled()
+    expect(container.querySelector('[role="img"]')).toBeNull()
+    expect(within(container).getByText(/graph TD/)).toBeTruthy()
+  })
+
+  it('falls back to the source (no diagram) when the source fails to parse', async () => {
+    mockRender.mockRejectedValue(new Error('Parse error on line 1'))
+
+    const { container } = render(<MermaidDiagram {...highlighterProps('graph TD; A--')} />)
+
+    await waitFor(() => {
+      expect(mockRender).toHaveBeenCalled()
+    })
+    await waitFor(() => {
+      expect(container.querySelector('[role="img"]')).toBeNull()
+      expect(container.textContent).toContain('graph TD')
+    })
+  })
+
+  it('falls back (no diagram, no render call) for an empty fence', () => {
+    const { container } = render(<MermaidDiagram {...highlighterProps('   ')} />)
+
+    expect(mockRender).not.toHaveBeenCalled()
+    expect(container.querySelector('[role="img"]')).toBeNull()
+  })
+})

--- a/apps/desktop/src/components/chat/mermaid-diagram.test.tsx
+++ b/apps/desktop/src/components/chat/mermaid-diagram.test.tsx
@@ -53,7 +53,7 @@ describe('MermaidDiagram', () => {
     expect(within(container).getByText(/graph TD/)).toBeTruthy()
   })
 
-  it('falls back to the source (no diagram) when the source fails to parse', async () => {
+  it('shows an error badge and the source when the source fails to parse', async () => {
     mockRender.mockRejectedValue(new Error('Parse error on line 1'))
 
     const { container } = render(<MermaidDiagram {...highlighterProps('graph TD; A--')} />)
@@ -62,7 +62,11 @@ describe('MermaidDiagram', () => {
       expect(mockRender).toHaveBeenCalled()
     })
     await waitFor(() => {
+      // No diagram, but a visible alert explaining why — not a silent fall-through.
       expect(container.querySelector('[role="img"]')).toBeNull()
+      const alert = container.querySelector('[role="alert"]')
+      expect(alert).toBeTruthy()
+      expect(alert?.textContent).toContain('Parse error on line 1')
       expect(container.textContent).toContain('graph TD')
     })
   })

--- a/apps/desktop/src/components/chat/mermaid-diagram.tsx
+++ b/apps/desktop/src/components/chat/mermaid-diagram.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import type { SyntaxHighlighterProps } from '@assistant-ui/react-streamdown'
+import { mermaid as mermaidPlugin } from '@streamdown/mermaid'
+import { type FC, useEffect, useState } from 'react'
+
+import {
+  CodeCard,
+  CodeCardBody,
+  CodeCardHeader,
+  CodeCardIcon,
+  CodeCardSubtitle,
+  CodeCardTitle
+} from '@/components/chat/code-card'
+import { SyntaxHighlighter } from '@/components/chat/shiki-highlighter'
+import { CopyButton } from '@/components/ui/copy-button'
+import { useI18n } from '@/i18n'
+import { useTheme } from '@/themes/context'
+
+/**
+ * Renders ```mermaid fences as diagrams. Registered per-language via
+ * `componentsByLanguage` on StreamdownTextPrimitive — the global
+ * `SyntaxHighlighter` override replaces streamdown's built-in code dispatcher
+ * (the only place its mermaid plugin is consulted), so a plugins-only setup
+ * never renders diagrams; this component is the supported escape hatch.
+ *
+ * While streaming (`defer`) or when the source fails to parse we fall back to
+ * the regular code card, so the user always at least sees the source.
+ */
+interface MermaidDiagramProps extends SyntaxHighlighterProps {
+  defer?: boolean
+}
+
+// mermaid.render() requires a document-unique element id per call.
+let renderSeq = 0
+
+export const MermaidDiagram: FC<MermaidDiagramProps> = props => {
+  const { code, defer = false } = props
+  const { t } = useI18n()
+  const { renderedMode } = useTheme()
+  const [svg, setSvg] = useState('')
+  const [failed, setFailed] = useState(false)
+  const source = (code ?? '').trim()
+
+  useEffect(() => {
+    if (defer || !source) {
+      return
+    }
+
+    let cancelled = false
+
+    setFailed(false)
+    const instance = mermaidPlugin.getMermaid({ theme: renderedMode === 'dark' ? 'dark' : 'default' })
+
+    instance
+      .render(`hermes-mermaid-${++renderSeq}`, source)
+      .then(({ svg: rendered }) => {
+        if (!cancelled) {
+          setSvg(rendered)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setSvg('')
+          setFailed(true)
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [source, defer, renderedMode])
+
+  if (defer || failed || !source) {
+    return <SyntaxHighlighter {...props} defer={defer} />
+  }
+
+  // Async render pending: keep showing the source, swap in the diagram when ready.
+  if (!svg) {
+    return <SyntaxHighlighter {...props} defer />
+  }
+
+  return (
+    <CodeCard>
+      <CodeCardHeader>
+        <CodeCardTitle>
+          <CodeCardIcon name="graph" />
+          {t.assistant.tool.code}
+          <CodeCardSubtitle> · mermaid</CodeCardSubtitle>
+        </CodeCardTitle>
+        <CopyButton
+          appearance="inline"
+          className="-my-1 -mr-1 h-5 px-1 opacity-55 hover:opacity-100"
+          iconClassName="size-2.5"
+          label={t.assistant.tool.copyCode}
+          showLabel={false}
+          text={source}
+        />
+      </CodeCardHeader>
+      <CodeCardBody>
+        {/* Mermaid output is sanitized by the library (securityLevel: strict). */}
+        <div
+          className="flex justify-center overflow-x-auto bg-background p-3 [&_svg]:h-auto [&_svg]:max-w-full"
+          dangerouslySetInnerHTML={{ __html: svg }}
+          role="img"
+        />
+      </CodeCardBody>
+    </CodeCard>
+  )
+}

--- a/apps/desktop/src/components/chat/mermaid-diagram.tsx
+++ b/apps/desktop/src/components/chat/mermaid-diagram.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import type { SyntaxHighlighterProps } from '@assistant-ui/react-streamdown'
-import { mermaid as mermaidPlugin } from '@streamdown/mermaid'
-import { type FC, useEffect, useState } from 'react'
+import { type FC, memo, useEffect, useId, useRef, useState } from 'react'
 
 import {
   CodeCard,
@@ -13,6 +12,7 @@ import {
   CodeCardTitle
 } from '@/components/chat/code-card'
 import { SyntaxHighlighter } from '@/components/chat/shiki-highlighter'
+import { Codicon } from '@/components/ui/codicon'
 import { CopyButton } from '@/components/ui/copy-button'
 import { useI18n } from '@/i18n'
 import { useTheme } from '@/themes/context'
@@ -31,15 +31,17 @@ interface MermaidDiagramProps extends SyntaxHighlighterProps {
   defer?: boolean
 }
 
-// mermaid.render() requires a document-unique element id per call.
-let renderSeq = 0
-
-export const MermaidDiagram: FC<MermaidDiagramProps> = props => {
+const MermaidDiagramImpl: FC<MermaidDiagramProps> = props => {
   const { code, defer = false } = props
   const { t } = useI18n()
   const { renderedMode } = useTheme()
   const [svg, setSvg] = useState('')
-  const [failed, setFailed] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  // mermaid.render() needs a document-unique element id per call. useId is unique
+  // per component instance (no colons — they break SVG id/CSS selectors); the
+  // counter keeps successive re-renders within one instance unique too.
+  const baseId = useId().replace(/:/g, '')
+  const renderCount = useRef(0)
   const source = (code ?? '').trim()
 
   useEffect(() => {
@@ -48,31 +50,56 @@ export const MermaidDiagram: FC<MermaidDiagramProps> = props => {
     }
 
     let cancelled = false
+    setError(null)
 
-    setFailed(false)
-    const instance = mermaidPlugin.getMermaid({ theme: renderedMode === 'dark' ? 'dark' : 'default' })
+    // Import mermaid only when a diagram actually renders. The desktop build is
+    // a single chunk, so this doesn't shrink the bundle, but it defers the heavy
+    // library's module-level initialization from app boot to first diagram use.
+    void import('@streamdown/mermaid')
+      .then(({ mermaid }) => {
+        const instance = mermaid.getMermaid({ theme: renderedMode === 'dark' ? 'dark' : 'default' })
 
-    instance
-      .render(`hermes-mermaid-${++renderSeq}`, source)
+        return instance.render(`${baseId}-${++renderCount.current}`, source)
+      })
       .then(({ svg: rendered }) => {
         if (!cancelled) {
           setSvg(rendered)
         }
       })
-      .catch(() => {
+      .catch((err: unknown) => {
         if (!cancelled) {
           setSvg('')
-          setFailed(true)
+          setError(err instanceof Error ? err.message : String(err))
         }
       })
 
     return () => {
       cancelled = true
     }
-  }, [source, defer, renderedMode])
+  }, [source, defer, renderedMode, baseId])
 
-  if (defer || failed || !source) {
+  if (defer || !source) {
     return <SyntaxHighlighter {...props} defer={defer} />
+  }
+
+  // Parse/render failure: show the source with a visible error badge so the
+  // user knows *why* no diagram appeared instead of a silent fall-through.
+  if (error) {
+    return (
+      <div className="space-y-1">
+        <div
+          className="flex items-start gap-1.5 px-0.5 text-[0.7rem] leading-snug text-destructive"
+          role="alert"
+          title={error}
+        >
+          <Codicon className="mt-px shrink-0" name="warning" size={12} />
+          <span>
+            {t.preview.diagramError}: {error.split('\n')[0]}
+          </span>
+        </div>
+        <SyntaxHighlighter {...props} />
+      </div>
+    )
   }
 
   // Async render pending: keep showing the source, swap in the diagram when ready.
@@ -100,6 +127,7 @@ export const MermaidDiagram: FC<MermaidDiagramProps> = props => {
       <CodeCardBody>
         {/* Mermaid output is sanitized by the library (securityLevel: strict). */}
         <div
+          aria-label="mermaid diagram"
           className="flex justify-center overflow-x-auto bg-background p-3 [&_svg]:h-auto [&_svg]:max-w-full"
           dangerouslySetInnerHTML={{ __html: svg }}
           role="img"
@@ -108,3 +136,5 @@ export const MermaidDiagram: FC<MermaidDiagramProps> = props => {
     </CodeCard>
   )
 }
+
+export const MermaidDiagram = memo(MermaidDiagramImpl)

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1581,6 +1581,7 @@ export const en: Translations = {
     sourceLineTitle: 'Click to select · shift-click to extend · drag to composer',
     source: 'SOURCE',
     renderedPreview: 'PREVIEW',
+    expand: 'Expand preview',
     unknownSize: 'unknown size',
     binaryTitle: 'This looks like a binary file',
     binaryBody: label => `Previewing ${label} may show unreadable text.`,

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1582,6 +1582,7 @@ export const en: Translations = {
     source: 'SOURCE',
     renderedPreview: 'PREVIEW',
     expand: 'Expand preview',
+    diagramError: 'Diagram error',
     unknownSize: 'unknown size',
     binaryTitle: 'This looks like a binary file',
     binaryBody: label => `Previewing ${label} may show unreadable text.`,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1721,6 +1721,7 @@ export const ja = defineLocale({
     sourceLineTitle: 'クリックして選択 · Shift クリックで拡張 · コンポーザーにドラッグ',
     source: 'ソース',
     renderedPreview: 'プレビュー',
+    expand: 'プレビューを拡大',
     unknownSize: 'サイズ不明',
     binaryTitle: 'これはバイナリファイルのようです',
     binaryBody: label => `${label} をプレビューすると読み取り不能なテキストが表示される場合があります。`,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1722,6 +1722,7 @@ export const ja = defineLocale({
     source: 'ソース',
     renderedPreview: 'プレビュー',
     expand: 'プレビューを拡大',
+    diagramError: '図のエラー',
     unknownSize: 'サイズ不明',
     binaryTitle: 'これはバイナリファイルのようです',
     binaryBody: label => `${label} をプレビューすると読み取り不能なテキストが表示される場合があります。`,

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1242,6 +1242,7 @@ export interface Translations {
     sourceLineTitle: string
     source: string
     renderedPreview: string
+    expand: string
     unknownSize: string
     binaryTitle: string
     binaryBody: (label: string) => string

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1243,6 +1243,7 @@ export interface Translations {
     source: string
     renderedPreview: string
     expand: string
+    diagramError: string
     unknownSize: string
     binaryTitle: string
     binaryBody: (label: string) => string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1667,6 +1667,7 @@ export const zhHant = defineLocale({
     sourceLineTitle: '點擊選取 · shift 點擊擴展 · 拖曳至輸入框',
     source: '原始碼',
     renderedPreview: '預覽',
+    expand: '放大預覽',
     unknownSize: '大小未知',
     binaryTitle: '這看起來像二進位檔案',
     binaryBody: label => `預覽 ${label} 可能會顯示無法讀取的文字。`,

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1668,6 +1668,7 @@ export const zhHant = defineLocale({
     source: '原始碼',
     renderedPreview: '預覽',
     expand: '放大預覽',
+    diagramError: '圖表錯誤',
     unknownSize: '大小未知',
     binaryTitle: '這看起來像二進位檔案',
     binaryBody: label => `預覽 ${label} 可能會顯示無法讀取的文字。`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1763,6 +1763,7 @@ export const zh: Translations = {
     source: '源码',
     renderedPreview: '预览',
     expand: '放大预览',
+    diagramError: '图表错误',
     unknownSize: '大小未知',
     binaryTitle: '这看起来像二进制文件',
     binaryBody: label => `预览 ${label} 可能会显示不可读文本。`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1762,6 +1762,7 @@ export const zh: Translations = {
     sourceLineTitle: '点击选择 · shift 点击扩展 · 拖到输入框',
     source: '源码',
     renderedPreview: '预览',
+    expand: '放大预览',
     unknownSize: '大小未知',
     binaryTitle: '这看起来像二进制文件',
     binaryBody: label => `预览 ${label} 可能会显示不可读文本。`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,6 +88,7 @@
         "@nous-research/ui": "^0.13.0",
         "@radix-ui/react-slot": "^1.2.4",
         "@streamdown/code": "^1.1.1",
+        "@streamdown/mermaid": "^1.0.2",
         "@tabler/icons-react": "^3.41.1",
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.2.4",
@@ -7263,6 +7264,18 @@
         "katex": "^0.16.27",
         "rehype-katex": "^7.0.1",
         "remark-math": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@streamdown/mermaid": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@streamdown/mermaid/-/mermaid-1.0.2.tgz",
+      "integrity": "sha512-Fr/4sBWnAeSnxM3PcrV/+DiZe5oPMq9gOkUIAH7ZauJeuwrZ/DVzD4g0zlav6AH0axh2m/sOfrfLtY5aLT7niw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mermaid": "^11.12.2"
       },
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0"


### PR DESCRIPTION
Fixes #40493

## What

Adds Claude-style live artifact rendering for fenced code blocks in desktop chat:

- ` ```html ` fences render in a sandboxed `<iframe>` with a **Rendered / Code** toggle.
- ` ```mermaid ` fences render as SVG via `@streamdown/mermaid`, following the active light/dark theme.

Both are wired via `componentsByLanguage` on `StreamdownTextPrimitive`. While the fence is still streaming (`defer`) — or when input is empty/unparseable — they fall back to the existing plain code card, so behavior is unchanged for incomplete content.

## Why

Models frequently answer with self-contained HTML demos and mermaid diagrams; today both render as static code. Live previews make those answers directly usable without leaving the chat.

## Security

- The HTML iframe is `sandbox="allow-scripts"` **only** — never `allow-same-origin` — so untrusted LLM output can't reach the renderer origin.
- Mermaid runs with `securityLevel: "strict"`.

## Testing

- 8 new unit tests (`html-preview.test.tsx`, `mermaid-diagram.test.tsx`): render-when-complete, fallback-while-streaming, fallback-on-empty/parse-failure, Rendered/Code toggle, and the sandbox attribute asserted directly (mermaid plugin mocked).
- `npm run typecheck` clean.

## Notes

Supersedes #40911 — same goal, reworked implementation (componentsByLanguage wiring instead of the earlier approach, plus the HTML preview and test coverage).