### PR TITLE
fix: add tool-search.md to sidebar under Features > Core

### DIFF
--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -59,6 +59,7 @@ const sidebars: SidebarsConfig = {
           label: 'Core',
           items: [
             'user-guide/features/tools',
+            'user-guide/features/tool-search',
             'user-guide/features/skills',
             'user-guide/features/lsp',
             'user-guide/features/curator',


### PR DESCRIPTION
## Summary

Fixes BUG-016: `user-guide/features/tool-search.md` was an orphaned documentation page — it was not referenced in the Docusaurus sidebar configuration at all.

## Changes

- Added `user-guide/features/tool-search` to the `Core` subcategory under `Features` in `website/sidebars.ts`
- Placed directly after the `tools` page entry, alphabetically and logically adjacent

## Verification

- The file exists at `website/docs/user-guide/features/tool-search.md`
- The page is live at https://hermes-agent.nousresearch.com/docs/user-guide/features/tool-search
- Sidebar now correctly links to it under Features → Core