### PR TITLE
fix(send_message): recognize WhatsApp JIDs as explicit send targets

### DIFF
--- a/tests/tools/test_send_message_target_parse.py
+++ b/tests/tools/test_send_message_target_parse.py
@@ -18,3 +18,44 @@ def test_photon_e164_target_is_explicit() -> None:
 def test_e164_target_still_requires_phone_platform() -> None:
     assert _parse_target_ref("matrix", "+15551234567")[2] is False
 
+
+def test_whatsapp_group_jid_is_explicit() -> None:
+    """WhatsApp group JIDs (e.g. 120363001234567890@g.us) must be recognized as explicit targets."""
+    chat_id, thread_id, is_explicit = _parse_target_ref("whatsapp", "120363001234567890@g.us")
+
+    assert chat_id == "120363001234567890@g.us"
+    assert thread_id is None
+    assert is_explicit is True
+
+
+def test_whatsapp_individual_jid_is_explicit() -> None:
+    """WhatsApp individual JIDs (e.g. 15551234567@s.whatsapp.net) must be explicit."""
+    chat_id, thread_id, is_explicit = _parse_target_ref("whatsapp", "15551234567@s.whatsapp.net")
+
+    assert chat_id == "15551234567@s.whatsapp.net"
+    assert thread_id is None
+    assert is_explicit is True
+
+
+def test_whatsapp_lid_jid_is_explicit() -> None:
+    """WhatsApp LID JIDs (e.g. 1234567890@lid) must be explicit."""
+    chat_id, thread_id, is_explicit = _parse_target_ref("whatsapp", "1234567890@lid")
+
+    assert chat_id == "1234567890@lid"
+    assert thread_id is None
+    assert is_explicit is True
+
+
+def test_whatsapp_jid_not_matched_for_other_platforms() -> None:
+    """JIDs should not be treated as explicit for non-WhatsApp platforms."""
+    assert _parse_target_ref("signal", "120363001234567890@g.us")[2] is False
+    assert _parse_target_ref("telegram", "15551234567@s.whatsapp.net")[2] is False
+
+
+def test_whatsapp_bare_phone_still_uses_e164() -> None:
+    """Bare phone numbers for WhatsApp should still match E.164 (with + prefix)."""
+    chat_id, _, is_explicit = _parse_target_ref("whatsapp", "+15551234567")
+
+    assert chat_id == "+15551234567"
+    assert is_explicit is True
+

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -40,6 +40,11 @@ _NUMERIC_TOPIC_RE = _TELEGRAM_TOPIC_TARGET_RE
 # downstream adapters (signal, etc.) expect.
 _PHONE_PLATFORMS = frozenset({"photon", "signal", "sms", "whatsapp"})
 _E164_TARGET_RE = re.compile(r"^\s*\+(\d{7,15})\s*$")
+# WhatsApp JIDs — individual chats use <number>@s.whatsapp.net, groups use
+# <number>@g.us, and LID-addressed contacts use <number>@lid.  These are
+# explicit send targets that should NOT fall through to home-channel
+# resolution.  See issue #18646.
+_WHATSAPP_JID_RE = re.compile(r"^\d+@(s\.whatsapp\.net|g\.us|lid)$")
 # Email addresses — a valid email like "user@domain.com" should be treated as
 # an explicit target for the email platform, not fall through to channel-name
 # resolution which has no way to resolve a raw address.
@@ -507,6 +512,10 @@ def _parse_target_ref(platform_name: str, target_ref: str):
             return topic, None, True
     if platform_name == "email":
         match = _EMAIL_TARGET_RE.fullmatch(target_ref)
+        if match:
+            return target_ref.strip(), None, True
+    if platform_name == "whatsapp":
+        match = _WHATSAPP_JID_RE.fullmatch(target_ref)
         if match:
             return target_ref.strip(), None, True
     if platform_name in _PHONE_PLATFORMS:


### PR DESCRIPTION
## What does this PR do?

Recognizes WhatsApp JIDs (group `@g.us`, individual `@s.whatsapp.net`, LID `@lid`) as explicit send targets in `send_message`'s target parser. Without this, `send_message(target='whatsapp:<group_jid>')` silently fell through to the home channel instead of delivering to the specified group.

## Related Issue

Fixes #18646

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/send_message_tool.py`: Added `_WHATSAPP_JID_RE` regex pattern and a WhatsApp-specific check in `_parse_target_ref()` before the E.164 phone-number fallback
- `tests/tools/test_send_message_target_parse.py`: Added 5 tests covering group JIDs, individual JIDs, LID JIDs, cross-platform isolation, and E.164 backward compatibility

## How to Test

1. Run `pytest tests/tools/test_send_message_target_parse.py -v` — all 7 tests should pass
2. Verify that `_parse_target_ref("whatsapp", "120363001234567890@g.us")` returns `("120363001234567890@g.us", None, True)`
3. Verify that `_parse_target_ref("signal", "120363001234567890@g.us")` returns `(None, None, False)` — JIDs should not match for other platforms

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `tools/send_message_tool.py::_parse_target_ref` (callers: 3 in send_message_tool.py, 1 in test files)
- Blast radius: LOW — adds a new code path before existing fallback; no existing behavior changed
- Related patterns: Similar to existing platform-specific JID/ID handlers (Slack `C`/`D`/`G` prefixes, Matrix `!`/`@` prefixes, XMPP `@` detection)
