### PR TITLE
Improve Kanban triage plan contracts

### DIFF
--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -88,7 +88,18 @@ Rules:
     DESCRIPTION (not just the name). When nothing matches well, use null
     and the system will route to the default_assignee.
   - Each child task body is what a fresh worker will read with no other
-    context — be specific about goal, approach, and acceptance criteria.
+    context — be specific about goal, approach, acceptance criteria, and
+    required verification evidence.
+  - Write acceptance criteria as concrete observable checks. Prefer
+    EARS-style phrasing: `WHEN <condition> THE SYSTEM SHALL <behavior>`.
+  - Include a `Verification evidence` section in each child body naming
+    the tests, screenshots, logs, command output, or docs the worker must
+    produce before marking the child done.
+  - Include negative/safety criteria for tasks involving deletion, data
+    loss, authentication, payments, production, public sharing, or external
+    side effects.
+  - If the task depends on context that is not present, include a safe
+    assumption or context request in the child body; do not silently guess.
 
 When the task is genuinely a single unit of work (no useful decomposition),
 return:

--- a/hermes_cli/kanban_specify.py
+++ b/hermes_cli/kanban_specify.py
@@ -68,6 +68,13 @@ heading, in this order:
   **Goal** — one sentence, user-facing outcome.
   **Approach** — 2-5 bullets on how a worker should tackle it.
   **Acceptance criteria** — checklist of concrete, verifiable conditions.
+      Prefer EARS-style criteria: `WHEN <condition> THE SYSTEM SHALL
+      <observable behavior>`. Include negative/safety criteria when the
+      task mentions data loss, deletion, auth, payments, production, or
+      external side effects.
+  **Verification evidence** — exact evidence a worker should produce
+      (tests, screenshots, logs, command output, or docs) so a later
+      reviewer can prove the acceptance criteria passed.
   **Out of scope** — short list of things NOT to touch (omit if nothing
       obvious; never invent scope creep).
 
@@ -77,6 +84,8 @@ Rules:
   - If the original idea is already detailed, preserve its substance and
     just reformat into the sections above.
   - Never add invented requirements the user didn't hint at.
+  - Do not hide uncertainty. If context is missing, write a small safe
+    assumption or evidence request in the spec instead of guessing.
   - No preamble, no closing remarks, no code fences around the JSON.
   - Output only the JSON object and nothing else.
 """

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -74,6 +74,14 @@ def _patch_list_profiles(names: list[str]):
     ]
 
 
+def test_decomposer_prompt_requests_traceable_acceptance_and_evidence():
+    prompt = decomp._SYSTEM_PROMPT
+    assert "EARS-style" in prompt
+    assert "WHEN <condition> THE SYSTEM SHALL" in prompt
+    assert "Verification evidence" in prompt
+    assert "context request" in prompt
+
+
 def test_decompose_with_fanout_creates_children(kanban_home):
     with kb.connect() as conn:
         tid = kb.create_task(conn, title="ship a feature", triage=True)

--- a/tests/hermes_cli/test_kanban_specify.py
+++ b/tests/hermes_cli/test_kanban_specify.py
@@ -60,6 +60,18 @@ def _patch_aux_client(content: str, *, model: str = "test-model"):
 
 
 # ---------------------------------------------------------------------------
+# Prompt contract
+# ---------------------------------------------------------------------------
+
+def test_specifier_prompt_requests_ears_and_evidence_sections():
+    prompt = spec._SYSTEM_PROMPT
+    assert "EARS-style" in prompt
+    assert "WHEN <condition> THE SYSTEM SHALL" in prompt
+    assert "**Verification evidence**" in prompt
+    assert "data loss, deletion, auth, payments, production" in prompt
+
+
+# ---------------------------------------------------------------------------
 # JSON extraction helpers
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Strengthen `kanban specify` task specs by asking for EARS-style acceptance criteria and explicit verification evidence.
- Strengthen `kanban decompose` child-task bodies with the same observable acceptance/evidence contract, plus safety/negative criteria guidance for risky tasks.
- Add prompt-contract regression tests so the planner guidance does not silently regress.

## Problem
Kanban triage/decomposition prompts already ask for acceptance criteria, but the criteria can be free-form and hard for later workers/reviewers to verify. A small prompt contract makes autonomous work orders more traceable without changing the Kanban database schema or provider behavior.

## Tests
- `python -m py_compile hermes_cli/kanban_specify.py hermes_cli/kanban_decompose.py`
- `python -m pytest tests/hermes_cli/test_kanban_specify.py tests/hermes_cli/test_kanban_decompose.py -q -o 'addopts='`
- `gitleaks detect --source . --no-banner --redact --log-opts='origin/main..HEAD'`
