### PR TITLE
fix(gateway): preserve explicit 127.0.0.1 in BlueBubbles webhook URL (#45308)

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -303,7 +303,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     def _webhook_url(self) -> str:
         """Compute the external webhook URL for BlueBubbles registration."""
         host = self.webhook_host
-        if host in {"0.0.0.0", "127.0.0.1", "localhost", "::"}:
+        if host in {"0.0.0.0", "localhost", "::"}:
             host = "localhost"
         return f"http://{host}:{self.webhook_port}{self.webhook_path}"
 

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -558,15 +558,20 @@ class TestBlueBubblesWebhookUrl:
 
     def test_default_host(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
-        # Default webhook_host is 0.0.0.0 → normalized to localhost
-        assert "localhost" in adapter._webhook_url
+        # Default webhook_host is 127.0.0.1 — preserved (not normalized) per GH-45308
+        assert "127.0.0.1" in adapter._webhook_url
         assert str(adapter.webhook_port) in adapter._webhook_url
         assert adapter.webhook_path in adapter._webhook_url
 
-    @pytest.mark.parametrize("host", ["0.0.0.0", "127.0.0.1", "localhost", "::"])
+    @pytest.mark.parametrize("host", ["0.0.0.0", "localhost", "::"])
     def test_local_hosts_normalized(self, monkeypatch, host):
         adapter = _make_adapter(monkeypatch, webhook_host=host)
         assert adapter._webhook_url.startswith("http://localhost:")
+
+    def test_127_0_0_1_preserved(self, monkeypatch):
+        """Explicit IPv4 loopback must round-trip unchanged (GH-45308)."""
+        adapter = _make_adapter(monkeypatch, webhook_host="127.0.0.1")
+        assert adapter._webhook_url.startswith("http://127.0.0.1:")
 
     def test_custom_host_preserved(self, monkeypatch):
         adapter = _make_adapter(monkeypatch, webhook_host="192.168.1.50")


### PR DESCRIPTION
Fixes #45308. Remove 127.0.0.1 from the host normalization set in _webhook_url so an explicitly-configured IPv4 loopback round-trips unchanged, preventing IPv6/IPv4 mismatch on macOS where localhost resolves to ::1.