### PR TITLE
fix(models): remove unavailable claude-fable-5

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -33,7 +33,6 @@ COPILOT_REASONING_EFFORTS_O_SERIES = ["low", "medium", "high"]
 # (model_id, display description shown in menus)
 OPENROUTER_MODELS: list[tuple[str, str]] = [
     # Anthropic
-    ("anthropic/claude-fable-5",               ""),
     ("anthropic/claude-opus-4.8",              ""),
     ("anthropic/claude-opus-4.8-fast",         "2x price, higher output speed"),
     ("anthropic/claude-sonnet-4.6",            ""),
@@ -156,7 +155,6 @@ def _xai_curated_models() -> list[str]:
 _PROVIDER_MODELS: dict[str, list[str]] = {
     "nous": [
         # Anthropic
-        "anthropic/claude-fable-5",
         "anthropic/claude-opus-4.8",
         "anthropic/claude-sonnet-4.6",
         "anthropic/claude-haiku-4.5",

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-06-12T23:38:08Z",
+  "updated_at": "2026-06-13T08:41:46Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -12,10 +12,6 @@
         "note": "Descriptions drive picker badges. Live /api/v1/models filters curated ids by tool-calling support and free pricing."
       },
       "models": [
-        {
-          "id": "anthropic/claude-fable-5",
-          "description": ""
-        },
         {
           "id": "anthropic/claude-opus-4.8",
           "description": ""
@@ -152,9 +148,6 @@
         "note": "Free-tier gating is determined live via Portal pricing (partition_nous_models_by_tier), not this manifest."
       },
       "models": [
-        {
-          "id": "anthropic/claude-fable-5"
-        },
         {
           "id": "anthropic/claude-opus-4.8"
         },


### PR DESCRIPTION
## Infographic

![Retired model removed](https://v3b.fal.media/files/b/0a9e1c70/t2wMinL6SvG6VwDEO3XBi_MuL196Kz.png)

## Summary

- Remove unavailable `anthropic/claude-fable-5` from the OpenRouter curated picker list.
- Remove the same slug from the Nous Portal fallback list.
- Regenerate `website/static/api/model-catalog.json` so the remote manifest matches the in-repo catalogs.

## Test Plan

- `env -u PYTEST_PLUGINS bash scripts/run_tests.sh tests/hermes_cli/test_model_catalog.py tests/hermes_cli/test_models.py`
- Import/manifest check confirming `anthropic/claude-fable-5` is absent from OpenRouter, Nous, and the generated manifest.
