### PR TITLE
optional-skills(devops): add system-health, backup-restore, hermes-diag, config-validator

### DIFF
--- a/optional-skills/devops/backup-restore/SKILL.md
+++ b/optional-skills/devops/backup-restore/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: backup-restore
+description: Create dated tarball backups of Hermes configs, profiles, and skills, pushed to git.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [devops, backup, restore, git, automation, cron]
+    category: devops
+    requires_toolsets: [terminal, cronjob]
+    related_skills: [config-validator, hermes-diag]
+---
+
+# Backup & Restore
+
+Create dated tarball backups of your Hermes setup and push them to a git remote. Works as a one-shot command or a recurring cron job.
+
+## When to Use
+
+- User asks to back up Hermes configuration or data
+- Setting up automated backups for a self-hosted Hermes instance
+- Before making major config changes (backup first, then modify)
+- Recovering from data loss or corruption
+
+## What it backs up
+
+| Source | Path (configurable) |
+|--------|---------------------|
+| Main config | `$HERMES_HOME/config.yaml` |
+| SOUL file | `$HERMES_HOME/SOUL.md` |
+| Profiles | `$HERMES_HOME/profiles/` |
+| Skills | `$HERMES_HOME/skills/` |
+
+### Excluded automatically
+
+- `*_key.txt`, `*_credentials` (secrets)
+- `.env` / `.env.*`
+- `__pycache__` / `*.pyc`
+- `.git/` directories
+- `node_modules/`
+
+## Usage
+
+### Manual run
+
+```bash
+bash $HERMES_HOME/skills/optional-skills/devops/backup-restore/scripts/backup.sh
+```
+
+### Weekly cron
+
+```bash
+cronjob(action='create', script='$HERMES_HOME/skills/optional-skills/devops/backup-restore/scripts/backup.sh', no_agent=True, schedule='0 2 * * 0')
+```
+
+## What the script does
+
+1. Creates a timestamped tarball: `backups/hermes-backup-YYYY-MM-DD-HHMMSS.tar.gz`
+2. Writes a manifest alongside it (sources, sizes, hostname)
+3. Commits to git (`git add`, `git commit`)
+4. Pushes to the configured remote
+5. Prunes backups older than the retention period (default: 4 weeks)
+
+Tarball paths are relative (portable across systems).
+
+## Configuration
+
+Edit the top of `backup.sh`:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `REPO_DIR` | `$HERMES_HOME` | Git repo to push backups to |
+| `SOURCES` | config, SOUL, profiles, skills | Paths to include |
+| `RETENTION_WEEKS` | 4 | How long to keep old backups |
+
+## Restore procedure
+
+1. List available backups:
+   ```bash
+   ls $HERMES_HOME/backups/hermes-backup-*.tar.gz
+   ```
+
+2. Extract to a temp directory:
+   ```bash
+   tar xzf $HERMES_HOME/backups/hermes-backup-YYYY-MM-DD-HHMMSS.tar.gz -C /tmp/restore/
+   ```
+
+3. Copy files back:
+   ```bash
+   cp -r /tmp/restore/config.yaml $HERMES_HOME/
+   cp -r /tmp/restore/profiles/* $HERMES_HOME/profiles/
+   cp -r /tmp/restore/skills/* $HERMES_HOME/skills/
+   ```
+
+4. Restore any cron jobs from the manifest.
+
+5. Re-add secrets (API keys, credentials — not backed up).
+
+6. Restart Hermes after config restore.
+
+## Common Pitfalls
+
+1. **Secrets are NOT backed up.** Re-add API keys and credentials after restore.
+2. **Git push fails if offline.** The backup is saved locally; push retries on the next run.
+3. **Backups older than retention period are auto-pruned.** Adjust `RETENTION_WEEKS` if needed.
+4. **Don't restore config while Hermes is running.** Restart Hermes after a config restore.
+
+## Verification Checklist
+
+- [ ] Run the script manually and confirm a tarball is created in `$HERMES_HOME/backups/`
+- [ ] Verify tarball content: `tar tzf $HERMES_HOME/backups/hermes-backup-*.tar.gz`
+- [ ] Check that the manifest was written alongside the tarball
+- [ ] Confirm secrets files are NOT in the tarball

--- a/optional-skills/devops/backup-restore/SKILL.md
+++ b/optional-skills/devops/backup-restore/SKILL.md
@@ -2,7 +2,7 @@
 name: backup-restore
 description: Create dated tarball backups of Hermes configs, profiles, and skills, pushed to git.
 version: 1.0.0
-author: Hermes Agent
+author: Vijay Selvaraj (vijays365), Hermes Agent
 license: MIT
 platforms: [linux, macos]
 metadata:
@@ -46,13 +46,13 @@ Create dated tarball backups of your Hermes setup and push them to a git remote.
 ### Manual run
 
 ```bash
-bash $HERMES_HOME/skills/optional-skills/devops/backup-restore/scripts/backup.sh
+bash $HERMES_HOME/skills/devops/backup-restore/scripts/backup.sh
 ```
 
 ### Weekly cron
 
 ```bash
-cronjob(action='create', script='$HERMES_HOME/skills/optional-skills/devops/backup-restore/scripts/backup.sh', no_agent=True, schedule='0 2 * * 0')
+cronjob(action='create', script='$HERMES_HOME/skills/devops/backup-restore/scripts/backup.sh', no_agent=True, schedule='0 2 * * 0')
 ```
 
 ## What the script does

