### PR TITLE
fix(agent): defer _ensure_db_session until after system prompt restore

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -87,8 +87,6 @@ def build_turn_context(
     # Guard stdio against OSError from broken pipes (systemd/headless/daemon).
     install_safe_stdio()
 
-    agent._ensure_db_session()
-
     # Tell auxiliary_client what the live main provider/model are for this turn.
     try:
         from agent.auxiliary_client import set_runtime_main
@@ -235,7 +233,11 @@ def build_turn_context(
 
     active_system_prompt = agent._cached_system_prompt
 
-    # Crash-resilience: persist the inbound user turn as soon as the session row exists.
+    # Crash-resilience: persist the inbound user turn as soon as the session
+    # row exists and has a valid system prompt.  _ensure_db_session runs here
+    # (after _restore_or_build_system_prompt) so the row is created with the
+    # actual system prompt, not NULL.  See issue #45499.
+    agent._ensure_db_session()
     try:
         agent._persist_session(messages, conversation_history)
     except Exception:

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -185,3 +185,43 @@ def test_no_review_when_memory_disabled():
     agent = _FakeAgent()
     ctx = _build(agent)
     assert ctx.should_review_memory is False
+
+
+def test_ensure_db_session_called_after_system_prompt_restore():
+    """_ensure_db_session must run after _restore_or_build_system_prompt so
+    the session row is created with the actual system prompt, not NULL.
+
+    Regression test for issue #45499: the API/gateway path creates a fresh
+    AIAgent with _cached_system_prompt=None.  If _ensure_db_session runs
+    first, the row is created with system_prompt=NULL, triggering a noisy
+    warning and a useless DB round-trip.
+    """
+    call_order = []
+
+    def _track_ensure_db(self):
+        call_order.append("ensure_db_session")
+
+    def _track_restore(agent, system_message, conversation_history):
+        call_order.append("restore_or_build_system_prompt")
+        agent._cached_system_prompt = "BUILT_PROMPT"
+
+    # Patch the fake agent's _ensure_db_session to track calls.
+    _FakeAgent._ensure_db_session = _track_ensure_db
+
+    agent = _FakeAgent()
+    agent._cached_system_prompt = None  # simulate fresh agent
+    _build(
+        agent,
+        system_message=None,
+        conversation_history=[{"role": "user", "content": "hi"}],
+        restore_or_build_system_prompt=_track_restore,
+    )
+
+    # restore must come before ensure_db_session
+    assert call_order == ["restore_or_build_system_prompt", "ensure_db_session"], \
+        f"Expected restore before ensure_db, got: {call_order}"
+    # The session row should be created with the built prompt, not NULL.
+    assert agent._cached_system_prompt == "BUILT_PROMPT"
+
+    # Clean up the monkeypatched class attribute.
+    del _FakeAgent._ensure_db_session


### PR DESCRIPTION
## What does this PR do?

Defers `_ensure_db_session()` in `build_turn_context()` to run after `_restore_or_build_system_prompt()` instead of before it. This prevents the session DB row from being created with `system_prompt=NULL` on fresh API/gateway agents, eliminating a spurious warning and an unnecessary DB round-trip on every turn.

## Related Issue

Fixes #45499

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/turn_context.py`: Moved `_ensure_db_session()` from line 90 (before system prompt restore) to line 237 (after system prompt restore, before `_persist_session()`). The session row is now created with the actual system prompt value instead of NULL.
- `tests/agent/test_turn_context.py`: Added `test_ensure_db_session_called_after_system_prompt_restore` — verifies call ordering with a fresh agent (`_cached_system_prompt=None`).

## How to Test

1. Run `pytest tests/agent/test_turn_context.py tests/agent/test_system_prompt_restore.py -v` — all 17 tests pass
2. Verify the new test specifically: `pytest tests/agent/test_turn_context.py::test_ensure_db_session_called_after_system_prompt_restore -v`
3. Manual: start a gateway/API session, send a message to a new session ID, and confirm no "Stored system prompt … is null" warning appears in `agent.log`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/turn_context.py::build_turn_context` (callers: 1 via `conversation_loop.py`)
- Blast radius: LOW — only changes call order within a single function; no API or interface changes
- Related patterns: `_ensure_db_session` also called from `codex_runtime.py` (lines 64, 141) — those paths are unaffected since they don't go through `build_turn_context`
