### PR TITLE
fix(web): require explicit Parallel backend selection

### DIFF
--- a/plugins/web/parallel/provider.py
+++ b/plugins/web/parallel/provider.py
@@ -5,9 +5,8 @@ Subclasses :class:`agent.web_search_provider.WebSearchProvider`.
 Search runs on one of two transports, picked by credential:
 
 - **No key →** the free hosted Search MCP at ``https://search.parallel.ai/mcp``
-  (anonymous Streamable-HTTP JSON-RPC). This makes ``web_search`` work out of
-  the box with zero setup, which is why ``parallel`` is the keyless default
-  backend in :func:`tools.web_tools._get_backend`.
+  (anonymous Streamable-HTTP JSON-RPC) when the user explicitly selects the
+  ``parallel`` backend.
 - **``PARALLEL_API_KEY`` →** the ``parallel`` SDK's v1 ``search`` / ``extract``
   REST endpoints (objective-tuned, mode-selectable, higher rate limits).
 
@@ -512,8 +511,8 @@ class ParallelWebSearchProvider(WebSearchProvider):
         Deliberately key-based: this gates the registry's active-provider walk
         and the ``hermes tools`` picker (auto-selecting Parallel for a user who
         hasn't named it), so it must not claim availability on the keyless path.
-        The keyless free-MCP path is reached independently via
-        :func:`tools.web_tools._get_backend`'s ``parallel`` terminal default.
+        The keyless free-MCP path is reached only when config explicitly selects
+        the ``parallel`` backend.
         """
         return bool(os.getenv("PARALLEL_API_KEY", "").strip())
 
@@ -529,8 +528,8 @@ class ParallelWebSearchProvider(WebSearchProvider):
         With ``PARALLEL_API_KEY`` set, uses the v1 ``search`` REST endpoint with
         the configured mode (``PARALLEL_SEARCH_MODE`` env var, default
         "advanced"; limit requested via advanced_settings.max_results, capped at
-        20). Without a key, falls back to the free hosted Search MCP so search
-        still works with zero setup.
+        20). Without a key, falls back to the free hosted Search MCP for users
+        who explicitly selected the ``parallel`` backend.
         """
         try:
             from tools.interrupt import is_interrupted
@@ -594,8 +593,7 @@ class ParallelWebSearchProvider(WebSearchProvider):
 
         With ``PARALLEL_API_KEY`` set, uses the async SDK's v1 ``extract`` for
         full page content. Without a key, falls back to the free hosted Search
-        MCP's ``web_fetch`` tool so extraction works with zero setup, mirroring
-        the keyless search path.
+        MCP's ``web_fetch`` tool, mirroring the explicit keyless search path.
 
         Returns the legacy list-of-results shape that
         :func:`tools.web_tools.web_extract_tool` expects: one entry per

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -975,11 +975,10 @@ def test_toolset_has_keys_treats_no_key_providers_as_configured():
     assert _toolset_has_keys("computer_use", config) is True
 
 
-def test_web_no_prompt_when_usable_keyless():
-    """Fresh install: web works via the free Parallel MCP, so enabling the web
-    toolset should not force provider setup."""
-    with patch("tools.web_tools.check_web_api_key", return_value=True):
-        assert _toolset_needs_configuration_prompt("web", {}) is False
+def test_web_prompts_when_no_backend_is_configured():
+    """Fresh install should ask the user to choose a web backend."""
+    with patch("tools.web_tools.check_web_api_key", return_value=False):
+        assert _toolset_needs_configuration_prompt("web", {}) is True
 
 
 def test_web_no_prompt_when_extract_backend_is_extract_capable():

--- a/tests/tools/test_web_keyless_default_fallback.py
+++ b/tests/tools/test_web_keyless_default_fallback.py
@@ -1,20 +1,17 @@
-"""Regression: the keyless Parallel web default must survive a failed sweep.
+"""Regression: bundled web providers must survive a failed sweep.
 
-``web_search`` / ``web_extract`` are documented to work out of the box with
-zero setup via the bundled keyless Parallel free-MCP backend. That guarantee
-only holds if the bundled ``plugins/web/*`` providers are registered in
-``agent.web_search_registry``. The dispatch triggers the general plugin sweep
-(:func:`hermes_cli.plugins._ensure_plugins_discovered`) to do that — but the
-sweep can finish without registering them (its exception swallowed as a
-warning, a packaged layout where it ran before the bundled tree was
-importable, or a stale empty-discovery cache). When that happened, *both*
-tools dead-ended on "No web {search,extract} provider configured" even though
-no setup should be needed.
+``web_search`` / ``web_extract`` rely on bundled ``plugins/web/*`` providers
+being registered in ``agent.web_search_registry``. The dispatch triggers the
+general plugin sweep (:func:`hermes_cli.plugins._ensure_plugins_discovered`) to
+do that, but the sweep can finish without registering them (its exception
+swallowed as a warning, a packaged layout where it ran before the bundled tree
+was importable, or a stale empty-discovery cache). When that happened, explicit
+bundled backends dead-ended on "No web {search,extract} provider configured".
 
 These tests pin the invariant that :func:`tools.web_tools._ensure_web_plugins_loaded`
-guarantees the keyless default is registered regardless of the sweep's outcome,
+guarantees bundled providers are registered regardless of the sweep's outcome,
 and that the direct-registration fallback honors an explicit ``plugins.disabled``
-entry. Real imports from the bundled plugin modules — no provider mocking.
+entry. Real imports from the bundled plugin modules, no provider mocking.
 """
 from __future__ import annotations
 
@@ -36,16 +33,16 @@ def _boom(*_a, **_k):
     raise RuntimeError("discovery boom")
 
 
-def test_keyless_default_registered_when_discovery_raises(monkeypatch):
-    """A swallowed discovery failure must not strand the keyless default."""
+def test_bundled_parallel_registered_when_discovery_raises(monkeypatch):
+    """A swallowed discovery failure must not strand bundled providers."""
     monkeypatch.setattr(plugins, "_ensure_plugins_discovered", _boom)
     assert reg.get_provider("parallel") is None
 
     web_tools._ensure_web_plugins_loaded()
 
     parallel = reg.get_provider("parallel")
-    assert parallel is not None, "keyless Parallel default not restored"
-    # It is the universal keyless default precisely because it does both.
+    assert parallel is not None, "Parallel provider not restored"
+    # The explicit parallel backend supports both tools.
     assert parallel.supports_search()
     assert parallel.supports_extract()
 
@@ -77,7 +74,7 @@ def test_fallback_honors_explicit_disable(monkeypatch):
 
 def test_fallback_is_noop_when_discovery_already_registered(monkeypatch):
     """Healthy path: don't pay for the direct sweep when parallel is present."""
-    # Pretend the general sweep already registered the keyless default.
+    # Pretend the general sweep already registered the bundled provider.
     import importlib
 
     class _Ctx:

--- a/tests/tools/test_web_providers.py
+++ b/tests/tools/test_web_providers.py
@@ -202,8 +202,8 @@ class TestPerCapabilityBackendSelection:
         monkeypatch.delenv("EXA_API_KEY", raising=False)
         monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-key")
         # The explicit per-capability choice (exa) is honored even though it's
-        # unavailable, so its setup error surfaces — we don't silently reroute
-        # to the shared backend (or the keyless Parallel default).
+        # unavailable, so its setup error surfaces; we don't silently reroute
+        # to the shared backend.
         assert web_tools._get_search_backend() == "exa"
 
     def test_fully_backward_compatible_with_web_backend_only(self, monkeypatch):
@@ -323,40 +323,21 @@ class TestUnconfiguredErrorEnvelopeParity:
         result = json.loads(out)
         assert "error" in result
 
-    def test_unconfigured_search_falls_back_to_free_parallel(self, monkeypatch):
-        """``web_search_tool`` with no creds routes to Parallel's free Search
-        MCP rather than erroring. The MCP transport is mocked so the test
-        stays offline; we assert dispatch landed on parallel and returned the
-        standard search envelope.
+    def test_unconfigured_search_returns_setup_error(self, monkeypatch):
+        """``web_search_tool`` with no creds returns a setup error.
+
+        No-config installs must not silently route queries to a hosted backend.
         """
         from tools import web_tools
-        import plugins.web.parallel.provider as parallel_provider
 
         self._clear_web_creds(monkeypatch)
         monkeypatch.setattr(web_tools, "_firecrawl_client", None, raising=False)
         monkeypatch.setattr(web_tools, "_firecrawl_client_config", None, raising=False)
         monkeypatch.setattr(web_tools, "_load_web_config", lambda: {})
-
-        captured = {}
-
-        def _fake_mcp(query, limit, api_key):
-            captured["query"] = query
-            captured["api_key"] = api_key
-            return {
-                "success": True,
-                "data": {"web": [
-                    {"url": "https://example.com", "title": "Example",
-                     "description": "hit", "position": 1},
-                ]},
-            }
-
-        monkeypatch.setattr(parallel_provider, "_mcp_web_search", _fake_mcp)
+        monkeypatch.setattr(web_tools, "_is_tool_gateway_ready", lambda: False)
 
         result = json.loads(web_tools.web_search_tool("hello world", limit=3))
-        assert result.get("success") is True, f"expected success, got {result}"
-        assert result["data"]["web"][0]["url"] == "https://example.com"
-        # Keyless path: dispatched to parallel with no Bearer token.
-        assert captured == {"query": "hello world", "api_key": None}
+        assert "Web tools are not configured" in result["error"]
 
 
 class TestDispatchersTriggerPluginDiscovery:

--- a/tests/tools/test_web_providers_ddgs.py
+++ b/tests/tools/test_web_providers_ddgs.py
@@ -190,11 +190,9 @@ class TestDDGSBackendWiring:
         monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: True)
         assert web_tools._get_backend() == "exa"
 
-    def test_auto_detect_prefers_keyless_parallel_over_ddgs(self, monkeypatch):
-        # With no credentials, keyless Parallel is the auto-detect default even
-        # when the ddgs package is installed — ddgs is search-only (can't
-        # extract), so Parallel is preferred so both search and extract work.
-        # ddgs remains reachable via an explicit web.backend=ddgs.
+    def test_auto_detect_does_not_use_ddgs_package_without_config(self, monkeypatch):
+        # Installing the optional ddgs package alone is not enough to opt into a
+        # web backend. ddgs remains reachable via explicit web.backend=ddgs.
         from tools import web_tools
         monkeypatch.setattr(web_tools, "_load_web_config", lambda: {})
         for key in ("FIRECRAWL_API_KEY", "FIRECRAWL_API_URL", "PARALLEL_API_KEY",
@@ -202,7 +200,7 @@ class TestDDGSBackendWiring:
             monkeypatch.delenv(key, raising=False)
         monkeypatch.setattr(web_tools, "_is_tool_gateway_ready", lambda: False)
         monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: True)
-        assert web_tools._get_backend() == "parallel"
+        assert web_tools._get_backend() == "firecrawl"
 
     def test_check_web_api_key_true_when_ddgs_configured(self, monkeypatch):
         from tools import web_tools

--- a/tests/tools/test_web_providers_searxng.py
+++ b/tests/tools/test_web_providers_searxng.py
@@ -313,9 +313,8 @@ class TestCheckWebApiKey:
         )
         assert web_tools.check_web_api_key() is True
 
-    def test_no_credentials_usable_via_free_parallel(self, monkeypatch):
-        """No credentials → check_web_api_key True: the keyless Parallel free MCP
-        services calls, so web is usable out of the box."""
+    def test_no_credentials_without_config_not_usable(self, monkeypatch):
+        """No credentials and no config -> setup is still required."""
         from tools import web_tools
         monkeypatch.setattr(web_tools, "_load_web_config", lambda: {})
         monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
@@ -327,7 +326,7 @@ class TestCheckWebApiKey:
         monkeypatch.setattr(web_tools, "_is_tool_gateway_ready", lambda: False)
         monkeypatch.setattr(web_tools, "check_firecrawl_api_key", lambda: False)
         monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: False)
-        assert web_tools.check_web_api_key() is True
+        assert web_tools.check_web_api_key() is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -384,14 +384,13 @@ class TestBackendSelection:
              patch.dict(os.environ, {"FIRECRAWL_API_KEY": "fc-test"}):
             assert _get_backend() == "firecrawl"
 
-    def test_fallback_no_keys_defaults_to_parallel(self):
-        """No credentials, no config → 'parallel' (free Search MCP works
-        keyless). Selection is purely credential-based."""
+    def test_fallback_no_keys_defaults_to_firecrawl_setup_error(self):
+        """No credentials, no config -> Firecrawl setup error path."""
         from tools.web_tools import _get_backend
         with patch("tools.web_tools._load_web_config", return_value={}), \
              patch("tools.web_tools._is_tool_gateway_ready", return_value=False), \
              patch("tools.web_tools._ddgs_package_importable", return_value=False):
-            assert _get_backend() == "parallel"
+            assert _get_backend() == "firecrawl"
 
     def test_invalid_config_falls_through_to_fallback(self):
         """web.backend=invalid → ignored, uses key-based fallback."""
@@ -626,10 +625,8 @@ class TestCheckWebApiKey:
             from tools.web_tools import check_web_api_key
             assert check_web_api_key() is True
 
-    def test_no_keys_usable_via_free_parallel(self):
-        """No credentials → check_web_api_key True: selection resolves to the
-        keyless Parallel free MCP, which genuinely services calls (web works out
-        of the box). check_web_api_key is a usability probe, not a key check."""
+    def test_no_keys_without_config_not_usable(self):
+        """No credentials and no config -> setup is still required."""
         from tools.web_tools import check_web_api_key
         with patch("tools.web_tools._load_web_config", return_value={}), \
              patch("tools.web_tools._is_tool_gateway_ready", return_value=False), \
@@ -638,11 +635,11 @@ class TestCheckWebApiKey:
             for k in ("PARALLEL_API_KEY", "FIRECRAWL_API_KEY", "FIRECRAWL_API_URL",
                       "TAVILY_API_KEY", "EXA_API_KEY", "SEARXNG_URL", "BRAVE_SEARCH_API_KEY"):
                 os.environ.pop(k, None)
-            assert check_web_api_key() is True
+            assert check_web_api_key() is False
 
     def test_typo_extract_backend_not_masked_by_parallel(self):
         """A typo'd per-capability backend is honored (so dispatch errors)
-        rather than silently falling through to keyless Parallel."""
+        rather than silently falling through to another provider."""
         from tools.web_tools import _get_extract_backend, check_web_api_key
         with patch("tools.web_tools._load_web_config",
                    return_value={"extract_backend": "parrallel"}):
@@ -650,11 +647,9 @@ class TestCheckWebApiKey:
             assert check_web_api_key() is False            # unknown → unusable
 
     def test_keyless_parallel_unusable_when_provider_disabled(self):
-        """If the bundled web-parallel provider is disabled/unregistered, the
-        keyless free-MCP path must NOT report web as usable — otherwise setup is
-        skipped but web tools fail at runtime with no provider."""
+        """Explicit keyless Parallel is unusable if its provider is disabled."""
         from tools.web_tools import check_web_api_key
-        with patch("tools.web_tools._load_web_config", return_value={}), \
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "parallel"}), \
              patch("tools.web_tools._parallel_provider_registered", return_value=False), \
              patch("tools.web_tools._is_tool_gateway_ready", return_value=False), \
              patch("tools.web_tools.check_firecrawl_api_key", return_value=False), \
@@ -667,11 +662,8 @@ class TestCheckWebApiKey:
                 os.environ.pop(var, None)
             assert check_web_api_key() is False
 
-    def test_extract_autodetect_skips_search_only_for_keyless_parallel(self):
-        """A search-only env credential (SEARXNG_URL) must not shadow the keyless
-        Parallel free-MCP extract fallback: extract auto-detect skips search-only
-        backends, so _get_extract_backend resolves to parallel (which can fetch),
-        while search auto-detect still prefers the configured searxng."""
+    def test_extract_autodetect_skips_search_only_to_setup_error(self):
+        """A search-only env credential must not make extract look configured."""
         from tools.web_tools import _get_extract_backend, _get_search_backend
         with patch("tools.web_tools._load_web_config", return_value={}), \
              patch.dict(os.environ, {}, clear=False):
@@ -683,7 +675,7 @@ class TestCheckWebApiKey:
             os.environ["SEARXNG_URL"] = "http://localhost:8080"
             with patch("tools.web_tools._is_tool_gateway_ready", return_value=False):
                 assert _get_search_backend() == "searxng"
-                assert _get_extract_backend() == "parallel"
+                assert _get_extract_backend() == "firecrawl"
 
     def test_configured_but_unavailable_backend_reports_unusable(self):
         """An explicitly configured backend with no creds (exa, no key) →

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -150,8 +150,7 @@ _KNOWN_WEB_BACKENDS = frozenset(
 
 # Backends that only service web_search (their provider's ``supports_extract()``
 # is False). They are skipped during *extract* auto-detect so a search-only
-# credential (e.g. SEARXNG_URL) does not shadow the keyless Parallel free-MCP
-# fallback, which would otherwise leave web_extract broken on a no-key install.
+# credential (e.g. SEARXNG_URL) does not make web_extract look configured.
 _SEARCH_ONLY_BACKENDS = frozenset({"searxng", "brave-free", "ddgs", "xai"})
 
 
@@ -163,10 +162,9 @@ def _get_backend(capability: str = "search") -> str:
     keys manually without running setup.
 
     ``capability`` ("search" | "extract") only affects auto-detect: for
-    ``extract`` we skip search-only backends (``_SEARCH_ONLY_BACKENDS``) so a
-    search-only credential never shadows the keyless Parallel free-MCP extract
-    fallback. An explicit ``web.backend`` value is honored as-is (explicit wins,
-    surfacing that backend's own search-only error rather than rerouting).
+    ``extract`` we skip search-only backends (``_SEARCH_ONLY_BACKENDS``). An
+    explicit ``web.backend`` value is honored as-is (explicit wins, surfacing
+    that backend's own search-only error rather than rerouting).
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
     if configured in _KNOWN_WEB_BACKENDS:
@@ -178,8 +176,10 @@ def _get_backend(capability: str = "search") -> str:
     # pre-empted by a Nous OAuth token whose subscription tier may not
     # actually grant web-search access (the gateway then fails at runtime
     # with "no subscription" and the tool returns an error to the agent
-    # without falling back). Free-tier backends (searxng / brave-free /
-    # keyless parallel / ddgs) trail the keyed ones.
+    # without falling back). Free-tier backends that still require an explicit
+    # user signal (searxng URL / Brave key) trail the keyed ones. When there is
+    # no configuration at all, fall back to Firecrawl's missing-credential
+    # error instead of silently routing user traffic to a hosted vendor.
     backend_candidates = (
         ("tavily", _has_env("TAVILY_API_KEY")),
         ("exa", _has_env("EXA_API_KEY")),
@@ -188,24 +188,19 @@ def _get_backend(capability: str = "search") -> str:
         ("firecrawl", _is_tool_gateway_ready()),
         ("searxng", _has_env("SEARXNG_URL")),
         ("brave-free", _has_env("BRAVE_SEARCH_API_KEY")),
-        # Keyless Parallel free MCP — always available, the intended no-key
-        # default for both search and extract. Ahead of ddgs (search-only, so it
-        # can't service web_extract); ddgs stays reachable via web.backend=ddgs.
-        ("parallel", True),
-        ("ddgs", _ddgs_package_importable()),
     )
     for backend, available in backend_candidates:
         if not available:
             continue
-        # For extract, skip search-only backends so the keyless Parallel
-        # free-MCP fallback (which can fetch URLs) is reached instead.
+        # For extract, skip search-only backends so a search credential does
+        # not pretend URL extraction is configured.
         if capability == "extract" and backend in _SEARCH_ONLY_BACKENDS:
             continue
         return backend
 
-    # Defensive terminal (the keyless ``parallel`` candidate above is always
-    # available, so this is effectively unreachable).
-    return "parallel"
+    # Preserve the legacy no-config behavior: no third-party request is made
+    # until Firecrawl reports its missing configuration at dispatch time.
+    return "firecrawl"
 
 
 def _get_search_backend() -> str:
@@ -239,9 +234,8 @@ def _get_capability_backend(capability: str) -> str:
     Reads ``web.{capability}_backend`` from config. Any explicit value is
     honored **regardless of availability** — including unrecognized typos like
     ``parrallel`` — so the dispatcher surfaces that backend's own setup/config
-    error rather than silently rerouting to the keyless Parallel default (which
-    would send user queries to a different provider and hide the
-    misconfiguration). This matches ``web_search_registry``'s "explicit config
+    error rather than silently rerouting to a different provider and hiding the
+    misconfiguration. This matches ``web_search_registry``'s "explicit config
     wins" rule. Only an *unset* value falls through to ``_get_backend()``.
     """
     cfg = _load_web_config()
@@ -256,8 +250,8 @@ def _is_backend_available(backend: str) -> bool:
     if backend == "exa":
         return _has_env("EXA_API_KEY")
     if backend == "parallel":
-        # Credential probe: True only with a real key. The keyless free-MCP
-        # fallback is handled by _get_backend()'s terminal default, not here.
+        # Credential probe: True only with a real key. Explicit keyless
+        # parallel is handled by _backend_usable(), not this generic probe.
         return _has_env("PARALLEL_API_KEY")
     if backend == "firecrawl":
         return check_firecrawl_api_key()
@@ -816,10 +810,10 @@ def _ensure_web_plugins_loaded() -> None:
     swallowed below as a warning, a packaged layout where discovery ran before
     the bundled tree was importable, or a stale empty-discovery cache). When
     that happens the registry is empty and *both* web_search and web_extract
-    dead-end on "No web {search,extract} provider configured" — even though the
-    keyless Parallel default is supposed to work with zero setup. So after
-    discovery we verify the keyless default landed and, if not, register the
-    bundled providers directly (see
+    dead-end on "No web {search,extract} provider configured" even when the user
+    explicitly configured a bundled backend. So after discovery we verify a
+    bundled provider landed and, if not, register the bundled providers directly
+    (see
     :func:`_register_bundled_web_providers_directly`).
     """
     try:
@@ -833,11 +827,10 @@ def _ensure_web_plugins_loaded() -> None:
         # clue in normal logs about the real cause.
         logger.warning("Web plugin discovery failed (non-fatal): %s", exc)
 
-    # Belt-and-suspenders: guarantee the keyless Parallel default (the
-    # documented zero-setup backend for both web_search and web_extract) is
-    # actually registered. The lookup is a cheap dict hit on the healthy path
-    # (discovery already registered it → no-op); only an empty registry pays
-    # for the direct-registration sweep.
+    # Belt-and-suspenders: guarantee the bundled web providers are registered.
+    # The lookup is a cheap dict hit on the healthy path (discovery already
+    # registered it -> no-op); only an empty registry pays for the direct
+    # registration sweep.
     try:
         from agent.web_search_registry import get_provider
 
@@ -854,9 +847,9 @@ def _register_bundled_web_providers_directly() -> None:
     (:func:`hermes_cli.plugins._ensure_plugins_discovered`), which auto-loads
     every ``plugins/web/<name>`` backend (they are ``kind: backend``). This
     fallback exists for the runtimes where that sweep does not leave the web
-    registry populated — so the keyless Parallel default (and any bundled
-    backend the user explicitly configured) keeps working instead of
-    surfacing a misleading "No web provider configured" error.
+    registry populated, so any bundled backend the user explicitly configured
+    keeps working instead of surfacing a misleading "No web provider configured"
+    error.
 
     Imports each bundled ``plugins/web/<name>`` package and calls its
     ``register()`` directly against :mod:`agent.web_search_registry`. Idempotent
@@ -1103,7 +1096,7 @@ async def web_extract_tool(
             else:
                 safe_urls.append(url)
 
-        # Tracks the free-tier Parallel extract path (no key → web_fetch via the
+        # Tracks explicit keyless Parallel extract (no key -> web_fetch via the
         # hosted Search MCP) so we can credit Parallel in the output/UI. Bound
         # here so empty/all-blocked inputs (which skip dispatch) stay defined.
         _free_parallel_extract = False
@@ -1331,12 +1324,10 @@ async def web_extract_tool(
 def web_tools_registered() -> bool:
     """Whether the web tools should be registered. Always True.
 
-    Registration is decoupled from credential readiness: with no credentials,
-    search/extract fall back to Parallel's free hosted Search MCP, and an
-    explicitly configured-but-unavailable backend must stay registered so
-    dispatch surfaces that backend's own setup error rather than the tool
-    silently vanishing. For "is web actually configured?" use
-    :func:`check_web_api_key`.
+    Registration is decoupled from credential readiness: an explicitly
+    configured-but-unavailable backend must stay registered so dispatch surfaces
+    that backend's own setup error rather than the tool silently vanishing. For
+    "is web actually configured?" use :func:`check_web_api_key`.
     """
     return True
 
@@ -1357,16 +1348,16 @@ def _parallel_provider_registered() -> bool:
 
 
 def _backend_usable(backend: str) -> bool:
-    """True when *backend* can service calls. Keyless Parallel counts (free MCP).
+    """True when *backend* can service calls.
 
     Unknown/typo'd backend names are not usable (so an explicit typo is reported
-    as a config problem rather than masked by the keyless fallback).
+    as a config problem rather than masked by a different provider).
     """
     if backend == "parallel" and not _has_env("PARALLEL_API_KEY"):
-        # Keyless Parallel is only genuinely usable when its provider is actually
-        # registered/enabled. If web-parallel is disabled or discovery failed,
-        # report unusable so setup is not skipped and the user is not left with
-        # web tools that fail at runtime ("No web search provider configured").
+        # Explicit keyless Parallel is only genuinely usable when its provider
+        # is actually registered/enabled. If web-parallel is disabled or
+        # discovery failed, report unusable so setup is not skipped and the user
+        # is not left with web tools that fail at runtime.
         return _parallel_provider_registered()
     return _is_backend_available(backend)
 
@@ -1377,10 +1368,10 @@ def check_web_api_key() -> bool:
     Probes the backends that :func:`_get_search_backend` /
     :func:`_get_extract_backend` actually select (not just shared
     ``web.backend``), so an explicit per-capability backend with missing
-    credentials — or a typo'd name — reports unusable instead of being masked by
-    the keyless Parallel fallback. Keyless Parallel itself genuinely services
-    calls, so a zero-setup install reports usable. Distinct from
-    :func:`web_tools_registered` (always True — whether the tool is offered).
+    credentials, a missing default config, or a typo'd name reports unusable
+    instead of being masked by a different provider. Explicit keyless Parallel
+    itself genuinely services calls when its provider is enabled. Distinct from
+    :func:`web_tools_registered` (always True, whether the tool is offered).
     """
     return _backend_usable(_get_search_backend()) and _backend_usable(_get_extract_backend())
 


### PR DESCRIPTION
## What does this PR do?

Fixes web backend auto-detect so a fresh install with no web config or credentials no longer silently selects Parallel's anonymous hosted Search MCP.

Why this matters: `web_search` / `web_extract` traffic should not route to a hosted vendor unless the user configured that backend or provided credentials.

Why this approach: this preserves explicit Parallel behavior. `web.backend=parallel`, `web.search_backend=parallel`, `web.extract_backend=parallel`, and `PARALLEL_API_KEY` still route to Parallel. No-config installs now fall through to the existing Firecrawl setup error instead of making an anonymous hosted request.

## Related Issue

Fixes #45058

## Type of Change

- [x] Bug fix

## Changes Made

- `tools/web_tools.py` - remove the unconditional keyless Parallel auto-detect candidate, stop package-only `ddgs` from acting as implicit opt-in, and return the Firecrawl setup/error path when no backend is configured.
- `plugins/web/parallel/provider.py` - clarify that keyless Parallel MCP is used only when Parallel is explicitly selected.
- `tests/tools/*` and `tests/hermes_cli/test_tools_config.py` - update backend-selection, setup-prompt, provider-registration, SearXNG, DDGS, and unconfigured-dispatch coverage.

## How to Test

1. `bash scripts/run_tests.sh tests/tools/test_web_tools_config.py tests/tools/test_web_providers_searxng.py tests/tools/test_web_providers_ddgs.py tests/tools/test_web_keyless_default_fallback.py tests/tools/test_web_providers.py tests/hermes_cli/test_tools_config.py` - 221 passed.
2. `bash scripts/run_tests.sh tests/plugins/web/test_parallel_keyless_mcp.py` - 35 passed.
3. `ruff check tools/web_tools.py plugins/web/parallel/provider.py tests/tools/test_web_tools_config.py tests/tools/test_web_providers_searxng.py tests/tools/test_web_providers_ddgs.py tests/tools/test_web_keyless_default_fallback.py tests/tools/test_web_providers.py tests/hermes_cli/test_tools_config.py tests/plugins/web/test_parallel_keyless_mcp.py` - passed.
4. `git diff --check` - passed.

## Checklist

- [x] Tests added/updated
- [x] Existing targeted tests pass
- [x] Comments/docs updated where behavior changed
- [x] No new dependencies
- [x] Config impact covered: web backend auto-detect now requires explicit provider signal before using Parallel anonymously
- [x] Cross-platform impact reviewed: Python selection logic only; validated through the repo test runner on WSL/Ubuntu from Windows

## Screenshots / Logs

N/A