### PR TITLE
fix(agent): preserve Copilot provider for explicit base URL

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4211,7 +4211,7 @@ def resolve_vision_provider_client(
 
 def get_auxiliary_extra_body() -> dict:
     """Return extra_body kwargs for auxiliary API calls.
-    
+
     Includes Nous Portal product tags when the auxiliary client is backed
     by Nous Portal. Returns empty dict otherwise.
     """
@@ -4220,7 +4220,7 @@ def get_auxiliary_extra_body() -> dict:
 
 def auxiliary_max_tokens_param(value: int) -> dict:
     """Return the correct max tokens kwarg for the auxiliary client's provider.
-    
+
     OpenRouter and local models use 'max_tokens'. Direct OpenAI with newer
     models (gpt-4o, o-series, gpt-5+) requires 'max_completion_tokens'.
     The Codex adapter translates max_tokens internally, so we use max_tokens

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4640,10 +4640,12 @@ def _resolve_task_provider_model(
     if cfg_provider:
         cfg_provider, cfg_base_url = _expand_direct_api_alias(cfg_provider, cfg_base_url)
 
-    if provider:
+    if provider and provider.strip().lower() != "auto":
         return provider, resolved_model, base_url, api_key, resolved_api_mode
     if base_url:
         return "custom", resolved_model, base_url, api_key, resolved_api_mode
+    if provider:
+        return provider, resolved_model, base_url, api_key, resolved_api_mode
 
     if task:
         # Config.yaml is the primary source for per-task overrides.

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4598,9 +4598,11 @@ def _resolve_task_provider_model(
       3. "auto" (full auto-detection chain)
 
     Returns (provider, model, base_url, api_key, api_mode) where model may
-    be None (use provider default). When base_url is set, provider is forced
-    to "custom" and the task uses that direct endpoint. api_mode is one of
-    "chat_completions", "codex_responses", or None (auto-detect).
+    be None (use provider default). A bare base_url is treated as a custom
+    endpoint, but an explicit first-class provider plus base_url keeps the
+    provider identity so provider-specific auth and headers still apply.
+    api_mode is one of "chat_completions", "codex_responses", or None
+    (auto-detect).
     """
     cfg_provider = None
     cfg_model = None
@@ -4638,10 +4640,10 @@ def _resolve_task_provider_model(
     if cfg_provider:
         cfg_provider, cfg_base_url = _expand_direct_api_alias(cfg_provider, cfg_base_url)
 
-    if base_url:
-        return "custom", resolved_model, base_url, api_key, resolved_api_mode
     if provider:
         return provider, resolved_model, base_url, api_key, resolved_api_mode
+    if base_url:
+        return "custom", resolved_model, base_url, api_key, resolved_api_mode
 
     if task:
         # Config.yaml is the primary source for per-task overrides.

--- a/tests/agent/test_auxiliary_provider_input.py
+++ b/tests/agent/test_auxiliary_provider_input.py
@@ -36,6 +36,22 @@ def test_openai_alias_with_explicit_base_url_still_routes_as_custom():
     assert api_mode is None
 
 
+def test_auto_provider_with_explicit_base_url_routes_as_custom():
+    """Explicit auto provider must not override an explicit endpoint."""
+    provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(
+        provider="auto",
+        model="gpt-4o-mini",
+        base_url="https://proxy.example.com/v1",
+        api_key="sk-test",
+    )
+
+    assert provider == "custom"
+    assert model == "gpt-4o-mini"
+    assert base_url == "https://proxy.example.com/v1"
+    assert api_key == "sk-test"
+    assert api_mode is None
+
+
 def test_resolved_copilot_client_uses_copilot_credentials_and_headers():
     """The preserved provider identity reaches Copilot auth, not custom auth."""
     from agent.auxiliary_client import resolve_provider_client

--- a/tests/agent/test_auxiliary_provider_input.py
+++ b/tests/agent/test_auxiliary_provider_input.py
@@ -1,0 +1,70 @@
+"""Auxiliary provider/model input resolution regressions."""
+
+from unittest.mock import MagicMock, patch
+
+from agent.auxiliary_client import _resolve_task_provider_model
+
+
+def test_explicit_copilot_base_url_preserves_provider_identity():
+    """Copilot is first-class even though it uses an OpenAI-compatible URL."""
+    provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(
+        provider="copilot",
+        model="gpt-5.4-mini",
+        base_url="https://api.githubcopilot.com",
+    )
+
+    assert provider == "copilot"
+    assert model == "gpt-5.4-mini"
+    assert base_url == "https://api.githubcopilot.com"
+    assert api_key is None
+    assert api_mode is None
+
+
+def test_openai_alias_with_explicit_base_url_still_routes_as_custom():
+    """The direct OpenAI alias remains custom because it is not first-class."""
+    provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(
+        provider="openai",
+        model="gpt-4o-mini",
+        base_url="https://proxy.example.com/v1",
+        api_key="sk-test",
+    )
+
+    assert provider == "custom"
+    assert model == "gpt-4o-mini"
+    assert base_url == "https://proxy.example.com/v1"
+    assert api_key == "sk-test"
+    assert api_mode is None
+
+
+def test_resolved_copilot_client_uses_copilot_credentials_and_headers():
+    """The preserved provider identity reaches Copilot auth, not custom auth."""
+    from agent.auxiliary_client import resolve_provider_client
+
+    fake_client = MagicMock()
+    fake_headers = {
+        "Authorization": "Bearer ghu_test",
+        "Editor-Version": "Hermes/0.0",
+    }
+
+    with patch(
+        "hermes_cli.auth.resolve_api_key_provider_credentials",
+        return_value={
+            "api_key": "ghu_test",
+            "base_url": "https://api.githubcopilot.com",
+        },
+    ), patch(
+        "hermes_cli.copilot_auth.copilot_request_headers",
+        return_value=fake_headers,
+    ), patch("agent.auxiliary_client.OpenAI", return_value=fake_client) as openai:
+        client, resolved_model = resolve_provider_client(
+            "copilot",
+            model="gpt-5.4-mini",
+            explicit_base_url="https://api.githubcopilot.com",
+            raw_codex=True,
+        )
+
+    assert client is fake_client
+    assert resolved_model == "gpt-5.4-mini"
+    assert openai.call_args.kwargs["api_key"] == "ghu_test"
+    assert openai.call_args.kwargs["base_url"] == "https://api.githubcopilot.com"
+    assert openai.call_args.kwargs["default_headers"] == fake_headers


### PR DESCRIPTION
## Summary
- Preserve explicit first-class providers when an auxiliary task also supplies a base URL.
- Keep bare `base_url` behavior as `custom`, so direct OpenAI-compatible endpoints still work.
- Add regression coverage for Copilot provider identity, Copilot auth/header routing, and the direct OpenAI alias fallback.

Fixes #45276

## Test Plan
- `$HOME/.hermes/hermes-agent/venv/bin/python -m pytest tests/agent/test_auxiliary_provider_input.py tests/agent/test_vision_routing_31179.py::TestOpenAiAliasForAuxiliary tests/run_agent/test_copilot_native_vision_headers.py -q`
