### PR TITLE
fix(slack): document SLACK_HOME_CHANNEL env vars in .env.example (#45256)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -331,6 +331,10 @@ BROWSER_INACTIVITY_TIMEOUT=120
 # Slack allowed users (comma-separated Slack user IDs)
 # SLACK_ALLOWED_USERS=
 
+# Slack home channel (default destination for cron deliveries)
+# SLACK_HOME_CHANNEL=                     # Channel ID (e.g. C0123456789)
+# SLACK_HOME_CHANNEL_NAME=                # Display name for home channel
+
 # =============================================================================
 # TELEGRAM INTEGRATION
 # =============================================================================


### PR DESCRIPTION
Fixes #45256. The .env.example was missing Slack home channel env vars (SLACK_HOME_CHANNEL, SLACK_HOME_CHANNEL_NAME) that the code already supports (gateway/config.py:1510-1517). Other platforms like Telegram and BlueBubbles already documented their equivalent vars. Users were trying non-existent names like SLACK_CHANNEL_HOME_NAME and getting errors.