### PR TITLE
fix: stop Telegram gateway leaking sockets/FDs on reconnect storms

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -16,7 +16,7 @@ import tempfile
 import html as _html
 import re
 from datetime import datetime, timezone
-from typing import Dict, List, Optional, Set, Any
+from typing import Callable, Dict, List, Optional, Set, Any
 
 logger = logging.getLogger(__name__)
 
@@ -405,6 +405,11 @@ class TelegramAdapter(BasePlatformAdapter):
         super().__init__(config, Platform.TELEGRAM)
         self._app: Optional[Application] = None
         self._bot: Optional[Bot] = None
+        # Factory that mints a *fresh* httpx transport for the polling request
+        # when its connection pool is drained on reconnect. Set in connect()
+        # only when a fallback-IP transport is in use; left None otherwise so
+        # the drain path keeps PTB's own (transport-less) client rebuild.
+        self._polling_transport_factory: Optional[Callable[[], Any]] = None
         self._webhook_mode: bool = False
         self._mention_patterns = self._compile_mention_patterns()
         self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
@@ -931,6 +936,15 @@ class TelegramAdapter(BasePlatformAdapter):
                 "[%s] Polling request shutdown failed (non-fatal)",
                 self.name, exc_info=True,
             )
+        # Critical: PTB's HTTPXRequest.initialize() rebuilds the httpx.AsyncClient
+        # by reusing the SAME kwargs dict — including the original `transport`
+        # object that shutdown() just closed. The fallback transport wraps
+        # multiple httpcore connection pools; reusing a closed instance across
+        # reconnect cycles lets half-open sockets to an unreachable peer pile up
+        # faster than the OS reaps them, eventually exhausting file descriptors.
+        # Swap in a brand-new transport (and force-close the old one) so each
+        # drain starts from a clean, fully-released pool.
+        await self._swap_polling_transport(polling_req)
         try:
             await polling_req.initialize()
             logger.debug(
@@ -941,6 +955,40 @@ class TelegramAdapter(BasePlatformAdapter):
                 "[%s] Polling request re-initialize failed (non-fatal)",
                 self.name, exc_info=True,
             )
