### PR TITLE
refactor(goal): share goal command architecture across surfaces

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1562,20 +1562,21 @@ class GatewaySlashCommandsMixin:
         agent starts working on it immediately — the post-turn
         continuation hook then takes over from there.
         """
-        from hermes_cli.goals import parse_goal_command
+        from hermes_cli.goals import handle_goal_command
 
         args = (event.get_command_args() or "").strip()
-        goal_cmd = parse_goal_command(args)
 
         mgr, session_entry = self._get_goal_manager_for_event(event)
         if mgr is None:
             return t("gateway.goal.unavailable")
 
-        if goal_cmd.action == "status":
-            return mgr.status_line()
+        result = handle_goal_command(mgr, args)
 
-        if goal_cmd.action == "pause":
-            state = mgr.pause(reason="user-paused")
+        if result.action == "status":
+            return result.status_line
+
+        if result.action == "pause":
+            state = result.state
             if state is None:
                 return t("gateway.goal.no_goal_set")
             try:
@@ -1587,13 +1588,13 @@ class GatewaySlashCommandsMixin:
                 logger.debug("goal pause: pending continuation cleanup failed: %s", exc)
             return t("gateway.goal.paused", goal=state.goal)
 
-        if goal_cmd.action == "resume":
-            state = mgr.resume()
+        if result.action == "resume":
+            state = result.state
             if state is None:
                 return t("gateway.goal.no_resume")
             adapter = self.adapters.get(event.source.platform) if event.source else None
             _quick_key = self._session_key_for_source(event.source) if event.source else None
-            prompt = mgr.next_continuation_prompt()
+            prompt = result.kickoff_prompt
             if adapter and _quick_key and prompt:
                 try:
                     kickoff_event = MessageEvent(
@@ -1608,9 +1609,7 @@ class GatewaySlashCommandsMixin:
                     logger.debug("goal resume continuation enqueue failed: %s", exc)
             return t("gateway.goal.resumed", goal=state.goal)
 
-        if goal_cmd.action == "clear":
-            had = mgr.has_goal()
-            mgr.clear()
+        if result.action == "clear":
             try:
                 adapter = self.adapters.get(event.source.platform) if event.source else None
                 _quick_key = self._session_key_for_source(event.source) if event.source else None
@@ -1618,13 +1617,13 @@ class GatewaySlashCommandsMixin:
                     self._clear_goal_pending_continuations(_quick_key, adapter)
             except Exception as exc:
                 logger.debug("goal clear: pending continuation cleanup failed: %s", exc)
-            return t("gateway.goal_cleared") if had else t("gateway.no_active_goal")
+            return t("gateway.goal_cleared") if result.had_goal else t("gateway.no_active_goal")
 
-        # Otherwise — treat the remaining text as the new goal.
-        try:
-            state = mgr.set(goal_cmd.text)
-        except ValueError as exc:
-            return t("gateway.goal.invalid", error=str(exc))
+        if result.error is not None:
+            return t("gateway.goal.invalid", error=str(result.error))
+        state = result.state
+        if state is None:
+            return t("gateway.goal.invalid", error="no state returned")
 
         # Queue the goal text as an immediate first turn so the agent
         # starts making progress. The post-turn hook takes over after.

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1591,6 +1591,21 @@ class GatewaySlashCommandsMixin:
             state = mgr.resume()
             if state is None:
                 return t("gateway.goal.no_resume")
+            adapter = self.adapters.get(event.source.platform) if event.source else None
+            _quick_key = self._session_key_for_source(event.source) if event.source else None
+            prompt = mgr.next_continuation_prompt()
+            if adapter and _quick_key and prompt:
+                try:
+                    kickoff_event = MessageEvent(
+                        text=prompt,
+                        message_type=MessageType.TEXT,
+                        source=event.source,
+                        message_id=event.message_id,
+                        channel_prompt=event.channel_prompt,
+                    )
+                    self._enqueue_fifo(_quick_key, kickoff_event, adapter)
+                except Exception as exc:
+                    logger.debug("goal resume continuation enqueue failed: %s", exc)
             return t("gateway.goal.resumed", goal=state.goal)
 
         if goal_cmd.action == "clear":

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1562,17 +1562,19 @@ class GatewaySlashCommandsMixin:
         agent starts working on it immediately — the post-turn
         continuation hook then takes over from there.
         """
