### PR TITLE
fix(install): bump bundled Node from 22 to 24 LTS

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -57,7 +57,7 @@ else
     INSTALL_DIR_EXPLICIT=false
 fi
 PYTHON_VERSION="3.11"
-NODE_VERSION="22"
+NODE_VERSION="24"
 
 # FHS-style root install layout (set by resolve_install_layout when applicable):
 #   code at /usr/local/lib/hermes-agent, command at /usr/local/bin/hermes,


### PR DESCRIPTION
## What

Change `NODE_VERSION` in `scripts/install.sh` from `22` to `24`.

## Why

Node 24 has been the active LTS since October 2025. The bundled Node 22 causes `EBADENGINE` warnings on every `hermes install` / `hermes update` because `@icons-pack/react-simple-icons@13.13.0` declares `engines.node >= 24`:

```
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: '@icons-pack/react-simple-icons@13.13.0',
npm warn EBADENGINE   required: { node: '>=24', pnpm: '>=10' },
npm warn EBADENGINE   current: { node: 'v22.22.3', npm: '10.9.8' }
npm warn EBADENGINE }
```

This warning repeats on every npm install cycle (Desktop app + browser tools), making update output noisy and masking real problems.

## How to test

1. Run `hermes update` or `hermes install`
2. Verify no `EBADENGINE` warnings appear
3. Verify the Desktop app builds and launches correctly

## Notes

- The existing `node_satisfies_build()` check (line 711) already accepts `>=22.12`, so Node 24 passes without logic changes
- The download URL template (`latest-v${NODE_VERSION}.x`) and PATH setup all use the variable and adapt automatically
- Cross-platform: the bundled Node version is platform-independent

Closes #45374