### PR TITLE
fix(cli): let --source flag override default platform in session creation

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -314,7 +314,7 @@ def build_memory_write_metadata(
         ),
         "session_id": agent.session_id or "",
         "parent_session_id": agent._parent_session_id or "",
-        "platform": agent.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+        "platform": os.environ.get("HERMES_SESSION_SOURCE") or agent.platform or "cli",
         "tool_name": "memory",
     }
     if task_id:

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -533,7 +533,7 @@ def compress_context(
             agent._session_db_created = False
             agent._session_db.create_session(
                 session_id=agent.session_id,
-                source=agent.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                source=os.environ.get("HERMES_SESSION_SOURCE") or agent.platform or "cli",
                 model=agent.model,
                 model_config=agent._session_init_model_config,
                 parent_session_id=old_session_id,

--- a/run_agent.py
+++ b/run_agent.py
@@ -510,7 +510,7 @@ class AIAgent:
         """Create session DB row on first use. Disables _session_db on failure."""
         if self._session_db_created or not self._session_db:
             return
-        source = self.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli")
+        source = os.environ.get("HERMES_SESSION_SOURCE") or self.platform or "cli"
         try:
             self._session_db.create_session(
                 session_id=self.session_id,

--- a/tests/test_source_flag_persistence.py
+++ b/tests/test_source_flag_persistence.py
@@ -1,0 +1,115 @@
+"""Tests for --source flag session persistence (issue #45107).
+
+Verify that HERMES_SESSION_SOURCE env var (set by `hermes chat --source`)
+takes precedence over the default platform source when creating sessions.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+class TestSourceFlagPersistence:
+    """Verify --source flag is respected in session creation."""
+
+    def _make_agent(self, db, platform="cli"):
+        """Create a minimal AIAgent with session_db wired up."""
+        from run_agent import AIAgent
+
+        agent = AIAgent.__new__(AIAgent)
+        agent._session_db = db
+        agent._session_db_created = False
+        agent.session_id = "test-source-session"
+        agent.platform = platform
+        agent.model = "test/model"
+        agent._session_init_model_config = {}
+        agent._cached_system_prompt = None
+        agent._parent_session_id = None
+        return agent
+
+    def test_source_flag_overrides_cli_platform(self, monkeypatch):
+        """When HERMES_SESSION_SOURCE is set, it should override platform='cli'."""
+        from hermes_state import SessionDB
+
+        monkeypatch.setenv("HERMES_SESSION_SOURCE", "distiller")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            try:
+                agent = self._make_agent(db, platform="cli")
+                agent._ensure_db_session()
+
+                sessions = db.list_sessions_rich(limit=1)
+                assert len(sessions) == 1
+                assert sessions[0]["source"] == "distiller"
+            finally:
+                db.close()
+
+    def test_platform_used_when_no_env_var(self, monkeypatch):
+        """Without HERMES_SESSION_SOURCE, platform should be used as source."""
+        from hermes_state import SessionDB
+
+        monkeypatch.delenv("HERMES_SESSION_SOURCE", raising=False)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            try:
+                agent = self._make_agent(db, platform="cli")
+                agent._ensure_db_session()
+
+                sessions = db.list_sessions_rich(limit=1)
+                assert len(sessions) == 1
+                assert sessions[0]["source"] == "cli"
+            finally:
+                db.close()
+
+    def test_platform_used_when_env_var_empty(self, monkeypatch):
+        """Empty HERMES_SESSION_SOURCE should fall through to platform."""
+        from hermes_state import SessionDB
+
+        monkeypatch.setenv("HERMES_SESSION_SOURCE", "")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            try:
+                agent = self._make_agent(db, platform="cli")
+                agent._ensure_db_session()
+
+                sessions = db.list_sessions_rich(limit=1)
+                assert len(sessions) == 1
+                assert sessions[0]["source"] == "cli"
+            finally:
+                db.close()
+
+    def test_gateway_platform_preserved_when_no_env_var(self, monkeypatch):
+        """Gateway platform (e.g. telegram) should be preserved when no env var."""
+        from hermes_state import SessionDB
+
+        monkeypatch.delenv("HERMES_SESSION_SOURCE", raising=False)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            try:
+                agent = self._make_agent(db, platform="telegram")
+                agent._ensure_db_session()
+
+                sessions = db.list_sessions_rich(limit=1)
+                assert len(sessions) == 1
+                assert sessions[0]["source"] == "telegram"
+            finally:
+                db.close()
+
+    def test_source_flag_overrides_gateway_platform(self, monkeypatch):
+        """HERMES_SESSION_SOURCE should also override gateway platform."""
+        from hermes_state import SessionDB
+
+        monkeypatch.setenv("HERMES_SESSION_SOURCE", "custom-tool")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SessionDB(db_path=Path(tmpdir) / "test.db")
+            try:
+                agent = self._make_agent(db, platform="telegram")
+                agent._ensure_db_session()
+
+                sessions = db.list_sessions_rich(limit=1)
+                assert len(sessions) == 1
+                assert sessions[0]["source"] == "custom-tool"
+            finally:
+                db.close()


### PR DESCRIPTION
## What does this PR do?

Fixes the `--source` flag for `hermes chat` being silently ignored. The flag was parsed and stored in `HERMES_SESSION_SOURCE` env var, but the session creation code checked `self.platform` first — which is always `"cli"` from the CLI path — so the env var was never reached.

## Related Issue

Fixes #45107

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `run_agent.py`: Swap precedence in `_ensure_db_session()` so `HERMES_SESSION_SOURCE` is checked before `self.platform`
- `agent/conversation_compression.py`: Same precedence fix in `compress_context()` session rotation
- `agent/background_review.py`: Same precedence fix in `build_memory_write_metadata()`
- `tests/test_source_flag_persistence.py`: 5 tests covering override, fallback, empty env, and gateway platform preservation

## How to Test

1. Run `hermes chat --source distiller -q "Say OK"` and verify the session has `source='distiller'` in `state.db`
2. Run `hermes chat -q "Say OK"` (no --source) and verify the session has `source='cli'`
3. Run `pytest tests/test_source_flag_persistence.py -v` — all 5 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `run_agent.py::_ensure_db_session`, `agent/conversation_compression.py::compress_context`, `agent/background_review.py::build_memory_write_metadata`
- Callers: `run_conversation()` → `_ensure_db_session()`, context compression rotation, memory write metadata builder
- Blast radius: LOW — only affects session source resolution when `HERMES_SESSION_SOURCE` env var is explicitly set
- Related pattern: `HERMES_SESSION_SOURCE` is set by `hermes_cli/main.py:cmd_chat()` when `--source` flag is passed; consumed by all 3 session-creation/metadata sites
