### PR TITLE
chore: add Kimi K2.7 code catalog slug

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -57,6 +57,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("qwen/qwen3.6-35b-a3b",                   ""),
     # MoonshotAI
     ("moonshotai/kimi-k2.6",                   "recommended"),
+    ("moonshotai/kimi-k2.7-code",              ""),
     # MiniMax
     ("minimax/minimax-m3",                     ""),
     # Z-AI
@@ -178,6 +179,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "qwen/qwen3.6-35b-a3b",
         # MoonshotAI
         "moonshotai/kimi-k2.6",
+        "moonshotai/kimi-k2.7-code",
         # MiniMax
         "minimax/minimax-m3",
         # Z-AI

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-06-09T17:20:16Z",
+  "updated_at": "2026-06-12T23:38:08Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -83,6 +83,10 @@
         {
           "id": "moonshotai/kimi-k2.6",
           "description": "recommended"
+        },
+        {
+          "id": "moonshotai/kimi-k2.7-code",
+          "description": ""
         },
         {
           "id": "minimax/minimax-m3",
@@ -198,6 +202,9 @@
         },
         {
           "id": "moonshotai/kimi-k2.6"
+        },
+        {
+          "id": "moonshotai/kimi-k2.7-code"
         },
         {
           "id": "minimax/minimax-m3"


### PR DESCRIPTION
## Summary
Adds `moonshotai/kimi-k2.7-code` to the curated OpenRouter and Nous model catalog so pickers can surface it from the docs-hosted manifest and in-repo fallback.

## Changes
- `hermes_cli/models.py`: add the slug to `OPENROUTER_MODELS` and `_PROVIDER_MODELS["nous"]`
- `website/static/api/model-catalog.json`: regenerate the published manifest

## Validation
| Check | Result |
|---|---|
| `python -m json.tool website/static/api/model-catalog.json` | pass |
| `scripts/run_tests.sh tests/hermes_cli/test_model_catalog.py` | 28 passed |

## Infographic

![Catalog slug added](https://v3b.fal.media/files/b/0a9e0f4b/hpjMf74bS7ZpG9G3iCEu0_VSCn3k4a.png)
