### PR TITLE
fix(doctor): don't recommend the npm-crashing audit fix; explain build-tool advisories

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1543,8 +1543,14 @@ def run_doctor(args):
                 total = critical + high + moderate
                 # Determine a scoped fix command for the remediation hint.
                 if audit_extra and audit_extra[0] == "--workspace":
-                    fix_scope = " ".join(audit_extra)
-                    fix_cmd = f"cd {npm_dir} && npm audit fix {fix_scope}"
+                    # Detection (`npm audit --workspace <name>`) is read-only and
+                    # safe, but `npm audit fix --workspace <name>` crashes on
+                    # current npm with "Cannot read properties of null (reading
+                    # 'edgesOut')" — an arborist bug with workspace-filtered
+                    # audit fix. Recommend the root-level `npm audit fix`, which
+                    # operates over every workspace and does not crash, instead
+                    # of handing the user a command that errors out.
+                    fix_cmd = f"cd {npm_dir} && npm audit fix"
                 elif audit_extra == ["--workspaces=false"]:
                     fix_cmd = f"cd {npm_dir} && npm audit fix --workspaces=false"
                 else:
@@ -1556,6 +1562,19 @@ def run_doctor(args):
                         f"{label} deps",
                         f"({critical} critical, {high} high, {moderate} moderate — run: {fix_cmd})"
                     )
+                    if audit_extra and audit_extra[0] == "--workspace":
+                        # The web/ui-tui workspace advisories are in build-time
+                        # tooling (esbuild/vite, etc.), not runtime code that ships
+                        # to users. `npm audit fix` here may also error with a known
+                        # npm arborist crash (edgesOut / isDescendantOf) on this
+                        # monorepo tree — in that case it is an npm bug, not a
+                        # Hermes one, and the advisories clear via a lockfile bump
+                        # rather than a manual fix.
+                        check_info(
+                            "  ^ build-time tooling (not runtime); if `npm audit fix` "
+                            "errors with an npm arborist crash it's a known npm bug — "
+                            "clears via a lockfile bump"
+                        )
                     issues.append(
                         f"{label} has {total} npm "
                         f"{'vulnerability' if total == 1 else 'vulnerabilities'}"

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1406,3 +1406,62 @@ class TestDoctorStaleMaxIterationsDrift:
             monkeypatch, tmp_path, fix=False, ghost=None, cfg_turns=400,
         )
         assert "shadows" not in out
+
+
+def test_npm_audit_fix_hint_avoids_crashing_workspace_flag(monkeypatch, tmp_path):
+    """`hermes doctor` must not hand users `npm audit fix --workspace <name>`:
+    that exact form crashes npm with "Cannot read properties of null (reading
+    'edgesOut')" (an arborist bug with workspace-filtered audit fix). The
+    remediation hint for a workspace vulnerability must be the root-level
+    `npm audit fix`, which works.
+
+    Regression for the Docker reports (Pinched-Nerve / lynch1972) where doctor
+    flagged the web/ui-tui workspaces and the suggested fix command errored out.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    project = tmp_path / "project"
+    (project / "node_modules").mkdir(parents=True)
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+
+    # Only npm is "installed" — keeps the rest of run_doctor's external checks
+    # quiet without affecting the npm-audit branch under test.
+    monkeypatch.setattr(
+        doctor_mod.shutil, "which", lambda cmd: "/usr/bin/npm" if cmd == "npm" else None
+    )
+
+    def mock_run(cmd, **kwargs):
+        if "audit" in cmd:
+            payload = (
+                '{"metadata": {"vulnerabilities": '
+                '{"critical": 0, "high": 2, "moderate": 0}}}'
+            )
+            return SimpleNamespace(returncode=1, stdout=payload, stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    import subprocess
+
+    monkeypatch.setattr(subprocess, "run", mock_run)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    # The workspace vulnerability is still reported ...
+    assert "web workspace" in out
+    # ... but the remediation must NOT use the npm-crashing per-workspace form
+    # (`npm audit fix --workspace web` / `--workspace ui-tui`). The unrelated
+    # root target's `--workspaces=false` is a different, non-crashing command.
+    assert "npm audit fix --workspace web" not in out
+    assert "npm audit fix --workspace ui-tui" not in out
+    # ... it offers the safe root-level command instead.
+    assert "&& npm audit fix)" in out
+    # ... and explains the workspace advisories are build-time tooling whose
+    # `npm audit fix` may itself hit a known npm arborist crash, so the user
+    # isn't left thinking a crashing command means a broken Hermes install.
+    assert "build-time tooling" in out
+    assert "known npm bug" in out


### PR DESCRIPTION
## Summary

`hermes doctor`'s npm-audit check flagged the `web` / `ui-tui` workspaces and told the user to run `npm audit fix --workspace <name>`. That exact form crashes current npm with `Cannot read properties of null (reading 'edgesOut')` — an arborist bug with workspace-filtered audit fix. Doctor was handing users a command that errors out.

- Recommend the root-level `npm audit fix` (operates over every workspace, doesn't crash on the `--workspace` filter) instead of the per-workspace form.
- Add a short note for the `web`/`ui-tui` advisories: they're **build-time tooling** (esbuild/vite, etc.), not runtime code, and even the root `npm audit fix` can hit a known npm arborist crash (`edgesOut` / `isDescendantOf`) on this monorepo tree — in which case it's an npm bug, not a Hermes one, and the advisories clear via a lockfile bump. This stops doctor from implying a broken install.

The actual esbuild/vite advisory remediation (lockfile bump) is handled by separate PRs (e.g. #45257 / #45315 / #45224); this PR only fixes doctor's misleading remediation advice.

Reported via Docker users (Pinched-Nerve, lynch1972).

## Test plan

- `scripts/run_tests.sh tests/hermes_cli/test_doctor.py` (65 passed)
- `test_npm_audit_fix_hint_avoids_crashing_workspace_flag` asserts the hint never uses `npm audit fix --workspace web|ui-tui`, offers the root `npm audit fix`, and surfaces the build-time-tooling / known-npm-bug note.