### PR TITLE
fix(desktop): restore last active session on startup

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
@@ -2,6 +2,9 @@ import { cleanup, render } from '@testing-library/react'
 import type { MutableRefObject } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import type { HermesConnection } from '@/global'
+import { setConnection, setSelectedStoredSessionId } from '@/store/session'
+
 import { useRouteResume } from './use-route-resume'
 
 interface HarnessProps {
@@ -29,7 +32,119 @@ function RouteResumeHarness(props: HarnessProps) {
 describe('useRouteResume', () => {
   afterEach(() => {
     cleanup()
+    setConnection(null)
+    setSelectedStoredSessionId(null)
+    window.localStorage.clear()
     vi.restoreAllMocks()
+  })
+
+  it('resumes the remembered session on root startup', () => {
+    const remoteConnection = {
+      baseUrl: 'https://gateway.example',
+      isFullscreen: false,
+      logs: [],
+      mode: 'remote',
+      nativeOverlayWidth: 0,
+      profile: 'default',
+      token: '',
+      windowButtonPosition: null,
+      wsUrl: 'wss://gateway.example/ws'
+    } satisfies HermesConnection
+
+    setConnection(remoteConnection)
+    setSelectedStoredSessionId('session-persisted')
+
+    const resumeSession = vi.fn(async () => undefined)
+    const startFreshSessionDraft = vi.fn()
+    const activeSessionIdRef: MutableRefObject<null | string> = { current: null }
+    const creatingSessionRef = { current: false }
+    const runtimeIdByStoredSessionIdRef = { current: new Map() }
+    const selectedStoredSessionIdRef: MutableRefObject<null | string> = { current: null }
+
+    render(
+      <RouteResumeHarness
+        activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
+        creatingSessionRef={creatingSessionRef}
+        currentView="chat"
+        freshDraftReady={false}
+        gatewayState="open"
+        locationPathname="/"
+        resumeSession={resumeSession}
+        routedSessionId={null}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        selectedStoredSessionId={null}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        startFreshSessionDraft={startFreshSessionDraft}
+      />
+    )
+
+    expect(resumeSession).toHaveBeenCalledTimes(1)
+    expect(resumeSession).toHaveBeenCalledWith('session-persisted', true)
+    expect(startFreshSessionDraft).not.toHaveBeenCalled()
+  })
+
+  it('starts a fresh draft on root startup when no session is remembered', () => {
+    const resumeSession = vi.fn(async () => undefined)
+    const startFreshSessionDraft = vi.fn()
+    const activeSessionIdRef: MutableRefObject<null | string> = { current: null }
+    const creatingSessionRef = { current: false }
+    const runtimeIdByStoredSessionIdRef = { current: new Map() }
+    const selectedStoredSessionIdRef: MutableRefObject<null | string> = { current: null }
+
+    render(
+      <RouteResumeHarness
+        activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
+        creatingSessionRef={creatingSessionRef}
+        currentView="chat"
+        freshDraftReady={false}
+        gatewayState="open"
+        locationPathname="/"
+        resumeSession={resumeSession}
+        routedSessionId={null}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        selectedStoredSessionId={null}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        startFreshSessionDraft={startFreshSessionDraft}
+      />
+    )
+
+    expect(resumeSession).not.toHaveBeenCalled()
+    expect(startFreshSessionDraft).toHaveBeenCalledTimes(1)
+    expect(startFreshSessionDraft).toHaveBeenCalledWith(true)
+  })
+
+  it('does not restore a remembered session while an explicit fresh draft is ready', () => {
+    setSelectedStoredSessionId('session-persisted')
+
+    const resumeSession = vi.fn(async () => undefined)
+    const startFreshSessionDraft = vi.fn()
+    const activeSessionIdRef: MutableRefObject<null | string> = { current: null }
+    const creatingSessionRef = { current: false }
+    const runtimeIdByStoredSessionIdRef = { current: new Map() }
+    const selectedStoredSessionIdRef: MutableRefObject<null | string> = { current: null }
+
+    render(
+      <RouteResumeHarness
+        activeSessionId={null}
+        activeSessionIdRef={activeSessionIdRef}
+        creatingSessionRef={creatingSessionRef}
+        currentView="chat"
+        freshDraftReady
+        gatewayState="open"
+        locationPathname="/"
+        resumeSession={resumeSession}
+        routedSessionId={null}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        selectedStoredSessionId={null}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        startFreshSessionDraft={startFreshSessionDraft}
+      />
+    )
+
+    expect(resumeSession).not.toHaveBeenCalled()
+    expect(startFreshSessionDraft).not.toHaveBeenCalled()
   })
 
   it('does not re-resume the old session during a /:sid -> /new transition', () => {

--- a/apps/desktop/src/app/session/hooks/use-route-resume.ts
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.ts
@@ -1,6 +1,7 @@
 import { type MutableRefObject, useEffect, useRef } from 'react'
 
 import { isNewChatRoute } from '@/app/routes'
+import { getRememberedSelectedStoredSessionId } from '@/store/session'
 
 interface RouteResumeOptions {
   activeSessionId: string | null
@@ -10,7 +11,7 @@ interface RouteResumeOptions {
   freshDraftReady: boolean
   gatewayState: string | undefined
   locationPathname: string
-  resumeSession: (sessionId: string, focus: boolean) => Promise<unknown>
+  resumeSession: (sessionId: string, replaceRoute: boolean) => Promise<unknown>
   routedSessionId: string | null
   runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>>
   selectedStoredSessionId: string | null
@@ -122,6 +123,17 @@ export function useRouteResume({
       (selectedStoredSessionId || activeSessionId || !freshDraftReady) &&
       !rawHashLooksLikeSession()
     ) {
+      const rememberedSessionId =
+        !selectedStoredSessionId && !activeSessionId && !freshDraftReady
+          ? getRememberedSelectedStoredSessionId()
+          : null
+
+      if (rememberedSessionId) {
+        void resumeSession(rememberedSessionId, true)
+
+        return
+      }
+
       startFreshSessionDraft(true)
     }
   }, [

--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -534,6 +534,10 @@ export function useSessionActions({
 
       await ensureGatewayProfile(sessionProfile)
 
+      if (replaceRoute) {
+        navigate(sessionRoute(storedSessionId), { replace: true })
+      }
+
       const cachedRuntimeId = runtimeIdByStoredSessionIdRef.current.get(storedSessionId)
       const cachedState = cachedRuntimeId && sessionStateByRuntimeIdRef.current.get(cachedRuntimeId)
 
@@ -652,6 +656,7 @@ export function useSessionActions({
           reconcileResumeMessages(toChatMessages(resumed.messages), currentMessages),
           currentMessages
         )
+
         // Keep the local snapshot when resume would only reshuffle runtime projection.
         const preferredMessages =
           localSnapshot.length > 0
@@ -706,6 +711,7 @@ export function useSessionActions({
       activeSessionIdRef,
       busyRef,
       copy,
+      navigate,
       requestGateway,
       runtimeIdByStoredSessionIdRef,
       selectedStoredSessionIdRef,

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -9,6 +9,7 @@ import type { SessionInfo, UsageStats } from '@/types/hermes'
 type Updater<T> = T | ((current: T) => T)
 
 const WORKSPACE_CWD_KEY = 'hermes.desktop.workspace-cwd'
+const SELECTED_STORED_SESSION_KEY = 'hermes.desktop.selected-stored-session'
 
 let configuredDefaultProjectDir = ''
 
@@ -19,10 +20,25 @@ function workspaceCwdKey(connection: HermesConnection | null = $connection.get()
 
   const base = encodeURIComponent(connection.baseUrl || 'remote')
   const profile = encodeURIComponent(connection.profile || 'default')
+
   return `${WORKSPACE_CWD_KEY}.remote.${base}.${profile}`
 }
 
+function selectedStoredSessionKey(connection: HermesConnection | null = $connection.get()): string {
+  if (connection?.mode !== 'remote') {
+    return SELECTED_STORED_SESSION_KEY
+  }
+
+  const base = encodeURIComponent(connection.baseUrl || 'remote')
+  const profile = encodeURIComponent(connection.profile || 'default')
+
+  return `${SELECTED_STORED_SESSION_KEY}.remote.${base}.${profile}`
+}
+
 export const getRememberedWorkspaceCwd = (): string => storedString(workspaceCwdKey())?.trim() || ''
+
+export const getRememberedSelectedStoredSessionId = (): string | null =>
+  storedString(selectedStoredSessionKey())?.trim() || null
 
 export const getConfiguredDefaultProjectDir = (): string => configuredDefaultProjectDir
 
@@ -64,6 +80,7 @@ export async function ensureDefaultWorkspaceCwd(): Promise<void> {
 
   if ($connection.get()?.mode === 'remote') {
     seedLiveCwd(remembered)
+
     return
   }
 
@@ -140,6 +157,7 @@ export function mergeSessionPage(
   }
 
   const incomingIds = new Set(incoming.map(session => session.id))
+
   // Deduplicate by compression lineage: when auto-compression rotates the tip
   // id (old #4 → new #5), the incoming page carries the new tip but the
   // previous list still holds the old one.  Without lineage-level dedup both
@@ -239,7 +257,12 @@ export const setSessionProfileTotals = (next: Updater<Record<string, number>>) =
 export const setSessionsLoading = (next: Updater<boolean>) => updateAtom($sessionsLoading, next)
 export const setWorkingSessionIds = (next: Updater<string[]>) => updateAtom($workingSessionIds, next)
 export const setActiveSessionId = (next: Updater<string | null>) => updateAtom($activeSessionId, next)
-export const setSelectedStoredSessionId = (next: Updater<string | null>) => updateAtom($selectedStoredSessionId, next)
+
+export const setSelectedStoredSessionId = (next: Updater<string | null>) => {
+  updateAtom($selectedStoredSessionId, next)
+  persistString(selectedStoredSessionKey(), $selectedStoredSessionId.get()?.trim() || null)
+}
+
 export const setMessages = (next: Updater<ChatMessage[]>) => updateAtom($messages, next)
 export const setFreshDraftReady = (next: Updater<boolean>) => updateAtom($freshDraftReady, next)
 export const setBusy = (next: Updater<boolean>) => updateAtom($busy, next)


### PR DESCRIPTION
## Summary
- Persist the selected Desktop stored session id per local/remote connection.
- On root chat startup, resume that remembered session before creating a fresh draft.
- Replace the route during resume so the restored chat no longer sits on the new-chat route.

## Problem
Desktop only kept the selected stored session id in renderer memory. After restart, the app mounted at `/` with no routed or selected session, so `useRouteResume` created a blank draft even though the server still had the previous conversation.

## Validation
- `npm run test:ui -- src/app/session/hooks/use-route-resume.test.tsx src/app/session/hooks/use-session-actions.test.tsx`
- `npm run typecheck`
- `npx eslint src/app/session/hooks/use-route-resume.ts src/app/session/hooks/use-route-resume.test.tsx src/app/session/hooks/use-session-actions.ts src/store/session.ts`

Fixes #45237