### PR TITLE
fix(bluebubbles): preserve 127.0.0.1 in webhook URL to fix IPv4 delivery

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -303,7 +303,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     def _webhook_url(self) -> str:
         """Compute the external webhook URL for BlueBubbles registration."""
         host = self.webhook_host
-        if host in {"0.0.0.0", "127.0.0.1", "localhost", "::"}:
+        if host in {"0.0.0.0", "localhost", "::"}:
             host = "localhost"
         return f"http://{host}:{self.webhook_port}{self.webhook_path}"
 

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -558,15 +558,22 @@ class TestBlueBubblesWebhookUrl:
 
     def test_default_host(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
-        # Default webhook_host is 0.0.0.0 → normalized to localhost
-        assert "localhost" in adapter._webhook_url
+        # Default webhook_host is 127.0.0.1 — preserved as-is (not normalized
+        # to localhost, which resolves to ::1 on macOS and breaks IPv4 delivery)
+        assert "127.0.0.1" in adapter._webhook_url
         assert str(adapter.webhook_port) in adapter._webhook_url
         assert adapter.webhook_path in adapter._webhook_url
 
-    @pytest.mark.parametrize("host", ["0.0.0.0", "127.0.0.1", "localhost", "::"])
+    @pytest.mark.parametrize("host", ["0.0.0.0", "localhost", "::"])
     def test_local_hosts_normalized(self, monkeypatch, host):
         adapter = _make_adapter(monkeypatch, webhook_host=host)
         assert adapter._webhook_url.startswith("http://localhost:")
+
+    def test_ipv4_loopback_preserved(self, monkeypatch):
+        """127.0.0.1 must NOT be normalised to localhost — on macOS the
+        latter resolves to ::1 first, breaking IPv4 webhook delivery."""
+        adapter = _make_adapter(monkeypatch, webhook_host="127.0.0.1")
+        assert adapter._webhook_url.startswith("http://127.0.0.1:")
 
     def test_custom_host_preserved(self, monkeypatch):
         adapter = _make_adapter(monkeypatch, webhook_host="192.168.1.50")


### PR DESCRIPTION
## What does this PR do?

Removes `127.0.0.1` from the local-host normalization set in `BlueBubblesAdapter._webhook_url` so that an explicitly-configured IPv4 loopback address round-trips unchanged. Previously, `127.0.0.1` was collapsed to `localhost`, which on macOS (and other IPv6-preferring systems) resolves to `::1` first — causing every webhook POST to hit `ECONNREFUSED` and silently dropping inbound messages including image attachments.

## Related Issue

Fixes #45308

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/bluebubbles.py`: Removed `"127.0.0.1"` from the normalization set in `_webhook_url` property so IPv4 loopback is preserved as-is
- `tests/gateway/test_bluebubbles.py`: Updated `test_default_host` to expect `127.0.0.1` (not `localhost`); removed `"127.0.0.1"` from `test_local_hosts_normalized` parametrize; added `test_ipv4_loopback_preserved` to guard against regression

## How to Test

1. Run `pytest tests/gateway/test_bluebubbles.py -q` — all 56 tests should pass
2. Verify `test_ipv4_loopback_preserved` confirms `127.0.0.1` is preserved in the webhook URL
3. Verify `test_local_hosts_normalized` still covers `0.0.0.0`, `localhost`, and `::` normalization

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_bluebubbles.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/platforms/bluebubbles.py::_webhook_url` (property, 6 lines)
- Blast radius: LOW — only affects BlueBubbles webhook URL computation; no other callers
- Related patterns: IPv6-preferring resolver on macOS is the root cause; similar normalization in other adapters (SMS, WhatsApp) may warrant review
