### PR TITLE
feat(discord): add session kickoff receipt tool

### DIFF
--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -195,3 +195,21 @@ def get_session_env(name: str, default: str = "") -> str:
             return value
     # Fall back to os.environ for CLI, cron, and test compatibility
     return os.getenv(name, default)
+
+
+def get_session_env_strict(name: str, default: str = "") -> str:
+    """Read a session context variable without falling back to ``os.environ``.
+
+    This is for trust-sensitive gateway-only checks where a process-global
+    environment value must not be accepted as proof of the current requester.
+    If the ContextVar was never set in this context, *default* is returned.
+    If it was explicitly set or cleared, that exact ContextVar value is
+    returned.
+    """
+    var = _VAR_MAP.get(name)
+    if var is None:
+        return default
+    value = var.get()
+    if value is _UNSET:
+        return default
+    return value

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -8,6 +8,7 @@ from gateway.run import GatewayRunner
 from gateway.session import SessionContext, SessionSource
 from gateway.session_context import (
     get_session_env,
+    get_session_env_strict,
     set_session_vars,
     clear_session_vars,
     _VAR_MAP,
@@ -130,6 +131,28 @@ def test_get_session_env_default_when_nothing_set(monkeypatch):
 
     assert get_session_env("HERMES_SESSION_PLATFORM") == ""
     assert get_session_env("HERMES_SESSION_PLATFORM", "fallback") == "fallback"
+
+
+def test_get_session_env_strict_ignores_os_environ(monkeypatch):
+    """Strict reads must not trust process-global spoofed gateway context."""
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "discord")
+    monkeypatch.setenv("HERMES_SESSION_USER_ID", "123456789012345678")
+
+    assert get_session_env("HERMES_SESSION_PLATFORM") == "discord"
+    assert get_session_env_strict("HERMES_SESSION_PLATFORM") == ""
+    assert get_session_env_strict("HERMES_SESSION_PLATFORM", "fallback") == "fallback"
+
+
+def test_get_session_env_strict_reads_contextvar_then_clear(monkeypatch):
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "discord")
+
+    tokens = set_session_vars(platform="discord", user_id="123456789012345678")
+    assert get_session_env_strict("HERMES_SESSION_PLATFORM") == "discord"
+    assert get_session_env_strict("HERMES_SESSION_USER_ID") == "123456789012345678"
+
+    clear_session_vars(tokens)
+    assert get_session_env_strict("HERMES_SESSION_PLATFORM") == ""
+    assert get_session_env_strict("HERMES_SESSION_USER_ID") == ""
 
 
 def test_set_session_env_handles_missing_optional_fields():

--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -63,6 +63,16 @@ def _valid_activation():
     )
 
 