+        from hermes_cli.goals import parse_goal_command
+
         args = (event.get_command_args() or "").strip()
-        lower = args.lower()
+        goal_cmd = parse_goal_command(args)
 
         mgr, session_entry = self._get_goal_manager_for_event(event)
         if mgr is None:
             return t("gateway.goal.unavailable")
 
-        if not args or lower == "status":
+        if goal_cmd.action == "status":
             return mgr.status_line()
 
-        if lower == "pause":
+        if goal_cmd.action == "pause":
             state = mgr.pause(reason="user-paused")
             if state is None:
                 return t("gateway.goal.no_goal_set")
@@ -1585,13 +1587,13 @@ class GatewaySlashCommandsMixin:
                 logger.debug("goal pause: pending continuation cleanup failed: %s", exc)
             return t("gateway.goal.paused", goal=state.goal)
 
-        if lower == "resume":
+        if goal_cmd.action == "resume":
             state = mgr.resume()
             if state is None:
                 return t("gateway.goal.no_resume")
             return t("gateway.goal.resumed", goal=state.goal)
 
-        if lower in {"clear", "stop", "done"}:
+        if goal_cmd.action == "clear":
             had = mgr.has_goal()
             mgr.clear()
             try:
@@ -1605,7 +1607,7 @@ class GatewaySlashCommandsMixin:
 
         # Otherwise — treat the remaining text as the new goal.
         try:
-            state = mgr.set(args)
+            state = mgr.set(goal_cmd.text)
         except ValueError as exc:
             return t("gateway.goal.invalid", error=str(exc))
 

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1792,7 +1792,7 @@ class CLICommandsMixin:
 
     def _handle_goal_command(self, cmd: str) -> None:
         """Dispatch /goal subcommands: set / status / pause / resume / clear."""
-        from hermes_cli.goals import parse_goal_command
+        from hermes_cli.goals import handle_goal_command
         from cli import _DIM, _RST, _cprint
         parts = (cmd or "").strip().split(None, 1)
         arg = parts[1].strip() if len(parts) > 1 else ""
@@ -1802,51 +1802,46 @@ class CLICommandsMixin:
             _cprint(f"  {_DIM}Goals unavailable (no active session).{_RST}")
             return
 
-        goal_cmd = parse_goal_command(arg)
+        result = handle_goal_command(mgr, arg)
 
-        # Bare /goal or /goal status → show current state
-        if goal_cmd.action == "status":
-            _cprint(f"  {mgr.status_line()}")
+        if result.action == "status":
+            _cprint(f"  {result.status_line}")
             return
 
-        if goal_cmd.action == "pause":
-            state = mgr.pause(reason="user-paused")
-            if state is None:
+        if result.action == "pause":
+            if result.state is None:
                 _cprint(f"  {_DIM}No goal set.{_RST}")
             else:
-                _cprint(f"  ⏸ Goal paused: {state.goal}")
+                _cprint(f"  ⏸ Goal paused: {result.state.goal}")
             return
 
-        if goal_cmd.action == "resume":
-            state = mgr.resume()
-            if state is None:
+        if result.action == "resume":
+            if result.state is None:
                 _cprint(f"  {_DIM}No goal to resume.{_RST}")
             else:
-                _cprint(f"  ▶ Goal resumed: {state.goal}")
-                prompt = mgr.next_continuation_prompt()
-                if prompt:
+                _cprint(f"  ▶ Goal resumed: {result.state.goal}")
+                if result.kickoff_prompt:
                     pending = getattr(self, "_pending_input", None)
                     if pending is not None:
-                        pending.put(prompt)
+                        pending.put(result.kickoff_prompt)
                     _cprint(f"  {_DIM}Queued the next continuation turn.{_RST}")
             return
 
-        if goal_cmd.action == "clear":
-            had = mgr.has_goal()
-            mgr.clear()
-            if had:
+        if result.action == "clear":
+            if result.had_goal:
                 _cprint("  ✓ Goal cleared.")
             else:
                 _cprint(f"  {_DIM}No active goal.{_RST}")
             return
 
