### PR TITLE
fix(auth): iterate token endpoints in Anthropic OAuth login flow

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1346,18 +1346,32 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
             "code_verifier": verifier,
         }).encode()
 
-        req = urllib.request.Request(
-            _OAUTH_TOKEN_URL,
-            data=exchange_data,
-            headers={
-                "Content-Type": "application/json",
-                "User-Agent": f"claude-cli/{_get_claude_code_version()} (external, cli)",
-            },
-            method="POST",
-        )
-
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            result = json.loads(resp.read().decode())
+        token_endpoints = [
+            "https://platform.claude.com/v1/oauth/token",
+            _OAUTH_TOKEN_URL,  # console.anthropic.com fallback
+        ]
+        result = None
+        last_error = None
+        for endpoint in token_endpoints:
+            req = urllib.request.Request(
+                endpoint,
+                data=exchange_data,
+                headers={
+                    "Content-Type": "application/json",
+                    "User-Agent": f"claude-cli/{_get_claude_code_version()} (external, cli)",
+                },
+                method="POST",
+            )
+            try:
+                with urllib.request.urlopen(req, timeout=15) as resp:
+                    result = json.loads(resp.read().decode())
+                break
+            except Exception as e:
+                last_error = e
+                continue
+        if result is None:
+            print(f"Token exchange failed: {last_error}")
+            return None
     except Exception as e:
         print(f"Token exchange failed: {e}")
         return None

--- a/tests/agent/test_anthropic_oauth_pkce.py
+++ b/tests/agent/test_anthropic_oauth_pkce.py
@@ -174,3 +174,117 @@ def test_callback_state_mismatch_aborts(monkeypatch, tmp_path, caplog):
     assert "url" not in captured_token, (
         "token exchange must NOT happen when state mismatches"
     )
+
+
+def test_token_exchange_falls_back_to_second_endpoint(monkeypatch, tmp_path):
+    """When the first token endpoint (platform.claude.com) returns 404,
+    the login flow must fall back to the second endpoint (console.anthropic.com).
+
+    Regression guard for issue #45250: the login flow previously used only
+    _OAUTH_TOKEN_URL (console.anthropic.com) which started returning 404,
+    while the refresh flow already had a fallback list.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    token_response = {
+        "access_token": "sk-ant-fallback",
+        "refresh_token": "sk-ant-refresh-fallback",
+        "expires_in": 3600,
+    }
+    attempted_urls: list[str] = []
+
+    import urllib.request
+
+    class _FakeResponse:
+        def __init__(self, body: bytes) -> None:
+            self._body = body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def read(self):
+            return self._body
+
+    def fake_urlopen(req, *_a, **_kw):
+        attempted_urls.append(req.full_url)
+        if "platform.claude.com" in req.full_url:
+            raise urllib.error.HTTPError(req.full_url, 404, "Not Found", {}, None)
+        return _FakeResponse(json.dumps(token_response).encode())
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr("webbrowser.open", lambda url: True)
+    monkeypatch.setattr(
+        "hermes_cli.auth._can_open_graphical_browser", lambda: True
+    )
+
+    # Capture the state from the auth URL to echo it back correctly
+    captured_auth_url: dict[str, str] = {}
+
+    def capturing_webbrowser(url):
+        captured_auth_url["url"] = url
+        return True
+
+    monkeypatch.setattr("webbrowser.open", capturing_webbrowser)
+
+    import builtins
+
+    def fake_input(*_a, **_kw):
+        url = captured_auth_url.get("url", "")
+        qs = parse_qs(urlparse(url).query)
+        state = qs.get("state", [""])[0]
+        return f"auth-code#{state}"
+
+    monkeypatch.setattr(builtins, "input", fake_input)
+
+    from agent.anthropic_adapter import run_hermes_oauth_login_pure
+
+    result = run_hermes_oauth_login_pure()
+
+    assert result is not None, "Login should succeed via fallback endpoint"
+    assert result["access_token"] == "sk-ant-fallback"
+    # Must have tried platform.claude.com first, then console.anthropic.com
+    assert len(attempted_urls) == 2, f"Expected 2 attempts, got {len(attempted_urls)}"
+    assert "platform.claude.com" in attempted_urls[0]
+    assert "console.anthropic.com" in attempted_urls[1]
+
+
+def test_token_exchange_all_endpoints_fail(monkeypatch, tmp_path):
+    """When both token endpoints fail, login must return None gracefully."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    import urllib.request
+
+    def fake_urlopen(req, *_a, **_kw):
+        raise urllib.error.HTTPError(req.full_url, 500, "Server Error", {}, None)
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr("webbrowser.open", lambda url: True)
+    monkeypatch.setattr(
+        "hermes_cli.auth._can_open_graphical_browser", lambda: True
+    )
+
+    captured_auth_url: dict[str, str] = {}
+
+    def capturing_webbrowser(url):
+        captured_auth_url["url"] = url
+        return True
+
+    monkeypatch.setattr("webbrowser.open", capturing_webbrowser)
+
+    import builtins
+
+    def fake_input(*_a, **_kw):
+        url = captured_auth_url.get("url", "")
+        qs = parse_qs(urlparse(url).query)
+        state = qs.get("state", [""])[0]
+        return f"auth-code#{state}"
+
+    monkeypatch.setattr(builtins, "input", fake_input)
+
+    from agent.anthropic_adapter import run_hermes_oauth_login_pure
+
+    result = run_hermes_oauth_login_pure()
+    assert result is None, "Login should return None when all endpoints fail"


### PR DESCRIPTION
## What does this PR do?

Makes the Anthropic OAuth login flow iterate multiple token endpoints (platform.claude.com first, then console.anthropic.com as fallback), matching the existing refresh flow pattern. Fixes the 404 error that broke `hermes auth add anthropic --type oauth` when the console.anthropic.com endpoint started returning 404.

## Related Issue

Fixes #45250

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `agent/anthropic_adapter.py`: Replace single-endpoint token exchange in `run_hermes_oauth_login_pure()` with a loop over `token_endpoints` list (platform.claude.com → console.anthropic.com fallback), mirroring `refresh_anthropic_oauth_pure()`
- `tests/agent/test_anthropic_oauth_pkce.py`: Add `test_token_exchange_falls_back_to_second_endpoint` (404 on first → succeeds on second) and `test_token_exchange_all_endpoints_fail` (both fail → returns None)

## How to Test

1. Run `pytest tests/agent/test_anthropic_oauth_pkce.py -v` — all 4 tests should pass
2. The new `test_token_exchange_falls_back_to_second_endpoint` verifies that when platform.claude.com returns 404, the flow falls back to console.anthropic.com and succeeds
3. The new `test_token_exchange_all_endpoints_fail` verifies graceful failure when both endpoints are down

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/anthropic_adapter.py::run_hermes_oauth_login_pure` (callers: auth CLI flow, hermes_cli/auth.py)
- Blast radius: LOW — isolated to Anthropic OAuth login path; refresh path unchanged
- Related patterns: Mirrors `refresh_anthropic_oauth_pure()` endpoint iteration at lines 937-958
