### PR TITLE
fix(nous): normalize Claude model ids on startup

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -357,7 +357,7 @@ def init_agent(
             normalize_model_for_provider,
         )
 
-        if agent.provider not in _AGGREGATOR_PROVIDERS:
+        if agent.provider == "nous" or agent.provider not in _AGGREGATOR_PROVIDERS:
             agent.model = normalize_model_for_provider(agent.model, agent.provider)
     except Exception:
         pass

--- a/cli.py
+++ b/cli.py
@@ -4305,7 +4305,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 normalize_model_for_provider,
             )
 
-            if resolved_provider not in _AGGREGATOR_PROVIDERS:
+            if resolved_provider == "nous" or resolved_provider not in _AGGREGATOR_PROVIDERS:
                 normalized_model = normalize_model_for_provider(current_model, resolved_provider)
                 if normalized_model and normalized_model != current_model:
                     if not self._model_is_default:

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -209,6 +209,41 @@ def _dots_to_hyphens(model_name: str) -> str:
     return model_name.replace(".", "-")
 
 
+def _restore_claude_dots(model_name: str) -> str:
+    """Repair Anthropic-native Claude IDs for aggregator providers.
+
+    Anthropic's native API uses hyphenated version segments such as
+    ``claude-sonnet-4-6``. Aggregators like Nous expect the dot-style slug
+    instead: ``anthropic/claude-sonnet-4.6``. When a user copies a native
+    Anthropic ID into a Nous/OpenRouter-configured profile, preserve the
+    existing vendor prefix (if any) and reinsert the first short digit-pair
+    dot.
+    """
+    prefix = ""
+    bare = model_name
+    if "/" in model_name:
+        prefix, bare = model_name.split("/", 1)
+        prefix = f"{prefix}/"
+
+    if "." in bare or not bare.lower().startswith("claude-"):
+        return model_name
+
+    parts = bare.split("-")
+    for idx in range(1, len(parts) - 1):
+        left = parts[idx]
+        right = parts[idx + 1]
+        if not (left.isdigit() and right.isdigit()):
+            continue
+        if len(left) > 2 or len(right) > 2:
+            continue
+        repaired = "-".join(parts[:idx]) + f"-{left}.{right}"
+        if idx + 2 < len(parts):
+            repaired += "-" + "-".join(parts[idx + 2 :])
+        return f"{prefix}{repaired}"
+
+    return model_name
+
+
 def _normalize_provider_alias(provider_name: str) -> str:
     """Resolve provider aliases to Hermes' canonical ids."""
     raw = (provider_name or "").strip().lower()
@@ -390,6 +425,8 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
 
     # --- Aggregators: need vendor/model format ---
     if provider in _AGGREGATOR_PROVIDERS:
+        if provider == "nous":
+            name = _restore_claude_dots(name)
         return _prepend_vendor(name)
 
     # --- OpenCode Zen / OpenCode Go: flat-namespace resellers.
@@ -469,4 +506,3 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
 # ---------------------------------------------------------------------------
 # Batch / convenience helpers
 # ---------------------------------------------------------------------------
-

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -274,6 +274,12 @@ class TestNormalizeModelForProvider:
         assert changed is False
         assert cli.model == "gpt-5.4"
 
+    def test_nous_repairs_hyphenated_claude_slug(self):
+        cli = _make_cli(model="anthropic/claude-sonnet-4-6")
+        changed = cli._normalize_model_for_provider("nous")
+        assert changed is True
+        assert cli.model == "anthropic/claude-sonnet-4.6"
+
     def test_native_provider_prefix_is_stripped_before_agent_startup(self):
         cli = _make_cli(model="zai/glm-5.1")
         changed = cli._normalize_model_for_provider("zai")

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -159,6 +159,15 @@ class TestAggregatorProviders:
         result = normalize_model_for_provider("gpt-5.4", "nous")
         assert result == "openai/gpt-5.4"
 
+    @pytest.mark.parametrize("model,expected", [
+        ("claude-sonnet-4-6", "anthropic/claude-sonnet-4.6"),
+        ("anthropic/claude-opus-4-6", "anthropic/claude-opus-4.6"),
+        ("claude-3-7-sonnet", "anthropic/claude-3.7-sonnet"),
+    ])
+    def test_nous_repairs_hyphenated_claude_versions(self, model, expected):
+        result = normalize_model_for_provider(model, "nous")
+        assert result == expected
+
     def test_vendor_already_present(self):
         result = normalize_model_for_provider("anthropic/claude-sonnet-4.6", "openrouter")
         assert result == "anthropic/claude-sonnet-4.6"


### PR DESCRIPTION
## Summary
- repair Anthropic-native Claude ids like `claude-sonnet-4-6` into Nous dot-style slugs like `anthropic/claude-sonnet-4.6`
- apply that Nous-specific normalization during CLI startup and agent init so existing broken configs recover at runtime
- add regression coverage for Nous model normalization and CLI startup behavior

## Scope
This addresses the dash-vs-dot runtime normalization half of #45362. It does not change catalog entitlement filtering yet.

## Proof
- uv run --frozen pytest tests/hermes_cli/test_model_normalize.py tests/hermes_cli/test_codex_models.py::TestNormalizeModelForProvider::test_nous_repairs_hyphenated_claude_slug -q
- uv run --frozen ruff check hermes_cli/model_normalize.py cli.py agent/agent_init.py tests/hermes_cli/test_model_normalize.py tests/hermes_cli/test_codex_models.py
- git diff --check HEAD^ HEAD