### PR TITLE
fix(lint/tests agent): remove unused imports and variables

### DIFF
--- a/tests/agent/test_cascading_interrupt_6600.py
+++ b/tests/agent/test_cascading_interrupt_6600.py
@@ -21,9 +21,7 @@ right before the force-close. The worker's exception handler checks it and
 exits cleanly (no retry, no fallback, no "reconnecting" status) instead of
 treating the forced error as transient.
 """
-import threading
 import time
-import types
 from unittest.mock import MagicMock
 
 import httpx

--- a/tests/agent/test_compression_concurrent_fork.py
+++ b/tests/agent/test_compression_concurrent_fork.py
@@ -34,7 +34,6 @@ import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
 
 from hermes_state import SessionDB
 

--- a/tests/agent/test_credits_policy.py
+++ b/tests/agent/test_credits_policy.py
@@ -6,12 +6,10 @@ CreditsState is constructed directly (not parsed from headers).
 
 from __future__ import annotations
 
-import pytest
 
 from agent.credits_tracker import (
     CREDITS_NOTICE_KIND,
     CREDITS_RESTORED_TTL_MS,
-    AgentNotice,
     CreditsState,
     evaluate_credits_notices,
 )

--- a/tests/agent/test_credits_tracker.py
+++ b/tests/agent/test_credits_tracker.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import Optional
 import pytest
 
 from agent.credits_tracker import CreditsState, parse_credits_headers

--- a/tests/agent/test_custom_providers_vision.py
+++ b/tests/agent/test_custom_providers_vision.py
@@ -8,7 +8,6 @@ the auxiliary vision_analyze path.
 
 from __future__ import annotations
 
-import pytest
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_memory_async_sync.py
+++ b/tests/agent/test_memory_async_sync.py
@@ -17,7 +17,6 @@ executor with a bounded timeout so a wedged provider can't hang teardown.
 """
 import time
 
-import pytest
 
 from agent.memory_provider import MemoryProvider
 from agent.memory_manager import MemoryManager

--- a/tests/agent/test_set_runtime_main_custom_provider.py
+++ b/tests/agent/test_set_runtime_main_custom_provider.py
@@ -3,7 +3,6 @@ so that _resolve_auto() can route custom: providers in Step 1.
 
 Fixes https://github.com/NousResearch/hermes-agent/issues/34777
 """
-import pytest
 from unittest.mock import patch, MagicMock
 
 


### PR DESCRIPTION
## What does this PR do?

Removes unused imports (F401) and unused variables (F841) via `ruff check --fix`.

## Root cause

Accumulated dead code from refactoring — symbols that were once used but are no longer referenced.

## Fix

`ruff check --select F401,F841,PLC2801 --fix`

## Why this shape

Auto-fix only — zero behavioral change. Each file change is purely cosmetic (removing unused symbols).

## Tests

- `ruff check` passes on changed files
- Existing tests unaffected (no logic change)

## Related PRs / issues

