### PR TITLE
fix(lint/unsafe-tests/cron): remove unused imports and variables

### DIFF
--- a/tests/cron/test_blueprint_catalog.py
+++ b/tests/cron/test_blueprint_catalog.py
@@ -9,7 +9,6 @@ cron job store.
 import importlib
 import json
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 

--- a/tests/cron/test_suggestions.py
+++ b/tests/cron/test_suggestions.py
@@ -6,7 +6,6 @@ HERMES_HOME so the real suggestions.json is never touched.
 """
 
 import importlib
-import json
 from pathlib import Path
 from unittest.mock import patch
 


### PR DESCRIPTION
Removes unused imports (F401) and unused variables (F841) via `ruff check --unsafe-fixes --fix`.