### PR TITLE
fix: account for Codex replay in compression tail budget

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -218,6 +218,51 @@ def _content_length_for_budget(raw_content: Any) -> int:
     return total
 
 
+def _serialized_length_for_budget(value: Any) -> int:
+    """Return a stable char-length for non-content replay/metadata fields."""
+    if value is None or value == "":
+        return 0
+    if isinstance(value, str):
+        return len(value)
+    try:
+        return len(json.dumps(value, ensure_ascii=False, sort_keys=True, default=str))
+    except (TypeError, ValueError):
+        return len(str(value))
+
+
+def _message_tokens_for_tail_budget(msg: Dict[str, Any]) -> int:
+    """Estimate a single message for compressor tail-budget decisions.
+
+    Preflight compression uses the full message shape, including provider
+    replay fields such as Codex encrypted reasoning. Tail protection must use
+    the same rough size class; otherwise an assistant message with tiny visible
+    content but large hidden replay blobs is protected as if it were small and
+    the post-compression session can remain near the context limit.
+
+    This is accounting-only: it does not mutate or prune replay fields.
+    """
+    raw_content = msg.get("content") or ""
+    msg_tokens = _content_length_for_budget(raw_content) // _CHARS_PER_TOKEN + 10
+
+    # Include tool call arguments in estimate, preserving the historical
+    # behavior while centralizing the calculation for both tail-budget passes.
+    for tc in msg.get("tool_calls") or []:
+        if isinstance(tc, dict):
+            args = tc.get("function", {}).get("arguments", "")
+            msg_tokens += len(args) // _CHARS_PER_TOKEN
+
+    for key in (
+        "reasoning",
+        "reasoning_content",
+        "reasoning_details",
+        "codex_reasoning_items",
+        "codex_message_items",
+    ):
+        msg_tokens += _serialized_length_for_budget(msg.get(key)) // _CHARS_PER_TOKEN
+
+    return msg_tokens
+
+
 def _content_text_for_contains(content: Any) -> str:
     """Return a best-effort text view of message content.
 
@@ -1894,15 +1939,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         cut_idx = n  # start from beyond the end
 
         for i in range(n - 1, head_end - 1, -1):
-            msg = messages[i]
-            raw_content = msg.get("content") or ""
-            content_len = _content_length_for_budget(raw_content)
-            msg_tokens = content_len // _CHARS_PER_TOKEN + 10  # +10 for role/metadata
-            # Include tool call arguments in estimate
-            for tc in msg.get("tool_calls") or []:
-                if isinstance(tc, dict):
-                    args = tc.get("function", {}).get("arguments", "")
-                    msg_tokens += len(args) // _CHARS_PER_TOKEN
+            msg_tokens = _message_tokens_for_tail_budget(messages[i])
             # Stop once we exceed the soft ceiling (unless we haven't hit min_tail yet)
             if accumulated + msg_tokens > soft_ceiling and (n - i) >= min_tail:
                 break
@@ -1927,14 +1964,7 @@ This compaction should PRIORITISE preserving all information related to the focu
             raw_budget = token_budget
             raw_accumulated = 0
             for j in range(n - 1, head_end - 1, -1):
-                raw_msg = messages[j]
-                raw_content = raw_msg.get("content") or ""
-                raw_len = _content_length_for_budget(raw_content)
-                raw_tok = raw_len // _CHARS_PER_TOKEN + 10
-                for tc in raw_msg.get("tool_calls") or []:
-                    if isinstance(tc, dict):
-                        args = tc.get("function", {}).get("arguments", "")
-                        raw_tok += len(args) // _CHARS_PER_TOKEN
+                raw_tok = _message_tokens_for_tail_budget(messages[j])
                 if raw_accumulated + raw_tok > raw_budget and (n - j) >= min_tail:
                     cut_idx = j
                     break

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -192,6 +192,114 @@ class TestCompress:
         assert msgs[-2]["content"] in result[-2]["content"]
 
 
+class TestTailBudgetCodexReplayFields:
+    def test_tail_cut_counts_codex_replay_and_reasoning_fields(self):
+        """Tail protection must budget hidden replay fields sent back to providers.
+
+        Codex Responses messages can have tiny visible content but large
+        `codex_reasoning_items`, `codex_message_items`, or provider-native
+        reasoning fields. Preflight compression counts these fields, so the
+        tail-cut budget must count them too; otherwise compression preserves an
+        oversized tail and immediately starts the next session near the limit.
+        """
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="test/model",
+                protect_first_n=1,
+                protect_last_n=1,
+                quiet_mode=True,
+            )
+
+        big_replay = "x" * 5_000
+        big_hidden_message = {
+            "role": "assistant",
+            "content": "ok",
+            "reasoning": "summary " + big_replay,
+            "reasoning_content": "scratchpad " + big_replay,
+            "reasoning_details": [{"text": "details " + big_replay}],
+            "codex_reasoning_items": [
+                {"type": "reasoning", "encrypted_content": "enc_" + big_replay}
+            ],
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "reply " + big_replay}],
+                }
+            ],
+        }
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "initial ask"},
+            {"role": "assistant", "content": "first answer"},
+            {"role": "user", "content": "older follow-up"},
+            big_hidden_message,
+        ]
+        messages.extend(
+            {
+                "role": "user" if i % 2 == 0 else "assistant",
+                "content": f"tail visible message {i}",
+            }
+            for i in range(14)
+        )
+
+        cut_idx = c._find_tail_cut_by_tokens(messages, head_end=1, token_budget=150)
+
+        assert cut_idx == 5
+        assert messages[4]["codex_reasoning_items"][0]["encrypted_content"].startswith("enc_")
+        assert messages[4]["codex_message_items"][0]["content"][0]["text"].startswith("reply ")
+
+    @pytest.mark.parametrize(
+        ("field_name", "field_value"),
+        [
+            ("reasoning", "x" * 5_000),
+            ("reasoning_content", "x" * 5_000),
+            ("reasoning_details", [{"text": "x" * 5_000}]),
+            (
+                "codex_reasoning_items",
+                [{"type": "reasoning", "encrypted_content": "x" * 5_000}],
+            ),
+            (
+                "codex_message_items",
+                [
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "x" * 5_000}],
+                    }
+                ],
+            ),
+        ],
+    )
+    def test_tail_cut_counts_each_hidden_replay_field(self, field_name, field_value):
+        """Each provider replay/reasoning field should affect tail budgeting."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="test/model",
+                protect_first_n=1,
+                protect_last_n=1,
+                quiet_mode=True,
+            )
+
+        hidden_message = {"role": "assistant", "content": "ok", field_name: field_value}
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "initial ask"},
+            {"role": "assistant", "content": "first answer"},
+            {"role": "user", "content": "older follow-up"},
+            hidden_message,
+        ]
+        messages.extend(
+            {
+                "role": "user" if i % 2 == 0 else "assistant",
+                "content": f"tail visible message {i}",
+            }
+            for i in range(14)
+        )
+
+        assert c._find_tail_cut_by_tokens(messages, head_end=1, token_budget=150) == 5
+
+
 class TestGenerateSummaryNoneContent:
     """Regression: content=None (from tool-call-only assistant messages) must not crash."""
 


