### PR TITLE
feat: add Clawley cockpit and operator utilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,6 +286,24 @@ Applies to TypeScript across Hermes: desktop, TUI, website, and future TS packag
 - `src/store` owns shared atoms.
 - `src/lib` owns shared pure helpers.
 
+## Maintainer Sweep Safety Pattern
+
+When doing GitHub maintenance, backlog cleanup, PR sweeps, guarded merge trains,
+or other agentic development operations in this repo, use the bundled
+`maintainer-sweep` skill and the ClawSweeper/Clownfish-style boundary:
+
+- LLM/Hermes/Codex workers produce proposals, reports, plans, and patches; they
+  do not directly comment, close, push, or merge from model judgment.
+- Start with a read-only durable sweep when operating on a backlog:
+  `python scripts/maintainer_sweep.py --repo OWNER/REPO --state-dir .hermes/maintainer --limit 50`.
+- Treat `.hermes/maintainer/repos/<repo>/items/*.md`, `dashboard.md`, and
+  `ledger.jsonl` as audit evidence, not permission to mutate GitHub.
+- A deterministic applicator or human must re-fetch live GitHub state and verify
+  authorization, branch/head/base, CI, mergeability, labels, and explicit allow
+  gates immediately before every public write.
+- Keep security, secrets, privacy, destructive infrastructure, and financial or
+  broker/live-execution changes human-gated.
+
 ## File Dependency Chain
 
 ```

--- a/docs/plans/clawley-operator-extensions.md
+++ b/docs/plans/clawley-operator-extensions.md
@@ -1,0 +1,70 @@
+# Clawley Operator Extensions Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Give Clawley/Hermes read-only operator primitives for daily briefs, maintainer-sweep-to-kanban proposals, and a later dashboard command center.
+
+**Architecture:** Scripts accept already-redacted local JSON snapshots and produce proposal/brief artifacts. They do not mutate GitHub, Kanban, Home Assistant, broker accounts, or QuantOS state. Later dashboard/cron wiring can consume these artifacts behind explicit gates.
+
+**Tech Stack:** Python scripts, pytest, Hermes cron, dashboard plugin system, maintainer-sweep output, Kanban proposal import.
+
+---
+
+## Task 1: Daily brief payload builder
+
+**Objective:** Build a read-only JSON/Markdown daily brief from redacted status sections.
+
+**Files:**
+- Create: `scripts/clawley_daily_brief.py`
+- Test: `tests/test_clawley_operator_extensions.py`
+
+**Acceptance:**
+- Emits `schema=clawley_daily_brief.v1`.
+- Emits `write_performed=false` and `read_only=true`.
+- Recommends only terminal next actions like reviewing blockers or failed cron jobs.
+- Does not call messaging APIs itself.
+
+## Task 2: Maintainer sweep → Kanban proposals
+
+**Objective:** Convert read-only maintainer-sweep `summary.json` payloads into Kanban proposal rows.
+
+**Files:**
+- Create: `scripts/maintainer_sweep_to_kanban_proposals.py`
+- Test: `tests/test_clawley_operator_extensions.py`
+
+**Acceptance:**
+- Emits `mutation_allowed=false` and `write_performed=false`.
+- Human-gates security/privacy/auth/infra/broker/live/trading labels.
+- Does not call Kanban or GitHub APIs.
+
+## Task 3: Clawley Command Center dashboard plugin
+
+**Objective:** Add a read-only dashboard tab for gateway, cron, kanban, maintainer-sweep, QuantOS and Home Assistant health.
+
+**Files:**
+- Future create: `plugins/clawley-cockpit/dashboard/manifest.json`
+- Future create: `plugins/clawley-cockpit/dashboard/plugin_api.py`
+- Future tests: dashboard/plugin API tests
+
+**Acceptance:**
+- Read-only endpoints only.
+- No raw secrets/prompts/private Telegram text.
+- Works on Tailscale-only dashboard deployment.
+
+## Task 4: Redacted observability event model
+
+**Objective:** Define local event records suitable for later OpenTelemetry/Langfuse/Phoenix export.
+
+**Files:**
+- Future create: `scripts/clawley_observability_event.py`
+- Future tests: redaction and schema tests
+
+**Acceptance:**
+- No prompt bodies, API keys, raw private IDs, or raw Telegram content.
+- Records run ID, tool name, duration/status, artifact refs, and safety flags.
+
+## Global gates
+
+- LLM output is proposal-only.
+- GitHub/Kanban/Home Assistant writes need separate deterministic applicators or explicit operator commands.
+- Cron jobs should deliver concise terminal-state briefs, not noisy continuous chatter.

--- a/plugins/clawley-cockpit/dashboard/dist/index.js
+++ b/plugins/clawley-cockpit/dashboard/dist/index.js
@@ -1,0 +1,35 @@
+// Clawley Cockpit dashboard plugin entry.
+// Kept deliberately dependency-light: the host dashboard loads this bundle and
+// can call window.ClawleyCockpit.mount(root, { apiBase }) when rendering the tab.
+(function () {
+  async function fetchStatus(apiBase) {
+    const response = await fetch(`${apiBase || '/api/plugins/clawley-cockpit'}/status`, { credentials: 'include' });
+    if (!response.ok) throw new Error(`status ${response.status}`);
+    return response.json();
+  }
+
+  function render(root, payload) {
+    const sections = payload.sections || {};
+    root.innerHTML = `
+      <section style="padding:16px;font-family:system-ui,sans-serif">
+        <h1>Clawley Cockpit</h1>
+        <p><strong>Read-only:</strong> ${payload.safety_flags && payload.safety_flags.read_only ? 'yes' : 'unknown'}</p>
+        <pre style="white-space:pre-wrap;background:#111;color:#eee;padding:12px;border-radius:8px">${escapeHtml(JSON.stringify(sections, null, 2))}</pre>
+      </section>`;
+  }
+
+  function escapeHtml(text) {
+    return String(text).replace(/[&<>"']/g, (ch) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[ch]));
+  }
+
+  window.ClawleyCockpit = {
+    async mount(root, options) {
+      root.textContent = 'Loading Clawley cockpit…';
+      try {
+        render(root, await fetchStatus(options && options.apiBase));
+      } catch (error) {
+        root.textContent = `Clawley cockpit unavailable: ${error.message}`;
+      }
+    },
+  };
+})();

--- a/plugins/clawley-cockpit/dashboard/manifest.json
+++ b/plugins/clawley-cockpit/dashboard/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "clawley-cockpit",
+  "label": "Clawley Cockpit",
+  "description": "Read-only operator overview for QuantOS, gateway, cron, kanban, and maintainer signals.",
+  "icon": "Gauge",
+  "version": "0.1.0",
+  "tab": {
+    "path": "/clawley",
+    "position": "after:kanban"
+  },
+  "slots": [],
+  "entry": "dist/index.js",
+  "api": "plugin_api.py"
+}

--- a/plugins/clawley-cockpit/dashboard/plugin_api.py
+++ b/plugins/clawley-cockpit/dashboard/plugin_api.py
@@ -1,0 +1,67 @@
+"""Clawley cockpit dashboard plugin — read-only backend API routes."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+def build_status_snapshot() -> dict[str, Any]:
+    """Build a side-effect-free local status snapshot for the dashboard tab."""
+
+    quantos_perf = _load_optional_json(os.environ.get("CLAWLEY_QUANTOS_CHANNEL_PERFORMANCE"))
+    return {
+        "schema": "clawley_cockpit_status.v1",
+        "write_performed": False,
+        "sections": {
+            "quantos": _quantos_section(quantos_perf),
+            "gateway": {"status": "available", "source": "dashboard_plugin_runtime"},
+            "cron": {"status": "not_mutated", "next_action": "wire_daily_brief_collector_when_ready"},
+            "kanban": {"status": "proposal_only", "github_mutation_allowed": False},
+            "maintainer_sweep": {"status": "proposal_only", "deterministic_apply_required": True},
+        },
+        "safety_flags": {
+            "read_only": True,
+            "write_performed": False,
+            "github_mutation_allowed": False,
+            "broker_order_submitted": False,
+            "live_trading": False,
+            "secrets_redacted": True,
+        },
+    }
+
+
+def _quantos_section(perf: dict[str, Any] | None) -> dict[str, Any]:
+    if perf is None:
+        return {"status": "not_configured", "next_action": "set_CLAWLEY_QUANTOS_CHANNEL_PERFORMANCE"}
+    raw_totals = perf.get("totals")
+    totals: dict[str, Any] = raw_totals if isinstance(raw_totals, dict) else {}
+    return {
+        "status": "available",
+        "source": perf.get("source", "unknown"),
+        "setups_total": totals.get("setups_total", 0),
+        "resolved_winrate": totals.get("resolved_winrate"),
+        "resolved_expectancy_r": totals.get("resolved_expectancy_r"),
+        "next_safe_action": perf.get("next_safe_action", "review_channel_performance_before_any_paper_bridge"),
+    }
+
+
+def _load_optional_json(path_value: str | None) -> dict[str, Any] | None:
+    if not path_value:
+        return None
+    try:
+        payload = json.loads(Path(path_value).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+@router.get("/status")
+async def status() -> dict[str, Any]:
+    return build_status_snapshot()

--- a/scripts/clawley_daily_brief.py
+++ b/scripts/clawley_daily_brief.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Build a read-only Clawley daily brief payload.
+
+This module is intentionally side-effect free: callers feed it already-redacted
+status snapshots from QuantOS, kanban, cron, gateway, or smart-home probes. It
+returns a compact JSON/Markdown brief suitable for a Telegram cron delivery.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def build_daily_brief(sections: dict[str, Any]) -> dict[str, Any]:
+    recommendations = _recommendations(sections)
+    payload = {
+        "schema": "clawley_daily_brief.v1",
+        "write_performed": False,
+        "safety_flags": {
+            "read_only": True,
+            "github_mutation_allowed": False,
+            "broker_order_submitted": False,
+            "live_trading": False,
+            "secrets_redacted": True,
+        },
+        "sections": sections,
+        "recommendations": recommendations,
+    }
+    payload["markdown"] = render_markdown(payload)
+    return payload
+
+
+def _recommendations(sections: dict[str, Any]) -> list[str]:
+    recs: list[str] = []
+    kanban_raw = sections.get("kanban")
+    cron_raw = sections.get("cron")
+    gateway_raw = sections.get("gateway")
+    kanban: dict[str, Any] = kanban_raw if isinstance(kanban_raw, dict) else {}
+    cron: dict[str, Any] = cron_raw if isinstance(cron_raw, dict) else {}
+    gateway: dict[str, Any] = gateway_raw if isinstance(gateway_raw, dict) else {}
+    if int(kanban.get("blocked", 0) or 0) > 0:
+        recs.append("review_blocked_kanban_items")
+    if int(cron.get("failed_last_24h", 0) or 0) > 0:
+        recs.append("inspect_failed_cron_jobs")
+    if int(gateway.get("errors_last_24h", 0) or 0) > 0:
+        recs.append("inspect_gateway_errors")
+    if not recs:
+        recs.append("no_operator_action_required")
+    return recs
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    lines = ["# Clawley daily brief", "", "Geen automatische acties uitgevoerd.", ""]
+    for key, value in payload["sections"].items():
+        lines.append(f"## {key}")
+        lines.append(json.dumps(value, sort_keys=True, ensure_ascii=False))
+        lines.append("")
+    lines.append("## Aanbevolen volgende stap")
+    for rec in payload["recommendations"]:
+        lines.append(f"- {rec}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, required=True, help="Redacted JSON status snapshot")
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args(argv)
+    payload = build_daily_brief(json.loads(args.input.read_text(encoding="utf-8")))
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"output": str(args.output), "write_performed": False, "read_only": True}, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/clawley_daily_brief_collector.py
+++ b/scripts/clawley_daily_brief_collector.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Collect redacted local status for the Clawley daily brief."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+
+def build_daily_brief_snapshot(
+    *,
+    quantos_channel_performance: str | Path | None = None,
+    gateway_log_lines: Iterable[str] = (),
+    kanban: dict[str, Any] | None = None,
+    cron: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    quantos: dict[str, Any] = {"telegram_channel_performance": _load_json_object(quantos_channel_performance)}
+    gateway_errors = sum(1 for line in gateway_log_lines if "error" in line.lower() or "exception" in line.lower())
+    return {
+        "schema": "clawley_daily_brief_snapshot.v1",
+        "quantos": quantos,
+        "kanban": kanban or {"blocked": 0, "ready": 0},
+        "cron": cron or {"failed_last_24h": 0},
+        "gateway": {"errors_last_24h": gateway_errors},
+        "safety_flags": {
+            "read_only": True,
+            "paths_redacted": True,
+            "secrets_redacted": True,
+            "write_performed": False,
+        },
+    }
+
+
+def _load_json_object(path: str | Path | None) -> dict[str, Any]:
+    if path is None:
+        return {"status": "not_supplied"}
+    try:
+        payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {"status": "missing"}
+    if not isinstance(payload, dict):
+        return {"status": "invalid_non_object"}
+    payload = dict(payload)
+    payload.pop("artifact_path", None)
+    payload.pop("path", None)
+    return payload
+
+
+def _tail_lines(path: Path, limit: int = 500) -> list[str]:
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except FileNotFoundError:
+        return []
+    return lines[-limit:]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--quantos-channel-performance", type=Path)
+    parser.add_argument("--gateway-log", type=Path)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args(argv)
+    snapshot = build_daily_brief_snapshot(
+        quantos_channel_performance=args.quantos_channel_performance,
+        gateway_log_lines=_tail_lines(args.gateway_log) if args.gateway_log else (),
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(snapshot, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"output": str(args.output), "read_only": True, "write_performed": False}, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/clawley_observability_event.py
+++ b/scripts/clawley_observability_event.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Redacted local observability event records for Clawley/Hermes runs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SENSITIVE_KEYS = {"prompt", "messages", "api_key", "apikey", "token", "authorization", "password", "secret"}
+
+
+def build_observability_event(
+    *,
+    run_id: str,
+    tool_name: str,
+    status: str,
+    duration_ms: float,
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "schema": "clawley_observability_event.v1",
+        "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "run_id": str(run_id),
+        "tool_name": str(tool_name),
+        "status": str(status),
+        "duration_ms": float(duration_ms),
+        "payload_redacted": _redact(payload or {}),
+        "safety_flags": {
+            "raw_prompt_logged": False,
+            "secrets_logged": False,
+            "raw_telegram_text_logged": False,
+            "pii_logged": False,
+            "local_event_only": True,
+        },
+    }
+
+
+def _redact(value: Any) -> Any:
+    if isinstance(value, dict):
+        result = {}
+        for key, item in value.items():
+            key_text = str(key)
+            if _is_sensitive_key(key_text):
+                result[key_text] = "[redacted]"
+            else:
+                result[key_text] = _redact(item)
+        return result
+    if isinstance(value, list):
+        return [_redact(item) for item in value]
+    return value
+
+
+def _is_sensitive_key(key: str) -> bool:
+    lowered = key.lower()
+    return lowered in SENSITIVE_KEYS or any(part in lowered for part in ("secret", "token", "password", "api_key"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--tool-name", required=True)
+    parser.add_argument("--status", required=True)
+    parser.add_argument("--duration-ms", type=float, required=True)
+    parser.add_argument("--payload-json", type=Path)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args(argv)
+    payload = json.loads(args.payload_json.read_text(encoding="utf-8")) if args.payload_json else {}
+    event = build_observability_event(run_id=args.run_id, tool_name=args.tool_name, status=args.status, duration_ms=args.duration_ms, payload=payload)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(event, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"output": str(args.output), "local_event_only": True}, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/maintainer_sweep.py
+++ b/scripts/maintainer_sweep.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Hermes maintainer sweep: durable, proposal-first GitHub backlog reports.
+
+This script intentionally performs no GitHub mutations. It borrows the useful
+ClawSweeper/Clownfish pattern for Hermes development work: hydrate live or
+fixture-backed issue/PR state, write one durable report per item, append an
+audit ledger event, and produce a compact dashboard that a human or a separate
+applicator can promote later.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+from typing import Any
+
+ACTION_STATE = "proposal"
+RECOMMENDATION = "needs_human"
+SCHEMA_VERSION = 1
+
+
+def _utc_now() -> str:
+    return dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _slug_repo(repo: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]+", "__", repo.strip()).strip("_") or "unknown_repo"
+
+
+def _stable_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def snapshot_hash(item: dict[str, Any]) -> str:
+    """Hash the hydrated item snapshot, excluding volatile local run metadata."""
+    return hashlib.sha256(_stable_json(item).encode("utf-8")).hexdigest()[:16]
+
+
+def _frontmatter(data: dict[str, Any]) -> str:
+    lines = ["---"]
+    for key, value in data.items():
+        if isinstance(value, bool):
+            rendered = "true" if value else "false"
+        elif value is None:
+            rendered = "null"
+        else:
+            rendered = json.dumps(value, ensure_ascii=False)
+        lines.append(f"{key}: {rendered}")
+    lines.append("---")
+    return "\n".join(lines)
+
+
+def _labels(item: dict[str, Any]) -> list[str]:
+    labels = item.get("labels") or []
+    out: list[str] = []
+    for label in labels:
+        if isinstance(label, str):
+            out.append(label)
+        elif isinstance(label, dict):
+            name = label.get("name")
+            if name:
+                out.append(str(name))
+    return out
+
+
+def _author_login(item: dict[str, Any]) -> str:
+    author = item.get("author") or {}
+    if isinstance(author, dict):
+        return str(author.get("login") or "")
+    return str(author or "")
+
+
+def item_kind(item: dict[str, Any]) -> str:
+    explicit = item.get("kind") or item.get("type")
+    if explicit:
+        return str(explicit).lower()
+    if "isDraft" in item or "headRefName" in item or "mergeable" in item:
+        return "pr"
+    return "issue"
+
+
+def normalize_item(raw: dict[str, Any], default_kind: str | None = None) -> dict[str, Any]:
+    item = dict(raw)
+    item["kind"] = default_kind or item_kind(item)
+    item["number"] = int(item.get("number") or 0)
+    item["title"] = str(item.get("title") or "")
+    item["url"] = str(item.get("url") or "")
+    item["state"] = str(item.get("state") or "unknown").lower()
+    item["labels"] = _labels(item)
+    item["author_login"] = _author_login(item)
+    return item
+
+
+def load_items_from_file(path: pathlib.Path) -> list[dict[str, Any]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(payload, list):
+        return [normalize_item(item) for item in payload]
+    if not isinstance(payload, dict):
+        raise ValueError("source JSON must be a list or object with issues/prs/items")
+    items: list[dict[str, Any]] = []
+    for key, kind in (("issues", "issue"), ("prs", "pr"), ("pull_requests", "pr"), ("items", None)):
+        values = payload.get(key) or []
+        if not isinstance(values, list):
+            raise ValueError(f"{key} must be a list")
+        items.extend(normalize_item(item, kind) for item in values)
+    return items
+
+
+def _run_gh_json(args: list[str]) -> list[dict[str, Any]]:
+    proc = subprocess.run(args, text=True, capture_output=True, check=False)
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip() or proc.stdout.strip() or f"command failed: {' '.join(args)}")
+    data = json.loads(proc.stdout or "[]")
+    if not isinstance(data, list):
+        raise ValueError(f"gh command returned non-list JSON: {' '.join(args)}")
+    return data
+
+
+def load_items_from_gh(repo: str, limit: int) -> list[dict[str, Any]]:
+    common_issue_fields = "number,title,state,updatedAt,labels,author,url,body"
+    common_pr_fields = (
+        "number,title,state,updatedAt,labels,author,url,body,isDraft,headRefName,"
+        "baseRefName,mergeable,reviewDecision,statusCheckRollup"
+    )
+    issues = _run_gh_json([
+        "gh", "issue", "list", "--repo", repo, "--state", "open", "--limit", str(limit), "--json", common_issue_fields
+    ])
+    prs = _run_gh_json([
+        "gh", "pr", "list", "--repo", repo, "--state", "open", "--limit", str(limit), "--json", common_pr_fields
+    ])
+    return [normalize_item(item, "issue") for item in issues] + [normalize_item(item, "pr") for item in prs]
+
+
+def build_report(repo: str, item: dict[str, Any], run_id: str) -> tuple[str, dict[str, Any]]:
+    h = snapshot_hash(item)
+    labels = item.get("labels") or []
+    gate = {
+        "schema_version": SCHEMA_VERSION,
+        "repo": repo,
+        "kind": item["kind"],
+        "number": item["number"],
+        "url": item.get("url", ""),
+        "snapshot_hash": h,
+        "run_id": run_id,
+        "action_state": ACTION_STATE,
+        "recommendation": RECOMMENDATION,
+        "mutation_allowed": False,
+    }
+    title = item.get("title") or f"{item['kind']} #{item['number']}"
+    body = [
+        _frontmatter(gate),
+        "",
+        f"# {item['kind'].upper()} #{item['number']}: {title}",
+        "",
+        "## Verdict",
+        "",
+        "- Recommendation: `needs_human`",
+        "- Action state: `proposal`",
+        "- Mutation allowed: `false`",
+        "",
+        "This report is read-only by construction. It is evidence for a future maintainer/applicator step, not permission to comment, close, push, or merge.",
+        "",
+        "## Snapshot",
+        "",
+        f"- URL: {item.get('url') or '(missing)'}",
+        f"- State: `{item.get('state')}`",
+        f"- Author: `{item.get('author_login') or '(unknown)'}`",
+        f"- Labels: {', '.join(f'`{label}`' for label in labels) if labels else '(none)'}",
+    ]
+    if item.get("kind") == "pr":
+        body.extend([
+            f"- Base: `{item.get('baseRefName') or ''}`",
+            f"- Head: `{item.get('headRefName') or ''}`",
+            f"- Draft: `{item.get('isDraft')}`",
+            f"- Mergeable: `{item.get('mergeable') or ''}`",
+            f"- Review decision: `{item.get('reviewDecision') or ''}`",
+        ])
+    body.extend([
+        f"- Snapshot hash: `{h}`",
+        "",
+        "## Required before apply",
+        "",
+        "1. Re-fetch live GitHub state immediately before any mutation.",
+        "2. Verify this snapshot hash or explicitly record why re-review supersedes it.",
+        "3. Keep LLM/worker output proposal-only; deterministic applicator owns writes.",
+        "4. Require explicit allow-gates for comments, closing, branch pushes, or merges.",
+        "",
+        "## Raw snapshot",
+        "",
+        "```json",
+        json.dumps(item, indent=2, sort_keys=True, ensure_ascii=False),
+        "```",
+        "",
+    ])
+    return "\n".join(body), gate
+
+
+def write_outputs(repo: str, items: list[dict[str, Any]], state_dir: pathlib.Path) -> dict[str, Any]:
+    run_id = _utc_now().replace(":", "").replace("-", "")
+    repo_slug = _slug_repo(repo)
+    base = state_dir / "repos" / repo_slug
+    records = base / "items"
+    records.mkdir(parents=True, exist_ok=True)
+    ledger = base / "ledger.jsonl"
+    gates: list[dict[str, Any]] = []
+    for item in sorted(items, key=lambda x: (x.get("kind", ""), int(x.get("number") or 0))):
+        report, gate = build_report(repo, item, run_id)
+        gates.append(gate)
+        report_path = records / f"{item['kind']}-{item['number']}.md"
+        report_path.write_text(report, encoding="utf-8")
+        with ledger.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps({"event": "report_written", "at": _utc_now(), "path": str(report_path), **gate}, sort_keys=True) + "\n")
+    dashboard = render_dashboard(repo, gates, run_id)
+    dashboard_path = base / "dashboard.md"
+    dashboard_path.write_text(dashboard, encoding="utf-8")
+    summary = {
+        "schema_version": SCHEMA_VERSION,
+        "repo": repo,
+        "run_id": run_id,
+        "state_dir": str(base),
+        "dashboard": str(dashboard_path),
+        "records": len(gates),
+        "mutation_allowed": False,
+        "action_state": ACTION_STATE,
+    }
+    (base / "summary.json").write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return summary
+
+
+def render_dashboard(repo: str, gates: list[dict[str, Any]], run_id: str) -> str:
+    issue_count = sum(1 for gate in gates if gate["kind"] == "issue")
+    pr_count = sum(1 for gate in gates if gate["kind"] == "pr")
+    lines = [
+        f"# Hermes Maintainer Sweep — {repo}",
+        "",
+        f"Run: `{run_id}`",
+        "",
+        "## Summary",
+        "",
+        f"- Records: {len(gates)}",
+        f"- Issues: {issue_count}",
+        f"- PRs: {pr_count}",
+        "- Mutation allowed: `false`",
+        "- Default recommendation: `needs_human`",
+        "",
+        "## Reports",
+        "",
+    ]
+    for gate in gates:
+        lines.append(
+            f"- `{gate['kind']}-{gate['number']}` — `{gate['recommendation']}` — "
+            f"snapshot `{gate['snapshot_hash']}` — [source]({gate['url']})"
+        )
+    lines.extend([
+        "",
+        "## Applicator contract",
+        "",
+        "Do not mutate GitHub from this dashboard. A separate deterministic applicator must re-fetch live state, verify maintainer authorization, branch/head/base/CI gates, and explicit allow flags before every write.",
+        "",
+    ])
+    return "\n".join(lines)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="GitHub repo in owner/name form")
+    parser.add_argument("--state-dir", default=".hermes/maintainer", help="durable state output directory")
+    parser.add_argument("--limit", type=int, default=50, help="max issues and max PRs to fetch with gh")
+    parser.add_argument("--source-file", type=pathlib.Path, help="fixture JSON with issues/prs/items; skips gh")
+    parser.add_argument("--json", action="store_true", help="print machine-readable summary")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    if args.limit < 1:
+        raise SystemExit("--limit must be >= 1")
+    if args.source_file:
+        items = load_items_from_file(args.source_file)
+    else:
+        items = load_items_from_gh(args.repo, args.limit)
+    summary = write_outputs(args.repo, items, pathlib.Path(args.state_dir))
+    if args.json:
+        print(json.dumps(summary, sort_keys=True))
+    else:
+        print(f"Wrote {summary['records']} read-only reports to {summary['state_dir']}")
+        print(f"Dashboard: {summary['dashboard']}")
+        print("Mutation allowed: false")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/maintainer_sweep_to_kanban_proposals.py
+++ b/scripts/maintainer_sweep_to_kanban_proposals.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Convert read-only maintainer-sweep summaries to Kanban proposals.
+
+No board writes happen here. This is the deterministic bridge from durable
+ClawSweeper/Clownfish-style reports to proposed work items a human/operator can
+review before importing into Hermes Kanban.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+HUMAN_GATE_LABELS = {"security", "privacy", "secrets", "auth", "infra", "broker", "trading", "live"}
+
+
+def build_kanban_proposals(summary: dict[str, Any]) -> dict[str, Any]:
+    repo = str(summary.get("repo") or "unknown/repo")
+    raw_items = summary.get("items")
+    items: list[Any] = raw_items if isinstance(raw_items, list) else []
+    proposals = [_proposal(repo, item) for item in items if isinstance(item, dict)]
+    return {
+        "schema": "maintainer_sweep_kanban_proposals.v1",
+        "repo": repo,
+        "source_action_state": summary.get("action_state", "proposal"),
+        "mutation_allowed": False,
+        "write_performed": False,
+        "proposals": proposals,
+        "totals": {
+            "source_records": int(summary.get("records", len(items)) or 0),
+            "proposal_count": len(proposals),
+            "human_gated": sum(1 for item in proposals if item["requires_human_gate"]),
+        },
+        "next_safe_action": "review_proposals_before_kanban_import",
+    }
+
+
+def _proposal(repo: str, item: dict[str, Any]) -> dict[str, Any]:
+    labels = _labels(item.get("labels"))
+    requires_human = bool(HUMAN_GATE_LABELS.intersection(labels)) or str(item.get("recommendation")) == "needs_human"
+    kind = str(item.get("kind") or item.get("type") or "item")
+    number = item.get("number", "unknown")
+    title = str(item.get("title") or "Untitled")
+    return {
+        "idempotency_key": f"maintainer-sweep:{repo}:{kind}:{number}",
+        "title": f"{repo} {kind} #{number}: {title}",
+        "status": "proposal",
+        "suggested_priority": "human_gate" if requires_human else "normal",
+        "requires_human_gate": requires_human,
+        "source": {"repo": repo, "kind": kind, "number": number, "labels": sorted(labels)},
+        "mutation_allowed": False,
+        "github_write_allowed": False,
+    }
+
+
+def _labels(value: Any) -> set[str]:
+    result: set[str] = set()
+    for label in value or []:
+        if isinstance(label, dict):
+            result.add(str(label.get("name") or "").lower())
+        else:
+            result.add(str(label).lower())
+    return {label for label in result if label}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, required=True, help="maintainer_sweep summary.json")
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args(argv)
+    proposals = build_kanban_proposals(json.loads(args.input.read_text(encoding="utf-8")))
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(proposals, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"output": str(args.output), "proposal_count": proposals["totals"]["proposal_count"], "write_performed": False}, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "jerryvdv@Claw.tail26a931.ts.net": "JerryVdV",
     "peterhao@Peters-MacBook-Air.local": "pinguarmy",
     "adalsteinnhelgason@Aalsteinns-MacBook-Pro-3.local": "AIalliAI",
     "barronlroth@gmail.com": "barronlroth",

