### PR TITLE
fix(lint/unsafe-plugins/2): remove unused imports and variables

### DIFF
--- a/plugins/image_gen/xai/__init__.py
+++ b/plugins/image_gen/xai/__init__.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 
 import requests
 

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -21,7 +21,6 @@ Usage:
 
 from __future__ import annotations
 
-import importlib
 import importlib.machinery
 import importlib.util
 import logging

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -129,7 +129,6 @@ def _fetch_hindsight_api_version(api_url: str, api_key: str | None = None,
     Any failure (timeout, 404, malformed JSON, missing key) → None, which
     the caller treats as "legacy API, no update_mode support".
     """
-    import urllib.error
     import urllib.request
     if not api_url:
         return None


### PR DESCRIPTION
Removes unused imports (F401) and unused variables (F841) via `ruff check --unsafe-fixes --fix`.