### PR TITLE
fix(install.ps1): guard uv venv stderr from terminating the install

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1420,8 +1420,31 @@ function Install-Venv {
         Remove-Item -Recurse -Force "venv"
     }
     
-    # uv creates the venv and pins the Python version in one step
-    & $UvCmd venv venv --python $PythonVersion
+    # uv creates the venv and pins the Python version in one step.
+    # Relax ErrorActionPreference around the call: uv writes informational
+    # lines ("Using CPython 3.11.9 interpreter at: ...") to stderr. With
+    # $ErrorActionPreference = "Stop" (set at the top of this script) and
+    # stderr attached to a pipe -- which is exactly how GUI onboarding
+    # wizards and CI drivers run this installer -- PowerShell 5.1 promotes
+    # the first stderr line to a terminating NativeCommandError even though
+    # uv exits 0 and the venv was created successfully, killing the whole
+    # install at this stage. Same class of fix as Test-Python / Install-Uv.
+    # Verify success by outcome (the venv interpreter exists) rather than
+    # exit-code/stderr semantics.
+    $prevEAP = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = "Continue"
+        $uvOutput = & $UvCmd venv venv --python $PythonVersion 2>&1
+        $uvExitCode = $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
+    if (-not (Test-Path "venv\Scripts\python.exe")) {
+        Write-Warn "uv venv output:"
+        Write-Host $uvOutput -ForegroundColor DarkGray
+        Pop-Location
+        throw "uv venv failed (exit $uvExitCode) -- virtual environment was not created"
+    }
 
     # Neutralize any inherited UV_PYTHON (e.g. $env:UV_PYTHON = "3.14" left in
     # the user's shell). uv honours UV_PYTHON over an existing venv for the


### PR DESCRIPTION
## Problem

`Install-Venv` calls `uv venv` bare:

```powershell
& $UvCmd venv venv --python $PythonVersion
```

uv writes informational lines (`Using CPython 3.11.9 interpreter at: ...`) to **stderr**. Under Windows PowerShell 5.1 with stderr attached to a pipe — which is exactly how GUI onboarding wizards and CI drivers run this installer (`powershell -Command "iex (irm .../install.ps1)" ` with stdout/stderr captured) — the script-level `$ErrorActionPreference = "Stop"` promotes the first stderr line to a terminating `NativeCommandError`. The install dies at the venv stage with:

```
[X] Installation failed: Using CPython 3.11.9 interpreter at: C:\...\python.exe
```

…even though `uv venv` exited 0 and the venv was created successfully. Running the script in a plain console does **not** reproduce it (console stderr doesn't trigger the promotion), which is presumably why this has survived — only piped-stderr callers hit it.

This is the same failure class already fixed in `Test-Python` and `Install-Uv` (and the comment in `Test-Python` notes a similar fix was previously landed as `ec1714e71` and lost in a release squash).

## Fix

Mirror the existing `Test-Python` pattern: relax `$ErrorActionPreference` around the uv call, capture output and exit code, and verify success by outcome — `venv\Scripts\python.exe` exists — rather than stderr/exit-code semantics. On failure, dump uv's output and throw with the exit code, after `Pop-Location` so the caller's CWD isn't left inside `$InstallDir`.

## Testing

- Hit and diagnosed in production: IrisGo's (desktop GUI wrapping hermes-agent) Windows onboarding spawns this script with piped stderr and died at this stage 100% of the time; with this guard applied the venv stage completes and the remaining stages (`dependencies` → `bootstrap-marker`) all pass (verified on Windows 11, PowerShell 5.1, uv 0.11.21).
- `[System.Management.Automation.Language.Parser]::ParseFile` reports 0 errors on the patched script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
