### PR TITLE
fix(skills): run youtube transcript helper through uv

### DIFF
--- a/skills/media/youtube-content/SKILL.md
+++ b/skills/media/youtube-content/SKILL.md
@@ -14,8 +14,11 @@ Extract transcripts from YouTube videos and convert them into useful formats.
 
 ## Setup
 
+Use `uv` so the dependency is installed into the same Hermes-managed environment
+that runs the helper script:
+
 ```bash
-pip install youtube-transcript-api
+uv pip install youtube-transcript-api
 ```
 
 ## Helper Script
@@ -24,16 +27,16 @@ pip install youtube-transcript-api
 
 ```bash
 # JSON output with metadata
-python3 SKILL_DIR/scripts/fetch_transcript.py "https://youtube.com/watch?v=VIDEO_ID"
+uv run python3 SKILL_DIR/scripts/fetch_transcript.py "https://youtube.com/watch?v=VIDEO_ID"
 
 # Plain text (good for piping into further processing)
-python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --text-only
+uv run python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --text-only
 
 # With timestamps
-python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --timestamps
+uv run python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --timestamps
 
 # Specific language with fallback chain
-python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --language tr,en
+uv run python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --language tr,en
 ```
 
 ## Output Formats
@@ -59,7 +62,7 @@ After fetching the transcript, format it based on what the user asks for:
 
 ## Workflow
 
-1. **Fetch** the transcript using the helper script with `--text-only --timestamps`.
+1. **Fetch** the transcript using the helper script with `--text-only --timestamps` via `uv run python3`.
 2. **Validate**: confirm the output is non-empty and in the expected language. If empty, retry without `--language` to get any available transcript. If still empty, tell the user the video likely has transcripts disabled.
 3. **Chunk if needed**: if the transcript exceeds ~50K characters, split into overlapping chunks (~40K with 2K overlap) and summarize each chunk before merging.
 4. **Transform** into the requested output format. If the user did not specify a format, default to a summary.
@@ -70,4 +73,4 @@ After fetching the transcript, format it based on what the user asks for:
 - **Transcript disabled**: tell the user; suggest they check if subtitles are available on the video page.
 - **Private/unavailable video**: relay the error and ask the user to verify the URL.
 - **No matching language**: retry without `--language` to fetch any available transcript, then note the actual language to the user.
-- **Dependency missing**: run `pip install youtube-transcript-api` and retry.
+- **Dependency missing**: run `uv pip install youtube-transcript-api` and retry.

--- a/skills/media/youtube-content/scripts/fetch_transcript.py
+++ b/skills/media/youtube-content/scripts/fetch_transcript.py
@@ -3,7 +3,7 @@
 Fetch a YouTube video transcript and output it as structured JSON.
 
 Usage:
-    python fetch_transcript.py <url_or_video_id> [--language en,tr] [--timestamps]
+    uv run python3 fetch_transcript.py <url_or_video_id> [--language en,tr] [--timestamps]
 
 Output (JSON):
     {
@@ -14,7 +14,7 @@ Output (JSON):
         "timestamped_text": "00:00 first line\n00:05 second line\n..."
     }
 
-Install dependency:  pip install youtube-transcript-api
+Install dependency:  uv pip install youtube-transcript-api
 """
 
 import argparse
@@ -56,7 +56,7 @@ def fetch_transcript(video_id: str, languages: list = None):
     try:
         from youtube_transcript_api import YouTubeTranscriptApi
     except ImportError:
-        print("Error: youtube-transcript-api not installed. Run: pip install youtube-transcript-api",
+        print("Error: youtube-transcript-api not installed. Run: uv pip install youtube-transcript-api",
               file=sys.stderr)
         sys.exit(1)
 

--- a/website/docs/user-guide/skills/bundled/media/media-youtube-content.md
+++ b/website/docs/user-guide/skills/bundled/media/media-youtube-content.md
@@ -34,8 +34,11 @@ Extract transcripts from YouTube videos and convert them into useful formats.
 
 ## Setup
 
+Use `uv` so the dependency is installed into the same Hermes-managed environment
+that runs the helper script:
+
 ```bash
-pip install youtube-transcript-api
+uv pip install youtube-transcript-api
 ```
 
 ## Helper Script
@@ -44,16 +47,16 @@ pip install youtube-transcript-api
 
 ```bash
 # JSON output with metadata
-python3 SKILL_DIR/scripts/fetch_transcript.py "https://youtube.com/watch?v=VIDEO_ID"
+uv run python3 SKILL_DIR/scripts/fetch_transcript.py "https://youtube.com/watch?v=VIDEO_ID"
 
 # Plain text (good for piping into further processing)
-python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --text-only
+uv run python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --text-only
 
 # With timestamps
-python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --timestamps
+uv run python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --timestamps
 
 # Specific language with fallback chain
-python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --language tr,en
+uv run python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --language tr,en
 ```
 
 ## Output Formats
@@ -79,7 +82,7 @@ After fetching the transcript, format it based on what the user asks for:
 
 ## Workflow
 
-1. **Fetch** the transcript using the helper script with `--text-only --timestamps`.
+1. **Fetch** the transcript using the helper script with `--text-only --timestamps` via `uv run python3`.
 2. **Validate**: confirm the output is non-empty and in the expected language. If empty, retry without `--language` to get any available transcript. If still empty, tell the user the video likely has transcripts disabled.
 3. **Chunk if needed**: if the transcript exceeds ~50K characters, split into overlapping chunks (~40K with 2K overlap) and summarize each chunk before merging.
 4. **Transform** into the requested output format. If the user did not specify a format, default to a summary.
@@ -90,4 +93,4 @@ After fetching the transcript, format it based on what the user asks for:
 - **Transcript disabled**: tell the user; suggest they check if subtitles are available on the video page.
 - **Private/unavailable video**: relay the error and ask the user to verify the URL.
 - **No matching language**: retry without `--language` to fetch any available transcript, then note the actual language to the user.
-- **Dependency missing**: run `pip install youtube-transcript-api` and retry.
+- **Dependency missing**: run `uv pip install youtube-transcript-api` and retry.


### PR DESCRIPTION
## What does this PR do?

Updates the bundled `media/youtube-content` skill so its setup and helper invocation use `uv` consistently. The skill previously instructed agents to install `youtube-transcript-api` with bare `pip` and run the helper with bare `python3`, which can miss Hermes' managed virtual environment and leave the helper unable to import the dependency.

The fix keeps the existing helper behavior and changes the skill guidance, helper docstring, missing-dependency hint, and generated docs page to use `uv pip install` and `uv run python3`.

## Related Issue

Support thread: https://discord.com/channels/1053877538025386074/1514728066298155138

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `skills/media/youtube-content/SKILL.md` to install `youtube-transcript-api` with `uv pip install`.
- Updated all documented helper invocations to use `uv run python3`.
- Updated `skills/media/youtube-content/scripts/fetch_transcript.py` usage and missing-dependency text to match the `uv` workflow.
- Regenerated `website/docs/user-guide/skills/bundled/media/media-youtube-content.md` from the skill docs.

## How to Test

1. `python3 -m compileall skills/media/youtube-content/scripts/fetch_transcript.py`
2. `uv run --frozen python3 skills/media/youtube-content/scripts/fetch_transcript.py --help`
3. `git diff --check -- skills/media/youtube-content/SKILL.md skills/media/youtube-content/scripts/fetch_transcript.py website/docs/user-guide/skills/bundled/media/media-youtube-content.md`

Full pytest was not run locally.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL / Ubuntu environment

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

N/A
