### PR TITLE
fix(install): default uv to native TLS on macOS

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -446,6 +446,11 @@ detect_os() {
         Darwin*)
             OS="macos"
             DISTRO="macos"
+            if [ -z "${UV_NATIVE_TLS:-}" ] && [ "${UV_NATIVE_TLS_MACOS_DEFAULTED:-}" != "1" ]; then
+                export UV_NATIVE_TLS=1
+                export UV_NATIVE_TLS_MACOS_DEFAULTED=1
+                log_info "Using macOS native TLS roots for uv downloads (UV_NATIVE_TLS=1)"
+            fi
             ;;
         CYGWIN*|MINGW*|MSYS*)
             OS="windows"

--- a/tests/test_install_sh_macos_native_tls.py
+++ b/tests/test_install_sh_macos_native_tls.py
@@ -1,0 +1,16 @@
+"""Regression for #45183: macOS installer should default uv to native TLS."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def test_install_script_defaults_uv_native_tls_on_macos_only_when_unset() -> None:
+    text = INSTALL_SH.read_text()
+
+    assert 'Darwin*)' in text
+    assert 'if [ -z "${UV_NATIVE_TLS:-}" ] && [ "${UV_NATIVE_TLS_MACOS_DEFAULTED:-}" != "1" ]; then' in text
+    assert 'export UV_NATIVE_TLS=1' in text
+    assert 'Using macOS native TLS roots for uv downloads (UV_NATIVE_TLS=1)' in text


### PR DESCRIPTION
Closes #45183

## Summary
- default the installer to `UV_NATIVE_TLS=1` on macOS when the caller has not already set `UV_NATIVE_TLS`
- keep the default idempotent with a one-shot guard so repeated `detect_os` calls do not spam or override user intent
- add a regression test that locks the macOS installer TLS default in `scripts/install.sh`

## Proof
- `bash -n scripts/install.sh`
- `uv run --frozen pytest tests/test_install_sh_macos_native_tls.py tests/test_install_sh_pythonpath_sanitization.py tests/test_install_sh_termux_network_prereqs.py tests/test_install_sh_symlink_stomp.py tests/test_install_sh_root_fhs_uv_python_path.py tests/test_install_sh_setup_wizard_tty_probe.py tests/test_install_sh_browser_install.py -q`
- `uv run --frozen ruff check tests/test_install_sh_macos_native_tls.py`
- `git diff --check HEAD^ HEAD`
