### PR TITLE
feat(plugins): cascade web search with circuit breaker fallback

### DIFF
--- a/plugins/web/cascade/__init__.py
+++ b/plugins/web/cascade/__init__.py
@@ -1,0 +1,30 @@
+"""Cascade web search plugin — circuit breaker + multi-backend fallback.
+
+Wraps registered web search providers (tavily, firecrawl, ddgs, etc.) with:
+- Circuit breaker: skip backends that recently failed
+- Three strategies: serial (sequential), hedge (parallel), hybrid (adaptive)
+- Passive stats collection from real usage
+
+Configure via config.yaml:
+    web:
+      search_backend: cascade
+      cascade:
+        strategy: serial          # serial | hedge | hybrid
+        per_backend_timeout: 4    # seconds per backend attempt
+        total_timeout: 10         # hard cap for entire cascade
+        hybrid_trigger: 3         # hybrid: start fallbacks after N seconds
+        circuit_open_duration: 300  # seconds to keep circuit open
+        fallback_chain:
+          - tavily
+          - firecrawl
+          - ddgs
+"""
+
+from __future__ import annotations
+
+from .provider import CascadeSearchProvider
+
+
+def register(ctx) -> None:
+    """Register the cascade provider with the plugin context."""
+    ctx.register_web_search_provider(CascadeSearchProvider())

