### PR TITLE
feat(models): add Z.AI GLM-5.2 to native zai provider + 1M context + thinking effort

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -209,7 +209,8 @@ DEFAULT_CONTEXT_LENGTHS = {
     # https://platform.minimax.io/docs/api-reference/text-chat-openai
     "minimax-m3": 1000000,
     "minimax": 204800,
-    # GLM
+    # GLM — GLM-5.2 has 1M context; older GLM models use 200K.
+    "glm-5.2": 1_000_000,
     "glm": 202752,
     # xAI Grok — xAI /v1/models does not return context_length metadata,
     # so these hardcoded fallbacks prevent Hermes from probing-down to

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -256,6 +256,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gemini-3.5-flash",
     ],
     "zai": [
+        "glm-5.2",
         "glm-5.1",
         "glm-5",
         "glm-5v-turbo",

--- a/plugins/model-providers/zai/__init__.py
+++ b/plugins/model-providers/zai/__init__.py
@@ -1,9 +1,74 @@
-"""ZAI / GLM provider profile."""
+"""ZAI / GLM provider profile.
+
+GLM-5.2+ models support ``thinking`` (enabled/disabled) with an optional
+``effort`` field (``high`` / ``max``) inside the thinking object.
+Older GLM models (5, 5.1, 4.x) only support ``type: enabled/disabled``.
+
+When the user has not configured reasoning, no thinking parameter is sent
+to preserve the default wire format.  This mirrors the pattern used by the
+DeepSeek profile (:mod:`plugins.model-providers.deepseek`).
+"""
+
+from __future__ import annotations
+
+from typing import Any
 
 from providers import register_provider
 from providers.base import ProviderProfile
 
-zai = ProviderProfile(
+
+def _model_supports_effort(model: str | None) -> bool:
+    """Return True for GLM models that accept the ``effort`` field.
+
+    GLM-5.2 is currently the only model that supports effort. Match
+    ``glm-5.2`` exactly or as a hyphen/suffix boundary (e.g.
+    ``glm-5.2-preview``) but not ``glm-5.20``.
+    """
+    m = (model or "").lower().strip()
+    # Strip vendor prefix (zai/, z-ai/, zhipu/)
+    for prefix in ("zai/", "z-ai/", "zhipu/"):
+        if m.startswith(prefix):
+            m = m[len(prefix):]
+    # Exact match or glm-5.2-* (variant suffix like -preview, -turbo).
+    # A regex-free boundary check: prefix must be followed by end-of-string
+    # or a hyphen, not another digit.
+    return m == "glm-5.2" or m.startswith("glm-5.2-")
+
+
+class ZAIProfile(ProviderProfile):
+    """Z.AI / GLM — thinking + effort inside the thinking object."""
+
+    def build_api_kwargs_extras(
+        self, *, reasoning_config: dict | None = None, model: str | None = None, **context
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        # When no reasoning config is set, preserve the default wire format
+        # (no thinking parameter) to avoid changing behavior for existing users.
+        if not isinstance(reasoning_config, dict):
+            return {}, {}
+
+        extra_body: dict[str, Any] = {}
+        top_level: dict[str, Any] = {}
+
+        enabled = reasoning_config.get("enabled", True) is not False
+        thinking: dict[str, Any] = {"type": "enabled" if enabled else "disabled"}
+
+        # Effort is GLM-5.2+ only. Older models (5.1, 5, 4.x) ignore the
+        # field, so don't send it — keeps the wire format clean.
+        if enabled and _model_supports_effort(model):
+            effort = (reasoning_config.get("effort") or "").strip().lower()
+            # Map Hermes effort levels to GLM's high/max.
+            # Hermes valid efforts: none, minimal, low, medium, high, xhigh.
+            if effort in {"xhigh", "max"}:
+                thinking["effort"] = "max"
+            elif effort == "high":
+                thinking["effort"] = "high"
+            # Lower efforts (none/minimal/low/medium) → omit, GLM uses server default.
+
+        extra_body["thinking"] = thinking
+        return extra_body, top_level
+
+
+zai = ZAIProfile(
     name="zai",
     aliases=("glm", "z-ai", "z.ai", "zhipu"),
     env_vars=("GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY"),
@@ -11,6 +76,7 @@ zai = ProviderProfile(
     description="Z.AI / GLM — Zhipu AI models",
     signup_url="https://z.ai/",
     fallback_models=(
+        "glm-5.2",
         "glm-5",
         "glm-4-9b",
     ),

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -220,6 +220,26 @@ class TestDefaultContextLengths:
                     f"{model_id}: expected {expected_ctx}, got {actual}"
                 )
 
+    def test_glm_52_context_1m(self):
+        """GLM-5.2 must resolve to 1M, not the generic GLM fallback of 202K."""
+        from agent.model_metadata import get_model_context_length
+        from unittest.mock import patch as mock_patch
+
+        assert DEFAULT_CONTEXT_LENGTHS["glm-5.2"] == 1_000_000
+        assert DEFAULT_CONTEXT_LENGTHS["glm"] == 202752
+
+        with mock_patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
+             mock_patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
+             mock_patch("agent.model_metadata.get_cached_context_length", return_value=None):
+            # GLM-5.2 (1M) must NOT fall through to the generic 202K entry
+            assert get_model_context_length("glm-5.2") == 1_000_000
+            # Vendor-prefixed forms (zai/glm-5.2, zhipu/glm-5.2)
+            assert get_model_context_length("zai/glm-5.2") == 1_000_000
+            assert get_model_context_length("zhipu/glm-5.2") == 1_000_000
+            # Older GLM variants still resolve to the generic 202K fallback
+            assert get_model_context_length("glm-5") == 202752
+            assert get_model_context_length("glm-5.1") == 202752
+
     def test_openrouter_live_metadata_beats_hardcoded_catchall(self):
         """OpenRouter-routed slugs resolve via the live OR catalog before the
         hardcoded family catch-all.

--- a/tests/plugins/model_providers/test_zai_profile.py
+++ b/tests/plugins/model_providers/test_zai_profile.py
@@ -1,0 +1,216 @@
+"""Unit tests for the Z.AI / GLM provider profile's thinking-mode wiring.
+
+GLM-5.2+ models accept ``extra_body.thinking`` with an optional ``effort``
+field (``high`` / ``max``).  Older GLM models (5.1, 5, 4.x) only support
+``thinking.type`` without effort.
+
+These tests pin the profile's wire-shape contract so Z.AI requests stay
+correctly shaped without going live.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def zai_profile():
+    """Resolve the registered Z.AI profile.
+
+    Going through ``providers.get_provider_profile`` keeps the test honest —
+    if someone later replaces the registered class with a plain
+    ``ProviderProfile``, every assertion below collapses.
+    """
+    import model_tools  # noqa: F401
+    import providers
+
+    profile = providers.get_provider_profile("zai")
+    assert profile is not None, "zai provider profile must be registered"
+    return profile
+
+
+class TestZAIThinkingWireShape:
+    """``build_api_kwargs_extras`` produces Z.AI's exact wire format."""
+
+    def test_no_reasoning_config_returns_empty(self, zai_profile):
+        """No reasoning_config → preserve default wire format (no thinking).
+
+        This is critical for backward compatibility: existing GLM users who
+        haven't configured reasoning must see no wire format change.
+        """
+        extra_body, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config=None, model="glm-5.2"
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
+    def test_glm52_enabled_with_xhigh_effort(self, zai_profile):
+        extra_body, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "xhigh"},
+            model="glm-5.2",
+        )
+        assert extra_body == {"thinking": {"type": "enabled", "effort": "max"}}
+        assert top_level == {}
+
+    def test_glm52_enabled_with_high_effort(self, zai_profile):
+        extra_body, _ = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="glm-5.2",
+        )
+        assert extra_body == {"thinking": {"type": "enabled", "effort": "high"}}
+
+    @pytest.mark.parametrize("effort", ["none", "minimal", "low", "medium", "", "garbage"])
+    def test_glm52_lower_efforts_omit_effort_field(self, zai_profile, effort):
+        """Lower or unknown efforts → omit effort, GLM uses server default."""
+        extra_body, _ = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": effort},
+            model="glm-5.2",
+        )
+        assert extra_body == {"thinking": {"type": "enabled"}}
+
+    def test_glm52_disabled_sends_disabled_marker(self, zai_profile):
+        extra_body, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False}, model="glm-5.2"
+        )
+        assert extra_body == {"thinking": {"type": "disabled"}}
+        assert top_level == {}
+
+    def test_disabled_ignores_effort_field(self, zai_profile):
+        """Effort silently dropped when thinking is off."""
+        extra_body, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False, "effort": "xhigh"},
+            model="glm-5.2",
+        )
+        assert extra_body == {"thinking": {"type": "disabled"}}
+        assert top_level == {}
+
+    @pytest.mark.parametrize("effort", ["xhigh", "max", "XHIGH", "  Max  "])
+    def test_xhigh_and_max_normalize_to_max(self, zai_profile, effort):
+        """All max-level efforts produce thinking.effort=max in extra_body."""
+        extra_body, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": effort},
+            model="glm-5.2",
+        )
+        assert extra_body["thinking"]["effort"] == "max"
+        assert top_level == {}
+
+    def test_case_insensitive_model_and_effort(self, zai_profile):
+        """Model names and efforts are case-insensitive."""
+        extra_body, _ = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "XHigh"},
+            model="GLM-5.2",
+        )
+        assert extra_body == {"thinking": {"type": "enabled", "effort": "max"}}
+
+    def test_vendor_prefixed_model(self, zai_profile):
+        """Vendor prefix stripped before matching."""
+        extra_body, _ = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "xhigh"},
+            model="zai/glm-5.2",
+        )
+        assert extra_body == {"thinking": {"type": "enabled", "effort": "max"}}
+
+
+class TestZAIModelGating:
+    """GLM-5.2+ gets effort; older models get thinking without effort."""
+
+    @pytest.mark.parametrize("model", ["glm-5.2", "GLM-5.2", "zai/glm-5.2", "zhipu/glm-5.2"])
+    def test_effort_capable_models_get_effort(self, zai_profile, model):
+        extra_body, _ = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "xhigh"}, model=model
+        )
+        assert extra_body["thinking"]["effort"] == "max"
+
+    @pytest.mark.parametrize(
+        "model",
+        ["glm-5.1", "glm-5", "glm-4.6", "glm-4.5", "glm-4-9b", "unknown-model", None, ""],
+    )
+    def test_older_models_omit_effort(self, zai_profile, model):
+        """Older GLM models get thinking.type but no effort field."""
+        extra_body, _ = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "xhigh"}, model=model
+        )
+        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert "effort" not in extra_body.get("thinking", {})
+
+    def test_glm_52_variant_matches(self, zai_profile):
+        """GLM-5.2-preview, glm-5.2-turbo etc. should also match."""
+        extra_body, _ = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "xhigh"},
+            model="glm-5.2-preview",
+        )
+        assert extra_body["thinking"]["effort"] == "max"
+
+    def test_glm_520_does_not_match(self, zai_profile):
+        """Hypothetical glm-5.20 must NOT match glm-5.2."""
+        extra_body, _ = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "xhigh"},
+            model="glm-5.20",
+        )
+        assert "effort" not in extra_body.get("thinking", {})
+
+
+class TestZAIBackwardCompat:
+    """Ensure the profile doesn't break existing GLM users."""
+
+    def test_none_reasoning_config_preserves_wire_format(self, zai_profile):
+        """The critical backward-compat test: no reasoning_config → no-op."""
+        for model in ["glm-5.1", "glm-5", "glm-4.6", "glm-5.2"]:
+            extra_body, top_level = zai_profile.build_api_kwargs_extras(
+                reasoning_config=None, model=model
+            )
+            assert extra_body == {}, f"model={model} should get empty extra_body"
+            assert top_level == {}, f"model={model} should get empty top_level"
+
+
+class TestZAITransportIntegration:
+    """End-to-end: the transport's full kwargs match Z.AI's expected wire format.
+
+    Mirrors the DeepSeek integration test pattern — verify the full
+    ``ChatCompletionsTransport().build_kwargs()`` output, not just the
+    profile method in isolation.
+    """
+
+    def test_glm52_xhigh_produces_correct_wire_shape(self, zai_profile):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="glm-5.2",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=None,
+            provider_profile=zai_profile,
+            reasoning_config={"enabled": True, "effort": "xhigh"},
+            base_url="https://api.z.ai/api/paas/v4",
+            provider_name="zai",
+        )
+        assert kwargs["model"] == "glm-5.2"
+        assert kwargs["extra_body"]["thinking"] == {"type": "enabled", "effort": "max"}
+
+    def test_glm51_no_reasoning_preserves_wire_format(self, zai_profile):
+        """Older model with no reasoning config → no thinking in wire."""
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="glm-5.1",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=None,
+            provider_profile=zai_profile,
+            reasoning_config=None,
+            base_url="https://api.z.ai/api/paas/v4",
+            provider_name="zai",
+        )
+        assert "thinking" not in kwargs.get("extra_body", {})
+
+    def test_glm52_disabled_thinking(self, zai_profile):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="glm-5.2",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=None,
+            provider_profile=zai_profile,
+            reasoning_config={"enabled": False},
+            base_url="https://api.z.ai/api/paas/v4",
+            provider_name="zai",
+        )
+        assert kwargs["extra_body"]["thinking"] == {"type": "disabled"}


