### PR TITLE
fix(lint/unsafe-tests/gateway/3): remove unused imports and variables

### DIFF
--- a/tests/gateway/test_weixin_typing.py
+++ b/tests/gateway/test_weixin_typing.py
@@ -1,6 +1,5 @@
 """Tests for WeChat iLink typing ticket refresh logic (issue #38085)."""
 
-import asyncio
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 


### PR DESCRIPTION
Removes unused imports (F401) and unused variables (F841) via `ruff check --unsafe-fixes --fix`.