### PR TITLE
feat(memory): agentic PARA routing and retrieval

### DIFF
--- a/agent/dual_memory.py
+++ b/agent/dual_memory.py
@@ -1,0 +1,466 @@
+"""Dual memory framework: personal workspace plus procedural skills.
+
+This module keeps the two memory classes intentionally separate:
+
+* Personal workspace (W): user-visible markdown knowledge assets organized
+  with a PARA state machine.
+* Procedural memory (S): agent-facing Skill Markdown distilled from repeated
+  successful workflows.
+
+The framework is local-file based and profile scoped through HERMES_HOME. It
+does not register model tools or mutate the system prompt mid-conversation.
+Callers can expose it through CLI commands, cron jobs, or a future background
+memory agent without adding permanent core tool schema footprint.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Literal, Sequence
+
+from hermes_constants import get_hermes_home, get_skills_dir
+
+ParaBucket = Literal["Projects", "Areas", "Resources", "Archives"]
+
+PARA_BUCKETS: tuple[ParaBucket, ...] = ("Projects", "Areas", "Resources", "Archives")
+MANIFEST_NAME = "_manifest.md"
+
+
+def default_workspace_root() -> Path:
+    """Return the default profile-scoped personal workspace root."""
+    return get_hermes_home() / "personal_workspace"
+
+
+def default_procedural_skills_root() -> Path:
+    """Return the default profile-scoped procedural skill root."""
+    return get_skills_dir() / "procedural-memory"
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _slugify(text: str, *, fallback: str = "untitled") -> str:
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", text.strip().lower()).strip("-")
+    return slug or fallback
+
+
+def _tokenize(text: str) -> set[str]:
+    return {t for t in re.findall(r"[a-zA-Z0-9][a-zA-Z0-9_-]{1,}", text.lower())}
+
+
+def _safe_relative_markdown_path(name: str) -> Path:
+    """Return a one-segment markdown filename derived from user/model text."""
+    slug = _slugify(name)
+    return Path(f"{slug}.md")
+
+
+def _frontmatter(data: dict[str, object]) -> str:
+    lines = ["---"]
+    for key, value in data.items():
+        if isinstance(value, list):
+            rendered = "[" + ", ".join(str(v) for v in value) + "]"
+        else:
+            rendered = str(value)
+        lines.append(f"{key}: {rendered}")
+    lines.append("---")
+    return "\n".join(lines)
+
+
+def route_item(title: str, content: str = "", *, status_hint: str = "") -> ParaBucket:
+    """Deterministically route a candidate workspace item into PARA.
+
+    A future memory agent can replace this with an LLM classifier that uses the
+    same output contract. The heuristic keeps the framework testable and useful
+    offline.
+    """
+    haystack = f"{title}\n{content}\n{status_hint}".lower()
+    if re.search(r"\b(done|completed|finished|inactive|archive|archived|retired)\b", haystack):
+        return "Archives"
+    if re.search(r"\b(deadline|due|milestone|ship|launch|deliver|project|sprint|todo|next step)\b", haystack):
+        return "Projects"
+    if re.search(r"\b(ongoing|maintain|responsibility|area|habit|routine|standard|policy)\b", haystack):
+        return "Areas"
+    return "Resources"
+
+
+@dataclass(frozen=True)
+class WorkspaceRecord:
+    """Manifest-level metadata for one personal workspace file."""
+
+    bucket: ParaBucket
+    path: Path
+    title: str
+    summary: str = ""
+    tags: tuple[str, ...] = ()
+    updated_at: str = ""
+
+
+@dataclass(frozen=True)
+class RetrievalResult:
+    """One top-k workspace retrieval result."""
+
+    record: WorkspaceRecord
+    score: int
+    content: str
+
+
+@dataclass
+class WorkspaceItem:
+    """A write candidate produced by a memory agent or CLI call."""
+
+    title: str
+    content: str
+    bucket: ParaBucket | None = None
+    summary: str = ""
+    tags: list[str] = field(default_factory=list)
+    backlinks: list[str] = field(default_factory=list)
+    status_hint: str = ""
+
+
+class PersonalWorkspace:
+    """PARA markdown workspace with manifest-based hierarchical retrieval."""
+
+    def __init__(self, root: Path | None = None):
+        self.root = root or default_workspace_root()
+
+    def initialize(self) -> None:
+        """Create the PARA directory skeleton and manifests."""
+        self.root.mkdir(parents=True, exist_ok=True)
+        for bucket in PARA_BUCKETS:
+            bucket_dir = self.root / bucket
+            bucket_dir.mkdir(parents=True, exist_ok=True)
+            manifest = bucket_dir / MANIFEST_NAME
+            if not manifest.exists():
+                manifest.write_text(self._empty_manifest(bucket), encoding="utf-8")
+
+    def write_item(self, item: WorkspaceItem, *, mode: Literal["new", "append", "update"] = "new") -> Path:
+        """Write a workspace item and refresh the bucket manifest.
+
+        ``new`` creates a unique file when a slug already exists. ``append``
+        appends a dated section to an existing slug. ``update`` replaces the
+        body of the existing slug while preserving the same filename.
+        """
+        if not item.title.strip():
+            raise ValueError("Workspace item title cannot be empty")
+        if not item.content.strip():
+            raise ValueError("Workspace item content cannot be empty")
+
+        self.initialize()
+        bucket = item.bucket or route_item(item.title, item.content, status_hint=item.status_hint)
+        bucket_dir = self.root / bucket
+        rel = _safe_relative_markdown_path(item.title)
+        path = bucket_dir / rel
+        if mode == "new":
+            path = self._unique_path(path)
+
+        now = _utc_now()
+        header = _frontmatter(
+            {
+                "title": item.title.strip(),
+                "bucket": bucket,
+                "summary": item.summary.strip() or self._summarize(item.content),
+                "tags": [t.strip() for t in item.tags if t.strip()],
+                "backlinks": [b.strip() for b in item.backlinks if b.strip()],
+                "updated_at": now,
+                "created_by": "hermes-dual-memory",
+            }
+        )
+        body = item.content.strip() + "\n"
+
+        if mode == "append" and path.exists():
+            with path.open("a", encoding="utf-8") as fh:
+                fh.write(f"\n\n## Update {now}\n\n{body}")
+        else:
+            path.write_text(f"{header}\n\n# {item.title.strip()}\n\n{body}", encoding="utf-8")
+
+        self.rebuild_manifest(bucket)
+        return path
+
+    def read_manifests(self) -> dict[ParaBucket, str]:
+        """Read the four PARA manifests without scanning file bodies."""
+        self.initialize()
+        return {
+            bucket: (self.root / bucket / MANIFEST_NAME).read_text(encoding="utf-8")
+            for bucket in PARA_BUCKETS
+        }
+
+    def retrieve(self, query: str, *, top_k: int = 3, candidate_limit: int = 8) -> list[RetrievalResult]:
+        """Two-stage retrieval using manifests first, then top candidate files."""
+        if top_k <= 0:
+            return []
+        manifests = self.read_manifests()
+        query_terms = _tokenize(query)
+        bucket_scores = [
+            (self._score_text(query_terms, f"{bucket}\n{manifest}"), bucket)
+            for bucket, manifest in manifests.items()
+        ]
+        relevant_buckets = [bucket for score, bucket in sorted(bucket_scores, reverse=True) if score > 0]
+        if not relevant_buckets:
+            relevant_buckets = list(PARA_BUCKETS)
+
+        records: list[WorkspaceRecord] = []
+        for bucket in relevant_buckets:
+            records.extend(self.parse_manifest(bucket, manifests[bucket]))
+
+        ranked_records = sorted(
+            ((self._score_record(query_terms, record), record) for record in records),
+            key=lambda pair: pair[0],
+            reverse=True,
+        )
+        results: list[RetrievalResult] = []
+        for score, record in ranked_records[:candidate_limit]:
+            path = self.root / record.bucket / record.path
+            if not path.exists() or path.name == MANIFEST_NAME:
+                continue
+            try:
+                content = path.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            full_score = score + self._score_text(query_terms, content)
+            if full_score > 0 or not query_terms:
+                results.append(RetrievalResult(record=record, score=full_score, content=content))
+
+        return sorted(results, key=lambda r: r.score, reverse=True)[:top_k]
+
+    def rebuild_manifest(self, bucket: ParaBucket) -> Path:
+        """Rebuild a bucket manifest from markdown files in that bucket."""
+        if bucket not in PARA_BUCKETS:
+            raise ValueError(f"Unknown PARA bucket: {bucket}")
+        bucket_dir = self.root / bucket
+        bucket_dir.mkdir(parents=True, exist_ok=True)
+        records = []
+        for path in sorted(bucket_dir.glob("*.md")):
+            if path.name == MANIFEST_NAME:
+                continue
+            text = path.read_text(encoding="utf-8", errors="replace")
+            meta = self._parse_frontmatter(text)
+            title = str(meta.get("title") or path.stem.replace("-", " ").title())
+            summary = str(meta.get("summary") or self._summarize(text))
+            tags = tuple(str(t).strip() for t in meta.get("tags", []) if str(t).strip())
+            updated = str(meta.get("updated_at") or "")
+            records.append(
+                WorkspaceRecord(
+                    bucket=bucket,
+                    path=Path(path.name),
+                    title=title,
+                    summary=summary,
+                    tags=tags,
+                    updated_at=updated,
+                )
+            )
+        manifest = bucket_dir / MANIFEST_NAME
+        manifest.write_text(self._render_manifest(bucket, records), encoding="utf-8")
+        return manifest
+
+    def parse_manifest(self, bucket: ParaBucket, text: str) -> list[WorkspaceRecord]:
+        """Parse records from a generated manifest."""
+        records: list[WorkspaceRecord] = []
+        for line in text.splitlines():
+            if not line.startswith("- ["):
+                continue
+            match = re.match(
+                r"- \[(?P<title>.*?)\]\((?P<path>.*?)\) - (?P<summary>.*?)(?: \| tags: (?P<tags>.*?))?(?: \| updated: (?P<updated>.*))?$",
+                line,
+            )
+            if not match:
+                continue
+            tags = tuple(
+                t.strip()
+                for t in (match.group("tags") or "").split(",")
+                if t.strip()
+            )
+            records.append(
+                WorkspaceRecord(
+                    bucket=bucket,
+                    path=Path(match.group("path")),
+                    title=match.group("title"),
+                    summary=match.group("summary").strip(),
+                    tags=tags,
+                    updated_at=(match.group("updated") or "").strip(),
+                )
+            )
+        return records
+
+    @staticmethod
+    def _empty_manifest(bucket: ParaBucket) -> str:
+        return (
+            f"# {bucket} Manifest\n\n"
+            "This manifest is the retrieval entry point for this PARA bucket.\n\n"
+            "- Files: none yet\n"
+        )
+
+    @staticmethod
+    def _render_manifest(bucket: ParaBucket, records: Sequence[WorkspaceRecord]) -> str:
+        lines = [
+            f"# {bucket} Manifest",
+            "",
+            "This manifest is the retrieval entry point for this PARA bucket.",
+            "",
+        ]
+        if not records:
+            lines.append("- Files: none yet")
+            return "\n".join(lines) + "\n"
+        for record in records:
+            tags = f" | tags: {', '.join(record.tags)}" if record.tags else ""
+            updated = f" | updated: {record.updated_at}" if record.updated_at else ""
+            lines.append(
+                f"- [{record.title}]({record.path.as_posix()}) - {record.summary}{tags}{updated}"
+            )
+        return "\n".join(lines) + "\n"
+
+    @staticmethod
+    def _summarize(text: str, *, limit: int = 160) -> str:
+        squashed = re.sub(r"\s+", " ", text).strip()
+        return squashed[: limit - 1] + "..." if len(squashed) > limit else squashed
+
+    @staticmethod
+    def _parse_frontmatter(text: str) -> dict[str, object]:
+        if not text.startswith("---\n"):
+            return {}
+        end = text.find("\n---", 4)
+        if end == -1:
+            return {}
+        meta: dict[str, object] = {}
+        for line in text[4:end].splitlines():
+            if ":" not in line:
+                continue
+            key, raw = line.split(":", 1)
+            value = raw.strip()
+            if value.startswith("[") and value.endswith("]"):
+                items = [v.strip() for v in value[1:-1].split(",") if v.strip()]
+                meta[key.strip()] = items
+            else:
+                meta[key.strip()] = value
+        return meta
+
+    @staticmethod
+    def _score_text(query_terms: set[str], text: str) -> int:
+        if not query_terms:
+            return 0
+        terms = _tokenize(text)
+        return len(query_terms & terms)
+
+    def _score_record(self, query_terms: set[str], record: WorkspaceRecord) -> int:
+        weighted = (
+            f"{record.title} {record.title} "
+            f"{record.summary} "
+            f"{' '.join(record.tags)} {' '.join(record.tags)}"
+        )
+        return self._score_text(query_terms, weighted)
+
+    @staticmethod
+    def _unique_path(path: Path) -> Path:
+        if not path.exists():
+            return path
+        stem = path.stem
+        suffix = path.suffix
+        for idx in range(2, 1000):
+            candidate = path.with_name(f"{stem}-{idx}{suffix}")
+            if not candidate.exists():
+                return candidate
+        raise RuntimeError(f"Could not allocate unique path for {path}")
+
+
+@dataclass
+class SkillDraft:
+    """A procedural memory candidate distilled from successful work."""
+
+    name: str
+    description: str
+    triggers: list[str]
+    steps: list[str]
+    constraints: list[str] = field(default_factory=list)
+    recovery: list[str] = field(default_factory=list)
+    source: str = ""
+
+
+class ProceduralMemory:
+    """Write procedural memory as normal Hermes Skill Markdown files."""
+
+    def __init__(self, root: Path | None = None):
+        self.root = root or default_procedural_skills_root()
+
+    def write_skill(self, draft: SkillDraft, *, overwrite: bool = False) -> Path:
+        """Create or update a procedural skill draft."""
+        if not draft.name.strip():
+            raise ValueError("Skill name cannot be empty")
+        if not draft.description.strip():
+            raise ValueError("Skill description cannot be empty")
+        if not draft.triggers:
+            raise ValueError("Skill draft must include at least one trigger")
+        if not draft.steps:
+            raise ValueError("Skill draft must include at least one step")
+
+        slug = _slugify(draft.name)
+        skill_dir = self.root / slug
+        skill_path = skill_dir / "SKILL.md"
+        if skill_path.exists() and not overwrite:
+            raise FileExistsError(f"Procedural skill already exists: {skill_path}")
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        skill_path.write_text(self.render_skill(draft), encoding="utf-8")
+        return skill_path
+
+    @staticmethod
+    def render_skill(draft: SkillDraft) -> str:
+        tags = ["procedural-memory", "agent-distilled"]
+        front = _frontmatter(
+            {
+                "name": _slugify(draft.name),
+                "description": draft.description.strip(),
+                "version": "0.1.0",
+                "author": "Hermes Memory Agent",
+                "platforms": "[linux, macos, windows]",
+                "metadata.hermes.tags": tags,
+                "metadata.hermes.created_by": "agent",
+            }
+        )
+        sections = [
+            front,
+            "",
+            f"# {draft.name.strip()}",
+            "",
+            "## When To Use",
+            "",
+            *[f"- {item.strip()}" for item in draft.triggers if item.strip()],
+            "",
+            "## Procedure",
+            "",
+            *[f"{idx}. {step.strip()}" for idx, step in enumerate(draft.steps, start=1) if step.strip()],
+        ]
+        if draft.constraints:
+            sections.extend(["", "## Constraints", "", *[f"- {c.strip()}" for c in draft.constraints if c.strip()]])
+        if draft.recovery:
+            sections.extend(["", "## Recovery", "", *[f"- {r.strip()}" for r in draft.recovery if r.strip()]])
+        if draft.source.strip():
+            sections.extend(["", "## Provenance", "", draft.source.strip()])
+        return "\n".join(sections).rstrip() + "\n"
+
+
+def filter_workspace_candidate(text: str) -> bool:
+    """Return True when content has durable user-facing knowledge value."""
+    stripped = text.strip()
+    if len(stripped) < 40:
+        return False
+    low = stripped.lower()
+    if re.search(r"\b(thanks|ok|sounds good|temporary|scratch|never mind)\b", low):
+        return False
+    return True
+
+
+def format_retrieval_results(results: Iterable[RetrievalResult]) -> str:
+    """Render retrieval results for CLI output or future context injection."""
+    chunks = []
+    for result in results:
+        record = result.record
+        chunks.append(
+            f"## {record.title}\n"
+            f"- bucket: {record.bucket}\n"
+            f"- path: {record.path.as_posix()}\n"
+            f"- score: {result.score}\n\n"
+            f"{result.content.strip()}"
+        )
+    return "\n\n".join(chunks)

--- a/agent/dual_memory.py
+++ b/agent/dual_memory.py
@@ -1,27 +1,36 @@
 """Dual memory framework: personal workspace plus procedural skills.
 
