### PR TITLE
fix: strip reasoning_content for providers that reject it

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2128,6 +2128,12 @@ def copy_reasoning_content_for_api(agent, source_msg: dict, api_msg: dict) -> No
     if source_msg.get("role") != "assistant":
         return
 
+    # 0. Reject-side providers: strip reasoning_content echoes from the
+    # outgoing API copy before any promotion/padding branch can re-add them.
+    if agent._rejects_reasoning_content_echo():
+        api_msg.pop("reasoning_content", None)
+        return
+
     # 1. Explicit reasoning_content already set — preserve it verbatim
     # (includes DeepSeek/Kimi's own space-placeholder written at creation
     # time, and any valid reasoning content from the same provider).

--- a/run_agent.py
+++ b/run_agent.py
@@ -4870,6 +4870,36 @@ class AIAgent:
         self._thinking_pad_cache = (key, result)
         return result
 
+    def _rejects_reasoning_content_echo(self) -> bool:
+        """Return True when the active provider rejects replayed reasoning_content.
+
+        Some strict OpenAI-compatible providers reject assistant-history
+        ``reasoning_content`` outright on replay instead of ignoring it.
+        Cross-provider fallback from a thinking model into those providers can
+        therefore fail with HTTP 400 / 422 unless the field is stripped from
+        the outgoing API copy.
+
+        Detection is provider/base-URL driven, not model-name driven, so
+        aggregators re-exporting the same model IDs (e.g. OpenRouter) are not
+        affected.
+        """
+        key = (self.provider, self.model, getattr(self, "_base_url_lower", self.base_url))
+        cached = getattr(self, "_reasoning_reject_cache", None)
+        if cached is not None and cached[0] == key:
+            return cached[1]
+
+        provider = (self.provider or "").lower()
+        provider_tag = provider.rsplit(":", 1)[-1]
+        result = (
+            provider_tag in {"cerebras", "groq", "mistral", "sambanova"}
+            or base_url_host_matches(self.base_url, "api.cerebras.ai")
+            or base_url_host_matches(self.base_url, "api.groq.com")
+            or base_url_host_matches(self.base_url, "api.mistral.ai")
+            or base_url_host_matches(self.base_url, "api.sambanova.ai")
+        )
+        self._reasoning_reject_cache = (key, result)
+        return result
+
     def _needs_kimi_tool_reasoning(self) -> bool:
         """Return True when the current provider is Kimi / Moonshot thinking mode.
 

--- a/tests/run_agent/test_reasoning_content_strip_for_rejecting_providers.py
+++ b/tests/run_agent/test_reasoning_content_strip_for_rejecting_providers.py
@@ -1,0 +1,121 @@
+"""Regression tests for rejecting-provider reasoning_content stripping.
+
+Cross-provider fallback can replay assistant turns carrying
+``reasoning_content`` from a thinking model into strict providers that reject
+that field outright. The outgoing API copy must strip the echo before the
+request is built, while preserving the existing DeepSeek/Kimi/MiMo add-side
+behavior.
+
+Refs #45332.
+"""
+
+from __future__ import annotations
+
+from run_agent import AIAgent
+
+
+def _make_agent(provider: str = "", model: str = "", base_url: str = "") -> AIAgent:
+    agent = object.__new__(AIAgent)
+    agent.provider = provider
+    agent.model = model
+    agent.base_url = base_url
+    agent.verbose_logging = False
+    return agent
+
+
+class TestRejectsReasoningContentEcho:
+    def test_custom_groq_provider(self) -> None:
+        agent = _make_agent(provider="custom:groq", model="llama-3.1-8b-instant")
+        assert agent._rejects_reasoning_content_echo() is True
+
+    def test_cerebras_base_url(self) -> None:
+        agent = _make_agent(
+            provider="custom",
+            model="gpt-oss-120b",
+            base_url="https://api.cerebras.ai/v1",
+        )
+        assert agent._rejects_reasoning_content_echo() is True
+
+    def test_mistral_base_url(self) -> None:
+        agent = _make_agent(
+            provider="custom",
+            model="mistral-small-latest",
+            base_url="https://api.mistral.ai/v1",
+        )
+        assert agent._rejects_reasoning_content_echo() is True
+
+    def test_sambanova_provider(self) -> None:
+        agent = _make_agent(
+            provider="custom:sambanova",
+            model="Meta-Llama-3.3-70B-Instruct",
+        )
+        assert agent._rejects_reasoning_content_echo() is True
+
+    def test_openrouter_alias_does_not_match_model_name(self) -> None:
+        agent = _make_agent(
+            provider="openrouter",
+            model="mistral/mistral-small-3.2-24b-instruct",
+            base_url="https://openrouter.ai/api/v1",
+        )
+        assert agent._rejects_reasoning_content_echo() is False
+
+    def test_cache_invalidates_when_provider_changes(self) -> None:
+        agent = _make_agent(
+            provider="custom:cerebras",
+            model="gpt-oss-120b",
+            base_url="https://api.cerebras.ai/v1",
+        )
+        assert agent._rejects_reasoning_content_echo() is True
+
+        agent.provider = "deepseek"
+        agent.model = "deepseek-v4-flash"
+        agent.base_url = "https://api.deepseek.com/v1"
+        assert agent._rejects_reasoning_content_echo() is False
+
+
+class TestCopyReasoningContentForApi:
+    def test_rejecting_provider_strips_explicit_reasoning_content(self) -> None:
+        agent = _make_agent(
+            provider="custom:groq",
+            model="llama-3.1-8b-instant",
+            base_url="https://api.groq.com/openai/v1",
+        )
+        source = {
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": "chain of thought",
+            "tool_calls": [{"id": "c1", "function": {"name": "terminal"}}],
+        }
+        api_msg = {"reasoning_content": "stale value"}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert "reasoning_content" not in api_msg
+
+    def test_rejecting_provider_does_not_promote_reasoning_field(self) -> None:
+        agent = _make_agent(
+            provider="custom:mistral",
+            model="mistral-small-latest",
+            base_url="https://api.mistral.ai/v1",
+        )
+        source = {
+            "role": "assistant",
+            "content": "",
+            "reasoning": "glm thinking text",
+        }
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert "reasoning_content" not in api_msg
+
+    def test_non_rejecting_provider_preserves_reasoning_content(self) -> None:
+        agent = _make_agent(
+            provider="openrouter",
+            model="z-ai/glm-5.1",
+            base_url="https://openrouter.ai/api/v1",
+        )
+        source = {
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": "keep me",
+        }
+        api_msg: dict = {}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg["reasoning_content"] == "keep me"


### PR DESCRIPTION
## Summary
- add a reject-side provider/base-url predicate for reasoning_content echo
- stop copying or promoting reasoning_content when falling back to providers that reject it
- add regression tests for recognized providers, cache invalidation, and strip/preserve behavior

Closes #45332

## Proof
- uv run --frozen pytest tests/run_agent/test_reasoning_content_strip_for_rejecting_providers.py tests/run_agent/test_deepseek_reasoning_content_echo.py -q
- uv run --frozen ruff check run_agent.py agent/agent_runtime_helpers.py tests/run_agent/test_reasoning_content_strip_for_rejecting_providers.py
- git diff --check HEAD^ HEAD