### PR TITLE
fix(lint/tests hermes/cli/2): remove unused imports and variables

### DIFF
--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -6,7 +6,6 @@ Covers:
 - _contains_gateway_lifecycle_command pattern matching
 """
 
-import os
 from argparse import Namespace
 
 import pytest

--- a/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
+++ b/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
@@ -11,8 +11,6 @@ import argparse
 import os
 import sys
 import tempfile
-from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
 
 import pytest
 

--- a/tests/hermes_cli/test_kanban_default_assignee.py
+++ b/tests/hermes_cli/test_kanban_default_assignee.py
@@ -7,7 +7,6 @@ the task is skipped (existing behavior preserved).
 from __future__ import annotations
 
 import json
-import os
 import sys
 import tempfile
 

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import stat
 from pathlib import Path
 from unittest.mock import MagicMock, patch

--- a/tests/hermes_cli/test_model_provider_persistence.py
+++ b/tests/hermes_cli/test_model_provider_persistence.py
@@ -6,7 +6,7 @@ isinstance(model, dict)) to silently fail — leaving the provider unset and
 falling back to auto-detection.
 """
 
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/hermes_cli/test_openai_picker_curated.py
+++ b/tests/hermes_cli/test_openai_picker_curated.py
@@ -18,10 +18,8 @@ Bug 2 — OpenRouter appeared authenticated whenever OPENAI_API_KEY was set
     in runtime_provider.py, independent of the overlay).
 """
 
-import os
 from unittest.mock import patch
 
-import pytest
 
 from hermes_cli import models as M
 from hermes_cli.providers import HERMES_OVERLAYS


### PR DESCRIPTION
## What does this PR do?

Removes unused imports (F401) and unused variables (F841) via `ruff check --fix`.

## Root cause

Accumulated dead code from refactoring — symbols that were once used but are no longer referenced.

## Fix

`ruff check --select F401,F841,PLC2801 --fix`

## Why this shape

Auto-fix only — zero behavioral change. Each file change is purely cosmetic (removing unused symbols).

## Tests

- `ruff check` passes on changed files
- Existing tests unaffected (no logic change)

## Related PRs / issues

