### PR TITLE
fix(lint/tests honcho): remove unused imports and variables

### DIFF
--- a/tests/honcho_plugin/test_cli.py
+++ b/tests/honcho_plugin/test_cli.py
@@ -1,7 +1,6 @@
 """Tests for plugins/memory/honcho/cli.py."""
 
 from types import SimpleNamespace
-import json
 
 
 class TestResolveApiKey:


### PR DESCRIPTION
## What does this PR do?

Removes unused imports (F401) and unused variables (F841) via `ruff check --fix`.

## Root cause

Accumulated dead code from refactoring — symbols that were once used but are no longer referenced.

## Fix

`ruff check --select F401,F841,PLC2801 --fix`

## Why this shape

Auto-fix only — zero behavioral change. Each file change is purely cosmetic (removing unused symbols).

## Tests

- `ruff check` passes on changed files
- Existing tests unaffected (no logic change)

## Related PRs / issues

