### PR TITLE
fix(lint/scripts): remove unused imports and variables

### DIFF
--- a/scripts/tool_search_livetest.py
+++ b/scripts/tool_search_livetest.py
@@ -30,7 +30,7 @@ import tempfile
 import time
 import traceback
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List
 
 # Force-isolate the test environment BEFORE any hermes imports.
 ORIGINAL_HOME = os.environ.get("HERMES_HOME")


### PR DESCRIPTION
Removes unused imports (F401) and unused variables (F841) via `ruff check --fix`.