+def _discord_message(message_id, content, author_id="424242424242424242", attachments=None, embeds=None):
+    return {
+        "id": message_id,
+        "content": content,
+        "author": {"id": author_id, "bot": True},
+        "attachments": attachments or [],
+        "embeds": embeds or [],
+        "timestamp": "2026-06-12T00:00:00Z",
+    }
+
 
 def _set_receipt_config(monkeypatch, *, enabled=True, server_actions=""):
     monkeypatch.setattr(
@@ -269,7 +279,12 @@ class TestSessionKickoffReceiptPrechecks:
     @patch("tools.discord_tool._discord_request")
     @pytest.mark.parametrize(
         "platform,user_id",
-        [("telegram", "123456789012345678"), ("discord", "not-a-snowflake"), ("", "")],
+        [
+            ("telegram", "123456789012345678"),
+            ("discord", "not-a-snowflake"),
+            ("discord", "１２３４５６７８９０１２３４５６７８"),
+            ("", ""),
+        ],
     )
     def test_unsupported_contextvar_sessions_fail_before_post(
         self, mock_req, monkeypatch, platform, user_id,
@@ -294,8 +309,13 @@ class TestSessionKickoffReceiptPrechecks:
         try:
             _assert_receipt_error(_receipt_call(post_intent="wrong"), "invalid_post_intent")
             _assert_receipt_error(_receipt_call(channel_id=" 151 "), "invalid_channel_id")
+            _assert_receipt_error(_receipt_call(channel_id="１２３"), "invalid_channel_id")
             _assert_receipt_error(
                 _receipt_call(expected_requester_user_id="abc"),
+                "invalid_expected_requester_user_id",
+            )
+            _assert_receipt_error(
+                _receipt_call(expected_requester_user_id="۱۲۳۴۵۶۷۸۹۰۱۲۳۴۵۶۷۸"),
                 "invalid_expected_requester_user_id",
             )
             _assert_receipt_error(
@@ -470,6 +490,243 @@ class TestSessionKickoffReceiptPositivePath:
             f"/channels/{channel_id}/messages/{message_id}"
             for message_id in result["message_ids"]
         ]
+
+
+class TestSessionKickoffReceiptNegativeHardening:
+    @patch("tools.discord_tool._discord_request")
+    def test_post_429_retries_then_passes(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        _set_receipt_config(monkeypatch)
+        sleeps = []
+        monkeypatch.setattr("tools.discord_tool.time.sleep", lambda seconds: sleeps.append(seconds))
+        channel_id = "1514919981337284668"
+        stored = {}
+        seen_rate_limit = {"value": False}
+
+        def fake_request(method, path, token, **kwargs):
+            if method == "POST" and not seen_rate_limit["value"]:
+                seen_rate_limit["value"] = True
+                raise DiscordAPIError(429, '{"retry_after": 0.25}')
+            if method == "POST":
+                body = kwargs["body"]
+                message_id = "900000000000000001"
+                stored[message_id] = _discord_message(message_id, body["content"])
+                return stored[message_id]
+            if method == "GET":
+                return stored[path.rsplit("/", 1)[-1]]
+            raise AssertionError(method)
+
+        mock_req.side_effect = fake_request
+        tokens = _discord_context()
+        try:
+            result = _receipt_call(channel_id=channel_id)
+        finally:
+            _clear_context(tokens)
+
+        assert result["status"] == "receipt_pass"
+        assert sleeps == [0.25]
+
+    @patch("tools.discord_tool._discord_request")
+    def test_post_429_retry_budget_exhaustion_fails_without_success(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        _set_receipt_config(monkeypatch)
+        sleeps = []
+        monkeypatch.setattr("tools.discord_tool.time.sleep", lambda seconds: sleeps.append(seconds))
+        mock_req.side_effect = DiscordAPIError(429, '{"retry_after": 9}')
+        tokens = _discord_context()
+        try:
+            result = _receipt_call()
+        finally:
+            _clear_context(tokens)
+
+        _assert_receipt_error(result, "post_rate_limited", status="post_failed")
+        assert result["message_ids"] == []
+        assert sleeps == [2.0, 2.0, 2.0, 2.0]
+        assert mock_req.call_count == 5
+
+    @patch("tools.discord_tool._discord_request")
+    def test_post_429_zero_retry_after_is_attempt_bounded(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        _set_receipt_config(monkeypatch)
+        sleeps = []
+        monkeypatch.setattr("tools.discord_tool.time.sleep", lambda seconds: sleeps.append(seconds))
+        mock_req.side_effect = DiscordAPIError(429, '{"retry_after": 0}')
+        tokens = _discord_context()
+        try:
+            result = _receipt_call()
+        finally:
+            _clear_context(tokens)
+
+        _assert_receipt_error(result, "post_rate_limited", status="post_failed")
+        assert result["message_ids"] == []
+        assert sleeps == []
+        assert mock_req.call_count == 5
+
+    @patch("tools.discord_tool._discord_request")
+    def test_partial_post_sanitizes_discord_error_body(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "secret-token")
+        _set_receipt_config(monkeypatch)
+        channel_id = "1514919981337284668"
+        stored = {}
+        long_body = (
+            '{"message":"boom ?token=abc123 secret-token /home/a01/.hermes/secret"}'
+            + ("x" * 1200)
+        )
+
+        def fake_request(method, path, token, **kwargs):
+            if method == "POST" and not stored:
+                body = kwargs["body"]
+                message_id = "900000000000000001"
+                stored[message_id] = _discord_message(message_id, body["content"])
+                return stored[message_id]
+            if method == "POST":
+                raise DiscordAPIError(500, long_body)
+            raise AssertionError("GET should not run after partial POST")
+
+        mock_req.side_effect = fake_request
+        tokens = _discord_context()
+        try:
+            result = _receipt_call(channel_id=channel_id, activation_content=_valid_activation())
+        finally:
+            _clear_context(tokens)
+
+        _assert_receipt_error(result, "partial_post", status="partial_post")
+        assert result["message_ids"] == ["900000000000000001"]
+        body = result["errors"][0]["body"]
+        assert len(body) <= 1000
+        assert "secret-token" not in body
+        assert "abc123" not in body
+        assert "/home/a01" not in body
+
+    @patch("tools.discord_tool._discord_request")
+    def test_fetch_retry_exhaustion_returns_fetch_failed(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        _set_receipt_config(monkeypatch)
+        sleeps = []
+        monkeypatch.setattr("tools.discord_tool.time.sleep", lambda seconds: sleeps.append(seconds))
+
+        def fake_request(method, path, token, **kwargs):
+            if method == "POST":
+                return _discord_message("900000000000000001", kwargs["body"]["content"])
+            if method == "GET":
+                raise DiscordAPIError(404, '{"message":"unknown message"}')
+            raise AssertionError(method)
+
+        mock_req.side_effect = fake_request
+        tokens = _discord_context()
+        try:
+            result = _receipt_call(max_fetch_attempts=2, fetch_delay_seconds=0.1)
+        finally:
+            _clear_context(tokens)
+
+        _assert_receipt_error(result, "message_fetch_failed", status="fetch_failed")
+        assert sleeps == [0.1]
+
+    @patch("tools.discord_tool._discord_request")
+    @pytest.mark.parametrize(
+        "mutation,error_code",
+        [
+            ("content", "content_mismatch"),
+            ("id", "content_mismatch"),
+            ("author", "author_mismatch"),
+            ("attachment", "unexpected_attachment_in_text_only_mvp"),
+            ("embed", "unexpected_embed_in_text_only_mvp"),
+            ("ping", "forbidden_mass_or_role_ping"),
+        ],
+    )
+    def test_fetched_validation_failures_never_receipt_pass(self, mock_req, monkeypatch, mutation, error_code):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        _set_receipt_config(monkeypatch)
+        stored = {}
+
+        def fake_request(method, path, token, **kwargs):
+            if method == "POST":
+                body = kwargs["body"]
+                message_id = "900000000000000001"
+                stored[message_id] = _discord_message(message_id, body["content"])
+                return stored[message_id]
+            if method == "GET":
+                message_id = path.rsplit("/", 1)[-1]
+                message = dict(stored[message_id])
+                message["author"] = dict(message["author"])
+                if mutation == "content":
+                    message["content"] += " altered"
+                elif mutation == "id":
+                    message["id"] = "900000000000000999"
+                elif mutation == "author":
+                    message["author"]["id"] = "111111111111111111"
+                elif mutation == "attachment":
+                    message["attachments"] = [{"filename": "x.txt", "size": 1}]
+                elif mutation == "embed":
+                    message["embeds"] = [{"type": "rich", "secret": "not returned"}]
+                elif mutation == "ping":
+                    message["content"] += " @everyone"
+                return message
+            raise AssertionError(method)
+
+        mock_req.side_effect = fake_request
+        tokens = _discord_context()
+        try:
+            result = _receipt_call()
+        finally:
+            _clear_context(tokens)
+
+        _assert_receipt_error(result, error_code, status="validation_failed")
+
+    @patch("tools.discord_tool._discord_request")
+    @pytest.mark.parametrize(
+        "drift,status,error_code",
+        [
+            ("dropped_middle", "fetch_failed", "message_fetch_failed"),
+            ("reordered", "validation_failed", "content_mismatch"),
+            ("extra_id", "validation_failed", "content_mismatch"),
+            ("fewer_ids", "validation_failed", "content_mismatch"),
+        ],
+    )
+    def test_multi_chunk_drift_never_receipt_pass(
+        self, mock_req, monkeypatch, drift, status, error_code,
+    ):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        _set_receipt_config(monkeypatch)
+        monkeypatch.setattr("tools.discord_tool._DISCORD_MESSAGE_LIMIT", 40)
+        seed = _valid_seed() + "\n" + ("chunk-body-" * 12)
+        stored = {}
+        order = []
+
+        def fake_request(method, path, token, **kwargs):
+            if method == "POST":
+                body = kwargs["body"]
+                message_id = str(900000000000000000 + len(order) + 1)
+                message = _discord_message(message_id, body["content"])
+                stored[message_id] = message
+                order.append(message_id)
+                return message
+            if method == "GET":
+                requested_id = path.rsplit("/", 1)[-1]
+                if len(order) < 3:
+                    raise AssertionError("test seed should produce at least three chunks")
+                if drift == "dropped_middle" and requested_id == order[1]:
+                    raise DiscordAPIError(404, '{"message":"unknown message"}')
+                if drift == "reordered":
+                    index = order.index(requested_id)
+                    return dict(stored[order[-index - 1]])
+                message = dict(stored[requested_id])
+                if drift == "extra_id" and requested_id == order[1]:
+                    message["id"] = "999999999999999999"
+                elif drift == "fewer_ids" and requested_id == order[1]:
+                    message["id"] = ""
+                return message
+            raise AssertionError(method)
+
+        mock_req.side_effect = fake_request
+        tokens = _discord_context()
+        try:
+            result = _receipt_call(seed_content=seed, max_fetch_attempts=1)
+        finally:
+            _clear_context(tokens)
+
+        assert len(order) >= 3
+        _assert_receipt_error(result, error_code, status=status)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -12,6 +12,8 @@ from tools.discord_tool import (
     _ACTIONS,
     _ADMIN_ACTIONS,
     _CORE_ACTIONS,
+    _SESSION_KICKOFF_RECEIPT_ACTION,
+    _SESSION_KICKOFF_RECEIPT_INTENT,
     _available_actions,
     _channel_type_name,
     _detect_capabilities,
@@ -41,6 +43,59 @@ def _mock_urlopen(response_data, status=200):
     mock_resp.__enter__ = MagicMock(return_value=mock_resp)
     mock_resp.__exit__ = MagicMock(return_value=False)
     return mock_resp
+
+
+def _valid_seed(user_id="123456789012345678"):
+    return (
+        f"<@{user_id}> Seed 1/1\n"
+        "PRE-START VERIFICATION GATE\n"
+        "Boundary: reply before mutation.\n"
+        "body"
+    )
+
+
+def _valid_activation():
+    return (
+        "Activation prompt template\n"
+        "Adoptable only by the user; user must adopt this prompt in their own message.\n"
+        "Instruction after adoption: Use the kickoff seed it references. Proceed only within those boundaries.\n"
+        "Forbidden actions: Class B actions without exact approval."
+    )
+
+
+
+def _set_receipt_config(monkeypatch, *, enabled=True, server_actions=""):
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"discord": {"session_kickoff_receipt_enabled": enabled, "server_actions": server_actions}},
+    )
+
+
+def _discord_context(user_id="123456789012345678"):
+    from gateway.session_context import set_session_vars
+    return set_session_vars(platform="discord", user_id=user_id)
+
+
+def _clear_context(tokens):
+    from gateway.session_context import clear_session_vars
+    clear_session_vars(tokens)
+
+
+def _receipt_call(**overrides):
+    kwargs = {
+        "action": _SESSION_KICKOFF_RECEIPT_ACTION,
+        "channel_id": "1514919981337284668",
+        "seed_content": _valid_seed(),
+        "post_intent": _SESSION_KICKOFF_RECEIPT_INTENT,
+    }
+    kwargs.update(overrides)
+    return json.loads(discord_core(**kwargs))
+
+
+def _assert_receipt_error(result, code, status="precheck_failed"):
+    assert result["status"] == status
+    assert result["receipt_pass"] is False
+    assert result["errors"][0]["code"] == code
 
 
 # ---------------------------------------------------------------------------
@@ -186,6 +241,235 @@ class TestDiscordServerValidation:
         assert "guild_id" in result["error"]
         assert "user_id" in result["error"]
         assert "role_id" in result["error"]
+
+
+class TestSessionKickoffReceiptPrechecks:
+    @patch("tools.discord_tool._discord_request")
+    def test_opt_in_disabled_fails_before_post(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        _set_receipt_config(monkeypatch, enabled=False)
+
+        result = _receipt_call()
+
+        _assert_receipt_error(result, "opt_in_disabled")
+        mock_req.assert_not_called()
+
+    @patch("tools.discord_tool._discord_request")
+    def test_spoofed_os_environ_does_not_satisfy_requester_trust(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "discord")
+        monkeypatch.setenv("HERMES_SESSION_USER_ID", "123456789012345678")
+        _set_receipt_config(monkeypatch)
+
+        result = _receipt_call()
+
+        _assert_receipt_error(result, "unsupported_session_context")
+        mock_req.assert_not_called()
+
+    @patch("tools.discord_tool._discord_request")
+    @pytest.mark.parametrize(
+        "platform,user_id",
+        [("telegram", "123456789012345678"), ("discord", "not-a-snowflake"), ("", "")],
+    )
+    def test_unsupported_contextvar_sessions_fail_before_post(
+        self, mock_req, monkeypatch, platform, user_id,
+    ):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        _set_receipt_config(monkeypatch)
+        from gateway.session_context import set_session_vars, clear_session_vars
+        tokens = set_session_vars(platform=platform, user_id=user_id)
+        try:
+            result = _receipt_call()
+        finally:
+            clear_session_vars(tokens)
+
+        _assert_receipt_error(result, "unsupported_session_context")
+        mock_req.assert_not_called()
+
+    @patch("tools.discord_tool._discord_request")
+    def test_invalid_intent_channel_and_expected_user_fail_before_post(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        _set_receipt_config(monkeypatch)
+        tokens = _discord_context()
+        try:
+            _assert_receipt_error(_receipt_call(post_intent="wrong"), "invalid_post_intent")
+            _assert_receipt_error(_receipt_call(channel_id=" 151 "), "invalid_channel_id")
+            _assert_receipt_error(
+                _receipt_call(expected_requester_user_id="abc"),
+                "invalid_expected_requester_user_id",
+            )
+            _assert_receipt_error(
+                _receipt_call(expected_requester_user_id="999999999999999999"),
+                "requester_user_id_mismatch",
+            )
+        finally:
+            _clear_context(tokens)
+        mock_req.assert_not_called()
+
+    @patch("tools.discord_tool._discord_request")
+    @pytest.mark.parametrize(
+        "seed",
+        ["", "\ufeff\u200b\n<@999999999999999999> wrong\nPRE-START VERIFICATION GATE\nBoundary: reply before mutation."],
+    )
+    def test_missing_or_wrong_first_line_mention_fails_before_post(self, mock_req, monkeypatch, seed):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        _set_receipt_config(monkeypatch)
+        tokens = _discord_context()
+        try:
+            result = _receipt_call(seed_content=seed)
+        finally:
+            _clear_context(tokens)
+
+        _assert_receipt_error(result, "missing_requester_mention_first_line")
+        mock_req.assert_not_called()
+
+    @patch("tools.discord_tool._discord_request")
+    @pytest.mark.parametrize(
+        "seed",
+        [
+            _valid_seed() + " @everyone",
+            _valid_seed() + " @here",
+            _valid_seed() + " <@&123456789012345678>",
+        ],
+    )
+    def test_forbidden_pings_fail_before_post(self, mock_req, monkeypatch, seed):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        _set_receipt_config(monkeypatch)
+        tokens = _discord_context()
+        try:
+            result = _receipt_call(seed_content=seed)
+        finally:
+            _clear_context(tokens)
+
+        _assert_receipt_error(result, "forbidden_mass_or_role_ping")
+        mock_req.assert_not_called()
+
+    @patch("tools.discord_tool._discord_request")
+    def test_missing_seed_or_activation_markers_fail_before_post(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        _set_receipt_config(monkeypatch)
+        tokens = _discord_context()
+        try:
+            missing_gate = "<@123456789012345678> hi\nBoundary: reply before mutation."
+            missing_boundary = "<@123456789012345678> hi\nPRE-START VERIFICATION GATE"
+            _assert_receipt_error(_receipt_call(seed_content=missing_gate), "missing_pre_start_gate")
+            _assert_receipt_error(_receipt_call(seed_content=missing_boundary), "missing_boundary_phrase")
+            _assert_receipt_error(
+                _receipt_call(activation_content="Activation prompt template"),
+                "missing_activation_marker",
+            )
+        finally:
+            _clear_context(tokens)
+        mock_req.assert_not_called()
+
+    @patch("tools.discord_tool._discord_request")
+    def test_retry_and_content_bounds_fail_before_post(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        _set_receipt_config(monkeypatch)
+        tokens = _discord_context()
+        try:
+            _assert_receipt_error(_receipt_call(max_fetch_attempts="3"), "invalid_max_fetch_attempts")
+            _assert_receipt_error(_receipt_call(max_fetch_attempts=0), "invalid_max_fetch_attempts")
+            _assert_receipt_error(_receipt_call(max_fetch_attempts=6), "invalid_max_fetch_attempts")
+            _assert_receipt_error(_receipt_call(fetch_delay_seconds="0.5"), "invalid_fetch_delay_seconds")
+            _assert_receipt_error(_receipt_call(fetch_delay_seconds=-0.1), "invalid_fetch_delay_seconds")
+            _assert_receipt_error(_receipt_call(max_fetch_attempts=5, fetch_delay_seconds=2.0), "invalid_fetch_delay_seconds")
+            too_large = _valid_seed() + ("x" * 20_001)
+            _assert_receipt_error(_receipt_call(seed_content=too_large), "content_too_large")
+            monkeypatch.setattr("tools.discord_tool._DISCORD_MESSAGE_LIMIT", 1)
+            _assert_receipt_error(_receipt_call(seed_content=_valid_seed()), "too_many_discord_chunks")
+        finally:
+            _clear_context(tokens)
+        mock_req.assert_not_called()
+
+    @patch("tools.discord_tool._discord_request")
+    def test_server_actions_allowlist_still_denies_runtime(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        _set_receipt_config(monkeypatch, enabled=True, server_actions="fetch_messages")
+        tokens = _discord_context()
+        try:
+            result = _receipt_call()
+        finally:
+            _clear_context(tokens)
+
+        assert "error" in result
+        assert "disabled by config" in result["error"]
+        mock_req.assert_not_called()
+
+
+class TestSessionKickoffReceiptPositivePath:
+    @patch("tools.discord_tool._discord_request")
+    def test_posts_text_chunks_and_fetches_exact_ids_for_receipt_pass(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        _set_receipt_config(monkeypatch)
+        channel_id = "1514919981337284668"
+        bot_author_id = "424242424242424242"
+        stored = {}
+
+        def fake_request(method, path, token, **kwargs):
+            assert token == "test-token"
+            if method == "POST":
+                assert path == f"/channels/{channel_id}/messages"
+                body = kwargs["body"]
+                message_id = str(900000000000000000 + len(stored) + 1)
+                message = {
+                    "id": message_id,
+                    "content": body["content"],
+                    "author": {"id": bot_author_id, "bot": True},
+                    "attachments": [],
+                    "embeds": [],
+                    "timestamp": "2026-06-12T00:00:00Z",
+                }
+                stored[message_id] = message
+                return message
+            if method == "GET":
+                prefix = f"/channels/{channel_id}/messages/"
+                assert path.startswith(prefix)
+                message_id = path.removeprefix(prefix)
+                return stored[message_id]
+            raise AssertionError(f"unexpected request {method} {path}")
+
+        mock_req.side_effect = fake_request
+        tokens = _discord_context()
+        try:
+            result = _receipt_call(
+                channel_id=channel_id,
+                activation_content=_valid_activation(),
+            )
+        finally:
+            _clear_context(tokens)
+
+        assert result["status"] == "receipt_pass"
+        assert result["receipt_pass"] is True
+        assert result["channel_id"] == channel_id
+        assert result["trusted_requester_user_id"] == "123456789012345678"
+        assert len(result["seed_message_ids"]) == 1
+        assert len(result["activation_message_ids"]) == 1
+        assert result["message_ids"] == result["seed_message_ids"] + result["activation_message_ids"]
+        assert result["evidence"]["first_seed_line"].startswith("<@123456789012345678>")
+        assert result["evidence"]["fetched_message_count"] == 2
+        assert result["evidence"]["expected_seed_chunk_count"] == 1
+        assert result["evidence"]["expected_activation_chunk_count"] == 1
+        assert result["evidence"]["bot_author_id"] == bot_author_id
+        assert result["evidence"]["embed_count"] == 0
+
+        post_calls = [call for call in mock_req.call_args_list if call.args[0] == "POST"]
+        get_calls = [call for call in mock_req.call_args_list if call.args[0] == "GET"]
+        assert len(post_calls) == 2
+        assert len(get_calls) == 2
+        for call in post_calls:
+            body = call.kwargs["body"]
+            assert body["flags"] == 4
+            assert body["allowed_mentions"] == {
+                "parse": [],
+                "users": ["123456789012345678"],
+                "roles": [],
+                "replied_user": False,
+            }
+        assert [call.args[1] for call in get_calls] == [
+            f"/channels/{channel_id}/messages/{message_id}"
+            for message_id in result["message_ids"]
+        ]
 
 
 # ---------------------------------------------------------------------------
@@ -565,7 +849,7 @@ class TestRegistration:
         from tools.registry import registry
         entry = registry._tools["discord_admin"]
         actions = set(entry.schema["parameters"]["properties"]["action"]["enum"])
-        expected_admin = set(_ACTIONS.keys()) - {"fetch_messages", "search_members", "create_thread"}
+        expected_admin = set(_ACTIONS.keys()) - set(_CORE_ACTIONS.keys())
         assert actions == expected_admin
 
     def test_all_actions_covered(self):
@@ -837,7 +1121,16 @@ class TestConfigAllowlist:
 class TestAvailableActions:
     def test_all_available_when_unrestricted(self):
         caps = {"detected": True, "has_members_intent": True, "has_message_content": True}
-        assert _available_actions(caps, None) == list(_ACTIONS.keys())
+        assert _available_actions(caps, None) == [
+            name for name in _ACTIONS if name != _SESSION_KICKOFF_RECEIPT_ACTION
+        ]
+
+    def test_receipt_action_requires_explicit_opt_in(self):
+        caps = {"detected": True, "has_members_intent": True, "has_message_content": True}
+        assert _SESSION_KICKOFF_RECEIPT_ACTION not in _available_actions(caps, None)
+        assert _SESSION_KICKOFF_RECEIPT_ACTION in _available_actions(
+            caps, None, receipt_enabled=True,
+        )
 
     def test_no_members_intent_hides_member_actions(self):
         caps = {"detected": True, "has_members_intent": False, "has_message_content": True}
@@ -902,8 +1195,24 @@ class TestDynamicSchema:
         mock_req.return_value = {"flags": (1 << 14) | (1 << 18)}
         schema = get_dynamic_schema_core()
         actions = set(schema["parameters"]["properties"]["action"]["enum"])
-        assert actions == set(_CORE_ACTIONS.keys())
+        assert actions == (set(_CORE_ACTIONS.keys()) - {_SESSION_KICKOFF_RECEIPT_ACTION})
         assert schema["name"] == "discord"
+
+    @patch("tools.discord_tool._discord_request")
+    def test_receipt_opt_in_adds_core_schema_action(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {"session_kickoff_receipt_enabled": True, "server_actions": ""}},
+        )
+        mock_req.return_value = {"flags": (1 << 14) | (1 << 18)}
+        schema = get_dynamic_schema_core()
+        assert schema is not None
+        actions = set(schema["parameters"]["properties"]["action"]["enum"])
+        assert _SESSION_KICKOFF_RECEIPT_ACTION in actions
+        props = schema["parameters"]["properties"]
+        assert props["post_intent"]["enum"] == [_SESSION_KICKOFF_RECEIPT_INTENT]
+        assert "seed_content" in props
 
     @patch("tools.discord_tool._discord_request")
     def test_full_intents_admin_schema(self, mock_req, monkeypatch):
@@ -1006,7 +1315,7 @@ class TestDynamicSchema:
         assert schema is not None
         assert schema["name"] == "discord"
         actions = set(schema["parameters"]["properties"]["action"]["enum"])
-        assert actions == set(_CORE_ACTIONS.keys())
+        assert actions == (set(_CORE_ACTIONS.keys()) - {_SESSION_KICKOFF_RECEIPT_ACTION})
 
 
 # ---------------------------------------------------------------------------

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -29,6 +29,7 @@ import json
 import logging
 import os
 import re
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -44,6 +45,7 @@ _SESSION_KICKOFF_RECEIPT_INTENT = "session_kickoff_receipt_v1"
 _DISCORD_MESSAGE_LIMIT = 2000
 _SESSION_KICKOFF_CONTENT_LIMIT = 20_000
 _SESSION_KICKOFF_CHUNK_LIMIT = 10
+_SESSION_KICKOFF_POST_429_ATTEMPT_LIMIT = 5
 _SUPPRESS_EMBEDS_FLAG = 4
 _BOUNDARY_PHRASES = (
     "Boundary: reply before mutation.",
@@ -107,8 +109,13 @@ def _session_kickoff_receipt_enabled() -> bool:
 
 
 def _is_discord_snowflake(value: Any) -> bool:
-    """Discord IDs used in REST paths must be simple decimal snowflake strings."""
-    return isinstance(value, str) and value.isdecimal() and 1 <= len(value) <= 20
+    """Discord IDs used in REST paths must be ASCII decimal snowflake strings."""
+    return (
+        isinstance(value, str)
+        and value.isascii()
+        and value.isdigit()
+        and 1 <= len(value) <= 20
+    )
 
 
 def _first_visible_line(text: str) -> str:
@@ -165,8 +172,10 @@ def _receipt_result(
     }
 
 
-def _receipt_error(code: str, message: str = "") -> Dict[str, str]:
-    return {"code": code, "message": message or code}
+def _receipt_error(code: str, message: str = "", **details: Any) -> Dict[str, Any]:
+    error = {"code": code, "message": message or code}
+    error.update(details)
+    return error
 
 
 def _receipt_json(status: str, code: str, **kwargs: Any) -> str:
@@ -216,13 +225,30 @@ def _post_receipt_message(
     channel_id: str,
     content: str,
     trusted_requester_user_id: str,
-) -> Dict[str, Any]:
+    retry_sleep_used: float,
+) -> Tuple[Dict[str, Any], float]:
     body = {
         "content": content,
         "flags": _SUPPRESS_EMBEDS_FLAG,
         "allowed_mentions": _receipt_allowed_mentions(trusted_requester_user_id),
     }
-    return _discord_request("POST", f"/channels/{channel_id}/messages", token, body=body)
+    rate_limit_attempts = 0
+    while True:
+        try:
+            return _discord_request("POST", f"/channels/{channel_id}/messages", token, body=body), retry_sleep_used
+        except DiscordAPIError as exc:
+            if exc.status != 429:
+                raise
+            rate_limit_attempts += 1
+            delay = _retry_after_seconds(exc)
+            if (
+                rate_limit_attempts >= _SESSION_KICKOFF_POST_429_ATTEMPT_LIMIT
+                or retry_sleep_used + delay > 8.0
+            ):
+                raise
+            if delay:
+                time.sleep(delay)
+            retry_sleep_used += delay
 
 
 def _fetch_receipt_message(token: str, channel_id: str, message_id: str) -> Dict[str, Any]:
@@ -246,6 +272,7 @@ def _receipt_failure(
     message_ids: Optional[List[str]] = None,
     seed_message_ids: Optional[List[str]] = None,
     activation_message_ids: Optional[List[str]] = None,
+    error: Optional[Dict[str, Any]] = None,
     evidence: Optional[Dict[str, Any]] = None,
 ) -> str:
     return json.dumps(_receipt_result(
@@ -255,7 +282,7 @@ def _receipt_failure(
         message_ids=message_ids,
         seed_message_ids=seed_message_ids,
         activation_message_ids=activation_message_ids,
-        errors=[_receipt_error(code)],
+        errors=[error or _receipt_error(code)],
         evidence=evidence,
     ))
 
@@ -299,15 +326,60 @@ def _discord_request(
             error_body = e.read().decode("utf-8", errors="replace")
         except Exception:
             pass
-        raise DiscordAPIError(e.code, error_body) from e
+        headers = dict(e.headers.items()) if e.headers else {}
+        raise DiscordAPIError(e.code, error_body, headers=headers) from e
 
 
 class DiscordAPIError(Exception):
     """Raised when a Discord API call fails."""
-    def __init__(self, status: int, body: str):
+    def __init__(self, status: int, body: str, headers: Optional[Dict[str, str]] = None):
         self.status = status
         self.body = body
+        self.headers = headers or {}
         super().__init__(f"Discord API error {status}: {body}")
+
+
+def _sanitize_discord_error_body(body: str) -> str:
+    value = str(body or "")
+    try:
+        from agent.redact import redact_sensitive_text
+        value = redact_sensitive_text(value, force=True)
+    except Exception:
+        pass
+    token = _get_bot_token()
+    if token:
+        value = value.replace(token, "<redacted>")
+    value = re.sub(
+        r"([?&](?:token|access_token|api_key|signature|sig)=)[^&\s]+",
+        r"\1<redacted>",
+        value,
+        flags=re.IGNORECASE,
+    )
+    value = re.sub(r"/home/[A-Za-z0-9._~+/@%-]+", "<local-path-redacted>", value)
+    return value[:1000]
+
+
+def _error_from_discord_exception(code: str, exc: DiscordAPIError) -> Dict[str, Any]:
+    return _receipt_error(
+        code,
+        http_status=exc.status,
+        body=_sanitize_discord_error_body(exc.body),
+    )
+
+
+def _retry_after_seconds(exc: DiscordAPIError) -> float:
+    retry_after: Any = None
+    try:
+        payload = json.loads(exc.body or "{}")
+        retry_after = payload.get("retry_after")
+    except Exception:
+        retry_after = None
+    if retry_after is None:
+        retry_after = (exc.headers or {}).get("Retry-After") or (exc.headers or {}).get("retry-after")
+    try:
+        return min(2.0, max(0.0, float(retry_after)))
+    except (TypeError, ValueError):
+        return 0.5
 
 
 # ---------------------------------------------------------------------------
@@ -745,7 +817,6 @@ def _post_session_kickoff_receipt(
             channel_id=channel_id, trusted_requester_user_id=requester_id,
             evidence={"first_seed_line": first_line},
         )
-    del attempts, delay
 
     expected_seed_chunks, seed_error = _split_discord_text(seed_content)
     if seed_error:
@@ -770,10 +841,13 @@ def _post_session_kickoff_receipt(
     activation_message_ids: List[str] = []
     message_ids: List[str] = []
     bot_author_id = ""
+    post_retry_sleep_used = 0.0
 
     try:
         for content in expected_seed_chunks:
-            posted = _post_receipt_message(token, channel_id, content, requester_id)
+            posted, post_retry_sleep_used = _post_receipt_message(
+                token, channel_id, content, requester_id, post_retry_sleep_used,
+            )
             posted_message_id = posted.get("id")
             message_id = posted_message_id if isinstance(posted_message_id, str) else ""
             author_id = _message_author_id(posted) if isinstance(posted, dict) else ""
@@ -791,7 +865,9 @@ def _post_session_kickoff_receipt(
             message_ids.append(message_id)
 
         for content in expected_activation_chunks:
-            posted = _post_receipt_message(token, channel_id, content, requester_id)
+            posted, post_retry_sleep_used = _post_receipt_message(
+                token, channel_id, content, requester_id, post_retry_sleep_used,
+            )
             posted_message_id = posted.get("id")
             message_id = posted_message_id if isinstance(posted_message_id, str) else ""
             author_id = _message_author_id(posted) if isinstance(posted, dict) else ""
@@ -805,34 +881,48 @@ def _post_session_kickoff_receipt(
                 )
             activation_message_ids.append(message_id)
             message_ids.append(message_id)
-    except DiscordAPIError:
+    except DiscordAPIError as exc:
         status = "partial_post" if message_ids else "post_failed"
-        code = "partial_post" if message_ids else "post_failed"
+        code = "post_rate_limited" if exc.status == 429 else ("partial_post" if message_ids else "sanitized_discord_error")
         return _receipt_failure(
             status, code,
             channel_id=channel_id, trusted_requester_user_id=requester_id,
             message_ids=message_ids, seed_message_ids=seed_message_ids,
             activation_message_ids=activation_message_ids,
+            error=_error_from_discord_exception(code, exc),
             evidence={"first_seed_line": first_line},
         )
 
     fetched_messages: List[Dict[str, Any]] = []
     try:
         for message_id in message_ids:
-            fetched = _fetch_receipt_message(token, channel_id, message_id)
-            if not isinstance(fetched, dict):
-                raise DiscordAPIError(0, "non-object Discord message response")
-            fetched_messages.append(fetched)
-    except DiscordAPIError:
+            last_fetch_error: Optional[DiscordAPIError] = None
+            for attempt_index in range(attempts or 1):
+                try:
+                    fetched = _fetch_receipt_message(token, channel_id, message_id)
+                    if not isinstance(fetched, dict):
+                        raise DiscordAPIError(0, "non-object Discord message response")
+                    fetched_messages.append(fetched)
+                    last_fetch_error = None
+                    break
+                except DiscordAPIError as exc:
+                    last_fetch_error = exc
+                    if attempt_index < (attempts or 1) - 1 and delay:
+                        time.sleep(delay)
+            if last_fetch_error is not None:
+                raise last_fetch_error
+    except DiscordAPIError as exc:
         return _receipt_failure(
             "fetch_failed", "message_fetch_failed",
             channel_id=channel_id, trusted_requester_user_id=requester_id,
             message_ids=message_ids, seed_message_ids=seed_message_ids,
             activation_message_ids=activation_message_ids,
+            error=_error_from_discord_exception("message_fetch_failed", exc),
             evidence={"first_seed_line": first_line},
         )
 
     expected_chunks = expected_seed_chunks + expected_activation_chunks
+    fetched_ids = [msg.get("id") if isinstance(msg.get("id"), str) else "" for msg in fetched_messages]
     fetched_contents = [str(msg.get("content", "")) for msg in fetched_messages]
     fetched_seed_content = "".join(fetched_contents[:len(expected_seed_chunks)])
     fetched_activation_content = "".join(fetched_contents[len(expected_seed_chunks):])
@@ -846,7 +936,15 @@ def _post_session_kickoff_receipt(
         "embed_count": sum(len(msg.get("embeds") or []) for msg in fetched_messages),
     }
 
-    if fetched_contents != expected_chunks:
+    if _has_forbidden_ping(fetched_seed_content) or _has_forbidden_ping(fetched_activation_content):
+        return _receipt_failure(
+            "validation_failed", "forbidden_mass_or_role_ping",
+            channel_id=channel_id, trusted_requester_user_id=requester_id,
+            message_ids=message_ids, seed_message_ids=seed_message_ids,
+            activation_message_ids=activation_message_ids,
+            evidence=evidence,
+        )
+    if fetched_ids != message_ids or fetched_contents != expected_chunks:
         return _receipt_failure(
             "validation_failed", "content_mismatch",
             channel_id=channel_id, trusted_requester_user_id=requester_id,
@@ -873,14 +971,6 @@ def _post_session_kickoff_receipt(
     if not any(phrase in fetched_seed_content for phrase in _BOUNDARY_PHRASES):
         return _receipt_failure(
             "validation_failed", "missing_boundary_phrase",
-            channel_id=channel_id, trusted_requester_user_id=requester_id,
-            message_ids=message_ids, seed_message_ids=seed_message_ids,
-            activation_message_ids=activation_message_ids,
-            evidence=evidence,
-        )
-    if _has_forbidden_ping(fetched_seed_content) or _has_forbidden_ping(fetched_activation_content):
-        return _receipt_failure(
-            "validation_failed", "forbidden_mass_or_role_ping",
             channel_id=channel_id, trusted_requester_user_id=requester_id,
             message_ids=message_ids, seed_message_ids=seed_message_ids,
             activation_message_ids=activation_message_ids,

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -28,6 +28,7 @@ actionable guidance the model can relay to the user.
 import json
 import logging
 import os
+import re
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -38,6 +39,31 @@ from tools.registry import registry
 logger = logging.getLogger(__name__)
 
 DISCORD_API_BASE = "https://discord.com/api/v10"
+_SESSION_KICKOFF_RECEIPT_ACTION = "post_session_kickoff_receipt_v1"
+_SESSION_KICKOFF_RECEIPT_INTENT = "session_kickoff_receipt_v1"
+_DISCORD_MESSAGE_LIMIT = 2000
+_SESSION_KICKOFF_CONTENT_LIMIT = 20_000
+_SESSION_KICKOFF_CHUNK_LIMIT = 10
+_SUPPRESS_EMBEDS_FLAG = 4
+_BOUNDARY_PHRASES = (
+    "Boundary: reply before mutation.",
+    "Boundary: reply in this thread before mutation.",
+    "awaiting explicit mutation approval",
+)
+_ACTIVATION_MARKERS = (
+    "Activation prompt template",
+    "Adoptable only by the user; user must adopt this prompt in their own message.",
+    "Instruction after adoption: Use the kickoff seed it references. Proceed only within those boundaries.",
+    "Class B actions without exact approval",
+)
+_INVISIBLE_LINE_CHARS = {
+    ord("\ufeff"): None,
+    ord("\u200b"): None,
+    ord("\u200c"): None,
+    ord("\u200d"): None,
+    ord("\u2060"): None,
+}
+_ROLE_PING_RE = re.compile(r"<@&\d{1,20}>")
 
 # Application flag bits (from GET /applications/@me → "flags").
 # Source: https://discord.com/developers/docs/resources/application#application-object-application-flags
@@ -53,6 +79,185 @@ _FLAG_GATEWAY_MESSAGE_CONTENT_LIMITED = 1 << 19
 def _get_bot_token() -> Optional[str]:
     """Resolve the Discord bot token from environment."""
     return os.getenv("DISCORD_BOT_TOKEN", "").strip() or None
+
+
+def _load_discord_config() -> Dict[str, Any]:
+    """Load the ``discord`` config block, returning an empty dict on failure."""
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+    except Exception as exc:
+        logger.debug("discord: could not load config (%s); using defaults.", exc)
+        return {}
+    raw = cfg.get("discord") if isinstance(cfg, dict) else None
+    return raw if isinstance(raw, dict) else {}
+
+
+def _as_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _session_kickoff_receipt_enabled() -> bool:
+    """Return whether the opt-in receipt action should be exposed/run."""
+    return _as_bool(_load_discord_config().get("session_kickoff_receipt_enabled", False))
+
+
+def _is_discord_snowflake(value: Any) -> bool:
+    """Discord IDs used in REST paths must be simple decimal snowflake strings."""
+    return isinstance(value, str) and value.isdecimal() and 1 <= len(value) <= 20
+
+
+def _first_visible_line(text: str) -> str:
+    """Return the first non-blank visible line after minimal Discord normalization."""
+    for line in str(text).splitlines():
+        normalized = line.translate(_INVISIBLE_LINE_CHARS)
+        if normalized.strip():
+            return normalized.lstrip()
+    return ""
+
+
+def _has_forbidden_ping(text: str) -> bool:
+    value = str(text)
+    return "@everyone" in value or "@here" in value or bool(_ROLE_PING_RE.search(value))
+
+
+def _split_discord_text(text: str) -> Tuple[Optional[List[str]], Optional[str]]:
+    """Split text into deterministic Discord message chunks or return an error code."""
+    value = str(text)
+    if len(value) > _SESSION_KICKOFF_CONTENT_LIMIT:
+        return None, "content_too_large"
+    chunks = [
+        value[index:index + _DISCORD_MESSAGE_LIMIT]
+        for index in range(0, len(value), _DISCORD_MESSAGE_LIMIT)
+    ] or [""]
+    if len(chunks) > _SESSION_KICKOFF_CHUNK_LIMIT:
+        return None, "too_many_discord_chunks"
+    return chunks, None
+
+
+def _receipt_result(
+    status: str,
+    *,
+    channel_id: str = "",
+    trusted_requester_user_id: str = "",
+    message_ids: Optional[List[str]] = None,
+    seed_message_ids: Optional[List[str]] = None,
+    activation_message_ids: Optional[List[str]] = None,
+    errors: Optional[List[Dict[str, Any]]] = None,
+    warnings: Optional[List[str]] = None,
+    evidence: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    return {
+        "status": status,
+        "receipt_pass": status == "receipt_pass",
+        "channel_id": channel_id,
+        "trusted_requester_user_id": trusted_requester_user_id,
+        "message_ids": message_ids or [],
+        "seed_message_ids": seed_message_ids or [],
+        "activation_message_ids": activation_message_ids or [],
+        "errors": errors or [],
+        "warnings": warnings or [],
+        "evidence": evidence or {},
+    }
+
+
+def _receipt_error(code: str, message: str = "") -> Dict[str, str]:
+    return {"code": code, "message": message or code}
+
+
+def _receipt_json(status: str, code: str, **kwargs: Any) -> str:
+    return json.dumps(_receipt_result(status, errors=[_receipt_error(code)], **kwargs))
+
+
+def _parse_receipt_fetch_options(
+    max_fetch_attempts: Any,
+    fetch_delay_seconds: Any,
+) -> Tuple[Optional[int], Optional[float], Optional[str]]:
+    if not isinstance(max_fetch_attempts, int) or isinstance(max_fetch_attempts, bool):
+        return None, None, "invalid_max_fetch_attempts"
+    if max_fetch_attempts < 1 or max_fetch_attempts > 5:
+        return None, None, "invalid_max_fetch_attempts"
+    if not isinstance(fetch_delay_seconds, (int, float)) or isinstance(fetch_delay_seconds, bool):
+        return None, None, "invalid_fetch_delay_seconds"
+    delay = float(fetch_delay_seconds)
+    if delay < 0 or delay > 2.0 or (max_fetch_attempts - 1) * delay >= 8.0:
+        return None, None, "invalid_fetch_delay_seconds"
+    return max_fetch_attempts, delay, None
+
+
+def _trusted_discord_requester_id() -> Optional[str]:
+    try:
+        from gateway.session_context import get_session_env_strict
+    except Exception:
+        return None
+    if get_session_env_strict("HERMES_SESSION_PLATFORM") != "discord":
+        return None
+    user_id = get_session_env_strict("HERMES_SESSION_USER_ID")
+    if not _is_discord_snowflake(user_id):
+        return None
+    return user_id
+
+
+def _receipt_allowed_mentions(trusted_requester_user_id: str) -> Dict[str, Any]:
+    return {
+        "parse": [],
+        "users": [trusted_requester_user_id],
+        "roles": [],
+        "replied_user": False,
+    }
+
+
+def _post_receipt_message(
+    token: str,
+    channel_id: str,
+    content: str,
+    trusted_requester_user_id: str,
+) -> Dict[str, Any]:
+    body = {
+        "content": content,
+        "flags": _SUPPRESS_EMBEDS_FLAG,
+        "allowed_mentions": _receipt_allowed_mentions(trusted_requester_user_id),
+    }
+    return _discord_request("POST", f"/channels/{channel_id}/messages", token, body=body)
+
+
+def _fetch_receipt_message(token: str, channel_id: str, message_id: str) -> Dict[str, Any]:
+    return _discord_request("GET", f"/channels/{channel_id}/messages/{message_id}", token)
+
+
+def _message_author_id(message: Dict[str, Any]) -> str:
+    author = message.get("author") if isinstance(message, dict) else None
+    if isinstance(author, dict):
+        value = author.get("id")
+        return value if isinstance(value, str) else ""
+    return ""
+
+
+def _receipt_failure(
+    status: str,
+    code: str,
+    *,
+    channel_id: str,
+    trusted_requester_user_id: str,
+    message_ids: Optional[List[str]] = None,
+    seed_message_ids: Optional[List[str]] = None,
+    activation_message_ids: Optional[List[str]] = None,
+    evidence: Optional[Dict[str, Any]] = None,
+) -> str:
+    return json.dumps(_receipt_result(
+        status,
+        channel_id=channel_id,
+        trusted_requester_user_id=trusted_requester_user_id,
+        message_ids=message_ids,
+        seed_message_ids=seed_message_ids,
+        activation_message_ids=activation_message_ids,
+        errors=[_receipt_error(code)],
+        evidence=evidence,
+    ))
 
 
 def _discord_request(
@@ -454,6 +659,278 @@ def _create_thread(
     })
 
 
+def _post_session_kickoff_receipt(
+    token: str,
+    channel_id: str = "",
+    seed_content: str = "",
+    post_intent: str = "",
+    expected_requester_user_id: str = "",
+    activation_content: str = "",
+    max_fetch_attempts: int = 3,
+    fetch_delay_seconds: float = 0.5,
+    **_kwargs: Any,
+) -> str:
+    """Opt-in Discord session-kickoff receipt action."""
+    if not _session_kickoff_receipt_enabled():
+        return _receipt_json("precheck_failed", "opt_in_disabled", channel_id=channel_id)
+
+    requester_id = _trusted_discord_requester_id()
+    if requester_id is None:
+        return _receipt_json("precheck_failed", "unsupported_session_context", channel_id=channel_id)
+
+    if post_intent != _SESSION_KICKOFF_RECEIPT_INTENT:
+        return _receipt_json(
+            "precheck_failed", "invalid_post_intent",
+            channel_id=channel_id, trusted_requester_user_id=requester_id,
+        )
+
+    if not _is_discord_snowflake(channel_id):
+        return _receipt_json(
+            "precheck_failed", "invalid_channel_id",
+            channel_id=channel_id, trusted_requester_user_id=requester_id,
+        )
+
+    if expected_requester_user_id:
+        if not _is_discord_snowflake(expected_requester_user_id):
+            return _receipt_json(
+                "precheck_failed", "invalid_expected_requester_user_id",
+                channel_id=channel_id, trusted_requester_user_id=requester_id,
+            )
+        if expected_requester_user_id != requester_id:
+            return _receipt_json(
+                "precheck_failed", "requester_user_id_mismatch",
+                channel_id=channel_id, trusted_requester_user_id=requester_id,
+            )
+
+    first_line = _first_visible_line(seed_content)
+    if not first_line.startswith(f"<@{requester_id}>"):
+        return _receipt_json(
+            "precheck_failed", "missing_requester_mention_first_line",
+            channel_id=channel_id, trusted_requester_user_id=requester_id,
+            evidence={"first_seed_line": first_line},
+        )
+
+    if _has_forbidden_ping(seed_content) or _has_forbidden_ping(activation_content):
+        return _receipt_json(
+            "precheck_failed", "forbidden_mass_or_role_ping",
+            channel_id=channel_id, trusted_requester_user_id=requester_id,
+            evidence={"first_seed_line": first_line},
+        )
+
+    if "PRE-START VERIFICATION GATE" not in seed_content:
+        return _receipt_json(
+            "precheck_failed", "missing_pre_start_gate",
+            channel_id=channel_id, trusted_requester_user_id=requester_id,
+            evidence={"first_seed_line": first_line},
+        )
+
+    if not any(phrase in seed_content for phrase in _BOUNDARY_PHRASES):
+        return _receipt_json(
+            "precheck_failed", "missing_boundary_phrase",
+            channel_id=channel_id, trusted_requester_user_id=requester_id,
+            evidence={"first_seed_line": first_line},
+        )
+
+    if activation_content and any(marker not in activation_content for marker in _ACTIVATION_MARKERS):
+        return _receipt_json(
+            "precheck_failed", "missing_activation_marker",
+            channel_id=channel_id, trusted_requester_user_id=requester_id,
+            evidence={"first_seed_line": first_line},
+        )
+
+    attempts, delay, option_error = _parse_receipt_fetch_options(max_fetch_attempts, fetch_delay_seconds)
+    if option_error:
+        return _receipt_json(
+            "precheck_failed", option_error,
+            channel_id=channel_id, trusted_requester_user_id=requester_id,
+            evidence={"first_seed_line": first_line},
+        )
+    del attempts, delay
+
+    expected_seed_chunks, seed_error = _split_discord_text(seed_content)
+    if seed_error:
+        return _receipt_json(
+            "precheck_failed", seed_error,
+            channel_id=channel_id, trusted_requester_user_id=requester_id,
+            evidence={"first_seed_line": first_line},
+        )
+    expected_activation_chunks: List[str] = []
+    if activation_content:
+        activation_chunks, activation_error = _split_discord_text(activation_content)
+        if activation_error:
+            return _receipt_json(
+                "precheck_failed", activation_error,
+                channel_id=channel_id, trusted_requester_user_id=requester_id,
+                evidence={"first_seed_line": first_line},
+            )
+        expected_activation_chunks = activation_chunks or []
+
+    expected_seed_chunks = expected_seed_chunks or []
+    seed_message_ids: List[str] = []
+    activation_message_ids: List[str] = []
+    message_ids: List[str] = []
+    bot_author_id = ""
+
+    try:
+        for content in expected_seed_chunks:
+            posted = _post_receipt_message(token, channel_id, content, requester_id)
+            posted_message_id = posted.get("id")
+            message_id = posted_message_id if isinstance(posted_message_id, str) else ""
+            author_id = _message_author_id(posted) if isinstance(posted, dict) else ""
+            if not _is_discord_snowflake(message_id) or not _is_discord_snowflake(author_id):
+                return _receipt_failure(
+                    "post_failed", "post_failed",
+                    channel_id=channel_id, trusted_requester_user_id=requester_id,
+                    message_ids=message_ids, seed_message_ids=seed_message_ids,
+                    activation_message_ids=activation_message_ids,
+                    evidence={"first_seed_line": first_line},
+                )
+            if not bot_author_id:
+                bot_author_id = author_id
+            seed_message_ids.append(message_id)
+            message_ids.append(message_id)
+
+        for content in expected_activation_chunks:
+            posted = _post_receipt_message(token, channel_id, content, requester_id)
+            posted_message_id = posted.get("id")
+            message_id = posted_message_id if isinstance(posted_message_id, str) else ""
+            author_id = _message_author_id(posted) if isinstance(posted, dict) else ""
+            if not _is_discord_snowflake(message_id) or not _is_discord_snowflake(author_id):
+                return _receipt_failure(
+                    "partial_post", "partial_post",
+                    channel_id=channel_id, trusted_requester_user_id=requester_id,
+                    message_ids=message_ids, seed_message_ids=seed_message_ids,
+                    activation_message_ids=activation_message_ids,
+                    evidence={"first_seed_line": first_line},
+                )
+            activation_message_ids.append(message_id)
+            message_ids.append(message_id)
+    except DiscordAPIError:
+        status = "partial_post" if message_ids else "post_failed"
+        code = "partial_post" if message_ids else "post_failed"
+        return _receipt_failure(
+            status, code,
+            channel_id=channel_id, trusted_requester_user_id=requester_id,
+            message_ids=message_ids, seed_message_ids=seed_message_ids,
+            activation_message_ids=activation_message_ids,
+            evidence={"first_seed_line": first_line},
+        )
+
+    fetched_messages: List[Dict[str, Any]] = []
+    try:
+        for message_id in message_ids:
+            fetched = _fetch_receipt_message(token, channel_id, message_id)
+            if not isinstance(fetched, dict):
+                raise DiscordAPIError(0, "non-object Discord message response")
+            fetched_messages.append(fetched)
+    except DiscordAPIError:
+        return _receipt_failure(
+            "fetch_failed", "message_fetch_failed",
+            channel_id=channel_id, trusted_requester_user_id=requester_id,
+            message_ids=message_ids, seed_message_ids=seed_message_ids,
+            activation_message_ids=activation_message_ids,
+            evidence={"first_seed_line": first_line},
+        )
+
+    expected_chunks = expected_seed_chunks + expected_activation_chunks
+    fetched_contents = [str(msg.get("content", "")) for msg in fetched_messages]
+    fetched_seed_content = "".join(fetched_contents[:len(expected_seed_chunks)])
+    fetched_activation_content = "".join(fetched_contents[len(expected_seed_chunks):])
+    fetched_first_line = _first_visible_line(fetched_seed_content)
+    evidence = {
+        "first_seed_line": fetched_first_line,
+        "fetched_message_count": len(fetched_messages),
+        "expected_seed_chunk_count": len(expected_seed_chunks),
+        "expected_activation_chunk_count": len(expected_activation_chunks),
+        "bot_author_id": bot_author_id,
+        "embed_count": sum(len(msg.get("embeds") or []) for msg in fetched_messages),
+    }
+
+    if fetched_contents != expected_chunks:
+        return _receipt_failure(
+            "validation_failed", "content_mismatch",
+            channel_id=channel_id, trusted_requester_user_id=requester_id,
+            message_ids=message_ids, seed_message_ids=seed_message_ids,
+            activation_message_ids=activation_message_ids,
+            evidence=evidence,
+        )
+    if not fetched_first_line.startswith(f"<@{requester_id}>"):
+        return _receipt_failure(
+            "validation_failed", "missing_requester_mention_first_line",
+            channel_id=channel_id, trusted_requester_user_id=requester_id,
+            message_ids=message_ids, seed_message_ids=seed_message_ids,
+            activation_message_ids=activation_message_ids,
+            evidence=evidence,
+        )
+    if "PRE-START VERIFICATION GATE" not in fetched_seed_content:
+        return _receipt_failure(
+            "validation_failed", "missing_pre_start_gate",
+            channel_id=channel_id, trusted_requester_user_id=requester_id,
+            message_ids=message_ids, seed_message_ids=seed_message_ids,
+            activation_message_ids=activation_message_ids,
+            evidence=evidence,
+        )
+    if not any(phrase in fetched_seed_content for phrase in _BOUNDARY_PHRASES):
+        return _receipt_failure(
+            "validation_failed", "missing_boundary_phrase",
+            channel_id=channel_id, trusted_requester_user_id=requester_id,
+            message_ids=message_ids, seed_message_ids=seed_message_ids,
+            activation_message_ids=activation_message_ids,
+            evidence=evidence,
+        )
+    if _has_forbidden_ping(fetched_seed_content) or _has_forbidden_ping(fetched_activation_content):
+        return _receipt_failure(
+            "validation_failed", "forbidden_mass_or_role_ping",
+            channel_id=channel_id, trusted_requester_user_id=requester_id,
+            message_ids=message_ids, seed_message_ids=seed_message_ids,
+            activation_message_ids=activation_message_ids,
+            evidence=evidence,
+        )
+    if expected_activation_chunks and any(marker not in fetched_activation_content for marker in _ACTIVATION_MARKERS):
+        return _receipt_failure(
+            "validation_failed", "missing_activation_marker",
+            channel_id=channel_id, trusted_requester_user_id=requester_id,
+            message_ids=message_ids, seed_message_ids=seed_message_ids,
+            activation_message_ids=activation_message_ids,
+            evidence=evidence,
+        )
+    for msg in fetched_messages:
+        if _message_author_id(msg) != bot_author_id:
+            return _receipt_failure(
+                "validation_failed", "author_mismatch",
+                channel_id=channel_id, trusted_requester_user_id=requester_id,
+                message_ids=message_ids, seed_message_ids=seed_message_ids,
+                activation_message_ids=activation_message_ids,
+                evidence=evidence,
+            )
+        if msg.get("attachments"):
+            return _receipt_failure(
+                "validation_failed", "unexpected_attachment_in_text_only_mvp",
+                channel_id=channel_id, trusted_requester_user_id=requester_id,
+                message_ids=message_ids, seed_message_ids=seed_message_ids,
+                activation_message_ids=activation_message_ids,
+                evidence=evidence,
+            )
+        if msg.get("embeds"):
+            return _receipt_failure(
+                "validation_failed", "unexpected_embed_in_text_only_mvp",
+                channel_id=channel_id, trusted_requester_user_id=requester_id,
+                message_ids=message_ids, seed_message_ids=seed_message_ids,
+                activation_message_ids=activation_message_ids,
+                evidence=evidence,
+            )
+
+    return json.dumps(_receipt_result(
+        "receipt_pass",
+        channel_id=channel_id,
+        trusted_requester_user_id=requester_id,
+        message_ids=message_ids,
+        seed_message_ids=seed_message_ids,
+        activation_message_ids=activation_message_ids,
+        evidence=evidence,
+    ))
+
+
 def _add_role(token: str, guild_id: str, user_id: str, role_id: str, **_kwargs: Any) -> str:
     """Add a role to a guild member."""
     _discord_request("PUT", f"/guilds/{guild_id}/members/{user_id}/roles/{role_id}", token)
@@ -479,6 +956,7 @@ _ACTIONS = {
     "member_info": _member_info,
     "search_members": _search_members,
     "fetch_messages": _fetch_messages,
+    _SESSION_KICKOFF_RECEIPT_ACTION: _post_session_kickoff_receipt,
     "list_pins": _list_pins,
     "pin_message": _pin_message,
     "unpin_message": _unpin_message,
@@ -488,7 +966,9 @@ _ACTIONS = {
     "remove_role": _remove_role,
 }
 
-_CORE_ACTION_NAMES = frozenset({"fetch_messages", "search_members", "create_thread"})
+_CORE_ACTION_NAMES = frozenset({
+    "fetch_messages", "search_members", "create_thread", _SESSION_KICKOFF_RECEIPT_ACTION,
+})
 _ADMIN_ACTION_NAMES = frozenset(_ACTIONS.keys()) - _CORE_ACTION_NAMES
 
 _CORE_ACTIONS = {k: v for k, v in _ACTIONS.items() if k in _CORE_ACTION_NAMES}
@@ -506,6 +986,11 @@ _ACTION_MANIFEST: List[Tuple[str, str, str]] = [
     ("member_info", "(guild_id, user_id)", "lookup a specific member"),
     ("search_members", "(guild_id, query)", "find members by name prefix"),
     ("fetch_messages", "(channel_id)", "recent messages; optional before/after snowflakes"),
+    (
+        _SESSION_KICKOFF_RECEIPT_ACTION,
+        "(channel_id, seed_content, post_intent)",
+        "post text-only session kickoff seed, fetch exact posted IDs, and validate receipt",
+    ),
     ("list_pins", "(channel_id)", "pinned messages in a channel"),
     ("pin_message", "(channel_id, message_id)", "pin a message"),
     ("unpin_message", "(channel_id, message_id)", "unpin a message"),
@@ -585,6 +1070,8 @@ def _load_allowed_actions_config() -> Optional[List[str]]:
 def _available_actions(
     caps: Dict[str, Any],
     allowlist: Optional[List[str]],
+    *,
+    receipt_enabled: bool = False,
 ) -> List[str]:
     """Compute the visible action list from intents + config allowlist.
 
@@ -592,6 +1079,8 @@ def _available_actions(
     """
     actions: List[str] = []
     for name in _ACTIONS:
+        if name == _SESSION_KICKOFF_RECEIPT_ACTION and not receipt_enabled:
+            continue
         # Intent filter
         if not caps.get("has_members_intent", True) and name in _INTENT_GATED_MEMBERS:
             continue
@@ -714,6 +1203,39 @@ def _build_schema(
         },
     }
 
+    if _SESSION_KICKOFF_RECEIPT_ACTION in actions:
+        properties.update({
+            "seed_content": {
+                "type": "string",
+                "description": "Text-only session kickoff seed content to post and validate.",
+            },
+            "post_intent": {
+                "type": "string",
+                "enum": [_SESSION_KICKOFF_RECEIPT_INTENT],
+                "description": "Required literal intent for the kickoff receipt action.",
+            },
+            "expected_requester_user_id": {
+                "type": "string",
+                "description": "Optional cross-check against trusted Discord gateway requester ID.",
+            },
+            "activation_content": {
+                "type": "string",
+                "description": "Optional text-only activation prompt posted after the seed.",
+            },
+            "max_fetch_attempts": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 5,
+                "description": "Fetch-by-ID retry attempts for posted messages (default 3).",
+            },
+            "fetch_delay_seconds": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 2.0,
+                "description": "Delay between fetch attempts; total retry sleep must stay under 8s.",
+            },
+        })
+
     return {
         "name": tool_name,
         "description": description,
@@ -735,7 +1257,12 @@ def _get_dynamic_schema(
         return None
     caps = _detect_capabilities(token)
     allowlist = _load_allowed_actions_config()
-    actions = [a for a in _available_actions(caps, allowlist) if a in action_subset]
+    actions = [
+        a for a in _available_actions(
+            caps, allowlist, receipt_enabled=_session_kickoff_receipt_enabled(),
+        )
+        if a in action_subset
+    ]
     if not actions:
         return None
     return _build_schema(actions, caps, tool_name=tool_name)
@@ -839,6 +1366,12 @@ def _run_discord_action(
     before: str = "",
     after: str = "",
     auto_archive_duration: int = 1440,
+    seed_content: str = "",
+    post_intent: str = "",
+    expected_requester_user_id: str = "",
+    activation_content: str = "",
+    max_fetch_attempts: int = 3,
+    fetch_delay_seconds: float = 0.5,
 ) -> str:
     """Shared handler logic for both discord tools."""
     token = _get_bot_token()
@@ -894,6 +1427,12 @@ def _run_discord_action(
             before=before,
             after=after,
             auto_archive_duration=auto_archive_duration,
+            seed_content=seed_content,
+            post_intent=post_intent,
+            expected_requester_user_id=expected_requester_user_id,
+            activation_content=activation_content,
+            max_fetch_attempts=max_fetch_attempts,
+            fetch_delay_seconds=fetch_delay_seconds,
         )
     except DiscordAPIError as e:
         logger.warning("Discord API error in %s action '%s': %s", tool_label, action, e)
@@ -923,6 +1462,8 @@ _HANDLER_DEFAULTS = {
     "action": "", "guild_id": "", "channel_id": "", "user_id": "",
     "role_id": "", "message_id": "", "query": "", "name": "",
     "limit": 50, "before": "", "after": "", "auto_archive_duration": 1440,
+    "seed_content": "", "post_intent": "", "expected_requester_user_id": "",
+    "activation_content": "", "max_fetch_attempts": 3, "fetch_delay_seconds": 0.5,
 }
 
 
@@ -934,7 +1475,8 @@ def _make_handler(handler_fn):
 
 
 _STATIC_CORE_SCHEMA = _build_schema(
-    list(_CORE_ACTIONS.keys()), caps={"detected": False}, tool_name="discord",
+    [name for name in _CORE_ACTIONS if name != _SESSION_KICKOFF_RECEIPT_ACTION],
+    caps={"detected": False}, tool_name="discord",
 )
 _STATIC_ADMIN_SCHEMA = _build_schema(
     list(_ADMIN_ACTIONS.keys()), caps={"detected": False}, tool_name="discord_admin",


### PR DESCRIPTION
## Summary

- Adds an opt-in Discord `post_session_kickoff_receipt_v1` action for session-kickoff continuation receipts.
- Adds strict session-context handling so receipt posting is only exposed for the trusted kickoff workflow context.
- Hardens receipt validation with bounded Discord retry behavior, ASCII-only snowflake checks, chunk/fetch drift detection, and sanitized bounded error evidence.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python -m pytest -p no:cacheprovider tests/gateway/test_session_env.py tests/tools/test_discord_tool.py -q` using the shared Hermes venv Python -> `138 passed`
- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile gateway/session_context.py tools/discord_tool.py tests/gateway/test_session_env.py tests/tools/test_discord_tool.py` using the same venv Python -> passed
- `git diff --check origin/main...HEAD` -> passed
- Independent staged S3 review -> `PASS_TO_COMMIT`
- Independent clean-branch PR review -> `PASS_TO_PUBLISH`

## Scope and boundaries

- Related ledger issue: cheong-yi/workspace-config#76.
- No issue-state change is requested by this PR.
- No live gateway/config/profile rollout, Discord smoke, branch cleanup, or issue closure is included.
- PR diff is limited to:
  - `gateway/session_context.py`
  - `tests/gateway/test_session_env.py`
  - `tools/discord_tool.py`
  - `tests/tools/test_discord_tool.py`
