### PR TITLE
fix(lint/tests acp): remove unused imports and variables

### DIFF
--- a/tests/acp/test_session_db_private_access.py
+++ b/tests/acp/test_session_db_private_access.py
@@ -9,11 +9,8 @@ Verifies that:
 
 import ast
 import json
-import tempfile
-from pathlib import Path
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock
 
-import pytest
 
 from hermes_state import SessionDB
 from acp_adapter.session import SessionManager


### PR DESCRIPTION
Removes unused imports (F401) and unused variables (F841) via `ruff check --fix`.