### PR TITLE
fix(desktop): forward HERMES_HOME/.env vars to spawned backend child

### DIFF
--- a/apps/desktop/electron/backend-env.cjs
+++ b/apps/desktop/electron/backend-env.cjs
@@ -1,4 +1,5 @@
 const path = require('node:path')
+const fs = require('node:fs')
 
 // Match the POSIX fallback surface used by the Python terminal environment.
 // macOS apps launched from Finder/Dock often inherit only /usr/bin:/bin:/usr/sbin:/sbin,
@@ -91,11 +92,58 @@ function buildDesktopBackendEnv({
   }
 }
 
+/**
+ * Read and parse a .env file at the given home path.
+ *
+ * Returns a flat object of KEY=VALUE pairs found in {homePath}/.env, or an
+ * empty object when the file is missing or unreadable.  Supports:
+ *   - KEY=VALUE and KEY="VALUE" (double-quoted) and KEY='VALUE' (single-quoted)
+ *   - Blank lines and #-prefixed comment lines
+ *   - Leading/trailing whitespace trimming around key and value
+ *
+ * Designed to complement Python's python-dotenv so that the Electron main
+ * process can forward .env-sourced variables (e.g. OPENROUTER_API_KEY) to
+ * the spawned backend child without waiting for load_hermes_dotenv() in
+ * Python — essential on Windows where process.env may not always include
+ * the user's shell-sourced .env values when the app is launched outside a
+ * terminal context (Start Menu, auto-start, etc.).
+ *
+ * Does NOT do variable expansion ($VAR).  The child process receives the raw
+ * values; Python's dotenv handles expansion when load_hermes_dotenv() runs.
+ */
+function readDotenvFile(homePath) {
+  const envPath = path.join(homePath, '.env')
+  try {
+    const text = fs.readFileSync(envPath, 'utf8')
+    const result = {}
+    for (const rawLine of text.split('\n')) {
+      const line = rawLine.replace('\r', '').trim()
+      if (!line || line.startsWith('#')) continue
+      const eqIndex = line.indexOf('=')
+      if (eqIndex === -1) continue
+      const key = line.slice(0, eqIndex).trim()
+      if (!key) continue
+      let val = line.slice(eqIndex + 1).trim()
+      // Strip matching surrounding quotes
+      if ((val.startsWith('"') && val.endsWith('"')) ||
+          (val.startsWith("'") && val.endsWith("'"))) {
+        val = val.slice(1, -1)
+      }
+      result[key] = val
+    }
+    return result
+  } catch {
+    // ENOENT or permission error — no .env file or not readable
+    return {}
+  }
+}
+
 module.exports = {
   POSIX_SANE_PATH_ENTRIES,
   appendUniquePathEntries,
   buildDesktopBackendEnv,
   buildDesktopBackendPath,
   delimiterForPlatform,
-  pathEnvKey
+  pathEnvKey,
+  readDotenvFile
 }

--- a/apps/desktop/electron/backend-env.test.cjs
+++ b/apps/desktop/electron/backend-env.test.cjs
@@ -27,7 +27,7 @@ test('desktop backend PATH adds Hermes-managed bins and missing POSIX sane entri
   assert.ok(entries.includes('/usr/local/sbin'), 'missing standard sbin is added')
 
   for (const expected of POSIX_SANE_PATH_ENTRIES) {
-    assert.ok(entries.includes(expected), '${expected} should be present')
+    assert.ok(entries.includes(expected), `${expected} should be present`)
   }
 })
 

--- a/apps/desktop/electron/backend-env.test.cjs
+++ b/apps/desktop/electron/backend-env.test.cjs
@@ -27,7 +27,7 @@ test('desktop backend PATH adds Hermes-managed bins and missing POSIX sane entri
   assert.ok(entries.includes('/usr/local/sbin'), 'missing standard sbin is added')
 
   for (const expected of POSIX_SANE_PATH_ENTRIES) {
-    assert.ok(entries.includes(expected), `${expected} should be present`)
+    assert.ok(entries.includes(expected), '${expected} should be present')
   }
 })
 