--- a/optional-skills/devops/backup-restore/scripts/backup.sh
+++ b/optional-skills/devops/backup-restore/scripts/backup.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# === Configuration: edit these before first use ===
+REPO_DIR="${HERMES_HOME:-$HOME/.hermes}"          # Git repo to push backups to
+BACKUP_DIR="${REPO_DIR}/backups"                   # Where tarballs are stored
+RETENTION_WEEKS=4                                  # Auto-prune older than this
+
+TIMESTAMP=$(date +%Y-%m-%d-%H%M%S)
+TARBALL="${BACKUP_DIR}/hermes-backup-${TIMESTAMP}.tar.gz"
+MANIFEST="${BACKUP_DIR}/manifest-${TIMESTAMP}.txt"
+
+# === Sources to backup (add/remove as needed) ===
+SOURCES=(
+  "${HERMES_HOME:-$HOME/.hermes}/config.yaml"
+  "${HERMES_HOME:-$HOME/.hermes}/SOUL.md"
+  "${HERMES_HOME:-$HOME/.hermes}/profiles"
+  "${HERMES_HOME:-$HOME/.hermes}/skills"
+)
+
+# === Exclude patterns ===
+EXCLUDES=(
+  "--exclude=*_key.txt"
+  "--exclude=*_credentials"
+  "--exclude=.env"
+  "--exclude=.env.*"
+  "--exclude=__pycache__"
+  "--exclude=*.pyc"
+  "--exclude=.git"
+  "--exclude=node_modules"
+  "--exclude=*.tar.gz"
+)
+
+echo "=== Backup: ${TIMESTAMP} ==="
+
+mkdir -p "${BACKUP_DIR}"
+
+for src in "${SOURCES[@]}"; do
+  [ ! -e "$src" ] && echo "WARNING: Source not found: $src"
+done
+
+echo "Creating tarball..."
+# Use -C for relative paths so tarball is portable
+PARENT_DIR="$(cd "$(dirname "${REPO_DIR}")" && pwd)"
+BASE_NAME="$(basename "${REPO_DIR}")"
+tar czf "${TARBALL}" "${EXCLUDES[@]}" -C "${PARENT_DIR}" \
+  "${SOURCES[@]#${PARENT_DIR}/}" 2>/dev/null
+
+echo "Writing manifest..."
+{
+  echo "Backup: ${TIMESTAMP}"
+  echo "Host: $(hostname)"
+  echo "Sources:"
+  for src in "${SOURCES[@]}"; do
+    if [ -e "$src" ]; then
+      size=$(du -sh "$src" 2>/dev/null | cut -f1)
+      echo "  ${src}  (${size})"
+    else
+      echo "  ${src}  (MISSING)"
+    fi
+  done
+  echo ""
+  echo "Tarball size: $(du -h "${TARBALL}" | cut -f1)"
+  echo "Tarball: ${TARBALL}"
+} > "${MANIFEST}"
+
+echo "Committing to git..."
+cd "${REPO_DIR}"
+git pull --rebase origin main 2>/dev/null || true
+git add backups/
+git commit -m "backup ${TIMESTAMP}" --quiet || echo "Nothing new to commit"
+
+echo "Pushing to git..."
+git push origin main 2>/dev/null || echo "WARNING: git push failed (offline?). Backup saved locally."
+
+echo "Pruning backups older than ${RETENTION_WEEKS} weeks..."
+find "${BACKUP_DIR}" -name "hermes-backup-*.tar.gz" -mtime +$((RETENTION_WEEKS * 7)) -delete 2>/dev/null || true
+find "${BACKUP_DIR}" -name "manifest-*.txt" -mtime +$((RETENTION_WEEKS * 7)) -delete 2>/dev/null || true
+
+echo ""
+echo "=== Backup complete ==="
+echo "Tarball: ${TARBALL}"
+echo "Size:    $(du -h "${TARBALL}" | cut -f1)"
+ls -lh "${BACKUP_DIR}" | grep hermes-backup

--- a/optional-skills/devops/config-validator/SKILL.md
+++ b/optional-skills/devops/config-validator/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: config-validator
+description: Validate all Hermes YAML config files — syntax, structure, profiles, gateway states, skills.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [devops, config, validation, yaml, troubleshooting]
+    category: devops
+    requires_toolsets: [terminal]
+    related_skills: [hermes-diag, system-health]
+---
+
+# Config Validator
+
+Validate all Hermes configuration YAML files for structural and semantic correctness.
+
+## When to Use
+
+- Before restarting Hermes after config changes
+- After editing config.yaml or profile configs manually
+- Debugging unexplained Hermes behavior (config issue?)
+- Setting up a new profile or migrating Hermes to a new machine
+- Scheduled config integrity check (cron)
+
+## Validation checks
+
+| Check | What it validates |
+|-------|------------------|
+| YAML syntax | Every `.yaml`/`.yml` file parses without error |
+| Model config | `model.default` and `model.provider` are present |
+| Profile existence | Each profile has `config.yaml`, `profile.yaml`, `SOUL.md` |
+| Gateway states | `gateway_state.json` is valid JSON with `gateway_state` key |
+| Skills directory | Skills dir exists and has content |
+
+## Usage
+
+```bash
+bash $HERMES_HOME/skills/optional-skills/devops/config-validator/scripts/validate-config.sh
+```
+
+Uses `$HERMES_HOME` (defaults to `~/.hermes`).
+
+## Prerequisites
+
+- Python 3 with `pyyaml` installed: `pip install pyyaml`
+- Or `uv` (recommended) — the script auto-selects `uv run --with pyyaml` when available
+
+## Output format
+
+```
+=== Config Validation ===
+
+--- Main config ---
+OK config.yaml: valid YAML
+OK config.yaml: model.default present
+OK config.yaml: model.provider present
+
+--- Profile configs ---
+OK default/config.yaml: valid YAML
+OK default: profile.yaml exists
+OK default: SOUL.md exists
+OK default: gateway_state.json exists
+...
+
+--- Gateway states ---
+OK default: gateway_state=running
+
+--- Skills ---
+OK 52 skills found across all categories
+
+=== Summary ===
+All clean
+```
+
+Exit codes: 0 (clean), 1 (warnings), 2 (errors).
+
+## Common Pitfalls
+
+1. **`pyyaml` must be installed.** If missing: `pip install pyyaml` or install `uv` for auto-resolved execution.
+2. **Profile configs are partial** (inherit from main). Missing optional fields are OK — only structural checks apply.
+3. **`gateway_state.json` uses the key `gateway_state`** (not `state`).
+4. **The script resolves paths relative to `$HERMES_HOME`** — ensure this env var is set correctly for your setup.
+
+## Verification Checklist
+
+- [ ] Run `bash $HERMES_HOME/skills/optional-skills/devops/config-validator/scripts/validate-config.sh`
+- [ ] Confirm exit code is 0 (all clean)
+- [ ] Verify all profiles are listed and pass
+- [ ] Break a config file intentionally and confirm the error is caught

