### PR TITLE
fix(desktop): close slash popover for non-args-completable commands

### DIFF
--- a/apps/desktop/src/app/chat/composer/text-utils.test.ts
+++ b/apps/desktop/src/app/chat/composer/text-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { blobDedupeKey, detectTrigger, extractClipboardImageBlobs } from './text-utils'
+import { blobDedupeKey, detectTrigger, extractClipboardImageBlobs, shouldKeepSlashTriggerLive } from './text-utils'
 
 describe('detectTrigger', () => {
   it('detects a bare slash trigger with an empty query', () => {
@@ -48,6 +48,27 @@ describe('detectTrigger', () => {
 
   it('still anchors at-mention triggers strictly at the token edge', () => {
     expect(detectTrigger('@file:path with space')).toBeNull()
+  })
+})
+
+describe('shouldKeepSlashTriggerLive', () => {
+  it('keeps the popover open when there is no space in the query', () => {
+    expect(shouldKeepSlashTriggerLive('hermes-agent')).toBe(true)
+    expect(shouldKeepSlashTriggerLive('')).toBe(true)
+  })
+
+  it('closes the popover for skill commands with arguments', () => {
+    expect(shouldKeepSlashTriggerLive('hermes-agent ')).toBe(false)
+    expect(shouldKeepSlashTriggerLive('hermes-agent help me with')).toBe(false)
+    expect(shouldKeepSlashTriggerLive('help ')).toBe(false)
+  })
+
+  it('keeps the popover open for args-completable commands', () => {
+    expect(shouldKeepSlashTriggerLive('personality alic')).toBe(true)
+    expect(shouldKeepSlashTriggerLive('tools enable foo')).toBe(true)
+    expect(shouldKeepSlashTriggerLive('resume my-session')).toBe(true)
+    expect(shouldKeepSlashTriggerLive('skin dark')).toBe(true)
+    expect(shouldKeepSlashTriggerLive('sessions ')).toBe(true)
   })
 })
 

--- a/apps/desktop/src/app/chat/composer/text-utils.ts
+++ b/apps/desktop/src/app/chat/composer/text-utils.ts
@@ -102,6 +102,30 @@ export function textBeforeCaret(editor: HTMLDivElement): string | null {
   return before.toString()
 }
 
+/** Commands whose arguments trigger live completion in the slash popover. */
+const ARGS_COMPLETABLE_COMMANDS = new Set([
+  '/handoff',
+  '/personality',
+  '/resume',
+  '/sessions',
+  '/skin',
+  '/switch',
+  '/tools'
+])
+
+/**
+ * Whether the slash trigger should stay open for the given query.
+ * When the query contains a space the user has finished selecting the
+ * command name and is typing arguments.  Only keep the popover open for
+ * commands that support argument completion; close it for all others
+ * (e.g. skills) to prevent "No matches found" from blocking input.
+ */
+export function shouldKeepSlashTriggerLive(query: string): boolean {
+  if (!query.includes(' ')) return true
+  const commandName = query.split(/\s+/, 1)[0]
+  return ARGS_COMPLETABLE_COMMANDS.has(`/${commandName}`.replace(/^\/\//, '/'))
+}
+
 export function detectTrigger(textBefore: string): TriggerState | null {
   const slash = SLASH_TRIGGER_RE.exec(textBefore)
 

--- a/apps/desktop/src/components/assistant-ui/thread.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread.tsx
@@ -51,7 +51,7 @@ import {
   renderComposerContents,
   RICH_INPUT_SLOT
 } from '@/app/chat/composer/rich-editor'
-import { detectTrigger, textBeforeCaret, type TriggerState } from '@/app/chat/composer/text-utils'
+import { detectTrigger, shouldKeepSlashTriggerLive, textBeforeCaret, type TriggerState } from '@/app/chat/composer/text-utils'
 import { ComposerTriggerPopover } from '@/app/chat/composer/trigger-popover'
 import {
   extractDroppedFiles,
@@ -1269,6 +1269,17 @@ const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sessionId }
 
     const before = textBeforeCaret(editor)
     const detected = detectTrigger(before ?? composerPlainText(editor))
+
+    // Close the popover for slash commands that don't support argument
+    // completion.  When the query already contains a space the user has
+    // finished selecting the command and is typing regular text — keeping
+    // the popover open produces "No matches found" and blocks input.
+    if (detected?.kind === '/' && !shouldKeepSlashTriggerLive(detected.query)) {
+      setTrigger(null)
+      setTriggerItems([])
+      setTriggerActive(0)
+      return
+    }
 
     if (detected) {
       const rect = editor.getBoundingClientRect()


### PR DESCRIPTION
## What does this PR do?

Fixes the Desktop slash command popover blocking input after selecting a skill command. When a user selects a skill (e.g. `/hermes-agent`) and continues typing, the popover reappears with "No matches found" because `SLASH_TRIGGER_RE` keeps the query alive across spaces — blocking the text input area.

## Related Issue

Fixes #45410

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/chat/composer/text-utils.ts`: Added `shouldKeepSlashTriggerLive()` — when the query contains a space, only keep the popover open for commands in `ARGS_COMPLETABLE_COMMANDS` (`/handoff`, `/personality`, `/resume`, `/sessions`, `/skin`, `/switch`, `/tools`). All other commands (including skills) close the popover.
- `apps/desktop/src/components/assistant-ui/thread.tsx`: Updated `refreshTrigger()` to call `shouldKeepSlashTriggerLive()` and close the popover for non-args-completable commands.
- `apps/desktop/src/app/chat/composer/text-utils.test.ts`: Added 3 test cases covering no-space queries, skill commands with spaces, and args-completable commands with spaces.

## How to Test

1. Run `npx vitest run src/app/chat/composer/text-utils.test.ts` — all 14 tests pass (11 existing + 3 new)
2. In the Desktop app, type `/` to open the slash popover
3. Select a skill command (e.g. `/hermes-agent`)
4. Continue typing text (e.g. "help me with...")
5. Verify the popover closes after the space and text input works normally
6. Type `/personality alic` — verify the popover stays open for arg completion

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `refreshTrigger()` in `thread.tsx`, `detectTrigger()` + `SLASH_TRIGGER_RE` in `text-utils.ts`
- Blast radius: LOW — change only affects the Desktop slash command popover behavior; no backend or gateway changes
- Related patterns: The `SLASH_TRIGGER_RE` regex intentionally allows spaces after the command name for arg completion (added for `/personality`, `/tools` etc.). The fix preserves this for those commands while closing the popover for all others.