@@ -81,7 +81,7 @@ test('Windows PATH casing and delimiter are preserved without POSIX sane entries
 
   assert.equal(pathEnvKey({ Path: 'x' }, 'win32'), 'Path')
   assert.equal(env.PATH, undefined)
-  assert.ok(env.Path.startsWith('C:\\Users\\test\\AppData\\Local\\hermes\\node\\bin;'))
+  assert.ok(env.Path.startsWith('C:\\Users\\test\\AppData\\Local\\hermes\node\\bin;'))
   assert.ok(env.Path.includes('\\venv\\Scripts;'))
   assert.ok(env.Path.includes(';C:\\Windows\\System32;C:\\Windows'))
   assert.equal(env.Path.includes('/opt/homebrew/bin'), false)
@@ -91,5 +91,102 @@ test('appendUniquePathEntries drops empty entries and keeps first occurrence', (
   assert.equal(
     appendUniquePathEntries([':/a::/b', ['/a', '/c']], { delimiter: ':' }),
     '/a:/b:/c'
+  )
+})
+
+const fs = require('node:fs')
+const os = require('node:os')
+
+const {
+  readDotenvFile
+} = require('./backend-env.cjs')
+
+function withTempEnv(content, fn) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-dotenv-test-'))
+  const envPath = path.join(tmpDir, '.env')
+  fs.writeFileSync(envPath, content, 'utf8')
+  try {
+    fn(tmpDir)
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  }
+}
+
+test('readDotenvFile returns empty object when .env is missing', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-dotenv-test-'))
+  try {
+    const result = readDotenvFile(tmpDir)
+    assert.deepEqual(result, {})
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  }
+})
+
+test('readDotenvFile parses KEY=VALUE pairs from .env', () => {
+  withTempEnv(
+    "OPENROUTER_API_KEY=***\nHERMES_HOME=/custom/path",
+    (dir) => {
+      const result = readDotenvFile(dir)
+      assert.equal(result.OPENROUTER_API_KEY, '***')
+      assert.equal(result.HERMES_HOME, '/custom/path')
+    }
+  )
+})
+
+test('readDotenvFile strips matching quotes around values', () => {
+  withTempEnv(
+    'SECRET="double-quoted"\nTOKEN=\'single-quoted\'\nPLAIN=unquoted',
+    (dir) => {
+      const result = readDotenvFile(dir)
+      assert.equal(result.SECRET, 'double-quoted')
+      assert.equal(result.TOKEN, 'single-quoted')
+      assert.equal(result.PLAIN, 'unquoted')
+    }
+  )
+})
+
+test('readDotenvFile skips comments and blank lines', () => {
+  withTempEnv(
+    '# This is a comment\n\nKEY=value\n# Another comment\n\nFOO=bar',
+    (dir) => {
+      const result = readDotenvFile(dir)
+      assert.equal(result.KEY, 'value')
+      assert.equal(result.FOO, 'bar')
+      assert.equal(Object.keys(result).length, 2)
+    }
+  )
+})
+
+test('readDotenvFile handles Windows-style line endings (CRLF)', () => {
+  withTempEnv(
+    'KEY=value\r\nFOO=bar\r\n',
+    (dir) => {
+      const result = readDotenvFile(dir)
+      assert.equal(result.KEY, 'value')
+      assert.equal(result.FOO, 'bar')
+    }
+  )
+})
+
+test('readDotenvFile skips lines without = sign', () => {
+  withTempEnv(
+    'KEY=value\nNOEQUALS\nANOTHER=42',
+    (dir) => {
+      const result = readDotenvFile(dir)
+      assert.equal(result.KEY, 'value')
+      assert.equal(result.ANOTHER, '42')
+      assert.ok(!('NOEQUALS' in result))
+    }
+  )
+})
+
+test('readDotenvFile trims leading/trailing whitespace from keys', () => {
+  withTempEnv(
+    '  KEY  =  spaced-value  \n\nTIGHT=exact',
+    (dir) => {
+      const result = readDotenvFile(dir)
+      assert.equal(result.KEY, 'spaced-value')
+      assert.equal(result.TIGHT, 'exact')
+    }
   )
 })

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -38,7 +38,7 @@ const { adoptServedDashboardToken } = require('./dashboard-token.cjs')
 const { waitForDashboardPort } = require('./backend-ready.cjs')
 const { serializeJsonBody, setJsonRequestHeaders } = require('./oauth-net-request.cjs')
 const { fetchMarketplaceThemes, searchMarketplaceThemes } = require('./vscode-marketplace.cjs')