--- a/optional-skills/devops/config-validator/SKILL.md
+++ b/optional-skills/devops/config-validator/SKILL.md
@@ -2,7 +2,7 @@
 name: config-validator
 description: Validate all Hermes YAML config files — syntax, structure, profiles, gateway states, skills.
 version: 1.0.0
-author: Hermes Agent
+author: Vijay Selvaraj (vijays365), Hermes Agent
 license: MIT
 platforms: [linux, macos]
 metadata:
@@ -38,7 +38,7 @@ Validate all Hermes configuration YAML files for structural and semantic correct
 ## Usage
 
 ```bash
-bash $HERMES_HOME/skills/optional-skills/devops/config-validator/scripts/validate-config.sh
+bash $HERMES_HOME/skills/devops/config-validator/scripts/validate-config.sh
 ```
 
 Uses `$HERMES_HOME` (defaults to `~/.hermes`).
@@ -86,7 +86,7 @@ Exit codes: 0 (clean), 1 (warnings), 2 (errors).
 
 ## Verification Checklist
 
-- [ ] Run `bash $HERMES_HOME/skills/optional-skills/devops/config-validator/scripts/validate-config.sh`
+- [ ] Run `bash $HERMES_HOME/skills/devops/config-validator/scripts/validate-config.sh`
 - [ ] Confirm exit code is 0 (all clean)
 - [ ] Verify all profiles are listed and pass
 - [ ] Break a config file intentionally and confirm the error is caught

--- a/optional-skills/devops/config-validator/scripts/validate-config.sh
+++ b/optional-skills/devops/config-validator/scripts/validate-config.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Config validator — checks all Hermes YAML configs for syntax and structure
+# Uses $HERMES_HOME (defaults to ~/.hermes)
+set -euo pipefail
+
+RED='\033[0;31m'; YEL='\033[1;33m'; GRN='\033[0;32m'; NC='\033[0m'
+errors=0; warnings=0
+ok()   { echo -e "${GRN}OK${NC} $1"; }
+warn() { echo -e "${YEL}WARN${NC} $1"; warnings=$((warnings+1)); }
+err()  { echo -e "${RED}ERR${NC} $1"; errors=$((errors+1)); }
+
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+PY="python3 -c"
+
+# Prefer uv for isolated YAML parsing
+if command -v uv &>/dev/null; then
+  PY="uv run --with pyyaml python3 -c"
+elif python3 -c "import yaml" 2>/dev/null; then
+  PY="python3 -c"
+else
+  echo "ERROR: pyyaml not installed. Run: pip install pyyaml"
+  echo "       Or install uv for auto-resolved execution."
+  exit 2
+fi
+
+validate_yaml() {
+  local path="$1" label="$2"
+  if [ ! -f "$path" ]; then
+    warn "${label}: file not found"
+    return 1
+  fi
+  if $PY "import yaml; yaml.safe_load(open('$path')); print('valid')" 2>/dev/null; then
+    ok "${label}: valid YAML"
+    return 0
+  else
+    err "${label}: invalid YAML"
+    return 1
+  fi
+}
+
+echo "=== Config Validation ==="
+echo ""
+
+echo "--- Main config ---"
+validate_yaml "${HERMES_HOME}/config.yaml" "config.yaml"
+echo ""
+
+echo "--- Profile configs ---"
+for pdir in "${HERMES_HOME}"/profiles/*/; do
+  [ -d "$pdir" ] || continue
+  name=$(basename "$pdir")
+  validate_yaml "${pdir}config.yaml" "${name}/config.yaml"
+  for f in "profile.yaml" "SOUL.md" "gateway_state.json"; do
+    [ -f "${pdir}${f}" ] && ok "${name}: $f exists" || warn "${name}: $f missing"
+  done
+done
+echo ""
+
+echo "--- Gateway states ---"
+for pdir in "${HERMES_HOME}"/profiles/*/; do
+  [ -d "$pdir" ] || continue
+  name=$(basename "$pdir"); sf="${pdir}gateway_state.json"
+  if [ -f "$sf" ]; then
+    state=$(python3 -c "import json; print(json.load(open('$sf')).get('gateway_state','unknown'))" 2>/dev/null)
+    ok "${name}: gateway_state=$state"
+  else
+    warn "${name}: no gateway_state.json"
+  fi
+done
+echo ""
+
+echo "--- Skills ---"
+total=$(ls -d "${HERMES_HOME}"/skills/*/*/SKILL.md 2>/dev/null | wc -l)
+ok "${total} skills found across all categories"
+echo ""
+
+echo "=== Summary ==="
+[ $errors -gt 0 ] && [ $warnings -gt 0 ] && echo -e "${RED}${errors} errors, ${warnings} warnings${NC}" && exit 2
+[ $errors -gt 0 ] && echo -e "${RED}${errors} errors${NC}" && exit 2
+[ $warnings -gt 0 ] && echo -e "${YEL}${warnings} warnings${NC}" && exit 1
+echo -e "${GRN}All clean${NC}" && exit 0

--- a/optional-skills/devops/config-validator/scripts/validate-config.sh
+++ b/optional-skills/devops/config-validator/scripts/validate-config.sh
@@ -38,18 +38,38 @@ validate_yaml() {
   fi
 }
 
+check_field() {
+  local path="$1" field="$2" label="$3"
+  if $PY "
+import yaml; c=yaml.safe_load(open('$path'))
+keys='$field'.split('.'); v=c
+for k in keys: v=v.get(k,{})
+print('found' if v else 'missing')
+" 2>/dev/null | grep -q found; then
+    ok "${label}: $field present"
+  else
+    err "${label}: $field missing"
+  fi
+}
+
 echo "=== Config Validation ==="
 echo ""
 
 echo "--- Main config ---"
