### PR TITLE
feat(feishu): render markdown tables as Interactive Cards + fix CuaDriver backend cache

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -609,6 +609,190 @@ def _build_markdown_post_rows(content: str) -> List[List[Dict[str, str]]]:
     return rows or [[{"tag": "md", "text": content}]]
 
 
+# ---------------------------------------------------------------------------
+# Markdown table → Feishu Interactive Card conversion
+# ---------------------------------------------------------------------------
+
+_MARKDOWN_TABLE_ROW_SEP_RE = re.compile(r"^\|[-|: ]+\|$")
+
+
+def _parse_markdown_table_segments(content: str) -> List[Dict[str, Any]]:
+    """Split content into segments and convert markdown tables to card table format.
+
+    Returns a list of element dicts suitable for a Feishu Interactive Card:
+      - {"tag": "markdown", "content": "..."} for non-table text
+      - {"tag": "table", ...} for parsed tables
+    """
+    if not content.strip():
+        return [{"tag": "markdown", "content": content}]
+
+    segments: List[Dict[str, Any]] = []
+    lines = content.splitlines()
+    i = 0
+    n = len(lines)
+
+    while i < n:
+        # Check if this line starts a markdown table
+        if _is_table_start(lines, i):
+            # Parse the full table starting at line i
+            table_end = _find_table_end(lines, i)
+            table_elements = _build_card_table_elements(lines[i:table_end + 1])
+            if table_elements:
+                segments.append(table_elements)
+            i = table_end + 1
+        else:
+            # Collect non-table text lines
+            text_lines: List[str] = []
+            while i < n and not _is_table_start(lines, i):
+                text_lines.append(lines[i])
+                i += 1
+            text_block = "\n".join(text_lines).strip()
+            if text_block:
+                segments.append({"tag": "markdown", "content": text_block})
+
+    return segments or [{"tag": "markdown", "content": content}]
+
+
+def _is_table_start(lines: List[str], idx: int) -> bool:
+    """Check if line[idx] starts a markdown table (header row followed by separator)."""
+    if idx + 1 >= len(lines):
+        return False
+    header = lines[idx].strip()
+    separator = lines[idx + 1].strip()
+    if not header.startswith("|") or not header.endswith("|"):
+        return False
+    if not separator.startswith("|") or not separator.endswith("|"):
+        return False
+    return bool(_MARKDOWN_TABLE_ROW_SEP_RE.match(separator))
+
+
+def _find_table_end(lines: List[str], start: int) -> int:
+    """Find the last line of a markdown table starting at start."""
+    # At minimum, include the separator row (start + 1)
+    end = start + 1 if start + 1 < len(lines) else start
+    for j in range(start + 2, len(lines)):
+        line = lines[j].strip()
+        if line.startswith("|") and line.endswith("|"):
+            end = j
+        else:
+            break
+    return end
+
+
+def _split_pipe_cells(row: str) -> List[str]:
+    """Split a markdown table row into cells, handling escaped pipes."""
+    row = row.strip()
+    if row.startswith("|"):
+        row = row[1:]
+    if row.endswith("|"):
+        row = row[:-1]
+    cells: List[str] = []
+    current: List[str] = []
+    escaped = False
+    for ch in row:
+        if ch == "\\":
+            escaped = not escaped
+            current.append(ch)
+        elif ch == "|" and not escaped:
+            cells.append("".join(current).strip())
+            current = []
+        else:
+            escaped = False
+            current.append(ch)
+    cells.append("".join(current).strip())
+    return cells
+
+
+def _detect_column_alignments(separator_row: str) -> List[str]:
+    """Detect text alignment from the separator row (|:---|:---:|---:|)."""
+    cells = _split_pipe_cells(separator_row)
+    alignments: List[str] = []
+    for cell in cells:
+        cell = cell.strip()
+        if cell.startswith(":") and cell.endswith(":"):
+            alignments.append("center")
+        elif cell.endswith(":"):
+            alignments.append("right")
+        elif cell.startswith(":"):
+            alignments.append("left")
+        else:
+            alignments.append("left")
+    return alignments
+
+
+def _build_card_table_elements(table_lines: List[str]) -> Dict[str, Any]:
+    """Convert parsed markdown table lines into a Feishu card table element."""
+    if len(table_lines) < 2:
+        return {"tag": "markdown", "content": "\n".join(table_lines)}
+
+    headers = _split_pipe_cells(table_lines[0])
+    alignments = _detect_column_alignments(table_lines[1])
+    data_rows = table_lines[2:] if len(table_lines) > 2 else []
+
+    # Build column definitions
+    columns: List[Dict[str, Any]] = []
+    col_names: List[str] = []
+    for ci, hdr in enumerate(headers):
+        col_name = f"col_{ci}"
+        col_names.append(col_name)
+        col_def: Dict[str, Any] = {
+            "name": col_name,
+            "display_name": hdr,
+            "data_type": "text",
+            "horizontal_align": alignments[ci] if ci < len(alignments) else "left",
+            "vertical_align": "top",
+            "width": "auto",
+        }
+        columns.append(col_def)
+
+    # Build row data
+    rows: List[Dict[str, str]] = []
+    for row_line in data_rows:
+        cells = _split_pipe_cells(row_line)
+        row_data: Dict[str, str] = {}
+        for ci, cell in enumerate(cells):
+            if ci < len(col_names):
+                row_data[col_names[ci]] = cell
+        if row_data:
+            rows.append(row_data)
+
+    if not rows:
+        return {"tag": "markdown", "content": "\n".join(table_lines)}
+
+    table_element: Dict[str, Any] = {
+        "tag": "table",
+        "page_size": min(max(len(rows), 1), 10),
+        "row_height": "low",
+        "header_style": {
+            "text_align": "left",
+            "text_size": "normal",
+            "background_style": "grey",
+            "text_color": "default",
+            "bold": True,
+            "lines": 1,
+        },
+        "columns": columns,
+        "rows": rows,
+    }
+    return table_element
+
+
+def _build_table_card_payload(content: str) -> str:
+    """Build an Interactive Card payload with proper table rendering.
+
+    Splits content into text and table segments, builds a card with
+    markdown elements for text and table elements for markdown tables.
+    """
+    segments = _parse_markdown_table_segments(content)
+
+    card: Dict[str, Any] = {
+        "config": {"wide_screen_mode": True},
+        "elements": segments,
+    }
+
+    return json.dumps(card, ensure_ascii=False)
+
+
 def parse_feishu_post_payload(
     payload: Any,
     *,
@@ -4374,12 +4558,12 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
+        # When content contains markdown tables, render them as a Feishu
+        # Interactive Card with proper table components instead of falling
+        # back to plain text. The card table component is supported on Feishu
+        # v7.4+ and renders native table formatting.
         if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
+            return "interactive", _build_table_card_payload(content)
         if _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}

