### PR TITLE
feat: show current model in /status command

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -440,12 +440,31 @@ class GatewaySlashCommandsMixin:
         ]
         if title:
             lines.append(t("gateway.status.title", title=title))
+        # Read current model from config
+        model_label = ""
+        try:
+            from gateway.run import _load_gateway_config
+            cfg = _load_gateway_config()
+            if cfg:
+                model_cfg = cfg.get("model", {})
+                if isinstance(model_cfg, dict):
+                    model_name = model_cfg.get("default", "")
+                    provider_name = model_cfg.get("provider", "")
+                    if model_name:
+                        model_label = f"{model_name}"
+                        if provider_name:
+                            model_label += f" ({provider_name})"
+        except Exception:
+            pass
+
         lines.extend([
             t("gateway.status.created", timestamp=session_entry.created_at.strftime('%Y-%m-%d %H:%M')),
             t("gateway.status.last_activity", timestamp=session_entry.updated_at.strftime('%Y-%m-%d %H:%M')),
             t("gateway.status.tokens", tokens=f"{db_total_tokens:,}"),
             t("gateway.status.agent_running", state=t("gateway.status.state_yes") if is_running else t("gateway.status.state_no")),
         ])
+        if model_label:
+            lines.append(f"Model: {model_label}")
         if queue_depth:
             lines.append(t("gateway.status.queued", count=queue_depth))
         if source.platform == Platform.MATRIX:


### PR DESCRIPTION
## Summary

Adds the current model name and provider to the `/status` slash command output. Currently `/status` shows session ID, title, timestamps, token counts, running state, and platforms — but not which model is active. This reads `model.default` and `model.provider` from `config.yaml` and appends a `Model:` line.

## Example output

```
📊 Session Status

Session: abc123...
Created: 2026-06-12 14:30
Last activity: 2026-06-12 15:45
Tokens: 42,500
Agent running: yes
Model: deepseek-v4-pro-260425 (custom)
Platforms: telegram
```

## Implementation

- Single block added to `_handle_status_command` in `gateway/slash_commands.py`
- Reads from config via the existing `_load_gateway_config` helper (lazy import to avoid cycle)
- No new dependencies, no i18n strings needed
- Gracefully handles missing config — model line is simply omitted if unavailable