### PR TITLE
fix(cli): honour fallback_providers nested under model: key (#45309)

### DIFF
--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -48,6 +48,24 @@ def _entry_identity(entry: dict[str, Any]) -> tuple[str, str, str]:
     )
 
 
+def _deep_fallback_value(config: dict[str, Any], key: str) -> Any:
+    """Return *config[key]* or ``config["model"][key]`` (nested form).
+
+    Users sometimes place ``fallback_providers`` / ``fallback_model`` under
+    the ``model:`` block for symmetry with ``default``/``provider``.  The
+    top-level value always wins when both exist.
+    """
+    top = config.get(key)
+    if top is not None:
+        return top
+    model_block = config.get("model")
+    if isinstance(model_block, dict):
+        nested = model_block.get(key)
+        if nested is not None:
+            return nested
+    return None
+
+
 def get_fallback_chain(config: dict[str, Any] | None) -> list[dict[str, Any]]:
     """Return the effective fallback chain merged across old and new config keys.
 
@@ -55,6 +73,9 @@ def get_fallback_chain(config: dict[str, Any] | None) -> list[dict[str, Any]]:
     order. Legacy ``fallback_model`` entries are appended afterwards unless
     they target the same provider/model/base_url route as an earlier entry.
     The returned list always contains fresh dict copies.
+
+    Both top-level and ``model:``-nested forms are accepted for each key;
+    the top-level value takes precedence when both exist.
     """
 
     config = config or {}
@@ -62,7 +83,7 @@ def get_fallback_chain(config: dict[str, Any] | None) -> list[dict[str, Any]]:
     seen: set[tuple[str, str, str]] = set()
 
     for key in ("fallback_providers", "fallback_model"):
-        for entry in _iter_fallback_entries(config.get(key)):
+        for entry in _iter_fallback_entries(_deep_fallback_value(config, key)):
             identity = _entry_identity(entry)
             if identity in seen:
                 continue


### PR DESCRIPTION
Fixes #45309. get_fallback_chain now also reads fallback_providers and fallback_model from under the model: config section, so operators who nest fallback config under model: get working failover instead of a silently empty chain.