### PR TITLE
fix(cron): pass target_model to resolve_runtime_provider in run_job

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1655,6 +1655,14 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             runtime_kwargs = {
                 "requested": job.get("provider"),
             }
+            # Pass target_model so the resolver computes api_mode from
+            # the model the job will actually use, not from model.default.
+            # Without this, a cron job pinned to a chat-completions model
+            # (e.g. deepseek-v4-flash) inherits the api_mode of model.default
+            # when that default happens to be an anthropic-routed model on
+            # the same provider.  (#45245)
+            if model:
+                runtime_kwargs["target_model"] = model
             if job.get("base_url"):
                 runtime_kwargs["explicit_base_url"] = job.get("base_url")
             runtime = resolve_runtime_provider(**runtime_kwargs)
@@ -1669,6 +1677,8 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                     continue
                 try:
                     fb_kwargs = {"requested": entry.get("provider")}
+                    if model:
+                        fb_kwargs["target_model"] = model
                     if entry.get("base_url"):
                         fb_kwargs["explicit_base_url"] = entry["base_url"]
                     if entry.get("api_key"):

--- a/tests/cron/test_codex_execution_paths.py
+++ b/tests/cron/test_codex_execution_paths.py
@@ -98,7 +98,7 @@ def test_cron_run_job_codex_path_handles_internal_401_refresh(monkeypatch):
     monkeypatch.setattr(run_agent, "AIAgent", _Codex401ThenSuccessAgent)
     monkeypatch.setattr(
         "hermes_cli.runtime_provider.resolve_runtime_provider",
-        lambda requested=None: {
+        lambda requested=None, **_kw: {
             "provider": "openai-codex",
             "api_mode": "codex_responses",
             "base_url": "https://chatgpt.com/backend-api/codex",

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1873,6 +1873,93 @@ class TestRunJobSkillBacked:
         assert "Instructions for maps." in prompt_arg
         assert "Combine the results." in prompt_arg
 
+    def test_run_job_passes_target_model_to_resolve_runtime_provider(
+        self, tmp_path
+    ):
+        """Cron job's model must drive api_mode via target_model (#45245).
+
+        When model.default is an anthropic-routed model (e.g. minimax-m3)
+        on the same provider as the job, the resolver would otherwise derive
+        api_mode from the config default instead of the job's own model.
+        """
+        job = {
+            "id": "target-model-job",
+            "name": "test",
+            "prompt": "hello",
+            "model": "deepseek-v4-flash",
+            "provider": "opencode-go",
+        }
+
+        captured_kwargs = {}
+
+        def _capture_resolve(**kwargs):
+            captured_kwargs.update(kwargs)
+            return {
+                "api_key": "test-key",
+                "base_url": "https://example.invalid/v1",
+                "provider": "opencode-go",
+                "api_mode": "chat_completions",
+            }
+
+        fake_db = MagicMock()
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 side_effect=_capture_resolve,
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            run_job(job)
+
+        assert captured_kwargs.get("target_model") == "deepseek-v4-flash"
+        assert captured_kwargs.get("requested") == "opencode-go"
+
+    def test_run_job_omits_target_model_when_job_has_no_model(self, tmp_path):
+        """When the job has no model, target_model must not be passed.
+
+        The resolver should fall back to model.default in that case.
+        """
+        job = {
+            "id": "no-model-job",
+            "name": "test",
+            "prompt": "hello",
+            "provider": "openrouter",
+        }
+
+        captured_kwargs = {}
+
+        def _capture_resolve(**kwargs):
+            captured_kwargs.update(kwargs)
+            return {
+                "api_key": "test-key",
+                "base_url": "https://example.invalid/v1",
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+            }
+
+        fake_db = MagicMock()
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 side_effect=_capture_resolve,
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            run_job(job)
+
+        assert "target_model" not in captured_kwargs
+        assert captured_kwargs.get("requested") == "openrouter"
+
 
 class TestSilentDelivery:
     """Verify that [SILENT] responses suppress delivery while still saving output."""


### PR DESCRIPTION
## What does this PR do?

Passes `target_model` from the cron job's config to `resolve_runtime_provider()` in `run_job()`, so the resolver computes `api_mode` and `base_url` from the model the job will actually use — not from `model.default`.

## Related Issue

Fixes #45245

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py`: Add `target_model=model` to `runtime_kwargs` and `fb_kwargs` when the job specifies a model, so `resolve_runtime_provider()` derives `api_mode` from the job's model instead of the config default
- `tests/cron/test_scheduler.py`: Two regression tests verifying `target_model` is passed when the job has a model, and omitted when it doesn't

## How to Test

1. Set `model.default` to an anthropic-routed model (e.g. `minimax-m3`) on a provider like `opencode-go`
2. Create a cron job pinned to a chat-completions model: `hermes cron create --name repro --model deepseek-v4-flash --provider opencode-go --schedule "*/5 * * * *" --prompt "say hi"`
3. Wait for a tick — the job should now resolve with `api_mode=chat_completions` instead of `anthropic_messages`
4. Run `pytest tests/cron/test_scheduler.py::TestRunJobSkillBacked::test_run_job_passes_target_model_to_resolve_runtime_provider tests/cron/test_scheduler.py::TestRunJobSkillBacked::test_run_job_omits_target_model_when_job_has_no_model -xvs`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `cron/scheduler.py:run_job()` → `hermes_cli/runtime_provider.py:resolve_runtime_provider()`
- Blast radius: LOW — cron job execution path only, no impact on CLI/gateway agent loops
- Related patterns: Same fix class as #18605 (delegate_task target_model) and #45254 (Anthropic OAuth endpoint iteration)
