### PR TITLE
fix(docker): disable SELinux labeling for bind mounts on enforcing hosts

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -469,6 +469,34 @@ def test_security_args_include_setuid_setgid_for_privdrop(monkeypatch):
     assert "SETGID" in added, "SETGID cap missing — image privilege-drop will fail"
 
 
+def test_security_args_disable_selinux_label(monkeypatch):
+    """SELinux-enforcing hosts (e.g. OpenSUSE, Fedora, RHEL) block bind mounts
+    unless the container opts out of SELinux labeling.
+
+    Without ``label=disable``, ``docker run -v /host/path:/workspace`` fails
+    with "permission denied" inside the container on SELinux-enforcing systems
+    (issue #45106).  The flag is a no-op on non-SELinux hosts.
+    """
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env()
+
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls, "docker run should have been called"
+    run_args = run_calls[0][0]
+
+    opts = [
+        run_args[i + 1]
+        for i, flag in enumerate(run_args[:-1])
+        if flag == "--security-opt"
+    ]
+    assert "label=disable" in opts, (
+        "SELinux label=disable missing — bind mounts will fail on "
+        "SELinux-enforcing hosts (OpenSUSE, Fedora, RHEL)"
+    )
+
+
 # ── run_as_host_user tests ────────────────────────────────────────
 
 

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -330,6 +330,7 @@ _BASE_SECURITY_ARGS = [
     "--cap-add", "CHOWN",
     "--cap-add", "FOWNER",
     "--security-opt", "no-new-privileges",
+    "--security-opt", "label=disable",
     "--pids-limit", "256",
     "--tmpfs", "/tmp:rw,nosuid,size=512m",
     "--tmpfs", "/var/tmp:rw,noexec,nosuid,size=256m",


### PR DESCRIPTION
## What does this PR do?

Adds `--security-opt label=disable` to the Docker container's base security args so that bind mounts work correctly on SELinux-enforcing hosts (OpenSUSE, Fedora, RHEL). Without this, volume mounts like `/workspace` and `/root` fail with "permission denied" inside the container because the host files lack the `container_t` SELinux context.

## Related Issue

Fixes #45106

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/environments/docker.py`: Added `"--security-opt", "label=disable"` to `_BASE_SECURITY_ARGS` to disable SELinux labeling for the container. This is a no-op on non-SELinux hosts.
- `tests/tools/test_docker_environment.py`: Added `test_security_args_disable_selinux_label` verifying the flag is present in `docker run` args.

## How to Test

1. On an SELinux-enforcing host (e.g. OpenSUSE Tumbleweed, Fedora, RHEL), configure Hermes with the Docker backend
2. Start a session and verify the container can access bind-mounted directories (`/workspace`, `/root`)
3. Run `python -m pytest tests/tools/test_docker_environment.py -x -q` — all 70 tests should pass
4. On a non-SELinux host, verify the flag is silently ignored (no behavior change)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/tools/test_docker_environment.py -q` and all tests pass (70/70)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `tools/environments/docker.py::_BASE_SECURITY_ARGS` (used by `_build_run_command` in DockerEnvironment)
- Blast radius: LOW — adds a single Docker security opt that is a no-op on non-SELinux hosts
- Related patterns: `--security-opt no-new-privileges` already present in the same list; `label=disable` is the standard Docker approach for SELinux compatibility
