### PR TITLE
fix(cli): add monitor to auxiliary model picker (issue #45303)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3058,6 +3058,7 @@ _AUX_TASKS: list[tuple[str, str, str]] = [
     ("kanban_decomposer", "Kanban decomposer", "task decomposition"),
     ("profile_describer", "Profile describer", "auto profile descriptions"),
     ("curator", "Curator", "skill-usage review pass"),
+    ("monitor", "Monitor", "mail/feed classifier scoring"),
 ]
 
 


### PR DESCRIPTION
## Summary

Adds the missing `monitor` auxiliary task to the interactive model picker menu in `hermes model` → "Configure auxiliary models...".

## Problem

The `monitor` auxiliary task exists in `DEFAULT_CONFIG` (config.py) and is a valid config key used by the cron/scripts/classify_items.py for mail/feed catalog automation. However, it was missing from the `_AUX_TASKS` list in `hermes_cli/main.py`, meaning users could only configure it via manual `config.yaml` edits or `hermes config set` — not through the interactive UI.

The `session_search` auxiliary task mentioned in the issue was already removed in PR #27590 (single-shape tool returns DB content directly), so only `monitor` needed to be added.

## Solution

Added `monitor` to the `_AUX_TASKS` list with an appropriate description ("mail/feed classifier scoring"). The entry is placed after `curator` following the order in `DEFAULT_CONFIG` (config.py).

## Testing

- All existing tests in `tests/hermes_cli/test_aux_config.py` pass (21 tests)
- All existing tests in `tests/hermes_cli/test_plugin_auxiliary_tasks.py` pass (15 tests)
- All curator tests pass (57 tests)
- Verified `monitor` now appears in `_all_aux_tasks()` output

Fixes #45303