### PR TITLE
fix(cron): respect empty enabled_toolsets array to disable all tools

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -99,7 +99,7 @@ def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
     surprise $4.63 run).
     """
     per_job = job.get("enabled_toolsets")
-    if per_job:
+    if per_job is not None:
         return per_job
     try:
         from hermes_cli.tools_config import _get_platform_tools  # lazy: avoid heavy import at cron module load


### PR DESCRIPTION
Fixes a bug where setting `enabled_toolsets=[]` on a cron job was ignored, causing all tools to be loaded instead of none.

**Root cause:** `if per_job:` treats an empty list `[]` as falsy, so the per-job override was silently skipped and the scheduler fell back to the global default (all tools).

**Fix:** Change the guard to `if per_job is not None:` so that an explicitly empty list is honored.

**Impact:** When users set `enabled_toolsets=[]` to disable tools for lightweight cron jobs (e.g. simple text summaries), the agent now correctly receives zero tools, eliminating unnecessary API calls from tool nudging loops.