### PR TITLE
Fix blank uv.exe console windows on Windows installs

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -64,6 +64,8 @@ except ModuleNotFoundError:
 import os
 import sys
 
+from hermes_cli._subprocess_compat import windows_hide_flags
+
 
 def _set_process_title() -> None:
     """Set the process title to 'hermes' so tools like 'ps', 'top', and
@@ -6666,6 +6668,7 @@ def _run_install_with_heartbeat(
             cwd=PROJECT_ROOT,
             check=True,
             env=env,
+            creationflags=windows_hide_flags(),
         )
     finally:
         done.set()

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -16,11 +16,13 @@ import logging
 import os
 import re
 import shutil
+import subprocess
 import sys
 import copy
 from pathlib import Path
 from typing import Optional, Dict, Any
 
+from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.nous_subscription import get_nous_subscription_features
 from tools.tool_backend_helpers import managed_nous_tools_enabled
 from utils import base_url_hostname
@@ -66,6 +68,15 @@ def _supports_same_provider_pool_setup(provider: str) -> bool:
     if not pconfig:
         return False
     return pconfig.auth_type in {"api_key", "oauth_device_code"}
+
+
+def _run_uv_pip_install_for_current_python(uv_bin: str, *packages: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [uv_bin, "pip", "install", "--python", sys.executable, *packages],
+        capture_output=True,
+        text=True,
+        creationflags=windows_hide_flags(),
+    )
 
 
 # Default model lists per provider — used as fallback when the live
@@ -1268,22 +1279,10 @@ def setup_terminal_backend(config: dict):
                 __import__("modal")
             except ImportError:
                 print_info("Installing modal SDK...")
-                import subprocess
 
                 uv_bin = shutil.which("uv")
                 if uv_bin:
-                    result = subprocess.run(
-                        [
-                            uv_bin,
-                            "pip",
-                            "install",
-                            "--python",
-                            sys.executable,
-                            "modal",
-                        ],
-                        capture_output=True,
-                        text=True,
-                    )
+                    result = _run_uv_pip_install_for_current_python(uv_bin, "modal")
                 else:
                     result = subprocess.run(
                         [sys.executable, "-m", "pip", "install", "modal"],
@@ -1328,15 +1327,10 @@ def setup_terminal_backend(config: dict):
             __import__("daytona")
         except ImportError:
             print_info("Installing daytona SDK...")
-            import subprocess
 
             uv_bin = shutil.which("uv")
             if uv_bin:
-                result = subprocess.run(
-                    [uv_bin, "pip", "install", "--python", sys.executable, "daytona"],
-                    capture_output=True,
-                    text=True,
-                )
+                result = _run_uv_pip_install_for_current_python(uv_bin, "daytona")
             else:
                 result = subprocess.run(
                     [sys.executable, "-m", "pip", "install", "daytona"],
@@ -1980,13 +1974,9 @@ def _setup_matrix():
                 __import__("mautrix")
             except ImportError:
                 print_info(f"Installing {matrix_pkg}...")
-                import subprocess
                 uv_bin = shutil.which("uv")
                 if uv_bin:
-                    result = subprocess.run(
-                        [uv_bin, "pip", "install", "--python", sys.executable, matrix_pkg],
-                        capture_output=True, text=True,
-                    )
+                    result = _run_uv_pip_install_for_current_python(uv_bin, matrix_pkg)
                 else:
                     result = subprocess.run(
                         [sys.executable, "-m", "pip", "install", matrix_pkg],

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -18,6 +18,7 @@ import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 
+from hermes_cli._subprocess_compat import windows_hide_flags
 
 from hermes_cli.config import (
     cfg_get,
@@ -612,6 +613,7 @@ def _pip_install(
                 [uv_bin, "pip", "install", *args],
                 capture_output=capture_output, text=True, timeout=timeout,
                 env=uv_env,
+                creationflags=windows_hide_flags(),
             )
             if result.returncode == 0:
                 return result

--- a/tests/hermes_cli/test_windows_uv_no_console.py
+++ b/tests/hermes_cli/test_windows_uv_no_console.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+
+import hermes_cli.main as hermes_main
+import hermes_cli.setup as setup_mod
+import hermes_cli.tools_config as tools_config
+import tools.lazy_deps as lazy_deps
+
+
+def test_lazy_deps_uv_install_hides_console(monkeypatch):
+    calls: list[tuple[list[str], dict]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(lazy_deps.shutil, "which", lambda name: "C:/uv.exe" if name == "uv" else None)
+    monkeypatch.setattr(lazy_deps, "windows_hide_flags", lambda: 0x1234)
+    monkeypatch.setattr(lazy_deps.subprocess, "run", fake_run)
+
+    result = lazy_deps._venv_pip_install(("example>=1,<2",))
+
+    assert result.success is True
+    assert calls[0][0] == ["C:/uv.exe", "pip", "install", "example>=1,<2"]
+    assert calls[0][1]["creationflags"] == 0x1234
+
+
+def test_tools_config_uv_install_hides_console(monkeypatch):
+    calls: list[tuple[list[str], dict]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(tools_config.shutil, "which", lambda name: "C:/uv.exe" if name == "uv" else None)
+    monkeypatch.setattr(tools_config, "windows_hide_flags", lambda: 0x5678)
+    monkeypatch.setattr(tools_config.subprocess, "run", fake_run)
+
+    result = tools_config._pip_install(["example>=1,<2"])
+
+    assert result.returncode == 0
+    assert calls[0][0] == ["C:/uv.exe", "pip", "install", "example>=1,<2"]
+    assert calls[0][1]["creationflags"] == 0x5678
+
+
+def test_run_install_with_heartbeat_hides_console(monkeypatch):
+    calls: list[tuple[list[str], dict]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(hermes_main, "windows_hide_flags", lambda: 0x9ABC)
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+
+    hermes_main._run_install_with_heartbeat(
+        ["C:/uv.exe", "pip", "install", "-e", "."],
+        heartbeat_interval_seconds=999,
+    )
+
+    assert calls[0][0] == ["C:/uv.exe", "pip", "install", "-e", "."]
+    assert calls[0][1]["creationflags"] == 0x9ABC
+
+
+def test_setup_uv_install_hides_console(monkeypatch):
+    calls: list[tuple[list[str], dict]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(setup_mod, "windows_hide_flags", lambda: 0xDEF0)
+    monkeypatch.setattr(setup_mod.subprocess, "run", fake_run)
+
+    result = setup_mod._run_uv_pip_install_for_current_python("C:/uv.exe", "modal")
+
+    assert result.returncode == 0
+    assert calls[0][0] == ["C:/uv.exe", "pip", "install", "--python", setup_mod.sys.executable, "modal"]
+    assert calls[0][1]["creationflags"] == 0xDEF0

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -61,6 +61,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Optional
 
+from hermes_cli._subprocess_compat import windows_hide_flags
+
 logger = logging.getLogger(__name__)
 
 
@@ -366,6 +368,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                 [uv_bin, "pip", "install", *specs],
                 capture_output=True, text=True, timeout=timeout, env=uv_env,
                 stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
             )
             if r.returncode == 0:
                 return _InstallResult(True, r.stdout or "", r.stderr or "")


### PR DESCRIPTION
Closes #45379

## Summary
- hide uv-backed pip install subprocesses behind CREATE_NO_WINDOW on Windows
- reuse a small setup helper for the three setup wizard uv install paths
- add regression tests covering the lazy deps, tools config, setup, and install-heartbeat paths

## Testing
- uv run --frozen pytest tests/hermes_cli/test_windows_uv_no_console.py
- uv run --frozen ruff check hermes_cli/main.py hermes_cli/setup.py hermes_cli/tools_config.py tools/lazy_deps.py tests/hermes_cli/test_windows_uv_no_console.py
- git diff --check HEAD^ HEAD