### PR TITLE
fix(cron): pass target_model to resolve_runtime_provider (#45245)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1654,6 +1654,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             # example DeepSeek) for cron jobs that do not pin provider/model.
             runtime_kwargs = {
                 "requested": job.get("provider"),
+                "target_model": model or None,
             }
             if job.get("base_url"):
                 runtime_kwargs["explicit_base_url"] = job.get("base_url")


### PR DESCRIPTION
Fixes #45245. The cron scheduler calls resolve_runtime_provider() without passing target_model, so for providers like opencode-go that serve both anthropic_messages and chat_completions models, the api_mode is derived from the stale persisted model.default instead of the job's actual model. This causes requests to land at the wrong API endpoint and 400. The fix passes target_model=model (the job's resolved model) in runtime_kwargs.