### PR DESCRIPTION
## Summary

Fix Hermes context compression tail budgeting for Codex Responses replay fields.

Preflight rough-token estimation counts the full message shape, including provider-native reasoning and Codex replay fields such as `reasoning_content`, `reasoning_details`, `codex_reasoning_items`, and `codex_message_items`. The compressor tail boundary calculation previously counted only visible `content` and `tool_calls`, so assistant messages with tiny visible content but large hidden replay payloads could be protected in the tail. That allowed post-compression sessions to remain near the context threshold and quickly re-trigger compression.

This patch adds an accounting-only helper for tail budgeting and uses it in both tail-budget passes. It does not prune, delete, or mutate replay fields, session DB records, memory, skills, or config.

## Changes

- Add `_serialized_length_for_budget()` for stable rough char-length accounting of replay/metadata fields.
- Add `_message_tokens_for_tail_budget()` to centralize compressor tail token estimation.
- Include these fields in tail budget estimation:
  - `reasoning`
  - `reasoning_content`
  - `reasoning_details`
  - `codex_reasoning_items`
  - `codex_message_items`
- Reuse the helper in both `_find_tail_cut_by_tokens()` budget loops.
- Add regression tests proving aggregate and per-field hidden replay payloads affect tail cut decisions and replay fields remain present.

## Verification

- RED evidence: with production file reverted, `TestTailBudgetCodexReplayFields::test_tail_cut_counts_codex_replay_and_reasoning_fields` failed with expected `cut_idx == 5`, actual `cut_idx == 4`.
- GREEN after patch:
  - `python -m pytest tests/agent/test_context_compressor.py::TestTailBudgetCodexReplayFields -q -o 'addopts='` -> 6 passed
  - Compression-focused suite -> 171 passed
  - `python -m ruff check agent/context_compressor.py tests/agent/test_context_compressor.py` -> All checks passed
  - `python -m compileall -q agent/context_compressor.py tests/agent/test_context_compressor.py` -> exit 0
  - `git diff --check` -> clean
  - Added-line static scan: hardcoded_secrets=0, shell_injection=0, dangerous_eval_exec=0, unsafe_pickle=0, sql_string_format=0
- Independent review: PASS; no security issue, no mutation/pruning, no role/tool-boundary regression found.

## Note

A broader `tests/agent` run produced 4 failures in unrelated vision-routing tests tied to local provider/credential auto-detection; compression-focused tests passed cleanly.
