### PR TITLE
fix(windows): set UTF-8 encoding for Copilot ACP subprocess

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -446,6 +446,8 @@ class CopilotACPClient:
                 bufsize=1,
                 cwd=self._acp_cwd,
                 env=_build_subprocess_env(),
+                encoding="utf-8",
+                errors="replace",
             )
         except FileNotFoundError as exc:
             raise RuntimeError(


### PR DESCRIPTION
## Summary

Fixes #45140 - UnicodeDecodeError on Windows when Copilot CLI emits UTF-8 characters.

**Problem:**
On Windows, Hermes crashes when the Copilot ACP subprocess emits UTF-8 characters (e.g. emojis). The `_stdout_reader` thread errors with a UnicodeDecodeError because `subprocess.Popen` is called with `text=True` but without `encoding`, so Python uses the system codepage (cp1252) which cannot decode certain UTF-8 bytes.

**Fix:**
Added `encoding='utf-8'` and `errors='replace'` to the `subprocess.Popen` call in `_run_prompt` method (line ~440).

**Testing:**
- Syntax validation passed
- The subprocess will now properly decode UTF-8 output from Copilot CLI on Windows
- Invalid bytes are replaced instead of crashing

**How to Test:**
1. On Windows, configure Hermes with Copilot provider
2. Trigger image analysis or any flow that prints emoji/non-latin characters
3. Previously: Hermes would crash with UnicodeDecodeError
4. Now: Characters display correctly, no crash

Closes #45140