### PR TITLE
feat(desktop): follow streaming output at bottom + jump-to-bottom button

### DIFF
--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -53,6 +53,7 @@ import { droppedFileInlineRefs, type SessionDragPayload, sessionInlineRef } from
 import type { ChatBarState } from './composer/types'
 import { type DroppedFile, partitionDroppedFiles } from './hooks/use-composer-actions'
 import { useFileDropZone } from './hooks/use-file-drop-zone'
+import { ScrollToBottomButton } from './scroll-to-bottom-button'
 import { SessionActionsMenu } from './sidebar/session-actions-menu'
 import { lastVisibleMessageIsUser, threadLoadingState } from './thread-loading'
 
@@ -391,6 +392,7 @@ export function ChatView({
             </Suspense>
           )}
         </AssistantRuntimeProvider>
+        {showChatBar && <ScrollToBottomButton />}
         <ChatDropOverlay kind={dragKind} />
         <ChatSwapOverlay profile={gatewaySwapTarget} />
       </div>

--- a/apps/desktop/src/app/chat/scroll-to-bottom-button.tsx
+++ b/apps/desktop/src/app/chat/scroll-to-bottom-button.tsx
@@ -1,0 +1,58 @@
+import { useStore } from '@nanostores/react'
+import { useRef } from 'react'
+
+import { Codicon } from '@/components/ui/codicon'
+import { useI18n } from '@/i18n'
+import { triggerHaptic } from '@/lib/haptics'
+import { cn } from '@/lib/utils'
+import { $threadJumpButtonVisible, requestScrollToBottom } from '@/store/thread-scroll'
+
+/**
+ * Floating "jump to bottom" control. Sits centered just above the composer,
+ * clearing the out-of-flow status stack via the same measured-height CSS vars
+ * the thread's bottom clearance uses (`--composer-measured-height` +
+ * `--status-stack-measured-height`), so it never overlaps the queue / subagent
+ * / background cards. Visible only while the user has scrolled meaningfully
+ * away from the bottom; clicking re-arms sticky-bottom and pins the viewport.
+ *
+ * Enter/exit motion lives in styles.css under `.thread-jump-button` — a
+ * directional scale (contract in from 1.1, contract out to 0.9) keyed off
+ * `data-state`. `idle` (never-shown) stays silent so it can't flash on mount;
+ * `in`/`out` only swap once it has actually appeared.
+ */
+export function ScrollToBottomButton() {
+  const { t } = useI18n()
+  const visible = useStore($threadJumpButtonVisible)
+  const hasShownRef = useRef(false)
+
+  if (visible) {
+    hasShownRef.current = true
+  }
+
+  const state = visible ? 'in' : hasShownRef.current ? 'out' : 'idle'
+
+  return (
+    <button
+      aria-hidden={!visible}
+      aria-label={t.assistant.thread.scrollToBottom}
+      className={cn(
+        'thread-jump-button absolute left-1/2 z-20 grid size-8 place-items-center rounded-full',
+        'border border-border/65 bg-(--composer-fill) text-muted-foreground hover:text-foreground',
+        'backdrop-blur-[0.75rem] [-webkit-backdrop-filter:blur(0.75rem)]',
+        !visible && 'pointer-events-none'
+      )}
+      data-state={state}
+      onClick={() => {
+        triggerHaptic('selection')
+        requestScrollToBottom()
+      }}
+      style={{
+        bottom: 'calc(var(--composer-measured-height) + var(--status-stack-measured-height) + 0.625rem)'
+      }}
+      tabIndex={visible ? 0 : -1}
+      type="button"
+    >
+      <Codicon name="arrow-down" size="1rem" />
+    </button>
+  )
+}

