### PR TITLE
fix(langfuse): default base URL to localhost; reap stale per-turn trace state

### DIFF
--- a/plugins/observability/langfuse/README.md
+++ b/plugins/observability/langfuse/README.md
@@ -23,7 +23,7 @@ Set these in `~/.hermes/.env` (or via `hermes tools`):
 ```bash
 HERMES_LANGFUSE_PUBLIC_KEY=pk-lf-...
 HERMES_LANGFUSE_SECRET_KEY=sk-lf-...
-HERMES_LANGFUSE_BASE_URL=https://cloud.langfuse.com   # or your self-hosted URL
+HERMES_LANGFUSE_BASE_URL=http://localhost:3000   # default; set https://cloud.langfuse.com for Langfuse Cloud
 ```
 
 Without the SDK or credentials the hooks no-op silently — the plugin fails

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -11,7 +11,7 @@ either is missing the hooks are inert.
 Required env vars (set via ``hermes tools`` or ~/.hermes/.env):
   HERMES_LANGFUSE_PUBLIC_KEY  - Langfuse project public key (pk-lf-...)
   HERMES_LANGFUSE_SECRET_KEY  - Langfuse project secret key (sk-lf-...)
-  HERMES_LANGFUSE_BASE_URL    - Langfuse server URL (default: https://cloud.langfuse.com)
+  HERMES_LANGFUSE_BASE_URL    - Langfuse server URL (default: http://localhost:3000)
 
 Optional env vars:
   HERMES_LANGFUSE_ENV         - environment tag (e.g. "production", "local")
@@ -55,6 +55,11 @@ class TraceState:
 _STATE_LOCK = threading.Lock()
 _TRACE_STATE: Dict[str, TraceState] = {}
 _LANGFUSE_CLIENT = None
+# A turn that errors between pre_llm_request and the final post_llm_call
+# never reaches _finish_trace, so its TraceState (and unended spans) would
+# otherwise live in _TRACE_STATE for the life of the process. Entries idle
+# longer than this are flushed by _reap_stale_traces on the next turn.
+_TRACE_STATE_TTL_SECONDS = 1800.0
 _READ_FILE_LINE_RE = re.compile(r"^\s*(\d+)\|(.*)$")
 _READ_FILE_HEAD_LINES = 25
 _READ_FILE_TAIL_LINES = 15
@@ -189,7 +194,10 @@ def _get_langfuse() -> Optional[Langfuse]:
         _LANGFUSE_CLIENT = _INIT_FAILED
         return None
 
-    base_url = _env("HERMES_LANGFUSE_BASE_URL") or _env("LANGFUSE_BASE_URL") or "https://cloud.langfuse.com"
+    # Default to the local self-hosted instance, not cloud.langfuse.com:
+    # this deployment is privacy-first, and a missing base URL must never
+    # cause trace payloads to leave the machine.
+    base_url = _env("HERMES_LANGFUSE_BASE_URL") or _env("LANGFUSE_BASE_URL") or "http://localhost:3000"
     environment = _env("HERMES_LANGFUSE_ENV") or _env("LANGFUSE_ENV")
     release = _env("HERMES_LANGFUSE_RELEASE") or _env("LANGFUSE_RELEASE")
     sample_rate = _env("HERMES_LANGFUSE_SAMPLE_RATE")
@@ -701,6 +709,19 @@ def _finish_trace(task_key: str, *, output: Any = None) -> None:
             pass
 
 
+def _reap_stale_traces() -> None:
+    now = time.time()
+    with _STATE_LOCK:
+        stale = [
+            task_key
+            for task_key, state in _TRACE_STATE.items()
+            if now - state.last_updated_at > _TRACE_STATE_TTL_SECONDS
+        ]
+    for task_key in stale:
+        _debug(f"reaping stale trace state for {task_key}")
+        _finish_trace(task_key)
+
+
 def _assistant_has_tool_calls(message: Any) -> bool:
     return bool(getattr(message, "tool_calls", None))
 
@@ -724,6 +745,8 @@ def on_pre_llm_call(*, task_id: str = "", session_id: str = "", platform: str = 
     client = _get_langfuse()
     if client is None:
         return
+
+    _reap_stale_traces()
 
     # messages is a list only for legacy Hermes branches that fired
     # pre_llm_call with API messages directly. Current Hermes fires
@@ -774,6 +797,8 @@ def on_pre_llm_request(
     client = _get_langfuse()
     if client is None:
         return
+
+    _reap_stale_traces()
 
     input_messages = _coerce_request_messages(
         request_messages=request_messages,


### PR DESCRIPTION
## What does this PR do?

Two independent fixes to the Langfuse observability plugin:

### 1. Default `HERMES_LANGFUSE_BASE_URL` to `http://localhost:3000`

With credentials set but no base URL, the plugin currently defaults to `https://cloud.langfuse.com` — meaning a self-hosted deployment that forgets the URL silently ships trace payloads (user inputs, assistant outputs, tool results) to a third-party cloud. That is the wrong failure mode: a missing URL on a cloud setup fails loudly (401s on flush, no traces appear), while a missing URL on a self-hosted setup leaks data invisibly.

Defaulting to localhost inverts that: misconfiguration now fails closed (connection refused, traces dropped, fail-open semantics preserved) instead of leaking. Cloud users set the URL explicitly — which the README and `hermes tools` flow already instruct. Happy to flip this to *requiring* an explicit base URL (no default at all) if maintainers prefer that over a localhost default.

### 2. Reap orphaned `TraceState` entries

A turn that errors between `pre_llm_request` and the final `post_llm_call` never reaches `_finish_trace`, so its `TraceState` (root span, generation/tool observation handles) stays in the module-level `_TRACE_STATE` dict for the life of the process — a slow leak in long-running gateway deployments, and the spans are never ended.

`TraceState` already tracks `last_updated_at`; this PR adds `_reap_stale_traces()`, called at the start of each turn from both `on_pre_llm_call` and `on_pre_llm_request`, which flushes entries idle longer than 30 minutes through the existing `_finish_trace` path (ends all observations, ends the root span, flushes the client).

Note: this is complementary to #45048 / #43677, which close contexts at normal finish and interpreter exit — this handles turns that died mid-flight while the process keeps running.

## Testing

`scripts/run_tests.sh tests/plugins/test_langfuse_plugin.py` — all 41 tests pass. Also running in production on a self-hosted Langfuse v3 deployment (gateway + Telegram platform) since this was written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)