### PR TITLE
fix(lint/tests run/agent): remove unused imports and variables

### DIFF
--- a/tests/run_agent/test_infinite_compaction_loop.py
+++ b/tests/run_agent/test_infinite_compaction_loop.py
@@ -16,7 +16,7 @@ The fix adds two safeguards:
 
 from unittest.mock import patch, MagicMock
 
-from agent.context_compressor import ContextCompressor, _CHARS_PER_TOKEN
+from agent.context_compressor import ContextCompressor
 
 
 # ---------------------------------------------------------------------------

--- a/tests/run_agent/test_notice_spine.py
+++ b/tests/run_agent/test_notice_spine.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import inspect
 from unittest.mock import patch
 
-import pytest
 
 from agent.credits_tracker import AgentNotice
 from run_agent import AIAgent

--- a/tests/run_agent/test_turn_completion_explainer.py
+++ b/tests/run_agent/test_turn_completion_explainer.py
@@ -18,7 +18,6 @@ pass identically in CI and locally.
 """
 
 import os
-import uuid
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 

--- a/tests/run_agent/test_vision_tool_messages.py
+++ b/tests/run_agent/test_vision_tool_messages.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-import pytest
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Removes unused imports (F401) and unused variables (F841) via `ruff check --fix`.

## Root cause

Accumulated dead code from refactoring — symbols that were once used but are no longer referenced.

## Fix

`ruff check --select F401,F841,PLC2801 --fix`

## Why this shape

Auto-fix only — zero behavioral change. Each file change is purely cosmetic (removing unused symbols).

## Tests

- `ruff check` passes on changed files
- Existing tests unaffected (no logic change)

## Related PRs / issues

