### PR TITLE
fix(skills): clean stale .bak before backup move in skill-update (#44942)

### DIFF
--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -569,6 +569,15 @@ def sync_skills(quiet: bool = False) -> dict:
                 try:
                     # Move old copy to a backup so we can restore on failure
                     backup = dest.with_suffix(".bak")
+                    # Clean stale .bak from a previous failed update — without
+                    # this, shutil.move() would place the live skill *inside*
+                    # the stale directory instead of replacing it, and a
+                    # subsequent copytree failure would restore stale junk.
+                    if backup.exists():
+                        try:
+                            _rmtree_writable(backup)
+                        except (OSError, IOError):
+                            logger.debug("Could not remove stale backup %s", backup, exc_info=True)
                     shutil.move(str(dest), str(backup))
                     try:
                         shutil.copytree(skill_src, dest)


### PR DESCRIPTION
Fixes #44942. Remove stale .bak directories before shutil.move() in sync_skills() to prevent the live skill from being nested inside a stale backup directory. Without this fix, a previous failed update could leave a .bak that would corrupt the next update's move and restore cycle.