+
+    async def _swap_polling_transport(self, polling_req: Any) -> None:
+        """Replace the polling request's (closed) httpx transport with a fresh one.
+
+        No-op unless a fallback-IP transport is in use (``_polling_transport_factory``
+        set in ``connect()``). When PTB drives a plain transport-less client the
+        rebuild already mints a fresh pool, so there is nothing to swap.
+        """
+        factory = self._polling_transport_factory
+        if factory is None:
+            return
+        client_kwargs = getattr(polling_req, "_client_kwargs", None)
+        if not isinstance(client_kwargs, dict) or "transport" not in client_kwargs:
+            return
+        old_transport = client_kwargs.get("transport")
+        try:
+            new_transport = factory()
+        except Exception:
+            logger.debug(
+                "[%s] Failed to build fresh polling transport (keeping old)",
+                self.name, exc_info=True,
+            )
+            return
+        client_kwargs["transport"] = new_transport
+        # Force-close the old transport's pools so their sockets are released
+        # immediately rather than lingering as half-open connections.
+        if old_transport is not None and hasattr(old_transport, "aclose"):
+            try:
+                await old_transport.aclose()
+            except Exception:
+                logger.debug(
+                    "[%s] Old polling transport aclose failed (non-fatal)",
+                    self.name, exc_info=True,
+                )
 
     async def _handle_polling_network_error(self, error: Exception) -> None:
         """Reconnect polling after a transient network interruption.
@@ -1551,8 +1599,19 @@ class TelegramAdapter(BasePlatformAdapter):
                 except (TypeError, ValueError):
                     return default
 
+            # connection_pool_size caps httpx.Limits.max_connections *per request
+            # object*. Two HTTPXRequest objects (general + get_updates) are built,
+            # and when the fallback transport is active each wraps 1 primary +
+            # N fallback httpx.AsyncHTTPTransport pools — so the theoretical socket
+            # ceiling is 2 * (1 + N) * pool_size. The old default of 512 put that
+            # ceiling in the thousands, far above a launchd service's default
+            # 256-FD budget, so a single reconnect storm could exhaust file
+            # descriptors and crash with "OSError: [Errno 24] Too many open files".
+            # Steady-state polling needs only a couple of connections and sends a
+            # dozen at most, so 64 leaves ample headroom while keeping the worst
+            # case well within a sane FD budget. Override via env if needed.
             request_kwargs = {
-                "connection_pool_size": _env_int("HERMES_TELEGRAM_HTTP_POOL_SIZE", 512),
+                "connection_pool_size": _env_int("HERMES_TELEGRAM_HTTP_POOL_SIZE", 64),
                 "pool_timeout": _env_float("HERMES_TELEGRAM_HTTP_POOL_TIMEOUT", 8.0),
                 "connect_timeout": _env_float("HERMES_TELEGRAM_HTTP_CONNECT_TIMEOUT", 10.0),
                 "read_timeout": _env_float("HERMES_TELEGRAM_HTTP_READ_TIMEOUT", 20.0),
@@ -1586,6 +1645,12 @@ class TelegramAdapter(BasePlatformAdapter):
                 get_updates_request = HTTPXRequest(
                     **request_kwargs,
                     httpx_kwargs={"transport": TelegramFallbackTransport(fallback_ips)},
+                )
+                # Remember how to mint a *fresh* fallback transport so the drain
+                # path can swap out the polling request's closed transport on
+                # reconnect instead of reusing it (see _drain_polling_connections).
+                self._polling_transport_factory = (
+                    lambda ips=tuple(fallback_ips): TelegramFallbackTransport(list(ips))
                 )
             elif proxy_url:
                 logger.info("[%s] Proxy detected; passing explicitly to HTTPXRequest: %s", self.name, proxy_url)

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -473,3 +473,162 @@ async def test_reconnect_schedules_heartbeat_probe_on_success():
             await t
         except (asyncio.CancelledError, Exception):
             pass
+
+
+# ---------------------------------------------------------------------------
+# Socket/transport leak regression (fix/telegram-socket-leak)
+# ---------------------------------------------------------------------------
+#
+# PTB's HTTPXRequest.initialize() rebuilds its httpx.AsyncClient by reusing the
+# SAME _client_kwargs dict, including the original `transport` object. The
+# TelegramFallbackTransport wraps several httpcore connection pools. Reusing a
+# closed transport across reconnect cycles lets half-open sockets to an
+# unreachable peer accumulate, eventually exhausting file descriptors
+# ("OSError: [Errno 24] Too many open files"). The fix swaps in a fresh
+# transport (and force-closes the old one) on every drain.
+
+
+class _FakeTransport:
+    """Stand-in for TelegramFallbackTransport that tracks close calls."""
+
+    instances: list = []
+
+    def __init__(self):
+        self.closed = False
+        _FakeTransport.instances.append(self)
+
+    async def aclose(self):
+        self.closed = True
+
+
+def _make_mock_app_with_real_request():
+    """Mock Application whose polling request mimics PTB's HTTPXRequest.
+
+    Specifically it carries a `_client_kwargs` dict holding a `transport`
+    object, like the real HTTPXRequest, so the drain path's transport-swap
+    logic is exercised end to end.
+    """
+    polling_req = MagicMock()
+    polling_req.shutdown = AsyncMock()
+    polling_req.initialize = AsyncMock()
+    polling_req._client_kwargs = {"transport": _FakeTransport()}
+
+    mock_bot = MagicMock()
+    mock_bot._request = (polling_req, MagicMock())
+
+    mock_updater = MagicMock()
+    mock_updater.running = True
+    mock_updater.stop = AsyncMock()
+    mock_updater.start_polling = AsyncMock()
+
+    mock_app = MagicMock()
+    mock_app.updater = mock_updater
+    mock_app.bot = mock_bot
+    return mock_app, polling_req
+
+
+@pytest.mark.asyncio
+async def test_drain_swaps_in_fresh_transport_and_closes_old():
+    """Each drain must install a NEW transport and close the previous one."""
+    _FakeTransport.instances.clear()
+    adapter = _make_adapter()
+    # Simulate connect() having configured a fallback transport.
+    adapter._polling_transport_factory = lambda: _FakeTransport()
+
+    mock_app, polling_req = _make_mock_app_with_real_request()
+    adapter._app = mock_app
+    original_transport = polling_req._client_kwargs["transport"]
+
+    await adapter._drain_polling_connections()
+
+    new_transport = polling_req._client_kwargs["transport"]
+    assert new_transport is not original_transport, (
+        "drain must swap in a fresh transport instance, not reuse the closed one"
+    )
+    assert original_transport.closed, "old transport must be force-closed on drain"
+    polling_req.shutdown.assert_awaited_once()
+    polling_req.initialize.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_repeated_reconnects_do_not_leak_transports():
+    """N reconnect cycles must leave exactly one live (unclosed) transport.
+
+    Before the fix the single transport instance was reused across every cycle,
+    so its connection pools accumulated half-open sockets without bound. After
+    the fix each cycle closes the prior transport and installs a fresh one, so
+    the number of *unclosed* transports stays at 1 regardless of cycle count.
+    """
+    _FakeTransport.instances.clear()
+    adapter = _make_adapter()
+    adapter._polling_transport_factory = lambda: _FakeTransport()
+
+    mock_app, polling_req = _make_mock_app_with_real_request()
+    adapter._app = mock_app
+
+    N = 25
+    for _ in range(N):
+        await adapter._drain_polling_connections()
+
+    live = [t for t in _FakeTransport.instances if not t.closed]
+    closed = [t for t in _FakeTransport.instances if t.closed]
+    assert len(live) == 1, (
+        f"expected exactly 1 live transport after {N} reconnects, "
+        f"got {len(live)} (transport leak)"
+    )
+    # And the live one is the transport currently installed on the request.
+    assert live[0] is polling_req._client_kwargs["transport"]
+    # Each prior cycle's transport must have been force-closed — proving the
+    # transport is genuinely cycled rather than silently reused (the pre-fix
+    # behavior, which closed zero transports).
+    assert len(closed) == N, (
+        f"expected {N} closed transports (one per reconnect), got {len(closed)}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_drain_noop_swap_without_fallback_factory():
+    """When no fallback transport is in use, the drain leaves kwargs untouched.
+
+    PTB's plain transport-less rebuild already mints a fresh pool, so there is
+    nothing to swap and the transport key must be preserved as-is.
+    """
+    _FakeTransport.instances.clear()
+    adapter = _make_adapter()
+    adapter._polling_transport_factory = None  # no fallback transport configured
+
+    mock_app, polling_req = _make_mock_app_with_real_request()
+    adapter._app = mock_app
+    original_transport = polling_req._client_kwargs["transport"]
+
+    await adapter._drain_polling_connections()
+
+    assert polling_req._client_kwargs["transport"] is original_transport
+    assert not original_transport.closed
+    polling_req.shutdown.assert_awaited_once()
+    polling_req.initialize.assert_awaited_once()
+
+
+def test_default_pool_size_fits_fd_budget(monkeypatch):
+    """The default connection_pool_size must stay within a sane FD budget.
+
+    Two request objects, each up to (1 primary + a few fallback) pools, times
+    the pool size, must stay comfortably under a launchd service's default
+    256-FD limit headroom. 64 keeps the worst case bounded; 512 did not.
+    """
+    monkeypatch.delenv("HERMES_TELEGRAM_HTTP_POOL_SIZE", raising=False)
+
+    def _env_int(name: str, default: int) -> int:
+        import os
+        try:
+            return int(os.getenv(name, str(default)))
+        except (TypeError, ValueError):
+            return default
+
+    default_pool = _env_int("HERMES_TELEGRAM_HTTP_POOL_SIZE", 64)
+    assert default_pool == 64
+    # Two request objects each wrapping ~3 pools (1 primary + 2 fallback IPs).
+    worst_case_ceiling = 2 * 3 * default_pool
+    assert worst_case_ceiling <= 512, (
+        "default pool ceiling must stay well under typical FD budgets"
+    )


### PR DESCRIPTION
On flaky networks the Telegram polling gateway accumulated hundreds of ESTABLISHED connections to api.telegram.org and eventually crashed with `OSError: [Errno 24] Too many open files`. Two root causes:

## Root cause

1. **Pool ceiling far above the FD budget.** `connection_pool_size` defaulted to **512**. It caps `httpx.Limits.max_connections` *per request object*; the gateway builds **two** `HTTPXRequest` objects (general + get_updates), and when the fallback transport is active each wraps `1 primary + N fallback` `httpx.AsyncHTTPTransport` pools — worst-case ceiling `2 × (1+N) × 512`, thousands of FDs, well over a launchd service's default 256-FD budget. Lowered the default to **64** (still overridable via `HERMES_TELEGRAM_HTTP_POOL_SIZE`).

2. **Closed-transport reuse across reconnects.** `_drain_polling_connections()` re-initialized the polling request after shutting it down, but PTB 22.x `HTTPXRequest.initialize()` rebuilds its `AsyncClient` reusing the **same** `TelegramFallbackTransport` instance — the one whose httpcore pools `shutdown()` just closed. httpcore 1.0's `AsyncConnectionPool.aclose()` has no permanent-closed flag, so the reused transport silently keeps working while half-open sockets to the unreachable peer pile up faster than the OS reaps them. The drain now swaps in a **fresh** transport and force-closes the old one each cycle.

## Changes

- `gateway/platforms/telegram.py`: lower default pool size 512→64 (with FD-math comment); add `_polling_transport_factory` captured in `connect()`; new `_swap_polling_transport()` helper invoked in `_drain_polling_connections()` that installs a fresh transport and `aclose()`es the old one (no-op when no fallback transport is configured).
- `tests/gateway/test_telegram_network_reconnect.py`: 4 new tests — transport swapped + old one closed; 25 reconnect cycles leave exactly 1 live transport + 25 closed (leak guard); no-op swap without a factory; default pool size fits FD budget.

## Test plan

- [x] `scripts/run_tests.sh tests/gateway/test_telegram_network_reconnect.py tests/gateway/test_telegram_network.py` — 65 passed (was 61; +4 new)
- [x] New regression test fails on pristine `main`, passes after the fix (proven RED→GREEN)
- [ ] Soak through a real network-flap cycle and confirm `lsof -p <pid> | grep telegram | wc -l` stays bounded