### PR TITLE
fix(gateway): bridge docker_extra_args config to TERMINAL_DOCKER_EXTRA_ARGS env var

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -607,6 +607,7 @@ def load_cli_config() -> Dict[str, Any]:
         "container_persistent": "TERMINAL_CONTAINER_PERSISTENT",
         "docker_volumes": "TERMINAL_DOCKER_VOLUMES",
         "docker_env": "TERMINAL_DOCKER_ENV",
+        "docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
         "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
         "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
         "docker_persist_across_processes": "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1037,6 +1037,7 @@ if _config_path.exists():
                 "container_persistent": "TERMINAL_CONTAINER_PERSISTENT",
                 "docker_volumes": "TERMINAL_DOCKER_VOLUMES",
                 "docker_env": "TERMINAL_DOCKER_ENV",
+                "docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
                 "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
                 "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
                 "docker_persist_across_processes": "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",

--- a/tests/tools/test_terminal_config_env_sync.py
+++ b/tests/tools/test_terminal_config_env_sync.py
@@ -301,3 +301,20 @@ def test_docker_forward_env_is_bridged_everywhere():
     assert "docker_forward_env" in _gateway_env_map_keys()
     assert "docker_forward_env" in _save_config_env_sync_keys()
     assert "TERMINAL_DOCKER_FORWARD_ENV" in _terminal_tool_env_var_names()
+
+
+def test_docker_extra_args_is_bridged_everywhere():
+    """Regression pin for ``terminal.docker_extra_args`` being silently ignored.
+
+    ``terminal.docker_extra_args`` in config.yaml specifies extra flags passed
+    verbatim to ``docker run`` (e.g. ``--gpus=all``).  The key was present in
+    terminal_tool._get_env_config (via _parse_env_var) and in
+    TERMINAL_CONFIG_ENV_MAP (hermes_cli/config.py), but missing from both
+    cli.py's env_mappings and gateway/run.py's _terminal_env_map.  So the
+    value was never bridged to TERMINAL_DOCKER_EXTRA_ARGS at startup, and the
+    flags were silently dropped regardless of what the user set.
+    """
+    assert "docker_extra_args" in _cli_env_map_keys()
+    assert "docker_extra_args" in _gateway_env_map_keys()
+    assert "docker_extra_args" in _save_config_env_sync_keys()
+    assert "TERMINAL_DOCKER_EXTRA_ARGS" in _terminal_tool_env_var_names()


### PR DESCRIPTION
## What does this PR do?

Bridges `terminal.docker_extra_args` from `config.yaml` to the `TERMINAL_DOCKER_EXTRA_ARGS` environment variable in both CLI and gateway startup paths. Without this, flags like `--gpus=all` were silently dropped.

## Related Issue

Fixes #45129

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py`: Add `docker_extra_args` → `TERMINAL_DOCKER_EXTRA_ARGS` to `env_mappings` dict so CLI-mode startup bridges the config value to the env var
- `gateway/run.py`: Add `docker_extra_args` → `TERMINAL_DOCKER_EXTRA_ARGS` to `_terminal_env_map` dict so gateway-mode startup bridges the config value to the env var
- `tests/tools/test_terminal_config_env_sync.py`: Add `test_docker_extra_args_is_bridged_everywhere()` regression test asserting all four bridge points (cli, gateway, config-set, terminal_tool consumer) are wired

## How to Test

1. Set `terminal.docker_extra_args: ["--gpus=all"]` in `config.yaml`
2. Start the gateway: `hermes gateway run --replace`
3. Create a Docker sandbox session and verify the container has GPU access: `docker inspect <container> | grep -A5 DeviceRequests`
4. Run the regression tests: `pytest tests/tools/test_terminal_config_env_sync.py -v`
5. Verify `test_docker_extra_args_is_bridged_everywhere` passes

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/run.py` `_terminal_env_map` (callers: 1, module-level dict consumed by config bridge loop at line 1047)
- Analyzed: `cli.py` `env_mappings` (callers: 1, local dict in `load_cli_config()` consumed by bridge loop at line 625)
- Blast radius: LOW — adds one key to two existing dicts, no control-flow changes
- Related patterns: Same bug class as `docker_run_as_host_user` (#18574), `docker_mount_cwd_to_workspace` (#20537), `docker_env` — all previously fixed instances of config keys missing from bridge maps
