### PR TITLE
fix(agent): credential-pool recovery for custom providers (custom vs custom:<name> mismatch)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -618,12 +618,33 @@ def recover_with_credential_pool(
     current_provider = (getattr(agent, "provider", "") or "").strip().lower()
     pool_provider = (getattr(pool, "provider", "") or "").strip().lower()
     if current_provider and pool_provider and current_provider != pool_provider:
-        _ra().logger.warning(
-            "Credential pool provider mismatch: pool=%s, agent=%s — "
-            "skipping pool mutation to avoid cross-provider contamination",
-            pool_provider, current_provider,
-        )
-        return False, has_retried_429
+        # Custom endpoints use two naming conventions for the SAME provider:
+        # the agent carries the generic ``custom`` label while the pool is
+        # keyed ``custom:<name>`` (see CUSTOM_POOL_PREFIX). A literal string
+        # compare treats them as a mismatch and skips recovery for every
+        # custom-provider user — 401s/429s then burn the full retry cycle
+        # with no rotation or refresh. Accept the pair as matching only when
+        # the agent's CURRENT base_url actually resolves to this pool key,
+        # so a fallback provider (or a different custom endpoint) still
+        # triggers the guard.
+        _custom_match = False
+        if current_provider == "custom" and pool_provider.startswith("custom:"):
+            try:
+                from agent.credential_pool import get_custom_provider_pool_key
+                _agent_base = (getattr(agent, "base_url", "") or "").strip()
+                _custom_match = bool(_agent_base) and (
+                    (get_custom_provider_pool_key(_agent_base) or "").strip().lower()
+                    == pool_provider
+                )
+            except Exception:
+                _custom_match = False
+        if not _custom_match:
+            _ra().logger.warning(
+                "Credential pool provider mismatch: pool=%s, agent=%s — "
+                "skipping pool mutation to avoid cross-provider contamination",
+                pool_provider, current_provider,
+            )
+            return False, has_retried_429
 
     effective_reason = classified_reason
     if effective_reason is None:

--- a/tests/agent/test_custom_pool_mismatch_guard.py
+++ b/tests/agent/test_custom_pool_mismatch_guard.py
@@ -1,0 +1,103 @@
+"""Regression tests for the credential-pool provider-mismatch guard with
+custom providers (Bernard's Fireworks report, June 2026).
+
+Custom endpoints carry two naming conventions for the same provider: the
+agent's ``provider`` attribute is the generic ``"custom"`` label while the
+pool is keyed ``custom:<normalized-name>`` (``CUSTOM_POOL_PREFIX``).  The
+defensive guard in ``recover_with_credential_pool`` compared the two
+literally, logged "Credential pool provider mismatch: pool=custom:<name>,
+agent=custom", and skipped recovery — so 401/429 recovery (refresh,
+rotation) never ran for ANY custom-provider user.
+
+The fix accepts the pair only when the agent's current base_url resolves to
+the same pool key, preserving the guard's original purpose (#33088/#33163:
+never mutate the primary's pool while a fallback provider is active).
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.agent_runtime_helpers import recover_with_credential_pool
+from agent.error_classifier import FailoverReason
+
+
+FIREWORKS_URL = "https://api.fireworks.ai/inference/v1"
+
+
+def _agent(provider, base_url, pool_provider):
+    agent = MagicMock()
+    agent.provider = provider
+    agent.base_url = base_url
+    pool = MagicMock()
+    pool.provider = pool_provider
+    agent._credential_pool = pool
+    return agent, pool
+
+
+class TestCustomPoolMismatchGuard:
+    def test_matching_custom_pool_reaches_recovery(self):
+        """agent=custom + pool=custom:<name> whose base_url matches must NOT
+        be treated as a cross-provider mismatch."""
+        agent, pool = _agent("custom", FIREWORKS_URL, "custom:fireworks")
+        # Rate-limit path deterministically calls pool.current() once past
+        # the guard (the auth path consults agent._is_entitlement_failure,
+        # which a MagicMock would answer truthily).
+        pool.current.return_value = None
+        with patch(
+            "agent.credential_pool.get_custom_provider_pool_key",
+            return_value="custom:fireworks",
+        ):
+            recover_with_credential_pool(
+                agent,
+                status_code=429,
+                has_retried_429=False,
+                classified_reason=FailoverReason.rate_limit,
+            )
+        assert pool.current.called, (
+            "guard short-circuited: pool never touched despite matching "
+            "custom base_url"
+        )
+
+    def test_unrelated_custom_pool_still_guarded(self):
+        """agent=custom pointed at a DIFFERENT endpoint than the pool's
+        custom provider must still skip pool mutation."""
+        agent, pool = _agent(
+            "custom", "https://other-endpoint.example/v1", "custom:fireworks"
+        )
+        with patch(
+            "agent.credential_pool.get_custom_provider_pool_key",
+            return_value="custom:other",
+        ):
+            recovered, _ = recover_with_credential_pool(
+                agent,
+                status_code=401,
+                has_retried_429=False,
+                classified_reason=FailoverReason.auth,
+            )
+        assert recovered is False
+        assert not pool.method_calls
+
+    def test_fallback_provider_still_guarded(self):
+        """Original #33088/#33163 contract: when a fallback provider is
+        active (agent.provider != pool.provider, non-custom), the pool is
+        never mutated."""
+        agent, pool = _agent("openai-codex", "https://chatgpt.com/backend-api", "custom:fireworks")
+        recovered, _ = recover_with_credential_pool(
+            agent,
+            status_code=401,
+            has_retried_429=False,
+            classified_reason=FailoverReason.auth,
+        )
+        assert recovered is False
+        assert not pool.method_calls
+
+    def test_plain_provider_mismatch_still_guarded(self):
+        agent, pool = _agent("openrouter", "https://openrouter.ai/api/v1", "anthropic")
+        recovered, _ = recover_with_credential_pool(
+            agent,
+            status_code=429,
+            has_retried_429=False,
+            classified_reason=FailoverReason.rate_limit,
+        )
+        assert recovered is False
+        assert not pool.method_calls


### PR DESCRIPTION
## Summary
Credential-pool recovery (401 refresh, 429 rotation) now actually runs for custom-provider users: the provider-mismatch guard no longer treats `agent=custom` vs `pool=custom:<name>` — two naming conventions for the same provider — as cross-provider contamination.

Root cause (field report, Fireworks setup): every error logged `Credential pool provider mismatch: pool=custom:api.fireworks.ai, agent=custom — skipping pool mutation`, so a dead key burned the full retry cycle every turn with no rotation or refresh attempt.

## Changes
- `agent/agent_runtime_helpers.py`: when `agent.provider == "custom"` and the pool key has the `custom:` prefix, accept the pair iff the agent's CURRENT `base_url` resolves to that exact pool key via `get_custom_provider_pool_key()` — the guard's original purpose (#33088/#33163: never mutate the primary's pool while a fallback provider is active) is preserved for fallbacks and for different custom endpoints
- `tests/agent/test_custom_pool_mismatch_guard.py`: 4 tests — matching custom endpoint reaches recovery; different custom endpoint still guarded; active fallback provider still guarded; plain provider mismatch still guarded

## Validation
| | Before | After |
|---|---|---|
| custom provider, 401/429 | guard skips → full retry burn, no recovery | refresh/rotation path runs |
| fallback provider active | guarded | guarded (unchanged) |
| different custom endpoint than pool | n/a (same skip) | guarded |
| pool + fallback-isolation + provider-fallback suites | — | 111 passed |

## Infographic

![custom-pool-guard](https://v3b.fal.media/files/b/0a9e0fbb/aj5AjC31eSiXQBApETmw__k9OX3thD.png)
