### PR TITLE
fix(feishu): auto-wrap markdown with headings/tables into Schema 2.0 card

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -157,6 +157,14 @@ _MARKDOWN_HINT_RE = re.compile(
 # Detect markdown tables: a line starting with | followed by a separator line.
 # Feishu post-type 'md' elements do not render tables, so we force text mode.
 _MARKDOWN_TABLE_RE = re.compile(r"^\|.*\|\n\|[-|: ]+\|", re.MULTILINE)
+# Markdown features that only render correctly in Schema 2.0 card JSON.
+# Post-type 'md' silently drops headings, blockquotes, and tables on most
+# clients.  Content matching this pattern is auto-wrapped into a Schema 2.0
+# card so agents can write plain markdown and get correct rendering.
+_FEISHU_CARD_RE = re.compile(
+    r"(^#{1,6}\s)|(^>\s)|(^\|.*\|\n\|[-|: ]+\|)",
+    re.MULTILINE,
+)
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
 _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
@@ -4374,12 +4382,36 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
-        if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
+        # Card JSON detection — if content is valid JSON with card keys,
+        # send as interactive card.  Supports both Schema 1.0 (top-level
+        # elements/header/config) and Schema 2.0 (body.elements, schema).
+        try:
+            parsed = json.loads(content)
+            if isinstance(parsed, dict) and (
+                "elements" in parsed
+                or "header" in parsed
+                or "config" in parsed
+                or "body" in parsed
+            ):
+                return "interactive", content
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+        # Feishu post-type 'md' elements do NOT render headings, blockquotes,
+        # or tables reliably on most clients.  Auto-wrap markdown containing
+        # these features into Schema 2.0 card JSON so it renders correctly —
+        # agents write plain markdown, the adapter handles the conversion.
+        if _FEISHU_CARD_RE.search(content):
+            card = {
+                "schema": "2.0",
+                "config": {"update_multi": True},
+                "body": {
+                    "elements": [
+                        {"tag": "markdown", "content": content},
+                    ],
+                },
+            }
+            return "interactive", json.dumps(card, ensure_ascii=False)
         if _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}


### PR DESCRIPTION
## Problem

Feishu post-type `md` elements silently drop **headings** (`#`), **blockquotes** (`>`), and **tables** on most clients. When agents send structured markdown (which is most non-trivial output), it renders as flat text or blank content.

This affects all agents on all profiles — any message with `#` headings or markdown tables that doesn't explicitly construct card JSON gets broken rendering.

## Current behavior

```
_build_outbound_payload detection chain:
1. _MARKDOWN_TABLE_RE → text (plain text fallback, tables still broken)
2. _MARKDOWN_HINT_RE  → post (headings/blockquotes silently dropped)
3. fallback           → text
```

Note: card JSON detection (config/header/elements/body keys) was documented in the skill reference but **not present** in the upstream code path.

## Fix

Three changes to `_build_outbound_payload`:

1. **Add card JSON detection** — if content is valid JSON with card keys (`config`, `header`, `elements`, `body`), send as `interactive`. This was documented but missing from the code.

2. **Add `_FEISHU_CARD_RE`** (module-level regex) — detects markdown features that require Schema 2.0 rendering: headings (`# ...`), blockquotes (`> ...`), and tables (`| ... |`).

3. **Auto-wrap matching content** into Schema 2.0 card JSON — agents write plain markdown, the adapter handles the conversion transparently.

New detection chain:
```
1. Card JSON (explicit)       → interactive
2. Card-worthy markdown       → interactive (Schema 2.0 auto-wrap)  ← NEW
3. Other markdown hints       → post
4. Plain text                 → text
```

## Testing

Verified locally on macOS with Feishu adapter. Messages containing `#` headings now render as Schema 2.0 cards with correct heading/table rendering. Messages with only bold/lists (no headings/tables) still correctly route to `post` format.

## Notes

- `_FEISHU_CARD_RE` is compiled once at module level alongside the existing `_MARKDOWN_TABLE_RE` and `_MARKDOWN_HINT_RE` patterns
- The card JSON detection block is placed before the markdown checks (consistent with the documented detection order)
- No new dependencies or config changes required
