### PR TITLE
fix(lint/unsafe-tests/run/agent/2): remove unused imports and variables

### DIFF
--- a/tests/run_agent/test_vision_tool_messages.py
+++ b/tests/run_agent/test_vision_tool_messages.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-import pytest
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Removes unused imports (F401) and unused variables (F841) via `ruff check --unsafe-fixes --fix`.