### PR TITLE
fix(agent): strip MEDIA directives from the deterministic fallback compaction summary too

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1110,6 +1110,10 @@ class ContextCompressor(ContextEngine):
 
         def _compact_fallback_turn(value: Any) -> str:
             text = redact_sensitive_text(_content_text_for_contains(value))
+            # Strip MEDIA delivery directives so a leaked MEDIA:<path> cannot
+            # re-trigger media reinjection from the persisted fallback summary
+            # (mirrors _serialize_for_summary; see #44708 / issue #14665).
+            text = _MEDIA_DIRECTIVE_RE.sub("[media attachment]", text)
             text = re.sub(r"\bgh[pousr]_[A-Za-z0-9_]{8,}\b", "[REDACTED]", text)
             text = re.sub(r"\s+", " ", text).strip()
             if len(text) > _FALLBACK_TURN_MAX_CHARS:
@@ -1270,7 +1274,10 @@ Continue from the most recent unfulfilled user ask and protected tail messages. 
 
 ## Critical Context
 Summary generation was unavailable, so this is a best-effort deterministic fallback for {len(turns_to_summarize)} compacted message(s).{reason_text}"""
-        summary = self._with_summary_prefix(redact_sensitive_text(body.strip()))
+        # Final guard: also strip MEDIA directives that can reach the body via
+        # tool-call args (_summarize_tool_result), which bypass the per-turn path.
+        clean_body = _MEDIA_DIRECTIVE_RE.sub("[media attachment]", redact_sensitive_text(body.strip()))
+        summary = self._with_summary_prefix(clean_body)
         if len(summary) > _FALLBACK_SUMMARY_MAX_CHARS:
             summary = summary[: _FALLBACK_SUMMARY_MAX_CHARS - 42].rstrip() + "\n...[fallback summary truncated]"
         return summary

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3120,17 +3120,17 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         return result
 
     def _augment_summary_lean(self, summary: str, turns_to_summarize: List[Dict[str, Any]]) -> str:
-        """Append deterministic lean-mode sections to a summary; no-op in legacy mode."""
-        if getattr(self, "tail_mode", "lean") != "lean":
-            return summary
-        for heading, build in (
-            (_LEAN_ANCHOR_HEADING, lambda: _redact_compaction_text(_build_anchor_index(turns_to_summarize))),
-            (_LEAN_USER_MESSAGES_HEADING, lambda: _redact_compaction_text(_build_verbatim_user_section(turns_to_summarize))),
-            (_LEAN_RECOVERY_HEADING, lambda: _build_recovery_footer(getattr(self, "_session_id", "") or "", len(turns_to_summarize))),
-        ):
-            if heading not in summary:
-                summary += build()
-        return summary
+        """Append lean-mode sections and keep delivery directives out of persisted summaries."""
+        if getattr(self, "tail_mode", "lean") == "lean":
+            for heading, build in (
+                (_LEAN_ANCHOR_HEADING, lambda: _redact_compaction_text(_build_anchor_index(turns_to_summarize))),
+                (_LEAN_USER_MESSAGES_HEADING, lambda: _redact_compaction_text(_build_verbatim_user_section(turns_to_summarize))),
+                (_LEAN_RECOVERY_HEADING, lambda: _build_recovery_footer(getattr(self, "_session_id", "") or "", len(turns_to_summarize))),
+            ):
+                if heading not in summary:
+                    summary += build()
+        # Both summary paths reach this point, after tool arguments and lean user text.
+        return _MEDIA_DIRECTIVE_RE.sub("[media attachment]", summary)
 
     @classmethod
     def _bound_summary_input(cls, content: str) -> str:

--- a/tests/agent/test_compressor_media_stripping.py
+++ b/tests/agent/test_compressor_media_stripping.py
@@ -54,3 +54,55 @@ class TestMediaDirectiveStripping:
         result = compressor._serialize_for_summary(turns)
         assert "MEDIA:" not in result
         assert result.count("[media attachment]") == 2
+
+
+class TestFallbackSummaryMediaStripping:
+    """MEDIA directives must also be stripped from the deterministic fallback
+    summary (the path taken when the LLM summarizer is unavailable). That
+    summary is *persisted*, so a leaked MEDIA:<path> would re-trigger media
+    reinjection on resume — the same bug #44708 fixed for the LLM path (#14665).
+    """
+
+    def test_media_stripped_from_fallback_assistant_content(self, compressor):
+        turns = [
+            {"role": "user", "content": "Please play MEDIA:/tmp/voice.ogg for me."},
+            {"role": "assistant", "content": "Sent the audio MEDIA:/tmp/voice.ogg."},
+        ]
+        result = compressor._build_static_fallback_summary(turns)
+        assert "MEDIA:/tmp/voice.ogg" not in result
+        assert "[media attachment]" in result
+
+    def test_media_stripped_from_fallback_tool_result(self, compressor):
+        turns = [
+            {"role": "tool", "tool_call_id": "t1", "content": "Generated MEDIA:/tmp/out.mp3 ok"},
+        ]
+        result = compressor._build_static_fallback_summary(turns)
+        assert "MEDIA:/tmp/out.mp3" not in result
+
+    def test_media_stripped_from_fallback_tool_args(self, compressor):
+        # A MEDIA: directive can reach the body through tool-call arguments
+        # (embedded by _summarize_tool_result and collected into relevant
+        # files), which bypass the per-turn text path — this is covered only by
+        # the final body scrub. The tool-call arg is the ONLY MEDIA source here,
+        # so "[media attachment]" appearing proves the arg actually reached the
+        # body and was scrubbed (positive control for the final guard); without
+        # the final scrub the raw directive would survive instead.
+        turns = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "t1", "function": {"name": "read_file", "arguments": '{"path": "MEDIA:/tmp/render.png"}'}}
+                ],
+            },
+            {"role": "tool", "tool_call_id": "t1", "content": "ok"},
+        ]
+        result = compressor._build_static_fallback_summary(turns)
+        assert "MEDIA:/tmp/render.png" not in result
+        assert "[media attachment]" in result
+
+    def test_non_media_path_preserved_in_fallback(self, compressor):
+        turns = [
+            {"role": "assistant", "content": "Edited /tmp/app.py and the tests pass."},
+        ]
+        result = compressor._build_static_fallback_summary(turns)
+        assert "/tmp/app.py" in result

--- a/tests/agent/test_compressor_media_stripping.py
+++ b/tests/agent/test_compressor_media_stripping.py
@@ -5,6 +5,7 @@ summaries — if they do, the downstream model re-emits them as active
 directives on the next turn.
 """
 import pytest
