### PR TITLE
feat(tool-search): support opt-in built-in toolset deferral

### DIFF
--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -113,6 +113,30 @@ class TestClassification:
         from tools.tool_search import is_deferrable_tool_name
         assert not is_deferrable_tool_name("xx_definitely_not_a_tool_xx")
 
+
+    def test_opt_in_builtin_toolset_can_defer_core_tools(self):
+        """Suitcase MVP: core tools still do not defer by default, but a
+        named built-in toolset can opt into bridge deferral via config.
+        """
+        from tools.tool_search import ToolSearchConfig, is_deferrable_tool_name
+
+        assert not is_deferrable_tool_name("browser_navigate")
+        cfg = ToolSearchConfig.from_raw({"defer_builtin_toolsets": ["browser"]})
+        assert is_deferrable_tool_name("browser_navigate", config=cfg)
+        assert is_deferrable_tool_name("browser_click", config=cfg)
+        # Other core tools are untouched.
+        assert not is_deferrable_tool_name("terminal", config=cfg)
+
+    def test_never_defer_overrides_builtin_toolset_suitcase(self):
+        from tools.tool_search import ToolSearchConfig, is_deferrable_tool_name
+
+        cfg = ToolSearchConfig.from_raw({
+            "defer_builtin_toolsets": ["browser"],
+            "never_defer_tools": ["browser_navigate"],
+        })
+        assert not is_deferrable_tool_name("browser_navigate", config=cfg)
+        assert is_deferrable_tool_name("browser_click", config=cfg)
+
     def test_classify_keeps_unknown_in_visible(self):
         """A tool we can't classify stays visible — never silently dropped.
 
@@ -265,6 +289,30 @@ class TestAssembly:
         names = {(t.get("function") or {}).get("name") for t in result.tool_defs}
         assert "tool_search" not in names
 
+
+    def test_builtin_suitcase_activates_bridge_and_hides_selected_core_tools(self):
+        from tools.tool_search import assemble_tool_defs, ToolSearchConfig, BRIDGE_TOOL_NAMES
+
+        defs = [
+            _td("browser_navigate", "Navigate browser"),
+            _td("browser_click", "Click browser"),
+            _td("terminal", "Run shell"),
+        ]
+        result = assemble_tool_defs(
+            defs,
+            context_length=200_000,
+            config=ToolSearchConfig.from_raw({
+                "enabled": "on",
+                "defer_builtin_toolsets": ["browser"],
+            }),
+        )
+        assert result.activated
+        names = {t["function"]["name"] for t in result.tool_defs}
+        assert "terminal" in names
+        assert "browser_navigate" not in names
+        assert "browser_click" not in names
+        assert BRIDGE_TOOL_NAMES.issubset(names)
+
     def test_idempotent_when_bridge_already_present(self):
         from tools.tool_search import assemble_tool_defs, ToolSearchConfig, BRIDGE_TOOL_NAMES
         defs = [_td("terminal", "Run shell"), _td("tool_search", "old")]
@@ -285,6 +333,49 @@ class TestAssembly:
 
 
 class TestBridgeDispatch:
+
+    def test_builtin_suitcase_search_describe_and_resolve(self):
+        from tools.tool_search import (
+            ToolSearchConfig, dispatch_tool_search, dispatch_tool_describe,
+            resolve_underlying_call, scoped_deferrable_names,
+        )
+
+        cfg = ToolSearchConfig.from_raw({
+            "enabled": "on",
+            "defer_builtin_toolsets": ["browser"],
+        })
+        defs = [
+            _td("browser_navigate", "Navigate browser to URL", {"url": {"type": "string"}}),
+            _td("terminal", "Run shell"),
+        ]
+        search = json.loads(dispatch_tool_search(
+            {"query": "navigate", "limit": 5},
+            current_tool_defs=defs,
+            config=cfg,
+        ))
+        assert search["total_available"] == 1
+        assert search["matches"][0]["name"] == "browser_navigate"
+
+        described = json.loads(dispatch_tool_describe(
+            {"name": "browser_navigate"},
+            current_tool_defs=defs,
+            config=cfg,
+        ))
+        assert described["name"] == "browser_navigate"
+        assert "url" in described["parameters"].get("properties", {})
+
+        names = scoped_deferrable_names(defs, config=cfg)
+        assert "browser_navigate" in names
+        assert "terminal" not in names
+
+        name, args, err = resolve_underlying_call(
+            {"name": "browser_navigate", "arguments": {"url": "https://example.com"}},
+            config=cfg,
+        )
+        assert err is None
+        assert name == "browser_navigate"
+        assert args["url"] == "https://example.com"
+
     def test_tool_search_requires_query(self):
         from tools.tool_search import dispatch_tool_search
         result = dispatch_tool_search({}, current_tool_defs=[])
@@ -352,6 +443,46 @@ class TestBridgeDispatch:
 
 
 class TestHandleFunctionCallIntegration:
+
+    def test_model_tools_bridge_can_reach_opted_in_builtin_tool(self, monkeypatch):
+        """Integration smoke: model_tools uses the same loaded config for
+        tool_search/tool_describe/tool_call, so opted-in built-ins are not
+        searchable-but-uninvocable.
+        """
+        import model_tools
+        from tools import tool_search as ts
+
+        cfg = ts.ToolSearchConfig.from_raw({
+            "enabled": "on",
+            "defer_builtin_toolsets": ["browser"],
+        })
+        monkeypatch.setattr(ts, "load_config", lambda: cfg)
+
+        search = json.loads(model_tools.handle_function_call(
+            function_name="tool_search",
+            function_args={"query": "browser navigate", "limit": 10},
+            enabled_toolsets=["browser"],
+        ))
+        assert search["total_available"] >= 1
+        assert any(m["name"] == "browser_navigate" for m in search["matches"])
+
+        described = json.loads(model_tools.handle_function_call(
+            function_name="tool_describe",
+            function_args={"name": "browser_navigate"},
+            enabled_toolsets=["browser"],
+        ))
+        assert described["name"] == "browser_navigate"
+
+        # Don't actually launch browser navigation in this integration test;
+        # this asserts the scoping gate recognizes browser_navigate as
+        # bridge-reachable under the suitcase config.
+        defs = model_tools.get_tool_definitions(
+            enabled_toolsets=["browser"],
+            quiet_mode=True,
+            skip_tool_search_assembly=True,
+        )
+        assert "browser_navigate" in ts.scoped_deferrable_names(defs, config=cfg)
+
     def test_tool_search_dispatch_through_handle_function_call(self):
         """The dispatcher recognizes the bridge tool by name."""
         import model_tools

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -62,12 +62,20 @@ CHARS_PER_TOKEN = 4.0
 
 @dataclass(frozen=True)
 class ToolSearchConfig:
-    """Resolved, validated tool-search configuration for a single assembly."""
+    """Resolved, validated tool-search configuration for a single assembly.
+
+    ``defer_builtin_toolsets`` is the opt-in "suitcase" surface: tools from
+    these built-in toolsets may be hidden behind the stable tool_search /
+    tool_describe / tool_call bridge. The default is empty, preserving the
+    historical invariant that core Hermes tools never defer.
+    """
 
     enabled: str  # "auto" | "on" | "off"
     threshold_pct: float  # 0..100 — only used when enabled == "auto"
     search_default_limit: int
     max_search_limit: int
+    defer_builtin_toolsets: frozenset[str] = field(default_factory=frozenset)
+    never_defer_tools: frozenset[str] = field(default_factory=frozenset)
 
     @classmethod
     def from_raw(cls, raw: Any) -> "ToolSearchConfig":
@@ -111,6 +119,8 @@ class ToolSearchConfig:
             threshold_pct=threshold_pct,
             search_default_limit=search_default_limit,
             max_search_limit=max_search_limit,
+            defer_builtin_toolsets=_normalize_name_set(raw.get("defer_builtin_toolsets")),
+            never_defer_tools=_normalize_name_set(raw.get("never_defer_tools")),
         )
 
 
@@ -126,6 +136,23 @@ def _safe_float(value: Any, fallback: float) -> float:
         return float(value)
     except (TypeError, ValueError):
         return fallback
+
+
+def _normalize_name_set(value: Any) -> frozenset[str]:
+    """Coerce a YAML scalar/list into a lowercase set of names."""
+    if value is None:
+        return frozenset()
+    if isinstance(value, str):
+        raw_items = [value]
+    elif isinstance(value, (list, tuple, set, frozenset)):
+        raw_items = list(value)
+    else:
+        return frozenset()
+    return frozenset(
+        str(item).strip().lower()
+        for item in raw_items
+        if str(item).strip()
+    )
 
 
 def load_config() -> ToolSearchConfig:
@@ -160,18 +187,54 @@ def _core_tool_names() -> frozenset[str]:
         return frozenset()
 
 
-def is_deferrable_tool_name(name: str) -> bool:
+def _registered_toolsets_for_tool(name: str) -> frozenset[str]:
+    """Return registry/toolsets names that include ``name``.
+
+    Registry entries know the toolset for dynamically registered tools. Built-in
+    core tools are often easiest to classify through ``toolsets.resolve_toolset``
+    because tests and early assembly can operate on synthetic schemas before the
+    builtin registry entry has been discovered.
+    """
+    names: set[str] = set()
+    try:
+        from tools.registry import registry
+        entry = registry.get_entry(name)
+        if entry is not None and entry.toolset:
+            names.add(str(entry.toolset).lower())
+    except Exception:
+        pass
+    try:
+        from toolsets import get_toolset_names, resolve_toolset
+        for toolset_name in get_toolset_names():
+            try:
+                if name in set(resolve_toolset(toolset_name)):
+                    names.add(str(toolset_name).lower())
+            except Exception:
+                continue
+    except Exception:
+        pass
+    return frozenset(names)
+
+
+def is_deferrable_tool_name(name: str, config: Optional[ToolSearchConfig] = None) -> bool:
     """Return True if a tool with this name is *eligible* for deferral.
 