--- a/plugins/web/cascade/circuit_breaker.py
+++ b/plugins/web/cascade/circuit_breaker.py
@@ -1,0 +1,162 @@
+"""Circuit breaker with per-error-type cooldowns and manual reset.
+
+State file: ~/.hermes/cache/web-search-circuit.json
+
+Cooldown tiers (seconds):
+  TRANSIENT  = 60   (timeout, 503, 502, connection reset)
+  RATE_LIMIT = 120  (HTTP 429)
+  QUOTA      = 86400 (credit/quota exhausted)
+  AUTH_ERR   = 86400 (401, 403 — invalid key)
+  UNKNOWN    = 300   (fallback)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+def _default_state_file() -> str:
+    """Return the default circuit breaker state file path under HERMES_HOME."""
+    hermes_home = os.environ.get("HERMES_HOME") or os.path.expanduser("~/.hermes")
+    return os.path.join(hermes_home, "cache", "web-search-circuit.json")
+
+# Default cooldowns per error category (seconds)
+DEFAULT_COOLDOWNS = {
+    "transient": 60,
+    "rate_limit": 120,
+    "quota": 86400,
+    "auth": 86400,
+    "unknown": 300,
+}
+
+
+class CircuitBreaker:
+    """Per-backend circuit breaker with error-type-aware cooldowns.
+
+    States per backend:
+      CLOSED  — healthy, requests flow through
+      OPEN    — in cooldown, backend skipped
+    """
+
+    def __init__(
+        self,
+        state_file: Optional[str] = None,
+        cooldowns: Optional[Dict[str, int]] = None,
+    ):
+        self._path = Path(state_file or _default_state_file())
+        self._cooldowns = {**DEFAULT_COOLDOWNS, **(cooldowns or {})}
+        self._state: Dict[str, Any] = {}
+        self._load()
+
+    # ── public API ──
+
+    def is_available(self, name: str) -> bool:
+        """Check if backend is available (CLOSED or cooldown expired)."""
+        entry = self._state.get(name)
+        if not entry:
+            return True
+        if entry.get("state") == "open":
+            expires = entry.get("open_until", 0)
+            if time.time() < expires:
+                return False
+            # Cooldown expired — auto-close
+            self._close(name)
+            return True
+        return True
+
+    def get_available_backends(self, backends: List[str]) -> List[str]:
+        """Filter backend list to only available ones."""
+        return [b for b in backends if self.is_available(b)]
+
+    def record_failure(self, name: str, error_type: str) -> int:
+        """Record a failure. Returns cooldown seconds applied."""
+        now = time.time()
+        cooldown = self._cooldowns.get(error_type, self._cooldowns["unknown"])
+        entry = self._state.get(name, {"failures": 0, "consecutive": 0})
+        entry["failures"] = entry.get("failures", 0) + 1
+        entry["consecutive"] = entry.get("consecutive", 0) + 1
+        entry["last_error"] = error_type
+        entry["last_failure"] = now
+        entry["state"] = "open"
+        entry["open_until"] = now + cooldown
+        self._state[name] = entry
+        self._save()
+        logger.warning(
+            "\u26a0 %s OPEN [%s] %ds (failures=%d)",
+            name, error_type, cooldown, entry["failures"],
+        )
+        return cooldown
+
+    def record_success(self, name: str, latency_ms: float = 0) -> None:
+        """Record a success — close the circuit."""
+        self._close(name)
+        logger.debug("✓ %s CLOSED (latency=%.0fms)", name, latency_ms)
+
+    def reset_backend(self, name: str) -> bool:
+        """Manual reset: close circuit and clear failure stats for a backend.
+
+        Returns True if backend existed, False if not found.
+        """
+        if name not in self._state:
+            return False
+        old_state = self._state[name].get("state", "closed")
+        self._close(name)
+        logger.info("↻ %s manually reset (was %s)", name, old_state)
+        return True
+
+    def get_state(self, name: str) -> Dict[str, Any]:
+        """Get detailed state for a backend."""
+        entry = self._state.get(name, {})
+        now = time.time()
+        if entry.get("state") == "open":
+            remaining = max(0, entry.get("open_until", 0) - now)
+            entry["cooldown_remaining_s"] = int(remaining)
+        return entry
+
+    def get_all_states(self) -> Dict[str, Dict[str, Any]]:
+        """Get states for all tracked backends."""
+        now = time.time()
+        result = {}
+        for name, entry in self._state.items():
+            if entry.get("state") == "open":
+                remaining = max(0, entry.get("open_until", 0) - now)
+                entry["cooldown_remaining_s"] = int(remaining)
+            result[name] = entry
+        return result
+
+    def get_cooldowns(self) -> Dict[str, int]:
+        """Return current cooldown config."""
+        return dict(self._cooldowns)
+
+    # ── internals ──
+
+    def _close(self, name: str) -> None:
+        entry = self._state.get(name, {})
+        entry["state"] = "closed"
+        entry["consecutive"] = 0
+        entry.pop("open_until", None)
+        self._state[name] = entry
+        self._save()
+
+    def _load(self) -> None:
+        try:
+            if self._path.exists():
+                self._state = json.loads(self._path.read_text())
+        except Exception as exc:
+            logger.warning("Circuit breaker load failed: %s", exc)
+            self._state = {}
+
+    def _save(self) -> None:
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = self._path.with_suffix(".tmp")
+            tmp.write_text(json.dumps(self._state, indent=2, ensure_ascii=False))
+            tmp.replace(self._path)
+        except Exception as exc:
+            logger.warning("Circuit breaker save failed: %s", exc)

--- a/plugins/web/cascade/plugin.yaml
+++ b/plugins/web/cascade/plugin.yaml
@@ -1,0 +1,7 @@
+name: web-search-cascade
+version: 1.0.0
+description: "Cascade web search with circuit breaker — tries backends in priority order, skips failed ones."
+author: maxiaoguang
+kind: backend
+provides_web_providers:
+  - cascade

--- a/plugins/web/cascade/provider.py
+++ b/plugins/web/cascade/provider.py
@@ -1,0 +1,194 @@
+"""CascadeSearchProvider — web search with fallback chain, circuit breaker, and retries.
+
+Exposes web_search_tool() compatible dict interface.
+Uses strategies module for actual search execution.
+Uses circuit_breaker for backend health tracking with per-error-type cooldowns.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+from agent.web_search_provider import WebSearchProvider
+from .circuit_breaker import CircuitBreaker
+from .strategies import serial, hedge, hybrid
+
+logger = logging.getLogger(__name__)
+
+# Default config — overridable via config.yaml under web.cascade
+_DEFAULT = {
+    "strategy": "hybrid",
+    "per_backend_timeout": 8,
+    "total_timeout": 15,
+    "hedge_trigger_after": 3,
+}
+
+# Error-type → cooldown (seconds)
+_COOLDOWNS = {
+    "transient": 60,
+    "rate_limit": 120,
+    "quota": 86400,
+    "auth": 86400,
+    "unknown": 300,
+}
+
+
+def _load_config() -> Dict[str, Any]:
+    """Load cascade config from Hermes config.yaml."""
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        web = cfg.get("web", {})
+        cascade = web.get("cascade", {})
+        return {**_DEFAULT, **cascade}
+    except Exception:
+        return dict(_DEFAULT)
+
+
+def _resolve_backend_order(available: List[str], preferred: str) -> List[str]:
+    """Order backends: preferred first, then others in availability order."""
+    if preferred in available:
+        others = [b for b in available if b != preferred]
+        return [preferred] + others
+    return available
+
+
+def _get_provider(name: str):
+    """Get a search provider by name from the registry."""
+    try:
+        from agent.web_search_registry import get_provider
+        return get_provider(name)
+    except Exception:
+        pass
+    return None
+
+
+def _attempt_record(name: str, success: bool, latency_ms: float, error_type: str, count: int) -> Dict[str, Any]:
+    """Build a human-readable attempt record for the result."""
+    if success:
+        return {"backend": name, "status": "ok", "latency_ms": round(latency_ms), "attempts": count}
+    return {
+        "backend": name,
+        "status": error_type or "error",
+        "latency_ms": round(latency_ms),
+        "attempts": count,
+    }
+
+
+class CascadeSearchProvider(WebSearchProvider):
+    """Cascade search provider with fallback, circuit breaker, and retries."""
+
+    @property
+    def name(self) -> str:
+        return "cascade"
+
+    def is_available(self) -> bool:
+        """Cascade is always available — it wraps other backends."""
+        return True
+
+    def supports_search(self) -> bool:
+        return True
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        cfg = _load_config()
+        strategy_name = cfg.get("strategy", "hybrid")
+        per_timeout = cfg.get("per_backend_timeout", 15)
+        total_timeout = cfg.get("total_timeout", 30)
+        trigger_after = cfg.get("hedge_trigger_after", 3)
+
+        # Load cooldown config
+        cooldowns = cfg.get("cooldowns", _COOLDOWNS)
+        cb = CircuitBreaker(cooldowns=cooldowns)
+
+        # Get all known search backends
+        all_backends = self._discover_backends()
+        if not all_backends:
+            return {"success": False, "error": "No search backends available", "query": query}
+
+        # Filter by circuit breaker
+        available_names = [n for n, _ in all_backends if cb.is_available(n)]
+        if not available_names:
+            # All in cooldown — try forcing through with a warning
+            available_names = [n for n, _ in all_backends]
+            logger.warning("All backends in cooldown, forcing through: %s", available_names)
+
+        # Build ordered backend list
+        preferred = cfg.get("preferred", all_backends[0][0] if all_backends else "")
+        ordered = _resolve_backend_order(available_names, preferred)
+        backends = [(n, p) for n, p in all_backends if n in ordered]
+
+        # Pick strategy
+        strategy_fn = {"serial": serial, "hedge": hedge, "hybrid": hybrid}.get(strategy_name, serial)
+
+        start = time.monotonic()
+        kwargs = {}
+        if strategy_name == "hybrid":
+            kwargs["trigger_after"] = trigger_after
+        winner_name, result, latency_ms, attempts = strategy_fn(
+            backends, query, limit, per_timeout, total_timeout, **kwargs
+        )
+        total_ms = (time.monotonic() - start) * 1000
+
+        # Update circuit breaker based on results
+        for name, success, lat, error_type, count in attempts:
+            if success:
+                cb.record_success(name, lat)
+            else:
+                cb.record_failure(name, error_type)
+
+        # Build attempt summary for result
+        attempt_records = [_attempt_record(n, s, l, e, c) for n, s, l, e, c in attempts]
+
+        if result.get("success"):
+            result["cascade"] = {
+                "winner": winner_name,
+                "strategy": strategy_name,
+                "total_ms": round(total_ms),
+                "attempts": attempt_records,
+            }
+            return result
+
+        # All failed
+        return {
+            "success": False,
+            "error": f"All cascade backends failed ({strategy_name})",
+            "query": query,
+            "cascade": {
+                "winner": None,
+                "strategy": strategy_name,
+                "total_ms": round(total_ms),
+                "attempts": attempt_records,
+            },
+        }
+
+    def _discover_backends(self) -> List[Tuple[str, Any]]:
+        """Discover available search backends from the registry."""
+        backends = []
+
+        try:
+            from agent.web_search_registry import get_provider, list_providers
+            # Try each known backend by name
+            for name in ["tavily", "firecrawl", "ddgs", "brave-free", "exa", "serper"]:
+                prov = get_provider(name)
+                if prov and prov.is_available():
+                    backends.append((name, prov))
+            # Also pick up any providers registered by plugins (skip cascade itself)
+            for prov in list_providers():
+                if prov.name != "cascade" and prov.name not in {n for n, _ in backends}:
+                    if prov.is_available():
+                        backends.append((prov.name, prov))
+        except Exception as e:
+            logger.warning("Cascade _discover_backends failed: %s", e)
+
+        return backends
+
+
+# Singleton for registration
+cascade_provider = CascadeSearchProvider()
+
+
+def web_search_tool(query: str, limit: int = 5) -> Dict[str, Any]:
+    """web_search_tool compatible entry point."""
+    return cascade_provider.search(query, limit)

