### PR TITLE
fix(state): heal null session message counts

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -107,7 +107,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 16
+SCHEMA_VERSION = 17
 
 # ---------------------------------------------------------------------------
 # WAL-compatibility fallback
@@ -1231,6 +1231,23 @@ class SessionDB:
                         "            WHERE m.session_id = sessions.id AND m.role = 'tool') "
                         "AND NOT EXISTS (SELECT 1 FROM sessions ch "
                         "                WHERE ch.parent_session_id = sessions.id)"
+                    )
+                except sqlite3.OperationalError:
+                    pass
+            if current_version < 17:
+                # v17: heal legacy rows whose message counters were left NULL.
+                # Those rows never recover under `message_count = message_count + 1`
+                # because SQLite preserves NULL through arithmetic.
+                try:
+                    cursor.execute(
+                        "UPDATE sessions "
+                        "SET message_count = ("
+                        "    SELECT COUNT(*) FROM messages WHERE messages.session_id = sessions.id"
+                        ") "
+                        "WHERE message_count IS NULL"
+                    )
+                    cursor.execute(
+                        "UPDATE sessions SET tool_call_count = 0 WHERE tool_call_count IS NULL"
                     )
                 except sqlite3.OperationalError:
                     pass
@@ -2441,13 +2458,15 @@ class SessionDB:
             # Update counters
             if num_tool_calls > 0:
                 conn.execute(
-                    """UPDATE sessions SET message_count = message_count + 1,
-                       tool_call_count = tool_call_count + ? WHERE id = ?""",
+                    """UPDATE sessions
+                       SET message_count = COALESCE(message_count, 0) + 1,
+                           tool_call_count = COALESCE(tool_call_count, 0) + ?
+                       WHERE id = ?""",
                     (num_tool_calls, session_id),
                 )
             else:
                 conn.execute(
-                    "UPDATE sessions SET message_count = message_count + 1 WHERE id = ?",
+                    "UPDATE sessions SET message_count = COALESCE(message_count, 0) + 1 WHERE id = ?",
                     (session_id,),
                 )
             return msg_id

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -355,6 +355,24 @@ class TestMessageStorage:
         session = db.get_session("s1")
         assert session["message_count"] == 2
 
+    def test_append_message_repairs_null_counters(self, db):
+        db.create_session(session_id="s1", source="api_server")
+        db._conn.execute(
+            "UPDATE sessions SET message_count = NULL, tool_call_count = NULL WHERE id = ?",
+            ("s1",),
+        )
+        db._conn.commit()
+
+        tool_calls = [
+            {"id": "call_1", "function": {"name": "web_search", "arguments": "{}"}},
+            {"id": "call_2", "function": {"name": "shell", "arguments": "{}"}},
+        ]
+        db.append_message("s1", role="assistant", content="", tool_calls=tool_calls)
+
+        session = db.get_session("s1")
+        assert session["message_count"] == 1
+        assert session["tool_call_count"] == 2
+
     def test_observed_flag_round_trips_for_gateway_replay(self, db):
         db.create_session(session_id="s1", source="telegram:-100")
         db.append_message(
@@ -4082,3 +4100,24 @@ class TestListCronJobRuns:
         detail = " ".join(row[-1] for row in plan)
         assert "USING INDEX" in detail or "USING COVERING INDEX" in detail, detail
         assert "idx_sessions_source" in detail, detail
+
+
+def test_schema_migration_backfills_null_message_counts(tmp_path):
+    db_path = tmp_path / "migration_state.db"
+    db = SessionDB(db_path=db_path)
+    db.create_session(session_id="s1", source="tui")
+    db.append_message("s1", role="user", content="hello")
+    db.append_message("s1", role="assistant", content="world")
+    db._conn.execute(
+        "UPDATE sessions SET message_count = NULL, tool_call_count = NULL WHERE id = ?",
+        ("s1",),
+    )
+    db._conn.execute("UPDATE schema_version SET version = 16")
+    db._conn.commit()
+    db.close()
+
+    reopened = SessionDB(db_path=db_path)
+    session = reopened.get_session("s1")
+    assert session["message_count"] == 2
+    assert session["tool_call_count"] == 0
+    reopened.close()


### PR DESCRIPTION
Fixes #45236.

## Summary
- backfill legacy `sessions.message_count IS NULL` rows during the SessionDB schema migration
- make `append_message()` heal `NULL` counters with `COALESCE(..., 0) + 1` so affected sessions recover on the next write
- add targeted SessionDB regression coverage for both the live repair path and the migration backfill

## Proof
- `pytest tests/test_hermes_state.py::TestMessageStorage::test_append_message_repairs_null_counters tests/test_hermes_state.py::test_schema_migration_backfills_null_message_counts`
- `uv run --frozen ruff check hermes_state.py tests/test_hermes_state.py`
- `git diff --check`