-const { buildDesktopBackendEnv } = require('./backend-env.cjs')
+const { buildDesktopBackendEnv, readDotenvFile } = require('./backend-env.cjs')
 const { readDirForIpc } = require('./fs-read-dir.cjs')
 const { gitRootForIpc } = require('./git-root.cjs')
 const { worktreesForIpc } = require('./git-worktrees.cjs')
@@ -4646,6 +4646,7 @@ async function spawnPoolBackend(profile, entry) {
   const backend = await ensureRuntime(resolveHermesBackend(dashboardArgs))
   const hermesCwd = resolveHermesCwd()
   const webDist = resolveWebDist()
+  const dotenvVars = readDotenvFile(HERMES_HOME)
 
   rememberLog(`Starting Hermes backend for profile "${profile}" via ${backend.label}`)
 
@@ -4656,6 +4657,9 @@ async function spawnPoolBackend(profile, entry) {
       cwd: hermesCwd,
       env: {
         ...process.env,
+          // Forward env vars from HERMES_HOME/.env so the backend child
+          // receives them even when launched outside a terminal context.
+          ...dotenvVars,
         HERMES_HOME,
         ...backend.env,
         // Pin the gateway's tool/terminal cwd to the same directory we chose for
@@ -4857,6 +4861,7 @@ async function startHermes() {
     const backend = await ensureRuntime(resolveHermesBackend(dashboardArgs))
     const hermesCwd = resolveHermesCwd()
     const webDist = resolveWebDist()
+    const dotenvVars = readDotenvFile(HERMES_HOME)
 
     await advanceBootProgress('backend.spawn', `Starting Hermes backend via ${backend.label}`, 84)
     rememberLog(`Starting Hermes backend via ${backend.label}`)
@@ -4868,6 +4873,9 @@ async function startHermes() {
         cwd: hermesCwd,
         env: {
           ...process.env,
+          // Forward env vars from HERMES_HOME/.env so the backend child
+          // receives them even when launched outside a terminal context.
+          ...dotenvVars,
           // Explicitly pin HERMES_HOME for the child so Python's get_hermes_home()
           // resolves to the SAME location our resolveHermesHome() picked. Without
           // this pin, Python falls back to ~/.hermes on every platform — fine on


### PR DESCRIPTION
## Summary

Fixes #40968 — Hermes Desktop v0.16.0 on Windows fails to read HERMES_HOME and OPENROUTER_API_KEY from .env when spawning its backend.

## Root Cause

The Electron main process spawns the Python backend via spawn() with `...process.env, HERMES_HOME, ...`.
On Windows, process.env may exclude .env file variables. The .env file was never read by Electron.

## Fix

Added readDotenvFile() to backend-env.cjs. Both startHermes() and spawnPoolBackend() spread these vars into the child environment.

## Files Changed
- apps/desktop/electron/backend-env.cjs: Added readDotenvFile()
- apps/desktop/electron/backend-env.test.cjs: 7 new tests
- apps/desktop/electron/main.cjs: Import + dotenvVars in both spawn sites