### PR TITLE
AION PR Intake Adapter v0.1 surface pack / PR 入口适配器 v0.1 表层包

### DIFF
--- a/docs/governance/aion-pr-intake-adapter-v0.1.evidence.json
+++ b/docs/governance/aion-pr-intake-adapter-v0.1.evidence.json
@@ -1,0 +1,26 @@
+{
+  "status": "STATIC_SURFACE_PACK_READY_FOR_PR_AUDIT",
+  "formal_record": "https://github.com/kiddhu/aion-governance/issues/448",
+  "standard_anchor": "https://github.com/kiddhu/aion-governance/pull/447",
+  "semantics": {
+    "label_and_pr_metadata": "intake_mirror_only",
+    "execution_trigger": "Hermes Kanban task.assignee + dispatcher pickup evidence",
+    "github_actions": "CI/checkers only, no business-flow dispatch"
+  },
+  "fixture_coverage": [
+    "label-only execution claim",
+    "missing assignee",
+    "missing dispatcher pickup",
+    "missing audit verdict",
+    "forbidden runtime flag",
+    "full-unattended overclaim"
+  ],
+  "risk_boundary": {
+    "runtime_gateway_cron_required_mode_live_scanner_source_writeback": false,
+    "production_payment_database_webhook_secret_customer_data": false,
+    "external_executor_real_run": false,
+    "issue_close_or_merge": false,
+    "full_unattended_ready_declared": false
+  },
+  "audit_target": "bafuxunan / 八府巡按"
+}

--- a/docs/governance/aion-pr-intake-adapter-v0.1.md
+++ b/docs/governance/aion-pr-intake-adapter-v0.1.md
@@ -1,0 +1,59 @@
+# AION PR Intake Adapter v0.1 surface pack / AION PR 入口适配器 v0.1 表层包
+
+## 中文摘要
+
+本表层包把 PR intake 标准化为 Hermes 原生 Kanban 语义的静态合约：GitHub label 与 PR metadata 只能作为 intake mirror（入口镜像），不得被解释为执行触发。真正的执行触发必须同时具备 Hermes Kanban `task.assignee` 与 dispatcher pickup/run 证据。GitHub 继续作为正式 ledger/evidence surface；GitHub Actions 只能运行 CI/checkers，不承载业务流调度。
+
+## English Summary
+
+This surface pack standardizes PR intake as a static contract over native Hermes Kanban semantics: GitHub labels and PR metadata are intake mirrors only and must not be interpreted as execution triggers. Execution requires Hermes Kanban `task.assignee` plus dispatcher pickup/run evidence. GitHub remains the formal ledger/evidence surface; GitHub Actions may run CI/checkers only and must not dispatch business flow.
+
+## Contract / 合约
+
+A valid PR intake packet must satisfy all of the following:
+
+1. `github_pr_metadata.intake_mirror_only` is `true`.
+2. `github_pr_metadata.label_claims_execution` is `false`.
+3. `execution_trigger.type` is exactly `hermes_kanban_task_assignee_and_dispatcher_pickup`.
+4. `execution_trigger.kanban_task.assignee` is non-empty.
+5. `execution_trigger.dispatcher_pickup.picked_up` is `true` and has non-empty `run_id` and `claimed_by`.
+6. `audit.verdict_required_before_merge` is `true` and `audit.current_head_verdict` is one of `PASS`, `CONDITIONAL_PASS`, or `BLOCK`.
+7. Every protected-surface / runtime / production flag remains `false`.
+8. `non_claims.full_unattended_ready` is `false`.
+
+## Trigger semantics / 触发语义
+
+| Surface | Allowed role | Not allowed |
+| --- | --- | --- |
+| GitHub label | Intake mirror, routing hint, ledger pointer | Execution source, scheduler, business-flow dispatcher |
+| PR metadata/body | Evidence mirror and audit request | Runtime enablement, Required Mode enablement, source-writeback activation |
+| Hermes Kanban task.assignee | Executor assignment | Audit PASS, merge permission, production authorization |
+| Hermes dispatcher pickup/run evidence | Execution trigger and executor-of-record evidence | Runtime/gateway/cron/live scanner activation |
+| GitHub Actions | CI/checker execution | Business-flow dispatch or actor scheduling |
+
+## Fail-closed cases / 失败关闭覆盖
+
+The checker and fixtures intentionally fail closed for:
+
+- label-only execution claim / 仅凭 label 声称执行
+- missing `task.assignee` / 缺少任务 assignee
+- missing dispatcher pickup / 缺少 dispatcher pickup 证据
+- missing current-head audit verdict / 缺少当前 head 审计结论
+- forbidden runtime flag / 禁止的 runtime 标志
+- full-unattended overclaim / full unattended 过度声明
+
+## Risk boundary / 风险边界
+
+This pack is static docs/schema/checker/fixtures/tests evidence only. It does not add or activate a runtime, gateway, cron job, Required Mode, live scanner, source writeback, production/payment/database/webhook/secret/customer-data access, external executor sandbox, real API execution, issue closure, merge, or full unattended-ready declaration.
+
+## Evidence artifacts / 证据产物
+
+- Contract schema: `schemas/aion_pr_intake_adapter_v0_1.schema.json`
+- Checker: `scripts/aion_pr_intake_adapter_v0_1_check.py`
+- Fixtures: `tests/fixtures/aion-pr-intake-adapter-v0.1/`
+- Tests: `tests/test_aion_pr_intake_adapter_v0_1_check.py`
+- Static evidence packet: `docs/governance/aion-pr-intake-adapter-v0.1.evidence.json`
+
+## Audit request / 审计请求
+
+Audit target: `bafuxunan / 八府巡按`. Please audit whether this PR preserves the #446/#447 standard: label/PR metadata are mirrors only; Hermes Kanban task assignment plus dispatcher pickup is the execution trigger; GitHub Actions are CI/checkers only; all runtime/production/full-unattended boundaries remain false.

