### PR TITLE
fix(routing): apply per-turn reasoning overrides

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -482,6 +482,7 @@ def init_agent(
     # Model response configuration
     agent.max_tokens = max_tokens  # None = use model default
     agent.reasoning_config = reasoning_config  # None = use default (medium for OpenRouter)
+    agent._turn_reasoning_config_override = None  # set by pre_llm_call hooks for the active turn only
     agent.service_tier = service_tier
     agent.request_overrides = dict(request_overrides or {})
     agent.prefill_messages = prefill_messages or []  # Prefilled conversation turns

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -552,9 +552,24 @@ def interruptible_api_call(agent, api_kwargs: dict):
 
 
 
+def _effective_reasoning_config(agent):
+    """Return the reasoning config for the current request.
+
+    ``agent.reasoning_config`` is the session/static config. ``pre_llm_call``
+    hooks may set ``_turn_reasoning_config_override`` for exactly the active
+    user turn so declarative routing can alter provider reasoning without
+    rebuilding the agent or mutating cached prompt context.
+    """
+    override = getattr(agent, "_turn_reasoning_config_override", None)
+    if isinstance(override, dict):
+        return override
+    return agent.reasoning_config
+
+
 def build_api_kwargs(agent, api_messages: list) -> dict:
     """Build the keyword arguments dict for the active API mode."""
     tools_for_api = agent.tools
+    reasoning_config = _effective_reasoning_config(agent)
 
     if agent.api_mode == "anthropic_messages":
         _transport = agent._get_transport()
@@ -569,7 +584,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             messages=anthropic_messages,
             tools=tools_for_api,
             max_tokens=ephemeral_out if ephemeral_out is not None else agent.max_tokens,
-            reasoning_config=agent.reasoning_config,
+            reasoning_config=reasoning_config,
             is_oauth=agent._is_anthropic_oauth,
             preserve_dots=agent._anthropic_preserve_dots(),
             context_length=ctx_len,
@@ -645,7 +660,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             model=agent.model,
             messages=_msgs_for_codex,
             tools=tools_for_api,
-            reasoning_config=agent.reasoning_config,
+            reasoning_config=reasoning_config,
             session_id=getattr(agent, "session_id", None),
             max_tokens=agent.max_tokens,
             timeout=agent._resolved_api_call_timeout(),
@@ -750,7 +765,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             max_tokens=agent.max_tokens,
             ephemeral_max_output_tokens=_ephemeral_out,
             max_tokens_param_fn=agent._max_tokens_param,
-            reasoning_config=agent.reasoning_config,
+            reasoning_config=reasoning_config,
             request_overrides=agent.request_overrides,
             session_id=getattr(agent, "session_id", None),
             provider_profile=_profile,
@@ -782,7 +797,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         max_tokens=agent.max_tokens,
         ephemeral_max_output_tokens=_ephemeral_out,
         max_tokens_param_fn=agent._max_tokens_param,
-        reasoning_config=agent.reasoning_config,
+        reasoning_config=reasoning_config,
         request_overrides=agent.request_overrides,
         session_id=getattr(agent, "session_id", None),
         model_lower=(agent.model or "").lower(),
@@ -1360,6 +1375,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
         # turns so Anthropic-family providers don't 400 the summary call.
         api_messages = agent._drop_thinking_only_and_merge_users(api_messages)
 
+        reasoning_config = _effective_reasoning_config(agent)
         summary_extra_body = {}
         try:
             from agent.auxiliary_client import _fixed_temperature_for_model, OMIT_TEMPERATURE as _OMIT_TEMP
@@ -1387,8 +1403,8 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             if _is_lmstudio_summary else None
         )
         if not _is_lmstudio_summary and agent._supports_reasoning_extra_body():
