### PR TITLE
fix(skills): run youtube transcript helper through uv

### DIFF
--- a/skills/media/youtube-content/SKILL.md
+++ b/skills/media/youtube-content/SKILL.md
@@ -14,8 +14,11 @@ Extract transcripts from YouTube videos and convert them into useful formats.
 
 ## Setup
 
+Use `uv` so the dependency is installed into the same Hermes-managed environment
+that runs the helper script:
+
 ```bash
-pip install youtube-transcript-api
+uv pip install youtube-transcript-api
 ```
 
 ## Helper Script
@@ -24,16 +27,16 @@ pip install youtube-transcript-api
 
 ```bash
 # JSON output with metadata
-python3 SKILL_DIR/scripts/fetch_transcript.py "https://youtube.com/watch?v=VIDEO_ID"
+uv run python3 SKILL_DIR/scripts/fetch_transcript.py "https://youtube.com/watch?v=VIDEO_ID"
 
 # Plain text (good for piping into further processing)
-python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --text-only
+uv run python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --text-only
 
 # With timestamps
-python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --timestamps
+uv run python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --timestamps
 
 # Specific language with fallback chain
-python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --language tr,en
+uv run python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --language tr,en
 ```
 
 ## Output Formats
@@ -59,7 +62,7 @@ After fetching the transcript, format it based on what the user asks for:
 
 ## Workflow
 
-1. **Fetch** the transcript using the helper script with `--text-only --timestamps`.
+1. **Fetch** the transcript using the helper script with `--text-only --timestamps` via `uv run python3`.
 2. **Validate**: confirm the output is non-empty and in the expected language. If empty, retry without `--language` to get any available transcript. If still empty, tell the user the video likely has transcripts disabled.
 3. **Chunk if needed**: if the transcript exceeds ~50K characters, split into overlapping chunks (~40K with 2K overlap) and summarize each chunk before merging.
 4. **Transform** into the requested output format. If the user did not specify a format, default to a summary.
@@ -70,4 +73,4 @@ After fetching the transcript, format it based on what the user asks for:
 - **Transcript disabled**: tell the user; suggest they check if subtitles are available on the video page.
 - **Private/unavailable video**: relay the error and ask the user to verify the URL.
 - **No matching language**: retry without `--language` to fetch any available transcript, then note the actual language to the user.
-- **Dependency missing**: run `pip install youtube-transcript-api` and retry.
+- **Dependency missing**: run `uv pip install youtube-transcript-api` and retry.

--- a/skills/media/youtube-content/scripts/fetch_transcript.py
+++ b/skills/media/youtube-content/scripts/fetch_transcript.py
@@ -3,7 +3,7 @@
 Fetch a YouTube video transcript and output it as structured JSON.
 
 Usage:
-    python fetch_transcript.py <url_or_video_id> [--language en,tr] [--timestamps]
+    uv run python3 fetch_transcript.py <url_or_video_id> [--language en,tr] [--timestamps]
 
 Output (JSON):
     {
@@ -14,7 +14,7 @@ Output (JSON):
         "timestamped_text": "00:00 first line\n00:05 second line\n..."
     }
 
-Install dependency:  pip install youtube-transcript-api
+Install dependency:  uv pip install youtube-transcript-api
 """
 
 import argparse
@@ -56,7 +56,7 @@ def fetch_transcript(video_id: str, languages: list = None):
     try:
         from youtube_transcript_api import YouTubeTranscriptApi
     except ImportError:
-        print("Error: youtube-transcript-api not installed. Run: pip install youtube-transcript-api",
+        print("Error: youtube-transcript-api not installed. Run: uv pip install youtube-transcript-api",
               file=sys.stderr)
         sys.exit(1)
 

--- a/website/docs/user-guide/skills/bundled/media/media-youtube-content.md
+++ b/website/docs/user-guide/skills/bundled/media/media-youtube-content.md
@@ -34,8 +34,11 @@ Extract transcripts from YouTube videos and convert them into useful formats.
 
 ## Setup
 
+Use `uv` so the dependency is installed into the same Hermes-managed environment
+that runs the helper script:
+
 ```bash
-pip install youtube-transcript-api
+uv pip install youtube-transcript-api
 ```
 
 ## Helper Script
@@ -44,16 +47,16 @@ pip install youtube-transcript-api
 
 ```bash
 # JSON output with metadata
-python3 SKILL_DIR/scripts/fetch_transcript.py "https://youtube.com/watch?v=VIDEO_ID"
+uv run python3 SKILL_DIR/scripts/fetch_transcript.py "https://youtube.com/watch?v=VIDEO_ID"
 
 # Plain text (good for piping into further processing)
-python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --text-only
+uv run python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --text-only
 
 # With timestamps
-python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --timestamps
+uv run python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --timestamps
 
 # Specific language with fallback chain
-python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --language tr,en
+uv run python3 SKILL_DIR/scripts/fetch_transcript.py "URL" --language tr,en
 ```
 
 ## Output Formats
@@ -79,7 +82,7 @@ After fetching the transcript, format it based on what the user asks for:
 
 ## Workflow
 
-1. **Fetch** the transcript using the helper script with `--text-only --timestamps`.
+1. **Fetch** the transcript using the helper script with `--text-only --timestamps` via `uv run python3`.
 2. **Validate**: confirm the output is non-empty and in the expected language. If empty, retry without `--language` to get any available transcript. If still empty, tell the user the video likely has transcripts disabled.
 3. **Chunk if needed**: if the transcript exceeds ~50K characters, split into overlapping chunks (~40K with 2K overlap) and summarize each chunk before merging.
 4. **Transform** into the requested output format. If the user did not specify a format, default to a summary.
@@ -90,4 +93,4 @@ After fetching the transcript, format it based on what the user asks for:
 - **Transcript disabled**: tell the user; suggest they check if subtitles are available on the video page.
 - **Private/unavailable video**: relay the error and ask the user to verify the URL.
 - **No matching language**: retry without `--language` to fetch any available transcript, then note the actual language to the user.
-- **Dependency missing**: run `pip install youtube-transcript-api` and retry.
+- **Dependency missing**: run `uv pip install youtube-transcript-api` and retry.


### PR DESCRIPTION
## Summary
Salvages PR #45127 by @helix4u onto current main: the bundled `media/youtube-content` skill now documents `uv pip install` / `uv run python3` instead of bare `pip` / `python3`, so the dependency lands in the Hermes-managed venv the helper actually runs from.

Root cause of the report (Discord, DrWayne): bare pip installed `youtube-transcript-api` into system python, the helper ran in the venv and couldn't import it, and every skill invocation burned turns on a fresh "installing" loop that polluted thread context.

## Changes
- `skills/media/youtube-content/SKILL.md`: setup, helper invocations, workflow note, missing-dep hint → uv
- `skills/media/youtube-content/scripts/fetch_transcript.py`: docstring + ImportError hint → uv
- `website/docs/.../media-youtube-content.md`: regenerated docs page

## Validation
| | Result |
|---|---|
| `python3 -m compileall fetch_transcript.py` | OK |
| `fetch_transcript.py --help` | OK |
| User-validated | DrWayne confirmed the uv variant works on his Hermes install |

Contributor commit cherry-picked with authorship preserved. Merge with rebase.

## Infographic

![youtube-skill-use-uv](https://v3b.fal.media/files/b/0a9e0e1f/Xd8YsgKqNnJ_edGaaNV94_GKWBXu3V.png)