--- a/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-virtualizer.tsx
@@ -14,13 +14,21 @@ import {
 
 import { setMutableRef } from '@/lib/mutable-ref'
 import { cn } from '@/lib/utils'
-import { setThreadScrolledUp } from '@/store/thread-scroll'
+import {
+  onScrollToBottomRequest,
+  resetThreadScroll,
+  setThreadJumpButtonVisible,
+  setThreadScrolledUp
+} from '@/store/thread-scroll'
 
 import { MessageRenderBoundary } from './message-render-boundary'
 
 const ESTIMATED_ITEM_HEIGHT = 220
 const OVERSCAN = 4
 const AT_BOTTOM_THRESHOLD = 4
+// Reveal the floating jump button only once scrolled meaningfully away — above
+// AT_BOTTOM_THRESHOLD so a sub-pixel settle never flashes it.
+const JUMP_BUTTON_THRESHOLD = 10
 
 type ThreadMessageComponents = ComponentProps<typeof ThreadPrimitive.MessageByIndex>['components']
 
@@ -309,7 +317,7 @@ function useThreadScrollAnchor({
     })
   }, [groupCount, pinToBottom, stickyBottomRef, virtualizer])
 
-  useEffect(() => () => setThreadScrolledUp(false), [])
+  useEffect(() => () => resetThreadScroll(), [])
 
   // Track at-bottom state, dim composer when scrolled up, disarm on user
   // scroll/wheel/touch.
