### PR TITLE
FGD-188 restore Telegram voice input diagnostics and empty STT handling

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1610,6 +1610,16 @@ class TelegramAdapter(BasePlatformAdapter):
             self._app = builder.build()
             self._bot = self._app.bot
             
+            # Earliest redacted media ingress diagnostic.  Registered in an
+            # earlier handler group so it observes voice/audio/media updates
+            # before the normal text/command/media routing filters decide which
+            # handler receives the update.  The diagnostic helper logs only
+            # shape metadata and returns without mutating the update.
+            self._app.add_handler(TelegramMessageHandler(
+                filters.ALL,
+                self._handle_ingress_diagnostic
+            ), group=-1)
+
             # Register handlers
             self._app.add_handler(TelegramMessageHandler(
                 filters.TEXT & ~filters.COMMAND,
@@ -5114,6 +5124,103 @@ class TelegramAdapter(BasePlatformAdapter):
             return MessageType.VOICE
         return MessageType.DOCUMENT
 
+    def _telegram_voice_media_event_kind(self, msg: Any) -> Optional[str]:
+        """Return the redacted diagnostic event kind for Telegram media ingress."""
+        if getattr(msg, "voice", None):
+            return "voice"
+        if any(
+            getattr(msg, attr, None)
+            for attr in ("audio", "photo", "video", "document", "sticker")
+        ):
+            return "media"
+        return None
+
+    def _telegram_ingress_message(self, update: Any) -> tuple[str, Any]:
+        """Return the first message-like object on a Telegram update.
+
+        Only the update/message shape is reported by diagnostics; identifiers,
+        bodies, file IDs, usernames, URLs, and paths are intentionally ignored.
+        """
+        for event_kind, attr in (
+            ("message", "message"),
+            ("edited_message", "edited_message"),
+            ("channel_post", "channel_post"),
+            ("edited_channel_post", "edited_channel_post"),
+        ):
+            msg = getattr(update, attr, None)
+            if msg is not None:
+                return event_kind, msg
+        return "none", None
+
+    def _log_telegram_media_ingress_diagnostic(self, update: Any) -> None:
+        """Emit earliest redacted Telegram media ingress diagnostics.
+
+        This runs before routing/media-handler matching and logs only update
+        shape metadata for voice/audio/media messages.  It deliberately omits
+        chat/user identifiers, file IDs, captions, message bodies, URLs, paths,
+        and config/env values.
+        """
+        event_kind, msg = self._telegram_ingress_message(update)
+        if msg is None:
+            return
+
+        has_voice = bool(getattr(msg, "voice", None))
+        has_audio = bool(getattr(msg, "audio", None))
+        has_photo = bool(getattr(msg, "photo", None))
+        has_video = bool(getattr(msg, "video", None))
+        has_document = bool(getattr(msg, "document", None))
+        has_sticker = bool(getattr(msg, "sticker", None))
+        has_media = any((has_voice, has_audio, has_photo, has_video, has_document, has_sticker))
+        if not has_media:
+            return
+
+        if has_voice:
+            message_kind = "voice"
+        elif has_audio:
+            message_kind = "audio"
+        else:
+            message_kind = "media"
+        thread_marker = "<ID>" if getattr(msg, "message_thread_id", None) is not None else "none"
+        logger.info(
+            "Telegram media ingress diagnostic: "
+            "event_kind=%s message_kind=%s has_voice=%s has_audio=%s has_media=%s "
+            "media_handler_expected=yes chat=<ID> thread=%s",
+            event_kind,
+            message_kind,
+            "yes" if has_voice else "no",
+            "yes" if has_audio else "no",
+            "yes" if has_media else "no",
+            thread_marker,
+        )
+
+    async def _handle_ingress_diagnostic(self, update: Any, context: Any) -> None:
+        """Observe Telegram update shape before normal routing without mutating it."""
+        self._log_telegram_media_ingress_diagnostic(update)
+
+    def _log_voice_media_route_decision(self, msg: Any, *, accepted: bool) -> None:
+        """Emit a redacted component-level route diagnostic for media ingress.
+
+        This intentionally avoids chat/user/thread values, captions, message
+        bodies, file IDs, URLs, paths, and config values. It only records the
+        route-gate outcome needed to tell whether Telegram media reached the
+        adapter and was accepted for downstream caching/STT.
+        """
+        event_kind = self._telegram_voice_media_event_kind(msg)
+        if event_kind is None:
+            return
+
+        decision = "accepted" if accepted else "dropped"
+        drop_gate = "none" if accepted else "route_gate"
+        thread_marker = "<ID>" if getattr(msg, "message_thread_id", None) is not None else "none"
+        logger.info(
+            "Telegram voice/media route diagnostic: "
+            "event_kind=%s route_decision=%s drop_gate=%s stt_reached=no chat=<ID> thread=%s",
+            event_kind,
+            decision,
+            drop_gate,
+            thread_marker,
+        )
+
     async def _cache_observed_media(self, msg: Message, event: MessageEvent) -> None:
         """Cache an unmentioned group attachment and annotate the observed text.
 
@@ -5560,7 +5667,9 @@ class TelegramAdapter(BasePlatformAdapter):
         """Handle incoming media messages, downloading images to local cache."""
         if not update.message:
             return
-        if not self._should_process_message(update.message):
+        accepted = self._should_process_message(update.message)
+        self._log_voice_media_route_decision(update.message, accepted=accepted)
+        if not accepted:
             if self._should_observe_unmentioned_group_message(update.message):
                 _m = update.message
                 _observe_type = self._media_message_type(_m)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11654,6 +11654,78 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return prefix
         return user_text
 
+    @staticmethod
+    def _is_useful_stt_transcript(transcript: object) -> bool:
+        """Return True when STT output contains usable spoken text.
+
+        Some providers return success with an empty string, whitespace, or
+        punctuation-only placeholders for silence/noise. Treat those as no
+        useful transcript so voice messages do not silently enter the agent as
+        empty user turns.
+        """
+        if not isinstance(transcript, str):
+            return False
+        cleaned = transcript.strip()
+        if not cleaned:
+            return False
+        return any(ch.isalnum() for ch in cleaned)
+
+    @staticmethod
+    def _stt_transcript_length_bucket(transcript: object) -> str:
+        if not isinstance(transcript, str):
+            return "none"
+        length = len(transcript.strip())
+        if length == 0:
+            return "0"
+        if length <= 20:
+            return "1-20"
+        if length <= 100:
+            return "21-100"
+        return "100+"
+
+    @staticmethod
+    def _classify_stt_error(error: object) -> str:
+        text = str(error or "").lower()
+        if (
+            "no stt provider" in text
+            or "voice_tools_openai_key" in text
+            or "openai_api_key" in text
+            or "api key" in text
+            or "provider" in text and "configured" in text
+        ):
+            return "provider_unavailable"
+        if (
+            "decode" in text
+            or "codec" in text
+            or "ffmpeg" in text
+            or "audio" in text and ("invalid" in text or "corrupt" in text)
+        ):
+            return "audio_decode_error"
+        if "module" in text or "import" in text or "dependency" in text or "not installed" in text:
+            return "dependency_error"
+        return "unknown_error"
+
+    @staticmethod
+    def _log_stt_result_diagnostic(
+        *,
+        stt_attempted: bool,
+        stt_provider_available: str,
+        stt_result_class: str,
+        transcript_non_empty: bool,
+        transcript_length_bucket: str = "none",
+    ) -> None:
+        """Emit redacted STT outcome metadata without paths/transcript text."""
+        logger.info(
+            "Telegram voice STT result diagnostic: "
+            "stt_attempted=%s stt_provider_available=%s "
+            "stt_result_class=%s transcript_non_empty=%s transcript_length_bucket=%s",
+            "yes" if stt_attempted else "no",
+            stt_provider_available,
+            stt_result_class,
+            "yes" if transcript_non_empty else "no",
+            transcript_length_bucket,
+        )
+
     async def _enrich_message_with_transcription(
         self,
         user_text: str,
@@ -11677,6 +11749,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 this to echo transcripts back to the user before the agent loop.
         """
         if not getattr(self.config, "stt_enabled", True):
+            self._log_stt_result_diagnostic(
+                stt_attempted=False,
+                stt_provider_available="unknown",
+                stt_result_class="provider_unavailable",
+                transcript_non_empty=False,
+            )
             notes = []
             for path in audio_paths:
                 abs_path = os.path.abspath(path)
@@ -11706,18 +11784,37 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.debug("Transcribing user voice: %s", path)
                 result = await asyncio.to_thread(transcribe_audio, path)
                 if result["success"]:
-                    transcript = result["transcript"]
-                    successful_transcripts.append(transcript)
-                    enriched_parts.append(
-                        f'[The user sent a voice message~ '
-                        f'Here\'s what they said: "{transcript}"]'
+                    transcript = result.get("transcript", "")
+                    useful_transcript = self._is_useful_stt_transcript(transcript)
+                    self._log_stt_result_diagnostic(
+                        stt_attempted=True,
+                        stt_provider_available="yes",
+                        stt_result_class="success_non_empty" if useful_transcript else "success_empty",
+                        transcript_non_empty=useful_transcript,
+                        transcript_length_bucket=self._stt_transcript_length_bucket(transcript),
                     )
+                    if useful_transcript:
+                        successful_transcripts.append(transcript)
+                        enriched_parts.append(
+                            f'[The user sent a voice message~ '
+                            f'Here\'s what they said: "{transcript}"]'
+                        )
+                    else:
+                        enriched_parts.append(
+                            "[The user sent a voice message, but speech-to-text "
+                            "did not produce usable transcript text. Ask the user "
+                            "to resend the voice note or type the message.]"
+                        )
                 else:
                     error = result.get("error", "unknown error")
-                    if (
-                        "No STT provider" in error
-                        or error.startswith("Neither VOICE_TOOLS_OPENAI_KEY nor OPENAI_API_KEY is set")
-                    ):
+                    result_class = self._classify_stt_error(error)
+                    self._log_stt_result_diagnostic(
+                        stt_attempted=True,
+                        stt_provider_available="no" if result_class == "provider_unavailable" else "unknown",
+                        stt_result_class=result_class,
+                        transcript_non_empty=False,
+                    )
+                    if result_class == "provider_unavailable":
                         _no_stt_note = (
                             "[The user sent a voice message but I can't listen "
                             "to it right now — no STT provider is configured. "
@@ -11738,6 +11835,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             f"transcribing it~ ({error})]"
                         )
             except Exception as e:
+                result_class = self._classify_stt_error(e)
+                self._log_stt_result_diagnostic(
+                    stt_attempted=True,
+                    stt_provider_available="unknown",
+                    stt_result_class=result_class,
+                    transcript_non_empty=False,
+                )
                 logger.error("Transcription error: %s", e)
                 enriched_parts.append(
                     "[The user sent a voice message but something went wrong "

--- a/tests/gateway/test_telegram_voice_route_diagnostic.py
+++ b/tests/gateway/test_telegram_voice_route_diagnostic.py
@@ -1,0 +1,228 @@
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+
+
+PRIVATE_CHAT_ID = "SHOULD_NOT_LEAK_CHAT_ID"
+PRIVATE_THREAD_ID = "424242"
+PRIVATE_USERNAME = "SHOULD_NOT_LEAK_USERNAME"
+PRIVATE_BODY = "SHOULD_NOT_LEAK_MESSAGE_BODY"
+PRIVATE_FILE_ID = "SHOULD_NOT_LEAK_FILE_ID"
+PRIVATE_URL = "SHOULD_NOT_LEAK_URL"
+PRIVATE_PATH = "SHOULD_NOT_LEAK_PRIVATE_PATH"
+PRIVATE_CONFIG_VALUE = "SHOULD_NOT_LEAK_PRIVATE_CONFIG_VALUE"
+
+
+def _make_adapter(require_mention=True):
+    from gateway.platforms.telegram import TelegramAdapter
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter.platform = Platform.TELEGRAM
+    adapter.config = PlatformConfig(
+        enabled=True,
+        token="***",
+        extra={
+            "require_mention": require_mention,
+            "allowed_topics": [],
+            "allowed_chats": [],
+            "group_allowed_chats": [],
+        },
+    )
+    adapter._bot = SimpleNamespace(id=999, username="hermes_bot")
+    adapter._mention_patterns = []
+    adapter._dm_topics_config = []
+    adapter._dm_topic_chat_ids = set()
+    adapter._is_callback_user_authorized = lambda user_id, **_kw: True
+    return adapter
+
+
+def _voice_message(*, text=PRIVATE_BODY, caption=PRIVATE_BODY, reply_to_bot=False):
+    reply_to_message = None
+    if reply_to_bot:
+        reply_to_message = SimpleNamespace(
+            from_user=SimpleNamespace(id=999),
+            message_id=10,
+            text="previous bot reply",
+            caption=None,
+        )
+    return SimpleNamespace(
+        message_id=42,
+        text=text,
+        caption=caption,
+        entities=[],
+        caption_entities=[],
+        message_thread_id=PRIVATE_THREAD_ID,
+        is_topic_message=True,
+        chat=SimpleNamespace(id=PRIVATE_CHAT_ID, type="group", title="Private Group", is_forum=True),
+        from_user=SimpleNamespace(id=111, full_name=PRIVATE_USERNAME, first_name="Test"),
+        reply_to_message=reply_to_message,
+        voice=SimpleNamespace(file_id=PRIVATE_FILE_ID, file_unique_id="unique", file_size=1234),
+        audio=None,
+        photo=None,
+        video=None,
+        document=None,
+        sticker=None,
+        file_path=PRIVATE_PATH,
+        url=PRIVATE_URL,
+        private_config=PRIVATE_CONFIG_VALUE,
+        date=None,
+    )
+
+
+def test_voice_route_diagnostic_logs_redacted_drop_without_sensitive_values(caplog):
+    adapter = _make_adapter(require_mention=True)
+    message = _voice_message(reply_to_bot=False)
+
+    with caplog.at_level(logging.INFO, logger="gateway.platforms.telegram"):
+        accepted = adapter._should_process_message(message)
+        adapter._log_voice_media_route_decision(message, accepted=accepted)
+
+    assert accepted is False
+    output = caplog.text
+    assert "Telegram voice/media route diagnostic" in output
+    assert "event_kind=voice" in output
+    assert "route_decision=dropped" in output
+    assert "drop_gate=route_gate" in output
+    assert "stt_reached=no" in output
+    assert "chat=<ID>" in output
+    assert "thread=<ID>" in output
+
+    for secret in (
+        PRIVATE_CHAT_ID,
+        PRIVATE_THREAD_ID,
+        PRIVATE_USERNAME,
+        PRIVATE_BODY,
+        PRIVATE_FILE_ID,
+        PRIVATE_URL,
+        PRIVATE_PATH,
+        PRIVATE_CONFIG_VALUE,
+    ):
+        assert secret not in output
+
+
+def test_voice_route_diagnostic_logs_redacted_accept_without_sensitive_values(caplog):
+    adapter = _make_adapter(require_mention=True)
+    message = _voice_message(reply_to_bot=True)
+
+    with caplog.at_level(logging.INFO, logger="gateway.platforms.telegram"):
+        accepted = adapter._should_process_message(message)
+        adapter._log_voice_media_route_decision(message, accepted=accepted)
+
+    assert accepted is True
+    output = caplog.text
+    assert "event_kind=voice" in output
+    assert "route_decision=accepted" in output
+    assert "drop_gate=none" in output
+    assert "stt_reached=no" in output
+
+    for secret in (
+        PRIVATE_CHAT_ID,
+        PRIVATE_THREAD_ID,
+        PRIVATE_USERNAME,
+        PRIVATE_BODY,
+        PRIVATE_FILE_ID,
+        PRIVATE_URL,
+        PRIVATE_PATH,
+        PRIVATE_CONFIG_VALUE,
+    ):
+        assert secret not in output
+
+
+@pytest.mark.asyncio
+async def test_media_handler_emits_redacted_drop_diagnostic_before_cache_or_stt(caplog):
+    adapter = _make_adapter(require_mention=True)
+
+    def _do_not_observe(message):
+        return False
+
+    adapter._should_observe_unmentioned_group_message = _do_not_observe
+    message = _voice_message(reply_to_bot=False)
+    update = SimpleNamespace(message=message, update_id=100)
+
+    with caplog.at_level(logging.INFO, logger="gateway.platforms.telegram"):
+        await adapter._handle_media_message(update, SimpleNamespace())
+
+    output = caplog.text
+    assert "Telegram voice/media route diagnostic" in output
+    assert "event_kind=voice" in output
+    assert "route_decision=dropped" in output
+    assert "drop_gate=route_gate" in output
+    assert "stt_reached=no" in output
+    assert "Cached user voice" not in output
+
+    for secret in (
+        PRIVATE_CHAT_ID,
+        PRIVATE_THREAD_ID,
+        PRIVATE_USERNAME,
+        PRIVATE_BODY,
+        PRIVATE_FILE_ID,
+        PRIVATE_URL,
+        PRIVATE_PATH,
+        PRIVATE_CONFIG_VALUE,
+    ):
+        assert secret not in output
+
+
+def test_ingress_diagnostic_logs_voice_before_media_handler_matching(caplog):
+    adapter = _make_adapter(require_mention=True)
+    message = _voice_message(reply_to_bot=True)
+    update = SimpleNamespace(message=message, edited_message=None, channel_post=None, update_id=100)
+
+    with caplog.at_level(logging.INFO, logger="gateway.platforms.telegram"):
+        adapter._log_telegram_media_ingress_diagnostic(update)
+
+    output = caplog.text
+    assert "Telegram media ingress diagnostic" in output
+    assert "event_kind=message" in output
+    assert "message_kind=voice" in output
+    assert "has_voice=yes" in output
+    assert "has_audio=no" in output
+    assert "has_media=yes" in output
+    assert "media_handler_expected=yes" in output
+    assert "chat=<ID>" in output
+    assert "thread=<ID>" in output
+
+    for secret in (
+        PRIVATE_CHAT_ID,
+        PRIVATE_THREAD_ID,
+        PRIVATE_USERNAME,
+        PRIVATE_BODY,
+        PRIVATE_FILE_ID,
+        PRIVATE_URL,
+        PRIVATE_PATH,
+        PRIVATE_CONFIG_VALUE,
+    ):
+        assert secret not in output
+
+
+def test_ingress_diagnostic_ignores_plain_text_to_avoid_unrelated_log_noise(caplog):
+    adapter = _make_adapter(require_mention=True)
+    text_message = SimpleNamespace(
+        message_id=43,
+        text="plain group chatter",
+        caption=None,
+        entities=[],
+        caption_entities=[],
+        message_thread_id=None,
+        chat=SimpleNamespace(id=PRIVATE_CHAT_ID, type="group", title="Private Group", is_forum=False),
+        from_user=SimpleNamespace(id=111, full_name=PRIVATE_USERNAME, first_name="Test"),
+        reply_to_message=None,
+        voice=None,
+        audio=None,
+        photo=None,
+        video=None,
+        document=None,
+        sticker=None,
+        date=None,
+    )
+    update = SimpleNamespace(message=text_message, edited_message=None, channel_post=None, update_id=101)
+
+    with caplog.at_level(logging.INFO, logger="gateway.platforms.telegram"):
+        adapter._log_telegram_media_ingress_diagnostic(update)
+        assert adapter._should_process_message(text_message) is False
+
+    assert "Telegram media ingress diagnostic" not in caplog.text
+    assert "Telegram voice/media route diagnostic" not in caplog.text

--- a/tests/gateway/test_voice_stt_result_diagnostic.py
+++ b/tests/gateway/test_voice_stt_result_diagnostic.py
@@ -1,0 +1,120 @@
+import logging
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from gateway.run import GatewayRunner
+
+
+PRIVATE_AUDIO_PATH = "/private/cache/SHOULD_NOT_LEAK_AUDIO.ogg"
+PRIVATE_TRANSCRIPT = "SHOULD_NOT_LEAK_TRANSCRIPT_BODY"
+
+
+def _runner(*, stt_enabled=True):
+    runner = object.__new__(GatewayRunner)
+    setattr(runner, "config", SimpleNamespace(stt_enabled=stt_enabled))
+    setattr(runner, "_has_setup_skill", lambda: False)
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_stt_success_empty_logs_redacted_diagnostic_and_no_useful_transcript(caplog):
+    runner = _runner()
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={"success": True, "transcript": "   "},
+    ):
+        with caplog.at_level(logging.INFO, logger="gateway.run"):
+            enriched, transcripts = await runner._enrich_message_with_transcription(
+                "",
+                [PRIVATE_AUDIO_PATH],
+            )
+
+    assert transcripts == []
+    assert "speech-to-text did not produce usable transcript text" in enriched
+    output = caplog.text
+    assert "Telegram voice STT result diagnostic" in output
+    assert "stt_attempted=yes" in output
+    assert "stt_provider_available=yes" in output
+    assert "stt_result_class=success_empty" in output
+    assert "transcript_non_empty=no" in output
+    assert "transcript_length_bucket=0" in output
+    assert PRIVATE_AUDIO_PATH not in output
+    assert PRIVATE_TRANSCRIPT not in output
+
+
+@pytest.mark.asyncio
+async def test_stt_success_punctuation_placeholder_treated_as_empty(caplog):
+    runner = _runner()
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={"success": True, "transcript": "... ... ..."},
+    ):
+        with caplog.at_level(logging.INFO, logger="gateway.run"):
+            enriched, transcripts = await runner._enrich_message_with_transcription(
+                "",
+                [PRIVATE_AUDIO_PATH],
+            )
+
+    assert transcripts == []
+    assert "Here's what they said" not in enriched
+    assert "speech-to-text did not produce usable transcript text" in enriched
+    output = caplog.text
+    assert "stt_result_class=success_empty" in output
+    assert "transcript_non_empty=no" in output
+    assert PRIVATE_AUDIO_PATH not in output
+
+
+@pytest.mark.asyncio
+async def test_stt_success_non_empty_logs_redacted_diagnostic(caplog):
+    runner = _runner()
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={"success": True, "transcript": PRIVATE_TRANSCRIPT},
+    ):
+        with caplog.at_level(logging.INFO, logger="gateway.run"):
+            enriched, transcripts = await runner._enrich_message_with_transcription(
+                "",
+                [PRIVATE_AUDIO_PATH],
+            )
+
+    assert transcripts == [PRIVATE_TRANSCRIPT]
+    assert PRIVATE_TRANSCRIPT in enriched
+    output = caplog.text
+    assert "Telegram voice STT result diagnostic" in output
+    assert "stt_result_class=success_non_empty" in output
+    assert "transcript_non_empty=yes" in output
+    assert "transcript_length_bucket=21-100" in output
+    assert PRIVATE_AUDIO_PATH not in output
+    # The transcript may appear in enriched text, but must never be logged.
+    assert PRIVATE_TRANSCRIPT not in output
+
+
+@pytest.mark.asyncio
+async def test_stt_provider_unavailable_logs_redacted_class(caplog):
+    runner = _runner()
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={"success": False, "error": "No STT provider configured"},
+    ):
+        with caplog.at_level(logging.INFO, logger="gateway.run"):
+            enriched, transcripts = await runner._enrich_message_with_transcription(
+                "",
+                [PRIVATE_AUDIO_PATH],
+            )
+
+    assert transcripts == []
+    assert "no STT provider is configured" in enriched
+    output = caplog.text
+    assert "Telegram voice STT result diagnostic" in output
+    assert "stt_attempted=yes" in output
+    assert "stt_provider_available=no" in output
+    assert "stt_result_class=provider_unavailable" in output
+    assert "transcript_non_empty=no" in output
+    assert PRIVATE_AUDIO_PATH not in output
+    assert "No STT provider configured" not in output


### PR DESCRIPTION
Issue: FGD-188

Summary:
- adds redacted Telegram media ingress diagnostic
- adds redacted voice/media route diagnostic
- adds redacted STT result diagnostic
- treats empty/placeholder STT output as no useful transcript
- confirms controlled voice probe succeeds on activated branch

Validation:
- targeted Telegram tests: 58 passed
- py_compile passed
- controlled Telegram voice probe succeeded

Safety:
- diagnostics redact chat IDs, usernames, file IDs, URLs, paths, tokens, transcript bodies, and secrets
- no Telegram webhook/bot mutation
- no STT install
- no deploy

Scope:
- gateway/platforms/telegram.py
- gateway/run.py
- tests/gateway/test_telegram_voice_route_diagnostic.py
- tests/gateway/test_voice_stt_result_diagnostic.py

Unrelated FGD-124 untracked files were not included:
- plugins/telegram_no_action_suppression/
- tests/gateway/test_telegram_no_action_suppression.py