### PR TITLE
fix(agent): apply /steer to per-call message copy, not canonical history

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -441,15 +441,17 @@ def init_agent(
     agent._interrupt_thread_signal_pending = False
     agent._client_lock = threading.RLock()
 
-    # /steer mechanism — inject a user note into the next tool result
+    # /steer mechanism — inject a user note into the next API request's
+    # tool-result copy without mutating canonical message history.
     # without interrupting the agent. Unlike interrupt(), steer() does
     # NOT set _interrupt_requested; it waits for the current tool batch
-    # to finish naturally, then the drain hook appends the text to the
-    # last tool result's content so the model sees it on its next
-    # iteration. Message-role alternation is preserved (we modify an
-    # existing tool message rather than inserting a new user turn).
+    # to finish naturally, then the drain hook queues the last tool result
+    # for API-only marker injection so the model sees it on its next
+    # iteration. Message-role alternation is preserved without polluting
+    # stored transcripts.
     agent._pending_steer: Optional[str] = None
     agent._pending_steer_lock = threading.Lock()
+    agent._pending_steer_api_injections = []
 
     # Concurrent-tool worker thread tracking.  `_execute_tool_calls_concurrent`
     # runs each tool on its own ThreadPoolExecutor worker — those worker

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -32,7 +32,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from hermes_cli.timeouts import get_provider_request_timeout
-from agent.prompt_builder import format_steer_marker
 from agent.tool_dispatch_helpers import _trajectory_normalize_msg, make_tool_result_message
 from agent.trajectory import convert_scratchpad_to_think
 from agent.credential_pool import STATUS_EXHAUSTED
@@ -2421,13 +2420,14 @@ def extract_api_error_context(error: Exception) -> Dict[str, Any]:
 
 
 def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: int) -> None:
-    """Append any pending /steer text to the last tool result in this turn.
+    """Queue any pending /steer text for the next API request's tool copy.
 
     Called at the end of a tool-call batch, before the next API call.
-    The steer is appended to the last ``role:"tool"`` message's content
-    with a clear marker so the model understands it came from the user
-    and NOT from the tool itself. Role alternation is preserved —
-    nothing new is inserted, we only modify existing content.
+    The steer is associated with the last ``role:"tool"`` message so
+    ``conversation_loop`` can append the marker to that message's per-call
+    ``api_messages`` copy. The canonical tool result remains byte-identical
+    to what the tool returned, preserving transcript integrity and prompt
+    cache stability on later turns.
 
     Args:
         messages: The running messages list.