--- a/tests/gateway/test_feishu_table_card.py
+++ b/tests/gateway/test_feishu_table_card.py
@@ -1,0 +1,333 @@
+"""Tests for Feishu Interactive Card table rendering from markdown tables."""
+
+import json
+from typing import Any, Dict, List
+
+
+def _import_module():
+    """Import the feishu module (lark_oapi not required for these tests)."""
+    from gateway.platforms.feishu import (
+        _build_card_table_elements,
+        _build_table_card_payload,
+        _detect_column_alignments,
+        _find_table_end,
+        _is_table_start,
+        _parse_markdown_table_segments,
+        _split_pipe_cells,
+    )
+    return {
+        "build_card_table_elements": _build_card_table_elements,
+        "build_table_card_payload": _build_table_card_payload,
+        "detect_column_alignments": _detect_column_alignments,
+        "find_table_end": _find_table_end,
+        "is_table_start": _is_table_start,
+        "parse_markdown_table_segments": _parse_markdown_table_segments,
+        "split_pipe_cells": _split_pipe_cells,
+    }
+
+
+class TestSplitPipeCells:
+    """Test _split_pipe_cells for parsing markdown table rows."""
+
+    def test_basic_row(self):
+        mod = _import_module()
+        row = "| Alice | 30 | Beijing |"
+        cells = mod["split_pipe_cells"](row)
+        assert cells == ["Alice", "30", "Beijing"], f"Got {cells}"
+
+    def test_row_without_outer_pipes(self):
+        mod = _import_module()
+        row = "Alice | 30 | Beijing"
+        cells = mod["split_pipe_cells"](row)
+        assert cells == ["Alice", "30", "Beijing"], f"Got {cells}"
+
+    def test_empty_cells(self):
+        mod = _import_module()
+        row = "|  |  |"
+        cells = mod["split_pipe_cells"](row)
+        assert cells == ["", ""], f"Got {cells}"
+
+    def test_escaped_pipe(self):
+        mod = _import_module()
+        row = r"| Cell with \| pipe | Normal |"
+        cells = mod["split_pipe_cells"](row)
+        assert cells == [r"Cell with \| pipe", "Normal"], f"Got {cells}"
+
+    def test_whitespace_trimming(self):
+        mod = _import_module()
+        row = "|  spaced  |  values  |"
+        cells = mod["split_pipe_cells"](row)
+        assert cells == ["spaced", "values"], f"Got {cells}"
+
+    def test_single_cell(self):
+        mod = _import_module()
+        row = "| only one |"
+        cells = mod["split_pipe_cells"](row)
+        assert cells == ["only one"], f"Got {cells}"
+
+
+class TestDetectColumnAlignments:
+    """Test alignment detection from separator rows."""
+
+    def test_left_align(self):
+        mod = _import_module()
+        result = mod["detect_column_alignments"]("| :--- | :--- |")
+        assert result == ["left", "left"], f"Got {result}"
+
+    def test_right_align(self):
+        mod = _import_module()
+        result = mod["detect_column_alignments"]("| ---: | ---: |")
+        assert result == ["right", "right"], f"Got {result}"
+
+    def test_center_align(self):
+        mod = _import_module()
+        result = mod["detect_column_alignments"]("| :---: | :---: |")
+        assert result == ["center", "center"], f"Got {result}"
+
+    def test_mixed_align(self):
+        mod = _import_module()
+        result = mod["detect_column_alignments"]("|:---|:---:|---:|")
+        assert result == ["left", "center", "right"], f"Got {result}"
+
+    def test_default_align(self):
+        mod = _import_module()
+        result = mod["detect_column_alignments"]("|---|---|---|")
+        assert result == ["left", "left", "left"], f"Got {result}"
+
+
+class TestIsTableStart:
+    """Test table start detection."""
+
+    def test_valid_table_start(self):
+        mod = _import_module()
+        lines = [
+            "| Name | Age |",
+            "|------|-----|",
+        ]
+        assert mod["is_table_start"](lines, 0) is True
+
+    def test_not_enough_lines(self):
+        mod = _import_module()
+        lines = ["| Name |"]
+        assert mod["is_table_start"](lines, 0) is False
+
+    def test_no_separator(self):
+        mod = _import_module()
+        lines = [
+            "| Name | Age |",
+            "Some text here",
+        ]
+        assert mod["is_table_start"](lines, 0) is False
+
+    def test_no_pipe(self):
+        mod = _import_module()
+        lines = [
+            "Name Age",
+            "----- ----",
+        ]
+        assert mod["is_table_start"](lines, 0) is False
+
+
+class TestFindTableEnd:
+    """Test finding end of a markdown table."""
+
+    def test_single_row_table(self):
+        mod = _import_module()
+        lines = [
+            "| A | B |",
+            "|---|---|",
+            "| 1 | 2 |",
+        ]
+        assert mod["find_table_end"](lines, 0) == 2
+
+    def test_multiple_rows(self):
+        mod = _import_module()
+        lines = [
+            "| A | B |",
+            "|---|---|",
+            "| 1 | 2 |",
+            "| 3 | 4 |",
+            "Some text after",
+        ]
+        assert mod["find_table_end"](lines, 0) == 3
+
+    def test_empty_table_stops_early(self):
+        mod = _import_module()
+        lines = [
+            "| A | B |",
+            "|---|---|",
+            "",
+            "after",
+        ]
+        assert mod["find_table_end"](lines, 0) == 1
+
+
+class TestBuildCardTableElements:
+    """Test building card table elements from markdown table lines."""
+
+    def test_basic_table(self):
+        mod = _import_module()
+        lines = [
+            "| Name | Age | City |",
+            "|------|------|------|",
+            "| Alice | 30 | Beijing |",
+            "| Bob | 25 | Shanghai |",
+        ]
+        result = mod["build_card_table_elements"](lines)
+        assert result["tag"] == "table"
+        assert len(result["columns"]) == 3
+        assert len(result["rows"]) == 2
+        assert result["columns"][0]["display_name"] == "Name"
+        assert result["rows"][0]["col_0"] == "Alice"
+        assert result["rows"][1]["col_1"] == "25"
+
+    def test_less_than_two_lines_falls_back(self):
+        mod = _import_module()
+        lines = ["| Only header |"]
+        result = mod["build_card_table_elements"](lines)
+        assert result["tag"] == "markdown"
+
+    def test_no_data_rows_falls_back(self):
+        mod = _import_module()
+        lines = [
+            "| A | B |",
+            "|---|---|",
+        ]
+        result = mod["build_card_table_elements"](lines)
+        assert result["tag"] == "markdown"
+
+    def test_honors_alignment(self):
+        mod = _import_module()
+        lines = [
+            "| Left | Right |",
+            "|:-----|------:|",
+            "| Text |   123 |",
+        ]
+        result = mod["build_card_table_elements"](lines)
+        assert result["columns"][0]["horizontal_align"] == "left"
+        assert result["columns"][1]["horizontal_align"] == "right"
+
+    def test_page_size_respected(self):
+        mod = _import_module()
+        lines = ["| A |", "|---|"] + [f"| {i} |" for i in range(15)]
+        result = mod["build_card_table_elements"](lines)
+        assert result["page_size"] == 10  # max 10
+
+    def test_column_width_auto(self):
+        mod = _import_module()
+        lines = [
+            "| A | B |",
+            "|---|---|",
+            "| 1 | 2 |",
+        ]
+        result = mod["build_card_table_elements"](lines)
+        for col in result["columns"]:
+            assert col["width"] == "auto"
+
+
+class TestParseMarkdownTableSegments:
+    """Test splitting content into mixed segments."""
+
+    def test_pure_table(self):
+        mod = _import_module()
+        content = "| A | B |\n|---|---|\n| 1 | 2 |"
+        segments = mod["parse_markdown_table_segments"](content)
+        assert len(segments) == 1
+        assert segments[0]["tag"] == "table"
+
+    def test_text_before_table(self):
+        mod = _import_module()
+        content = "Some text\n\n| A | B |\n|---|---|\n| 1 | 2 |"
+        segments = mod["parse_markdown_table_segments"](content)
+        assert len(segments) == 2
+        assert segments[0]["tag"] == "markdown"
+        assert "Some text" in segments[0]["content"]
+        assert segments[1]["tag"] == "table"
+
+    def test_text_after_table(self):
+        mod = _import_module()
+        content = "| A | B |\n|---|---|\n| 1 | 2 |\n\nEnd text"
+        segments = mod["parse_markdown_table_segments"](content)
+        assert len(segments) == 2
+        assert segments[0]["tag"] == "table"
+        assert segments[1]["tag"] == "markdown"
+        assert "End text" in segments[1]["content"]
+
+    def test_multiple_tables(self):
+        mod = _import_module()
+        content = (
+            "First:\n\n| X |\n|---|\n| 1 |\n\n"
+            "Second:\n\n| Y |\n|---|\n| 2 |"
+        )
+        segments = mod["parse_markdown_table_segments"](content)
+        assert len(segments) == 4
+        assert segments[0]["tag"] == "markdown"
+        assert segments[1]["tag"] == "table"
+        assert segments[2]["tag"] == "markdown"
+        assert segments[3]["tag"] == "table"
+
+    def test_pure_text(self):
+        mod = _import_module()
+        content = "Just some plain text without any tables."
+        segments = mod["parse_markdown_table_segments"](content)
+        assert len(segments) == 1
+        assert segments[0]["tag"] == "markdown"
+        assert segments[0]["content"] == content
+
+    def test_empty_content(self):
+        mod = _import_module()
+        segments = mod["parse_markdown_table_segments"]("")
+        assert len(segments) == 1
+        assert segments[0]["tag"] == "markdown"
+
+    def test_text_with_pipes_but_no_table(self):
+        mod = _import_module()
+        content = "Some | text with | pipes but not | a table"
+        segments = mod["parse_markdown_table_segments"](content)
+        assert len(segments) == 1
+        assert segments[0]["tag"] == "markdown"
+
+
+class TestBuildTableCardPayload:
+    """Test building the full card JSON payload."""
+
+    def test_returns_valid_json(self):
+        mod = _import_module()
+        content = "| A | B |\n|---|---|\n| 1 | 2 |"
+        payload = mod["build_table_card_payload"](content)
+        card = json.loads(payload)
+        assert "config" in card
+        assert "elements" in card
+        assert card["config"]["wide_screen_mode"] is True
+
+    def test_card_contains_table_element(self):
+        mod = _import_module()
+        content = "| Header | Value |\n|--------|------:|\n| Alpha | 100 |\n| Beta | 200 |"
+        payload = mod["build_table_card_payload"](content)
+        card = json.loads(payload)
+        assert len(card["elements"]) == 1
+        elem = card["elements"][0]
+        assert elem["tag"] == "table"
+        assert len(elem["columns"]) == 2
+        assert len(elem["rows"]) == 2
+        assert elem["columns"][0]["display_name"] == "Header"
+        assert elem["columns"][1]["display_name"] == "Value"
+
+    def test_mixed_content_card(self):
+        mod = _import_module()
+        content = "Summary:\n\n| Item | Count |\n|------|------:|\n| A | 5 |\n| B | 3 |\n\nDone."
+        payload = mod["build_table_card_payload"](content)
+        card = json.loads(payload)
+        assert len(card["elements"]) == 3
+        assert card["elements"][0]["tag"] == "markdown"
+        assert card["elements"][1]["tag"] == "table"
+        assert card["elements"][2]["tag"] == "markdown"
+
+    def test_payload_utf8_safe(self):
+        mod = _import_module()
+        content = "| 姓名 | 城市 |\n|------|------|\n| 张三 | 北京 |\n| 李四 | 上海 |"
+        payload = mod["build_table_card_payload"](content)
+        card = json.loads(payload)
+        assert len(card["elements"]) == 1
+        assert card["elements"][0]["rows"][0]["col_0"] == "张三"
+        assert card["elements"][0]["rows"][0]["col_1"] == "北京"

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -131,6 +131,17 @@ _always_allow: set = set()  # action names the user unlocked for the session
 def _get_backend() -> ComputerUseBackend:
     global _backend
     with _backend_lock:
