### PR TITLE
fix(desktop): add show/hide ignored files toggle to file tree

### DIFF
--- a/apps/desktop/src/app/right-sidebar/files/ipc.ts
+++ b/apps/desktop/src/app/right-sidebar/files/ipc.ts
@@ -131,13 +131,21 @@ async function filterIgnored(entries: HermesReadDirEntry[], rootPath: string, di
   return rules.length > 0 ? entries.filter(entry => !ignoredBy(rules, entry)) : entries
 }
 
-export async function readProjectDir(dirPath: string, rootPath = dirPath): Promise<HermesReadDirResult> {
+export async function readProjectDir(
+  dirPath: string,
+  rootPath = dirPath,
+  { showIgnored = false }: { showIgnored?: boolean } = {}
+): Promise<HermesReadDirResult> {
   if (!window.hermesDesktop) {
     return { entries: [], error: 'no-bridge' }
   }
 
   const result = await readDesktopDir(dirPath)
   const entries = (result?.entries ?? []).filter(entry => !ALWAYS_EXCLUDED.has(entry.name))
+
+  if (showIgnored) {
+    return { ...result, entries }
+  }
 
   return { ...result, entries: await filterIgnored(entries, rootPath, dirPath) }
 }

--- a/apps/desktop/src/app/right-sidebar/files/use-project-tree.test.ts
+++ b/apps/desktop/src/app/right-sidebar/files/use-project-tree.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { HermesReadDirResult } from '@/global'
 import { $connection } from '@/store/session'
+import { $workspaceChangeTick } from '@/store/workspace-events'
 
 import { clearProjectDirCache, readProjectDir } from './ipc'
 import { resetProjectTreeState, useProjectTree } from './use-project-tree'
@@ -268,5 +269,61 @@ describe('useProjectTree', () => {
 
     await waitFor(() => expect(result.current.rootError).toBe('no-bridge'))
     expect(result.current.data).toEqual([])
+  })
+
+  it('toggles showIgnored and carries the setting into loadChildren and revalidateTree', async () => {
+    const gitRoot = vi.fn(async () => '/p')
+    const readFileDataUrl = vi.fn(async () => `data:text/plain;base64,${btoa('ignored.log\n')}`)
+    readDir.mockImplementation(async path => {
+      if (path === '/p') {
+        return ok([
+          { name: '.gitignore', path: '/p/.gitignore', isDirectory: false },
+          { name: 'src', path: '/p/src', isDirectory: true }
+        ])
+      }
+
+      if (path === '/p/src') {
+        return ok([
+          { name: 'app.ts', path: '/p/src/app.ts', isDirectory: false },
+          { name: 'ignored.log', path: '/p/src/ignored.log', isDirectory: false }
+        ])
+      }
+
+      return ok([])
+    })
+    ;(window as unknown as { hermesDesktop: unknown }).hermesDesktop = { gitRoot, readDir, readFileDataUrl }
+
+    const { result } = renderHook(() => useProjectTree('/p'))
+    await waitFor(() => expect(result.current.rootLoading).toBe(false))
+
+    // Expand src folder
+    await act(async () => {
+      await result.current.loadChildren('/p/src')
+    })
+
+    // By default showIgnored is false, so ignored.log is filtered out
+    const srcNode = result.current.data.find(n => n.name === 'src')
+    expect(srcNode?.children?.map(c => c.name)).toEqual(['app.ts'])
+
+    // Toggle showIgnored
+    await act(async () => {
+      result.current.toggleShowIgnored()
+    })
+
+    // Now it should reload the root and when expanding children it should include ignored.log
+    await act(async () => {
+      await result.current.loadChildren('/p/src')
+    })
+    const srcNodeAfter = result.current.data.find(n => n.name === 'src')
+    expect(srcNodeAfter?.children?.map(c => c.name)).toEqual(['app.ts', 'ignored.log'])
+
+    // Bumping workspaceChangeTick triggers revalidateTree which should also keep ignored.log
+    await act(async () => {
+      $workspaceChangeTick.set($workspaceChangeTick.get() + 1)
+    })
+
+    // Check that it still has ignored.log after revalidation
+    const srcNodeAfterReval = result.current.data.find(n => n.name === 'src')
+    expect(srcNodeAfterReval?.children?.map(c => c.name)).toEqual(['app.ts', 'ignored.log'])
   })
 })

--- a/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
+++ b/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
@@ -224,6 +224,7 @@ export function resetProjectTreeState() {
   lastConnectionKey = ''
   clearProjectTree()
   clearProjectDirCache()
+  $showIgnored.set(false)
 }
 
 // Non-destructive refresh: re-read every currently-loaded directory and merge
