### PR TITLE
gateway: add budget/credit exhaustion error message

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -125,6 +125,17 @@ _GATEWAY_RATE_LIMIT_RE = re.compile(
     re.IGNORECASE,
 )
 
+_GATEWAY_BUDGET_ERROR_RE = re.compile(
+    r"("  # credit / budget exhaustion — needs human intervention, not waiting
+    r"budget\s+(?:limit\s+)?(?:exceed|reached)"
+    r"|credit\s+(?:limit\s+)?(?:exceed|exhaust|reached)"
+    r"|credit\s+balance\s+(?:is\s+)?(?:too\s+low|insufficient)"
+    r"|insufficient\s+(?:credit|balance|fund)"
+    r"|billing\s+(?:limit|threshold)"
+    r")",
+    re.IGNORECASE,
+)
+
 _GATEWAY_SECRET_PATTERNS = (
     re.compile(r"\bsk-[A-Za-z0-9][A-Za-z0-9_\-]{12,}\b"),
     re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
@@ -238,6 +249,11 @@ def _gateway_provider_error_reply(text: str) -> str:
         return (
             "⚠️ The model provider rejected the request. I kept the raw provider "
             "error out of chat; check gateway logs for details or try rephrasing."
+        )
+    if _GATEWAY_BUDGET_ERROR_RE.search(text):
+        return (
+            "💰 The model provider's credit / budget limit has been reached. "
+            "Top up your account or wait for the limit to reset."
         )
     if _GATEWAY_RATE_LIMIT_RE.search(text):
         return "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again."
@@ -8529,6 +8545,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     user_config=_load_gateway_config(),
                     platform_key=_platform_config_key(source.platform),
                     model=agent_result.get("model"),
+                    provider=agent_result.get("provider"),
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
                     cwd=os.environ.get("TERMINAL_CWD", ""),
@@ -14308,6 +14325,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _output_toks = getattr(_agent, "session_completion_tokens", 0)
                 _context_length = getattr(_agent.context_compressor, "context_length", 0) or 0
             _resolved_model = getattr(_agent, "model", None) if _agent else None
+            _resolved_provider = getattr(_agent, "provider", None) if _agent else None
 
             if not final_response:
                 error_msg = f"⚠️ {result['error']}" if result.get("error") else ""
@@ -14484,6 +14502,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "input_tokens": _input_toks,
                 "output_tokens": _output_toks,
                 "model": _resolved_model,
+                "provider": _resolved_provider,
                 "context_length": _context_length,
                 "session_id": effective_session_id,
                 "response_previewed": result.get("response_previewed", False),


### PR DESCRIPTION
Provider errors for exhausted credits or budget limits were falling through to the unhelpful catch-all message. This adds a specific budget-error classifier so users see an actionable message instead of having to dig through gateway logs.

### Before
⚠️ The model provider failed after retries. I kept raw provider details out of chat; check gateway logs for diagnostics.

### After  
💰 The model provider's credit / budget limit has been reached. Top up your account or wait for the limit to reset.

### What it catches
- OpenRouter: "API key budget limit exceeded (daily limit)"
- Anthropic: "Your credit balance is too low to access the API"
- DeepSeek: "Insufficient balance. Please top up your account."
- OpenAI: billing threshold errors
- Any provider returning budget/credit/balance exhaustion messages

### What it doesn't touch
- Auth errors (401, invalid API key) — unchanged
- Policy/moderation blocks — unchanged  
- Transient rate limits (429) — unchanged
- The catch-all for truly unknown errors — unchanged

The new check runs before the rate-limit check so "budget limit" isn't misclassified as a transient rate limit.