-            if agent.reasoning_config is not None:
-                summary_extra_body["reasoning"] = agent.reasoning_config
+            if reasoning_config is not None:
+                summary_extra_body["reasoning"] = reasoning_config
             else:
                 summary_extra_body["reasoning"] = {
                     "enabled": True,
@@ -1460,7 +1476,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             if agent.api_mode == "anthropic_messages":
                 _tsum = agent._get_transport()
                 _ant_kw = _tsum.build_kwargs(model=agent.model, messages=api_messages, tools=None,
-                               max_tokens=agent.max_tokens, reasoning_config=agent.reasoning_config,
+                               max_tokens=agent.max_tokens, reasoning_config=reasoning_config,
                                is_oauth=agent._is_anthropic_oauth,
                                preserve_dots=agent._anthropic_preserve_dots())
                 summary_response = agent._anthropic_messages_create(_ant_kw)
@@ -1491,7 +1507,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
                 _tretry = agent._get_transport()
                 _ant_kw2 = _tretry.build_kwargs(model=agent.model, messages=api_messages, tools=None,
                                 is_oauth=agent._is_anthropic_oauth,
-                                max_tokens=agent.max_tokens, reasoning_config=agent.reasoning_config,
+                                max_tokens=agent.max_tokens, reasoning_config=reasoning_config,
                                 preserve_dots=agent._anthropic_preserve_dots())
                 retry_response = agent._anthropic_messages_create(_ant_kw2)
                 _retry_result = _tretry.normalize_response(retry_response, strip_tool_prefix=agent._is_anthropic_oauth)

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -34,6 +34,37 @@ from agent.model_metadata import estimate_request_tokens_rough
 logger = logging.getLogger(__name__)
 
 
+def _normalize_hook_reasoning_config(value: Any) -> Optional[Dict[str, Any]]:
+    """Return a safe reasoning_config override from a pre_llm_call hook result.
+
+    Hooks are allowed to lower, raise, or disable reasoning for the current user
+    turn, but only through the same public effort vocabulary Hermes already
+    accepts in config.yaml. Malformed hook output is ignored instead of leaking
+    arbitrary provider kwargs into model requests.
+    """
+    if not isinstance(value, dict):
+        return None
+
+    if value.get("enabled") is False:
+        return {"enabled": False}
+
+    effort = value.get("effort")
+    if isinstance(effort, str) and effort.strip():
+        try:
+            from hermes_constants import parse_reasoning_effort
+            parsed = parse_reasoning_effort(effort)
+        except Exception:
+            parsed = None
+        if parsed is not None:
+            return parsed
+        return None
+
+    if value.get("enabled") is True:
+        return {"enabled": True}
+
+    return None
+
+
 @dataclass
 class TurnContext:
     """Values produced by the turn prologue and consumed by the turn loop."""
@@ -314,7 +345,11 @@ def build_turn_context(
                     break
 
     # Plugin hook: pre_llm_call (context injected into user message, not system prompt).
+    # Hooks may also return a per-turn reasoning_config override.  Clear any stale
+    # value before running hooks so a no-op/failed hook cannot leak a lower or
+    # higher reasoning tier into the next user turn.
     plugin_user_context = ""
+    agent._turn_reasoning_config_override = None
     try:
         from hermes_cli.plugins import invoke_hook as _invoke_hook
         _pre_results = _invoke_hook(
@@ -330,13 +365,20 @@ def build_turn_context(
             sender_id=getattr(agent, "_user_id", None) or "",
         )
         _ctx_parts: list[str] = []
+        _turn_reasoning_config = None
         for r in _pre_results:
             if isinstance(r, dict) and r.get("context"):
                 _ctx_parts.append(str(r["context"]))
             elif isinstance(r, str) and r.strip():
                 _ctx_parts.append(r)
+            if isinstance(r, dict) and _turn_reasoning_config is None:
+                _turn_reasoning_config = _normalize_hook_reasoning_config(
+                    r.get("reasoning_config")
+                )
         if _ctx_parts:
             plugin_user_context = "\n\n".join(_ctx_parts)
+        if _turn_reasoning_config is not None:
+            agent._turn_reasoning_config_override = _turn_reasoning_config
     except Exception as exc:
         logger.warning("pre_llm_call hook failed: %s", exc)
 

--- a/tests/agent/test_reasoning_config_override.py
+++ b/tests/agent/test_reasoning_config_override.py
@@ -1,0 +1,65 @@
+"""Per-turn reasoning override plumbing tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent.chat_completion_helpers import build_api_kwargs
+
+
+class _CapturingTransport:
+    def __init__(self):
+        self.params: dict[str, Any] | None = None
+
+    def build_kwargs(self, **kwargs):
+        self.params = kwargs
+        return kwargs
+
+
+class _FakeCodexAgent:
+    def __init__(self):
+        self.api_mode = "codex_responses"
+        self.provider = "openai-codex"
+        self.model = "gpt-5.5"
+        self.base_url = "https://chatgpt.com/backend-api/codex"
+        self._base_url_hostname = "chatgpt.com"
+        self._base_url_lower = self.base_url
+        self.tools = []
+        self.max_tokens = None
+        self.request_overrides = {}
+        self.reasoning_config = {"enabled": True, "effort": "xhigh"}
+        self._turn_reasoning_config_override: dict[str, Any] | None = None
+        self.session_id = "sess-1"
+        self._codex_reasoning_replay_enabled = True
+        self.transport = _CapturingTransport()
+
+    def _get_transport(self):
+        return self.transport
+
+    def _prepare_messages_for_non_vision_model(self, messages):
+        return messages
+
+    def _github_models_reasoning_extra_body(self):
+        return None
+
+    def _resolved_api_call_timeout(self):
+        return None
+
+
+def test_build_api_kwargs_prefers_turn_reasoning_override():
+    agent = _FakeCodexAgent()
+    agent._turn_reasoning_config_override = {"enabled": False}
+
+    kwargs = build_api_kwargs(agent, [{"role": "user", "content": "hi"}])
+
+    assert kwargs["reasoning_config"] == {"enabled": False}
+    assert agent.transport.params is not None
+    assert agent.transport.params["reasoning_config"] == {"enabled": False}
+
+
+def test_build_api_kwargs_uses_static_reasoning_when_no_turn_override():
+    agent = _FakeCodexAgent()
+
+    kwargs = build_api_kwargs(agent, [{"role": "user", "content": "hi"}])
+
+    assert kwargs["reasoning_config"] == {"enabled": True, "effort": "xhigh"}

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -9,6 +9,7 @@ confirm the prologue produces the right ``TurnContext`` and applies the
 from __future__ import annotations
 
 import types
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -68,6 +69,7 @@ class _FakeAgent:
         self._invalid_tool_retries = -1
         self._vision_supported = None
         self._persist_calls = 0
+        self._turn_reasoning_config_override: dict[str, Any] | None = None
 
     # --- methods the prologue calls ---
     def _ensure_db_session(self):
@@ -185,3 +187,29 @@ def test_no_review_when_memory_disabled():
     agent = _FakeAgent()
     ctx = _build(agent)
     assert ctx.should_review_memory is False
+
+
+def test_pre_llm_hook_can_set_turn_reasoning_override():
+    agent = _FakeAgent()
+    with patch(
+        "hermes_cli.plugins.invoke_hook",
+        return_value=[
+            {
+                "context": "routing context",
+                "reasoning_config": {"enabled": False},
+            }
+        ],
+    ):
+        ctx = _build(agent, user_message="please do a quick lookup")
+
+    assert ctx.plugin_user_context == "routing context"
+    assert agent._turn_reasoning_config_override == {"enabled": False}
+
+
+def test_pre_llm_hook_clears_stale_turn_reasoning_override_when_absent():
+    agent = _FakeAgent()
+    agent._turn_reasoning_config_override = {"enabled": False}
+    with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
+        _build(agent, user_message="now do the next thing")
+
+    assert agent._turn_reasoning_config_override is None


### PR DESCRIPTION
## Summary
- Adds per-turn `reasoning_config` override plumbing from `pre_llm_call` hooks into request construction.
- Clears stale override state at the start of each turn and prefers the hook-provided override over static `agent.reasoning_config` only for the active request.
- Adds regression coverage for hook capture, stale clearing, fallback to static config, and request kwargs construction.

## Verification
- `PYTHONPATH=$WT /Users/colecarden/.hermes/hermes-agent/venv/bin/python -m py_compile agent/turn_context.py agent/chat_completion_helpers.py agent/agent_init.py tests/agent/test_turn_context.py tests/agent/test_reasoning_config_override.py`
- `PYTHONPATH=$WT /Users/colecarden/.hermes/hermes-agent/venv/bin/python -m pytest tests/agent/test_turn_context.py tests/agent/test_reasoning_config_override.py tests/run_agent/test_run_agent.py -q` → `387 passed, 1 warning`
- `git diff --check origin/main..HEAD`
- Public/privacy scan over `origin/main..HEAD` → no hits

## Notes
- Clean branch from current `origin/main`; excludes unrelated local Hermes commits and dirty checkout files.
- Local candidate branch: `cole/cost-routing-overrides-20260612T231237Z`
- Final clean SHA: `a7809303fc9c7adc5de6f74561f54fc7c4b1c3e4`
- Supersedes earlier local-only SHA from the dirty branch: `94fa164628fb5f64465b50fd0a4226d96d044a37`
- Rebased onto current `origin/main` before publication: `1899c8f50`
- The runtime hook update under `~/.hermes/hooks/declarative-routing.py` is local operator configuration and is not included in this upstream PR branch.
- No merge, deploy, gateway restart, or TUI restart has been performed.
