### PR TITLE
fix(install): skip node/npm/npx symlinks when system versions exist

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -847,9 +847,15 @@ install_node() {
     local node_link_dir
     node_link_dir="$(get_command_link_dir)"
     mkdir -p "$node_link_dir"
-    ln -sf "$HERMES_HOME/node/bin/node" "$node_link_dir/node"
-    ln -sf "$HERMES_HOME/node/bin/npm"  "$node_link_dir/npm"
-    ln -sf "$HERMES_HOME/node/bin/npx"  "$node_link_dir/npx"
+    # Only symlink node/npm/npx when no system-installed version exists.
+    # Creating unconditionally shadows Homebrew/nvm installs on macOS
+    # where ~/.local/bin precedes /opt/homebrew/bin in PATH (#45279).
+    local _cmd
+    for _cmd in node npm npx; do
+        if ! command -v "$_cmd" >/dev/null 2>&1; then
+            ln -sf "$HERMES_HOME/node/bin/$_cmd" "$node_link_dir/$_cmd"
+        fi
+    done
 
     export PATH="$HERMES_HOME/node/bin:$PATH"
 

--- a/tests/test_install_sh_node_symlink_shadow.py
+++ b/tests/test_install_sh_node_symlink_shadow.py
@@ -1,0 +1,50 @@
+"""Regression for #45279: installer must not shadow system node/npm/npx.
+
+On macOS user installs, ``install_node()`` used to unconditionally symlink
+node/npm/npx into ``~/.local/bin``.  When that directory precedes
+``/opt/homebrew/bin`` (or nvm) in ``$PATH``, the symlinks silently replace
+the user's real Node toolchain with Hermes' bundled copy.
+
+The fix: only create a symlink when ``command -v <cmd>`` finds no existing
+binary on ``$PATH``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def _extract_install_node_function() -> str:
+    """Return the body of the ``install_node()`` shell function."""
+    text = INSTALL_SH.read_text()
+    start = text.index("install_node()")
+    # Find the closing brace at column 0 that ends the function.
+    rest = text[start:]
+    depth = 0
+    for i, ch in enumerate(rest):
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return rest[: i + 1]
+    raise AssertionError("Could not find end of install_node()")
+
+
+def test_install_node_does_not_unconditionally_symlink() -> None:
+    """The old ``ln -sf`` block must be replaced with a ``command -v`` guard."""
+    body = _extract_install_node_function()
+    # The unconditional symlinks must be gone.
+    assert 'ln -sf "$HERMES_HOME/node/bin/node" "$node_link_dir/node"' not in body
+    assert 'ln -sf "$HERMES_HOME/node/bin/npm"  "$node_link_dir/npm"' not in body
+    assert 'ln -sf "$HERMES_HOME/node/bin/npx"  "$node_link_dir/npx"' not in body
+
+
+def test_install_node_checks_command_before_symlinking() -> None:
+    """Symlinks must only be created when the command is absent from $PATH."""
+    body = _extract_install_node_function()
+    assert 'command -v "$_cmd"' in body or "command -v '$_cmd'" in body
+    assert "ln -sf" in body  # symlinks still created, just conditionally


### PR DESCRIPTION
## What does this PR do?

Prevents the POSIX installer from shadowing the user's system-installed Node.js (Homebrew, nvm, etc.) by only creating `node`/`npm`/`npx` symlinks in `~/.local/bin` when no existing binary is found on `$PATH`.

## Related Issue

Fixes #45279

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/install.sh`: Wrap the `ln -sf` calls for node/npm/npx in a `command -v` guard so symlinks are only created when the command is absent from `$PATH`. The comment explains the rationale and links to the issue.
- `tests/test_install_sh_node_symlink_shadow.py`: Two regression tests verifying (1) unconditional symlinks are removed, and (2) the `command -v` guard is present.

## How to Test

1. On macOS with Homebrew node installed (`brew install node`), verify `which node` resolves to `/opt/homebrew/bin/node`.
2. Run the installer: `curl -fsSL https://raw.githubusercontent.com/liuhao1024/hermes-agent/fix/install-skip-node-symlinks-when-system-exists/scripts/install.sh | bash`
3. After install, verify `which node` still resolves to `/opt/homebrew/bin/node` (not `~/.local/bin/node`).
4. Verify `~/.local/bin/node` does NOT exist (symlink was skipped).
5. Run the regression tests: `pytest tests/test_install_sh_node_symlink_shadow.py -v`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `scripts/install.sh::install_node()` (symlink creation block, lines 847-855)
- Blast radius: LOW — only affects fresh install path; existing installs unaffected; Hermes runtime already resolves bundled node via `$HERMES_HOME/node/bin` prepended to PATH
- Related patterns: `test_uninstall_node_symlinks.py` (uninstall path), `test_install_sh_symlink_stomp.py` (symlink regression)
