### PR TITLE
fix(termux): use direct bash path in launcher shim

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1531,8 +1531,12 @@ setup_path() {
     # the rm, `cat >` follows the symlink and overwrites the venv pip entry
     # point with this shim — making `exec "$HERMES_BIN"` self-recurse. (#21454)
     rm -f "$command_link_dir/hermes"
+    launcher_shebang='#!/usr/bin/env bash'
+    if [ "$DISTRO" = "termux" ] && [ -n "${PREFIX:-}" ]; then
+        launcher_shebang="#!$PREFIX/bin/bash"
+    fi
     cat > "$command_link_dir/hermes" <<EOF
-#!/usr/bin/env bash
+$launcher_shebang
 unset PYTHONPATH
 unset PYTHONHOME
 exec "$HERMES_BIN" "\$@"

--- a/tests/test_install_sh_symlink_stomp.py
+++ b/tests/test_install_sh_symlink_stomp.py
@@ -120,3 +120,40 @@ def test_re_running_setup_path_block_preserves_pip_entry_point(tmp_path: Path) -
     assert f'exec "{pip_entry}"' in shim_text
     shim_mode = shim_path.stat().st_mode
     assert shim_mode & stat.S_IXUSR, "shim must be user-executable"
+
+
+def test_termux_shim_uses_direct_prefix_bash_path(tmp_path: Path) -> None:
+    """Termux launcher must avoid /usr/bin/env in the kernel shebang path."""
+    hermes_bin = tmp_path / "venv" / "bin" / "hermes"
+    hermes_bin.parent.mkdir(parents=True)
+    hermes_bin.write_text("#!/usr/bin/env python\n")
+    hermes_bin.chmod(hermes_bin.stat().st_mode | stat.S_IXUSR)
+
+    command_link_dir = tmp_path / "prefix_bin"
+    command_link_dir.mkdir()
+
+    block = _extract_setup_path_shim_block()
+    prefix = "/data/data/com.termux/files/usr"
+    script = (
+        "set -e\n"
+        f'DISTRO="termux"\n'
+        f'PREFIX="{prefix}"\n'
+        f'HERMES_BIN="{hermes_bin}"\n'
+        f'command_link_dir="{command_link_dir}"\n'
+        f"{block}\n"
+    )
+    result = subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, (
+        f"shim-write block failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+
+    shim_text = (command_link_dir / "hermes").read_text()
+    assert shim_text.startswith(f"#!{prefix}/bin/bash\n"), (
+        "Termux launcher must use the direct PREFIX bash path so the kernel "
+        "can execute the shim shebang."
+    )


### PR DESCRIPTION
## Summary
- use the direct `$PREFIX/bin/bash` shebang when `install.sh` generates the Termux `hermes` launcher shim
- keep the existing `/usr/bin/env bash` launcher path for non-Termux installs
- add a regression test that executes the real shim-write block and asserts the Termux shebang stays kernel-executable

## Why
On Termux, `/usr/bin/env` is a symlink to the `coreutils` multi-call binary, so the kernel cannot use it as a shebang interpreter. The generated `hermes` wrapper then fails with `bad interpreter` before Hermes starts.

## Verification
- `bash -n scripts/install.sh`
- `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest tests/test_install_sh_symlink_stomp.py tests/test_install_sh_pythonpath_sanitization.py`
- `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/ruff check tests/test_install_sh_symlink_stomp.py`
- `git diff --check HEAD^ HEAD`

Closes #45321