### PR TITLE
fix(agent): catch RuntimeError from Path.expanduser/home when $HOME is unset

### DIFF
--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -144,7 +144,7 @@ class SubdirectoryHintTracker:
                 if parent == p:
                     break  # filesystem root
                 p = parent
-        except (OSError, ValueError):
+        except (OSError, ValueError, RuntimeError):
             pass
 
     def _extract_paths_from_command(self, cmd: str, candidates: Set[Path]):
@@ -188,7 +188,7 @@ class SubdirectoryHintTracker:
         try:
             if not path.is_relative_to(self.working_dir):
                 return False
-        except (OSError, ValueError):
+        except (OSError, ValueError, RuntimeError):
             # Older Python or path resolution error — fall back to parent
             # check as a best-effort safeguard.
             if not _is_ancestor_or_same(self.working_dir, path):
@@ -210,7 +210,7 @@ class SubdirectoryHintTracker:
                     directory, self.working_dir,
                 )
                 return None
-        except (OSError, ValueError):
+        except (OSError, ValueError, RuntimeError):
             if not _is_ancestor_or_same(self.working_dir, directory):
                 logger.debug(
                     "Skipping hint files in %s — outside working_dir %s",
@@ -245,7 +245,7 @@ class SubdirectoryHintTracker:
                     try:
                         rel_path = str(hint_path.relative_to(Path.home()))
                         rel_path = "~/" + rel_path
-                    except ValueError:
+                    except (ValueError, RuntimeError):
                         pass  # keep absolute
                 found_hints.append((rel_path, content))
                 # First match wins per directory (like startup loading)

--- a/tests/agent/test_subdirectory_hints_runtime_error.py
+++ b/tests/agent/test_subdirectory_hints_runtime_error.py
@@ -1,0 +1,112 @@
+"""Tests for agent.subdirectory_hints RuntimeError guards.
+
+Python 3.11+ raises RuntimeError (not OSError/ValueError) from
+Path.expanduser() and Path.home() when $HOME is unset.  These tests
+verify that the hint tracker handles the missing-$HOME case gracefully
+instead of crashing the agent conversation loop.
+
+Regression test for https://github.com/NousResearch/hermes-agent/issues/45401
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agent.subdirectory_hints import SubdirectoryHintTracker
+
+
+@pytest.fixture()
+def tracker(tmp_path: Path) -> SubdirectoryHintTracker:
+    """Create a tracker rooted in a temporary directory."""
+    return SubdirectoryHintTracker(working_dir=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# _add_path_candidate — expanduser() RuntimeError
+# ---------------------------------------------------------------------------
+
+class TestAddPathCandidateRuntimeError:
+    """expanduser() raises RuntimeError when $HOME is unset (Python 3.11+)."""
+
+    def test_expanduser_runtime_error_gracefully_skipped(
+        self, tracker: SubdirectoryHintTracker, tmp_path: Path
+    ) -> None:
+        """_add_path_candidate must not crash when expanduser() raises RuntimeError."""
+        candidates: set[Path] = set()
+
+        with patch("pathlib.Path.expanduser", side_effect=RuntimeError("Could not determine home directory.")):
+            # Should not raise — RuntimeError is caught
+            tracker._add_path_candidate("~/some/path", candidates)
+
+        # Candidate set should be empty (path was skipped)
+        assert candidates == set()
+
+
+# ---------------------------------------------------------------------------
+# _is_valid_subdir — is_relative_to() RuntimeError
+# ---------------------------------------------------------------------------
+
+class TestIsValidSubdirRuntimeError:
+    """is_relative_to() may raise RuntimeError on some Python builds."""
+
+    def test_is_relative_to_runtime_error_returns_false(
+        self, tracker: SubdirectoryHintTracker, tmp_path: Path
+    ) -> None:
+        """_is_valid_subdir must return False (not crash) when is_relative_to raises RuntimeError."""
+        # Use a path outside the working directory so _is_ancestor_or_same
+        # also returns False after the RuntimeError fallback.
+        outside = Path("/tmp/outside-workdir-subdir")
+        outside.mkdir(exist_ok=True)
+        try:
+            with patch.object(Path, "is_relative_to", side_effect=RuntimeError("Could not determine home directory.")):
+                result = tracker._is_valid_subdir(outside)
+        finally:
+            outside.rmdir()
+
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# _load_hints_for_directory — is_relative_to() + Path.home() RuntimeError
+# ---------------------------------------------------------------------------
+
+class TestLoadHintsForDirectoryRuntimeError:
+    """_load_hints_for_directory must not crash when $HOME is unset."""
+
+    def test_is_relative_to_runtime_error_returns_none(
+        self, tracker: SubdirectoryHintTracker, tmp_path: Path
+    ) -> None:
+        """When is_relative_to raises RuntimeError, returns None (skip directory)."""
+        subdir = tmp_path / "project"
+        subdir.mkdir()
+
+        with patch.object(Path, "is_relative_to", side_effect=RuntimeError("Could not determine home directory.")):
+            result = tracker._load_hints_for_directory(subdir)
+
+        assert result is None
+
+    def test_path_home_runtime_error_in_relative_path_fallback(
+        self, tracker: SubdirectoryHintTracker, tmp_path: Path
+    ) -> None:
+        """When Path.home() raises RuntimeError in the relative-path fallback, hint is still returned."""
+        subdir = tmp_path / "project"
+        subdir.mkdir()
+        hint_file = subdir / "AGENTS.md"
+        hint_file.write_text("# Test hint\n")
+
+        original_home = Path.home
+
+        def _no_home():
+            raise RuntimeError("Could not determine home directory.")
+
+        with patch.object(Path, "home", side_effect=_no_home):
+            result = tracker._load_hints_for_directory(subdir)
+
+        # Hint should still be loaded — the RuntimeError only affects the
+        # display path fallback, not the actual content.
+        assert result is not None
+        assert "Test hint" in result


### PR DESCRIPTION
## What does this PR do?

Catches `RuntimeError` from `Path.expanduser()` and `Path.home()` in `SubdirectoryHintTracker` when the `$HOME` environment variable is unset, preventing the agent conversation loop from crashing.

## Related Issue

Fixes #45401

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/subdirectory_hints.py`: Added `RuntimeError` to 4 `except` clauses that previously only caught `(OSError, ValueError)`. On Python 3.11+, `Path.expanduser()` and `Path.home()` raise `RuntimeError` when `$HOME` is unset — this was unhandled and crashed the agent.
- `tests/agent/test_subdirectory_hints_runtime_error.py`: 4 tests covering each RuntimeError site — `_add_path_candidate`, `_is_valid_subdir`, `_load_hints_for_directory` (is_relative_to), and the `Path.home()` relative-path fallback.

## How to Test

1. `python -m pytest tests/agent/test_subdirectory_hints_runtime_error.py -v` — all 4 tests should pass
2. Verify the fix manually: `unset HOME && hermes chat` — should no longer crash with `RuntimeError: Could not determine home directory`
3. Confirm normal behavior: with `$HOME` set, hint tracking works as before

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/subdirectory_hints.py` (callers: 2 in `agent/tool_executor.py`, 1 in `agent/agent_init.py`)
- Blast radius: LOW — only adds exception types to existing catch clauses, no control-flow changes
- Related patterns: Python 3.11+ pathlib RuntimeError on missing $HOME
