### PR TITLE
fix(dashboard): skill installs from the dashboard silently auto-cancel

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -8105,7 +8105,8 @@ async def install_skill_hub(body: SkillInstallRequest, profile: Optional[str] = 
         raise HTTPException(status_code=400, detail="identifier is required")
     try:
         proc = _spawn_hermes_action(
-            _profile_cli_args(body.profile or profile) + ["skills", "install", identifier],
+            _profile_cli_args(body.profile or profile)
+            + ["skills", "install", identifier, "--yes"],
             "skills-install",
         )
     except HTTPException:
@@ -8843,7 +8844,7 @@ async def create_profile_endpoint(body: ProfileCreate):
             continue
         try:
             proc = _spawn_hermes_action(
-                ["-p", body.name, "skills", "install", ident],
+                ["-p", body.name, "skills", "install", ident, "--yes"],
                 "skills-install",
             )
             hub_installs.append({"identifier": ident, "pid": proc.pid})

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2690,7 +2690,12 @@ class TestNewEndpoints:
         assert data["hub_installs"] == [{"identifier": "someuser/some-skill", "pid": 4321}]
 
         # Hub install was scoped to the new profile.
-        assert spawned == [(["-p", "builder", "skills", "install", "someuser/some-skill"], "skills-install")]
+        assert spawned == [
+            (
+                ["-p", "builder", "skills", "install", "someuser/some-skill", "--yes"],
+                "skills-install",
+            )
+        ]
 
         # Verify the writes landed in the NEW profile's config, not the root.
         prof_dir = get_hermes_home() / "profiles" / "builder"

--- a/tests/hermes_cli/test_web_server_skills_profiles.py
+++ b/tests/hermes_cli/test_web_server_skills_profiles.py
@@ -178,7 +178,10 @@ class TestProfileScopedHubActions:
         )
         assert resp.status_code == 200
         assert calls == [
-            (["-p", "worker_alpha", "skills", "install", "official/demo"], "skills-install")
+            (
+                ["-p", "worker_alpha", "skills", "install", "official/demo", "--yes"],
+                "skills-install",
+            )
         ]
 
     def test_hub_install_without_profile_keeps_legacy_argv(
@@ -200,7 +203,7 @@ class TestProfileScopedHubActions:
             "/api/skills/hub/install", json={"identifier": "official/demo"}
         )
         assert resp.status_code == 200
-        assert calls == [["skills", "install", "official/demo"]]
+        assert calls == [["skills", "install", "official/demo", "--yes"]]
 
     def test_hub_install_unknown_profile_404(self, client, isolated_profiles):
         resp = client.post(


### PR DESCRIPTION
## Summary
Skill installs triggered from the web dashboard now actually install. Previously every dashboard install silently no-opped: the server spawned `hermes skills install <id>` with stdin=DEVNULL but without `--yes`, so `do_install()`'s `Confirm [y/N]` prompt hit EOF, defaulted to "n", and wrote "Installation cancelled." into a background action log the user never sees.

Reported by @thervconsortium on X ("auto cancels & nothing installs", no interactivity after clicking install).

## Changes
- `hermes_cli/web_server.py`: pass `--yes` on both install spawn sites — `/api/skills/hub/install` and the new-profile `hub_skills` install loop. Matches the uninstall endpoint, which already passed `--yes`. Clicking install in the dashboard is the explicit consent.
- tests: updated the three argv-snapshot assertions to expect `--yes`.

## Validation
| | Before | After |
|---|---|---|
| Spawned argv with stdin=DEVNULL vs temp HERMES_HOME | "Installation cancelled." | skill installed (arxiv, SAFE verdict) |
| tests/hermes_cli/test_web_server*.py + test_skills_install_flags.py | — | 290 passed |

## Infographic

![dashboard-skill-install-fix](https://v3b.fal.media/files/b/0a9e0960/GS4KEReKFgCjOMrDiLgzA_a0KXVutH.png)
