### PR TITLE
fix(agent): re-enter retry loop on genuine Nous 429 so fallback guard runs (from #44061)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2631,10 +2631,13 @@ def run_conversation(
                     except Exception:
                         pass
                     if _genuine_nous_rate_limit:
-                        # Skip straight to max_retries -- the
-                        # top-of-loop guard will handle fallback or
-                        # bail cleanly.
-                        retry_count = max_retries
+                        # Re-enter the loop exactly once so the
+                        # top-of-loop Nous guard handles fallback or
+                        # bails cleanly. (Setting retry_count to
+                        # max_retries would make the while condition
+                        # false immediately and the guard would never
+                        # run -- no fallback, generic exhaustion error.)
+                        retry_count = max(0, max_retries - 1)
                         continue
                     # Upstream capacity 429: fall through to normal
                     # retry logic.  A different model (or the same

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -46,6 +46,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
     "peterhao@Peters-MacBook-Air.local": "pinguarmy",
+    "adalsteinnhelgason@Aalsteinns-MacBook-Pro-3.local": "AIalliAI",
     "barronlroth@gmail.com": "barronlroth",
     "ondrej.drapalik@gmail.com": "OndrejDrapalik",
     "tomasz.panek@gmail.com": "tomekpanek",

--- a/tests/run_agent/test_nous_429_fallback_reentry.py
+++ b/tests/run_agent/test_nous_429_fallback_reentry.py
@@ -1,0 +1,75 @@
+"""Regression guard: a genuine Nous 429 must re-enter the retry loop so the
+top-of-loop Nous rate-limit guard can activate the fallback chain.
+
+Bug (found in the #44061 audit): the genuine-rate-limit branch in
+``agent/conversation_loop.py`` set ``retry_count = max_retries`` then
+``continue``-d, intending the top-of-loop guard to "handle fallback or bail
+cleanly".  But the loop condition is ``while retry_count < max_retries`` —
+setting retry_count equal to max_retries makes the condition False
+immediately, so the guard NEVER runs.  No fallback activation, no clean
+rate-limit message: the turn dies with the generic retry-exhaustion error.
+
+The fix sets ``retry_count = max(0, max_retries - 1)`` so the loop body runs
+exactly once more: the guard sees the breaker state recorded by
+``record_nous_rate_limit()`` moments earlier and either activates a fallback
+provider (resetting retry_count) or returns the explicit rate-limit failure.
+"""
+from __future__ import annotations
+
+import inspect
+import re
+
+
+def _loop_reenters(retry_count: int, max_retries: int) -> bool:
+    """Mirror of the ``while retry_count < max_retries`` loop condition."""
+    return retry_count < max_retries
+
+
+class TestGenuineNous429ReentersLoop:
+    """The assignment used by the genuine-429 branch must leave the loop
+    condition True so the top-of-loop guard gets a chance to run."""
+
+    def test_fixed_assignment_reenters_for_typical_max_retries(self):
+        for max_retries in (1, 2, 3, 5, 10):
+            retry_count = max(0, max_retries - 1)
+            assert _loop_reenters(retry_count, max_retries), (
+                f"max_retries={max_retries}: guard would never run"
+            )
+
+    def test_buggy_assignment_never_reenters(self):
+        """Documents the bug shape: retry_count = max_retries exits the
+        loop immediately, skipping the fallback guard."""
+        for max_retries in (1, 2, 3, 5, 10):
+            retry_count = max_retries
+            assert not _loop_reenters(retry_count, max_retries)
+
+
+class TestSourceUsesReentrantAssignment:
+    """Belt-and-suspenders: the production source must use the re-entrant
+    form in the genuine-Nous-429 branch.  Protects against an accidental
+    revert (e.g. a stale-branch merge resolving in favor of the old code)."""
+
+    def test_genuine_branch_does_not_skip_to_max_retries(self):
+        from agent import conversation_loop
+
+        src = inspect.getsource(conversation_loop)
+        # Locate the genuine-rate-limit branch.
+        match = re.search(
+            r"if _genuine_nous_rate_limit:\n(?:.*\n)*?\s*continue\n",
+            src,
+        )
+        # There are two `if _genuine_nous_rate_limit` sites (record + branch);
+        # the regex above finds the first block ending in `continue`, which is
+        # the retry-count branch.
+        assert match is not None, (
+            "genuine-Nous-429 branch not found in conversation_loop — "
+            "update this test if the branch was refactored"
+        )
+        block = match.group(0)
+        assert "retry_count = max(0, max_retries - 1)" in block, (
+            "genuine-Nous-429 branch must re-enter the retry loop "
+            "(retry_count = max(0, max_retries - 1)); "
+            "`retry_count = max_retries` makes the while condition False "
+            "and the fallback guard never runs."
+        )
+        assert "retry_count = max_retries\n" not in block


### PR DESCRIPTION
## Summary
A genuine Nous 429 now re-enters the retry loop so the top-of-loop rate-limit guard actually runs the fallback chain (or bails with the explicit rate-limit message) instead of dying with the generic retry-exhaustion error.

Root cause: the genuine-429 branch set `retry_count = max_retries` then `continue`-d — but the loop condition is `while retry_count < max_retries`, so the guard it was deferring to never executed.

## Changes
- `agent/conversation_loop.py`: `retry_count = max(0, max_retries - 1)` in the genuine-Nous-429 branch — loop body runs exactly once more; guard sees the breaker state recorded by `record_nous_rate_limit()` and activates fallback / returns the clean failure
- `tests/run_agent/test_nous_429_fallback_reentry.py`: loop-condition invariant + source guard against revert
- `scripts/release.py`: AUTHOR_MAP entry for @AIalliAI

## Validation
| | Before | After |
|---|---|---|
| Genuine Nous 429, fallback configured | generic "retries exhausted" error, no fallback | guard runs → fallback activated (retry_count reset) |
| Genuine Nous 429, no fallback | generic error | explicit rate-limit message w/ reset time |
| `tests/run_agent/` fallback + nous_rate_guard suites | — | 64 passed |

## Attribution
Extracted from the #44061 audit (the verified-REAL agent-loop claim) — @AIalliAI's fix cherry-picked with authorship preserved; rebase-merge to keep per-commit credit.

## Infographic

![nous-429-fallback-reentry](https://v3b.fal.media/files/b/0a9e08cc/Fw_HQzXLNuJ0_Jqw4dZ8T_kSXFe8s2.png)
