### PR TITLE
fix(desktop): stop stranding queued prompts across backend bounces

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -1411,7 +1411,11 @@ export function ChatBar({
     }
 
     void runDrain(() => entry)
-      .then(sent => void (sent ? undefined : onFail()))
+      .then(sent => {
+        if (!sent) {
+          onFail()
+        }
+      })
       .catch(onFail)
   }, [activeQueueSessionKey, busy, pickDrainHead, queuedPrompts, runDrain, t])
 
@@ -1437,7 +1441,7 @@ export function ChatBar({
     if (shouldAutoDrain({ isBusy: busy, queueLength: queuedPrompts.length })) {
       autoDrainNext()
     }
-  }, [activeQueueSessionKey, autoDrainNext, busy, queuedPrompts.length])
+  }, [autoDrainNext, busy, queuedPrompts.length])
 
   // Queue-edit cleanup: on session swap the scope effect already stashed the
   // edit snapshot; only restore into the composer when still on the same scope.

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -43,13 +43,16 @@ import {
 import {
   $queuedPromptsBySession,
   enqueueQueuedPrompt,
+  MAX_AUTO_DRAIN_ATTEMPTS,
+  migrateQueuedPrompts,
   promoteQueuedPrompt,
   type QueuedPromptEntry,
   removeQueuedPrompt,
-  shouldAutoDrainOnSettle,
+  shouldAutoDrain,
   updateQueuedPrompt
 } from '@/store/composer-queue'
 import { $statusItemsBySession } from '@/store/composer-status'
+import { notify } from '@/store/notifications'
 import { $gatewayState, $messages, setSessionPickerOpen } from '@/store/session'
 import { $threadScrolledUp } from '@/store/thread-scroll'
 import { useTheme } from '@/themes'
@@ -196,11 +199,14 @@ export function ChatBar({
   const composerSurfaceRef = useRef<HTMLDivElement | null>(null)
   const editorRef = useRef<HTMLDivElement | null>(null)
   const draftRef = useRef(draft)
-  const previousBusyRef = useRef(busy)
   const pendingDraftPersistRef = useRef<{ scope: string | null; text: string } | null>(null)
   const activeQueueSessionKeyRef = useRef(activeQueueSessionKey)
   activeQueueSessionKeyRef.current = activeQueueSessionKey
+  const prevQueueKeyRef = useRef(activeQueueSessionKey)
   const drainingQueueRef = useRef(false)
+  // Per-entry auto-drain failure counts; bounds retries so a persistent 404
+  // can't spin-loop. Cleared on success; reset naturally on remount/reconnect.
+  const drainFailuresRef = useRef(new Map<string, number>())
   const urlInputRef = useRef<HTMLInputElement | null>(null)
 
   const [urlOpen, setUrlOpen] = useState(false)
@@ -1326,6 +1332,7 @@ export function ChatBar({
           return false
         }
 
+        drainFailuresRef.current.delete(entry.id)
         removeQueuedPrompt(activeQueueSessionKey, entry.id)
         resetBrowseState(sessionId)
 
@@ -1337,15 +1344,16 @@ export function ChatBar({
     [activeQueueSessionKey, onSubmit, queuedPrompts, sessionId]
   )
 
-  const drainNextQueued = useCallback(
-    () =>
-      runDrain(entries => {
-        const skip = queueEdit?.entryId
+  const pickDrainHead = useCallback(
+    (entries: QueuedPromptEntry[]) => {
+      const skip = queueEditRef.current?.entryId
 
-        return skip ? entries.find(e => e.id !== skip) : entries[0]
-      }),
-    [queueEdit, runDrain]
+      return skip ? entries.find(e => e.id !== skip) : entries[0]
+    },
+    [] // reads the edit id off a ref so the lock-holder always sees the latest
   )
+
+  const drainNextQueued = useCallback(() => runDrain(pickDrainHead), [pickDrainHead, runDrain])
 
   const sendQueuedNow = useCallback(
     (id: string) => {
@@ -1364,30 +1372,72 @@ export function ChatBar({
         return true
       }
 
+      // A manual send clears the auto-drain backoff so a stuck entry the user
+      // taps gets a fresh attempt (and re-enables auto-retry on success).
+      drainFailuresRef.current.delete(id)
+
       return runDrain(entries => entries.find(e => e.id === id))
     },
     [activeQueueSessionKey, busy, onCancel, queueEdit, runDrain]
   )
 
-  // Auto-drain on busy → false (turn settled). Queued turns always flow once
-  // the session is idle again — whether the turn finished naturally or the
-  // user interrupted it. Interrupting to reach a queued message is the whole
-  // point of the queue, so we never suppress the drain. To cancel queued
-  // turns, the user deletes them from the panel.
-  useEffect(() => {
-    const wasBusy = previousBusyRef.current
-    previousBusyRef.current = busy
-
-    if (
-      shouldAutoDrainOnSettle({
-        isBusy: busy,
-        queueLength: queuedPrompts.length,
-        wasBusy
-      })
-    ) {
-      void drainNextQueued()
+  // Edge-independent auto-drain: send the head whenever the session is idle and
+  // the queue is non-empty, bounding retries so a thrown/rejected onSubmit (e.g.
+  // a stale-session 404) can't strand the entry permanently nor spin-loop. The
+  // drain lock serializes sends; a remount/reconnect resets the failure counts.
+  const autoDrainNext = useCallback(() => {
+    if (busy || drainingQueueRef.current || !activeQueueSessionKey) {
+      return
     }
-  }, [busy, drainNextQueued, queuedPrompts.length])
+
+    const entry = pickDrainHead(queuedPrompts)
+
+    if (!entry || (drainFailuresRef.current.get(entry.id) ?? 0) >= MAX_AUTO_DRAIN_ATTEMPTS) {
+      return
+    }
+
+    const onFail = () => {
+      const fails = (drainFailuresRef.current.get(entry.id) ?? 0) + 1
+      drainFailuresRef.current.set(entry.id, fails)
+
+      if (fails >= MAX_AUTO_DRAIN_ATTEMPTS) {
+        notify({
+          id: 'composer-queue-stuck',
+          kind: 'error',
+          title: t.composer.queueStuckTitle,
+          message: t.composer.queueStuckBody
+        })
+      }
+    }
+
+    void runDrain(() => entry)
+      .then(sent => void (sent ? undefined : onFail()))
+      .catch(onFail)
+  }, [activeQueueSessionKey, busy, pickDrainHead, queuedPrompts, runDrain, t])
+
+  // Re-key on a runtime session-id change. A stable stored id (queueSessionKey)
+  // never churns, so a change there is a real session switch and must NOT
+  // migrate; only the runtime-derived key (queueSessionKey falsy → key is
+  // sessionId) churns on a backend bounce/resume of the same conversation.
+  useEffect(() => {
+    const prev = prevQueueKeyRef.current
+    prevQueueKeyRef.current = activeQueueSessionKey
+
+    if (queueSessionKey || !prev || !activeQueueSessionKey || prev === activeQueueSessionKey) {
+      return
+    }
+
+    migrateQueuedPrompts(prev, activeQueueSessionKey)
+  }, [activeQueueSessionKey, queueSessionKey])
+
+  // Queued turns flow whenever the session is idle — on the busy→false settle
+  // edge, on mount/reconnect, and after a re-key — so a swallowed edge can't
+  // strand them. To cancel queued turns, the user deletes them from the panel.
+  useEffect(() => {
+    if (shouldAutoDrain({ isBusy: busy, queueLength: queuedPrompts.length })) {
+      autoDrainNext()
+    }
+  }, [activeQueueSessionKey, autoDrainNext, busy, queuedPrompts.length])
 
   // Queue-edit cleanup: on session swap the scope effect already stashed the
   // edit snapshot; only restore into the composer when still on the same scope.

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -436,7 +436,7 @@ export function ChatView({
                 onSteer={onSteer}
                 onSubmit={onSubmit}
                 onTranscribeAudio={onTranscribeAudio}
-                queueSessionKey={selectedSessionId || activeSessionId}
+                queueSessionKey={selectedSessionId}
                 sessionId={activeSessionId}
                 state={chatBarState}
               />

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
@@ -364,6 +364,45 @@ describe('usePromptActions submit / queue drain semantics', () => {
     })
   })
 
+  it('a fromQueue drain that hits "session busy" stays quiet (no error bubble) and a retry sends it', async () => {
+    // The drain can fire on the settle edge before the gateway has fully wound
+    // the turn down → transient 4009. It must not append a red "session busy"
+    // bubble; the entry stays queued and the next idle retry succeeds.
+    let attempt = 0
+    const seeds: Record<string, unknown>[] = []
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'prompt.submit') {
+        attempt += 1
+
+        if (attempt === 1) {
+          throw new Error('4009: session busy')
+        }
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => seeds.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    const first = await handle!.submitText('queued during a turn', { fromQueue: true })
+    expect(first).toBe(false)
+    // No assistant-error message was appended for the transient busy.
+    expect(seeds.some(s => Array.isArray(s.messages) && (s.messages as { error?: string }[]).some(m => m.error))).toBe(
+      false
+    )
+
+    const second = await handle!.submitText('queued during a turn', { fromQueue: true })
+    expect(second).toBe(true)
+  })
+
   it('a normal (non-queue) submit still respects the busyRef guard', async () => {
     const busyRef = { current: true }
     const requestGateway = vi.fn(async () => ({}) as never)

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
@@ -325,6 +325,45 @@ describe('usePromptActions submit / queue drain semantics', () => {
     })
   })
 
+  it('a rejected fromQueue drain returns false (entry stays queued) and a later retry sends it', async () => {
+    // A stale-session 404 must not strand the queued entry: submitPrompt returns
+    // false on failure so the composer keeps it, and the edge-independent
+    // auto-drain re-attempts once the session is idle again. storedSessionId is
+    // null so the session.resume recovery path is skipped and the error surfaces.
+    let attempt = 0
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'prompt.submit') {
+        attempt += 1
+
+        if (attempt === 1) {
+          throw new Error('404: {"detail":"Session not found"}')
+        }
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    render(
+      <Harness
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        storedSessionId={null}
+      />
+    )
+
+    const first = await handle!.submitText('please send me', { fromQueue: true })
+    expect(first).toBe(false)
+
+    const second = await handle!.submitText('please send me', { fromQueue: true })
+    expect(second).toBe(true)
+    expect(requestGateway).toHaveBeenCalledWith('prompt.submit', {
+      session_id: RUNTIME_SESSION_ID,
+      text: 'please send me'
+    })
+  })
+
   it('a normal (non-queue) submit still respects the busyRef guard', async () => {
     const busyRef = { current: true }
     const requestGateway = vi.fn(async () => ({}) as never)

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.test.tsx
@@ -364,10 +364,10 @@ describe('usePromptActions submit / queue drain semantics', () => {
     })
   })
 
-  it('a fromQueue drain that hits "session busy" stays quiet (no error bubble) and a retry sends it', async () => {
-    // The drain can fire on the settle edge before the gateway has fully wound
-    // the turn down → transient 4009. It must not append a red "session busy"
-    // bubble; the entry stays queued and the next idle retry succeeds.
+  it('rides out a transient "session busy" so the user never sees it (retries, no error bubble)', async () => {
+    // A submit racing the settle edge can hit a transient 4009 before the turn
+    // has fully wound down. It must be invisible: retried in place until the
+    // gateway accepts, never a red "session busy" bubble.
     let attempt = 0
     const seeds: Record<string, unknown>[] = []
     const requestGateway = vi.fn(async (method: string) => {
@@ -392,15 +392,12 @@ describe('usePromptActions submit / queue drain semantics', () => {
       />
     )
 
-    const first = await handle!.submitText('queued during a turn', { fromQueue: true })
-    expect(first).toBe(false)
+    expect(await handle!.submitText('sent while settling')).toBe(true)
+    expect(attempt).toBe(2) // rode past the busy on the second try
     // No assistant-error message was appended for the transient busy.
     expect(seeds.some(s => Array.isArray(s.messages) && (s.messages as { error?: string }[]).some(m => m.error))).toBe(
       false
     )
-
-    const second = await handle!.submitText('queued during a turn', { fromQueue: true })
-    expect(second).toBe(true)
   })
 
   it('a normal (non-queue) submit still respects the busyRef guard', async () => {
@@ -879,7 +876,7 @@ describe('usePromptActions sleep/wake session recovery', () => {
     const requestGateway = vi.fn(async (method: string) => {
       calls.push(method)
       if (method === 'prompt.submit') {
-        throw new Error('session busy')
+        throw new Error('gateway exploded')
       }
       return {} as never
     })

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -714,9 +714,17 @@ export function usePromptActions({
 
         return true
       } catch (err) {
+        releaseBusy()
+
+        // A queued drain that raced a not-yet-settled turn gets a transient
+        // "session busy" (4009). Don't surface an error bubble/toast — the entry
+        // stays queued and the composer's bounded auto-drain retries when idle.
+        if (options?.fromQueue && isSessionBusyError(err)) {
+          return false
+        }
+
         const message = inlineErrorMessage(err, copy.promptFailed)
 
-        releaseBusy()
         updateSessionState(sessionId, state => ({
           ...state,
           messages: [

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -118,16 +118,38 @@ function isSessionNotFoundError(error: unknown): boolean {
 }
 
 // The gateway refuses prompt.submit while a turn is running (4009 "session
-// busy"). Edit/restore (revert) can fire mid-turn, so they interrupt first then
-// retry the submit until the cooperative interrupt has wound the turn down.
-const REWIND_INTERRUPT_TIMEOUT_MS = 6_000
-const REWIND_RETRY_INTERVAL_MS = 150
+// busy"). It's a transient concurrency guard, never a user-facing error: a
+// submit racing the settle edge (or a rewind interrupting mid-turn) just waits
+// a beat for the turn to wind down, then lands. Bounded so a genuinely stuck
+// turn still surfaces eventually.
+const SESSION_BUSY_RETRY_TIMEOUT_MS = 6_000
+const SESSION_BUSY_RETRY_INTERVAL_MS = 150
 
 function isSessionBusyError(error: unknown): boolean {
   return /session busy/i.test(error instanceof Error ? error.message : String(error))
 }
 
 const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms))
+
+// Retry a gateway call across transient "session busy" so it never reaches the
+// user — the turn settles within the deadline and the call lands.
+async function withSessionBusyRetry<T>(call: () => Promise<T>): Promise<T> {
+  const deadline = Date.now() + SESSION_BUSY_RETRY_TIMEOUT_MS
+
+  for (;;) {
+    try {
+      return await call()
+    } catch (err) {
+      if (isSessionBusyError(err) && Date.now() < deadline) {
+        await sleep(SESSION_BUSY_RETRY_INTERVAL_MS)
+
+        continue
+      }
+
+      throw err
+    }
+  }
+}
 
 function base64FromDataUrl(dataUrl: string): string {
   const comma = dataUrl.indexOf(',')
@@ -683,7 +705,7 @@ export function usePromptActions({
         let submitErr: unknown = null
 
         try {
-          await requestGateway('prompt.submit', { session_id: sessionId, text })
+          await withSessionBusyRetry(() => requestGateway('prompt.submit', { session_id: sessionId, text }))
         } catch (firstErr) {
           if (isSessionNotFoundError(firstErr) && selectedStoredSessionIdRef.current) {
             // Re-register the session in the gateway and get a fresh live ID.
@@ -695,7 +717,7 @@ export function usePromptActions({
 
             if (recoveredId) {
               activeSessionIdRef.current = recoveredId
-              await requestGateway('prompt.submit', { session_id: recoveredId, text })
+              await withSessionBusyRetry(() => requestGateway('prompt.submit', { session_id: recoveredId, text }))
             } else {
               submitErr = firstErr
             }
@@ -1460,9 +1482,8 @@ export function usePromptActions({
   // text is submitted as a fresh turn. Callers confirm before invoking; errors
   // are rethrown so the confirmation dialog can surface them inline.
   // Submit a rewind (truncate-before-ordinal + resubmit). Because edit/restore
-  // can fire while a turn is streaming, interrupt the live turn first, then
-  // retry the submit until the gateway stops reporting "session busy" — the
-  // interrupt is cooperative, so the running turn takes a beat to wind down.
+  // can fire while a turn is streaming, interrupt the live turn first — the
+  // cooperative interrupt takes a beat, so the shared busy-retry rides it out.
   const submitRewindPrompt = useCallback(
     async (sessionId: string, text: string, truncateOrdinal: number | undefined, wasRunning: boolean) => {
       if (wasRunning) {
@@ -1473,27 +1494,13 @@ export function usePromptActions({
         }
       }
 
-      const deadline = Date.now() + REWIND_INTERRUPT_TIMEOUT_MS
-
-      for (;;) {
-        try {
-          await requestGateway('prompt.submit', {
-            session_id: sessionId,
-            text,
-            ...(truncateOrdinal !== undefined && { truncate_before_user_ordinal: truncateOrdinal })
-          })
-
-          return
-        } catch (err) {
-          if (isSessionBusyError(err) && Date.now() < deadline) {
-            await sleep(REWIND_RETRY_INTERVAL_MS)
-
-            continue
-          }
-
-          throw err
-        }
-      }
+      await withSessionBusyRetry(() =>
+        requestGateway('prompt.submit', {
+          session_id: sessionId,
+          text,
+          ...(truncateOrdinal !== undefined && { truncate_before_user_ordinal: truncateOrdinal })
+        })
+      )
     },
     [requestGateway]
   )

--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -8,7 +8,16 @@ import {
   type SyntaxHighlighterProps
 } from '@assistant-ui/react-streamdown'
 import { code } from '@streamdown/code'
-import { type ComponentProps, memo, type ReactNode, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  type ComponentProps,
+  memo,
+  type ReactNode,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
 
 import { PreviewAttachment } from '@/components/chat/preview-attachment'
 import { SyntaxHighlighter } from '@/components/chat/shiki-highlighter'

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1210,6 +1210,8 @@ export const en: Translations = {
     queueSendNext: 'Next',
     queueSend: 'Send',
     queueDelete: 'Delete',
+    queueStuckTitle: 'Queued message not sent',
+    queueStuckBody: 'A queued turn kept failing to send. It is still in the queue — try sending it again.',
     previewUnavailable: 'Preview unavailable',
     previewLabel: label => `Preview ${label}`,
     couldNotPreview: label => `Could not preview ${label}`,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1348,6 +1348,8 @@ export const ja = defineLocale({
     queueSendNext: '次に送信',
     queueSend: '送信',
     queueDelete: '削除',
+    queueStuckTitle: 'キュー内のメッセージを送信できません',
+    queueStuckBody: 'キューに入れたターンの送信が繰り返し失敗しました。まだキューに残っています。もう一度送信してください。',
     previewUnavailable: 'プレビューは利用できません',
     previewLabel: label => `${label} のプレビュー`,
     couldNotPreview: label => `${label} をプレビューできませんでした`,

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -925,6 +925,8 @@ export interface Translations {
     queueSendNext: string
     queueSend: string
     queueDelete: string
+    queueStuckTitle: string
+    queueStuckBody: string
     previewUnavailable: string
     previewLabel: (label: string) => string
     couldNotPreview: (label: string) => string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1304,6 +1304,8 @@ export const zhHant = defineLocale({
     queueSendNext: '下一個',
     queueSend: '傳送',
     queueDelete: '刪除',
+    queueStuckTitle: '佇列訊息未送出',
+    queueStuckBody: '佇列中的對話多次傳送失敗。它仍在佇列中，請重試傳送。',
     previewUnavailable: '預覽不可用',
     previewLabel: label => `預覽 ${label}`,
     couldNotPreview: label => `無法預覽 ${label}`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1398,6 +1398,8 @@ export const zh: Translations = {
     queueSendNext: '下一个',
     queueSend: '发送',
     queueDelete: '删除',
+    queueStuckTitle: '排队消息未发送',
+    queueStuckBody: '排队的对话多次发送失败。它仍在队列中，请重试发送。',
     previewUnavailable: '预览不可用',
     previewLabel: label => `预览 ${label}`,
     couldNotPreview: label => `无法预览 ${label}`,

--- a/apps/desktop/src/store/composer-queue.test.ts
+++ b/apps/desktop/src/store/composer-queue.test.ts
@@ -7,9 +7,10 @@ import {
   dequeueQueuedPrompt,
   enqueueQueuedPrompt,
   getQueuedPrompts,
+  migrateQueuedPrompts,
   promoteQueuedPrompt,
   removeQueuedPrompt,
-  shouldAutoDrainOnSettle,
+  shouldAutoDrain,
   updateQueuedPrompt,
   updateQueuedPromptText
 } from './composer-queue'
@@ -117,32 +118,53 @@ describe('composer queue store', () => {
   })
 })
 
-describe('shouldAutoDrainOnSettle', () => {
-  const base = { isBusy: false, queueLength: 1, wasBusy: true }
-
-  it('drains the next queued prompt when a turn settles', () => {
-    expect(shouldAutoDrainOnSettle(base)).toBe(true)
+describe('migrateQueuedPrompts', () => {
+  beforeEach(() => {
+    window.localStorage.removeItem(QUEUE_STORAGE_KEY)
+    $queuedPromptsBySession.set({})
   })
 
-  it('drains after an interrupt — the settle edge is the same', () => {
-    // Interrupting to reach a queued message is the point of the queue; the
-    // gateway emits the same settle whether the turn finished or was stopped.
-    expect(shouldAutoDrainOnSettle(base)).toBe(true)
+  it('moves entries from a dead runtime key onto the live one', () => {
+    enqueueQueuedPrompt('rt-old', { attachments: [], text: 'stranded' })
+
+    expect(migrateQueuedPrompts('rt-old', 'rt-new')).toBe(true)
+    expect(getQueuedPrompts('rt-old')).toEqual([])
+    expect(getQueuedPrompts('rt-new').map(e => e.text)).toEqual(['stranded'])
+    // The dead key is dropped from the store entirely.
+    expect($queuedPromptsBySession.get()['rt-old']).toBeUndefined()
   })
 
-  it('does not drain when the queue is empty', () => {
-    expect(shouldAutoDrainOnSettle({ ...base, queueLength: 0 })).toBe(false)
+  it('appends after existing target entries (FIFO preserved)', () => {
+    enqueueQueuedPrompt('rt-new', { attachments: [], text: 'already here' })
+    enqueueQueuedPrompt('rt-old', { attachments: [], text: 'migrated' })
+
+    migrateQueuedPrompts('rt-old', 'rt-new')
+
+    expect(getQueuedPrompts('rt-new').map(e => e.text)).toEqual(['already here', 'migrated'])
   })
 
-  it('ignores steady busy state (no true → false transition)', () => {
-    expect(shouldAutoDrainOnSettle({ ...base, isBusy: true })).toBe(false)
+  it('is a no-op when source is empty or keys match', () => {
+    expect(migrateQueuedPrompts('rt-old', 'rt-new')).toBe(false)
+    expect(migrateQueuedPrompts('rt-x', 'rt-x')).toBe(false)
+  })
+})
+
+describe('shouldAutoDrain', () => {
+  it('drains whenever idle with a non-empty queue', () => {
+    expect(shouldAutoDrain({ isBusy: false, queueLength: 1 })).toBe(true)
   })
 
-  it('ignores busy entry (false → true, not a settle)', () => {
-    expect(shouldAutoDrainOnSettle({ ...base, isBusy: true, wasBusy: false })).toBe(false)
+  it('drains on mount/reconnect with no observed busy edge', () => {
+    // The whole point of dropping the edge: a remount resets the busy ref, so an
+    // edge-gated drain would strand the entry. Idle + non-empty must still fire.
+    expect(shouldAutoDrain({ isBusy: false, queueLength: 2 })).toBe(true)
   })
 
-  it('ignores steady idle state (was not busy)', () => {
-    expect(shouldAutoDrainOnSettle({ ...base, wasBusy: false })).toBe(false)
+  it('does not drain mid-turn', () => {
+    expect(shouldAutoDrain({ isBusy: true, queueLength: 1 })).toBe(false)
+  })
+
+  it('does not drain an empty queue', () => {
+    expect(shouldAutoDrain({ isBusy: false, queueLength: 0 })).toBe(false)
   })
 })

--- a/apps/desktop/src/store/composer-queue.ts
+++ b/apps/desktop/src/store/composer-queue.ts
@@ -209,31 +209,58 @@ export const clearQueuedPrompts = (key: string | null | undefined) => {
   writeSession(sid, [])
 }
 
-/** Inputs to {@link shouldAutoDrainOnSettle}, captured at a `busy` transition. */
-export interface AutoDrainSettleInput {
-  wasBusy: boolean
+/**
+ * Move pending entries from a dead session key onto a live one, preserving FIFO
+ * (existing target entries first, migrated entries appended). A backend bounce /
+ * resume can mint a fresh runtime session id for the *same* conversation; the
+ * entries enqueued under the old id would otherwise be stranded under a key
+ * nothing reads anymore. No-op unless both keys resolve and differ.
+ */
+export const migrateQueuedPrompts = (
+  fromKey: string | null | undefined,
+  toKey: string | null | undefined
+): boolean => {
+  const from = sidOf(fromKey)
+  const to = sidOf(toKey)
+
+  if (!from || !to || from === to) {
+    return false
+  }
+
+  const pending = queueFor(from)
+
+  if (pending.length === 0) {
+    return false
+  }
+
+  const next = { ...$queuedPromptsBySession.get() }
+  delete next[from]
+  next[to] = [...queueFor(to), ...pending]
+
+  $queuedPromptsBySession.set(next)
+  save(next)
+
+  return true
+}
+
+/** Inputs to {@link shouldAutoDrain}. */
+export interface AutoDrainInput {
   isBusy: boolean
   queueLength: number
 }
 
 /**
- * Decide whether the composer should auto-drain the next queued prompt when a
- * turn settles (busy transitions true → false).
+ * Decide whether the composer should auto-drain the next queued prompt.
  *
- * Queued turns always advance once the session is idle again, whether the turn
- * finished naturally or the user interrupted it. Interrupting to reach a queued
- * message is the whole point of the queue, so we never suppress the drain. The
- * gateway guarantees a settle (message.complete + session.info running:false)
- * even after an interrupt, so this single edge reliably advances the queue. To
- * cancel queued turns the user deletes them from the panel.
+ * Edge-independent on purpose: the queue must advance whenever the session is
+ * idle and has pending entries, NOT only on an observed busy true → false edge.
+ * A backend bounce / websocket reconnect remounts the composer and resets the
+ * busy ref to the current value, swallowing the settle edge — an edge-gated
+ * drain would then strand the entry forever. The caller's drain lock
+ * (`drainingQueueRef`) serializes sends so being edge-free can't double-submit.
  */
-export const shouldAutoDrainOnSettle = (params: AutoDrainSettleInput): boolean => {
-  const { isBusy, queueLength, wasBusy } = params
+export const shouldAutoDrain = ({ isBusy, queueLength }: AutoDrainInput): boolean => !isBusy && queueLength > 0
 
-  // Only react to a true → false transition; ignore steady state and entry.
-  if (isBusy || !wasBusy) {
-    return false
-  }
-
-  return queueLength > 0
-}
+/** Auto-drain attempts for one entry before we stop retrying and toast. The
+ * entry stays queued for a manual send; a remount/reconnect resets the count. */
+export const MAX_AUTO_DRAIN_ATTEMPTS = 4

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1157,6 +1157,10 @@ canvas {
   margin-block-end: 0 !important;
 }
 
+[data-slot='aui_assistant-message-content'] .aui-md .aui-md-table thead {
+  border-bottom-color: var(--dt-border) !important;
+}
+
 /* Tool / thinking blocks are scaffolding around the model's reply, so we
    keep them transparent and fade them slightly. The reading column (prose)
    stays at full strength; scaffolding lifts back to full opacity on


### PR DESCRIPTION
## Summary

A message typed while the agent was mid-turn ("you good kid?") could stick as a dead pending bubble at the bottom of the chat and **never send** — no backend turn, no API call, no response (only a window reload cleared it). Handoff logs confirmed the text never reached the backend, and that the dashboard backend bounced repeatedly that session (update handoff + a second profile spinning up, dashboard port churning `50533 → 60624 → 49175 → 49537`), same stale-session family as the `404 Session not found` the renderer logged.

This is a **renderer-only** state bug in the composer queue drain. Three things, fixed as a class:

### 1. Swallowed busy edge (the strand)
The auto-drain fired *only* on an observed `busy:true→false` edge via `previousBusyRef`. A backend bounce/reconnect remounts the composer and resets that ref to the *current* busy value, so `wasBusy === isBusy`, the settle edge is lost, and the queue never drains. Replaced `shouldAutoDrainOnSettle` with the edge-independent **`shouldAutoDrain`** (`!isBusy && queueLength > 0`), now driven on the settle edge, on mount/reconnect, and after a re-key. `drainingQueueRef` still serializes sends.

### 2. Queue keyed to a session id that changed (the dead key)
The key was `queueSessionKey || sessionId`. When a resume mints a new runtime session id for the same conversation, the entry strands under a dead key. `chat/index.tsx` now passes the **stable stored id** (`selectedSessionId`) as `queueSessionKey` (resolved value unchanged), so the composer can tell runtime churn from a real session switch, and **`migrateQueuedPrompts`** re-keys pending entries **only** on a runtime-id change (never on a deliberate switch).

### 3. "Session busy" / failed drains never strand and never leak to the user
- A thrown/rejected `onSubmit` (e.g. stale-session 404) keeps the entry queued and retries on the next idle, bounded by `MAX_AUTO_DRAIN_ATTEMPTS` to avoid spin-loops, with one quiet toast on give-up (entry remains for a manual send, which clears the backoff; a remount/reconnect resets the count).
- **`session busy` (4009) is now invisible to the user.** It's the gateway's concurrency guard, not an error — the queue covers the deliberate "type while busy" case, so the only leak was a submit racing the settle edge. The rewind path's busy-retry is generalized into a shared **`withSessionBusyRetry`** wrapping *every* `prompt.submit` (fresh send, session-resume resubmit, rewind), so a transient busy is ridden out within a bounded deadline and the call lands silently.

No backend changes, no new env vars; renderer-only so prompt caching / role alternation are untouched (the lock prevents duplicate `prompt.submit`s).

## Test plan

- [x] `apps/desktop` typecheck (`npm run typecheck`)
- [x] Lint of changed files (0 errors)
- [x] `composer-queue.test.ts` — edge-free drain fires on idle+non-empty (remount/reconnect case); `migrateQueuedPrompts` re-keys and preserves FIFO
- [x] `use-prompt-actions.test.tsx` — rejected `fromQueue` drain keeps the entry + a later retry sends it; a transient `session busy` is ridden out transparently (no error bubble)
- [x] Confirmed the unrelated `src/` test failures (gateway-boot, Windows paths, model-settings, streaming, pane-shell) also fail on clean `main`