--- a/schemas/aion_pr_intake_adapter_v0_1.schema.json
+++ b/schemas/aion_pr_intake_adapter_v0_1.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hermes-agent.nousresearch.com/schemas/aion_pr_intake_adapter_v0_1.schema.json",
+  "title": "AION PR Intake Adapter v0.1 static packet",
+  "type": "object",
+  "required": [
+    "version",
+    "github_pr_metadata",
+    "execution_trigger",
+    "audit",
+    "protected_surfaces",
+    "non_claims"
+  ],
+  "properties": {
+    "version": {"const": "aion_pr_intake_adapter_v0_1"},
+    "github_pr_metadata": {
+      "type": "object",
+      "required": ["intake_mirror_only", "label_claims_execution", "actions_business_flow_dispatch"],
+      "properties": {
+        "intake_mirror_only": {"const": true},
+        "label_claims_execution": {"const": false},
+        "actions_business_flow_dispatch": {"const": false}
+      }
+    },
+    "execution_trigger": {
+      "type": "object",
+      "required": ["type", "kanban_task", "dispatcher_pickup"],
+      "properties": {
+        "type": {"const": "hermes_kanban_task_assignee_and_dispatcher_pickup"},
+        "kanban_task": {
+          "type": "object",
+          "required": ["task_id", "assignee"],
+          "properties": {
+            "task_id": {"type": "string"},
+            "assignee": {"type": "string", "minLength": 1}
+          }
+        },
+        "dispatcher_pickup": {
+          "type": "object",
+          "required": ["picked_up", "run_id", "claimed_by"],
+          "properties": {
+            "picked_up": {"const": true},
+            "run_id": {"type": "string", "minLength": 1},
+            "claimed_by": {"type": "string", "minLength": 1}
+          }
+        }
+      }
+    },
+    "audit": {
+      "type": "object",
+      "required": ["verdict_required_before_merge", "current_head_verdict"],
+      "properties": {
+        "verdict_required_before_merge": {"const": true},
+        "current_head_verdict": {"enum": ["PASS", "CONDITIONAL_PASS", "BLOCK"]}
+      }
+    },
+    "protected_surfaces": {"type": "object"},
+    "non_claims": {
+      "type": "object",
+      "required": ["full_unattended_ready"],
+      "properties": {"full_unattended_ready": {"const": false}}
+    }
+  }
+}

