### PR TITLE
fix(cron): pass target_model to resolve_runtime_provider for pinned-model jobs

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1655,6 +1655,8 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             runtime_kwargs = {
                 "requested": job.get("provider"),
             }
+            if model:
+                runtime_kwargs["target_model"] = model
             if job.get("base_url"):
                 runtime_kwargs["explicit_base_url"] = job.get("base_url")
             runtime = resolve_runtime_provider(**runtime_kwargs)
@@ -1669,6 +1671,8 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                     continue
                 try:
                     fb_kwargs = {"requested": entry.get("provider")}
+                    if model:
+                        fb_kwargs["target_model"] = model
                     if entry.get("base_url"):
                         fb_kwargs["explicit_base_url"] = entry["base_url"]
                     if entry.get("api_key"):

--- a/tests/cron/test_codex_execution_paths.py
+++ b/tests/cron/test_codex_execution_paths.py
@@ -98,14 +98,14 @@ def test_cron_run_job_codex_path_handles_internal_401_refresh(monkeypatch):
     monkeypatch.setattr(run_agent, "AIAgent", _Codex401ThenSuccessAgent)
     monkeypatch.setattr(
         "hermes_cli.runtime_provider.resolve_runtime_provider",
-        lambda requested=None: {
+        lambda requested=None, **_kw: {
             "provider": "openai-codex",
             "api_mode": "codex_responses",
             "base_url": "https://chatgpt.com/backend-api/codex",
             "api_key": "codex-token",
         },
     )
-    monkeypatch.setattr("hermes_cli.runtime_provider.format_runtime_provider_error", lambda exc: str(exc))
+    monkeypatch.setattr("hermes_cli.runtime_provider.format_runtime_provider_error", lambda exc, **_kw: str(exc))
 
     _Codex401ThenSuccessAgent.refresh_attempts = 0
     _Codex401ThenSuccessAgent.last_init = {}

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1472,6 +1472,82 @@ class TestRunJobSessionPersistence:
         assert fake_db.close.call_count == 2
 
 
+class TestRunJobTargetModel:
+    """Verify that cron jobs pass target_model to resolve_runtime_provider."""
+
+    def test_target_model_forwarded_to_runtime_resolver(self, tmp_path):
+        """When a job pins model, resolve_runtime_provider must receive
+        target_model so api_mode is computed from the job's model, not
+        the unrelated config default (regression: #45245)."""
+        job = {
+            "id": "test-tm",
+            "name": "test",
+            "prompt": "hello",
+            "model": "deepseek-v4-flash",
+            "provider": "opencode-go",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://opencode.ai/zen/go/v1",
+                     "provider": "opencode-go",
+                     "api_mode": "chat_completions",
+                 },
+             ) as mock_resolve, \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+
+            run_job(job)
+
+        mock_resolve.assert_called_once()
+        call_kwargs = mock_resolve.call_args.kwargs
+        assert call_kwargs.get("target_model") == "deepseek-v4-flash"
+        assert call_kwargs.get("requested") == "opencode-go"
+
+    def test_empty_model_omits_target_model(self, tmp_path):
+        """When a job has no model field, target_model should not be passed
+        so the resolver falls back to config default as designed."""
+        job = {
+            "id": "test-no-tm",
+            "name": "test",
+            "prompt": "hello",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ) as mock_resolve, \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+
+            run_job(job)
+
+        mock_resolve.assert_called_once()
+        call_kwargs = mock_resolve.call_args.kwargs
+        assert "target_model" not in call_kwargs
+
+
 class TestRunJobConfigLogging:
     """Verify that config.yaml parse failures are logged, not silently swallowed."""
 


### PR DESCRIPTION
## What does this PR do?

Passes `target_model` from cron job configuration to `resolve_runtime_provider()` so the API surface (`api_mode`, `base_url`) is computed from the model the job will actually use, not from the unrelated `model.default` config.

## Related Issue

Fixes #45245

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py`: Pass `target_model=model` to `resolve_runtime_provider()` when the job specifies a model — both in the primary resolution path and the auth-error fallback chain
- `tests/cron/test_scheduler.py`: Two new tests in `TestRunJobTargetModel` — verifies `target_model` is forwarded when job has a model, and omitted when job has no model

## How to Test

1. Configure `model.default` to an Anthropic-routed model on a provider that supports both API surfaces (e.g. `minimax-m3` on `opencode-go`)
2. Create a cron job pinned to a chat-completions model on the same provider: `hermes cron create --model deepseek-v4-flash --provider opencode-go --schedule "*/5 * * * *" --prompt "say hi"`
3. Run the job and verify it resolves to `api_mode='chat_completions'` with the correct `/v1` base URL, instead of falling through to `anthropic_messages`
4. Run `pytest tests/cron/test_scheduler.py::TestRunJobTargetModel -xvs` — both tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/cron/test_scheduler.py -q` and related tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `cron/scheduler.py::run_job` (runtime_kwargs construction at line 1655, fallback chain at line 1671)
- Blast radius: LOW — only affects cron job provider resolution when `target_model` is set; no change for jobs without a model field
- Related patterns: Same root cause as #18586 (delegate_task version); `resolve_runtime_provider` already accepts `target_model` since the delegate_task fix
