### PR TITLE
fix(slack): resolve attachment race condition with files.info retry

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -2527,8 +2527,66 @@ class SlackAdapter(BasePlatformAdapter):
                         )
                     continue
 
+            # Slack sometimes fires the message event before file processing
+            # completes — the file object has an id/name but no download URL.
+            # When this happens, retry via files.info with backoff to let Slack
+            # finish processing.  This is the same approach used for Slack
+            # Connect files (file_access == "check_file_info") but for regular
+            # uploads that arrive as stubs due to the race condition.
             mimetype = f.get("mimetype", "unknown")
             url = f.get("url_private_download") or f.get("url_private", "")
+            if not url and f.get("id"):
+                file_id = f["id"]
+                _race_resolved = False
+                for _retry in range(3):
+                    _delay = 0.5 * (2 ** _retry)  # 0.5s, 1s, 2s
+                    logger.debug(
+                        "[Slack] File %s has no URL yet (race condition), "
+                        "retrying via files.info in %.1fs (attempt %d/3)",
+                        file_id, _delay, _retry + 1,
+                    )
+                    await asyncio.sleep(_delay)
+                    try:
+                        info_resp = await self._get_client(channel_id).files_info(
+                            file=file_id
+                        )
+                        if info_resp.get("ok"):
+                            resolved_file = info_resp["file"]
+                            url = (
+                                resolved_file.get("url_private_download")
+                                or resolved_file.get("url_private", "")
+                            )
+                            if url:
+                                # Update mimetype from the resolved file object
+                                # in case the stub had a missing/generic type.
+                                mimetype = resolved_file.get("mimetype", mimetype)
+                                f = resolved_file
+                                _race_resolved = True
+                                logger.info(
+                                    "[Slack] File %s URL resolved after %d retries",
+                                    file_id, _retry + 1,
+                                )
+                                break
+                        else:
+                            logger.debug(
+                                "[Slack] files.info returned error for %s: %s",
+                                file_id, info_resp.get("error"),
+                            )
+                    except Exception as _e:
+                        logger.debug(
+                            "[Slack] files.info call failed for %s: %s",
+                            file_id, _e,
+                        )
+                if not _race_resolved:
+                    file_label = f.get("name") or file_id
+                    notice = (
+                        f"Slack attachment '{file_label}' was not yet available "
+                        f"for download (file still processing). Try re-sending "
+                        f"the file or send a follow-up message referencing it."
+                    )
+                    attachment_notices.append(notice)
+                    logger.warning("[Slack] %s", notice)
+                    continue
             if mimetype.startswith("image/") and url:
                 try:
                     ext = "." + mimetype.split("/")[-1].split(";")[0]

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1673,6 +1673,192 @@ class TestIncomingDocumentHandling:
 
 
 # ---------------------------------------------------------------------------
