### PR TITLE
fix(cli): add CREATE_NO_WINDOW flag to uv subprocess calls (#45379)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6645,6 +6645,8 @@ def _run_install_with_heartbeat(
     can stay quiet for minutes. Emit a simple elapsed-time heartbeat so users
     know ``hermes update`` is still progressing even if pip/uv itself is silent.
     """
+    from hermes_cli._subprocess_compat import windows_hide_flags
+
     done = threading.Event()
     start = _time.time()
 
@@ -6666,6 +6668,7 @@ def _run_install_with_heartbeat(
             cwd=PROJECT_ROOT,
             check=True,
             env=env,
+            creationflags=windows_hide_flags(),
         )
     finally:
         done.set()

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -21,6 +21,7 @@ import copy
 from pathlib import Path
 from typing import Optional, Dict, Any
 
+from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.nous_subscription import get_nous_subscription_features
 from tools.tool_backend_helpers import managed_nous_tools_enabled
 from utils import base_url_hostname
@@ -1283,6 +1284,7 @@ def setup_terminal_backend(config: dict):
                         ],
                         capture_output=True,
                         text=True,
+                        creationflags=windows_hide_flags(),
                     )
                 else:
                     result = subprocess.run(
@@ -1336,6 +1338,7 @@ def setup_terminal_backend(config: dict):
                     [uv_bin, "pip", "install", "--python", sys.executable, "daytona"],
                     capture_output=True,
                     text=True,
+                    creationflags=windows_hide_flags(),
                 )
             else:
                 result = subprocess.run(
@@ -1986,6 +1989,7 @@ def _setup_matrix():
                     result = subprocess.run(
                         [uv_bin, "pip", "install", "--python", sys.executable, matrix_pkg],
                         capture_output=True, text=True,
+                        creationflags=windows_hide_flags(),
                     )
                 else:
                     result = subprocess.run(

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -24,6 +24,7 @@ from hermes_cli.config import (
     load_config, save_config, get_env_value, save_env_value,
 )
 from hermes_cli.colors import Colors, color
+from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.nous_subscription import (
     apply_nous_managed_defaults,
     get_nous_subscription_features,
@@ -612,6 +613,7 @@ def _pip_install(
                 [uv_bin, "pip", "install", *args],
                 capture_output=capture_output, text=True, timeout=timeout,
                 env=uv_env,
+                creationflags=windows_hide_flags(),
             )
             if result.returncode == 0:
                 return result

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -61,6 +61,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Optional
 
+from hermes_cli._subprocess_compat import windows_hide_flags
+
 logger = logging.getLogger(__name__)
 
 
@@ -366,6 +368,7 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                 [uv_bin, "pip", "install", *specs],
                 capture_output=True, text=True, timeout=timeout, env=uv_env,
                 stdin=subprocess.DEVNULL,
+                creationflags=windows_hide_flags(),
             )
             if r.returncode == 0:
                 return _InstallResult(True, r.stdout or "", r.stderr or "")


### PR DESCRIPTION
Fixes #45379. On Windows, uv.exe spawns a blank console window on every subprocess invocation because creationflags=CREATE_NO_WINDOW was missing from 6 subprocess.run() calls across 4 files. This adds the existing windows_hide_flags() helper from _subprocess_compat.py to each uv-specific call site, suppressing the console flash. The helper returns 0 on non-Windows so POSIX is unaffected.