-        # Otherwise treat the arg as the goal text.
-        try:
-            state = mgr.set(goal_cmd.text)
-        except ValueError as exc:
-            _cprint(f"  Invalid goal: {exc}")
+        if result.error is not None:
+            _cprint(f"  Invalid goal: {result.error}")
+            return
+        if result.state is None:
+            _cprint("  Invalid goal: no state returned")
             return
 
+        state = result.state
         _cprint(f"  ⊙ Goal set ({state.max_turns}-turn budget): {state.goal}")
         _cprint(
             f"  {_DIM}After each turn, a judge model will check if the goal is done. "

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1823,10 +1823,12 @@ class CLICommandsMixin:
                 _cprint(f"  {_DIM}No goal to resume.{_RST}")
             else:
                 _cprint(f"  ▶ Goal resumed: {state.goal}")
-                _cprint(
-                    f"  {_DIM}Send any message (or press Enter on an empty prompt "
-                    f"is a no-op; type 'continue' to kick it off).{_RST}"
-                )
+                prompt = mgr.next_continuation_prompt()
+                if prompt:
+                    pending = getattr(self, "_pending_input", None)
+                    if pending is not None:
+                        pending.put(prompt)
+                    _cprint(f"  {_DIM}Queued the next continuation turn.{_RST}")
             return
 
         if goal_cmd.action == "clear":

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1792,6 +1792,7 @@ class CLICommandsMixin:
 
     def _handle_goal_command(self, cmd: str) -> None:
         """Dispatch /goal subcommands: set / status / pause / resume / clear."""
+        from hermes_cli.goals import parse_goal_command
         from cli import _DIM, _RST, _cprint
         parts = (cmd or "").strip().split(None, 1)
         arg = parts[1].strip() if len(parts) > 1 else ""
@@ -1801,14 +1802,14 @@ class CLICommandsMixin:
             _cprint(f"  {_DIM}Goals unavailable (no active session).{_RST}")
             return
 
-        lower = arg.lower()
+        goal_cmd = parse_goal_command(arg)
 
         # Bare /goal or /goal status → show current state
-        if not arg or lower == "status":
+        if goal_cmd.action == "status":
             _cprint(f"  {mgr.status_line()}")
             return
 
-        if lower == "pause":
+        if goal_cmd.action == "pause":
             state = mgr.pause(reason="user-paused")
             if state is None:
                 _cprint(f"  {_DIM}No goal set.{_RST}")
@@ -1816,7 +1817,7 @@ class CLICommandsMixin:
                 _cprint(f"  ⏸ Goal paused: {state.goal}")
             return
 
-        if lower == "resume":
+        if goal_cmd.action == "resume":
             state = mgr.resume()
             if state is None:
                 _cprint(f"  {_DIM}No goal to resume.{_RST}")
@@ -1828,7 +1829,7 @@ class CLICommandsMixin:
                 )
             return
 
-        if lower in {"clear", "stop", "done"}:
+        if goal_cmd.action == "clear":
             had = mgr.has_goal()
             mgr.clear()
             if had:
@@ -1839,7 +1840,7 @@ class CLICommandsMixin:
 
         # Otherwise treat the arg as the goal text.
         try:
-            state = mgr.set(arg)
+            state = mgr.set(goal_cmd.text)
         except ValueError as exc:
             _cprint(f"  Invalid goal: {exc}")
             return

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -35,7 +35,7 @@ import re
 import time
 from dataclasses import dataclass, field, asdict
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -132,6 +132,36 @@ JUDGE_USER_PROMPT_WITH_SUBGOALS_TEMPLATE = (
     "is NOT done — return CONTINUE.\n\n"
     "Is the goal AND every additional criterion satisfied?"
 )