@@ -2463,22 +2463,13 @@ def apply_pending_steer_to_tool_results(agent, messages: list, num_tool_msgs: in
             existing = getattr(agent, "_pending_steer", None)
             agent._pending_steer = (existing + "\n" + steer_text) if existing else steer_text
         return
-    marker = format_steer_marker(steer_text)
-    existing_content = messages[target_idx].get("content", "")
-    if not isinstance(existing_content, str):
-        # Anthropic multimodal content blocks — preserve them and append
-        # a text block at the end.
-        try:
-            blocks = list(existing_content) if existing_content else []
-            blocks.append({"type": "text", "text": marker.lstrip()})
-            messages[target_idx]["content"] = blocks
-        except Exception:
-            # Fall back to string replacement if content shape is unexpected.
-            messages[target_idx]["content"] = f"{existing_content}{marker}"
-    else:
-        messages[target_idx]["content"] = existing_content + marker
+    pending_injections = getattr(agent, "_pending_steer_api_injections", None)
+    if pending_injections is None:
+        pending_injections = []
+        agent._pending_steer_api_injections = pending_injections
+    pending_injections.append((messages[target_idx], steer_text))
     _ra().logger.info(
-        "Delivered /steer to agent after tool batch (%d chars): %s",
+        "Queued /steer for next API request after tool batch (%d chars): %s",
         len(steer_text),
         steer_text[:120] + ("..." if len(steer_text) > 120 else ""),
     )

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -115,6 +115,42 @@ def _ollama_context_limit_error(agent: Any, request_tokens: int) -> Optional[str
     )
 
 
+def _restash_pending_steer(agent: Any, steer_text: str) -> None:
+    """Put drained /steer text back so a later tool/API path can consume it."""
+    _lock = getattr(agent, "_pending_steer_lock", None)
+    if _lock is not None:
+        with _lock:
+            if agent._pending_steer:
+                agent._pending_steer = agent._pending_steer + "\n" + steer_text
+            else:
+                agent._pending_steer = steer_text
+    else:
+        existing = getattr(agent, "_pending_steer", None)
+        agent._pending_steer = (existing + "\n" + steer_text) if existing else steer_text
+
+
+def _inject_steer_into_api_message_copy(api_msg: Dict[str, Any], steer_text: str) -> None:
+    """Append a /steer marker to an API-only message copy.
+
+    The caller passes the shallow-copied ``api_msg`` built for this provider
+    request, never the canonical ``messages`` entry that gets persisted.
+    """
+    from agent.prompt_builder import format_steer_marker
+
+    marker = format_steer_marker(steer_text)
+    existing = api_msg.get("content", "")
+    if isinstance(existing, str):
+        api_msg["content"] = existing + marker
+    else:
+        # Multimodal content blocks — append text block.
+        try:
+            blocks = list(existing) if existing else []
+            blocks.append({"type": "text", "text": marker})
+            api_msg["content"] = blocks
+        except Exception:
+            pass
+
+
 def _ra():
     """Lazy reference to ``run_agent`` so callers can patch
     ``run_agent.handle_function_call`` / ``run_agent._set_interrupt`` /
@@ -527,48 +563,33 @@ def run_conversation(
         # which may never come if the model returns a final response.
         #
         # We scan backwards for the last tool-role message in the messages
-        # list.  If found, the steer is appended there.  If not (first
+        # list.  If found, the steer is appended later to that message's
+        # per-call api_messages copy.  If not (first
         # iteration, no tools yet), the steer stays pending for the next
         # tool batch — injecting into a user message would break role
         # alternation, and there's no tool output to piggyback on.
+        _pending_api_steer_injections = list(
+            getattr(agent, "_pending_steer_api_injections", []) or []
+        )
+        if _pending_api_steer_injections:
+            agent._pending_steer_api_injections = []
+
         _pre_api_steer = agent._drain_pending_steer()
         if _pre_api_steer:
-            _injected = False
+            _pre_api_steer_target_msg = None
             for _si in range(len(messages) - 1, -1, -1):
                 _sm = messages[_si]
                 if isinstance(_sm, dict) and _sm.get("role") == "tool":
-                    from agent.prompt_builder import format_steer_marker
-                    marker = format_steer_marker(_pre_api_steer)
-                    existing = _sm.get("content", "")
-                    if isinstance(existing, str):
-                        _sm["content"] = existing + marker
-                    else:
-                        # Multimodal content blocks — append text block
-                        try:
-                            blocks = list(existing) if existing else []
-                            blocks.append({"type": "text", "text": marker})
-                            _sm["content"] = blocks
-                        except Exception:
-                            pass
-                    _injected = True
-                    logger.debug(
-                        "Pre-API-call steer drain: injected into tool msg at index %d",
-                        _si,
-                    )
+                    _pre_api_steer_target_msg = _sm
                     break
-            if not _injected:
+            if _pre_api_steer_target_msg is None:
                 # No tool message to inject into — put it back so
                 # the post-tool-execution drain picks it up later.
-                _lock = getattr(agent, "_pending_steer_lock", None)
-                if _lock is not None:
-                    with _lock:
-                        if agent._pending_steer:
-                            agent._pending_steer = agent._pending_steer + "\n" + _pre_api_steer
-                        else:
-                            agent._pending_steer = _pre_api_steer
-                else:
-                    existing = getattr(agent, "_pending_steer", None)
-                    agent._pending_steer = (existing + "\n" + _pre_api_steer) if existing else _pre_api_steer
+                _restash_pending_steer(agent, _pre_api_steer)
+            else:
+                _pending_api_steer_injections.append(
+                    (_pre_api_steer_target_msg, _pre_api_steer)
+                )
 
         # Prepare messages for API call
         # If we have an ephemeral system prompt, prepend it to the messages
@@ -608,8 +629,20 @@ def run_conversation(
             )
 
         api_messages = []
+        _injected_api_steer_indices = set()
         for idx, msg in enumerate(messages):
             api_msg = msg.copy()
+
+            for _steer_idx, (_target_msg, _steer_text) in enumerate(
+                _pending_api_steer_injections
+            ):
+                if msg is _target_msg:
+                    _inject_steer_into_api_message_copy(api_msg, _steer_text)
+                    _injected_api_steer_indices.add(_steer_idx)
+                    logger.debug(
+                        "Pre-API-call steer drain: injected into API tool msg copy at index %d",
+                        idx,
+                    )
 
             # Inject ephemeral context into the current turn's user message.
             # Sources: memory manager prefetch + plugin pre_llm_call hooks
@@ -651,6 +684,13 @@ def run_conversation(
             # Keep 'reasoning_details' - OpenRouter uses this for multi-turn reasoning context
             # The signature field helps maintain reasoning continuity
             api_messages.append(api_msg)
+
+        if len(_injected_api_steer_indices) < len(_pending_api_steer_injections):
+            for _steer_idx, (_target_msg, _steer_text) in enumerate(
+                _pending_api_steer_injections
+            ):
+                if _steer_idx not in _injected_api_steer_indices:
+                    _restash_pending_steer(agent, _steer_text)
 
         # Build the final system message: cached prompt + ephemeral system prompt.
         # Ephemeral additions are API-call-time only (not persisted to session DB).

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -759,9 +759,10 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         enforce_turn_budget(turn_tool_msgs, env=get_active_env(effective_task_id))
 
     # ── /steer injection ──────────────────────────────────────────────
-    # Append any pending user steer text to the last tool result so the
-    # agent sees it on its next iteration. Runs AFTER budget enforcement
-    # so the steer marker is never truncated. See steer() for details.
+    # Queue any pending user steer text against the last tool result so
+    # the next API request can inject it into a per-call message copy.
+    # Runs AFTER budget enforcement so the steer marker is never truncated.
+    # See steer() for details.
     if num_tools > 0:
         agent._apply_pending_steer_to_tool_results(messages, num_tools)
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -2380,15 +2380,17 @@ class AIAgent:
         if _steer_lock is not None:
             with _steer_lock:
                 self._pending_steer = None
+        self._pending_steer_api_injections = []
 
     def steer(self, text: str) -> bool:
         """
-        Inject a user message into the next tool result without interrupting.
+        Inject a user message into the next API request without interrupting.
 
         Unlike interrupt(), this does NOT stop the current tool call. The
-        text is stashed and the agent loop appends it to the LAST tool
-        result's content once the current tool batch finishes. The model
-        sees the steer as part of the tool output on its next iteration.
+        text is stashed and the agent loop associates it with the LAST tool
+        result once the current tool batch finishes. The model sees the
+        steer in the next API request's tool-message copy; the stored tool
+        result remains unchanged.
 
         Thread-safe: callable from gateway/CLI/TUI threads. Multiple calls
         before the drain point concatenate with newlines.

--- a/tests/run_agent/test_steer.py
+++ b/tests/run_agent/test_steer.py
@@ -11,6 +11,7 @@ import threading
 
 import pytest
 
+from agent.conversation_loop import _inject_steer_into_api_message_copy
 from agent.prompt_builder import STEER_MARKER_OPEN, format_steer_marker
 from run_agent import AIAgent
 
@@ -23,6 +24,7 @@ def _bare_agent() -> AIAgent:
     agent = object.__new__(AIAgent)
     agent._pending_steer = None
     agent._pending_steer_lock = threading.Lock()
+    setattr(agent, "_pending_steer_api_injections", [])
     return agent
 
 
@@ -73,7 +75,7 @@ class TestSteerDrain:
 
 
 class TestSteerInjection:
-    def test_appends_to_last_tool_result(self):
+    def test_queues_last_tool_result_for_api_copy_injection(self):
         agent = _bare_agent()
         agent.steer("please also check auth.log")
         messages = [
@@ -83,11 +85,17 @@ class TestSteerInjection:
             {"role": "tool", "content": "ls output B", "tool_call_id": "b"},
         ]
         agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=2)
