### PR TITLE
fix(gateway): hard-exit launchd service restarts after teardown

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15758,6 +15758,25 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     logger.info("Cron ticker stopped")
 
 
+def _finalize_gateway_exit(runner: "GatewayRunner") -> None:
+    """Exit the gateway process after teardown completed."""
+    exit_code = runner.exit_code
+    if exit_code is None:
+        return
+    if (
+        sys.platform == "darwin"
+        and exit_code == GATEWAY_SERVICE_RESTART_EXIT_CODE
+        and getattr(runner, "_restart_via_service", False)
+    ):
+        logger.warning(
+            "launchd service restart teardown finished; forcing os._exit(%s) "
+            "so KeepAlive observes the process death",
+            exit_code,
+        )
+        os._exit(exit_code)
+    raise SystemExit(exit_code)
+
+
 async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = False, verbosity: Optional[int] = 0) -> bool:
     """
     Start the gateway and run until interrupted.
@@ -16187,7 +16206,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         pass
 
     if runner.exit_code is not None:
-        raise SystemExit(runner.exit_code)
+        _finalize_gateway_exit(runner)
 
     # When an unexpected SIGTERM caused the shutdown and it wasn't a planned
     # restart (/restart, /update, SIGUSR1), exit non-zero so systemd's

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -141,7 +141,9 @@ async def test_gateway_stop_systemd_service_restart_exits_cleanly(tmp_path, monk
     monkeypatch.setenv("INVOCATION_ID", "systemd-test")
     runner._launch_systemd_restart_shortcut = MagicMock()
 
-    with patch("gateway.status.remove_pid_file"), patch("gateway.status.write_runtime_status"):
+    with patch("gateway.run.sys.platform", "linux"), patch(
+        "gateway.status.remove_pid_file"
+    ), patch("gateway.status.write_runtime_status"):
         await runner.stop(restart=True, service_restart=True)
 
     runner._launch_systemd_restart_shortcut.assert_called_once_with()
@@ -161,6 +163,38 @@ async def test_gateway_stop_launchd_service_restart_keeps_nonzero_exit(tmp_path,
         await runner.stop(restart=True, service_restart=True)
 
     assert runner._exit_code == GATEWAY_SERVICE_RESTART_EXIT_CODE
+
+
+def test_finalize_gateway_exit_force_exits_launchd_service_restart(monkeypatch):
+    runner = MagicMock()
+    runner.exit_code = GATEWAY_SERVICE_RESTART_EXIT_CODE
+    runner._restart_via_service = True
+    forced_codes = []
+
+    def fake_exit(code):
+        forced_codes.append(code)
+        raise RuntimeError("hard-exit")
+
+    monkeypatch.setattr(gateway_run.sys, "platform", "darwin")
+    monkeypatch.setattr(gateway_run.os, "_exit", fake_exit)
+
+    with pytest.raises(RuntimeError, match="hard-exit"):
+        gateway_run._finalize_gateway_exit(runner)
+
+    assert forced_codes == [GATEWAY_SERVICE_RESTART_EXIT_CODE]
+
+
+def test_finalize_gateway_exit_keeps_regular_system_exit_off_launchd(monkeypatch):
+    runner = MagicMock()
+    runner.exit_code = GATEWAY_SERVICE_RESTART_EXIT_CODE
+    runner._restart_via_service = True
+
+    monkeypatch.setattr(gateway_run.sys, "platform", "linux")
+
+    with pytest.raises(SystemExit) as excinfo:
+        gateway_run._finalize_gateway_exit(runner)
+
+    assert excinfo.value.code == GATEWAY_SERVICE_RESTART_EXIT_CODE
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- force a hard process exit after teardown on macOS launchd service restarts so KeepAlive sees the PID die
- keep ordinary `SystemExit` behavior for non-launchd paths
- add shutdown tests for the launchd hard-exit path and tighten the existing systemd assertion to pin its platform

## Testing
- `uv run --frozen pytest tests/gateway/test_gateway_shutdown.py`
- `uv run --frozen ruff check gateway/run.py tests/gateway/test_gateway_shutdown.py`
- `git diff --check HEAD^ HEAD`

Fixes #45361.
