### PR TITLE
fix(desktop): upgrade electron-builder to 26.15.3

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -114,7 +114,7 @@
     "concurrently": "^10.0.3",
     "cross-env": "^10.1.0",
     "electron": "^40.9.3",
-    "electron-builder": "^26.8.1",
+    "electron-builder": "^26.15.3",
     "eslint": "^9.39.4",
     "eslint-plugin-perfectionist": "^5.9.0",
     "eslint-plugin-react": "^7.37.5",


### PR DESCRIPTION
## What

Upgrade `electron-builder` from `26.8.1` to `26.15.3` in `apps/desktop/package.json`.

## Why

`electron-builder@26.8.1` pulls in three deprecated transitive dependencies that emit warnings on every `hermes install` / `hermes update`:

```
npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory.
npm warn deprecated rimraf@2.6.3: Rimraf versions prior to v4 are no longer supported
npm warn deprecated glob@7.2.3: Old versions of glob are not supported, and contain widely publicized security vulnerabilities
```

Dependency chain:
```
electron-builder@26.8.1
├── app-builder-lib@26.8.1
│   ├── @electron/asar@3.4.1 → glob@7.2.3 → inflight@1.0.6
│   └── electron-builder-squirrel-windows@26.8.1
│       └── electron-winstaller@5.4.0 → temp@0.9.4 → rimraf@2.6.3 → glob@7.2.3
```

## How to test

1. Run `hermes update` or `hermes install`
2. Verify no `npm warn deprecated` lines for `inflight`, `rimraf@2`, or `glob@7`
3. Verify the Desktop app builds correctly (`npm run dist`)

Closes #45375