### PR TITLE
fix(telemetry): clamp last_prompt_tokens to >= 0 in turn finalization

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -346,7 +346,7 @@ def finalize_turn(
         "prompt_tokens": agent.session_prompt_tokens,
         "completion_tokens": agent.session_completion_tokens,
         "total_tokens": agent.session_total_tokens,
-        "last_prompt_tokens": getattr(agent.context_compressor, "last_prompt_tokens", 0) or 0,
+        "last_prompt_tokens": max(getattr(agent.context_compressor, "last_prompt_tokens", 0) or 0, 0),
         "estimated_cost_usd": agent.session_estimated_cost_usd,
         "cost_status": agent.session_cost_status,
         "cost_source": agent.session_cost_source,


### PR DESCRIPTION
`last_prompt_tokens` could surface a negative value in turn finalization telemetry; this clamps it to `>= 0`. One-line fix.

_Submitted as a draft for maintainer review; happy to adjust to contribution conventions._