### PR TITLE
docs(telegram): add read-state limitation note for private DM topics (#45295)

### DIFF
--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -630,6 +630,10 @@ platforms:
 3. Each topic maps to an isolated session key: `agent:main:telegram:dm:{chat_id}:{thread_id}`
 4. Messages in each topic have their own conversation history, memory flush, and context window
 
+:::caution Read-state limitation
+Telegram private DM topics have a Bot API read-state limitation. Hermes can receive messages from a user-created topic and route replies back into that topic, but normal bot accounts don't expose a reliable API for marking the topic copy of an incoming user message as read. Telegram may show the root "All Messages" chat and the topic with different unread/read indicators. This is expected Telegram behaviour, not necessarily a Hermes processing failure.
+:::
+
 ### Root DM handling
 
 By default, messages sent to the root DM (outside any topic) are processed


### PR DESCRIPTION
## What does this PR do?

Adds a caution note to the Telegram Private Chat Topics documentation explaining the Bot API read-state limitation. When a user sends a message in a private DM topic, Telegram may show different unread/read indicators between the root "All Messages" chat and the topic — this is expected Telegram behaviour, not a Hermes bug.

## Related Issue

Fixes #45295

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- `website/docs/user-guide/messaging/telegram.md`: Added `:::caution` block after the "How it works" section documenting the read-state limitation for private DM topics

## How to Test

1. Visit the Telegram docs page at https://hermes-agent.nousresearch.com/docs/user-guide/messaging/telegram
2. Navigate to the "Private Chat Topics" section
3. Verify the "Read-state limitation" caution block appears after the "How it works" numbered list

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes — N/A (docs-only)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (docs-only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Code Intelligence

- Analyzed: `website/docs/user-guide/messaging/telegram.md` (Private Chat Topics section)
- Blast radius: LOW — docs-only, no code changes
- Related patterns: Telegram Bot API read-state limitation
