### PR TITLE
fix(lint/core): remove unused imports and variables

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -169,9 +169,6 @@ _COMMAND_SPINNER_FRAMES = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧
 # User-managed env files should override stale shell exports on restart.
 from hermes_constants import get_hermes_home, display_hermes_home
 from hermes_cli.browser_connect import (
-    DEFAULT_BROWSER_CDP_URL,
-    is_browser_debug_ready,
-    manual_chrome_debug_command,
     try_launch_chrome_debug,
 )
 from hermes_cli.env_loader import load_hermes_dotenv

--- a/run_agent.py
+++ b/run_agent.py
@@ -502,7 +502,7 @@ class AIAgent:
 
             self._session_db = SessionDB()
             return self._session_db
-        except Exception as exc:
+        except Exception:
             logger.debug("SessionDB unavailable for recall", exc_info=True)
             return None
 


### PR DESCRIPTION
Removes unused imports (F401) and unused variables (F841) via `ruff check --fix`.