### PR TITLE
fix(docker): chown parent gateways/ dir in log/run to prevent s6-log crash loop

### DIFF
--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -675,6 +675,10 @@ class S6ServiceManager:
             f': "${{HERMES_HOME:=/opt/data}}"\n'
             f'log_dir="$HERMES_HOME/logs/gateways/{prof}"\n'
             f'mkdir -p "$log_dir"\n'
+            # mkdir -p may create the parent gateways/ dir as root when
+            # this script first runs; chown it so later profiles added
+            # as the hermes user can mkdir their leaf dirs.  (#45258)
+            f'chown hermes:hermes "$HERMES_HOME/logs/gateways" 2>/dev/null || true\n'
             f'chown -R hermes:hermes "$log_dir" 2>/dev/null || true\n'
             # Skip the drop when already non-root (CAP_SETGID).
             f'[ "$(id -u)" = 0 ] || exec s6-log 1 n10 s1000000 T "$log_dir"\n'

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -563,6 +563,11 @@ def test_s6_register_creates_service_dir_and_triggers_scan(
         "destination so supervised stdout reaches docker logs. Saw: "
         f"{log_text!r}"
     )
+    # Parent gateways/ dir must also be chown'd so that profiles added
+    # later (as the hermes user) can mkdir their leaf dirs. (#45258)
+    assert 'chown hermes:hermes "$HERMES_HOME/logs/gateways"' in log_text, (
+        f"log/run must chown the parent gateways/ dir; saw: {log_text!r}"
+    )
 
     # s6-svscanctl -a was invoked against the scandir
     assert any(
@@ -907,3 +912,37 @@ def test_s6_stop_tolerates_marker_write_failure(monkeypatch, s6_scandir):
     mgr.stop("gateway-coder")  # must not raise
 
     assert any(cmd[0] == "s6-svc" and "-d" in cmd for cmd in svc_calls)
+
+
+def test_render_log_run_chowns_parent_gateways_dir() -> None:
+    """Regression test: _render_log_run must chown the parent gateways/ dir.
+
+    When the first profile's log service runs as root, mkdir -p creates
+    ``$HERMES_HOME/logs/gateways/`` as root:root.  Without an explicit
+    chown on the *parent* directory, profiles added later (running as the
+    hermes user) cannot mkdir their leaf dirs and s6-log enters a fatal
+    crash-loop.  See issue #45258.
+    """
+    from hermes_cli.service_manager import S6ServiceManager
+
+    script = S6ServiceManager._render_log_run("default")
+
+    # Parent gateways/ dir is chown'd BEFORE the recursive leaf chown.
+    lines = script.splitlines()
+    parent_chown_idx = None
+    leaf_chown_idx = None
+    for i, line in enumerate(lines):
+        if "chown hermes:hermes" in line and "logs/gateways\"" in line and "-R" not in line:
+            parent_chown_idx = i
+        if "chown -R hermes:hermes" in line:
+            leaf_chown_idx = i
+
+    assert parent_chown_idx is not None, (
+        f"Missing parent gateways/ chown in:\n{script}"
+    )
+    assert leaf_chown_idx is not None, (
+        f"Missing leaf dir chown in:\n{script}"
+    )
+    assert parent_chown_idx < leaf_chown_idx, (
+        f"Parent chown must come before leaf chown; got parent@{parent_chown_idx} > leaf@{leaf_chown_idx}"
+    )


### PR DESCRIPTION
## What does this PR do?

Fixes an ownership gap in the s6 log/run script for per-profile gateway services. When the first profile's log service runs as root, `mkdir -p` creates `$HERMES_HOME/logs/gateways/` as `root:root`. The existing `chown -R` only targets the leaf directory, so the parent stays root-owned. Profiles added later (running as the hermes user) fail to `mkdir` their leaf dirs and `s6-log` enters a fatal crash loop.

This PR adds an explicit `chown hermes:hermes "$HERMES_HOME/logs/gateways"` before the recursive leaf chown. No-op when the parent is already hermes-owned.

## Related Issue

Fixes #45258

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/service_manager.py` (`_render_log_run`): Add `chown hermes:hermes "$HERMES_HOME/logs/gateways"` after `mkdir -p` and before the existing recursive leaf chown. This ensures the parent directory created by the first profile's root-context run is hermes-owned, allowing later profiles to create their leaf directories.
- `tests/hermes_cli/test_service_manager.py`: Add regression test `test_render_log_run_chowns_parent_gateways_dir` verifying the parent chown exists and appears before the leaf chown. Add assertion to existing integration test `test_s6_register_creates_service_dir_and_triggers_scan`.

## How to Test

1. Run `pytest tests/hermes_cli/test_service_manager.py -q -k "log_run or register_creates_service_dir"` — 2 tests should pass
2. Inspect the generated script: `python -c "from hermes_cli.service_manager import S6ServiceManager; print(S6ServiceManager._render_log_run('test'))"` — verify `chown hermes:hermes "$HERMES_HOME/logs/gateways"` appears between `mkdir -p` and `chown -R`
3. In a Docker container: register two gateway profiles, stop/start, verify `stat /opt/data/logs/gateways` shows `hermes:hermes` ownership on both parent and children

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (Docker/s6 only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `_render_log_run` in `hermes_cli/service_manager.py` (callers: `register_profile_gateway`, 1 flow)
- Blast radius: LOW — only affects s6-supervised Docker deployments with multiple gateway profiles
- Related patterns: Same ownership-gap family as #27221 (closed), distinct from #34457 (lock collision)
