### PR TITLE
fix(agent): metadata flag on compression summary messages, wire-safe key (salvages #38434)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -69,6 +69,21 @@ SUMMARY_PREFIX = (
 )
 LEGACY_SUMMARY_PREFIX = "[CONTEXT SUMMARY]:"
 
+# Metadata key added to context compression summary messages so that frontends
+# (CLI, Desktop, gateway, TUI) can distinguish them from real assistant/user
+# messages and filter or render them appropriately without content-prefix
+# heuristics. See https://github.com/NousResearch/hermes-agent/issues/38389
+#
+# Underscore-prefixed ON PURPOSE: the wire sanitizers
+# (agent/transports/chat_completions.py convert_messages and the summary-path
+# mirror in agent/chat_completion_helpers.py) strip every top-level message
+# key starting with "_" before the request leaves the process. Strict
+# OpenAI-compatible gateways (Fireworks, Mistral, Moonshot/Kimi, opencode-go)
+# reject payloads carrying unknown keys with "Extra inputs are not permitted",
+# poisoning every subsequent request in the session — a bare key like
+# "is_compressed_summary" would reach the wire and trip exactly that.
+COMPRESSED_SUMMARY_METADATA_KEY = "_compressed_summary"
+
 # Appended to every standalone summary message (and to the merged-into-tail
 # prefix) so the model has an unambiguous "summary ends here" boundary.
 # Without it, weak models read the verbatim "## Active Task" quote as fresh
@@ -1653,6 +1668,19 @@ This compaction should PRIORITISE preserving all information related to the focu
             return True
         return any(text.startswith(p) for p in _HISTORICAL_SUMMARY_PREFIXES)
 
+    @staticmethod
+    def _has_compressed_summary_metadata(message: Any) -> bool:
+        """Return True if *message* carries the compressed-summary flag.
+
+        Callers (frontends, CLI, gateway) can use this to distinguish context
+        compaction summaries from real assistant or user messages without
+        relying on content-prefix heuristics.  The flag is in-process only —
+        the wire sanitizers strip underscore-prefixed keys before API calls.
+        """
+        if not isinstance(message, dict):
+            return False
+        return bool(message.get(COMPRESSED_SUMMARY_METADATA_KEY))
+
     @classmethod
     def _derive_auto_focus_topic(
         cls,
@@ -2341,7 +2369,11 @@ This compaction should PRIORITISE preserving all information related to the focu
             summary = summary + "\n\n" + _SUMMARY_END_MARKER
 
         if not _merge_summary_into_tail:
-            compressed.append({"role": summary_role, "content": summary})
+            compressed.append({
+                "role": summary_role,
+                "content": summary,
+                COMPRESSED_SUMMARY_METADATA_KEY: True,
+            })
 
         for i in range(compress_end, n_messages):
             msg = messages[i].copy()
@@ -2352,6 +2384,9 @@ This compaction should PRIORITISE preserving all information related to the focu
                     merged_prefix,
                     prepend=True,
                 )
+                # Mark the merged message so frontends can identify it as
+                # containing a compression summary prefix.
+                msg[COMPRESSED_SUMMARY_METADATA_KEY] = True
                 _merge_summary_into_tail = False
             compressed.append(msg)
 

