### PR TITLE
fix(lint/unsafe-plugins/1): remove unused imports and variables

### DIFF
--- a/plugins/context_engine/__init__.py
+++ b/plugins/context_engine/__init__.py
@@ -18,7 +18,6 @@ Usage:
 
 from __future__ import annotations
 
-import importlib
 import importlib.util
 import logging
 import sys

--- a/plugins/dashboard_auth/basic/__init__.py
+++ b/plugins/dashboard_auth/basic/__init__.py
@@ -65,7 +65,7 @@ import logging
 import os
 import secrets
 import time
-from typing import Any, Optional
+from typing import Optional
 
 from hermes_cli.dashboard_auth import (
     DashboardAuthProvider,

--- a/plugins/google_meet/cli.py
+++ b/plugins/google_meet/cli.py
@@ -88,7 +88,7 @@ def register_cli(subparser: argparse.ArgumentParser) -> None:
     try:
         from plugins.google_meet.node.cli import register_cli as _register_node_cli
         _register_node_cli(node_p)
-    except Exception as e:  # pragma: no cover — defensive
+    except Exception:  # pragma: no cover — defensive
         # If the node module fails to import for any reason (optional dep
         # missing at import time etc.), leave the subparser present but
         # flag it. The argparse dispatch will surface a clear error.

--- a/plugins/image_gen/fal/__init__.py
+++ b/plugins/image_gen/fal/__init__.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 from typing import Any, Dict, List, Optional
 
 from agent.image_gen_provider import (


### PR DESCRIPTION
Removes unused imports (F401) and unused variables (F841) via `ruff check --unsafe-fixes --fix`.