### PR TITLE
feat: inject delegation context preamble

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -489,6 +489,8 @@ def load_cli_config() -> Dict[str, Any]:
             "provider": "",    # Subagent provider override (empty = inherit parent provider)
             "base_url": "",    # Direct OpenAI-compatible endpoint for subagents
             "api_key": "",     # API key for delegation.base_url (falls back to OPENAI_API_KEY)
+            "context_preamble": "",       # Optional inline policy text injected into child prompts
+            "context_preamble_file": "",  # Optional file with profile policy injected into child prompts
         },
         "onboarding": {
             # First-touch hint flags (see agent/onboarding.py).  Each hint is

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1782,6 +1782,11 @@ DEFAULT_CONFIG = {
         # Flip to true only if you trust delegated work to run dangerous cmds
         # without human review (cron pipelines, batch automation, etc.).
         "subagent_auto_approve": False,
+        # Optional policy/preamble injected into every delegate_task child
+        # system prompt. Use the file form for profile-local policy generated
+        # outside Hermes core (for example ~/.local/share/.../DELEGATION_GUARD.md).
+        "context_preamble": "",
+        "context_preamble_file": "",
     },
 
     # Ephemeral prefill messages file — JSON list of {role, content} dicts

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -13,6 +13,7 @@ import json
 import os
 import threading
 import time
+import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -141,6 +142,48 @@ class TestChildSystemPrompt(unittest.TestCase):
     def test_empty_context_ignored(self):
         prompt = _build_child_system_prompt("Do something", "  ")
         self.assertNotIn("CONTEXT", prompt)
+
+    def test_context_preamble_injected_before_task(self):
+        prompt = _build_child_system_prompt(
+            "Fix the tests",
+            context_preamble="Read the profile rulebook before routing.",
+        )
+        self.assertLess(
+            prompt.index("Read the profile rulebook before routing."),
+            prompt.index("YOUR TASK"),
+        )
+        self.assertIn("PARENT / PROFILE POLICY", prompt)
+
+    @patch("tools.delegate_tool._load_config")
+    def test_configured_context_preamble_file_reaches_child_prompt(self, mock_cfg):
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as fh:
+            fh.write("Current default reviewer: laura-aider-review-diff")
+            preamble_path = fh.name
+        self.addCleanup(lambda: os.path.exists(preamble_path) and os.unlink(preamble_path))
+        mock_cfg.return_value = {"context_preamble_file": preamble_path}
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+            _build_child_agent(
+                task_index=0,
+                goal="Choose reviewer",
+                context=None,
+                toolsets=["file"],
+                model=None,
+                max_iterations=3,
+                task_count=1,
+                parent_agent=parent,
+            )
+
+            _, kwargs = MockAgent.call_args
+            prompt = kwargs["ephemeral_system_prompt"]
+            self.assertIn("Current default reviewer: laura-aider-review-diff", prompt)
+            self.assertLess(
+                prompt.index("Current default reviewer: laura-aider-review-diff"),
+                prompt.index("YOUR TASK"),
+            )
 
 
 class TestStripBlockedTools(unittest.TestCase):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -566,6 +566,7 @@ DEFAULT_MAX_ITERATIONS = 50
 # in via delegation.child_timeout_seconds.
 DEFAULT_CHILD_TIMEOUT: Optional[float] = None
 _HEARTBEAT_INTERVAL = 30  # seconds between parent activity heartbeats during delegation
+_CONTEXT_PREAMBLE_MAX_CHARS = 12000
 # Stale-heartbeat thresholds. A child with no API-call progress is either:
 #   - idle between turns (no current_tool) — probably stuck on a slow API call
 #   - inside a tool (current_tool set) — probably running a legitimately long
@@ -625,6 +626,7 @@ def _build_child_system_prompt(
     goal: str,
     context: Optional[str] = None,
     *,
+    context_preamble: Optional[str] = None,
     workspace_path: Optional[str] = None,
     role: str = "leaf",
     max_spawn_depth: int = 2,
@@ -638,11 +640,13 @@ def _build_child_system_prompt(
     The depth note is literal truth (grounded in the passed config) so
     the LLM doesn't confabulate nesting capabilities that don't exist.
     """
-    parts = [
-        "You are a focused subagent working on a specific delegated task.",
-        "",
-        f"YOUR TASK:\n{goal}",
-    ]
+    parts = ["You are a focused subagent working on a specific delegated task."]
+    if context_preamble and str(context_preamble).strip():
+        parts.append(
+            "\nPARENT / PROFILE POLICY:\n"
+            f"{str(context_preamble).strip()}"
+        )
+    parts.extend(["", f"YOUR TASK:\n{goal}"])
     if context and context.strip():
         parts.append(f"\nCONTEXT:\n{context}")
     if workspace_path and str(workspace_path).strip():
@@ -695,6 +699,47 @@ def _build_child_system_prompt(
             f"is capped at max_spawn_depth={max_spawn_depth}. {child_note}"
         )
     return "\n".join(parts)
+
+
+def _load_context_preamble(cfg: Optional[dict]) -> str:
+    """Load optional profile/delegation policy injected into child prompts.
+
+    User-facing config:
+      - delegation.context_preamble: inline text
+      - delegation.context_preamble_file: path to a UTF-8 text/markdown file
+
+    The file form keeps profile-specific policy out of Hermes core while still
+    letting every delegated child inherit a small guard. Missing/unreadable
+    files are warnings, not hard failures: delegation should not break because
+    an optional guard path is stale.
+    """
+    if not isinstance(cfg, dict):
+        return ""
+
+    chunks: List[str] = []
+    inline = cfg.get("context_preamble")
+    if inline and str(inline).strip():
+        chunks.append(str(inline).strip())
+
+    file_value = cfg.get("context_preamble_file")
+    if file_value and str(file_value).strip():
+        path = os.path.expandvars(os.path.expanduser(str(file_value).strip()))
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                content = fh.read(_CONTEXT_PREAMBLE_MAX_CHARS + 1).strip()
+            if content:
+                chunks.append(content[:_CONTEXT_PREAMBLE_MAX_CHARS])
+        except Exception as exc:
+            logger.warning(
+                "Could not read delegation.context_preamble_file %r: %s",
+                path,
+                exc,
+            )
+
+    preamble = "\n\n".join(chunks).strip()
+    if len(preamble) > _CONTEXT_PREAMBLE_MAX_CHARS:
+        preamble = preamble[:_CONTEXT_PREAMBLE_MAX_CHARS].rstrip()
+    return preamble
 
 
 def _resolve_workspace_hint(parent_agent) -> Optional[str]:
@@ -1029,9 +1074,11 @@ def _build_child_agent(
         child_toolsets.append("delegation")
 
     workspace_hint = _resolve_workspace_hint(parent_agent)
+    context_preamble = _load_context_preamble(delegation_cfg)
     child_prompt = _build_child_system_prompt(
         goal,
         context,
+        context_preamble=context_preamble,
         workspace_path=workspace_hint,
         role=effective_role,
         max_spawn_depth=max_spawn,


### PR DESCRIPTION
## Summary
- add optional `delegation.context_preamble` and `delegation.context_preamble_file` config keys
- inject the resolved preamble near the top of `delegate_task` child system prompts
- keep missing/unreadable preamble files non-fatal and bounded to 12k chars
- add tests for direct prompt injection and configured file injection

## Tests
- `python -m pytest tests/tools/test_delegate.py -q`

## Risk / compatibility
- Default config values are empty, so behavior is unchanged unless a user opts in.
- File-based preamble keeps profile/local policy outside Hermes core, making this small and upstream-friendly.