### PR TITLE
fix(desktop): preserve named custom model providers

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -771,8 +771,9 @@ def _normalize_main_model_assignment(provider: str, model: str) -> tuple[str, st
     prov_in = (provider or "").strip()
     model_in = (model or "").strip()
     canonical = normalize_provider(prov_in)
+    is_named_custom = prov_in.lower().startswith("custom:")
 
-    if canonical not in _KNOWN_PROVIDER_NAMES and "/" in model_in:
+    if canonical not in _KNOWN_PROVIDER_NAMES and not is_named_custom and "/" in model_in:
         # Vendor prefix posing as a provider (analytics fallback). Resolve
         # against the user's current provider when it's an aggregator that
         # serves vendor-prefixed slugs; otherwise default to openrouter.

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1823,6 +1823,18 @@ class TestWebServerEndpoints:
         assert data["ok"] is True
         assert data.get("gateway_tools", []) == []
 
+    def test_normalize_main_model_assignment_preserves_named_custom_provider(self):
+        """Named custom providers are valid provider slugs, not model vendors."""
+        from hermes_cli.web_server import _normalize_main_model_assignment
+
+        provider, model = _normalize_main_model_assignment(
+            "custom:polza.ai",
+            "deepseek/deepseek-v4-flash",
+        )
+
+        assert provider == "custom:polza.ai"
+        assert model == "deepseek/deepseek-v4-flash"
+
     def test_apply_main_model_assignment_base_url_and_context_reconcile(self):
         """The shared main-slot assignment helper must persist a supplied
         base_url, clear a stale base_url only when switching providers, preserve


### PR DESCRIPTION
## Summary
- preserve named custom provider slugs such as `custom:polza.ai` in the Desktop model assignment API
- prevent vendor-prefixed model IDs from incorrectly triggering the OpenRouter fallback
- add a regression test covering the Desktop selection flow

## Reproduction
1. Configure a named OpenAI-compatible custom provider, for example Polza.ai.
2. In Desktop Settings > Model, select that provider and a vendor-prefixed model such as `deepseek/deepseek-v4-flash`.
3. Click Apply.
4. Observe that `model.provider` is persisted as `openrouter`, so Gateway reports missing OpenRouter credentials.

## Root cause
`_normalize_main_model_assignment` treated every provider absent from the built-in registry as a possible model vendor. Named custom provider slugs are user-defined and therefore absent from that registry, so models containing `/` caused the provider to be rewritten to the current aggregator or OpenRouter.

## Verification
- `pytest tests/hermes_cli/test_web_server.py -q`: 274 passed
- `ruff check hermes_cli/web_server.py tests/hermes_cli/test_web_server.py`: passed
- `npm --prefix apps/desktop run build`: passed
- runtime resolution verified for `custom:polza.ai` with its configured base URL and credential pool