-        # The LAST tool result is modified; earlier ones are untouched.
+        # Canonical tool results are untouched.
         assert messages[2]["content"] == "ls output A"
-        assert "ls output B" in messages[3]["content"]
-        assert STEER_MARKER_OPEN in messages[3]["content"]
-        assert "please also check auth.log" in messages[3]["content"]
+        assert messages[3]["content"] == "ls output B"
+        # The LAST tool result is queued for API-only injection.
+        assert getattr(agent, "_pending_steer_api_injections") == [
+            (messages[3], "please also check auth.log")
+        ]
+        api_msg = messages[3].copy()
+        _inject_steer_into_api_message_copy(api_msg, "please also check auth.log")
+        assert STEER_MARKER_OPEN in api_msg["content"]
+        assert "please also check auth.log" in api_msg["content"]
         # And pending_steer is consumed.
         assert agent._pending_steer is None
 
@@ -99,6 +107,7 @@ class TestSteerInjection:
         ]
         agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=1)
         assert messages[-1]["content"] == "output"  # unchanged
+        assert getattr(agent, "_pending_steer_api_injections") == []
 
     def test_no_op_when_num_tool_msgs_zero(self):
         agent = _bare_agent()
@@ -112,14 +121,20 @@ class TestSteerInjection:
         """The injection marker must attribute the appended text to the user
         via the explicit out-of-band marker (which the system prompt tells the
         model to trust) — otherwise the model reads it as untrusted tool output
-        and refuses it as suspected prompt injection.  Cache-safe: it only
-        rewrites existing tool content, never the message-role sequence.
+        and refuses it as suspected prompt injection. Cache-safe: it only
+        rewrites the API request copy, never the stored message-role sequence.
         """
         agent = _bare_agent()
         agent.steer("stop after next step")
         messages = [{"role": "tool", "content": "x", "tool_call_id": "1"}]
         agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=1)
