### PR TITLE
fix(lint/tests cron): remove unused imports and variables

### DIFF
--- a/tests/cron/test_blueprint_catalog.py
+++ b/tests/cron/test_blueprint_catalog.py
@@ -9,7 +9,6 @@ cron job store.
 import importlib
 import json
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 

--- a/tests/cron/test_parallel_pool.py
+++ b/tests/cron/test_parallel_pool.py
@@ -4,12 +4,9 @@ These verify the fix for the tick-blocking issue where as_completed(timeout=600)
 prevented the ticker thread from firing, causing all other jobs to be fast-forwarded.
 """
 
-import concurrent.futures
 import threading
 import time
-from unittest.mock import patch
 
-import pytest
 
 
 class TestPersistentPool:

--- a/tests/cron/test_suggestions.py
+++ b/tests/cron/test_suggestions.py
@@ -6,7 +6,6 @@ HERMES_HOME so the real suggestions.json is never touched.
 """
 
 import importlib
-import json
 from pathlib import Path
 from unittest.mock import patch
 


### PR DESCRIPTION
## What does this PR do?

Removes unused imports (F401) and unused variables (F841) via `ruff check --fix`.

## Root cause

Accumulated dead code from refactoring — symbols that were once used but are no longer referenced.

## Fix

`ruff check --select F401,F841,PLC2801 --fix`

## Why this shape

Auto-fix only — zero behavioral change. Each file change is purely cosmetic (removing unused symbols).

## Tests

- `ruff check` passes on changed files
- Existing tests unaffected (no logic change)

## Related PRs / issues

