### PR TITLE
fix(matrix): preserve markdown table structure

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -209,7 +209,7 @@ class _MatrixHtmlSanitizer(HTMLParser):
     _ALLOWED_TAGS = {
         "a", "b", "blockquote", "br", "code", "del", "em", "h1", "h2", "h3",
         "h4", "h5", "h6", "hr", "i", "li", "ol", "p", "pre", "s", "strike",
-        "strong", "ul",
+        "strong", "table", "tbody", "td", "th", "thead", "tr", "ul",
     }
     _VOID_TAGS = {"br", "hr"}
 

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1090,6 +1090,24 @@ class TestMatrixMarkdownToHtml:
         assert "<code" in result
         assert "print" in result
 
+    def test_matrix_markdown_preserves_table_structure(self):
+        table = "\n".join(
+            [
+                "| Item | Quantity |",
+                "| --- | --- |",
+                "| Apples | 4 |",
+                "| Bread | 1 |",
+            ]
+        )
+
+        result = self.adapter._markdown_to_html(table)
+
+        assert "<table>" in result
+        assert "<thead>" in result
+        assert "<tbody>" in result
+        assert "<th>Item</th>" in result
+        assert "<td>Apples</td>" in result
+
 
 # ---------------------------------------------------------------------------
 # Helper: display name extraction


### PR DESCRIPTION
## Summary
- Allow Matrix-formatted HTML table tags through the outbound sanitizer.
- Add a regression test for markdown pipe tables so `formatted_body` keeps `<table>`, header, and cell structure instead of flattening cell text.

## Test Plan
- [x] `uv run --extra dev python -m pytest tests/gateway/test_matrix.py::TestMatrixMarkdownToHtml tests/gateway/test_matrix.py::TestMatrixRenderingPayloads::test_render_plain_and_html_body -q`
- [x] `uv run --extra dev ruff check gateway/platforms/matrix.py tests/gateway/test_matrix.py`

Closes #45421
