### PR TITLE
feat(mattermost): make MAX_POST_LENGTH configurable via env var

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -9,6 +9,7 @@ Environment variables:
     MATTERMOST_TOKEN            Bot token or personal-access token
     MATTERMOST_ALLOWED_USERS    Comma-separated user IDs
     MATTERMOST_HOME_CHANNEL     Channel ID for cron/notification delivery
+    MATTERMOST_MAX_POST_LENGTH  Max chars per post (default: 16383)
 """
 
 from __future__ import annotations
@@ -32,9 +33,8 @@ from gateway.platforms.base import (
 
 logger = logging.getLogger(__name__)
 
-# Mattermost post size limit (server default is 16383, but 4000 is the
-# practical limit for readable messages — matching OpenClaw's choice).
-MAX_POST_LENGTH = 4000
+# Mattermost post size limit (server default is 16383).
+MAX_POST_LENGTH = int(os.getenv("MATTERMOST_MAX_POST_LENGTH", "16383"))
 
 # Channel type codes returned by the Mattermost API.
 _CHANNEL_TYPE_MAP = {

--- a/plugins/platforms/mattermost/plugin.yaml
+++ b/plugins/platforms/mattermost/plugin.yaml
@@ -47,3 +47,7 @@ optional_env:
     description: "If set, the bot only responds in these channels (whitelist)."
     prompt: "Allowed channel IDs (comma-separated)"
     password: false
+  - name: MATTERMOST_MAX_POST_LENGTH
+    description: "Max characters per post before splitting into chunks (default: 16383, the server limit)."
+    prompt: "Max post length"
+    password: false


### PR DESCRIPTION
## What does this PR do?

Makes the Mattermost post-length limit configurable via the `MATTERMOST_MAX_POST_LENGTH` env var (default `16383`, the Mattermost server limit), instead of being hard-coded to 4000. Useful for servers configured with a different `MaxPostSize`.

## Related Issue

Fixes #

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/platforms/mattermost/adapter.py` — read `MAX_POST_LENGTH` from env var with 16383 default
- `plugins/platforms/mattermost/plugin.yaml` — document `MATTERMOST_MAX_POST_LENGTH` in `optional_env`

## How to Test

1. Set `MATTERMOST_MAX_POST_LENGTH=8192` (or any value ≤ your server's `MaxPostSize`)
2. Send a long response through the Mattermost gateway
3. Verify posts are truncated at the configured length instead of the hard-coded 4000

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- your platform -->

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A