+
+
+@dataclass(frozen=True)
+class GoalDecision:
+    """Structured result from ``GoalManager.evaluate_after_turn``.
+
+    CLI, gateway, and TUI call sites historically treated goal decisions as
+    dicts.  Keep that mapping-shaped API while giving the goal loop a named
+    internal contract so future status/message changes do not require callers
+    to reverse-engineer ad-hoc dict literals.
+    """
+
+    status: Optional[str]
+    should_continue: bool
+    continuation_prompt: Optional[str]
+    verdict: str
+    reason: str
+    message: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self.to_dict().get(key, default)
+
+    def __getitem__(self, key: str) -> Any:
+        return self.to_dict()[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.to_dict())
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -622,8 +652,8 @@ class GoalManager:
         last_response: str,
         *,
         user_initiated: bool = True,
-    ) -> Dict[str, Any]:
-        """Run the judge and update state. Return a decision dict.
+    ) -> GoalDecision:
+        """Run the judge and update state. Return a structured decision.
 
         ``user_initiated`` distinguishes a real user prompt (True) from a
         continuation prompt we fed ourselves (False). Both increment
@@ -639,14 +669,14 @@ class GoalManager:
         """
         state = self._state
         if state is None or state.status != "active":
-            return {
-                "status": state.status if state else None,
-                "should_continue": False,
-                "continuation_prompt": None,
-                "verdict": "inactive",
-                "reason": "no active goal",
-                "message": "",
-            }
+            return GoalDecision(
+                status=state.status if state else None,
+                should_continue=False,
+                continuation_prompt=None,
+                verdict="inactive",
+                reason="no active goal",
+                message="",
+            )
 
         # Count the turn that just finished.
         state.turns_used += 1
@@ -669,14 +699,14 @@ class GoalManager:
         if verdict == "done":
             state.status = "done"
             save_goal(self.session_id, state)
-            return {
-                "status": "done",
-                "should_continue": False,
-                "continuation_prompt": None,
-                "verdict": "done",
-                "reason": reason,
-                "message": f"✓ Goal achieved: {reason}",
-            }
+            return GoalDecision(
+                status="done",
+                should_continue=False,
+                continuation_prompt=None,
+                verdict="done",
+                reason=reason,
+                message=f"✓ Goal achieved: {reason}",
+            )
 
         # Auto-pause when the judge model can't produce the expected JSON
         # verdict N turns in a row. Points the user at the goal_judge config
@@ -690,13 +720,13 @@ class GoalManager:
                 f"judge model returned unparseable output {state.consecutive_parse_failures} turns in a row"
             )
             save_goal(self.session_id, state)
-            return {
-                "status": "paused",
-                "should_continue": False,
-                "continuation_prompt": None,
-                "verdict": "continue",
-                "reason": reason,
-                "message": (
+            return GoalDecision(
+                status="paused",
+                should_continue=False,
+                continuation_prompt=None,
+                verdict="continue",
+                reason=reason,
+                message=(
                     f"⏸ Goal paused — the judge model ({state.consecutive_parse_failures} turns) "
                     "isn't returning the required JSON verdict. Route the judge to a stricter "
                     "model in ~/.hermes/config.yaml:\n"
@@ -706,35 +736,35 @@ class GoalManager:
                     "      model: google/gemini-3-flash-preview\n"
                     "Then /goal resume to continue."
                 ),
-            }
+            )
 
         if state.turns_used >= state.max_turns:
             state.status = "paused"
             state.paused_reason = f"turn budget exhausted ({state.turns_used}/{state.max_turns})"
             save_goal(self.session_id, state)
-            return {
-                "status": "paused",
-                "should_continue": False,
-                "continuation_prompt": None,
-                "verdict": "continue",
-                "reason": reason,
-                "message": (
+            return GoalDecision(
+                status="paused",
+                should_continue=False,
+                continuation_prompt=None,
+                verdict="continue",
+                reason=reason,
+                message=(
                     f"⏸ Goal paused — {state.turns_used}/{state.max_turns} turns used. "
                     "Use /goal resume to keep going, or /goal clear to stop."
                 ),
-            }
+            )
 
         save_goal(self.session_id, state)
-        return {
-            "status": "active",
-            "should_continue": True,
-            "continuation_prompt": self.next_continuation_prompt(),
-            "verdict": "continue",
-            "reason": reason,
-            "message": (
+        return GoalDecision(
+            status="active",
+            should_continue=True,
+            continuation_prompt=self.next_continuation_prompt(),
+            verdict="continue",
+            reason=reason,
+            message=(
                 f"↻ Continuing toward goal ({state.turns_used}/{state.max_turns}): {reason}"
             ),
-        }
+        )
 
     def next_continuation_prompt(self) -> Optional[str]:
         if not self._state or self._state.status != "active":
@@ -895,6 +925,7 @@ def run_kanban_goal_loop(
 
 
 __all__ = [
+    "GoalDecision",
     "GoalState",
     "GoalManager",
     "CONTINUATION_PROMPT_TEMPLATE",

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -806,6 +806,42 @@ class GoalManager:
         return CONTINUATION_PROMPT_TEMPLATE.format(goal=self._state.goal)
 
 
+@dataclass(frozen=True)
+class GoalCommandResult:
+    """Surface-agnostic outcome of applying a parsed /goal command."""
+
+    action: str
+    state: Optional[GoalState] = None
+    status_line: str = ""
+    had_goal: bool = False
+    kickoff_prompt: Optional[str] = None
+    error: Optional[Exception] = None
+
+
+def handle_goal_command(manager: GoalManager, raw_args: str) -> GoalCommandResult:
+    """Apply a /goal command to a manager without formatting UI text."""
+    command = parse_goal_command(raw_args)
+
+    if command.action == "status":
+        return GoalCommandResult(action="status", status_line=manager.status_line())
+    if command.action == "pause":
+        return GoalCommandResult(action="pause", state=manager.pause(reason="user-paused"))
+    if command.action == "resume":
+        state = manager.resume()
+        prompt = manager.next_continuation_prompt() if state is not None else None
+        return GoalCommandResult(action="resume", state=state, kickoff_prompt=prompt)
+    if command.action == "clear":
+        had_goal = manager.has_goal()
+        manager.clear()
+        return GoalCommandResult(action="clear", had_goal=had_goal)
+
+    try:
+        state = manager.set(command.text)
+    except ValueError as exc:
+        return GoalCommandResult(action="set", error=exc)
+    return GoalCommandResult(action="set", state=state, kickoff_prompt=state.goal)
+
+
 # ──────────────────────────────────────────────────────────────────────
 # Kanban worker goal loop
 # ──────────────────────────────────────────────────────────────────────
@@ -955,6 +991,7 @@ def run_kanban_goal_loop(
 
 __all__ = [
     "GoalCommand",
+    "GoalCommandResult",
     "GoalDecision",
     "GoalState",
     "GoalManager",
@@ -969,6 +1006,7 @@ __all__ = [
     "save_goal",
     "clear_goal",
     "judge_goal",
+    "handle_goal_command",
     "parse_goal_command",
     "run_kanban_goal_loop",
 ]

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -135,6 +135,35 @@ JUDGE_USER_PROMPT_WITH_SUBGOALS_TEMPLATE = (
 
 
 @dataclass(frozen=True)
+class GoalCommand:
+    """Normalized /goal command intent shared by CLI, TUI, and gateway."""
+
+    action: str  # status | pause | resume | clear | set
+    text: str = ""
+
+
+def parse_goal_command(raw_args: str) -> GoalCommand:
+    """Parse args after /goal into a stable action.
+
+    Only exact control words are treated as commands; any longer text is the
+    goal body. This keeps goals like "status page audit" from being mistaken
+    for `/goal status` while removing duplicated lower/alias parsing across
+    frontends.
+    """
+    text = (raw_args or "").strip()
+    lower = text.lower()
+    if not text or lower == "status":
+        return GoalCommand(action="status")
+    if lower == "pause":
+        return GoalCommand(action="pause")
+    if lower == "resume":
+        return GoalCommand(action="resume")
+    if lower in {"clear", "stop", "done"}:
+        return GoalCommand(action="clear")
+    return GoalCommand(action="set", text=text)
+
+
+@dataclass(frozen=True)
 class GoalDecision:
     """Structured result from ``GoalManager.evaluate_after_turn``.
 