-validate_yaml "${HERMES_HOME}/config.yaml" "config.yaml"
+if validate_yaml "${HERMES_HOME}/config.yaml" "config.yaml"; then
+  check_field "${HERMES_HOME}/config.yaml" "model.default" "config.yaml"
+  check_field "${HERMES_HOME}/config.yaml" "model.provider" "config.yaml"
+fi
 echo ""
 
 echo "--- Profile configs ---"
 for pdir in "${HERMES_HOME}"/profiles/*/; do
   [ -d "$pdir" ] || continue
   name=$(basename "$pdir")
-  validate_yaml "${pdir}config.yaml" "${name}/config.yaml"
+  if validate_yaml "${pdir}config.yaml" "${name}/config.yaml"; then
+    check_field "${pdir}config.yaml" "model.default" "${name}/config.yaml"
+    check_field "${pdir}config.yaml" "model.provider" "${name}/config.yaml"
+  fi
   for f in "profile.yaml" "SOUL.md" "gateway_state.json"; do
     [ -f "${pdir}${f}" ] && ok "${name}: $f exists" || warn "${name}: $f missing"
   done

--- a/optional-skills/devops/hermes-diag/SKILL.md
+++ b/optional-skills/devops/hermes-diag/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: hermes-diag
+description: One-shot Hermes diagnostics — check profiles, gateways, configs, disk, memory, and recent errors.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux]
+metadata:
+  hermes:
+    tags: [devops, diagnostics, health, troubleshooting, monitoring]
+    category: devops
+    requires_toolsets: [terminal]
+    related_skills: [config-validator, system-health]
+---
+
+# Hermes Diagnostics
+
+Single command to assess overall Hermes system health. Checks gateways, configs, disk, memory, uptime, recent errors, and skills count.
+
+## When to Use
+
+- User reports Hermes isn't working correctly
+- Before and after config changes to verify system health
+- Routine system check for self-hosted Hermes instances
+- Troubleshooting gateway connection issues
+
+## What it checks
+
+| Check | What it inspects | Source |
+|-------|------------------|--------|
+| Gateway states | Each profile's gateway status | `gateway_state.json` per profile |
+| Config validity | YAML syntax and required fields | Delegates to `config-validator` |
+| Disk usage | Root partition fill percentage | `df -h` |
+| Memory | RAM and swap usage | `free -m` |
+| Uptime | System uptime and load averages | `uptime`, `/proc/loadavg` |
+| Errors | Recent gateway log errors (24h) | Profile log files |
+| Skills | Count of installed skills | `$HERMES_HOME/skills/` tree |
+
+## Usage
+
+```bash
+bash $HERMES_HOME/skills/optional-skills/devops/hermes-diag/scripts/hermes-diag.sh
+```
+
+The script uses `$HERMES_HOME` (defaults to `~/.hermes`).
+
+## Output format
+
+Color-coded with emoji indicators:
+
+```
+  Hermes Diagnostics — myserver
+  2026-06-12 21:06:44
+
+── Gateway States ──
+  ✅ default: running
+  ✅ codi: running
+
+── Config ──
+  ✅ All configs valid
+
+── Disk Usage ──
+  ✅ /: 42% used
+
+── Memory ──
+  ✅ Memory: 62% used
+  ✅ Swap: 0% used
+
+── Uptime ──
+  ✅ up 5 days, 14 hours
+  ✅ Load: 0.45 0.52 0.48
+
+── Recent Errors ──
+  ✅ No recent errors
+
+── Skills ──
+  ✅ 52 skills installed
+```
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | All clear |
+| 1 | Warnings (non-critical) |
+| 2 | Errors detected |
+
+## Common Pitfalls
+
+1. **Log paths depend on profile directories** under `$HERMES_HOME/profiles/`.
+2. **Gateway status in `gateway_state.json` may lag a few seconds** behind the actual process state.
+3. **The disk check inspects root (`/`)** — adjust if Hermes data is on a separate volume.
+4. **The config validator sub-check requires `validate-config.sh`** at the expected path. Install `config-validator` for full coverage.
+
+## Verification Checklist
+
+- [ ] Run `bash $HERMES_HOME/skills/optional-skills/devops/hermes-diag/scripts/hermes-diag.sh`
+- [ ] Confirm all checks return ✅ or acceptable ⚠️
+- [ ] Verify the exit code matches the expected system state (0 for clean)

--- a/optional-skills/devops/hermes-diag/SKILL.md
+++ b/optional-skills/devops/hermes-diag/SKILL.md
@@ -2,7 +2,7 @@
 name: hermes-diag
 description: One-shot Hermes diagnostics — check profiles, gateways, configs, disk, memory, and recent errors.
 version: 1.0.0
-author: Hermes Agent
+author: Vijay Selvaraj (vijays365), Hermes Agent
 license: MIT
 platforms: [linux]
 metadata:
@@ -39,7 +39,7 @@ Single command to assess overall Hermes system health. Checks gateways, configs,
 ## Usage
 
 ```bash
-bash $HERMES_HOME/skills/optional-skills/devops/hermes-diag/scripts/hermes-diag.sh
+bash $HERMES_HOME/skills/devops/hermes-diag/scripts/hermes-diag.sh
 ```
 
 The script uses `$HERMES_HOME` (defaults to `~/.hermes`).
@@ -94,6 +94,6 @@ Color-coded with emoji indicators:
 
 ## Verification Checklist
 
-- [ ] Run `bash $HERMES_HOME/skills/optional-skills/devops/hermes-diag/scripts/hermes-diag.sh`
+- [ ] Run `bash $HERMES_HOME/skills/devops/hermes-diag/scripts/hermes-diag.sh`
 - [ ] Confirm all checks return ✅ or acceptable ⚠️
 - [ ] Verify the exit code matches the expected system state (0 for clean)

--- a/optional-skills/devops/hermes-diag/scripts/hermes-diag.sh
+++ b/optional-skills/devops/hermes-diag/scripts/hermes-diag.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Hermes diagnostics — one-shot system health check
+# Uses $HERMES_HOME (defaults to ~/.hermes)
+set -euo pipefail
+
+RED='\033[0;31m'; YEL='\033[1;33m'; GRN='\033[0;32m'; CYA='\033[0;36m'; NC='\033[0m'
+errors=0; warnings=0
+ok()   { echo -e "  ${GRN}✅${NC} $1"; }
+warn() { echo -e "  ${YEL}⚠️ ${NC} $1"; warnings=$((warnings+1)); }
+err()  { echo -e "  ${RED}❌${NC} $1"; errors=$((errors+1)); }
+sec()  { echo -e "\n${CYA}── $1 ──${NC}"; }
+
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+
+echo -e "${CYA}══════════════════════════════════════${NC}"
+echo -e "${CYA}  Hermes Diagnostics — $(hostname)${NC}"
+echo -e "${CYA}  $(date '+%Y-%m-%d %H:%M:%S')${NC}"
+echo -e "${CYA}══════════════════════════════════════${NC}"
+
+sec "Gateway States"
+for pdir in "$HERMES_HOME"/profiles/*/; do
+  [ -d "$pdir" ] || continue
+  name=$(basename "$pdir"); sf="${pdir}gateway_state.json"
+  [ -f "$sf" ] || { err "${name}: no state"; continue; }
+  state=$(python3 -c "import json; print(json.load(open('$sf')).get('gateway_state','unknown'))")
+  case "$state" in running) ok "${name}: ${state}";; *) warn "${name}: ${state}";; esac
+done
+
+sec "Config"
+VALIDATOR="${HERMES_HOME}/scripts/validate-config.sh"
+if [ -f "$VALIDATOR" ]; then
+  bash "$VALIDATOR" >/dev/null 2>&1 && ok "All configs valid" || err "Config issues (run validate-config.sh)"
+else
+  warn "Validator script not found at $VALIDATOR"
+fi
+
+sec "Cron Jobs"
+echo "    Use cronjob(action='list') in a Hermes session to inspect active jobs."
+
+sec "Disk Usage"
+for mp in /; do
+  pct=$(df -h "$mp" 2>/dev/null | awk 'NR==2{print $5}' | tr -d '%')
+  [ "$pct" -gt 85 ] && err "${mp}: ${pct}% used" || [ "$pct" -gt 70 ] && warn "${mp}: ${pct}% used" || ok "${mp}: ${pct}% used"
+done
+
+sec "Memory"
+mem=$(free -m | awk '/Mem:/{printf "%.0f", $3/$2*100}')
+swap=$(free -m | awk '/Swap:/{if($2>0) printf "%.0f", $3/$2*100; else print "0"}')
+[ "$mem" -gt 85 ] && err "Memory: ${mem}% used" || [ "$mem" -gt 70 ] && warn "Memory: ${mem}% used" || ok "Memory: ${mem}% used"
+[ "$swap" -gt 20 ] && warn "Swap: ${swap}% used" || ok "Swap: ${swap}% used"
+
+sec "Uptime"
+ok "$(uptime -p)"
+ok "Load: $(cat /proc/loadavg | cut -d' ' -f1-3)"
+
+sec "Recent Errors (last 24h)"
+log_files=""
+for pdir in "$HERMES_HOME"/profiles/*/; do
+  [ -d "$pdir" ] || continue
+  found=$(find "${pdir}logs/" -name "gateway*" -mtime -1 2>/dev/null || true)
+  [ -n "$found" ] && log_files="$log_files$found"$'\n'
+done
+if [ -z "$log_files" ]; then
+  ok "No log files found"
+else
+  err_count=$(echo "$log_files" | xargs grep -l "error\|traceback\|exception" 2>/dev/null | wc -l || true)
+  [ "$err_count" -gt 0 ] && warn "${err_count} files with errors" || ok "No recent errors"
+fi
+
+sec "Skills"
+total=$(ls -d "$HERMES_HOME"/skills/*/*/SKILL.md 2>/dev/null | wc -l)
+ok "${total} skills installed"
+
+echo ""
+echo -e "${CYA}══════════════════════════════════════${NC}"
+[ $errors -gt 0 -a $warnings -gt 0 ] && { echo -e "  ${RED}${errors} errors, ${warnings} warnings${NC}"; exit 2; }
+[ $errors -gt 0 ] && { echo -e "  ${RED}${errors} errors${NC}"; exit 2; }
+[ $warnings -gt 0 ] && { echo -e "  ${YEL}${warnings} warnings${NC}"; exit 1; }
+echo -e "  ${GRN}All clear ✅${NC}"

