### PR TITLE
fix(auxiliary): use free default models for auxiliary tasks (#44894)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -483,8 +483,8 @@ NOUS_EXTRA_BODY = _nous_extra_body()
 auxiliary_is_nous: bool = False
 
 # Default auxiliary models per provider
-_OPENROUTER_MODEL = "google/gemini-3-flash-preview"
-_NOUS_MODEL = "google/gemini-3-flash-preview"
+_OPENROUTER_MODEL = "google/gemma-3-27b-it:free"
+_NOUS_MODEL = "google/gemma-3-27b-it:free"
 _NOUS_DEFAULT_BASE_URL = "https://inference-api.nousresearch.com/v1"
 _ANTHROPIC_DEFAULT_BASE_URL = "https://api.anthropic.com"
 _AUTH_JSON_PATH = get_hermes_home() / "auth.json"

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -981,7 +981,7 @@ class TestAuxiliaryPoolAwareness:
             client, model = _try_nous()
 
         assert client is not None
-        assert model == "google/gemini-3-flash-preview"
+        assert model == "google/gemma-3-27b-it:free"
         assert mock_openai.call_args.kwargs["api_key"] == pooled_token
         assert mock_openai.call_args.kwargs["base_url"] == "https://inference.pool.example/v1"
 
@@ -1009,14 +1009,14 @@ class TestAuxiliaryPoolAwareness:
         with (
             patch("agent.auxiliary_client._read_nous_auth", return_value={"access_token": "***"}),
             patch("agent.auxiliary_client._resolve_nous_runtime_api", return_value=("fresh-agent-key", fresh_base)),
-            patch("hermes_cli.models.get_nous_recommended_aux_model", return_value="google/gemini-3-flash-preview") as mock_rec,
+            patch("hermes_cli.models.get_nous_recommended_aux_model", return_value="google/gemma-3-27b-it:free") as mock_rec,
             patch("agent.auxiliary_client.OpenAI"),
         ):
             from agent.auxiliary_client import _try_nous
             client, model = _try_nous(vision=True)
 
         assert client is not None
-        assert model == "google/gemini-3-flash-preview"
+        assert model == "google/gemma-3-27b-it:free"
         assert mock_rec.call_args.kwargs["vision"] is True
 
     def test_try_nous_falls_back_when_recommendation_lookup_raises(self):
@@ -1032,7 +1032,7 @@ class TestAuxiliaryPoolAwareness:
             client, model = _try_nous()
 
         assert client is not None
-        assert model == "google/gemini-3-flash-preview"
+        assert model == "google/gemma-3-27b-it:free"
 
     def test_call_llm_retries_nous_after_401(self):
         class _Auth401(Exception):
@@ -1379,7 +1379,7 @@ class TestRefreshNousRecommendedModel:
         )
         out = _refresh_nous_recommended_model(
             vision=True, stale_model="openai/gpt-5.4-mini")
-        assert out == "google/gemini-3-flash-preview"
+        assert out == "google/gemma-3-27b-it:free"
 
     def test_falls_back_to_default_when_portal_unavailable(self, monkeypatch):
         def _boom(**kw):
@@ -1388,17 +1388,17 @@ class TestRefreshNousRecommendedModel:
             "hermes_cli.models.get_nous_recommended_aux_model", _boom)
         out = _refresh_nous_recommended_model(
             vision=False, stale_model="some/dead-model")
-        assert out == "google/gemini-3-flash-preview"
+        assert out == "google/gemma-3-27b-it:free"
 
     def test_returns_none_when_no_distinct_alternative(self, monkeypatch):
         """When the failed model IS the default and the Portal has nothing
         else, there's no usable alternative."""
         monkeypatch.setattr(
             "hermes_cli.models.get_nous_recommended_aux_model",
-            lambda **kw: "google/gemini-3-flash-preview",
+            lambda **kw: "google/gemma-3-27b-it:free",
         )
         out = _refresh_nous_recommended_model(
-            vision=False, stale_model="google/gemini-3-flash-preview")
+            vision=False, stale_model="google/gemma-3-27b-it:free")
         assert out is None
 
 
@@ -1568,9 +1568,9 @@ class TestCallLlmPaymentFallback:
         primary_client.chat.completions.create.side_effect = server_err
 
         with patch("agent.auxiliary_client._get_cached_client",
-                    return_value=(primary_client, "google/gemini-3-flash-preview")), \
+                    return_value=(primary_client, "google/gemma-3-27b-it:free")), \
              patch("agent.auxiliary_client._resolve_task_provider_model",
-                    return_value=("auto", "google/gemini-3-flash-preview", None, None, None)):
+                    return_value=("auto", "google/gemma-3-27b-it:free", None, None, None)):
             with pytest.raises(Exception, match="Internal Server Error"):
                 call_llm(
                     task="compression",
@@ -2837,7 +2837,7 @@ class TestVisionAutoSkipsKimiCoding:
 
         def fake_strict(provider, model=None):
             if provider == "openrouter":
-                return fake_or_client, "google/gemini-3-flash-preview"
+                return fake_or_client, "google/gemma-3-27b-it:free"
             if provider == "nous":
                 return None, None
             raise AssertionError(
@@ -2852,7 +2852,7 @@ class TestVisionAutoSkipsKimiCoding:
         provider, client, model = resolve_vision_provider_client()
         assert provider == "openrouter"
         assert client is fake_or_client
-        assert model == "google/gemini-3-flash-preview"
+        assert model == "google/gemma-3-27b-it:free"
 
     def test_kimi_coding_cn_skipped_too(self, monkeypatch):
         """Same skip applies to the CN variant."""
@@ -3777,9 +3777,9 @@ class TestAuxUnhealthyCache:
         nous_client.chat.completions.create.return_value = nous_resp
 
         with patch("agent.auxiliary_client._get_cached_client",
-                    return_value=(primary_client, "google/gemini-3-flash-preview")), \
+                    return_value=(primary_client, "google/gemma-3-27b-it:free")), \
              patch("agent.auxiliary_client._resolve_task_provider_model",
-                    return_value=("auto", "google/gemini-3-flash-preview", None, None, None)), \
+                    return_value=("auto", "google/gemma-3-27b-it:free", None, None, None)), \
              patch("agent.auxiliary_client._try_payment_fallback",
                     return_value=(nous_client, "n-model", "nous")), \
              patch("agent.auxiliary_client._build_call_kwargs",


### PR DESCRIPTION
Fixes #44894. Change _OPENROUTER_MODEL and _NOUS_MODEL from paid google/gemini-3-flash-preview to free google/gemma-3-27b-it:free. This prevents surprise charges on OpenRouter when users have their key set but use a local main provider for chat.