@@ -925,6 +954,7 @@ def run_kanban_goal_loop(
 
 
 __all__ = [
+    "GoalCommand",
     "GoalDecision",
     "GoalState",
     "GoalManager",
@@ -939,5 +969,6 @@ __all__ = [
     "save_goal",
     "clear_goal",
     "judge_goal",
+    "parse_goal_command",
     "run_kanban_goal_loop",
 ]

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -181,6 +181,32 @@ class TestJudgeGoal:
 # ──────────────────────────────────────────────────────────────────────
 
 
+class TestGoalDecision:
+    def test_goal_decision_behaves_like_mapping_for_callers(self):
+        from hermes_cli.goals import GoalDecision
+
+        decision = GoalDecision(
+            status="active",
+            should_continue=True,
+            continuation_prompt="next step",
+            verdict="continue",
+            reason="more work",
+            message="↻ Continuing toward goal",
+        )
+
+        assert decision["status"] == "active"
+        assert decision.get("continuation_prompt") == "next step"
+        assert decision.get("missing", "fallback") == "fallback"
+        assert decision.to_dict() == {
+            "status": "active",
+            "should_continue": True,
+            "continuation_prompt": "next step",
+            "verdict": "continue",
+            "reason": "more work",
+            "message": "↻ Continuing toward goal",
+        }
+
+
 class TestGoalManager:
     def test_no_goal_initial(self, hermes_home):
         from hermes_cli.goals import GoalManager

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -207,6 +207,41 @@ class TestGoalCommandParsing:
         assert parsed.text == "Build the thing with STATUS in the title"
 
 
+class TestGoalCommandHandling:
+    def test_handle_set_and_resume_share_mutation_contract(self, hermes_home):
+        from hermes_cli.goals import GoalManager, handle_goal_command
+
+        mgr = GoalManager(session_id="cmd-shared", default_max_turns=4)
+        set_result = handle_goal_command(mgr, "write a brief")
+        assert set_result.action == "set"
+        assert set_result.state is not None
+        assert set_result.kickoff_prompt == "write a brief"
+
+        pause_result = handle_goal_command(mgr, "pause")
+        assert pause_result.action == "pause"
+        assert pause_result.state is not None
+        assert pause_result.state.status == "paused"
+
+        resume_result = handle_goal_command(mgr, "resume")
+        assert resume_result.action == "resume"
+        assert resume_result.state is not None
+        assert resume_result.kickoff_prompt is not None
+        assert "[Continuing toward your standing goal]" in resume_result.kickoff_prompt
+
+    def test_handle_status_and_clear_are_surface_neutral(self, hermes_home):
+        from hermes_cli.goals import GoalManager, handle_goal_command
+
+        mgr = GoalManager(session_id="cmd-neutral")
+        status = handle_goal_command(mgr, "status")
+        assert status.action == "status"
+        assert status.status_line == "No active goal. Set one with /goal <text>."
+
+        assert handle_goal_command(mgr, "clear").had_goal is False
+        handle_goal_command(mgr, "ship it")
+        assert handle_goal_command(mgr, "done").had_goal is True
+        assert mgr.state is None
+
+
 class TestGoalDecision:
     def test_goal_decision_behaves_like_mapping_for_callers(self):
         from hermes_cli.goals import GoalDecision

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -181,6 +181,32 @@ class TestJudgeGoal:
 # ──────────────────────────────────────────────────────────────────────
 
 
+class TestGoalCommandParsing:
+    def test_empty_and_status_are_status_action(self):
+        from hermes_cli.goals import parse_goal_command
+
+        assert parse_goal_command("").action == "status"
+        assert parse_goal_command("   ").action == "status"
+        assert parse_goal_command("status").action == "status"
+        assert parse_goal_command("STATUS").action == "status"
+
+    def test_control_aliases_are_normalized(self):
+        from hermes_cli.goals import parse_goal_command
+
+        assert parse_goal_command("pause").action == "pause"
+        assert parse_goal_command("resume").action == "resume"
+        assert parse_goal_command("clear").action == "clear"
+        assert parse_goal_command("stop").action == "clear"
+        assert parse_goal_command("done").action == "clear"
+
+    def test_everything_else_is_goal_text_preserved(self):
+        from hermes_cli.goals import parse_goal_command
+
+        parsed = parse_goal_command("  Build the thing with STATUS in the title  ")
+        assert parsed.action == "set"
+        assert parsed.text == "Build the thing with STATUS in the title"
+
+
 class TestGoalDecision:
     def test_goal_decision_behaves_like_mapping_for_callers(self):
         from hermes_cli.goals import GoalDecision

--- a/tests/tui_gateway/test_goal_command.py
+++ b/tests/tui_gateway/test_goal_command.py
@@ -134,13 +134,14 @@ def test_goal_pause_after_set(server, session):
     assert GoalManager(session_key).state.status == "paused"
 
 
-def test_goal_resume_reactivates(server, session):
+def test_goal_resume_reactivates_and_returns_send(server, session):
     sid, session_key, _ = session
     _call(server, "command.dispatch", name="goal", arg="write a story", session_id=sid)
     _call(server, "command.dispatch", name="goal", arg="pause", session_id=sid)
     r = _call(server, "command.dispatch", name="goal", arg="resume", session_id=sid)
-    assert r["result"]["type"] == "exec"
-    assert "resumed" in r["result"]["output"].lower()
+    assert r["result"]["type"] == "send"
+    assert "resumed" in r["result"]["notice"].lower()
+    assert "[Continuing toward your standing goal]" in r["result"]["message"]
 
     from hermes_cli.goals import GoalManager
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8070,7 +8070,7 @@ def _(rid, params: dict) -> dict:
         if not session:
             return _err(rid, 4001, "no active session")
         try:
-            from hermes_cli.goals import GoalManager, parse_goal_command
+            from hermes_cli.goals import GoalManager, handle_goal_command
         except Exception as exc:
             return _err(rid, 5030, f"goals unavailable: {exc}")
 
@@ -8085,44 +8085,39 @@ def _(rid, params: dict) -> dict:
             max_turns = 20
         mgr = GoalManager(session_id=sid_key, default_max_turns=max_turns)
 
-        goal_cmd = parse_goal_command(arg)
-        if goal_cmd.action == "status":
-            return _ok(rid, {"type": "exec", "output": mgr.status_line()})
-        if goal_cmd.action == "pause":
-            state = mgr.pause(reason="user-paused")
-            out = "No goal set." if state is None else f"⏸ Goal paused: {state.goal}"
+        result = handle_goal_command(mgr, arg)
+        if result.action == "status":
+            return _ok(rid, {"type": "exec", "output": result.status_line})
+        if result.action == "pause":
+            out = "No goal set." if result.state is None else f"⏸ Goal paused: {result.state.goal}"
             return _ok(rid, {"type": "exec", "output": out})
-        if goal_cmd.action == "resume":
-            state = mgr.resume()
-            if state is None:
+        if result.action == "resume":
+            if result.state is None:
                 return _ok(rid, {"type": "exec", "output": "No goal to resume."})
-            prompt = mgr.next_continuation_prompt()
-            if not prompt:
-                return _ok(rid, {"type": "exec", "output": f"▶ Goal resumed: {state.goal}"})
+            if not result.kickoff_prompt:
+                return _ok(rid, {"type": "exec", "output": f"▶ Goal resumed: {result.state.goal}"})
             return _ok(
                 rid,
                 {
                     "type": "send",
-                    "notice": f"▶ Goal resumed: {state.goal}",
-                    "message": prompt,
+                    "notice": f"▶ Goal resumed: {result.state.goal}",
+                    "message": result.kickoff_prompt,
                 },
             )
-        if goal_cmd.action == "clear":
-            had = mgr.has_goal()
-            mgr.clear()
+        if result.action == "clear":
             return _ok(
                 rid,
                 {
                     "type": "exec",
-                    "output": "✓ Goal cleared." if had else "No active goal.",
+                    "output": "✓ Goal cleared." if result.had_goal else "No active goal.",
                 },
             )
 
-        # Otherwise — treat the remaining text as the new goal.
-        try:
-            state = mgr.set(goal_cmd.text)
-        except ValueError as exc:
-            return _err(rid, 4004, f"invalid goal: {exc}")
+        if result.error is not None:
+            return _err(rid, 4004, f"invalid goal: {result.error}")
+        state = result.state
+        if state is None:
+            return _err(rid, 4004, "invalid goal: no state returned")
 
         notice = (
             f"⊙ Goal set ({state.max_turns}-turn budget): {state.goal}\n"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8070,7 +8070,7 @@ def _(rid, params: dict) -> dict:
         if not session:
             return _err(rid, 4001, "no active session")
         try:
-            from hermes_cli.goals import GoalManager
+            from hermes_cli.goals import GoalManager, parse_goal_command
         except Exception as exc:
             return _err(rid, 5030, f"goals unavailable: {exc}")
 
@@ -8085,14 +8085,14 @@ def _(rid, params: dict) -> dict:
             max_turns = 20
         mgr = GoalManager(session_id=sid_key, default_max_turns=max_turns)
 
-        lower = arg.strip().lower()
-        if not arg.strip() or lower == "status":
+        goal_cmd = parse_goal_command(arg)
+        if goal_cmd.action == "status":
             return _ok(rid, {"type": "exec", "output": mgr.status_line()})
-        if lower == "pause":
+        if goal_cmd.action == "pause":
             state = mgr.pause(reason="user-paused")
             out = "No goal set." if state is None else f"⏸ Goal paused: {state.goal}"
             return _ok(rid, {"type": "exec", "output": out})
-        if lower == "resume":
+        if goal_cmd.action == "resume":
             state = mgr.resume()
             if state is None:
                 return _ok(rid, {"type": "exec", "output": "No goal to resume."})
@@ -8106,7 +8106,7 @@ def _(rid, params: dict) -> dict:
                     ),
                 },
             )
