### PR TITLE
fix(bluebubbles): de-duplicate inbound DM emissions to prevent double replies

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 import re
+import time
 import uuid
 from collections import OrderedDict
 from datetime import datetime
@@ -150,6 +151,9 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._private_api_enabled: Optional[bool] = None
         self._helper_connected: bool = False
         self._guid_cache: OrderedDict[str, str] = OrderedDict()
+        # Fingerprints of recently-handled inbound messages, used to drop the
+        # duplicate emissions BlueBubbles sends for DMs (see _is_duplicate_inbound).
+        self._recent_inbound_messages: Dict[str, float] = {}
 
     # ------------------------------------------------------------------
     # API helpers
@@ -860,6 +864,20 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 return candidate.strip()
         return None
 
+    def _is_duplicate_inbound(self, key: Optional[str], ttl: float = 60.0) -> bool:
+        """Return True if this inbound fingerprint was handled within ``ttl`` seconds."""
+        if not key:
+            return False
+        now = time.monotonic()
+        # Opportunistic cleanup keeps the map small without a background task.
+        for old_key, seen_at in list(self._recent_inbound_messages.items()):
+            if now - seen_at > ttl:
+                self._recent_inbound_messages.pop(old_key, None)
+        if key in self._recent_inbound_messages:
+            return True
+        self._recent_inbound_messages[key] = now
+        return False
+
     async def _handle_webhook(self, request):
         from aiohttp import web
 
@@ -993,6 +1011,33 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         if not sender or not (chat_guid or chat_identifier) or not text:
             return web.json_response({"error": "missing message fields"}, status=400)
 
+        message_id = self._value(
+            record.get("guid"),
+            record.get("messageGuid"),
+            record.get("id"),
+        )
+        # BlueBubbles can emit the same inbound DM twice (once keyed by the raw
+        # chat GUID, once by the normalized handle), which makes the gateway reply
+        # twice. Fingerprint and drop exact repeats. Media is part of the
+        # fingerprint on purpose: an "updated" message carrying attachments can
+        # follow an earlier text-only "new" message with the same guid, and that
+        # update must still be processed.
+        dedupe_key = "|".join(
+            [
+                message_id or "",
+                sender,
+                text,
+                ",".join(media_urls),
+                ",".join(media_types),
+            ]
+        )
+        if self._is_duplicate_inbound(dedupe_key):
+            logger.info(
+                "[bluebubbles] duplicate inbound message ignored: %s",
+                _redact(dedupe_key),
+            )
+            return web.Response(text="ok")
+
         session_chat_id = chat_guid or chat_identifier
         is_group = bool(record.get("isGroup")) or (";+;" in (chat_guid or ""))
         if is_group and self.require_mention:
@@ -1015,11 +1060,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             message_type=msg_type,
             source=source,
             raw_message=payload,
-            message_id=self._value(
-                record.get("guid"),
-                record.get("messageGuid"),
-                record.get("id"),
-            ),
+            message_id=message_id,
             reply_to_message_id=self._value(
                 record.get("threadOriginatorGuid"),
                 record.get("associatedMessageGuid"),

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -830,3 +830,95 @@ class TestBlueBubblesWebhookRegistration:
             adapter._unregister_webhook()
         )
         assert ok is False
