### PR TITLE
fix(kanban): default to rollback journal policy

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -58,14 +58,15 @@ worktrees so that research / ops / digital-twin workloads work alongside
 coding workloads.  See ``docs/hermes-kanban-v1-spec.pdf`` for the full
 design specification.
 
-Concurrency strategy: WAL mode + ``BEGIN IMMEDIATE`` for write
+Concurrency strategy: rollback journaling by default (override with
+``HERMES_KANBAN_JOURNAL=wal`` when desired) + ``BEGIN IMMEDIATE`` for write
 transactions + compare-and-swap (CAS) updates on ``tasks.status`` and
-``tasks.claim_lock``.  SQLite serializes writers via its WAL lock, so at
-most one claimer can win any given task.  Losers observe zero affected
-rows and move on -- no retry loops, no distributed-lock machinery.
-The CAS coordination is **per-board** — each board is a separate DB,
-so multi-board installs get the same atomicity guarantees without any
-new locking.
+``tasks.claim_lock``.  SQLite serializes writers behind the write
+transaction, so at most one claimer can win any given task.  Losers
+observe zero affected rows and move on -- no retry loops, no
+distributed-lock machinery.  The CAS coordination is **per-board** —
+each board is a separate DB, so multi-board installs get the same
+atomicity guarantees without any new locking.
 """
 
 from __future__ import annotations
@@ -1463,9 +1464,16 @@ def connect(
                 # checks for DELETE mode. Respect HERMES_KANBAN_JOURNAL before running
                 # the WAL helper; otherwise every kanban connection silently flips the
                 # DB back to WAL and the watchdog oscillates DELETE -> WAL -> DELETE.
-                journal_policy = os.getenv("HERMES_KANBAN_JOURNAL", "wal").strip().lower()
+                journal_policy = os.getenv("HERMES_KANBAN_JOURNAL", "delete").strip().lower()
                 if journal_policy in {"delete", "persist", "truncate"}:
-                    conn.execute(f"PRAGMA journal_mode={journal_policy.upper()}")
+                    result = conn.execute(
+                        f"PRAGMA journal_mode={journal_policy.upper()}"
+                    ).fetchone()
+                    actual = result[0].lower() if result else ""
+                    if actual != journal_policy:
+                        raise RuntimeError(
+                            f"Kanban DB journal_mode requested {journal_policy}, got {actual}"
+                        )
                 else:
                     # WAL doesn't work on network filesystems (NFS/SMB/FUSE). Shared helper
                     # falls back to DELETE with one WARNING so kanban stays usable there.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1457,15 +1457,25 @@ def connect(
                 # sidecar files for a fresh database. Keep it in the same process-local
                 # critical section as schema initialization so concurrent gateway
                 # startup threads do not race before _INITIALIZED_PATHS is populated.
-                # WAL doesn't work on network filesystems (NFS/SMB/FUSE). Shared helper
-                # falls back to DELETE with one WARNING so kanban stays usable there.
-                # See hermes_state._WAL_INCOMPAT_MARKERS for detection logic.
-                from hermes_state import apply_wal_with_fallback
-                apply_wal_with_fallback(conn, db_label=f"kanban.db ({path.name})")
+                #
+                # Some deployments intentionally force rollback journaling for kanban
+                # because several user services share the same DB and the watchdog
+                # checks for DELETE mode. Respect HERMES_KANBAN_JOURNAL before running
+                # the WAL helper; otherwise every kanban connection silently flips the
+                # DB back to WAL and the watchdog oscillates DELETE -> WAL -> DELETE.
+                journal_policy = os.getenv("HERMES_KANBAN_JOURNAL", "wal").strip().lower()
+                if journal_policy in {"delete", "persist", "truncate"}:
+                    conn.execute(f"PRAGMA journal_mode={journal_policy.upper()}")
+                else:
+                    # WAL doesn't work on network filesystems (NFS/SMB/FUSE). Shared helper
+                    # falls back to DELETE with one WARNING so kanban stays usable there.
+                    # See hermes_state._WAL_INCOMPAT_MARKERS for detection logic.
+                    from hermes_state import apply_wal_with_fallback
+                    apply_wal_with_fallback(conn, db_label=f"kanban.db ({path.name})")
+                    conn.execute("PRAGMA wal_autocheckpoint=100")
                 # FULL (was NORMAL): fsync before each checkpoint to narrow the
                 # crash window that can leave a b-tree page header torn.
                 conn.execute("PRAGMA synchronous=FULL")
-                conn.execute("PRAGMA wal_autocheckpoint=100")
                 conn.execute("PRAGMA foreign_keys=ON")
                 # Zero freed pages so a later torn write cannot expose stale
                 # cell content; persisted in the DB header for new DBs.

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -67,6 +67,22 @@
   gap: 0.75rem;
   align-items: start;
   overflow-x: auto;
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--color-muted-foreground) 45%, transparent) transparent;
+  padding-bottom: 0.35rem;
+}
+.hermes-kanban-columns::-webkit-scrollbar {
+  height: 0.6rem;
+}
+.hermes-kanban-columns::-webkit-scrollbar-track {
+  background: transparent;
+}
+.hermes-kanban-columns::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--color-muted-foreground) 45%, transparent);
+  border-radius: 999px;
+}
+.hermes-kanban-columns::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in srgb, var(--color-muted-foreground) 65%, transparent);
 }
 
 .hermes-kanban-column {

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2664,6 +2664,7 @@ def test_connect_falls_back_to_delete_on_locking_protocol(tmp_path, monkeypatch,
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_JOURNAL", "wal")
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
     # Clear module cache so a fresh connect() is attempted
@@ -4119,9 +4120,10 @@ def test_write_txn_post_commit_check_fires_every_call(tmp_path):
     conn.close()
 
 
-def test_connect_sets_wal_autocheckpoint_100(tmp_path):
-    """connect() sets wal_autocheckpoint to 100."""
+def test_connect_sets_wal_autocheckpoint_100(tmp_path, monkeypatch):
+    """connect() sets wal_autocheckpoint to 100 when WAL is requested."""
     from hermes_cli.kanban_db import connect
+    monkeypatch.setenv("HERMES_KANBAN_JOURNAL", "wal")
     db = tmp_path / "test.db"
     conn = connect(db_path=db)
     val = conn.execute("PRAGMA wal_autocheckpoint").fetchone()[0]

--- a/tests/hermes_cli/test_kanban_db_journal_policy.py
+++ b/tests/hermes_cli/test_kanban_db_journal_policy.py
@@ -24,14 +24,14 @@ def test_connect_respects_delete_journal_policy(tmp_path, monkeypatch):
     assert _journal_mode(db_path) == "delete"
 
 
-def test_connect_defaults_to_wal_policy(tmp_path, monkeypatch):
+def test_connect_defaults_to_delete_journal_policy(tmp_path, monkeypatch):
     db_path = tmp_path / "kanban.db"
     monkeypatch.delenv("HERMES_KANBAN_JOURNAL", raising=False)
 
     conn = kanban_db.connect(db_path=db_path)
     try:
-        assert conn.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
+        assert conn.execute("PRAGMA journal_mode").fetchone()[0] == "delete"
     finally:
         conn.close()
 
-    assert _journal_mode(db_path) == "wal"
+    assert _journal_mode(db_path) == "delete"

--- a/tests/hermes_cli/test_kanban_db_journal_policy.py
+++ b/tests/hermes_cli/test_kanban_db_journal_policy.py
@@ -1,0 +1,37 @@
+import sqlite3
+
+from hermes_cli import kanban_db
+
+
+def _journal_mode(path):
+    conn = sqlite3.connect(str(path))
+    try:
+        return conn.execute("PRAGMA journal_mode").fetchone()[0]
+    finally:
+        conn.close()
+
+
+def test_connect_respects_delete_journal_policy(tmp_path, monkeypatch):
+    db_path = tmp_path / "kanban.db"
+    monkeypatch.setenv("HERMES_KANBAN_JOURNAL", "delete")
+
+    conn = kanban_db.connect(db_path=db_path)
+    try:
+        assert conn.execute("PRAGMA journal_mode").fetchone()[0] == "delete"
+    finally:
+        conn.close()
+
+    assert _journal_mode(db_path) == "delete"
+
+
+def test_connect_defaults_to_wal_policy(tmp_path, monkeypatch):
+    db_path = tmp_path / "kanban.db"
+    monkeypatch.delenv("HERMES_KANBAN_JOURNAL", raising=False)
+
+    conn = kanban_db.connect(db_path=db_path)
+    try:
+        assert conn.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
+    finally:
+        conn.close()
+
+    assert _journal_mode(db_path) == "wal"


### PR DESCRIPTION
## Summary
- default Kanban DB journal policy to rollback journaling unless WAL is explicitly requested
- verify rollback journal PRAGMA return values instead of silently accepting failures
- keep WAL fallback/autocheckpoint coverage behind explicit HERMES_KANBAN_JOURNAL=wal tests

## Test Plan
- uv run --with pytest python -m pytest -q tests/hermes_cli/test_kanban_db_journal_policy.py tests/hermes_cli/test_kanban_db.py