-This module keeps the two memory classes intentionally separate:
+Two memory classes:
 
 * Personal workspace (W): user-visible markdown knowledge assets organized
-  with a PARA state machine.
+  with a PARA state machine (Projects / Areas / Resources / Archives).
 * Procedural memory (S): agent-facing Skill Markdown distilled from repeated
   successful workflows.
 
-The framework is local-file based and profile scoped through HERMES_HOME. It
-does not register model tools or mutate the system prompt mid-conversation.
-Callers can expose it through CLI commands, cron jobs, or a future background
-memory agent without adding permanent core tool schema footprint.
+Agentic layer (requires an LLMCallable):
+
+* ``agentic_route``  — LLM reads manifests and classifies a new item.
+* ``agentic_retrieve`` — LLM reads manifests, selects files, returns results.
+* ``extract_knowledge_items`` — LLM extracts durable knowledge from a session.
+* ``ingest_session`` — full pipeline: extract → route → write.
+* ``make_llm_fn`` — builds an LLMCallable from the hermes config.
+
+The framework is local-file based and profile-scoped through HERMES_HOME.
 """
 
 from __future__ import annotations
 
+import logging
+import os
 import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable, Literal, Sequence
+from typing import Callable, Iterable, Literal, Optional, Sequence
 
 from hermes_constants import get_hermes_home, get_skills_dir
+
+logger = logging.getLogger(__name__)
 
 ParaBucket = Literal["Projects", "Areas", "Resources", "Archives"]
 
@@ -464,3 +473,458 @@ def format_retrieval_results(results: Iterable[RetrievalResult]) -> str:
             f"{result.content.strip()}"
         )
     return "\n\n".join(chunks)
+
+
+# ---------------------------------------------------------------------------
+# Agentic layer — LLM-powered routing, retrieval, and knowledge extraction
+# ---------------------------------------------------------------------------
+
+# ``(system_prompt, messages) -> response_text``
+LLMCallable = Callable[[str, list[dict]], str]
+
+_DEFAULT_MEMORY_MODEL = "google/gemini-2.5-flash-lite"
+
+
+def make_llm_fn(
+    model: Optional[str] = None,
+    api_key: Optional[str] = None,
+    base_url: Optional[str] = None,
+) -> LLMCallable:
+    """Return an LLMCallable backed by the hermes model config.
+
+    Resolution order per parameter:
+    1. Explicit argument
+    2. ``~/.hermes/config.yaml`` model section
+    3. Environment variables (``OPENROUTER_API_KEY``, ``OPENAI_API_KEY``)
+    """
+    # Pull ~/.hermes/.env into os.environ so API keys are visible
+    try:
+        from hermes_cli.config import reload_env
+        reload_env()
+    except Exception:
+        pass
+
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config().get("model", {})
+    except Exception:
+        cfg = {}
+
+    resolved_base_url = (
+        base_url
+        or cfg.get("base_url")
+        or os.environ.get("OPENAI_BASE_URL")
+        or "https://openrouter.ai/api/v1"
+    )
+    resolved_api_key = (
+        api_key
+        or cfg.get("api_key")
+        or os.environ.get("OPENROUTER_API_KEY")
+        or os.environ.get("OPENAI_API_KEY")
+        or "no-key"
+    )
+    resolved_model = model or cfg.get("model") or _DEFAULT_MEMORY_MODEL
+
+    from openai import OpenAI  # type: ignore[import-untyped]
+    client = OpenAI(base_url=resolved_base_url, api_key=resolved_api_key)
+
+    def _call(system: str, messages: list[dict]) -> str:
+        full_messages = [{"role": "system", "content": system}] + messages
+        response = client.chat.completions.create(
+            model=resolved_model,
+            max_tokens=4096,
+            messages=full_messages,
+        )
+        return response.choices[0].message.content or ""
+
+    return _call
+
+
+# ── Prompts ─────────────────────────────────────────────────────────────────
+
+_ROUTE_SYSTEM = """\
+You are a personal knowledge management expert applying the PARA method.
+Classify a new item into exactly one bucket.
+
+PARA definitions:
+
+Projects  — Active work toward a specific, bounded outcome with a deadline or
+            clear end state requiring action now.
+            Examples: "Implement PPO for CartPole (due Friday)", "Write Chapter 3".
+
+Areas     — Ongoing domains of mastery or responsibility with no fixed end date.
+            Knowledge you continuously maintain and develop.
+            Examples: "Reinforcement Learning study notes", "Python practices".
+
+Resources — Reference material that stands on its own; useful to retrieve later
+            regardless of any active project. Concepts, algorithms, comparisons.
+            Examples: "Policy Gradient derivation", "Off-policy RL comparison".
+
+Archives  — Inactive, completed, or paused items.
+            Examples: "Completed: RL Homework 4", "Retired fitness tracker".
+
+Priority (apply in order):
+1. Completion/inactivity signals (done, finished, archived) → Archives
+2. Specific goal + deadline or next-action required → Projects
+3. Ongoing learning domain / living knowledge base → Areas
+4. Standalone concept, technique, or reference → Resources
+"""
+
+_ROUTE_USER_TMPL = """\
+## Current Workspace Manifests
+
+### Projects
+{projects}
+
+### Areas
+{areas}
+
+### Resources
+{resources}
+
+### Archives
+{archives}
+
+---
+## Item to Classify
+
+**Title**: {title}
+
+**Content preview** (first 600 chars):
+{content_excerpt}
+
+---
+Respond in EXACTLY this format (two lines only):
+
+BUCKET: <Projects | Areas | Resources | Archives>
+REASON: <one sentence>
+
+Note: The user is taking a RL class now. So, RL related notes are likely to be in the RL folder under Projects.
+"""
+
+_RETRIEVE_SYSTEM = """\
+You are a personal knowledge retrieval assistant.
+Given a query and four PARA workspace manifests, select the files most likely
+to answer the query. Be selective — choose only genuinely relevant files.
+"""
+
+_RETRIEVE_USER_TMPL = """\
+## Query
+{query}
+
+## Manifests
+
+### Projects
+{projects}
+
+### Areas
+{areas}
+
+### Resources
+{resources}
+
+### Archives
+{archives}
+
+---
+List up to {top_k} files, most relevant first.
+Only list files that appear in the manifests above.
+
+Respond in EXACTLY this format:
+
+RELEVANCE: <one sentence on what you expect to find>
+FILES:
+- <Bucket>/<filename.md>
+- <Bucket>/<filename.md>
+
+If nothing is relevant write: FILES: none
+"""
+
+_EXTRACT_SYSTEM = """\
+You are a personal knowledge distillation expert.
+Read a conversation and extract items with DURABLE EPISTEMIC VALUE worth
+keeping in a PARA workspace.
+
+Extract when the content is:
+- A conceptual explanation of an algorithm, method, or theorem
+- A technical derivation or proof worth referencing later
+- A comparison or trade-off analysis between approaches
+- A decision with rationale that shapes future study or work
+
+Do NOT extract:
+- Task completion records ("I finished X")
+- Transient requests or clarifying questions
+- Conversational filler
+- Raw tool outputs (unless they contain standalone durable knowledge)
+
+For each item output this block, then a line with only ---:
+
+TITLE: <concise, search-friendly title, ≤10 words>
+BUCKET: <Projects | Areas | Resources | Archives>
+TAGS: <3–5 comma-separated lowercase tags>
+SUMMARY: <1–2 sentences>
+CONTENT:
+<cleaned-up, self-contained markdown; rewrite for standalone readability>
+---
+"""
+
+_EXTRACT_USER_TMPL = """\
+Extract all durable knowledge items from the session below.
+If there are none, respond with exactly: NO_ITEMS
+
+Session:
+---
+{session_text}
+---
+"""
+
+
+# ── Routing ──────────────────────────────────────────────────────────────────
+
+def agentic_route(
+    item: WorkspaceItem,
+    workspace: PersonalWorkspace,
+    llm_fn: LLMCallable,
+) -> ParaBucket:
+    """Ask the LLM to classify ``item`` into a PARA bucket.
+
+    The LLM receives all four manifests so it classifies consistently with
+    the existing taxonomy.  Raises ``ValueError`` if the response cannot be
+    parsed into a valid bucket.
+    """
+    manifests = workspace.read_manifests()
+    prompt = _ROUTE_USER_TMPL.format(
+        projects=manifests["Projects"].strip(),
+        areas=manifests["Areas"].strip(),
+        resources=manifests["Resources"].strip(),
+        archives=manifests["Archives"].strip(),
+        title=item.title.strip(),
+        content_excerpt=item.content.strip()[:600],
+    )
+    response = llm_fn(_ROUTE_SYSTEM, [{"role": "user", "content": prompt}])
+    bucket = _parse_bucket(response)
+    if bucket is None:
+        raise ValueError(
+            f"agentic_route: LLM returned unparseable bucket for {item.title!r}.\n"
+            f"Raw response:\n{response}"
+        )
+    reason = _parse_reason(response)
+    logger.info("agentic_route: %r → %s  (%s)", item.title, bucket, reason)
+    return bucket
+
+
+# ── Retrieval ────────────────────────────────────────────────────────────────
+
+def agentic_retrieve(
+    query: str,
+    workspace: PersonalWorkspace,
+    llm_fn: LLMCallable,
+    *,
+    top_k: int = 3,
+) -> list[RetrievalResult]:
+    """LLM-driven two-step retrieval: manifest scan → file selection → read.
+
+    Step 1 — LLM reads all four manifests and names which files to read.
+    Step 2 — Those files are loaded and returned as ``RetrievalResult`` objects
+             in the LLM's ranked order (most relevant first).
+
+    Raises ``ValueError`` if the LLM selects no files or names files that do
+    not exist in the workspace.
+    """
+    workspace.initialize()
+    manifests = workspace.read_manifests()
+    prompt = _RETRIEVE_USER_TMPL.format(
+        query=query.strip(),
+        projects=manifests["Projects"].strip(),
+        areas=manifests["Areas"].strip(),
+        resources=manifests["Resources"].strip(),
+        archives=manifests["Archives"].strip(),
+        top_k=top_k * 2,
+    )
+    response = llm_fn(_RETRIEVE_SYSTEM, [{"role": "user", "content": prompt}])
+    selected = _parse_file_list(response)
+
+    relevance = _parse_relevance(response)
+    logger.info("agentic_retrieve: query=%r  relevance=%s  files=%s", query, relevance, selected)
+
+    if not selected:
+        raise ValueError(
+            f"agentic_retrieve: LLM selected no files for query {query!r}.\n"
+            f"Raw response:\n{response}"
+        )
+
+    results: list[RetrievalResult] = []
+    missing: list[str] = []
+    for bucket, filename in selected[:top_k]:
+        file_path = workspace.root / bucket / filename
+        if not file_path.exists() or file_path.name == MANIFEST_NAME:
+            missing.append(f"{bucket}/{filename}")
+            continue
+        content = file_path.read_text(encoding="utf-8")
+        record = WorkspaceRecord(
+            bucket=bucket,  # type: ignore[arg-type]
+            path=Path(filename),
+            title=_extract_title(content, filename),
+            summary=_extract_summary(content),
+        )
+        results.append(RetrievalResult(record=record, score=len(results), content=content))
+
+    if missing:
+        logger.warning("agentic_retrieve: LLM named non-existent files: %s", missing)
+    if not results:
+        raise ValueError(
+            f"agentic_retrieve: none of the LLM-selected files exist in the workspace.\n"
+            f"Selected: {selected}\nMissing: {missing}"
+        )
+    return results
+
+
+# ── Knowledge extraction ─────────────────────────────────────────────────────
+
+def extract_knowledge_items(
+    session_text: str,
+    llm_fn: LLMCallable,
+) -> list[WorkspaceItem]:
+    """Extract durable knowledge items from raw conversation text.
+
+    Returns a list of ``WorkspaceItem`` objects with ``bucket`` pre-assigned.
+    Items that fail the ``filter_workspace_candidate`` quality gate are dropped.
+    Returns an empty list (never raises) when the session has no durable content.
+    """
+    if not session_text.strip():
+        return []
+    prompt = _EXTRACT_USER_TMPL.format(session_text=session_text.strip())
+    response = llm_fn(_EXTRACT_SYSTEM, [{"role": "user", "content": prompt}])
+    if "NO_ITEMS" in response.upper():
+        logger.info("extract_knowledge_items: no durable items in session")
+        return []
+    items = _parse_item_blocks(response)
+    logger.info("extract_knowledge_items: extracted %d item(s)", len(items))
+    for item in items:
+        logger.info("  · [%s] %s", item.bucket or "?", item.title)
+    return items
+
+
+def ingest_session(
+    session_text: str,
+    workspace: PersonalWorkspace,
+    llm_fn: LLMCallable,
+    *,
+    write_mode: Literal["new", "append", "update"] = "new",
+) -> list[Path]:
+    """Extract knowledge from ``session_text``, route each item, write to workspace.
+
+    Items with a bucket pre-assigned by the extractor skip a second routing
+    call.  Items without a bucket go through ``agentic_route``.
+
+    Returns the list of paths written.
+    """
+    items = extract_knowledge_items(session_text, llm_fn)
+    if not items:
+        return []
+    workspace.initialize()
+    written: list[Path] = []
+    for item in items:
+        if item.bucket is None:
+            item.bucket = agentic_route(item, workspace, llm_fn)
+        path = workspace.write_item(item, mode=write_mode)
+        logger.info("ingest_session: wrote %s  →  %s", item.title, path)
+        written.append(path)
+    return written
+
+
+# ── Parse helpers ────────────────────────────────────────────────────────────
+
+def _parse_bucket(text: str) -> Optional[ParaBucket]:
+    m = re.search(r"BUCKET\s*:\s*(Projects|Areas|Resources|Archives)", text, re.IGNORECASE)
+    if not m:
+        return None
+    raw = m.group(1).strip()
+    for b in PARA_BUCKETS:
+        if b.lower() == raw.lower():
+            return b  # type: ignore[return-value]
+    return None
+
+
+def _parse_reason(text: str) -> str:
+    m = re.search(r"REASON\s*:\s*(.+)", text)
+    return m.group(1).strip() if m else ""
+
+
+def _parse_relevance(text: str) -> str:
+    m = re.search(r"RELEVANCE\s*:\s*(.+)", text)
+    return m.group(1).strip() if m else ""
+
+
+def _parse_file_list(text: str) -> list[tuple[str, str]]:
+    """Parse ``FILES:\\n- Bucket/file.md`` lines from an LLM response."""
+    results: list[tuple[str, str]] = []
+    in_files = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.upper().startswith("FILES:"):
+            rest = stripped.split(":", 1)[1].strip()
+            if rest.lower() == "none":
+                return []
+            in_files = True
+            continue
+        if in_files and stripped.startswith("-"):
+            entry = stripped.lstrip("- ").strip()
+            if "/" in entry:
+                bucket_raw, filename = entry.split("/", 1)
+                for b in PARA_BUCKETS:
+                    if b.lower() == bucket_raw.strip().lower():
+                        results.append((b, filename.strip()))
+                        break
+        elif in_files and stripped and not stripped.startswith("-"):
+            break
+    return results
+
+
+def _parse_item_blocks(text: str) -> list[WorkspaceItem]:
+    items: list[WorkspaceItem] = []
+    for block in re.split(r"\n---\n", text):
+        block = block.strip()
+        if not block:
+            continue
+        item = _parse_single_block(block)
+        if item is not None and filter_workspace_candidate(item.content):
+            items.append(item)
+    return items
+
+
+def _parse_single_block(block: str) -> Optional[WorkspaceItem]:
+    title_m = re.search(r"^TITLE:\s*(.+)$", block, re.MULTILINE)
+    bucket_m = re.search(r"^BUCKET:\s*(Projects|Areas|Resources|Archives)", block, re.MULTILINE | re.IGNORECASE)
+    tags_m = re.search(r"^TAGS:\s*(.+)$", block, re.MULTILINE)
+    summary_m = re.search(r"^SUMMARY:\s*(.+)$", block, re.MULTILINE)
+    content_m = re.search(r"^CONTENT:\s*\n(.*)", block, re.MULTILINE | re.DOTALL)
+    if not title_m or not content_m:
+        return None
+    title = title_m.group(1).strip()
+    content = content_m.group(1).strip()
+    if not title or not content:
+        return None
+    bucket: Optional[ParaBucket] = None
+    if bucket_m:
+        raw = bucket_m.group(1).strip()
+        for b in PARA_BUCKETS:
+            if b.lower() == raw.lower():
+                bucket = b  # type: ignore[assignment]
+                break
+    tags = [t.strip() for t in tags_m.group(1).split(",") if t.strip()] if tags_m else []
+    summary = summary_m.group(1).strip() if summary_m else ""
+    return WorkspaceItem(title=title, content=content, bucket=bucket, summary=summary, tags=tags)
+
+
+def _extract_title(content: str, fallback: str) -> str:
+    for pat in (r'^title:\s*["\']?(.+?)["\']?\s*$', r'^#\s+(.+)$'):
+        m = re.search(pat, content, re.MULTILINE)
+        if m:
+            return m.group(1).strip()
+    return Path(fallback).stem.replace("-", " ").title()
+
+
+def _extract_summary(content: str) -> str:
+    m = re.search(r'^summary:\s*["\']?(.+?)["\']?\s*$', content, re.MULTILINE)
+    return m.group(1).strip() if m else ""

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -499,6 +499,20 @@ memory:
   memory_char_limit: 2200   # ~800 tokens
   user_char_limit: 1375     # ~500 tokens
 
+  # Dual memory framework (off by default):
+  #   W = user-facing PARA markdown workspace
+  #   S = agent-facing procedural Skill Markdown
+  #
+  # Use `hermes memory workspace init` to create:
+  #   ~/.hermes/personal_workspace/{Projects,Areas,Resources,Archives}/_manifest.md
+  #
+  # Use `hermes memory procedural distill ...` to write distilled workflows to:
+  #   ~/.hermes/skills/procedural-memory/<skill>/SKILL.md
+  dual_memory:
+    enabled: false
+    personal_workspace_dir: ""  # empty = ~/.hermes/personal_workspace
+    procedural_skills_dir: ""   # empty = ~/.hermes/skills/procedural-memory
+
   # Periodic memory nudge: remind the agent to consider saving memories
   # every N user turns. Set to 0 to disable. Only active when memory is enabled.
   nudge_interval: 10        # Nudge every 10 user turns (0 = disabled)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1694,6 +1694,15 @@ DEFAULT_CONFIG = {
         # "hindsight", "holographic", "retaindb", "byterover".
         # Only ONE external provider is allowed at a time.
         "provider": "",
+        # Dual memory framework:
+        # - personal_workspace is user-facing PARA markdown (W)
+        # - procedural_skills is agent-facing Skill Markdown (S)
+        # Empty paths use profile-scoped defaults under HERMES_HOME.
+        "dual_memory": {
+            "enabled": False,
+            "personal_workspace_dir": "",
+            "procedural_skills_dir": "",
+        },
     },
 
     # Subagent delegation — override the provider:model used by delegate_task

--- a/hermes_cli/dual_memory.py
+++ b/hermes_cli/dual_memory.py
@@ -1,0 +1,108 @@
+"""CLI helpers for the dual memory framework."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from agent.dual_memory import (
+    PARA_BUCKETS,
+    PersonalWorkspace,
+    ProceduralMemory,
+    SkillDraft,
+    WorkspaceItem,
+    default_procedural_skills_root,
+    default_workspace_root,
+    filter_workspace_candidate,
+    format_retrieval_results,
+)
+
+
+def _read_content(args) -> str:
+    file_value = getattr(args, "file", None)
+    if file_value:
+        return Path(file_value).expanduser().read_text(encoding="utf-8")
+    parts = getattr(args, "content", None) or []
+    if parts:
+        return " ".join(parts)
+    if not sys.stdin.isatty():
+        return sys.stdin.read()
+    return ""
+
+
+def cmd_workspace(args) -> None:
+    """Handle ``hermes memory workspace ...``."""
+    action = getattr(args, "workspace_command", None)
+    workspace = PersonalWorkspace()
+
+    if action == "init":
+        workspace.initialize()
+        print(f"\n  Personal workspace initialized: {default_workspace_root()}\n")
+        return
+
+    if action == "add":
+        content = _read_content(args).strip()
+        if not filter_workspace_candidate(content):
+            print("\n  Skipped: content is too short or too transient for workspace memory.\n")
+            return
+        bucket = getattr(args, "bucket", None) or None
+        if bucket and bucket not in PARA_BUCKETS:
+            print(f"\n  Unknown PARA bucket: {bucket}\n")
+            return
+        item = WorkspaceItem(
+            title=getattr(args, "title", "").strip(),
+            content=content,
+            bucket=bucket,
+            summary=(getattr(args, "summary", "") or "").strip(),
+            tags=list(getattr(args, "tag", []) or []),
+            backlinks=list(getattr(args, "backlink", []) or []),
+            status_hint=(getattr(args, "status_hint", "") or "").strip(),
+        )
+        path = workspace.write_item(item, mode=getattr(args, "mode", "new"))
+        print(f"\n  Wrote workspace item: {path}\n")
+        return
+
+    if action == "search":
+        query = getattr(args, "query", "").strip()
+        results = workspace.retrieve(query, top_k=getattr(args, "top_k", 3))
+        if not results:
+            print("\n  No workspace matches.\n")
+            return
+        print()
+        print(format_retrieval_results(results))
+        print()
+        return
+
+    print("\n  Usage: hermes memory workspace {init,add,search}\n")
+
+
+def cmd_procedural(args) -> None:
+    """Handle ``hermes memory procedural ...``."""
+    action = getattr(args, "procedural_command", None)
+    procedural = ProceduralMemory()
+
+    if action == "distill":
+        steps = list(getattr(args, "step", []) or [])
+        triggers = list(getattr(args, "trigger", []) or [])
+        constraints = list(getattr(args, "constraint", []) or [])
+        recovery = list(getattr(args, "recovery", []) or [])
+        source = _read_content(args).strip()
+        draft = SkillDraft(
+            name=getattr(args, "name", "").strip(),
+            description=getattr(args, "description", "").strip(),
+            triggers=triggers,
+            steps=steps,
+            constraints=constraints,
+            recovery=recovery,
+            source=source,
+        )
+        try:
+            path = procedural.write_skill(draft, overwrite=getattr(args, "overwrite", False))
+        except FileExistsError as exc:
+            print(f"\n  {exc}\n  Re-run with --overwrite to replace it.\n")
+            return
+        print(f"\n  Wrote procedural skill: {path}")
+        print(f"  Skills root: {default_procedural_skills_root()}\n")
+        return
+
+    print("\n  Usage: hermes memory procedural distill ...\n")

