### PR TITLE
fix(lint/unsafe-tests/honcho): remove unused imports and variables

### DIFF
--- a/tests/honcho_plugin/test_cli.py
+++ b/tests/honcho_plugin/test_cli.py
@@ -1,7 +1,6 @@
 """Tests for plugins/memory/honcho/cli.py."""
 
 from types import SimpleNamespace
-import json
 
 
 class TestResolveApiKey:


### PR DESCRIPTION
Removes unused imports (F401) and unused variables (F841) via `ruff check --unsafe-fixes --fix`.