### PR TITLE
fix(desktop): upgrade electron to 42.4.0

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -113,7 +113,7 @@
     "@vitejs/plugin-react": "^6.0.1",
     "concurrently": "^10.0.3",
     "cross-env": "^10.1.0",
-    "electron": "^40.9.3",
+    "electron": "^42.4.0",
     "electron-builder": "^26.8.1",
     "eslint": "^9.39.4",
     "eslint-plugin-perfectionist": "^5.9.0",
@@ -130,7 +130,7 @@
     "wait-on": "^9.0.5"
   },
   "build": {
-    "electronVersion": "40.9.3",
+    "electronVersion": "42.4.0",
     "appId": "com.nousresearch.hermes",
     "productName": "Hermes",
     "executableName": "Hermes",


### PR DESCRIPTION
## What

Upgrade `electron` from `40.9.3` to `42.4.0` in `apps/desktop/package.json`, and update `build.electronVersion` to match.

## Why

`electron@40.9.3` pulls in deprecated `boolean@3.2.0` via `@electron/get → global-agent → boolean`:

```
npm warn deprecated boolean@3.2.0: Package no longer supported.
```

Dependency chain:
```
electron@40.9.3
└── @electron/get@2.0.3
    └── global-agent@3.0.0
        ├── boolean@3.2.0
        └── roarr@2.15.4 → boolean@3.2.0 (deduped)
```

## How to test

1. Run `hermes update` or `hermes install`
2. Verify no `npm warn deprecated boolean` line
3. Verify the Desktop app builds and launches correctly (`npm run build && npm start`)
4. Test chat, composer, file attachments, and settings

Closes #45377