### PR TITLE
fix(lint/tests gateway/1): remove unused imports and variables

### DIFF
--- a/tests/gateway/test_compression_concurrent_sessions.py
+++ b/tests/gateway/test_compression_concurrent_sessions.py
@@ -23,7 +23,6 @@ import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
 
 from hermes_state import SessionDB
 

--- a/tests/gateway/test_compression_session_id_persistence.py
+++ b/tests/gateway/test_compression_session_id_persistence.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import ast
 import inspect
 import textwrap
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock
 
 from gateway import run as gateway_run
 from gateway.session_context import set_current_session_id, get_session_env

--- a/tests/gateway/test_discord_voice_mixer.py
+++ b/tests/gateway/test_discord_voice_mixer.py
@@ -9,7 +9,7 @@ integration (install on join, play routing, ack) is tested with the standard
 
 import os
 import sys
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 

--- a/tests/gateway/test_max_tokens_propagation.py
+++ b/tests/gateway/test_max_tokens_propagation.py
@@ -11,7 +11,6 @@ Precedence verified here:
 """
 
 import importlib
-import os
 import sys
 import textwrap
 

--- a/tests/gateway/test_notice_rendering.py
+++ b/tests/gateway/test_notice_rendering.py
@@ -94,7 +94,6 @@ def test_real_policy_notices_render_without_doubling():
 
 # ── Delivery seam: a rendered notice line goes out via _deliver_platform_notice ──
 
-import threading
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest

--- a/tests/gateway/test_stream_events.py
+++ b/tests/gateway/test_stream_events.py
@@ -9,7 +9,6 @@ can't render it.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
 
 from gateway.stream_dispatch import GatewayEventDispatcher
 from gateway.stream_events import (

--- a/tests/gateway/test_weixin_typing.py
+++ b/tests/gateway/test_weixin_typing.py
@@ -1,6 +1,5 @@
 """Tests for WeChat iLink typing ticket refresh logic (issue #38085)."""
 
-import asyncio
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 


### PR DESCRIPTION
## What does this PR do?

Removes unused imports (F401) and unused variables (F841) via `ruff check --fix`.

## Root cause

Accumulated dead code from refactoring — symbols that were once used but are no longer referenced.

## Fix

`ruff check --select F401,F841,PLC2801 --fix`

## Why this shape

Auto-fix only — zero behavioral change. Each file change is purely cosmetic (removing unused symbols).

## Tests

- `ruff check` passes on changed files
- Existing tests unaffected (no logic change)

## Related PRs / issues

