### PR TITLE
fix(desktop): migrate rcedit to @electron/rcedit

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -123,7 +123,7 @@
     "globals": "^16.5.0",
     "jsdom": "^29.1.1",
     "prettier": "^3.8.3",
-    "rcedit": "^5.0.2",
+    "@electron/rcedit": "^5.0.2",
     "typescript": "^6.0.3",
     "vite": "^8.0.10",
     "vitest": "^4.1.5",

--- a/apps/desktop/scripts/set-exe-identity.cjs
+++ b/apps/desktop/scripts/set-exe-identity.cjs
@@ -52,11 +52,11 @@ async function stampExeIdentity(exe, desktopRoot = path.resolve(__dirname, '..')
     throw new Error(`icon not found: ${icon}`)
   }
 
-  // rcedit is a direct devDependency of apps/desktop, so it resolves whether
+  // @electron/rcedit is a direct devDependency of apps/desktop, so it resolves whether
   // we're run from the desktop dir or the repo root (workspace hoist).
-  // rcedit@5 exports a NAMED `rcedit` function (CommonJS: { rcedit }), not a
+  // @electron/rcedit@5 exports a NAMED `rcedit` function (CommonJS: { rcedit }), not a
   // default export.
-  const mod = require('rcedit')
+  const mod = require('@electron/rcedit')
   const rcedit = typeof mod === 'function' ? mod : mod.rcedit
   if (typeof rcedit !== 'function') {
     throw new Error(`unexpected rcedit export shape: ${typeof mod} keys=${Object.keys(mod)}`)


### PR DESCRIPTION
## What

Replace deprecated `rcedit@5.0.2` with `@electron/rcedit@5.0.2` — the officially maintained fork published by the Electron team.

Changes:
- `apps/desktop/package.json`: `rcedit` → `@electron/rcedit`
- `apps/desktop/scripts/set-exe-identity.cjs`: update `require('rcedit')` → `require('@electron/rcedit')` and related comments

## Why

`rcedit@5.0.2` is deprecated ("Package no longer supported"). The npm registry directs users to `@electron/rcedit`, which is maintained under the official Electron GitHub organization with an identical API.

```
npm warn deprecated rcedit@5.0.2: Package no longer supported.
```

## How to test

1. Run `hermes update` or `hermes install`
2. Verify no `npm warn deprecated rcedit` line
3. On Windows: verify the built `Hermes.exe` has the correct icon and version metadata (the `set-exe-identity.cjs` script uses this package)

## Notes

- `@electron/rcedit` is a direct fork with the same interface — no API changes needed
- The export shape handling in `set-exe-identity.cjs` (named vs default) works identically

Closes #45376