--- a/hermes_cli/dual_memory.py
+++ b/hermes_cli/dual_memory.py
@@ -15,6 +15,7 @@ from agent.dual_memory import (
     default_workspace_root,
     filter_workspace_candidate,
     format_retrieval_results,
+    make_llm_fn,
 )
 
 
@@ -28,6 +29,10 @@ def _read_content(args) -> str:
     if not sys.stdin.isatty():
         return sys.stdin.read()
     return ""
+
+
+def _llm_fn(args=None):
+    return make_llm_fn(model=getattr(args, "model", None) or None)
 
 
 def cmd_workspace(args) -> None:
@@ -73,7 +78,46 @@ def cmd_workspace(args) -> None:
         print()
         return
 
-    print("\n  Usage: hermes memory workspace {init,add,search}\n")
+    if action == "agentic-search":
+        from agent.dual_memory import agentic_retrieve
+        query = getattr(args, "query", "").strip()
+        print(f"\n  Searching (agentic): {query!r} …\n")
+        results = agentic_retrieve(query, workspace, _llm_fn(args), top_k=getattr(args, "top_k", 3))
+        if not results:
+            print("  No results.\n")
+            return
+        print(format_retrieval_results(results))
+        print()
+        return
+
+    if action == "seed":
+        from agent.dual_memory import ingest_session
+        seed_dir_str = getattr(args, "seed_dir", None)
+        if not seed_dir_str:
+            print("\n  --seed-dir is required.\n")
+            return
+        seed_dir = Path(seed_dir_str).expanduser()
+        if not seed_dir.is_dir():
+            print(f"\n  Directory not found: {seed_dir}\n")
+            return
+        llm = _llm_fn(args)
+        md_files = sorted(seed_dir.glob("*.md"))
+        if not md_files:
+            print(f"\n  No .md files in {seed_dir}\n")
+            return
+        print(f"\n  Ingesting {len(md_files)} file(s) from {seed_dir}\n")
+        all_written = []
+        for md_file in md_files:
+            print(f"  → {md_file.name}")
+            written = ingest_session(md_file.read_text(encoding="utf-8"), workspace, llm)
+            all_written.extend(written)
+        print(f"\n  Wrote {len(all_written)} item(s) total:")
+        for p in all_written:
+            print(f"    {p}")
+        print()
+        return
+
+    print("\n  Usage: hermes memory workspace {init,add,search,agentic-search,seed}\n")
 
 
 def cmd_procedural(args) -> None:
