### PR TITLE
fix(bedrock): honor resolve_bedrock_region() on runtime init paths

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -151,6 +151,26 @@ def _merge_custom_provider_extra_body(agent, custom_providers: List[Dict[str, An
     agent.request_overrides = overrides
 
 
+def _resolve_bedrock_runtime_region(base_url: Optional[str]) -> str:
+    """Resolve the AWS region for the Bedrock runtime init paths.
+
+    An explicit region embedded in the endpoint host
+    (``bedrock-runtime.<region>.amazonaws.com``) is the highest-priority
+    signal and always wins. When base_url carries no region, fall back to
+    ``resolve_bedrock_region()`` so the runtime honors the same AWS-SDK
+    precedence (AWS_REGION env, then AWS_DEFAULT_REGION, then the
+    ~/.aws/config profile region, then us-east-1) that model discovery, the
+    model picker, doctor, and auth already use. Previously these paths
+    hardcoded us-east-1 on no base_url match, which silently routed an
+    EU/AP user with a profile-configured region to us-east-1 at inference
+    time even though discovery showed their real region.
+    """
+    from agent.bedrock_adapter import resolve_bedrock_region
+
+    _region_match = re.search(r"bedrock-runtime\.([a-z0-9-]+)\.", base_url or "")
+    return _region_match.group(1) if _region_match else resolve_bedrock_region()
+
+
 def init_agent(
     agent,
     base_url: str = None,
@@ -623,8 +643,8 @@ def init_agent(
         _is_bedrock_anthropic = agent.provider == "bedrock"
         if _is_bedrock_anthropic:
             from agent.anthropic_adapter import build_anthropic_bedrock_client
-            _region_match = re.search(r"bedrock-runtime\.([a-z0-9-]+)\.", base_url or "")
-            _br_region = _region_match.group(1) if _region_match else "us-east-1"
+            # base_url region wins; otherwise consult AWS-SDK precedence.
+            _br_region = _resolve_bedrock_runtime_region(base_url)
             agent._bedrock_region = _br_region
             agent._anthropic_client = build_anthropic_bedrock_client(_br_region)
             agent._anthropic_api_key = "aws-sdk"
@@ -697,9 +717,10 @@ def init_agent(
                     print(f"🔑 Using token: {effective_key[:8]}...{effective_key[-4:]}")
     elif agent.api_mode == "bedrock_converse":
         # AWS Bedrock — uses boto3 directly, no OpenAI client needed.
-        # Region is extracted from the base_url or defaults to us-east-1.
-        _region_match = re.search(r"bedrock-runtime\.([a-z0-9-]+)\.", base_url or "")
-        agent._bedrock_region = _region_match.group(1) if _region_match else "us-east-1"
+        # base_url region wins; otherwise consult AWS-SDK precedence
+        # (env, then ~/.aws/config profile, then us-east-1) instead of
+        # silently hardcoding us-east-1.
+        agent._bedrock_region = _resolve_bedrock_runtime_region(base_url)
         # Guardrail config — read from config.yaml at init time.
         agent._bedrock_guardrail_config = None
         try:

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -509,6 +509,26 @@ def _normalize_run_budget_seconds(value) -> Optional[float]:
     return seconds
 
 
+def _resolve_bedrock_runtime_region(base_url: Optional[str]) -> str:
+    """Resolve the AWS region for the Bedrock runtime init paths.
+
+    An explicit region embedded in the endpoint host
+    (``bedrock-runtime.<region>.amazonaws.com``) is the highest-priority
+    signal and always wins. When base_url carries no region, fall back to
+    ``resolve_bedrock_region()`` so the runtime honors the same AWS-SDK
+    precedence (AWS_REGION env, then AWS_DEFAULT_REGION, then the
+    ~/.aws/config profile region, then us-east-1) that model discovery, the
+    model picker, doctor, and auth already use. Previously these paths
+    hardcoded us-east-1 on no base_url match, which silently routed an
+    EU/AP user with a profile-configured region to us-east-1 at inference
+    time even though discovery showed their real region.
+    """
+    from agent.bedrock_adapter import resolve_bedrock_region
+
+    _region_match = re.search(r"bedrock-runtime\.([a-z0-9-]+)\.", base_url or "")
+    return _region_match.group(1) if _region_match else resolve_bedrock_region()
+
+
 def init_agent(
     agent,
     base_url: str = None,
@@ -1140,8 +1160,8 @@ def init_agent(
         _is_bedrock_anthropic = agent.provider == "bedrock"
         if _is_bedrock_anthropic:
             from agent.anthropic_adapter import build_anthropic_bedrock_client
-            _region_match = re.search(r"bedrock-runtime\.([a-z0-9-]+)\.", base_url or "")
-            _br_region = _region_match.group(1) if _region_match else "us-east-1"
+            # base_url region wins; otherwise consult AWS-SDK precedence.
+            _br_region = _resolve_bedrock_runtime_region(base_url)
             agent._bedrock_region = _br_region
             agent._anthropic_client = build_anthropic_bedrock_client(_br_region)
             agent._anthropic_api_key = "aws-sdk"
@@ -1234,9 +1254,10 @@ def init_agent(
             print(f"🤖 AI Agent initialized with MoA preset: {agent.model}")
     elif agent.api_mode == "bedrock_converse":
         # AWS Bedrock — uses boto3 directly, no OpenAI client needed.
-        # Region is extracted from the base_url or defaults to us-east-1.
-        _region_match = re.search(r"bedrock-runtime\.([a-z0-9-]+)\.", base_url or "")
-        agent._bedrock_region = _region_match.group(1) if _region_match else "us-east-1"
+        # base_url region wins; otherwise consult AWS-SDK precedence
+        # (env, then ~/.aws/config profile, then us-east-1) instead of
+        # silently hardcoding us-east-1.
+        agent._bedrock_region = _resolve_bedrock_runtime_region(base_url)
         # Guardrail config — read from config.yaml at init time.
         agent._bedrock_guardrail_config = None
         try:

--- a/tests/agent/test_bedrock_runtime_region.py
+++ b/tests/agent/test_bedrock_runtime_region.py
@@ -1,0 +1,73 @@
+"""Tests for Bedrock runtime region resolution in agent_init.
+
+The runtime init paths in ``agent.agent_init`` previously hardcoded
+``us-east-1`` whenever base_url carried no region. That diverged from the
+rest of the Bedrock surface (model discovery, the picker, doctor, auth),
+which all resolve region via ``resolve_bedrock_region()`` with the AWS-SDK
+precedence (AWS_REGION env, then AWS_DEFAULT_REGION, then the ~/.aws/config
+profile region, then us-east-1). The split meant an EU/AP user with a
+profile-configured region saw their real region in discovery but routed to
+us-east-1 at inference time.
+
+These tests pin the behavior contract of the shared
+``_resolve_bedrock_runtime_region`` helper that both runtime paths use:
+  1. An explicit region in the endpoint host always wins.
+  2. With no region in base_url, the helper consults resolve_bedrock_region().
+"""
+
+from unittest.mock import patch
+
+
+class TestResolveBedrockRuntimeRegion:
+    def test_explicit_base_url_region_wins(self):
+        """A region in the endpoint host beats any env/profile resolution."""
+        from agent.agent_init import _resolve_bedrock_runtime_region
+
+        url = "https://bedrock-runtime.eu-west-1.amazonaws.com"
+        # Even if resolve_bedrock_region would return something else, the
+        # explicit endpoint region takes precedence and the helper is not
+        # consulted for a value.
+        with patch(
+            "agent.bedrock_adapter.resolve_bedrock_region",
+            return_value="ap-southeast-2",
+        ):
+            assert _resolve_bedrock_runtime_region(url) == "eu-west-1"
+
+    def test_no_base_url_region_falls_back_to_resolver(self):
+        """With no region in base_url, fall back to resolve_bedrock_region()."""
+        from agent.agent_init import _resolve_bedrock_runtime_region
+
+        with patch(
+            "agent.bedrock_adapter.resolve_bedrock_region",
+            return_value="eu-central-1",
+        ):
+            # Previously this returned the hardcoded "us-east-1".
+            assert _resolve_bedrock_runtime_region(None) == "eu-central-1"
+            assert _resolve_bedrock_runtime_region("") == "eu-central-1"
+
+    def test_base_url_without_bedrock_host_falls_back_to_resolver(self):
+        """A base_url that has no bedrock-runtime region also defers."""
+        from agent.agent_init import _resolve_bedrock_runtime_region
+
+        with patch(
+            "agent.bedrock_adapter.resolve_bedrock_region",
+            return_value="eu-central-1",
+        ):
+            assert (
+                _resolve_bedrock_runtime_region("https://example.invalid/v1")
+                == "eu-central-1"
+            )
+
+    def test_resolver_us_east_1_default_is_preserved(self):
+        """When the resolver yields us-east-1, the helper returns us-east-1.
+
+        This guards against a regression for the common no-env, no-profile
+        case: behavior for those users is unchanged.
+        """
+        from agent.agent_init import _resolve_bedrock_runtime_region
+
+        with patch(
+            "agent.bedrock_adapter.resolve_bedrock_region",
+            return_value="us-east-1",
+        ):
+            assert _resolve_bedrock_runtime_region(None) == "us-east-1"


### PR DESCRIPTION
## What this changes

The two AWS Bedrock runtime init paths in `agent/agent_init.py` (the
`anthropic_messages` bedrock path and the `bedrock_converse` path) previously
hardcoded `us-east-1` whenever `base_url` carried no region. That diverged from
the rest of the Bedrock surface (model discovery, the model picker, doctor, and
auth), which all resolve region via `agent/bedrock_adapter.py:resolve_bedrock_region()`
using AWS-SDK precedence:

```
1. AWS_REGION env var
2. AWS_DEFAULT_REGION env var
3. botocore configured region (~/.aws/config or SSO profile)
4. us-east-1 (hard fallback)
```

This PR adds a small shared helper, `_resolve_bedrock_runtime_region(base_url)`,
that both runtime paths now use. An explicit region embedded in the endpoint
host (`bedrock-runtime.<region>.amazonaws.com`) stays the highest-priority
signal and still wins. Only the no-match branch changes: it now consults
`resolve_bedrock_region()` instead of hardcoding `us-east-1`.

## The bug this fixes

An EU/AP (or any non-us-east-1) user who sets their region in `~/.aws/config`
via a named profile, with no `AWS_REGION` env var and no region in `base_url`,
gets a split-brain: the model picker shows their real region (eu-central-1,
say) because discovery uses the helper, but inference silently routes to
us-east-1 because the runtime paths did not. The result is an opaque Bedrock
error (model not enabled in us-east-1) or silent cross-region latency and
billing, with nothing pointing at region as the cause.

## Source signal

Surfaced while tracking Claude Code's Bedrock region-precedence work
(v2.1.172 added reading the region from `~/.aws` config files when
`AWS_REGION` is not set, matching AWS SDK precedence):
https://github.com/anthropics/claude-code/releases/tag/v2.1.172

That prompted a targeted read of whether the Hermes runtime path honored the
same precedence. The helper (`resolve_bedrock_region`) already did, and is
already used and tested elsewhere; the runtime wiring in `agent_init.py` did
not call it. This PR closes that one gap.

## Baseline verified on main

`git show origin/main:agent/agent_init.py` still shows both runtime paths
resolving region as `_region_match.group(1) if _region_match else "us-east-1"`
(lines 627 and 702 as of this PR), and `grep -c resolve_bedrock_region` against
that file on `main` returns 0. The gap is live on `main`, not just an older
checkout.

## Test evidence

New `tests/agent/test_bedrock_runtime_region.py` pins the behavior contract of
the shared helper:
- explicit base_url region wins over any env/profile resolution
- no region in base_url falls back to `resolve_bedrock_region()`
- a non-bedrock base_url also defers to the resolver
- a regression guard: when the resolver yields `us-east-1`, the helper returns
  `us-east-1` (the common no-env, no-profile case is unchanged)

```
bash scripts/run_tests.sh tests/agent/test_bedrock_runtime_region.py
=== Summary: 1 files, 4 tests passed, 0 failed (100% complete) ===
```

Static security scan over the added lines (secrets, shell injection, eval/exec,
pickle, SQL string-formatting): clean. Self-review checklist: no debug prints,
no commented-out code, no new env var, no config key, base_url precedence
preserved, lazy import avoids a circular dependency.

## Why this is safe to merge

- Additive and reversible: only the no-base_url-region branch changes; revert
  is one commit, no migration, no config change.
- base_url precedence is unchanged (an explicit endpoint region still wins).
- The helper it now calls is the same one the rest of the Bedrock surface uses
  and is already tested.
- Users with no env, no profile region, and no base_url region still resolve to
  `us-east-1` exactly as before (covered by a regression test).
- No security boundary, no forbidden surface, no new dependency.

## Provenance

Draft proposal:
`working/draft-proposals/2026-06-10-bedrock-runtime-region-precedence.md` in the
Argus profile. Baseline read and gap confirmed on `origin/main`.

Opened as a draft for maintainer review. Not for self-merge.
