### PR TITLE
fix(auxiliary_client): skip async close() during cache eviction

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2609,8 +2609,9 @@ def _evict_cached_clients(provider: str) -> None:
             if client is not None:
                 _force_close_async_httpx(client)
                 try:
+                    import inspect
                     close_fn = getattr(client, "close", None)
-                    if callable(close_fn):
+                    if close_fn and not inspect.iscoroutinefunction(close_fn):
                         close_fn()
                 except Exception:
                     pass
@@ -4369,8 +4370,9 @@ def _store_cached_client(cache_key: tuple, client: Any, default_model: Optional[
         if old_entry is not None and old_entry[0] is not client:
             _force_close_async_httpx(old_entry[0])
             try:
+                import inspect
                 close_fn = getattr(old_entry[0], "close", None)
-                if callable(close_fn):
+                if close_fn and not inspect.iscoroutinefunction(close_fn):
                     close_fn()
             except Exception:
                 pass

--- a/tests/agent/test_auxiliary_cache_async_close.py
+++ b/tests/agent/test_auxiliary_cache_async_close.py
@@ -1,0 +1,61 @@
+"""Tests for _store_cached_client async-close guard in agent.auxiliary_client."""
+import pytest
+
+
+def test_store_cached_client_skips_async_close():
+    """Cache eviction must not call async close() synchronously.
+
+    When the evicted client's close() is a coroutine function, calling it
+    from the synchronous _store_cached_client path creates an unawaited
+    coroutine warning.  The guard must skip async close() and let
+    _force_close_async_httpx handle the transport teardown.
+    """
+    import warnings
+    from agent.auxiliary_client import _store_cached_client, _client_cache
+
+    class AsyncCloseClient:
+        async def close(self):
+            return None
+
+    class ReplacementClient:
+        pass
+
+    cache_key = ("test_async_close", "model")
+    old_client = AsyncCloseClient()
+    _client_cache[cache_key] = (old_client, "model", None)
+
+    new_client = ReplacementClient()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _store_cached_client(cache_key, new_client, "model")
+
+    runtime_warnings = [w for w in caught if issubclass(w.category, RuntimeWarning)]
+    coroutine_warnings = [w for w in runtime_warnings if "coroutine" in str(w.message).lower()]
+    assert coroutine_warnings == [], (
+        f"Unawaited coroutine warnings: {coroutine_warnings}"
+    )
+    assert _client_cache[cache_key][0] is new_client
+
+
+def test_store_cached_client_calls_sync_close():
+    """Sync close() must still be called during cache eviction."""
+    from agent.auxiliary_client import _store_cached_client, _client_cache
+
+    close_called = []
+
+    class SyncCloseClient:
+        def close(self):
+            close_called.append(True)
+
+    class ReplacementClient:
+        pass
+
+    cache_key = ("test_sync_close", "model")
+    old_client = SyncCloseClient()
+    _client_cache[cache_key] = (old_client, "model", None)
+
+    new_client = ReplacementClient()
+    _store_cached_client(cache_key, new_client, "model")
+
+    assert close_called, "Sync close() should have been called"
+    assert _client_cache[cache_key][0] is new_client


### PR DESCRIPTION
## What does this PR do?

Fixes unawaited coroutine warnings during auxiliary-client cache eviction. When `_store_cached_client()` evicts an old client whose `close()` method is a coroutine (e.g., AsyncOpenAI), calling it synchronously creates a `RuntimeWarning: coroutine 'AsyncAPIClient.close' was never awaited`. The fix adds an `inspect.iscoroutinefunction` guard matching the existing pattern in `shutdown_cached_clients()`.

## Related Issue

Fixes #45328

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py`: Added `inspect.iscoroutinefunction` guard in `_store_cached_client()` and the manual cache-eviction path (lines ~4372 and ~2612) to skip synchronous `close()` on async clients — `_force_close_async_httpx()` already handles transport teardown
- `tests/agent/test_auxiliary_cache_async_close.py`: 2 tests verifying async close is skipped (no unawaited coroutine warning) and sync close is still called

## How to Test

1. Run `pytest tests/agent/test_auxiliary_cache_async_close.py -v` — both tests should pass
2. The async-close test seeds `_client_cache` with an `AsyncCloseClient`, replaces it via `_store_cached_client()`, and asserts zero `RuntimeWarning` about unawaited coroutines
3. The sync-close test verifies that synchronous `close()` methods are still called during eviction

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/auxiliary_client.py::_store_cached_client` (callers: cache refresh paths, 2 call sites fixed)
- Blast radius: LOW — only affects cache eviction, no behavioral change for sync clients
- Related patterns: mirrors existing `shutdown_cached_clients()` guard at line 4497