@@ -106,3 +150,140 @@ def cmd_procedural(args) -> None:
         return
 
     print("\n  Usage: hermes memory procedural distill ...\n")
+
+
+def cmd_agent(args) -> None:
+    """Handle ``hermes memory agent ...``."""
+    action = getattr(args, "agent_command", None)
+
+    if action == "schedule":
+        _agent_schedule(args)
+        return
+
+    if action == "ingest":
+        _agent_ingest(args)
+        return
+
+    print("\n  Usage: hermes memory agent {schedule,ingest}\n")
+
+
+def _agent_schedule(args) -> None:
+    """Register a nightly memory ingestion cron job via hermes cron."""
+    from cron.jobs import create_job, list_jobs
+
+    schedule = getattr(args, "schedule", None) or "0 2 * * *"
+    existing = [j for j in list_jobs() if j.get("name") == "memory-agent-nightly"]
+    if existing and not getattr(args, "force", False):
+        job = existing[0]
+        print(f"\n  Nightly memory agent already scheduled (id: {job['id']}).")
+        print(f"  Schedule: {job.get('schedule_display', schedule)}")
+        print("  Use --force to replace it.\n")
+        return
+
+    job = create_job(
+        prompt=None,
+        schedule=schedule,
+        name="memory-agent-nightly",
+        script="memory_agent_ingest.py",
+        no_agent=True,
+    )
+    _write_ingest_script()
+    print(f"\n  Scheduled nightly memory agent (id: {job['id']})")
+    print(f"  Schedule: {schedule}")
+    print(f"  Script:   ~/.hermes/scripts/memory_agent_ingest.py\n")
+
+
+def _agent_ingest(args) -> None:
+    """Run one-shot knowledge ingestion (seed dir or last N hours from state.db)."""
+    import time
+    from agent.dual_memory import ingest_session
+
+    workspace = PersonalWorkspace()
+    llm = _llm_fn(args)
+
+    seed_dir_str = getattr(args, "seed_dir", None)
+    if seed_dir_str:
+        seed_dir = Path(seed_dir_str).expanduser()
+        md_files = sorted(seed_dir.glob("*.md"))
+        print(f"\n  Ingesting {len(md_files)} seed file(s) …\n")
+        all_written = []
+        for f in md_files:
+            written = ingest_session(f.read_text(encoding="utf-8"), workspace, llm)
+            all_written.extend(written)
+        print(f"  Done — wrote {len(all_written)} item(s)\n")
+        return
+
+    # Production: read from state.db
+    since_hours = float(getattr(args, "since_hours", 24))
+    cutoff = time.time() - since_hours * 3600.0
+    try:
+        from hermes_state import SessionDB
+        db = SessionDB()
+        with db._lock:  # noqa: SLF001
+            rows = db._conn.execute(  # noqa: SLF001
+                "SELECT id, title FROM sessions WHERE started_at >= ? ORDER BY started_at",
+                (cutoff,),
+            ).fetchall()
+    except Exception as exc:
+        print(f"\n  Could not read sessions: {exc}\n")
+        return
+
+    if not rows:
+        print(f"\n  No sessions in the last {since_hours:.0f}h.\n")
+        return
+
+    print(f"\n  Ingesting {len(rows)} session(s) from last {since_hours:.0f}h …\n")
+    all_written = []
+    for row in rows:
+        sid = row[0]
+        messages = db.get_messages(sid)
+        parts = [
+            f"{m['role'].upper()}: {m['content']}"
+            for m in messages
+            if m.get("role") in ("user", "assistant") and isinstance(m.get("content"), str)
+        ]
+        session_text = "\n\n".join(parts)
+        if session_text.strip():
+            written = ingest_session(session_text, workspace, llm)
+            all_written.extend(written)
+
+    print(f"  Done — wrote {len(all_written)} item(s)\n")
+
+
+def _write_ingest_script() -> None:
+    """Write the standalone Python script that the cron job executes."""
+    from hermes_constants import get_hermes_home
+    scripts_dir = get_hermes_home() / "scripts"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    script = scripts_dir / "memory_agent_ingest.py"
+    script.write_text(
+        "#!/usr/bin/env python3\n"
+        '"""Nightly memory agent — run by hermes cron, no agent layer."""\n'
+        "import sys, os\n"
+        "sys.path.insert(0, os.path.expanduser('~/.hermes'))\n"
+        "from agent.dual_memory import PersonalWorkspace, make_llm_fn, ingest_session\n"
+        "from hermes_state import SessionDB\n"
+        "import time\n\n"
+        "workspace = PersonalWorkspace()\n"
+        "llm = make_llm_fn()\n"
+        "db = SessionDB()\n"
+        "cutoff = time.time() - 24 * 3600\n"
+        "with db._lock:\n"
+        "    rows = db._conn.execute(\n"
+        "        'SELECT id FROM sessions WHERE started_at >= ? ORDER BY started_at',\n"
+        "        (cutoff,),\n"
+        "    ).fetchall()\n"
+        "written = []\n"
+        "for (sid,) in rows:\n"
+        "    msgs = db.get_messages(sid)\n"
+        "    text = '\\n\\n'.join(\n"
+        "        f\"{m['role'].upper()}: {m['content']}\"\n"
+        "        for m in msgs\n"
+        "        if m.get('role') in ('user', 'assistant') and isinstance(m.get('content'), str)\n"
+        "    )\n"
+        "    if text.strip():\n"
+        "        written.extend(ingest_session(text, workspace, llm))\n"
+        "print(f'memory-agent-nightly: wrote {len(written)} item(s)')\n",
+        encoding="utf-8",
+    )
+    script.chmod(0o755)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10747,6 +10747,14 @@ def cmd_memory(args):
             f"\n  Memory reset complete. New sessions will start with a blank slate."
         )
         print(f"  Files were in: {display_hermes_home()}/memories/\n")
