### PR TITLE
fix(auth): try fallback token endpoints for Anthropic OAuth login (#45250)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1346,18 +1346,36 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
             "code_verifier": verifier,
         }).encode()
 
-        req = urllib.request.Request(
-            _OAUTH_TOKEN_URL,
-            data=exchange_data,
-            headers={
-                "Content-Type": "application/json",
-                "User-Agent": f"claude-cli/{_get_claude_code_version()} (external, cli)",
-            },
-            method="POST",
-        )
-
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            result = json.loads(resp.read().decode())
+        # Try multiple token endpoints — the original console.anthropic.com
+        # URL may 404 if Anthropic has migrated the endpoint.  The refresh
+        # flow already uses this same fallback list (see
+        # refresh_anthropic_oauth_pure).
+        _token_endpoints = [
+            "https://platform.claude.com/v1/oauth/token",
+            "https://console.anthropic.com/v1/oauth/token",
+        ]
+        last_error = None
+        result = None
+        for endpoint in _token_endpoints:
+            req = urllib.request.Request(
+                endpoint,
+                data=exchange_data,
+                headers={
+                    "Content-Type": "application/json",
+                    "User-Agent": f"claude-cli/{_get_claude_code_version()} (external, cli)",
+                },
+                method="POST",
+            )
+            try:
+                with urllib.request.urlopen(req, timeout=15) as resp:
+                    result = json.loads(resp.read().decode())
+                break
+            except Exception as exc:
+                last_error = exc
+                logger.debug("Anthropic OAuth token exchange failed at %s: %s", endpoint, exc)
+                continue
+        if result is None:
+            raise last_error or ValueError("Anthropic OAuth token exchange failed at all endpoints")
     except Exception as e:
         print(f"Token exchange failed: {e}")
         return None

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -5389,23 +5389,38 @@ def _submit_anthropic_pkce(session_id: str, code_input: str) -> Dict[str, Any]:
         "redirect_uri": _ANTHROPIC_OAUTH_REDIRECT_URI,
         "code_verifier": sess["verifier"],
     }).encode()
-    req = urllib.request.Request(
-        _ANTHROPIC_OAUTH_TOKEN_URL,
-        data=exchange_data,
-        headers={
-            "Content-Type": "application/json",
-            "User-Agent": "hermes-dashboard/1.0",
-        },
-        method="POST",
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=20) as resp:
-            result = json.loads(resp.read().decode())
-    except Exception as e:
+    # Try multiple token endpoints — the original console.anthropic.com
+    # URL may 404 if Anthropic has migrated the endpoint.
+    _anthropic_token_endpoints = [
+        "https://platform.claude.com/v1/oauth/token",
+        "https://console.anthropic.com/v1/oauth/token",
+    ]
+    result = None
+    last_exchange_error = None
+    for _endpoint in _anthropic_token_endpoints:
+        req = urllib.request.Request(
+            _endpoint,
+            data=exchange_data,
+            headers={
+                "Content-Type": "application/json",
+                "User-Agent": "hermes-dashboard/1.0",
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=20) as resp:
+                result = json.loads(resp.read().decode())
+            break
+        except Exception as exc:
+            last_exchange_error = exc
+            _log.debug("Anthropic OAuth token exchange failed at %s: %s", _endpoint, exc)
+            continue
+    if result is None:
+        err_msg = f"Token exchange failed: {last_exchange_error}"
         with _oauth_sessions_lock:
             sess["status"] = "error"
-            sess["error_message"] = f"Token exchange failed: {e}"
-        return {"ok": False, "status": "error", "message": sess["error_message"]}
+            sess["error_message"] = err_msg
+        return {"ok": False, "status": "error", "message": err_msg}
 
     access_token = result.get("access_token", "")
     refresh_token = result.get("refresh_token", "")


### PR DESCRIPTION
Fixes #45250. The Anthropic OAuth login flow used a single hardcoded token endpoint (console.anthropic.com) which returns 404. The refresh flow already had a fallback list trying platform.claude.com first then console.anthropic.com. This fix applies the same fallback pattern to both the CLI login flow (run_hermes_oauth_login_pure) and the web server dashboard flow.