### PR TITLE
fix(desktop): render and queue clarify prompts

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -19,12 +19,12 @@ import { gatewayEventRequiresSessionId } from '@/lib/gateway-events'
 import { triggerHaptic } from '@/lib/haptics'
 import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
 import { parseTodos } from '@/lib/todos'
-import { setClarifyRequest } from '@/store/clarify'
+import { clearClarifyRequest, hasClarifyRequest, setClarifyRequest } from '@/store/clarify'
 import { refreshBackgroundProcesses } from '@/store/composer-status'
 import { $gateway } from '@/store/gateway'
 import { notify } from '@/store/notifications'
 import { requestDesktopOnboarding } from '@/store/onboarding'
-import { clearAllPrompts, setApprovalRequest, setSecretRequest, setSudoRequest } from '@/store/prompts'
+import { clearAllPrompts, hasBlockingPrompt, setApprovalRequest, setSecretRequest, setSudoRequest } from '@/store/prompts'
 import {
   setCurrentBranch,
   setCurrentCwd,
@@ -860,6 +860,8 @@ export function useMessageStream({
         // session so a background turn finishing can't wipe the active chat's
         // prompt, and vice versa.
         clearAllPrompts(sessionId)
+        clearClarifyRequest(undefined, sessionId)
+        updateSessionState(sessionId, state => (state.needsInput ? { ...state, needsInput: false } : state))
 
         flushQueuedDeltas(sessionId)
 
@@ -888,11 +890,11 @@ export function useMessageStream({
         if (sessionId) {
           flushQueuedDeltas(sessionId)
           upsertToolCall(sessionId, toTodoPayload(payload) ?? payload, 'complete', event.type)
-          // A pending clarify blocks the turn, so the first tool.complete after
-          // one is the clarify resolving — drop the "needs input" flag here so
-          // the sidebar indicator clears as soon as it's answered, not only at
-          // message.complete.
-          updateSessionState(sessionId, state => (state.needsInput ? { ...state, needsInput: false } : state))
+          // Recompute the sidebar badge from the live prompt stores. This keeps
+          // the indicator accurate when a clarify resolves, times out, or when
+          // another queued clarify/prompt is still pending for the same session.
+          const stillNeedsInput = hasClarifyRequest(sessionId) || hasBlockingPrompt(sessionId)
+          updateSessionState(sessionId, state => (state.needsInput === stillNeedsInput ? state : { ...state, needsInput: stillNeedsInput }))
 
           // terminal/process tool calls are the only things that spawn or reap
           // background processes — sync the composer status stack right after.
@@ -930,8 +932,9 @@ export function useMessageStream({
         // one. clarify.request is a one-shot event; if we dropped it for an
         // unfocused session, that session would block on `clarify.respond`
         // indefinitely and re-focusing it could never recover (the event is
-        // gone). Parking it per-session lets the user answer once they switch
-        // over; the inline ClarifyTool reads the active session's entry.
+        // gone). Parking it per-session as a FIFO queue matches the Python
+        // gateway's own clarify model and lets the user answer once they switch
+        // over; the desktop overlay reads the active session's oldest entry.
         const requestId = typeof payload?.request_id === 'string' ? payload.request_id : ''
         const question = typeof payload?.question === 'string' ? payload.question : ''
 
@@ -1029,6 +1032,8 @@ export function useMessageStream({
         // the failed turn (same intent as the message.complete clear).
         if (sessionId) {
           clearAllPrompts(sessionId)
+          clearClarifyRequest(undefined, sessionId)
+          updateSessionState(sessionId, state => (state.needsInput ? { ...state, needsInput: false } : state))
         }
 
         if (looksLikeProviderSetup) {

--- a/apps/desktop/src/components/prompt-overlays.test.tsx
+++ b/apps/desktop/src/components/prompt-overlays.test.tsx
@@ -1,0 +1,88 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { HermesGateway } from '@/hermes'
+import { $clarifyRequests, setClarifyRequest } from '@/store/clarify'
+import { $gateway } from '@/store/gateway'
+import { clearAllPrompts } from '@/store/prompts'
+import { $activeSessionId } from '@/store/session'
+
+import { PromptOverlays } from './prompt-overlays'
+
+function mockGateway() {
+  const request = vi.fn().mockResolvedValue({ ok: true })
+  $gateway.set({ request } as unknown as HermesGateway)
+
+  return request
+}
+
+afterEach(() => {
+  cleanup()
+  clearAllPrompts()
+  $clarifyRequests.set({})
+  $activeSessionId.set(null)
+  $gateway.set(null)
+  vi.restoreAllMocks()
+})
+
+describe('PromptOverlays clarify dialog', () => {
+  it('renders the active clarify request as a modal and answers a choice', async () => {
+    const request = mockGateway()
+    $activeSessionId.set('sess-1')
+    setClarifyRequest({
+      requestId: 'req-1',
+      question: 'Which option?',
+      choices: ['Alpha', 'Beta'],
+      sessionId: 'sess-1'
+    })
+
+    render(<PromptOverlays />)
+
+    expect(screen.getByText('Which option?')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Alpha' }))
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith('clarify.respond', {
+        request_id: 'req-1',
+        answer: 'Alpha'
+      })
+    })
+    expect($clarifyRequests.get()['sess-1']).toBeUndefined()
+  })
+
+  it('advances to the next queued clarify for the same session after the first resolves', async () => {
+    const request = mockGateway()
+    $activeSessionId.set('sess-1')
+    setClarifyRequest({
+      requestId: 'req-1',
+      question: 'First question?',
+      choices: ['First answer'],
+      sessionId: 'sess-1'
+    })
+    setClarifyRequest({
+      requestId: 'req-2',
+      question: 'Second question?',
+      choices: ['Second answer'],
+      sessionId: 'sess-1'
+    })
+
+    render(<PromptOverlays />)
+
+    expect(screen.getByText('First question?')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'First answer' }))
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith('clarify.respond', {
+        request_id: 'req-1',
+        answer: 'First answer'
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Second question?')).toBeTruthy()
+    })
+    expect($clarifyRequests.get()['sess-1']?.[0]?.requestId).toBe('req-2')
+  })
+})

--- a/apps/desktop/src/components/prompt-overlays.tsx
+++ b/apps/desktop/src/components/prompt-overlays.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useStore } from '@nanostores/react'
-import { type FormEvent, useCallback, useEffect, useState } from 'react'
+import { type FormEvent, type KeyboardEvent, useCallback, useEffect, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import {
@@ -13,26 +13,189 @@ import {
   DialogTitle
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
+import { KbdCombo } from '@/components/ui/kbd'
+import { Textarea } from '@/components/ui/textarea'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
-import { KeyRound, Loader2, Lock } from '@/lib/icons'
+import { HelpCircle, KeyRound, Loader2, Lock } from '@/lib/icons'
+import { $clarifyRequest, clearClarifyRequest } from '@/store/clarify'
 import { $gateway } from '@/store/gateway'
 import { notifyError } from '@/store/notifications'
 import { $secretRequest, $sudoRequest, clearSecretRequest, clearSudoRequest } from '@/store/prompts'
 
-// Renders the modal mid-turn prompts the gateway raises and waits on: sudo
-// password and skill secret capture. (Dangerous-command / execute_code approval
-// is rendered INLINE on the pending tool row instead — see
+// Renders the modal mid-turn prompts the gateway raises and waits on: clarify,
+// sudo password, and skill secret capture. (Dangerous-command / execute_code
+// approval is rendered INLINE on the pending tool row instead — see
 // components/assistant-ui/tool-approval.tsx — so it reads like an inline "Run"
 // affordance rather than a blocking modal.) Each Python-side caller blocks the
 // agent thread until the matching `*.respond` RPC lands; without a renderer the
-// agent stalls until its timeout and the tool is BLOCKED (the bug this fixes —
-// desktop handled clarify.request but not these). Any close path (Esc, backdrop
-// click) funnels through Radix's single `onOpenChange(false)` and maps to a
-// refusal, so silence is never mistaken for consent, matching the TUI. We
+// agent stalls until its timeout and the tool is BLOCKED. Any close path (Esc,
+// backdrop click) funnels through Radix's single `onOpenChange(false)` and maps
+// to a refusal, so silence is never mistaken for consent, matching the TUI. We
 // deliberately do NOT add onEscapeKeyDown / onInteractOutside handlers — they'd
 // fire a second `*.respond` alongside onOpenChange (double-send) or block the
 // backdrop-dismiss path.
+
+function ClarifyDialog() {
+  const { t } = useI18n()
+  const copy = t.assistant.clarify
+  const request = useStore($clarifyRequest)
+  const gateway = useStore($gateway)
+  const [typing, setTyping] = useState(false)
+  const [draft, setDraft] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const choices = request?.choices ?? []
+  const choicesCount = request?.choices?.length ?? 0
+  const hasChoices = choices.length > 0
+
+  useEffect(() => {
+    setTyping(choicesCount === 0)
+    setDraft('')
+    setSubmitting(false)
+  }, [choicesCount, request?.requestId])
+
+  const send = useCallback(
+    async (answer: string) => {
+      if (!request) {
+        return
+      }
+
+      if (!gateway) {
+        notifyError(new Error(copy.gatewayDisconnected), copy.sendFailed)
+
+        return
+      }
+
+      setSubmitting(true)
+
+      try {
+        await gateway.request<{ ok?: boolean }>('clarify.respond', {
+          request_id: request.requestId,
+          answer
+        })
+        triggerHaptic(answer.trim() ? 'submit' : 'cancel')
+        clearClarifyRequest(request.requestId, request.sessionId)
+      } catch (error) {
+        notifyError(error, copy.sendFailed)
+        setSubmitting(false)
+      }
+    },
+    [copy.gatewayDisconnected, copy.sendFailed, gateway, request]
+  )
+
+  const onOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open && !submitting && request) {
+        void send('')
+      }
+    },
+    [request, send, submitting]
+  )
+
+  const onSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+      const trimmed = draft.trim()
+
+      if (trimmed) {
+        void send(trimmed)
+      }
+    },
+    [draft, send]
+  )
+
+  const onDraftKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault()
+        const trimmed = draft.trim()
+
+        if (trimmed) {
+          void send(trimmed)
+        }
+      }
+    },
+    [draft, send]
+  )
+
+  if (!request) {
+    return null
+  }
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open>
+      <DialogContent className="max-w-lg" showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle icon={HelpCircle}>{request.question || copy.loadingQuestion}</DialogTitle>
+          <DialogDescription>{hasChoices ? copy.other : copy.placeholder}</DialogDescription>
+        </DialogHeader>
+
+        {!typing && hasChoices ? (
+          <>
+            <div className="grid gap-2">
+              {choices.map((choice, index) => (
+                <Button
+                  className="h-auto justify-start whitespace-normal px-3 py-2 text-left"
+                  disabled={submitting}
+                  key={`${index}-${choice}`}
+                  onClick={() => void send(choice)}
+                  variant="outline"
+                >
+                  {choice}
+                </Button>
+              ))}
+              <Button disabled={submitting} onClick={() => setTyping(true)} type="button" variant="ghost">
+                {copy.other}
+              </Button>
+            </div>
+            <DialogFooter>
+              <Button disabled={submitting} onClick={() => void send('')} type="button" variant="ghost">
+                {copy.skip}
+              </Button>
+            </DialogFooter>
+          </>
+        ) : (
+          <form className="grid gap-3" onSubmit={onSubmit}>
+            <Textarea
+              autoFocus
+              className="min-h-24 resize-y"
+              disabled={submitting}
+              onChange={event => setDraft(event.target.value)}
+              onKeyDown={onDraftKeyDown}
+              placeholder={copy.placeholder}
+              value={draft}
+            />
+            <div className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+              <KbdCombo combo="mod+enter" size="sm" />
+              {copy.shortcutSuffix}
+            </div>
+            <DialogFooter>
+              {hasChoices && (
+                <Button
+                  disabled={submitting}
+                  onClick={() => {
+                    setTyping(false)
+                    setDraft('')
+                  }}
+                  type="button"
+                  variant="ghost"
+                >
+                  {copy.back}
+                </Button>
+              )}
+              <Button disabled={submitting} onClick={() => void send('')} type="button" variant="ghost">
+                {copy.skip}
+              </Button>
+              <Button disabled={submitting || !draft.trim()} type="submit">
+                {submitting ? <Loader2 className="size-3.5 animate-spin" /> : copy.send}
+              </Button>
+            </DialogFooter>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
 
 function SudoDialog() {
   const { t } = useI18n()
@@ -227,6 +390,7 @@ function SecretDialog() {
 export function PromptOverlays() {
   return (
     <>
+      <ClarifyDialog />
       <SudoDialog />
       <SecretDialog />
     </>

--- a/apps/desktop/src/store/clarify.test.ts
+++ b/apps/desktop/src/store/clarify.test.ts
@@ -33,8 +33,15 @@ describe('clarify store', () => {
     setClarifyRequest(clarify('session-a', 'req-a'))
     setClarifyRequest(clarify('session-b', 'req-b'))
 
-    expect($clarifyRequests.get()['session-a']?.requestId).toBe('req-a')
-    expect($clarifyRequests.get()['session-b']?.requestId).toBe('req-b')
+    expect($clarifyRequests.get()['session-a']?.[0]?.requestId).toBe('req-a')
+    expect($clarifyRequests.get()['session-b']?.[0]?.requestId).toBe('req-b')
+  })
+
+  it('queues multiple clarify requests for the same session oldest-first', () => {
+    setClarifyRequest(clarify('session-a', 'req-a1'))
+    setClarifyRequest(clarify('session-a', 'req-a2'))
+
+    expect($clarifyRequests.get()['session-a']?.map(request => request.requestId)).toEqual(['req-a1', 'req-a2'])
   })
 
   it('exposes only the active session via the focus-scoped view', () => {
@@ -58,7 +65,18 @@ describe('clarify store', () => {
     clearClarifyRequest('req-a', 'session-a')
 
     expect($clarifyRequests.get()['session-a']).toBeUndefined()
-    expect($clarifyRequests.get()['session-b']?.requestId).toBe('req-b')
+    expect($clarifyRequests.get()['session-b']?.[0]?.requestId).toBe('req-b')
+  })
+
+  it('clears only the matching request inside a same-session queue', () => {
+    setClarifyRequest(clarify('session-a', 'req-a1'))
+    setClarifyRequest(clarify('session-a', 'req-a2'))
+    $activeSessionId.set('session-a')
+
+    clearClarifyRequest('req-a1', 'session-a')
+
+    expect($clarifyRequests.get()['session-a']?.map(request => request.requestId)).toEqual(['req-a2'])
+    expect($clarifyRequest.get()?.requestId).toBe('req-a2')
   })
 
   it('ignores a stale clear whose request id no longer matches', () => {
@@ -66,7 +84,7 @@ describe('clarify store', () => {
 
     clearClarifyRequest('req-a1', 'session-a')
 
-    expect($clarifyRequests.get()['session-a']?.requestId).toBe('req-a2')
+    expect($clarifyRequests.get()['session-a']?.[0]?.requestId).toBe('req-a2')
   })
 
   it('clears by request id across sessions when no session hint is given', () => {
@@ -76,6 +94,17 @@ describe('clarify store', () => {
     clearClarifyRequest('shared')
 
     expect($clarifyRequests.get()['session-a']).toBeUndefined()
-    expect($clarifyRequests.get()['session-b']?.requestId).toBe('other')
+    expect($clarifyRequests.get()['session-b']?.[0]?.requestId).toBe('other')
+  })
+
+  it('clears the whole session queue when a turn ends', () => {
+    setClarifyRequest(clarify('session-a', 'req-a1'))
+    setClarifyRequest(clarify('session-a', 'req-a2'))
+    $activeSessionId.set('session-a')
+
+    clearClarifyRequest(undefined, 'session-a')
+
+    expect($clarifyRequests.get()['session-a']).toBeUndefined()
+    expect($clarifyRequest.get()).toBeNull()
   })
 })

--- a/apps/desktop/src/store/clarify.ts
+++ b/apps/desktop/src/store/clarify.ts
@@ -12,54 +12,109 @@ export interface ClarifyRequest {
 // Pending clarify requests keyed by the runtime session id that raised them.
 // Storing per-session (instead of one shared slot) lets a *background* session
 // park its clarify request while the user is looking at a different chat, then
-// resolve it once they switch over — without a second concurrent clarify
-// clobbering the first. A request with no session id lands under the empty key.
+// resolve it once they switch over — without another session clobbering it. We
+// store a FIFO queue per session because the Python gateway itself allows more
+// than one clarify to be pending in the same session (tools/clarify_gateway.py
+// keeps a list per session and resolves oldest-first). A request with no
+// session id lands under the empty key.
 const keyFor = (sessionId: string | null | undefined): string => sessionId ?? ''
 
-export const $clarifyRequests = atom<Record<string, ClarifyRequest>>({})
+type ClarifyQueues = Record<string, ClarifyRequest[]>
 
-// The clarify request for the currently-viewed session. The inline ClarifyTool
-// only ever mounts inside the active session's transcript, so it reads this
-// focus-scoped view rather than reaching into the whole map.
+function queueFor(requests: ClarifyQueues, sessionId: string | null | undefined): ClarifyRequest[] {
+  return requests[keyFor(sessionId)] ?? []
+}
+
+export const $clarifyRequests = atom<ClarifyQueues>({})
+
+// The ACTIVE clarify request for the currently-viewed session (oldest pending).
+// Both the modal overlay and the inline ClarifyTool only ever care about the
+// head of the active session's queue.
 export const $clarifyRequest = computed(
   [$clarifyRequests, $activeSessionId],
-  (requests, activeId) => requests[keyFor(activeId)] ?? null
+  (requests, activeId) => queueFor(requests, activeId)[0] ?? null
 )
 
+export function hasClarifyRequest(sessionId?: string | null): boolean {
+  const requests = $clarifyRequests.get()
+
+  if (sessionId !== undefined) {
+    return queueFor(requests, sessionId).length > 0
+  }
+
+  return Object.values(requests).some(queue => queue.length > 0)
+}
+
 export function setClarifyRequest(request: ClarifyRequest): void {
-  $clarifyRequests.set({ ...$clarifyRequests.get(), [keyFor(request.sessionId)]: request })
+  const all = $clarifyRequests.get()
+  const key = keyFor(request.sessionId)
+  const queue = [...queueFor(all, request.sessionId)]
+  const existingIndex = queue.findIndex(value => value.requestId === request.requestId)
+
+  if (existingIndex >= 0) {
+    queue[existingIndex] = request
+  } else {
+    queue.push(request)
+  }
+
+  $clarifyRequests.set({ ...all, [key]: queue })
 }
 
 export function clearClarifyRequest(requestId?: string, sessionId?: string | null): void {
   const requests = $clarifyRequests.get()
 
   // Targeted clear when the caller knows the session (the common path from the
-  // inline ClarifyTool answering its own request).
+  // overlay / inline ClarifyTool answering its own request). With no request id
+  // we drop the whole session queue (turn ended, timeout, interrupt).
   if (sessionId !== undefined) {
     const key = keyFor(sessionId)
-    const current = requests[key]
+    const current = queueFor(requests, sessionId)
 
-    if (!current || (requestId && current.requestId !== requestId)) {
+    if (!current.length) {
+      return
+    }
+
+    const nextQueue = requestId ? current.filter(value => value.requestId !== requestId) : []
+
+    if (requestId && nextQueue.length === current.length) {
       return
     }
 
     const next = { ...requests }
-    delete next[key]
+
+    if (nextQueue.length > 0) {
+      next[key] = nextQueue
+    } else {
+      delete next[key]
+    }
+
     $clarifyRequests.set(next)
 
     return
   }
 
-  // Fallback with no session hint: drop every entry matching the request id
-  // (or clear all when none is given).
-  const next: Record<string, ClarifyRequest> = {}
+  if (!requestId) {
+    if (Object.keys(requests).length > 0) {
+      $clarifyRequests.set({})
+    }
+
+    return
+  }
+
+  // Fallback with no session hint: drop matching request ids across every
+  // parked session queue.
+  const next: ClarifyQueues = {}
   let changed = false
 
-  for (const [key, value] of Object.entries(requests)) {
-    if (requestId && value.requestId !== requestId) {
-      next[key] = value
-    } else {
+  for (const [key, queue] of Object.entries(requests)) {
+    const filtered = queue.filter(value => value.requestId !== requestId)
+
+    if (filtered.length !== queue.length) {
       changed = true
+    }
+
+    if (filtered.length > 0) {
+      next[key] = filtered
     }
   }
 

--- a/apps/desktop/src/store/prompts.ts
+++ b/apps/desktop/src/store/prompts.ts
@@ -23,6 +23,7 @@ interface KeyedPrompt {
 interface PromptStore<T extends KeyedPrompt> {
   $active: ReadableAtom<null | T>
   clear: (sessionId?: string | null, requestId?: string) => void
+  has: (sessionId?: string | null) => boolean
   reset: () => void
   set: (request: T) => void
 }
@@ -37,6 +38,15 @@ function keyedPromptStore<T extends KeyedPrompt>(): PromptStore<T> {
 
   return {
     $active: computed([$all, $activeSessionId], (all, activeId) => all[keyFor(activeId)] ?? null),
+    has(sessionId) {
+      const all = $all.get()
+
+      if (sessionId !== undefined) {
+        return Boolean(all[keyFor(sessionId)])
+      }
+
+      return Object.keys(all).length > 0
+    },
     reset: () => $all.set({}),
     set: request => $all.set({ ...$all.get(), [keyFor(request.sessionId)]: request }),
     clear(sessionId, requestId) {
@@ -99,6 +109,10 @@ export const clearSudoRequest = sudo.clear
 export const $secretRequest = secret.$active
 export const setSecretRequest = secret.set
 export const clearSecretRequest = secret.clear
+
+export function hasBlockingPrompt(sessionId?: string | null): boolean {
+  return approval.has(sessionId) || sudo.has(sessionId) || secret.has(sessionId)
+}
 
 // Drop in-flight prompts for `sessionId` (a turn ended) across all three kinds —
 // or every parked prompt when no session is given (global reset / tests).


### PR DESCRIPTION
## Summary

This patch comes out of debugging a real Hermes Desktop failure mode where `clarify` requests could leave the agent waiting for input without reliably surfacing a visible option modal to the user.

The root causes I found were:

- `clarify` was not wired into the same blocking overlay path as other prompt types (`sudo` / `secret`), so the renderer could wait for `clarify.respond` without showing an obvious modal.
- clarify state was effectively single-slot per session instead of queue-based, so multiple pending clarify requests in the same session could overwrite each other.
- cleanup / `needsInput` recomputation on tool completion and message completion did not fully account for pending clarify requests, which could leave stale waiting state behind.

## What changed

- add a real clarify dialog to `PromptOverlays`
- convert clarify state to a per-session FIFO queue
- advance automatically to the next queued clarify after the current one is answered
- recompute prompt waiting state from remaining pending prompts instead of clearing it blindly on tool completion
- clear clarify state on message completion / error paths alongside other prompt cleanup
- add regression tests for:
  - clarify modal rendering
  - answering a choice-based clarify
  - advancing from the first clarify to the second in the same session queue

## Validation

I revalidated this patch on a clean branch based on current `origin/main`:

- targeted vitest run: `src/store/clarify.test.ts` + `src/components/prompt-overlays.test.tsx` (**10 tests passed**)
- `tsc -p . --noEmit` (**passed**)
- `vite build` (**passed**)

## Notes / honesty

I was not able to automate the packaged desktop shell itself end-to-end because of local macOS accessibility restrictions, so the evidence here is renderer/store-level regression coverage plus a clean production build. I wanted to be explicit about that instead of overstating the verification scope.