+    elif sub == "workspace":
+        from hermes_cli.dual_memory import cmd_workspace
+
+        cmd_workspace(args)
+    elif sub == "procedural":
+        from hermes_cli.dual_memory import cmd_procedural
+
+        cmd_procedural(args)
     else:
         from hermes_cli.memory_setup import memory_command
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10755,6 +10755,10 @@ def cmd_memory(args):
         from hermes_cli.dual_memory import cmd_procedural
 
         cmd_procedural(args)
+    elif sub == "agent":
+        from hermes_cli.dual_memory import cmd_agent
+
+        cmd_agent(args)
     else:
         from hermes_cli.memory_setup import memory_command
 

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -468,5 +468,13 @@ def memory_command(args) -> None:
             cmd_setup(args)
     elif sub == "status":
         cmd_status(args)
+    elif sub == "workspace":
+        from hermes_cli.dual_memory import cmd_workspace
+
+        cmd_workspace(args)
+    elif sub == "procedural":
+        from hermes_cli.dual_memory import cmd_procedural
+
+        cmd_procedural(args)
     else:
         cmd_status(args)

--- a/hermes_cli/subcommands/memory.py
+++ b/hermes_cli/subcommands/memory.py
@@ -50,4 +50,52 @@ def build_memory_parser(subparsers, *, cmd_memory: Callable) -> None:
         default="all",
         help="Which store to reset: 'all' (default), 'memory', or 'user'",
     )
