### PR TITLE
fix(computer_use): mark parsed element bounds as unknown, not silent zeros (#44763)

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1109,6 +1109,96 @@ class TestElementLabelParsing:
         assert labels[15] == "Search"
 
 
+class TestParsedElementBoundsKnown:
+    """Bug #44763: parser must mark element bounds as unknown, not silently zero.
+
+    cua-driver's get_window_state markdown tree is ``[index] role (id) "label"``
+    — it does not include spatial coordinates. The parser was setting
+    ``bounds=(0, 0, 0, 0)`` for every parsed element, which the formatter then
+    rendered as ``@ (0, 0, 0, 0)`` — silently lying to the model about
+    available geometry and breaking spatial grounding (#44763).
+
+    The fix: parsed elements get ``bounds_known=False`` by default. The
+    formatter renders ``<unknown>`` for those, and ``_element_to_dict``
+    surfaces the ``bounds_known`` flag so callers can branch on it.
+
+    A future change that adds a bounds-bearing cua-driver format should
+    populate ``bounds`` and flip ``bounds_known=True``; the behavior contract
+    is "unknown ⇔ formatter says <unknown>".
+    """
+
+    def test_parsed_elements_have_bounds_known_false(self):
+        from tools.computer_use.cua_backend import _parse_elements_from_tree
+        tree = (
+            '  - [1] AXWindow "Main Window"\n'
+            '  - [14] AXButton "One"\n'
+            "[15] AXButton (2) id=Two\n"
+        )
+        els = _parse_elements_from_tree(tree)
+        assert len(els) == 3
+        for e in els:
+            assert e.bounds_known is False, (
+                "parsed elements from cua-driver markdown must default to "
+                f"bounds_known=False (got {e.bounds_known!r} for #{e.index})"
+            )
+
+    def test_explicit_construction_keeps_bounds_known_default(self):
+        """Default-constructed UIElement (e.g. test fixtures) stays known=False."""
+        from tools.computer_use.backend import UIElement
+        e = UIElement(index=1, role="AXButton", label="x")
+        assert e.bounds_known is False
+
+    def test_explicit_construction_with_bounds_known_true(self):
+        from tools.computer_use.backend import UIElement
+        e = UIElement(
+            index=1, role="AXButton", label="x",
+            bounds=(10, 20, 30, 40), bounds_known=True,
+        )
+        assert e.bounds_known is True
+        assert e.bounds == (10, 20, 30, 40)
+
+    def test_formatter_renders_unknown_for_parsed_elements(self):
+        """Formatter must not display misleading ``(0, 0, 0, 0)`` for parsed elements."""
+        from tools.computer_use.tool import _format_elements
+        from tools.computer_use.cua_backend import _parse_elements_from_tree
+        tree = '  - [1] AXButton "Continue"\n'
+        els = _parse_elements_from_tree(tree)
+        lines = _format_elements(els)
+        assert len(lines) == 1
+        # Pre-fix: this line was ``#1 AXButton 'Continue' @ (0, 0, 0, 0)``.
+        # Post-fix: it must say ``<unknown>`` so the model knows the geometry
+        # is unavailable, not at the screen origin.
+        assert "<unknown>" in lines[0], lines
+        assert "(0, 0, 0, 0)" not in lines[0], (
+            "formatter must not silently display (0, 0, 0, 0) for unknown "
+            f"bounds (got: {lines[0]!r})"
+        )
+
+    def test_formatter_renders_known_bounds_when_flag_set(self):
+        """Formatter must still show explicit bounds when bounds_known=True."""
+        from tools.computer_use.tool import _format_elements
+        from tools.computer_use.backend import UIElement
+        e = UIElement(
+            index=1, role="AXButton", label="Continue",
+            bounds=(10, 20, 30, 40), bounds_known=True,
+        )
+        lines = _format_elements([e])
+        assert "(10, 20, 30, 40)" in lines[0], lines
+
+    def test_element_to_dict_includes_bounds_known(self):
+        """_element_to_dict surfaces bounds_known so downstream callers can branch."""
+        from tools.computer_use.tool import _element_to_dict
+        from tools.computer_use.backend import UIElement
+        e = UIElement(index=1, role="AXButton", label="x", bounds=(1, 2, 3, 4))
+        d = _element_to_dict(e)
+        assert d["bounds_known"] is False
+        e2 = UIElement(
+            index=2, role="AXButton", label="x",
+            bounds=(1, 2, 3, 4), bounds_known=True,
+        )
+        assert _element_to_dict(e2)["bounds_known"] is True
+
+
 class TestCaptureAfterAppContext:
     """Bug 2: capture_after=True loses app context after actions.
 

--- a/tools/computer_use/backend.py
+++ b/tools/computer_use/backend.py
@@ -14,12 +14,26 @@ from typing import Any, Dict, List, Optional, Tuple
 
 @dataclass
 class UIElement:
-    """One interactable element on the current screen."""
+    """One interactable element on the current screen.
 
+    ``bounds`` carries (x, y, w, h) in logical pixels when the source provides
+    them. ``bounds_known`` distinguishes "we got real geometry" (``True``)
+    from "the backend didn't expose geometry, so this is a sentinel"
+    (``False``). The default of ``False`` is deliberate: cua-driver's
+    ``get_window_state`` markdown tree (``[index] role (id) "label"``) does
+    NOT include spatial coordinates, and silently returning ``(0, 0, 0, 0)``
+    made downstream consumers (the LLM, the test suite, the formatter) think
+    every element sat at the screen origin — see #44763. Callers that
+    construct ``UIElement`` from a geometry-bearing source (future
+    cua-driver structured output, a different backend, test fixtures) must
+    set ``bounds_known=True`` explicitly so the formatter and the dict
+    serializer can be honest about it.
+    """
     index: int                       # 1-based SOM index
     role: str                        # AX role (AXButton, AXTextField, ...)
     label: str = ""                  # AXTitle / AXDescription / AXValue snippet
     bounds: Tuple[int, int, int, int] = (0, 0, 0, 0)  # x, y, w, h (logical px)
+    bounds_known: bool = False       # False → ``bounds`` is a sentinel, not geometry
     app: str = ""                    # owning bundle ID or app name
     pid: int = 0                     # owning process PID
     window_id: int = 0               # SkyLight / CG window ID

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -786,7 +786,11 @@ def _format_elements(elements: List[UIElement], max_lines: int = 40) -> List[str
     out: List[str] = []
     for e in elements[:max_lines]:
         label = e.label.replace("\n", " ")[:60]
-        out.append(f"  #{e.index} {e.role} {label!r} @ {e.bounds}"
+        # When the backend didn't provide geometry, render an honest
+        # ``<unknown>`` sentinel instead of misleading ``(0, 0, 0, 0)``
+        # zeros (see #44763 — silent zeros broke spatial grounding).
+        bounds_str = f"{e.bounds}" if e.bounds_known else "<unknown>"
+        out.append(f"  #{e.index} {e.role} {label!r} @ {bounds_str}"
                    + (f" [{e.app}]" if e.app else ""))
     if len(elements) > max_lines:
         out.append(f"  ... +{len(elements) - max_lines} more (call capture with app= to narrow)")
@@ -799,6 +803,7 @@ def _element_to_dict(e: UIElement) -> Dict[str, Any]:
         "role": e.role,
         "label": e.label,
         "bounds": list(e.bounds),
+        "bounds_known": e.bounds_known,
         "app": e.app,
     }
 


### PR DESCRIPTION
## Summary

`cua-driver`'s `get_window_state` markdown tree is `[index] role (id) "label"` — it does not include spatial coordinates. The parser in `tools/computer_use/cua_backend.py::_parse_elements_from_tree` was setting `bounds=(0, 0, 0, 0)` on every parsed `UIElement` anyway, and the formatter in `tools/computer_use/tool.py::_format_elements` then rendered that as `@ (0, 0, 0, 0)` for every element. The model and any consumer of the formatted text silently received misleading coordinates, breaking spatial grounding for `computer_use(mode="som")` and `computer_use(mode="ax")` captures (#44763).

The fix: add a `bounds_known: bool = False` field to `UIElement` (default = "unknown" — BC-safe because it's a defaulted dataclass field), and have the formatter render `<unknown>` instead of misleading zeros for parsed elements. The dict serializer surfaces the flag so downstream callers can branch. A future cua-driver format that adds bounds to the tree can flip `bounds_known=True` — the behavior contract is "unknown ⇔ formatter says `<unknown>`".

## Fix

**`tools/computer_use/backend.py` — `UIElement`:**

```python
@dataclass
class UIElement:
    """One interactable element on the current screen.

    ``bounds`` carries (x, y, w, h) in logical pixels when the source provides
    them. ``bounds_known`` distinguishes "we got real geometry" (``True``)
    from "the backend didn't expose geometry, so this is a sentinel"
    (``False``). The default of ``False`` is deliberate: cua-driver's
    ``get_window_state`` markdown tree (``[index] role (id) "label"``) does
    NOT include spatial coordinates, and silently returning ``(0, 0, 0, 0)``
    made downstream consumers (the LLM, the test suite, the formatter) think
    every element sat at the screen origin — see #44763.
    """
    index: int
    role: str
    label: str = ""
    bounds: Tuple[int, int, int, int] = (0, 0, 0, 0)
    bounds_known: bool = False       # False → ``bounds`` is a sentinel, not geometry
    app: str = ""
    pid: int = 0
    window_id: int = 0
    attributes: Dict[str, Any] = field(default_factory=dict)
```

**`tools/computer_use/tool.py` — formatter + dict:**

```python
def _format_elements(elements, max_lines=40):
    out = []
    for e in elements[:max_lines]:
        label = e.label.replace("\n", " ")[:60]
        bounds_str = f"{e.bounds}" if e.bounds_known else "<unknown>"
        out.append(f"  #{e.index} {e.role} {label!r} @ {bounds_str}"
                   + (f" [{e.app}]" if e.app else ""))
    ...

def _element_to_dict(e):
    return {
        "index": e.index,
        "role": e.role,
        "label": e.label,
        "bounds": list(e.bounds),
        "bounds_known": e.bounds_known,   # NEW
        "app": e.app,
    }
```

The parser (`_parse_elements_from_tree`) is intentionally NOT changed — it relies on the new field's default. The default `bounds_known=False` correctly says "this came from the markdown tree, which doesn't include geometry".

## Test-first proof

`tests/tools/test_computer_use.py::TestParsedElementBoundsKnown` (6 tests):

| Test | Pre-fix | Post-fix |
|---|---|---|
| `test_parsed_elements_have_bounds_known_false` | `AttributeError: 'UIElement' object has no attribute 'bounds_known'` | PASS |
| `test_explicit_construction_keeps_bounds_known_default` | `AttributeError` (field missing) | PASS |
| `test_explicit_construction_with_bounds_known_true` | `TypeError: ... got an unexpected keyword argument 'bounds_known'` | PASS |
| `test_formatter_renders_unknown_for_parsed_elements` | `AssertionError: "<unknown>" not in "#1 AXButton 'Continue' @ (0, 0, 0, 0)"` | PASS |
| `test_formatter_renders_known_bounds_when_flag_set` | `TypeError: ... got an unexpected keyword argument 'bounds_known'` | PASS |
| `test_element_to_dict_includes_bounds_known` | `KeyError: 'bounds_known'` | PASS |

The formatter test asserts the invariant: **unknown ⇔ `<unknown>` in the rendered line, `(0, 0, 0, 0)` not in the rendered line**. The pre-fix test failure literally shows the old buggy output, which is the bug-class repro.

## Test plan

- [x] 6 new tests in `TestParsedElementBoundsKnown` pass
- [x] All 85 existing `tests/tools/test_computer_use.py` tests pass (zero regressions)
- [x] All 44 tests in `test_computer_use_capture_routing.py` + `test_computer_use_vision_routing.py` pass
- [ ] CI will run `scripts/run_tests.sh tests/tools/test_computer_use.py` (the canonical Python runner)

## Reproduction

Pre-fix, run:
```python
from tools.computer_use.cua_backend import _parse_elements_from_tree
from tools.computer_use.tool import _format_elements
tree = '  - [1] AXButton "Continue"\n'
print(_format_elements(_parse_elements_from_tree(tree)))
# Output: ["  #1 AXButton 'Continue' @ (0, 0, 0, 0)"]  ← the bug
```

Post-fix, the same call prints:
```
["  #1 AXButton 'Continue' @ <unknown>"]
```

In a real Hermes session, the model can now distinguish "no geometry available" from "element happens to be at the screen origin" and stop inventing spatial relationships that don't exist.

## Notes for reviewers

### Why not parse bounds from cua-driver's output?

I confirmed by reading the existing test fixture at `tests/tools/test_computer_use.py:1100` (`TestElementLabelParsing`) and the regex at `tools/computer_use/cua_backend.py:67` (`_ELEMENT_LINE_RE`) that cua-driver's markdown format genuinely does not include spatial coordinates. The reporter's #44763 hit the same conclusion: the bounds-bearing axis lives in the SOM-overlaid PNG, not in the AX-tree text. Adding a parser that "parses" non-existent bounds would be aspirational rather than corrective. This PR fixes the **schema honesty** (silently-zero → explicitly-unknown); a future cua-driver release that adds bounds to the tree can flip `bounds_known=True` and the contract holds.

### Behavior change in `_format_elements` (BC note)

Pre-fix: `out.append(f"  #{e.index} {e.role} {label!r} @ {e.bounds}")` rendered `@ (0, 0, 0, 0)`.
Post-fix: parsed elements render `@ <unknown>`. Explicit-constructed elements with `bounds_known=True` still render the bounds tuple.

This is a deliberate text-format change, called out in the BC review below. The previous text was the bug; the new text is the truth. Downstream consumers (model prompts, log scrapers, tests) that grep for `(0, 0, 0, 0)` will see fewer matches — but those matches were always a lie.

### Peer review (Step 3.5)

- **DRY**: PASS — reuses the existing `UIElement` dataclass; no new helper, no new module.
- **SOLID**: PASS — S: parser still does one thing; O: caller flow unchanged; D: no new abstract deps.
- **YAGNI**: PASS — minimum surface: 1 field + 1 formatter branch + 1 dict key.
- **KISS**: PASS — "Add a bool field to disambiguate known vs unknown" is the minimum semantic.
- **AGENTS.md**: PASS — smallest footprint, extend don't duplicate, no new env vars, no `config.yaml` change, behavior-contract test (asserts the invariant, not a frozen value).
- **BC**: PASS — see checklist below.

### BC review (Step 3.5.6 — HARD GATE)

- **3.5.6.1 Public API surface**: `UIElement` is a `@dataclass`; adding a field WITH A DEFAULT is non-breaking per PEP 557. Existing constructors (`UIElement(index=1, role="X", label="y")`) still work; the new field defaults to `False`. No signature change to `_parse_elements_from_tree` or `_format_elements`. ✓
- **3.5.6.2 Config schema**: no config touched, no env var touched, no CLI flag touched. ✓
- **3.5.6.3 Persisted state**: no DB or file schema change. ✓
- **3.5.6.4 Wire formats**: `_element_to_dict` adds the `bounds_known` key. Adding a field to a JSON output is additive (clients ignore unknown fields). ✓
- **3.5.6.5 Behavior / error messages / log lines**: `_format_elements` text changes from `@ (0, 0, 0, 0)` to `@ <unknown>` for parsed elements. **This is the behavior change.** Justified: the prior text was the bug; the new text is honest. Documented at the top of "Notes for reviewers" and called out in the parser docstring. ✓
- **3.5.6.6 Extreme checks**: `__all__` not touched; no decorator/metaclass change; no async/sync change; `UIElement` subclassability preserved (dataclass with default); no pickling involved; `repr(UIElement)` unchanged. ✓

**Verdict**: zero BC breaks.

## Related

- Fixes #44763
- Claim comment: https://github.com/NousResearch/hermes-agent/issues/44763#issuecomment-4696931035
