### PR TITLE
feat(security): deny writes to secondary shell startup files and global git config (Claude Code v2.1.160-inspired)

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -51,6 +51,10 @@ def build_write_denied_paths(home: str) -> set[str]:
             os.path.join(home, ".profile"),
             os.path.join(home, ".bash_profile"),
             os.path.join(home, ".zprofile"),
+            os.path.join(home, ".zshenv"),
+            os.path.join(home, ".zlogin"),
+            os.path.join(home, ".bash_login"),
+            os.path.join(home, ".gitconfig"),
             os.path.join(home, ".netrc"),
             os.path.join(home, ".pgpass"),
             os.path.join(home, ".npmrc"),
@@ -78,6 +82,7 @@ def build_write_denied_prefixes(home: str) -> list[str]:
             os.path.join(home, ".azure"),
             os.path.join(home, ".config", "gh"),
             os.path.join(home, ".config", "gcloud"),
+            os.path.join(home, ".config", "git"),
         ]
     ]
 

--- a/tests/tools/test_write_deny.py
+++ b/tests/tools/test_write_deny.py
@@ -69,8 +69,23 @@ class TestWriteDenyExactPaths:
 
     def test_shell_profiles(self):
         home = str(Path.home())
-        for name in [".bashrc", ".zshrc", ".profile", ".bash_profile", ".zprofile"]:
+        for name in [
+            ".bashrc", ".zshrc", ".profile", ".bash_profile", ".zprofile",
+            ".zshenv", ".zlogin", ".bash_login",
+        ]:
             assert _is_write_denied(os.path.join(home, name)) is True, f"{name} should be denied"
+
+    def test_global_git_config_paths(self):
+        home = str(Path.home())
+        for path in [
+            os.path.join(home, ".gitconfig"),
+            os.path.join(home, ".config", "git", "config"),
+            os.path.join(home, ".config", "git", "hooks", "pre-commit"),
+        ]:
+            assert _is_write_denied(path) is True, f"{path} should be denied"
+
+    def test_project_git_config_allowed(self):
+        assert _is_write_denied("/tmp/someproject/.git/config") is False
 
     def test_package_manager_configs(self):
         home = str(Path.home())

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -252,7 +252,7 @@ THREAT_PATTERNS = [
     (r'\bcrontab\b',
      "persistence_cron", "medium", "persistence",
      "modifies cron jobs"),
-    (r'\.(bashrc|zshrc|profile|bash_profile|bash_login|zprofile|zlogin)\b',
+    (r'\.(bashrc|zshrc|zshenv|profile|bash_profile|bash_login|zprofile|zlogin)\b',
      "shell_rc_mod", "medium", "persistence",
      "references shell startup file"),
     (r'authorized_keys',


### PR DESCRIPTION
## Summary
Writes to secondary shell startup files (`~/.zshenv`, `~/.zlogin`, `~/.bash_login`) and global git config (`~/.gitconfig`, `~/.config/git/`) are now denied by the shared file-safety layer — closing the same persistence/code-execution gap Claude Code patched in v2.1.160.

## Source
Claude Code changelog v2.1.160–2.1.161 (Jun 2, 2026): "Security: prompt before writing shell startup files (`.zshenv`, `.bash_login`) and `~/.config/git/`" — https://code.claude.com/docs/en/changelog

## How our implementation differs
| | Claude Code | hermes-agent |
|---|---|---|
| Mechanism | Permission prompt before write | Hard deny in the shared write denylist (`agent/file_safety.py`), consistent with our existing `.bashrc`/`.zshrc` handling |
| Scope | Startup files + `~/.config/git/` | Same, plus `~/.gitconfig` (classic location) and `~/.zlogin` |
| Project-local `.git/config` | n/a | Intentionally NOT denied — legit workflow target (verified by test) |

Why hard-deny instead of prompt: hermes already hard-denies the primary startup files (`.bashrc`, `.zshrc`, `.profile`, ...) via `build_write_denied_paths()`; the new entries are the same vector through less common files, so they get the same treatment. As documented in `file_safety.py`, this is defense-in-depth, not a security boundary — the terminal tool can still touch these with explicit shell commands (which go through dangerous-command approval).

## Changes
- `agent/file_safety.py`: +4 exact deny paths (`.zshenv`, `.zlogin`, `.bash_login`, `.gitconfig`), +1 prefix deny (`~/.config/git/`)
- `tools/skills_guard.py`: `zshenv` added to the `shell_rc_mod` persistence regex
- `tests/tools/test_write_deny.py`: new paths covered + project-local `.git/config` stays writable

## Validation
| Check | Result |
|---|---|
| `tests/tools/test_write_deny.py` + 4 sibling file-safety test files | 100 passed |
| E2E (`write_file_tool` with real imports, isolated `HERMES_HOME`) | all 6 new paths denied, pre-existing file contents untouched; legit writes + project `.git/config` still work |
