### PR TITLE
docs(docker): clarify per-profile gateway ports (no gateway.port key)

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1107,10 +1107,16 @@ def _maybe_register_gateway_service(profile_name: str) -> None:
     can re-register manually later via the gateway start command,
     which goes through the same dispatch path.
 
-    Port selection is governed by the profile's ``config.yaml``
-    (``[gateway] port = …``) — there is no Python-side allocator
-    (PR #30136 review item I5 retired the SHA-256-derived range
-    [9200, 9800) because it was dead code through the entire stack).
+    Port selection: each supervised profile gateway loads its own
+    ``HERMES_HOME`` and binds the port resolved by ``gateway/config.py``
+    from that profile's environment — ``API_SERVER_PORT`` (or
+    ``platforms.api_server.extra.port`` in the profile's
+    ``config.yaml``), defaulting to 8642. There is no ``[gateway] port``
+    key and no Python-side allocator (PR #30136 review item I5 retired
+    the SHA-256-derived range [9200, 9800) as dead code), so two
+    profiles that both leave the port at its default will both try to
+    bind 8642 — give each profile a distinct ``API_SERVER_PORT`` in its
+    ``.env``.
 
     Host short-circuit: check ``detect_service_manager()`` first and
     return immediately if it isn't ``"s6"``. This keeps host

--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -585,15 +585,20 @@ class S6ServiceManager:
         would instead look up ``$HERMES_HOME/profiles/default/`` — a
         completely different (and almost always nonexistent) profile.
 
