### PR TITLE
fix(desktop): kill previous backend process before retry to prevent EADDRINUSE on port 9120 (#44707)

### DIFF
--- a/apps/desktop/electron/backend-ready.cjs
+++ b/apps/desktop/electron/backend-ready.cjs
@@ -1,5 +1,12 @@
 const _READY_RE = /^HERMES_DASHBOARD_READY port=(\d+)/m
 
+// Default boot timeout for the HERMES_DASHBOARD_READY announcement.
+// Cold starts on machines with a large SQLite DB or many installed skills can
+// take well over a minute before uvicorn binds and emits the ready line.
+// 120 s keeps things responsive while allowing room for slow first-boot scans.
+// Override with HERMES_DESKTOP_BOOT_TIMEOUT_MS (milliseconds) if needed.
+const DEFAULT_BOOT_TIMEOUT_MS = Number(process.env.HERMES_DESKTOP_BOOT_TIMEOUT_MS) || 120_000
+
 /**
  * Watch a child process's stdout for the `HERMES_DASHBOARD_READY port=<N>`
  * line that web_server.py prints after uvicorn binds its socket.
@@ -13,7 +20,7 @@ const _READY_RE = /^HERMES_DASHBOARD_READY port=(\d+)/m
  * on every terminal path — resolve, reject, or timeout — so repeated
  * backend spawns don't leak listener slots on the child.
  */
-function waitForDashboardPort(child, timeoutMs = 45_000) {
+function waitForDashboardPort(child, timeoutMs = DEFAULT_BOOT_TIMEOUT_MS) {
   return new Promise((resolve, reject) => {
     let buf = ''
     let done = false

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -4813,6 +4813,17 @@ async function startHermes() {
   }
   if (connectionPromise) return connectionPromise
 
+  // Kill any previous backend process that may still be running from a prior
+  // startup attempt that timed out. Without this guard, a timed-out process A
+  // keeps running (it just took too long to announce its port), and when the
+  // renderer retries, process B spawns without killing A first — leading to a
+  // port conflict (EADDRINUSE) if both processes eventually try to bind the
+  // same OS-assigned ephemeral port. (#44707)
+  if (hermesProcess && !hermesProcess.killed) {
+    rememberLog('[startHermes] killing lingering backend process from previous attempt before retry')
+    await teardownPrimaryBackendAndWait()
+  }
+
   connectionPromise = (async () => {
     await advanceBootProgress('backend.resolve', 'Resolving Hermes backend', 8)
     // Resolve for the desktop's primary profile so a per-profile remote
@@ -5294,6 +5305,9 @@ ipcMain.handle('hermes:bootstrap:repair', async () => {
   // startHermes() re-runs the full installer (refreshing a broken/partial
   // venv), and clear any latched failure + live connection. The renderer
   // reloads afterwards to re-drive the boot flow from scratch.
+  // Uses teardownPrimaryBackendAndWait() rather than the fire-and-forget
+  // resetHermesConnection() so the old process is dead before the renderer
+  // triggers the next startHermes(), preventing EADDRINUSE from orphans. (#44707)
   rememberLog('[bootstrap] repair requested by renderer; clearing marker + latched failure')
   try {
     if (fileExists(BOOTSTRAP_COMPLETE_MARKER)) {
@@ -5303,7 +5317,7 @@ ipcMain.handle('hermes:bootstrap:repair', async () => {
     rememberLog(`[bootstrap] failed to remove marker during repair: ${error.message}`)
   }
   bootstrapFailure = null
-  resetHermesConnection()
+  await teardownPrimaryBackendAndWait()
   return { ok: true }
 })
 ipcMain.handle('hermes:bootstrap:cancel', async () => {


### PR DESCRIPTION
## Summary

Fixes #44707 — Desktop boot race condition where a retry spawns a new backend process without killing the previous one, leading to EADDRINUSE and a zombie process accumulation loop.

### Root cause

When the `waitForDashboardPort` timeout fires (45 s on cold starts), `connectionPromise` is cleared but `hermesProcess` still references the timed-out process (it is still starting up). The next `startHermes()` call enters because `connectionPromise === null`, overwrites `hermesProcess` with a new spawn, and orphans the old process. If the orphaned process eventually binds the same OS-assigned ephemeral port, the new process hits EADDRINUSE.

### Changes

**`apps/desktop/electron/main.cjs`**
- `startHermes()`: added an orphan-kill guard — if `hermesProcess` is still alive when a fresh `startHermes()` enters (timeout-after-null scenario), `teardownPrimaryBackendAndWait()` is called first so the old process is dead before spawning anew.
- `hermes:bootstrap:repair` IPC handler: replaced fire-and-forget `resetHermesConnection()` with `await teardownPrimaryBackendAndWait()` so the old process is fully dead (SIGTERM → 5 s SIGKILL on Windows via `taskkill /T /F`) before the renderer triggers the next boot.

**`apps/desktop/electron/backend-ready.cjs`**
- Raised `waitForDashboardPort` default timeout from 45 s to 120 s (configurable via `HERMES_DESKTOP_BOOT_TIMEOUT_MS`) to give cold starts — large SQLite DB, skill scanning — a realistic window to announce their port before the timeout fires and the retry loop begins.

## Test plan

- [ ] Cold-start desktop with a large install; confirm a single backend process is spawned and comes up healthy within 120 s
- [ ] Simulate a slow cold start (> 45 s) and confirm no second process is spawned; old process is killed before retry
- [ ] Click "Repair" in desktop settings; confirm the old backend process is gone before the renderer reloads
- [ ] `HERMES_DESKTOP_BOOT_TIMEOUT_MS=10000` smoke test: timeout fires, orphan is killed, retry succeeds