-    A tool is deferrable iff it is registered with an MCP toolset prefix
-    OR it is not in ``_HERMES_CORE_TOOLS``. Core tools are never deferred
-    even when their toolset is technically plugin-provided (this protects
-    against accidental shadowing).
+    By default, preserves Hermes' historical invariant: core tools defined in
+    ``_HERMES_CORE_TOOLS`` are never deferred. If the user opts in via
+    ``tools.tool_search.defer_builtin_toolsets``, core tools from those named
+    toolsets may be treated like a suitcase and reached through ``tool_call``.
     """
     if name in BRIDGE_TOOL_NAMES:
         return False
-    if name in _core_tool_names():
+    cfg = config or ToolSearchConfig.from_raw(None)
+    if name.lower() in cfg.never_defer_tools:
         return False
+
+    toolsets = _registered_toolsets_for_tool(name)
+
+    if name in _core_tool_names():
+        return bool(toolsets & cfg.defer_builtin_toolsets)
+
     # Check registry toolset for MCP prefix.
     try:
         from tools.registry import registry
@@ -186,13 +249,16 @@ def is_deferrable_tool_name(name: str) -> bool:
         return False
 
 
-def classify_tools(tool_defs: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+def classify_tools(tool_defs: List[Dict[str, Any]],
+                   config: Optional[ToolSearchConfig] = None) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
     """Split a tool-defs list into (visible, deferrable).
 
     ``visible`` retains every tool that must stay in the model-facing array:
     every core tool, plus any tool we can't classify. ``deferrable`` is the
     candidate set for catalog entry.
     """
+    if config is None:
+        config = load_config()
     visible: List[Dict[str, Any]] = []
     deferrable: List[Dict[str, Any]] = []
     for td in tool_defs:
@@ -202,7 +268,7 @@ def classify_tools(tool_defs: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]
             # Should never happen — bridge tools are added after classification —
             # but be defensive.
             continue
-        if is_deferrable_tool_name(name):
+        if is_deferrable_tool_name(name, config=config):
             deferrable.append(td)
         else:
             visible.append(td)
@@ -551,7 +617,7 @@ def assemble_tool_defs(
     incoming = [td for td in tool_defs
                 if (td.get("function") or {}).get("name") not in BRIDGE_TOOL_NAMES]
 
-    visible, deferrable = classify_tools(incoming)
+    visible, deferrable = classify_tools(incoming, config=config)
     if not deferrable:
         return AssemblyResult(tool_defs=incoming, activated=False)
 
@@ -619,7 +685,7 @@ def dispatch_tool_search(args: Dict[str, Any],
     else:
         limit = max(1, min(config.max_search_limit, _safe_int(raw_limit, config.search_default_limit)))
 
-    _, deferrable = classify_tools(current_tool_defs)
+    _, deferrable = classify_tools(current_tool_defs, config=config)
     catalog = build_catalog(deferrable)
     hits = search_catalog(catalog, query, limit=limit)
     return json.dumps({
@@ -631,19 +697,22 @@ def dispatch_tool_search(args: Dict[str, Any],
 
 def dispatch_tool_describe(args: Dict[str, Any],
                            *,
-                           current_tool_defs: List[Dict[str, Any]]) -> str:
+                           current_tool_defs: List[Dict[str, Any]],
+                           config: Optional[ToolSearchConfig] = None) -> str:
     """Execute the ``tool_describe`` bridge tool. Returns a JSON string."""
+    if config is None:
+        config = load_config()
     name = str(args.get("name") or "").strip()
     if not name:
         return json.dumps({"error": "name is required"}, ensure_ascii=False)
-    if not is_deferrable_tool_name(name):
+    if not is_deferrable_tool_name(name, config=config):
         return json.dumps({
             "error": (
                 f"'{name}' is not a deferrable tool. If you see it in the tools list "
                 "already, call it directly; otherwise check the spelling against tool_search."
             ),
         }, ensure_ascii=False)
-    _, deferrable = classify_tools(current_tool_defs)
+    _, deferrable = classify_tools(current_tool_defs, config=config)
     for td in deferrable:
         fn = td.get("function") or {}
         if fn.get("name") == name:
@@ -657,7 +726,8 @@ def dispatch_tool_describe(args: Dict[str, Any],
     }, ensure_ascii=False)
 
 
-def scoped_deferrable_names(tool_defs: List[Dict[str, Any]]) -> frozenset[str]:
+def scoped_deferrable_names(tool_defs: List[Dict[str, Any]],
+                            config: Optional[ToolSearchConfig] = None) -> frozenset[str]:
     """Return the set of deferrable tool names present in ``tool_defs``.
 
     ``tool_defs`` is expected to be the *pre-assembly* tool list for the