--- a/skills/github/maintainer-sweep/SKILL.md
+++ b/skills/github/maintainer-sweep/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: maintainer-sweep
+description: "ClawSweeper/Clownfish-style GitHub maintenance for Hermes: read-only sweeps, durable reports, proposal-first workers, and deterministic apply gates."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [github, maintenance, agents, safety, ci, pr-review]
+    related_skills: [github-pr-workflow, github-code-review, github-issues, codex, hermes-agent]
+---
+
+# Maintainer Sweep
+
+Use this when the user asks Hermes to maintain a GitHub repo, clean up a backlog, review PRs/issues in bulk, run a guarded merge train, or make ClawSweeper/Clownfish-style agentic development safer.
+
+The pattern is: **LLMs propose; deterministic code applies.** Do not let a model comment, close, push, or merge directly from its own judgment.
+
+## Core invariants
+
+1. **Proposal first** — every issue/PR gets a durable report before any public comment or mutation.
+2. **One durable record per item** — include source URL, snapshot hash, evidence, recommendation, proposed comment/action, and gate status.
+3. **Worker without write credentials** — Codex/Hermes/Claude workers may inspect, classify, and produce artifacts, but must not hold GitHub write tokens.
+4. **Deterministic applicator** — a separate script/tool re-fetches live GitHub state and owns comments, labels, closes, branch pushes, and merges.
+5. **Live-state recheck** — immediately before every mutation, verify target repo, item number, current head SHA/branch/base, labels, author/permission, CI, mergeability, and snapshot freshness.
+6. **Explicit allow gates** — no mutation unless the specific capability is opened (`ALLOW_COMMENT`, `ALLOW_CLOSE`, `ALLOW_FIX_PR`, `ALLOW_MERGE`, etc.). Keep gates closed by default and reset them after the execution window.
+7. **Security out of scope** — secrets, auth bypasses, vulnerability reports, supply-chain issues, exploitability, privacy leaks, and broker/live-trading changes go to human/security review.
+8. **Audit ledger** — append every report, promotion, block, and mutation decision to a machine-readable ledger.
+
+## Hermes-native first pass
+
+From a repo checkout, run a read-only sweep:
+
+```bash
+python scripts/maintainer_sweep.py --repo OWNER/REPO --state-dir .hermes/maintainer --limit 50
+```
+
+For tests or offline runs, use a fixture:
+
+```bash
+python scripts/maintainer_sweep.py --repo OWNER/REPO --source-file /tmp/items.json --state-dir .hermes/maintainer --json
+```
+
+Outputs:
+
+```text
+.hermes/maintainer/repos/OWNER__REPO/
+  items/issue-123.md
+  items/pr-456.md
+  ledger.jsonl
+  dashboard.md
+  summary.json
+```
+
+The shipped `scripts/maintainer_sweep.py` is deliberately read-only. It writes `mutation_allowed: false` and `action_state: proposal` so later lanes cannot accidentally treat a report as permission to act.
+
+## Recommended development loop
+
+1. **Sweep**: generate read-only reports and dashboard.
+2. **Cluster**: group reports by implementation surface/risk boundary.
+3. **Plan**: create a small fix/cleanup plan from one safe cluster.
+4. **Worker**: delegate implementation to a worker without write credentials, preferably on a worktree/branch.
+5. **Verify**: run tests, inspect diff, and request review if risk is non-trivial.
+6. **Apply**: only deterministic code or the operator performs public comments/closes/merges after live-state gates pass.
+7. **Ledger**: record why each item was applied, blocked, skipped, or escalated.
+
+## Promotion rules
+
+Safe candidates for automation:
+
+- docs typo or broken link
+- deterministic test repair
+- narrow CI/config fix
+- stale generated dashboard/report update
+- duplicate/superseded close with exact canonical reference and no fresh target-side activity
+
+Always human-gated:
+
+- security/privacy/supply-chain/auth findings
+- secrets or credential handling
+- destructive data migrations
+- infrastructure permissions or deployment changes
+- financial/trading/broker/live execution changes
+- ambiguous product decisions or active maintainer disagreement
+
+## Merge gate checklist
+
+Before any automerge or guarded merge train:
+
+- base branch is expected
+- source branch prefix is allowlisted
+- PR is not draft
+- mergeable is clean/mergeable
+- required CI is green at the exact head SHA
+- no requested changes or unresolved threads
+- no unreviewed security/infra/broker side effects
+- live PR head SHA matches reviewed SHA
+- explicit merge gate is open for this run
+
+## Reporting style
+
+Keep summaries terse and evidence-centric:
+
+- what was swept
+- report/dashboard path
+- candidate clusters
+- applied actions, if any
+- blocked/skipped reasons
+- next safe action
+
+Do not say “done” for proposed reports alone. Say “read-only sweep complete” unless the applicator actually mutated and verified GitHub state.