-        Port selection: the gateway picks its bind port from the
-        profile's ``config.yaml`` (``[gateway] port = ...``) — that
-        is the single source of truth. Previously this method took a
-        ``port`` parameter that was passed in but never substituted
-        into the rendered script (it was carried in for "API parity"
-        with a deterministic SHA-256 allocator in
-        ``hermes_cli.profiles._allocate_gateway_port``). PR #30136
-        review item I5 retired both the allocator and the parameter
-        because they were dead code through the entire stack.
+        Port selection: the gateway binds the port resolved by
+        ``gateway/config.py`` from the profile's own environment —
+        ``API_SERVER_PORT`` (or ``platforms.api_server.extra.port`` in
+        that profile's ``config.yaml``), defaulting to 8642. There is
+        no ``[gateway] port`` key and no Python-side allocator: because
+        each supervised profile gateway loads its own ``HERMES_HOME``,
+        two profiles that both leave the port unset will both try to
+        bind 8642 — give each profile a distinct ``API_SERVER_PORT`` in
+        its ``.env``. Previously this method took a ``port`` parameter
+        that was passed in but never substituted into the rendered
+        script (carried for "API parity" with a deterministic SHA-256
+        allocator in ``hermes_cli.profiles._allocate_gateway_port``).
+        PR #30136 review item I5 retired both the allocator and the
+        parameter because they were dead code through the entire stack.
         """
         import shlex
         lines = [

--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -205,6 +205,29 @@ docker exec hermes hermes profile delete coder
 
 Under the hood, `hermes gateway start/stop/restart` inside the container is intercepted and routed to `s6-svc` against the right service directory; you don't need to learn the s6 commands directly. For raw supervisor state, use `/command/s6-svstat /run/service/gateway-<name>` (note `/command/` is on PATH only for processes spawned by the supervision tree — when calling from `docker exec`, pass the absolute path).
 
+### Reaching more than one profile from outside the container
+
+Two different surfaces reach a profile's gateway from outside, and they behave differently — don't conflate them:
+
+**Hermes Desktop (and the web dashboard).** The Desktop app's **Remote Gateway** connection talks to a `hermes dashboard` backend (default **port 9119**, enabled by `HERMES_DASHBOARD=1`) — *not* the OpenAI API server. One dashboard backend serves **every** co-located profile: the app's profile switcher sends the target profile with each request and the backend opens that profile's `HERMES_HOME` on disk. So you do **not** need a second port — or a second connection — per profile for Desktop; one `:9119` connection covers them all through the switcher.
+
+**OpenAI-compatible API clients (Open WebUI, LobeChat, `/v1/...`).** These talk to each profile's **API server**, which binds **port 8642 for every profile** (resolved from `API_SERVER_PORT` / `platforms.api_server.extra.port` — there is no auto-allocation and no `config.yaml`/`gateway.port` key). If you want a client to reach a *specific* second profile, give that profile a distinct `API_SERVER_PORT` in **its own** `.env`, otherwise its gateway tries to bind 8642 too and conflicts with the default profile:
+
+```sh
+# Create the profile (registers its gateway-<name> s6 slot)
+docker exec hermes hermes profile create work
+
+# Point its API server at a free port (write to the profile's own .env)
+cat >> /opt/data/profiles/work/.env <<'EOF'
+API_SERVER_ENABLED=true
+API_SERVER_PORT=8643
+EOF
+
+docker exec hermes hermes -p work gateway restart
+```
+
+Keep `API_SERVER_PORT` in each profile's **own** `.env`, never in the container-wide `environment:` block — a global value would force every profile onto the same port and they would collide. With bridge networking, publish the extra port in `docker-compose.yml` (`- "8643:8643"`); with `network_mode: host` it is already reachable on the host. The default profile's 8642 connection is untouched.
+
 ### Why one container with many profiles, not many containers
 
 Before the s6 migration, "one container per profile" was the recommended pattern because there was no in-container supervisor to manage multiple gateways. With s6 as PID 1, that's no longer necessary, and the single-container layout is simpler in almost every dimension:


### PR DESCRIPTION
## Summary

A Docker user asked how to add a second profile while keeping their working Desktop **Remote Gateway** connection, and guessed they should set `gateway: port: 8643` in the new profile's config. That key does not exist — and two of our own docstrings told them it did. While documenting this I also separated the two surfaces people conflate.

## Changes

* `hermes_cli/service_manager.py`, `hermes_cli/profiles.py`: the profile-gateway docstrings claimed the bind port comes from `[gateway] port` in config.yaml ("the single source of truth"). No such key is read anywhere. Point them at the real mechanism (`API_SERVER_PORT` / `platforms.api_server.extra.port`, default 8642) and spell out the consequence: each supervised profile gateway loads its own `HERMES_HOME`, so two profiles left at the default both try to bind 8642 — give each a distinct `API_SERVER_PORT` in its `.env`.
* `website/docs/user-guide/docker.md`: add a "Reaching more than one profile from outside the container" subsection that distinguishes:
  - **Hermes Desktop** → connects to a `hermes dashboard` backend (**9119**), and one dashboard serves **every** co-located profile via its profile switcher (profile sent per request; backend opens that profile's `HERMES_HOME`). No per-profile port / second connection needed for Desktop.
  - **OpenAI-compatible API clients** (Open WebUI, LobeChat, `/v1`) → talk to each profile's **API server** (8642, no auto-allocation); reaching a specific second profile needs a distinct `API_SERVER_PORT` in that profile's own `.env` (and never in the container-wide `environment:` block, or every profile collides).

Docs/comment accuracy only — no behavior change.

## Note

An earlier revision of the docs incorrectly said the Desktop Remote Gateway talks to the 8642 API server. It does not — Desktop connects to the dashboard (9119); 8642 is only for OpenAI-compatible `/v1` clients. Corrected (evidence: `apps/desktop/electron/connection-config.cjs`, `tui_gateway/server.py` profile param, `website/docs/user-guide/desktop.md`).

## Test plan

* No code paths changed; docstrings + docs only.
* Verified no `gateway.port` / `[gateway] port` config key is read; the Desktop Remote Gateway target is the dashboard (`hermes dashboard`, 9119), not the 8642 API server.