### PR TITLE
fix(lint/tools): remove unused imports and variables

### DIFF
--- a/tools/env_probe.py
+++ b/tools/env_probe.py
@@ -33,7 +33,6 @@ import logging
 import os
 import shutil
 import subprocess
-import sys
 import threading
 from typing import Optional
 

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -708,7 +708,7 @@ def archive_skill(skill_name: str) -> Tuple[bool, str]:
 
     try:
         skill_dir.rename(dest)
-    except OSError as e:
+    except OSError:
         # Cross-device — fall back to shutil.move
         import shutil
         try:


### PR DESCRIPTION
Removes unused imports (F401) and unused variables (F841) via `ruff check --fix`.