+
+    workspace_parser = memory_sub.add_parser(
+        "workspace",
+        help="Manage the user-facing PARA personal workspace",
+        description="Initialize, write, and search the dual-memory personal workspace.",
+    )
+    workspace_sub = workspace_parser.add_subparsers(dest="workspace_command")
+    workspace_sub.add_parser("init", help="Create Projects/Areas/Resources/Archives manifests")
+    workspace_add = workspace_sub.add_parser("add", help="Add a markdown item to the PARA workspace")
+    workspace_add.add_argument("--title", required=True, help="Workspace item title")
+    workspace_add.add_argument(
+        "--bucket",
+        choices=["Projects", "Areas", "Resources", "Archives"],
+        default=None,
+        help="Explicit PARA bucket; omitted means auto-route",
+    )
+    workspace_add.add_argument(
+        "--mode",
+        choices=["new", "append", "update"],
+        default="new",
+        help="Write behavior when the slug already exists",
+    )
+    workspace_add.add_argument("--summary", default="", help="Short manifest summary")
+    workspace_add.add_argument("--status-hint", default="", help="Routing hint such as due, ongoing, done")
+    workspace_add.add_argument("--tag", action="append", default=[], help="Tag to add; repeatable")
+    workspace_add.add_argument("--backlink", action="append", default=[], help="Backlink to add; repeatable")
+    workspace_add.add_argument("--file", default="", help="Read item content from a markdown/text file")
+    workspace_add.add_argument("content", nargs="*", help="Item content; stdin is accepted when omitted")
+    workspace_search = workspace_sub.add_parser("search", help="Search via manifests, then load top files")
+    workspace_search.add_argument("query", help="Search query")
+    workspace_search.add_argument("--top-k", type=int, default=3, help="Number of files to load")
+
+    procedural_parser = memory_sub.add_parser(
+        "procedural",
+        help="Manage agent-facing procedural Skill Markdown",
+        description="Distill reusable successful workflows into skill drafts.",
+    )
+    procedural_sub = procedural_parser.add_subparsers(dest="procedural_command")
+    procedural_distill = procedural_sub.add_parser("distill", help="Write a procedural skill draft")
+    procedural_distill.add_argument("--name", required=True, help="Skill display name")
+    procedural_distill.add_argument("--description", required=True, help="Short skill description")
+    procedural_distill.add_argument("--trigger", action="append", required=True, help="When to use it; repeatable")
+    procedural_distill.add_argument("--step", action="append", required=True, help="Procedure step; repeatable")
+    procedural_distill.add_argument("--constraint", action="append", default=[], help="Constraint; repeatable")
+    procedural_distill.add_argument("--recovery", action="append", default=[], help="Failure recovery rule; repeatable")
+    procedural_distill.add_argument("--file", default="", help="Read provenance/source trace from a file")
+    procedural_distill.add_argument("--overwrite", action="store_true", help="Replace an existing skill draft")
+    procedural_distill.add_argument("content", nargs="*", help="Optional provenance/source trace")
     memory_parser.set_defaults(func=cmd_memory)

--- a/hermes_cli/subcommands/memory.py
+++ b/hermes_cli/subcommands/memory.py
@@ -82,6 +82,25 @@ def build_memory_parser(subparsers, *, cmd_memory: Callable) -> None:
     workspace_search.add_argument("query", help="Search query")
     workspace_search.add_argument("--top-k", type=int, default=3, help="Number of files to load")
 
+    workspace_agentic = workspace_sub.add_parser(
+        "agentic-search",
+        help="LLM-powered search: reads manifests, selects and loads the most relevant files",
+    )
+    workspace_agentic.add_argument("query", help="Natural-language search query")
+    workspace_agentic.add_argument("--top-k", type=int, default=3, help="Number of files to load")
+    workspace_agentic.add_argument("--model", default=None, help="Override LLM model for this call")
+
+    workspace_seed = workspace_sub.add_parser(
+        "seed",
+        help="Ingest knowledge from a directory of session markdown files into the workspace",
+    )
+    workspace_seed.add_argument(
+        "--seed-dir",
+        required=True,
+        help="Path to a directory of .md session files to extract and ingest",
+    )
+    workspace_seed.add_argument("--model", default=None, help="Override LLM model for this call")
+
     procedural_parser = memory_sub.add_parser(
         "procedural",
         help="Manage agent-facing procedural Skill Markdown",
@@ -98,4 +117,42 @@ def build_memory_parser(subparsers, *, cmd_memory: Callable) -> None:
     procedural_distill.add_argument("--file", default="", help="Read provenance/source trace from a file")
     procedural_distill.add_argument("--overwrite", action="store_true", help="Replace an existing skill draft")
     procedural_distill.add_argument("content", nargs="*", help="Optional provenance/source trace")
+    agent_parser = memory_sub.add_parser(
+        "agent",
+        help="Memory agent: nightly knowledge ingestion into the personal workspace",
+    )
+    agent_sub = agent_parser.add_subparsers(dest="agent_command")
+
+    agent_schedule = agent_sub.add_parser(
+        "schedule",
+        help="Register a nightly ingestion cron job in hermes cron (default: 2 AM daily)",
+    )
+    agent_schedule.add_argument(
+        "--schedule",
+        default="0 2 * * *",
+        help="Cron expression or interval (default: '0 2 * * *')",
+    )
+    agent_schedule.add_argument(
+        "--force",
+        action="store_true",
+        help="Replace existing nightly job if already registered",
+    )
+
+    agent_ingest = agent_sub.add_parser(
+        "ingest",
+        help="Run a one-shot ingestion now (seed dir or sessions from state.db)",
+    )
+    agent_ingest.add_argument(
+        "--seed-dir",
+        default=None,
+        help="Ingest .md files from this directory instead of state.db",
+    )
+    agent_ingest.add_argument(
+        "--since-hours",
+        type=float,
+        default=24.0,
+        help="How many hours back to look in state.db (default: 24)",
+    )
+    agent_ingest.add_argument("--model", default=None, help="Override LLM model")
+
     memory_parser.set_defaults(func=cmd_memory)

--- a/package-lock.json
+++ b/package-lock.json
@@ -19659,7 +19659,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19676,7 +19675,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19693,7 +19691,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19710,7 +19707,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19727,7 +19723,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19744,7 +19739,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19761,7 +19755,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19778,7 +19771,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19795,7 +19787,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19812,7 +19803,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19829,7 +19819,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19846,7 +19835,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19863,7 +19851,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19880,7 +19867,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19897,7 +19883,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19914,7 +19899,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19931,7 +19915,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19948,7 +19931,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19965,7 +19947,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19982,7 +19963,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19999,7 +19979,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20016,7 +19995,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20033,7 +20011,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20050,7 +20027,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20067,7 +20043,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20084,7 +20059,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }

