### PR TITLE
fix(delegation): subagents silently ignore the configured delegation model in long-running sessions

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -2795,5 +2795,99 @@ class TestFallbackModelInheritance(unittest.TestCase):
         self.assertIsNone(kwargs["fallback_model"])
 
 
+class TestLoadConfigMergesDiskUnderRuntimeSnapshot(unittest.TestCase):
+    """Regression tests for the delegation model-inheritance bug (issue #11999).
+
+    ``_load_config`` reads from two sources: the always-fresh on-disk config
+    (``hermes_cli.config.load_config``) and the import-time ``cli.CLI_CONFIG``
+    snapshot, which can go stale/partial in a long-running process. The old
+    code returned the snapshot wholesale whenever it was truthy, so a *partial*
+    snapshot (e.g. provider set, model missing) blanked out the disk-configured
+    model and caused subagents to silently inherit the parent's primary model.
+
+    These tests exercise the real ``_load_config`` against patched copies of
+    both sources, then run the merged result through the real
+    ``_resolve_delegation_credentials`` to prove the effective child model is
+    what the user configured — not the parent's.
+    """
+
+    def _load_with(self, disk, runtime):
+        """Run the real _load_config with patched disk + runtime sources."""
+        import tools.delegate_tool as dt
+
+        fake_cli = MagicMock()
+        fake_cli.CLI_CONFIG = {"delegation": runtime}
+        with patch.dict("sys.modules", {"cli": fake_cli}), patch(
+            "hermes_cli.config.load_config", return_value={"delegation": disk}
+        ):
+            return dt._load_config()
+
+    # --- _load_config merge behaviour (the unit fixed) ----------------------
+
+    def test_partial_snapshot_backfills_model_from_disk(self):
+        """THE BUG: snapshot has provider but no model. Disk has the model.
+
+        Before the fix the partial snapshot was returned wholesale, so the
+        merged config had no ``model`` and credential resolution fell back to
+        the parent's (expensive) model. After the fix the disk model is
+        backfilled so the configured cheaper model survives.
+        """
+        disk = {"model": "claude-haiku-4.5", "provider": "anthropic"}
+        runtime = {"provider": "anthropic"}  # stale/partial: model dropped
+        cfg = self._load_with(disk, runtime)
+        self.assertEqual(cfg["model"], "claude-haiku-4.5")
+        self.assertEqual(cfg["provider"], "anthropic")
+
+    def test_empty_snapshot_falls_back_to_disk(self):
+        """Empty runtime snapshot → disk config is used verbatim."""
+        disk = {"model": "claude-haiku-4.5", "provider": "anthropic"}
+        cfg = self._load_with(disk, {})
+        self.assertEqual(cfg["model"], "claude-haiku-4.5")
+
+    def test_runtime_override_beats_disk(self):
+        """A genuine in-process override (non-empty model in the snapshot)
+        still wins over disk — preserves intentional mid-session model swaps."""
+        disk = {"model": "claude-haiku-4.5", "provider": "anthropic"}
+        runtime = {"model": "claude-sonnet-4.6", "provider": "anthropic"}
+        cfg = self._load_with(disk, runtime)
+        self.assertEqual(cfg["model"], "claude-sonnet-4.6")
+
+    def test_empty_string_in_snapshot_does_not_blank_disk(self):
+        """An empty-string value in the snapshot counts as 'unset' and must not
+        overwrite a real disk value (YAML round-trips often leave '' fields)."""
+        disk = {"model": "claude-haiku-4.5", "provider": "anthropic"}
+        runtime = {"model": "", "provider": "anthropic", "base_url": ""}
+        cfg = self._load_with(disk, runtime)
+        self.assertEqual(cfg["model"], "claude-haiku-4.5")
+
+    def test_both_empty_returns_empty(self):
+        """No disk config and no snapshot → empty dict (inherit parent), the
+        documented behaviour when delegation is entirely unconfigured."""
+        cfg = self._load_with({}, {})
+        self.assertEqual(cfg, {})
+
+    # --- end-to-end: merged config flows into resolved child model ----------
+    # Uses the keyless base_url path so resolution needs no real provider key,
+    # proving the disk-backfilled model reaches _resolve_delegation_credentials.
+
+    def test_partial_snapshot_model_reaches_resolved_credentials(self):
+        """End-to-end proof via the direct-endpoint (base_url) path: a partial
+        snapshot that drops ``model`` no longer yields a None child model —
+        the disk model is backfilled and shows up in resolved credentials.
+        """
+        parent = _make_mock_parent(depth=0)
+        parent.model = "claude-opus-4-8"  # primary we must NOT silently inherit
+        disk = {
+            "model": "claude-haiku-4.5",
+            "base_url": "https://api.anthropic.com",
+        }
+        runtime = {"base_url": "https://api.anthropic.com"}  # model dropped
+        cfg = self._load_with(disk, runtime)
+        creds = _resolve_delegation_credentials(cfg, parent)
+        effective_model = creds["model"] or parent.model
+        self.assertEqual(effective_model, "claude-haiku-4.5")
+        self.assertNotEqual(effective_model, "claude-opus-4-8")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2612,28 +2612,63 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
 
 
 def _load_config() -> dict:
