### PR TITLE
fix(models): strip :cloud/-cloud suffix for ollama-cloud model IDs

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -456,6 +456,14 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
         # rejects "MiMo-V2.5-Pro" but accepts "mimo-v2.5-pro").
         if provider in _LOWERCASE_MODEL_PROVIDERS:
             result = result.lower()
+        # Ollama Cloud: models.dev appends :cloud/-cloud suffixes that
+        # the live API does not use.  Strip them so that config entries
+        # copied from models.dev resolve to the correct bare model ID.
+        if provider == "ollama-cloud":
+            for suffix in (":cloud", "-cloud"):
+                if result.endswith(suffix):
+                    result = result[: -len(suffix)]
+                    break
         return result
 
     # --- Authoritative native providers: preserve user-facing slugs as-is ---

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3547,6 +3547,11 @@ def validate_requested_model(
             requested,
             api_key=api_key,
         ) or requested
+    elif normalized == "ollama-cloud":
+        # models.dev may append :cloud/-cloud to Ollama Cloud IDs (e.g.
+        # ``deepseek-v4-flash:cloud``).  The live API uses bare IDs, so
+        # strip the suffix before the set-membership check below.
+        requested_for_lookup = _strip_ollama_cloud_suffix(requested)
 
     if not requested:
         return {

--- a/tests/hermes_cli/test_ollama_cloud_suffix_strip.py
+++ b/tests/hermes_cli/test_ollama_cloud_suffix_strip.py
@@ -1,0 +1,80 @@
+"""Regression tests for ollama-cloud :cloud/-cloud suffix stripping.
+
+models.dev appends ``:cloud`` / ``-cloud`` suffixes to Ollama Cloud model IDs
+(e.g. ``deepseek-v4-flash:cloud``).  Both ``normalize_model_for_provider`` and
+``validate_requested_model`` must strip these so bare IDs match the live API
+catalog.  See issue #45137.
+"""
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# normalize_model_for_provider
+# ---------------------------------------------------------------------------
+
+class TestOllamaCloudSuffixStripping:
+    """normalize_model_for_provider strips :cloud/-cloud for ollama-cloud."""
+
+    @pytest.fixture(autouse=True)
+    def _import(self):
+        from hermes_cli.model_normalize import normalize_model_for_provider
+        self.normalize = normalize_model_for_provider
+
+    def test_colon_cloud_suffix_stripped(self):
+        assert self.normalize("deepseek-v4-flash:cloud", "ollama-cloud") == "deepseek-v4-flash"
+
+    def test_hyphen_cloud_suffix_stripped(self):
+        assert self.normalize("deepseek-v4-flash-cloud", "ollama-cloud") == "deepseek-v4-flash"
+
+    def test_bare_id_unchanged(self):
+        assert self.normalize("deepseek-v4-flash", "ollama-cloud") == "deepseek-v4-flash"
+
+    def test_provider_prefix_stripped_before_suffix(self):
+        assert self.normalize("ollama-cloud/deepseek-v4-flash:cloud", "ollama-cloud") == "deepseek-v4-flash"
+
+    def test_no_double_strip(self):
+        """A bare name ending in -cloud that is NOT a suffix is preserved."""
+        # "nextcloud" is a real app name; ensure we only strip the trailing
+        # suffix, not arbitrary substrings.
+        assert self.normalize("nextcloud", "ollama-cloud") == "nextcloud"
+
+    def test_colon_cloud_suffix_model_with_hyphen_cloud_in_name(self):
+        """Model 'something-cloud' with additional ':cloud' suffix."""
+        assert self.normalize("something-cloud:cloud", "ollama-cloud") == "something-cloud"
+
+
+# ---------------------------------------------------------------------------
+# validate_requested_model
+# ---------------------------------------------------------------------------
+
+class TestOllamaCloudValidationSuffixStrip:
+    """validate_requested_model strips :cloud/-cloud for ollama-cloud lookups."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_api(self, monkeypatch):
+        """Mock fetch_api_models to return clean bare IDs."""
+        from hermes_cli import models as _m
+        self._models = _m
+
+        def _fake_fetch(api_key=None, base_url=None, **_kw):
+            return ["deepseek-v4-flash", "kimi-k2.6", "llama-4-maverick"]
+
+        monkeypatch.setattr(_m, "fetch_api_models", _fake_fetch)
+        # Also mock fetch_ollama_cloud_models to return the same list
+        monkeypatch.setattr(_m, "fetch_ollama_cloud_models", lambda **_kw: ["deepseek-v4-flash", "kimi-k2.6", "llama-4-maverick"])
+
+    def test_colon_cloud_suffix_accepted(self):
+        result = self._models.validate_requested_model("deepseek-v4-flash:cloud", "ollama-cloud")
+        assert result["accepted"] is True
+        assert result["recognized"] is True
+
+    def test_hyphen_cloud_suffix_accepted(self):
+        result = self._models.validate_requested_model("deepseek-v4-flash-cloud", "ollama-cloud")
+        assert result["accepted"] is True
+        assert result["recognized"] is True
+
+    def test_bare_id_accepted(self):
+        result = self._models.validate_requested_model("deepseek-v4-flash", "ollama-cloud")
+        assert result["accepted"] is True
+        assert result["recognized"] is True


### PR DESCRIPTION
## What does this PR do?

Strips `:cloud`/`-cloud` suffixes from model IDs for the `ollama-cloud` provider, fixing validation failures when model names include the suffix appended by models.dev.

## Related Issue

Fixes #45137

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/model_normalize.py`: Added `:cloud`/`-cloud` suffix stripping in `normalize_model_for_provider()` for the `ollama-cloud` provider, so that config entries copied from models.dev (e.g. `deepseek-v4-flash:cloud`) resolve to the bare API ID (`deepseek-v4-flash`).
- `hermes_cli/models.py`: Added ollama-cloud-specific normalization in `validate_requested_model()` using the existing `_strip_ollama_cloud_suffix()` helper, so that suffixed model names pass the live API lookup.
- `tests/hermes_cli/test_ollama_cloud_suffix_strip.py`: 9 regression tests covering `:cloud` suffix, `-cloud` suffix, bare IDs, provider prefix stripping, and validation acceptance.

## How to Test

1. Configure `provider: ollama-cloud` with a valid `OLLAMA_API_KEY`
2. Run `hermes -m deepseek-v4-flash:cloud -z "hello"` — should resolve to `deepseek-v4-flash` and work
3. Run `pytest tests/hermes_cli/test_ollama_cloud_suffix_strip.py -v` — all 9 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `normalize_model_for_provider` (callers: 8, used in agent_init, cli, model_switch, chat_completion_helpers, auxiliary_client)
- Analyzed: `validate_requested_model` (callers: 3, used in model_switch)
- Blast radius: LOW — changes are scoped to ollama-cloud provider only, using existing `_strip_ollama_cloud_suffix` helper
- Related patterns: `_strip_ollama_cloud_suffix` already used in `fetch_ollama_cloud_models` for dedup; this PR extends it to normalization and validation paths