@@ -323,6 +331,13 @@ function useThreadScrollAnchor({
     const disarm = () => {
       setMutableRef(stickyBottomRef, false)
       programmaticScrollPendingRef.current = 0
+    }
+
+    // Dim the composer the instant we leave the bottom; reveal the jump button
+    // only once scrolled meaningfully away.
+    const publishScrollDistance = (dist: number) => {
+      setThreadScrolledUp(dist > AT_BOTTOM_THRESHOLD)
+      setThreadJumpButtonVisible(dist > JUMP_BUTTON_THRESHOLD)
     }
 
     const onScroll = () => {
@@ -342,22 +357,19 @@ function useThreadScrollAnchor({
         lastClientHeightRef.current = el.clientHeight
         // Always re-arm — sticky-bottom should hold through clamp races.
         setMutableRef(stickyBottomRef, true)
-        const atBottom = el.scrollHeight - (top + el.clientHeight) <= AT_BOTTOM_THRESHOLD
-        setThreadScrolledUp(!atBottom)
+        publishScrollDistance(el.scrollHeight - (top + el.clientHeight))
 
         return
       }
 
-      // Disarm only when `scrollTop` decreases while both content height and
-      // viewport height are stable. A bare `top < lastTopRef.current` check is
-      // unsafe: virtualizer measurement, streaming markdown, composer resizing,
-      // window resizing, and toolbar/status updates can all move scrollTop as a
-      // layout side effect. Wheel-up and touchmove still disarm immediately via
-      // their own listeners below, so real user intent remains covered.
+      // Disarm on ANY upward movement (even 1px), but only while content +
+      // viewport height are stable — virtualizer measurement, streaming
+      // markdown, and composer/window resize all shift scrollTop as a layout
+      // side effect. Wheel-up and touchmove disarm immediately too (below).
       const heightGrew = el.scrollHeight > lastHeightRef.current
       const clientHeightChanged = Math.abs(el.clientHeight - lastClientHeightRef.current) > 1
 
-      if (!heightGrew && !clientHeightChanged && top + 1 < lastTopRef.current) {
+      if (!heightGrew && !clientHeightChanged && top < lastTopRef.current) {
         setMutableRef(stickyBottomRef, false)
       }
 
@@ -365,13 +377,14 @@ function useThreadScrollAnchor({
       lastHeightRef.current = el.scrollHeight
       lastClientHeightRef.current = el.clientHeight
 
-      const atBottom = el.scrollHeight - (top + el.clientHeight) <= AT_BOTTOM_THRESHOLD
+      const distFromBottom = el.scrollHeight - (top + el.clientHeight)
 
-      if (atBottom) {
+      // Re-arm follow only once genuinely back at the bottom.
+      if (distFromBottom <= AT_BOTTOM_THRESHOLD) {
         setMutableRef(stickyBottomRef, true)
       }
 
-      setThreadScrolledUp(!atBottom)
+      publishScrollDistance(distFromBottom)
     }
 
     const onWheel = (event: WheelEvent) => {
@@ -391,15 +404,28 @@ function useThreadScrollAnchor({
     }
   }, [scrollerRef, stickyBottomRef])
 
-  // Intentionally NO streaming auto-follow. Earlier builds ran a
-  // ResizeObserver here that re-pinned the viewport to the bottom on every
-  // content growth while a turn was running, so the chat tracked tokens as
-  // they streamed. That behavior is removed by request: once a turn is in
-  // flight the viewport stays exactly where the user left it. The viewport
-  // is still moved to the bottom ONCE per user submit / new turn / session
-  // change (see the layout effect and the session-change effect below) so a
-  // freshly submitted message lands in view — but it does not chase the
-  // stream afterward.
+  // Streaming auto-follow: while — and ONLY while — parked at the bottom, chase
+  // content growth (streaming tokens, late measurement, Shiki re-highlight) so
+  // the tail stays in view. One upward pixel (scroll/wheel/touch above) flips
+  // the gate false and following stops until the user returns to the bottom.
+  // Keyed on the virtualizer's own size signal and pinned in useLayoutEffect —
+  // the virtualizer's scrollToFn runs in the same pre-paint pass, so the two
+  // don't fight (no rubber-banding). pinToBottom no-ops at bottom, so rapid
+  // growth is cheap.
+  const totalSize = virtualizer.getTotalSize()
+  const prevTotalSizeRef = useRef<number | null>(null)
+  useLayoutEffect(() => {
+    const prev = prevTotalSizeRef.current
+    prevTotalSizeRef.current = totalSize
+
+    if (enabled && prev !== null && totalSize > prev && stickyBottomRef.current) {
+      pinToBottom()
+    }
+  }, [enabled, pinToBottom, stickyBottomRef, totalSize])
+
+  // The floating jump button asks us to return to the bottom; same re-arm + pin
+  // path as a new turn.
+  useEffect(() => onScrollToBottomRequest(jumpToBottom), [jumpToBottom])
 
   // Jump to bottom on session change OR when an empty thread first gets
   // content. Both share the same intent and the same effect.

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1666,6 +1666,7 @@ export const en: Translations = {
       stopReading: 'Stop reading',
       readAloud: 'Read aloud',
       editMessage: 'Edit message',
+      scrollToBottom: 'Scroll to bottom',
       stop: 'Stop',
       restorePrevious: 'Restore previous checkpoint',
       restoreCheckpoint: 'Restore checkpoint',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1325,6 +1325,7 @@ export interface Translations {
       stopReading: string
       readAloud: string
       editMessage: string
+      scrollToBottom: string
       stop: string
       restorePrevious: string
       restoreCheckpoint: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1846,6 +1846,7 @@ export const zh: Translations = {
       stopReading: '停止朗读',
       readAloud: '朗读',
       editMessage: '编辑消息',
+      scrollToBottom: '滚动到底部',
       stop: '停止',
       restorePrevious: '恢复上一个检查点',
       restoreCheckpoint: '恢复检查点',

--- a/apps/desktop/src/store/thread-scroll.ts
+++ b/apps/desktop/src/store/thread-scroll.ts
@@ -1,11 +1,35 @@
-import { atom } from 'nanostores'
+import { atom, type WritableAtom } from 'nanostores'
 
+// `$threadScrolledUp` flips the instant the viewport leaves the bottom (dims the
+// composer / status stack). `$threadJumpButtonVisible` trips a little further up
+// (~10px) so the floating jump control only shows once meaningfully away.
 export const $threadScrolledUp = atom(false)
+export const $threadJumpButtonVisible = atom(false)
 
-export function setThreadScrolledUp(value: boolean) {
-  if ($threadScrolledUp.get() === value) {
-    return
+// Skip no-op writes so subscribers don't churn on every scroll tick.
+const setter = (target: WritableAtom<boolean>) => (value: boolean) => {
+  if (target.get() !== value) {
+    target.set(value)
   }
-
-  $threadScrolledUp.set(value)
 }
+
+export const setThreadScrolledUp = setter($threadScrolledUp)
+export const setThreadJumpButtonVisible = setter($threadJumpButtonVisible)
+
+export const resetThreadScroll = () => {
+  setThreadScrolledUp(false)
+  setThreadJumpButtonVisible(false)
+}
+
+// Cross-component bridge: the jump button lives by the composer, the re-arm +
+// pin machinery lives in the virtualizer. The virtualizer registers a handler;
+// the button fires it. Mirrors the composer focus/insert emitter pattern.
+const handlers = new Set<() => void>()
+
+export const onScrollToBottomRequest = (handler: () => void) => {
+  handlers.add(handler)
+
+  return () => void handlers.delete(handler)
+}
+
+export const requestScrollToBottom = () => handlers.forEach(handler => handler())

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1255,6 +1255,62 @@ canvas {
   }
 }
 
+/* Floating "jump to bottom" control (see scroll-to-bottom-button.tsx).
+   Directional scale: it contracts toward 1 as it arrives (from 1.1) and keeps
+   contracting to 0.9 as it leaves — always shrinking in the direction of
+   travel, so the motion reads as a soft settle / recede rather than a pop. The
+   X half-offset stays baked into every transform so `left-1/2` centering holds
+   through the animation. */
+.thread-jump-button {
+  opacity: 0;
+  transform: translateX(-50%) translateY(0.3rem) scale(0.9);
+}
+
+.thread-jump-button[data-state='in'] {
+  animation: thread-jump-in 200ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+.thread-jump-button[data-state='out'] {
+  animation: thread-jump-out 180ms ease-in forwards;
+}
+
+@keyframes thread-jump-in {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(0.3rem) scale(1.1);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0) scale(1);
+  }
+}
+
+@keyframes thread-jump-out {
+  from {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0) scale(1);
+  }
+
+  to {
+    opacity: 0;
+    transform: translateX(-50%) translateY(0.3rem) scale(0.9);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .thread-jump-button[data-state='in'],
+  .thread-jump-button[data-state='out'] {
+    animation: none;
+    transition: opacity 120ms linear;
+  }
+
+  .thread-jump-button[data-state='in'] {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0) scale(1);
+  }
+}
+
 @keyframes code-card-stream-glow {
   from {
     border-color: color-mix(in srgb, var(--dt-ring) 18%, var(--ui-stroke-tertiary));
@@ -1276,4 +1332,3 @@ canvas {
     animation: none;
   }
 }
-


### PR DESCRIPTION
## Summary

Restores streaming autoscroll for the desktop chat thread and adds a floating jump-to-bottom control. Supersedes #43624.

- **Strict sticky-bottom follow.** While the viewport is parked at the bottom, the tail chases content growth (streaming tokens, late measurement, Shiki re-highlight). It's a `useLayoutEffect` keyed on the virtualizer's own total-size signal and pinned in the same pre-paint pass as its `scrollToFn`, so the two never rubber-band. `pinToBottom` no-ops at bottom, so rapid growth stays cheap.
- **One-pixel disarm.** The follow gate is a single boolean. Any upward movement (even 1px) via scroll/wheel/touch flips it false and following stops dead until the user returns to the bottom. We still gate the scroll-position disarm on content + viewport height being stable so virtualizer measurement / markdown / resize don't false-trip it.
- **Jump-to-bottom button.** Appears once scrolled ~10px away — above the composer-dim threshold (`AT_BOTTOM_THRESHOLD`) so a sub-pixel settle never flashes it. Centered above the composer, respecting the status stack via the existing `--composer-measured-height` / `--status-stack-measured-height` CSS vars. Subtle scale + vertical slide in/out, honouring `prefers-reduced-motion`. No shadow.
- **Wiring.** The button bridges to the virtualizer's re-arm + pin path through a small nanostore emitter in `store/thread-scroll.ts` (mirrors the composer focus/insert emitter pattern). New i18n key `assistant.thread.scrollToBottom` (en + zh).

## Test plan

- [ ] Stream a long response while parked at the bottom — view follows the tail.
- [ ] Scroll up 1px mid-stream — following stops immediately; jump button fades in after ~10px.
- [ ] Click the jump button — returns to bottom, re-arms follow, button fades out.
- [ ] Resize the composer / window mid-stream — no spurious disarm, button placement tracks the status stack.
- [ ] `prefers-reduced-motion` — button cross-fades without scale/slide.