### PR TITLE
fix(anthropic): try platform.claude.com for OAuth code exchange

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1346,18 +1346,36 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
             "code_verifier": verifier,
         }).encode()
 
-        req = urllib.request.Request(
+        # Anthropic migrated the OAuth token endpoint from console.anthropic.com
+        # to platform.claude.com; the legacy host now 404s on code exchange.
+        # Try the new endpoint first, fall back to the old one — mirroring the
+        # multi-endpoint logic already used by the token-refresh path.
+        exchange_endpoints = [
+            "https://platform.claude.com/v1/oauth/token",
             _OAUTH_TOKEN_URL,
-            data=exchange_data,
-            headers={
-                "Content-Type": "application/json",
-                "User-Agent": f"claude-cli/{_get_claude_code_version()} (external, cli)",
-            },
-            method="POST",
-        )
-
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            result = json.loads(resp.read().decode())
+        ]
+        result = None
+        last_error = None
+        for endpoint in exchange_endpoints:
+            req = urllib.request.Request(
+                endpoint,
+                data=exchange_data,
+                headers={
+                    "Content-Type": "application/json",
+                    "User-Agent": f"claude-cli/{_get_claude_code_version()} (external, cli)",
+                },
+                method="POST",
+            )
+            try:
+                with urllib.request.urlopen(req, timeout=15) as resp:
+                    result = json.loads(resp.read().decode())
+                break
+            except Exception as exc:
+                last_error = exc
+                logger.debug("Anthropic token exchange failed at %s: %s", endpoint, exc)
+                continue
+        if result is None:
+            raise last_error if last_error else RuntimeError("token exchange failed")
     except Exception as e:
         print(f"Token exchange failed: {e}")
         return None


### PR DESCRIPTION
## Problem

`hermes auth add anthropic --type oauth` (Claude Pro/Max subscription login) fails at the token-exchange step with:

```
Token exchange failed: HTTP Error 404: Not Found
Anthropic OAuth login did not return credentials.
```

Anthropic migrated its OAuth token endpoint from `console.anthropic.com` to `platform.claude.com`. The legacy host now returns 404 for the authorization-code exchange.

## Root cause

The token **refresh** path (`_refresh_claude_code_token`) already tries both hosts:

```python
token_endpoints = [
    "https://platform.claude.com/v1/oauth/token",
    "https://console.anthropic.com/v1/oauth/token",
]
```

But the authorization-code **exchange** in `run_hermes_oauth_login_pure()` was still hardcoded to the single legacy `_OAUTH_TOKEN_URL` (`console.anthropic.com`), so initial login 404s while refresh would have worked.

## Fix

Make the code exchange iterate the same endpoint list the refresh path uses — `platform.claude.com` first, `console.anthropic.com` as fallback — preserving the last error for the failure message. No behavior change beyond the endpoint fallback.

## Testing

Reproduced the 404 on a real `hermes auth add anthropic --type oauth` run, applied the fix, and the subscription OAuth login then completed successfully (credential stored, `hermes auth list anthropic` shows the active oauth credential). Syntax checked with `ast.parse`.