### PR TITLE
fix(desktop): restore or recreate main window on second-instance activation

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -6350,9 +6350,10 @@ if (!_gotSingleInstanceLock) {
   app.on('second-instance', (_event, argv) => {
     const url = _extractDeepLink(argv)
     if (url) handleDeepLink(url)
-    else if (mainWindow) {
-      if (mainWindow.isMinimized()) mainWindow.restore()
-      mainWindow.focus()
+    else if (mainWindow && !mainWindow.isDestroyed()) {
+      focusWindow(mainWindow)
+    } else if (app.isReady()) {
+      createWindow()
     }
   })
 }


### PR DESCRIPTION
## What

When a second app instance launches without a deep link, focus the existing window via the `focusWindow` helper (which guards restore/show/focus atomically and now checks for a destroyed ref), and **recreate the window** if it's gone while the app is ready — instead of silently doing nothing.

## Why

Clicking the Hermes shortcut while an instance was already running but its window had been closed/destroyed previously appeared to do nothing (or could crash on a destroyed `BrowserWindow` ref), making the app look like it failed to launch.

## Testing

`npm run typecheck` clean; existing electron platform tests unaffected. Manually verified on Windows: relaunching the shortcut with a destroyed window now recreates it, and with a minimized window restores+focuses it.