--- a/optional-skills/devops/system-health/SKILL.md
+++ b/optional-skills/devops/system-health/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: system-health
+description: VPS system health monitoring — collect memory, CPU, disk stats and optionally email reports.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux]
+metadata:
+  hermes:
+    tags: [devops, monitoring, health, system, vps, cron]
+    category: devops
+    requires_toolsets: [terminal, cronjob]
+    related_skills: [hermes-diag, config-validator]
+---
+
+# System Health Monitoring
+
+Monitor VPS resource usage (memory, CPU, disk) and optionally email reports via the AgentMail API.
+
+## When to Use
+
+- User asks about server health or resource usage
+- User wants automated health reports emailed periodically
+- Setting up monitoring for a new VPS or server
+- Troubleshooting performance issues (checking memory/CPU/disk)
+
+## Quick check (ad-hoc)
+
+```bash
+# All in one
+free -h
+cat /proc/loadavg
+df -h /
+uptime
+ps aux --sort=-%mem | head -6
+```
+
+## Automated reporting script
+
+A standalone Python script at `$HERMES_HOME/skills/optional-skills/devops/system-health/scripts/system-health-report.py` collects all stats and sends an email report.
+
+### Metrics and thresholds
+
+| Metric | Source | Default threshold |
+|--------|--------|-------------------|
+| Memory usage | `free -m` | Warn if >85% used |
+| Swap usage | `free -m` | Warn if >20% used |
+| CPU load (1/5/15min) | `/proc/loadavg` | Warn if 1min > nproc×0.8 |
+| Disk usage | `df -h` for `/` | Warn if >80% |
+| Uptime | `uptime` | Info only |
+| Top 5 memory consumers | `ps` | Info only |
+
+### Configuration
+
+Edit the top of the script to set:
+
+- `TO_EMAIL` — recipient email address
+- `FROM_EMAIL` — your AgentMail sender inbox
+- `API_KEY_FILE` — path to your AgentMail API key
+- `THRESHOLDS` — warning level overrides
+
+### Cron usage
+
+```bash
+cronjob(action='create', script='$HERMES_HOME/skills/optional-skills/devops/system-health/scripts/system-health-report.py', no_agent=True, schedule='0 8 * * 2,5')
+```
+
+The script is self-contained — no LLM tokens needed on each run.
+
+## Output format
+
+When all metrics are within thresholds, the subject starts with ✅. If any threshold is exceeded, it starts with ⚠️.
+
+Example output (body):
+
+```
+System Health Report — myserver
+================================
+Uptime: up 14 days, 3 hours
+
+Memory:  3200MB / 7746MB (41.3%)
+Swap:    0MB / 0MB (0%)
+CPU Load: 0.45 (1m) / 0.52 (5m) / 0.48 (15m) — 4 cores
+Disk /:  30G / 75G used (40%) — 45G avail
+
+All metrics within thresholds.
+
+Top 5 memory consumers:
+USER       PID %CPU %MEM ...
+...
+```
+
+## Common Pitfalls
+
+1. **API key not set.** The script reads the API key from `API_KEY_FILE`. Store it outside version control.
+2. **Recipient email not configured.** Update `TO_EMAIL` at the top of the script before first use.
+3. **AgentMail not available.** Modify the `send_email()` function to use any other email API (SMTP, SendGrid, etc.).
+
+## Verification Checklist
+
+- [ ] Run `python3 $HERMES_HOME/skills/optional-skills/devops/system-health/scripts/system-health-report.py` and confirm stats are printed
+- [ ] Check an email arrives at the configured recipient
+- [ ] Verify the subject line includes ✅ (normal) or ⚠️ (warning)

