### PR TITLE
fix(agent): catch RuntimeError from Path.expanduser/home when $HOME is unset

### DIFF
--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -144,7 +144,7 @@ class SubdirectoryHintTracker:
                 if parent == p:
                     break  # filesystem root
                 p = parent
-        except (OSError, ValueError):
+        except (OSError, ValueError, RuntimeError):
             pass
 
     def _extract_paths_from_command(self, cmd: str, candidates: Set[Path]):
@@ -245,7 +245,7 @@ class SubdirectoryHintTracker:
                     try:
                         rel_path = str(hint_path.relative_to(Path.home()))
                         rel_path = "~/" + rel_path
-                    except ValueError:
+                    except (ValueError, RuntimeError):
                         pass  # keep absolute
                 found_hints.append((rel_path, content))
                 # First match wins per directory (like startup loading)

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -325,3 +325,38 @@ class TestOutsideWorkspaceRejection:
         outside.mkdir(exist_ok=True)
         tracker = SubdirectoryHintTracker(working_dir=str(project))
         assert tracker._is_valid_subdir(outside) is False
+
+    def test_expanduser_runtime_error_when_home_unset(self, project):
+        """_add_path_candidate should not crash when $HOME is unset (Python 3.11+).
+
+        Path.expanduser() raises RuntimeError when $HOME is unset on some
+        platforms. The except clause must catch it.
+        """
+        tracker = SubdirectoryHintTracker(working_dir=str(project))
+        with patch("pathlib.Path.expanduser", side_effect=RuntimeError("Could not determine home directory")):
+            # Should not raise — gracefully skip the path
+            candidates = set()
+            tracker._add_path_candidate("~/some/path", candidates)
+            assert candidates == set()
+
+    def test_path_home_runtime_error_in_relative_display(self, project):
+        """Relative path display should not crash when Path.home() raises RuntimeError.
+
+        When $HOME is unset, Path.home() raises RuntimeError on some platforms.
+        The relative-path fallback must catch it and keep the absolute path.
+        """
+        tracker = SubdirectoryHintTracker(working_dir=str(project))
+        # Create a hint file in a subdirectory
+        subdir = project / "sub"
+        subdir.mkdir()
+        (subdir / "AGENTS.md").write_text("sub hints")
+        # Read a file in that subdirectory to trigger hint loading
+        (subdir / "main.py").write_text("print('hello')")
+        with patch("pathlib.Path.home", side_effect=RuntimeError("Could not determine home directory")):
+            # Should not raise — gracefully falls back to absolute path
+            result = tracker.check_tool_call(
+                "read_file", {"path": str(subdir / "main.py")}
+            )
+            # Result should still contain the hint content
+            assert result is not None
+            assert "sub hints" in result


### PR DESCRIPTION
## What does this PR do?

Fixes a crash in `subdirectory_hints.py` when the `$HOME` environment variable is unset. On Python 3.11+, `Path.expanduser()` and `Path.home()` raise `RuntimeError` (not `OSError` or `ValueError`) when `$HOME` is unset, but the existing `except` clauses only caught the latter two — allowing the `RuntimeError` to propagate and crash the agent conversation loop.

## Related Issue

Fixes #45401

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/subdirectory_hints.py`: Added `RuntimeError` to both `except` clauses that handle `Path.expanduser()` (line 147) and `Path.home()` (line 248) calls
- `tests/agent/test_subdirectory_hints.py`: Added 2 regression tests verifying graceful handling when `expanduser()` and `Path.home()` raise `RuntimeError`

## How to Test

1. Run `pytest tests/agent/test_subdirectory_hints.py -v` — all 27 tests should pass
2. On a Linux system (or container) without `$HOME` set: `env -u HOME python -c "from agent.subdirectory_hints import SubdirectoryHintTracker; t = SubdirectoryHintTracker(working_dir='.'); print('OK')"` — should not crash
3. Verify existing functionality still works: `pytest tests/agent/test_subdirectory_hints.py::TestSubdirectoryHintTracker -v`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/subdirectory_hints.py` — `_add_path_candidate()`, `_load_hints_for_file()`
- Blast radius: LOW — only affects error handling in hint discovery, no control flow changes
- Related patterns: `Path.expanduser()` / `Path.home()` RuntimeError on Python 3.11+ when `$HOME` is unset (common in containers/CI)
