### PR TITLE
fix(process): silence failed notify_on_complete exits

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12006,67 +12006,71 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # --- Agent-triggered completion: inject synthetic message ---
                 # Skip if the agent already consumed the result via wait/poll/log
                 from tools.process_registry import process_registry as _pr_check
-                if agent_notify and not _pr_check.is_completion_consumed(session_id):
-                    from tools.ansi_strip import strip_ansi
-                    _raw = strip_ansi(session.output_buffer) if session.output_buffer else ""
-                    # Truncate at line boundaries so notifications never start
-                    # mid-line (fixes #23284). Keep the last ~2000 chars but
-                    # snap to the nearest preceding newline, then prepend a
-                    # truncation marker when output was cut.
-                    _LIMIT = 2000
-                    if len(_raw) > _LIMIT:
-                        _tail = _raw[-_LIMIT:]
-                        _nl = _tail.find("\n")
-                        _tail = _tail[_nl + 1:] if _nl != -1 else _tail
-                        _out = f"[… output truncated — showing last {len(_tail)} chars]\n{_tail}"
-                    else:
-                        _out = _raw
-                    synth_text = (
-                        f"[IMPORTANT: Background process {session_id} completed "
-                        f"(exit code {session.exit_code}).\n"
-                        f"Command: {session.command}\n"
-                        f"Output:\n{_out}]"
-                    )
-                    source = self._build_process_event_source({
-                        "session_id": session_id,
-                        "session_key": session_key,
-                        "platform": platform_name,
-                        "chat_id": chat_id,
-                        "thread_id": thread_id,
-                        "user_id": user_id,
-                        "user_name": user_name,
-                    })
-                    if not source:
-                        logger.warning(
-                            "Dropping completion notification with no routing metadata for process %s",
-                            session_id,
+                if agent_notify:
+                    if (
+                        session.exit_code == 0
+                        and not _pr_check.is_completion_consumed(session_id)
+                    ):
+                        from tools.ansi_strip import strip_ansi
+                        _raw = strip_ansi(session.output_buffer) if session.output_buffer else ""
+                        # Truncate at line boundaries so notifications never start
+                        # mid-line (fixes #23284). Keep the last ~2000 chars but
+                        # snap to the nearest preceding newline, then prepend a
+                        # truncation marker when output was cut.
+                        _LIMIT = 2000
+                        if len(_raw) > _LIMIT:
+                            _tail = _raw[-_LIMIT:]
+                            _nl = _tail.find("\n")
+                            _tail = _tail[_nl + 1:] if _nl != -1 else _tail
+                            _out = f"[… output truncated — showing last {len(_tail)} chars]\n{_tail}"
+                        else:
+                            _out = _raw
+                        synth_text = (
+                            f"[IMPORTANT: Background process {session_id} completed "
+                            f"(exit code {session.exit_code}).\n"
+                            f"Command: {session.command}\n"
+                            f"Output:\n{_out}]"
                         )
-                        break
-
-                    adapter = None
-                    for p, a in self.adapters.items():
-                        if p == source.platform:
-                            adapter = a
-                            break
-                    if adapter and source.chat_id:
-                        try:
-                            synth_event = MessageEvent(
-                                text=synth_text,
-                                message_type=MessageType.TEXT,
-                                source=source,
-                                internal=True,
-                                message_id=message_id,
-                            )
-                            logger.info(
-                                "Process %s finished — injecting agent notification for session %s chat=%s thread=%s",
+                        source = self._build_process_event_source({
+                            "session_id": session_id,
+                            "session_key": session_key,
+                            "platform": platform_name,
+                            "chat_id": chat_id,
+                            "thread_id": thread_id,
+                            "user_id": user_id,
+                            "user_name": user_name,
+                        })
+                        if not source:
+                            logger.warning(
+                                "Dropping completion notification with no routing metadata for process %s",
                                 session_id,
-                                session_key,
-                                source.chat_id,
-                                source.thread_id,
                             )
-                            await adapter.handle_message(synth_event)
-                        except Exception as e:
-                            logger.error("Agent notify injection error: %s", e)
+                            break
+
+                        adapter = None
+                        for p, a in self.adapters.items():
+                            if p == source.platform:
+                                adapter = a
+                                break
+                        if adapter and source.chat_id:
+                            try:
+                                synth_event = MessageEvent(
+                                    text=synth_text,
+                                    message_type=MessageType.TEXT,
+                                    source=source,
+                                    internal=True,
+                                    message_id=message_id,
+                                )
+                                logger.info(
+                                    "Process %s finished — injecting agent notification for session %s chat=%s thread=%s",
+                                    session_id,
+                                    session_key,
+                                    source.chat_id,
+                                    source.thread_id,
+                                )
+                                await adapter.handle_message(synth_event)
+                            except Exception as e:
+                                logger.error("Agent notify injection error: %s", e)
                     break
 
                 # --- Normal text-only notification ---

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -358,6 +358,37 @@ async def test_agent_notification_no_message_id_is_tolerated(monkeypatch, tmp_pa
 
 
 @pytest.mark.asyncio
+async def test_agent_notification_ignores_failed_exit(monkeypatch, tmp_path):
+    import tools.process_registry as pr_module
+
+    sessions = [SimpleNamespace(
+        output_buffer="FAILED\n", exited=True, exit_code=1, command="pytest",
+    )]
+    monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+
+    watcher = {
+        "session_id": "proc_failed",
+        "check_interval": 0,
+        "session_key": "agent:main:telegram:dm:123:24296",
+        "platform": "telegram",
+        "chat_id": "123",
+        "thread_id": "24296",
+        "notify_on_complete": True,
+    }
+    await runner._run_process_watcher(watcher)
+
+    adapter.handle_message.assert_not_awaited()
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_inject_watch_notification_carries_message_id_reply_anchor(monkeypatch, tmp_path):
     from gateway.session import SessionSource
 

--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -102,7 +102,7 @@ class TestCompletionQueue:
         assert "build succeeded" in completion["output"]
 
     def test_move_to_finished_nonzero_exit(self, registry):
-        """Nonzero exit codes are captured correctly."""
+        """Nonzero exit codes stay silent for notify_on_complete."""
         s = _make_session(
             notify_on_complete=True,
             output="FAILED",
@@ -114,9 +114,7 @@ class TestCompletionQueue:
         with patch.object(registry, "_write_checkpoint"):
             registry._move_to_finished(s)
 
-        completion = registry.completion_queue.get_nowait()
-        assert completion["exit_code"] == 1
-        assert "FAILED" in completion["output"]
+        assert registry.completion_queue.empty()
 
     def test_move_to_finished_idempotent_no_duplicate(self, registry):
         """Calling _move_to_finished twice must NOT enqueue two notifications.
@@ -125,9 +123,9 @@ class TestCompletionQueue:
         _move_to_finished() for the same session, producing duplicate
         [SYSTEM: Background process ...] messages.
         """
-        s = _make_session(notify_on_complete=True, output="done", exit_code=-15)
+        s = _make_session(notify_on_complete=True, output="done", exit_code=0)
         s.exited = True
-        s.exit_code = -15
+        s.exit_code = 0
         registry._running[s.id] = s
         with patch.object(registry, "_write_checkpoint"):
             registry._move_to_finished(s)  # first call — should enqueue
@@ -136,7 +134,7 @@ class TestCompletionQueue:
 
         assert registry.completion_queue.qsize() == 1
         completion = registry.completion_queue.get_nowait()
-        assert completion["exit_code"] == -15  # from the first (kill) call
+        assert completion["exit_code"] == 0  # from the first successful call
 
     def test_output_truncated_to_2000(self, registry):
         """Long output is truncated to last 2000 chars."""

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -992,6 +992,17 @@ def test_format_completion_event():
     assert "Output:\ndone]" in result
 
 
+def test_format_completion_event_nonzero_exit_returns_none():
+    evt = {
+        "type": "completion",
+        "session_id": "proc_fail",
+        "command": "pytest",
+        "exit_code": 1,
+        "output": "FAILED",
+    }
+    assert format_process_notification(evt) is None
+
+
 def test_format_watch_match_event():
     evt = {
         "type": "watch_match",
@@ -1093,6 +1104,29 @@ def test_drain_notifications_skips_consumed():
         process_registry._completion_consumed.discard("proc_consumed")
         while not process_registry.completion_queue.empty():
             process_registry.completion_queue.get_nowait()
+
+
+def test_drain_notifications_skips_failed_completions():
+    from tools.process_registry import process_registry
+
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+
+    process_registry.completion_queue.put({
+        "type": "completion",
+        "session_id": "proc_fail",
+        "command": "pytest",
+        "exit_code": 1,
+        "output": "FAILED",
+    })
+
+    try:
+        results = process_registry.drain_notifications()
+        assert results == []
+    finally:
+        while not process_registry.completion_queue.empty():
+            process_registry.completion_queue.get_nowait()
+        process_registry._completion_consumed.discard("proc_fail")
 
 
 def test_drain_notifications_empty_queue():

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -872,10 +872,11 @@ class ProcessRegistry:
             self._finished[session.id] = session
         self._write_checkpoint()
 
-        # Only enqueue completion notification on the FIRST move.  Without
-        # this guard, kill_process() and the reader thread can both call
-        # _move_to_finished(), producing duplicate [IMPORTANT: ...] messages.
-        if was_running and session.notify_on_complete:
+        # Only enqueue completion notification on the FIRST successful move.
+        # Without this guard, kill_process() and the reader thread can both
+        # call _move_to_finished(), producing duplicate [IMPORTANT: ...]
+        # messages. Failed/killed exits stay silent for notify_on_complete.
+        if was_running and session.notify_on_complete and session.exit_code == 0:
             from tools.ansi_strip import strip_ansi
             output_tail = strip_ansi(session.output_buffer[-2000:]) if session.output_buffer else ""
             self.completion_queue.put({
@@ -1524,6 +1525,8 @@ def format_process_notification(evt: dict) -> "str | None":
         return text
 
     _exit = evt.get("exit_code", "?")
+    if _exit not in {0, None, "?"}:
+        return None
     _out = evt.get("output", "")
     return (
         f"[IMPORTANT: Background process {_sid} completed "


### PR DESCRIPTION
## Summary
- only enqueue/format notify_on_complete completions for exit_code 0
- suppress gateway agent-injected completion messages for failed or killed background processes
- add regression coverage for process-registry and gateway watcher paths

## Testing
- uv run --frozen pytest tests/tools/test_notify_on_complete.py tests/tools/test_process_registry.py tests/gateway/test_background_process_notifications.py -q
- uv run --frozen ruff check tools/process_registry.py gateway/run.py tests/tools/test_notify_on_complete.py tests/tools/test_process_registry.py tests/gateway/test_background_process_notifications.py
- git diff --check HEAD^ HEAD

Closes #45352