### PR TITLE
fix(cron): skip delivery for WebUI-origin cron jobs

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -434,8 +434,15 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
 
     if deliver_value == "origin":
         if origin:
+            platform = origin["platform"]
+            # WebUI surfaces cron runs by reading the local session DB —
+            # no external gateway delivery is needed. Returning None
+            # treats it like "local", avoiding "unknown platform 'webui'"
+            # errors (#45360).
+            if platform.lower() == "webui":
+                return None
             return {
-                "platform": origin["platform"],
+                "platform": platform,
                 "chat_id": str(origin["chat_id"]),
                 "thread_id": origin.get("thread_id"),
             }

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -87,6 +87,28 @@ class TestResolveDeliveryTarget:
             "thread_id": "17585",
         }
 
+    def test_webui_origin_platform_returns_none(self):
+        """WebUI reads from local session DB — no gateway delivery needed (#45360)."""
+        job = {
+            "deliver": "origin",
+            "origin": {
+                "platform": "webui",
+                "chat_id": "session-abc",
+            },
+        }
+        assert _resolve_delivery_target(job) is None
+
+    def test_webui_origin_platform_case_insensitive(self):
+        """Platform name comparison should be case-insensitive."""
+        job = {
+            "deliver": "origin",
+            "origin": {
+                "platform": "WebUI",
+                "chat_id": "session-abc",
+            },
+        }
+        assert _resolve_delivery_target(job) is None
+
     @pytest.mark.parametrize(
         ("platform", "env_var", "chat_id"),
         [


### PR DESCRIPTION
## What does this PR do?

Fixes the `unknown platform 'webui'` delivery error for WebUI-origin cron jobs. When a cron job is created from the WebUI with `deliver=origin`, the saved origin platform is `webui`. The scheduler tried to resolve this via `Platform("webui")` which raised a `ValueError`, recording the error in `last_delivery_error`. Since WebUI surfaces cron runs by reading the local session DB, no external gateway delivery is needed — returning `None` (local-only) is the correct behavior.

## Related Issue

Fixes #45360 (second part — unknown platform delivery error)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py`: In `_resolve_single_delivery_target()`, when origin platform is `"webui"` (case-insensitive), return `None` instead of building a delivery target that would fail at `Platform()` resolution.
- `tests/cron/test_scheduler.py`: Add 2 tests — `test_webui_origin_platform_returns_none` and `test_webui_origin_platform_case_insensitive`.

## How to Test

1. Create a cron job from the WebUI dashboard with `deliver=origin`
2. Wait for the job to fire (or trigger manually)
3. Verify `last_delivery_error` is **not** set to `"unknown platform 'webui'"`
4. Verify the cron session is readable in WebUI as a normal chat transcript
5. Run `pytest tests/cron/test_scheduler.py::TestResolveDeliveryTarget -v` — all tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `_resolve_single_delivery_target` (callers: `_resolve_delivery_targets`, flows: cron delivery pipeline)
- Blast radius: LOW — single function, only affects delivery target resolution for "webui" origin platform
- Related patterns: `Platform._missing_()` handles known plugin platforms but "webui" is not a registered plugin; the correct fix is to short-circuit before Platform resolution, not to register "webui" as a platform