--- a/optional-skills/devops/system-health/SKILL.md
+++ b/optional-skills/devops/system-health/SKILL.md
@@ -2,7 +2,7 @@
 name: system-health
 description: VPS system health monitoring — collect memory, CPU, disk stats and optionally email reports.
 version: 1.0.0
-author: Hermes Agent
+author: Vijay Selvaraj (vijays365), Hermes Agent
 license: MIT
 platforms: [linux]
 metadata:
@@ -37,7 +37,7 @@ ps aux --sort=-%mem | head -6
 
 ## Automated reporting script
 
-A standalone Python script at `$HERMES_HOME/skills/optional-skills/devops/system-health/scripts/system-health-report.py` collects all stats and sends an email report.
+A standalone Python script at `$HERMES_HOME/skills/devops/system-health/scripts/system-health-report.py` collects all stats and sends an email report.
 
 ### Metrics and thresholds
 
@@ -62,7 +62,7 @@ Edit the top of the script to set:
 ### Cron usage
 
 ```bash
-cronjob(action='create', script='$HERMES_HOME/skills/optional-skills/devops/system-health/scripts/system-health-report.py', no_agent=True, schedule='0 8 * * 2,5')
+cronjob(action='create', script='$HERMES_HOME/skills/devops/system-health/scripts/system-health-report.py', no_agent=True, schedule='0 8 * * 2,5')
 ```
 
 The script is self-contained — no LLM tokens needed on each run.
@@ -98,6 +98,6 @@ USER       PID %CPU %MEM ...
 
 ## Verification Checklist
 
-- [ ] Run `python3 $HERMES_HOME/skills/optional-skills/devops/system-health/scripts/system-health-report.py` and confirm stats are printed
+- [ ] Run `python3 $HERMES_HOME/skills/devops/system-health/scripts/system-health-report.py` and confirm stats are printed
 - [ ] Check an email arrives at the configured recipient
 - [ ] Verify the subject line includes ✅ (normal) or ⚠️ (warning)

--- a/optional-skills/devops/system-health/scripts/system-health-report.py
+++ b/optional-skills/devops/system-health/scripts/system-health-report.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""VPS system health report — collects stats and emails report via AgentMail API.
+
+CONFIGURATION — edit these values at the top of the file before first use.
+"""
+
+import json
+import subprocess
+import urllib.request
+
+# --- Configuration: set these before running ---
+TO_EMAIL = "you@example.com"                     # Where to send reports
+FROM_EMAIL = "your-agent@agentmail.to"           # Your AgentMail inbox address
+API_KEY_FILE="~/.hermes/agentmail_key.txt"  # Path to AgentMail API key
+THRESHOLDS = {
+    "mem_pct": 85,
+    "swap_pct": 20,
+    "disk_pct": 80,
+    "cpu_load": 0.8,
+}
+
+
+def run(cmd):
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=30).stdout.strip()
+
+
+def get_nproc():
+    return int(run(["nproc"]) or "1")
+
+
+def get_memory():
+    out = run(["free", "-m"])
+    total = used = pct = swap_total = swap_used = swap_pct = 0
+    for line in out.splitlines():
+        if line.startswith("Mem:"):
+            parts = line.split()
+            total, used = int(parts[1]), int(parts[2])
+            pct = round(used / total * 100, 1) if total else 0
+        elif line.startswith("Swap:"):
+            parts = line.split()
+            swap_total, swap_used = int(parts[1]), int(parts[2])
+            swap_pct = round(swap_used / swap_total * 100, 1) if swap_total else 0
+    return total, used, pct, swap_total, swap_used, swap_pct
+
+
+def get_cpu_load():
+    loadavg = open("/proc/loadavg").read().strip().split()
+    return float(loadavg[0]), float(loadavg[1]), float(loadavg[2])
+
+
+def get_disk():
+    parts = run(["df", "-h", "/"]).splitlines()[-1].split()
+    return parts[1], parts[2], parts[3], int(parts[4].rstrip("%"))
+
+
+def get_uptime():
+    return run(["uptime", "-p"])
+
+
+def get_top_procs(n=5):
+    lines = run(["ps", "aux", "--sort=-%mem"]).splitlines()
+    if len(lines) < 2:
+        return "No data"
+    return "\n".join(lines[: n + 1])
+
+
+def send_email(subject, body):
+    api_key_path = os.path.expanduser(API_KEY_FILE)
+    with open(api_key_path) as f:
+        api_key = f.read().strip()
+    payload = json.dumps({"to": [TO_EMAIL], "subject": subject, "text": body}).encode()
+    req = urllib.request.Request(
+        f"https://api.agentmail.to/v0/inboxes/{FROM_EMAIL}/messages/send",
+        data=payload,
+        method="POST",
+    )
+    req.add_header("Authorization", f"Bearer {api_key}")
+    req.add_header("Content-Type", "application/json")
+    try:
+        resp = urllib.request.urlopen(req, timeout=30)
+        result = json.loads(resp.read())
+        print(f"Email sent: {result.get('id', 'unknown')}")
+    except urllib.error.HTTPError as e:
+        print(f"FAILED: HTTP {e.code} {e.read().decode()}")
+        raise
+
+
+def main():
+    import os  # noqa — used inside send_email
+
+    nproc = get_nproc()
+    load_1, load_5, load_15 = get_cpu_load()
+    mem_total, mem_used, mem_pct, swap_total, swap_used, swap_pct = get_memory()
+    disk_total, disk_used, disk_avail, disk_pct = get_disk()
+    uptime = get_uptime()
+    top_procs = get_top_procs()
+
+    warnings = []
+    if mem_pct > THRESHOLDS["mem_pct"]:
+        warnings.append(f"Memory at {mem_pct}%")
+    if swap_pct > THRESHOLDS["swap_pct"]:
+        warnings.append(f"Swap at {swap_pct}%")
+    if load_1 > nproc * THRESHOLDS["cpu_load"]:
+        warnings.append(f"CPU load {load_1} (limit {nproc*0.8:.1f}, {nproc} cores)")
+    if disk_pct > THRESHOLDS["disk_pct"]:
+        warnings.append(f"Disk at {disk_pct}%")
+
+    hostname = run(["hostname"])
+    prefix = "⚠️ " if warnings else "✅ "
+    subject = f"{prefix}System Health — {hostname}"
+
+    body = f"""System Health Report — {hostname}
+================================
+Uptime: {uptime}
+
+Memory:  {mem_used}MB / {mem_total}MB ({mem_pct}%)
+Swap:    {swap_used}MB / {swap_total}MB ({swap_pct}%)
+CPU Load: {load_1} (1m) / {load_5} (5m) / {load_15} (15m) — {nproc} cores
+Disk /:  {disk_used} / {disk_total} used ({disk_pct}%) — {disk_avail} avail
+
+"""
+
+    if warnings:
+        body += "⚠️  Warnings:\n" + "\n".join(f"  • {w}" for w in warnings) + "\n\n"
+    else:
+        body += "All metrics within thresholds.\n\n"
+
+    body += f"Top 5 memory consumers:\n{top_procs}\n"
+
+    send_email(subject, body)
+    print(f"Subject: {subject}")
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/devops/system-health/scripts/system-health-report.py
+++ b/optional-skills/devops/system-health/scripts/system-health-report.py
@@ -5,6 +5,7 @@ CONFIGURATION — edit these values at the top of the file before first use.
 """
 
 import json