+        if _backend is not None:
+            # If the cached backend failed to start (e.g. missing 'mcp' on first
+            # attempt), re-create it. Check by trying its is_available() which
+            # returns True even if _started is False (it only checks the binary).
+            try:
+                from tools.computer_use.cua_backend import CuaDriverBackend
+                if isinstance(_backend, CuaDriverBackend) and _backend._session._started is False:
+                    _backend.stop()
+                    _backend = None
+            except Exception:
+                pass
         if _backend is None:
             backend_name = os.environ.get("HERMES_COMPUTER_USE_BACKEND", "cua").lower()
             if backend_name in {"cua", "cua-driver", ""}:


### PR DESCRIPTION
## Summary

### 1. Feishu Markdown Table -> Interactive Card
Previously, when the agent produced a reply containing a markdown table, Feishu rendered it as a blank message via the post msg_type. Now detects markdown tables and renders them as Feishu Interactive Cards with native table components (supported on Feishu v7.4+).

### 2. CuaDriver Backend Cache Fix
When CuaDriverBackend failed to start on first attempt (e.g. missing mcp binary), _backend was cached as not-None with a dead session. Subsequent _get_backend() calls returned the stale instance instead of re-creating it. Now checks _session._started before reusing the cache.

## Changes
- gateway/platforms/feishu.py - markdown table detection + Interactive Card rendering
- tests/gateway/test_feishu_table_card.py - comprehensive test suite (333 lines)
- tools/computer_use/tool.py - CuaDriver backend cache freshness check

## Test Plan
- [x] Unit tests pass (test_feishu_table_card.py)
- [x] Manual test: table renders as card in Feishu DM