### PR TITLE
fix(send): helpful error when --file gets a binary; document MEDIA: attachments

### DIFF
--- a/hermes_cli/send_cmd.py
+++ b/hermes_cli/send_cmd.py
@@ -59,7 +59,20 @@ def _read_message_body(
             return sys.stdin.read()
         try:
             return Path(file_path).read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError) as exc:
+        except UnicodeDecodeError:
+            print(
+                f"hermes send: {file_path} is not a text file. --file reads the "
+                "message *body* (logs, reports, markdown).\n"
+                "To send an image/document/audio file as a native attachment, "
+                "reference it with MEDIA: in the message text instead:\n"
+                f'  hermes send --to telegram "MEDIA:{file_path}"\n'
+                f'  hermes send --to telegram "optional caption MEDIA:{file_path}"\n'
+                "Add [[as_document]] to deliver an image as an uncompressed file:\n"
+                f'  hermes send --to telegram "[[as_document]] MEDIA:{file_path}"',
+                file=sys.stderr,
+            )
+            sys.exit(_USAGE_EXIT)
+        except OSError as exc:
             print(f"hermes send: cannot read {file_path}: {exc}", file=sys.stderr)
             sys.exit(_USAGE_EXIT)
 
@@ -367,6 +380,7 @@ def register_send_subparser(subparsers) -> argparse.ArgumentParser:
             "  echo \"RAM 92%\" | hermes send --to telegram:-1001234567890\n"
             "  hermes send --to discord:#ops --file /tmp/report.md\n"
             "  hermes send --to slack:#eng --subject \"[CI]\" --file build.log\n"
+            "  hermes send --to telegram \"MEDIA:/tmp/chart.png\"   # send a media attachment\n"
             "  hermes send --list                  # all platforms\n"
             "  hermes send --list telegram         # filter by platform\n"
             "\n"
@@ -403,7 +417,11 @@ def register_send_subparser(subparsers) -> argparse.ArgumentParser:
         "--file",
         metavar="PATH",
         default=None,
-        help="Read message body from PATH. Use '-' to force stdin.",
+        help=(
+            "Read message body from PATH (text only). Use '-' to force stdin. "
+            "To send an image/document as an attachment, use MEDIA:<path> in "
+            "the message text instead."
+        ),
     )
 
     parser.add_argument(

--- a/tests/hermes_cli/test_send_cmd.py
+++ b/tests/hermes_cli/test_send_cmd.py
@@ -172,7 +172,7 @@ def test_file_not_found_is_usage_error(fake_tool, capsys, monkeypatch):
     assert "cannot read" in err.lower()
 
 
-def test_file_decode_error_is_usage_error(fake_tool, capsys, monkeypatch, tmp_path):
+def test_file_decode_error_suggests_media_directive(fake_tool, capsys, monkeypatch, tmp_path):
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
     bad = tmp_path / "bad-bytes.bin"
     bad.write_bytes(b"\xff\xfe\x00")
@@ -182,7 +182,9 @@ def test_file_decode_error_is_usage_error(fake_tool, capsys, monkeypatch, tmp_pa
         send_cmd.cmd_send(args)
     assert exc.value.code == 2
     err = capsys.readouterr().err
-    assert "cannot read" in err.lower()
+    assert "not a text file" in err.lower()
+    assert f"MEDIA:{bad}" in err
+    assert "[[as_document]]" in err
 
 
 def test_tool_error_returns_failure_exit(monkeypatch, capsys):

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -361,13 +361,29 @@ For bot-token platforms (Telegram, Discord, Slack, Signal, SMS, WhatsApp-CloudAP
 | Option | Description |
 |--------|-------------|
 | `-t`, `--to <TARGET>` | Delivery target. Formats: `platform` (uses home channel), `platform:chat_id`, `platform:chat_id:thread_id`, or `platform:#channel-name`. Examples: `telegram`, `telegram:-1001234567890`, `discord:#ops`, `slack:C0123ABCD`, `signal:+15551234567`. |
-| `-f`, `--file <PATH>` | Read the message body from `PATH`. Pass `-` to force reading from stdin. |
+| `-f`, `--file <PATH>` | Read the message body from `PATH` (text files only — logs, reports, markdown). Pass `-` to force reading from stdin. To send an image or other binary file, use `MEDIA:<path>` (see below). |
 | `-s`, `--subject <LINE>` | Prepend a subject/header line before the message body. |
 | `-l`, `--list [platform]` | List configured targets across all platforms (or only the given platform). |
 | `-q`, `--quiet` | Suppress stdout on success — useful in scripts (rely on exit code only). |
 | `--json` | Emit raw JSON result instead of human-readable output. |
 
 If neither a positional `message` argument nor `--file` is provided, `hermes send` reads from stdin when it is not a TTY. Exit codes: `0` on success, `1` on delivery/backend failure, `2` on usage errors.
+
+### Sending images and other media
+
+`--file` is for *text* bodies only. To deliver an image, document, video, or audio file as a native platform attachment, reference it inside the message text with the `MEDIA:<local_path>` directive:
+
+```bash
+hermes send --to telegram "MEDIA:/tmp/screenshot.png"
+hermes send --to telegram "Build chart for today MEDIA:/tmp/chart.png"   # with caption
+hermes send --to discord:#ops "MEDIA:/tmp/report.pdf"
+```
+
+By default, image files are sent as photos (platforms like Telegram recompress these). Add `[[as_document]]` to the message to deliver them as uncompressed file attachments instead:
+
+```bash
+hermes send --to telegram "[[as_document]] MEDIA:/tmp/screenshot.png"
+```
 
 Examples:
 


### PR DESCRIPTION
## Summary
`hermes send --file <image>` now prints a usage error explaining that `--file` is text-only and showing the `MEDIA:<path>` / `[[as_document]]` syntax for sending native attachments, instead of a raw `'utf-8' codec can't decode byte 0x89` traceback.

Reported by Valentyn (Discord): `hermes send --to telegram --file <png>` → UnicodeDecodeError with no guidance.

## Changes
- `hermes_cli/send_cmd.py`: split UnicodeDecodeError out of the generic OSError handler; the error message includes copy-pasteable MEDIA: examples using the user's own path. `--file` help text and epilog now mention MEDIA:.
- `tests/hermes_cli/test_send_cmd.py`: decode-error test now asserts the hint (MEDIA: with the path, `[[as_document]]`) appears.
- `website/docs/reference/cli-commands.md`: new "Sending images and other media" section under `hermes send`.

## Validation
| | Before | After |
|---|---|---|
| `--file image.png` | raw codec traceback | usage error + MEDIA: examples, exit 2 |
| `tests/hermes_cli/test_send_cmd.py` | 21 pass | 21 pass |

## Infographic

![hermes-send-media-guidance](https://v3b.fal.media/files/b/0a9e07ac/uRA_B9_bHuCVYnRuRRZ23_ob1HlKjg.png)