+import os
 import subprocess
 import urllib.request
 
@@ -86,7 +87,6 @@ def send_email(subject, body):
 
 
 def main():
-    import os  # noqa — used inside send_email
 
     nproc = get_nproc()
     load_1, load_5, load_15 = get_cpu_load()

--- a/tests/skills/test_backup_restore_skill.py
+++ b/tests/skills/test_backup_restore_skill.py
@@ -1,0 +1,53 @@
+"""Smoke tests for the backup-restore optional skill."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+SKILL_DIR = Path(__file__).resolve().parents[2] / "optional-skills" / "devops" / "backup-restore"
+
+
+@pytest.fixture(scope="module")
+def frontmatter() -> dict:
+    src = (SKILL_DIR / "SKILL.md").read_text()
+    m = re.search(r"^---\n(.*?)\n---", src, re.DOTALL)
+    assert m, "SKILL.md missing YAML frontmatter"
+    return yaml.safe_load(m.group(1))
+
+
+def test_skill_dir_exists() -> None:
+    assert SKILL_DIR.is_dir()
+
+
+def test_skill_md_present() -> None:
+    assert (SKILL_DIR / "SKILL.md").is_file()
+
+
+def test_name_matches_dir(frontmatter) -> None:
+    assert frontmatter["name"] == "backup-restore"
+
+
+def test_author_credits_contributor(frontmatter) -> None:
+    author = frontmatter["author"]
+    assert "vijays365" in author, f"author should credit the contributor: {author!r}"
+
+
+def test_license_mit(frontmatter) -> None:
+    assert frontmatter["license"] == "MIT"
+
+
+def test_script_exists() -> None:
+    assert (SKILL_DIR / "scripts" / "backup.sh").is_file()
+
+
+def test_skill_has_pitfalls_section() -> None:
+    src = (SKILL_DIR / "SKILL.md").read_text()
+    assert "## Common Pitfalls" in src or "## Pitfalls" in src
+
+
+def test_paths_use_installed_layout() -> None:
+    src = (SKILL_DIR / "SKILL.md").read_text()
+    assert "skills/optional-skills/devops" not in src, "paths should not include 'optional-skills' prefix"

--- a/tests/skills/test_config_validator_skill.py
+++ b/tests/skills/test_config_validator_skill.py
@@ -1,0 +1,67 @@
+"""Smoke tests for the config-validator optional skill."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+SKILL_DIR = Path(__file__).resolve().parents[2] / "optional-skills" / "devops" / "config-validator"
+
+
+@pytest.fixture(scope="module")
+def frontmatter() -> dict:
+    src = (SKILL_DIR / "SKILL.md").read_text()
+    m = re.search(r"^---\n(.*?)\n---", src, re.DOTALL)
+    assert m, "SKILL.md missing YAML frontmatter"
+    return yaml.safe_load(m.group(1))
+
+
+def test_skill_dir_exists() -> None:
+    assert SKILL_DIR.is_dir()
+
+
+def test_skill_md_present() -> None:
+    assert (SKILL_DIR / "SKILL.md").is_file()
+
+
+def test_name_matches_dir(frontmatter) -> None:
+    assert frontmatter["name"] == "config-validator"
+
+
+def test_author_credits_contributor(frontmatter) -> None:
+    author = frontmatter["author"]
+    assert "vijays365" in author, f"author should credit the contributor: {author!r}"
+
+
+def test_license_mit(frontmatter) -> None:
+    assert frontmatter["license"] == "MIT"
+
+
+def test_script_exists() -> None:
+    assert (SKILL_DIR / "scripts" / "validate-config.sh").is_file()
+
+
+def test_script_has_model_checks() -> None:
+    """Must check model.default and model.provider per SKILL.md docs."""
+    src = (SKILL_DIR / "scripts" / "validate-config.sh").read_text()
+    assert "model.default" in src, "script must check model.default"
+    assert "model.provider" in src, "script must check model.provider"
+
+
+def test_script_uses_if_guarded_yaml_check() -> None:
+    """validate_yaml must be called inside an if guard, not bare under set -e."""
+    src = (SKILL_DIR / "scripts" / "validate-config.sh").read_text()
+    assert "if validate_yaml" in src, "validate_yaml must be if-guarded, not bare under set -e"
+
+
+def test_skill_has_pitfalls_section() -> None:
+    src = (SKILL_DIR / "SKILL.md").read_text()
+    assert "## Common Pitfalls" in src or "## Pitfalls" in src
+
+
+def test_paths_use_installed_layout() -> None:
+    """SKILL.md must reference installed paths, not repo paths."""
+    src = (SKILL_DIR / "SKILL.md").read_text()
+    assert "skills/optional-skills/devops" not in src, "paths should not include 'optional-skills' prefix"