-    """Load delegation config from CLI_CONFIG or persistent config.
+    """Load delegation config, merging on-disk config under the runtime snapshot.
 
-    Checks the runtime config (cli.py CLI_CONFIG) first, then falls back
-    to the persistent config (hermes_cli/config.py load_config()) so that
-    ``delegation.model`` / ``delegation.provider`` are picked up regardless
-    of the entry point (CLI, gateway, cron).
+    Two config sources exist and they can disagree:
+
+    * ``hermes_cli.config.load_config()`` reads ``~/.hermes/config.yaml`` and is
+      kept fresh — it re-reads disk whenever the file's (mtime, size) changes.
+    * ``cli.CLI_CONFIG`` is a snapshot taken **once** at module import
+      (``cli.py``: ``CLI_CONFIG = load_cli_config()``). In a long-running
+      process (CLI session, gateway, HermesPilot) it never refreshes, so it can
+      hold a stale or partial ``delegation`` block — e.g. one captured before
+      the user configured ``delegation.model`` / ``delegation.provider``.
+
+    The previous implementation returned the runtime snapshot wholesale the
+    moment it was truthy (``if cfg: return cfg``). When that snapshot was a
+    *partial* dict (say ``{"provider": "anthropic"}`` with no ``model``), the
+    missing keys were never backfilled from disk: ``_resolve_delegation_credentials``
+    then resolved ``model`` to ``None`` and the subagent silently inherited the
+    parent's (expensive primary) model instead of the configured cheaper one.
+    See GitHub issue #11999.
+
+    Fix: load disk config as the base layer and overlay only the runtime keys
+    that are actually set (non-empty). This way:
+
+    * Fresh on-disk values are always the fallback for any key the snapshot
+      lacks — no more silent inheritance from a partial snapshot.
+    * A genuine runtime override (a non-empty value in ``CLI_CONFIG``) still
+      wins, preserving in-process model/provider swaps.
     """
-    try:
-        from cli import CLI_CONFIG
-
-        cfg = CLI_CONFIG.get("delegation") or {}
-        if cfg:
-            return cfg
-    except Exception:
-        pass
+    disk: dict = {}
     try:
         from hermes_cli.config import load_config
 
-        full = load_config()
-        return full.get("delegation") or {}
+        disk = load_config().get("delegation") or {}
     except Exception:
-        return {}
+        disk = {}
+
+    runtime: dict = {}
+    try:
+        from cli import CLI_CONFIG
+
+        runtime = CLI_CONFIG.get("delegation") or {}
+    except Exception:
+        runtime = {}
+
+    if not runtime:
+        return disk
+    if not disk:
+        return runtime
+
+    # Disk is the base; overlay only runtime keys that are actually set so a
+    # partial/stale snapshot can never blank out a value the user configured
+    # on disk. Empty string / None in the snapshot means "unset" → keep disk.
+    merged = dict(disk)
+    for key, value in runtime.items():
+        if value not in (None, ""):
+            merged[key] = value
+    return merged
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What this fixes

Hermes lets you run delegated "grunt work" on a cheaper model than your main agent — you set `delegation.model` in `config.yaml` (e.g. Haiku/Sonnet) while your primary agent runs on something expensive (e.g. Opus). This is the core cost-tiering lever for `delegate_task`.

This PR fixes a bug where that setting is **silently ignored in any long-running Hermes process** — a gateway, a HermesPilot instance, or a CLI session that's been open a while. Instead of the cheap model you configured, every delegated subagent quietly runs on your **expensive primary model**. You get billed at primary rates for work you explicitly routed to a cheaper model, with no warning — the subagent result even reports the wrong model name.

This is a **follow-up to #11999** (the more total "subagents always inherit the parent" version, closed/completed in April). That fix introduced the dual-source `_load_config()` helper but left one edge case unhandled — described below.

## Root cause

`tools/delegate_tool.py::_load_config()` reads delegation config from two places:

1. **On-disk `config.yaml`** via `hermes_cli.config.load_config()` — always fresh; it re-reads whenever the file's `(mtime, size)` changes.
2. **An in-memory snapshot** (`cli.CLI_CONFIG`) taken **once** at module import and never refreshed for the life of the process.

The old code returned the in-memory snapshot the moment it was truthy:

```python
cfg = CLI_CONFIG.get("delegation") or {}
if cfg:
    return cfg          # ← short-circuits, never consults disk
```

The problem is a **partial** snapshot. If `CLI_CONFIG["delegation"]` has *some* keys but not `model` — e.g. `{"provider": "anthropic"}`, which happens when the snapshot was captured before delegation was fully configured — it's returned as-is. The missing `model` is never backfilled from the fresh on-disk config. Downstream, `_resolve_delegation_credentials` resolves `model` to `None`, and `None` means **"inherit the parent's model"** — so the subagent runs on the expensive primary.

(An *empty* snapshot `{}` happened to work, because `{} or {}` is falsy and fell through to disk. Only the partial case is broken — which is why it's easy to miss.)

## The fix

Load on-disk config as the **base layer**, then overlay only the snapshot keys that are actually set (non-empty):

```python
merged = dict(disk)
for key, value in runtime.items():
    if value not in (None, ""):
        merged[key] = value
return merged
```

Result:
- Any field the snapshot is missing falls back to the fresh `config.yaml` value — **no more silent inheritance**.
- A genuine in-session override (a non-empty value actively set at runtime) still wins, so intentional mid-session model swaps keep working.
- Empty-string values (common after YAML round-trips, e.g. `base_url: ''`) are treated as "unset" and don't clobber real disk values.

## Verification

I confirmed `load_config()` is genuinely fresh (it's `(mtime, size)`-cached and re-reads on change), then reproduced the failure and the fix against the real functions in a live process.

New test class `TestLoadConfigMergesDiskUnderRuntimeSnapshot` in `tests/tools/test_delegate.py` covers:

- **partial snapshot backfill** — the actual bug (provider set, model dropped → model still resolves to the configured value, not the parent's)
- empty snapshot → disk used verbatim
- runtime override precedence (non-empty snapshot value wins)
- empty-string treated as unset (doesn't blank a disk value)
- both-empty → empty dict (documented "inherit parent" behaviour when delegation is entirely unconfigured)
- an **end-to-end** check that the backfilled model reaches resolved credentials, via the keyless `base_url` path (so it needs no real provider key in CI)

All new tests pass, and the existing `TestDelegationCredentialResolution` and `tests/hermes_cli/test_config_drift.py` suites stay green on top of current `main`.

```
tests/tools/test_delegate.py | 94 +++++++++++++++++++++++++++++++++
tools/delegate_tool.py       | 65 ++++++++++++++++-------
2 files changed, 144 insertions(+), 15 deletions(-)
```

## Notes for reviewers

- No behavior change for the already-working empty-snapshot and fully-populated-snapshot cases — only the partial-snapshot case changes (from "silently inherit parent" to "backfill from disk").
- One pre-existing, unrelated flake (`TestDelegateHeartbeat::test_heartbeat_does_not_trip_idle_stale_while_inside_tool`) fails identically on `main` with these changes stashed — it's a wall-clock timing assertion, not affected by this PR.
