### PR TITLE
fix(desktop): keep profile color picker open from the context menu

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
@@ -467,6 +467,10 @@ function ProfileSquare({ active, color, label, onDelete, onRecolor, onRename, on
           aria-label={p.actionsFor(label)}
           className="w-40"
           collisionPadding={{ bottom: 44, left: 8, right: 8, top: 8 }}
+          // Menu close refocuses the trigger — which doubles as the popover
+          // anchor — so the picker reads it as focus-outside and dies on open.
+          // Suppress the refocus and the picker survives.
+          onCloseAutoFocus={event => event.preventDefault()}
         >
           <ContextMenuItem onSelect={() => setPickerOpen(true)}>
             <Codicon name="symbol-color" size="0.875rem" />


### PR DESCRIPTION
## Summary
Right-click a profile rail square → **Color...** flashed the swatch picker open then immediately closed it (long-press to recolor worked fine).

**Cause:** the picker is a Radix `Popover` whose anchor is the square button — the same element that is the `ContextMenu` trigger. On dismiss the menu restores focus to that trigger, the popover reads the refocus as a focus-outside event, and closes itself the instant it opens.

**Fix:** suppress the menu's close auto-focus (`onCloseAutoFocus` → `preventDefault`) so focus never lands back on the shared anchor and the picker survives the dismiss. Long-press is unaffected — it never goes through the menu lifecycle.

## Test plan
- [x] Right-click a named profile square → **Color...** → picker stays open
- [x] Pick a swatch → applies and closes
- [x] Long-press a square → picker still opens
- [x] **Rename** / **Delete** menu items still work