-        content = messages[-1]["content"]
+        assert messages[-1]["content"] == "x"
+        assert getattr(agent, "_pending_steer_api_injections") == [
+            (messages[-1], "stop after next step")
+        ]
+        api_msg = messages[-1].copy()
+        _inject_steer_into_api_message_copy(api_msg, "stop after next step")
+        content = api_msg["content"]
         assert STEER_MARKER_OPEN in content
         assert "stop after next step" in content
 
@@ -133,7 +148,10 @@ class TestSteerInjection:
             {"role": "tool", "content": list(original_blocks), "tool_call_id": "1"}
         ]
         agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=1)
-        new_content = messages[-1]["content"]
+        assert messages[-1]["content"] == original_blocks
+        api_msg = messages[-1].copy()
+        _inject_steer_into_api_message_copy(api_msg, "extra note")
+        new_content = api_msg["content"]
         assert isinstance(new_content, list)
         assert len(new_content) == 2
         assert new_content[0] == {"type": "text", "text": "existing output"}
@@ -157,6 +175,7 @@ class TestSteerInjection:
         assert messages[-1]["content"] == "y"
         # And the steer is back in pending so the fallback can grab it
         assert agent._pending_steer == "ping"
+        assert getattr(agent, "_pending_steer_api_injections") == []
 
 
 class TestSteerThreadSafety:
