### PR TITLE
fix(analytics): show estimated cost + pin per-profile scoping with tests

### DIFF
--- a/tests/hermes_cli/test_web_server_profile_unification.py
+++ b/tests/hermes_cli/test_web_server_profile_unification.py
@@ -643,3 +643,104 @@ class TestProfileScopedChatPty:
         with pytest.raises(web_server.HTTPException) as exc:
             web_server._resolve_chat_argv(profile="ghost")
         assert exc.value.status_code == 404
+
+
+class TestProfileScopedAnalytics:
+    def test_usage_analytics_reads_target_profile_state_db(
+        self, client, isolated_profiles
+    ):
+        from hermes_state import SessionDB
+
+        default_db = SessionDB(db_path=isolated_profiles["default"] / "state.db")
+        worker_db = SessionDB(db_path=isolated_profiles["worker_beta"] / "state.db")
+        try:
+            default_db.create_session(
+                session_id="default-analytics-session",
+                source="cli",
+                model="default-model",
+            )
+            default_db.update_token_counts(
+                "default-analytics-session",
+                input_tokens=11,
+                output_tokens=7,
+                absolute=True,
+            )
+            worker_db.create_session(
+                session_id="worker-analytics-session",
+                source="cli",
+                model="worker-model",
+            )
+            worker_db.update_token_counts(
+                "worker-analytics-session",
+                input_tokens=101,
+                output_tokens=29,
+                absolute=True,
+            )
+        finally:
+            default_db.close()
+            worker_db.close()
+
+        default_resp = client.get("/api/analytics/usage?days=7")
+        assert default_resp.status_code == 200
+        default_data = default_resp.json()
+        assert default_data["totals"]["total_input"] == 11
+        assert default_data["totals"]["total_output"] == 7
+        assert [row["model"] for row in default_data["by_model"]] == ["default-model"]
+
+        worker_resp = client.get(
+            "/api/analytics/usage",
+            params={"days": 7, "profile": "worker_beta"},
+        )
+        assert worker_resp.status_code == 200
+        worker_data = worker_resp.json()
+        assert worker_data["totals"]["total_input"] == 101
+        assert worker_data["totals"]["total_output"] == 29
+        assert [row["model"] for row in worker_data["by_model"]] == ["worker-model"]
+
+    def test_models_analytics_reads_target_profile_state_db(
+        self, client, isolated_profiles
+    ):
+        from hermes_state import SessionDB
+
+        default_db = SessionDB(db_path=isolated_profiles["default"] / "state.db")
+        worker_db = SessionDB(db_path=isolated_profiles["worker_beta"] / "state.db")
+        try:
+            default_db.create_session(
+                session_id="default-models-analytics-session",
+                source="cli",
+                model="default-model",
+            )
+            default_db.update_token_counts(
+                "default-models-analytics-session",
+                input_tokens=3,
+                output_tokens=4,
+                absolute=True,
+            )
+            worker_db.create_session(
+                session_id="worker-models-analytics-session",
+                source="cli",
+                model="worker-model",
+            )
+            worker_db.update_token_counts(
+                "worker-models-analytics-session",
+                input_tokens=13,
+                output_tokens=17,
+                absolute=True,
+            )
+        finally:
+            default_db.close()
+            worker_db.close()
+
+        default_resp = client.get("/api/analytics/models?days=7")
+        assert default_resp.status_code == 200
+        assert [row["model"] for row in default_resp.json()["models"]] == ["default-model"]
+
+        worker_resp = client.get(
+            "/api/analytics/models",
+            params={"days": 7, "profile": "worker_beta"},
+        )
+        assert worker_resp.status_code == 200
+        worker_models = worker_resp.json()["models"]
+        assert [row["model"] for row in worker_models] == ["worker-model"]
+        assert worker_models[0]["input_tokens"] == 13
+        assert worker_models[0]["output_tokens"] == 17

--- a/web/src/pages/AnalyticsPage.tsx
+++ b/web/src/pages/AnalyticsPage.tsx
@@ -39,6 +39,12 @@ function formatTokens(n: number): string {
   return String(n);
 }
 
