### PR TITLE
fix(telegram): honor server retry_after on flood-control fallback send

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -856,10 +856,13 @@ class GatewayStreamConsumer:
                 if result.success:
                     break
                 if attempt == 0 and self._is_flood_error(result):
+                    retry_after = getattr(result, "retry_after", None)
+                    wait = max(float(retry_after), 3.0) if retry_after else 3.0
                     logger.debug(
-                        "Flood control on fallback send, retrying in 3s"
+                        "Flood control on fallback send, retrying in %.1fs",
+                        wait,
                     )
-                    await asyncio.sleep(3.0)
+                    await asyncio.sleep(wait)
                 else:
                     break  # non-flood error or second attempt failed
 


### PR DESCRIPTION
On a Telegram flood-control error during a fallback send, the code waited a flat 3s instead of the server-supplied `retry_after`. This waits `max(retry_after, 3.0)`, reducing repeated flood errors.

_Submitted as a draft for maintainer review._