### PR TITLE
fix(lint/agent): remove unused imports and variables

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -18,19 +18,15 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import random
 import re
 import ssl
-import threading
 import time
-import uuid
 from typing import Any, Dict, List, Optional
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
-from agent.iteration_budget import IterationBudget
 from agent.turn_context import build_turn_context
 from agent.turn_retry_state import TurnRetryState
 from agent.memory_manager import build_memory_context_block

--- a/agent/transports/__init__.py
+++ b/agent/transports/__init__.py
@@ -7,11 +7,11 @@ Usage:
 """
 
 from agent.transports.types import (
-    NormalizedResponse,
-    ToolCall,
-    Usage,
-    build_tool_call,
-    map_finish_reason,
+    NormalizedResponse as NormalizedResponse,
+    ToolCall as ToolCall,
+    Usage as Usage,
+    build_tool_call as build_tool_call,
+    map_finish_reason as map_finish_reason,
 )  # noqa: F401
 
 _REGISTRY: dict = {}


### PR DESCRIPTION
Removes unused imports (F401) and unused variables (F841) via `ruff check --fix`.