### PR TITLE
fix(desktop): keep recents sorted unless manually reordered

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -55,6 +55,7 @@ import {
   $sidebarPinsOpen,
   $sidebarRecentsOpen,
   $sidebarSessionOrderIds,
+  $sidebarSessionOrderManual,
   $sidebarWorkspaceOrderIds,
   $sidebarWorkspaceParentOrderIds,
   pinSession,
@@ -65,6 +66,7 @@ import {
   setSidebarPinsOpen,
   setSidebarRecentsOpen,
   setSidebarSessionOrderIds,
+  setSidebarSessionOrderManual,
   setSidebarWorkspaceOrderIds,
   setSidebarWorkspaceParentOrderIds,
   SIDEBAR_SESSIONS_PAGE_SIZE,
@@ -99,6 +101,7 @@ import type { SidebarNavItem } from '../../types'
 
 import { SidebarCronJobsSection } from './cron-jobs-section'
 import { SidebarLoadMoreRow } from './load-more-row'
+import { resolveManualSessionOrderIds } from './order'
 import { ProfileRail } from './profile-switcher'
 import { SidebarSessionRow } from './session-row'
 import { VirtualSessionList } from './virtual-session-list'
@@ -354,6 +357,7 @@ export function ChatSidebar({
   // otherwise be stuck in the grouped view with no way out.
   const showAllProfiles = multiProfile && profileScope === ALL_PROFILES
   const agentOrderIds = useStore($sidebarSessionOrderIds)
+  const agentOrderManual = useStore($sidebarSessionOrderManual)
   const workspaceOrderIds = useStore($sidebarWorkspaceOrderIds)
   const workspaceParentOrderIds = useStore($sidebarWorkspaceParentOrderIds)
   const [searchQuery, setSearchQuery] = useState('')
@@ -517,19 +521,29 @@ export function ChatSidebar({
   )
 
   useEffect(() => {
-    const next = reconcileOrderIds(
+    const next = resolveManualSessionOrderIds(
       unpinnedAgentSessions.map(s => s.id),
-      agentOrderIds
+      agentOrderIds,
+      agentOrderManual
     )
 
-    if (!sameIds(next, agentOrderIds)) {
+    if (!next.length && agentOrderManual) {
+      setSidebarSessionOrderManual(false)
+    }
+
+    if (!next.length && agentOrderIds.length) {
+      setSidebarSessionOrderIds([])
+      return
+    }
+
+    if (next.length && !sameIds(next, agentOrderIds)) {
       setSidebarSessionOrderIds(next)
     }
-  }, [agentOrderIds, unpinnedAgentSessions])
+  }, [agentOrderIds, agentOrderManual, unpinnedAgentSessions])
 
   const agentSessions = useMemo(
-    () => orderByIds(unpinnedAgentSessions, s => s.id, agentOrderIds),
-    [unpinnedAgentSessions, agentOrderIds]
+    () => (agentOrderManual ? orderByIds(unpinnedAgentSessions, s => s.id, agentOrderIds) : unpinnedAgentSessions),
+    [unpinnedAgentSessions, agentOrderIds, agentOrderManual]
   )
 
   // Recents are local-only: messaging-platform sessions are fetched as their
@@ -752,7 +766,10 @@ export function ChatSidebar({
 
   // Each reorderable list reports its OWN new id order; persisting is a direct,
   // typed write — no id-prefix sniffing to figure out which level moved.
-  const reorderSessions = (ids: string[]) => setSidebarSessionOrderIds(ids)
+  const reorderSessions = (ids: string[]) => {
+    setSidebarSessionOrderManual(true)
+    setSidebarSessionOrderIds(ids)
+  }
 
   const reorderParents = (ids: string[]) => setSidebarWorkspaceParentOrderIds(ids)
 

--- a/apps/desktop/src/app/chat/sidebar/order.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/order.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveManualSessionOrderIds } from './order'
+
+describe('resolveManualSessionOrderIds', () => {
+  it('clears legacy auto-seeded order until the user manually reorders sessions', () => {
+    expect(resolveManualSessionOrderIds(['newest', 'older'], ['older', 'newest'], false)).toEqual([])
+  })
+
+  it('keeps a manual order and surfaces newly seen sessions first', () => {
+    expect(resolveManualSessionOrderIds(['newest', 'older', 'oldest'], ['oldest', 'older'], true)).toEqual([
+      'newest',
+      'oldest',
+      'older'
+    ])
+  })
+
+  it('clears manual order when none of the saved ids still exist', () => {
+    expect(resolveManualSessionOrderIds(['newest'], ['gone'], true)).toEqual([])
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/order.ts
+++ b/apps/desktop/src/app/chat/sidebar/order.ts
@@ -1,0 +1,17 @@
+export function resolveManualSessionOrderIds(currentIds: string[], orderIds: string[], manual: boolean): string[] {
+  if (!manual || !currentIds.length || !orderIds.length) {
+    return []
+  }
+
+  const current = new Set(currentIds)
+  const retained = orderIds.filter(id => current.has(id))
+
+  if (!retained.length) {
+    return []
+  }
+
+  const retainedSet = new Set(retained)
+  const fresh = currentIds.filter(id => !retainedSet.has(id))
+
+  return [...fresh, ...retained]
+}

--- a/apps/desktop/src/lib/storage.test.ts
+++ b/apps/desktop/src/lib/storage.test.ts
@@ -1,0 +1,25 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { persistStringArray, storedStringArray } from './storage'
+
+describe('string array storage', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('removes the key for an empty array', () => {
+    window.localStorage.setItem('test.order', JSON.stringify(['a']))
+
+    persistStringArray('test.order', [])
+
+    expect(window.localStorage.getItem('test.order')).toBeNull()
+    expect(storedStringArray('test.order')).toEqual([])
+  })
+
+  it('persists non-empty arrays', () => {
+    persistStringArray('test.order', ['a', 'b'])
+
+    expect(window.localStorage.getItem('test.order')).toBe(JSON.stringify(['a', 'b']))
+    expect(storedStringArray('test.order')).toEqual(['a', 'b'])
+  })
+})

--- a/apps/desktop/src/lib/storage.ts
+++ b/apps/desktop/src/lib/storage.ts
@@ -58,7 +58,11 @@ export function storedStringArray(key: string): string[] {
 
 export function persistStringArray(key: string, value: string[]) {
   try {
-    window.localStorage.setItem(key, JSON.stringify(value))
+    if (value.length === 0) {
+      window.localStorage.removeItem(key)
+    } else {
+      window.localStorage.setItem(key, JSON.stringify(value))
+    }
   } catch {
     // Pins are a local preference; restricted storage should not break chat.
   }

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -25,6 +25,7 @@ const SIDEBAR_AGENTS_GROUPED_STORAGE_KEY = 'hermes.desktop.agentsGroupedByWorksp
 const SIDEBAR_CRON_OPEN_STORAGE_KEY = 'hermes.desktop.sidebarCronOpen'
 const SIDEBAR_MESSAGING_OPEN_STORAGE_KEY = 'hermes.desktop.sidebarMessagingOpen'
 const SIDEBAR_SESSION_ORDER_STORAGE_KEY = 'hermes.desktop.sessionOrder'
+const SIDEBAR_SESSION_ORDER_MANUAL_STORAGE_KEY = 'hermes.desktop.sessionOrder.manual'
 const SIDEBAR_WORKSPACE_ORDER_STORAGE_KEY = 'hermes.desktop.workspaceOrder'
 const SIDEBAR_WORKSPACE_PARENT_ORDER_STORAGE_KEY = 'hermes.desktop.workspaceParentOrder'
 const PANES_FLIPPED_STORAGE_KEY = 'hermes.desktop.panesFlipped'
@@ -58,6 +59,7 @@ export const $sidebarWidth: ReadableAtom<number> = computed($paneStates, states 
 
 export const $pinnedSessionIds = atom(storedStringArray(SIDEBAR_PINNED_STORAGE_KEY))
 export const $sidebarSessionOrderIds = atom(storedStringArray(SIDEBAR_SESSION_ORDER_STORAGE_KEY))
+export const $sidebarSessionOrderManual = atom(storedBoolean(SIDEBAR_SESSION_ORDER_MANUAL_STORAGE_KEY, false))
 export const $sidebarWorkspaceOrderIds = atom(storedStringArray(SIDEBAR_WORKSPACE_ORDER_STORAGE_KEY))
 // Order of the top-level repo "parent" groups in the worktree tree (worktrees
 // within a parent reuse $sidebarWorkspaceOrderIds).
@@ -88,6 +90,7 @@ $pinnedSessionIds.subscribe(ids => persistStringArray(SIDEBAR_PINNED_STORAGE_KEY
 $sidebarCronOpen.subscribe(open => persistBoolean(SIDEBAR_CRON_OPEN_STORAGE_KEY, open))
 $sidebarMessagingOpenIds.subscribe(ids => persistStringArray(SIDEBAR_MESSAGING_OPEN_STORAGE_KEY, [...ids]))
 $sidebarSessionOrderIds.subscribe(ids => persistStringArray(SIDEBAR_SESSION_ORDER_STORAGE_KEY, [...ids]))
+$sidebarSessionOrderManual.subscribe(manual => persistBoolean(SIDEBAR_SESSION_ORDER_MANUAL_STORAGE_KEY, manual))
 $sidebarWorkspaceOrderIds.subscribe(ids => persistStringArray(SIDEBAR_WORKSPACE_ORDER_STORAGE_KEY, [...ids]))
 $sidebarWorkspaceParentOrderIds.subscribe(ids =>
   persistStringArray(SIDEBAR_WORKSPACE_PARENT_ORDER_STORAGE_KEY, [...ids])
@@ -167,6 +170,12 @@ export function setSidebarAgentsGrouped(grouped: boolean) {
 export function setSidebarSessionOrderIds(ids: string[]) {
   if (!arraysEqual($sidebarSessionOrderIds.get(), ids)) {
     $sidebarSessionOrderIds.set(ids)
+  }
+}
+
+export function setSidebarSessionOrderManual(manual: boolean) {
+  if ($sidebarSessionOrderManual.get() !== manual) {
+    $sidebarSessionOrderManual.set(manual)
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

Desktop recents were treating an auto-generated session order as if the user had manually reordered sessions. Once `hermes.desktop.sessionOrder` existed, a session that became newest again could stay at its saved position instead of returning to the top of the sidebar.

This PR makes recency ordering the default again. Session drag order now only applies after an explicit drag reorder, and legacy auto-seeded `hermes.desktop.sessionOrder` values are cleared on load unless the new manual-order flag is set.

## Related Issue

Refs #42516

Support thread: https://discord.com/channels/1053877538025386074/1514734327924133958

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added an explicit `hermes.desktop.sessionOrder.manual` localStorage flag in `apps/desktop/src/store/layout.ts`.
- Updated `apps/desktop/src/app/chat/sidebar/index.tsx` so recents only apply persisted session order after a real drag reorder.
- Added `apps/desktop/src/app/chat/sidebar/order.ts` to resolve manual order and clear stale/non-manual order state.
- Updated `apps/desktop/src/lib/storage.ts` so empty string arrays remove their localStorage key instead of persisting `[]`.
- Added focused tests for manual session order and empty string-array persistence.

## How to Test

1. Open Desktop with existing sessions and no manual recents drag order.
2. Start or resume a session so it becomes the most recent.
3. Confirm it appears at the top of the Sessions list instead of staying at a stale saved position.
4. Drag recents manually and confirm the manual order persists.

Verification run:

- `npx --prefix apps/desktop vitest run src/app/chat/sidebar/order.test.ts src/lib/storage.test.ts --environment jsdom` -> 2 files / 5 tests passed
- `npm --prefix apps/desktop run typecheck` -> passed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: focused Desktop tests/typecheck from Linux workspace

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

No screenshot. This is covered by the focused order/storage tests above.
