### PR TITLE
fix(lint/tests tools/1): remove unused imports and variables

### DIFF
--- a/tests/tools/test_blueprints.py
+++ b/tests/tools/test_blueprints.py
@@ -5,15 +5,12 @@ the create-job bridge, and the export round-trip without touching the real
 cron store.
 """
 
-import sys
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from tools.blueprints import (
     BlueprintError,
-    BlueprintSpec,
     create_blueprint_job,
     export_blueprint,
     parse_blueprint,

--- a/tests/tools/test_command_guards.py
+++ b/tests/tools/test_command_guards.py
@@ -15,7 +15,6 @@ from tools.approval import (
 )
 
 # Ensure the module is importable so we can patch it
-import tools.tirith_security
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -1466,7 +1466,6 @@ def test_container_finished_at_returns_none_on_zero_value():
     map to None so the reaper treats the container as unreapable."""
     # Direct test of the parsing helper — no subprocess needed since the
     # check happens after the inspect call returns.
-    import subprocess as _subprocess
 
     class _MockRun:
         def __init__(self, stdout):

--- a/tests/tools/test_docker_orphan_reaper_integration.py
+++ b/tests/tools/test_docker_orphan_reaper_integration.py
@@ -10,7 +10,6 @@ reaper on container creation, and the ``terminal.docker_orphan_reaper: false``
 opt-out would silently do nothing.
 """
 
-import os
 from unittest.mock import patch
 
 import tools.terminal_tool as terminal_tool

--- a/tests/tools/test_env_probe.py
+++ b/tests/tools/test_env_probe.py
@@ -1,6 +1,5 @@
 """Tests for tools/env_probe.py — local Python toolchain probe."""
 
-import sys
 
 import pytest
 


### PR DESCRIPTION
## What does this PR do?

Removes unused imports (F401) and unused variables (F841) via `ruff check --fix`.

## Root cause

Accumulated dead code from refactoring — symbols that were once used but are no longer referenced.

## Fix

`ruff check --select F401,F841,PLC2801 --fix`

## Why this shape

Auto-fix only — zero behavioral change. Each file change is purely cosmetic (removing unused symbols).

## Tests

- `ruff check` passes on changed files
- Existing tests unaffected (no logic change)

## Related PRs / issues