--- a/tests/agent/test_dual_memory.py
+++ b/tests/agent/test_dual_memory.py
@@ -1,0 +1,140 @@
+from pathlib import Path
+
+import pytest
+
+from agent.dual_memory import (
+    PARA_BUCKETS,
+    PersonalWorkspace,
+    ProceduralMemory,
+    SkillDraft,
+    WorkspaceItem,
+    default_procedural_skills_root,
+    default_workspace_root,
+    filter_workspace_candidate,
+    route_item,
+)
+
+
+@pytest.fixture()
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+def test_default_paths_are_profile_scoped(hermes_home):
+    assert default_workspace_root() == hermes_home / "personal_workspace"
+    assert default_procedural_skills_root() == hermes_home / "skills" / "procedural-memory"
+
+
+def test_workspace_init_creates_para_manifests(hermes_home):
+    workspace = PersonalWorkspace()
+    workspace.initialize()
+
+    for bucket in PARA_BUCKETS:
+        manifest = hermes_home / "personal_workspace" / bucket / "_manifest.md"
+        assert manifest.exists()
+        assert f"# {bucket} Manifest" in manifest.read_text(encoding="utf-8")
+
+
+def test_route_item_uses_para_state_machine_signals():
+    assert route_item("Ship mobile app", "deadline next Friday") == "Projects"
+    assert route_item("Writing habit", "ongoing responsibility") == "Areas"
+    assert route_item("OAuth reference notes", "Reusable reference material") == "Resources"
+    assert route_item("Old launch plan", "completed and archived") == "Archives"
+
+
+def test_workspace_write_refreshes_manifest_and_retrieves_top_file(hermes_home):
+    workspace = PersonalWorkspace()
+    path = workspace.write_item(
+        WorkspaceItem(
+            title="Literature Review Plan",
+            content="Paper notes about retrieval augmented generation and memory routing.",
+            bucket="Projects",
+            summary="RAG memory routing research plan",
+            tags=["research", "rag"],
+        )
+    )
+
+    assert path == hermes_home / "personal_workspace" / "Projects" / "literature-review-plan.md"
+    manifest = path.parent / "_manifest.md"
+    manifest_text = manifest.read_text(encoding="utf-8")
+    assert "Literature Review Plan" in manifest_text
+    assert "tags: research, rag" in manifest_text
+
+    results = workspace.retrieve("rag routing", top_k=1)
+    assert len(results) == 1
+    assert results[0].record.title == "Literature Review Plan"
+    assert "retrieval augmented generation" in results[0].content
+
+
+def test_workspace_append_preserves_existing_file(hermes_home):
+    workspace = PersonalWorkspace()
+    first = workspace.write_item(
+        WorkspaceItem(
+            title="Course Notes",
+            content="Initial notes about the course project with a concrete deadline.",
+            bucket="Projects",
+        )
+    )
+    second = workspace.write_item(
+        WorkspaceItem(
+            title="Course Notes",
+            content="Added notes about the grading rubric and final deliverable.",
+            bucket="Projects",
+        ),
+        mode="append",
+    )
+
+    assert second == first
+    text = first.read_text(encoding="utf-8")
+    assert "Initial notes" in text
+    assert "Added notes" in text
+    assert "## Update" in text
+
+
+def test_filter_workspace_candidate_rejects_transient_content():
+    assert not filter_workspace_candidate("ok thanks")
+    assert not filter_workspace_candidate("short")
+    assert filter_workspace_candidate(
+        "This project decision is durable: use the PARA workspace for user-visible research notes."
+    )
+
+
+def test_procedural_memory_writes_skill_markdown(hermes_home):
+    procedural = ProceduralMemory()
+    path = procedural.write_skill(
+        SkillDraft(
+            name="Dataset Triage",
+            description="Triage user Obsidian datasets for dual-memory experiments.",
+            triggers=["A task asks to evaluate a personal knowledge-base dataset."],
+            steps=[
+                "Inventory projects, courses, and literature notes.",
+                "Map each note to Projects, Areas, Resources, or Archives.",
+                "Record failure cases for later workflow refinement.",
+            ],
+            constraints=["Do not overwrite user-authored notes."],
+            recovery=["If classification is ambiguous, keep the note in Resources and add a backlink."],
+            source="Distilled from a successful dataset preparation trajectory.",
+        )
+    )
+
+    assert path == hermes_home / "skills" / "procedural-memory" / "dataset-triage" / "SKILL.md"
+    text = path.read_text(encoding="utf-8")
+    assert "name: dataset-triage" in text
+    assert "## When To Use" in text
+    assert "## Procedure" in text
+    assert "Do not overwrite user-authored notes." in text
+
+
+def test_procedural_memory_refuses_accidental_overwrite(hermes_home):
+    procedural = ProceduralMemory()
+    draft = SkillDraft(
+        name="Repeatable Flow",
+        description="A reusable flow.",
+        triggers=["When the same flow succeeds repeatedly."],
+        steps=["Run the known-good steps."],
+    )
+    procedural.write_skill(draft)
+    with pytest.raises(FileExistsError):
+        procedural.write_skill(draft)

