### PR TITLE
fix(cron): pass target_model to resolve_runtime_provider

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3048,6 +3048,8 @@ def run_job(
             # example DeepSeek) for cron jobs that do not pin provider/model.
             runtime_kwargs = {
                 "requested": job.get("provider"),
+                # Multi-surface providers select their API mode from this model.
+                "target_model": model,
             }
             if job.get("base_url"):
                 runtime_kwargs["explicit_base_url"] = job.get("base_url")

--- a/tests/cron/test_codex_execution_paths.py
+++ b/tests/cron/test_codex_execution_paths.py
@@ -98,7 +98,7 @@ def test_cron_run_job_codex_path_handles_internal_401_refresh(monkeypatch):
     monkeypatch.setattr(run_agent, "AIAgent", _Codex401ThenSuccessAgent)
     monkeypatch.setattr(
         "hermes_cli.runtime_provider.resolve_runtime_provider",
-        lambda requested=None: {
+        lambda requested=None, **_kwargs: {
             "provider": "openai-codex",
             "api_mode": "codex_responses",
             "base_url": "https://chatgpt.com/backend-api/codex",

--- a/tests/cron/test_cron_target_model.py
+++ b/tests/cron/test_cron_target_model.py
@@ -1,0 +1,72 @@
+"""Regression coverage for model-aware cron runtime resolution.
+
+OpenCode Go serves models through multiple API surfaces. The cron scheduler
+must resolve the runtime from the model the job will run, rather than an
+unrelated ``model.default`` value.
+"""
+
+from unittest.mock import MagicMock, patch
+
+
+def test_cron_agent_uses_pinned_model_for_opencode_runtime(tmp_path, monkeypatch):
+    """A DeepSeek cron job must not inherit MiniMax's Anthropic API mode."""
+    (tmp_path / "config.yaml").write_text(
+        "model:\n  provider: opencode-go\n  default: minimax-m3\n",
+        encoding="utf-8",
+    )
+    (tmp_path / ".env").write_text(
+        "OPENCODE_GO_API_KEY=test-opencode-go-key\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_CRON_TIMEOUT", "0")
+    monkeypatch.delenv("HERMES_MODEL", raising=False)
+    monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+    monkeypatch.delenv("OPENCODE_GO_BASE_URL", raising=False)
+
+    fake_db = MagicMock()
+    fake_agent = MagicMock()
+    fake_agent.run_conversation.return_value = {
+        "completed": True,
+        "final_response": "ok",
+        "messages": [],
+    }
+    job = {
+        "id": "opencode-go-model-routing",
+        "name": "OpenCode Go model routing",
+        "prompt": "ping",
+        "model": "deepseek-v4-flash",
+        "provider": "opencode-go",
+        "deliver": "local",
+    }
+
+    with (
+        patch("cron.scheduler._hermes_home", tmp_path),
+        patch("cron.scheduler._get_hermes_home", return_value=tmp_path),
+        patch("cron.scheduler.claim_dispatch", return_value=True),
+        patch("cron.scheduler.save_job_output", return_value=tmp_path / "output.md"),
+        patch("cron.scheduler._deliver_result", return_value=None),
+        patch("cron.scheduler.mark_job_run") as mark_job_run,
+        patch("cron.scheduler._resolve_origin", return_value=None),
+        patch("cron.scheduler._build_job_prompt", return_value="ping"),
+        patch("hermes_cli.env_loader.load_hermes_dotenv"),
+        patch("hermes_cli.env_loader.reset_secret_source_cache"),
+        patch("hermes_state.SessionDB", return_value=fake_db),
+        patch("tools.mcp_tool.discover_mcp_tools", return_value=[]),
+        patch("agent.auxiliary_client.cleanup_stale_async_clients"),
+        patch("run_agent.AIAgent", return_value=fake_agent) as agent_cls,
+    ):
+        from cron.scheduler import run_one_job
+
+        processed = run_one_job(job)
+
+    assert processed is True
+    agent_cls.assert_called_once()
+    mark_job_run.assert_called_once()
+    assert mark_job_run.call_args.args[1] is True
+
+    agent_kwargs = agent_cls.call_args.kwargs
+    assert agent_kwargs["model"] == "deepseek-v4-flash"
+    assert agent_kwargs["provider"] == "opencode-go"
+    assert agent_kwargs["api_mode"] == "chat_completions"
+    assert agent_kwargs["base_url"] == "https://opencode.ai/zen/go/v1"


### PR DESCRIPTION
# fix(cron): pass target_model to resolve_runtime_provider

Closes the cron-path analogue of #18586.

## Problem

A cron job pinned to `deepseek-v4-flash` on `opencode-go` was routed through the
Anthropic Messages API when `model.default` was `minimax-m3`. The request used
the wrong API mode and base URL, then failed with a 400 response.

## Root cause

`run_job()` resolves an effective model from the job override, `HERMES_MODEL`,
or `model.default`, but did not pass that model to `resolve_runtime_provider()`.
The resolver therefore used `model.default` to select the OpenCode Go API
surface even when the cron job would run a different model.

## Fix

Pass `target_model=model` from the cron scheduler so provider resolution uses
the same effective model that is given to `AIAgent`. This is the same narrow
caller-side fix used for the delegation path; resolver behaviour is unchanged.

The existing Codex cron test stub now accepts extra resolver kwargs so it does
not duplicate the resolver signature.

## Regression test

`tests/cron/test_cron_target_model.py` now exercises the real runtime resolver
instead of mocking it. The test creates a temporary `HERMES_HOME` with:

- `model.provider: opencode-go`
- `model.default: minimax-m3`
- a cron job pinned to `deepseek-v4-flash`

It captures the constructed `AIAgent` and asserts:

- `model == "deepseek-v4-flash"`
- `provider == "opencode-go"`
- `api_mode == "chat_completions"`
- `base_url == "https://opencode.ai/zen/go/v1"`

With the scheduler fix removed, this test fails because the agent receives
`api_mode == "anthropic_messages"`. With the fix applied, it passes.

## Verification

- Targeted cron and runtime-provider tests: 166 passed
- Full `tests/cron/` suite: 694 passed
- Ruff checks on changed files: passed
- Windows-footgun scan: passed
- `git diff --check`: passed

No dependencies, configuration formats, migrations, or resolver behaviour were
changed.