### PR DESCRIPTION
## Summary

`GLM-5.2` now appears in the Z.AI native model picker and resolves to its correct 1M context length on every surface, with `thinking` + `effort` parameter support for reasoning depth control.

**Why this needed a manual edit:** The Z.AI provider lists are hardcoded in `_PROVIDER_MODELS` and `model_metadata.py` — the live `/models` API returns 7 GLM models but not `glm-5.2`, so it falls through to the static curated list and must be added by hand.

**Why effort matters:** GLM-5.2 accepts an `effort` field (`high`/`max`) inside the `thinking` object. Verified against the live Z.AI API: `effort=max` produces significantly more reasoning tokens than baseline. Without this PR, Hermes `reasoning_effort: xhigh` is silently ignored for Z.AI.

## Changes

**Model registration:**
- `agent/model_metadata.py`: add `DEFAULT_CONTEXT_LENGTHS` key `"glm-5.2": 1_000_000`. Longest-key-first substring matching makes it win over the generic `"glm": 202752` catch-all.
- `hermes_cli/models.py`: add to `_PROVIDER_MODELS["zai"]` curated list (native Z.AI picker only).

**Thinking effort implementation:**
- `plugins/model-providers/zai/__init__.py`: `ZAIProfile` class overrides `build_api_kwargs_extras()` to emit `thinking.type` + optional `effort`. Mirrors the DeepSeek profile pattern (`ProviderProfile` subclass + override).
  - Effort mapping per [Z.AI official docs](https://docs.z.ai/devpack/latest-model): `xhigh`/`max` → `max`, `high` → `high`, lower efforts omitted (server default = `high`)
  - Effort is sent for GLM-5.2 only — guarded by `_model_supports_effort()` with boundary matching (`glm-5.2` or `glm-5.2-*`, not `glm-5.20`)
  - When `reasoning_config=None`, returns empty dicts — preserves default wire format for existing GLM users (5.1, 5, 4.x)
  - The `thinking` parameter itself works across all GLM models on both endpoints (verified); `effort` is a GLM-5.2 feature.
  - `glm-5.2` added to `fallback_models` for picker display until the live `/models` API includes it.

**Tests:**
- `tests/plugins/model_providers/test_zai_profile.py` — 35 tests: wire shape, model gating, backward compat, transport integration
- `tests/agent/test_model_metadata.py` — GLM-5.2 context length resolution test

## Model facts (from Z.AI docs)

- ID `glm-5.2`, 1M context window, max output 131,072 tokens, reasoning enabled
- API endpoints: `https://api.z.ai/api/paas/v4` (standard) and `https://api.z.ai/api/coding/paas/v4` (Coding Plan)
- GLM-5.2 is currently available on the Coding Plan endpoint; standard endpoint support is expected soon
- The `thinking` and `effort` parameters are accepted on both endpoints (verified)
- Effort mapping: `low`/`medium`/`high` → `high`, `xhigh`/`max` → `max`
- https://docs.z.ai/devpack/latest-model

## Context length

The context length is set to `1_000_000`, matching the [Z.AI official docs](https://docs.z.ai/devpack/latest-model) which explicitly state 1,000,000 tokens. A power-of-two approximation (1,048,576) has been used in some references, but the documented spec value is preferred.

## Validation

| Input | Resolves to |
|---|---|
| `glm-5.2` / `zai/glm-5.2` | 1,000,000 ctx |
| `glm-5.1` / `glm-5` | 202,752 ctx (unchanged) |
| `glm-4.6` / `glm-4.5` | 202,752 ctx (unchanged) |

Effort wire shape (`build_api_kwargs_extras`):

| Config | extra_body |
|---|---|
| `None` (no reasoning) | `{}` (preserved default) |
| `{enabled: True, effort: xhigh}` | `{thinking: {type: enabled, effort: max}}` |
| `{enabled: True, effort: high}` | `{thinking: {type: enabled, effort: high}}` |
| `{enabled: True, effort: medium}` | `{thinking: {type: enabled}}` |
| `{enabled: False}` | `{thinking: {type: disabled}}` |

Full test suite: 5899 passed, 2 skipped. The 19 pre-existing failures (LSP, coding-context, vision-routing) are unrelated to this change and reproduce on `main`. GLM-5.2 specific tests: 35 passed (effort profile) + 101 passed (model metadata, includes 1 new GLM-5.2 test).

## Related

Also addresses #45519.

- **#45538** — context length entry only.
- **#45695** — context length + setup/auth surfaces, with empirical needle-in-haystack verification at 789K tokens.
- **#45739** — context length + OpenRouter/Nous catalogs + auth probing.
- **#45751** — context length + kimi-k2.7-code + live/curated model merge fix.
- **#45806** — context length + OpenRouter/curated model lists.

This PR adds `thinking`/`effort` support on top, which none of the above cover.