--- a/scripts/aion_pr_intake_adapter_v0_1_check.py
+++ b/scripts/aion_pr_intake_adapter_v0_1_check.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Fail-closed checker for AION PR Intake Adapter v0.1 static packets."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+DEFAULT_FIXTURE_DIR = Path("tests/fixtures/aion-pr-intake-adapter-v0.1")
+FORBIDDEN_SURFACE_FLAGS = (
+    "runtime_enabled",
+    "gateway_mutated",
+    "cron_enabled",
+    "required_mode_enabled",
+    "live_scanner_enabled",
+    "source_writeback_enabled",
+    "production_access",
+    "payment_access",
+    "database_access",
+    "webhook_access",
+    "secret_access",
+    "customer_data_access",
+    "external_executor_real_run",
+)
+
+
+def _get(packet: dict[str, Any], path: str) -> Any:
+    cur: Any = packet
+    for part in path.split("."):
+        if not isinstance(cur, dict) or part not in cur:
+            return None
+        cur = cur[part]
+    return cur
+
+
+def validate_packet(packet: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if packet.get("version") != "aion_pr_intake_adapter_v0_1":
+        errors.append("version must be aion_pr_intake_adapter_v0_1")
+
+    if _get(packet, "github_pr_metadata.intake_mirror_only") is not True:
+        errors.append("github_pr_metadata.intake_mirror_only must be true")
+    if _get(packet, "github_pr_metadata.label_claims_execution") is not False:
+        errors.append("GitHub label/PR metadata must not claim execution")
+    if _get(packet, "github_pr_metadata.actions_business_flow_dispatch") is not False:
+        errors.append("GitHub Actions business-flow dispatch must be false")
+
+    if _get(packet, "execution_trigger.type") != "hermes_kanban_task_assignee_and_dispatcher_pickup":
+        errors.append("execution trigger must be Hermes Kanban assignee + dispatcher pickup")
+    if not _get(packet, "execution_trigger.kanban_task.assignee"):
+        errors.append("execution trigger requires non-empty task.assignee")
+    if _get(packet, "execution_trigger.dispatcher_pickup.picked_up") is not True:
+        errors.append("execution trigger requires dispatcher pickup evidence")
+    if not _get(packet, "execution_trigger.dispatcher_pickup.run_id"):
+        errors.append("dispatcher pickup requires run_id")
+    if not _get(packet, "execution_trigger.dispatcher_pickup.claimed_by"):
+        errors.append("dispatcher pickup requires claimed_by")
+
+    if _get(packet, "audit.verdict_required_before_merge") is not True:
+        errors.append("audit verdict must be required before merge")
+    if _get(packet, "audit.current_head_verdict") not in {"PASS", "CONDITIONAL_PASS", "BLOCK"}:
+        errors.append("current-head audit verdict is missing or invalid")
+
+    protected = packet.get("protected_surfaces")
+    if not isinstance(protected, dict):
+        errors.append("protected_surfaces must be an object with explicit false flags")
+    else:
+        for flag in FORBIDDEN_SURFACE_FLAGS:
+            if protected.get(flag) is not False:
+                errors.append(f"protected surface flag must be false: {flag}")
+
+    if _get(packet, "non_claims.full_unattended_ready") is not False:
+        errors.append("full_unattended_ready must be false")
+    return errors
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as fh:
+        data = json.load(fh)
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def check_fixture_dir(fixture_dir: Path) -> dict[str, Any]:
+    valid_files = sorted((fixture_dir / "valid").glob("*.json"))
+    invalid_files = sorted((fixture_dir / "invalid").glob("*.json"))
+    results: dict[str, Any] = {"valid": {}, "invalid": {}}
+    failures: list[str] = []
+
+    for path in valid_files:
+        errors = validate_packet(load_json(path))
+        results["valid"][str(path)] = errors
+        if errors:
+            failures.append(f"valid fixture failed {path}: {errors}")
+
+    for path in invalid_files:
+        errors = validate_packet(load_json(path))
+        results["invalid"][str(path)] = errors
+        if not errors:
+            failures.append(f"invalid fixture unexpectedly passed {path}")
+
+    results["verdict"] = "PASS" if not failures else "FAIL"
+    results["failures"] = failures
+    results["fixture_count"] = len(valid_files) + len(invalid_files)
+    results["valid_fixture_count"] = len(valid_files)
+    results["invalid_fixture_count"] = len(invalid_files)
+    return results
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--fixture-dir", type=Path, default=DEFAULT_FIXTURE_DIR)
+    parser.add_argument("--packet", type=Path, help="Validate one packet instead of the fixture suite")
+    args = parser.parse_args()
+    if args.packet:
+        errors = validate_packet(load_json(args.packet))
+        print(json.dumps({"verdict": "PASS" if not errors else "FAIL", "errors": errors}, indent=2))
+        return 0 if not errors else 1
+    result = check_fixture_dir(args.fixture_dir)
+    print(json.dumps(result, indent=2))
+    return 0 if result["verdict"] == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/aion-pr-intake-adapter-v0.1/invalid/forbidden-runtime-flag.invalid.json
+++ b/tests/fixtures/aion-pr-intake-adapter-v0.1/invalid/forbidden-runtime-flag.invalid.json
@@ -1,0 +1,8 @@
+{
+  "version": "aion_pr_intake_adapter_v0_1",
+  "github_pr_metadata": {"intake_mirror_only": true, "label_claims_execution": false, "actions_business_flow_dispatch": false},
+  "execution_trigger": {"type": "hermes_kanban_task_assignee_and_dispatcher_pickup", "kanban_task": {"task_id": "t_e1b5ce0d", "assignee": "agent007"}, "dispatcher_pickup": {"picked_up": true, "run_id": "178", "claimed_by": "agent007-gateway"}},
+  "audit": {"verdict_required_before_merge": true, "current_head_verdict": "PASS"},
+  "protected_surfaces": {"runtime_enabled": true, "gateway_mutated": false, "cron_enabled": false, "required_mode_enabled": false, "live_scanner_enabled": false, "source_writeback_enabled": false, "production_access": false, "payment_access": false, "database_access": false, "webhook_access": false, "secret_access": false, "customer_data_access": false, "external_executor_real_run": false},
+  "non_claims": {"full_unattended_ready": false}
+}

--- a/tests/fixtures/aion-pr-intake-adapter-v0.1/invalid/full-unattended-overclaim.invalid.json
+++ b/tests/fixtures/aion-pr-intake-adapter-v0.1/invalid/full-unattended-overclaim.invalid.json
@@ -1,0 +1,8 @@
+{
+  "version": "aion_pr_intake_adapter_v0_1",
+  "github_pr_metadata": {"intake_mirror_only": true, "label_claims_execution": false, "actions_business_flow_dispatch": false},
+  "execution_trigger": {"type": "hermes_kanban_task_assignee_and_dispatcher_pickup", "kanban_task": {"task_id": "t_e1b5ce0d", "assignee": "agent007"}, "dispatcher_pickup": {"picked_up": true, "run_id": "178", "claimed_by": "agent007-gateway"}},
+  "audit": {"verdict_required_before_merge": true, "current_head_verdict": "PASS"},
+  "protected_surfaces": {"runtime_enabled": false, "gateway_mutated": false, "cron_enabled": false, "required_mode_enabled": false, "live_scanner_enabled": false, "source_writeback_enabled": false, "production_access": false, "payment_access": false, "database_access": false, "webhook_access": false, "secret_access": false, "customer_data_access": false, "external_executor_real_run": false},
+  "non_claims": {"full_unattended_ready": true}
+}

--- a/tests/fixtures/aion-pr-intake-adapter-v0.1/invalid/label-only-execution-claim.invalid.json
+++ b/tests/fixtures/aion-pr-intake-adapter-v0.1/invalid/label-only-execution-claim.invalid.json
@@ -1,0 +1,8 @@
+{
+  "version": "aion_pr_intake_adapter_v0_1",
+  "github_pr_metadata": {"intake_mirror_only": true, "label_claims_execution": true, "actions_business_flow_dispatch": false},
+  "execution_trigger": {"type": "hermes_kanban_task_assignee_and_dispatcher_pickup", "kanban_task": {"task_id": "t_e1b5ce0d", "assignee": "agent007"}, "dispatcher_pickup": {"picked_up": true, "run_id": "178", "claimed_by": "agent007-gateway"}},
+  "audit": {"verdict_required_before_merge": true, "current_head_verdict": "PASS"},
+  "protected_surfaces": {"runtime_enabled": false, "gateway_mutated": false, "cron_enabled": false, "required_mode_enabled": false, "live_scanner_enabled": false, "source_writeback_enabled": false, "production_access": false, "payment_access": false, "database_access": false, "webhook_access": false, "secret_access": false, "customer_data_access": false, "external_executor_real_run": false},
+  "non_claims": {"full_unattended_ready": false}
+}

--- a/tests/fixtures/aion-pr-intake-adapter-v0.1/invalid/missing-assignee.invalid.json
+++ b/tests/fixtures/aion-pr-intake-adapter-v0.1/invalid/missing-assignee.invalid.json
@@ -1,0 +1,8 @@
+{
+  "version": "aion_pr_intake_adapter_v0_1",
+  "github_pr_metadata": {"intake_mirror_only": true, "label_claims_execution": false, "actions_business_flow_dispatch": false},
+  "execution_trigger": {"type": "hermes_kanban_task_assignee_and_dispatcher_pickup", "kanban_task": {"task_id": "t_e1b5ce0d", "assignee": ""}, "dispatcher_pickup": {"picked_up": true, "run_id": "178", "claimed_by": "agent007-gateway"}},
+  "audit": {"verdict_required_before_merge": true, "current_head_verdict": "PASS"},
+  "protected_surfaces": {"runtime_enabled": false, "gateway_mutated": false, "cron_enabled": false, "required_mode_enabled": false, "live_scanner_enabled": false, "source_writeback_enabled": false, "production_access": false, "payment_access": false, "database_access": false, "webhook_access": false, "secret_access": false, "customer_data_access": false, "external_executor_real_run": false},
+  "non_claims": {"full_unattended_ready": false}
+}

--- a/tests/fixtures/aion-pr-intake-adapter-v0.1/invalid/missing-audit-verdict.invalid.json
+++ b/tests/fixtures/aion-pr-intake-adapter-v0.1/invalid/missing-audit-verdict.invalid.json
@@ -1,0 +1,8 @@
+{
+  "version": "aion_pr_intake_adapter_v0_1",
+  "github_pr_metadata": {"intake_mirror_only": true, "label_claims_execution": false, "actions_business_flow_dispatch": false},
+  "execution_trigger": {"type": "hermes_kanban_task_assignee_and_dispatcher_pickup", "kanban_task": {"task_id": "t_e1b5ce0d", "assignee": "agent007"}, "dispatcher_pickup": {"picked_up": true, "run_id": "178", "claimed_by": "agent007-gateway"}},
+  "audit": {"verdict_required_before_merge": true, "current_head_verdict": ""},
+  "protected_surfaces": {"runtime_enabled": false, "gateway_mutated": false, "cron_enabled": false, "required_mode_enabled": false, "live_scanner_enabled": false, "source_writeback_enabled": false, "production_access": false, "payment_access": false, "database_access": false, "webhook_access": false, "secret_access": false, "customer_data_access": false, "external_executor_real_run": false},
+  "non_claims": {"full_unattended_ready": false}
+}

--- a/tests/fixtures/aion-pr-intake-adapter-v0.1/invalid/missing-dispatcher-pickup.invalid.json
+++ b/tests/fixtures/aion-pr-intake-adapter-v0.1/invalid/missing-dispatcher-pickup.invalid.json
@@ -1,0 +1,8 @@
+{
+  "version": "aion_pr_intake_adapter_v0_1",
+  "github_pr_metadata": {"intake_mirror_only": true, "label_claims_execution": false, "actions_business_flow_dispatch": false},
+  "execution_trigger": {"type": "hermes_kanban_task_assignee_and_dispatcher_pickup", "kanban_task": {"task_id": "t_e1b5ce0d", "assignee": "agent007"}, "dispatcher_pickup": {"picked_up": false, "run_id": "178", "claimed_by": "agent007-gateway"}},
+  "audit": {"verdict_required_before_merge": true, "current_head_verdict": "PASS"},
+  "protected_surfaces": {"runtime_enabled": false, "gateway_mutated": false, "cron_enabled": false, "required_mode_enabled": false, "live_scanner_enabled": false, "source_writeback_enabled": false, "production_access": false, "payment_access": false, "database_access": false, "webhook_access": false, "secret_access": false, "customer_data_access": false, "external_executor_real_run": false},
+  "non_claims": {"full_unattended_ready": false}
+}

--- a/tests/fixtures/aion-pr-intake-adapter-v0.1/valid/hermes-kanban-pr-intake.valid.json
+++ b/tests/fixtures/aion-pr-intake-adapter-v0.1/valid/hermes-kanban-pr-intake.valid.json
@@ -1,0 +1,30 @@
+{
+  "version": "aion_pr_intake_adapter_v0_1",
+  "github_pr_metadata": {
+    "intake_mirror_only": true,
+    "label_claims_execution": false,
+    "actions_business_flow_dispatch": false
+  },
+  "execution_trigger": {
+    "type": "hermes_kanban_task_assignee_and_dispatcher_pickup",
+    "kanban_task": {"task_id": "t_e1b5ce0d", "assignee": "agent007"},
+    "dispatcher_pickup": {"picked_up": true, "run_id": "178", "claimed_by": "agent007-gateway"}
+  },
+  "audit": {"verdict_required_before_merge": true, "current_head_verdict": "PASS"},
+  "protected_surfaces": {
+    "runtime_enabled": false,
+    "gateway_mutated": false,
+    "cron_enabled": false,
+    "required_mode_enabled": false,
+    "live_scanner_enabled": false,
+    "source_writeback_enabled": false,
+    "production_access": false,
+    "payment_access": false,
+    "database_access": false,
+    "webhook_access": false,
+    "secret_access": false,
+    "customer_data_access": false,
+    "external_executor_real_run": false
+  },
+  "non_claims": {"full_unattended_ready": false}
+}

--- a/tests/test_aion_pr_intake_adapter_v0_1_check.py
+++ b/tests/test_aion_pr_intake_adapter_v0_1_check.py
@@ -1,0 +1,51 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.aion_pr_intake_adapter_v0_1_check import check_fixture_dir, validate_packet
+
+FIXTURE_DIR = Path("tests/fixtures/aion-pr-intake-adapter-v0.1")
+
+
+def load(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_valid_fixture_passes():
+    packet = load(FIXTURE_DIR / "valid/hermes-kanban-pr-intake.valid.json")
+    assert validate_packet(packet) == []
+
+
+def test_invalid_fixtures_fail_closed():
+    invalid_files = sorted((FIXTURE_DIR / "invalid").glob("*.invalid.json"))
+    assert {p.name for p in invalid_files} == {
+        "label-only-execution-claim.invalid.json",
+        "missing-assignee.invalid.json",
+        "missing-dispatcher-pickup.invalid.json",
+        "missing-audit-verdict.invalid.json",
+        "forbidden-runtime-flag.invalid.json",
+        "full-unattended-overclaim.invalid.json",
+    }
+    for path in invalid_files:
+        assert validate_packet(load(path)), path
+
+
+def test_fixture_suite_reports_pass_when_invalids_fail_closed():
+    result = check_fixture_dir(FIXTURE_DIR)
+    assert result["verdict"] == "PASS"
+    assert result["fixture_count"] == 7
+    assert result["valid_fixture_count"] == 1
+    assert result["invalid_fixture_count"] == 6
+
+
+def test_checker_cli_outputs_pass():
+    proc = subprocess.run(
+        [sys.executable, "scripts/aion_pr_intake_adapter_v0_1_check.py"],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    payload = json.loads(proc.stdout)
+    assert payload["verdict"] == "PASS"
+    assert payload["fixture_count"] == 7


### PR DESCRIPTION
## 中文摘要
- 新增 AION PR Intake Adapter v0.1 静态表层包，用 repo-backed docs/schema/checker/fixtures/tests 明确 PR intake 语义。
- 明确编码：GitHub label / PR metadata 只是 intake mirror；真正执行触发必须是 Hermes Kanban `task.assignee` + dispatcher pickup/run evidence。
- 增加 fail-closed checker 和 7 个 fixtures，覆盖 label-only execution claim、missing assignee、missing dispatcher pickup、missing audit verdict、forbidden runtime flag、full-unattended overclaim。

## English Summary
- Adds the AION PR Intake Adapter v0.1 static surface pack with repo-backed docs/schema/checker/fixtures/tests.
- Explicitly encodes that GitHub labels / PR metadata are intake mirrors only; execution requires Hermes Kanban `task.assignee` plus dispatcher pickup/run evidence.
- Adds a fail-closed checker and 7 fixtures covering label-only execution claims, missing assignee, missing dispatcher pickup, missing audit verdict, forbidden runtime flag, and full-unattended overclaim.

## Evidence / 验收证据
- Formal control issue: https://github.com/kiddhu/aion-governance/issues/448
- Standard anchor: https://github.com/kiddhu/aion-governance/pull/447
- Local tests:
  - `python -m pytest tests/test_aion_pr_intake_adapter_v0_1_check.py -q` -> `4 passed in 0.30s`
  - `python scripts/aion_pr_intake_adapter_v0_1_check.py` -> `verdict: PASS`, `fixture_count: 7`, `valid_fixture_count: 1`, `invalid_fixture_count: 6`
  - `python -m py_compile scripts/aion_pr_intake_adapter_v0_1_check.py` -> PASS
- Changed-file secret scan: `SECRET_SCAN_PASS changed_files=12`

## Changed files / 变更文件
- `docs/governance/aion-pr-intake-adapter-v0.1.md`
- `docs/governance/aion-pr-intake-adapter-v0.1.evidence.json`
- `schemas/aion_pr_intake_adapter_v0_1.schema.json`
- `scripts/aion_pr_intake_adapter_v0_1_check.py`
- `tests/test_aion_pr_intake_adapter_v0_1_check.py`
- `tests/fixtures/aion-pr-intake-adapter-v0.1/valid/hermes-kanban-pr-intake.valid.json`
- `tests/fixtures/aion-pr-intake-adapter-v0.1/invalid/forbidden-runtime-flag.invalid.json`
- `tests/fixtures/aion-pr-intake-adapter-v0.1/invalid/full-unattended-overclaim.invalid.json`
- `tests/fixtures/aion-pr-intake-adapter-v0.1/invalid/label-only-execution-claim.invalid.json`
- `tests/fixtures/aion-pr-intake-adapter-v0.1/invalid/missing-assignee.invalid.json`
- `tests/fixtures/aion-pr-intake-adapter-v0.1/invalid/missing-audit-verdict.invalid.json`
- `tests/fixtures/aion-pr-intake-adapter-v0.1/invalid/missing-dispatcher-pickup.invalid.json`

## Risk Boundary / 风险边界
- Static docs/schema/checker/fixtures/tests only.
- No hand-rolled orchestration runtime or duplicate scheduler.
- No GitHub Actions business-flow dispatch; Actions remain CI/checkers only.
- No runtime/gateway/cron/Required Mode/live scanner/source writeback activation.
- No production/payment/database/webhook/secret/customer-data access.
- No external executor sandbox or real API execution.
- No issue closure, merge, deployment, or label/Kanban mutation in this PR.

## Non-claims / 不声明
- Not production-ready.
- Not payment/legal/settlement safe PASS.
- Not full unattended ready.
- Not live scanner enabled.
- Not runtime/gateway/cron/webhook configured.
- Not a real external executor, scheduler, or source-writeback activation.

## 需要 Monarch 授权的下一步
- Any runtime/gateway/config/cron/webhook/live scanner activation requires separate Monarch authorization.
- Any real API/DB/payment/customer-data/secret/external executor access requires separate Monarch authorization.
- Any production/payment/legal/full-unattended PASS declaration requires separate Monarch authorization.

## Next Monarch Gate
- Runtime/gateway/config/cron/webhook/live scanner activation requires separate Monarch authorization.
- Real API/DB/payment/customer-data/secret/external executor access requires separate Monarch authorization.
- Production/payment/legal/full-unattended PASS declaration requires separate Monarch authorization.

## Audit request / 审计请求
@bafuxunan please perform C2 formal current-head audit for PR Intake Adapter v0.1 against the PR head SHA. Audit focus:
1. Label/PR metadata remain intake mirrors only.
2. `task.assignee` + dispatcher pickup is the only execution trigger.
3. GitHub Actions are CI/checkers only, not business-flow dispatch.
4. Invalid fixtures fail closed for all required cases.
5. Forbidden runtime/production/full-unattended surfaces remain false.

Closes no issue automatically. Formal control record remains https://github.com/kiddhu/aion-governance/issues/448.