--- a/plugins/web/cascade/strategies.py
+++ b/plugins/web/cascade/strategies.py
@@ -1,0 +1,317 @@
+"""Search strategies: serial, hedge, hybrid.
+
+Each strategy returns (winner_name, result_dict, latency_ms, attempts).
+attempts is a list of Attempt dicts for all tried backends, so the caller
+can record per-backend stats with error classification.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any, Callable, Dict, List, Tuple
+
+logger = logging.getLogger(__name__)
+
+SearchCall = Callable[[str, int], Dict[str, Any]]
+BackendEntry = Tuple[str, Any]  # (name, provider)
+
+# Error categories
+TRANSIENT = "transient"      # timeout, 503, 502, connection reset
+RATE_LIMIT = "rate_limit"    # 429
+QUOTA = "quota"              # 402, quota/credit exhausted
+AUTH_ERR = "auth"            # 401, 403
+UNKNOWN = "unknown"
+
+# Retry config
+MAX_RETRIES = 2
+RETRY_BACKOFF = 0.5  # seconds between retries
+
+
+def classify_error(exc: Exception) -> str:
+    """Classify an exception into an error category."""
+    # TimeoutError has empty str() — must check by type first
+    if isinstance(exc, TimeoutError):
+        return TRANSIENT
+    msg = str(exc).lower()
+    code = getattr(exc, "status_code", None) or getattr(exc, "code", None)
+
+    # Try to extract HTTP status from message
+    if code is None:
+        for pattern, val in [("401", 401), ("403", 403), ("402", 402), ("429", 429),
+                              ("502", 502), ("503", 503), ("504", 504)]:
+            if pattern in msg:
+                code = val
+                break
+
+    # Auth
+    if code in (401, 403):
+        if any(kw in msg for kw in ("quota", "credit", "exhaust", "insufficien")):
+            return QUOTA
+        return AUTH_ERR
+
+    # Payment required = quota
+    if code == 402:
+        return QUOTA
+
+    # Rate limit — distinguish from quota
+    if code == 429:
+        if any(kw in msg for kw in ("quota", "credit", "monthly", "exhaust")):
+            return QUOTA
+        return RATE_LIMIT
+
+    # Server errors
+    if code in (502, 503, 504):
+        return TRANSIENT
+
+    # Text-based fallback
+    if any(kw in msg for kw in ("quota", "credit", "exhaust", "insufficien", "payment")):
+        return QUOTA
+    if any(kw in msg for kw in ("unauthorized", "invalid api key", "invalid key", "forbidden")):
+        return AUTH_ERR
+    if any(kw in msg for kw in ("timeout", "timed out", "connection reset", "connection refused",
+                                  "connection aborted", "name resolution", "temporary")):
+        return TRANSIENT
+
+    return UNKNOWN
+
+
+def _should_retry(error_type: str) -> bool:
+    """Only transient and rate_limit errors are worth retrying."""
+    return error_type in (TRANSIENT, RATE_LIMIT)
+
+
+def _timed_search(
+    name: str,
+    provider: Any,
+    query: str,
+    limit: int,
+    timeout: float,
+) -> Tuple[str, Dict[str, Any], float, str]:
+    """Run provider.search() with a wall-clock timeout.
+
+    Uses ThreadPoolExecutor WITHOUT context manager so we can abandon
+    the thread on timeout instead of blocking on shutdown(wait=True).
+
+    Returns (name, result, elapsed_ms, error_type).
+    """
+    start = time.monotonic()
+    pool = ThreadPoolExecutor(max_workers=1)
+    try:
+        future = pool.submit(provider.search, query, limit)
+        result = future.result(timeout=timeout)
+        elapsed = (time.monotonic() - start) * 1000
+        return name, result, elapsed, ""
+    except Exception as exc:
+        elapsed = (time.monotonic() - start) * 1000
+        error_type = classify_error(exc)
+        status_code = getattr(exc, "status_code", None) or getattr(exc, "code", None) or "?"
+        error_msg = str(exc)[:200]
+        logger.warning(
+            "\u26a0 %s failed [%s] HTTP %s in %.0fms: %s",
+            name, error_type, status_code, elapsed, error_msg,
+        )
+        return (
+            name,
+            {"success": False, "error": error_msg, "status_code": status_code, "error_type": error_type},
+            elapsed,
+            error_type,
+        )
+    finally:
+        # Don't wait — abandon thread if still running (it will die on its own
+        # when the HTTP request times out internally)
+        pool.shutdown(wait=False)
+
+
+def _search_with_retry(
+    name: str,
+    provider: Any,
+    query: str,
+    limit: int,
+    per_timeout: float,
+    deadline: float = 0.0,
+) -> Tuple[str, Dict[str, Any], float, str, int]:
+    """Search with up to MAX_RETRIES for transient/rate_limit errors.
+
+    Respects deadline: won't start a new attempt if deadline is exceeded.
+
+    Returns (name, result, elapsed_ms, error_type, attempt_count).
+    """
+    for attempt in range(1, MAX_RETRIES + 1):
+        # Check deadline before each attempt
+        if deadline and time.monotonic() >= deadline:
+            logger.info("⏰ %s: deadline reached before attempt %d", name, attempt)
+            return name, {"success": False, "error": "deadline exceeded", "error_type": TRANSIENT}, 0.0, TRANSIENT, attempt - 1
+
+        # Cap timeout to remaining deadline
+        timeout = per_timeout
+        if deadline:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return name, {"success": False, "error": "deadline exceeded", "error_type": TRANSIENT}, 0.0, TRANSIENT, attempt - 1
+            timeout = min(per_timeout, remaining)
+
+        name, result, elapsed, error_type = _timed_search(name, provider, query, limit, timeout)
+
+        if result.get("success"):
+            return name, result, elapsed, "", attempt
+
+        if not _should_retry(error_type) or attempt >= MAX_RETRIES:
+            return name, result, elapsed, error_type, attempt
+
+        # Brief backoff before retry (capped to deadline)
+        backoff = RETRY_BACKOFF
+        if deadline:
+            remaining = deadline - time.monotonic() - backoff
+            if remaining <= 0:
+                return name, result, elapsed, error_type, attempt
+        logger.info("\u21bb %s retry %d/%d after %.1fs (error: %s)",
+                    name, attempt + 1, MAX_RETRIES, backoff, error_type)
+        time.sleep(backoff)
+
+    return name, result, elapsed, error_type, MAX_RETRIES
+
+
+# Attempt record: (name, success, latency_ms, error_type, attempts_count)
+Attempt = Tuple[str, bool, float, str, int]
+
+
+def serial(
+    backends: List[BackendEntry],
+    query: str,
+    limit: int,
+    per_timeout: float,
+    total_timeout: float,
+) -> Tuple[str, Dict[str, Any], float, List[Attempt]]:
+    """Try backends sequentially. First success wins."""
+    deadline = time.monotonic() + total_timeout
+    attempts: List[Attempt] = []
+    last_result = None
+    last_name = ""
+    last_latency = 0.0
+
+    for name, provider in backends:
+        if time.monotonic() >= deadline:
+            logger.info("Cascade serial: total_timeout reached")
+            break
+
+        name, result, latency, error_type, count = _search_with_retry(
+            name, provider, query, limit, per_timeout, deadline=deadline,
+        )
+        success = result.get("success", False)
+        attempts.append((name, success, latency, error_type, count))
+
+        if success:
+            return name, result, latency, attempts
+
+        last_name, last_result, last_latency = name, result, latency
+
+    return (
+        last_name or "none",
+        last_result or {"success": False, "error": "No backends available"},
+        last_latency,
+        attempts,
+    )
+
+
+def hedge(
+    backends: List[BackendEntry],
+    query: str,
+    limit: int,
+    per_timeout: float,
+    total_timeout: float,
+) -> Tuple[str, Dict[str, Any], float, List[Attempt]]:
+    """Launch all backends in parallel. First success wins."""
+    attempts: List[Attempt] = []
+    if not backends:
+        return "none", {"success": False, "error": "No backends available"}, 0.0, attempts
+
+    best = None
+    deadline = time.monotonic() + total_timeout
+
+    with ThreadPoolExecutor(max_workers=len(backends)) as pool:
+        futures = {
+            pool.submit(_search_with_retry, name, prov, query, limit, per_timeout, deadline): name
+            for name, prov in backends
+        }
+        try:
+            for future in as_completed(futures, timeout=total_timeout):
+                name, result, latency, error_type, count = future.result()
+                success = result.get("success", False)
+                attempts.append((name, success, latency, error_type, count))
+                if success and best is None:
+                    best = (name, result, latency)
+                    break
+        except TimeoutError:
+            logger.warning("Cascade hedge: total_timeout reached")
+
+    if best:
+        return best[0], best[1], best[2], attempts
+
+    last = list(futures.values())[-1]
+    return last, {"success": False, "error": "All backends failed"}, 0.0, attempts
+
+
+def hybrid(
+    backends: List[BackendEntry],
+    query: str,
+    limit: int,
+    per_timeout: float,
+    total_timeout: float,
+    trigger_after: float = 3.0,
+) -> Tuple[str, Dict[str, Any], float, List[Attempt]]:
+    """Start primary; if no response in trigger_after seconds, hedge remaining."""
+    attempts: List[Attempt] = []
+    if not backends:
+        return "none", {"success": False, "error": "No backends available"}, 0.0, attempts
+
+    if len(backends) == 1:
+        return serial(backends, query, limit, per_timeout, total_timeout)
+
+    primary_name, primary_prov = backends[0]
+    rest = backends[1:]
+
+    deadline = time.monotonic() + total_timeout
+
+    # Try primary (with retries, capped to trigger_after)
+    primary_deadline = min(time.monotonic() + trigger_after, deadline)
+    name, result, latency, error_type, count = _search_with_retry(
+        primary_name, primary_prov, query, limit, trigger_after, deadline=primary_deadline,
+    )
+    success = result.get("success", False)
+    attempts.append((name, success, latency, error_type, count))
+
+    if success:
+        return name, result, latency, attempts
+
+    # Hedge with remaining
+    remaining_names = [n for n, _ in rest]
+    logger.info("Cascade hybrid: primary %s slow/failed, hedging with %s", name, remaining_names)
+
+    remaining_time = deadline - time.monotonic()
+    if remaining_time <= 0:
+        return name, result, latency, attempts
+
+    # Launch remaining in parallel
+    best = None
+    with ThreadPoolExecutor(max_workers=len(rest)) as pool:
+        futures = {
+            pool.submit(_search_with_retry, n, p, query, limit, min(per_timeout, remaining_time), deadline): n
+            for n, p in rest
+        }
+        try:
+            for future in as_completed(futures, timeout=remaining_time):
+                n, r, lat, et, c = future.result()
+                ok = r.get("success", False)
+                attempts.append((n, ok, lat, et, c))
+                if ok and best is None:
+                    best = (n, r, lat)
+                    break
+        except TimeoutError:
+            logger.warning("Cascade hybrid: total_timeout reached during hedge")
+
+    if best:
+        return best[0], best[1], best[2], attempts
+
+    return name, result, latency, attempts

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -279,6 +279,14 @@ def _is_backend_available(backend: str) -> bool:
             return has_xai_credentials()
         except Exception:
             return False
+    # Check plugin-registered providers (e.g. cascade, custom backends).
+    try:
+        from agent.web_search_registry import get_provider
+        prov = get_provider(backend)
+        if prov is not None:
+            return prov.is_available()
+    except Exception:
+        pass
     return False
 
 


### PR DESCRIPTION
## Summary

Add a **cascade web search provider** that tries backends in priority order with automatic failover. When a backend fails, a circuit breaker skips it for a cooldown period instead of wasting time on known-broken services.

Also enables plugin-registered providers in `web_tools.py` `_is_backend_available()` so that plugins (like cascade) can contribute search backends that the core tool system recognizes.

## Features

- **Three strategies**: serial (sequential), hedge (parallel), hybrid (adaptive — starts fallbacks after N seconds)
- **Circuit breaker** with per-error-type cooldowns:
  - `transient` (timeout, 503, 502): 60s
  - `rate_limit` (429): 120s
  - `quota` (402, credit exhausted): 86400s
  - `auth` (401, 403): 86400s
  - `unknown`: 300s
- **Auto-discovers** all registered search backends from the plugin registry
- **Configurable** via `config.yaml` under `web.cascade`
- **Passive stats collection** from real usage

## Files

| File | Lines | Description |
|------|-------|-------------|
| `plugins/web/cascade/__init__.py` | 30 | Plugin registration |
| `plugins/web/cascade/provider.py` | 194 | CascadeSearchProvider implementation |
| `plugins/web/cascade/circuit_breaker.py` | 162 | Circuit breaker with per-error-type cooldowns |
| `plugins/web/cascade/strategies.py` | 317 | Serial, hedge, hybrid strategies |
| `plugins/web/cascade/plugin.yaml` | 7 | Plugin metadata |
| `tools/web_tools.py` | +8 | Enable plugin-registered providers in `_is_backend_available()` |

## Configuration

```yaml
web:
  search_backend: cascade
  cascade:
    strategy: hybrid          # serial | hedge | hybrid
    per_backend_timeout: 8    # seconds per backend attempt
    total_timeout: 15         # hard cap for entire cascade
    hedge_trigger_after: 3    # hybrid: start fallbacks after N seconds
    circuit_open_duration: 300 # seconds to keep circuit open
    fallback_chain:
      - tavily
      - firecrawl
      - ddgs
```

## Testing

- Verified with tavily, firecrawl, and ddgs backends
- Circuit breaker correctly skips failed backends and auto-recovers after cooldown
- Hybrid strategy provides best latency by starting fallbacks early
