### PR TITLE
fix(compression): append END OF CONTEXT SUMMARY marker to all standalone summaries (salvages #33346)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -69,6 +69,16 @@ SUMMARY_PREFIX = (
 )
 LEGACY_SUMMARY_PREFIX = "[CONTEXT SUMMARY]:"
 
+# Appended to every standalone summary message (and to the merged-into-tail
+# prefix) so the model has an unambiguous "summary ends here" boundary.
+# Without it, weak models read the verbatim "## Active Task" quote as fresh
+# user input (#11475, #14521) or regurgitate an assistant-role summary as
+# their own output (#33256).
+_SUMMARY_END_MARKER = (
+    "--- END OF CONTEXT SUMMARY — "
+    "respond to the message below, not the summary above ---"
+)
+
 # Handoff prefixes that shipped in earlier releases. A summary persisted under
 # one of these can be inherited into a resumed lineage (#35344); when it is
 # re-normalized on re-compaction we must strip the OLD prefix too, otherwise the
@@ -1616,7 +1626,13 @@ This compaction should PRIORITISE preserving all information related to the focu
         text = (summary or "").strip()
         for prefix in (SUMMARY_PREFIX, LEGACY_SUMMARY_PREFIX, *_HISTORICAL_SUMMARY_PREFIXES):
             if text.startswith(prefix):
-                return text[len(prefix):].lstrip()
+                text = text[len(prefix):].lstrip()
+                break
+        # Strip the trailing end marker too — a rehydrated handoff body that
+        # keeps it would leak the boundary directive into the iterative-update
+        # summarizer prompt (and the marker is re-appended on insertion anyway).
+        if text.endswith(_SUMMARY_END_MARKER):
+            text = text[: -len(_SUMMARY_END_MARKER)].rstrip()
         return text
 
     @classmethod
@@ -2199,11 +2215,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         # the explicit end marker so the model has a clear "summary ends
         # here, respond to the message below" signal.
         if not _merge_summary_into_tail:
-            summary = (
-                summary
-                + "\n\n--- END OF CONTEXT SUMMARY — "
-                "respond to the message below, not the summary above ---"
-            )
+            summary = summary + "\n\n" + _SUMMARY_END_MARKER
 
         if not _merge_summary_into_tail:
             compressed.append({"role": summary_role, "content": summary})
@@ -2211,11 +2223,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         for i in range(compress_end, n_messages):
             msg = messages[i].copy()
             if _merge_summary_into_tail and i == compress_end:
-                merged_prefix = (
-                    summary
-                    + "\n\n--- END OF CONTEXT SUMMARY — "
-                    "respond to the message below, not the summary above ---\n\n"
-                )
+                merged_prefix = summary + "\n\n" + _SUMMARY_END_MARKER + "\n\n"
                 msg["content"] = _append_text_to_content(
                     msg.get("content"),
                     merged_prefix,

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -2193,10 +2193,12 @@ This compaction should PRIORITISE preserving all information related to the focu
 
         # When the summary lands as a standalone role="user" message,
         # weak models read the verbatim "## Active Task" quote of a past
-        # user request as fresh input (#11475, #14521). Append the explicit
-        # end marker — the same one used in the merge-into-tail path — so
-        # the model has a clear "summary above, not new input" signal.
-        if not _merge_summary_into_tail and summary_role == "user":
+        # user request as fresh input (#11475, #14521).
+        # When it lands as role="assistant", models may regurgitate the
+        # summary text as their own output (#33256). In both cases, append
+        # the explicit end marker so the model has a clear "summary ends
+        # here, respond to the message below" signal.
+        if not _merge_summary_into_tail:
             summary = (
                 summary
                 + "\n\n--- END OF CONTEXT SUMMARY — "

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -1252,6 +1252,48 @@ class TestCompressWithClient:
             "respond to the message below, not the summary above ---"
         )
 
+    def test_assistant_role_summary_carries_end_marker(self):
+        """When the summary lands as standalone role='assistant' (head ends
+        with user), the message body must include the explicit
+        '--- END OF CONTEXT SUMMARY ---' marker. Without it, models may
+        regurgitate the summary text as their own output (#33256).
+        """
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "[CONTEXT SUMMARY]: stuff happened"
+        mock_client.chat.completions.create.return_value = mock_response
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=2, protect_last_n=2)
+
+        # head_last=user → summary_role="assistant" (same setup as
+        # test_summary_role_avoids_consecutive_user_when_head_ends_with_user).
+        # With min_tail=3, tail = last 3 messages (indices 5-7).
+        # head_last=user, tail_first=user → the assistant-role summary does
+        # not collide with either neighbor and should be inserted standalone.
+        msgs = [
+            {"role": "system", "content": "system prompt"},
+            {"role": "user", "content": "msg 1"},
+            {"role": "user", "content": "msg 2"},  # last head — user
+            {"role": "assistant", "content": "msg 3"},
+            {"role": "user", "content": "msg 4"},
+            {"role": "user", "content": "msg 5"},
+            {"role": "assistant", "content": "msg 6"},
+            {"role": "user", "content": "msg 7"},
+        ]
+        with patch("agent.context_compressor.call_llm", return_value=mock_response):
+            result = c.compress(msgs)
+
+        summary_msg = next(
+            m for m in result if (m.get("content") or "").startswith(SUMMARY_PREFIX)
+        )
+        assert summary_msg["role"] == "assistant"
+        assert "END OF CONTEXT SUMMARY" in summary_msg["content"]
+        assert summary_msg["content"].rstrip().endswith(
+            "respond to the message below, not the summary above ---"
+        )
+
     def test_summary_role_avoids_consecutive_user_messages(self):
         """Summary role should alternate with the last head message to avoid consecutive same-role messages."""
         mock_client = MagicMock()


### PR DESCRIPTION
## Summary
The "END OF CONTEXT SUMMARY" boundary marker is now appended to every standalone compaction summary regardless of role — previously only `role="user"` summaries got it, so an assistant-role summary could be regurgitated verbatim by the model as its own reply (#33256).

Closes #33256.

## Changes
- `agent/context_compressor.py`: drop the `summary_role == "user"` gate on the end marker (from #33346 by @Tranquil-Flow, + his 4 regression tests)
- Follow-up: marker hoisted to `_SUMMARY_END_MARKER` module constant (was duplicated at the standalone + merged-into-tail sites); `_strip_summary_prefix` now also strips a trailing marker so rehydrated handoff bodies don't leak the boundary directive into the iterative-update summarizer prompt

## Validation
| | Before | After |
|---|---|---|
| Standalone assistant-role summary | no end marker → model echoes summary as reply | marker appended |
| Rehydrated handoff body | trailing marker leaks into summarizer prompt | stripped, re-appended on insertion |
| compressor + prefix-semantics + continuity + historical-media suites | — | 133 passed |

## Attribution
Salvages #33346 by @Tranquil-Flow — cherry-picked with authorship preserved; rebase-merge to keep per-commit credit.

## Infographic

![summary-end-marker-all-roles](https://v3b.fal.media/files/b/0a9e0983/mlXx1o3GCO8n3I7J73ULM_ycc6sWtL.png)
