### PR TITLE
fix(hermes_state): set message_count and tool_call_count to 0 on session creation

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1187,8 +1187,8 @@ class SessionDB:
         def _do(conn):
             conn.execute(
                 """INSERT OR IGNORE INTO sessions (id, source, user_id, model, model_config,
-                   system_prompt, parent_session_id, cwd, started_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   system_prompt, parent_session_id, cwd, started_at, message_count, tool_call_count)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0)""",
                 (
                     session_id,
                     source,


### PR DESCRIPTION
## Summary

In `_insert_session_row`, the INSERT statement did not include `message_count` and `tool_call_count` columns. This caused these columns to remain NULL on session creation when the columns' DEFAULT 0 was not applied (e.g., on older databases where the schema evolved without defaults).

## Impact

- Desktop sidebar with `min_messages=1` incorrectly filters out api_server/tui sessions
- 150 TUI sessions had only 3 with `message_count >= 1`
- 35 api_server sessions had 0 with `message_count >= 1`

## Fix

Explicitly set `message_count = 0` and `tool_call_count = 0` in the INSERT statement (2-line change).

## Test Plan

- Existing tests pass: `message_count` column already has `DEFAULT 0` in DDL; this fix is defensive for schema evolution edge cases
- Workaround SQL from the issue already works as a backfill

Closes #45236