### PR TITLE
fix(profiles): also exclude response_store.db (+wal/shm) and hermes_state.db from --clone-all

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -109,14 +109,25 @@ _CLONE_ALL_DEFAULT_EXCLUDE_ROOT: frozenset[str] = frozenset({
 #
 # Rationale per item:
 #   state.db (+wal/shm) — SQLite session store (can reach many GB)
+#   response_store.db (+wal/shm) — per-profile gateway response store; carrying
+#                         it would resurrect the SOURCE profile's stored API
+#                         responses in the clone (cross-profile bleed) and can
+#                         be multi-GB
+#   hermes_state.db     — legacy per-profile state DB
 #   sessions            — per-session transcript/data dirs
 #   backups             — `hermes backup` archives
 #   state-snapshots     — quick-backup snapshot trees
 #   checkpoints         — session checkpoint data
+# This DB family mirrors the runtime-state entries already in
+# ``_DEFAULT_EXPORT_EXCLUDE_ROOT`` below.
 _CLONE_ALL_HISTORY_EXCLUDE_ROOT: frozenset[str] = frozenset({
     "state.db",
     "state.db-wal",
     "state.db-shm",
+    "response_store.db",
+    "response_store.db-wal",
+    "response_store.db-shm",
+    "hermes_state.db",
     "sessions",
     "backups",
     "state-snapshots",

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -57,6 +57,8 @@ _CLONE_ALL_DEFAULT_EXCLUDE_ROOT: frozenset[str] = frozenset({
 # duplicate deliveries) the moment its gateway starts. The empty dir is recreated below.
 _CLONE_ALL_HISTORY_EXCLUDE_ROOT: frozenset[str] = frozenset({
     "state.db", "state.db-wal", "state.db-shm", "sessions", "backups", "state-snapshots", "checkpoints",
+    # API responses and legacy state belong to the source profile, not its clone.
+    "response_store.db", "response_store.db-wal", "response_store.db-shm", "hermes_state.db",
     "cron",
 })
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -321,15 +321,20 @@ class TestCreateProfile:
         assert (profile_dir / "logs" / "gateway.log").read_text() == "log"
 
     def test_clone_all_excludes_history_artifacts(self, profile_env):
-        """--clone-all excludes the source's session history, backups, and
-        snapshots — a clone is a fresh workspace, and these can reach tens
-        of GB.  Applies to ANY source profile, not just default.
+        """--clone-all excludes the source's session history, runtime-state
+        DBs, backups, and snapshots — a clone is a fresh workspace, and these
+        can reach tens of GB.  Applies to ANY source profile, not just default.
         """
         tmp_path = profile_env
         default_home = tmp_path / ".hermes"
         (default_home / "state.db").write_text("sessions-data")
         (default_home / "state.db-wal").write_text("wal")
         (default_home / "state.db-shm").write_text("shm")
+        # Per-profile runtime-state DBs that belong to the SOURCE profile
+        (default_home / "response_store.db").write_text("source-responses")
+        (default_home / "response_store.db-wal").write_text("wal")
+        (default_home / "response_store.db-shm").write_text("shm")
+        (default_home / "hermes_state.db").write_text("legacy-state")
         (default_home / "sessions" / "20260101_old").mkdir(parents=True)
         (default_home / "backups").mkdir(exist_ok=True)
         (default_home / "backups" / "backup.tar.gz").write_text("archive")
@@ -337,20 +342,24 @@ class TestCreateProfile:
         (default_home / "checkpoints" / "cp1").mkdir(parents=True)
         # Data that should still copy
         (default_home / "config.yaml").write_text("model: gpt-4")
-        # Nested dirs with the same names must NOT be excluded (root-only)
+        # Nested files/dirs with the same names must NOT be excluded (root-only)
         (default_home / "workspace" / "backups").mkdir(parents=True)
         (default_home / "workspace" / "backups" / "user-data.txt").write_text("mine")
+        (default_home / "workspace" / "response_store.db").write_text("nested-keep")
 
         profile_dir = create_profile("fresh", clone_all=True, no_alias=True)
 
         for history in (
             "state.db", "state.db-wal", "state.db-shm",
+            "response_store.db", "response_store.db-wal", "response_store.db-shm",
+            "hermes_state.db",
             "sessions", "backups", "state-snapshots", "checkpoints",
         ):
             assert not (profile_dir / history).exists(), history
         assert (profile_dir / "config.yaml").read_text() == "model: gpt-4"
-        # Root-only: nested same-name dirs survive
+        # Root-only: nested same-name dir/file survive
         assert (profile_dir / "workspace" / "backups" / "user-data.txt").read_text() == "mine"
+        assert (profile_dir / "workspace" / "response_store.db").read_text() == "nested-keep"
 
     def test_clone_config_missing_files_skipped(self, profile_env):
         """Clone config gracefully skips files that don't exist in source."""

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -190,6 +190,22 @@ class TestCreateProfile:
         assert (profile_dir / ".env").read_text().strip() == "KEY=val"
         assert (profile_dir / "SOUL.md").read_text() == "Be helpful."
 
+    @pytest.mark.parametrize("source_name", ["default", "source"])
+    def test_clone_all_keeps_runtime_databases_out_of_new_profile(self, profile_env, source_name):
+        source = profile_env / ".hermes" if source_name == "default" else create_profile("source", no_alias=True)
+        databases = ("response_store.db", "response_store.db-wal", "response_store.db-shm", "hermes_state.db")
+        (source / "workspace").mkdir(exist_ok=True)
+        for name in databases:
+            (source / name).write_text("source history")
+            (source / "workspace" / name).write_text("user file")
+
+        cloned = create_profile("fresh", clone_from=source_name, clone_all=True, no_alias=True)
+
+        for name in databases:
+            assert not (cloned / name).exists(), name
+            assert (cloned / "workspace" / name).read_text() == "user file"
+            assert (source / name).read_text() == "source history"
+
     def test_clone_all_does_not_copy_cron_jobs(self, profile_env):
         # Cron jobs are scheduled work bound to the source profile + origin channel; a clone
         # that inherits jobs.json fires every job twice (two gateways, same job ids).


### PR DESCRIPTION
#45246 added `_CLONE_ALL_HISTORY_EXCLUDE_ROOT` so `--clone-all` stops carrying the source profile's runtime state into a fresh clone. It covers `state.db` (+wal/shm), `sessions`, `backups`, etc., but omits two sibling per-profile artifacts:

- `response_store.db` (+`-wal`/`-shm`) — the per-profile gateway response store (`get_hermes_home()/"response_store.db"`)
- `hermes_state.db` — the legacy per-profile state DB

The repo's own `_DEFAULT_EXPORT_EXCLUDE_ROOT` already lists this exact DB family, so the omission looks accidental. With it missing, `--clone-all` currently copies a potentially multi-GB `response_store.db` into the new profile **and** resurrects the SOURCE profile's stored API responses there (cross-profile response bleed) — the runtime-state carry-over #45246 set out to prevent.

This adds the family to the root-level exclude set (the exclusion is root-only, so a nested same-name file is still preserved). Test extends `test_clone_all_excludes_history_artifacts` to cover the new DBs and the nested-preservation case.

If this already landed via a different patch, feel free to close and mark accordingly.