### PR TITLE
docs(telegram): document private DM topic read-state limitation

### DIFF
--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -583,6 +583,10 @@ If you work on several long-running projects, topics keep their context separate
 
 Each topic gets its own conversation session, history, and context — completely isolated from the others.
 
+### Read-state limitation
+
+Telegram private DM topics have a Bot API read-state limitation. Hermes can receive messages from a user-created topic and route replies back into that topic, but normal bot accounts don't expose a reliable API for marking the topic copy of an incoming user message as read. Telegram may show the root 'All Messages' chat and the topic with different unread/read indicators. This is expected Telegram behaviour, not necessarily a Hermes processing failure.
+
 ### Configuration
 
 :::caution Prerequisites


### PR DESCRIPTION
## Summary

Documents a known Telegram Bot API limitation in the private DM topics
section of the user guide, so users don't misread it as a Hermes bug.

## Background

Telegram private DM topics (Bot API 9.4) allow multiple isolated
sessions within a single DM. There is a known read-state limitation:
when a user sends a message in a user-created topic, the Bot API
does not expose a reliable way to mark the topic copy of that
incoming message as read. Telegram may then show the root 'All
Messages' view as read while the topic stays unread (or vice versa).

## Fix

Added a new 'Read-state limitation' subsection to the
`## Private Chat Topics (Bot API 9.4)` section of
`website/docs/user-guide/messaging/telegram.md`, between 'Use case'
and 'Configuration'. The wording uses the suggested text from
issue #45295.

## Impact

No code change. No behaviour change. Pure documentation. Users who
hit this Telegram behaviour will see the explanation in the docs
instead of filing a bug report against Hermes.

Fixes #45295