### PR TITLE
fix(lint/unsafe-tests/root): remove unused imports and variables

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -795,7 +795,6 @@ def _live_system_guard(request, monkeypatch):
         return _GuardedPopen
 
     real_run = _subprocess.run
-    real_popen = _subprocess.Popen
     real_call = _subprocess.call
     real_check_call = _subprocess.check_call
     real_check_output = _subprocess.check_output

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -462,7 +462,6 @@ class TestSessionContext:
         """Session context is per-thread — one thread's context doesn't leak."""
         hermes_logging.setup_logging(hermes_home=hermes_home)
 
-        results = {}
 
         def thread_a():
             hermes_logging.set_session_context("thread_a_session")

--- a/tests/test_ipv4_preference.py
+++ b/tests/test_ipv4_preference.py
@@ -51,7 +51,6 @@ class TestApplyIPv4Preference:
         from hermes_constants import apply_ipv4_preference
 
         calls = []
-        original = socket.getaddrinfo
 
         def mock_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
             calls.append(family)
@@ -69,7 +68,6 @@ class TestApplyIPv4Preference:
         from hermes_constants import apply_ipv4_preference
 
         calls = []
-        original = socket.getaddrinfo
 
         def mock_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
             calls.append(family)

--- a/tests/test_lazy_session_regressions.py
+++ b/tests/test_lazy_session_regressions.py
@@ -156,7 +156,6 @@ class TestSyncSessionKeyAfterAutoCompress:
 
         # Track if _sync_session_key_after_compress was called
         sync_calls = []
-        original_sync = server._sync_session_key_after_compress
 
         def _tracking_sync(sid, sess, **kwargs):
             sync_calls.append((sid, sess.get("session_key")))

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -498,7 +498,7 @@ class TestEventBridge:
 @pytest.fixture
 def mcp_server_e2e(populated_sessions_dir, mock_session_db, monkeypatch):
     """Create a fully wired MCP server for E2E testing."""
-    mcp = pytest.importorskip("mcp", reason="MCP SDK not installed")
+    pytest.importorskip("mcp", reason="MCP SDK not installed")
     import mcp_serve
     monkeypatch.setattr(mcp_serve, "_get_sessions_dir", lambda: populated_sessions_dir)
     monkeypatch.setattr(mcp_serve, "_get_session_db", lambda: mock_session_db)

--- a/tests/test_minimax_oauth.py
+++ b/tests/test_minimax_oauth.py
@@ -272,7 +272,6 @@ def test_poll_token_error_raises():
 
 def test_poll_token_timeout_raises():
     # expired_in is a small duration (treated as seconds from now, already expired)
-    expired_in = 1  # 1 second from now
     # Make sleep a no-op and time.time advance quickly by using a small deadline
     # We use a duration-style expired_in (small enough to not be a unix timestamp)
     # duration mode: deadline = time.time() + max(1, expired_in)
@@ -293,7 +292,7 @@ def test_poll_token_timeout_raises():
     client.post.return_value = pending_resp
 
     import hermes_cli.auth as auth_module
-    with patch.object(auth_module, "time") as mock_time_mod:
+    with patch.object(auth_module, "time"):
         # We need to patch the 'time' module used inside _minimax_poll_token
         # The function imports 'import time as _time' locally.
         # Patch time.sleep and time.time in the auth module's local scope.

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -247,7 +247,7 @@ class TestCronTimezone:
 
         # Create a job with a NAIVE past timestamp (simulating pre-tz data)
         from cron.jobs import create_job, load_jobs, save_jobs, get_due_jobs
-        job = create_job(prompt="Test job", schedule="every 1h")
+        create_job(prompt="Test job", schedule="every 1h")
         jobs = load_jobs()
         # Force a naive (no timezone) past timestamp
         naive_past = (datetime.now() - timedelta(seconds=30)).isoformat()
@@ -322,7 +322,7 @@ class TestCronTimezone:
 
         from cron.jobs import create_job, load_jobs, save_jobs, get_due_jobs
 
-        job = create_job(prompt="Bug repro", schedule="every 1h")
+        create_job(prompt="Bug repro", schedule="every 1h")
         jobs = load_jobs()
 
         # Simulate a naive timestamp that was written by datetime.now() on a

--- a/tests/test_trajectory_compressor_async.py
+++ b/tests/test_trajectory_compressor_async.py
@@ -45,7 +45,7 @@ class TestAsyncClientLazyCreation:
 
         mock_async_openai = MagicMock()
         with patch("openai.AsyncOpenAI", mock_async_openai):
-            client = comp._get_async_client()
+            comp._get_async_client()
 
         mock_async_openai.assert_called_once_with(
             api_key="test-key",
@@ -75,8 +75,8 @@ class TestAsyncClientLazyCreation:
             return instance
 
         with patch("openai.AsyncOpenAI", side_effect=mock_constructor):
-            client1 = comp._get_async_client()
-            client2 = comp._get_async_client()
+            comp._get_async_client()
+            comp._get_async_client()
 
         # Should have created two separate instances
         assert call_count == 2

--- a/tests/test_yuanbao_integration.py
+++ b/tests/test_yuanbao_integration.py
@@ -375,7 +375,7 @@ class TestP0ChatLockEviction:
 
         # Lock the oldest entry
         oldest_key = next(iter(adapter._outbound._chat_locks))
-        oldest_lock = adapter._outbound._chat_locks[oldest_key]
+        adapter._outbound._chat_locks[oldest_key]
         # Simulate a held lock by acquiring it in a non-async way (set _locked)
         # asyncio.Lock is not held until actually acquired; so we test the
         # method logic by acquiring the first lock manually.


### PR DESCRIPTION
Removes unused imports (F401) and unused variables (F841) via `ruff check --unsafe-fixes --fix`.