### PR TITLE
fix(desktop): reserve titlebar safe areas for native controls

### DIFF
--- a/apps/desktop/src/app/overlays/overlay-view.tsx
+++ b/apps/desktop/src/app/overlays/overlay-view.tsx
@@ -49,7 +49,7 @@ export function OverlayView({
 
   return (
     <div
-      className="fixed inset-0 z-50 bg-black/22 p-3 backdrop-blur-[0.125rem] sm:p-6"
+      className="fixed inset-x-0 bottom-0 top-(--titlebar-height) z-50 bg-black/22 p-3 backdrop-blur-[0.125rem] sm:p-6"
       onClick={event => {
         if (event.target === event.currentTarget) {
           closeOverlay()

--- a/apps/desktop/src/app/shell/app-shell.tsx
+++ b/apps/desktop/src/app/shell/app-shell.tsx
@@ -1,6 +1,6 @@
 import { useStore } from '@nanostores/react'
 import type { CSSProperties, ReactNode } from 'react'
-import { useSyncExternalStore } from 'react'
+import { useEffect, useSyncExternalStore } from 'react'
 
 import { NotificationStack } from '@/components/notifications'
 import { PaneShell } from '@/components/pane-shell'
@@ -22,7 +22,7 @@ import { SIDEBAR_COLLAPSE_MEDIA_QUERY } from '../layout-constants'
 
 import { KeybindPanel } from './keybind-panel'
 import { StatusbarControls, type StatusbarItem } from './statusbar-controls'
-import { TITLEBAR_HEIGHT, titlebarControlsPosition } from './titlebar'
+import { TITLEBAR_HEIGHT, titlebarControlsPosition, titlebarSafeArea } from './titlebar'
 import { TitlebarControls, type TitlebarTool } from './titlebar-controls'
 
 interface AppShellProps {
@@ -85,7 +85,24 @@ export function AppShell({
   // on macOS, where window controls sit on the left and are reported via
   // windowButtonPosition instead). The right tool cluster has to clear them.
   const nativeOverlayWidth = connection?.nativeOverlayWidth ?? 0
+  const titlebarSafe = titlebarSafeArea(connection?.windowButtonPosition, nativeOverlayWidth, isFullscreen)
   const titlebarToolsRight = nativeOverlayWidth > 0 ? `${nativeOverlayWidth}px` : '0.75rem'
+
+  useEffect(() => {
+    const root = document.documentElement
+
+    // AppShell already owns the titlebar height. Mirror it to :root because
+    // Radix portals mount under <body>, outside the SidebarProvider subtree.
+    root.style.setProperty('--titlebar-height', `${TITLEBAR_HEIGHT}px`)
+    root.style.setProperty('--titlebar-safe-left', `${titlebarSafe.left}px`)
+    root.style.setProperty('--titlebar-safe-right', `${titlebarSafe.right}px`)
+
+    return () => {
+      root.style.removeProperty('--titlebar-height')
+      root.style.removeProperty('--titlebar-safe-left')
+      root.style.removeProperty('--titlebar-safe-right')
+    }
+  }, [titlebarSafe.left, titlebarSafe.right])
 
   // The inset clears the top-left titlebar buttons when nothing covers the
   // window's left edge. Default layout: the sessions sidebar sits there.
@@ -152,6 +169,8 @@ export function AppShell({
           '--titlebar-content-inset': `${titlebarContentInset}px`,
           '--titlebar-controls-left': `${titlebarControls.left}px`,
           '--titlebar-controls-top': `${titlebarControls.top}px`,
+          '--titlebar-safe-left': `${titlebarSafe.left}px`,
+          '--titlebar-safe-right': `${titlebarSafe.right}px`,
           '--titlebar-tools-right': titlebarToolsRight,
           '--titlebar-tools-width': titlebarToolsWidth,
           // Anchor for the pane-tool cluster's right edge in TitlebarControls.

--- a/apps/desktop/src/app/shell/titlebar-controls.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.tsx
@@ -137,13 +137,11 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
     }
   ]
 
-  // While a full-screen overlay (settings, command center, …) is open it should
-  // visually own the window. These control clusters are `fixed` at a higher
-  // z-index than the overlay card, so they'd otherwise bleed over it — hide them
-  // and let the overlay's own chrome (close button, drag region) take over.
-  if (isOverlayView(appViewForPath(location.pathname))) {
-    return null
-  }
+  // Full-screen route overlays (settings, command center, …) should coexist
+  // with the persistent titlebar chrome instead of unmounting it. Keep the
+  // controls visible as spatial anchors, but make Hermes-owned buttons inert
+  // while the overlay owns focus/interactions. Native OS controls remain native.
+  const overlayRouteOpen = isOverlayView(appViewForPath(location.pathname))
 
   const visibleSystemTools = systemTools.filter(tool => !tool.hidden)
   const settingsTool = visibleSystemTools.find(tool => tool.id === 'settings')
@@ -152,6 +150,13 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
 
   return (
     <>
+      {overlayRouteOpen && (
+        <div
+          aria-hidden="true"
+          className="pointer-events-none fixed inset-x-0 top-0 z-60 h-(--titlebar-height) bg-(--ui-chat-surface-background)"
+        />
+      )}
+
       <div
         aria-label={t.shell.windowControls}
         className="fixed left-(--titlebar-controls-left) top-(--titlebar-controls-top) z-70 flex translate-y-0.5 flex-row items-center gap-x-1 pointer-events-auto select-none [-webkit-app-region:no-drag]"
@@ -159,7 +164,7 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
         {leftToolbarTools
           .filter(tool => !tool.hidden)
           .map(tool => (
-            <TitlebarToolButton key={tool.id} navigate={navigate} tool={tool} />
+            <TitlebarToolButton disabled={overlayRouteOpen} key={tool.id} navigate={navigate} tool={tool} />
           ))}
       </div>
 
@@ -177,7 +182,7 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
           className="fixed top-(--titlebar-controls-top) right-[calc(var(--titlebar-tools-right)+var(--shell-preview-toolbar-gap,0))] z-70 flex flex-row items-center gap-x-1 pointer-events-auto select-none [-webkit-app-region:no-drag]"
         >
           {visiblePaneTools.map(tool => (
-            <TitlebarToolButton key={tool.id} navigate={navigate} tool={tool} />
+            <TitlebarToolButton disabled={overlayRouteOpen} key={tool.id} navigate={navigate} tool={tool} />
           ))}
         </div>
       )}
@@ -187,29 +192,51 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
         className="fixed right-(--titlebar-tools-right) top-(--titlebar-controls-top) z-70 flex flex-row items-center justify-end gap-x-1 pointer-events-auto select-none [-webkit-app-region:no-drag]"
       >
         {visibleSystemToolsBeforeSettings.map(tool => (
-          <TitlebarToolButton key={tool.id} navigate={navigate} tool={tool} />
+          <TitlebarToolButton disabled={overlayRouteOpen} key={tool.id} navigate={navigate} tool={tool} />
         ))}
-        {settingsTool && <TitlebarToolButton navigate={navigate} tool={settingsTool} />}
-        <TitlebarToolButton navigate={navigate} tool={rightSidebarTool} />
+        {settingsTool && <TitlebarToolButton disabled={overlayRouteOpen} navigate={navigate} tool={settingsTool} />}
+        <TitlebarToolButton disabled={overlayRouteOpen} navigate={navigate} tool={rightSidebarTool} />
       </div>
     </>
   )
 }
 
-function TitlebarToolButton({ navigate, tool }: { navigate: ReturnType<typeof useNavigate>; tool: TitlebarTool }) {
+function TitlebarToolButton({
+  disabled = false,
+  navigate,
+  tool
+}: {
+  disabled?: boolean
+  navigate: ReturnType<typeof useNavigate>
+  tool: TitlebarTool
+}) {
   // Titlebar actions never show an active background — state reads from the
   // icon itself (e.g. the mute/unmute glyph). aria-pressed still carries it
   // for a11y.
-  const className = cn(titlebarButtonClass, 'bg-transparent select-none', tool.className)
+  const isDisabled = disabled || tool.disabled
+
+  const className = cn(
+    titlebarButtonClass,
+    'bg-transparent select-none',
+    isDisabled && 'pointer-events-none opacity-45',
+    tool.className
+  )
 
   if (tool.href) {
     return (
       <Button asChild className={className} size="icon-titlebar" variant="ghost">
         <a
+          aria-disabled={isDisabled || undefined}
           aria-label={tool.label}
           href={tool.href}
+          onClick={event => {
+            if (isDisabled) {
+              event.preventDefault()
+            }
+          }}
           onPointerDown={event => event.stopPropagation()}
           rel="noreferrer"
+          tabIndex={isDisabled ? -1 : undefined}
           target="_blank"
           title={tool.title ?? tool.label}
         >
@@ -224,7 +251,7 @@ function TitlebarToolButton({ navigate, tool }: { navigate: ReturnType<typeof us
       aria-label={tool.label}
       aria-pressed={tool.active ?? undefined}
       className={className}
-      disabled={tool.disabled}
+      disabled={isDisabled}
       onClick={() => {
         if (tool.to) {
           navigate(tool.to)

--- a/apps/desktop/src/app/shell/titlebar.test.ts
+++ b/apps/desktop/src/app/shell/titlebar.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  MACOS_TRAFFIC_LIGHTS_SAFE_WIDTH,
   TITLEBAR_CONTROL_OFFSET_X,
   TITLEBAR_EDGE_INSET,
   TITLEBAR_FALLBACK_WINDOW_BUTTON_X,
-  titlebarControlsPosition
+  titlebarControlsPosition,
+  titlebarSafeArea
 } from './titlebar'
 
 describe('titlebarControlsPosition', () => {
@@ -22,5 +24,22 @@ describe('titlebarControlsPosition', () => {
 
   it('uses the macOS fallback while the initial window state is unknown', () => {
     expect(titlebarControlsPosition(undefined).left).toBe(TITLEBAR_FALLBACK_WINDOW_BUTTON_X + TITLEBAR_CONTROL_OFFSET_X)
+  })
+})
+
+describe('titlebarSafeArea', () => {
+  it('models visible macOS traffic lights as left reserved chrome', () => {
+    expect(titlebarSafeArea({ x: 24, y: 10 })).toEqual({
+      left: 24 + MACOS_TRAFFIC_LIGHTS_SAFE_WIDTH,
+      right: 0
+    })
+  })
+
+  it('models Windows/Linux titleBarOverlay controls as right reserved chrome', () => {
+    expect(titlebarSafeArea(null, 138)).toEqual({ left: 0, right: 138 })
+  })
+
+  it('clears the macOS left reservation while fullscreen hides traffic lights', () => {
+    expect(titlebarSafeArea({ x: 24, y: 10 }, 0, true)).toEqual({ left: 0, right: 0 })
   })
 })

--- a/apps/desktop/src/app/shell/titlebar.ts
+++ b/apps/desktop/src/app/shell/titlebar.ts
@@ -7,6 +7,10 @@ export const TITLEBAR_CONTROL_OFFSET_X = 74
 export const TITLEBAR_CONTROL_HEIGHT = 22
 export const TITLEBAR_CONTROLS_TOP = (TITLEBAR_HEIGHT - TITLEBAR_CONTROL_HEIGHT) / 2
 export const TITLEBAR_FALLBACK_WINDOW_BUTTON_X = 24
+// Conservative horizontal footprint of the macOS traffic-light cluster,
+// measured from Electron's reported left edge. Native controls paint outside
+// DOM stacking, so shell-level chrome needs this modeled as reserved space.
+export const MACOS_TRAFFIC_LIGHTS_SAFE_WIDTH = 74
 // Edge inset used when no left-side native controls take up that space —
 // Windows/Linux (native overlay is on the right) and macOS fullscreen
 // (traffic lights are hidden). Matches the right-cluster's 0.75rem padding.
@@ -19,13 +23,29 @@ export const titlebarButtonClass =
   'text-muted-foreground/85 hover:bg-(--ui-control-hover-background) hover:text-foreground'
 
 export const titlebarHeaderBaseClass =
-  'pointer-events-none relative z-3 flex h-(--titlebar-height) w-full min-w-0 shrink-0 items-center justify-start gap-3 overflow-hidden border-b border-(--ui-stroke-tertiary) bg-(--ui-chat-surface-background) px-[max(0.75rem,var(--titlebar-content-inset,0rem))] pr-[calc(var(--titlebar-tools-right,0.75rem)+var(--titlebar-tools-width,0px)+0.75rem)]'
+  'pointer-events-none relative z-3 flex h-(--titlebar-height) w-full min-w-0 shrink-0 items-center justify-start gap-3 overflow-hidden bg-(--ui-chat-surface-background) px-[max(0.75rem,var(--titlebar-content-inset,0rem))] pr-[calc(var(--titlebar-tools-right,0.75rem)+var(--titlebar-tools-width,0px)+0.75rem)]'
 
 // Title row inside the header — must stay in the flex truncate chain.
 export const titlebarHeaderTitleClass = 'min-w-0 flex-1 overflow-hidden'
 
 export const titlebarHeaderShadowClass =
   "after:pointer-events-none after:absolute after:left-0 after:right-0 after:top-full after:h-4 after:bg-linear-to-b after:from-(--ui-chat-surface-background) after:to-transparent after:content-['']"
+
+export function titlebarSafeArea(
+  windowButtonPosition: HermesConnection['windowButtonPosition'] | undefined,
+  nativeOverlayWidth = 0,
+  isFullscreen = false
+) {
+  const safeLeft =
+    windowButtonPosition !== null && !isFullscreen
+      ? (windowButtonPosition?.x ?? TITLEBAR_FALLBACK_WINDOW_BUTTON_X) + MACOS_TRAFFIC_LIGHTS_SAFE_WIDTH
+      : 0
+
+  return {
+    left: safeLeft,
+    right: nativeOverlayWidth
+  }
+}
 
 export function titlebarControlsPosition(
   windowButtonPosition: HermesConnection['windowButtonPosition'] | undefined,

--- a/apps/desktop/src/themes/context.tsx
+++ b/apps/desktop/src/themes/context.tsx
@@ -165,6 +165,12 @@ const mixesFor = (isDark: boolean): Record<string, string> => ({
   '--theme-mix-bubble': isDark ? '46%' : '0%'
 })
 
+function chromeSurfaceColor(background: string, isDark: boolean): string {
+  // Mirrors --ui-bg-chrome from styles.css. Electron's Windows/Linux
+  // titleBarOverlay needs a concrete hex color, not a CSS color-mix() token.
+  return mix(background, isDark ? '#0d0d0e' : '#f3f3f3', isDark ? 0.26 : 0.08)
+}
+
 function applyTheme(theme: DesktopTheme, mode: 'light' | 'dark') {
   if (typeof document === 'undefined') {
     return
@@ -223,7 +229,7 @@ function applyTheme(theme: DesktopTheme, mode: 'light' | 'dark') {
   }
 
   window.hermesDesktop?.setTitleBarTheme?.({
-    background: c.background,
+    background: chromeSurfaceColor(c.background, isDark),
     foreground: c.foreground
   })
 


### PR DESCRIPTION
## What does this PR do?

Adds a platform-aware titlebar safe-area foundation for Hermes Desktop so renderer chrome treats native window controls as reserved native regions instead of normal DOM space.

On Windows/Linux, Electron's `titleBarOverlay` paints native min/max/close controls above the renderer on the right. On macOS, traffic lights occupy the top-left titlebar region. This PR exposes those regions as shell-owned CSS variables and updates route-overlay chrome so fullscreen overlay screens coexist with persistent titlebar chrome instead of unmounting it or letting underlying pane/sidebar borders bleed through.

Fixes:
<img width="189" height="106" alt="image" src="https://github.com/user-attachments/assets/56d54013-2547-4935-82f8-a01e7b98484a" />


This is intentionally a focused foundation PR, not a full modal/window-chrome redesign. Shared Radix dialogs/sheets keep their existing full-window modal backdrops; migrating them to a future DesktopDialog-style primitive should be a follow-up.

## Related Issue

N/A — no existing issue found. Searched open PRs for titlebar/titleBarOverlay/native window-control overlap and did not find a duplicate.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/shell/titlebar.ts`
  - Adds `titlebarSafeArea(...)` to model macOS traffic-light and Windows/Linux `titleBarOverlay` safe areas.
  - Removes the titlebar bottom border so the Windows native control overlay does not create a partial/broken border seam.
- `apps/desktop/src/app/shell/app-shell.tsx`
  - Computes `--titlebar-safe-left` and `--titlebar-safe-right` from native window metadata.
  - Mirrors `--titlebar-height` and safe-area variables to `document.documentElement` so portaled chrome can consume them later.
- `apps/desktop/src/app/shell/titlebar-controls.tsx`
  - Keeps Hermes titlebar controls rendered during route overlays, but disables/inerts app-owned buttons while the overlay owns focus.
  - Adds a titlebar-height mask behind controls during route overlays so underlying sidebar/pane borders do not show through the safe band.
- `apps/desktop/src/app/overlays/overlay-view.tsx`
  - Starts route-overlay backdrops below the titlebar band.
- `apps/desktop/src/themes/context.tsx`
  - Sends Electron a concrete mixed chrome-surface color for Windows/Linux native `titleBarOverlay`, matching the renderer titlebar surface instead of the raw theme background.
- `apps/desktop/src/app/shell/titlebar.test.ts`
  - Adds coverage for macOS traffic-light safe area, Windows/Linux right-side native overlay width, and macOS fullscreen behavior.

## How to Test

1. macOS: open Hermes Desktop, then open route overlays such as Settings or Command Center.
   - Titlebar chrome remains visible.
   - Hermes-owned titlebar buttons are visually disabled/inert.
   - The titlebar safe band does not show underlying sidebar or pane borders.
2. Windows: open Hermes Desktop with a dark/blue theme.
   - Native min/max/close overlay background matches the titlebar chrome surface.
   - The right-side renderer titlebar controls do not sit under native window controls.
   - The titlebar band does not show a partial bottom border under the native control overlay.
3. Run verification commands:
   - `cd apps/desktop && npx eslint src/app/shell/titlebar.ts src/app/shell/app-shell.tsx src/app/shell/titlebar-controls.tsx src/app/overlays/overlay-view.tsx src/themes/context.tsx src/app/shell/titlebar.test.ts`
   - `cd apps/desktop && npm run test:ui -- src/app/shell/titlebar.test.ts`
   - `cd apps/desktop && npm run typecheck`
   - `cd apps/desktop && npm run build`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1; Windows visual validation of the native titlebar overlay/safe-area behavior

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Test Results

Passed:

```text
cd apps/desktop && npx eslint src/app/shell/titlebar.ts src/app/shell/app-shell.tsx src/app/shell/titlebar-controls.tsx src/app/overlays/overlay-view.tsx src/themes/context.tsx src/app/shell/titlebar.test.ts
cd apps/desktop && npm run test:ui -- src/app/shell/titlebar.test.ts
  ✓ src/app/shell/titlebar.test.ts (7 tests)
cd apps/desktop && npm run typecheck
cd apps/desktop && npm run build
  ✓ built
  ✓ assert-dist-built: dist/index.html + assets present
```

Full Python suite note:

```text
uv run pytest tests/ -q
```

was attempted after installing dev extras. It exceeded the 10-minute local command limit after showing unrelated failures outside this desktop renderer change. The repo's preferred wrapper was also attempted:

```text
scripts/run_tests.sh
```

and reached an unrelated failure in `tests/agent/test_anthropic_adapter.py` credential-resolution tests:

```text
FAILED tests/agent/test_anthropic_adapter.py::TestResolveAnthropicToken::test_falls_back_to_claude_code_credentials
FAILED tests/agent/test_anthropic_adapter.py::TestResolveAnthropicToken::test_prefers_refreshable_claude_code_credentials_over_static_anthropic_token
FAILED tests/agent/test_anthropic_adapter.py::TestRunOauthSetupToken::test_returns_token_from_credential_files
FAILED tests/agent/test_anthropic_adapter.py::TestRunOauthSetupToken::test_returns_token_from_env_var
FAILED tests/agent/test_anthropic_adapter.py::TestRunOauthSetupToken::test_returns_none_when_no_creds_found
```

Those failures are not in the touched desktop files and appear unrelated to this PR.

## Screenshots / Logs
Windows
<img width="1248" height="855" alt="image" src="https://github.com/user-attachments/assets/37891090-8155-4482-91be-15b601cfa236" />
<img width="1236" height="853" alt="image" src="https://github.com/user-attachments/assets/7191fc59-a600-4424-8d32-9d262cf2f1d2" />

macOS
<img width="1273" height="758" alt="Screenshot 2026-06-12 at 4 18 58 PM" src="https://github.com/user-attachments/assets/c85bd2c5-da0f-47fa-af6d-a25b506eeb11" />
<img width="1278" height="752" alt="Screenshot 2026-06-12 at 4 20 45 PM" src="https://github.com/user-attachments/assets/f578e664-eee8-46b3-8aca-a813ecaae782" />