+
+
+class TestBlueBubblesInboundDedupe:
+    @pytest.mark.asyncio
+    async def test_duplicate_dm_emission_is_deduplicated(self, monkeypatch):
+        """BlueBubbles emits a DM twice (once keyed by the raw chat GUID, once by
+        the normalized handle). The gateway must dispatch it only once."""
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+
+        emission_a = _FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {
+                "guid": "msg-dup-1",
+                "text": "hello there",
+                "handle": {"address": "+15555550100"},
+                "isFromMe": False,
+                "isGroup": False,
+                "chats": [{"guid": "iMessage;-;+15555550100"}],
+            },
+        })
+        emission_b = _FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {
+                "guid": "msg-dup-1",
+                "text": "hello there",
+                "handle": {"address": "+15555550100"},
+                "isFromMe": False,
+                "isGroup": False,
+            },
+        })
+
+        assert (await adapter._handle_webhook(emission_a)).status == 200
+        await asyncio.sleep(0)
+        assert (await adapter._handle_webhook(emission_b)).status == 200
+        await asyncio.sleep(0)
+
+        assert [event.text for event in handled] == ["hello there"]
+
+    @pytest.mark.asyncio
+    async def test_attachment_update_after_text_is_not_deduplicated(self, monkeypatch):
+        """An 'updated' message that adds attachments after an earlier text-only
+        message with the same guid must still be processed, because media is part
+        of the dedupe fingerprint."""
+        adapter = _make_adapter(monkeypatch, send_read_receipts=False)
+        handled = []
+
+        async def fake_handle_message(event):
+            handled.append(event)
+
+        async def fake_download_attachment(att_guid, att):
+            return "/cache/" + att_guid
+
+        monkeypatch.setattr(adapter, "handle_message", fake_handle_message)
+        monkeypatch.setattr(adapter, "_download_attachment", fake_download_attachment)
+
+        text_only = _FakeBlueBubblesRequest({
+            "type": "new-message",
+            "data": {
+                "guid": "msg-update-1",
+                "text": "look at this",
+                "handle": {"address": "+15555550100"},
+                "isFromMe": False,
+                "isGroup": False,
+                "chats": [{"guid": "iMessage;-;+15555550100"}],
+            },
+        })
+        with_attachment = _FakeBlueBubblesRequest({
+            "type": "updated-message",
+            "data": {
+                "guid": "msg-update-1",
+                "text": "look at this",
+                "handle": {"address": "+15555550100"},
+                "isFromMe": False,
+                "isGroup": False,
+                "chats": [{"guid": "iMessage;-;+15555550100"}],
+                "attachments": [{"guid": "att-1", "mimeType": "image/png"}],
+            },
+        })
+
+        assert (await adapter._handle_webhook(text_only)).status == 200
+        await asyncio.sleep(0)
+        assert (await adapter._handle_webhook(with_attachment)).status == 200
+        await asyncio.sleep(0)
+
+        assert len(handled) == 2
+        assert handled[1].media_urls == ["/cache/att-1"]


### PR DESCRIPTION
## What does this PR do?

The BlueBubbles gateway replies **twice** to a single inbound DM. BlueBubbles emits the same inbound iMessage twice for direct messages — once keyed by the raw chat GUID (e.g. `iMessage;-;+1555...`) and once by the normalized phone/email handle. `_handle_webhook` treated those two emissions as distinct messages and dispatched the agent for each, so the user receives two responses to one message.

This adds lightweight inbound de-duplication: each message is fingerprinted by `(message_id, sender, text, media)` with a 60s TTL, and exact repeats are dropped before dispatch.

Media is intentionally part of the fingerprint. BlueBubbles can send an `updated-message` carrying attachments shortly after an earlier text-only `new-message` with the *same* guid; a naive message-id dedupe would discard that update and silently drop inbound images. Including the media in the fingerprint lets the attachment-bearing update through while still collapsing true duplicates.

## Related Issue

No existing issue — this is a direct bug fix. Happy to open a tracking issue first if maintainers prefer.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/bluebubbles.py`:
  - add `self._recent_inbound_messages` fingerprint map to `BlueBubblesAdapter.__init__`
  - add `_is_duplicate_inbound(key, ttl=60.0)` with opportunistic TTL cleanup (no background task)
  - in `_handle_webhook`, build a media-aware `dedupe_key` and acknowledge-and-skip exact repeats (returns `200 ok`, no dispatch)
  - hoist `message_id` so it's computed once and reused
- `tests/gateway/test_bluebubbles.py`:
  - `TestBlueBubblesInboundDedupe` — covers (a) duplicate DM emission dispatched once, and (b) an attachment `updated-message` after a text-only `new-message` is still processed

## How to Test

1. `pytest tests/gateway/test_bluebubbles.py -q`
2. Reproduction (manual): with a BlueBubbles DM gateway, send a single direct message — without this change the agent replies twice; with it, once.
3. Attachment case: send a photo DM; confirm the attachment-bearing update is processed (not dropped as a duplicate of any preceding text-only emission).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(bluebubbles): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25)

> Note on the suite: I ran the affected module — `pytest tests/gateway/test_bluebubbles.py` → **58 passed** (56 existing + 2 new), no regressions. I did not run the full `tests/` suite in this environment.

### Documentation & Housekeeping

- [x] Documentation — N/A (internal behavior fix, covered by docstrings/comments)
- [x] `cli-config.yaml.example` — N/A (no config keys added/changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact considered — fix is platform-agnostic (pure Python dict/time logic)
