### PR TITLE
fix(lint/tests gateway/2): remove unused imports and variables

### DIFF
--- a/tests/gateway/test_matrix_approval_reaction_fail_closed.py
+++ b/tests/gateway/test_matrix_approval_reaction_fail_closed.py
@@ -13,7 +13,6 @@ from collections import deque
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
-import pytest
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_matrix_project_context_isolation.py
+++ b/tests/gateway/test_matrix_project_context_isolation.py
@@ -6,7 +6,7 @@ import asyncio
 import time
 from datetime import datetime
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 

--- a/tests/gateway/test_platform_reconnect_fd_leak.py
+++ b/tests/gateway/test_platform_reconnect_fd_leak.py
@@ -22,8 +22,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -16,9 +16,8 @@ from unittest.mock import AsyncMock, MagicMock, patch, call
 
 import pytest
 
-from gateway.config import Platform, PlatformConfig
+from gateway.config import PlatformConfig
 from gateway.platforms.base import (
-    MessageEvent,
     MessageType,
     is_host_excluded_by_no_proxy,
 )

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -1,6 +1,5 @@
 """Tests for Slack Block Kit approval buttons and thread context fetching."""
 
-import asyncio
 import sys
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -16,7 +16,6 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from gateway.config import PlatformConfig
-from gateway.platforms.base import SendResult
 from gateway.platforms.telegram import TelegramAdapter
 from telegram.error import BadRequest, NetworkError, TimedOut
 


### PR DESCRIPTION
## What does this PR do?

Removes unused imports (F401) and unused variables (F841) via `ruff check --fix`.

## Root cause

Accumulated dead code from refactoring — symbols that were once used but are no longer referenced.

## Fix

`ruff check --select F401,F841,PLC2801 --fix`

## Why this shape

Auto-fix only — zero behavioral change. Each file change is purely cosmetic (removing unused symbols).

## Tests

- `ruff check` passes on changed files
- Existing tests unaffected (no logic change)

## Related PRs / issues

