### PR TITLE
fix: model fallback config

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5356,6 +5356,31 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
                         "Add the API endpoint URL, e.g.: base_url: https://api.example.com/v1",
                     ))
 
+    # ── Check for fallback keys mistakenly nested under model: ───────────
+    model_cfg = config.get("model")
+    if isinstance(model_cfg, dict):
+        for nested_key in ("fallback_providers", "fallback_model"):
+            if nested_key in model_cfg:
+                if nested_key == "fallback_providers":
+                    example = (
+                        f"  {nested_key}:\n"
+                        "    - provider: ...\n"
+                        "      model: ..."
+                    )
+                else:
+                    example = (
+                        f"  {nested_key}:\n"
+                        "    provider: ...\n"
+                        "    model: ..."
+                    )
+                issues.append(ConfigIssue(
+                    "warning",
+                    f"{nested_key} is nested under model: - move it to the top level",
+                    f"Move {nested_key} to the top level of config.yaml:\n"
+                    f"{example}\n"
+                    "It still works for compatibility, but this placement is deprecated.",
+                ))
+
     # ── fallback_model: single dict OR list of dicts (chain) ─────────────
     fb = config.get("fallback_model")
     if fb is not None:
@@ -5413,7 +5438,6 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
         ))
 
     # ── model section: should exist when custom_providers is configured ──