@@ -242,7 +243,7 @@ async function revalidateTree(cwd: string): Promise<void> {
   clearProjectDirCache()
 
   const reconcile = async (dirPath: string, existing: TreeNode[]): Promise<TreeNode[]> => {
-    const { entries, error } = await readProjectDir(dirPath, rootPath)
+    const { entries, error } = await readProjectDir(dirPath, rootPath, { showIgnored: $showIgnored.get() })
 
     if (error) {
       return existing // keep the last-known children on a transient read error

--- a/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
+++ b/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
@@ -72,10 +72,14 @@ export interface UseProjectTreeResult {
   openState: Record<string, boolean>
   rootError: string | null
   rootLoading: boolean
+  /** When true, gitignored entries are visible in the tree. */
+  showIgnored: boolean
   collapseAll: () => void
   loadChildren: (id: string) => Promise<void>
   refreshRoot: () => Promise<void>
   setNodeOpen: (id: string, open: boolean) => void
+  /** Toggle gitignore filtering on/off and reload the tree immediately. */
+  toggleShowIgnored: () => void
 }
 
 interface ProjectTreeState {
@@ -105,6 +109,7 @@ const initialState: ProjectTreeState = {
 
 const inflight = new Set<string>()
 const $projectTree = atom<ProjectTreeState>(initialState)
+const $showIgnored = atom<boolean>(false)
 let nextRootRequestId = 0
 let lastConnectionKey = ''
 
@@ -181,14 +186,15 @@ async function loadRoot(cwd: string, { force = false }: { force?: boolean } = {}
     rootLoading: true
   })
 
+  const showIgnored = $showIgnored.get()
   let resolvedCwd = cwd
-  let { entries, error } = await readProjectDir(cwd, cwd)
+  let { entries, error } = await readProjectDir(cwd, cwd, { showIgnored })
 
   if (error) {
     const fallback = await fallbackRootFor(cwd)
 
     if (fallback) {
-      const retry = await readProjectDir(fallback, fallback)
+      const retry = await readProjectDir(fallback, fallback, { showIgnored })
 
       if (!retry.error) {
         resolvedCwd = fallback
@@ -277,9 +283,15 @@ export function useProjectTree(cwd: string): UseProjectTreeResult {
   const state = useStore($projectTree)
   const connection = useStore($connection)
   const workspaceTick = useStore($workspaceChangeTick)
+  const showIgnored = useStore($showIgnored)
   const connectionKey = `${connection?.mode || 'local'}:${connection?.profile || ''}:${connection?.baseUrl || ''}`
 
   const refreshRoot = useCallback(() => loadRoot(cwd, { force: true }), [cwd])
+
+  const toggleShowIgnored = useCallback(() => {
+    $showIgnored.set(!$showIgnored.get())
+    void loadRoot(cwd, { force: true })
+  }, [cwd])
 
   const setNodeOpen = useCallback(
     (id: string, open: boolean) => {
@@ -333,7 +345,7 @@ export function useProjectTree(cwd: string): UseProjectTreeResult {
       })
 
       const rootPath = $projectTree.get().resolvedCwd || cwd
-      const { entries, error } = await readProjectDir(id, rootPath)
+      const { entries, error } = await readProjectDir(id, rootPath, { showIgnored: $showIgnored.get() })
 
       inflight.delete(id)
 
@@ -428,7 +440,9 @@ export function useProjectTree(cwd: string): UseProjectTreeResult {
       refreshRoot,
       rootError: state.cwd === cwd ? state.rootError : null,
       rootLoading: state.cwd === cwd ? state.rootLoading : Boolean(cwd),
-      setNodeOpen
+      setNodeOpen,
+      showIgnored,
+      toggleShowIgnored
     }),
     [
       collapseAll,
@@ -436,6 +450,8 @@ export function useProjectTree(cwd: string): UseProjectTreeResult {
       loadChildren,
       refreshRoot,
       setNodeOpen,
+      showIgnored,
+      toggleShowIgnored,
       state.collapseNonce,
       state.cwd,
       state.data,

--- a/apps/desktop/src/app/right-sidebar/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.tsx
@@ -47,7 +47,9 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder }: RightSide
     refreshRoot,
     rootError,
     rootLoading,
-    setNodeOpen
+    setNodeOpen,
+    showIgnored,
+    toggleShowIgnored
   } = useProjectTree(hasWorkspace ? currentCwd : '')
 
   const cwdName =
@@ -98,7 +100,9 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder }: RightSide
         onNodeOpenChange={setNodeOpen}
         onPreviewFile={previewFile}
         onRefresh={() => void refreshRoot()}
+        onToggleShowIgnored={toggleShowIgnored}
         openState={openState}
+        showIgnored={showIgnored}
       />
     </aside>
   )
@@ -110,6 +114,8 @@ interface FilesystemTabProps extends FileTreeBodyProps {
   hasWorkspace: boolean
   onCollapseAll: () => void
   onRefresh: () => void
+  onToggleShowIgnored: () => void
+  showIgnored: boolean
 }
 
 // Sidebar palette + hover-reveal: header actions stay reachable while moving
@@ -135,7 +141,9 @@ function FilesystemTab({
   onNodeOpenChange,
   onPreviewFile,
   onRefresh,
-  openState
+  onToggleShowIgnored,
+  openState,
+  showIgnored
 }: FilesystemTabProps) {
   const { t } = useI18n()
   const r = t.rightSidebar
@@ -174,6 +182,18 @@ function FilesystemTab({
             variant="ghost"
           >
             <Codicon name="collapse-all" size="0.8125rem" />
+          </Button>
+        </Tip>
+        <Tip label={showIgnored ? r.hideIgnoredFiles : r.showIgnoredFiles}>
+          <Button
+            aria-label={showIgnored ? r.hideIgnoredFiles : r.showIgnoredFiles}
+            className={cn(HEADER_ACTION_CLASS, showIgnored && 'text-foreground opacity-100')}
+            disabled={!hasWorkspace}
+            onClick={onToggleShowIgnored}
+            size="icon-xs"
+            variant="ghost"
+          >
+            <Codicon name={showIgnored ? 'eye' : 'eye-closed'} size="0.8125rem" />
           </Button>
         </Tip>
       </RightSidebarSectionHeader>

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2200,6 +2200,8 @@ export const en: Translations = {
     openFolder: 'Open folder',
     refreshTree: 'Refresh tree',
     collapseAll: 'Collapse all folders',
+    showIgnoredFiles: 'Show ignored files',
+    hideIgnoredFiles: 'Hide ignored files',
     previewUnavailable: 'Preview unavailable',
     couldNotPreview: path => `Could not preview ${path}`,
     noProjectTitle: 'No project',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2119,6 +2119,8 @@ export const ja = defineLocale({
     openFolder: 'フォルダーを開く',
     refreshTree: 'ツリーを更新',
     collapseAll: 'すべてのフォルダーを折りたたむ',
+    showIgnoredFiles: '無視されたファイルを表示',
+    hideIgnoredFiles: '無視されたファイルを非表示',
     previewUnavailable: 'プレビューは利用できません',
     couldNotPreview: path => `${path} をプレビューできませんでした`,
     noProjectTitle: 'プロジェクトなし',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1829,6 +1829,8 @@ export interface Translations {
     openFolder: string
     refreshTree: string
     collapseAll: string
+    showIgnoredFiles: string
+    hideIgnoredFiles: string
     previewUnavailable: string
     couldNotPreview: (path: string) => string
     noProjectTitle: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2054,6 +2054,8 @@ export const zhHant = defineLocale({
     openFolder: '開啟資料夾',
     refreshTree: '重新整理檔案樹',
     collapseAll: '收合所有資料夾',
+    showIgnoredFiles: '顯示已忽略的檔案',
+    hideIgnoredFiles: '隱藏已忽略的檔案',
     previewUnavailable: '預覽不可用',
     couldNotPreview: path => `無法預覽 ${path}`,
     noProjectTitle: '沒有專案',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2365,6 +2365,8 @@ export const zh: Translations = {
     openFolder: '打开文件夹',
     refreshTree: '刷新文件树',
     collapseAll: '折叠所有文件夹',
+    showIgnoredFiles: '显示已忽略的文件',
+    hideIgnoredFiles: '隐藏已忽略的文件',
     previewUnavailable: '预览不可用',
     couldNotPreview: path => `无法预览 ${path}`,
     noProjectTitle: '没有项目',


### PR DESCRIPTION
## Problem

The desktop file-tree silently hides every entry matched by `.gitignore` with no way to toggle that behaviour off. Gitignored workspace folders (build artifacts, vendored deps, generated output) are invisible even when the user explicitly wants to navigate them.

Closes #45286

## Solution

Add a persistent module-level `$showIgnored` atom (nanostores) that controls whether `filterIgnored` runs inside `readProjectDir`. A new eye/eye-closed icon button in the file-tree header toggles the atom and force-reloads the root. The state survives component remounts within a session.

### Files changed

| File | Change |
|------|--------|
| `apps/desktop/src/app/right-sidebar/files/ipc.ts` | Added `showIgnored` option to `readProjectDir`; when `true`, bypasses `filterIgnored` entirely |
| `apps/desktop/src/app/right-sidebar/files/use-project-tree.ts` | Added `$showIgnored` atom; wired into `loadRoot`, `loadChildren`, `toggleShowIgnored`; exposed `showIgnored` / `toggleShowIgnored` from the hook |
| `apps/desktop/src/app/right-sidebar/index.tsx` | Added toggle button (eye/eye-closed codicon) to the sidebar header; passes `showIgnored` active style |
| `apps/desktop/src/i18n/en.ts` | Added `showIgnoredFiles` / `hideIgnoredFiles` strings |

## Test plan

- [ ] Open a repo with a `.gitignore` that hides files/folders — confirm they are absent by default
- [ ] Click the eye button — tree reloads and ignored entries appear
- [ ] Click the eye button again — tree reloads and ignored entries disappear
- [ ] Button is disabled when no folder is open (`hasCwd === false`)
- [ ] Active state (full opacity) renders when `showIgnored` is true
- [ ] State persists across manual refreshes within the session
- [ ] Existing `ipc.test.ts` tests pass (no regressions to the gitignore-filter path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)