### PR TITLE
fix(lint/tests root): remove unused imports and variables

### DIFF
--- a/tests/test_honcho_client_config.py
+++ b/tests/test_honcho_client_config.py
@@ -3,7 +3,6 @@
 import json
 import os
 import stat
-from pathlib import Path
 
 import pytest
 

--- a/tests/test_output_cap_parsing.py
+++ b/tests/test_output_cap_parsing.py
@@ -1,4 +1,3 @@
-import pytest
 from agent.model_metadata import parse_available_output_tokens_from_error
 
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -4,7 +4,6 @@ The server now uses uvicorn.Server directly (not uvicorn.run) so we stub
 Config + Server + asyncio.run to capture kwargs without starting an event loop.
 """
 
-import asyncio
 import contextlib
 
 import uvicorn

--- a/tests/test_wheel_locales_e2e.py
+++ b/tests/test_wheel_locales_e2e.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 import glob
 import os
 import subprocess
-import sys
 import tarfile
 import venv
 from pathlib import Path


### PR DESCRIPTION
Removes unused imports (F401) and unused variables (F841) via `ruff check --fix`.