### PR TITLE
fix(skills): resolve category/skill path format in _find_skill()

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -12,6 +12,7 @@ from tools.skill_manager_tool import (
     _validate_category,
     _validate_frontmatter,
     _validate_file_path,
+    _find_skill,
     _create_skill,
     _edit_skill,
     _patch_skill,
@@ -196,6 +197,51 @@ class TestValidateFilePath:
         # Only SKILL.md gets the root-level exception, not arbitrary files.
         err = _validate_file_path("README.md")
         assert "File must be under one of:" in err
+
+
+# ---------------------------------------------------------------------------
+# _find_skill
+# ---------------------------------------------------------------------------
+
+
+class TestFindSkill:
+    """_find_skill must resolve both bare and category/skill names."""
+
+    def test_bare_name(self, tmp_path):
+        skill_dir = tmp_path / "my-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(VALID_SKILL_CONTENT)
+        with _skill_dir(tmp_path):
+            result = _find_skill("my-skill")
+        assert result is not None
+        assert result["path"] == skill_dir
+
+    def test_category_slash_skill_name(self, tmp_path):
+        cat_dir = tmp_path / "mlops" / "axolotl"
+        cat_dir.mkdir(parents=True)
+        (cat_dir / "SKILL.md").write_text(VALID_SKILL_CONTENT)
+        with _skill_dir(tmp_path):
+            result = _find_skill("mlops/axolotl")
+        assert result is not None
+        assert result["path"] == cat_dir
+
+    def test_nonexistent_returns_none(self, tmp_path):
+        with _skill_dir(tmp_path):
+            assert _find_skill("no-such-skill") is None
+
+    def test_category_slash_nonexistent_returns_none(self, tmp_path):
+        with _skill_dir(tmp_path):
+            assert _find_skill("mlops/no-such-skill") is None
+
+    def test_bare_name_still_works_when_category_also_exists(self, tmp_path):
+        """Bare 'axolotl' under a category dir is found by the rglob fallback."""
+        cat_dir = tmp_path / "mlops" / "axolotl"
+        cat_dir.mkdir(parents=True)
+        (cat_dir / "SKILL.md").write_text(VALID_SKILL_CONTENT)
+        with _skill_dir(tmp_path):
+            result = _find_skill("axolotl")
+        assert result is not None
+        assert result["path"] == cat_dir
 
 
 # ---------------------------------------------------------------------------

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -282,11 +282,21 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     Searches the local skills dir (~/.hermes/skills/) first, then any
     external dirs configured via skills.external_dirs.  Returns
     {"path": Path} or None.
+
+    Supports ``category/skill`` names (e.g. ``"mlops/axolotl"``) by
+    trying a direct path join first, matching ``skill_view()`` behaviour.
     """
     from agent.skill_utils import get_all_skills_dirs, is_excluded_skill_path
     for skills_dir in get_all_skills_dirs():
         if not skills_dir.exists():
             continue
+        # Fast path: direct join handles "category/skill" and bare "skill".
+        direct = skills_dir / name
+        direct_md = direct / "SKILL.md"
+        if direct.is_dir() and direct_md.exists():
+            if not is_excluded_skill_path(direct_md):
+                return {"path": direct}
+        # Slow path: flat name may live under a category directory.
         for skill_md in skills_dir.rglob("SKILL.md"):
             if is_excluded_skill_path(skill_md):
                 continue
@@ -350,6 +360,13 @@ def _find_skill_in_other_profiles(name: str) -> List[Tuple[str, Path]]:
         if not skills_dir.is_dir():
             continue
         try:
+            # Fast path: direct join handles "category/skill" names.
+            direct = skills_dir / name
+            direct_md = direct / "SKILL.md"
+            if direct.is_dir() and direct_md.exists():
+                if not is_excluded_skill_path(direct_md):
+                    matches.append((profile_name, direct))
+                    continue
             for skill_md in skills_dir.rglob("SKILL.md"):
                 if is_excluded_skill_path(skill_md):
                     continue


### PR DESCRIPTION
## What does this PR do?

Fixes `_find_skill()` and `_find_skill_in_other_profiles()` to resolve `category/skill` path format names (e.g. `"mlops/axolotl"`). Previously, both functions only compared `skill_md.parent.name == name`, which fails for nested paths because `parent.name` is just the leaf directory name. The fix adds a direct path join check (`skills_dir / name`) before the rglob fallback, matching the approach already used by `skill_view()` in `skills_tool.py`.

## Related Issue

Fixes #45307

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skill_manager_tool.py`: Added direct path join fast-path in `_find_skill()` and `_find_skill_in_other_profiles()` to handle `category/skill` names before falling back to rglob
- `tests/tools/test_skill_manager_tool.py`: Added `TestFindSkill` class with 5 tests covering bare names, category/skill names, nonexistent lookups, and coexistence

## How to Test

1. Run `pytest tests/tools/test_skill_manager_tool.py::TestFindSkill -v` — all 5 new tests should pass
2. Run `pytest tests/tools/test_skill_manager_tool.py -q` — all 95 tests should pass
3. Verify `test_category_slash_skill_name` confirms `"mlops/axolotl"` resolves correctly
4. Verify `test_bare_name_still_works_when_category_also_exists` confirms the rglob fallback still works for bare names

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/tools/test_skill_manager_tool.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `tools/skill_manager_tool.py::_find_skill`, `_find_skill_in_other_profiles`
- Blast radius: LOW — both functions are lookup-only, no side effects; callers include `skill_manage()` dispatch and error messages
- Related patterns: `skill_view()` in `skills_tool.py` already uses the direct-path approach (Strategy 1); this fix aligns `_find_skill()` with that behaviour