-        if lower in {"clear", "stop", "done"}:
+        if goal_cmd.action == "clear":
             had = mgr.has_goal()
             mgr.clear()
             return _ok(
@@ -8119,7 +8119,7 @@ def _(rid, params: dict) -> dict:
 
         # Otherwise — treat the remaining text as the new goal.
         try:
-            state = mgr.set(arg)
+            state = mgr.set(goal_cmd.text)
         except ValueError as exc:
             return _err(rid, 4004, f"invalid goal: {exc}")
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8096,14 +8096,15 @@ def _(rid, params: dict) -> dict:
             state = mgr.resume()
             if state is None:
                 return _ok(rid, {"type": "exec", "output": "No goal to resume."})
+            prompt = mgr.next_continuation_prompt()
+            if not prompt:
+                return _ok(rid, {"type": "exec", "output": f"▶ Goal resumed: {state.goal}"})
             return _ok(
                 rid,
                 {
-                    "type": "exec",
-                    "output": (
-                        f"▶ Goal resumed: {state.goal}\n"
-                        "Send any message to continue, or wait — I'll take the next step on the next turn."
-                    ),
+                    "type": "send",
+                    "notice": f"▶ Goal resumed: {state.goal}",
+                    "message": prompt,
                 },
             )
         if goal_cmd.action == "clear":


### PR DESCRIPTION
## Summary
- introduce structured GoalDecision and GoalCommandResult contracts
- centralize /goal parsing and mutation handling in hermes_cli.goals
- migrate CLI, gateway, and TUI handlers to the shared goal command handler
- make /goal resume immediately enqueue/return the next continuation prompt across surfaces

## Test Plan
- scripts/run_tests.sh tests/hermes_cli/test_goals.py tests/hermes_cli/test_kanban_goal_mode.py tests/tui_gateway/test_goal_command.py tests/gateway/test_goal_status_notice.py tests/gateway/test_goal_verdict_send.py tests/gateway/test_goal_max_turns_config.py tests/cli/test_cli_goal_interrupt.py
- manual live check of set → pause → resume → done → status via GoalManager/handle_goal_command

## Notes
- Broader gateway/TUI sweep was also run with lower parallelism; remaining failures were unrelated existing/environment issues: /var vs /private/var path normalization, gateway shutdown exit code expectation, shutdown diagnostic subprocess spawn, and test_api_server hitting too many open files.