### PR TITLE
fix(gateway): chown logs/gateways parent so late-added profiles can log

### DIFF
--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -316,6 +316,7 @@ as_hermes mkdir -p \
     "$HERMES_HOME/cron" \
     "$HERMES_HOME/sessions" \
     "$HERMES_HOME/logs" \
+    "$HERMES_HOME/logs/gateways" \
     "$HERMES_HOME/hooks" \
     "$HERMES_HOME/memories" \
     "$HERMES_HOME/skills" \

--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -675,6 +675,15 @@ class S6ServiceManager:
             f': "${{HERMES_HOME:=/opt/data}}"\n'
             f'log_dir="$HERMES_HOME/logs/gateways/{prof}"\n'
             f'mkdir -p "$log_dir"\n'
+            # The gateways/ parent must be chowned too (non-recursively):
+            # `mkdir -p` creates it root-owned on a root-context boot, and a
+            # leaf-only chown leaves it that way — every profile registered
+            # later then runs its log service as hermes and crash-loops on
+            # `mkdir: Permission denied`. The parent chown runs on every
+            # root-context boot, so it also heals volumes already poisoned
+            # by older images. Non-recursive on purpose: sibling profile
+            # dirs are each managed by their own log/run. See #45258.
+            f'chown hermes:hermes "$HERMES_HOME/logs/gateways" 2>/dev/null || true\n'
             f'chown -R hermes:hermes "$log_dir" 2>/dev/null || true\n'
             # Skip the drop when already non-root (CAP_SETGID).
             f'[ "$(id -u)" = 0 ] || exec s6-log 1 n10 s1000000 T "$log_dir"\n'

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -907,3 +907,38 @@ def test_s6_stop_tolerates_marker_write_failure(monkeypatch, s6_scandir):
     mgr.stop("gateway-coder")  # must not raise
 
     assert any(cmd[0] == "s6-svc" and "-d" in cmd for cmd in svc_calls)
+
+
+def test_s6_log_run_chowns_gateways_parent(s6_scandir, fake_subprocess_run) -> None:
+    """The log/run script must chown the logs/gateways/ parent, not just the leaf.
+
+    Regression guard for #45258: `mkdir -p` creates the gateways/ parent
+    root-owned on a root-context boot, and a leaf-only chown leaves it that
+    way. Every profile registered later then runs its log service as the
+    dropped hermes user and s6-log crash-loops on `mkdir: Permission denied`.
+    """
+    mgr = S6ServiceManager(scandir=s6_scandir)
+    mgr.register_profile_gateway("coder")
+
+    log_text = (s6_scandir / "gateway-coder" / "log" / "run").read_text()
+
+    parent_chown = 'chown hermes:hermes "$HERMES_HOME/logs/gateways"'
+    assert parent_chown in log_text, (
+        "log/run must chown the logs/gateways parent so profiles added "
+        f"after a root-context boot can create their leaf dirs. Saw: {log_text!r}"
+    )
+    # Non-recursive on purpose: sibling profile leaf dirs are each managed
+    # by their own log/run; a recursive parent chown would race them.
+    assert 'chown -R hermes:hermes "$HERMES_HOME/logs/gateways"' not in log_text
+
+    # Ordering: mkdir creates the parent, then the parent chown repairs its
+    # ownership, then the leaf chown — all before s6-log execs.
+    mkdir_idx = log_text.index('mkdir -p "$log_dir"')
+    parent_idx = log_text.index(parent_chown)
+    leaf_idx = log_text.index('chown -R hermes:hermes "$log_dir"')
+    exec_idx = log_text.index("s6-log 1 ")
+    assert mkdir_idx < parent_idx < leaf_idx < exec_idx
+
+    # The parent path must be a runtime env expansion, never a baked-in
+    # absolute path (same contract as the log_dir itself).
+    assert '/opt/data/logs/gateways"' not in log_text

