### PR TITLE
fix(commands): add /voice to Telegram menu priority list

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -548,6 +548,7 @@ _TELEGRAM_MENU_PRIORITY = (
     "background",
     # Lower-priority but still useful operational built-ins.
     "reasoning",
+    "voice",
     "usage",
     "platforms",
     "platform",

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -1151,6 +1151,7 @@ class TestTelegramMenuCommands:
             "new",
             "stop",
             "status",
+            "voice",
         ):
             assert name in names
 


### PR DESCRIPTION
## What does this PR do?

Adds `/voice` to the `_TELEGRAM_MENU_PRIORITY` list so that the voice/TTS toggle command is visible in Telegram's capped command menu (30 commands max).

## Related Issue

Fixes #45175

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/commands.py`: Added `"voice"` to `_TELEGRAM_MENU_PRIORITY` tuple, positioned after `"reasoning"` (both are operational mode toggles)
- `tests/hermes_cli/test_commands.py`: Added `"voice"` to `test_operational_builtins_survive_thirty_command_cap` assertion list

## How to Test

1. Run `pytest tests/hermes_cli/test_commands.py -k "telegram" -q` — all 39 tests pass including the updated cap-survival test
2. Start a Telegram gateway session and type `/` — `/voice` should appear in the command menu
3. Verify the command is positioned within the first 30 entries (it now ranks ~23rd in the priority list)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `_TELEGRAM_MENU_PRIORITY` (used by `_prioritize_telegram_menu_commands` → `telegram_menu_commands` → telegram adapter menu registration)
- Callers: `telegram_menu_commands()` at 2 call sites in `gateway/platforms/telegram.py` (lines 1746, 5180)
- Blast radius: LOW — additive change (1 string to a tuple), no control flow modified
- Related patterns: Priority-list ordering determines which commands survive the 30-command Telegram menu cap
