### PR TITLE
chore(website): bump joi 17.13.3 -> 17.13.4 (GHSA-q7cg-457f-vx79)

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -11697,9 +11697,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.13.3",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
-      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "version": "17.13.4",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.4.tgz",
+      "integrity": "sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/hoek": "^9.3.0",


### PR DESCRIPTION
## Summary
- `joi` 17.13.3 -> 17.13.4 in `website/package-lock.json` (transitive via `joi ^17.9.2` under `@docusaurus/*`), clearing GHSA-q7cg-457f-vx79 (moderate; uncaught RangeError on deeply nested recursive `link()` schemas, published 2026-06-11).
- Lockfile-only, generated with `npm audit fix --package-lock-only`. No `package.json` / direct-dependency change; `lockfileVersion` unchanged (3).

## Verification
- `npm --prefix website audit` before: 1 moderate (joi). After: **0 vulnerabilities** (dev deps included).
- Exposure is build-time only (statically-built Docusaurus site).

Minimal successor to #39450, whose website work was otherwise already absorbed by `4cecb1a1` on `main`.