### PR TITLE
fix(cli): preserve --source across CLI self-relaunch (#45107)

### DIFF
--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -366,7 +366,8 @@ def build_top_level_parser():
         default=argparse.SUPPRESS,
         help="Skip auto-injection of AGENTS.md, SOUL.md, .cursorrules, memory, and preloaded skills. Combine with --ignore-user-config for a fully isolated run.",
     )
-    chat_parser.add_argument(
+    _inherited_flag(
+        chat_parser,
         "--source",
         default=None,
         help="Session source tag for filtering (default: cli). Use 'tool' for third-party integrations that should not appear in user session lists.",

--- a/run_agent.py
+++ b/run_agent.py
@@ -510,7 +510,7 @@ class AIAgent:
         """Create session DB row on first use. Disables _session_db on failure."""
         if self._session_db_created or not self._session_db:
             return
-        source = self.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli")
+        source = os.environ.get("HERMES_SESSION_SOURCE") or self.platform or "cli"
         try:
             self._session_db.create_session(
                 session_id=self.session_id,

--- a/tests/test_relaunch_source_inheritance.py
+++ b/tests/test_relaunch_source_inheritance.py
@@ -1,0 +1,36 @@
+"""Regression test for #45107.
+
+`hermes chat --source <name>` was recorded as source='cli' because the CLI
+drops --source when it self-relaunches: the flag was registered with plain
+add_argument() instead of _inherited_flag(), so it never entered the relaunch
+inheritance table. These tests pin the flag into that table.
+"""
+from hermes_cli.relaunch import (
+    _build_inherited_flag_table,
+    _extract_inherited_flags,
+)
+
+
+def test_source_flag_is_in_relaunch_inheritance_table():
+    table = _build_inherited_flag_table()
+    assert ("--source", True) in table, (
+        "--source must be tagged inherit_on_relaunch so it survives a "
+        "self-relaunch (regression #45107)"
+    )
+
+
+def test_source_value_survives_relaunch_extraction():
+    argv = ["chat", "--source", "distiller", "-q", "hello"]
+
+    preserved = _extract_inherited_flags(argv)
+
+    assert "--source" in preserved
+    assert preserved[preserved.index("--source") + 1] == "distiller"
+
+
+def test_source_equals_form_survives_relaunch_extraction():
+    argv = ["chat", "--source=distiller", "-q", "hello"]
+
+    preserved = _extract_inherited_flags(argv)
+
+    assert "--source=distiller" in preserved

--- a/tests/test_session_source_precedence.py
+++ b/tests/test_session_source_precedence.py
@@ -1,0 +1,36 @@
+"""Regression tests for explicit CLI session source precedence (#45107)."""
+
+from unittest import mock
+
+from run_agent import AIAgent
+
+
+def _agent_with_session_db(*, platform):
+    agent = AIAgent.__new__(AIAgent)
+    agent._session_db_created = False
+    agent._session_db = mock.Mock()
+    agent.session_id = "test-session"
+    agent.platform = platform
+    agent.model = "test-model"
+    agent._session_init_model_config = {"model": "test-model"}
+    agent._cached_system_prompt = "system"
+    agent._parent_session_id = None
+    return agent
+
+
+def test_explicit_source_overrides_cli_platform(monkeypatch):
+    monkeypatch.setenv("HERMES_SESSION_SOURCE", "distiller")
+    agent = _agent_with_session_db(platform="cli")
+
+    agent._ensure_db_session()
+
+    assert agent._session_db.create_session.call_args.kwargs["source"] == "distiller"
+
+
+def test_gateway_platform_used_when_no_explicit_source(monkeypatch):
+    monkeypatch.delenv("HERMES_SESSION_SOURCE", raising=False)
+    agent = _agent_with_session_db(platform="telegram")
+
+    agent._ensure_db_session()
+
+    assert agent._session_db.create_session.call_args.kwargs["source"] == "telegram"


### PR DESCRIPTION
## What & Why
Fixes #45107. `hermes chat --source <name>` was recorded as
`source='cli'` in `state.db`.

## Root cause
There were two related paths:

1. `--source` was registered on the `chat` subparser with a plain
   `add_argument()`, while every other session-affecting flag uses
   `_inherited_flag()`. `relaunch._build_inherited_flag_table()` only carries
   flags tagged `inherit_on_relaunch=True` across a self-relaunch (default
   startup, `sessions browse`, post-setup relaunch). Because `--source` lacked
   that tag, it was stripped on relaunch; the relaunched process never set
   `HERMES_SESSION_SOURCE`, so the session row defaulted to `cli`.
2. On the direct `hermes chat -q --source <name>` path, the CLI constructs the
   agent with `platform="cli"`. `run_agent.py` resolved the persisted session
   source as `self.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli")`,
   so the default CLI platform short-circuited the explicit source env var.

## Fix
- Register `--source` via `_inherited_flag()` so it survives self-relaunch,
  matching `--model`, `--yolo`, `--ignore-rules`, etc.
- Resolve the persisted session source as
  `os.environ.get("HERMES_SESSION_SOURCE") or self.platform or "cli"`, so an
  explicit CLI `--source` wins over the default `cli` platform while gateway
  platforms (telegram/discord/etc.) still record their real platform when the
  env var is unset.

## Tests
Adds:

- `tests/test_relaunch_source_inheritance.py`: asserts `--source` is in the
  relaunch inheritance table and that its value is preserved in both
  `--source X` and `--source=X` forms.
- `tests/test_session_source_precedence.py`: asserts explicit
  `HERMES_SESSION_SOURCE` overrides `platform="cli"`, and gateway platform
  tagging still works when no explicit source is set.

## How to test
```bash
scripts/run_tests.sh tests/test_relaunch_source_inheritance.py tests/test_session_source_precedence.py -q
hermes chat --source distiller -q "ok"
sqlite3 ~/.hermes/state.db "SELECT source FROM sessions ORDER BY started_at DESC LIMIT 1;"  # -> distiller
```

## Update
The PR now covers both cases: the self-relaunch path and the direct `-q` path.
Local verification on Windows/Git Bash:

```text
pytest tests/test_relaunch_source_inheritance.py tests/test_session_source_precedence.py -q
# 5 passed

hermes chat --source distiller -q "Say OK and nothing else."
# OK
# latest session source: distiller
```

## Platforms tested
Windows/Git Bash. Change is platform-agnostic (argparse registration + session
source precedence only).
