### PR TITLE
feat(kanban): support scheduled task start times via scheduled_at (re-land of #24429, dropped by #28384)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -801,6 +801,8 @@ class Task:
     # set the env var. Lets clients render a per-session board without
     # relying on tenant + time-window heuristics.
     session_id: Optional[str] = None
+    # Earliest dispatch time (unix epoch seconds). NULL = no constraint.
+    scheduled_at: Optional[int] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -875,6 +877,9 @@ class Task:
             ),
             session_id=(
                 row["session_id"] if "session_id" in keys else None
+            ),
+            scheduled_at=(
+                int(row["scheduled_at"]) if "scheduled_at" in keys and row["scheduled_at"] else None
             ),
         )
 
@@ -1037,7 +1042,11 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- for tasks created from the CLI, dashboard, or any path that doesn't
     -- set the env var. Indexed so per-session list queries stay cheap on
     -- larger boards.
-    session_id           TEXT
+    session_id           TEXT,
+    -- Earliest time (unix epoch seconds) at which this task may be dispatched.
+    -- NULL = no scheduling constraint (dispatch immediately when ready).
+    -- The dispatcher skips tasks where scheduled_at > now().
+    scheduled_at         INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -1666,6 +1675,7 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         # which is the correct default (they keep the global behaviour
         # they were getting before the column existed).
         _add_column_if_missing(conn, "tasks", "max_retries", "max_retries INTEGER")
+    _add_column_if_missing(conn, "tasks", "scheduled_at", "scheduled_at INTEGER")
 
     if "model_override" not in cols:
         conn.execute("ALTER TABLE tasks ADD COLUMN model_override TEXT")
@@ -1706,6 +1716,10 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     )
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_tasks_session_id ON tasks(session_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_tasks_scheduled_at "
+        "ON tasks(scheduled_at) WHERE scheduled_at IS NOT NULL"
     )
 
     # task_events gained a run_id column; back-fill it as NULL for
