### PR TITLE
fix(pricing): add official docs pricing entry for claude-fable-5

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -84,6 +84,21 @@ _UTC_NOW = lambda: datetime.now(timezone.utc)
 # Official docs snapshot entries. Models whose published pricing and cache
 # semantics are stable enough to encode exactly.
 _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
+    # ── Anthropic Claude Fable 5 ─────────────────────────────────────────
+    # $10/$50 base, $1 cache hits, $12.50 5m cache writes.
+    # Source: https://platform.claude.com/docs/en/about-claude/pricing
+    (
+        "anthropic",
+        "claude-fable-5",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("10.00"),
+        output_cost_per_million=Decimal("50.00"),
+        cache_read_cost_per_million=Decimal("1.00"),
+        cache_write_cost_per_million=Decimal("12.50"),
+        source="official_docs_snapshot",
+        source_url="https://platform.claude.com/docs/en/about-claude/pricing",
+        pricing_version="anthropic-pricing-2026-06",
+    ),
     # ── Anthropic Claude 4.8 ─────────────────────────────────────────────
     # Same $5/$25 base pricing as 4.6/4.7.  Fast-mode variant is a separate
     # model ID with 2x premium (vs the 6x premium on older Opus generations).


### PR DESCRIPTION
**Bug:** Without a pricing entry for `claude-fable-5`, sessions using this model log \$0.00 cost and `cost_status=unknown`, breaking cost visibility and making it impossible to track spend.

**Fix:** Adds a single snapshot entry to `_OFFICIAL_DOCS_PRICING` for `claude-fable-5`, style-matched to existing entries (e.g., `claude-opus-4-8`).

**Source:** https://platform.claude.com/docs/en/about-claude/pricing

**Verification:**
```python
from agent.usage_pricing import get_pricing_entry
entry = get_pricing_entry('claude-fable-5', provider='anthropic')
assert entry is not None
print(entry)
```