### PR TITLE
fix(lint/unsafe-tests/hermes/cli/2): remove unused imports and variables

### DIFF
--- a/tests/hermes_cli/test_kanban_default_assignee.py
+++ b/tests/hermes_cli/test_kanban_default_assignee.py
@@ -7,7 +7,6 @@ the task is skipped (existing behavior preserved).
 from __future__ import annotations
 
 import json
-import os
 import sys
 import tempfile
 

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import stat
 from pathlib import Path
 from unittest.mock import MagicMock, patch

--- a/tests/hermes_cli/test_model_provider_persistence.py
+++ b/tests/hermes_cli/test_model_provider_persistence.py
@@ -6,7 +6,7 @@ isinstance(model, dict)) to silently fail — leaving the provider unset and
 falling back to auto-detection.
 """
 
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/hermes_cli/test_openai_picker_curated.py
+++ b/tests/hermes_cli/test_openai_picker_curated.py
@@ -18,10 +18,8 @@ Bug 2 — OpenRouter appeared authenticated whenever OPENAI_API_KEY was set
     in runtime_provider.py, independent of the overlay).
 """
 
-import os
 from unittest.mock import patch
 
-import pytest
 
 from hermes_cli import models as M
 from hermes_cli.providers import HERMES_OVERLAYS

--- a/tests/hermes_cli/test_plugins_cmd_category_discovery.py
+++ b/tests/hermes_cli/test_plugins_cmd_category_discovery.py
@@ -6,11 +6,9 @@ and path-derived key against the enabled/disabled sets.
 """
 
 import json
-import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_secrets_bitwarden_non_tty.py
+++ b/tests/hermes_cli/test_secrets_bitwarden_non_tty.py
@@ -6,9 +6,7 @@ because getpass.getpass() and console.input() require an interactive terminal.
 from __future__ import annotations
 
 import argparse
-from unittest.mock import patch
 
-import pytest
 
 
 class TestCmdSetupNonTtyGuard:

--- a/tests/hermes_cli/test_setup_model_provider.py
+++ b/tests/hermes_cli/test_setup_model_provider.py
@@ -7,7 +7,7 @@ that the setup wizard correctly syncs config from disk after the call.
 
 from __future__ import annotations
 
-from hermes_cli.config import load_config, save_config, save_env_value
+from hermes_cli.config import load_config, save_config
 from hermes_cli.nous_subscription import NousFeatureState, NousSubscriptionFeatures
 from hermes_cli.setup import _print_setup_summary, setup_model_provider
 


### PR DESCRIPTION
Removes unused imports (F401) and unused variables (F841) via `ruff check --unsafe-fixes --fix`.