### PR TITLE
fix(installer): skip node/npm/npx symlinks for user installs (#45279)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -846,10 +846,17 @@ install_node() {
 
     local node_link_dir
     node_link_dir="$(get_command_link_dir)"
-    mkdir -p "$node_link_dir"
-    ln -sf "$HERMES_HOME/node/bin/node" "$node_link_dir/node"
-    ln -sf "$HERMES_HOME/node/bin/npm"  "$node_link_dir/npm"
-    ln -sf "$HERMES_HOME/node/bin/npx"  "$node_link_dir/npx"
+    # Only create node/npm/npx symlinks for root/FHS installs where they
+    # are needed for command resolution from a login shell.  For user
+    # installs (~/.local/bin) the symlinks would shadow the user's own
+    # Homebrew/nvm node — Hermes invokes its bundled node via absolute
+    # path in its own subprocesses anyway.  (GH-45279)
+    if [ "$ROOT_FHS_LAYOUT" = true ] || is_termux; then
+        mkdir -p "$node_link_dir"
+        ln -sf "$HERMES_HOME/node/bin/node" "$node_link_dir/node"
+        ln -sf "$HERMES_HOME/node/bin/npm"  "$node_link_dir/npm"
+        ln -sf "$HERMES_HOME/node/bin/npx"  "$node_link_dir/npx"
+    fi
 
     export PATH="$HERMES_HOME/node/bin:$PATH"
 


### PR DESCRIPTION
Fixes #45279. The installer now only creates node/npm/npx symlinks in the command bin dir for root/FHS and Termux installs. For user installs (~/.local/bin), the symlinks are skipped to avoid shadowing the user's Homebrew/nvm node. Hermes invokes its bundled node via absolute path in its own subprocesses.