--- a/tests/test_clawley_cockpit_plugin.py
+++ b/tests/test_clawley_cockpit_plugin.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _load_plugin_api():
+    path = ROOT / "plugins" / "clawley-cockpit" / "dashboard" / "plugin_api.py"
+    spec = importlib.util.spec_from_file_location("clawley_cockpit_plugin_api", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_clawley_cockpit_plugin_status_is_read_only() -> None:
+    module = _load_plugin_api()
+
+    status = module.build_status_snapshot()
+
+    assert status["schema"] == "clawley_cockpit_status.v1"
+    assert status["write_performed"] is False
+    assert status["safety_flags"]["read_only"] is True
+    assert status["sections"]["quantos"]["status"] in {"not_configured", "available"}

--- a/tests/test_clawley_operator_extensions.py
+++ b/tests/test_clawley_operator_extensions.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.clawley_daily_brief import build_daily_brief
+from scripts.maintainer_sweep_to_kanban_proposals import build_kanban_proposals
+
+
+def test_maintainer_sweep_to_kanban_proposals_is_read_only() -> None:
+    summary = {
+        "repo": "acme/widgets",
+        "records": 3,
+        "mutation_allowed": False,
+        "action_state": "proposal",
+        "items": [
+            {"kind": "issue", "number": 1, "title": "Fix docs typo", "recommendation": "safe_candidate", "labels": ["docs"]},
+            {"kind": "pr", "number": 2, "title": "Dangerous auth change", "recommendation": "needs_human", "labels": ["security"]},
+        ],
+    }
+
+    proposals = build_kanban_proposals(summary)
+
+    assert proposals["write_performed"] is False
+    assert proposals["mutation_allowed"] is False
+    assert proposals["repo"] == "acme/widgets"
+    assert proposals["proposals"][0]["status"] == "proposal"
+    assert proposals["proposals"][0]["suggested_priority"] == "normal"
+    assert proposals["proposals"][1]["requires_human_gate"] is True
+    assert proposals["next_safe_action"] == "review_proposals_before_kanban_import"
+
+
+def test_daily_brief_summarises_sources_without_actions() -> None:
+    payload = build_daily_brief(
+        {
+            "quantos": {"pat_fx": {"setups_total": 114, "resolved_expectancy_r": 0.117}},
+            "kanban": {"blocked": 2, "ready": 4},
+            "cron": {"failed_last_24h": 1},
+            "gateway": {"errors_last_24h": 0},
+        }
+    )
+
+    assert payload["schema"] == "clawley_daily_brief.v1"
+    assert payload["write_performed"] is False
+    assert payload["safety_flags"]["read_only"] is True
+    assert payload["sections"]["quantos"]["pat_fx"]["setups_total"] == 114
+    assert payload["recommendations"][0] == "review_blocked_kanban_items"
+    assert payload["recommendations"][1] == "inspect_failed_cron_jobs"
+    assert "Geen automatische acties uitgevoerd" in payload["markdown"]

--- a/tests/test_clawley_operator_extensions.py
+++ b/tests/test_clawley_operator_extensions.py
@@ -9,6 +9,8 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from scripts.clawley_daily_brief import build_daily_brief
+from scripts.clawley_daily_brief_collector import build_daily_brief_snapshot
+from scripts.clawley_observability_event import build_observability_event
 from scripts.maintainer_sweep_to_kanban_proposals import build_kanban_proposals
 
 
@@ -52,3 +54,33 @@ def test_daily_brief_summarises_sources_without_actions() -> None:
     assert payload["recommendations"][0] == "review_blocked_kanban_items"
     assert payload["recommendations"][1] == "inspect_failed_cron_jobs"
     assert "Geen automatische acties uitgevoerd" in payload["markdown"]
+
+
+def test_daily_brief_collector_redacts_paths_and_loads_optional_json(tmp_path: pathlib.Path) -> None:
+    quantos_summary = tmp_path / "summary.json"
+    quantos_summary.write_text(json.dumps({"source": "pat", "totals": {"setups_total": 114}}), encoding="utf-8")
+
+    snapshot = build_daily_brief_snapshot(quantos_channel_performance=quantos_summary, gateway_log_lines=["ok", "ERROR badness"])
+
+    assert snapshot["quantos"]["telegram_channel_performance"]["totals"]["setups_total"] == 114
+    assert snapshot["gateway"]["errors_last_24h"] == 1
+    assert str(tmp_path) not in json.dumps(snapshot)
+    assert snapshot["safety_flags"]["read_only"] is True
+
+
+def test_observability_event_redacts_secret_and_prompt_payloads() -> None:
+    event = build_observability_event(
+        run_id="run-1",
+        tool_name="terminal",
+        status="ok",
+        duration_ms=12.5,
+        payload={"prompt": "secret prompt", "api_key": "sk-test", "artifact": "/tmp/x.json"},
+    )
+
+    encoded = json.dumps(event, sort_keys=True)
+    assert event["schema"] == "clawley_observability_event.v1"
+    assert event["payload_redacted"]["prompt"] == "[redacted]"
+    assert event["payload_redacted"]["api_key"] == "[redacted]"
+    assert "secret prompt" not in encoded
+    assert "sk-test" not in encoded
+    assert event["safety_flags"]["raw_prompt_logged"] is False

--- a/tests/test_maintainer_sweep.py
+++ b/tests/test_maintainer_sweep.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts import maintainer_sweep
+
+
+def test_maintainer_sweep_fixture_writes_proposal_reports(tmp_path: pathlib.Path) -> None:
+    source = tmp_path / "items.json"
+    source.write_text(
+        json.dumps(
+            {
+                "issues": [
+                    {
+                        "number": 12,
+                        "title": "Bug in scheduler",
+                        "state": "OPEN",
+                        "url": "https://github.com/acme/widgets/issues/12",
+                        "labels": [{"name": "bug"}],
+                        "author": {"login": "alice"},
+                    }
+                ],
+                "prs": [
+                    {
+                        "number": 34,
+                        "title": "fix: scheduler bug",
+                        "state": "OPEN",
+                        "url": "https://github.com/acme/widgets/pull/34",
+                        "labels": ["ci"],
+                        "author": {"login": "bot"},
+                        "isDraft": False,
+                        "baseRefName": "main",
+                        "headRefName": "clawley/scheduler-bug",
+                        "mergeable": "MERGEABLE",
+                        "reviewDecision": "APPROVED",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    state_dir = tmp_path / "state"
+    rc = maintainer_sweep.main(
+        ["--repo", "acme/widgets", "--source-file", str(source), "--state-dir", str(state_dir), "--json"]
+    )
+
+    assert rc == 0
+    repo_dir = state_dir / "repos" / "acme__widgets"
+    summary = json.loads((repo_dir / "summary.json").read_text(encoding="utf-8"))
+    assert summary["records"] == 2
+    assert summary["mutation_allowed"] is False
+    assert summary["action_state"] == "proposal"
+
+    issue_report = (repo_dir / "items" / "issue-12.md").read_text(encoding="utf-8")
+    pr_report = (repo_dir / "items" / "pr-34.md").read_text(encoding="utf-8")
+    dashboard = (repo_dir / "dashboard.md").read_text(encoding="utf-8")
+    ledger_lines = (repo_dir / "ledger.jsonl").read_text(encoding="utf-8").strip().splitlines()
+
+    assert "recommendation: \"needs_human\"" in issue_report
+    assert "mutation_allowed: false" in issue_report
+    assert "Raw snapshot" in issue_report
+    assert "Base: `main`" in pr_report
+    assert "Do not mutate GitHub from this dashboard" in dashboard
+    assert len(ledger_lines) == 2
+    assert all(json.loads(line)["mutation_allowed"] is False for line in ledger_lines)
+
+
+def test_snapshot_hash_is_stable_for_same_item() -> None:
+    item = {"number": 1, "title": "x", "labels": ["a", "b"]}
+    assert maintainer_sweep.snapshot_hash(item) == maintainer_sweep.snapshot_hash(dict(reversed(item.items())))


### PR DESCRIPTION
## Summary
- Adds Clawley operator proposal utilities for maintainer-sweep to Kanban-style gated handoffs.
- Adds a redacted local observability event model for operator telemetry.
- Adds a Clawley cockpit plugin API and lightweight dashboard entry.
- Adds a read-only daily brief builder/collector for QuantOS/Hermes status.

## Safety
- Read-only status/brief/cockpit paths.
- No prompt, secret, or raw Telegram text logging.
- Proposal-only Kanban bridge; no automatic GitHub/Kanban mutation.
- No broker or live trading authority.

## Test plan
- `python -m pytest tests/test_clawley_operator_extensions.py tests/test_clawley_cockpit_plugin.py -q -o 'addopts='`
