### PR TITLE
feat(mattermost): add ignore prefix for no-response messages

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -9,6 +9,7 @@ Environment variables:
     MATTERMOST_TOKEN            Bot token or personal-access token
     MATTERMOST_ALLOWED_USERS    Comma-separated user IDs
     MATTERMOST_HOME_CHANNEL     Channel ID for cron/notification delivery
+    MATTERMOST_IGNORE_PREFIX    Prefix that suppresses a response (default: "!")
 """
 
 from __future__ import annotations
@@ -48,6 +49,10 @@ _CHANNEL_TYPE_MAP = {
 _RECONNECT_BASE_DELAY = 2.0
 _RECONNECT_MAX_DELAY = 60.0
 _RECONNECT_JITTER = 0.2
+
+# Ignore prefix: messages starting with this prefix are stored but don't trigger response.
+# Set to empty string to disable.
+_IGNORE_PREFIX = os.getenv("MATTERMOST_IGNORE_PREFIX", "!")
 
 
 def check_mattermost_requirements() -> bool:
@@ -781,6 +786,15 @@ class MattermostAdapter(BasePlatformAdapter):
                     message_text = re.sub(
                         re.escape(pattern), "", message_text, flags=re.IGNORECASE
                     ).strip()
+
+        # Ignore prefix: messages starting with prefix are stored but don't trigger response.
+        # This allows posting reference material that will appear in context for later messages.
+        if _IGNORE_PREFIX and message_text.startswith(_IGNORE_PREFIX):
+            logger.debug(
+                "Mattermost: ignoring message with '%s' prefix (channel=%s, post=%s)",
+                _IGNORE_PREFIX, channel_id, post_id,
+            )
+            return
 
         # Resolve sender info.
         sender_id = post.get("user_id", "")

--- a/plugins/platforms/mattermost/plugin.yaml
+++ b/plugins/platforms/mattermost/plugin.yaml
@@ -47,3 +47,7 @@ optional_env:
     description: "If set, the bot only responds in these channels (whitelist)."
     prompt: "Allowed channel IDs (comma-separated)"
     password: false
+  - name: MATTERMOST_IGNORE_PREFIX
+    description: "Messages starting with this prefix are stored for context but do not trigger a response. Empty to disable. Default: !"
+    prompt: "Ignore prefix"
+    password: false


### PR DESCRIPTION
## What does this PR do?

Adds `MATTERMOST_IGNORE_PREFIX` (default `!`) for the Mattermost adapter. Messages beginning with the configured prefix are still stored in the session transcript (so they appear in later context) but do not trigger an agent response. Set the env var to an empty string to disable the feature.

## Related Issue

Fixes #

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/platforms/mattermost/adapter.py` — add prefix check in message handling; skip agent dispatch when prefix matches
- `plugins/platforms/mattermost/plugin.yaml` — document `MATTERMOST_IGNORE_PREFIX` in `optional_env`

## How to Test

1. Set `MATTERMOST_IGNORE_PREFIX=!` (default)
2. Send `!remind me later` in a Mattermost channel where Hermes is active
3. Verify Hermes does not respond but the message is stored in the session transcript
4. Set `MATTERMOST_IGNORE_PREFIX=` (empty) and verify all messages trigger responses as before

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- your platform -->

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A