### PR TITLE
fix(security): stop /api/status leaking host paths and PID on gated binds

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1640,17 +1640,16 @@ async def get_status():
         # Module not importable yet (early startup) — leave as [].
         pass
 
-    return {
+    # Always-public liveness + auth-gate shape. Safe for external uptime
+    # probes (NAS's wildcard-subdomain liveness probe), the SPA's pre-login
+    # bootstrap, and anyone who can curl the host — i.e. exactly the audience
+    # ``PUBLIC_API_PATHS`` documents this endpoint as serving.
+    status = {
         "version": __version__,
         "release_date": __release_date__,
-        "hermes_home": str(get_hermes_home()),
-        "config_path": str(get_config_path()),
-        "env_path": str(get_env_path()),
         "config_version": current_ver,
         "latest_config_version": latest_ver,
         "gateway_running": gateway_running,
-        "gateway_pid": gateway_pid,
-        "gateway_health_url": _GATEWAY_HEALTH_URL,
         "gateway_state": gateway_state,
         "gateway_platforms": gateway_platforms,
         "gateway_exit_reason": gateway_exit_reason,
@@ -1659,6 +1658,27 @@ async def get_status():
         "auth_required": auth_required,
         "auth_providers": auth_providers,
     }
+
+    # Absolute host paths, the gateway PID, and the internal gateway health
+    # URL are deployment recon a liveness probe never needs. ``/api/status``
+    # is in ``PUBLIC_API_PATHS`` so it bypasses dashboard auth; on a
+    # network-exposed (gated) bind that means *any* unauthenticated caller
+    # reaches it, and leaking host metadata there contradicts the allowlist's
+    # own contract ("version, gateway state, active session count, and the
+    # dashboard auth-gate shape. No bodies, no session content, no secrets").
+    # Surface this detail only on a loopback / ``--insecure`` bind, where the
+    # dashboard is local-only and the caller is already inside the trust
+    # envelope — the same loopback/gated split ``should_require_auth`` draws.
+    if not auth_required:
+        status.update({
+            "hermes_home": str(get_hermes_home()),
+            "config_path": str(get_config_path()),
+            "env_path": str(get_env_path()),
+            "gateway_pid": gateway_pid,
+            "gateway_health_url": _GATEWAY_HEALTH_URL,
+        })
+
+    return status
 
 
 _WINDOWS_11_MIN_BUILD = 22000

--- a/tests/hermes_cli/test_dashboard_auth_status_endpoint.py
+++ b/tests/hermes_cli/test_dashboard_auth_status_endpoint.py
@@ -96,3 +96,40 @@ def test_status_preserves_existing_fields(loopback_client):
     }
     missing = expected_keys - set(body.keys())
     assert not missing, f"/api/status dropped fields: {missing}"
+
+
+# Host-local detail (absolute paths, PID, internal gateway URL) is deployment
+# recon a liveness probe never needs. ``/api/status`` bypasses dashboard auth
+# (it is in ``PUBLIC_API_PATHS``), so on a network-exposed bind it must not
+# leak that detail to anonymous callers.
+_HOST_DETAIL_FIELDS = frozenset({
+    "hermes_home", "config_path", "env_path", "gateway_pid",
+    "gateway_health_url",
+})
+
+
+def test_status_withholds_host_detail_in_gated_mode(gated_client):
+    """On a gated (non-loopback) bind, the public ``/api/status`` probe must
+    expose only the liveness + auth-gate shape — never absolute host paths,
+    the gateway PID, or the internal gateway health URL. The endpoint
+    bypasses dashboard auth, so anyone who can reach the host hits it cold."""
+    r = gated_client.get("/api/status")
+    assert r.status_code == 200
+    body = r.json()
+    # Liveness / auth-gate shape stays public.
+    for key in ("version", "gateway_state", "auth_required", "auth_providers"):
+        assert key in body, f"liveness field {key!r} must stay public"
+    # Deployment recon must be withheld from the anonymous public probe.
+    leaked = _HOST_DETAIL_FIELDS & set(body.keys())
+    assert not leaked, f"/api/status leaked host detail under the gate: {leaked}"
+
+
+def test_status_includes_host_detail_in_loopback_mode(loopback_client):
+    """Counterpart to the gated case: a loopback bind is local-only, so the
+    full payload (including host paths and PID) is still served — preserving
+    the StatusPage / ``hermes status`` experience for local operators."""
+    r = loopback_client.get("/api/status")
+    assert r.status_code == 200
+    body = r.json()
+    missing = _HOST_DETAIL_FIELDS - set(body.keys())
+    assert not missing, f"loopback /api/status should keep host detail: {missing}"


### PR DESCRIPTION
## What

`/api/status` is in `PUBLIC_API_PATHS` and bypasses dashboard auth, but it
also returned absolute `hermes_home`, `config_path`, `env_path`, the gateway
PID, and the internal `gateway_health_url`. That exceeds the payload its own
allowlist documents as public — "version, gateway state, active session
count, and the dashboard auth-gate shape. No bodies, no session content, no
secrets" — leaking deployment recon to any unauthenticated caller on a
network-exposed (gated) bind.

## Fix

Withhold the host-local detail (absolute paths, PID, internal gateway URL)
unless the bind is loopback / `--insecure`, where the dashboard is local-only
and the caller is already inside the trust envelope — the same loopback/gated
split `should_require_auth` already draws. The public liveness probe and the
auth-gate badge are unchanged; loopback still returns the full payload.

## Tests

Run: `python -m pytest tests/hermes_cli/test_dashboard_auth_status_endpoint.py
tests/hermes_cli/test_web_server.py tests/hermes_cli/test_dashboard_auth_middleware.py
tests/hermes_cli/test_dashboard_auth_gate.py
tests/hermes_cli/test_dashboard_auth_401_reauth.py
tests/hermes_cli/test_web_server_host_header.py -k "status or gated or host or unauth"`

Results:
- `test_dashboard_auth_status_endpoint.py` — 5 passed, incl. 2 new invariants:
  gated mode withholds host detail; loopback keeps the full payload.
- `test_web_server.py` (`/api/status` incl. remote-gateway fallback) — 10 passed.
- `test_dashboard_auth_middleware.py` / `_gate.py` / `_401_reauth.py` /
  `test_web_server_host_header.py` — 104 passed, 1 skipped.

The Docker gate integration test (`tests/docker/test_dashboard.py`) asserts
only `/api/status` reachability + `auth_required`, both preserved by this
change.