### PR TITLE
fix(whatsapp): add Node.js entrypoint for whatsmeow Go bridge

### DIFF
--- a/scripts/whatsmeow-bridge/bridge.js
+++ b/scripts/whatsmeow-bridge/bridge.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+const { spawnSync } = require('child_process');
+const path = require('path');
+const bridge = path.join(__dirname, 'whatsmeow-bridge');
+const result = spawnSync(bridge, process.argv.slice(2), { stdio: 'inherit' });
+process.exit(result.status || 0);


### PR DESCRIPTION
Fixes #45267

## Problem

The WhatsApp gateway adapter always invokes the bridge as:

```
node <bridge_script> [args]
```

When `bridge_script` points to the Go ELF binary (`whatsmeow-bridge`), Node.js tries to parse it as JavaScript and throws:

```
SyntaxError: Invalid or unexpected token
```

The bridge process dies immediately, causing the WhatsApp connection to time out after 30s with no useful error in the UI.

A bash wrapper (`bridge-wrapper.sh`) already existed with a comment acknowledging this — but it fails identically because `node bridge-wrapper.sh` also can't parse shell as JS.

## Fix

Add `scripts/whatsmeow-bridge/bridge.js` — a 6-line Node.js entrypoint that `spawnSync`s the Go binary with forwarded args and inherited stdio:

```js
#!/usr/bin/env node
const { spawnSync } = require('child_process');
const path = require('path');
const bridge = path.join(__dirname, 'whatsmeow-bridge');
const result = spawnSync(bridge, process.argv.slice(2), { stdio: 'inherit' });
process.exit(result.status || 0);
```

Users configuring the whatsmeow bridge should set:

```yaml
gateway:
  platforms:
    whatsapp:
      extra:
        bridge_script: /path/to/scripts/whatsmeow-bridge/bridge.js
```

## Testing

Verified on Ubuntu 22.04 ARM64 (Oracle A1 Flex), Node.js v20, whatsmeow Go bridge v1.0:
- `node bridge.js` correctly exec's the Go binary
- WhatsApp paired and connected successfully via `hermes whatsapp`
- Gateway connects and stays connected across restarts