### PR TITLE
feat(mattermost): isolate thread sessions from channel sessions

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -786,8 +786,10 @@ class MattermostAdapter(BasePlatformAdapter):
         sender_id = post.get("user_id", "")
         sender_name = data.get("sender_name", "").lstrip("@") or sender_id
 
-        # Thread support: if the post is in a thread, use root_id.
-        thread_id = post.get("root_id") or None
+        # Thread support: use root_id for replies, or post's own ID for root posts.
+        # This ensures the root post creating a thread gets an isolated session key,
+        # and all replies in that thread share the same session via root_id linkage.
+        thread_id = post.get("root_id") or post.get("id")
 
         # Determine message type.
         file_ids = post.get("file_ids") or []


### PR DESCRIPTION
## What does this PR do?

Uses the post's own id as the thread id for root posts (`post.get("root_id") or post.get("id")`), so a root post that starts a thread gets its own isolated session instead of sharing the channel session. Replies in the thread continue to share that session via `root_id`.

## Related Issue

Fixes #

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/platforms/mattermost/adapter.py` — change `thread_id` assignment from `post.get("root_id")` to `post.get("root_id") or post.get("id")`

## How to Test

1. Start a new thread in a Mattermost channel by posting a root message mentioning Hermes
2. Verify the root post gets its own session (not shared with the channel)
3. Reply in the thread and verify the session is shared between the root and its replies
4. Post a separate root message and verify it gets a different session

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- your platform -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A