+# TestFileAttachmentRaceCondition
+# ---------------------------------------------------------------------------
+
+
+class TestFileAttachmentRaceCondition:
+    """Verify that files arriving without url_private (Slack race condition)
+    are resolved via files.info retries."""
+
+    def _make_event(
+        self, files=None, text="hello", channel_type="im", blocks=None, attachments=None
+    ):
+        return {
+            "text": text,
+            "user": "U_USER",
+            "channel": "D123",
+            "channel_type": channel_type,
+            "ts": "1234567890.000001",
+            "files": files or [],
+            "blocks": blocks or [],
+            "attachments": attachments or [],
+        }
+
+    @pytest.mark.asyncio
+    async def test_file_race_resolves_after_retry(self, adapter):
+        """File without url_private should be resolved via files.info retry."""
+        # Stub file object: has id but no URL (simulates race condition)
+        stub_file = {
+            "id": "F_RACE1",
+            "mimetype": "image/png",
+            "name": "screenshot.png",
+            # no url_private_download or url_private
+        }
+        resolved_file = {
+            "id": "F_RACE1",
+            "mimetype": "image/png",
+            "name": "screenshot.png",
+            "url_private_download": "https://files.slack.com/screenshot.png",
+            "size": 4096,
+        }
+
+        client = adapter._get_client("D123")
+        client.files_info = AsyncMock(
+            return_value={"ok": True, "file": resolved_file}
+        )
+
+        with patch.object(
+            adapter, "_download_slack_file", new_callable=AsyncMock
+        ) as dl, patch("gateway.platforms.slack.asyncio.sleep", new_callable=AsyncMock):
+            dl.return_value = "/tmp/hermes/cache/images/img_test.png"
+            event = self._make_event(files=[stub_file])
+            await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.message_type == MessageType.PHOTO
+        assert len(msg_event.media_urls) == 1
+        # files.info was called at least once
+        client.files_info.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_file_race_fails_after_all_retries(self, adapter):
+        """File that never gets a URL after 3 retries should produce an
+        attachment notice, not a silent skip."""
+        stub_file = {
+            "id": "F_RACE2",
+            "mimetype": "image/jpeg",
+            "name": "photo.jpg",
+        }
+        # files.info always returns a file without URL
+        still_no_url = {
+            "id": "F_RACE2",
+            "mimetype": "image/jpeg",
+            "name": "photo.jpg",
+            # still no url_private_download
+        }
+
+        client = adapter._get_client("D123")
+        client.files_info = AsyncMock(
+            return_value={"ok": True, "file": still_no_url}
+        )
+
+        with patch("gateway.platforms.slack.asyncio.sleep", new_callable=AsyncMock):
+            event = self._make_event(
+                text="check this", files=[stub_file]
+            )
+            await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert "[Slack attachment notice]" in msg_event.text
+        assert "photo.jpg" in msg_event.text
+        assert "not yet available" in msg_event.text
+        assert "check this" in msg_event.text
+        # 3 retries should have been attempted
+        assert client.files_info.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_file_race_resolves_on_second_retry(self, adapter):
+        """files.info returns no URL on first try, then succeeds on second."""
+        stub_file = {
+            "id": "F_RACE3",
+            "name": "doc.pdf",
+            "mimetype": "application/pdf",
+        }
+        no_url_file = {
+            "id": "F_RACE3",
+            "name": "doc.pdf",
+            "mimetype": "application/pdf",
+        }
+        resolved_file = {
+            "id": "F_RACE3",
+            "name": "doc.pdf",
+            "mimetype": "application/pdf",
+            "url_private_download": "https://files.slack.com/doc.pdf",
+            "size": 2048,
+        }
+
+        client = adapter._get_client("D123")
+        # First call: no URL; second call: has URL
+        client.files_info = AsyncMock(
+            side_effect=[
+                {"ok": True, "file": no_url_file},
+                {"ok": True, "file": resolved_file},
+            ]
+        )
+
+        with patch.object(
+            adapter, "_download_slack_file_bytes", new_callable=AsyncMock
+        ) as dl, patch("gateway.platforms.slack.asyncio.sleep", new_callable=AsyncMock):
+            dl.return_value = b"%PDF-1.4 fake content"
+            event = self._make_event(files=[stub_file])
+            await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.message_type == MessageType.DOCUMENT
+        assert client.files_info.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_file_with_url_skips_race_retry(self, adapter):
+        """Files that already have url_private should NOT trigger files.info."""
+        normal_file = {
+            "id": "F_NORMAL",
+            "mimetype": "image/png",
+            "name": "normal.png",
+            "url_private_download": "https://files.slack.com/normal.png",
+            "size": 1024,
+        }
+
+        client = adapter._get_client("D123")
+        client.files_info = AsyncMock()
+
+        with patch.object(
+            adapter, "_download_slack_file", new_callable=AsyncMock
+        ) as dl:
+            dl.return_value = "/tmp/hermes/cache/images/img_normal.png"
+            event = self._make_event(files=[normal_file])
+            await adapter._handle_slack_message(event)
+
+        # files.info should NOT have been called — file already had a URL
+        client.files_info.assert_not_awaited()
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.message_type == MessageType.PHOTO
+
+    @pytest.mark.asyncio
+    async def test_file_race_files_info_api_error(self, adapter):
+        """When files.info returns an API error during race retry,
+        should still produce a notice after exhausting retries."""
+        stub_file = {
+            "id": "F_RACE_ERR",
+            "mimetype": "image/png",
+            "name": "broken.png",
+        }
+
+        client = adapter._get_client("D123")
+        client.files_info = AsyncMock(
+            return_value={"ok": False, "error": "file_not_found"}
+        )
+
+        with patch("gateway.platforms.slack.asyncio.sleep", new_callable=AsyncMock):
+            event = self._make_event(text="look at this", files=[stub_file])
+            await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert "[Slack attachment notice]" in msg_event.text
+        assert "broken.png" in msg_event.text
+
+
+# ---------------------------------------------------------------------------
 # TestMessageRouting
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

Slack sometimes fires the `message` event before file uploads finish processing. The file object arrives with an `id` and `name` but no `url_private_download` or `url_private`. 

Previously this caused a **silent skip** — the file fell through all `if/elif` branches with no notice. The user would see an error or 'unsupported attachment' on the first message, but the follow-up would work because by then the conversation history mentioned the file.

## Fix

When a file object has an `id` but no download URL, retry via `files.info` with exponential backoff (0.5s, 1s, 2s) up to 3 times. This gives Slack time to finish processing the upload.

- If the URL resolves → download proceeds normally
- If all retries fail → an explicit attachment notice is injected so the user knows the file wasn't processed (instead of silent skip)

This mirrors the existing pattern for Slack Connect files (`file_access == 'check_file_info'`) but applies it to regular uploads that arrive as stubs due to the race condition.

## Tests

5 new tests in `TestFileAttachmentRaceCondition`:
- resolve-on-first-retry
- resolve-on-second-retry  
- exhaust-all-retries (produces notice)
- normal-file-skips-retry (no regression)
- API-error during retry

All 199 existing Slack tests continue to pass.