--- a/tests/skills/test_hermes_diag_skill.py
+++ b/tests/skills/test_hermes_diag_skill.py
@@ -1,0 +1,53 @@
+"""Smoke tests for the hermes-diag optional skill."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+SKILL_DIR = Path(__file__).resolve().parents[2] / "optional-skills" / "devops" / "hermes-diag"
+
+
+@pytest.fixture(scope="module")
+def frontmatter() -> dict:
+    src = (SKILL_DIR / "SKILL.md").read_text()
+    m = re.search(r"^---\n(.*?)\n---", src, re.DOTALL)
+    assert m, "SKILL.md missing YAML frontmatter"
+    return yaml.safe_load(m.group(1))
+
+
+def test_skill_dir_exists() -> None:
+    assert SKILL_DIR.is_dir()
+
+
+def test_skill_md_present() -> None:
+    assert (SKILL_DIR / "SKILL.md").is_file()
+
+
+def test_name_matches_dir(frontmatter) -> None:
+    assert frontmatter["name"] == "hermes-diag"
+
+
+def test_author_credits_contributor(frontmatter) -> None:
+    author = frontmatter["author"]
+    assert "vijays365" in author, f"author should credit the contributor: {author!r}"
+
+
+def test_license_mit(frontmatter) -> None:
+    assert frontmatter["license"] == "MIT"
+
+
+def test_script_exists() -> None:
+    assert (SKILL_DIR / "scripts" / "hermes-diag.sh").is_file()
+
+
+def test_skill_has_pitfalls_section() -> None:
+    src = (SKILL_DIR / "SKILL.md").read_text()
+    assert "## Common Pitfalls" in src or "## Pitfalls" in src
+
+
+def test_paths_use_installed_layout() -> None:
+    src = (SKILL_DIR / "SKILL.md").read_text()
+    assert "skills/optional-skills/devops" not in src, "paths should not include 'optional-skills' prefix"

--- a/tests/skills/test_system_health_skill.py
+++ b/tests/skills/test_system_health_skill.py
@@ -1,0 +1,69 @@
+"""Smoke tests for the system-health optional skill."""
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+SKILL_DIR = Path(__file__).resolve().parents[2] / "optional-skills" / "devops" / "system-health"
+
+
+@pytest.fixture(scope="module")
+def frontmatter() -> dict:
+    src = (SKILL_DIR / "SKILL.md").read_text()
+    m = re.search(r"^---\n(.*?)\n---", src, re.DOTALL)
+    assert m, "SKILL.md missing YAML frontmatter"
+    return yaml.safe_load(m.group(1))
+
+
+def test_skill_dir_exists() -> None:
+    assert SKILL_DIR.is_dir()
+
+
+def test_skill_md_present() -> None:
+    assert (SKILL_DIR / "SKILL.md").is_file()
+
+
+def test_name_matches_dir(frontmatter) -> None:
+    assert frontmatter["name"] == "system-health"
+
+
+def test_author_credits_contributor(frontmatter) -> None:
+    author = frontmatter["author"]
+    assert "vijays365" in author, f"author should credit the contributor: {author!r}"
+
+
+def test_license_mit(frontmatter) -> None:
+    assert frontmatter["license"] == "MIT"
+
+
+@pytest.mark.parametrize("path", ["scripts/system-health-report.py"])
+def test_shipped_scripts_parse(path: str) -> None:
+    src = (SKILL_DIR / path).read_text()
+    ast.parse(src)
+
+
+def test_script_imports_os_at_module_level() -> None:
+    src = (SKILL_DIR / "scripts" / "system-health-report.py").read_text()
+    tree = ast.parse(src)
+    top_level_imports = {n.name for n in ast.walk(tree) if isinstance(n, ast.Import)}
+    assert "os" in top_level_imports, "os must be imported at module level"
+
+
+def test_script_has_no_local_os_import() -> None:
+    """os should NOT be imported inside main() — that causes NameError in send_email()."""
+    src = (SKILL_DIR / "scripts" / "system-health-report.py").read_text()
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "main":
+            for child in ast.walk(node):
+                if isinstance(child, ast.Import) and any(a.name == "os" for a in child.names):
+                    pytest.fail("import os found inside main() — must be at module level")
+
+
+def test_skill_has_pitfalls_section() -> None:
+    src = (SKILL_DIR / "SKILL.md").read_text()
+    assert "## Common Pitfalls" in src or "## Pitfalls" in src


### PR DESCRIPTION
## Summary

Adds 4 DevOps skills to `optional-skills/devops/`:

| Skill | Description |
|-------|-------------|
| **system-health** | VPS health monitoring — memory, CPU, disk stats with optional email reports via AgentMail API |
| **backup-restore** | Dated tarball backups of Hermes configs/profiles/skills, pushed to git |
| **hermes-diag** | One-shot diagnostics — profiles, gateways, configs, disk, memory, errors |
| **config-validator** | Validate all Hermes YAML configs for syntax and structure |

All four follow the optional-skills format (SKILL.md + scripts/). Tested against a live Hermes installation.

## Testing

Each skill was tested:
- `config-validator`: validated 4 profiles, all configs, gateway states — exit 0
- `hermes-diag`: checked gateways, config, disk (66%), memory (62%), uptime, errors — all ✅
- `backup-restore`: created tarball with relative paths, git commit — exit 0
- `system-health`: collected all stats, formatted report correctly

No personal data or hardcoded paths. All scripts use `$HERMES_HOME` (defaults to `~/.hermes`).

Source repo with full history: https://github.com/vijays365/hermes-skills