### PR TITLE
feat: configurable model for background memory and skill reviews

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1116,6 +1116,13 @@ def init_agent(
             agent._memory_enabled = mem_config.get("memory_enabled", False)
             agent._user_profile_enabled = mem_config.get("user_profile_enabled", False)
             agent._memory_nudge_interval = int(mem_config.get("nudge_interval", 10))
+            # Review model config: allow the background review fork to use a
+            # different model/provider than the main conversation.
+            review_cfg = mem_config.get("review", {})
+            agent._memory_review_provider = review_cfg.get("provider", "") or None
+            agent._memory_review_model = review_cfg.get("model", "") or None
+            agent._memory_review_base_url = review_cfg.get("base_url", "") or None
+            agent._memory_review_api_key_env = review_cfg.get("api_key_env", "") or None
             if agent._memory_enabled or agent._user_profile_enabled:
                 from tools.memory_tool import MemoryStore
                 agent._memory_store = MemoryStore(
@@ -1231,6 +1238,13 @@ def init_agent(
     try:
         skills_config = _agent_cfg.get("skills", {})
         agent._skill_nudge_interval = int(skills_config.get("creation_nudge_interval", 10))
+        # Review model config: allow the background skill-review fork to use a
+        # different model/provider than the main conversation.
+        review_cfg = skills_config.get("review", {})
+        agent._skill_review_provider = review_cfg.get("provider", "") or None
+        agent._skill_review_model = review_cfg.get("model", "") or None
+        agent._skill_review_base_url = review_cfg.get("base_url", "") or None
+        agent._skill_review_api_key_env = review_cfg.get("api_key_env", "") or None
     except Exception:
         pass
 

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -399,15 +399,43 @@ def _run_review_in_thread(
             # Match parent's toolset config so ``tools[]`` is byte-identical
             # in the request body — Anthropic's cache key includes it.
             # (The runtime whitelist below still restricts dispatch.)
+            # Use review-specific model/provider if configured, otherwise
+            # fall back to the parent's main model (current default behavior).
+            _review_model = (
+                getattr(agent, "_memory_review_model", None)
+                or getattr(agent, "_skill_review_model", None)
+                or agent.model
+            )
+            _review_provider = (
+                getattr(agent, "_memory_review_provider", None)
+                or getattr(agent, "_skill_review_provider", None)
+                or agent.provider
+            )
+            _review_base_url = (
+                getattr(agent, "_memory_review_base_url", None)
+                or getattr(agent, "_skill_review_base_url", None)
+                or _parent_runtime.get("base_url")
+            )
+            # Resolve review API key: use env var if specified, else parent's.
+            _review_api_key_env = (
+                getattr(agent, "_memory_review_api_key_env", None)
+                or getattr(agent, "_skill_review_api_key_env", None)
+                or None
+            )
+            _review_api_key = (
+                os.environ.get(_review_api_key_env)
+                if _review_api_key_env
+                else _parent_runtime.get("api_key")
+            )
             review_agent = AIAgent(
-                model=agent.model,
+                model=_review_model,
                 max_iterations=16,
                 quiet_mode=True,
                 platform=agent.platform,
-                provider=agent.provider,
+                provider=_review_provider,
                 api_mode=_parent_api_mode,
-                base_url=_parent_runtime.get("base_url") or None,
-                api_key=_parent_runtime.get("api_key") or None,
+                base_url=_review_base_url or None,
+                api_key=_review_api_key,
                 credential_pool=getattr(agent, "_credential_pool", None),
                 parent_session_id=agent.session_id,
                 enabled_toolsets=getattr(agent, "enabled_toolsets", None),

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1737,6 +1737,17 @@ DEFAULT_CONFIG = {
         # "hindsight", "holographic", "retaindb", "byterover".
         # Only ONE external provider is allowed at a time.
         "provider": "",
+        # Model used for the background self-improvement review fork.
+        # When unset (null), the fork inherits the parent's main model
+        # (current default behavior). Set to override the review to a
+        # different provider/model — e.g. a cheap model for memory review
+        # while keeping your main model for the conversation itself.
+        "review": {
+            "provider": "",    # empty = inherit parent's provider
+            "model": "",       # empty = inherit parent's model
+            "base_url": "",    # optional: custom endpoint for review
+            "api_key_env": "", # optional: env var name for review API key
+        },
     },
 
     # Subagent delegation — override the provider:model used by delegate_task
@@ -1846,6 +1857,16 @@ DEFAULT_CONFIG = {
         #                     never crammed into a chat bubble), apply with
         #                     /skills approve <id> or drop with /skills reject <id>.
         "write_approval": False,
+        # Model used for the background skill-review fork.
+        # Same semantics as memory.review — when unset, the fork inherits
+        # the parent's main model. Useful for routing skill reviews to a
+        # cheaper model while keeping the main model for conversation.
+        "review": {
+            "provider": "",    # empty = inherit parent's provider
+            "model": "",       # empty = inherit parent's model
+            "base_url": "",    # optional: custom endpoint for review
+            "api_key_env": "", # optional: env var name for review API key
+        },
     },
 
     # Curator — background skill maintenance.


### PR DESCRIPTION
## feat: configurable model for background memory and skill reviews

Adds `memory.review` and `skills.review` config sections to allow the
background self-improvement review fork to use a different model/provider
than the main conversation.

When unset (default), the fork inherits the parent's main model —
current behavior is preserved.

### Config schema

```yaml
memory:
  review:
    provider: ""      # empty = inherit parent provider
    model: ""         # empty = inherit parent model
    base_url: ""      # optional: custom endpoint
    api_key_env: ""   # optional: env var name for API key

skills:
  review:
    provider: ""
    model: ""
    base_url: ""
    api_key_env: ""
```

### Example usage

```yaml
memory:
  review:
    provider: custom
    model: gemma-e4b
    base_url: "http://0.0.0.0:4001"
```

This addresses #13578.