### PR TITLE
fix(nix): remove deprecated MESSAGING_CWD env var from nixosModules

### DIFF
--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -883,7 +883,6 @@
             HOME = cfg.stateDir;
             HERMES_HOME = "${cfg.stateDir}/.hermes";
             HERMES_MANAGED = "true";
-            MESSAGING_CWD = cfg.workingDirectory;
           };
 
           serviceConfig = {
@@ -980,7 +979,6 @@
                 --env HERMES_HOME=${containerDataDir}/.hermes \
                 --env HERMES_MANAGED=true \
                 --env HOME=${containerHomeDir} \
-                --env MESSAGING_CWD=${containerWorkDir} \
                 ${lib.concatStringsSep " " cfg.container.extraOptions} \
                 ${cfg.container.image} \
                 ${containerDataDir}/current-package/bin/hermes gateway run --replace ${lib.concatStringsSep " " cfg.extraArgs}


### PR DESCRIPTION
## Summary

Remove the deprecated `MESSAGING_CWD` env var from the nix module. It was
the pre-config.yaml way to set the working directory for messaging
tools and has been deprecated in favor of `terminal.cwd` in
`config.yaml`. The nix module was still setting it, which produced
a startup warning on every nixos install.

## Changes

- **nix/nixosModules.nix line 886** — removed `MESSAGING_CWD = cfg.workingDirectory;` from the systemd service `environment` block
- **nix/nixosModules.nix line 983** — removed `--env MESSAGING_CWD=${containerWorkDir} \` from the container invocation

## Behavior

The Python fallback in `load_hermes_dotenv` still honors
`MESSAGING_CWD` if set externally (e.g. by an older `.env`),
so no behavior change for users who set it manually. New installs
will get the warning-free experience.

Fixes #44485