-    model_cfg = config.get("model")
     if cp and not model_cfg:
         issues.append(ConfigIssue(
             "warning",

--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -51,18 +51,28 @@ def _entry_identity(entry: dict[str, Any]) -> tuple[str, str, str]:
 def get_fallback_chain(config: dict[str, Any] | None) -> list[dict[str, Any]]:
     """Return the effective fallback chain merged across old and new config keys.
 
-    ``fallback_providers`` remains the primary source of truth and keeps its
-    order. Legacy ``fallback_model`` entries are appended afterwards unless
-    they target the same provider/model/base_url route as an earlier entry.
-    The returned list always contains fresh dict copies.
+    Top-level ``fallback_providers`` remains the primary source of truth and
+    keeps its order. ``model.fallback_providers`` is accepted as a compatibility
+    source for configs that colocate model routing options under ``model``.
+    Legacy ``fallback_model`` entries are appended afterwards unless they target
+    the same provider/model/base_url route as an earlier entry. The returned
+    list always contains fresh dict copies.
     """
 
     config = config or {}
+    model_config = config.get("model") if isinstance(config.get("model"), dict) else {}
     chain: list[dict[str, Any]] = []
     seen: set[tuple[str, str, str]] = set()
 
-    for key in ("fallback_providers", "fallback_model"):
-        for entry in _iter_fallback_entries(config.get(key)):
+    sources = (
+        config.get("fallback_providers"),
+        model_config.get("fallback_providers"),
+        config.get("fallback_model"),
+        model_config.get("fallback_model"),
+    )
+
+    for source in sources:
+        for entry in _iter_fallback_entries(source):
             identity = _entry_identity(entry)
             if identity in seen:
                 continue

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -170,6 +170,37 @@ class TestFallbackModelValidation:
         assert any("fallback_model[0]" in i.message and "should be a dict" in i.message for i in issues)
 
 
+class TestNestedModelFallbackValidation:
+    """Fallback keys nested under model still work, but should warn."""
+
+    def test_nested_fallback_providers_warns_to_move_to_top_level(self):
+        issues = validate_config_structure({
+            "model": {
+                "provider": "openai",
+                "default": "gpt-5",
+                "fallback_providers": [
+                    {"provider": "openrouter", "model": "fallback-model"},
+                ],
+            },
+        })
+
+        warnings = [i for i in issues if i.severity == "warning"]
+        assert any("fallback_providers" in i.message and "top level" in i.message for i in warnings)
+        assert any("still works" in i.hint and "deprecated" in i.hint for i in warnings)
+
+    def test_nested_fallback_model_warns_to_move_to_top_level(self):
+        issues = validate_config_structure({
+            "model": {
+                "provider": "openai",
+                "default": "gpt-5",
+                "fallback_model": {"provider": "openrouter", "model": "fallback-model"},
+            },
+        })
+
+        warnings = [i for i in issues if i.severity == "warning"]
+        assert any("fallback_model" in i.message and "top level" in i.message for i in warnings)
+
+
 class TestMissingModelSection:
     """Warn when custom_providers exists but model section is missing."""
 

--- a/tests/hermes_cli/test_fallback_cmd.py
+++ b/tests/hermes_cli/test_fallback_cmd.py
@@ -54,6 +54,52 @@ class TestReadChain:
             {"provider": "nous", "model": "Hermes-4-Llama-3.1-405B"},
         ]
 
+    def test_reads_fallback_providers_nested_under_model(self):
+        from hermes_cli.fallback_cmd import _read_chain
+        cfg = {
+            "model": {
+                "default": "primary-model",
+                "provider": "primary",
+                "fallback_providers": [
+                    {"provider": "openrouter", "model": "anthropic/claude-sonnet-4.6"},
+                ],
+            }
+        }
+        assert _read_chain(cfg) == [
+            {"provider": "openrouter", "model": "anthropic/claude-sonnet-4.6"},
+        ]
+
+    def test_reads_legacy_fallback_model_nested_under_model(self):
+        from hermes_cli.fallback_cmd import _read_chain
+        cfg = {
+            "model": {
+                "default": "primary-model",
+                "provider": "primary",
+                "fallback_model": {"provider": "nous", "model": "Hermes-4"},
+            }
+        }
+        assert _read_chain(cfg) == [{"provider": "nous", "model": "Hermes-4"}]
+
+    def test_merges_top_level_before_nested_fallbacks(self):
+        from hermes_cli.fallback_cmd import _read_chain
+        cfg = {
+            "fallback_providers": [
+                {"provider": "openrouter", "model": "anthropic/claude-sonnet-4.6"},
+            ],
+            "model": {
+                "fallback_providers": [
+                    {"provider": "OpenRouter", "model": "anthropic/claude-sonnet-4.6"},
+                    {"provider": "nous", "model": "Hermes-4"},
+                ],
+                "fallback_model": {"provider": "backup", "model": "backup-model"},
+            },
+        }
+        assert _read_chain(cfg) == [
+            {"provider": "openrouter", "model": "anthropic/claude-sonnet-4.6"},
+            {"provider": "nous", "model": "Hermes-4"},
+            {"provider": "backup", "model": "backup-model"},
+        ]
+
     def test_merges_new_and_legacy_formats(self):
         from hermes_cli.fallback_cmd import _read_chain
         cfg = {


### PR DESCRIPTION
## Summary
- Accept fallback_providers and fallback_model when they are nested under model:.
- Preserve canonical top-level fallback ordering first, then merge nested entries and legacy entries with existing dedupe rules.
- Route cron fallback loading through the same shared parser used by the other agent entry points.

## Problem
The fallback-chain parser only read fallback_providers and fallback_model from the top level of config.yaml. If a user placed fallback_providers under model:, Hermes silently built an empty fallback chain, so provider failover never engaged when the primary provider failed.

## Validation
- `$HOME/.hermes/hermes-agent/venv/bin/pytest -q tests/hermes_cli/test_fallback_cmd.py::TestReadChain`
- `$HOME/.hermes/hermes-agent/venv/bin/pytest -q tests/cron/test_scheduler.py::TestRunJobConfigEnvVarExpansion::test_nested_model_fallback_providers_are_passed_to_agent`
- `$HOME/.hermes/hermes-agent/venv/bin/pytest -q tests/cron/test_scheduler.py::TestRunJobConfigEnvVarExpansion tests/gateway/test_auth_fallback.py tests/test_tui_gateway_server.py::test_load_fallback_model_merges_chain_providers_first`
- `$HOME/.hermes/hermes-agent/venv/bin/pytest -q tests/cli/test_cli_init.py::TestFallbackChainInit::test_merges_new_and_legacy_fallback_config`
- `$HOME/.hermes/hermes-agent/venv/bin/ruff check hermes_cli/fallback_config.py cron/scheduler.py tests/hermes_cli/test_fallback_cmd.py tests/cron/test_scheduler.py`

Fixes #45309