### PR TITLE
fix(lsp): count document lines by LSP line endings, not str.splitlines()

### DIFF
--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 import sys
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Set
@@ -104,6 +105,12 @@ def uri_to_path(uri: str) -> str:
     return os.path.normpath(unquote(raw))
 
 
+# LSP recognises only \n, \r\n and \r as line endings. str.splitlines()
+# additionally breaks on \v, \f, \x1c-\x1e, \x85, U+2028 and U+2029, which
+# would over-count lines and yield a wrong end position.
+_LSP_LINE_ENDING_RE = re.compile(r"\r\n|\r|\n")
+
+
 def _end_position(text: str) -> Dict[str, int]:
     """Return the LSP Position at the end of ``text``.
 
@@ -111,17 +118,11 @@ def _end_position(text: str) -> Dict[str, int]:
     for ``textDocument/didChange`` regardless of the server's declared
     sync mode.
     """
-    if not text:
-        return {"line": 0, "character": 0}
-    lines = text.splitlines(keepends=False)
-    last_line = len(lines) - 1
-    last_col = len(lines[-1]) if lines else 0
-    # If the text ends with a trailing newline, ``splitlines`` won't
-    # represent it.  The end position is then the start of the next
-    # (empty) line — line index is len(lines), column 0.
-    if text.endswith(("\n", "\r")):
-        return {"line": last_line + 1, "character": 0}
-    return {"line": last_line, "character": last_col}
+    # Split on LSP line endings only. The last element is the final line's
+    # content; for a trailing newline it is "", giving column 0 on the next
+    # line. An empty document yields [""] -> line 0, character 0.
+    lines = _LSP_LINE_ENDING_RE.split(text)
+    return {"line": len(lines) - 1, "character": len(lines[-1])}
 
 
 class LSPClient:

--- a/tests/agent/lsp/test_end_position.py
+++ b/tests/agent/lsp/test_end_position.py
@@ -1,0 +1,40 @@
+"""Tests for ``_end_position`` — the whole-document replace range endpoint.
+
+LSP Positions count lines by LSP line endings only (``\\n``, ``\\r\\n``,
+``\\r``). ``str.splitlines()`` also breaks on ``\\v``, ``\\f``, the
+information separators ``\\x1c``-``\\x1e``, ``\\x85`` (NEL) and the Unicode
+separators U+2028 / U+2029, which would over-count lines and produce a wrong
+end position for documents that contain those bytes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.lsp.client import _end_position
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("", {"line": 0, "character": 0}),
+        ("abc", {"line": 0, "character": 3}),
+        ("abc\ndef", {"line": 1, "character": 3}),
+        ("abc\n", {"line": 1, "character": 0}),
+        ("abc\r\ndef", {"line": 1, "character": 3}),
+        ("abc\r\n", {"line": 1, "character": 0}),
+        ("abc\rdef", {"line": 1, "character": 3}),  # old-Mac CR is an LSP ending
+        ("a\nb\nc", {"line": 2, "character": 1}),
+    ],
+)
+def test_lsp_line_endings(text, expected):
+    assert _end_position(text) == expected
+
+
+@pytest.mark.parametrize(
+    "sep",
+    ["\v", "\f", "\x1c", "\x1d", "\x1e", "\x85", "\u2028", "\u2029"],
+)
+def test_non_lsp_separators_do_not_start_a_new_line(sep):
+    # These are NOT LSP line endings, so "a<sep>b" is a single 3-char line.
+    assert _end_position(f"a{sep}b") == {"line": 0, "character": 3}


### PR DESCRIPTION
## Problem

`_end_position` (in `agent/lsp/client.py`) computes the end `Position` used to build the single-range, whole-document `textDocument/didChange` replacement:

```python
lines = text.splitlines(keepends=False)
last_line = len(lines) - 1
...
```

`str.splitlines()` breaks on **more separators than LSP recognises**. LSP counts lines by `\n`, `\r\n` and `\r` only, but `splitlines()` additionally splits on `\v`, `\f`, the information separators `\x1c`–`\x1e`, `\x85` (NEL), and the Unicode separators U+2028 / U+2029.

So a document containing any of those bytes — a form-feed page break (common in Python/Lisp/Emacs files), or a U+2028 inside a JavaScript string literal — makes `_end_position` report too many lines. The replace range then no longer spans the whole document, the server's in-memory mirror desyncs from the real file, and diagnostics are wrong until the next full resync.

Confirmed against `main`:

```
BUG  'a\x0cb'    got={'line': 1, 'character': 1}   expected={'line': 0, 'character': 3}   # \f
BUG  'a\x0bb'    got={'line': 1, 'character': 1}   expected={'line': 0, 'character': 3}   # \v
BUG  'a b'  got={'line': 1, 'character': 1}   expected={'line': 0, 'character': 3}
BUG  'a b'  got={'line': 1, 'character': 1}   expected={'line': 0, 'character': 3}
BUG  'a\x85b'    got={'line': 1, 'character': 1}   expected={'line': 0, 'character': 3}   # NEL
```

## Fix

Split on the LSP line-ending set only:

```python
_LSP_LINE_ENDING_RE = re.compile(r"\r\n|\r|\n")

def _end_position(text: str) -> Dict[str, int]:
    lines = _LSP_LINE_ENDING_RE.split(text)
    return {"line": len(lines) - 1, "character": len(lines[-1])}
```

This also naturally handles the empty-document case (`[""]` → line 0, char 0) and the trailing-newline case (`"abc\n"` → `["abc", ""]` → line 1, char 0), so those special cases are removed.

(The `character` value remains a code-point count, matching the previous behaviour; servers that negotiate UTF-16/UTF-32 offsets are out of scope for this fix.)

## Tests

Added `tests/agent/lsp/test_end_position.py`:
- LSP line endings: `\n`, `\r\n`, `\r`, leading/trailing, multi-line, empty.
- each non-LSP separator (`\v`, `\f`, `\x1c`–`\x1e`, `\x85`, U+2028, U+2029) stays on one line.

## Verification

```
$ uv run pytest tests/agent/lsp/test_end_position.py -q
16 passed

$ uv run pytest tests/agent/lsp/test_protocol.py tests/agent/lsp/test_lifecycle.py -q
26 passed

$ uv run ruff check agent/lsp/client.py tests/agent/lsp/test_end_position.py
All checks passed!
```