### PR TITLE
[verified] Avoid hung detached /restart watcher on launchd

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4362,11 +4362,45 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         cmd = " ".join(shlex.quote(part) for part in hermes_cmd)
         shell_cmd = (
-            f"while kill -0 {current_pid} 2>/dev/null; do sleep 0.2; done; "
+            "pid="
+            f"{current_pid}; "
+            "original_cmd=\"\"; "
+            "original_cmd=$(ps -p \"$pid\" -o command= 2>/dev/null); "
+            "wait_for_pid() { "
+            "  local pid=$1 "
+            "  local attempts=$2 "
+            "  local delay=$3 "
+            "  local i=0 "
+            "  while kill -0 \"$pid\" 2>/dev/null; do "
+            "    i=$((i + 1)); "
+            "    if [ \"$i\" -ge \"$attempts\" ]; then "
+            "      return 1; "
+            "    fi; "
+            "    sleep \"$delay\"; "
+            "  done; "
+            "  return 0; "
+            "}; "
+            "if ! wait_for_pid \"$pid\" 150 0.2; then "
+            "  if [ -n \"$original_cmd\" ]; then "
+            "    current_cmd=$(ps -p \"$pid\" -o command= 2>/dev/null); "
+            "    if [ \"$current_cmd\" = \"$original_cmd\" ]; then "
+            "      kill -TERM \"$pid\" 2>/dev/null || true; "
+            "      for _ in 1 2 3 4 5 6 7 8 9 10; do "
+            "        sleep 0.2; "
+            "        if ! kill -0 \"$pid\" 2>/dev/null; then "
+            "          break; "
+            "        fi; "
+            "      done; "
+            "      if kill -0 \"$pid\" 2>/dev/null; then "
+            "        kill -KILL \"$pid\" 2>/dev/null || true; "
+            "      fi; "
+            "    fi; "
+            "  fi; "
+            "fi; "
             f"{cmd} gateway restart"
         )
+
         # Same marker scrub as the Windows watcher above: this watcher runs
-        # `hermes gateway restart` from outside the gateway, but it inherits
         # _HERMES_GATEWAY=1 from us, and the CLI's self-restart loop guard
         # refuses to run when that marker is set — silently (DEVNULL), so the
         # gateway stops and never comes back.

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -215,7 +215,10 @@ async def test_launch_detached_restart_command_uses_setsid(monkeypatch):
     cmd, kwargs = popen_calls[0]
     assert cmd[:2] == ["/usr/bin/setsid", "bash"]
     assert "gateway restart" in cmd[-1]
-    assert "kill -0 321" in cmd[-1]
+    assert "wait_for_pid \"$pid\" 150 0.2" in cmd[-1]
+    assert "kill -TERM \"$pid\"" in cmd[-1]
+    assert "kill -KILL \"$pid\"" in cmd[-1]
+    assert "kill -0 \"$pid\"" in cmd[-1]
     assert kwargs["start_new_session"] is True
     assert kwargs["stdout"] is subprocess.DEVNULL
     assert kwargs["stderr"] is subprocess.DEVNULL


### PR DESCRIPTION
## Summary
- Added a bounded restart watcher for detached `/restart` flows on non-Linux platforms, where the old implementation waited indefinitely on `kill -0`.
- The watcher now waits up to 150 iterations (~30s), then only force-terminates the old process with `SIGTERM`/`SIGKILL` when the command path still matches the original process command.
- Added a regression-style assertion that the generated detached-restart shell command includes the new bounded wait and fallback kill logic.

## Testing
- `python3 -m pytest tests/gateway/test_restart_drain.py -q`
- `python3 -m py_compile gateway/run.py tests/gateway/test_restart_drain.py`
- `ruff check gateway/run.py tests/gateway/test_restart_drain.py`

Closes #45361
