### PR TITLE
fix(windows): kill hermes before recreating venv to release _bcrypt.pyd lock

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1417,6 +1417,15 @@ function Install-Venv {
     
     if (Test-Path "venv") {
         Write-Info "Virtual environment already exists, recreating..."
+        # On Windows, native Python extensions (e.g. _bcrypt.pyd) are loaded as
+        # DLLs by any running hermes process. Windows denies deletion of loaded
+        # DLLs, so kill any hermes.exe tree before removing the venv.
+        if ($env:OS -eq "Windows_NT") {
+            $myPid = $PID
+            Write-Info "Stopping any running hermes processes before recreating venv..."
+            & taskkill /F /T /IM hermes.exe /FI "PID ne $myPid" 2>$null | Out-Null
+            Start-Sleep -Milliseconds 800
+        }
         Remove-Item -Recurse -Force "venv"
     }
     


### PR DESCRIPTION
## Problem

On Windows, the installer fails when trying to recreate the venv during a repair or update:

```
Cannot remove item ...\venv\Lib\site-packages\bcrypt\_bcrypt.pyd:
Access to the path '_bcrypt.pyd' is denied.
```

Native Python extensions (`.pyd` files) are Windows DLLs. When a `hermes` process is running, `_bcrypt.pyd` is mapped into its address space and Windows denies any attempt to delete it — even with `-Force`.

## Root cause

`Install-Venv` in `scripts/install.ps1` calls `Remove-Item -Recurse -Force "venv"` while the Hermes desktop app (and its Python backend subprocess) is still running. The `--update` flow in `update.rs` already handles this via `force_kill_other_hermes()` + `wait_for_venv_free()`, but the full reinstall/repair path through `install.ps1` had no equivalent guard.

## Fix

Add a `taskkill /F /T /IM hermes.exe` call (with an 800ms grace period) before the `Remove-Item`, mirroring the existing pattern in `update.rs`.

## Test

Reproduced on Windows 11 with Hermes running during a repair install. With this fix the venv is deleted and recreated successfully.