### PR TITLE
fix(desktop): block sends to archived sessions

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
@@ -71,11 +71,10 @@ function Harness({
   seedMessages?: unknown[]
   storedSessionId?: null | string
 }) {
-  const activeSessionIdRef: MutableRefObject<string | null> = { current: RUNTIME_SESSION_ID }
-  const selectedStoredSessionIdRef: MutableRefObject<string | null> = {
-    current: storedSessionId === undefined ? RUNTIME_SESSION_ID : storedSessionId
-  }
-  const localBusyRef = busyRef ?? { current: false }
+  const activeSessionIdRef = useRef<string | null>(RUNTIME_SESSION_ID)
+  const selectedStoredSessionIdRef = useRef<string | null>(storedSessionId === undefined ? RUNTIME_SESSION_ID : storedSessionId)
+  const fallbackBusyRef = useRef(false)
+  const localBusyRef = busyRef ?? fallbackBusyRef
   const stateRef = useRef({
     messages: seedMessages ?? [],
     busy: false,
@@ -125,6 +124,7 @@ describe('usePromptActions /title', () => {
 
   afterEach(() => {
     cleanup()
+    setSessions(() => [])
     vi.restoreAllMocks()
   })
 
@@ -268,8 +268,13 @@ describe('usePromptActions desktop slash pickers', () => {
 })
 
 describe('usePromptActions submit / queue drain semantics', () => {
+  beforeEach(() => {
+    setSessions(() => [sessionInfo()])
+  })
+
   afterEach(() => {
     cleanup()
+    setSessions(() => [])
     vi.restoreAllMocks()
   })
 
@@ -344,11 +349,29 @@ describe('usePromptActions submit / queue drain semantics', () => {
     expect(accepted).toBe(false)
     expect(requestGateway).not.toHaveBeenCalledWith('prompt.submit', expect.anything())
   })
+
+  it('blocks sends into an archived stored session before prompt.submit', async () => {
+    setSessions(() => [sessionInfo({ archived: true })])
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />)
+
+    const accepted = await handle!.submitText('should not revive archived chat')
+
+    expect(accepted).toBe(false)
+    expect(requestGateway).not.toHaveBeenCalledWith('prompt.submit', expect.anything())
+  })
 })
 
 describe('usePromptActions steerPrompt', () => {
+  beforeEach(() => {
+    setSessions(() => [sessionInfo()])
+  })
+
   afterEach(() => {
     cleanup()
+    setSessions(() => [])
     vi.restoreAllMocks()
   })
 
@@ -520,6 +543,10 @@ describe('usePromptActions restoreToMessage', () => {
 })
 
 describe('usePromptActions file attachment sync', () => {
+  beforeEach(() => {
+    setSessions(() => [sessionInfo()])
+  })
+
   afterEach(() => {
     cleanup()
     $connection.set(null)
@@ -714,6 +741,7 @@ describe('usePromptActions sleep/wake session recovery', () => {
 
   afterEach(() => {
     cleanup()
+    setSessions(() => [])
     vi.restoreAllMocks()
   })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -561,6 +561,19 @@ export function usePromptActions({
         return false
       }
 
+      const storedSessionId = selectedStoredSessionIdRef.current
+      const storedSession = storedSessionId ? $sessions.get().find(session => session.id === storedSessionId) : null
+
+      if (storedSession?.archived) {
+        notify({
+          kind: 'error',
+          title: copy.archivedSessionBlockedTitle,
+          message: copy.archivedSessionBlockedMessage
+        })
+
+        return false
+      }
+
       const optimisticId = `user-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
 
       const buildUserMessage = (): ChatMessage => ({

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1776,6 +1776,8 @@ export const en: Translations = {
     branchFailed: 'Branch failed',
     deleteFailed: 'Delete failed',
     archived: 'Archived',
+    archivedSessionBlockedTitle: 'Archived chat',
+    archivedSessionBlockedMessage: 'This chat is archived. Restore it or start a new chat before sending.',
     archiveFailed: 'Archive failed',
     cwdChangeFailed: 'Working directory change failed',
     cwdStagedTitle: 'Working directory staged',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1918,6 +1918,8 @@ export const ja = defineLocale({
     branchFailed: 'ブランチに失敗しました',
     deleteFailed: '削除に失敗しました',
     archived: 'アーカイブしました',
+    archivedSessionBlockedTitle: 'アーカイブ済みチャット',
+    archivedSessionBlockedMessage: 'このチャットはアーカイブ済みです。送信するには復元するか、新しいチャットを開始してください。',
     archiveFailed: 'アーカイブに失敗しました',
     cwdChangeFailed: '作業ディレクトリの変更に失敗しました',
     cwdStagedTitle: '作業ディレクトリがステージングされました',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1433,6 +1433,8 @@ export interface Translations {
     branchFailed: string
     deleteFailed: string
     archived: string
+    archivedSessionBlockedTitle: string
+    archivedSessionBlockedMessage: string
     archiveFailed: string
     cwdChangeFailed: string
     cwdStagedTitle: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1955,6 +1955,8 @@ export const zh: Translations = {
     branchFailed: '分支失败',
     deleteFailed: '删除失败',
     archived: '已归档',
+    archivedSessionBlockedTitle: '已归档对话',
+    archivedSessionBlockedMessage: '此对话已归档。发送前请恢复它或开始新对话。',
     archiveFailed: '归档失败',
     cwdChangeFailed: '工作目录更改失败',
     cwdStagedTitle: '工作目录已暂存',


### PR DESCRIPTION
## Summary
- block Desktop prompt sends when the selected stored session is archived
- show localized restore/start-new guidance instead of reviving archived chats
- add a regression test that ensures `prompt.submit` is not called for archived sessions

## Validation
- `git diff --check origin/main...HEAD`
- `npm --workspace apps/desktop run test:ui -- src/app/session/hooks/use-prompt-actions.test.tsx`
- `npm --workspace apps/desktop run typecheck`

## Notes
- This replaces the old `fix/desktop-archived-session-send-guard` branch with a clean branch based on current `origin/main`.