### PR TITLE
fix(lint/tests scripts): remove unused imports and variables

### DIFF
--- a/tests/scripts/test_build_skills_index_health.py
+++ b/tests/scripts/test_build_skills_index_health.py
@@ -14,8 +14,6 @@ These tests pin the two contracts that prevent a recurrence:
   2. A healthy crawl exits zero AND writes the file with every source present.
 """
 
-import os
-import sys
 import types
 
 import pytest


### PR DESCRIPTION
## What does this PR do?

Removes unused imports (F401) and unused variables (F841) via `ruff check --fix`.

## Root cause

Accumulated dead code from refactoring — symbols that were once used but are no longer referenced.

## Fix

`ruff check --select F401,F841,PLC2801 --fix`

## Why this shape

Auto-fix only — zero behavioral change. Each file change is purely cosmetic (removing unused symbols).

## Tests

- `ruff check` passes on changed files
- Existing tests unaffected (no logic change)

## Related PRs / issues

