### PR TITLE
fix(kanban): auto-complete review-required blocked tasks on unblock

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4244,7 +4244,36 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
     the leaked run is closed as ``reclaimed`` inside the same txn so the
     runs invariant (``current_run_id IS NULL`` ⇔ run row in terminal
     state) holds for the rest of this function's lifetime.
+
+    Special case: when the task was blocked with a ``review-required:`` reason,
+    the work is already done and the reviewer has approved + merged the PR.
+    Unblocking in this state triggers an infinite respawn-guard loop (the
+    ``active_pr`` guard defers re-spawn every tick because a PR URL exists
+    in recent comments).  Instead, auto-complete the task directly — no
+    respawn is needed because all the real work (coding, review, merge)
+    already happened.
     """
+    # Check whether this is a review-required block → if so, auto-complete.
+    blocked_event = conn.execute(
+        "SELECT payload FROM task_events "
+        "WHERE task_id = ? AND kind = 'blocked' "
+        "ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    if blocked_event and blocked_event["payload"]:
+        try:
+            payload = json.loads(blocked_event["payload"])
+        except (json.JSONDecodeError, TypeError):
+            payload = {}
+        if isinstance(payload, dict) and isinstance(payload.get("reason"), str):
+            if payload["reason"].startswith("review-required:"):
+                # Work is done, review approved — complete directly.
+                return complete_task(
+                    conn, task_id,
+                    result="auto-completed on unblock (review approved)",
+                    summary=payload["reason"][len("review-required:"):].strip(),
+                )
+
     now = int(time.time())
     with write_txn(conn):
         stale = conn.execute(

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -185,7 +185,7 @@ def test_unblock_clears_sticky_state_and_lets_block_recover(kanban_home: Path) -
         kb.claim_task(conn, tid)
         kb.block_task(
             conn, tid,
-            reason="review-required: ...",
+            reason="needs clarification on IP vs user_id",
             expected_run_id=kb.get_task(conn, tid).current_run_id,
         )
         assert kb.unblock_task(conn, tid)


### PR DESCRIPTION
## Problem

When a worker blocks with `review-required:` and the reviewer approves+merges the PR, unblocking the task triggers an infinite Respawn Guard loop:

1. Worker blocks with `review-required: ...` → task is `blocked`
2. Reviewer approves PR + merges
3. Reviewer runs `hermes kanban unblock <id>` → `unblock_task()` → task → `ready`
4. Dispatcher picks up `ready` task → `check_respawn_guard()` sees PR URL in recent comments → returns `active_pr` → defers
5. 60s later → same → infinite `respawn_guarded` events

Root cause: `unblock_task` unconditionally transitions blocked→ready, triggering dispatch→respawn→active_pr guard→defer→retry loop.

## Fix (Option A from task spec)

`unblock_task()` now checks the most recent `blocked` event's reason. If it starts with `review-required:`, the task is auto-completed via `complete_task()` — no respawn needed because all real work (coding, review, merge) already happened.

## Changes

- **kanban_db.py**: `unblock_task()` gains review-required detection (~29 lines added to docstring + 19 lines of logic)
- **test_kanban_blocked_sticky.py**: Updated `test_unblock_clears_sticky_state_and_lets_block_recover` to use a generic reason instead of `review-required:` to preserve its original intent

## Test Results

All 270 kanban tests pass:
- `test_kanban_blocked_sticky.py`: 6/6 ✓
- `test_kanban_core_functionality.py`: 167/167 ✓
- `test_kanban_tools.py`: 84/84 ✓
- `test_kanban_notifier.py`: 6/6 ✓
- `test_kanban_watchers_mixin.py`: 3/3 ✓
- `test_kanban_notifier_watcher_dispatch_gate.py`: 3/3 ✓
- `test_kanban_cli.py::test_run_slash_block_unblock_cycle`: 1/1 ✓

## Edge cases handled

- Non-`review-required:` blocks: unchanged behavior (→ ready/todo)
- Block without reason field: unchanged behavior
- Block with non-dict payload: unchanged behavior
- Block with JSON parse error: unchanged behavior
- Circuit breaker block (no `blocked` event): unchanged behavior