+function formatCost(n: number): string {
+  if (!Number.isFinite(n) || n <= 0) return "$0.00";
+  if (n < 0.01) return `$${n.toFixed(4)}`;
+  return `$${n.toFixed(2)}`;
+}
+
 function formatDate(day: string): string {
   try {
     const d = new Date(day + "T00:00:00");
@@ -256,7 +262,8 @@ function DailyTable({ daily }: { daily: AnalyticsDailyEntry[] }) {
                 <SortHeader label={t.analytics.date} col="day" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-left py-2 pr-4 font-medium" />
                 <SortHeader label={t.sessions.title} col="sessions" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 px-4 font-medium" />
                 <SortHeader label={t.analytics.input} col="input_tokens" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 px-4 font-medium" />
-                <SortHeader label={t.analytics.output} col="output_tokens" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 pl-4 font-medium" />
+                <SortHeader label={t.analytics.output} col="output_tokens" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 px-4 font-medium" />
+                <SortHeader label={t.models.estimatedCost} col="estimated_cost" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 pl-4 font-medium" />
               </tr>
             </thead>
             <tbody>
@@ -276,10 +283,13 @@ function DailyTable({ daily }: { daily: AnalyticsDailyEntry[] }) {
                         {formatTokens(d.input_tokens)}
                       </span>
                   </td>
-                  <td className="text-right py-2 pl-4">
+                  <td className="text-right py-2 px-4">
                     <span style={{ color: "var(--series-output-token)" }}>
                         {formatTokens(d.output_tokens)}
                       </span>
+                  </td>
+                  <td className="text-right py-2 pl-4 text-muted-foreground">
+                    {formatCost(d.estimated_cost)}
                   </td>
                 </tr>
               ))}
@@ -314,7 +324,8 @@ function ModelTable({ models }: { models: AnalyticsModelEntry[] }) {
               <tr className="border-b border-border text-muted-foreground text-xs">
                 <SortHeader label={t.analytics.model} col="model" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-left py-2 pr-4 font-medium" />
                 <SortHeader label={t.sessions.title} col="sessions" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 px-4 font-medium" />
-                <SortHeader label={t.analytics.tokens} col="input_tokens" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 pl-4 font-medium" />
+                <SortHeader label={t.analytics.tokens} col="input_tokens" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 px-4 font-medium" />
+                <SortHeader label={t.models.estimatedCost} col="estimated_cost" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 pl-4 font-medium" />
               </tr>
             </thead>
             <tbody>
@@ -329,7 +340,7 @@ function ModelTable({ models }: { models: AnalyticsModelEntry[] }) {
                   <td className="text-right py-2 px-4 text-muted-foreground">
                     {m.sessions}
                   </td>
-                  <td className="text-right py-2 pl-4">
+                  <td className="text-right py-2 px-4">
                     <span style={{ color: "var(--series-input-token)" }}>
                       {formatTokens(m.input_tokens)}
                     </span>
@@ -337,6 +348,9 @@ function ModelTable({ models }: { models: AnalyticsModelEntry[] }) {
                     <span style={{ color: "var(--series-output-token)" }}>
                       {formatTokens(m.output_tokens)}
                     </span>
+                  </td>
+                  <td className="text-right py-2 pl-4 text-muted-foreground">
+                    {formatCost(m.estimated_cost)}
                   </td>
                 </tr>
               ))}
@@ -556,6 +570,10 @@ export default function AnalyticsPage() {
                     {
                       label: t.analytics.output,
                       value: formatTokens(data.totals.total_output),
+                    },
+                    {
+                      label: t.models.estimatedCost,
+                      value: formatCost(data.totals.total_estimated_cost),
                     },
                     {
                       label: t.analytics.totalSessions,


### PR DESCRIPTION
## What does this PR do?

Fixes the analytics dashboard for issue #45148. The backend per-profile routing of `/api/analytics/{usage,models}` landed on main separately (62b4618e9), so after rebasing this PR now contributes the remaining pieces:

- regression tests pinning that `/api/analytics/usage` and `/api/analytics/models` read the requested profile's state DB (not the default profile's)
- the missing cost display on the Analytics page: an `Est. Cost` column in the daily and per-model tables plus an `Est. Cost` summary tile, all sourced consistently from `estimated_cost` / `total_estimated_cost` (per review feedback)

## Related Issue

Fixes #45148

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tests/hermes_cli/test_web_server_profile_unification.py`: new `TestProfileScopedAnalytics` class covering both analytics endpoints with two isolated profiles
- `web/src/pages/AnalyticsPage.tsx`: `formatCost` helper, `Est. Cost` sortable column in the daily and per-model tables, `Est. Cost` summary tile

## How to Test

1. Open the dashboard, choose a non-default profile, and go to the Analytics page — values reflect that profile and the estimated cost is shown.
2. `pytest tests/hermes_cli/test_web_server_profile_unification.py -q` (34 passed)
3. `npm run typecheck` in `web/` passes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
