### PR TITLE
fix(desktop): prevent sidebar buttons from shifting under macOS traffic lights on zoom

### DIFF
--- a/apps/desktop/src/app/shell/app-shell.tsx
+++ b/apps/desktop/src/app/shell/app-shell.tsx
@@ -57,8 +57,21 @@ function subscribeWindowSize(cb: () => void) {
   }
 }
 
-const viewportIsFullscreen = () =>
-  window.innerWidth >= window.screen.width && window.innerHeight >= window.screen.height
+export const viewportIsFullscreen = () => {
+  if (window.innerWidth < window.screen.width || window.innerHeight < window.screen.height) {
+    return false
+  }
+  // On macOS, true fullscreen (green button) hides the menu bar, making
+  // screen.availHeight equal to screen.height.  "Zoom" (double-click titlebar
+  // to fill the screen) keeps the menu bar visible, so availHeight < height.
+  // In zoom mode the traffic-light buttons are still visible at the top-left,
+  // so we must NOT treat it as fullscreen — otherwise the titlebar controls
+  // shift underneath them (issue #45264).
+  if (window.screen.availHeight < window.screen.height) {
+    return false
+  }
+  return true
+}
 
 export function AppShell({
   children,

--- a/apps/desktop/src/app/shell/titlebar.test.ts
+++ b/apps/desktop/src/app/shell/titlebar.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest'
+// @vitest-environment jsdom
+import { describe, expect, it, vi, afterEach } from 'vitest'
 
 import {
   TITLEBAR_CONTROL_OFFSET_X,
@@ -6,6 +7,7 @@ import {
   TITLEBAR_FALLBACK_WINDOW_BUTTON_X,
   titlebarControlsPosition
 } from './titlebar'
+import { viewportIsFullscreen } from './app-shell'
 
 describe('titlebarControlsPosition', () => {
   it('offsets controls from visible traffic lights', () => {
@@ -22,5 +24,45 @@ describe('titlebarControlsPosition', () => {
 
   it('uses the macOS fallback while the initial window state is unknown', () => {
     expect(titlebarControlsPosition(undefined).left).toBe(TITLEBAR_FALLBACK_WINDOW_BUTTON_X + TITLEBAR_CONTROL_OFFSET_X)
+  })
+})
+
+describe('viewportIsFullscreen', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  function mockScreen(overrides: Partial<Screen>) {
+    const defaults = { width: 1920, height: 1080, availHeight: 1080, availWidth: 1920 }
+    Object.defineProperty(window, 'screen', { value: { ...defaults, ...overrides }, configurable: true })
+  }
+
+  it('returns false when viewport is smaller than screen', () => {
+    mockScreen({ width: 1920, height: 1080 })
+    vi.stubGlobal('innerWidth', 1600)
+    vi.stubGlobal('innerHeight', 900)
+    expect(viewportIsFullscreen()).toBe(false)
+  })
+
+  it('returns true for true macOS fullscreen (menu bar hidden, availHeight equals height)', () => {
+    mockScreen({ width: 1920, height: 1080, availHeight: 1080, availWidth: 1920 })
+    vi.stubGlobal('innerWidth', 1920)
+    vi.stubGlobal('innerHeight', 1080)
+    expect(viewportIsFullscreen()).toBe(true)
+  })
+
+  it('returns false for macOS zoom (menu bar visible, availHeight < height) — #45264', () => {
+    // macOS menu bar is 25px; availHeight is screen.height minus menu bar
+    mockScreen({ width: 1920, height: 1080, availHeight: 1055, availWidth: 1920 })
+    vi.stubGlobal('innerWidth', 1920)
+    vi.stubGlobal('innerHeight', 1055)
+    expect(viewportIsFullscreen()).toBe(false)
+  })
+
+  it('returns true on Windows/Linux where availHeight equals height (no menu bar)', () => {
+    mockScreen({ width: 1920, height: 1080, availHeight: 1080, availWidth: 1920 })
+    vi.stubGlobal('innerWidth', 1920)
+    vi.stubGlobal('innerHeight', 1080)
+    expect(viewportIsFullscreen()).toBe(true)
   })
 })


### PR DESCRIPTION
## What does this PR do?

Fixes the sidebar and session-swap buttons shifting underneath macOS traffic-light controls when the window is maximized via "zoom" (double-click titlebar). The viewport fullscreen fallback incorrectly treated zoom as fullscreen, pinning the titlebar controls to the left edge where they collided with the still-visible traffic lights.

## Related Issue

Fixes #45264

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/shell/app-shell.tsx`: Updated `viewportIsFullscreen()` to distinguish true macOS fullscreen (menu bar hidden, `screen.availHeight === screen.height`) from zoom/maximize (menu bar visible, `availHeight < screen.height`). Exported the function for testing.
- `apps/desktop/src/app/shell/titlebar.test.ts`: Added 4 tests for `viewportIsFullscreen` covering windowed, true fullscreen, macOS zoom (#45264 regression), and Windows/Linux cases.

## How to Test

1. Open Hermes Desktop on macOS in a windowed state
2. Observe sidebar/swap buttons are to the right of the red/yellow/green traffic lights
3. Double-click the titlebar to zoom (maximize) the window
4. Verify the buttons stay to the right of the traffic lights (do NOT shift underneath them)
5. Enter true fullscreen (green button) — buttons should pin to the left edge (traffic lights hidden)
6. Run: `cd apps/desktop && npx vitest run src/app/shell/titlebar.test.ts` — all 8 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `npx vitest run src/app/shell/titlebar.test.ts` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

⚠️ GitNexus unavailable (stale index) — grep-based fallback used.
- Checked files: `apps/desktop/src/app/shell/app-shell.tsx`, `apps/desktop/src/app/shell/titlebar.ts`, `apps/desktop/src/app/shell/titlebar.test.ts`
- Blast radius: LOW — isolated to viewport fullscreen detection, no cross-module impact
- Related patterns: `titlebarControlsPosition()` unchanged; only the `viewportIsFullscreen` fallback refined