+import json
 from unittest.mock import patch
 from agent.context_compressor import ContextCompressor
 
@@ -62,6 +63,41 @@ class TestMediaDirectiveStripping:
         assert "[image]" in result
         assert "base64" not in result
 
+
+@pytest.mark.parametrize("mode", ["legacy", "lean"])
+def test_fallback_summary_never_preserves_delivery_directives(compressor, mode):
+    compressor.tail_mode = mode
+    sources = [
+        [{"role": "user", "content": "Please play MEDIA:/tmp/voice.ogg"}],
+        [{"role": "assistant", "content": "Sent MEDIA:/tmp/voice.ogg"}],
+        [{"role": "tool", "tool_call_id": "t1", "content": "Generated MEDIA:/tmp/out.mp3"}],
+        [
+            {"role": "assistant", "tool_calls": [{"id": "t1", "function": {
+                "name": "read_file", "arguments": json.dumps({"path": "MEDIA:/tmp/render.png"}),
+            }}]},
+            {"role": "tool", "tool_call_id": "t1", "content": "ok"},
+        ],
+    ]
+    for turns in sources:
+        turns = turns + [{"role": "assistant", "content": "Edited /tmp/app.py; tests pass."}]
+        result = compressor._build_static_fallback_summary(turns, reason="provider unavailable")
+        assert "MEDIA:" not in result
+        assert "[media attachment]" in result
+        assert "/tmp/app.py" in result
+
+
+@pytest.mark.parametrize("mode", ["legacy", "lean"])
+def test_summary_augmentation_cannot_reintroduce_delivery_directives(compressor, mode):
+    compressor.tail_mode = mode
+    result = compressor._augment_summary_lean(
+        "Previous summary: MEDIA:/tmp/old.png; preserve /tmp/app.py.",
+        [{"role": "user", "content": "Please play MEDIA:/tmp/new.ogg"}],
+    )
+    assert "MEDIA:" not in result
+    assert "[media attachment]" in result
+    assert "/tmp/app.py" in result
+    if mode == "lean":
+        assert "Please play" in result
 
 
 


### PR DESCRIPTION
#44708 strips `MEDIA:<path>` directives from the LLM-summarizer input (`_serialize_for_summary`), but the sibling deterministic `_build_static_fallback_summary` path has no such strip.

That fallback runs when the summarizer/aux-model is unavailable (provider outage) and **persists** its output. So a `MEDIA:` directive in a compacted turn currently survives verbatim into the persisted fallback summary and can re-trigger the media reinjection #44708/#14665 fixed — exactly on the path where the summary is the only continuity record.

This applies the existing `_MEDIA_DIRECTIVE_RE` strip in the fallback builder: at the per-turn chokepoint (mirroring `_serialize_for_summary`) and once on the assembled body, which also covers MEDIA directives that arrive through tool-call args (`_summarize_tool_result` / relevant files) and bypass the per-turn path.

Tests extend `tests/agent/test_compressor_media_stripping.py` to cover the fallback path (assistant content, tool result, and the tool-arg bypass).

If this already landed via a different patch, feel free to close and mark accordingly.