### PR TITLE
fix: cron model.default fallback + VIRTUAL_ENV leak into subprocesses (P1 bugs)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1593,7 +1593,9 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                     if isinstance(_model_cfg, str):
                         model = _model_cfg
                     elif isinstance(_model_cfg, dict):
-                        model = _model_cfg.get("default", model)
+                        default = _model_cfg.get("default")
+                        if default:
+                            model = default
         except Exception as e:
             logger.warning("Job '%s': failed to load config.yaml, using defaults: %s", job_id, e)
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -184,6 +184,18 @@ def _build_provider_env_blocklist() -> frozenset:
         "MODAL_TOKEN_ID",
         "MODAL_TOKEN_SECRET",
         "DAYTONA_API_KEY",
+        # Virtual environment leakage (issue #23473): gateway/scheduler
+        # set VIRTUAL_ENV for their own process but must not pass it
+        # to subprocesses — package managers treat it as an implicit
+        # activation marker and may reinstall the Hermes venv against
+        # a project's dependencies, silently destroying the runtime.
+        "VIRTUAL_ENV",
+        "VIRTUAL_ENV_PROMPT",
+        "UV_PROJECT_ENVIRONMENT",
+        "POETRY_ACTIVE",
+        "PIPENV_ACTIVE",
+        "CONDA_PREFIX",
+        "CONDA_DEFAULT_ENV",
     })
     return frozenset(blocked)
 


### PR DESCRIPTION
## Summary

Two P1 bug fixes discovered during systematic review of open issues.

### Fix 1: Cron model.default fallback robustness (#43899)

When a cron job has no explicit `model` override, the scheduler falls back to `config.yaml`'s `model.default`. The previous `.get('default', model)` could propagate an empty string to `AIAgent` when the default key was absent or `None`, causing `HTTP 400: Model parameter is required`.

**Fix:** Check truthiness of the default value before assigning — ensures empty/None values don't silently replace a valid model.

### Fix 2: Block VIRTUAL_ENV leakage into subprocesses (#23473)

The gateway and scheduler set `VIRTUAL_ENV` for their own process resolution but never scrubbed it from subprocess environments. Package managers (`uv`, `poetry`, `pipenv`, `conda`) treat an inherited `VIRTUAL_ENV` as an implicit activation marker, potentially reinstalling the Hermes venv against arbitrary project dependencies — silently destroying the runtime. Still reproduces on v0.16.0 (confirmed 2026-06-12).

**Fix:** Add `VIRTUAL_ENV`, `VIRTUAL_ENV_PROMPT`, `UV_PROJECT_ENVIRONMENT`, `POETRY_ACTIVE`, `PIPENV_ACTIVE`, `CONDA_PREFIX`, and `CONDA_DEFAULT_ENV` to `_HERMES_PROVIDER_ENV_BLOCKLIST` in `tools/environments/local.py`.

### Note on #13079 (read_file dedup)

Also investigated during this pass — the dedup return at `tools/file_tools.py:835-841` already uses `status: "unchanged"` with `content_returned: false` and the dedup message is in the `message` field (not `content`). The `_content_is_dedup_stub` guard at line 575-601 provides a write-back safety net. This bug appears to be already resolved in the current codebase and may just need issue closure.

## Changes

| File | Change | Lines |
|------|--------|-------|
| `cron/scheduler.py` | Defensive `model.default` fallback | +3 / -1 |
| `tools/environments/local.py` | Blocklist 7 venv-related env vars | +12 |

## Verification

- Both changes are additive/safe — no behavioral regression for existing working configs
- Env blocklist uses the existing filtering mechanism already applied to 50+ other vars
- Cron model fallback preserves the existing string-config path (line 1593-1594)

Closes #43899, closes #23473