### PR TITLE
fix(dashboard): restore last chat on bare /chat startup

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -10111,6 +10111,10 @@ def _resolve_chat_argv(
         if latest_resume:
             resume = latest_resume
         env["HERMES_TUI_RESUME"] = resume
+    else:
+        auto_resume = _dashboard_most_recent_session_id(profile=profile)
+        if auto_resume:
+            env["HERMES_TUI_RESUME"] = auto_resume
 
     if sidecar_url:
         env["HERMES_TUI_SIDECAR_URL"] = sidecar_url
@@ -10124,6 +10128,30 @@ def _resolve_chat_argv(
             env["HERMES_TUI_GATEWAY_URL"] = gateway_ws_url
 
     return list(argv), str(cwd) if cwd else None, env
+
+
+def _dashboard_most_recent_session_id(profile: Optional[str] = None) -> Optional[str]:
+    """Return the most recently active human-facing session id for /chat."""
+    db = _open_session_db_for_profile(profile)
+    try:
+        rows = db.list_sessions_rich(
+            source=None,
+            limit=200,
+            order_by_last_active=True,
+        )
+        for row in rows:
+            src = (row.get("source") or "").strip().lower()
+            if src == "tool":
+                continue
+            session_id = (row.get("id") or "").strip()
+            if session_id:
+                return session_id
+        return None
+    except Exception:
+        _log.debug("Dashboard auto-resume lookup failed", exc_info=True)
+        return None
+    finally:
+        db.close()
 
 
 def _build_gateway_ws_url() -> Optional[str]:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4604,6 +4604,80 @@ class TestPtyWebSocket:
         assert env["HERMES_TUI_INLINE"] == "1"
         assert env["HERMES_TUI_DISABLE_MOUSE"] == "1"
 
+    def test_resolve_chat_argv_auto_resumes_most_recent_session(self, monkeypatch):
+        """Bare /chat should reopen the most recently active stored session."""
+        import hermes_cli.main as main_mod
+
+        monkeypatch.setattr(
+            main_mod,
+            "_make_tui_argv",
+            lambda project_root, tui_dev=False: (["node", "dist/entry.js"], "/tmp/ui-tui"),
+        )
+        monkeypatch.setattr(
+            self.ws_module,
+            "_dashboard_most_recent_session_id",
+            lambda profile=None: "sess-auto-42",
+        )
+
+        _argv, _cwd, env = self.ws_module._resolve_chat_argv()
+
+        assert env["HERMES_TUI_RESUME"] == "sess-auto-42"
+
+    def test_resolve_chat_argv_explicit_resume_beats_auto_resume(self, monkeypatch):
+        """An explicit ?resume= must win over the dashboard's auto-resume default."""
+        import hermes_cli.main as main_mod
+
+        monkeypatch.setattr(
+            main_mod,
+            "_make_tui_argv",
+            lambda project_root, tui_dev=False: (["node", "dist/entry.js"], "/tmp/ui-tui"),
+        )
+        monkeypatch.setattr(
+            self.ws_module,
+            "_dashboard_most_recent_session_id",
+            lambda profile=None: "sess-auto-42",
+        )
+        monkeypatch.setattr(
+            self.ws_module,
+            "_session_latest_descendant",
+            lambda session_id: ("sess-leaf-99", [session_id, "sess-leaf-99"]),
+        )
+
+        _argv, _cwd, env = self.ws_module._resolve_chat_argv(resume="sess-root-1")
+
+        assert env["HERMES_TUI_RESUME"] == "sess-leaf-99"
+
+    def test_dashboard_most_recent_session_id_uses_last_active_order(self, monkeypatch):
+        captured: dict = {}
+
+        class _DB:
+            def list_sessions_rich(self, *, source=None, limit=200, order_by_last_active=False):
+                captured["source"] = source
+                captured["limit"] = limit
+                captured["order_by_last_active"] = order_by_last_active
+                return [
+                    {"id": "tool-1", "source": "tool"},
+                    {"id": "api-1", "source": "api_server"},
+                ]
+
+            def close(self):
+                return None
+
+        monkeypatch.setattr(
+            self.ws_module,
+            "_open_session_db_for_profile",
+            lambda profile=None: _DB(),
+        )
+
+        result = self.ws_module._dashboard_most_recent_session_id()
+
+        assert result == "api-1"
+        assert captured == {
+            "source": None,
+            "limit": 200,
+            "order_by_last_active": True,
+        }
+
     def test_resolve_chat_argv_applies_terminal_backend_config(
         self, monkeypatch, _isolate_hermes_home
     ):


### PR DESCRIPTION
## Summary
- auto-resume the most recently active human-facing session when dashboard chat starts without an explicit `resume` id
- keep explicit `resume` routing authoritative so session deep-links still win
- cover the new `/chat` startup path with focused web server tests

## Validation
- `uv run --frozen pytest tests/hermes_cli/test_web_server.py -k 'dashboard_most_recent_session_id or auto_resumes_most_recent_session or explicit_resume_beats_auto_resume'`
- `uv run --frozen ruff check hermes_cli/web_server.py tests/hermes_cli/test_web_server.py`
- `git diff --check`

Fixes #45237