--- a/tests/tools/test_stage2_hook_log_dir_seed.py
+++ b/tests/tools/test_stage2_hook_log_dir_seed.py
@@ -1,0 +1,60 @@
+"""Contract test: the s6-overlay stage2 hook seeds $HERMES_HOME/logs/gateways
+as the hermes user.
+
+Regression guard for #45258: the per-profile gateway log service
+(`gateway-<profile>/log/run`) creates `logs/gateways/` via `mkdir -p` but only
+chowns the leaf `logs/gateways/<profile>`. If the first log service to boot
+runs in root context, the `gateways/` parent is created root-owned and stays
+that way; every profile registered later runs its log service as the dropped
+hermes user and s6-log crash-loops on `mkdir: Permission denied`.
+
+Seeding `logs/gateways` in stage2 (cont-init runs before any service starts)
+guarantees the parent already exists hermes-owned by the time the first
+log/run executes its `mkdir -p`.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STAGE2_HOOK = REPO_ROOT / "docker" / "stage2-hook.sh"
+
+
+@pytest.fixture(scope="module")
+def stage2_text() -> str:
+    if not STAGE2_HOOK.exists():
+        pytest.skip("docker/stage2-hook.sh not present in this checkout")
+    return STAGE2_HOOK.read_text()
+
+
+def _seed_mkdir_block(text: str) -> str:
+    """Extract the `as_hermes mkdir -p \\ ...` seed block."""
+    m = re.search(r"as_hermes mkdir -p \\\n(?:[^\n]*\\\n)*[^\n]*\n", text)
+    assert m, "stage2-hook.sh must contain the as_hermes mkdir -p seed block"
+    return m.group(0)
+
+
+def test_logs_gateways_is_seeded(stage2_text: str) -> None:
+    block = _seed_mkdir_block(stage2_text)
+    assert '"$HERMES_HOME/logs/gateways"' in block, (
+        "logs/gateways must be seeded hermes-owned in stage2 so profiles "
+        "added after first boot can create their log dirs (#45258)"
+    )
+    # The parent must also be seeded so mkdir -p inside the block never
+    # creates logs/ implicitly with surprising ownership.
+    assert '"$HERMES_HOME/logs"' in block
+
+
+def test_logs_subtree_is_healed_when_chown_needed(stage2_text: str) -> None:
+    """The needs_chown repair loop must cover the logs subtree recursively —
+    that is what makes the seed entry above sufficient (no separate
+    logs/gateways loop entry needed)."""
+    m = re.search(r"for sub in ([^;]*); do", stage2_text)
+    assert m, "stage2-hook.sh must contain the needs_chown subdir repair loop"
+    assert "logs" in m.group(1).split(), (
+        "the needs_chown loop must recursively chown logs/ — it covers "
+        "logs/gateways, so the seed list does not need a loop twin"
+    )


### PR DESCRIPTION
## What does this PR do?

Fixes the s6-log fatal crash-loop for gateway profiles added after a container's first boot.

The per-profile log service script (`gateway-<profile>/log/run`, rendered by `service_manager._render_log_run`) creates `$HERMES_HOME/logs/gateways/` via `mkdir -p` but only ever chowns the **leaf** `logs/gateways/<profile>`. When the first log service boots in root context, the `gateways/` parent is created `root:root` and stays that way. Every profile registered later runs its log service as the dropped `hermes` user, its `mkdir -p` fails with `EACCES`, and `s6-log` enters a sub-second fatal crash-loop that floods the container log indefinitely. The stage2 recursive heal doesn't catch it either: it is gated on `needs_chown`, which is false on a normal boot where the top-level `$HERMES_HOME` is already hermes-owned.

Two complementary fixes (options 1 + 2 from the issue):

1. **`_render_log_run`**: chown the `gateways/` parent (non-recursively) before the existing leaf chown. This runs on every root-context boot, so it not only prevents new poisoning but also **heals volumes already poisoned by older images** on the next container restart. Non-recursive on purpose — sibling profile leaf dirs are each managed by their own `log/run`.
2. **`docker/stage2-hook.sh`**: seed `logs/gateways` in the `as_hermes mkdir -p` block. cont-init runs before any service starts, so on fresh boots the parent already exists hermes-owned by the time the first `log/run` executes its `mkdir -p`.

The `needs_chown` repair loop needs no twin entry: it already chowns `logs/` recursively, which covers `logs/gateways` (asserted by a new contract test so the invariant is guarded).

## Related Issue

Fixes #45258

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/service_manager.py` — `_render_log_run()`: add non-recursive parent chown line between `mkdir -p` and the leaf chown, with a comment explaining the root-context-boot poisoning and self-healing behavior.
- `docker/stage2-hook.sh` — add `"$HERMES_HOME/logs/gateways"` to the hermes-owned seed `mkdir -p` list.
- `tests/hermes_cli/test_service_manager.py` — new `test_s6_log_run_chowns_gateways_parent`: asserts the parent chown is present, non-recursive, correctly ordered (`mkdir` → parent chown → leaf chown → `exec s6-log`), and uses `$HERMES_HOME` runtime expansion rather than a baked-in path.
- `tests/tools/test_stage2_hook_log_dir_seed.py` — new contract tests (following the existing `test_stage2_hook_*` pattern): `logs/gateways` is in the seed block, and the `needs_chown` loop still covers `logs` recursively.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_service_manager.py tests/tools/test_stage2_hook_log_dir_seed.py` — passes (57 + 2 tests).
2. Revert the two source hunks and re-run: both new tests fail (`test_s6_log_run_chowns_gateways_parent`, `test_logs_gateways_is_seeded`).
3. Rendered script verified with `sh -n` and `shellcheck --severity=error -s sh` (same severity as the docker-lint workflow); `docker/stage2-hook.sh` also passes `shellcheck --severity=error`.
4. Manual repro per the issue: in a container where `logs/gateways` is root-owned, profiles added after first boot crash-loop with `s6-log: fatal: unable to mkdir ... Permission denied`; after this change a container restart heals the parent ownership and the affected log services start.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (WSL2), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — inline comments document the ownership contract; N/A otherwise
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — container-only code path (s6 services + stage2 hook); no host-platform impact
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