@@ -2072,6 +2086,7 @@ def create_task(
     initial_status: str = "running",
     session_id: Optional[str] = None,
     board: Optional[str] = None,
+    scheduled_at: Optional[int] = None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -2236,8 +2251,9 @@ def create_task(
                         id, title, body, assignee, status, priority,
                         created_by, created_at, workspace_kind, workspace_path,
                         branch_name, tenant, idempotency_key, max_runtime_seconds,
-                        skills, max_retries, goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        skills, max_retries, goal_mode, goal_max_turns, session_id,
+                        scheduled_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -2259,6 +2275,7 @@ def create_task(
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
+                        int(scheduled_at) if scheduled_at is not None else None,
                     ),
                 )
                 for pid in parents:
@@ -3040,8 +3057,9 @@ def claim_task(
              WHERE id = ?
                AND status = 'ready'
                AND claim_lock IS NULL
+               AND (scheduled_at IS NULL OR scheduled_at <= ?)
             """,
-            (lock, expires, now, task_id),
+            (lock, expires, now, task_id, now),
         )
         if cur.rowcount != 1:
             return None
@@ -6108,10 +6126,13 @@ def dispatch_once(
             ).fetchone()[0]
         )
 
+    now_for_schedule = int(time.time())
     ready_rows = conn.execute(
         "SELECT id, assignee FROM tasks "
         "WHERE status = 'ready' AND claim_lock IS NULL "
-        "ORDER BY priority DESC, created_at ASC"
+        "AND (scheduled_at IS NULL OR scheduled_at <= ?) "
+        "ORDER BY priority DESC, created_at ASC",
+        (now_for_schedule,),
     ).fetchall()
     # Honour kanban.max_in_progress: if the board already has enough running
     # tasks, skip spawning this tick so slow workers (local LLMs,

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -4372,3 +4372,60 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+# ---------------------------------------------------------------------------
+# scheduled_at — deferred task dispatch (per-task start time)
+# ---------------------------------------------------------------------------
+
+
+def test_create_task_defaults_scheduled_at_to_none(kanban_home):
+    """A task created without scheduled_at has no scheduling constraint."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="now", assignee="alice")
+        t = kb.get_task(conn, tid)
+    assert t is not None
+    assert t.scheduled_at is None
+
+
+def test_create_task_persists_scheduled_at(kanban_home):
+    """scheduled_at round-trips through create_task -> get_task."""
+    when = int(time.time()) + 3600
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn, title="later", assignee="alice", scheduled_at=when
+        )
+        t = kb.get_task(conn, tid)
+    assert t is not None
+    assert t.scheduled_at == when
+
+
+def test_claim_task_blocked_until_scheduled_at(kanban_home):
+    """claim_task refuses a ready task whose scheduled_at is in the future,
+    and succeeds once the scheduled time has passed."""
+    future = int(time.time()) + 3600
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn, title="deferred", assignee="alice", scheduled_at=future
+        )
+        # Task is 'ready' but not yet due -> claim must return None.
+        assert kb.get_task(conn, tid).status == "ready"
+        assert kb.claim_task(conn, tid) is None
+
+        # Move the scheduled time into the past -> claim must now succeed.
+        past = int(time.time()) - 1
+        conn.execute(
+            "UPDATE tasks SET scheduled_at = ? WHERE id = ?", (past, tid)
+        )
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        assert claimed.status == "running"
+
+
+def test_claim_task_unscheduled_is_immediately_claimable(kanban_home):
+    """A ready task with scheduled_at=NULL is claimable right away."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="immediate", assignee="alice")
+        claimed = kb.claim_task(conn, tid)
+    assert claimed is not None
+    assert claimed.status == "running"

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -814,6 +814,7 @@ def _handle_create(args: dict, **kw) -> str:
                     int(goal_max_turns) if goal_max_turns is not None else None
                 ),
                 initial_status=str(initial_status),
+                scheduled_at=args.get("scheduled_at"),
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
                 session_id=session_id,
             )
@@ -1298,6 +1299,16 @@ KANBAN_CREATE_SCHEMA = {
                     "continuation turns the worker may take before the task "
                     "is blocked for review. Ignored unless goal_mode is "
                     "true. Defaults to the goal-engine default (20)."
+                ),
+            },
+            "scheduled_at": {
+                "type": "integer",
+                "description": (
+                    "Unix epoch timestamp. The task will not be "
+                    "dispatched until this time arrives. NULL or "
+                    "omitted = dispatch immediately when ready. Use "
+                    "this to defer work to a future time — e.g. "
+                    "tomorrow morning, next Friday evening."
                 ),
             },
             "board": _board_schema_prop(),


### PR DESCRIPTION
## Summary

Re-lands the per-task `scheduled_at` deferred-dispatch feature. This was originally #24429, recorded as merged via #28384 (commit `d8ad431d`) — but the `scheduled_at` changes are **not present** in that merge commit's tree, nor in current `main`. The diff was dropped during the rebase-merge, so the feature never actually shipped.

This PR is a clean rebase of that work onto current `main`, with conflicts resolved, a latent legacy-DB bug fixed, and regression tests added so the gate can't silently disappear again.

## What it does

Adds an optional `scheduled_at` (INTEGER, unix epoch) column to the Kanban `tasks` table. When set, the dispatcher and claim path skip the task until `scheduled_at <= now`. `NULL` (default) preserves existing behavior.

## Changes

- **`hermes_cli/kanban_db.py`**
  - `tasks.scheduled_at INTEGER` column + additive migration (`_add_column_if_missing`) for legacy DBs.
  - Partial index `idx_tasks_scheduled_at` created in `_migrate_add_optional_columns` **after** the column exists (not in `SCHEMA_SQL`), matching the existing optional-column index pattern (`idx_tasks_session_id`, `idx_tasks_tenant`). The old branch put it in `SCHEMA_SQL`, which aborts legacy-DB init with `no such column: scheduled_at` — fixed here.
  - `claim_task` and `dispatch_once` gate on `(scheduled_at IS NULL OR scheduled_at <= ?)`, bound to `now`.
  - `create_task` accepts `scheduled_at`; round-trips through `from_row`.
- **`tools/kanban_tools.py`** — `scheduled_at` accepted on the kanban create_task MCP tool (arg + schema prop).
- **`tests/hermes_cli/test_kanban_db.py`** — 4 regression tests: default NULL, round-trip, claim deferral until due, immediate claim when unscheduled.

## Verification

400 kanban tests pass (`tests/hermes_cli/test_kanban_db*.py`, `test_kanban_cli.py`, `test_kanban_diagnostics.py`, `tools/test_kanban_tools.py`).

Supersedes #24429. Re-fixes what #28384 dropped.