@@ -208,10 +227,11 @@ class TestPreApiCallSteerDrain:
     fix for the scenario where /steer sent during model thinking only lands
     after the agent is completely done."""
 
-    def test_pre_api_drain_injects_into_last_tool_result(self):
+    def test_pre_api_drain_injects_into_api_copy_without_mutating_tool_result(self):
         """If a steer is pending when the main loop starts building
-        api_messages, it should be injected into the last tool result
-        in the messages list."""
+        api_messages, it should be injected into the API request copy while
+        the stored tool result remains byte-identical to the original output.
+        """
         agent = _bare_agent()
         # Simulate messages after a tool batch completed
         messages = [
@@ -221,18 +241,29 @@ class TestPreApiCallSteerDrain:
             ]},
             {"role": "tool", "content": "output here", "tool_call_id": "tc1"},
         ]
+        original_tool_content = messages[-1]["content"]
         # Steer arrives during API call (set after tool execution)
         agent.steer("focus on error handling")
         # Simulate what the pre-API-call drain does:
         _pre_api_steer = agent._drain_pending_steer()
         assert _pre_api_steer == "focus on error handling"
-        # Inject into last tool msg (mirrors the new code in run_conversation)
+        target_idx = None
         for _si in range(len(messages) - 1, -1, -1):
             if messages[_si].get("role") == "tool":
-                messages[_si]["content"] += format_steer_marker(_pre_api_steer)
+                target_idx = _si
                 break
-        assert STEER_MARKER_OPEN in messages[-1]["content"]
-        assert "focus on error handling" in messages[-1]["content"]
+        assert target_idx == 2
+
+        api_messages = []
+        for idx, msg in enumerate(messages):
+            api_msg = msg.copy()
+            if idx == target_idx:
+                _inject_steer_into_api_message_copy(api_msg, _pre_api_steer)
+            api_messages.append(api_msg)
+
+        assert messages[-1]["content"] == original_tool_content
+        assert STEER_MARKER_OPEN in api_messages[-1]["content"]
+        assert "focus on error handling" in api_messages[-1]["content"]
         assert agent._pending_steer is None
 
     def test_pre_api_drain_restashes_when_no_tool_message(self):
@@ -269,13 +300,19 @@ class TestPreApiCallSteerDrain:
             {"role": "tool", "content": "search results", "tool_call_id": "tc1"},
         ]
         agent.steer("change approach")
+        original_tool_content = messages[2]["content"]
         _pre_api_steer = agent._drain_pending_steer()
         assert _pre_api_steer is not None
+        target_idx = None
         for _si in range(len(messages) - 1, -1, -1):
             if messages[_si].get("role") == "tool":
-                messages[_si]["content"] += format_steer_marker(_pre_api_steer)
+                target_idx = _si
                 break
-        assert "change approach" in messages[2]["content"]
+        assert target_idx == 2
+        api_msg = messages[target_idx].copy()
+        _inject_steer_into_api_message_copy(api_msg, _pre_api_steer)
+        assert messages[2]["content"] == original_tool_content
+        assert "change approach" in api_msg["content"]
 
 
 class TestSteerMarkerContract:


### PR DESCRIPTION
The pre-API-call `/steer` drain mutated the canonical messages list in place, which (1) permanently wrote the steer marker into the stored tool result and (2) invalidated the provider prompt-cache prefix mid-turn. This moves steer injection to the per-call `api_messages` copy (the same pattern the ephemeral-injection path already uses), preserving replay-until-consumed semantics without touching canonical history. Includes a byte-identity regression test.

_Submitted as a draft for maintainer review; the diff touches several call sites to thread the per-call copy — happy to split or adjust._