### PR TITLE
fix(lint/unsafe-tests/hermes/cli/3): remove unused imports and variables

### DIFF
--- a/tests/hermes_cli/test_systemd_optional_directives.py
+++ b/tests/hermes_cli/test_systemd_optional_directives.py
@@ -12,7 +12,6 @@ from both the installed and expected text before comparison.
 
 from __future__ import annotations
 
-import pytest
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_uninstall_node_symlinks.py
+++ b/tests/hermes_cli/test_uninstall_node_symlinks.py
@@ -6,7 +6,6 @@ PATH, shadowing an existing nvm. Uninstall must remove those symlinks, but
 only when they still resolve into the Hermes-managed node dir.
 """
 
-import os
 from pathlib import Path
 
 import pytest

--- a/tests/hermes_cli/test_update_interrupted_recovery.py
+++ b/tests/hermes_cli/test_update_interrupted_recovery.py
@@ -7,7 +7,6 @@ finished automatically on the next launch instead of leaving a half-built venv.
 
 from __future__ import annotations
 
-from pathlib import Path
 
 import hermes_cli.main as m
 

--- a/tests/hermes_cli/test_verify_core_dependencies.py
+++ b/tests/hermes_cli/test_verify_core_dependencies.py
@@ -16,9 +16,7 @@ The verification step:
 
 from __future__ import annotations
 
-import subprocess
 import textwrap
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/hermes_cli/test_web_server_fs.py
+++ b/tests/hermes_cli/test_web_server_fs.py
@@ -1,5 +1,4 @@
 import base64
-from pathlib import Path
 
 import pytest
 


### PR DESCRIPTION
Removes unused imports (F401) and unused variables (F841) via `ruff check --unsafe-fixes --fix`.