### PR TITLE
fix: declare websockets as a core dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,9 @@ dependencies = [
   # (which is a silent killer on Windows — see CONTRIBUTING.md) and
   # `os.killpg` (which doesn't exist on Windows).
   "psutil==7.2.2",
+  # Browser CDP supervisor + browser_dialog import this directly. Keep core
+  # so browser tool discovery doesn't fail on lean installs.
+  "websockets==15.0.1",
   # .gitignore-aware file matching for desktop build stamp.
   "pathspec==1.1.1",
   "fastapi>=0.104.0,<1",

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -28,9 +28,9 @@ logger = logging.getLogger(__name__)
 
 CDP_DOCS_URL = "https://chromedevtools.github.io/devtools-protocol/"
 
-# ``websockets`` is a transitive dependency of hermes-agent (via fal_client
-# and firecrawl-py) and is already imported by gateway/platforms/feishu.py.
-# Wrap the import so a clean error surfaces if the package is ever absent.
+# ``websockets`` is a direct hermes-agent dependency because the browser CDP
+# supervisor and browser_dialog tool import it during tool discovery. Wrap the
+# import so a clean error surfaces if an environment is stale or incomplete.
 try:
     import websockets
     from websockets.exceptions import WebSocketException

--- a/uv.lock
+++ b/uv.lock
@@ -1418,6 +1418,7 @@ dependencies = [
     { name = "tzdata", marker = "sys_platform == 'win32'" },
     { name = "urllib3" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "websockets" },
 ]
 
 [package.optional-dependencies]
@@ -1691,6 +1692,7 @@ requires-dist = [
     { name = "urllib3", specifier = ">=2.7.0,<3" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.24.0,<1" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'web'", specifier = "==0.41.0" },
+    { name = "websockets", specifier = "==15.0.1" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
 provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "pty", "honcho", "vision", "mcp", "nemo-relay", "homeassistant", "sms", "computer-use", "acp", "mistral", "bedrock", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]


### PR DESCRIPTION
## Summary
- declare `websockets==15.0.1` as a core Hermes dependency
- update the `browser_cdp` import comment to reflect that `browser_cdp`, `browser_dialog`, and the browser supervisor import `websockets` directly during tool discovery
- refresh `uv.lock`

## Why
The browser CDP stack imports `websockets` directly from core tool modules. Relying on it as a transitive dependency from optional integrations can make lean installs or dependency-pruned environments fail tool discovery with `No module named 'websockets'`.

## Tests
- `git diff --check`
- `uv lock --check`
- `/Users/yehaotian/hermes-agent/.venv/bin/python -m pytest tests/tools/test_browser_cdp_tool.py tests/tools/test_browser_supervisor.py::test_browser_dialog_tool_no_supervisor tests/tools/test_browser_supervisor.py::test_browser_dialog_invalid_action tests/tools/test_browser_supervisor.py::test_browser_cdp_frame_id_missing_supervisor -q -o 'addopts='`
