### PR TITLE
fix(desktop): allow dismissing settled tool rows

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool-approval-group.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool-approval-group.test.tsx
@@ -1,5 +1,5 @@
 import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
-import { cleanup, render, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { clearAllPrompts, setApprovalRequest } from '@/store/prompts'
@@ -104,6 +104,84 @@ function groupedPendingMessage(): ThreadMessage {
   } as ThreadMessage
 }
 
+function pendingOnlyMessage(): ThreadMessage {
+  return {
+    id: 'assistant-pending-only',
+    role: 'assistant',
+    content: [
+      {
+        type: 'tool-call',
+        toolCallId: 'term-only',
+        toolName: 'terminal',
+        args: { command: 'sleep 10' },
+        argsText: JSON.stringify({ command: 'sleep 10' })
+      }
+    ],
+    status: { type: 'running' },
+    createdAt,
+    metadata: {
+      unstable_state: null,
+      unstable_annotations: [],
+      unstable_data: [],
+      steps: [],
+      custom: {}
+    }
+  } as ThreadMessage
+}
+
+function completedOnlyMessage(): ThreadMessage {
+  return {
+    id: 'assistant-completed-only',
+    role: 'assistant',
+    content: [
+      {
+        type: 'tool-call',
+        toolCallId: 'read-only',
+        toolName: 'read_file',
+        args: { path: '/etc/hosts' },
+        argsText: JSON.stringify({ path: '/etc/hosts' }),
+        result: { content: '127.0.0.1 localhost' }
+      }
+    ],
+    status: { type: 'complete', reason: 'stop' },
+    createdAt,
+    metadata: {
+      unstable_state: null,
+      unstable_annotations: [],
+      unstable_data: [],
+      steps: [],
+      custom: {}
+    }
+  } as ThreadMessage
+}
+
+function failedOnlyMessage(): ThreadMessage {
+  return {
+    id: 'assistant-failed-only',
+    role: 'assistant',
+    content: [
+      {
+        type: 'tool-call',
+        toolCallId: 'term-failed',
+        toolName: 'terminal',
+        args: { command: 'exit 1' },
+        argsText: JSON.stringify({ command: 'exit 1' }),
+        isError: true,
+        result: { stderr: 'boom' }
+      }
+    ],
+    status: { type: 'complete', reason: 'stop' },
+    createdAt,
+    metadata: {
+      unstable_state: null,
+      unstable_annotations: [],
+      unstable_data: [],
+      steps: [],
+      custom: {}
+    }
+  } as ThreadMessage
+}
+
 function GroupHarness({ message }: { message: ThreadMessage }) {
   const runtime = useExternalStoreRuntime<ThreadMessage>({
     messages: [message],
@@ -154,5 +232,41 @@ describe('flat tool list approval surfacing', () => {
       // in a `hidden` subtree.
       expect(bar?.closest('[hidden]')).toBeNull()
     })
+  })
+
+  it('lets completed tool rows be dismissed', async () => {
+    const { container } = render(<GroupHarness message={completedOnlyMessage()} />)
+
+    const dismiss = await screen.findByLabelText('Dismiss')
+
+    expect(container.querySelectorAll('[data-slot="tool-block"]').length).toBeGreaterThan(1)
+
+    fireEvent.click(dismiss)
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Dismiss')).toBeNull()
+    })
+  })
+
+  it('lets failed tool rows be dismissed', async () => {
+    render(<GroupHarness message={failedOnlyMessage()} />)
+
+    const dismiss = await screen.findByLabelText('Dismiss')
+
+    fireEvent.click(dismiss)
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Dismiss')).toBeNull()
+    })
+  })
+
+  it('does not show dismiss for pending tool rows', async () => {
+    const { container } = render(<GroupHarness message={pendingOnlyMessage()} />)
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('[data-slot="tool-block"]').length).toBeGreaterThan(0)
+    })
+
+    expect(screen.queryByLabelText('Dismiss')).toBeNull()
   })
 })

--- a/apps/desktop/src/components/assistant-ui/tool-fallback.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool-fallback.tsx
@@ -2,7 +2,7 @@
 
 import { type ToolCallMessagePartProps, useAuiState } from '@assistant-ui/react'
 import { useStore } from '@nanostores/react'
-import { createContext, type FC, type PropsWithChildren, type ReactNode, useContext, useMemo } from 'react'
+import { createContext, type FC, type PropsWithChildren, type ReactNode, useContext, useMemo, useState } from 'react'
 
 import { AnsiText } from '@/components/assistant-ui/ansi-text'
 import { useElapsedSeconds } from '@/components/chat/activity-timer'