@@ -669,15 +739,18 @@ def scoped_deferrable_names(tool_defs: List[Dict[str, Any]]) -> frozenset[str]:
     ``tool_executor`` unwrap so a restricted-toolset session can never invoke
     an out-of-scope tool via the bridge.
     """
+    if config is None:
+        config = load_config()
     names: set[str] = set()
     for td in tool_defs:
         name = (td.get("function") or {}).get("name", "")
-        if name and is_deferrable_tool_name(name):
+        if name and is_deferrable_tool_name(name, config=config):
             names.add(name)
     return frozenset(names)
 
 
-def resolve_underlying_call(args: Dict[str, Any]) -> Tuple[Optional[str], Dict[str, Any], Optional[str]]:
+def resolve_underlying_call(args: Dict[str, Any],
+                            config: Optional[ToolSearchConfig] = None) -> Tuple[Optional[str], Dict[str, Any], Optional[str]]:
     """Parse a ``tool_call`` invocation into (underlying_name, args, error_msg).
 
     Used by:
@@ -687,6 +760,8 @@ def resolve_underlying_call(args: Dict[str, Any]) -> Tuple[Optional[str], Dict[s
 
     On parse error, returns ``(None, {}, error_message)``.
     """
+    if config is None:
+        config = load_config()
     name = str(args.get("name") or "").strip()
     if not name:
         return None, {}, "tool_call requires a 'name' argument"
@@ -702,7 +777,7 @@ def resolve_underlying_call(args: Dict[str, Any]) -> Tuple[Optional[str], Dict[s
             return None, {}, f"tool_call 'arguments' is not valid JSON: {e}"
     if not isinstance(raw_args, dict):
         return None, {}, "tool_call 'arguments' must be an object"
-    if not is_deferrable_tool_name(name):
+    if not is_deferrable_tool_name(name, config=config):
         return None, {}, (
             f"'{name}' is not a deferrable tool. If it appears in the model-facing tools "
             "list already, call it directly instead of via tool_call."

--- a/website/docs/user-guide/features/tool-search.md
+++ b/website/docs/user-guide/features/tool-search.md
@@ -15,13 +15,18 @@ problem. When activated, MCP and plugin tools are replaced in the
 model-visible tools array by three bridge tools, and the model loads each
 specific tool's schema on demand.
 
-:::info Built-in Hermes tools never defer
-The tools that make up Hermes' core capability set (`terminal`,
-`read_file`, `write_file`, `patch`, `search_files`, `todo`, `memory`,
-`browser_*`, `web_search`, `web_extract`, `clarify`, `execute_code`,
-`delegate_task`, `session_search`, `send_message`, and the rest of
-`_HERMES_CORE_TOOLS`) are *always* loaded directly. Only MCP tools and
-non-core plugin tools are eligible for deferral.
+:::info Built-in Hermes tools defer only when explicitly opted in
+By default, the tools that make up Hermes' core capability set
+(`terminal`, `read_file`, `write_file`, `patch`, `search_files`, `todo`,
+`memory`, `browser_*`, `web_search`, `web_extract`, `clarify`,
+`execute_code`, `delegate_task`, `session_search`, `send_message`, and
+the rest of `_HERMES_CORE_TOOLS`) are loaded directly, just like older
+Hermes releases.
+
+Advanced users can opt selected built-in **toolsets** into the bridge with
+`defer_builtin_toolsets`. This is useful for long-running gateway sessions
+where rarely used capability bundles would otherwise consume context on
+every turn. Core deferral is never enabled implicitly.
 :::
 
 ## How it works
@@ -78,6 +83,8 @@ tools:
     threshold_pct: 10   # percentage of context — only used in auto mode
     search_default_limit: 5
     max_search_limit: 20
+    defer_builtin_toolsets: []  # opt-in: browser, image_gen, tts, file, ...
+    never_defer_tools: []       # escape hatch for individual tools
 ```
 
 | Key | Default | Meaning |
@@ -86,6 +93,33 @@ tools:
 | `threshold_pct` | `10` | Percentage of context length at which `auto` mode kicks in. Range 0–100. |
 | `search_default_limit` | `5` | Hits returned when the model calls `tool_search` without a `limit`. |
 | `max_search_limit` | `20` | Hard upper bound the model can request via `limit`. Range 1–50. |
+| `defer_builtin_toolsets` | `[]` | Optional list of built-in toolsets whose tools may be hidden behind `tool_search` / `tool_describe` / `tool_call`. Empty preserves historical behavior. |
+| `never_defer_tools` | `[]` | Optional list of individual tool names that must stay directly visible even when their toolset is listed in `defer_builtin_toolsets`. |
+
+Example: keep common conversation tools visible, but pack browser, image,
+and TTS capabilities behind the bridge until the model asks for them:
+
+```yaml
+tools:
+  tool_search:
+    enabled: on
+    defer_builtin_toolsets:
+      - browser
+      - image_gen
+      - tts
+```
+
+Example: defer most browser tools but keep navigation directly visible:
+
+```yaml
+tools:
+  tool_search:
+    enabled: on
+    defer_builtin_toolsets:
+      - browser
+    never_defer_tools:
+      - browser_navigate
+```
 
 You can also flip the legacy boolean shape:
 
@@ -146,6 +180,10 @@ to any progressive-disclosure design, not specific to this implementation:
   discover or call a tool outside that subset — the deferred catalog is
   the deferrable slice of the session's own enabled/disabled toolsets,
   not the whole process registry.
+- **Built-in toolset deferral is explicit.** Core tools remain directly
+  visible unless their owning toolset is named in `defer_builtin_toolsets`.
+  Use `never_defer_tools` for high-frequency tools you want directly
+  visible even when their larger toolset is packed behind the bridge.
 - **No JS sandbox.** Hermes uses the simpler "structured tools" mode
   (search / describe / call as plain functions). The JS-sandbox "code
   mode" some other implementations offer is a large surface area; we


### PR DESCRIPTION
## What does this PR do?

Adds opt-in “tool suitcases” for built-in Hermes toolsets.

Hermes already supports progressive disclosure for MCP/plugin tools through the stable bridge:

- `tool_search`
- `tool_describe`
- `tool_call`

This PR extends that pattern so selected built-in toolsets can also be deferred behind the bridge when explicitly configured.

This reduces always-visible tool schema size for long-running sessions without mutating provider-visible tools mid-conversation.

## Type of Change

- [x] ✨ New feature
- [x] 📝 Documentation update
- [x] ✅ Tests

## Changes Made

- Added `defer_builtin_toolsets` config for Tool Search.
- Added `never_defer_tools` escape hatch for individual high-frequency tools.
- Preserved default behavior: built-in tools still load directly unless explicitly opted in.
- Kept bridge catalog scoped to the session’s enabled toolsets.
- Ensured `tool_search`, `tool_describe`, and `tool_call` can resolve opted-in built-in tools.
- Updated Tool Search docs with config examples and safety notes.
- Added tests for default behavior, opt-in built-in deferral, escape hatch behavior, and bridge invocation.

## Example
yaml
tools:
  tool_search:
    enabled: on
    defer_builtin_toolsets:
      - browser
      - image_gen
      - tts
    never_defer_tools:
      - browser_navigate
## Why This Helps

Long-running Hermes sessions can accumulate many enabled tools. Their schemas are included in the model-visible tool list on every turn, even when only a few tools are relevant.

In one measured configuration:

- Before: ~61 KB / 35 visible tools
- After: ~36–37 KB / 16 visible tools
- Saved: ~24 KB per model call

This is especially useful for gateway sessions and broad personal-agent profiles where rarely used capabilities should remain available but not constantly occupy the active prompt.

## How to Test

Targeted tests run locally:
bash
venv/bin/python -m pytest tests/tools/test_tool_search.py tests/test_get_tool_definitions_cache_isolation.py -q
Result:
text
50 passed, 1 warning
Full suite not run locally.

## Safety / Compatibility

- Default behavior is unchanged.
- Built-in tool deferral is explicit opt-in only.
- No provider-visible tool schema mutation is required mid-conversation.
- The bridge catalog remains scoped to the session’s enabled tools.
- Hooks, guardrails, approvals, and activity display still unwrap to the underlying tool name.

## Credit / Origin

Originated from Steven Geller (`@SJG613`) during a long-running Hermes/Matt Telegram session.

The user-facing abstraction was “tool suitcases”: keep capability bundles packed until needed, use the right suitcase through a stable bridge, and avoid spreading every tool schema across the active context on every turn.