### PR TITLE
fix(weixin): drain getupdates before disconnect

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -87,6 +87,7 @@ LONG_POLL_TIMEOUT_MS = 35_000
 API_TIMEOUT_MS = 15_000
 CONFIG_TIMEOUT_MS = 10_000
 QR_TIMEOUT_MS = 35_000
+DISCONNECT_DRAIN_TIMEOUT_MS = 5_000
 
 MAX_CONSECUTIVE_FAILURES = 3
 RETRY_DELAY_SECONDS = 2
@@ -421,6 +422,7 @@ async def _get_updates(
     token: str,
     sync_buf: str,
     timeout_ms: int,
+    swallow_timeout: bool = True,
 ) -> Dict[str, Any]:
     try:
         return await _api_post(
@@ -432,6 +434,8 @@ async def _get_updates(
             timeout_ms=timeout_ms,
         )
     except asyncio.TimeoutError:
+        if not swallow_timeout:
+            raise
         return {"ret": 0, "msgs": [], "get_updates_buf": sync_buf}
 
 
@@ -1322,6 +1326,7 @@ class WeixinAdapter(BasePlatformAdapter):
                 await self._poll_task
             except asyncio.CancelledError:
                 pass
+        await self._drain_poll_session_on_disconnect()
         self._poll_task = None
         if self._poll_session and not self._poll_session.closed:
             await self._poll_session.close()
@@ -1332,6 +1337,37 @@ class WeixinAdapter(BasePlatformAdapter):
         self._release_platform_lock()
         self._mark_disconnected()
         logger.info("[%s] Disconnected", self.name)
+
+    async def _drain_poll_session_on_disconnect(self) -> None:
+        session = self._poll_session
+        if (
+            session is None
+            or session.closed
+            or not self._token
+            or not self._account_id
+        ):
+            return
+
+        sync_buf = _load_sync_buf(self._hermes_home, self._account_id)
+        try:
+            response = await _get_updates(
+                session,
+                base_url=self._base_url,
+                token=self._token,
+                sync_buf=sync_buf,
+                timeout_ms=DISCONNECT_DRAIN_TIMEOUT_MS,
+                swallow_timeout=False,
+            )
+        except asyncio.TimeoutError:
+            logger.warning("[%s] terminal getUpdates drain timed out during disconnect", self.name)
+            return
+        except Exception as exc:
+            logger.warning("[%s] terminal getUpdates drain failed during disconnect: %s", self.name, exc)
+            return
+
+        new_sync_buf = str(response.get("get_updates_buf") or "")
+        if new_sync_buf:
+            _save_sync_buf(self._hermes_home, self._account_id, new_sync_buf)
 
     async def _poll_loop(self) -> None:
         assert self._poll_session is not None

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -1205,3 +1205,71 @@ class TestWeixinApiTimeout:
             )
         )
         assert result == {"ret": 0, "msgs": [], "get_updates_buf": "buf-123"}
+
+    def test_get_updates_can_propagate_timeout_for_terminal_disconnect_drain(self):
+        session = _StubSession(_StubResponse(delay=1.0))
+        with pytest.raises(asyncio.TimeoutError):
+            asyncio.run(
+                weixin._get_updates(
+                    session,
+                    base_url="https://weixin.example.com",
+                    token="tok",
+                    sync_buf="buf-123",
+                    timeout_ms=1,
+                    swallow_timeout=False,
+                )
+            )
+
+
+class TestWeixinDisconnectDrain:
+    @pytest.mark.asyncio
+    async def test_disconnect_drains_poll_session_before_closing(self):
+        adapter = _make_adapter()
+        poll_session = AsyncMock()
+        poll_session.closed = False
+        send_session = AsyncMock()
+        send_session.closed = False
+        adapter._poll_session = poll_session
+        adapter._send_session = send_session
+        adapter._poll_task = asyncio.create_task(asyncio.sleep(3600))
+
+        with patch.object(weixin, "_load_sync_buf", return_value="buf-123"), \
+             patch.object(weixin, "_save_sync_buf") as save_sync_buf_mock, \
+             patch.object(weixin, "_get_updates", new_callable=AsyncMock) as get_updates_mock:
+            get_updates_mock.return_value = {"ret": 0, "msgs": [], "get_updates_buf": "buf-456"}
+
+            await adapter.disconnect()
+
+        get_updates_mock.assert_awaited_once_with(
+            poll_session,
+            base_url=adapter._base_url,
+            token=adapter._token,
+            sync_buf="buf-123",
+            timeout_ms=weixin.DISCONNECT_DRAIN_TIMEOUT_MS,
+            swallow_timeout=False,
+        )
+        save_sync_buf_mock.assert_called_once_with(adapter._hermes_home, adapter._account_id, "buf-456")
+        poll_session.close.assert_awaited_once()
+        send_session.close.assert_awaited_once()
+        assert adapter._poll_task is None
+
+    @pytest.mark.asyncio
+    async def test_disconnect_continues_cleanup_when_terminal_drain_times_out(self):
+        adapter = _make_adapter()
+        poll_session = AsyncMock()
+        poll_session.closed = False
+        send_session = AsyncMock()
+        send_session.closed = False
+        adapter._poll_session = poll_session
+        adapter._send_session = send_session
+
+        with patch.object(weixin, "_load_sync_buf", return_value="buf-123"), \
+             patch.object(weixin, "_get_updates", new_callable=AsyncMock) as get_updates_mock, \
+             patch.object(weixin.logger, "warning") as warning_mock:
+            get_updates_mock.side_effect = asyncio.TimeoutError()
+
+            await adapter.disconnect()
+
+        warning_mock.assert_called_once()
+        poll_session.close.assert_awaited_once()
+        send_session.close.assert_awaited_once()


### PR DESCRIPTION
Fixes #45325

## Summary
- add a bounded final `getupdates` drain during `WeixinAdapter.disconnect()` before closing the poll session
- let disconnect surface drain timeouts as warnings instead of silently swallowing them
- add regressions for the disconnect drain path and the non-swallowed timeout mode

## Testing
- uv run --frozen pytest tests/gateway/test_weixin.py
- uv run --frozen ruff check gateway/platforms/weixin.py tests/gateway/test_weixin.py
- git diff --check HEAD^ HEAD

Residual CI attribution: recent company PRs #45349, #45345, and #45324 are all green on required checks, so there is no known shared baseline red for this candidate.