### PR TITLE
fix(cli): custom provider dedup overwrites same-URL entries with different names

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3600,11 +3600,18 @@ def _save_custom_provider(
     if not isinstance(providers, list):
         providers = []
 
-    # Check if this URL is already saved — update model/context_length if so
+    # Check if this provider is already saved — update if name+url match.
+    # Same URL with a DIFFERENT name creates a new entry (multiple profiles
+    # for one endpoint, e.g. different API keys or model subsets).
     for entry in providers:
         if isinstance(entry, dict) and entry.get("base_url", "").rstrip(
             "/"
         ) == base_url.rstrip("/"):
+            # If the user gave an explicit name that differs from this
+            # entry's name, skip — it's a different provider profile.
+            entry_name = str(entry.get("name", "") or "").strip()
+            if name and entry_name and name != entry_name:
+                continue
             changed = False
             if model and entry.get("model") != model:
                 entry["model"] = model

--- a/tests/hermes_cli/test_custom_provider_model_switch.py
+++ b/tests/hermes_cli/test_custom_provider_model_switch.py
@@ -693,3 +693,74 @@ class TestCustomProviderDiscoverModels:
             _model_flow_named_custom({}, provider_info)
 
         mock_fetch.assert_not_called()
+
+
+class TestSaveCustomProviderDedupByName:
+    """Regression tests: same URL, different name creates new entry."""
+
+    def test_same_url_different_name_creates_new_entry(self, config_home):
+        """Two providers sharing one URL but with different names."""
+        from hermes_cli.main import _save_custom_provider
+
+        with patch("builtins.print"):
+            _save_custom_provider(
+                "https://api.poe.com/v1",
+                api_key="key1",
+                model="model-a",
+                name="POE-Account-1",
+            )
+            _save_custom_provider(
+                "https://api.poe.com/v1",
+                api_key="key2",
+                model="model-b",
+                name="POE-Account-2",
+            )
+
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        assert len(cfg["custom_providers"]) == 2
+        assert cfg["custom_providers"][0]["name"] == "POE-Account-1"
+        assert cfg["custom_providers"][1]["name"] == "POE-Account-2"
+
+    def test_same_url_same_name_updates_existing(self, config_home):
+        """Same URL and same name updates the existing entry."""
+        from hermes_cli.main import _save_custom_provider
+
+        with patch("builtins.print"):
+            _save_custom_provider(
+                "https://api.poe.com/v1",
+                api_key="key1",
+                model="model-a",
+                name="POE-Main",
+            )
+            _save_custom_provider(
+                "https://api.poe.com/v1",
+                api_key="key2",
+                model="model-b",
+                name="POE-Main",
+            )
+
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        assert len(cfg["custom_providers"]) == 1
+        assert cfg["custom_providers"][0]["model"] == "model-b"
+
+    def test_same_url_no_name_auto_generated_dedup(self, config_home):
+        """No explicit name: auto-generated from URL, dedup by URL."""
+        from hermes_cli.main import _save_custom_provider
+
+        with patch("builtins.print"):
+            _save_custom_provider(
+                "https://api.poe.com/v1",
+                api_key="key1",
+                model="model-a",
+            )
+            _save_custom_provider(
+                "https://api.poe.com/v1",
+                api_key="key2",
+                model="model-b",
+            )
+
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        assert len(cfg["custom_providers"]) == 1  # dedup'd (same auto-name)


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where `_save_custom_provider()` deduplicates custom provider entries by `base_url` only. When a user creates a second provider for the same endpoint with a different name (e.g. a different API key or model subset), the wizard silently overwrites the first entry instead of creating a new one.

**Scenario:** A POE user wants two profiles — one for personal use, one for work. Both use `https://api.poe.com/v1`. The wizard asks for a display name each time, but the second entry silently replaces the first.

## Related Issue

Fixes #45481

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py` — `_save_custom_provider()`: dedup loop now compares both `base_url` AND `name`. Same URL with a different name skips the entry (creates new). Same URL + same name still updates. No name = auto-generated = dedup by URL only (unchanged).
- `tests/hermes_cli/test_custom_provider_model_switch.py` — 3 new regression tests in `TestSaveCustomProviderDedupByName`:
  - `test_same_url_different_name_creates_new_entry`
  - `test_same_url_same_name_updates_existing`
  - `test_same_url_no_name_auto_generated_dedup`

## How to Test

1. `pytest tests/hermes_cli/test_custom_provider_model_switch.py -v`
2. All 21 tests pass (18 existing + 3 new)
3. Manual: run `hermes model` twice with same URL + different names, verify two entries exist in config.yaml

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(cli):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: Linux (Ubuntu)

### Documentation & Housekeeping

- [x] N/A — no config keys added or changed