@@ -12,10 +12,13 @@ import { DiffLines } from '@/components/chat/diff-lines'
 import { DisclosureRow } from '@/components/chat/disclosure-row'
 import { PreviewAttachment } from '@/components/chat/preview-attachment'
 import { ZoomableImage } from '@/components/chat/zoomable-image'
+import { Button } from '@/components/ui/button'
+import { Codicon } from '@/components/ui/codicon'
 import { CopyButton } from '@/components/ui/copy-button'
 import { FadeText } from '@/components/ui/fade-text'
 import { GlyphSpinner } from '@/components/ui/glyph-spinner'
 import { ToolIcon } from '@/components/ui/tool-icon'
+import { Tip } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
 import { PrettyLink, LinkifiedText as SharedLinkifiedText, urlSlugTitleLabel } from '@/lib/external-link'
 import { AlertCircle, CheckCircle2 } from '@/lib/icons'
@@ -193,13 +196,16 @@ function useDisclosureOpen(disclosureId: string, fallbackOpen = false): boolean 
 function ToolEntry({ part }: ToolEntryProps) {
   const { t } = useI18n()
   const copy = t.assistant.tool
+  const statusCopy = t.statusStack
   const messageId = useAuiState(s => s.message.id)
   const messageRunning = useAuiState(selectMessageRunning)
   const embedded = useContext(ToolEmbedContext)
+  const [dismissed, setDismissed] = useState(false)
   const toolViewMode = useStore($toolViewMode)
   const disclosureId = `tool-entry:${messageId}:${toolPartDisclosureId(part)}`
   const open = useDisclosureOpen(disclosureId)
   const isPending = messageRunning && part.result === undefined
+  const canDismiss = !isPending && !embedded
   // Only animate entries that mount while their message is actively
   // streaming — historical sessions mount with `messageRunning === false`,
   // so they paint statically without a settle cascade. The wrapping group
@@ -284,7 +290,27 @@ function ToolEntry({ part }: ToolEntryProps) {
   const trailing =
     isPending && !embedded ? (
       <ActivityTimerText className={TOOL_HEADER_DURATION_CLASS} seconds={elapsed} />
+    ) : canDismiss ? (
+      <Tip label={statusCopy.dismiss}>
+        <Button
+          aria-label={statusCopy.dismiss}
+          className="-mr-1 size-5 rounded-md text-(--ui-text-tertiary) opacity-0 transition-opacity hover:text-(--ui-text-primary) hover:opacity-100 group-hover/disclosure-row:opacity-80 group-focus-within/disclosure-row:opacity-80"
+          onClick={event => {
+            event.stopPropagation()
+            setDismissed(true)
+          }}
+          size="icon-xs"
+          type="button"
+          variant="ghost"
+        >
+          <Codicon name="close" size="0.75rem" />
+        </Button>
+      </Tip>
     ) : undefined
+
+  if (dismissed) {
+    return null
+  }
 
   return (
     <div


### PR DESCRIPTION
## What does this PR do?

Adds a local dismiss affordance for settled Desktop inline tool rows.

Desktop renders terminal/file/tool activity as inline assistant message parts. Completed and failed rows could remain visually stuck at the bottom of a chat with no way to clear them short of starting a fresh session or changing the view. This keeps running rows visible, but lets users hide completed/failed rows locally without mutating the stored chat history.

## Related Issue

Discord support thread: https://discord.com/channels/1053877538025386074/1515073825023463464

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/components/assistant-ui/tool-fallback.tsx`
  - Adds a hover/focus dismiss button for non-running tool rows.
  - Keeps pending/running tool rows visible.
  - Stores dismissal in local component state only, so history is not rewritten.
- `apps/desktop/src/components/assistant-ui/tool-approval-group.test.tsx`
  - Covers completed row dismissal.
  - Covers failed row dismissal.
  - Covers pending rows not exposing dismissal.

## How to Test

1. Run `npm exec --workspace=apps/desktop -- vitest run --environment jsdom src/components/assistant-ui/tool-approval-group.test.tsx`.
2. Run `npm exec --workspace=apps/desktop -- eslint src/components/assistant-ui/tool-fallback.tsx src/components/assistant-ui/tool-approval-group.test.tsx`.
3. Run `npm exec --workspace=apps/desktop -- tsc -p . --noEmit`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL / Desktop TypeScript checks

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted checks:

```text
npm exec --workspace=apps/desktop -- vitest run --environment jsdom src/components/assistant-ui/tool-approval-group.test.tsx
Test Files  1 passed (1)
Tests  5 passed (5)
```

```text
npm exec --workspace=apps/desktop -- eslint src/components/assistant-ui/tool-fallback.tsx src/components/assistant-ui/tool-approval-group.test.tsx
passed
```

```text
npm exec --workspace=apps/desktop -- tsc -p . --noEmit
passed
```

Python `pytest tests/ -q` was not run; this is a Desktop-only TypeScript/UI change.