--- a/tests/agent/test_compressed_summary_metadata.py
+++ b/tests/agent/test_compressed_summary_metadata.py
@@ -1,0 +1,93 @@
+"""Regression tests for the compressed-summary metadata flag (#38389).
+
+The compressor marks summary messages with ``COMPRESSED_SUMMARY_METADATA_KEY``
+so frontends (CLI, Desktop, gateway, TUI) can distinguish them from real
+assistant/user messages without content-prefix heuristics.
+
+Two invariants:
+1. The flag is present on exactly the summary-bearing message after compress()
+   (standalone insertion AND merge-into-tail).
+2. The key is underscore-prefixed so the chat-completions wire sanitizer
+   strips it — strict gateways (Fireworks, Mistral, Moonshot/Kimi,
+   opencode-go) reject unknown message keys with "Extra inputs are not
+   permitted", poisoning the session.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.context_compressor import (
+    COMPRESSED_SUMMARY_METADATA_KEY,
+    ContextCompressor,
+)
+
+
+def _make_compressor():
+    with patch(
+        "agent.context_compressor.get_model_context_length", return_value=8000
+    ):
+        return ContextCompressor(
+            model="test-model", quiet_mode=True, config_context_length=8000
+        )
+
+
+def _make_messages(n_turns=30):
+    msgs = [{"role": "system", "content": "sys"}]
+    for i in range(n_turns):
+        msgs.append({"role": "user", "content": f"question {i} " + "x" * 400})
+        msgs.append({"role": "assistant", "content": f"answer {i} " + "y" * 400})
+    return msgs
+
+
+def _compress(cc, msgs):
+    resp = MagicMock()
+    resp.choices[0].message.content = "## Active Task\nstuff"
+    with patch("agent.context_compressor.call_llm", return_value=resp):
+        return cc.compress(msgs, current_tokens=100_000, force=True)
+
+
+class TestMetadataFlagSet:
+    def test_exactly_one_flagged_message_after_compress(self):
+        cc = _make_compressor()
+        out = _compress(cc, _make_messages())
+        flagged = [
+            m for m in out
+            if isinstance(m, dict) and m.get(COMPRESSED_SUMMARY_METADATA_KEY)
+        ]
+        assert len(flagged) == 1
+        # The flagged message is the one carrying the compaction handoff.
+        assert "[CONTEXT COMPACTION" in flagged[0]["content"]
+
+    def test_helper_detects_flag(self):
+        assert ContextCompressor._has_compressed_summary_metadata(
+            {COMPRESSED_SUMMARY_METADATA_KEY: True}
+        )
+        assert not ContextCompressor._has_compressed_summary_metadata(
+            {"role": "assistant", "content": "hi"}
+        )
+        assert not ContextCompressor._has_compressed_summary_metadata("not a dict")
+        assert not ContextCompressor._has_compressed_summary_metadata(None)
+
+
+class TestMetadataFlagNeverReachesWire:
+    def test_key_is_underscore_prefixed(self):
+        """The wire sanitizers strip every top-level message key starting
+        with '_'. A bare key would reach strict gateways (Fireworks etc.)
+        and 400 with 'Extra inputs are not permitted'."""
+        assert COMPRESSED_SUMMARY_METADATA_KEY.startswith("_")
+
+    def test_chat_completions_transport_strips_flag(self):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        cc = _make_compressor()
+        out = _compress(cc, _make_messages())
+        wire = ChatCompletionsTransport().convert_messages(out, model="some-model")
+        assert not any(
+            isinstance(m, dict) and COMPRESSED_SUMMARY_METADATA_KEY in m
+            for m in wire
+        )
+        # Sanitization must not destroy the in-process flag on the originals.
+        assert any(
+            isinstance(m, dict) and m.get(COMPRESSED_SUMMARY_METADATA_KEY)
+            for m in out
+        )


### PR DESCRIPTION
## Summary
Context compression summary messages now carry an in-process metadata flag (`_compressed_summary: True`) so frontends (CLI, Desktop, gateway, TUI) can identify them without content-prefix heuristics (#38389).

Closes #38389. (Dupes #38391, #38392 close with it.)

## Changes
- `agent/context_compressor.py`: flag set on the standalone summary message AND the merge-into-tail message; `_has_compressed_summary_metadata()` helper for consumers — from #38434 by @kyssta-exe
- **Key renamed during salvage:** the PR used `is_compressed_summary` (bare key) — that would ride messages onto the wire, and strict gateways (Fireworks, Mistral, Moonshot/Kimi, opencode-go) 400 on unknown message keys ("Extra inputs are not permitted"). Renamed to underscore-prefixed `_compressed_summary`, which the existing wire sanitizers (`ChatCompletionsTransport.convert_messages` + the summary-path mirror in `chat_completion_helpers.py`) already strip
- `tests/agent/test_compressed_summary_metadata.py`: flag set in-process, underscore invariant, transport strips it without destroying the in-process flag

## Validation
| | Result |
|---|---|
| E2E (real `compress()` + real `ChatCompletionsTransport`) | 61→13 msgs, exactly 1 flagged, 0 wire leaks, originals intact |
| metadata + prefix-semantics + anchor suites | 33 passed |

## Attribution
Salvages #38434 by @kyssta-exe — commit re-applied onto current main (conflicted with the `_SUMMARY_END_MARKER` hoist) with authorship preserved; rebase-merge to keep per-commit credit. The key rename is our follow-up commit.

## Infographic

![compressed-summary-metadata](https://v3b.fal.media/files/b/0a9e0f1f/7uYx8nAnuYc9C-5Uk7334_iHUDjVXl.png)