--- a/tests/agent/test_memory_agent.py
+++ b/tests/agent/test_memory_agent.py
@@ -1,0 +1,336 @@
+"""Tests for the agentic layer in agent.dual_memory.
+
+All LLM calls are replaced with a mock so tests are fast and offline.
+Set log_cli = true in pyproject.toml (or pass -s) to watch INFO decisions.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from agent.dual_memory import (
+    PARA_BUCKETS,
+    PersonalWorkspace,
+    WorkspaceItem,
+    _parse_bucket,
+    _parse_file_list,
+    _parse_item_blocks,
+    agentic_retrieve,
+    agentic_route,
+    extract_knowledge_items,
+    ingest_session,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+@pytest.fixture()
+def workspace(hermes_home):
+    ws = PersonalWorkspace()
+    ws.initialize()
+    return ws
+
+
+def mock_llm(response: str):
+    """Return an LLMCallable that always returns ``response``."""
+
+    def _fn(system: str, messages: list) -> str:  # noqa: ARG001
+        return response
+
+    return _fn
+
+
+# ---------------------------------------------------------------------------
+# _parse_bucket
+# ---------------------------------------------------------------------------
+
+
+def test_parse_bucket_all_four():
+    for bucket in PARA_BUCKETS:
+        assert _parse_bucket(f"BUCKET: {bucket}") == bucket
+
+
+def test_parse_bucket_case_insensitive():
+    assert _parse_bucket("bucket: resources") == "Resources"
+
+
+def test_parse_bucket_returns_none_on_garbage():
+    assert _parse_bucket("I cannot determine the bucket") is None
+
+
+# ---------------------------------------------------------------------------
+# _parse_file_list
+# ---------------------------------------------------------------------------
+
+
+def test_parse_file_list_basic():
+    response = (
+        "RELEVANCE: policy gradient concepts\n"
+        "FILES:\n"
+        "- Resources/policy-gradient-basics.md\n"
+        "- Areas/rl-notes.md\n"
+    )
+    assert _parse_file_list(response) == [
+        ("Resources", "policy-gradient-basics.md"),
+        ("Areas", "rl-notes.md"),
+    ]
+
+
+def test_parse_file_list_none():
+    assert _parse_file_list("FILES: none") == []
+
+
+def test_parse_file_list_case_insensitive_bucket():
+    assert _parse_file_list("FILES:\n- resources/pg.md\n") == [("Resources", "pg.md")]
+
+
+# ---------------------------------------------------------------------------
+# agentic_route — no fallback, raises on bad LLM output
+# ---------------------------------------------------------------------------
+
+
+def test_agentic_route_uses_llm_bucket(workspace, caplog):
+    item = WorkspaceItem(
+        title="Policy Gradient Derivation",
+        content="REINFORCE derives the gradient via log-probability times return.",
+    )
+    with caplog.at_level(logging.INFO, logger="agent.dual_memory"):
+        bucket = agentic_route(item, workspace, mock_llm("BUCKET: Resources\nREASON: standalone reference"))
+    assert bucket == "Resources"
+    assert any("Resources" in r.message for r in caplog.records)
+    assert any("standalone reference" in r.message for r in caplog.records)
+
+
+def test_agentic_route_all_four_buckets(workspace):
+    for expected in PARA_BUCKETS:
+        item = WorkspaceItem(title="test", content="test content for routing purposes " * 3)
+        assert agentic_route(item, workspace, mock_llm(f"BUCKET: {expected}\nREASON: test")) == expected
+
+
+def test_agentic_route_raises_on_unparseable_response(workspace):
+    item = WorkspaceItem(title="X", content="some content that passes the quality gate easily")
+    with pytest.raises(ValueError, match="unparseable bucket"):
+        agentic_route(item, workspace, mock_llm("I'm not sure which category fits."))
+
+
+def test_agentic_route_raises_on_llm_exception(workspace):
+    item = WorkspaceItem(title="X", content="content content content content content content")
+
+    def _fail(system, messages):
+        raise RuntimeError("network timeout")
+
+    with pytest.raises(RuntimeError, match="network timeout"):
+        agentic_route(item, workspace, _fail)
+
+
+# ---------------------------------------------------------------------------
+# agentic_retrieve — no fallback, raises when nothing found
+# ---------------------------------------------------------------------------
+
+
+def test_agentic_retrieve_reads_selected_file(workspace, caplog):
+    workspace.write_item(
+        WorkspaceItem(
+            title="Policy Gradient Basics",
+            content="∇J(θ) = E[∇logπ(a|s)·G]. The REINFORCE update rule.",
+            bucket="Resources",
+            tags=["policy-gradient", "reinforce"],
+        )
+    )
+    response = (
+        "RELEVANCE: policy gradient reference\n"
+        "FILES:\n- Resources/policy-gradient-basics.md\n"
+    )
+    with caplog.at_level(logging.INFO, logger="agent.dual_memory"):
+        results = agentic_retrieve("policy gradient", workspace, mock_llm(response), top_k=3)
+    assert len(results) == 1
+    assert results[0].record.bucket == "Resources"
+    assert "REINFORCE" in results[0].content
+    assert any("policy gradient" in r.message for r in caplog.records)
+
+
+def test_agentic_retrieve_raises_when_llm_selects_none(workspace):
+    with pytest.raises(ValueError, match="selected no files"):
+        agentic_retrieve("bellman equation", workspace, mock_llm("FILES: none"))
+
+
+def test_agentic_retrieve_raises_when_llm_names_missing_file(workspace):
+    with pytest.raises(ValueError, match="none of the LLM-selected files exist"):
+        agentic_retrieve(
+            "ppo",
+            workspace,
+            mock_llm("FILES:\n- Resources/does-not-exist.md\n"),
+        )
+
+
+def test_agentic_retrieve_raises_on_llm_exception(workspace):
+    def _fail(system, messages):
+        raise ConnectionError("timeout")
+
+    with pytest.raises(ConnectionError):
+        agentic_retrieve("q-learning", workspace, _fail)
+
+
+# ---------------------------------------------------------------------------
+# _parse_item_blocks
+# ---------------------------------------------------------------------------
+
+_SAMPLE = """\
+TITLE: Policy Gradient Theorem
+BUCKET: Resources
+TAGS: policy-gradient, reinforce, rl
+SUMMARY: Derivation of ∇J(θ) via log-probability trick.
+CONTENT:
+∇J(θ) = E_τ[∑_t ∇logπ_θ(a_t|s_t)·G_t]. Computed via REINFORCE.
+---
+
+TITLE: Off-Policy RL Overview
+BUCKET: Areas
+TAGS: off-policy, importance-sampling
+SUMMARY: Survey of off-policy RL methods.
+CONTENT:
+Off-policy methods learn about a target policy while following a behaviour policy.
+Key methods: Q-learning, DQN, SAC.
+---
+"""
+
+
+def test_parse_item_blocks_count():
+    assert len(_parse_item_blocks(_SAMPLE)) == 2
+
+
+def test_parse_item_blocks_first():
+    item = _parse_item_blocks(_SAMPLE)[0]
+    assert item.title == "Policy Gradient Theorem"
+    assert item.bucket == "Resources"
+    assert "policy-gradient" in item.tags
+    assert "REINFORCE" in item.content
+
+
+def test_parse_item_blocks_second():
+    item = _parse_item_blocks(_SAMPLE)[1]
+    assert item.title == "Off-Policy RL Overview"
+    assert item.bucket == "Areas"
+
+
+# ---------------------------------------------------------------------------
+# extract_knowledge_items
+# ---------------------------------------------------------------------------
+
+
+def test_extract_returns_items(caplog):
+    with caplog.at_level(logging.INFO, logger="agent.dual_memory"):
+        items = extract_knowledge_items("USER: explain REINFORCE\nASSISTANT: ...", mock_llm(_SAMPLE))
+    assert len(items) == 2
+    assert any("2 item" in r.message for r in caplog.records)
+
+
+def test_extract_returns_empty_on_no_items(caplog):
+    with caplog.at_level(logging.INFO, logger="agent.dual_memory"):
+        items = extract_knowledge_items("ok thanks", mock_llm("NO_ITEMS"))
+    assert items == []
+    assert any("no durable" in r.message for r in caplog.records)
+
+
+def test_extract_propagates_llm_exception():
+    def _fail(system, messages):
+        raise RuntimeError("quota exceeded")
+
+    with pytest.raises(RuntimeError, match="quota exceeded"):
+        extract_knowledge_items("some session text here to pass length check", _fail)
+
+
+# ---------------------------------------------------------------------------
+# ingest_session — end-to-end
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_session_writes_to_workspace(workspace, caplog):
+    block = (
+        "TITLE: REINFORCE Rule\n"
+        "BUCKET: Resources\n"
+        "TAGS: reinforce, policy-gradient\n"
+        "SUMMARY: The REINFORCE policy gradient update.\n"
+        "CONTENT:\n"
+        "Δθ = α·∇logπ_θ(a|s)·G. Monte Carlo policy gradient, unbiased but high variance.\n"
+        "---\n"
+    )
+    with caplog.at_level(logging.INFO, logger="agent.dual_memory"):
+        written = ingest_session("USER: explain REINFORCE\nASSISTANT: ...", workspace, mock_llm(block))
+    assert len(written) == 1
+    assert written[0].exists()
+    assert "Resources" in str(written[0])
+    assert any("REINFORCE Rule" in r.message for r in caplog.records)
+
+
+def test_ingest_session_routes_items_without_bucket(workspace):
+    """Items extracted without a bucket trigger a second agentic_route call."""
+    block_no_bucket = (
+        "TITLE: Actor-Critic Methods\n"
+        "TAGS: actor-critic, rl\n"
+        "SUMMARY: Combines policy and value learning.\n"
+        "CONTENT:\n"
+        "Actor-critic uses a policy (actor) and a value function (critic). "
+        "The critic reduces variance compared to pure REINFORCE.\n"
+        "---\n"
+    )
+    calls = []
+
+    def _sequential(system, messages):
+        calls.append(len(calls))
+        if len(calls) == 1:
+            return block_no_bucket
+        return "BUCKET: Resources\nREASON: standalone reference"
+
+    written = ingest_session("RL session text", workspace, _sequential)
+    assert len(written) == 1
+    assert "Resources" in str(written[0])
+    assert len(calls) == 2  # extract call + route call
+
+
+def test_ingest_session_empty_returns_no_writes(workspace):
+    written = ingest_session("short", workspace, mock_llm("NO_ITEMS"))
+    assert written == []
+
+
+# ---------------------------------------------------------------------------
+# run via seed dir (integration of ingest_session loop)
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_seed_dir(workspace, tmp_path, caplog):
+    seed_dir = tmp_path / "seed"
+    seed_dir.mkdir()
+    (seed_dir / "session1.md").write_text(
+        "USER: explain value functions\nASSISTANT: V(s) = E[∑ γ^t r_t].",
+        encoding="utf-8",
+    )
+    block = (
+        "TITLE: Value Function Definition\n"
+        "BUCKET: Resources\n"
+        "TAGS: value-function, rl\n"
+        "SUMMARY: V(s) = expected discounted return from s.\n"
+        "CONTENT:\n"
+        "V(s) = E[∑_{t=0}^∞ γ^t r_t | s_0 = s]. Baseline in actor-critic methods.\n"
+        "---\n"
+    )
+    # Simulate the CLI seed loop directly
+    llm = mock_llm(block)
+    written = []
+    for f in sorted(seed_dir.glob("*.md")):
+        written.extend(ingest_session(f.read_text(encoding="utf-8"), workspace, llm))
+    assert len(written) == 1
+    assert written[0].exists()

--- a/tests/hermes_cli/test_dual_memory_cli.py
+++ b/tests/hermes_cli/test_dual_memory_cli.py
@@ -1,0 +1,74 @@
+import argparse
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from hermes_cli import memory_setup
+from hermes_cli.subcommands.memory import build_memory_parser
+
+
+def test_memory_workspace_parser_accepts_add_command():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    build_memory_parser(subparsers, cmd_memory=lambda args: None)
+
+    args = parser.parse_args(
+        [
+            "memory",
+            "workspace",
+            "add",
+            "--title",
+            "Research Plan",
+            "--bucket",
+            "Projects",
+            "--tag",
+            "research",
+            "durable project note with enough content to save",
+        ]
+    )
+
+    assert args.command == "memory"
+    assert args.memory_command == "workspace"
+    assert args.workspace_command == "add"
+    assert args.title == "Research Plan"
+    assert args.bucket == "Projects"
+    assert args.tag == ["research"]
+
+
+def test_memory_procedural_parser_accepts_distill_command():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    build_memory_parser(subparsers, cmd_memory=lambda args: None)
+
+    args = parser.parse_args(
+        [
+            "memory",
+            "procedural",
+            "distill",
+            "--name",
+            "Dataset Triage",
+            "--description",
+            "Triage datasets.",
+            "--trigger",
+            "When a dataset arrives.",
+            "--step",
+            "Inspect the files.",
+        ]
+    )
+
+    assert args.memory_command == "procedural"
+    assert args.procedural_command == "distill"
+    assert args.trigger == ["When a dataset arrives."]
+    assert args.step == ["Inspect the files."]
+
+
+def test_memory_setup_router_delegates_dual_memory_commands():
+    workspace_args = SimpleNamespace(memory_command="workspace")
+    procedural_args = SimpleNamespace(memory_command="procedural")
+
+    with patch("hermes_cli.dual_memory.cmd_workspace") as workspace:
+        memory_setup.memory_command(workspace_args)
+    workspace.assert_called_once_with(workspace_args)
+
+    with patch("hermes_cli.dual_memory.cmd_procedural") as procedural:
+        memory_setup.memory_command(procedural_args)
+    procedural.assert_called_once_with(procedural_args)


### PR DESCRIPTION
## Summary

- **agentic_route**: LLM 读全部 4 个 manifest 再分类，取代 regex 关键词匹配，支持 taxonomy-consistent 放置
- **agentic_retrieve**: 两步链 — manifest scan → LLM 选文件 → 读文件返回，仿 Claude Code 上下文检索
- **ingest_session**: LLM 从对话文本蒸馏知识条目并写入工作区
- 全部 LLM 函数合并进 `agent/dual_memory.py`，无独立模块
- 无 fallback：LLM 失败直接 raise，调用方处理
- INFO 日志在每次路由决策时打印 bucket + reason

## New CLI

    hermes memory workspace agentic-search "<query>"
    hermes memory workspace seed --seed-dir <path>
    hermes memory agent ingest [--seed-dir | --since-hours 24]
    hermes memory agent schedule [--schedule "0 2 * * *"]

`schedule` 命令使用现有 `cron.jobs.create_job()` 基础设施。

## Test plan

- [ ] `pytest tests/agent/test_memory_agent.py tests/agent/test_dual_memory.py -v --log-cli-level=INFO` — 32 tests，全部 mock LLM 离线
- [ ] `hermes memory workspace seed --seed-dir data/seed_data_01` — 真实 LLM，摄取 6 个 RL session
- [ ] `hermes memory workspace agentic-search "PPO vs TRPO"` — 真实 LLM 检索
- [ ] `hermes memory agent schedule` — 确认 cron job 出现在 `hermes cron list`