### PR TITLE
fix(cli): add missing monitor task to auxiliary model picker (#45303)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3058,6 +3058,7 @@ _AUX_TASKS: list[tuple[str, str, str]] = [
     ("kanban_decomposer", "Kanban decomposer", "task decomposition"),
     ("profile_describer", "Profile describer", "auto profile descriptions"),
     ("curator", "Curator", "skill-usage review pass"),
+    ("monitor", "Monitor", "mail/item urgency classifier"),
 ]
 
 

--- a/tests/hermes_cli/test_aux_config.py
+++ b/tests/hermes_cli/test_aux_config.py
@@ -58,6 +58,20 @@ def test_aux_tasks_keys_all_exist_in_default_config():
     )
 
 
+def test_default_config_auxiliary_keys_all_in_aux_tasks():
+    """Every DEFAULT_CONFIG auxiliary task must appear in the picker menu.
+
+    Regression guard: `monitor` was in DEFAULT_CONFIG but missing from
+    ``_AUX_TASKS``, so the interactive ``hermes model`` picker didn't show it.
+    """
+    aux_keys = {k for k, _name, _desc in _AUX_TASKS}
+    default_keys = set(DEFAULT_CONFIG["auxiliary"].keys())
+    missing = default_keys - aux_keys
+    assert not missing, (
+        f"DEFAULT_CONFIG.auxiliary has tasks missing from _AUX_TASKS picker: {missing}"
+    )
+
+
 # ── _format_aux_current ─────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What does this PR do?

Adds the missing `monitor` auxiliary task to the interactive `hermes model` → "Configure auxiliary models" picker. The `monitor` task (used by `cron/scripts/classify_items.py` for mail/item urgency scoring) was defined in `DEFAULT_CONFIG` but absent from `_AUX_TASKS`, so users couldn't configure it through the UI — only via `hermes config set`.

Also adds a reverse-sync test that catches future `DEFAULT_CONFIG` tasks missing from the picker.

## Related Issue

Fixes #45303

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py`: Added `("monitor", "Monitor", "mail/item urgency classifier")` to `_AUX_TASKS` list
- `tests/hermes_cli/test_aux_config.py`: Added `test_default_config_auxiliary_keys_all_in_aux_tasks` — reverse-sync guard ensuring every `DEFAULT_CONFIG["auxiliary"]` key appears in the picker

## How to Test

1. Run `hermes model`, select a provider, then choose "Configure auxiliary models..."
2. Verify "Monitor" appears in the task list (was previously missing)
3. Run `pytest tests/hermes_cli/test_aux_config.py tests/hermes_cli/test_plugin_auxiliary_tasks.py -xvs` — all 37 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_aux_config.py tests/hermes_cli/test_plugin_auxiliary_tasks.py -xvs` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `_AUX_TASKS` (callers: `_all_aux_tasks`, `_aux_config_menu`, `_reset_aux_to_auto`)
- Blast radius: LOW — single list addition, no control-flow changes
- Related patterns: `_AUX_TASKS` ↔ `DEFAULT_CONFIG["auxiliary"]` sync guard
