### PR TITLE
fix(lint/unsafe-tests/hermes/cli/1): remove unused imports and variables

### DIFF
--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -710,7 +710,6 @@ class TestSubcommandCompletion:
 
     def test_tools_enable_completes_toolset_names(self, monkeypatch):
         """`/tools enable ` should suggest currently-disabled toolsets."""
-        from hermes_cli import commands as commands_mod
 
         # `web` is enabled, `spotify` is disabled — enabling should only offer
         # the disabled ones.

--- a/tests/hermes_cli/test_dashboard_auth_gate.py
+++ b/tests/hermes_cli/test_dashboard_auth_gate.py
@@ -110,7 +110,6 @@ def _stub_uvicorn_run(monkeypatch):
     returns immediately (rather than blocking on the event loop). Returns the dict
     that will capture the keyword args.
     """
-    import asyncio
     import contextlib
     import uvicorn
     captured: dict = {"kwargs": {}}

--- a/tests/hermes_cli/test_default_interface_resolution.py
+++ b/tests/hermes_cli/test_default_interface_resolution.py
@@ -22,7 +22,6 @@ These tests pin that precedence at every layer that makes the decision:
 
 from __future__ import annotations
 
-import os
 from types import SimpleNamespace
 
 import pytest

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1337,7 +1337,6 @@ class TestDoctorStaleMaxIterationsDrift:
 
     def _run_config_section(self, monkeypatch, tmp_path, *, fix, ghost, cfg_turns,
                             os_environ_value=None):
-        import pathlib
         import contextlib
         import io
         from argparse import Namespace

--- a/tests/hermes_cli/test_ensure_hermes_home_uid_34107.py
+++ b/tests/hermes_cli/test_ensure_hermes_home_uid_34107.py
@@ -13,9 +13,7 @@ runs after every directory creation in the home-init path).
 """
 from __future__ import annotations
 
-import os
 import sys
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -6,7 +6,6 @@ Covers:
 - _contains_gateway_lifecycle_command pattern matching
 """
 
-import os
 from argparse import Namespace
 
 import pytest
@@ -181,7 +180,7 @@ class TestCronCreateLifecycleBlock:
             profile=None,
             no_agent=False,
         )
-        rc = cron_command(args)
+        cron_command(args)
         # The lifecycle guard passes (no gateway command in prompt).
         # The API rejects it for "requires prompt or skill" → rc 1, but
         # the error message is about prompt/skill, NOT about "Blocked".

--- a/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
+++ b/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
@@ -11,8 +11,6 @@ import argparse
 import os
 import sys
 import tempfile
-from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
 
 import pytest
 


### PR DESCRIPTION
Removes unused imports (F401) and unused variables (F841) via `ruff check --unsafe-fixes --fix`.